### PR TITLE
Revert "fix(playground-ui): display processor count on agents page"

### DIFF
--- a/.changeset/dry-eagles-shine.md
+++ b/.changeset/dry-eagles-shine.md
@@ -1,5 +1,0 @@
----
-'@mastra/playground-ui': patch
----
-
-Fixed processor count not displaying on the agents page in playground

--- a/packages/playground-ui/src/domains/agents/components/agent-table/columns.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-table/columns.tsx
@@ -102,10 +102,7 @@ export const columns: ColumnDef<AgentTableColumn>[] = [
             {(inputProcessorsCount > 0 || outputProcessorsCount > 0) && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Badge variant="default" icon={<ProcessorIcon className="text-accent4" />}>
-                    {inputProcessorsCount + outputProcessorsCount} processor
-                    {inputProcessorsCount + outputProcessorsCount > 1 ? 's' : ''}
-                  </Badge>
+                  <Badge variant="default" icon={<ProcessorIcon className="text-accent4" />} />
                 </TooltipTrigger>
                 <TooltipContent className="flex flex-col gap-1">
                   <a


### PR DESCRIPTION
Reverts mastra-ai/mastra#12075

All the processors get combined so showing a count doesn't make sense

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The processor count on the agents page badge now displays as an icon only, with count details accessible via tooltip on hover.

* **Chores**
  * Removed associated changelog entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->