### PR TITLE
fix(@mastra/client-js, @mastra/react): Match client network signature with core

### DIFF
--- a/.changeset/fiery-birds-burn.md
+++ b/.changeset/fiery-birds-burn.md
@@ -1,6 +1,8 @@
 ---
-'@mastra/client-js': patch
-'@mastra/react': patch
+'@mastra/client-js': major
+'@mastra/react': major
 ---
 
-Match client-js network signature with core
+**Fixed:** Align `Agent.network` with core and update `@mastra/react` network usage.
+
+**Before**

--- a/.changeset/fiery-birds-burn.md
+++ b/.changeset/fiery-birds-burn.md
@@ -1,0 +1,6 @@
+---
+'@mastra/client-js': patch
+'@mastra/react': patch
+---
+
+Match client-js network signature with core

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -1280,7 +1280,10 @@ export class Agent extends BaseResource {
     return response;
   }
 
-  async network(params: NetworkStreamParams): Promise<
+  async network(
+    messages: MessageListInput,
+    params: Omit<NetworkStreamParams, 'messages'>,
+  ): Promise<
     Response & {
       processDataStream: ({
         onChunk,
@@ -1291,7 +1294,10 @@ export class Agent extends BaseResource {
   > {
     const response: Response = await this.request(`/api/agents/${this.agentId}/network`, {
       method: 'POST',
-      body: params,
+      body: {
+        messages,
+        ...params,
+      },
       stream: true,
     });
 

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -242,8 +242,7 @@ export const useChat = ({ agentId, resourceId, initializeMessages }: MastraChatP
 
     const runId = uuid();
 
-    const response = await agent.network({
-      messages: coreUserMessages,
+    const response = await agent.network(coreUserMessages, {
       maxSteps,
       modelSettings: {
         frequencyPenalty,

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/client.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/client.mdx
@@ -9,6 +9,33 @@ Client SDK changes align with server-side API updates including renamed utilitie
 
 ## Changed
 
+### `messages` is now identical to `@mastra/core/agent` syntax
+
+The `messages` argument is now the first argument of the `generate`, `stream` and `network` method calls, similar to the NodeJS version in `@mastra/core/agent`.
+
+To migrate, move `messages` to the first argument of the method call:
+
+**Using `@mastra/client-js`:**
+
+```diff
+  const agent = client.getAgent('my-agent');
+
+-  await agent.generate({
+-    messages: [...]
++  await agent.generate([...], {
+  });
+
+-  await agent.stream({
+-    messages: [...]
++  await agent.stream([...], {
+  });
+
+-  await agent.network({
+-    messages: [...]
++  await agent.network([...], {
+  });
+```
+
 ### `threadId` and `resourceId` to `memory` option
 
 The `threadId` and `resourceId` options have been removed from agent method calls. Use the `memory` option instead, which provides a cleaner API for memory configuration. This applies to both `@mastra/client-js` and `@mastra/react` packages.
@@ -20,8 +47,7 @@ To migrate, move `threadId` and `resourceId` into the `memory` option:
 ```diff
   const agent = client.getAgent('my-agent');
 
-  await agent.generate({
-    messages: [...],
+  await agent.generate([...], {
 -   threadId: 'thread-123',
 -   resourceId: 'user-456',
 +   memory: {
@@ -30,8 +56,7 @@ To migrate, move `threadId` and `resourceId` into the `memory` option:
 +   },
   });
 
-  await agent.stream({
-    messages: [...],
++  await agent.stream([...], {
 -   threadId: 'thread-123',
 -   resourceId: 'user-456',
 +   memory: {
@@ -59,8 +84,7 @@ The `useChat` hook internally passes the memory option when you provide a `threa
 The `memory` option also supports passing thread metadata when creating new threads:
 
 ```typescript
-await agent.generate({
-  messages: [...],
+await agent.generate([...], {
   memory: {
     thread: {
       id: 'thread-123',


### PR DESCRIPTION
## Summary
- Updates `agent.network()` method signature in `@mastra/client-js` to use `messages` as the first argument, matching the `@mastra/core/agent` API
- Updates `@mastra/react` `useChat` hook to use the new signature
- Updates migration docs to document this breaking change alongside the existing `generate`/`stream` migration notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Network method signature updated: messages is now the first parameter instead of a nested property.
  * threadId and resourceId options replaced with a unified memory option.

* **Documentation**
  * Added migration guide with code examples for upgrading to the latest client SDK versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->