### PR TITLE
Add custom span formatter at exporter level

### DIFF
--- a/.changeset/add-custom-span-formatter-to-exporters.md
+++ b/.changeset/add-custom-span-formatter-to-exporters.md
@@ -1,0 +1,36 @@
+---
+'@mastra/core': patch
+'@mastra/observability': patch
+---
+
+Added `customSpanFormatter` option to exporters for per-exporter span transformation. This allows different formatting for different observability platforms (e.g., plain text for Braintrust, structured data for Langfuse).
+
+**Configuration example:**
+
+```ts
+import { BraintrustExporter } from "@mastra/braintrust";
+import { SpanType } from "@mastra/core/observability";
+import type { CustomSpanFormatter } from "@mastra/core/observability";
+
+const plainTextFormatter: CustomSpanFormatter = (span) => {
+  if (span.type === SpanType.AGENT_RUN && Array.isArray(span.input)) {
+    const userMessage = span.input.find((m) => m.role === "user");
+    return { ...span, input: userMessage?.content ?? span.input };
+  }
+  return span;
+};
+
+const exporter = new BraintrustExporter({
+  customSpanFormatter: plainTextFormatter,
+});
+```
+
+Also added `chainFormatters` utility to combine multiple formatters:
+
+```ts
+import { chainFormatters } from "@mastra/observability";
+
+const exporter = new BraintrustExporter({
+  customSpanFormatter: chainFormatters([formatter1, formatter2]),
+});
+```

--- a/.changeset/add-custom-span-formatter-to-exporters.md
+++ b/.changeset/add-custom-span-formatter-to-exporters.md
@@ -3,7 +3,7 @@
 '@mastra/observability': patch
 ---
 
-Added `customSpanFormatter` option to exporters for per-exporter span transformation. This allows different formatting for different observability platforms (e.g., plain text for Braintrust, structured data for Langfuse).
+Added `customSpanFormatter` option to exporters for per-exporter span transformation. This allows different formatting for different observability platforms (e.g., plain text for Braintrust, structured data for Langfuse). Formatters support both synchronous and asynchronous operations, enabling use cases like async data enrichment from external APIs.
 
 **Configuration example:**
 
@@ -12,6 +12,7 @@ import { BraintrustExporter } from "@mastra/braintrust";
 import { SpanType } from "@mastra/core/observability";
 import type { CustomSpanFormatter } from "@mastra/core/observability";
 
+// Sync formatter
 const plainTextFormatter: CustomSpanFormatter = (span) => {
   if (span.type === SpanType.AGENT_RUN && Array.isArray(span.input)) {
     const userMessage = span.input.find((m) => m.role === "user");
@@ -20,17 +21,23 @@ const plainTextFormatter: CustomSpanFormatter = (span) => {
   return span;
 };
 
+// Async formatter for data enrichment
+const enrichmentFormatter: CustomSpanFormatter = async (span) => {
+  const userData = await fetchUserData(span.metadata?.userId);
+  return { ...span, metadata: { ...span.metadata, userName: userData.name } };
+};
+
 const exporter = new BraintrustExporter({
   customSpanFormatter: plainTextFormatter,
 });
 ```
 
-Also added `chainFormatters` utility to combine multiple formatters:
+Also added `chainFormatters` utility to combine multiple formatters (supports mixed sync/async):
 
 ```ts
 import { chainFormatters } from "@mastra/observability";
 
 const exporter = new BraintrustExporter({
-  customSpanFormatter: chainFormatters([formatter1, formatter2]),
+  customSpanFormatter: chainFormatters([syncFormatter, asyncFormatter]),
 });
 ```

--- a/.changeset/add-custom-span-formatter-to-exporters.md
+++ b/.changeset/add-custom-span-formatter-to-exporters.md
@@ -3,12 +3,12 @@
 '@mastra/observability': patch
 ---
 
-Added `customSpanFormatter` option to exporters for per-exporter span transformation. This allows different formatting for different observability platforms (e.g., plain text for Braintrust, structured data for Langfuse). Formatters support both synchronous and asynchronous operations, enabling use cases like async data enrichment from external APIs.
+Added `customSpanFormatter` option to exporters for per-exporter span transformation. This allows different formatting per exporter and supports both synchronous and asynchronous operations, including async data enrichment.
 
 **Configuration example:**
 
 ```ts
-import { BraintrustExporter } from "@mastra/braintrust";
+import { DefaultExporter } from "@mastra/observability";
 import { SpanType } from "@mastra/core/observability";
 import type { CustomSpanFormatter } from "@mastra/core/observability";
 
@@ -27,7 +27,7 @@ const enrichmentFormatter: CustomSpanFormatter = async (span) => {
   return { ...span, metadata: { ...span.metadata, userName: userData.name } };
 };
 
-const exporter = new BraintrustExporter({
+const exporter = new DefaultExporter({
   customSpanFormatter: plainTextFormatter,
 });
 ```

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -669,6 +669,90 @@ Processors are executed in the order they're defined, allowing you to chain mult
 - Sampling high-volume traces
 - Enriching spans with business context
 
+## Custom Span Formatters
+
+Custom span formatters allow you to transform how spans appear in specific observability platforms. Unlike span processors (which operate at the observability level before export), custom span formatters are configured per-exporter, allowing different formatting for different destinations.
+
+### Use Cases
+
+- **Extract plain text from AI SDK messages** - Convert structured message arrays to readable text
+- **Transform input/output formats** - Customize how data appears in specific platforms
+- **Platform-specific field mapping** - Add or remove fields based on platform requirements
+
+### Configuration
+
+Add a `customSpanFormatter` to any exporter configuration:
+
+```ts title="src/mastra/index.ts"
+import { BraintrustExporter } from "@mastra/braintrust";
+import { LangfuseExporter } from "@mastra/langfuse";
+import { SpanType } from "@mastra/core/observability";
+import type { CustomSpanFormatter } from "@mastra/core/observability";
+
+// Formatter that extracts plain text from AI messages
+const plainTextFormatter: CustomSpanFormatter = (span) => {
+  if (span.type === SpanType.AGENT_RUN && Array.isArray(span.input)) {
+    const userMessage = span.input.find((m) => m.role === "user");
+    return {
+      ...span,
+      input: userMessage?.content ?? span.input,
+    };
+  }
+  return span;
+};
+
+export const mastra = new Mastra({
+  observability: new Observability({
+    configs: {
+      default: {
+        serviceName: "my-service",
+        exporters: [
+          // Braintrust gets plain text formatting
+          new BraintrustExporter({
+            customSpanFormatter: plainTextFormatter,
+          }),
+          // Langfuse keeps the original structured format
+          new LangfuseExporter(),
+        ],
+      },
+    },
+  }),
+});
+```
+
+### Chaining Multiple Formatters
+
+Use `chainFormatters` to combine multiple formatters:
+
+```ts
+import { chainFormatters } from "@mastra/observability";
+
+const inputFormatter: CustomSpanFormatter = (span) => ({
+  ...span,
+  input: extractPlainText(span.input),
+});
+
+const outputFormatter: CustomSpanFormatter = (span) => ({
+  ...span,
+  output: extractPlainText(span.output),
+});
+
+const exporter = new BraintrustExporter({
+  customSpanFormatter: chainFormatters([inputFormatter, outputFormatter]),
+});
+```
+
+### Comparison: Span Processors vs Custom Span Formatters
+
+| Feature | Span Processors | Custom Span Formatters |
+| --- | --- | --- |
+| Configuration level | Observability config | Per-exporter |
+| Operates on | Internal `Span` object | Exported `ExportedSpan` data |
+| Applies to | All exporters | Single exporter |
+| Use case | Security, filtering, enrichment | Platform-specific formatting |
+
+Use span processors for transformations that should apply to all exporters (like `SensitiveDataFilter`). Use custom span formatters when different exporters need different representations of the same data.
+
 ## Serialization Options
 
 Serialization options control how span data (input, output, and attributes) is truncated before export. This is useful when working with large payloads, deeply nested objects, or when you need to optimize trace storage.

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -629,9 +629,10 @@ Mastra provides two ways to transform span data before it reaches your observabi
 | Configuration level | Observability config | Per-exporter |
 | Operates on | Internal `Span` object | Exported `ExportedSpan` data |
 | Applies to | All exporters | Single exporter |
-| Use case | Security, filtering, enrichment | Platform-specific formatting |
+| Async support | No | Yes |
+| Use case | Security, filtering, enrichment | Platform-specific formatting, async enrichment |
 
-Use **span processors** for transformations that should apply to all exporters (like redacting sensitive data). Use **custom span formatters** when different exporters need different representations of the same data (like plain text for one platform and structured data for another).
+Use **span processors** for synchronous transformations that should apply to all exporters (like redacting sensitive data). Use **custom span formatters** when different exporters need different representations of the same data (like plain text for one platform and structured data for another), or when you need to perform asynchronous operations like fetching data from external APIs.
 
 ### Span Processors
 
@@ -684,13 +685,14 @@ Processors are executed in the order they're defined, allowing you to chain mult
 
 ### Custom Span Formatters
 
-Custom span formatters transform how spans appear in specific observability platforms. Unlike span processors, formatters are configured per-exporter, allowing different formatting for different destinations.
+Custom span formatters transform how spans appear in specific observability platforms. Unlike span processors, formatters are configured per-exporter, allowing different formatting for different destinations. Formatters support both synchronous and asynchronous operations.
 
 #### Use Cases
 
 - **Extract plain text from AI SDK messages** - Convert structured message arrays to readable text
 - **Transform input/output formats** - Customize how data appears in specific platforms
 - **Platform-specific field mapping** - Add or remove fields based on platform requirements
+- **Async data enrichment** - Fetch additional context from external APIs or databases
 
 #### Configuration
 
@@ -735,7 +737,7 @@ export const mastra = new Mastra({
 
 #### Chaining Multiple Formatters
 
-Use `chainFormatters` to combine multiple formatters:
+Use `chainFormatters` to combine multiple formatters. Chains support both sync and async formatters:
 
 ```ts
 import { chainFormatters } from "@mastra/observability";
@@ -754,6 +756,68 @@ const exporter = new BraintrustExporter({
   customSpanFormatter: chainFormatters([inputFormatter, outputFormatter]),
 });
 ```
+
+#### Async Formatters
+
+Custom span formatters support asynchronous operations, enabling use cases like fetching data from external APIs or databases to enrich your spans:
+
+```ts
+import type { CustomSpanFormatter } from "@mastra/core/observability";
+
+// Async formatter that enriches spans with user data
+const userEnrichmentFormatter: CustomSpanFormatter = async (span) => {
+  const userId = span.metadata?.userId;
+  if (!userId) return span;
+
+  // Fetch user data from your API or database
+  const userData = await fetchUserData(userId);
+
+  return {
+    ...span,
+    metadata: {
+      ...span.metadata,
+      userName: userData.name,
+      userEmail: userData.email,
+      department: userData.department,
+    },
+  };
+};
+
+// Async formatter that looks up additional context
+const contextEnrichmentFormatter: CustomSpanFormatter = async (span) => {
+  if (span.type !== SpanType.AGENT_RUN) return span;
+
+  // Fetch experiment configuration
+  const experimentConfig = await getExperimentConfig(span.metadata?.experimentId);
+
+  return {
+    ...span,
+    metadata: {
+      ...span.metadata,
+      experimentVariant: experimentConfig?.variant,
+      experimentGroup: experimentConfig?.group,
+    },
+  };
+};
+
+// Use async formatters with an exporter
+const exporter = new BraintrustExporter({
+  customSpanFormatter: userEnrichmentFormatter,
+});
+
+// Or chain sync and async formatters together
+const exporter = new LangfuseExporter({
+  customSpanFormatter: chainFormatters([
+    plainTextFormatter,           // sync
+    userEnrichmentFormatter,      // async
+    contextEnrichmentFormatter,   // async
+  ]),
+});
+```
+
+:::note
+Async formatters add latency to span export. Keep async operations fast (under 100ms) to avoid slowing down your application. Consider using caching for frequently accessed data.
+:::
 
 ## Serialization Options
 

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -620,15 +620,28 @@ execute: async (inputData, context) => {
 
 Child spans automatically inherit the trace context from their parent, maintaining the relationship hierarchy in your observability platform.
 
-## Span Processors
+## Span Formatting
 
-Span processors allow you to transform, filter, or enrich trace data before it's exported. They act as a pipeline between span creation and export, enabling you to modify spans for security, compliance, or debugging purposes. Mastra includes built-in processors and supports custom implementations.
+Mastra provides two ways to transform span data before it reaches your observability platform: **span processors** and **custom span formatters**. Both allow you to modify, filter, or enrich trace data, but they operate at different levels and serve different purposes.
 
-### Built-in Processors
+| Feature | Span Processors | Custom Span Formatters |
+| --- | --- | --- |
+| Configuration level | Observability config | Per-exporter |
+| Operates on | Internal `Span` object | Exported `ExportedSpan` data |
+| Applies to | All exporters | Single exporter |
+| Use case | Security, filtering, enrichment | Platform-specific formatting |
+
+Use **span processors** for transformations that should apply to all exporters (like redacting sensitive data). Use **custom span formatters** when different exporters need different representations of the same data (like plain text for one platform and structured data for another).
+
+### Span Processors
+
+Span processors transform, filter, or enrich trace data before it's exported. They act as a pipeline between span creation and export, enabling you to modify spans for security, compliance, or debugging purposes. Processors run once and affect all exporters.
+
+#### Built-in Processors
 
 - [Sensitive Data Filter](/docs/v1/observability/tracing/processors/sensitive-data-filter) redacts sensitive information. It is enabled in the default observability config.
 
-### Creating Custom Processors
+#### Creating Custom Processors
 
 You can create custom span processors by implementing the `SpanOutputProcessor` interface. Here's a simple example that converts all input text in spans to lowercase:
 
@@ -661,25 +674,25 @@ export const mastra = new Mastra({
 });
 ```
 
-Processors are executed in the order they're defined, allowing you to chain multiple transformations. Common use cases for custom processors include:
+Processors are executed in the order they're defined, allowing you to chain multiple transformations. Common use cases include:
 
+- Redacting sensitive data (passwords, tokens, API keys)
 - Adding environment-specific metadata
 - Filtering out spans based on criteria
 - Normalizing data formats
-- Sampling high-volume traces
 - Enriching spans with business context
 
-## Custom Span Formatters
+### Custom Span Formatters
 
-Custom span formatters allow you to transform how spans appear in specific observability platforms. Unlike span processors (which operate at the observability level before export), custom span formatters are configured per-exporter, allowing different formatting for different destinations.
+Custom span formatters transform how spans appear in specific observability platforms. Unlike span processors, formatters are configured per-exporter, allowing different formatting for different destinations.
 
-### Use Cases
+#### Use Cases
 
 - **Extract plain text from AI SDK messages** - Convert structured message arrays to readable text
 - **Transform input/output formats** - Customize how data appears in specific platforms
 - **Platform-specific field mapping** - Add or remove fields based on platform requirements
 
-### Configuration
+#### Configuration
 
 Add a `customSpanFormatter` to any exporter configuration:
 
@@ -720,7 +733,7 @@ export const mastra = new Mastra({
 });
 ```
 
-### Chaining Multiple Formatters
+#### Chaining Multiple Formatters
 
 Use `chainFormatters` to combine multiple formatters:
 
@@ -741,17 +754,6 @@ const exporter = new BraintrustExporter({
   customSpanFormatter: chainFormatters([inputFormatter, outputFormatter]),
 });
 ```
-
-### Comparison: Span Processors vs Custom Span Formatters
-
-| Feature | Span Processors | Custom Span Formatters |
-| --- | --- | --- |
-| Configuration level | Observability config | Per-exporter |
-| Operates on | Internal `Span` object | Exported `ExportedSpan` data |
-| Applies to | All exporters | Single exporter |
-| Use case | Security, filtering, enrichment | Platform-specific formatting |
-
-Use span processors for transformations that should apply to all exporters (like `SensitiveDataFilter`). Use custom span formatters when different exporters need different representations of the same data.
 
 ## Serialization Options
 

--- a/observability/mastra/src/exporters/base.test.ts
+++ b/observability/mastra/src/exporters/base.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Unit tests for BaseExporter and customSpanFormatter functionality.
+ */
+
+import { SpanType, TracingEventType } from '@mastra/core/observability';
+import type { TracingEvent, AnyExportedSpan, CustomSpanFormatter } from '@mastra/core/observability';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BaseExporter } from './base';
+import type { BaseExporterConfig } from './base';
+import { chainFormatters } from './span-formatters';
+
+// Test implementation of BaseExporter
+class TestExporter extends BaseExporter {
+  name = 'test-exporter';
+
+  public exportedEvents: TracingEvent[] = [];
+
+  constructor(config: BaseExporterConfig = {}) {
+    super(config);
+  }
+
+  protected async _exportTracingEvent(event: TracingEvent): Promise<void> {
+    this.exportedEvents.push(event);
+  }
+}
+
+function createMockSpan(overrides: Partial<AnyExportedSpan> = {}): AnyExportedSpan {
+  return {
+    id: 'span-1',
+    traceId: 'trace-1',
+    name: 'test-span',
+    type: SpanType.AGENT_RUN,
+    isRootSpan: true,
+    isEvent: false,
+    startTime: new Date(),
+    input: { messages: [{ role: 'user', content: 'Hello' }] },
+    output: { text: 'Hi there!' },
+    ...overrides,
+  };
+}
+
+function createTracingEvent(span: AnyExportedSpan): TracingEvent {
+  return {
+    type: TracingEventType.SPAN_ENDED,
+    exportedSpan: span,
+  };
+}
+
+describe('BaseExporter', () => {
+  describe('customSpanFormatter', () => {
+    it('should apply customSpanFormatter to exported spans', async () => {
+      const formatter: CustomSpanFormatter = span => ({
+        ...span,
+        input: 'formatted-input',
+        output: 'formatted-output',
+      });
+
+      const exporter = new TestExporter({ customSpanFormatter: formatter });
+      const span = createMockSpan();
+      const event = createTracingEvent(span);
+
+      await exporter.exportTracingEvent(event);
+
+      expect(exporter.exportedEvents).toHaveLength(1);
+      expect(exporter.exportedEvents[0].exportedSpan.input).toBe('formatted-input');
+      expect(exporter.exportedEvents[0].exportedSpan.output).toBe('formatted-output');
+    });
+
+    it('should not modify span when no formatter is configured', async () => {
+      const exporter = new TestExporter();
+      const span = createMockSpan({
+        input: 'original-input',
+        output: 'original-output',
+      });
+      const event = createTracingEvent(span);
+
+      await exporter.exportTracingEvent(event);
+
+      expect(exporter.exportedEvents).toHaveLength(1);
+      expect(exporter.exportedEvents[0].exportedSpan.input).toBe('original-input');
+      expect(exporter.exportedEvents[0].exportedSpan.output).toBe('original-output');
+    });
+
+    it('should handle formatter errors gracefully and use original span', async () => {
+      const errorFormatter: CustomSpanFormatter = () => {
+        throw new Error('Formatter error');
+      };
+
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+
+      const exporter = new TestExporter({
+        customSpanFormatter: errorFormatter,
+        logger: logger as any,
+      });
+      const span = createMockSpan({
+        input: 'original-input',
+      });
+      const event = createTracingEvent(span);
+
+      await exporter.exportTracingEvent(event);
+
+      // Should use original span when formatter throws
+      expect(exporter.exportedEvents).toHaveLength(1);
+      expect(exporter.exportedEvents[0].exportedSpan.input).toBe('original-input');
+      // Should log the error
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error in customSpanFormatter'),
+        expect.any(Object),
+      );
+    });
+
+    it('should allow selective formatting based on span type', async () => {
+      const formatter: CustomSpanFormatter = span => {
+        if (span.type === SpanType.AGENT_RUN) {
+          return { ...span, input: 'agent-formatted' };
+        }
+        return span;
+      };
+
+      const exporter = new TestExporter({ customSpanFormatter: formatter });
+
+      // AGENT_RUN span should be formatted
+      const agentSpan = createMockSpan({
+        id: 'span-1',
+        type: SpanType.AGENT_RUN,
+        input: 'original',
+      });
+      await exporter.exportTracingEvent(createTracingEvent(agentSpan));
+
+      // TOOL_CALL span should NOT be formatted
+      const toolSpan = createMockSpan({
+        id: 'span-2',
+        type: SpanType.TOOL_CALL,
+        input: 'original',
+      });
+      await exporter.exportTracingEvent(createTracingEvent(toolSpan));
+
+      expect(exporter.exportedEvents).toHaveLength(2);
+      expect(exporter.exportedEvents[0].exportedSpan.input).toBe('agent-formatted');
+      expect(exporter.exportedEvents[1].exportedSpan.input).toBe('original');
+    });
+
+    it('should preserve original span properties not modified by formatter', async () => {
+      const formatter: CustomSpanFormatter = span => ({
+        ...span,
+        input: 'modified',
+      });
+
+      const exporter = new TestExporter({ customSpanFormatter: formatter });
+      const span = createMockSpan({
+        id: 'my-id',
+        traceId: 'my-trace',
+        name: 'my-name',
+        attributes: { key: 'value' },
+        metadata: { meta: 'data' },
+      });
+      await exporter.exportTracingEvent(createTracingEvent(span));
+
+      const exported = exporter.exportedEvents[0].exportedSpan;
+      expect(exported.id).toBe('my-id');
+      expect(exported.traceId).toBe('my-trace');
+      expect(exported.name).toBe('my-name');
+      expect(exported.attributes).toEqual({ key: 'value' });
+      expect(exported.metadata).toEqual({ meta: 'data' });
+      expect(exported.input).toBe('modified');
+    });
+  });
+});
+
+describe('chainFormatters', () => {
+  it('should chain multiple formatters in order', async () => {
+    const formatter1: CustomSpanFormatter = span => ({
+      ...span,
+      input: `${span.input}-first`,
+    });
+    const formatter2: CustomSpanFormatter = span => ({
+      ...span,
+      input: `${span.input}-second`,
+    });
+    const formatter3: CustomSpanFormatter = span => ({
+      ...span,
+      input: `${span.input}-third`,
+    });
+
+    const chained = chainFormatters([formatter1, formatter2, formatter3]);
+    const exporter = new TestExporter({ customSpanFormatter: chained });
+
+    const span = createMockSpan({ input: 'start' });
+    await exporter.exportTracingEvent(createTracingEvent(span));
+
+    expect(exporter.exportedEvents[0].exportedSpan.input).toBe('start-first-second-third');
+  });
+
+  it('should handle empty formatter array', async () => {
+    const chained = chainFormatters([]);
+    const exporter = new TestExporter({ customSpanFormatter: chained });
+
+    const span = createMockSpan({ input: 'original' });
+    await exporter.exportTracingEvent(createTracingEvent(span));
+
+    expect(exporter.exportedEvents[0].exportedSpan.input).toBe('original');
+  });
+
+  it('should handle single formatter', async () => {
+    const formatter: CustomSpanFormatter = span => ({
+      ...span,
+      input: 'single',
+    });
+
+    const chained = chainFormatters([formatter]);
+    const exporter = new TestExporter({ customSpanFormatter: chained });
+
+    const span = createMockSpan({ input: 'original' });
+    await exporter.exportTracingEvent(createTracingEvent(span));
+
+    expect(exporter.exportedEvents[0].exportedSpan.input).toBe('single');
+  });
+
+  it('should allow different formatters to modify different fields', async () => {
+    const inputFormatter: CustomSpanFormatter = span => ({
+      ...span,
+      input: 'formatted-input',
+    });
+    const outputFormatter: CustomSpanFormatter = span => ({
+      ...span,
+      output: 'formatted-output',
+    });
+    const nameFormatter: CustomSpanFormatter = span => ({
+      ...span,
+      name: 'formatted-name',
+    });
+
+    const chained = chainFormatters([inputFormatter, outputFormatter, nameFormatter]);
+    const exporter = new TestExporter({ customSpanFormatter: chained });
+
+    const span = createMockSpan({
+      input: 'original-input',
+      output: 'original-output',
+      name: 'original-name',
+    });
+    await exporter.exportTracingEvent(createTracingEvent(span));
+
+    const exported = exporter.exportedEvents[0].exportedSpan;
+    expect(exported.input).toBe('formatted-input');
+    expect(exported.output).toBe('formatted-output');
+    expect(exported.name).toBe('formatted-name');
+  });
+});

--- a/observability/mastra/src/exporters/base.test.ts
+++ b/observability/mastra/src/exporters/base.test.ts
@@ -169,6 +169,89 @@ describe('BaseExporter', () => {
       expect(exported.metadata).toEqual({ meta: 'data' });
       expect(exported.input).toBe('modified');
     });
+
+    it('should apply async customSpanFormatter to exported spans', async () => {
+      const asyncFormatter: CustomSpanFormatter = async span => {
+        // Simulate async operation
+        await new Promise(resolve => setTimeout(resolve, 10));
+        return {
+          ...span,
+          input: 'async-formatted-input',
+          output: 'async-formatted-output',
+        };
+      };
+
+      const exporter = new TestExporter({ customSpanFormatter: asyncFormatter });
+      const span = createMockSpan();
+      const event = createTracingEvent(span);
+
+      await exporter.exportTracingEvent(event);
+
+      expect(exporter.exportedEvents).toHaveLength(1);
+      expect(exporter.exportedEvents[0].exportedSpan.input).toBe('async-formatted-input');
+      expect(exporter.exportedEvents[0].exportedSpan.output).toBe('async-formatted-output');
+    });
+
+    it('should handle async formatter errors gracefully and use original span', async () => {
+      const errorAsyncFormatter: CustomSpanFormatter = async () => {
+        await new Promise(resolve => setTimeout(resolve, 5));
+        throw new Error('Async formatter error');
+      };
+
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+
+      const exporter = new TestExporter({
+        customSpanFormatter: errorAsyncFormatter,
+        logger: logger as any,
+      });
+      const span = createMockSpan({
+        input: 'original-input',
+      });
+      const event = createTracingEvent(span);
+
+      await exporter.exportTracingEvent(event);
+
+      // Should use original span when async formatter throws
+      expect(exporter.exportedEvents).toHaveLength(1);
+      expect(exporter.exportedEvents[0].exportedSpan.input).toBe('original-input');
+      // Should log the error
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error in customSpanFormatter'),
+        expect.any(Object),
+      );
+    });
+
+    it('should handle async formatter that rejects with original span', async () => {
+      const rejectingFormatter: CustomSpanFormatter = () => {
+        return Promise.reject(new Error('Rejected!'));
+      };
+
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+
+      const exporter = new TestExporter({
+        customSpanFormatter: rejectingFormatter,
+        logger: logger as any,
+      });
+      const span = createMockSpan({
+        input: 'original-input',
+      });
+
+      await exporter.exportTracingEvent(createTracingEvent(span));
+
+      expect(exporter.exportedEvents).toHaveLength(1);
+      expect(exporter.exportedEvents[0].exportedSpan.input).toBe('original-input');
+      expect(logger.error).toHaveBeenCalled();
+    });
   });
 });
 
@@ -249,5 +332,83 @@ describe('chainFormatters', () => {
     expect(exported.input).toBe('formatted-input');
     expect(exported.output).toBe('formatted-output');
     expect(exported.name).toBe('formatted-name');
+  });
+
+  it('should chain async formatters in order', async () => {
+    const asyncFormatter1: CustomSpanFormatter = async span => {
+      await new Promise(resolve => setTimeout(resolve, 5));
+      return {
+        ...span,
+        input: `${span.input}-async1`,
+      };
+    };
+    const asyncFormatter2: CustomSpanFormatter = async span => {
+      await new Promise(resolve => setTimeout(resolve, 5));
+      return {
+        ...span,
+        input: `${span.input}-async2`,
+      };
+    };
+
+    const chained = chainFormatters([asyncFormatter1, asyncFormatter2]);
+    const exporter = new TestExporter({ customSpanFormatter: chained });
+
+    const span = createMockSpan({ input: 'start' });
+    await exporter.exportTracingEvent(createTracingEvent(span));
+
+    expect(exporter.exportedEvents[0].exportedSpan.input).toBe('start-async1-async2');
+  });
+
+  it('should chain mixed sync and async formatters', async () => {
+    const syncFormatter: CustomSpanFormatter = span => ({
+      ...span,
+      input: `${span.input}-sync`,
+    });
+    const asyncFormatter: CustomSpanFormatter = async span => {
+      await new Promise(resolve => setTimeout(resolve, 5));
+      return {
+        ...span,
+        input: `${span.input}-async`,
+      };
+    };
+    const anotherSyncFormatter: CustomSpanFormatter = span => ({
+      ...span,
+      input: `${span.input}-sync2`,
+    });
+
+    const chained = chainFormatters([syncFormatter, asyncFormatter, anotherSyncFormatter]);
+    const exporter = new TestExporter({ customSpanFormatter: chained });
+
+    const span = createMockSpan({ input: 'start' });
+    await exporter.exportTracingEvent(createTracingEvent(span));
+
+    expect(exporter.exportedEvents[0].exportedSpan.input).toBe('start-sync-async-sync2');
+  });
+
+  it('should handle async formatter enrichment use case', async () => {
+    // Simulate an async enrichment formatter that fetches external data
+    const enrichmentFormatter: CustomSpanFormatter = async span => {
+      // Simulate API call delay
+      await new Promise(resolve => setTimeout(resolve, 10));
+      // Simulate enriched data from external source
+      const enrichedData = { userName: 'John Doe', department: 'Engineering' };
+      return {
+        ...span,
+        metadata: { ...span.metadata, ...enrichedData },
+      };
+    };
+
+    const exporter = new TestExporter({ customSpanFormatter: enrichmentFormatter });
+    const span = createMockSpan({
+      metadata: { userId: 'user-123' },
+    });
+    await exporter.exportTracingEvent(createTracingEvent(span));
+
+    const exported = exporter.exportedEvents[0].exportedSpan;
+    expect(exported.metadata).toEqual({
+      userId: 'user-123',
+      userName: 'John Doe',
+      department: 'Engineering',
+    });
   });
 });

--- a/observability/mastra/src/exporters/base.test.ts
+++ b/observability/mastra/src/exporters/base.test.ts
@@ -4,7 +4,7 @@
 
 import { SpanType, TracingEventType } from '@mastra/core/observability';
 import type { TracingEvent, AnyExportedSpan, CustomSpanFormatter } from '@mastra/core/observability';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { BaseExporter } from './base';
 import type { BaseExporterConfig } from './base';
 import { chainFormatters } from './span-formatters';

--- a/observability/mastra/src/exporters/base.ts
+++ b/observability/mastra/src/exporters/base.ts
@@ -157,13 +157,16 @@ export abstract class BaseExporter implements ObservabilityExporter {
    * Apply the customSpanFormatter if configured.
    * This is called automatically by exportTracingEvent before _exportTracingEvent.
    *
+   * Supports both synchronous and asynchronous formatters. If the formatter
+   * returns a Promise, it will be awaited.
+   *
    * @param event - The incoming tracing event
    * @returns The (possibly modified) event to process
    */
-  protected applySpanFormatter(event: TracingEvent): TracingEvent {
+  protected async applySpanFormatter(event: TracingEvent): Promise<TracingEvent> {
     if (this.baseConfig.customSpanFormatter) {
       try {
-        const formattedSpan = this.baseConfig.customSpanFormatter(event.exportedSpan);
+        const formattedSpan = await this.baseConfig.customSpanFormatter(event.exportedSpan);
         return {
           ...event,
           exportedSpan: formattedSpan,
@@ -191,7 +194,7 @@ export abstract class BaseExporter implements ObservabilityExporter {
     if (this.isDisabled) {
       return;
     }
-    const processedEvent = this.applySpanFormatter(event);
+    const processedEvent = await this.applySpanFormatter(event);
     await this._exportTracingEvent(processedEvent);
   }
 

--- a/observability/mastra/src/exporters/base.ts
+++ b/observability/mastra/src/exporters/base.ts
@@ -9,7 +9,12 @@
 
 import { ConsoleLogger, LogLevel } from '@mastra/core/logger';
 import type { IMastraLogger } from '@mastra/core/logger';
-import type { TracingEvent, ObservabilityExporter, InitExporterOptions, CustomSpanFormatter } from '@mastra/core/observability';
+import type {
+  TracingEvent,
+  ObservabilityExporter,
+  InitExporterOptions,
+  CustomSpanFormatter,
+} from '@mastra/core/observability';
 
 /**
  * Base configuration that all exporters should support

--- a/observability/mastra/src/exporters/base.ts
+++ b/observability/mastra/src/exporters/base.ts
@@ -9,7 +9,7 @@
 
 import { ConsoleLogger, LogLevel } from '@mastra/core/logger';
 import type { IMastraLogger } from '@mastra/core/logger';
-import type { TracingEvent, ObservabilityExporter, InitExporterOptions, ExporterSpanFormatter } from '@mastra/core/observability';
+import type { TracingEvent, ObservabilityExporter, InitExporterOptions, CustomSpanFormatter } from '@mastra/core/observability';
 
 /**
  * Base configuration that all exporters should support
@@ -43,7 +43,7 @@ export interface BaseExporterConfig {
    * });
    * ```
    */
-  customSpanFormatter?: ExporterSpanFormatter;
+  customSpanFormatter?: CustomSpanFormatter;
 }
 
 /**

--- a/observability/mastra/src/exporters/index.ts
+++ b/observability/mastra/src/exporters/index.ts
@@ -6,6 +6,9 @@
 export * from './base';
 export * from './tracking';
 
+// Span formatters for exporter customization
+export * from './span-formatters';
+
 // Core types and interfaces
 export * from './cloud';
 export * from './console';

--- a/observability/mastra/src/exporters/span-formatters.ts
+++ b/observability/mastra/src/exporters/span-formatters.ts
@@ -1,0 +1,256 @@
+/**
+ * Utility span formatters for common use cases.
+ *
+ * These formatters can be used with the `customSpanFormatter` option on
+ * TrackingExporter-based exporters (Braintrust, Langfuse, etc.).
+ */
+
+import { SpanType } from '@mastra/core/observability';
+import type { AnyExportedSpan, ExporterSpanFormatter } from '@mastra/core/observability';
+
+/**
+ * AI SDK message content part interface.
+ * Supports text, tool-call, tool-result, and other content types.
+ */
+interface ContentPart {
+  type: string;
+  text?: string;
+  content?: string;
+  toolCallId?: string;
+  toolName?: string;
+  args?: unknown;
+  input?: unknown;
+  result?: unknown;
+  output?: unknown;
+}
+
+/**
+ * AI SDK message interface.
+ * Used in both v4 and v5 formats.
+ */
+interface AIMessage {
+  role: 'user' | 'assistant' | 'system' | 'tool';
+  content: string | ContentPart[];
+  [key: string]: unknown;
+}
+
+/**
+ * Checks if a value looks like an AI SDK message array.
+ */
+function isMessageArray(value: unknown): value is AIMessage[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    typeof value[0] === 'object' &&
+    value[0] !== null &&
+    'role' in value[0]
+  );
+}
+
+/**
+ * Extracts text content from an AI SDK message.
+ *
+ * Handles:
+ * - Simple string content
+ * - Array of content parts (AI SDK format)
+ * - Nested text fields
+ */
+function extractMessageText(message: AIMessage): string {
+  const { content } = message;
+
+  // Simple string content
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  // Array of content parts
+  if (Array.isArray(content)) {
+    const textParts: string[] = [];
+
+    for (const part of content) {
+      if (typeof part === 'string') {
+        textParts.push(part);
+      } else if (part && typeof part === 'object') {
+        if (part.type === 'text' && typeof part.text === 'string') {
+          textParts.push(part.text);
+        } else if (typeof part.content === 'string') {
+          textParts.push(part.content);
+        }
+      }
+    }
+
+    return textParts.join('\n');
+  }
+
+  return '';
+}
+
+/**
+ * Extracts the user's input message text from a message array.
+ *
+ * Finds the last 'user' role message and extracts its text content.
+ * Returns undefined if no user message is found.
+ */
+function extractUserInputText(messages: AIMessage[]): string | undefined {
+  // Find the last user message
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg?.role === 'user') {
+      return extractMessageText(msg);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Extracts the assistant's output message text from a message array.
+ *
+ * Finds the last 'assistant' role message and extracts its text content.
+ * Returns undefined if no assistant message is found.
+ */
+function extractAssistantOutputText(messages: AIMessage[]): string | undefined {
+  // Find the last assistant message
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg?.role === 'assistant') {
+      return extractMessageText(msg);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Extracts plain text from span output.
+ *
+ * Handles various output formats:
+ * - String output (returns as-is)
+ * - Object with 'text' field
+ * - Array of messages (extracts last assistant message)
+ */
+function extractOutputText(output: unknown): string | undefined {
+  if (typeof output === 'string') {
+    return output;
+  }
+
+  if (output && typeof output === 'object') {
+    // Handle { text: "..." } format
+    if ('text' in output && typeof (output as any).text === 'string') {
+      return (output as any).text;
+    }
+
+    // Handle { content: "..." } format
+    if ('content' in output && typeof (output as any).content === 'string') {
+      return (output as any).content;
+    }
+
+    // Handle message array format
+    if (isMessageArray(output)) {
+      return extractAssistantOutputText(output);
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Creates a span formatter that extracts plain text from AI SDK message arrays.
+ *
+ * This formatter is useful for making traces more readable in observability platforms
+ * like Braintrust and Langfuse, where raw JSON payloads can be difficult to read.
+ *
+ * The formatter:
+ * - Extracts the last user message text for input
+ * - Extracts text from the output (handles various formats)
+ * - Only modifies spans of the specified types
+ *
+ * @param options - Configuration options
+ * @param options.spanTypes - Array of span types to format (default: AGENT_RUN only)
+ * @param options.formatInput - Whether to format input (default: true)
+ * @param options.formatOutput - Whether to format output (default: true)
+ *
+ * @example
+ * ```typescript
+ * const braintrustExporter = new BraintrustExporter({
+ *   customSpanFormatter: createPlainTextFormatter(),
+ * });
+ *
+ * // Or with custom options:
+ * const formatter = createPlainTextFormatter({
+ *   spanTypes: [SpanType.AGENT_RUN, SpanType.MODEL_GENERATION],
+ *   formatInput: true,
+ *   formatOutput: true,
+ * });
+ * ```
+ */
+export function createPlainTextFormatter(options: {
+  spanTypes?: SpanType[];
+  formatInput?: boolean;
+  formatOutput?: boolean;
+} = {}): ExporterSpanFormatter {
+  const {
+    spanTypes = [SpanType.AGENT_RUN],
+    formatInput = true,
+    formatOutput = true,
+  } = options;
+
+  const targetTypes = new Set(spanTypes);
+
+  return (span: AnyExportedSpan): AnyExportedSpan => {
+    // Only format specified span types
+    if (!targetTypes.has(span.type)) {
+      return span;
+    }
+
+    let modifiedSpan = span;
+
+    // Format input if enabled and input is a message array
+    if (formatInput && isMessageArray(span.input)) {
+      const plainTextInput = extractUserInputText(span.input);
+      if (plainTextInput !== undefined) {
+        modifiedSpan = {
+          ...modifiedSpan,
+          input: plainTextInput,
+        };
+      }
+    }
+
+    // Format output if enabled
+    if (formatOutput && span.output !== undefined) {
+      const plainTextOutput = extractOutputText(span.output);
+      if (plainTextOutput !== undefined) {
+        modifiedSpan = {
+          ...modifiedSpan,
+          output: plainTextOutput,
+        };
+      }
+    }
+
+    return modifiedSpan;
+  };
+}
+
+/**
+ * Composes multiple span formatters into a single formatter.
+ *
+ * Formatters are applied in order, with each receiving the output of the previous.
+ *
+ * @param formatters - Array of formatters to compose
+ * @returns A single formatter that applies all formatters in sequence
+ *
+ * @example
+ * ```typescript
+ * const composedFormatter = composeFormatters([
+ *   createPlainTextFormatter(),
+ *   myCustomRedactionFormatter,
+ * ]);
+ *
+ * const exporter = new BraintrustExporter({
+ *   customSpanFormatter: composedFormatter,
+ * });
+ * ```
+ */
+export function composeFormatters(formatters: ExporterSpanFormatter[]): ExporterSpanFormatter {
+  return (span: AnyExportedSpan): AnyExportedSpan => {
+    return formatters.reduce((currentSpan, formatter) => formatter(currentSpan), span);
+  };
+}

--- a/observability/mastra/src/exporters/span-formatters.ts
+++ b/observability/mastra/src/exporters/span-formatters.ts
@@ -1,255 +1,30 @@
 /**
- * Utility span formatters for common use cases.
- *
- * These formatters can be used with the `customSpanFormatter` option on
- * TrackingExporter-based exporters (Braintrust, Langfuse, etc.).
+ * Utility functions for working with custom span formatters.
  */
 
-import { SpanType } from '@mastra/core/observability';
-import type { AnyExportedSpan, ExporterSpanFormatter } from '@mastra/core/observability';
+import type { AnyExportedSpan, CustomSpanFormatter } from '@mastra/core/observability';
 
 /**
- * AI SDK message content part interface.
- * Supports text, tool-call, tool-result, and other content types.
- */
-interface ContentPart {
-  type: string;
-  text?: string;
-  content?: string;
-  toolCallId?: string;
-  toolName?: string;
-  args?: unknown;
-  input?: unknown;
-  result?: unknown;
-  output?: unknown;
-}
-
-/**
- * AI SDK message interface.
- * Used in both v4 and v5 formats.
- */
-interface AIMessage {
-  role: 'user' | 'assistant' | 'system' | 'tool';
-  content: string | ContentPart[];
-  [key: string]: unknown;
-}
-
-/**
- * Checks if a value looks like an AI SDK message array.
- */
-function isMessageArray(value: unknown): value is AIMessage[] {
-  return (
-    Array.isArray(value) &&
-    value.length > 0 &&
-    typeof value[0] === 'object' &&
-    value[0] !== null &&
-    'role' in value[0]
-  );
-}
-
-/**
- * Extracts text content from an AI SDK message.
- *
- * Handles:
- * - Simple string content
- * - Array of content parts (AI SDK format)
- * - Nested text fields
- */
-function extractMessageText(message: AIMessage): string {
-  const { content } = message;
-
-  // Simple string content
-  if (typeof content === 'string') {
-    return content;
-  }
-
-  // Array of content parts
-  if (Array.isArray(content)) {
-    const textParts: string[] = [];
-
-    for (const part of content) {
-      if (typeof part === 'string') {
-        textParts.push(part);
-      } else if (part && typeof part === 'object') {
-        if (part.type === 'text' && typeof part.text === 'string') {
-          textParts.push(part.text);
-        } else if (typeof part.content === 'string') {
-          textParts.push(part.content);
-        }
-      }
-    }
-
-    return textParts.join('\n');
-  }
-
-  return '';
-}
-
-/**
- * Extracts the user's input message text from a message array.
- *
- * Finds the last 'user' role message and extracts its text content.
- * Returns undefined if no user message is found.
- */
-function extractUserInputText(messages: AIMessage[]): string | undefined {
-  // Find the last user message
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (msg?.role === 'user') {
-      return extractMessageText(msg);
-    }
-  }
-  return undefined;
-}
-
-/**
- * Extracts the assistant's output message text from a message array.
- *
- * Finds the last 'assistant' role message and extracts its text content.
- * Returns undefined if no assistant message is found.
- */
-function extractAssistantOutputText(messages: AIMessage[]): string | undefined {
-  // Find the last assistant message
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (msg?.role === 'assistant') {
-      return extractMessageText(msg);
-    }
-  }
-  return undefined;
-}
-
-/**
- * Extracts plain text from span output.
- *
- * Handles various output formats:
- * - String output (returns as-is)
- * - Object with 'text' field
- * - Array of messages (extracts last assistant message)
- */
-function extractOutputText(output: unknown): string | undefined {
-  if (typeof output === 'string') {
-    return output;
-  }
-
-  if (output && typeof output === 'object') {
-    // Handle { text: "..." } format
-    if ('text' in output && typeof (output as any).text === 'string') {
-      return (output as any).text;
-    }
-
-    // Handle { content: "..." } format
-    if ('content' in output && typeof (output as any).content === 'string') {
-      return (output as any).content;
-    }
-
-    // Handle message array format
-    if (isMessageArray(output)) {
-      return extractAssistantOutputText(output);
-    }
-  }
-
-  return undefined;
-}
-
-/**
- * Creates a span formatter that extracts plain text from AI SDK message arrays.
- *
- * This formatter is useful for making traces more readable in observability platforms
- * like Braintrust and Langfuse, where raw JSON payloads can be difficult to read.
- *
- * The formatter:
- * - Extracts the last user message text for input
- * - Extracts text from the output (handles various formats)
- * - Only modifies spans of the specified types
- *
- * @param options - Configuration options
- * @param options.spanTypes - Array of span types to format (default: AGENT_RUN only)
- * @param options.formatInput - Whether to format input (default: true)
- * @param options.formatOutput - Whether to format output (default: true)
- *
- * @example
- * ```typescript
- * const braintrustExporter = new BraintrustExporter({
- *   customSpanFormatter: createPlainTextFormatter(),
- * });
- *
- * // Or with custom options:
- * const formatter = createPlainTextFormatter({
- *   spanTypes: [SpanType.AGENT_RUN, SpanType.MODEL_GENERATION],
- *   formatInput: true,
- *   formatOutput: true,
- * });
- * ```
- */
-export function createPlainTextFormatter(options: {
-  spanTypes?: SpanType[];
-  formatInput?: boolean;
-  formatOutput?: boolean;
-} = {}): ExporterSpanFormatter {
-  const {
-    spanTypes = [SpanType.AGENT_RUN],
-    formatInput = true,
-    formatOutput = true,
-  } = options;
-
-  const targetTypes = new Set(spanTypes);
-
-  return (span: AnyExportedSpan): AnyExportedSpan => {
-    // Only format specified span types
-    if (!targetTypes.has(span.type)) {
-      return span;
-    }
-
-    let modifiedSpan = span;
-
-    // Format input if enabled and input is a message array
-    if (formatInput && isMessageArray(span.input)) {
-      const plainTextInput = extractUserInputText(span.input);
-      if (plainTextInput !== undefined) {
-        modifiedSpan = {
-          ...modifiedSpan,
-          input: plainTextInput,
-        };
-      }
-    }
-
-    // Format output if enabled
-    if (formatOutput && span.output !== undefined) {
-      const plainTextOutput = extractOutputText(span.output);
-      if (plainTextOutput !== undefined) {
-        modifiedSpan = {
-          ...modifiedSpan,
-          output: plainTextOutput,
-        };
-      }
-    }
-
-    return modifiedSpan;
-  };
-}
-
-/**
- * Composes multiple span formatters into a single formatter.
+ * Chains multiple span formatters into a single formatter.
  *
  * Formatters are applied in order, with each receiving the output of the previous.
  *
- * @param formatters - Array of formatters to compose
+ * @param formatters - Array of formatters to chain
  * @returns A single formatter that applies all formatters in sequence
  *
  * @example
  * ```typescript
- * const composedFormatter = composeFormatters([
- *   createPlainTextFormatter(),
- *   myCustomRedactionFormatter,
+ * const chainedFormatter = chainFormatters([
+ *   myPlainTextFormatter,
+ *   myRedactionFormatter,
  * ]);
  *
  * const exporter = new BraintrustExporter({
- *   customSpanFormatter: composedFormatter,
+ *   customSpanFormatter: chainedFormatter,
  * });
  * ```
  */
-export function composeFormatters(formatters: ExporterSpanFormatter[]): ExporterSpanFormatter {
+export function chainFormatters(formatters: CustomSpanFormatter[]): CustomSpanFormatter {
   return (span: AnyExportedSpan): AnyExportedSpan => {
     return formatters.reduce((currentSpan, formatter) => formatter(currentSpan), span);
   };

--- a/observability/mastra/src/exporters/span-formatters.ts
+++ b/observability/mastra/src/exporters/span-formatters.ts
@@ -8,15 +8,24 @@ import type { AnyExportedSpan, CustomSpanFormatter } from '@mastra/core/observab
  * Chains multiple span formatters into a single formatter.
  *
  * Formatters are applied in order, with each receiving the output of the previous.
+ * Supports both synchronous and asynchronous formatters - if any formatter returns
+ * a Promise, the entire chain will return a Promise.
  *
- * @param formatters - Array of formatters to chain
+ * @param formatters - Array of formatters to chain (can be sync or async)
  * @returns A single formatter that applies all formatters in sequence
  *
  * @example
  * ```typescript
+ * // Chain sync formatters
  * const chainedFormatter = chainFormatters([
  *   myPlainTextFormatter,
  *   myRedactionFormatter,
+ * ]);
+ *
+ * // Chain mixed sync and async formatters
+ * const asyncChainedFormatter = chainFormatters([
+ *   myPlainTextFormatter,     // sync
+ *   myAsyncEnrichmentFormatter, // async
  * ]);
  *
  * const exporter = new BraintrustExporter({
@@ -25,7 +34,11 @@ import type { AnyExportedSpan, CustomSpanFormatter } from '@mastra/core/observab
  * ```
  */
 export function chainFormatters(formatters: CustomSpanFormatter[]): CustomSpanFormatter {
-  return (span: AnyExportedSpan): AnyExportedSpan => {
-    return formatters.reduce((currentSpan, formatter) => formatter(currentSpan), span);
+  return async (span: AnyExportedSpan): Promise<AnyExportedSpan> => {
+    let currentSpan = span;
+    for (const formatter of formatters) {
+      currentSpan = await formatter(currentSpan);
+    }
+    return currentSpan;
   };
 }

--- a/observability/mastra/src/exporters/tracking.ts
+++ b/observability/mastra/src/exporters/tracking.ts
@@ -906,6 +906,10 @@ export abstract class TrackingExporter<
   /**
    * Hook called before processing each tracing event.
    * Override to transform or enrich the event before processing.
+   *
+   * Note: The customSpanFormatter is applied at the BaseExporter level before this hook.
+   * Subclasses can override this to add additional pre-processing logic.
+   *
    * @param event - The incoming tracing event
    * @returns The (possibly modified) event to process
    */

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -1195,7 +1195,7 @@ export interface SpanOutputProcessor {
  * @example
  * ```typescript
  * // Custom formatter that extracts plain text from AI messages
- * const plainTextFormatter: ExporterSpanFormatter = (span) => {
+ * const plainTextFormatter: CustomSpanFormatter = (span) => {
  *   if (span.type === SpanType.AGENT_RUN && Array.isArray(span.input)) {
  *     const userMessage = span.input.find(m => m.role === 'user');
  *     return {
@@ -1212,7 +1212,7 @@ export interface SpanOutputProcessor {
  * });
  * ```
  */
-export type ExporterSpanFormatter = (span: AnyExportedSpan) => AnyExportedSpan;
+export type CustomSpanFormatter = (span: AnyExportedSpan) => AnyExportedSpan;
 
 // ============================================================================
 // Tracing Config Selector Interfaces

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -1175,6 +1175,45 @@ export interface SpanOutputProcessor {
   shutdown(): Promise<void>;
 }
 
+/**
+ * Function type for formatting exported spans at the exporter level.
+ *
+ * This allows customization of how spans appear in vendor-specific observability platforms
+ * (e.g., Langfuse, Braintrust). Unlike SpanOutputProcessor which operates on the internal
+ * Span object before export, this formatter operates on the ExportedSpan data structure
+ * after the span has been prepared for export.
+ *
+ * Use cases:
+ * - Extract plain text from structured AI SDK messages for better readability
+ * - Transform input/output format for specific vendor requirements
+ * - Add or remove fields based on the target platform
+ * - Redact or transform sensitive data in a vendor-specific way
+ *
+ * @param span - The exported span to format
+ * @returns The formatted span (can be the same object with modifications, or a new object)
+ *
+ * @example
+ * ```typescript
+ * // Custom formatter that extracts plain text from AI messages
+ * const plainTextFormatter: ExporterSpanFormatter = (span) => {
+ *   if (span.type === SpanType.AGENT_RUN && Array.isArray(span.input)) {
+ *     const userMessage = span.input.find(m => m.role === 'user');
+ *     return {
+ *       ...span,
+ *       input: userMessage?.content ?? span.input,
+ *     };
+ *   }
+ *   return span;
+ * };
+ *
+ * // Use with an exporter
+ * new BraintrustExporter({
+ *   customSpanFormatter: plainTextFormatter,
+ * });
+ * ```
+ */
+export type ExporterSpanFormatter = (span: AnyExportedSpan) => AnyExportedSpan;
+
 // ============================================================================
 // Tracing Config Selector Interfaces
 // ============================================================================

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -1183,18 +1183,20 @@ export interface SpanOutputProcessor {
  * Span object before export, this formatter operates on the ExportedSpan data structure
  * after the span has been prepared for export.
  *
- * Use cases:
+ * Formatters can be synchronous or asynchronous, enabling use cases like:
  * - Extract plain text from structured AI SDK messages for better readability
  * - Transform input/output format for specific vendor requirements
  * - Add or remove fields based on the target platform
  * - Redact or transform sensitive data in a vendor-specific way
+ * - Enrich spans with data from external APIs (async)
+ * - Perform database lookups to add context (async)
  *
  * @param span - The exported span to format
- * @returns The formatted span (can be the same object with modifications, or a new object)
+ * @returns The formatted span (sync) or a Promise resolving to the formatted span (async)
  *
  * @example
  * ```typescript
- * // Custom formatter that extracts plain text from AI messages
+ * // Synchronous formatter that extracts plain text from AI messages
  * const plainTextFormatter: CustomSpanFormatter = (span) => {
  *   if (span.type === SpanType.AGENT_RUN && Array.isArray(span.input)) {
  *     const userMessage = span.input.find(m => m.role === 'user');
@@ -1206,13 +1208,22 @@ export interface SpanOutputProcessor {
  *   return span;
  * };
  *
+ * // Async formatter that enriches spans with external data
+ * const enrichmentFormatter: CustomSpanFormatter = async (span) => {
+ *   const userData = await fetchUserData(span.metadata?.userId);
+ *   return {
+ *     ...span,
+ *     metadata: { ...span.metadata, userName: userData.name },
+ *   };
+ * };
+ *
  * // Use with an exporter
  * new BraintrustExporter({
  *   customSpanFormatter: plainTextFormatter,
  * });
  * ```
  */
-export type CustomSpanFormatter = (span: AnyExportedSpan) => AnyExportedSpan;
+export type CustomSpanFormatter = (span: AnyExportedSpan) => AnyExportedSpan | Promise<AnyExportedSpan>;
 
 // ============================================================================
 // Tracing Config Selector Interfaces


### PR DESCRIPTION
Add ability to customize how spans are formatted before being sent to observability platforms like Braintrust, Langfuse, etc. This enables use cases like:
- Extracting plain text from AI SDK message arrays
- Transforming input/output format for vendor requirements
- Adding/removing fields based on target platform

Changes:
- Add ExporterSpanFormatter type to @mastra/core/observability
- Add customSpanFormatter config option to BaseExporterConfig
- Apply formatter in BaseExporter.exportTracingEvent
- Add chainFormatters utility
- Export formatters from @mastra/observability

## Related Issue(s)

This addresses the need described in issue #9822 where Braintrust displays raw JSON instead of human-readable text.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-exporter custom span formatter option for transforming spans before export.
  * chainFormatters utility to compose multiple formatters.
  * New public CustomSpanFormatter type.

* **Behavior**
  * Formatters run before exporter export hooks; async formatters supported. Formatter errors are logged and original span is preserved.

* **Documentation**
  * Expanded guides with examples for processors vs. per-exporter formatters, chaining, and async considerations.

* **Tests**
  * Comprehensive tests for formatting, chaining, selective application, error handling, and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->