### PR TITLE
refactor(playground-ui): extract shared style primitives for form components

### DIFF
--- a/.changeset/pretty-days-knock.md
+++ b/.changeset/pretty-days-knock.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Extracted shared style primitives for form components (Input, Button, Select, Popover, CombinedButtons) to reduce code duplication. Added new primitives in form-element.ts and created dropdown-content.ts for consistent dropdown styling across the design system.

--- a/packages/playground-ui/src/ds/components/Button/Button.tsx
+++ b/packages/playground-ui/src/ds/components/Button/Button.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
-import { formElementSizes, formElementFocus, type FormElementSize } from '@/ds/primitives/form-element';
+import {
+  formElementSizes,
+  formElementFocus,
+  formElementBorder,
+  formElementRadius,
+  formElementDisabled,
+  type FormElementSize,
+} from '@/ds/primitives/form-element';
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   as?: React.ElementType;
@@ -22,44 +29,32 @@ const sizeClasses = {
 };
 
 const variantClasses = {
-  default: 'bg-surface2 hover:bg-surface4 text-neutral3 hover:text-neutral6 disabled:opacity-50',
-  light: 'bg-surface3 hover:bg-surface5 text-neutral6 disabled:opacity-50',
-  outline: 'bg-transparent hover:bg-surface2 text-neutral3 hover:text-neutral6 disabled:opacity-50',
-  ghost: 'bg-transparent border-transparent hover:bg-surface2 text-neutral3 hover:text-neutral6 disabled:opacity-50',
+  default: 'bg-surface2 hover:bg-surface4 text-neutral3 hover:text-neutral6',
+  light: 'bg-surface3 hover:bg-surface5 text-neutral6',
+  outline: 'bg-transparent hover:bg-surface2 text-neutral3 hover:text-neutral6',
+  ghost: 'bg-transparent border-transparent hover:bg-surface2 text-neutral3 hover:text-neutral6',
 };
+
+const buttonBase = cn(
+  'px-2 text-ui-md inline-flex items-center justify-center',
+  formElementBorder,
+  formElementRadius,
+  formElementFocus,
+  formElementDisabled,
+);
 
 export function buttonVariants(options?: { variant?: ButtonProps['variant']; size?: ButtonProps['size'] }) {
   const variant = options?.variant || 'default';
   const size = options?.size || 'md';
 
-  return cn(
-    'bg-surface2 border border-border1 px-2 text-ui-md inline-flex items-center justify-center rounded-md border',
-    formElementFocus,
-    variantClasses[variant],
-    sizeClasses[size],
-  );
+  return cn(buttonBase, variantClasses[variant], sizeClasses[size]);
 }
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, as, size = 'md', variant = 'default', ...props }, ref) => {
     const Component = as || 'button';
 
-    return (
-      <Component
-        ref={ref}
-        className={cn(
-          'bg-surface2 border border-border1 px-2 text-ui-md inline-flex items-center justify-center rounded-md border',
-          formElementFocus,
-          variantClasses[variant],
-          sizeClasses[size],
-          className,
-          {
-            'cursor-not-allowed': props.disabled,
-          },
-        )}
-        {...props}
-      />
-    );
+    return <Component ref={ref} className={cn(buttonVariants({ variant, size }), className)} {...props} />;
   },
 );
 

--- a/packages/playground-ui/src/ds/components/CombinedButtons/combined-buttons.tsx
+++ b/packages/playground-ui/src/ds/components/CombinedButtons/combined-buttons.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils';
+import { formElementBorder } from '@/ds/primitives/form-element';
 import React from 'react';
 
 export interface CombinedButtonsProps {
@@ -10,7 +11,8 @@ export const CombinedButtons = ({ className, children }: CombinedButtonsProps) =
   return (
     <div
       className={cn(
-        'flex items-center text-ui-sm border border-border1 rounded-lg overflow-hidden',
+        'flex items-center text-ui-sm rounded-lg overflow-hidden',
+        formElementBorder,
         '[&>button]:border-0 [&>button:not(:first-child)]:border-l [&>button:not(:first-child)]:border-border1',
         '[&>button]:rounded-none [&>button:first-child]:rounded-l-lg [&>button:last-child]:rounded-r-lg',
         className,

--- a/packages/playground-ui/src/ds/components/Input/input.tsx
+++ b/packages/playground-ui/src/ds/components/Input/input.tsx
@@ -3,20 +3,32 @@ import type { VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
-import { formElementSizes, formElementFocus, formElementRadius } from '@/ds/primitives/form-element';
+import {
+  formElementSizes,
+  formElementFocus,
+  formElementRadius,
+  formElementBorder,
+  formElementDisabled,
+  formElementPlaceholder,
+  formElementShadow,
+  formElementBgTransparent,
+} from '@/ds/primitives/form-element';
 
 const inputVariants = cva(
   cn(
-    'flex w-full text-neutral6 border bg-transparent shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+    'flex w-full text-neutral6 transition-colors',
+    formElementBgTransparent,
+    formElementShadow,
     formElementRadius,
     formElementFocus,
+    formElementDisabled,
   ),
   {
     variants: {
       variant: {
-        default: 'border border-border1 placeholder:text-neutral3',
-        filled: 'border bg-inputFill border-border1 placeholder:text-neutral3',
-        unstyled: 'border-0 bg-transparent placeholder:text-neutral3',
+        default: cn(formElementBorder, formElementPlaceholder),
+        filled: cn('bg-inputFill', formElementBorder, formElementPlaceholder),
+        unstyled: cn('border-0', formElementBgTransparent, formElementPlaceholder),
       },
       size: {
         sm: `${formElementSizes.sm} px-2 text-ui-sm`,

--- a/packages/playground-ui/src/ds/components/Popover/popover.tsx
+++ b/packages/playground-ui/src/ds/components/Popover/popover.tsx
@@ -2,6 +2,7 @@ import * as PopoverPrimitive from '@radix-ui/react-popover';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import { dropdownContent } from '@/ds/primitives/dropdown-content';
 
 const Popover = PopoverPrimitive.Root;
 
@@ -16,11 +17,7 @@ const PopoverContent = React.forwardRef<
       ref={ref}
       align={align}
       sideOffset={sideOffset}
-      className={cn(
-        'z-50 w-72 rounded-md border border-border1 bg-surface3 text-neutral5 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className && /\bp-\S+/.test(className) ? false : `p-4`,
-        className,
-      )}
+      className={cn('z-50 w-72', dropdownContent, className && /\bp-\S+/.test(className) ? false : `p-4`, className)}
       {...props}
     />
   </PopoverPrimitive.Portal>

--- a/packages/playground-ui/src/ds/components/Select/select.tsx
+++ b/packages/playground-ui/src/ds/components/Select/select.tsx
@@ -7,8 +7,14 @@ import {
   formElementSizes,
   formElementFocus,
   formElementRadius,
+  formElementBorder,
+  formElementDisabled,
+  formElementPlaceholder,
+  formElementShadow,
+  formElementBgTransparent,
   type FormElementSize,
 } from '@/ds/primitives/form-element';
+import { dropdownContent } from '@/ds/primitives/dropdown-content';
 
 const Select = SelectPrimitive.Root;
 
@@ -31,9 +37,14 @@ const SelectTrigger = React.forwardRef<React.ElementRef<typeof SelectPrimitive.T
     <SelectPrimitive.Trigger
       ref={ref}
       className={cn(
-        'flex w-full items-center justify-between border border-border1 bg-transparent py-2 shadow-sm placeholder:text-neutral3 disabled:cursor-not-allowed disabled:opacity-50',
+        'flex w-full items-center justify-between py-2',
+        formElementBorder,
+        formElementBgTransparent,
+        formElementShadow,
         formElementRadius,
         formElementFocus,
+        formElementDisabled,
+        formElementPlaceholder,
         selectTriggerSizeClasses[size],
         className,
       )}
@@ -56,7 +67,8 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 min-w-[8rem] max-h-dropdown-max-height overflow-y-auto overflow-x-hidden rounded-md border border-border1 bg-surface3 text-neutral5 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'relative z-50 min-w-[8rem] max-h-dropdown-max-height overflow-y-auto overflow-x-hidden',
+        dropdownContent,
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className,

--- a/packages/playground-ui/src/ds/primitives/dropdown-content.ts
+++ b/packages/playground-ui/src/ds/primitives/dropdown-content.ts
@@ -1,0 +1,16 @@
+import { formElementBorder } from './form-element';
+
+// Base styles for dropdown content (Select, Popover)
+export const dropdownContentBase = `rounded-md ${formElementBorder} bg-surface3 text-neutral5 shadow-md`;
+
+// Animation classes for dropdown open/close transitions
+export const dropdownAnimations = [
+  'data-[state=open]:animate-in data-[state=closed]:animate-out',
+  'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+  'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+  'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
+  'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+].join(' ');
+
+// Combined base + animations for full dropdown content styling
+export const dropdownContent = `${dropdownContentBase} ${dropdownAnimations}`;

--- a/packages/playground-ui/src/ds/primitives/form-element.ts
+++ b/packages/playground-ui/src/ds/primitives/form-element.ts
@@ -9,4 +9,19 @@ export const formElementFocusWithin =
   'focus-within:outline focus-within:outline-1 focus-within:outline-accent1 focus-within:-outline-offset-2';
 export const formElementRadius = 'rounded-md';
 
+// Shared border style
+export const formElementBorder = 'border border-border1';
+
+// Disabled state
+export const formElementDisabled = 'disabled:cursor-not-allowed disabled:opacity-50';
+
+// Placeholder text color
+export const formElementPlaceholder = 'placeholder:text-neutral3';
+
+// Shadow for form inputs
+export const formElementShadow = 'shadow-sm';
+
+// Transparent background
+export const formElementBgTransparent = 'bg-transparent';
+
 export type FormElementSize = keyof typeof formElementSizes;


### PR DESCRIPTION
Extracted shared style primitives for form components to reduce code duplication across the design system.

**Changes:**
- Extended `form-element.ts` with new primitives: `formElementBorder`, `formElementDisabled`, `formElementPlaceholder`, `formElementShadow`, `formElementBgTransparent`
- Created `dropdown-content.ts` for consistent dropdown styling (Select, Popover)
- Updated Input, Button, Select, Popover, and CombinedButtons to use shared primitives
- Fixed Button component duplicate className definitions

No visual changes - all components maintain their existing appearance while sharing consistent, centralized styles.