### PR TITLE
fix(@mastra/react): Use new syntax for generate/stream REST API calls

### DIFF
--- a/.changeset/kind-turtles-serve.md
+++ b/.changeset/kind-turtles-serve.md
@@ -2,8 +2,4 @@
 '@mastra/react': patch
 ---
 
----
-'@mastra/react': patch
----
-
 Fixed compatibility with updated `@mastra/client-js` generate and stream API signatures

--- a/.changeset/kind-turtles-serve.md
+++ b/.changeset/kind-turtles-serve.md
@@ -2,4 +2,8 @@
 '@mastra/react': patch
 ---
 
-Use new syntax isntead of old syntax to call generate/stream rest api
+---
+'@mastra/react': patch
+---
+
+Fixed compatibility with updated `@mastra/client-js` generate and stream API signatures

--- a/.changeset/kind-turtles-serve.md
+++ b/.changeset/kind-turtles-serve.md
@@ -1,0 +1,5 @@
+---
+'@mastra/react': patch
+---
+
+Use new syntax isntead of old syntax to call generate/stream rest api

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -111,8 +111,7 @@ export const useChat = ({ agentId, resourceId, initializeMessages }: MastraChatP
 
     const agent = clientWithAbort.getAgent(agentId);
 
-    const response = await agent.generate({
-      messages: coreUserMessages,
+    const response = await agent.generate(coreUserMessages, {
       runId: uuid(),
       maxSteps,
       modelSettings: {
@@ -182,8 +181,7 @@ export const useChat = ({ agentId, resourceId, initializeMessages }: MastraChatP
 
     const runId = uuid();
 
-    const response = await agent.stream({
-      messages: coreUserMessages,
+    const response = await agent.stream(coreUserMessages, {
       runId,
       maxSteps,
       modelSettings: {


### PR DESCRIPTION
## Summary
- Updates `useChat` hook in `@mastra/react` to use the new function signature for `agent.generate()` and `agent.stream()` methods
- Changes from `{ messages: coreUserMessages, ...options }` to `(coreUserMessages, { ...options })` syntax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Core messaging call signatures changed: message lists are now passed as the first argument rather than inside the options object — update SDK call sites to the new syntax.

* **Chores**
  * Patch release entry added documenting compatibility adjustments with updated client streaming/generation signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->