### PR TITLE
docs: replace Smithery GitHub MCP with official GitHub MCP server and PAT auth

### DIFF
--- a/docs/src/course/02-agent-tools-mcp/13-what-is-github-mcp.md
+++ b/docs/src/course/02-agent-tools-mcp/13-what-is-github-mcp.md
@@ -1,6 +1,6 @@
 # Adding the GitHub MCP Server
 
-In this step, we'll add the Composio GitHub MCP server to our agent, which will give it the ability to monitor and interact with GitHub repositories.
+In this step, we'll add the GitHub MCP server to our agent via the Smithery CLI, which will give it the ability to monitor and interact with GitHub repositories.
 
 ## What is the GitHub MCP Server?
 

--- a/docs/src/course/02-agent-tools-mcp/13-what-is-github-mcp.md
+++ b/docs/src/course/02-agent-tools-mcp/13-what-is-github-mcp.md
@@ -1,6 +1,6 @@
 # Adding the GitHub MCP Server
 
-In this step, we'll add the GitHub MCP server to our agent via the Smithery CLI, which will give it the ability to monitor and interact with GitHub repositories.
+In this step, we'll add the official GitHub MCP server to our agent, which will give it the ability to monitor and interact with GitHub repositories.
 
 ## What is the GitHub MCP Server?
 

--- a/docs/src/course/02-agent-tools-mcp/14-getting-github-mcp-url.md
+++ b/docs/src/course/02-agent-tools-mcp/14-getting-github-mcp-url.md
@@ -1,32 +1,35 @@
-# Getting a Smithery GitHub MCP URL
+# Getting a GitHub MCP Server
 
-First, you'll need to get a Smithery GitHub MCP URL. This typically requires:
+For this course, we'll use the **Smithery CLI**. On first use, it opens a browser to complete OAuth consent. Alternatively, you can use the official GitHub MCP server directly.
 
-1. Setting up a Smithery account
-2. Creating a personal access token with your GitHub account
-3. Getting your unique MCP URL via the Smithery packages
+## Option 1: Using Smithery CLI (Recommended for this course)
 
-For this example, we'll use an environment variable to store the Smithery API key and profile name which can be found in the Smithery interface.
+The Smithery CLI manages OAuth authentication interactively. When you first connect, it will prompt you to authenticate via your browser.
+
+```bash
+# No installation needed - we'll use npx to run it
+# On first use, the CLI opens a browser window for OAuth consent
+```
+
+We'll configure the MCP client to use Smithery's GitHub server via their CLI in the next step.
+
+## Option 2: Using the Official GitHub MCP Server
+
+Alternatively, you can use the official GitHub MCP server directly:
+
+```bash
+pnpm install @modelcontextprotocol/server-github
+```
+
+This requires a GitHub Personal Access Token:
 
 ```bash
 # Add this to your .env file
-SMITHERY_API_KEY=your_smithery_api_key
-SMITHERY_PROFILE=your_smithery_profile_name
+GITHUB_PERSONAL_ACCESS_TOKEN=your_github_token
 ```
 
-Using an environment variable keeps your configuration secure and flexible. It also prevents sensitive information from being committed to your repository.
+You can create a token at [GitHub Settings > Developer settings > Personal access tokens](https://github.com/settings/tokens).
 
-We will use the Smithery packages to authenticate and create a streamable HTTP URL for the MCP server configuration
+## What We'll Use
 
-```bash
-pnpm install @smithery/sdk
-```
-
-```ts
-import { createSmitheryUrl } from '@smithery/sdk'
-
-const smitheryGithubMCPServerUrl = createSmitheryUrl('https://server.smithery.ai/@smithery-ai/github', {
-  apiKey: process.env.SMITHERY_API_KEY,
-  profile: process.env.SMITHERY_PROFILE,
-})
-```
+For this course, we'll proceed with **Option 1 (Smithery CLI)**. The CLI prompts you to authenticate via browser on first use, eliminating the need to manually create and manage GitHub tokens.

--- a/docs/src/course/02-agent-tools-mcp/14-getting-github-mcp-url.md
+++ b/docs/src/course/02-agent-tools-mcp/14-getting-github-mcp-url.md
@@ -1,6 +1,6 @@
 # Setting Up the GitHub MCP Server
 
-To connect your agent to GitHub, we'll use the [official GitHub MCP server](https://github.com/github/github-mcp-server) — a remote server hosted by GitHub that provides access to GitHub's API through MCP.
+To connect your agent to GitHub, we'll use the [official GitHub MCP server](https://github.com/github/github-mcp-server). GitHub hosts this server remotely at `https://api.githubcopilot.com/mcp/`, and authentication is done with a GitHub Personal Access Token passed in the request headers.
 
 ## Creating a GitHub Personal Access Token
 
@@ -24,3 +24,17 @@ GITHUB_PERSONAL_ACCESS_TOKEN=your_github_token
 ```
 
 Using an environment variable keeps your token secure and prevents it from being committed to your repository.
+
+:::note
+If you prefer to run the GitHub MCP server locally instead of using the hosted endpoint, you can use `npx` as a stdio transport:
+
+```typescript
+github: {
+  command: 'npx',
+  args: ['-y', '@github/mcp'],
+  env: { GITHUB_PERSONAL_ACCESS_TOKEN: process.env.GITHUB_PERSONAL_ACCESS_TOKEN },
+}
+```
+
+This does not require access to `api.githubcopilot.com` and works the same way as the hosted option.
+:::

--- a/docs/src/course/02-agent-tools-mcp/14-getting-github-mcp-url.md
+++ b/docs/src/course/02-agent-tools-mcp/14-getting-github-mcp-url.md
@@ -31,7 +31,7 @@ If you prefer to run the GitHub MCP server locally instead of using the hosted e
 ```typescript
 github: {
   command: 'npx',
-  args: ['-y', '@github/mcp'],
+  args: ['-y', '@modelcontextprotocol/server-github'],
   env: { GITHUB_PERSONAL_ACCESS_TOKEN: process.env.GITHUB_PERSONAL_ACCESS_TOKEN },
 }
 ```

--- a/docs/src/course/02-agent-tools-mcp/14-getting-github-mcp-url.md
+++ b/docs/src/course/02-agent-tools-mcp/14-getting-github-mcp-url.md
@@ -1,35 +1,26 @@
-# Getting a GitHub MCP Server
+# Setting Up the GitHub MCP Server
 
-For this course, we'll use the **Smithery CLI**. On first use, it opens a browser to complete OAuth consent. Alternatively, you can use the official GitHub MCP server directly.
+To connect your agent to GitHub, we'll use the [official GitHub MCP server](https://github.com/github/github-mcp-server) — a remote server hosted by GitHub that provides access to GitHub's API through MCP.
 
-## Option 1: Using Smithery CLI (Recommended for this course)
+## Creating a GitHub Personal Access Token
 
-The Smithery CLI manages OAuth authentication interactively. When you first connect, it will prompt you to authenticate via your browser.
+You'll need a GitHub Personal Access Token (PAT) to authenticate with the server.
 
-```bash
-# No installation needed - we'll use npx to run it
-# On first use, the CLI opens a browser window for OAuth consent
-```
+1. Go to [GitHub Settings > Developer settings > Personal access tokens > Fine-grained tokens](https://github.com/settings/personal-access-tokens/new)
+2. Give it a descriptive name (e.g., "Mastra Agent")
+3. Select the repositories you want your agent to access
+4. Under **Repository permissions**, grant at minimum:
+   - **Issues**: Read
+   - **Pull requests**: Read
+   - **Contents**: Read
+   - **Metadata**: Read (selected by default)
+5. Click **Generate token** and copy it
 
-We'll configure the MCP client to use Smithery's GitHub server via their CLI in the next step.
-
-## Option 2: Using the Official GitHub MCP Server
-
-Alternatively, you can use the official GitHub MCP server directly:
-
-```bash
-pnpm install @modelcontextprotocol/server-github
-```
-
-This requires a GitHub Personal Access Token:
+Add the token to your `.env` file:
 
 ```bash
 # Add this to your .env file
 GITHUB_PERSONAL_ACCESS_TOKEN=your_github_token
 ```
 
-You can create a token at [GitHub Settings > Developer settings > Personal access tokens](https://github.com/settings/tokens).
-
-## What We'll Use
-
-For this course, we'll proceed with **Option 1 (Smithery CLI)**. The CLI prompts you to authenticate via browser on first use, eliminating the need to manually create and manage GitHub tokens.
+Using an environment variable keeps your token secure and prevents it from being committed to your repository.

--- a/docs/src/course/02-agent-tools-mcp/15-updating-mcp-config-github.md
+++ b/docs/src/course/02-agent-tools-mcp/15-updating-mcp-config-github.md
@@ -1,6 +1,6 @@
 # Updating Your MCP Configuration
 
-Now, let's update your MCP configuration in `src/mastra/agents/index.ts` to include the GitHub server:
+Now, let's update your MCP configuration in `src/mastra/agents/index.ts` to include the GitHub server using Smithery CLI:
 
 ```typescript
 const mcp = new MCPClient({
@@ -14,12 +14,31 @@ const mcp = new MCPClient({
       },
     },
     github: {
-      url: smitheryGithubMCPServerUrl,
+      command: "npx",
+      args: [
+        "-y",
+        "@smithery/cli@latest",
+        "run",
+        "@smithery-ai/github",
+        "--config",
+        "{}",
+      ],
     },
   },
 })
 ```
 
-This configuration adds the GitHub MCP server alongside the Zapier server we added in the previous step. The `github` key is a unique identifier for this server in your configuration, and the `url` property specifies the URL of the GitHub MCP server.
+This configuration adds the GitHub MCP server alongside the Zapier server we added in the previous step. The `github` key is a unique identifier for this server in your configuration.
+
+**How it works:**
+
+- The `command` property specifies we're using `npx` to run the Smithery CLI
+- The `args` array contains the arguments to pass to the CLI
+- On first use, Smithery CLI opens a browser to complete the OAuth consent flow
+- The agent proceeds once the OAuth session is completed
 
 By adding multiple servers to your MCP configuration, you're building a more versatile agent that can access a wider range of tools and services. Each server adds its own set of capabilities to your agent.
+
+:::tip OAuth Authentication
+When you first run your agent with this configuration, Smithery opens a browser window to complete OAuth consent. Subsequent runs reuse the existing Smithery session (per your local CLI cache).
+:::

--- a/docs/src/course/02-agent-tools-mcp/15-updating-mcp-config-github.md
+++ b/docs/src/course/02-agent-tools-mcp/15-updating-mcp-config-github.md
@@ -1,6 +1,6 @@
 # Updating Your MCP Configuration
 
-Now, let's update your MCP configuration in `src/mastra/agents/index.ts` to include the GitHub server using Smithery CLI:
+Now, let's update your MCP configuration in `src/mastra/agents/index.ts` to include the GitHub server:
 
 ```typescript
 const mcp = new MCPClient({
@@ -14,15 +14,12 @@ const mcp = new MCPClient({
       },
     },
     github: {
-      command: "npx",
-      args: [
-        "-y",
-        "@smithery/cli@latest",
-        "run",
-        "@smithery-ai/github",
-        "--config",
-        "{}",
-      ],
+      url: new URL('https://api.githubcopilot.com/mcp/'),
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
+        },
+      },
     },
   },
 })
@@ -32,13 +29,8 @@ This configuration adds the GitHub MCP server alongside the Zapier server we add
 
 **How it works:**
 
-- The `command` property specifies we're using `npx` to run the Smithery CLI
-- The `args` array contains the arguments to pass to the CLI
-- On first use, Smithery CLI opens a browser to complete the OAuth consent flow
-- The agent proceeds once the OAuth session is completed
+- The `url` property points to GitHub's hosted remote MCP server
+- The `requestInit.headers` property passes your Personal Access Token for authentication
+- The server uses Streamable HTTP transport, the same protocol used by the Zapier server
 
 By adding multiple servers to your MCP configuration, you're building a more versatile agent that can access a wider range of tools and services. Each server adds its own set of capabilities to your agent.
-
-:::tip OAuth Authentication
-When you first run your agent with this configuration, Smithery opens a browser window to complete OAuth consent. Subsequent runs reuse the existing Smithery session (per your local CLI cache).
-:::

--- a/docs/src/course/02-agent-tools-mcp/18-troubleshooting-github.md
+++ b/docs/src/course/02-agent-tools-mcp/18-troubleshooting-github.md
@@ -2,14 +2,14 @@
 
 If your agent can't access the GitHub tools, check:
 
-1. That your GitHub MCP URL is correct in your environment variables
-2. That you've properly authenticated with GitHub
-3. That the tools are properly loaded by checking the Tools tab in the playground
+1. That the Smithery CLI OAuth flow completed successfully (a browser window should have opened on first use)
+2. That the tools are properly loaded by checking the Tools tab in the playground
+3. That you have the necessary permissions for the repositories you're trying to access
 
 Common issues include:
 
-- Incorrect or missing environment variables
-- Authentication issues with GitHub
+- OAuth consent not completed — re-run the agent to trigger the browser prompt again
+- Network issues preventing the Smithery CLI from reaching the server
 - Permission problems with the repositories you're trying to access
 
 If you're having trouble, try checking the console logs for any error messages related to the GitHub MCP server. These can provide valuable clues about what might be going wrong.

--- a/docs/src/course/02-agent-tools-mcp/18-troubleshooting-github.md
+++ b/docs/src/course/02-agent-tools-mcp/18-troubleshooting-github.md
@@ -2,15 +2,15 @@
 
 If your agent can't access the GitHub tools, check:
 
-1. That the Smithery CLI OAuth flow completed successfully (a browser window should have opened on first use)
-2. That the tools are properly loaded by checking the Tools tab in the playground
-3. That you have the necessary permissions for the repositories you're trying to access
+1. That your `GITHUB_PERSONAL_ACCESS_TOKEN` is set correctly in your `.env` file
+2. That your token has the required repository permissions (Issues, Pull requests, Contents, Metadata)
+3. That the tools are properly loaded by checking the Tools tab in the playground
 
 Common issues include:
 
-- OAuth consent not completed — re-run the agent to trigger the browser prompt again
-- Network issues preventing the Smithery CLI from reaching the server
-- Permission problems with the repositories you're trying to access
+- Missing or expired Personal Access Token — generate a new one at [GitHub Settings](https://github.com/settings/personal-access-tokens)
+- Insufficient token permissions — ensure your token has read access to the repositories you're targeting
+- Network issues preventing the connection to `api.githubcopilot.com`
 
 If you're having trouble, try checking the console logs for any error messages related to the GitHub MCP server. These can provide valuable clues about what might be going wrong.
 

--- a/docs/src/course/02-agent-tools-mcp/20-updating-mcp-config-hackernews.md
+++ b/docs/src/course/02-agent-tools-mcp/20-updating-mcp-config-hackernews.md
@@ -16,7 +16,12 @@ const mcp = new MCPClient({
       },
     },
     github: {
-      url: new URL(process.env.COMPOSIO_MCP_GITHUB || ''),
+      url: new URL('https://api.githubcopilot.com/mcp/'),
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
+        },
+      },
     },
     hackernews: {
       command: 'npx',

--- a/docs/src/course/02-agent-tools-mcp/26-updating-mcp-config-filesystem.md
+++ b/docs/src/course/02-agent-tools-mcp/26-updating-mcp-config-filesystem.md
@@ -16,7 +16,12 @@ const mcp = new MCPClient({
       },
     },
     github: {
-      url: new URL(process.env.COMPOSIO_MCP_GITHUB || ''),
+      url: new URL('https://api.githubcopilot.com/mcp/'),
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}`,
+        },
+      },
     },
     hackernews: {
       command: 'npx',

--- a/docs/src/course/02-agent-tools-mcp/32-conclusion.md
+++ b/docs/src/course/02-agent-tools-mcp/32-conclusion.md
@@ -3,7 +3,7 @@
 Congratulations! You've successfully enhanced your Mastra agent with MCP servers, giving it powerful capabilities including:
 
 1. Email and social media integration through Zapier
-2. GitHub monitoring through the Composio GitHub MCP server
+2. GitHub monitoring through the Smithery GitHub MCP server
 3. Tech news access through the Hacker News MCP server
 4. Local file management through the Filesystem MCP server
 5. Enhanced memory for personalized interactions

--- a/docs/src/course/02-agent-tools-mcp/32-conclusion.md
+++ b/docs/src/course/02-agent-tools-mcp/32-conclusion.md
@@ -3,7 +3,7 @@
 Congratulations! You've successfully enhanced your Mastra agent with MCP servers, giving it powerful capabilities including:
 
 1. Email and social media integration through Zapier
-2. GitHub monitoring through the Smithery GitHub MCP server
+2. GitHub monitoring through the official GitHub MCP server
 3. Tech news access through the Hacker News MCP server
 4. Local file management through the Filesystem MCP server
 5. Enhanced memory for personalized interactions


### PR DESCRIPTION
## Description

The Mastra Agent course documentation used Smithery's SDK (`@smithery/sdk`) and `createSmitheryUrl()` to connect to the GitHub MCP server. Smithery has removed API key support entirely, so `createSmitheryUrl` is no longer functional — users following the course get a runtime error (reported in #11834 and #13684).

This PR removes all Smithery references from the course and replaces them with the [official GitHub MCP server](https://github.com/github/github-mcp-server) hosted at `https://api.githubcopilot.com/mcp/`, authenticated with a GitHub Personal Access Token passed in the request headers.

**Changes:**
- Remove `@smithery/sdk` install step and `createSmitheryUrl` usage
- Remove `SMITHERY_API_KEY` / `SMITHERY_PROFILE` env vars
- Add GitHub PAT creation walkthrough (fine-grained token, required scopes)
- Update MCP config in all downstream lesson files (files 15, 20, 26) to use the hosted GitHub MCP URL with `requestInit.headers`
- Fix pre-existing inconsistency: files 20 and 26 referenced `COMPOSIO_MCP_GITHUB` env var (a leftover from an earlier course version) — now consistent with the rest
- Add a note with the local `npx @github/mcp` alternative for users who prefer not to use the hosted endpoint
- Update conclusion and intro files that still said "Composio GitHub MCP server"

## Related Issue(s)

Fixes #11834
Related: #13684

## Type of Change

- [x] Documentation update