### PR TITLE
Fix Braintrust Thread view truncation for tool calls

### DIFF
--- a/.changeset/sixty-shirts-chew.md
+++ b/.changeset/sixty-shirts-chew.md
@@ -1,0 +1,7 @@
+---
+'@mastra/braintrust': patch
+---
+
+Fix Thread view truncation in Braintrust when LLM generations include tool calls.
+
+The Braintrust exporter now reconstructs LLM output in OpenAI Chat Completion format by examining child `MODEL_STEP` and `TOOL_CALL` spans. This enables Braintrust's Thread view to properly display the full conversation flow including tool calls and their results.

--- a/observability/braintrust/src/braintrust-nesting.test.ts
+++ b/observability/braintrust/src/braintrust-nesting.test.ts
@@ -167,10 +167,11 @@ describe('BraintrustExporter - Non-External Case', () => {
     // Get the Braintrust span from the exporter's internal state
     const traceData = exporter._getTraceData(mastraRoot.traceId);
 
-    const braintrustSpan = traceData.getSpan({ spanId: mastraRoot.id });
-    expect(braintrustSpan).toBeDefined();
+    // getSpan() returns BraintrustSpanData, access .span for the underlying Braintrust Span
+    const spanData = traceData.getSpan({ spanId: mastraRoot.id });
+    expect(spanData).toBeDefined();
 
-    const internals = getSpanInternals(braintrustSpan!);
+    const internals = getSpanInternals(spanData!.span);
 
     // Root span should have rootSpanId = its own spanId
     expect(internals.rootSpanId).toBe(internals.spanId);
@@ -221,10 +222,11 @@ describe('BraintrustExporter - Non-External Case', () => {
     });
 
     // Get Braintrust spans from exporter
+    // getSpan() returns BraintrustSpanData, access .span for the underlying Braintrust Span
     const traceData = exporter._getTraceData(mastraRoot.traceId);
-    const rootBt = traceData.getSpan({ spanId: 'root-span' });
-    const llmBt = traceData.getSpan({ spanId: 'llm-span' });
-    const toolBt = traceData.getSpan({ spanId: 'tool-span' });
+    const rootBt = traceData.getSpan({ spanId: 'root-span' })!.span;
+    const llmBt = traceData.getSpan({ spanId: 'llm-span' })!.span;
+    const toolBt = traceData.getSpan({ spanId: 'tool-span' })!.span;
 
     const root = getSpanInternals(rootBt);
     const llm = getSpanInternals(llmBt);
@@ -279,11 +281,12 @@ describe('BraintrustExporter - Non-External Case', () => {
       });
     }
 
+    // getSpan() returns BraintrustSpanData, access .span for the underlying Braintrust Span
     const traceData = exporter._getTraceData(traceId);
-    const l1 = getSpanInternals(traceData.getSpan({ spanId: 'l1' }));
-    const l2 = getSpanInternals(traceData.getSpan({ spanId: 'l2' }));
-    const l3 = getSpanInternals(traceData.getSpan({ spanId: 'l3' }));
-    const l4 = getSpanInternals(traceData.getSpan({ spanId: 'l4' }));
+    const l1 = getSpanInternals(traceData.getSpan({ spanId: 'l1' })!.span);
+    const l2 = getSpanInternals(traceData.getSpan({ spanId: 'l2' })!.span);
+    const l3 = getSpanInternals(traceData.getSpan({ spanId: 'l3' })!.span);
+    const l4 = getSpanInternals(traceData.getSpan({ spanId: 'l4' })!.span);
 
     // All share rootSpanId
     expect(l1.rootSpanId).toBe(l1.spanId);
@@ -353,12 +356,13 @@ describe('BraintrustExporter - External Case', () => {
     });
 
     // Get Braintrust spans
+    // getSpan() returns BraintrustSpanData, access .span for the underlying Braintrust Span
     const traceData = exporter._getTraceData(mastraRoot.traceId);
-    const rootBt = traceData.getSpan({ spanId: 'mastra-root' });
-    const childBt = traceData.getSpan({ spanId: 'mastra-child' });
+    const rootBtData = traceData.getSpan({ spanId: 'mastra-root' });
+    const childBtData = traceData.getSpan({ spanId: 'mastra-child' });
 
-    const root = getSpanInternals(rootBt);
-    const child = getSpanInternals(childBt);
+    const root = getSpanInternals(rootBtData!.span);
+    const child = getSpanInternals(childBtData!.span);
 
     // Both should have external span as their root
     expect(root.rootSpanId).toBe(externalInternals.spanId);
@@ -370,8 +374,8 @@ describe('BraintrustExporter - External Case', () => {
     expect(child.spanParents).toEqual([root.spanId]);
 
     // Cleanup
-    childBt!.end();
-    rootBt!.end();
+    childBtData!.span.end();
+    rootBtData!.span.end();
     externalSpan.end();
   });
 });

--- a/observability/braintrust/src/formatter.ts
+++ b/observability/braintrust/src/formatter.ts
@@ -1,0 +1,301 @@
+/**
+ * Message format conversion utilities for Braintrust.
+ *
+ * Converts AI SDK message format (v4/v5) to OpenAI Chat Completion format,
+ * which Braintrust requires for proper rendering of threads.
+ */
+
+// ==============================================================================
+// Utility functions
+// ==============================================================================
+
+/**
+ * Remove null and undefined values from an object (shallow)
+ */
+export function removeNullish<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  return Object.fromEntries(Object.entries(obj).filter(([_, v]) => v != null)) as Partial<T>;
+}
+
+// ==============================================================================
+// Type definitions for AI SDK message format conversion to OpenAI format
+// ==============================================================================
+
+/**
+ * AI SDK content part types (both v4 and v5)
+ */
+interface AISDKTextPart {
+  type: 'text';
+  text: string;
+}
+
+interface AISDKImagePart {
+  type: 'image';
+  image?: string | Uint8Array | URL;
+  mimeType?: string;
+}
+
+interface AISDKFilePart {
+  type: 'file';
+  data?: string | Uint8Array | URL;
+  filename?: string;
+  name?: string;
+  mimeType?: string;
+}
+
+interface AISDKReasoningPart {
+  type: 'reasoning';
+  text?: string;
+}
+
+interface AISDKToolCallPart {
+  type: 'tool-call';
+  toolCallId: string;
+  toolName: string;
+  args?: unknown; // AI SDK v4
+  input?: unknown; // AI SDK v5
+}
+
+interface AISDKToolResultPart {
+  type: 'tool-result';
+  toolCallId: string;
+  result?: unknown; // AI SDK v4
+  output?: unknown; // AI SDK v5
+}
+
+type AISDKContentPart =
+  | AISDKTextPart
+  | AISDKImagePart
+  | AISDKFilePart
+  | AISDKReasoningPart
+  | AISDKToolCallPart
+  | AISDKToolResultPart
+  | { type: string; [key: string]: unknown }; // Catch-all for unknown types
+
+/**
+ * AI SDK message format (input format for conversion)
+ */
+interface AISDKMessage {
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  content: string | AISDKContentPart[];
+  [key: string]: unknown; // Allow additional properties
+}
+
+/**
+ * OpenAI Chat Completion tool call format
+ */
+export interface OpenAIToolCall {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+/**
+ * OpenAI Chat Completion message format (output format)
+ */
+export interface OpenAIMessage {
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  content: string;
+  tool_calls?: OpenAIToolCall[];
+  tool_call_id?: string;
+  [key: string]: unknown; // Allow additional properties
+}
+
+// ==============================================================================
+// Message conversion functions
+// ==============================================================================
+
+/**
+ * Converts a content part to a string representation.
+ * Handles text, image, file, reasoning, and other content types.
+ */
+function convertContentPart(part: AISDKContentPart | null | undefined): string | null {
+  if (!part || typeof part !== 'object') {
+    return null;
+  }
+
+  switch (part.type) {
+    case 'text':
+      return (part as AISDKTextPart).text || null;
+
+    case 'image':
+      // Represent image content with a placeholder
+      return '[image]';
+
+    case 'file': {
+      // Represent file content with filename if available
+      const filePart = part as AISDKFilePart;
+      if (filePart.filename || filePart.name) {
+        return `[file: ${filePart.filename || filePart.name}]`;
+      }
+      return '[file]';
+    }
+
+    case 'reasoning': {
+      // Represent reasoning/thinking content
+      const reasoningPart = part as AISDKReasoningPart;
+      if (typeof reasoningPart.text === 'string' && reasoningPart.text.length > 0) {
+        return `[reasoning: ${reasoningPart.text.substring(0, 100)}${reasoningPart.text.length > 100 ? '...' : ''}]`;
+      }
+      return '[reasoning]';
+    }
+
+    case 'tool-call':
+      // Tool calls are handled separately in assistant messages
+      return null;
+
+    case 'tool-result':
+      // Tool results are handled separately in tool messages
+      return null;
+
+    default: {
+      // For unknown types, try to extract any text-like content
+      const unknownPart = part as { type?: string; text?: string; content?: string };
+      if (typeof unknownPart.text === 'string') {
+        return unknownPart.text;
+      }
+      if (typeof unknownPart.content === 'string') {
+        return unknownPart.content;
+      }
+      // Represent unknown content type
+      return `[${unknownPart.type || 'unknown'}]`;
+    }
+  }
+}
+
+/**
+ * Serializes tool result data to a string for OpenAI format.
+ */
+function serializeToolResult(resultData: unknown): string {
+  if (typeof resultData === 'string') {
+    return resultData;
+  }
+  if (resultData && typeof resultData === 'object' && 'value' in resultData) {
+    const valueData = (resultData as { value: unknown }).value;
+    return typeof valueData === 'string' ? valueData : JSON.stringify(valueData);
+  }
+  if (resultData === undefined || resultData === null) {
+    return '';
+  }
+  try {
+    return JSON.stringify(resultData);
+  } catch {
+    return '[unserializable result]';
+  }
+}
+
+/**
+ * Converts AI SDK message format to OpenAI Chat Completion format for Braintrust.
+ *
+ * Supports both AI SDK v4 and v5 formats:
+ *   - v4 uses 'args' for tool calls and 'result' for tool results
+ *   - v5 uses 'input' for tool calls and 'output' for tool results
+ *
+ * AI SDK format:
+ *   { role: "user", content: [{ type: "text", text: "hello" }] }
+ *   { role: "assistant", content: [{ type: "text", text: "..." }, { type: "tool-call", toolCallId: "...", toolName: "...", args: {...} }] }
+ *   { role: "tool", content: [{ type: "tool-result", toolCallId: "...", result: {...} }] }
+ *
+ * OpenAI format (what Braintrust expects):
+ *   { role: "user", content: "hello" }
+ *   { role: "assistant", content: "...", tool_calls: [{ id: "...", type: "function", function: { name: "...", arguments: "..." } }] }
+ *   { role: "tool", content: "result", tool_call_id: "..." }
+ */
+export function convertAISDKMessage(message: AISDKMessage | OpenAIMessage | unknown): OpenAIMessage | unknown {
+  if (!message || typeof message !== 'object') {
+    return message;
+  }
+
+  const { role, content, ...rest } = message as AISDKMessage;
+
+  // If content is already a string, return as-is (already in OpenAI format)
+  if (typeof content === 'string') {
+    return message;
+  }
+
+  // If content is an array (AI SDK format), convert based on role
+  if (Array.isArray(content)) {
+    // Handle empty content arrays
+    if (content.length === 0) {
+      return { role, content: '', ...rest };
+    }
+
+    // For user/system messages, extract text and represent non-text content
+    if (role === 'user' || role === 'system') {
+      const contentParts = content.map((part: AISDKContentPart) => convertContentPart(part)).filter(Boolean);
+
+      return {
+        role,
+        content: contentParts.length > 0 ? contentParts.join('\n') : '',
+        ...rest,
+      };
+    }
+
+    // For assistant messages, extract text, non-text content, AND tool calls
+    if (role === 'assistant') {
+      const contentParts = content
+        .filter((part: AISDKContentPart) => part?.type !== 'tool-call')
+        .map((part: AISDKContentPart) => convertContentPart(part))
+        .filter(Boolean);
+
+      const toolCallParts = content.filter((part: AISDKContentPart) => part?.type === 'tool-call');
+
+      const result: OpenAIMessage = {
+        role,
+        content: contentParts.length > 0 ? (contentParts as string[]).join('\n') : '',
+        ...rest,
+      };
+
+      // Add tool_calls array if there are tool calls
+      if (toolCallParts.length > 0) {
+        result.tool_calls = toolCallParts.map((tc: AISDKContentPart) => {
+          const toolCall = tc as AISDKToolCallPart;
+          const toolCallId = toolCall.toolCallId;
+          const toolName = toolCall.toolName;
+          // Support both v4 'args' and v5 'input'
+          const args = toolCall.args ?? toolCall.input;
+
+          let argsString: string;
+          if (typeof args === 'string') {
+            argsString = args;
+          } else if (args !== undefined && args !== null) {
+            argsString = JSON.stringify(args);
+          } else {
+            argsString = '{}';
+          }
+
+          return {
+            id: toolCallId,
+            type: 'function' as const,
+            function: {
+              name: toolName,
+              arguments: argsString,
+            },
+          };
+        });
+      }
+
+      return result;
+    }
+
+    // For tool messages, convert to OpenAI tool message format
+    if (role === 'tool') {
+      const toolResult = content.find((part): part is AISDKToolResultPart => part?.type === 'tool-result');
+      if (toolResult) {
+        // Support both v4 'result' and v5 'output' fields
+        const resultData = toolResult.output ?? toolResult.result;
+        const resultContent = serializeToolResult(resultData);
+
+        return {
+          role: 'tool',
+          content: resultContent,
+          tool_call_id: toolResult.toolCallId,
+        } as OpenAIMessage;
+      }
+    }
+  }
+
+  return message;
+}

--- a/observability/braintrust/src/thread-reconstruction.ts
+++ b/observability/braintrust/src/thread-reconstruction.ts
@@ -1,0 +1,133 @@
+/**
+ * Thread view reconstruction for Braintrust.
+ *
+ * Reconstructs LLM output in OpenAI Chat Completion format by examining
+ * child MODEL_STEP and TOOL_CALL spans. This enables Braintrust's Thread
+ * view to properly display the full conversation flow including tool calls.
+ *
+ * See THREAD_VIEW_RECONSTRUCTION.md for details.
+ */
+
+import { removeNullish } from './formatter';
+import type { OpenAIMessage } from './formatter';
+
+// ==============================================================================
+// Thread view reconstruction types
+// ==============================================================================
+
+/**
+ * Tool call data accumulated from MODEL_STEP and TOOL_CALL spans
+ */
+export interface ThreadToolCall {
+  toolCallId: string;
+  toolName: string;
+  args: unknown;
+  result?: unknown; // filled in when TOOL_CALL ends
+  startTime?: Date; // from TOOL_CALL span, for ordering multiple tool calls within a step
+}
+
+/**
+ * Step data accumulated from MODEL_STEP spans for Thread view reconstruction
+ */
+export interface ThreadStepData {
+  stepSpanId: string;
+  stepIndex: number; // for ordering steps correctly
+  text?: string;
+  toolCalls?: ThreadToolCall[];
+}
+
+/**
+ * Accumulated data for reconstructing Braintrust Thread view.
+ * Populated for MODEL_GENERATION spans as child MODEL_STEP and TOOL_CALL spans complete.
+ */
+export type ThreadData = ThreadStepData[];
+
+/**
+ * Tool result data stored when TOOL_CALL spans end (before MODEL_STEP ends)
+ */
+export interface PendingToolResult {
+  result: unknown;
+  startTime: Date;
+}
+
+// ==============================================================================
+// Thread view reconstruction
+// ==============================================================================
+
+/**
+ * Reconstruct the Thread view output from accumulated threadData.
+ * Converts to OpenAI Chat Completion message format.
+ */
+export function reconstructThreadOutput(threadData: ThreadData, originalOutput: unknown): OpenAIMessage[] {
+  const messages: OpenAIMessage[] = [];
+
+  // Sort steps by stepIndex
+  const sortedSteps = [...threadData].sort((a, b) => a.stepIndex - b.stepIndex);
+
+  for (const step of sortedSteps) {
+    // Sort tool calls by startTime within each step
+    const sortedToolCalls = step.toolCalls
+      ? [...step.toolCalls].sort((a, b) => {
+          if (!a.startTime || !b.startTime) return 0;
+          return a.startTime.getTime() - b.startTime.getTime();
+        })
+      : [];
+
+    if (sortedToolCalls.length > 0) {
+      // Add assistant message with tool_calls
+      messages.push({
+        role: 'assistant',
+        content: step.text || '',
+        tool_calls: sortedToolCalls.map(tc => {
+          // Clean null/undefined values from args before stringifying
+          const cleanArgs =
+            tc.args && typeof tc.args === 'object' && !Array.isArray(tc.args)
+              ? removeNullish(tc.args as Record<string, unknown>)
+              : tc.args;
+          return {
+            id: tc.toolCallId,
+            type: 'function' as const,
+            function: {
+              name: tc.toolName,
+              arguments: typeof cleanArgs === 'string' ? cleanArgs : JSON.stringify(cleanArgs),
+            },
+          };
+        }),
+      });
+
+      // Add tool messages for each result
+      for (const tc of sortedToolCalls) {
+        if (tc.result !== undefined) {
+          messages.push({
+            role: 'tool',
+            content: typeof tc.result === 'string' ? tc.result : JSON.stringify(tc.result),
+            tool_call_id: tc.toolCallId,
+          });
+        }
+      }
+    } else if (step.text) {
+      // Step with text only (final response)
+      messages.push({
+        role: 'assistant',
+        content: step.text,
+      });
+    }
+  }
+
+  // If we have messages and the last one is a tool message,
+  // add the final assistant text from original output
+  if (messages.length > 0) {
+    const lastMessage = messages[messages.length - 1]!;
+    const originalText = (originalOutput as { text?: string })?.text;
+
+    // If the last message is a tool response and we have final text, add it
+    if (originalText && lastMessage.role === 'tool') {
+      messages.push({
+        role: 'assistant',
+        content: originalText,
+      });
+    }
+  }
+
+  return messages;
+}

--- a/observability/braintrust/src/tracing.test.ts
+++ b/observability/braintrust/src/tracing.test.ts
@@ -681,6 +681,171 @@ describe('BraintrustExporter', () => {
     });
   });
 
+  /**
+   * Test for GitHub issue #11735: Thread view truncated for last turn in Braintrust
+   *
+   * When an LLM generation includes tool calls, the Braintrust exporter should
+   * reconstruct the output in OpenAI format by examining child TOOL_CALL spans.
+   *
+   * The span hierarchy for tool use looks like:
+   *   MODEL_GENERATION (parent)
+   *     └── TOOL_CALL (child) - contains tool input (args) and output (result)
+   *
+   * When the MODEL_GENERATION span ends, the exporter should look at completed
+   * child TOOL_CALL spans and reconstruct the Thread view output as:
+   *   1. Assistant message with tool_calls array
+   *   2. Tool message(s) with results
+   *   3. Final assistant message with text content
+   *
+   * @see https://github.com/mastra-ai/mastra/issues/11735
+   */
+  it('should reconstruct LLM output from steps for Thread view (issue #11735)', async () => {
+    const traceId = 'step-output-reconstruction-trace';
+
+    // Create the MODEL_GENERATION span - no modelSteps in output, just final text
+    const llmSpan = createMockSpan({
+      id: 'model-gen-span',
+      traceId,
+      name: 'gpt-4-call',
+      type: SpanType.MODEL_GENERATION,
+      isRoot: true,
+      input: [{ role: 'user', content: 'What is 2+2?' }],
+      // Simple output - just the final text response
+      output: {
+        text: 'The answer is 4.',
+      },
+      attributes: { model: 'gpt-4', provider: 'openai' },
+    });
+
+    // Create MODEL_STEP span (step 0) - contains the tool call
+    // MODEL_STEP output has the toolCalls array from the LLM response
+    const modelStep0Span = createMockSpan({
+      id: 'model-step-0-span',
+      traceId,
+      name: 'Model Step 0',
+      type: SpanType.MODEL_STEP,
+      isRoot: false,
+      input: {},
+      // MODEL_STEP output contains toolCalls from the LLM response
+      output: {
+        text: '',
+        toolCalls: [{ toolCallId: 'tc-1', toolName: 'calculator', args: { a: 2, b: 2 } }],
+      },
+      attributes: { stepIndex: 0 },
+    });
+    modelStep0Span.parentSpanId = llmSpan.id;
+
+    // Create TOOL_CALL span - child of MODEL_STEP, contains the tool execution result
+    const toolCallSpan = createMockSpan({
+      id: 'tool-call-span',
+      traceId,
+      name: 'calculator',
+      type: SpanType.TOOL_CALL,
+      isRoot: false,
+      // Input contains the tool call details (including toolCallId for matching)
+      input: {
+        toolCallId: 'tc-1',
+        toolName: 'calculator',
+        args: { a: 2, b: 2 },
+      },
+      // Output contains the tool result
+      output: {
+        result: 4,
+      },
+      attributes: { toolId: 'calculator', success: true },
+    });
+    toolCallSpan.parentSpanId = modelStep0Span.id;
+
+    // Create MODEL_STEP span (step 1) - contains the final text response
+    const modelStep1Span = createMockSpan({
+      id: 'model-step-1-span',
+      traceId,
+      name: 'Model Step 1',
+      type: SpanType.MODEL_STEP,
+      isRoot: false,
+      input: {},
+      // Final step has the text response
+      output: {
+        text: 'The answer is 4.',
+        toolCalls: [],
+      },
+      attributes: { stepIndex: 1 },
+    });
+    modelStep1Span.parentSpanId = llmSpan.id;
+
+    // Start all spans in order
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: llmSpan,
+    });
+
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: modelStep0Span,
+    });
+
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: toolCallSpan,
+    });
+
+    // End TOOL_CALL span first (tool execution completes)
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_ENDED,
+      exportedSpan: { ...toolCallSpan, endTime: new Date() },
+    });
+
+    // End MODEL_STEP 0 (first LLM call with tool calls)
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_ENDED,
+      exportedSpan: { ...modelStep0Span, endTime: new Date() },
+    });
+
+    // Start and end MODEL_STEP 1 (second LLM call with final response)
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: modelStep1Span,
+    });
+
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_ENDED,
+      exportedSpan: { ...modelStep1Span, endTime: new Date() },
+    });
+
+    // Reset mock to capture only the MODEL_GENERATION end call
+    mockSpan.log.mockClear();
+
+    // End MODEL_GENERATION span - this should reconstruct output from child spans
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_ENDED,
+      exportedSpan: { ...llmSpan, endTime: new Date() },
+    });
+
+    // The output should be reconstructed from MODEL_STEP and TOOL_CALL spans into OpenAI format:
+    // 1. Assistant message with tool_calls array (from MODEL_STEP 0 output.toolCalls)
+    // 2. Tool message with result (from TOOL_CALL span output)
+    // 3. Final assistant message with text (from MODEL_STEP 1 output.text)
+    expect(mockSpan.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: [
+          {
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              {
+                id: 'tc-1',
+                type: 'function',
+                function: { name: 'calculator', arguments: '{"a":2,"b":2}' },
+              },
+            ],
+          },
+          { role: 'tool', content: '{"result":4}', tool_call_id: 'tc-1' },
+          { role: 'assistant', content: 'The answer is 4.' },
+        ],
+      }),
+    );
+  });
+
   describe('AI SDK v5 Message Conversion', () => {
     it('should convert AI SDK v5 user messages to OpenAI format', async () => {
       const llmSpan = createMockSpan({
@@ -2308,9 +2473,10 @@ describe('BraintrustExporter with braintrustLogger parameter', () => {
     // Verify spans are stored correctly in spanData.spans
     // This proves getBraintrustParent() can find the right parent for each child
     expect(traceData.activeSpanCount()).toBe(3);
-    expect(traceData.getSpan({ spanId: 'agent-span-id' })).toBe(mockAgentSpan);
-    expect(traceData.getSpan({ spanId: 'llm-span-id' })).toBe(mockLlmSpan);
-    expect(traceData.getSpan({ spanId: 'tool-span-id' })).toBe(mockToolSpan);
+    // getSpan() returns BraintrustSpanData, access .span for the underlying Braintrust Span
+    expect(traceData.getSpan({ spanId: 'agent-span-id' })?.span).toBe(mockAgentSpan);
+    expect(traceData.getSpan({ spanId: 'llm-span-id' })?.span).toBe(mockLlmSpan);
+    expect(traceData.getSpan({ spanId: 'tool-span-id' })?.span).toBe(mockToolSpan);
 
     // The key proof of correct nesting:
     // - mockAgentSpan was returned by mockExternalSpan.startSpan()


### PR DESCRIPTION
## Description

Braintrust's Thread view expects LLM span output in OpenAI Chat Completion format to properly render multi-turn conversations with tool calls. Previously, MODEL_GENERATION spans only had simple output like { text: "..." }, causing the Thread view to be truncated.

Approach: Rather than modifying core observability to accumulate step data, the Braintrust exporter now reconstructs Thread view output from the existing span hierarchy:

```
MODEL_GENERATION
  └── MODEL_STEP (step 0) - contains toolCalls array
  │     └── TOOL_CALL - contains result
  └── MODEL_STEP (step 1) - contains final text
```

Changes:
  - Added BraintrustSpanData wrapper type with spanType, threadData, and pendingToolResults
  - When MODEL_STEP ends: accumulate step data (text, toolCalls) on parent MODEL_GENERATION
  - When TOOL_CALL ends: store result in pendingToolResults (since TOOL_CALL ends before MODEL_STEP)
  - When MODEL_GENERATION ends: merge pending results and reconstruct OpenAI format output

## Related Issue(s)

Fixes: #11735

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Thread view truncation when displaying AI-powered tool interactions. Tool calls and their results now render completely, enabling users to see the full conversation flow including all tool exchanges and interactions in the thread view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->