### PR TITLE
fix(playground-ui): sync Dialog, Popover, Select styling for consistency

### DIFF
--- a/.changeset/crisp-owls-slide.md
+++ b/.changeset/crisp-owls-slide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Aligned border, background, and radius styles across Dialog, AlertDialog, Popover, and Select components for visual consistency. All overlay components now use border-border1, bg-surface3, and rounded-md.

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata-model-switcher.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata-model-switcher.tsx
@@ -443,7 +443,7 @@ export const AgentMetadataModelSwitcher = ({
                   <div
                     key={provider.id}
                     data-provider-highlighted={isHighlighted}
-                    className={`flex items-center gap-2 cursor-pointer hover:bg-surface5 px-3 py-4 rounded ${
+                    className={`flex items-center gap-2 cursor-pointer hover:bg-surface5 px-3 py-2 rounded-md ${
                       isHighlighted ? 'outline outline-2 outline-blue-500' : ''
                     } ${isSelected ? 'bg-surface5' : ''}`}
                     onClick={() => handleProviderSelect(provider)}

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata-model-switcher.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata-model-switcher.tsx
@@ -619,7 +619,7 @@ export const AgentMetadataModelSwitcher = ({
                     <div
                       key={`${model.provider}-${model.model}`}
                       data-model-highlighted={isHighlighted}
-                      className={`flex items-center gap-2 px-4 py-3 cursor-pointer rounded hover:bg-surface5 ${
+                      className={`flex items-center gap-2 px-3 py-2 cursor-pointer rounded-md hover:bg-surface5 ${
                         isHighlighted ? 'outline outline-2 outline-blue-500' : ''
                       } ${isSelected ? 'bg-surface5' : ''}`}
                       onMouseDown={e => {

--- a/packages/playground-ui/src/domains/configuration/components/mastra-version-footer.tsx
+++ b/packages/playground-ui/src/domains/configuration/components/mastra-version-footer.tsx
@@ -6,7 +6,7 @@ import { Txt } from '@/ds/components/Txt/Txt';
 import { useMastraPackages } from '../hooks/use-mastra-packages';
 import { usePackageUpdates, type PackageUpdateInfo } from '../hooks/use-package-updates';
 import { cn } from '@/lib/utils';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogDescription } from '@/ds/components/Dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogDescription, DialogBody } from '@/ds/components/Dialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
 import { SelectField } from '@/ds/components/FormFields';
 
@@ -167,11 +167,12 @@ const PackagesModalContent = ({
     <DialogContent className="max-w-2xl">
       <DialogHeader>
         <DialogTitle>Installed Mastra Packages</DialogTitle>
-        <DialogDescription className="sr-only">View and update installed Mastra packages</DialogDescription>
+        <DialogDescription>View and update installed Mastra packages</DialogDescription>
       </DialogHeader>
 
-      {/* Status summary */}
-      <div className="text-sm text-neutral3 py-2">
+      <DialogBody>
+        {/* Status summary */}
+        <div className="text-sm text-neutral3 py-2">
         {isLoadingUpdates ? (
           <span className="text-neutral3">Checking for updates...</span>
         ) : !hasUpdates ? (
@@ -293,6 +294,7 @@ const PackagesModalContent = ({
           </button>
         </div>
       )}
+      </DialogBody>
     </DialogContent>
   );
 };

--- a/packages/playground-ui/src/domains/configuration/components/mastra-version-footer.tsx
+++ b/packages/playground-ui/src/domains/configuration/components/mastra-version-footer.tsx
@@ -6,7 +6,7 @@ import { Txt } from '@/ds/components/Txt/Txt';
 import { useMastraPackages } from '../hooks/use-mastra-packages';
 import { usePackageUpdates, type PackageUpdateInfo } from '../hooks/use-package-updates';
 import { cn } from '@/lib/utils';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/ds/components/Dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogDescription } from '@/ds/components/Dialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
 import { SelectField } from '@/ds/components/FormFields';
 
@@ -164,9 +164,10 @@ const PackagesModalContent = ({
   });
 
   return (
-    <DialogContent className="bg-surface1 border-border1 max-w-2xl">
+    <DialogContent className="max-w-2xl">
       <DialogHeader>
-        <DialogTitle className="text-text1">Installed Mastra Packages</DialogTitle>
+        <DialogTitle>Installed Mastra Packages</DialogTitle>
+        <DialogDescription className="sr-only">View and update installed Mastra packages</DialogDescription>
       </DialogHeader>
 
       {/* Status summary */}

--- a/packages/playground-ui/src/domains/configuration/components/mastra-version-footer.tsx
+++ b/packages/playground-ui/src/domains/configuration/components/mastra-version-footer.tsx
@@ -6,7 +6,15 @@ import { Txt } from '@/ds/components/Txt/Txt';
 import { useMastraPackages } from '../hooks/use-mastra-packages';
 import { usePackageUpdates, type PackageUpdateInfo } from '../hooks/use-package-updates';
 import { cn } from '@/lib/utils';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogDescription, DialogBody } from '@/ds/components/Dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogDescription,
+  DialogBody,
+} from '@/ds/components/Dialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
 import { SelectField } from '@/ds/components/FormFields';
 
@@ -173,127 +181,127 @@ const PackagesModalContent = ({
       <DialogBody>
         {/* Status summary */}
         <div className="text-sm text-neutral3 py-2">
-        {isLoadingUpdates ? (
-          <span className="text-neutral3">Checking for updates...</span>
-        ) : !hasUpdates ? (
-          <span className="text-accent1">✓ All packages are up to date</span>
-        ) : (
-          <div className="flex items-center gap-3">
-            {outdatedCount > 0 && (
-              <span className="flex items-center gap-1.5">
-                <StatusBadge value={outdatedCount} variant="warning" />
-                <span>package{outdatedCount !== 1 ? 's' : ''} outdated</span>
-              </span>
-            )}
-            {deprecatedCount > 0 && (
-              <span className="flex items-center gap-1.5">
-                <StatusBadge value={deprecatedCount} variant="error" />
-                <span>package{deprecatedCount !== 1 ? 's' : ''} deprecated</span>
-              </span>
-            )}
+          {isLoadingUpdates ? (
+            <span className="text-neutral3">Checking for updates...</span>
+          ) : !hasUpdates ? (
+            <span className="text-accent1">✓ All packages are up to date</span>
+          ) : (
+            <div className="flex items-center gap-3">
+              {outdatedCount > 0 && (
+                <span className="flex items-center gap-1.5">
+                  <StatusBadge value={outdatedCount} variant="warning" />
+                  <span>package{outdatedCount !== 1 ? 's' : ''} outdated</span>
+                </span>
+              )}
+              {deprecatedCount > 0 && (
+                <span className="flex items-center gap-1.5">
+                  <StatusBadge value={deprecatedCount} variant="error" />
+                  <span>package{deprecatedCount !== 1 ? 's' : ''} deprecated</span>
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Package list */}
+        <div className="max-h-64 overflow-y-auto border border-border1 rounded-md">
+          <div className="grid grid-cols-[1fr_auto_auto] text-sm">
+            {packages.map((pkg, index) => (
+              <div key={pkg.name} className={cn('contents', index > 0 && '[&>div]:border-t [&>div]:border-border1')}>
+                <div className="py-2 px-3 font-mono text-text1 truncate min-w-0">
+                  <a
+                    href={`https://www.npmjs.com/package/${pkg.name}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="hover:text-accent1 hover:underline inline-flex items-center gap-1 group"
+                  >
+                    {pkg.name}
+                    <ExternalLink className="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+                  </a>
+                </div>
+                <div className="py-2 px-3 font-mono text-neutral3 flex items-center gap-1.5">
+                  {pkg.isOutdated || pkg.isDeprecated ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span
+                          className={cn(
+                            'cursor-help',
+                            pkg.isDeprecated ? 'text-red-500' : pkg.isOutdated ? 'text-yellow-500' : '',
+                          )}
+                        >
+                          {pkg.version}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {pkg.isDeprecated
+                          ? pkg.deprecationMessage || 'This version is deprecated'
+                          : 'Newer version available'}
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    <span>{pkg.version}</span>
+                  )}
+                </div>
+                <div className="py-2 px-3 font-mono text-neutral3 flex items-center">
+                  {(pkg.isOutdated || pkg.isDeprecated) && pkg.latestVersion && (
+                    <>
+                      <MoveRight className="w-4 h-4 mx-2 text-neutral3" />
+                      <span className="text-accent1">{pkg.latestVersion}</span>
+                    </>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Copy current versions button - always visible */}
+        <button
+          onClick={handleCopyAll}
+          className="flex items-center justify-center gap-2 w-full py-2 px-3 rounded bg-surface2 hover:bg-surface3 text-neutral3 hover:text-neutral1 transition-colors"
+        >
+          {isCopiedAll ? <Check className="w-4 h-4 text-accent1" /> : <Copy className="w-4 h-4" />}
+          <Txt as="span" variant="ui-sm">
+            {isCopiedAll ? 'Copied!' : 'Copy current versions'}
+          </Txt>
+        </button>
+
+        {/* Update command section */}
+        {hasUpdates && updateCommand && (
+          <div className="space-y-3 pt-2 border-t border-border1">
+            <div className="flex items-center gap-2 text-sm text-neutral3 pt-3">
+              <Info className="w-4 h-4" />
+              <span>Use the command below to update your packages</span>
+            </div>
+
+            <div className="flex gap-2 items-center">
+              <SelectField
+                value={packageManager}
+                onValueChange={value => onPackageManagerChange(value as PackageManager)}
+                options={[
+                  { label: 'pnpm', value: 'pnpm' },
+                  { label: 'npm', value: 'npm' },
+                  { label: 'yarn', value: 'yarn' },
+                  { label: 'bun', value: 'bun' },
+                ]}
+              />
+
+              <pre className="flex-1 text-sm text-neutral3 bg-surface2 rounded-md px-3 py-1.5 overflow-x-auto whitespace-pre-wrap break-all">
+                {updateCommand}
+              </pre>
+            </div>
+
+            <button
+              onClick={handleCopyCommand}
+              className="flex items-center justify-center gap-2 w-full py-2 px-3 rounded bg-surface2 hover:bg-surface3 text-neutral3 hover:text-neutral1 transition-colors"
+            >
+              {isCopiedCommand ? <Check className="w-4 h-4 text-accent1" /> : <Copy className="w-4 h-4" />}
+              <Txt as="span" variant="ui-sm">
+                {isCopiedCommand ? 'Copied!' : 'Copy command'}
+              </Txt>
+            </button>
           </div>
         )}
-      </div>
-
-      {/* Package list */}
-      <div className="max-h-64 overflow-y-auto border border-border1 rounded-md">
-        <div className="grid grid-cols-[1fr_auto_auto] text-sm">
-          {packages.map((pkg, index) => (
-            <div key={pkg.name} className={cn('contents', index > 0 && '[&>div]:border-t [&>div]:border-border1')}>
-              <div className="py-2 px-3 font-mono text-text1 truncate min-w-0">
-                <a
-                  href={`https://www.npmjs.com/package/${pkg.name}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:text-accent1 hover:underline inline-flex items-center gap-1 group"
-                >
-                  {pkg.name}
-                  <ExternalLink className="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity" />
-                </a>
-              </div>
-              <div className="py-2 px-3 font-mono text-neutral3 flex items-center gap-1.5">
-                {pkg.isOutdated || pkg.isDeprecated ? (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span
-                        className={cn(
-                          'cursor-help',
-                          pkg.isDeprecated ? 'text-red-500' : pkg.isOutdated ? 'text-yellow-500' : '',
-                        )}
-                      >
-                        {pkg.version}
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {pkg.isDeprecated
-                        ? pkg.deprecationMessage || 'This version is deprecated'
-                        : 'Newer version available'}
-                    </TooltipContent>
-                  </Tooltip>
-                ) : (
-                  <span>{pkg.version}</span>
-                )}
-              </div>
-              <div className="py-2 px-3 font-mono text-neutral3 flex items-center">
-                {(pkg.isOutdated || pkg.isDeprecated) && pkg.latestVersion && (
-                  <>
-                    <MoveRight className="w-4 h-4 mx-2 text-neutral3" />
-                    <span className="text-accent1">{pkg.latestVersion}</span>
-                  </>
-                )}
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* Copy current versions button - always visible */}
-      <button
-        onClick={handleCopyAll}
-        className="flex items-center justify-center gap-2 w-full py-2 px-3 rounded bg-surface2 hover:bg-surface3 text-neutral3 hover:text-neutral1 transition-colors"
-      >
-        {isCopiedAll ? <Check className="w-4 h-4 text-accent1" /> : <Copy className="w-4 h-4" />}
-        <Txt as="span" variant="ui-sm">
-          {isCopiedAll ? 'Copied!' : 'Copy current versions'}
-        </Txt>
-      </button>
-
-      {/* Update command section */}
-      {hasUpdates && updateCommand && (
-        <div className="space-y-3 pt-2 border-t border-border1">
-          <div className="flex items-center gap-2 text-sm text-neutral3 pt-3">
-            <Info className="w-4 h-4" />
-            <span>Use the command below to update your packages</span>
-          </div>
-
-          <div className="flex gap-2 items-center">
-            <SelectField
-              value={packageManager}
-              onValueChange={value => onPackageManagerChange(value as PackageManager)}
-              options={[
-                { label: 'pnpm', value: 'pnpm' },
-                { label: 'npm', value: 'npm' },
-                { label: 'yarn', value: 'yarn' },
-                { label: 'bun', value: 'bun' },
-              ]}
-            />
-
-            <pre className="flex-1 text-sm text-neutral3 bg-surface2 rounded-md px-3 py-1.5 overflow-x-auto whitespace-pre-wrap break-all">
-              {updateCommand}
-            </pre>
-          </div>
-
-          <button
-            onClick={handleCopyCommand}
-            className="flex items-center justify-center gap-2 w-full py-2 px-3 rounded bg-surface2 hover:bg-surface3 text-neutral3 hover:text-neutral1 transition-colors"
-          >
-            {isCopiedCommand ? <Check className="w-4 h-4 text-accent1" /> : <Copy className="w-4 h-4" />}
-            <Txt as="span" variant="ui-sm">
-              {isCopiedCommand ? 'Copied!' : 'Copy command'}
-            </Txt>
-          </button>
-        </div>
-      )}
       </DialogBody>
     </DialogContent>
   );

--- a/packages/playground-ui/src/domains/workflows/components/workflow-information.tsx
+++ b/packages/playground-ui/src/domains/workflows/components/workflow-information.tsx
@@ -92,7 +92,7 @@ export function WorkflowInformation({ workflowId, initialRunId }: WorkflowInform
   }
 
   return (
-    <div className="grid grid-rows-[auto_1fr] h-full overflow-y-auto border-l border-border1">
+    <div className="grid grid-rows-[auto_1fr] h-full overflow-y-auto">
       <EntityHeader icon={<WorkflowIcon />} title={workflow?.name || ''} isLoading={isLoading}>
         <div className="flex items-center gap-2 pt-2">
           <Tooltip>

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-code-dialog-content.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-code-dialog-content.tsx
@@ -42,7 +42,7 @@ export const CodeDialogContent = ({
   if (typeof data !== 'string') {
     const content = JSON.stringify(data, null, 2);
     return (
-      <div className="max-h-[500px] overflow-auto relative p-4">
+      <div className="max-h-[500px] overflow-auto relative">
         <div className="absolute right-2 top-2 bg-surface4 rounded-full z-10">
           <CopyButton content={content} />
         </div>
@@ -65,7 +65,7 @@ export const CodeDialogContent = ({
   }
 
   return (
-    <div className="max-h-[500px] overflow-auto relative p-4">
+    <div className="max-h-[500px] overflow-auto relative">
       <div className="absolute right-2 top-2 bg-surface4 rounded-full z-10">
         <CopyButton content={data} />
       </div>

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-condition-node.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-condition-node.tsx
@@ -10,7 +10,7 @@ import { Highlight, themes } from 'prism-react-renderer';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/ds/components/Collapsible';
 import { ChevronDown } from 'lucide-react';
 import { getConditionIconAndColor } from './workflow-node-badges';
-import { Dialog, DialogContent, DialogTitle, DialogHeader, DialogDescription } from '@/ds/components/Dialog';
+import { Dialog, DialogContent, DialogTitle, DialogHeader, DialogDescription, DialogBody } from '@/ds/components/Dialog';
 import { ScrollArea } from '@/ds/components/ScrollArea';
 import { useCurrentRun } from '../context/use-current-run';
 import { Badge } from '@/ds/components/Badge';
@@ -144,9 +144,10 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
                       <DialogContent className="max-w-[30rem]">
                         <DialogHeader>
                           <DialogTitle className="sr-only">Condition Function</DialogTitle>
-                          <DialogDescription className="sr-only">View the condition function code</DialogDescription>
+                          <DialogDescription>View the condition function code</DialogDescription>
                         </DialogHeader>
-                        <ScrollArea className="w-full" maxHeight="400px">
+                        <DialogBody>
+                          <ScrollArea className="w-full" maxHeight="400px">
                           <Highlight
                             theme={themes.oneDark}
                             code={String(condition.fnString).trim()}
@@ -172,7 +173,8 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
                               </pre>
                             )}
                           </Highlight>
-                        </ScrollArea>
+                          </ScrollArea>
+                        </DialogBody>
                       </DialogContent>
                     </Dialog>
                   </div>

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-condition-node.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-condition-node.tsx
@@ -10,7 +10,7 @@ import { Highlight, themes } from 'prism-react-renderer';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/ds/components/Collapsible';
 import { ChevronDown } from 'lucide-react';
 import { getConditionIconAndColor } from './workflow-node-badges';
-import { Dialog, DialogContent, DialogTitle } from '@/ds/components/Dialog';
+import { Dialog, DialogContent, DialogTitle, DialogHeader, DialogDescription } from '@/ds/components/Dialog';
 import { ScrollArea } from '@/ds/components/ScrollArea';
 import { useCurrentRun } from '../context/use-current-run';
 import { Badge } from '@/ds/components/Badge';
@@ -141,9 +141,12 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
                     </Highlight>
 
                     <Dialog open={openDialog} onOpenChange={setOpenDialog}>
-                      <DialogContent className="max-w-[30rem] bg-surface2 p-4">
-                        <DialogTitle className="sr-only">Condition Function</DialogTitle>
-                        <ScrollArea className="w-full p-2 pt-4" maxHeight="400px">
+                      <DialogContent className="max-w-[30rem]">
+                        <DialogHeader>
+                          <DialogTitle className="sr-only">Condition Function</DialogTitle>
+                          <DialogDescription className="sr-only">View the condition function code</DialogDescription>
+                        </DialogHeader>
+                        <ScrollArea className="w-full" maxHeight="400px">
                           <Highlight
                             theme={themes.oneDark}
                             code={String(condition.fnString).trim()}

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-condition-node.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-condition-node.tsx
@@ -10,7 +10,14 @@ import { Highlight, themes } from 'prism-react-renderer';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/ds/components/Collapsible';
 import { ChevronDown } from 'lucide-react';
 import { getConditionIconAndColor } from './workflow-node-badges';
-import { Dialog, DialogContent, DialogTitle, DialogHeader, DialogDescription, DialogBody } from '@/ds/components/Dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogHeader,
+  DialogDescription,
+  DialogBody,
+} from '@/ds/components/Dialog';
 import { ScrollArea } from '@/ds/components/ScrollArea';
 import { useCurrentRun } from '../context/use-current-run';
 import { Badge } from '@/ds/components/Badge';
@@ -148,31 +155,31 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
                         </DialogHeader>
                         <DialogBody>
                           <ScrollArea className="w-full" maxHeight="400px">
-                          <Highlight
-                            theme={themes.oneDark}
-                            code={String(condition.fnString).trim()}
-                            language="javascript"
-                          >
-                            {({ className, style, tokens, getLineProps, getTokenProps }) => (
-                              <pre
-                                className={`${className} relative font-mono text-sm overflow-x-auto p-3 w-full rounded-lg mt-2 dark:bg-zinc-800`}
-                                style={{
-                                  ...style,
-                                  backgroundColor: '#121212',
-                                  padding: '0 0.75rem 0 0',
-                                }}
-                              >
-                                {tokens.map((line, i) => (
-                                  <div key={i} {...getLineProps({ line })}>
-                                    <span className="inline-block mr-2 text-neutral3">{i + 1}</span>
-                                    {line.map((token, key) => (
-                                      <span key={key} {...getTokenProps({ token })} />
-                                    ))}
-                                  </div>
-                                ))}
-                              </pre>
-                            )}
-                          </Highlight>
+                            <Highlight
+                              theme={themes.oneDark}
+                              code={String(condition.fnString).trim()}
+                              language="javascript"
+                            >
+                              {({ className, style, tokens, getLineProps, getTokenProps }) => (
+                                <pre
+                                  className={`${className} relative font-mono text-sm overflow-x-auto p-3 w-full rounded-lg mt-2 dark:bg-zinc-800`}
+                                  style={{
+                                    ...style,
+                                    backgroundColor: '#121212',
+                                    padding: '0 0.75rem 0 0',
+                                  }}
+                                >
+                                  {tokens.map((line, i) => (
+                                    <div key={i} {...getLineProps({ line })}>
+                                      <span className="inline-block mr-2 text-neutral3">{i + 1}</span>
+                                      {line.map((token, key) => (
+                                        <span key={key} {...getTokenProps({ token })} />
+                                      ))}
+                                    </div>
+                                  ))}
+                                </pre>
+                              )}
+                            </Highlight>
                           </ScrollArea>
                         </DialogBody>
                       </DialogContent>

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-step-action-bar.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-step-action-bar.tsx
@@ -1,5 +1,12 @@
 import { Button } from '@/ds/components/Button';
-import { Dialog, DialogContent, DialogTitle, DialogHeader, DialogDescription, DialogBody } from '@/ds/components/Dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogHeader,
+  DialogDescription,
+  DialogBody,
+} from '@/ds/components/Dialog';
 import { CodeDialogContent } from './workflow-code-dialog-content';
 import { useContext, useMemo, useState } from 'react';
 import { cn } from '@/lib/utils';

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-step-action-bar.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-step-action-bar.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/ds/components/Button';
-import { Dialog, DialogContent, DialogTitle } from '@/ds/components/Dialog';
+import { Dialog, DialogContent, DialogTitle, DialogHeader, DialogDescription } from '@/ds/components/Dialog';
 import { CodeDialogContent } from './workflow-code-dialog-content';
 import { useContext, useMemo, useState } from 'react';
 import { cn } from '@/lib/utils';
@@ -65,8 +65,7 @@ export const WorkflowStepActionBar = ({
 
   const workflowStatus = result?.status ?? runSnapshot?.status;
 
-  const dialogContentClass = 'bg-surface2 rounded-lg border border-border1 max-w-4xl w-full px-0';
-  const dialogTitleClass = 'border-b border-border1 pb-4 px-6';
+  const dialogContentClass = 'max-w-4xl w-full';
 
   const showTimeTravel =
     !withoutTimeTravel && stepKey && !mapConfig && workflowStatus !== 'running' && workflowStatus !== 'paused';
@@ -192,9 +191,11 @@ export const WorkflowStepActionBar = ({
               </Button>
               <Dialog open={isTimeTravelOpen} onOpenChange={setIsTimeTravelOpen}>
                 <DialogContent className={dialogContentClass}>
-                  <DialogTitle className={dialogTitleClass}>Time travel to {stepKey}</DialogTitle>
-
-                  <div className="px-4 overflow-scroll max-h-[600px]">
+                  <DialogHeader>
+                    <DialogTitle>Time travel to {stepKey}</DialogTitle>
+                    <DialogDescription className="sr-only">Time travel to a specific workflow step</DialogDescription>
+                  </DialogHeader>
+                  <div className="overflow-auto max-h-[600px]">
                     <WorkflowTimeTravelForm stepKey={stepKey} closeModal={() => setIsTimeTravelOpen(false)} />
                   </div>
                 </DialogContent>
@@ -217,9 +218,11 @@ export const WorkflowStepActionBar = ({
               </Button>
               <Dialog open={isPerStepRunOpen} onOpenChange={setIsPerStepRunOpen}>
                 <DialogContent className={dialogContentClass}>
-                  <DialogTitle className={dialogTitleClass}>Run step {stepKey}</DialogTitle>
-
-                  <div className="px-4 overflow-scroll max-h-[600px]">
+                  <DialogHeader>
+                    <DialogTitle>Run step {stepKey}</DialogTitle>
+                    <DialogDescription className="sr-only">Run a specific workflow step</DialogDescription>
+                  </DialogHeader>
+                  <div className="overflow-auto max-h-[600px]">
                     <WorkflowTimeTravelForm
                       stepKey={stepKey}
                       closeModal={() => setIsPerStepRunOpen(false)}
@@ -245,9 +248,11 @@ export const WorkflowStepActionBar = ({
               </Button>
               <Dialog open={isContinueRunOpen} onOpenChange={setIsContinueRunOpen}>
                 <DialogContent className={dialogContentClass}>
-                  <DialogTitle className={dialogTitleClass}>Continue run {stepKey}</DialogTitle>
-
-                  <div className="px-4 overflow-scroll max-h-[600px]">
+                  <DialogHeader>
+                    <DialogTitle>Continue run {stepKey}</DialogTitle>
+                    <DialogDescription className="sr-only">Continue the workflow run from this step</DialogDescription>
+                  </DialogHeader>
+                  <div className="overflow-auto max-h-[600px]">
                     <WorkflowTimeTravelForm
                       stepKey={stepKey}
                       closeModal={() => setIsContinueRunOpen(false)}
@@ -273,9 +278,11 @@ export const WorkflowStepActionBar = ({
 
               <Dialog open={isInputOpen} onOpenChange={setIsInputOpen}>
                 <DialogContent className={dialogContentClass}>
-                  <DialogTitle className={dialogTitleClass}>{stepName} input</DialogTitle>
-
-                  <div className="px-4 overflow-hidden">
+                  <DialogHeader>
+                    <DialogTitle>{stepName} input</DialogTitle>
+                    <DialogDescription className="sr-only">View the input data for this step</DialogDescription>
+                  </DialogHeader>
+                  <div className="overflow-hidden">
                     <CodeDialogContent data={input} />
                   </div>
                 </DialogContent>
@@ -291,9 +298,11 @@ export const WorkflowStepActionBar = ({
 
               <Dialog open={isResumeDataOpen} onOpenChange={setIsResumeDataOpen}>
                 <DialogContent className={dialogContentClass}>
-                  <DialogTitle className={dialogTitleClass}>{stepName} resume data</DialogTitle>
-
-                  <div className="px-4 overflow-hidden">
+                  <DialogHeader>
+                    <DialogTitle>{stepName} resume data</DialogTitle>
+                    <DialogDescription className="sr-only">View the resume data for this step</DialogDescription>
+                  </DialogHeader>
+                  <div className="overflow-hidden">
                     <CodeDialogContent data={resumeData} />
                   </div>
                 </DialogContent>
@@ -309,8 +318,11 @@ export const WorkflowStepActionBar = ({
 
               <Dialog open={isOutputOpen} onOpenChange={setIsOutputOpen}>
                 <DialogContent className={dialogContentClass}>
-                  <DialogTitle className={dialogTitleClass}>{stepName} output</DialogTitle>
-                  <div className="px-4 overflow-hidden">
+                  <DialogHeader>
+                    <DialogTitle>{stepName} output</DialogTitle>
+                    <DialogDescription className="sr-only">View the output data for this step</DialogDescription>
+                  </DialogHeader>
+                  <div className="overflow-hidden">
                     <CodeDialogContent data={output ?? suspendOutput} />
                   </div>
                 </DialogContent>
@@ -326,9 +338,11 @@ export const WorkflowStepActionBar = ({
 
               <Dialog open={isErrorOpen} onOpenChange={setIsErrorOpen}>
                 <DialogContent className={dialogContentClass}>
-                  <DialogTitle className={dialogTitleClass}>{stepName} error</DialogTitle>
-
-                  <div className="px-4 overflow-hidden">
+                  <DialogHeader>
+                    <DialogTitle>{stepName} error</DialogTitle>
+                    <DialogDescription className="sr-only">View the error details for this step</DialogDescription>
+                  </DialogHeader>
+                  <div className="overflow-hidden">
                     <CodeDialogContent data={error} />
                   </div>
                 </DialogContent>
@@ -344,9 +358,11 @@ export const WorkflowStepActionBar = ({
 
               <Dialog open={isTripwireOpen} onOpenChange={setIsTripwireOpen}>
                 <DialogContent className={dialogContentClass}>
-                  <DialogTitle className={dialogTitleClass}>{stepName} tripwire</DialogTitle>
-
-                  <div className="px-4 overflow-hidden">
+                  <DialogHeader>
+                    <DialogTitle>{stepName} tripwire</DialogTitle>
+                    <DialogDescription className="sr-only">View the tripwire details for this step</DialogDescription>
+                  </DialogHeader>
+                  <div className="overflow-hidden">
                     <CodeDialogContent
                       data={{
                         reason: tripwire.reason,

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-step-action-bar.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-step-action-bar.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@/ds/components/Button';
-import { Dialog, DialogContent, DialogTitle, DialogHeader, DialogDescription } from '@/ds/components/Dialog';
+import { Dialog, DialogContent, DialogTitle, DialogHeader, DialogDescription, DialogBody } from '@/ds/components/Dialog';
 import { CodeDialogContent } from './workflow-code-dialog-content';
 import { useContext, useMemo, useState } from 'react';
 import { cn } from '@/lib/utils';
@@ -193,11 +193,11 @@ export const WorkflowStepActionBar = ({
                 <DialogContent className={dialogContentClass}>
                   <DialogHeader>
                     <DialogTitle>Time travel to {stepKey}</DialogTitle>
-                    <DialogDescription className="sr-only">Time travel to a specific workflow step</DialogDescription>
+                    <DialogDescription>Time travel to a specific workflow step</DialogDescription>
                   </DialogHeader>
-                  <div className="overflow-auto max-h-[600px]">
+                  <DialogBody className="max-h-[600px]">
                     <WorkflowTimeTravelForm stepKey={stepKey} closeModal={() => setIsTimeTravelOpen(false)} />
-                  </div>
+                  </DialogBody>
                 </DialogContent>
               </Dialog>
             </>
@@ -220,9 +220,9 @@ export const WorkflowStepActionBar = ({
                 <DialogContent className={dialogContentClass}>
                   <DialogHeader>
                     <DialogTitle>Run step {stepKey}</DialogTitle>
-                    <DialogDescription className="sr-only">Run a specific workflow step</DialogDescription>
+                    <DialogDescription>Run a specific workflow step</DialogDescription>
                   </DialogHeader>
-                  <div className="overflow-auto max-h-[600px]">
+                  <DialogBody className="max-h-[600px]">
                     <WorkflowTimeTravelForm
                       stepKey={stepKey}
                       closeModal={() => setIsPerStepRunOpen(false)}
@@ -230,7 +230,7 @@ export const WorkflowStepActionBar = ({
                       buttonText="Run step"
                       inputData={stepPayload?.input}
                     />
-                  </div>
+                  </DialogBody>
                 </DialogContent>
               </Dialog>
 
@@ -250,9 +250,9 @@ export const WorkflowStepActionBar = ({
                 <DialogContent className={dialogContentClass}>
                   <DialogHeader>
                     <DialogTitle>Continue run {stepKey}</DialogTitle>
-                    <DialogDescription className="sr-only">Continue the workflow run from this step</DialogDescription>
+                    <DialogDescription>Continue the workflow run from this step</DialogDescription>
                   </DialogHeader>
-                  <div className="overflow-auto max-h-[600px]">
+                  <DialogBody className="max-h-[600px]">
                     <WorkflowTimeTravelForm
                       stepKey={stepKey}
                       closeModal={() => setIsContinueRunOpen(false)}
@@ -260,7 +260,7 @@ export const WorkflowStepActionBar = ({
                       buttonText="Continue run"
                       inputData={stepPayload?.input}
                     />
-                  </div>
+                  </DialogBody>
                 </DialogContent>
               </Dialog>
             </>
@@ -280,11 +280,11 @@ export const WorkflowStepActionBar = ({
                 <DialogContent className={dialogContentClass}>
                   <DialogHeader>
                     <DialogTitle>{stepName} input</DialogTitle>
-                    <DialogDescription className="sr-only">View the input data for this step</DialogDescription>
+                    <DialogDescription>View the input data for this step</DialogDescription>
                   </DialogHeader>
-                  <div className="overflow-hidden">
+                  <DialogBody>
                     <CodeDialogContent data={input} />
-                  </div>
+                  </DialogBody>
                 </DialogContent>
               </Dialog>
             </>
@@ -300,11 +300,11 @@ export const WorkflowStepActionBar = ({
                 <DialogContent className={dialogContentClass}>
                   <DialogHeader>
                     <DialogTitle>{stepName} resume data</DialogTitle>
-                    <DialogDescription className="sr-only">View the resume data for this step</DialogDescription>
+                    <DialogDescription>View the resume data for this step</DialogDescription>
                   </DialogHeader>
-                  <div className="overflow-hidden">
+                  <DialogBody>
                     <CodeDialogContent data={resumeData} />
-                  </div>
+                  </DialogBody>
                 </DialogContent>
               </Dialog>
             </>
@@ -320,11 +320,11 @@ export const WorkflowStepActionBar = ({
                 <DialogContent className={dialogContentClass}>
                   <DialogHeader>
                     <DialogTitle>{stepName} output</DialogTitle>
-                    <DialogDescription className="sr-only">View the output data for this step</DialogDescription>
+                    <DialogDescription>View the output data for this step</DialogDescription>
                   </DialogHeader>
-                  <div className="overflow-hidden">
+                  <DialogBody>
                     <CodeDialogContent data={output ?? suspendOutput} />
-                  </div>
+                  </DialogBody>
                 </DialogContent>
               </Dialog>
             </>
@@ -340,11 +340,11 @@ export const WorkflowStepActionBar = ({
                 <DialogContent className={dialogContentClass}>
                   <DialogHeader>
                     <DialogTitle>{stepName} error</DialogTitle>
-                    <DialogDescription className="sr-only">View the error details for this step</DialogDescription>
+                    <DialogDescription>View the error details for this step</DialogDescription>
                   </DialogHeader>
-                  <div className="overflow-hidden">
+                  <DialogBody>
                     <CodeDialogContent data={error} />
-                  </div>
+                  </DialogBody>
                 </DialogContent>
               </Dialog>
             </>
@@ -360,9 +360,9 @@ export const WorkflowStepActionBar = ({
                 <DialogContent className={dialogContentClass}>
                   <DialogHeader>
                     <DialogTitle>{stepName} tripwire</DialogTitle>
-                    <DialogDescription className="sr-only">View the tripwire details for this step</DialogDescription>
+                    <DialogDescription>View the tripwire details for this step</DialogDescription>
                   </DialogHeader>
-                  <div className="overflow-hidden">
+                  <DialogBody>
                     <CodeDialogContent
                       data={{
                         reason: tripwire.reason,
@@ -371,7 +371,7 @@ export const WorkflowStepActionBar = ({
                         processorId: tripwire.processorId,
                       }}
                     />
-                  </div>
+                  </DialogBody>
                 </DialogContent>
               </Dialog>
             </>

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
@@ -17,7 +17,14 @@ import { Txt } from '@/ds/components/Txt';
 
 import { GetWorkflowResponse } from '@mastra/client-js';
 import { CodeEditor } from '@/ds/components/CodeEditor';
-import { Dialog, DialogTitle, DialogContent, DialogHeader, DialogDescription } from '@/ds/components/Dialog';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogHeader,
+  DialogDescription,
+  DialogBody,
+} from '@/ds/components/Dialog';
 import { WorkflowStatus } from './workflow-status';
 import { WorkflowInputData } from './workflow-input-data';
 import { isObjectEmpty } from '@/lib/object';
@@ -400,14 +407,14 @@ const WorkflowJsonDialog = ({ result }: { result: Record<string, unknown> }) => 
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-6xl max-h-[90vh]">
+        <DialogContent className="max-w-6xl">
           <DialogHeader>
             <DialogTitle>Workflow Execution (JSON)</DialogTitle>
-            <DialogDescription className="sr-only">JSON view of the workflow execution result</DialogDescription>
+            <DialogDescription>JSON view of the workflow execution result</DialogDescription>
           </DialogHeader>
-          <div className="w-full h-full overflow-auto">
+          <DialogBody className="max-h-[90vh]">
             <CodeEditor data={result} className="p-4" />
-          </div>
+          </DialogBody>
         </DialogContent>
       </Dialog>
     </>

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
@@ -17,7 +17,7 @@ import { Txt } from '@/ds/components/Txt';
 
 import { GetWorkflowResponse } from '@mastra/client-js';
 import { CodeEditor } from '@/ds/components/CodeEditor';
-import { Dialog, DialogPortal, DialogTitle, DialogContent } from '@/ds/components/Dialog';
+import { Dialog, DialogTitle, DialogContent, DialogHeader, DialogDescription } from '@/ds/components/Dialog';
 import { WorkflowStatus } from './workflow-status';
 import { WorkflowInputData } from './workflow-input-data';
 import { isObjectEmpty } from '@/lib/object';
@@ -301,7 +301,6 @@ export function WorkflowTrigger({
           <Button
             variant="light"
             className="w-full"
-            size="lg"
             onClick={handleCancelWorkflowRun}
             disabled={
               !!cancelResponse?.message ||
@@ -326,10 +325,10 @@ export function WorkflowTrigger({
           <>
             <hr className="border-border1 border my-5" />
             <div className="flex flex-col gap-2">
-              <Txt variant="ui-xs" className="px-4 text-neutral3">
+              <Txt variant="ui-xs" className="text-neutral3">
                 Status
               </Txt>
-              <div className="px-4 flex flex-col gap-4">
+              <div className="flex flex-col gap-4">
                 {Object.entries(workflowActivePaths)
                   .filter(([key, _]) => key !== 'input' && !key.endsWith('.input'))
                   .map(([stepId, step]) => {
@@ -394,7 +393,7 @@ const WorkflowJsonDialog = ({ result }: { result: Record<string, unknown> }) => 
 
   return (
     <>
-      <Button variant="light" onClick={() => setOpen(true)} className="w-full" size="lg">
+      <Button variant="light" onClick={() => setOpen(true)} className="w-full">
         <Icon>
           <Braces className="text-neutral3" />
         </Icon>
@@ -402,14 +401,15 @@ const WorkflowJsonDialog = ({ result }: { result: Record<string, unknown> }) => 
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogPortal>
-          <DialogContent className="max-w-6xl max-h-[90vh] overflow-y-auto overflow-x-hidden bg-surface2">
+        <DialogContent className="max-w-6xl max-h-[90vh]">
+          <DialogHeader>
             <DialogTitle>Workflow Execution (JSON)</DialogTitle>
-            <div className="w-full h-full overflow-x-scroll">
-              <CodeEditor data={result} className="p-4" />
-            </div>
-          </DialogContent>
-        </DialogPortal>
+            <DialogDescription className="sr-only">JSON view of the workflow execution result</DialogDescription>
+          </DialogHeader>
+          <div className="w-full h-full overflow-auto">
+            <CodeEditor data={result} className="p-4" />
+          </div>
+        </DialogContent>
       </Dialog>
     </>
   );

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
@@ -323,8 +323,7 @@ export function WorkflowTrigger({
 
         {hasWorkflowActivePaths && (
           <>
-            <hr className="border-border1 border my-5" />
-            <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-2 pt-5 border-t border-border1">
               <Txt variant="ui-xs" className="text-neutral3">
                 Status
               </Txt>

--- a/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.tsx
+++ b/packages/playground-ui/src/ds/components/AlertDialog/alert-dialog.tsx
@@ -51,7 +51,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-surface3 p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border1 bg-surface3 p-6 shadow-lg duration-200 rounded-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
         className,
       )}
       {...props}

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.stories.tsx
@@ -99,7 +99,8 @@ export const LongContent: Story = {
               dolore magna aliqua.
             </p>
             <p className="text-sm text-neutral5">
-              Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+              Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+              consequat.
             </p>
             <p className="text-sm text-neutral5">
               Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import {
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -86,27 +87,29 @@ export const LongContent: Story = {
       <DialogTrigger asChild>
         <Button>View Terms</Button>
       </DialogTrigger>
-      <DialogContent className="max-h-[80vh] overflow-y-auto">
+      <DialogContent>
         <DialogHeader>
           <DialogTitle>Terms of Service</DialogTitle>
           <DialogDescription>Please read these terms carefully.</DialogDescription>
         </DialogHeader>
-        <div className="py-4 space-y-4">
-          <p className="text-sm text-neutral5">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
-            dolore magna aliqua.
-          </p>
-          <p className="text-sm text-neutral5">
-            Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-          </p>
-          <p className="text-sm text-neutral5">
-            Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-          </p>
-          <p className="text-sm text-neutral5">
-            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
-            laborum.
-          </p>
-        </div>
+        <DialogBody className="max-h-[80vh]">
+          <div className="py-4 space-y-4">
+            <p className="text-sm text-neutral5">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et
+              dolore magna aliqua.
+            </p>
+            <p className="text-sm text-neutral5">
+              Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+            </p>
+            <p className="text-sm text-neutral5">
+              Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            </p>
+            <p className="text-sm text-neutral5">
+              Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+              laborum.
+            </p>
+          </div>
+        </DialogBody>
         <DialogFooter>
           <Button variant="outline">Decline</Button>
           <Button>Accept</Button>

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-surface1 p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border1 bg-surface3 p-6 shadow-lg duration-200 rounded-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
         className,
       )}
       {...props}

--- a/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
+++ b/packages/playground-ui/src/ds/components/Dialog/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border1 bg-surface3 p-6 shadow-lg duration-200 rounded-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border1 bg-surface3 py-6 shadow-lg duration-200 rounded-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
         className,
       )}
       {...props}
@@ -52,7 +52,10 @@ const DialogContent = React.forwardRef<
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+  <div
+    className={cn('flex flex-col space-y-1.5 text-center sm:text-left border-b border-border1 pb-4 px-6', className)}
+    {...props}
+  />
 );
 DialogHeader.displayName = 'DialogHeader';
 
@@ -60,6 +63,11 @@ const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
   <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
 );
 DialogFooter.displayName = 'DialogFooter';
+
+const DialogBody = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('overflow-y-auto px-6 max-h-[50vh]', className)} {...props} />
+);
+DialogBody.displayName = 'DialogBody';
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
@@ -77,7 +85,7 @@ const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description ref={ref} className={cn('text-sm text-neutral3', className)} {...props} />
+  <DialogPrimitive.Description ref={ref} className={cn('sr-only', className)} {...props} />
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
@@ -90,6 +98,7 @@ export {
   DialogContent,
   DialogHeader,
   DialogFooter,
+  DialogBody,
   DialogTitle,
   DialogDescription,
 };

--- a/packages/playground-ui/src/ds/components/Popover/popover.tsx
+++ b/packages/playground-ui/src/ds/components/Popover/popover.tsx
@@ -17,7 +17,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 w-72 rounded-md border bg-surface3 text-neutral5 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-50 w-72 rounded-md border border-border1 bg-surface3 text-neutral5 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className && /\bp-\S+/.test(className) ? false : `p-4`,
         className,
       )}

--- a/packages/playground-ui/src/ds/components/Select/select.tsx
+++ b/packages/playground-ui/src/ds/components/Select/select.tsx
@@ -56,7 +56,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 min-w-[8rem] max-h-dropdown-max-height overflow-y-auto overflow-x-hidden rounded-md border bg-surface3 text-neutral5 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'relative z-50 min-w-[8rem] max-h-dropdown-max-height overflow-y-auto overflow-x-hidden rounded-md border border-border1 bg-surface3 text-neutral5 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className,

--- a/packages/playground-ui/src/lib/ai-ui/attachments/attach-file-dialog.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/attachments/attach-file-dialog.tsx
@@ -1,6 +1,13 @@
 import { useComposerRuntime } from '@assistant-ui/react';
 
-import { Dialog, DialogHeader, DialogTitle, DialogContent, DialogDescription, DialogBody } from '@/ds/components/Dialog';
+import {
+  Dialog,
+  DialogHeader,
+  DialogTitle,
+  DialogContent,
+  DialogDescription,
+  DialogBody,
+} from '@/ds/components/Dialog';
 import { FormEvent } from 'react';
 import { Input } from '@/ds/components/Input';
 import { Button } from '@/ds/components/Button';

--- a/packages/playground-ui/src/lib/ai-ui/attachments/attach-file-dialog.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/attachments/attach-file-dialog.tsx
@@ -1,6 +1,6 @@
 import { useComposerRuntime } from '@assistant-ui/react';
 
-import { Dialog, DialogHeader, DialogTitle, DialogContent } from '@/ds/components/Dialog';
+import { Dialog, DialogHeader, DialogTitle, DialogContent, DialogDescription } from '@/ds/components/Dialog';
 import { FormEvent } from 'react';
 import { Input } from '@/ds/components/Input';
 import { Button } from '@/ds/components/Button';
@@ -46,9 +46,10 @@ export const AttachFileDialog = ({ onOpenChange, open }: AttachFileDialogProps) 
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="bg-surface3">
+      <DialogContent>
         <DialogHeader>
           <DialogTitle>Add attachment</DialogTitle>
+          <DialogDescription className="sr-only">Add a file attachment via URL or from your computer</DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="flex flex-row items-end gap-4">

--- a/packages/playground-ui/src/lib/ai-ui/attachments/attach-file-dialog.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/attachments/attach-file-dialog.tsx
@@ -1,6 +1,6 @@
 import { useComposerRuntime } from '@assistant-ui/react';
 
-import { Dialog, DialogHeader, DialogTitle, DialogContent, DialogDescription } from '@/ds/components/Dialog';
+import { Dialog, DialogHeader, DialogTitle, DialogContent, DialogDescription, DialogBody } from '@/ds/components/Dialog';
 import { FormEvent } from 'react';
 import { Input } from '@/ds/components/Input';
 import { Button } from '@/ds/components/Button';
@@ -49,44 +49,46 @@ export const AttachFileDialog = ({ onOpenChange, open }: AttachFileDialogProps) 
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Add attachment</DialogTitle>
-          <DialogDescription className="sr-only">Add a file attachment via URL or from your computer</DialogDescription>
+          <DialogDescription>Add a file attachment via URL or from your computer</DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="flex flex-row items-end gap-4">
-          <div className="w-full space-y-1">
-            <Label htmlFor="url-attachment" className="text-neutral3 text-ui-md">
-              Public URL
-            </Label>
-            <Input
-              type="text"
-              name="url-attachment"
-              id="url-attachment"
-              className="w-full"
-              placeholder="https://placehold.co/600x400/png"
-            />
+        <DialogBody>
+          <form onSubmit={handleSubmit} className="flex flex-row items-end gap-4">
+            <div className="w-full space-y-1">
+              <Label htmlFor="url-attachment" className="text-neutral3 text-ui-md">
+                Public URL
+              </Label>
+              <Input
+                type="text"
+                name="url-attachment"
+                id="url-attachment"
+                className="w-full"
+                placeholder="https://placehold.co/600x400/png"
+              />
+            </div>
+            <Button type="submit" className="!h-8" variant="light">
+              <Icon>
+                <Link />
+              </Icon>
+              Add
+            </Button>
+          </form>
+
+          <hr className="my-2 border border-border1" />
+
+          <div className="space-y-2">
+            <Txt variant="ui-md" className="text-neutral3">
+              Or from your computer
+            </Txt>
+            <button
+              onClick={addFilInputAttachment}
+              className="w-full h-40 border border-border1 rounded-lg text-neutral3 border-dashed flex flex-col items-center justify-center gap-2 hover:bg-surface2 active:bg-surface3"
+            >
+              <CloudUpload className="size-12" />
+              <Txt variant="header-md">Add a local file</Txt>
+            </button>
           </div>
-          <Button type="submit" className="!h-8" variant="light">
-            <Icon>
-              <Link />
-            </Icon>
-            Add
-          </Button>
-        </form>
-
-        <hr className="my-2 border border-border1" />
-
-        <div className="space-y-2">
-          <Txt variant="ui-md" className="text-neutral3">
-            Or from your computer
-          </Txt>
-          <button
-            onClick={addFilInputAttachment}
-            className="w-full h-40 border border-border1 rounded-lg text-neutral3 border-dashed flex flex-col items-center justify-center gap-2 hover:bg-surface2 active:bg-surface3"
-          >
-            <CloudUpload className="size-12" />
-            <Txt variant="header-md">Add a local file</Txt>
-          </button>
-        </div>
+        </DialogBody>
       </DialogContent>
     </Dialog>
   );

--- a/packages/playground-ui/src/lib/ai-ui/attachments/attachment-preview-dialog.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/attachments/attachment-preview-dialog.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogTitle, DialogContent } from '@/ds/components/Dialog';
+import { Dialog, DialogTitle, DialogContent, DialogHeader, DialogDescription } from '@/ds/components/Dialog';
 import { FileText } from 'lucide-react';
 import { useState } from 'react';
 
@@ -40,11 +40,12 @@ interface PdfPreviewDialogProps {
 export const PdfPreviewDialog = ({ data, open, onOpenChange }: PdfPreviewDialogProps) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl bg-surface2">
-        <div className="h-full w-full">
-          <DialogTitle className="pb-4">PDF preview</DialogTitle>
-          {open && <iframe src={data} width="100%" height="600px"></iframe>}
-        </div>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>PDF preview</DialogTitle>
+          <DialogDescription className="sr-only">Preview of the PDF document</DialogDescription>
+        </DialogHeader>
+        {open && <iframe src={data} width="100%" height="600px"></iframe>}
       </DialogContent>
     </Dialog>
   );
@@ -76,11 +77,12 @@ interface ImagePreviewDialogProps {
 export const ImagePreviewDialog = ({ src, open, onOpenChange }: ImagePreviewDialogProps) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl bg-surface2">
-        <div className="h-full w-full">
-          <DialogTitle className="pb-4">Image preview</DialogTitle>
-          {open && <img src={src} alt="Image" />}
-        </div>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Image preview</DialogTitle>
+          <DialogDescription className="sr-only">Preview of the image</DialogDescription>
+        </DialogHeader>
+        {open && <img src={src} alt="Image" />}
       </DialogContent>
     </Dialog>
   );
@@ -116,11 +118,12 @@ interface TxtPreviewDialogProps {
 export const TxtPreviewDialog = ({ data, open, onOpenChange }: TxtPreviewDialogProps) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl bg-surface2 h-[80vh] overflow-y-auto">
-        <div className="h-full w-full">
-          <DialogTitle className="pb-4">Text preview</DialogTitle>
-          {open && <div className="whitespace-pre-wrap">{data}</div>}
-        </div>
+      <DialogContent className="max-w-4xl h-[80vh]">
+        <DialogHeader>
+          <DialogTitle>Text preview</DialogTitle>
+          <DialogDescription className="sr-only">Preview of the text file</DialogDescription>
+        </DialogHeader>
+        {open && <div className="whitespace-pre-wrap overflow-y-auto">{data}</div>}
       </DialogContent>
     </Dialog>
   );

--- a/packages/playground-ui/src/lib/ai-ui/attachments/attachment-preview-dialog.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/attachments/attachment-preview-dialog.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogTitle, DialogContent, DialogHeader, DialogDescription } from '@/ds/components/Dialog';
+import { Dialog, DialogTitle, DialogContent, DialogHeader, DialogDescription, DialogBody } from '@/ds/components/Dialog';
 import { FileText } from 'lucide-react';
 import { useState } from 'react';
 
@@ -43,9 +43,9 @@ export const PdfPreviewDialog = ({ data, open, onOpenChange }: PdfPreviewDialogP
       <DialogContent className="max-w-4xl">
         <DialogHeader>
           <DialogTitle>PDF preview</DialogTitle>
-          <DialogDescription className="sr-only">Preview of the PDF document</DialogDescription>
+          <DialogDescription>Preview of the PDF document</DialogDescription>
         </DialogHeader>
-        {open && <iframe src={data} width="100%" height="600px"></iframe>}
+        <DialogBody>{open && <iframe src={data} width="100%" height="600px"></iframe>}</DialogBody>
       </DialogContent>
     </Dialog>
   );
@@ -80,9 +80,9 @@ export const ImagePreviewDialog = ({ src, open, onOpenChange }: ImagePreviewDial
       <DialogContent className="max-w-4xl">
         <DialogHeader>
           <DialogTitle>Image preview</DialogTitle>
-          <DialogDescription className="sr-only">Preview of the image</DialogDescription>
+          <DialogDescription>Preview of the image</DialogDescription>
         </DialogHeader>
-        {open && <img src={src} alt="Image" />}
+        <DialogBody>{open && <img src={src} alt="Image" />}</DialogBody>
       </DialogContent>
     </Dialog>
   );
@@ -121,9 +121,9 @@ export const TxtPreviewDialog = ({ data, open, onOpenChange }: TxtPreviewDialogP
       <DialogContent className="max-w-4xl h-[80vh]">
         <DialogHeader>
           <DialogTitle>Text preview</DialogTitle>
-          <DialogDescription className="sr-only">Preview of the text file</DialogDescription>
+          <DialogDescription>Preview of the text file</DialogDescription>
         </DialogHeader>
-        {open && <div className="whitespace-pre-wrap overflow-y-auto">{data}</div>}
+        <DialogBody>{open && <div className="whitespace-pre-wrap">{data}</div>}</DialogBody>
       </DialogContent>
     </Dialog>
   );

--- a/packages/playground-ui/src/lib/ai-ui/attachments/attachment-preview-dialog.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/attachments/attachment-preview-dialog.tsx
@@ -1,4 +1,11 @@
-import { Dialog, DialogTitle, DialogContent, DialogHeader, DialogDescription, DialogBody } from '@/ds/components/Dialog';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogHeader,
+  DialogDescription,
+  DialogBody,
+} from '@/ds/components/Dialog';
 import { FileText } from 'lucide-react';
 import { useState } from 'react';
 

--- a/packages/playground-ui/src/lib/ai-ui/tools/badges/network-choice-metadata-dialog.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/badges/network-choice-metadata-dialog.tsx
@@ -25,13 +25,13 @@ const NetworkChoiceMetadata = ({ selectionReason, open, onOpenChange, input }: N
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="border-border1 border bg-surface3 p-0 gap-0">
-        <DialogHeader className="p-4">
+      <DialogContent>
+        <DialogHeader>
           <DialogTitle>Agent Network Metadata</DialogTitle>
           <DialogDescription>View the metadata of the agent's network choice.</DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 p-4 border-t border-border1">
+        <div className="space-y-4">
           <div className="space-y-2">
             <Txt className="text-neutral3">Selection Reason</Txt>
             <div className="text-neutral6 text-ui-md">{selectionReason}</div>

--- a/packages/playground-ui/src/lib/ai-ui/tools/badges/network-choice-metadata-dialog.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/badges/network-choice-metadata-dialog.tsx
@@ -1,4 +1,4 @@
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/ds/components/Dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogBody } from '@/ds/components/Dialog';
 import { Txt } from '@/ds/components/Txt';
 import { CodeEditor } from '@/ds/components/CodeEditor';
 import { TooltipIconButton } from '../../tooltip-icon-button';
@@ -31,7 +31,7 @@ const NetworkChoiceMetadata = ({ selectionReason, open, onOpenChange, input }: N
           <DialogDescription>View the metadata of the agent's network choice.</DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4">
+        <DialogBody className="space-y-4">
           <div className="space-y-2">
             <Txt className="text-neutral3">Selection Reason</Txt>
             <div className="text-neutral6 text-ui-md">{selectionReason}</div>
@@ -43,7 +43,7 @@ const NetworkChoiceMetadata = ({ selectionReason, open, onOpenChange, input }: N
               <div className="text-neutral6 text-ui-md">{inputSlot}</div>
             </div>
           )}
-        </div>
+        </DialogBody>
       </DialogContent>
     </Dialog>
   );

--- a/packages/playground-ui/src/lib/ai-ui/tools/badges/network-choice-metadata-dialog.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/badges/network-choice-metadata-dialog.tsx
@@ -1,4 +1,11 @@
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogBody } from '@/ds/components/Dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+} from '@/ds/components/Dialog';
 import { Txt } from '@/ds/components/Txt';
 import { CodeEditor } from '@/ds/components/CodeEditor';
 import { TooltipIconButton } from '../../tooltip-icon-button';


### PR DESCRIPTION
Dialog, AlertDialog, Popover, and Select components had inconsistent styling (different borders, backgrounds, and border-radius). This PR aligns them all to use:

- `border border-border1`
- `bg-surface3`
- `rounded-md`

The Dialog also had `sm:rounded-lg` which only applied radius on small screens and above - now it's `rounded-md` consistently at all breakpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Unified visual styling across dialogs, alert dialogs, popovers, and selects using consistent border, background, and radius tokens.
  * Adjusted spacing and border radius across UI components for improved visual consistency and cohesive overlay appearance.
* **Refactor**
  * Dialog layouts reorganized to consistently separate headers, descriptions, and content areas for clearer, more predictable UI presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->