### PR TITLE
fix(convex): resolve missing getStore() method on ConvexStore

### DIFF
--- a/.changeset/fix-convex-store-getstore-method.md
+++ b/.changeset/fix-convex-store-getstore-method.md
@@ -1,0 +1,5 @@
+---
+"@mastra/convex": patch
+---
+
+Fixed ConvexStore to properly expose the inherited getStore() method from MastraStorage. Changed the stores property declaration from an initialized property to a declared property, allowing proper inheritance resolution. Added createTable() and alterTable() as no-op methods for schema compatibility since Convex uses a declarative schema.

--- a/.changeset/fix-convex-store-getstore-method.md
+++ b/.changeset/fix-convex-store-getstore-method.md
@@ -2,4 +2,7 @@
 "@mastra/convex": patch
 ---
 
-Fixed ConvexStore to properly expose the inherited getStore() method from MastraStorage. Changed the stores property declaration from an initialized property to a declared property, allowing proper inheritance resolution. Added createTable() and alterTable() as no-op methods for schema compatibility since Convex uses a declarative schema.
+Fixed ConvexStore so storage.getStore(domain) works properly, preventing runtime errors in flows that access domain stores.
+Added no-op schema methods (createTable, alterTable) to keep storage migrations compatible with Convex's declarative schema.
+Relates to `#11361`.
+

--- a/stores/convex/src/storage/db/index.ts
+++ b/stores/convex/src/storage/db/index.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto';
 
 import { MastraBase } from '@mastra/core/base';
 import { TABLE_WORKFLOW_SNAPSHOT } from '@mastra/core/storage';
-import type { TABLE_NAMES } from '@mastra/core/storage';
+import type { StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
 
 import { ConvexAdminClient } from '../client';
 import type { EqualityFilter } from '../types';
@@ -52,6 +52,30 @@ export class ConvexDB extends MastraBase {
 
   async hasColumn(_table: string, _column: string): Promise<boolean> {
     return true;
+  }
+
+  async createTable({
+    tableName,
+    schema: _schema,
+  }: {
+    tableName: TABLE_NAMES;
+    schema: Record<string, StorageColumn>;
+  }): Promise<void> {
+    // No-op for Convex; schema is managed server-side via schema.ts
+    this.logger.debug(`ConvexDB: createTable called for ${tableName} (schema managed server-side)`);
+  }
+
+  async alterTable({
+    tableName,
+    schema: _schema,
+    ifNotExists: _ifNotExists,
+  }: {
+    tableName: TABLE_NAMES;
+    schema: Record<string, StorageColumn>;
+    ifNotExists: string[];
+  }): Promise<void> {
+    // No-op for Convex; schema is managed server-side via schema.ts
+    this.logger.debug(`ConvexDB: alterTable called for ${tableName} (schema managed server-side)`);
   }
 
   async clearTable({ tableName }: { tableName: TABLE_NAMES }): Promise<void> {

--- a/stores/convex/src/storage/index.ts
+++ b/stores/convex/src/storage/index.ts
@@ -91,7 +91,7 @@ const isClientConfig = (config: ConvexStoreConfig): config is ConvexStoreConfig 
  * ```
  */
 export class ConvexStore extends MastraStorage {
-  stores: StorageDomains = {} as StorageDomains;
+  declare stores: StorageDomains;
 
   constructor(config: ConvexStoreConfig) {
     super({ id: config.id, name: config.name ?? 'ConvexStore', disableInit: config.disableInit });


### PR DESCRIPTION
## Description

Fixed Convexstore property declaration to properly expose inherited getStore() method from MastraStorage base class. 
Changed from explicit initialization to `declare` keyword for better TypeScript inheritance resolution.

## Related Issue(s)

Fixes #12060

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added no-op schema management calls to the public API for compatibility with declarative schemas.

* **Bug Fixes**
  * Fixed store access so callers can obtain underlying stores reliably (prevents runtime errors).

* **Refactor**
  * Simplified storage property declaration to improve initialization and inheritance behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->