### PR TITLE
refactor: rename MastraStorage to MastraCompositeStore

### DIFF
--- a/.changeset/sparkly-boxes-act.md
+++ b/.changeset/sparkly-boxes-act.md
@@ -1,0 +1,40 @@
+---
+'@mastra/core': major
+'@mastra/cloudflare-d1': patch
+'@mastra/clickhouse': patch
+'@mastra/cloudflare': patch
+'@mastra/dynamodb': patch
+'@mastra/mongodb': patch
+'@mastra/upstash': patch
+'@mastra/convex': patch
+'@mastra/libsql': patch
+'@mastra/lance': patch
+'@mastra/mssql': patch
+'@mastra/pg': patch
+---
+
+Renamed MastraStorage to MastraCompositeStore for better clarity. The old MastraStorage name remains available as a deprecated alias for backward compatibility, but will be removed in a future version.
+
+**Migration:**
+
+Update your imports and usage:
+
+```typescript
+// Before
+import { MastraStorage } from '@mastra/core/storage';
+
+const storage = new MastraStorage({
+  id: 'composite',
+  domains: { ... }
+});
+
+// After
+import { MastraCompositeStore } from '@mastra/core/storage';
+
+const storage = new MastraCompositeStore({
+  id: 'composite',
+  domains: { ... }
+});
+```
+
+The new name better reflects that this is a composite storage implementation that routes different domains (workflows, traces, messages) to different underlying stores, avoiding confusion with the general "Mastra Storage" concept.

--- a/docs/src/content/en/docs/memory/storage.mdx
+++ b/docs/src/content/en/docs/memory/storage.mdx
@@ -74,17 +74,17 @@ This is useful when all primitives share the same storage backend and have simil
 
 #### Composite storage
 
-Add storage to your Mastra instance using `MastraStorage` and configure individual storage domains to use different storage providers.
+Add storage to your Mastra instance using `MastraCompositeStore` and configure individual storage domains to use different storage providers.
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from "@mastra/core";
-import { MastraStorage } from "@mastra/core/storage";
+import { MastraCompositeStore } from "@mastra/core/storage";
 import { MemoryLibSQL } from "@mastra/libsql";
 import { WorkflowsPG } from "@mastra/pg";
 import { ObservabilityStorageClickhouse } from "@mastra/clickhouse";
 
 export const mastra = new Mastra({
-  storage: new MastraStorage({
+  storage: new MastraCompositeStore({
     id: "composite",
     domains: {
       memory: new MemoryLibSQL({ url: "file:./memory.db" }),

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/storage.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/storage.mdx
@@ -50,19 +50,19 @@ USING snapshot::jsonb;
 
 ## Added
 
-### Storage composition in MastraStorage
+### Storage composition in MastraCompositeStore
 
-`MastraStorage` can now compose storage domains from different adapters. Use it when you need different databases for different purposes - for example, PostgreSQL for memory and workflows, but a specialized database for observability.
+`MastraCompositeStore` can now compose storage domains from different adapters. Use it when you need different databases for different purposes - for example, PostgreSQL for memory and workflows, but a specialized database for observability.
 
 ```typescript
-import { MastraStorage } from "@mastra/core/storage";
+import { MastraCompositeStore } from "@mastra/core/storage";
 import { MemoryPG, WorkflowsPG, ScoresPG } from "@mastra/pg";
 import { MemoryLibSQL } from "@mastra/libsql";
 import { Mastra } from "@mastra/core";
 
 // Compose domains from different stores
 const mastra = new Mastra({
-  storage: new MastraStorage({
+  storage: new MastraCompositeStore({
     id: "composite",
     domains: {
       memory: new MemoryLibSQL({ url: "file:./local.db" }),

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/storage.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/storage.mdx
@@ -77,6 +77,36 @@ See the [Storage Composition reference](/reference/v1/storage/composite) for mor
 
 ## Changed
 
+### `MastraStorage` renamed to `MastraCompositeStore`
+
+The `MastraStorage` class has been renamed to `MastraCompositeStore` to better reflect its role as a composite storage implementation that routes different domains to different underlying stores. This avoids confusion with the general "Mastra Storage" concept (the `storage` property on the Mastra instance).
+
+The old `MastraStorage` name remains available as a deprecated alias for backward compatibility, but will be removed in a future version.
+
+To migrate, update your imports and instantiation:
+
+```diff
+- import { MastraStorage } from "@mastra/core/storage";
++ import { MastraCompositeStore } from "@mastra/core/storage";
+  import { MemoryLibSQL } from "@mastra/libsql";
+  import { WorkflowsPG } from "@mastra/pg";
+
+  export const mastra = new Mastra({
+-   storage: new MastraStorage({
++   storage: new MastraCompositeStore({
+      id: "composite",
+      domains: {
+        memory: new MemoryLibSQL({ url: "file:./memory.db" }),
+        workflows: new WorkflowsPG({ connectionString: process.env.DATABASE_URL }),
+      },
+    }),
+  });
+```
+
+:::note
+If you're using a single store implementation (like `PostgresStore` or `LibSQLStore`) directly, no changes are needed. This only affects code that explicitly uses `MastraStorage` for composite storage.
+:::
+
 ### Required `id` property for storage instances
 
 Storage instances now require an `id` property. This unique identifier is used for tracking and managing storage instances within Mastra. The `id` should be a descriptive, unique string for each storage instance in your application.

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -307,7 +307,7 @@ export const mastra = new Mastra({
 
 ### storage
 
-**Type:** `MastraStorage`
+**Type:** `MastraCompositeStore`
 
 Storage provider for persisting application data. Used by memory, workflows, traces, and other components that require persistence. Mastra supports multiple database backends including PostgreSQL, MongoDB, libSQL, and more.
 

--- a/docs/src/content/en/reference/core/getStorage.mdx
+++ b/docs/src/content/en/reference/core/getStorage.mdx
@@ -25,7 +25,7 @@ This method does not accept any parameters.
   content={[
     {
       name: "storage",
-      type: "MastraStorage | undefined",
+      type: "MastraCompositeStore | undefined",
       description:
         "The configured storage instance, or undefined if no storage has been configured.",
     },

--- a/docs/src/content/en/reference/core/mastra-class.mdx
+++ b/docs/src/content/en/reference/core/mastra-class.mdx
@@ -59,7 +59,7 @@ Visit the [Configuration reference](/reference/v1/configuration) for detailed do
     },
     {
       name: "storage",
-      type: "MastraStorage",
+      type: "MastraCompositeStore",
       description: "Storage engine instance for persisting data",
       isOptional: true,
     },

--- a/docs/src/content/en/reference/core/setStorage.mdx
+++ b/docs/src/content/en/reference/core/setStorage.mdx
@@ -7,7 +7,7 @@ packages:
 
 # Mastra.setStorage()
 
-The `.setStorage()` method is used to set the storage instance for the Mastra instance. This method accepts a single `MastraStorage` parameter.
+The `.setStorage()` method is used to set the storage instance for the Mastra instance. This method accepts a single `MastraCompositeStore` parameter.
 
 ## Usage example
 
@@ -26,7 +26,7 @@ mastra.setStorage(
   content={[
     {
       name: "storage",
-      type: "MastraStorage",
+      type: "MastraCompositeStore",
       description: "The storage instance to set for the Mastra instance.",
     },
   ]}

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -40,7 +40,7 @@ export const agent = new Agent({
   content={[
     {
       name: "storage",
-      type: "MastraStorage",
+      type: "MastraCompositeStore",
       description:
         'Storage implementation for persisting memory data. Defaults to `new DefaultStorage({ config: { url: "file:memory.db" } })` if not provided.',
       isOptional: true,

--- a/docs/src/content/en/reference/storage/composite.mdx
+++ b/docs/src/content/en/reference/storage/composite.mdx
@@ -10,11 +10,11 @@ packages:
 
 # Composite Storage
 
-`MastraStorage` can compose storage domains from different providers. Use it when you need different databases for different purposes. For example, use LibSQL for memory and PostgreSQL for workflows.
+`MastraCompositeStore` can compose storage domains from different providers. Use it when you need different databases for different purposes. For example, use LibSQL for memory and PostgreSQL for workflows.
 
 ## Installation
 
-`MastraStorage` is included in `@mastra/core`:
+`MastraCompositeStore` is included in `@mastra/core`:
 
 ```bash
 npm install @mastra/core@beta
@@ -45,13 +45,13 @@ Mastra organizes storage into five specialized domains, each handling a specific
 Import domain classes directly from each store package and compose them:
 
 ```typescript title="src/mastra/index.ts"
-import { MastraStorage } from "@mastra/core/storage";
+import { MastraCompositeStore } from "@mastra/core/storage";
 import { WorkflowsPG, ScoresPG } from "@mastra/pg";
 import { MemoryLibSQL } from "@mastra/libsql";
 import { Mastra } from "@mastra/core";
 
 export const mastra = new Mastra({
-  storage: new MastraStorage({
+  storage: new MastraCompositeStore({
     id: "composite",
     domains: {
       memory: new MemoryLibSQL({ url: "file:./local.db" }),
@@ -67,7 +67,7 @@ export const mastra = new Mastra({
 Use `default` to specify a fallback storage, then override specific domains:
 
 ```typescript title="src/mastra/index.ts"
-import { MastraStorage } from "@mastra/core/storage";
+import { MastraCompositeStore } from "@mastra/core/storage";
 import { PostgresStore } from "@mastra/pg";
 import { MemoryLibSQL } from "@mastra/libsql";
 import { Mastra } from "@mastra/core";
@@ -78,7 +78,7 @@ const pgStore = new PostgresStore({
 });
 
 export const mastra = new Mastra({
-  storage: new MastraStorage({
+  storage: new MastraCompositeStore({
     id: "composite",
     default: pgStore,
     domains: {
@@ -100,7 +100,7 @@ export const mastra = new Mastra({
     },
     {
       name: "default",
-      type: "MastraStorage",
+      type: "MastraCompositeStore",
       description:
         "Default storage adapter. Domains not explicitly specified in `domains` will use this storage's domains as fallbacks.",
       isOptional: true,
@@ -154,14 +154,14 @@ export const mastra = new Mastra({
 
 ## Initialization
 
-`MastraStorage` initializes each configured domain independently. When passed to the Mastra class, `init()` is called automatically:
+`MastraCompositeStore` initializes each configured domain independently. When passed to the Mastra class, `init()` is called automatically:
 
 ```typescript title="src/mastra/index.ts"
-import { MastraStorage } from "@mastra/core/storage";
+import { MastraCompositeStore } from "@mastra/core/storage";
 import { MemoryPG, WorkflowsPG, ScoresPG } from "@mastra/pg";
 import { Mastra } from "@mastra/core";
 
-const storage = new MastraStorage({
+const storage = new MastraCompositeStore({
   id: "composite",
   domains: {
     memory: new MemoryPG({ connectionString: process.env.DATABASE_URL }),
@@ -178,10 +178,10 @@ export const mastra = new Mastra({
 If using storage directly, call `init()` explicitly:
 
 ```typescript
-import { MastraStorage } from "@mastra/core/storage";
+import { MastraCompositeStore } from "@mastra/core/storage";
 import { MemoryPG } from "@mastra/pg";
 
-const storage = new MastraStorage({
+const storage = new MastraCompositeStore({
   id: "composite",
   domains: {
     memory: new MemoryPG({ connectionString: process.env.DATABASE_URL }),
@@ -202,11 +202,11 @@ const thread = await memoryStore?.getThreadById({ threadId: "..." });
 Use a local database for development while keeping production data in a managed service:
 
 ```typescript
-import { MastraStorage } from "@mastra/core/storage";
+import { MastraCompositeStore } from "@mastra/core/storage";
 import { MemoryPG, WorkflowsPG, ScoresPG } from "@mastra/pg";
 import { MemoryLibSQL } from "@mastra/libsql";
 
-const storage = new MastraStorage({
+const storage = new MastraCompositeStore({
   id: "composite",
   domains: {
     // Use local SQLite for development, PostgreSQL for production
@@ -225,11 +225,11 @@ const storage = new MastraStorage({
 Use a time-series database for traces while keeping other data in PostgreSQL:
 
 ```typescript
-import { MastraStorage } from "@mastra/core/storage";
+import { MastraCompositeStore } from "@mastra/core/storage";
 import { MemoryPG, WorkflowsPG, ScoresPG } from "@mastra/pg";
 import { ObservabilityStorageClickhouse } from "@mastra/clickhouse";
 
-const storage = new MastraStorage({
+const storage = new MastraCompositeStore({
   id: "composite",
   domains: {
     memory: new MemoryPG({ connectionString: process.env.DATABASE_URL }),

--- a/packages/core/src/action/index.ts
+++ b/packages/core/src/action/index.ts
@@ -2,14 +2,14 @@ import type { Agent } from '../agent';
 import type { IMastraLogger } from '../logger';
 import type { Mastra } from '../mastra';
 import type { MastraMemory } from '../memory';
-import type { MastraStorage } from '../storage';
+import type { MastraCompositeStore } from '../storage';
 import type { SchemaWithValidation } from '../stream';
 import type { MastraTTS } from '../tts';
 import type { MastraVector } from '../vector';
 
 export type MastraPrimitives = {
   logger?: IMastraLogger;
-  storage?: MastraStorage;
+  storage?: MastraCompositeStore;
   agents?: Record<string, Agent>;
   tts?: Record<string, MastraTTS>;
   vectors?: Record<string, MastraVector>;

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -20,7 +20,7 @@ import { NoOpObservability } from '../observability';
 import type { Processor } from '../processors';
 import type { MastraServerBase } from '../server/base';
 import type { Middleware, ServerConfig } from '../server/types';
-import type { MastraStorage, WorkflowRuns, StorageAgentType, StorageScorerConfig } from '../storage';
+import type { MastraCompositeStore, WorkflowRuns, StorageAgentType, StorageScorerConfig } from '../storage';
 import { augmentWithInit } from '../storage/storageWithInit';
 import type { ToolLoopAgentLike } from '../tool-loop-agent';
 import { isToolLoopAgentLike, toolLoopAgentToMastraAgent } from '../tool-loop-agent';
@@ -113,7 +113,7 @@ export interface Config<
    * Storage provider for persisting data, conversation history, and workflow state.
    * Required for agent memory and workflow persistence.
    */
-  storage?: MastraStorage;
+  storage?: MastraCompositeStore;
 
   /**
    * Vector stores for semantic search and retrieval-augmented generation (RAG).
@@ -295,7 +295,7 @@ export class Mastra<
     path: string;
   }> = [];
 
-  #storage?: MastraStorage;
+  #storage?: MastraCompositeStore;
   #scorers?: TScorers;
   #tools?: TTools;
   #processors?: TProcessors;
@@ -2347,7 +2347,7 @@ export class Mastra<
    * });
    * ```
    */
-  public setStorage(storage: MastraStorage) {
+  public setStorage(storage: MastraCompositeStore) {
     this.#storage = augmentWithInit(storage);
   }
 

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -15,7 +15,7 @@ import { isProcessorWorkflow } from '../processors';
 import { MessageHistory, WorkingMemory, SemanticRecall } from '../processors/memory';
 import type { RequestContext } from '../request-context';
 import type {
-  MastraStorage,
+  MastraCompositeStore,
   StorageListMessagesInput,
   StorageListThreadsInput,
   StorageListThreadsOutput,
@@ -97,7 +97,7 @@ export abstract class MastraMemory extends MastraBase {
 
   MAX_CONTEXT_TOKENS?: number;
 
-  protected _storage?: MastraStorage;
+  protected _storage?: MastraCompositeStore;
   vector?: MastraVector;
   embedder?: MastraEmbeddingModel<string>;
   embedderOptions?: MastraEmbeddingOptions;
@@ -201,7 +201,7 @@ https://mastra.ai/en/docs/memory/overview`,
     return this._storage;
   }
 
-  public setStorage(storage: MastraStorage) {
+  public setStorage(storage: MastraCompositeStore) {
     this._storage = augmentWithInit(storage);
   }
 

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -6,7 +6,7 @@ export type { MastraDBMessage } from '../agent';
 import type { EmbeddingModelId } from '../llm/model/index.js';
 import type { MastraLanguageModel, MastraModelConfig } from '../llm/model/shared.types';
 import type { RequestContext } from '../request-context';
-import type { MastraStorage } from '../storage';
+import type { MastraCompositeStore } from '../storage';
 import type { DynamicArgument } from '../types';
 import type { MastraEmbeddingModel, MastraEmbeddingOptions, MastraVector } from '../vector';
 import type { MemoryProcessor } from '.';
@@ -447,7 +447,7 @@ export type SharedMemoryConfig = {
    * storage: new LibSQLStore({ id: 'agent-memory-storage', url: "file:./agent-memory.db" })
    * ```
    */
-  storage?: MastraStorage;
+  storage?: MastraCompositeStore;
 
   /**
    * Configuration for memory behaviors including conversation history, semantic recall,

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -59,13 +59,13 @@ export function calculatePagination(
 export type MastraStorageDomains = Partial<StorageDomains>;
 
 /**
- * Configuration options for MastraStorage.
+ * Configuration options for MastraCompositeStore.
  *
  * Can be used in two ways:
  * 1. By store implementations: `{ id, name, disableInit? }` - stores set `this.stores` directly
  * 2. For composition: `{ id, default?, domains?, disableInit? }` - compose domains from multiple stores
  */
-export interface MastraStorageConfig {
+export interface MastraCompositeStoreConfig {
   /**
    * Unique identifier for this storage instance.
    */
@@ -73,7 +73,7 @@ export interface MastraStorageConfig {
 
   /**
    * Name of the storage adapter (used for logging).
-   * Required for store implementations extending MastraStorage.
+   * Required for store implementations extending MastraCompositeStore.
    */
   name?: string;
 
@@ -81,7 +81,7 @@ export interface MastraStorageConfig {
    * Default storage adapter to use for domains not explicitly specified.
    * If provided, domains from this storage will be used as fallbacks.
    */
-  default?: MastraStorage;
+  default?: MastraCompositeStore;
 
   /**
    * Individual domain overrides. Each domain can come from a different storage adapter.
@@ -135,7 +135,7 @@ export interface MastraStorageConfig {
  * @example
  * ```typescript
  * // Composition: mix domains from different stores
- * const storage = new MastraStorage({
+ * const storage = new MastraCompositeStore({
  *   id: 'composite',
  *   default: pgStore,
  *   domains: {
@@ -148,7 +148,7 @@ export interface MastraStorageConfig {
  * await memory?.saveThread({ thread });
  * ```
  */
-export class MastraStorage extends MastraBase {
+export class MastraCompositeStore extends MastraBase {
   protected hasInitialized: null | Promise<boolean> = null;
   protected shouldCacheInit = true;
 
@@ -160,8 +160,8 @@ export class MastraStorage extends MastraBase {
    */
   disableInit: boolean = false;
 
-  constructor(config: MastraStorageConfig) {
-    const name = config.name ?? 'MastraStorage';
+  constructor(config: MastraCompositeStoreConfig) {
+    const name = config.name ?? 'MastraCompositeStore';
 
     if (!config.id || typeof config.id !== 'string' || config.id.trim() === '') {
       throw new Error(`${name}: id must be provided and cannot be empty.`);
@@ -186,7 +186,7 @@ export class MastraStorage extends MastraBase {
 
       if (!hasDefaultDomains && !hasOverrideDomains) {
         throw new Error(
-          'MastraStorage requires at least one storage source. Provide either a default storage with domains or domain overrides.',
+          'MastraCompositeStore requires at least one storage source. Provide either a default storage with domains or domain overrides.',
         );
       }
 
@@ -259,3 +259,13 @@ export class MastraStorage extends MastraBase {
     await this.hasInitialized;
   }
 }
+
+/**
+ * @deprecated Use MastraCompositeStoreConfig instead. This alias will be removed in a future version.
+ */
+export interface MastraStorageConfig extends MastraCompositeStoreConfig {}
+
+/**
+ * @deprecated Use MastraCompositeStore instead. This alias will be removed in a future version.
+ */
+export class MastraStorage extends MastraCompositeStore {}

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -1,4 +1,4 @@
-import { MastraStorage } from './base';
+import { MastraCompositeStore } from './base';
 import type { StorageDomains } from './base';
 import { InMemoryAgentsStorage } from './domains/agents/inmemory';
 import { InMemoryDB } from './domains/inmemory-db';
@@ -25,7 +25,7 @@ import { WorkflowsInMemory } from './domains/workflows/inmemory';
  * await workflows?.persistWorkflowSnapshot({ workflowName, runId, snapshot });
  * ```
  */
-export class InMemoryStore extends MastraStorage {
+export class InMemoryStore extends MastraCompositeStore {
   stores: StorageDomains;
 
   /**

--- a/packages/core/src/storage/storageWithInit.ts
+++ b/packages/core/src/storage/storageWithInit.ts
@@ -1,8 +1,8 @@
-import type { MastraStorage } from './base';
+import type { MastraCompositeStore } from './base';
 
 const isAugmentedSymbol = Symbol('isAugmented');
 
-export function augmentWithInit(storage: MastraStorage): MastraStorage {
+export function augmentWithInit(storage: MastraCompositeStore): MastraCompositeStore {
   let hasInitialized: null | Promise<void> = null;
 
   const ensureInit = async () => {

--- a/stores/clickhouse/src/storage/index.ts
+++ b/stores/clickhouse/src/storage/index.ts
@@ -1,7 +1,7 @@
 import type { ClickHouseClient, ClickHouseClientConfigOptions } from '@clickhouse/client';
 import { createClient } from '@clickhouse/client';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
+import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
 import type { TABLE_NAMES, StorageDomains, TABLE_SCHEMAS } from '@mastra/core/storage';
 import { MemoryStorageClickhouse } from './domains/memory';
 import { ObservabilityStorageClickhouse } from './domains/observability';
@@ -162,7 +162,7 @@ const isClientConfig = (config: ClickhouseConfig): config is ClickhouseConfig & 
  * await observability?.createSpan(span);
  * ```
  */
-export class ClickhouseStore extends MastraStorage {
+export class ClickhouseStore extends MastraCompositeStore {
   protected db: ClickHouseClient;
   protected ttl: ClickhouseConfig['ttl'] = {};
 

--- a/stores/cloudflare-d1/src/storage/index.ts
+++ b/stores/cloudflare-d1/src/storage/index.ts
@@ -1,6 +1,6 @@
 import type { D1Database } from '@cloudflare/workers-types';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
-import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
+import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
 import type { StorageDomains } from '@mastra/core/storage';
 import Cloudflare from 'cloudflare';
 import { MemoryStorageD1 } from './domains/memory';
@@ -94,7 +94,7 @@ export interface D1Client {
  * await workflows?.persistWorkflowSnapshot({ workflowName, runId, snapshot });
  * ```
  */
-export class D1Store extends MastraStorage {
+export class D1Store extends MastraCompositeStore {
   private client?: D1Client;
   private binding?: D1Database;
   private tablePrefix: string;

--- a/stores/cloudflare/src/storage/index.ts
+++ b/stores/cloudflare/src/storage/index.ts
@@ -2,7 +2,7 @@ import type { KVNamespace } from '@cloudflare/workers-types';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   createStorageErrorId,
-  MastraStorage,
+  MastraCompositeStore,
   TABLE_MESSAGES,
   TABLE_THREADS,
   TABLE_WORKFLOW_SNAPSHOT,
@@ -38,7 +38,7 @@ import type { CloudflareStoreConfig, CloudflareWorkersConfig, CloudflareRestConf
  * await workflows?.persistWorkflowSnapshot({ workflowName, runId, snapshot });
  * ```
  */
-export class CloudflareStore extends MastraStorage {
+export class CloudflareStore extends MastraCompositeStore {
   stores: StorageDomains;
   private client?: Cloudflare;
   private accountId?: string;

--- a/stores/convex/src/storage/index.ts
+++ b/stores/convex/src/storage/index.ts
@@ -1,5 +1,5 @@
 import type { StorageDomains } from '@mastra/core/storage';
-import { MastraStorage } from '@mastra/core/storage';
+import { MastraCompositeStore } from '@mastra/core/storage';
 
 import type { ConvexAdminClientConfig } from './client';
 import { ConvexAdminClient } from './client';
@@ -90,7 +90,7 @@ const isClientConfig = (config: ConvexStoreConfig): config is ConvexStoreConfig 
  * await workflows?.persistWorkflowSnapshot({ workflowName, runId, snapshot });
  * ```
  */
-export class ConvexStore extends MastraStorage {
+export class ConvexStore extends MastraCompositeStore {
   declare stores: StorageDomains;
 
   constructor(config: ConvexStoreConfig) {

--- a/stores/dynamodb/src/storage/index.ts
+++ b/stores/dynamodb/src/storage/index.ts
@@ -2,7 +2,7 @@ import { DynamoDBClient, DescribeTableCommand } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { StorageDomains } from '@mastra/core/storage';
-import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
+import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
 
 import type { Service } from 'electrodb';
 import { getElectroDbService } from '../entities';
@@ -215,7 +215,7 @@ type MastraService = Service<Record<string, any>> & {
  * await workflows?.persistWorkflowSnapshot({ workflowName, runId, snapshot });
  * ```
  */
-export class DynamoDBStore extends MastraStorage {
+export class DynamoDBStore extends MastraCompositeStore {
   private tableName: string;
   private client: DynamoDBDocumentClient;
   private service: MastraService;

--- a/stores/lance/src/storage/index.ts
+++ b/stores/lance/src/storage/index.ts
@@ -1,7 +1,7 @@
 import { connect } from '@lancedb/lancedb';
 import type { Connection, ConnectionOptions } from '@lancedb/lancedb';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
+import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
 import type { StorageDomains } from '@mastra/core/storage';
 import { StoreMemoryLance } from './domains/memory';
 import { StoreScoresLance } from './domains/scores';
@@ -71,7 +71,7 @@ export interface LanceStorageClientOptions extends LanceStorageOptions {
  * await workflows?.persistWorkflowSnapshot({ workflowName, runId, snapshot });
  * ```
  */
-export class LanceStorage extends MastraStorage {
+export class LanceStorage extends MastraCompositeStore {
   stores: StorageDomains;
   private lanceClient!: Connection;
   /**

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@libsql/client';
 import type { Client } from '@libsql/client';
 import type { StorageDomains } from '@mastra/core/storage';
-import { MastraStorage } from '@mastra/core/storage';
+import { MastraCompositeStore } from '@mastra/core/storage';
 
 import { AgentsLibSQL } from './domains/agents';
 import { MemoryLibSQL } from './domains/memory';
@@ -78,7 +78,7 @@ export type LibSQLConfig =
  * await workflows?.persistWorkflowSnapshot({ workflowName, runId, snapshot });
  * ```
  */
-export class LibSQLStore extends MastraStorage {
+export class LibSQLStore extends MastraCompositeStore {
   private client: Client;
   private readonly maxRetries: number;
   private readonly initialBackoffMs: number;

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -1,6 +1,6 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { StorageDomains } from '@mastra/core/storage';
-import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
+import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
 import type { MongoDBConnector } from './connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from './db';
 import { MongoDBAgentsStorage } from './domains/agents';
@@ -38,7 +38,7 @@ export type { MongoDBDomainConfig } from './db';
  * await workflows?.persistWorkflowSnapshot({ workflowName, runId, snapshot });
  * ```
  */
-export class MongoDBStore extends MastraStorage {
+export class MongoDBStore extends MastraCompositeStore {
   #connector: MongoDBConnector;
 
   stores: StorageDomains;

--- a/stores/mssql/src/storage/index.ts
+++ b/stores/mssql/src/storage/index.ts
@@ -1,5 +1,5 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
+import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
 import type { StorageDomains, CreateIndexOptions } from '@mastra/core/storage';
 
 import sql from 'mssql';
@@ -143,7 +143,7 @@ const isPoolConfig = (config: MSSQLConfigType): config is MSSQLConfigType & { po
  * await observability?.createSpan(span);
  * ```
  */
-export class MSSQLStore extends MastraStorage {
+export class MSSQLStore extends MastraCompositeStore {
   public pool: sql.ConnectionPool;
   private schema?: string;
   private isConnected: Promise<boolean> | null = null;

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -1,5 +1,5 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { createStorageErrorId, MastraStorage } from '@mastra/core/storage';
+import { createStorageErrorId, MastraCompositeStore } from '@mastra/core/storage';
 import type { StorageDomains } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
 import { Pool } from 'pg';
@@ -55,7 +55,7 @@ export type { PgDomainConfig, PgDomainClientConfig, PgDomainPoolConfig, PgDomain
  * const rows = await store.db.any('SELECT * FROM my_table');
  * ```
  */
-export class PostgresStore extends MastraStorage {
+export class PostgresStore extends MastraCompositeStore {
   #pool: Pool;
   #db: DbClient;
   #ownsPool: boolean;

--- a/stores/upstash/src/storage/index.ts
+++ b/stores/upstash/src/storage/index.ts
@@ -1,4 +1,4 @@
-import { MastraStorage } from '@mastra/core/storage';
+import { MastraCompositeStore } from '@mastra/core/storage';
 import type { StorageDomains } from '@mastra/core/storage';
 import { Redis } from '@upstash/redis';
 import { StoreMemoryUpstash } from './domains/memory';
@@ -92,7 +92,7 @@ const isClientConfig = (config: UpstashConfig): config is UpstashConfig & { clie
  * await workflows?.persistWorkflowSnapshot({ workflowName, runId, snapshot });
  * ```
  */
-export class UpstashStore extends MastraStorage {
+export class UpstashStore extends MastraCompositeStore {
   private redis: Redis;
   stores: StorageDomains;
 


### PR DESCRIPTION
## Summary

Rename `MastraStorage` class to `MastraCompositeStore` to better reflect its role as the composite/domain-based storage implementation. This addresses confusion where "Mastra Storage" referred to both the top-level storage concept and a specific implementation strategy.

As discussed in the team conversation, the name `MastraStorage` was confusing because it could refer to either:
1. The top-level storage concept (the `storage` property on Mastra)
2. The specific composite/domain-based storage implementation

The new name `MastraCompositeStore` makes it clear this is one particular implementation that routes different domains (workflows, traces, messages) to different underlying stores.

## Changes

- ✅ Renamed `MastraStorage` class to `MastraCompositeStore`
- ✅ Renamed `MastraStorageConfig` interface to `MastraCompositeStoreConfig`
- ✅ Added deprecated aliases for backward compatibility
- ✅ Updated all documentation references (8 docs files)
- ✅ Updated all code references in packages/core
- ✅ Updated all 11 store implementations to extend `MastraCompositeStore`
- ✅ Storage tests pass (64/64)
- ✅ Build successful
- ✅ Type checking passes

## Backward Compatibility

Backward compatibility is maintained through deprecated aliases:
```typescript
/** @deprecated Use MastraCompositeStore instead */
export class MastraStorage extends MastraCompositeStore {}

/** @deprecated Use MastraCompositeStoreConfig instead */
export interface MastraStorageConfig extends MastraCompositeStoreConfig {}
```

Existing code using `MastraStorage` will continue to work, but users should migrate to `MastraCompositeStore` for new code.

## Breaking Changes

While backward compatibility is maintained, this is marked as a breaking change because:
- The deprecated `MastraStorage` alias will be removed in a future version
- Users should start using `MastraCompositeStore` in new code

## Test Plan

- [x] Storage tests pass (64/64 tests)
- [x] Build completes successfully
- [x] Type checking passes
- [x] Pre-commit hooks pass (lint-staged, prettier)

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed public storage API from MastraStorage to MastraCompositeStore across the core framework and storage connectors.
  * Kept MastraStorage as a deprecated alias for backward compatibility.

* **Documentation**
  * Updated guides, configuration references, and examples to use MastraCompositeStore and added migration guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->