### PR TITLE
fix(playground-ui): display processor count on agents page

### DIFF
--- a/.changeset/dry-eagles-shine.md
+++ b/.changeset/dry-eagles-shine.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed processor count not displaying on the agents page in playground

--- a/packages/playground-ui/src/domains/agents/components/agent-table/columns.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-table/columns.tsx
@@ -102,7 +102,10 @@ export const columns: ColumnDef<AgentTableColumn>[] = [
             {(inputProcessorsCount > 0 || outputProcessorsCount > 0) && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Badge variant="default" icon={<ProcessorIcon className="text-accent4" />} />
+                  <Badge variant="default" icon={<ProcessorIcon className="text-accent4" />}>
+                    {inputProcessorsCount + outputProcessorsCount} processor
+                    {inputProcessorsCount + outputProcessorsCount > 1 ? 's' : ''}
+                  </Badge>
                 </TooltipTrigger>
                 <TooltipContent className="flex flex-col gap-1">
                   <a


### PR DESCRIPTION
The processor badge on the agents page wasn't showing a count like the other badges (agents, tools, workflows). Now it displays the total number of processors.

Before: just a processor icon with no count
After: shows "2 processors" (or "1 processor" for singular)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed processor count visibility on the agents page in the playground interface. The processor badge now dynamically displays the total number of processors with appropriate pluralized labeling for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->