### PR TITLE
fix(deployer): Re-add `/api`

### DIFF
--- a/.changeset/quiet-lemons-watch.md
+++ b/.changeset/quiet-lemons-watch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Add back `/api` route during `mastra dev` which was accidentally removed.

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -163,19 +163,21 @@ export async function createHonoServer(
     healthHandler,
   );
 
-  app.get(
-    '/api',
-    describeRoute({
-      description: 'API Welcome Page',
-      tags: ['system'],
-      responses: {
-        200: {
-          description: 'Success',
+  if (options?.isDev) {
+    app.get(
+      '/api',
+      describeRoute({
+        description: 'API Welcome Page',
+        tags: ['system'],
+        responses: {
+          200: {
+            description: 'Success',
+          },
         },
-      },
-    }),
-    rootHandler,
-  );
+      }),
+      rootHandler,
+    );
+  }
 
   // Register auth middleware (authentication and authorization)
   // This is handled by the server adapter now

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -166,7 +166,7 @@ export async function createHonoServer(
   app.get(
     '/api',
     describeRoute({
-      description: 'Get API status',
+      description: 'API Welcome Page',
       tags: ['system'],
       responses: {
         200: {

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -163,7 +163,7 @@ export async function createHonoServer(
     healthHandler,
   );
 
-  if (options?.isDev) {
+  if (options?.isDev || server?.build?.swaggerUI) {
     app.get(
       '/api',
       describeRoute({

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -21,6 +21,7 @@ import { handleClientsRefresh, handleTriggerClientsRefresh, isHotReloadDisabled 
 import { errorHandler } from './handlers/error';
 import { healthHandler } from './handlers/health';
 import { restartAllActiveWorkflowRunsHandler } from './handlers/restart-active-runs';
+import { rootHandler } from './handlers/root';
 import type { ServerBundleOptions } from './types';
 import { html } from './welcome';
 
@@ -160,6 +161,20 @@ export async function createHonoServer(
       },
     }),
     healthHandler,
+  );
+
+  app.get(
+    '/api',
+    describeRoute({
+      description: 'Get API status',
+      tags: ['system'],
+      responses: {
+        200: {
+          description: 'Success',
+        },
+      },
+    }),
+    rootHandler,
   );
 
   // Register auth middleware (authentication and authorization)
@@ -316,6 +331,7 @@ export async function createHonoServer(
 
     // Skip if it's an API route
     if (
+      requestPath === '/api' ||
       requestPath.startsWith('/api/') ||
       requestPath.startsWith('/swagger-ui') ||
       requestPath.startsWith('/openapi.json')


### PR DESCRIPTION
## Description

In the logs we output `http://localhost:4111/api` as a link but the route was not existent anymore after https://github.com/mastra-ai/mastra/pull/10263 removed it. This PR restores the route.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reintroduced the /api route in development to restore the API welcome page.
  * Prevented API routes from being served as studio/application HTML, ensuring correct routing for API requests during development.
  * Added a dev-only API welcome response to provide a clear entry point and guidance for local API usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->