### PR TITLE
fix(docs): CSS fixes for ToC scrolling, pagination, and inline code overflow

### DIFF
--- a/docs/src/components/feedback-form.tsx
+++ b/docs/src/components/feedback-form.tsx
@@ -199,7 +199,7 @@ export const FeedbackForm = ({
                 className="flex items-start gap-0 flex-col"
               >
                 <span className="text-lg font-semibold">Share feedback</span>
-                <span className="text-xs text(--mastra-text-secondary)">
+                <span className="text-xs text-(--mastra-text-secondary)">
                   Tell us how this can be better.
                 </span>
               </Label>
@@ -243,7 +243,7 @@ export const FeedbackForm = ({
                     <FormControl>
                       <Textarea
                         placeholder="Your feedback..."
-                        className="min-h-[80px] w-full text-black dark:text-white resize-none text-sm"
+                        className="min-h-20 w-full text-black dark:text-white resize-none text-sm"
                         {...field}
                       />
                     </FormControl>

--- a/docs/src/components/feedback-trigger.tsx
+++ b/docs/src/components/feedback-trigger.tsx
@@ -34,10 +34,10 @@ export const FeedbackTrigger: React.FC = () => {
         </Button>
       </DialogTrigger>
       <DialogPortal>
-        <DialogOverlay className="fixed inset-0 transition-opacity z-250 bg-black/40" />
+        <DialogOverlay className="fixed inset-0 transition-opacity z-250 bg-black/50 backdrop-blur-[2px]" />
         <DialogContent className="dialog-panel data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 z-260 fixed left-1/2 top-[200px] -translate-x-1/2">
           <div className="flex relative top-1/2 justify-center items-start p-4 min-h-full">
-            <div className="ring ring-neutral-200 dark:ring-(--border) shadow-2xl duration-150 ease-out data-closed:transform-[scale(95%)] data-closed:opacity-0 dark:border-(--border) h-fit w-[448px] mx-auto rounded-xl bg-(--ifm-background-color) dark:bg-(--mastra-surface-2) transition-all">
+            <div className="ring ring-neutral-200 dark:ring-(--border) shadow-2xl duration-150 ease-out data-closed:transform-[scale(95%)] data-closed:opacity-0 dark:border-(--border) h-fit w-md mx-auto rounded-xl bg-(--ifm-background-color) dark:bg-(--mastra-surface-2) transition-all">
               <DialogTitle className="sr-only">Send Feedback</DialogTitle>
               <div className="w-full">
                 <FeedbackForm

--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -193,7 +193,7 @@ for await (const chunk of stream.textStream) {
 }
 ```
 
-### Completion using `onFinish()`
+<h3 id="#completion-using-onfinish">Completion using `onFinish()`</h3>
 
 When streaming responses, the `onFinish()` callback runs after the LLM finishes generating its response and all tool executions are complete.
 It provides the final `text`, execution `steps`, `finishReason`, token `usage` statistics, and other metadata useful for monitoring or logging.

--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -193,7 +193,7 @@ for await (const chunk of stream.textStream) {
 }
 ```
 
-<h3 id="#completion-using-onfinish">Completion using `onFinish()`</h3>
+<h3 id="completion-using-onfinish">Completion using `onFinish()`</h3>
 
 When streaming responses, the `onFinish()` callback runs after the LLM finishes generating its response and all tool executions are complete.
 It provides the final `text`, execution `steps`, `finishReason`, token `usage` statistics, and other metadata useful for monitoring or logging.

--- a/docs/src/content/en/docs/agents/structured-output.mdx
+++ b/docs/src/content/en/docs/agents/structured-output.mdx
@@ -208,11 +208,7 @@ console.log(response.object);
 
 :::info[Gemini 2.5 with tools]
 
-Gemini 2.5 models do not support combining `response_format` (structured output) with function calling (tools) in the same API call. If your agent has tools and you're using `structuredOutput` with a Gemini 2.5 model, you must set `jsonPromptInjection: true` to avoid the error:
-
-```
-Function calling with a response mime type: 'application/json' is unsupported
-```
+Gemini 2.5 models do not support combining `response_format` (structured output) with function calling (tools) in the same API call. If your agent has tools and you're using `structuredOutput` with a Gemini 2.5 model, you must set `jsonPromptInjection: true` to avoid the error `Function calling with a response mime type: 'application/json' is unsupported`.
 
 ```typescript
 const response = await agentWithTools.generate("Your prompt", {

--- a/docs/src/content/en/docs/rag/vector-databases.mdx
+++ b/docs/src/content/en/docs/rag/vector-databases.mdx
@@ -49,7 +49,7 @@ await store.upsert({
 });
 ```
 
-### Using MongoDB Atlas Vector search
+<h3>Using MongoDB Atlas Vector search</h3>
 
 For detailed setup instructions and best practices, see the [official MongoDB Atlas Vector Search documentation](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-overview/?utm_campaign=devrel&utm_source=third-party-content&utm_medium=cta&utm_content=mastra-docs).
 
@@ -77,7 +77,7 @@ await store.upsert({
 });
 ```
 
-### Using PostgreSQL with pgvector
+<h3>Using PostgreSQL with pgvector</h3>
 
 PostgreSQL with the pgvector extension is a good solution for teams already using PostgreSQL who want to minimize infrastructure complexity.
 For detailed setup instructions and best practices, see the [official pgvector repository](https://github.com/pgvector/pgvector).
@@ -345,7 +345,7 @@ await store.upsert({
 });
 ```
 
-### Using LanceDB
+<h3>Using LanceDB</h3>
 
 LanceDB is an embedded vector database built on the Lance columnar format, suitable for local development or cloud deployment.
 For detailed setup instructions and best practices, see the [official LanceDB documentation](https://lancedb.github.io/lancedb/).

--- a/docs/src/content/en/guides/deployment/digital-ocean.mdx
+++ b/docs/src/content/en/guides/deployment/digital-ocean.mdx
@@ -19,18 +19,18 @@ For more information on how to create a new Mastra application,
 refer to our [getting started guide](/guides/v1/getting-started/quickstart)
 :::
 
+## Instructions
+
 <Tabs>
 
   <TabItem value="app-platform" label="App Platform">
 
-## App Platform
-
-### Prerequisites
+<h3>Prerequisites</h3>
 
 - A Git repository containing your Mastra application. This can be a [GitHub](https://github.com/) repository, [GitLab](https://gitlab.com/) repository, or any other compatible source provider.
 - A [Digital Ocean account](https://www.digitalocean.com/)
 
-### Deployment Steps
+<h3>Deployment Steps</h3>
 
 <Steps>
 
@@ -105,11 +105,9 @@ The Digital Ocean App Platform uses an ephemeral file system, meaning that any f
 
   <TabItem value="droplets" label="Droplets">
 
-## Droplets
-
 Deploy your Mastra application to Digital Ocean's Droplets.
 
-### Prerequisites
+<h3>Prerequisites</h3>
 
 - A [Digital Ocean account](https://www.digitalocean.com/)
 - A [Droplet](https://docs.digitalocean.com/products/droplets/) running Ubuntu 24+
@@ -118,7 +116,7 @@ Deploy your Mastra application to Digital Ocean's Droplets.
 - SSL certificate configured (e.g., using [Let's Encrypt](https://letsencrypt.org/))
 - Node.js 22.13.0 or later installed on your droplet
 
-### Deployment Steps
+<h3>Deployment Steps</h3>
 
 <Steps>
 

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -828,10 +828,9 @@ kbd {
   article p code,
   article li code,
   article td code {
-    font-size: 0.875rem;
+    font-size: 0.875em;
     padding: 0.12em 0.25em;
-    border-radius: 0.375rem;
-    white-space: nowrap;
+    border-radius: 0.375em;
     background: color-mix(in oklab, #000 3%, transparent);
     border: 1px solid color-mix(in oklab, #000 4%, transparent);
   }

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -1253,14 +1253,16 @@ kbd {
 
   .theme-doc-toc-desktop.theme-doc-toc-desktop {
     position: static !important;
+    overflow-y: unset !important;
+    max-height: none !important;
   }
 
-  .toc-wrapper,
   #toc-column {
     position: sticky;
     overflow-y: auto;
     top: calc(var(--ifm-navbar-height) + 2rem);
     max-height: calc(100vh - var(--ifm-navbar-height) - 8rem);
+    scrollbar-width: thin;
   }
 
   .menu__link--sublist {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -744,30 +744,6 @@ kbd {
     justify-content: space-between;
   }
 
-  .pagination-nav a {
-    text-decoration: none;
-  }
-
-  .pagination-nav__link:not(.pagination-nav__link--next) {
-    padding-inline-start: 0px;
-  }
-
-  .pagination-nav__link--next:is(.pagination-nav__link--next) {
-    padding-inline-end: 0px;
-  }
-
-  .pagination-nav__label.pagination-nav__label {
-    padding-inline-start: 0px;
-
-    &::before {
-      content: "";
-    }
-
-    &::after {
-      content: "";
-    }
-  }
-
   /* Highlighted lines in code blocks */
   .theme-code-block-highlighted-line {
     box-shadow: 2px 0 var(--mastra-green-accent-2) inset;

--- a/docs/src/theme/DocItem/Layout/index.tsx
+++ b/docs/src/theme/DocItem/Layout/index.tsx
@@ -64,7 +64,7 @@ export default function DocItemLayout({ children }: Props): ReactNode {
 
       {docTOC.desktop ? (
         <div id="toc-column" className={clsx("col col--3")}>
-          <div className="">{docTOC.desktop}</div>
+          {docTOC.desktop}
         </div>
       ) : (
         <div id="toc-column" className={clsx("col col--3")}>

--- a/docs/src/theme/DocItem/TOC/Desktop/index.tsx
+++ b/docs/src/theme/DocItem/TOC/Desktop/index.tsx
@@ -9,7 +9,7 @@ import TOC from "@theme/TOC";
 export default function DocItemTOCDesktop(): ReactNode {
   const { toc, frontMatter } = useDoc();
   return (
-    <div className="toc-wrapper">
+    <>
       <div className="flex items-center text-(--mastra-text-secondary) gap-1.5">
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -39,6 +39,6 @@ export default function DocItemTOCDesktop(): ReactNode {
         {/* TODO: Move feedback to side footer */}
         <FeedbackTrigger />
       </div>
-    </div>
+    </>
   );
 }

--- a/docs/src/theme/Navbar/Search/index.tsx
+++ b/docs/src/theme/Navbar/Search/index.tsx
@@ -95,7 +95,7 @@ export default function SearchContainer({ locale }: { locale: string }) {
         </Button>
       </DialogTrigger>
       <DialogPortal>
-        <DialogOverlay className="fixed inset-0 transition-opacity z-250 bg-black/40 backdrop-blur-[2px]">
+        <DialogOverlay className="fixed inset-0 transition-opacity z-250 bg-black/50 backdrop-blur-[2px]">
           <DialogContent className="dialog-panel p-6 z-260 relative my-8 lg:my-[15vh] mx-auto max-w-2xl">
             <DialogTitle className="sr-only">Search documentation</DialogTitle>
             <div className="w-full shadow-2xl duration-150 ease-out dark:border-(--border) h-fit mx-auto rounded-xl bg-(--ifm-background-color) dark:bg-(--mastra-surface-2) transition-all">

--- a/docs/src/theme/PaginatorNavLink/index.tsx
+++ b/docs/src/theme/PaginatorNavLink/index.tsx
@@ -7,40 +7,45 @@ export default function PaginatorNavLink(props: Props): ReactNode {
   const { permalink, title, subLabel, isNext } = props;
   return (
     <Link
-      className={cn("flex flex-col", isNext ? "items-baseline" : "")}
+      className={cn(
+        "flex items-center hover:no-underline! gap-2 py-4",
+        isNext ? "flex-row-reverse pl-4 2xl:-mr-8" : "flex-row pr-4 2xl:-ml-8",
+      )}
       to={permalink}
     >
-      {subLabel && (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={cn("size-6", isNext ? "rotate-180" : "")}
+      >
+        <path d="m15 18-6-6 6-6" />
+      </svg>
+      <div>
+        {subLabel && (
+          <div
+            className={cn(
+              "text-sm text-(--mastra-text-tertiary)",
+              isNext ? "text-right" : "text-left",
+            )}
+          >
+            {subLabel}
+          </div>
+        )}
         <div
           className={cn(
-            "text-sm text-(--mastra-text-tertiary)",
-            isNext ? "text-left" : "",
+            "flex items-center gap-2 font-medium text-lg",
+            isNext ? "flex-row-reverse text-right" : "flex-row text-left",
           )}
         >
-          {subLabel}
+          {title}
         </div>
-      )}
-      <div
-        className={cn(
-          "flex -ml-8 items-center gap-2",
-          isNext ? "flex-row-reverse" : "flex-row",
-        )}
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className={cn("size-6", isNext ? "rotate-180" : "")}
-        >
-          <path d="m15 18-6-6 6-6" />
-        </svg>
-        <div className="font-medium">{title}</div>
       </div>
     </Link>
   );


### PR DESCRIPTION
Fixes a few CSS issues in the docs:

- Fixed double scrollbar on the table of contents by moving sticky positioning to the column wrapper
- Fixed prev/next pagination links - arrows were misaligned and the layout was inconsistent
- Fixed long inline code snippets overflowing their containers (removed `white-space: nowrap`)
- Improved feedback form overlay with subtle backdrop blur
- Removed tab headings from ToC by using raw `<h3>` elements instead of markdown headings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a CSS class typo in the feedback form and adjusted textarea height for consistent spacing.

* **Style**
  * Increased dialog overlay opacity and added blur; made dialog widths responsive.
  * Updated table-of-contents scrollbar/height behavior and code-inline sizing.
  * Refined pagination navigation layout and visuals; removed/updated some pagination styles.
  * Minor TOC layout/DOM tweaks affecting styling scope.

* **Documentation**
  * Standardized heading formatting across guides and simplified an error example for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->