### PR TITLE
Fix/11749  network result object undefined

### DIFF
--- a/.changeset/all-jars-feel.md
+++ b/.changeset/all-jars-feel.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+---
+
+When using agent networks, the routing agent could fail with a cryptic TypeError: Cannot read properties of undefined (reading 'primitiveId') if the object from tryGenerateWithJsonFallback was undefined. This adds a guard that throws a descriptive MastraError with debugging details (response text, finish reason, usage) to help users diagnose the issue.
+Fixes #11749

--- a/.changeset/all-jars-feel.md
+++ b/.changeset/all-jars-feel.md
@@ -2,5 +2,6 @@
 '@mastra/core': patch
 ---
 
-When using agent networks, the routing agent could fail with a cryptic TypeError: Cannot read properties of undefined (reading 'primitiveId') if the object from tryGenerateWithJsonFallback was undefined. This adds a guard that throws a descriptive MastraError with debugging details (response text, finish reason, usage) to help users diagnose the issue.
+When using agent networks, the routing agent could fail with a cryptic `TypeError: Cannot read properties of undefined` if the generation response was missing or malformed. This made it difficult to diagnose why routing failed. The release now throws a descriptive error with debugging details (response text, finish reason, usage) to help identify the root cause.
+
 Fixes #11749

--- a/packages/core/src/agent/agent-network.test.ts
+++ b/packages/core/src/agent/agent-network.test.ts
@@ -1900,14 +1900,13 @@ describe('Agent - network - routing agent output', () => {
 
     // Collect chunks - the error will be thrown during iteration
     const chunks: any[] = [];
-    let thrownError: Error | undefined;
 
     try {
       for await (const chunk of anStream) {
         chunks.push(chunk);
       }
-    } catch (e) {
-      thrownError = e as Error;
+    } catch {
+      // Error is expected - the workflow step fails with our MastraError
     }
 
     // The spy should have been called

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -494,6 +494,20 @@ export async function createNetworkLoop({
 
       const object = await result.object;
 
+      if (!object) {
+        throw new MastraError({
+          id: 'AGENT_NETWORK_ROUTING_AGENT_INVALID_OUTPUT',
+          domain: ErrorDomain.AGENT_NETWORK,
+          category: ErrorCategory.SYSTEM,
+          text: `Routing agent returned undefined for 'object'. This may indicate an issue with the model's response or structured output parsing.`,
+          details: {
+            text: result.text?.substring(0, 1000) ?? null,
+            finishReason: result.finishReason ?? null,
+            usage: JSON.stringify(result.usage) ?? null,
+          },
+        });
+      }
+
       const isComplete = object.primitiveId === 'none' && object.primitiveType === 'none';
 
       // When routing agent handles request itself (no delegation), emit text events

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -501,7 +501,6 @@ export async function createNetworkLoop({
           category: ErrorCategory.SYSTEM,
           text: `Routing agent returned undefined for 'object'. This may indicate an issue with the model's response or structured output parsing.`,
           details: {
-            text: result.text?.substring(0, 1000) ?? null,
             finishReason: result.finishReason ?? null,
             usage: JSON.stringify(result.usage) ?? null,
           },


### PR DESCRIPTION
## Description

When using agent networks with certain models (like `gpt-5-mini`), the routing agent could fail with a cryptic `TypeError: Cannot read properties of undefined (reading 'primitiveId')` if `tryGenerateWithJsonFallback` returned an undefined `object`. This PR adds a guard that throws a descriptive `MastraError` with debugging details (response text, finish reason, usage) to help users diagnose the root cause.

## Related Issue(s)

Fixes #11749

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added defensive validation for routing agent outputs to prevent crashes when an unexpected or missing response is encountered, and now surface a descriptive error with diagnostic details for easier debugging.

* **Tests**
  * Added tests covering routing-agent error handling and successful streaming routing behavior to ensure robust handling of malformed and well-formed outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->