### PR TITLE
fix(playground): improve sidebar nav and scorer page

### DIFF
--- a/.changeset/fix-ui-improvements.md
+++ b/.changeset/fix-ui-improvements.md
@@ -1,0 +1,5 @@
+---
+"@mastra/playground": patch
+---
+
+Fixed sidebar navigation active state detection and scorer page loading state and type handling

--- a/.changeset/fix-ui-improvements.md
+++ b/.changeset/fix-ui-improvements.md
@@ -1,5 +1,0 @@
----
-"@mastra/playground": patch
----
-
-Fixed sidebar navigation active state detection and scorer page loading state and type handling

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -189,10 +189,7 @@ export function AppSidebar() {
               )}
               <MainSidebar.NavList>
                 {filteredLinks.map(link => {
-                  const [_, pagePath] = pathname.split('/');
-                  const lowercasedPagePath = link.name.toLowerCase();
-                  const isActive = link.url === pathname || link.name === pathname || pagePath === lowercasedPagePath;
-
+                  const isActive = pathname.startsWith(link.url);
                   return <MainSidebar.NavLink key={link.name} state={state} link={link} isActive={isActive} />;
                 })}
               </MainSidebar.NavList>

--- a/packages/playground/src/pages/scorers/scorer/index.tsx
+++ b/packages/playground/src/pages/scorers/scorer/index.tsx
@@ -2,7 +2,6 @@ import {
   Breadcrumb,
   Crumb,
   ScoresList,
-  scoresListColumns,
   Header,
   MainContentLayout,
   PageHeader,
@@ -16,7 +15,6 @@ import {
   HeaderAction,
   Button,
   DocsIcon,
-  EntryListSkeleton,
   getToNextEntryFn,
   getToPreviousEntryFn,
   useAgents,
@@ -24,11 +22,14 @@ import {
   HeaderGroup,
   ScorerCombobox,
   toast,
+  Spinner,
 } from '@mastra/playground-ui';
 import { useParams, Link, useSearchParams } from 'react-router';
 import { GaugeIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
+import { ClientScoreRowData } from '@mastra/client-js';
+import { ScoreRowData } from '@mastra/core/evals';
 
 export default function Scorer() {
   const { scorerId } = useParams()! as { scorerId: string };
@@ -202,12 +203,19 @@ export default function Scorer() {
             />
 
             {isLoadingScores ? (
-              <EntryListSkeleton columns={scoresListColumns} />
+              <div className="h-full w-full flex items-center justify-center">
+                <Spinner />
+              </div>
             ) : (
               <ScoresList
                 scores={scores}
                 selectedScoreId={selectedScoreId}
-                pagination={pagination}
+                pagination={{
+                  total: pagination?.total || 0,
+                  hasMore: pagination?.hasMore || false,
+                  perPage: pagination?.perPage || 0,
+                  page: pagination?.page || 0,
+                }}
                 onScoreClick={handleScoreClick}
                 onPageChange={setScoresPage}
                 errorMsg={scoresError?.message}
@@ -218,7 +226,7 @@ export default function Scorer() {
       </MainContentLayout>
       <ScoreDialog
         scorerName={scorer?.scorer?.config?.name}
-        score={scores.find(s => s.id === selectedScoreId)}
+        score={mapScore(scores.find(s => s.id === selectedScoreId))}
         isOpen={dialogIsOpen}
         onClose={() => setDialogIsOpen(false)}
         onNext={toNextScore}
@@ -228,3 +236,12 @@ export default function Scorer() {
     </>
   );
 }
+
+const mapScore = (score?: ClientScoreRowData): ScoreRowData | undefined => {
+  if (!score) return undefined;
+  return {
+    ...score,
+    createdAt: new Date(score.createdAt),
+    updatedAt: new Date(score.updatedAt),
+  };
+};


### PR DESCRIPTION
Couple of small fixes in the playground:

- Sidebar navigation now uses `pathname.startsWith(link.url)` instead of splitting and comparing paths, so nested routes highlight correctly
- Scorer page uses a spinner instead of skeleton during loading
- Fixed pagination prop to handle undefined values properly
- Added type mapping for score dates (`createdAt`/`updatedAt`) to convert strings to Date objects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed sidebar navigation active state detection for improved visual feedback.
  * Improved scorer page loading state display.
  * Enhanced type safety for score data handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->