### PR TITLE
refactor(playground-ui): remove legacy spacing tokens

### DIFF
--- a/.changeset/khaki-parrots-stay.md
+++ b/.changeset/khaki-parrots-stay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Removed legacy spacing tokens (sm, md, lg) from the design system. These tokens were deprecated aliases that mapped to standard Tailwind spacing values (0.5, 1, 2). All components have been updated to use the standard spacing tokens directly.

--- a/packages/playground-ui/src/ds/components/Badge/Badge.tsx
+++ b/packages/playground-ui/src/ds/components/Badge/Badge.tsx
@@ -21,8 +21,8 @@ export const Badge = ({ icon, variant = 'default', className, children, ...props
   return (
     <div
       className={cn(
-        'font-mono bg-surface4 text-ui-sm gap-md h-badge-default inline-flex items-center rounded-md shrink-0',
-        icon ? 'pl-md pr-1.5' : 'px-1.5',
+        'font-mono bg-surface4 text-ui-sm gap-1 h-badge-default inline-flex items-center rounded-md shrink-0',
+        icon ? 'pl-1 pr-1.5' : 'px-1.5',
         icon || variant === 'default' ? 'text-neutral5' : variantClasses[variant],
         className,
       )}

--- a/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
@@ -12,7 +12,7 @@ export interface BreadcrumbProps {
 export const Breadcrumb = ({ children, label }: BreadcrumbProps) => {
   return (
     <nav aria-label={label}>
-      <ol className="gap-sm flex items-center">{children}</ol>
+      <ol className="gap-0.5 flex items-center">{children}</ol>
     </nav>
   );
 };

--- a/packages/playground-ui/src/ds/components/Button/Button.tsx
+++ b/packages/playground-ui/src/ds/components/Button/Button.tsx
@@ -16,9 +16,9 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 }
 
 const sizeClasses = {
-  sm: `${formElementSizes.sm} gap-sm`,
-  md: `${formElementSizes.md} gap-md`,
-  lg: `${formElementSizes.lg} gap-lg`,
+  sm: `${formElementSizes.sm} gap-0.5`,
+  md: `${formElementSizes.md} gap-1`,
+  lg: `${formElementSizes.lg} gap-2`,
 };
 
 const variantClasses = {
@@ -33,7 +33,7 @@ export function buttonVariants(options?: { variant?: ButtonProps['variant']; siz
   const size = options?.size || 'md';
 
   return cn(
-    'bg-surface2 border border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border',
+    'bg-surface2 border border-border1 px-2 text-ui-md inline-flex items-center justify-center rounded-md border',
     formElementFocus,
     variantClasses[variant],
     sizeClasses[size],
@@ -48,7 +48,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       <Component
         ref={ref}
         className={cn(
-          'bg-surface2 border border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border',
+          'bg-surface2 border border-border1 px-2 text-ui-md inline-flex items-center justify-center rounded-md border',
           formElementFocus,
           variantClasses[variant],
           sizeClasses[size],

--- a/packages/playground-ui/src/ds/components/Header/Header.tsx
+++ b/packages/playground-ui/src/ds/components/Header/Header.tsx
@@ -33,5 +33,5 @@ export const HeaderAction = ({ children }: HeaderProps) => {
 };
 
 export const HeaderGroup = ({ children }: HeaderProps) => {
-  return <div className="gap-lg flex items-center">{children}</div>;
+  return <div className="gap-2 flex items-center">{children}</div>;
 };

--- a/packages/playground-ui/src/ds/tokens/spacings.ts
+++ b/packages/playground-ui/src/ds/tokens/spacings.ts
@@ -35,11 +35,6 @@ export const Spacings = {
   '72': '18rem', // 288px
   '80': '20rem', // 320px
   '96': '24rem', // 384px
-
-  // Legacy aliases for backwards compatibility
-  sm: '0.125rem', // 2px (was sm: '2px')
-  md: '0.25rem', // 4px (was md: '4px')
-  lg: '0.5rem', // 8px (was lg: '8px')
 } as const;
 
 export type Spacing = keyof typeof Spacings;

--- a/packages/playground-ui/src/lib/ai-ui/thread.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/thread.tsx
@@ -192,12 +192,12 @@ const EditComposer = () => {
 
       <div>
         <ComposerPrimitive.Cancel asChild>
-          <button className="bg-surface2 border border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border h-form-sm gap-md hover:bg-surface4 text-neutral3 hover:text-neutral6">
+          <button className="bg-surface2 border border-border1 px-2 text-ui-md inline-flex items-center justify-center rounded-md border h-form-sm gap-1 hover:bg-surface4 text-neutral3 hover:text-neutral6">
             Cancel
           </button>
         </ComposerPrimitive.Cancel>
         <ComposerPrimitive.Send asChild>
-          <button className="bg-surface2 border border-border1 px-lg text-ui-md inline-flex items-center justify-center rounded-md border h-form-sm gap-md hover:bg-surface4 text-neutral3 hover:text-neutral6">
+          <button className="bg-surface2 border border-border1 px-2 text-ui-md inline-flex items-center justify-center rounded-md border h-form-sm gap-1 hover:bg-surface4 text-neutral3 hover:text-neutral6">
             Send
           </button>
         </ComposerPrimitive.Send>


### PR DESCRIPTION
Removes the deprecated legacy spacing tokens (`sm`, `md`, `lg`) from the design system and updates all components to use standard Tailwind spacing values directly.

**Token mapping:**
- `sm` → `0.5` (2px)
- `md` → `1` (4px)  
- `lg` → `2` (8px)

Updated components: Button, Badge, Breadcrumb, Header, and Thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized design system spacing tokens by removing legacy aliases and updating all components to use unified spacing values for consistent styling across the Playground UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->