### PR TITLE
fix: resolve type inference issue by importing from 'zod' instead of 'zod/v3'

### DIFF
--- a/.changeset/petite-yaks-wait.md
+++ b/.changeset/petite-yaks-wait.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix type recursion by importing from 'zod' instead of 'zod/v3'

--- a/e2e-tests/commonjs/commonjs.test.ts
+++ b/e2e-tests/commonjs/commonjs.test.ts
@@ -15,6 +15,7 @@ describe('commonjs', () => {
     console.log('registry', registry);
     console.log('tag', tag);
     fixturePath = await mkdtemp(join(tmpdir(), 'mastra-commonjs-test-'));
+    console.log('fixturePath', fixturePath);
 
     process.env.npm_config_registry = registry;
     await setupTestProject(fixturePath);

--- a/packages/core/src/types/zod-compat.ts
+++ b/packages/core/src/types/zod-compat.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod/v3';
+import type { z } from 'zod';
 
 /**
  * Type compatibility layer for Zod v3 and v4

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { CoreMessage } from '@internal/ai-sdk-v4';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 import { Agent } from '../../agent';
 import type { MastraDBMessage } from '../../agent';
 import { MessageList } from '../../agent/message-list';

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -1,6 +1,6 @@
 import type { WritableStream } from 'node:stream/web';
 import type { TextStreamPart } from '@internal/ai-sdk-v4';
-import type { z } from 'zod/v3';
+import type { z } from 'zod';
 import type { SerializedError } from '../error';
 import type { MastraScorers } from '../evals';
 import type { PubSub } from '../events/pubsub';


### PR DESCRIPTION
Fixes a type recursion issue caused by importing from `zod/v3` subpath. Changed the imports to use `zod` directly.

```ts
// before
import type { z } from 'zod/v3';

// after  
import type { z } from 'zod';
```

This was causing TypeScript to struggle with type inference in downstream projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved type recursion issues in Zod schema compatibility.

* **Chores**
  * Updated module import paths for enhanced compatibility.
  * Enhanced debugging capabilities in the test suite.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->