### PR TITLE
fix(playground-ui): check span.entityType for scorer eligibility

### DIFF
--- a/.changeset/flat-toes-love.md
+++ b/.changeset/flat-toes-love.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed scorer eligibility check in observability to also check span.entityType field

--- a/packages/playground-ui/src/domains/observability/components/span-tabs.tsx
+++ b/packages/playground-ui/src/domains/observability/components/span-tabs.tsx
@@ -14,6 +14,7 @@ import { CircleGaugeIcon } from 'lucide-react';
 import type { ListScoresResponse } from '@mastra/core/evals';
 import type { GetScorerResponse } from '@mastra/client-js';
 import { SpanRecord } from '@mastra/core/storage';
+import { EntityType } from '@mastra/core/observability';
 
 type SpanTabsProps = {
   trace?: SpanRecord;
@@ -45,9 +46,9 @@ export function SpanTabs({
   const { Link } = useLinkComponent();
 
   let entityType;
-  if (span?.attributes?.agentId) {
+  if (span?.attributes?.agentId || span?.entityType === EntityType.AGENT) {
     entityType = 'Agent';
-  } else if (span?.attributes?.workflowId) {
+  } else if (span?.attributes?.workflowId || span?.entityType === EntityType.WORKFLOW_RUN) {
     entityType = 'Workflow';
   }
 


### PR DESCRIPTION
The scorer eligibility check in the observability span scoring UI was only checking `span.attributes.agentId` to determine if a span was an agent span. However, agent spans store their entity type at `span.entityType` (root level), not in attributes.

This caused all agent-type scorers to be filtered out even when viewing a top-level agent span, showing "No eligible scorers have been defined to run."

Now the check also looks at `span.entityType === EntityType.AGENT` and `span.entityType === EntityType.WORKFLOW_RUN`:

```tsx
if (span?.attributes?.agentId || span?.entityType === EntityType.AGENT) {
  entityType = 'Agent';
} else if (span?.attributes?.workflowId || span?.entityType === EntityType.WORKFLOW_RUN) {
  entityType = 'Workflow';
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced observability features to more accurately identify and classify agents and workflow runs through improved entity type detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->