### PR TITLE
fix(ai-sdk): emit start chunk with messageId by default

### DIFF
--- a/.changeset/witty-phones-share.md
+++ b/.changeset/witty-phones-share.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed start chunk being dropped when using toAISdkStream with partial options. The start message with messageId is now correctly emitted according to the AI SDK stream protocol.

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -179,8 +179,8 @@ export function AgentNetworkToAISDKTransformer() {
 
 export function AgentStreamToAISDKTransformer<OUTPUT>({
   lastMessageId,
-  sendStart,
-  sendFinish,
+  sendStart = true,
+  sendFinish = true,
   sendReasoning,
   sendSources,
   messageMetadata,


### PR DESCRIPTION
When calling `toAISdkStream` with partial options like `{ from: 'agent' }`, the `start` chunk with `messageId` was silently dropped because `sendStart` defaulted to `undefined` instead of `true`.

This fix adds default values to `AgentStreamToAISDKTransformer` so the stream now correctly emits both chunks per the AI SDK protocol:

```
data: {"type":"start","messageId":"..."}
data: {"type":"start-step"}
```

Previously only `start-step` was emitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where start messages were being dropped when using streaming with partial options, ensuring proper message emission according to the AI SDK protocol.

* **Improvements**
  * Made streaming configuration parameters optional with sensible defaults for easier implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->