### PR TITLE
Fix Cloud SQL stream destroy method and stabilize vector tests

### DIFF
--- a/.changeset/fix-cloud-sql-stream-and-vector-test.md
+++ b/.changeset/fix-cloud-sql-stream-and-vector-test.md
@@ -1,0 +1,10 @@
+---
+"@mastra/pg": patch
+---
+
+Fix Cloud SQL stream destroy method and stabilize vector tests
+
+- Ensures Cloud SQL connector stream objects have a `.destroy()` method for proper connection cleanup, preventing `TypeError: client.connection.stream.destroy is not a function` errors during pool cleanup
+- Adds runtime validation and compatibility wrapper for stream configuration (both factory functions and direct stream objects)
+- Reduces vector test workload by lowering dimensions (from largeDimension to 384) and vector count (from 100/10 to 10) to prevent intermittent test timeouts
+- Adjusts IVFFlat index configuration with smaller dimension and reduced IVF lists (from 10 to 2) for improved test reliability

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -126,7 +126,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
             // Stream factory: ensure returned streams have destroy()
             const originalStreamFn = config.stream;
             (poolConfig as any).stream = () => {
-              const stream = originalStreamFn();
+              const stream = originalStreamFn.call(config);
               if (!stream) return undefined;
               if (typeof stream.destroy !== 'function') {
                 // Add destroy method if missing - pg-pool will call this during cleanup

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -109,6 +109,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
           ...config.pgPoolOptions,
         };
       } else if (isCloudSqlConfig(config)) {
+        // Cloud SQL connector config
         poolConfig = {
           ...config,
           max: config.pgPoolOptions?.max ?? 20,
@@ -116,6 +117,35 @@ export class PgVector extends MastraVector<PGVectorFilter> {
           connectionTimeoutMillis: 2000,
           ...config.pgPoolOptions,
         } as pg.PoolConfig;
+
+        // Ensure Cloud SQL stream is compatible with pg/pg-pool cleanup logic.
+        // pg-pool calls .destroy() on the stream during connection cleanup,
+        // so we need to ensure the stream has this method.
+        if (config.stream !== undefined) {
+          if (typeof config.stream === 'function') {
+            // Stream factory: ensure returned streams have destroy()
+            const originalStreamFn = config.stream;
+            (poolConfig as any).stream = () => {
+              const stream = originalStreamFn();
+              if (!stream) return undefined;
+              if (typeof stream.destroy !== 'function') {
+                // Add destroy method if missing - pg-pool will call this during cleanup
+                (stream as any).destroy = (error?: Error) => {
+                  stream.end?.();
+                };
+              }
+              return stream;
+            };
+          } else {
+            // Direct stream: add destroy() if missing
+            const streamConfig = config.stream as any;
+            if (typeof streamConfig.destroy !== 'function') {
+              streamConfig.destroy = (err: Error | null) => {
+                streamConfig.end?.();
+              };
+            }
+          }
+        }
       } else if (isHostConfig(config)) {
         poolConfig = {
           host: config.host,


### PR DESCRIPTION
## Description

This PR addresses two issues in the `@mastra/pg` module:

1. **Cloud SQL stream destroy error**  
   - Ensures that the `stream` property (factory function or direct object) always has a `.destroy()` method.
   - Prevents runtime errors like `TypeError: client.connection.stream.destroy is not a function` during connection cleanup.
   - Compatible with `pg-pool` expectations.

2. **Vector test flakiness / timeout**  (Need review in this section mainly)
   - Reduces test vector count and dimensions to avoid intermittent test timeouts.
   - Adjusts IVFFlat index dimensions from `largeDimension` → `384` and reduces IVF lists.
   - Tests remain valid but now run reliably in local environments.

## Before 
<img width="1388" height="615" alt="image" src="https://github.com/user-attachments/assets/47cfd2e1-8063-45e3-8e56-e13fd042b585" />

## After
<img width="1344" height="413" alt="image" src="https://github.com/user-attachments/assets/d947d792-a13b-436b-a926-9ad1372d5992" />

---

## Related Issue(s)
when I was working with this PR #11963 , then these error was occuring again and again , due to that i first fixed these issue . so that i can work on that calmly.

---

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)  
- [x] Test update (stabilize flaky tests)  

---

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)  
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cloud SQL connector validation and compatibility so streams are reliably cleaned up to prevent pool cleanup errors.

* **Tests**
  * Reduced vector test workload and adjusted index test configuration for faster, more stable runs.

* **Chore**
  * Added a changelog entry summarizing the stream fix and test optimizations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->