### PR TITLE
Add flush method to observability instances

### DIFF
--- a/.changeset/add-flush-type-to-core.md
+++ b/.changeset/add-flush-type-to-core.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": minor
+---
+
+Added `flush()` method to `ObservabilityExporter`, `ObservabilityBridge`, and `ObservabilityInstance` interfaces

--- a/.changeset/add-observability-flush-method.md
+++ b/.changeset/add-observability-flush-method.md
@@ -1,5 +1,4 @@
 ---
-"@mastra/core": minor
 "@mastra/observability": patch
 "@mastra/otel-exporter": patch
 "@mastra/otel-bridge": patch
@@ -13,7 +12,7 @@
 "@mastra/langsmith": patch
 ---
 
-Added flush() method to observability exporters and instances for serverless environments
+Added `flush()` method to observability exporters and instances for serverless environments
 
 This feature allows flushing buffered spans without shutting down the exporter, which is useful in serverless environments like Vercel's fluid compute where runtime instances can be reused across multiple requests.
 
@@ -32,16 +31,5 @@ await exporters[0].flush();
 **Why this matters:**
 
 In serverless environments, you may need to ensure all spans are exported before the runtime instance is terminated, while keeping the exporter active for future requests. Unlike shutdown(), flush() does not release resources or prevent future exports.
-
-**Affected exporters:**
-- DefaultExporter (storage persistence)
-- CloudExporter (Mastra Cloud)
-- OtelExporter (OpenTelemetry)
-- OtelBridge (OpenTelemetry bridge)
-- DatadogExporter (Datadog LLM Observability)
-- LaminarExporter (Laminar)
-- SentryExporter (Sentry)
-- ArizeExporter (Arize Phoenix)
-- TrackingExporter and its subclasses (Langfuse, LangSmith, Braintrust, PostHog)
 
 Closes #11372

--- a/.changeset/add-observability-flush-method.md
+++ b/.changeset/add-observability-flush-method.md
@@ -1,10 +1,16 @@
 ---
 "@mastra/core": minor
-"@mastra/observability": minor
-"@mastra/otel-exporter": minor
-"@mastra/otel-bridge": minor
-"@mastra/langfuse": minor
-"@mastra/posthog": minor
+"@mastra/observability": patch
+"@mastra/otel-exporter": patch
+"@mastra/otel-bridge": patch
+"@mastra/langfuse": patch
+"@mastra/posthog": patch
+"@mastra/datadog": patch
+"@mastra/laminar": patch
+"@mastra/sentry": patch
+"@mastra/arize": patch
+"@mastra/braintrust": patch
+"@mastra/langsmith": patch
 ---
 
 Added flush() method to observability exporters and instances for serverless environments
@@ -32,6 +38,10 @@ In serverless environments, you may need to ensure all spans are exported before
 - CloudExporter (Mastra Cloud)
 - OtelExporter (OpenTelemetry)
 - OtelBridge (OpenTelemetry bridge)
+- DatadogExporter (Datadog LLM Observability)
+- LaminarExporter (Laminar)
+- SentryExporter (Sentry)
+- ArizeExporter (Arize Phoenix)
 - TrackingExporter and its subclasses (Langfuse, LangSmith, Braintrust, PostHog)
 
 Closes #11372

--- a/.changeset/add-observability-flush-method.md
+++ b/.changeset/add-observability-flush-method.md
@@ -1,0 +1,37 @@
+---
+"@mastra/core": minor
+"@mastra/observability": minor
+"@mastra/otel-exporter": minor
+"@mastra/otel-bridge": minor
+"@mastra/langfuse": minor
+"@mastra/posthog": minor
+---
+
+Added flush() method to observability exporters and instances for serverless environments
+
+This feature allows flushing buffered spans without shutting down the exporter, which is useful in serverless environments like Vercel's fluid compute where runtime instances can be reused across multiple requests.
+
+**New API:**
+
+```typescript
+// Flush all exporters via the observability instance
+const observability = mastra.getObservability();
+await observability.flush();
+
+// Or flush individual exporters
+const exporters = observability.getExporters();
+await exporters[0].flush();
+```
+
+**Why this matters:**
+
+In serverless environments, you may need to ensure all spans are exported before the runtime instance is terminated, while keeping the exporter active for future requests. Unlike shutdown(), flush() does not release resources or prevent future exports.
+
+**Affected exporters:**
+- DefaultExporter (storage persistence)
+- CloudExporter (Mastra Cloud)
+- OtelExporter (OpenTelemetry)
+- OtelBridge (OpenTelemetry bridge)
+- TrackingExporter and its subclasses (Langfuse, LangSmith, Braintrust, PostHog)
+
+Closes #11372

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -896,6 +896,54 @@ app.post("/api/analyze", async (req, res) => {
 
 This creates a single distributed trace that includes both the HTTP request handling and the Mastra agent execution, viewable in your observability platform of choice.
 
+## Flushing Traces in Serverless Environments
+
+In serverless environments like Vercel's fluid compute, AWS Lambda, or Cloudflare Workers, runtime instances can be reused across multiple requests. The `flush()` method allows you to ensure all buffered spans are exported before the runtime terminates, without shutting down the exporter (which would prevent future exports).
+
+### Using flush()
+
+Call `flush()` on the observability instance to flush all exporters:
+
+```ts
+// Get the observability instance from Mastra
+const observability = mastra.getObservability();
+
+// Flush all buffered spans to all exporters
+await observability.flush();
+```
+
+### When to Use flush()
+
+Use `flush()` in these scenarios:
+
+- **End of serverless function execution**: Ensure spans are exported before the runtime is paused or terminated
+- **Before long-running operations**: Flush accumulated spans before a potentially slow operation
+- **Periodic flushing**: In long-running processes, periodically flush to ensure timely data availability
+
+```ts
+// Example: Vercel serverless function
+export async function POST(req: Request) {
+  const result = await agent.generate({
+    messages: [{ role: "user", content: await req.text() }],
+  });
+
+  // Ensure spans are exported before function completes
+  const observability = mastra.getObservability();
+  await observability.flush();
+
+  return Response.json(result);
+}
+```
+
+### flush() vs shutdown()
+
+| Method | Behavior | Use Case |
+| --- | --- | --- |
+| `flush()` | Exports buffered spans, keeps exporter active | Serverless environments, periodic flushing |
+| `shutdown()` | Exports buffered spans, releases resources | Application shutdown, graceful termination |
+
+Use `flush()` when you need to ensure data is exported but want to keep the exporter ready for future requests. Use `shutdown()` only when the application is terminating.
+
 ## What Gets Traced
 
 Mastra automatically creates spans for:

--- a/docs/src/content/en/reference/observability/tracing/exporters/arize.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/arize.mdx
@@ -125,6 +125,14 @@ async export(spans: ReadOnlySpan[]): Promise<void>
 
 Batch exports spans using OpenTelemetry with OpenInference semantic conventions.
 
+### flush
+
+```typescript
+async flush(): Promise<void>
+```
+
+Force flushes any buffered spans to the configured endpoint without shutting down the exporter. Useful in serverless environments where you need to ensure spans are exported before the runtime terminates.
+
 ### shutdown
 
 ```typescript

--- a/docs/src/content/en/reference/observability/tracing/exporters/braintrust.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/braintrust.mdx
@@ -85,6 +85,14 @@ async export(spans: ReadOnlySpan[]): Promise<void>
 
 Batch exports spans to Braintrust.
 
+### flush
+
+```typescript
+async flush(): Promise<void>
+```
+
+Force flushes any buffered spans to Braintrust without shutting down the exporter. Useful in serverless environments where you need to ensure spans are exported before the runtime terminates.
+
 ### shutdown
 
 ```typescript

--- a/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
@@ -87,6 +87,14 @@ Processes tracing events. Only exports SPAN_ENDED events to Cloud.
   ]}
 />
 
+### flush
+
+```typescript
+async flush(): Promise<void>
+```
+
+Force flushes any buffered events to Mastra Cloud without shutting down the exporter. Useful in serverless environments where you need to ensure spans are exported before the runtime terminates.
+
 ### shutdown
 
 ```typescript

--- a/docs/src/content/en/reference/observability/tracing/exporters/datadog.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/datadog.mdx
@@ -93,6 +93,14 @@ async exportTracingEvent(event: TracingEvent): Promise<void>
 
 Exports a tracing event to Datadog LLM Observability.
 
+### flush
+
+```typescript
+async flush(): Promise<void>
+```
+
+Force flushes any buffered spans to Datadog without shutting down the exporter. Useful in serverless environments where you need to ensure spans are exported before the runtime terminates.
+
 ### shutdown
 
 ```typescript

--- a/docs/src/content/en/reference/observability/tracing/exporters/default-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/default-exporter.mdx
@@ -114,6 +114,14 @@ Processes a tracing event according to the resolved strategy.
   ]}
 />
 
+### flush
+
+```typescript
+async flush(): Promise<void>
+```
+
+Force flushes any buffered events to storage without shutting down the exporter. Useful in serverless environments where you need to ensure spans are exported before the runtime terminates.
+
 ### shutdown
 
 ```typescript

--- a/docs/src/content/en/reference/observability/tracing/exporters/laminar.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/laminar.mdx
@@ -99,6 +99,14 @@ async exportTracingEvent(event: TracingEvent): Promise<void>
 
 Exports a tracing event to Laminar.
 
+### flush
+
+```typescript
+async flush(): Promise<void>
+```
+
+Force flushes any buffered spans to Laminar without shutting down the exporter. Useful in serverless environments where you need to ensure spans are exported before the runtime terminates.
+
 ### shutdown
 
 ```typescript

--- a/docs/src/content/en/reference/observability/tracing/exporters/langfuse.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/langfuse.mdx
@@ -93,6 +93,14 @@ async export(spans: ReadOnlySpan[]): Promise<void>
 
 Batch exports spans to Langfuse.
 
+### flush
+
+```typescript
+async flush(): Promise<void>
+```
+
+Force flushes any buffered spans to Langfuse without shutting down the exporter. Useful in serverless environments where you need to ensure spans are exported before the runtime terminates.
+
 ### shutdown
 
 ```typescript

--- a/docs/src/content/en/reference/observability/tracing/exporters/langsmith.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/langsmith.mdx
@@ -93,6 +93,14 @@ async exportTracingEvent(event: TracingEvent): Promise<void>
 
 Exports a tracing event to LangSmith.
 
+### flush
+
+```typescript
+async flush(): Promise<void>
+```
+
+Force flushes any pending spans to LangSmith without shutting down the exporter. Useful in serverless environments where you need to ensure spans are exported before the runtime terminates.
+
 ### shutdown
 
 ```typescript

--- a/docs/src/content/en/reference/observability/tracing/exporters/otel.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/otel.mdx
@@ -263,6 +263,14 @@ async exportTracingEvent(event: TracingEvent): Promise<void>
 
 Exports a tracing event to the configured OTEL backend.
 
+### flush
+
+```typescript
+async flush(): Promise<void>
+```
+
+Force flushes any buffered spans to the OTEL backend without shutting down the exporter. Useful in serverless environments where you need to ensure spans are exported before the runtime terminates.
+
 ### shutdown
 
 ```typescript

--- a/docs/src/content/en/reference/observability/tracing/exporters/posthog.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/posthog.mdx
@@ -98,6 +98,14 @@ async exportTracingEvent(event: TracingEvent): Promise<void>
 
 Exports a tracing event to PostHog.
 
+### flush
+
+```typescript
+async flush(): Promise<void>
+```
+
+Force flushes any buffered events to PostHog without shutting down the exporter. Useful in serverless environments where you need to ensure spans are exported before the runtime terminates.
+
 ### shutdown
 
 ```typescript

--- a/docs/src/content/en/reference/observability/tracing/exporters/sentry.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/sentry.mdx
@@ -79,6 +79,14 @@ async exportTracingEvent(event: TracingEvent): Promise<void>
 
 Exports a tracing event to Sentry. Handles SPAN_STARTED, SPAN_UPDATED, and SPAN_ENDED events.
 
+### flush
+
+```typescript
+async flush(): Promise<void>
+```
+
+Force flushes any pending spans to Sentry without shutting down the exporter. Waits up to 2 seconds for pending data to be sent. Useful in serverless environments where you need to ensure spans are exported before the runtime terminates.
+
 ### shutdown
 
 ```typescript

--- a/docs/src/content/en/reference/observability/tracing/interfaces.mdx
+++ b/docs/src/content/en/reference/observability/tracing/interfaces.mdx
@@ -34,6 +34,9 @@ interface ObservabilityInstance {
     options: StartSpanOptions<TType>,
   ): Span<TType>;
 
+  /** Force flush any buffered spans without shutting down */
+  flush(): Promise<void>;
+
   /** Shutdown observability and clean up resources */
   shutdown(): Promise<void>;
 }
@@ -153,6 +156,9 @@ interface ObservabilityExporter {
     scorerName: string;
     metadata?: Record<string, any>;
   }): Promise<void>;
+
+  /** Force flush any buffered spans without shutting down */
+  flush(): Promise<void>;
 
   /** Shutdown exporter */
   shutdown(): Promise<void>;

--- a/observability/laminar/src/tracing.ts
+++ b/observability/laminar/src/tracing.ts
@@ -418,6 +418,22 @@ export class LaminarExporter extends BaseExporter {
     }
   }
 
+  /**
+   * Force flush any buffered spans without shutting down the exporter.
+   * This is useful in serverless environments where you need to ensure spans
+   * are exported before the runtime instance is terminated.
+   */
+  async flush(): Promise<void> {
+    if (this.isDisabled || !this.processor) return;
+
+    try {
+      await this.processor.forceFlush();
+      this.logger.debug('[LaminarExporter] Flushed pending spans');
+    } catch (error) {
+      this.logger.error('[LaminarExporter] Error flushing spans', { error });
+    }
+  }
+
   async shutdown(): Promise<void> {
     try {
       await this.processor?.shutdown();

--- a/observability/langfuse/src/tracing.ts
+++ b/observability/langfuse/src/tracing.ts
@@ -365,6 +365,15 @@ export class LangfuseExporter extends TrackingExporter<
     }
   }
 
+  /**
+   * Force flush any buffered data to Langfuse without shutting down.
+   */
+  protected override async _flush(): Promise<void> {
+    if (this.#client) {
+      await this.#client.flushAsync();
+    }
+  }
+
   override async _postShutdown(): Promise<void> {
     if (this.#client) {
       await this.#client.shutdownAsync();

--- a/observability/mastra/src/exporters/base.ts
+++ b/observability/mastra/src/exporters/base.ts
@@ -157,6 +157,19 @@ export abstract class BaseExporter implements ObservabilityExporter {
   }): Promise<void>;
 
   /**
+   * Force flush any buffered/queued spans without shutting down the exporter.
+   *
+   * This is useful in serverless environments where you need to ensure spans
+   * are exported before the runtime instance is terminated, while keeping
+   * the exporter active for future requests.
+   *
+   * Default implementation is a no-op. Override to add flush logic.
+   */
+  async flush(): Promise<void> {
+    this.logger.debug(`${this.name} flush called (no-op in base class)`);
+  }
+
+  /**
    * Shutdown the exporter and clean up resources
    *
    * Default implementation just logs. Override to add custom cleanup.

--- a/observability/mastra/src/exporters/tracking.ts
+++ b/observability/mastra/src/exporters/tracking.ts
@@ -1241,8 +1241,33 @@ export abstract class TrackingExporter<
   }
 
   // ============================================================================
-  // Shutdown Hooks (Override in subclass as needed)
+  // Flush and Shutdown Hooks (Override in subclass as needed)
   // ============================================================================
+
+  /**
+   * Hook called by flush() to perform vendor-specific flush logic.
+   * Override to send buffered data to the vendor's API.
+   *
+   * Unlike _postShutdown(), this method should NOT release resources,
+   * as the exporter will continue to be used after flushing.
+   */
+  protected async _flush(): Promise<void> {}
+
+  /**
+   * Force flush any buffered data without shutting down the exporter.
+   * This is useful in serverless environments where you need to ensure spans
+   * are exported before the runtime instance is terminated.
+   *
+   * Subclasses should override _flush() to implement vendor-specific flush logic.
+   */
+  async flush(): Promise<void> {
+    if (this.isDisabled) {
+      return;
+    }
+
+    this.logger.debug(`${this.name}: Flushing`);
+    await this._flush();
+  }
 
   /**
    * Hook called at the start of shutdown, before cancelling timers and aborting spans.

--- a/observability/otel-exporter/src/tracing.ts
+++ b/observability/otel-exporter/src/tracing.ts
@@ -211,6 +211,17 @@ export class OtelExporter extends BaseExporter {
     }
   }
 
+  /**
+   * Force flush any buffered spans without shutting down the exporter.
+   * Delegates to the BatchSpanProcessor's forceFlush() method.
+   */
+  async flush(): Promise<void> {
+    if (this.processor) {
+      await this.processor.forceFlush();
+      this.logger.debug('[OtelExporter] Flushed pending spans');
+    }
+  }
+
   async shutdown(): Promise<void> {
     // Shutdown the processor to flush any remaining spans
     if (this.processor) {

--- a/observability/posthog/src/tracing.ts
+++ b/observability/posthog/src/tracing.ts
@@ -512,6 +512,15 @@ export class PosthogExporter extends TrackingExporter<
     }
   }
 
+  /**
+   * Force flush any buffered data to PostHog without shutting down.
+   */
+  protected override async _flush(): Promise<void> {
+    if (this.#client) {
+      await this.#client.flush();
+    }
+  }
+
   override async _postShutdown(): Promise<void> {
     if (this.#client) {
       await this.#client.shutdown();

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -646,6 +646,18 @@ export interface ObservabilityInstance {
   rebuildSpan<TType extends SpanType>(cached: ExportedSpan<TType>): Span<TType>;
 
   /**
+   * Force flush any buffered/queued spans from all exporters and the bridge
+   * without shutting down the observability instance.
+   *
+   * This is useful in serverless environments (like Vercel's fluid compute) where
+   * you need to ensure all spans are exported before the runtime instance is
+   * terminated, while keeping the observability system active for future requests.
+   *
+   * Unlike shutdown(), flush() does not release resources or prevent future tracing.
+   */
+  flush(): Promise<void>;
+
+  /**
    * Shutdown tracing and clean up resources
    */
   shutdown(): Promise<void>;
@@ -1103,6 +1115,16 @@ export interface ObservabilityExporter {
     metadata?: Record<string, any>;
   }): Promise<void>;
 
+  /**
+   * Force flush any buffered/queued spans without shutting down the exporter.
+   * This is useful in serverless environments where you need to ensure spans
+   * are exported before the runtime instance is terminated, while keeping
+   * the exporter active for future requests.
+   *
+   * Unlike shutdown(), flush() does not release resources or prevent future exports.
+   */
+  flush(): Promise<void>;
+
   /** Shutdown exporter */
   shutdown(): Promise<void>;
 }
@@ -1158,6 +1180,16 @@ export interface ObservabilityBridge {
    * @returns Span identifiers (spanId, traceId, parentSpanId) from bridge, or undefined if creation fails
    */
   createSpan(options: CreateSpanOptions<SpanType>): SpanIds | undefined;
+
+  /**
+   * Force flush any buffered/queued spans without shutting down the bridge.
+   * This is useful in serverless environments where you need to ensure spans
+   * are exported before the runtime instance is terminated, while keeping
+   * the bridge active for future requests.
+   *
+   * Unlike shutdown(), flush() does not release resources or prevent future exports.
+   */
+  flush(): Promise<void>;
 
   /** Shutdown bridge and cleanup resources */
   shutdown(): Promise<void>;


### PR DESCRIPTION
## Description

Added flush() method to observability exporters and instances for serverless environments

This feature allows flushing buffered spans without shutting down the exporter, which is useful in serverless environments like Vercel's fluid compute where runtime instances can be reused across multiple requests.

**New API:**

```typescript
// Flush all exporters via the observability instance
const observability = mastra.getObservability();
await observability.flush();

// Or flush individual exporters
const exporters = observability.getExporters();
await exporters[0].flush();
```

**Why this matters:**

In serverless environments, you may need to ensure all spans are exported before the runtime instance is terminated, while keeping the exporter active for future requests. Unlike shutdown(), flush() does not release resources or prevent future exports.

## Related Issue(s)

Closes: #11372

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public flush() API to the observability instance, bridge, and individual exporters to force-send buffered spans without shutting down.
  * Flush is safe for reused/serverless runtimes and preserves exporter lifecycle for future exports.

* **Documentation**
  * Added guidance and reference docs describing flush usage, behavior, and serverless examples across all exporters.

* **Tests**
  * Added and updated tests covering flush behavior and its interaction with shutdown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->