### PR TITLE
(docs) Document workflow run result type narrowing behavior 

### DIFF
--- a/docs/src/content/en/docs/workflows/error-handling.mdx
+++ b/docs/src/content/en/docs/workflows/error-handling.mdx
@@ -69,7 +69,7 @@ For scenarios where you need to handle workflow completion without awaiting the 
 
 Called when a workflow completes with any status (success, failed, suspended, or tripwire):
 
-```typescript {8-15} title="src/mastra/workflows/order-workflow.ts"
+```typescript {8-17} title="src/mastra/workflows/order-workflow.ts"
 import { createWorkflow } from "@mastra/core/workflows";
 import { z } from "zod";
 
@@ -79,7 +79,9 @@ const orderWorkflow = createWorkflow({
   outputSchema: z.object({ orderId: z.string(), status: z.string() }),
   options: {
     onFinish: async (result) => {
-      await db.updateOrderStatus(result.result?.orderId, result.status);
+      if (result.status === 'success') {
+        await db.updateOrderStatus(result.result.orderId, result.status);
+      }
       await analytics.track('workflow_completed', {
         workflowId: 'order-processing',
         status: result.status,

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -244,11 +244,39 @@ for await (const chunk of result.fullStream) {
 
 ### Workflow status types
 
-When running a workflow, its `status` can be `running`, `suspended`, `success`, or `failed`.
+When running a workflow, its `status` can be `success`, `failed`, `suspended`, `tripwire`, or `paused`.
+
+### Workflow result type
+
+The return type of `run.start()` is a discriminated union based on the `status` property. You can always safely access `result.status`, `result.input`, `result.steps`, and optionally `result.state` regardless of the status.
+
+Additionally, depending on the status, different properties are available:
+
+| Status      | Unique properties               | Description                                              |
+| ----------- | ------------------------------- | -------------------------------------------------------- |
+| `success`   | `result`                        | The workflow's output data                               |
+| `failed`    | `error`                         | The error that caused the failure                        |
+| `tripwire`  | `tripwire`                      | Contains `reason`, `retry?`, `metadata?`, `processorId?` |
+| `suspended` | `suspendPayload`, `suspended`   | Suspension data and array of suspended step paths        |
+| `paused`    | _(none)_                        | Only common properties available                         |
+
+To access status-specific properties, check the `status` first:
+
+```typescript
+const result = await run.start({ inputData: { message: "Hello world" } });
+
+if (result.status === "success") {
+  console.log(result.result); // Only available when status is "success"
+} else if (result.status === "failed") {
+  console.log(result.error.message);
+} else if (result.status === "suspended") {
+  console.log(result.suspendPayload);
+}
+```
 
 ### Workflow output
 
-The workflow output includes the full execution lifecycle, showing the input and output for each step. It also includes the status of each step, the overall workflow status, and the final result. This gives you clear insight into how data moved through the workflow, what each step produced, and how the workflow completed.
+Here's an example of a successful workflow result, showing the `input`, `steps`, and `result` properties:
 
 ```json
 {
@@ -261,7 +289,7 @@ The workflow output includes the full execution lifecycle, showing the input and
       },
       "output": {
         "formatted": "HELLO WORLD"
-      },
+      }
     },
     "step-2": {
       "status": "success",
@@ -270,7 +298,7 @@ The workflow output includes the full execution lifecycle, showing the input and
       },
       "output": {
         "emphasized": "HELLO WORLD!!!"
-      },
+      }
     }
   },
   "input": {

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -219,36 +219,41 @@ const result = await run.start({
   }
 });
 
-console.log(result);
+if (result.status === "success") {
+  console.log(result.result);
+}
 ```
   </TabItem>
   <TabItem value="stream" label="Stream">
-Create a workflow run instance using `.createRun()`, then call `.stream()` with `inputData` matching the workflow's `inputSchema`. The workflow emits events as each step executes, which you can iterate over to track progress.
+Create a workflow run instance using `.createRun()`, then call `.stream()` with `inputData` matching the workflow's `inputSchema`. Iterate over `fullStream` to track progress, then await `result` to get the final workflow result.
 
 ```typescript
 const run = await testWorkflow.createRun();
 
-const result = await run.stream({
+const stream = await run.stream({
   inputData: {
     message: "Hello world"
   }
 });
 
-for await (const chunk of result.fullStream) {
+for await (const chunk of stream.fullStream) {
   console.log(chunk);
+}
+
+// Get the final result (same type as run.start())
+const result = await stream.result;
+
+if (result.status === "success") {
+  console.log(result.result);
 }
 ```
   </TabItem>
 </Tabs>
 
 
-### Workflow status types
-
-When running a workflow, its `status` can be `success`, `failed`, `suspended`, `tripwire`, or `paused`.
-
 ### Workflow result type
 
-The return type of `run.start()` is a discriminated union based on the `status` property. You can always safely access `result.status`, `result.input`, `result.steps`, and optionally `result.state` regardless of the status.
+Both `run.start()` and `stream.result` return a discriminated union based on the `status` property, which can be `success`, `failed`, `suspended`, `tripwire`, or `paused`. You can always safely access `result.status`, `result.input`, `result.steps`, and optionally `result.state` regardless of the status.
 
 Additionally, depending on the status, different properties are available:
 

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -230,7 +230,7 @@ Create a workflow run instance using `.createRun()`, then call `.stream()` with 
 ```typescript
 const run = await testWorkflow.createRun();
 
-const stream = await run.stream({
+const stream = run.stream({
   inputData: {
     message: "Hello world"
   }

--- a/docs/src/content/en/docs/workflows/time-travel.mdx
+++ b/docs/src/content/en/docs/workflows/time-travel.mdx
@@ -164,18 +164,20 @@ Use `timeTravelStream()` to receive streaming events during time travel executio
 ```typescript
 const run = await workflow.createRun();
 
-const output = run.timeTravelStream({
+const stream = run.timeTravelStream({
   step: "step2",
   inputData: { value: 10 },
 });
 
-// Access the stream
-for await (const event of output.fullStream) {
+for await (const event of stream.fullStream) {
   console.log(event.type, event.payload);
 }
 
-// Get final result
-const result = await output.result;
+const result = await stream.result;
+
+if (result.status === "success") {
+  console.log(result.result);
+}
 ```
 
 ## Time travel with initial state


### PR DESCRIPTION
inspired by this question https://github.com/mastra-ai/mastra/issues/11892


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow streaming patterns to use stream.result for final outcomes.
  * Expanded workflow status model to include: success, failed, suspended, tripwire, and paused statuses with status-specific properties.
  * Added status-specific access examples for handling different workflow outcomes.
  * Clarified error-handling guidance with conditional database updates based on workflow status.
  * Updated time-travel streaming examples with refined access patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->