### PR TITLE
fix(core): resolve AI SDK v5/v6 type conflict with OpenRouter provider

### DIFF
--- a/.changeset/fix-openrouter-ai-sdk-v5-v6-conflict.md
+++ b/.changeset/fix-openrouter-ai-sdk-v5-v6-conflict.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fix build failure caused by AI SDK v5/v6 type incompatibility with OpenRouter provider. Added pnpm override to force `@openrouter/ai-sdk-provider@1.2.3` to use `ai@^5.0.97` instead of `ai@^6.0.1`, resolving the TypeScript error where `LanguageModelV2ProviderDefinedTool` (v5) was incompatible with `LanguageModelV2ProviderTool` (v6).
+
+This fixes the build error: `Type '"provider-defined"' is not assignable to type '"provider"'` at `packages/core/src/llm/model/gateways/models-dev.ts:205`.

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "cookie": ">=0.7.2",
     "tmp": ">=0.2.5",
     "jsondiffpatch": ">=0.7.3",
+    "@openrouter/ai-sdk-provider>ai": "^5.0.97",
     "ssri": ">=6.0.2",
     "jws": "^4.0.1"
   },
@@ -109,7 +110,8 @@
     "overrides": {
       "client-js-e2e-tests-zod-v3>zod": "^3.24.0",
       "client-js-e2e-tests-zod-v4>zod": "^4.3.5",
-      "better-auth": "^1.4.5"
+      "better-auth": "^1.4.5",
+      "@openrouter/ai-sdk-provider>ai": "^5.0.97"
     }
   },
   "license": "Apache-2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   cookie: '>=0.7.2'
   tmp: '>=0.2.5'
   jsondiffpatch: '>=0.7.3'
+  '@openrouter/ai-sdk-provider>ai': ^5.0.97
   ssri: '>=6.0.2'
   jws: ^4.0.1
   client-js-e2e-tests-zod-v3>zod: ^3.24.0
@@ -9337,7 +9338,7 @@ packages:
     resolution: {integrity: sha512-a6Nc8dPRHakRH9966YJ/HZJhLOds7DuPTscNZDoAr+Aw+tEFUlacSJMvb/b3gukn74mgbuaJRji9YOn62ipfVg==}
     engines: {node: '>=18'}
     peerDependencies:
-      ai: ^5.0.0
+      ai: ^5.0.97
       zod: ^3.24.1 || ^v4
 
   '@openrouter/sdk@0.1.27':


### PR DESCRIPTION
## Summary
Fixes TypeScript build failure in `@mastra/core` caused by AI SDK v5/v6 type incompatibility when using the OpenRouter provider.

## Problem
The build was failing with this error at `packages/core/src/llm/model/gateways/models-dev.ts:205`:
```
Type '"provider-defined"' is not assignable to type '"provider"'
```

### Root Cause
- `@openrouter/ai-sdk-provider@1.2.3` declares peer dependency `ai@^5.0.0`
- pnpm was resolving this with `ai@6.0.1` instead of `ai@5.x`
- AI SDK v5 uses `LanguageModelV2ProviderDefinedTool` with `type: 'provider-defined'`
- AI SDK v6 uses `LanguageModelV2ProviderTool` with `type: 'provider'`
- This created a type mismatch when OpenRouter models were returned as `LanguageModelV2`

## Solution
Added pnpm overrides in root `package.json` to force `@openrouter/ai-sdk-provider` to use `ai@^5.0.97`:
```json
"resolutions": {
  "@openrouter/ai-sdk-provider>ai": "^5.0.97"
},
"pnpm": {
  "overrides": {
    "@openrouter/ai-sdk-provider>ai": "^5.0.97"
  }
}
```

## Verification
✅ `pnpm build:core` now succeeds without TypeScript errors  
✅ All other builds remain unaffected  
✅ Maintains compatibility with existing AI SDK v5 infrastructure

## Testing
```bash
# Clean build test
pnpm install
pnpm build:core  # Should succeed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a build failure affecting OpenRouter AI SDK integration by resolving version conflicts between dependent packages, improving deployment reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->