### PR TITLE
docs: add Mastra Cloud Store storage configuration requirements

### DIFF
--- a/docs/src/content/en/docs/agents/agent-memory.mdx
+++ b/docs/src/content/en/docs/agents/agent-memory.mdx
@@ -106,6 +106,10 @@ export const memoryAgent = new Agent({
 });
 ```
 
+:::warning
+**Mastra Cloud Store limitation**: Agent-level storage is not supported when using [Mastra Cloud Store](/docs/v1/mastra-cloud/deployment#using-mastra-cloud-store). If you use Mastra Cloud Store, configure storage on the Mastra instance instead. This limitation does not apply if you bring your own database.
+:::
+
 ## Message history
 
 Include a `memory` object with both `resource` and `thread` to track message history during agent calls.

--- a/docs/src/content/en/docs/agents/agent-memory.mdx
+++ b/docs/src/content/en/docs/agents/agent-memory.mdx
@@ -106,8 +106,8 @@ export const memoryAgent = new Agent({
 });
 ```
 
-:::warning
-**Mastra Cloud Store limitation**: Agent-level storage is not supported when using [Mastra Cloud Store](/docs/v1/mastra-cloud/deployment#using-mastra-cloud-store). If you use Mastra Cloud Store, configure storage on the Mastra instance instead. This limitation does not apply if you bring your own database.
+:::warning[Mastra Cloud Store limitation]
+Agent-level storage is not supported when using [Mastra Cloud Store](/docs/v1/mastra-cloud/deployment#using-mastra-cloud-store). If you use Mastra Cloud Store, configure storage on the Mastra instance instead. This limitation does not apply if you bring your own database.
 :::
 
 ## Message history

--- a/docs/src/content/en/docs/mastra-cloud/deployment.mdx
+++ b/docs/src/content/en/docs/mastra-cloud/deployment.mdx
@@ -33,8 +33,8 @@ Changes to settings require a new deployment to take effect
 
 Mastra Cloud offers two storage options:
 
-1. **Mastra Cloud Store** - Managed storage provided by Mastra Cloud
-2. **Bring your own database** - Connect to your own external database
+1. **Mastra Cloud Store**: Managed storage provided by Mastra Cloud
+1. **Bring your own database**: Connect to your own external database
 
 ### Using Mastra Cloud Store
 
@@ -55,7 +55,7 @@ export const mastra = new Mastra({
 });
 ```
 
-Agents can use Memory without specifying storage—they inherit from the Mastra instance:
+Agents can use Memory without specifying storage as they inherit from the Mastra instance:
 
 ```typescript title="src/mastra/agents/my-agent.ts"
 import { Agent } from "@mastra/core/agent";

--- a/docs/src/content/en/docs/mastra-cloud/deployment.mdx
+++ b/docs/src/content/en/docs/mastra-cloud/deployment.mdx
@@ -29,6 +29,53 @@ Click the **Deployments** menu item to view build logs. Open **Settings** to con
 Changes to settings require a new deployment to take effect
 :::
 
+## Storage configuration
+
+Mastra Cloud offers two storage options:
+
+1. **Mastra Cloud Store** - Managed storage provided by Mastra Cloud
+2. **Bring your own database** - Connect to your own external database
+
+### Using Mastra Cloud Store
+
+When using the managed Mastra Cloud Store (enabled in your project settings), storage must be configured on the `Mastra` instance, not on individual agent `Memory` instances.
+
+Configure storage on your Mastra instance:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from "@mastra/core";
+import { LibSQLStore } from "@mastra/libsql";
+
+export const mastra = new Mastra({
+  storage: new LibSQLStore({
+    id: "mastra-store",
+    url: "file:./mastra.db",
+  }),
+  agents: { myAgent },
+});
+```
+
+Agents can use Memory without specifying storage—they inherit from the Mastra instance:
+
+```typescript title="src/mastra/agents/my-agent.ts"
+import { Agent } from "@mastra/core/agent";
+import { Memory } from "@mastra/memory";
+
+export const myAgent = new Agent({
+  id: "my-agent",
+  memory: new Memory({
+    // No storage here - uses instance-level storage from Mastra Cloud Store
+    options: {
+      lastMessages: 20,
+    },
+  }),
+});
+```
+
+### Bring your own database
+
+If you don't use Mastra Cloud Store, you can use any [storage provider](/docs/v1/memory/storage#supported-providers) with any configuration. Set your database connection strings as environment variables in your project's **Settings** page.
+
 ## Using your deployment
 
 After deployment, interact with your agents using the [Mastra Client](/docs/v1/server/mastra-client) or call the REST API endpoints directly.

--- a/docs/src/content/en/docs/memory/storage.mdx
+++ b/docs/src/content/en/docs/memory/storage.mdx
@@ -127,8 +127,8 @@ export const agent = new Agent({
 
 This is useful when different agents need to store data in separate databases for security, compliance, or organizational reasons.
 
-:::warning
-**Mastra Cloud Store limitation**: Agent-level storage is not supported when using [Mastra Cloud Store](/docs/v1/mastra-cloud/deployment#using-mastra-cloud-store). If you use Mastra Cloud Store, configure storage on the Mastra instance instead. This limitation does not apply if you bring your own database.
+:::warning[Mastra Cloud Store limitation]
+Agent-level storage is not supported when using [Mastra Cloud Store](/docs/v1/mastra-cloud/deployment#using-mastra-cloud-store). If you use Mastra Cloud Store, configure storage on the Mastra instance instead. This limitation does not apply if you bring your own database.
 :::
 
 ## Threads and resources

--- a/docs/src/content/en/docs/memory/storage.mdx
+++ b/docs/src/content/en/docs/memory/storage.mdx
@@ -127,6 +127,10 @@ export const agent = new Agent({
 
 This is useful when different agents need to store data in separate databases for security, compliance, or organizational reasons.
 
+:::warning
+**Mastra Cloud Store limitation**: Agent-level storage is not supported when using [Mastra Cloud Store](/docs/v1/mastra-cloud/deployment#using-mastra-cloud-store). If you use Mastra Cloud Store, configure storage on the Mastra instance instead. This limitation does not apply if you bring your own database.
+:::
+
 ## Threads and resources
 
 Mastra organizes memory into threads using two identifiers:


### PR DESCRIPTION
Fixes #12007

Documents storage configuration requirements when using Mastra Cloud Store. Users were running into deployment issues because agent-level storage isn't supported with the managed store.

Added a new "Storage configuration" section to the Mastra Cloud deployment docs explaining:
- How to configure storage when using Mastra Cloud Store (must be on the Mastra instance, not on agent Memory)
- That users can use any storage provider if they bring their own database

Also added warning notes to the memory/storage and agent-memory docs pointing to the Cloud limitations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified storage configuration for deployments, covering Mastra Cloud Store and bring-your-own-database options.
  * Added a dedicated storage configuration section explaining instance-level storage and how agents inherit storage settings.
  * Inserted warnings noting that agent-level storage is not supported with Mastra Cloud Store and advising configuring storage at the instance level.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->