### PR TITLE
fix(evals): correct targetResult type in onItemComplete callback

### DIFF
--- a/.changeset/loud-pillows-matter.md
+++ b/.changeset/loud-pillows-matter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the type of targetResult in the onItemComplete callback for runEvals. The parameter was incorrectly typed as a Promise, but the actual value passed is already resolved. Users no longer need to await targetResult inside their callback.

--- a/packages/core/src/evals/run/index.ts
+++ b/packages/core/src/evals/run/index.ts
@@ -40,7 +40,7 @@ export function runEvals<TAgent extends Agent>(config: {
   target: TAgent;
   onItemComplete?: (params: {
     item: RunEvalsDataItem<TAgent>;
-    targetResult: ReturnType<Agent['generate']>;
+    targetResult: Awaited<ReturnType<Agent['generate']>>;
     scorerResults: Record<string, any>; // Flat structure: { scorerName: result }
   }) => void | Promise<void>;
   concurrency?: number;


### PR DESCRIPTION
The `targetResult` parameter in the `onItemComplete` callback for `runEvals` was typed as `ReturnType<Agent['generate']>`, which TypeScript interprets as a Promise. However, the value is already awaited before being passed to the callback, so it's actually the resolved result.

This was causing confusion where users felt they needed to await `targetResult` even though it wasn't necessary.

**Before:**
```typescript
onItemComplete: async ({ targetResult }) => {
  const result = await targetResult; // unnecessary await
  console.log(result.text);
}
```

**After:**
```typescript
onItemComplete: ({ targetResult }) => {
  console.log(targetResult.text); // just use it directly
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated callback parameter handling in `runEvals`: the `targetResult` parameter now passes resolved values directly instead of Promises. Your `onItemComplete` callbacks no longer need to await the result parameter.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->