### PR TITLE
fixed migration tool

### DIFF
--- a/.changeset/solid-teams-film.md
+++ b/.changeset/solid-teams-film.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'mastra': patch
+---
+
+Fixed migration CLI failing with MIGRATION_REQUIRED error during Mastra import. Added MASTRA_DISABLE_STORAGE_INIT environment variable to skip auto-initialization of storage, allowing the migration command to import user's Mastra config without triggering the migration check. Also improved the migration prompt display to show warning messages before the confirmation dialog.

--- a/packages/cli/src/commands/migrate/MigrateBundler.test.ts
+++ b/packages/cli/src/commands/migrate/MigrateBundler.test.ts
@@ -71,18 +71,17 @@ describe('MigrateBundler', () => {
       expect(entry).toContain('mastra.getStorage()');
     });
 
-    it('should generate entry script that calls storage.init()', () => {
+    it('should generate entry script that accesses observabilityStore directly from storage.stores', () => {
       const bundler = new MigrateBundler();
       const entry = (bundler as any).getEntry();
 
-      expect(entry).toContain('await storage.init()');
+      expect(entry).toContain('storage.stores?.observability');
     });
 
     it('should generate entry script that calls observabilityStore.migrateSpans()', () => {
       const bundler = new MigrateBundler();
       const entry = (bundler as any).getEntry();
 
-      expect(entry).toContain("storage.getStore('observability')");
       expect(entry).toContain('observabilityStore.migrateSpans()');
     });
 
@@ -126,17 +125,6 @@ describe('MigrateBundler', () => {
 
       expect(entry).toContain('catch (error)');
       expect(entry).toContain('error instanceof Error ? error.message');
-    });
-
-    it('should generate entry script that handles MIGRATION_REQUIRED errors from init()', () => {
-      const bundler = new MigrateBundler();
-      const entry = (bundler as any).getEntry();
-
-      // The script should catch MIGRATION_REQUIRED errors and continue with migration
-      expect(entry).toContain('MIGRATION_REQUIRED');
-      expect(entry).toContain('migrationRequired');
-      // Should have nested try-catch for init()
-      expect(entry).toMatch(/try\s*\{[\s\S]*await storage\.init\(\)[\s\S]*\}\s*catch\s*\(initError\)/);
     });
   });
 

--- a/packages/cli/src/commands/migrate/MigrateBundler.ts
+++ b/packages/cli/src/commands/migrate/MigrateBundler.ts
@@ -60,26 +60,9 @@ export class MigrateBundler extends BuildBundler {
       }
 
       try {
-        // Try to initialize storage - but catch MIGRATION_REQUIRED errors
-        // since that's exactly what we're here to fix
-        let migrationRequired = false;
-        try {
-          await storage.init();
-        } catch (initError) {
-          // Check if this is a MIGRATION_REQUIRED error (which is expected)
-          const errorMessage = initError instanceof Error ? initError.message : String(initError);
-          const errorId = (initError as any)?.id || '';
-          if (errorMessage.includes('MIGRATION_REQUIRED') || errorId.includes('MIGRATION_REQUIRED')) {
-            migrationRequired = true;
-            // This is expected - continue with migration
-          } else {
-            // Re-throw other errors
-            throw initError;
-          }
-        }
-
-        // Get the observability store
-        const observabilityStore = await storage.getStore('observability');
+        // Access the observability store directly from storage.stores
+        // This bypasses the init proxy that would re-throw MIGRATION_REQUIRED errors
+        const observabilityStore = storage.stores?.observability;
 
         if (!observabilityStore) {
           console.log(JSON.stringify({
@@ -100,6 +83,28 @@ export class MigrateBundler extends BuildBundler {
             message: 'Migration not supported for this storage backend.',
           }));
           process.exit(1);
+        }
+
+        // Try to initialize the observability store - catch MIGRATION_REQUIRED errors
+        // since that's exactly what we're here to fix
+        try {
+          await observabilityStore.init();
+        } catch (initError) {
+          // Check if this is a MIGRATION_REQUIRED error (which is expected)
+          const errorMessage = initError instanceof Error ? initError.message : String(initError);
+          const errorId = initError?.id || '';
+
+          // Check for various forms of the migration required indicator
+          const isMigrationRequired =
+            errorId.includes('MIGRATION_REQUIRED') ||
+            errorMessage.includes('MIGRATION_REQUIRED') ||
+            errorMessage.includes('MIGRATION REQUIRED');
+
+          if (!isMigrationRequired) {
+            // Re-throw non-migration errors
+            throw initError;
+          }
+          // MIGRATION_REQUIRED is expected - continue with migration
         }
 
         // Run the migration

--- a/packages/cli/src/commands/migrate/migrate.ts
+++ b/packages/cli/src/commands/migrate/migrate.ts
@@ -34,17 +34,14 @@ export async function migrate({
   const mastraDir = dir ? (dir.startsWith('/') ? dir : join(process.cwd(), dir)) : join(process.cwd(), 'src', 'mastra');
   const dotMastraPath = join(rootDir, '.mastra');
 
-  logger.info(pc.cyan('Mastra Storage Migration'));
-  logger.info('');
+  p.intro(pc.cyan('Mastra Storage Migration'));
 
   // Show backup warning and ask for confirmation (unless --yes flag is used)
   if (!yes) {
-    logger.info(pc.yellow('⚠️  Warning: This migration will modify your database.'));
-    logger.info('');
-    logger.info('   Before proceeding, please ensure you have:');
-    logger.info('   • Created a backup of your database');
-    logger.info('   • Tested this migration in a non-production environment');
-    logger.info('');
+    p.log.warn(pc.yellow('Warning: This migration will modify your database.'));
+    p.log.message('Before proceeding, please ensure you have:');
+    p.log.message('  • Created a backup of your database');
+    p.log.message('  • Tested this migration in a non-production environment');
 
     const confirmed = await p.confirm({
       message: 'Have you backed up your database and are ready to proceed?',
@@ -52,13 +49,10 @@ export async function migrate({
     });
 
     if (p.isCancel(confirmed) || !confirmed) {
-      logger.info('');
-      logger.info('Migration cancelled. Please back up your database before running this command.');
-      logger.info(pc.dim('Tip: Use --yes or -y to skip this prompt in CI/automation.'));
+      p.log.info('Migration cancelled. Please back up your database before running this command.');
+      p.log.message(pc.dim('Tip: Use --yes or -y to skip this prompt in CI/automation.'));
       process.exit(0);
     }
-
-    logger.info('');
   }
 
   try {
@@ -92,6 +86,7 @@ export async function migrate({
       cwd: rootDir,
       env: {
         NODE_ENV: 'production',
+        MASTRA_DISABLE_STORAGE_INIT: 'true', // Prevent MIGRATION_REQUIRED error during import
         ...Object.fromEntries(loadedEnv),
       },
       stdio: ['inherit', 'pipe', 'pipe'],

--- a/packages/core/src/storage/storageWithInit.test.ts
+++ b/packages/core/src/storage/storageWithInit.test.ts
@@ -109,4 +109,55 @@ describe('augmentWithInit', () => {
     // init should only be called once
     expect(mockStorage.init).toHaveBeenCalledTimes(1);
   });
+
+  it('should NOT call init when MASTRA_DISABLE_STORAGE_INIT is true', async () => {
+    const originalEnv = process.env.MASTRA_DISABLE_STORAGE_INIT;
+    process.env.MASTRA_DISABLE_STORAGE_INIT = 'true';
+
+    try {
+      const mockStorage = {
+        init: vi.fn().mockResolvedValue(true),
+        listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0, hasMore: false }),
+        disableInit: false,
+      } as unknown as MastraStorage;
+
+      const augmentedStorage = augmentWithInit(mockStorage);
+      await augmentedStorage.listMessages({ threadId: '1' });
+
+      expect(mockStorage.init).not.toHaveBeenCalled();
+      expect(mockStorage.listMessages).toHaveBeenCalled();
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.MASTRA_DISABLE_STORAGE_INIT;
+      } else {
+        process.env.MASTRA_DISABLE_STORAGE_INIT = originalEnv;
+      }
+    }
+  });
+
+  it('should still allow explicit init() call when MASTRA_DISABLE_STORAGE_INIT is true', async () => {
+    const originalEnv = process.env.MASTRA_DISABLE_STORAGE_INIT;
+    process.env.MASTRA_DISABLE_STORAGE_INIT = 'true';
+
+    try {
+      const mockStorage = {
+        init: vi.fn().mockResolvedValue(true),
+        listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0, hasMore: false }),
+        disableInit: false,
+      } as unknown as MastraStorage;
+
+      const augmentedStorage = augmentWithInit(mockStorage);
+
+      // Explicit init should work even when env var is set
+      await augmentedStorage.init();
+
+      expect(mockStorage.init).toHaveBeenCalled();
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.MASTRA_DISABLE_STORAGE_INIT;
+      } else {
+        process.env.MASTRA_DISABLE_STORAGE_INIT = originalEnv;
+      }
+    }
+  });
 });

--- a/packages/core/src/storage/storageWithInit.ts
+++ b/packages/core/src/storage/storageWithInit.ts
@@ -11,6 +11,11 @@ export function augmentWithInit(storage: MastraCompositeStore): MastraCompositeS
       return;
     }
 
+    // Environment variable equivalent of disableInit - used by migration CLI
+    if (process.env.MASTRA_DISABLE_STORAGE_INIT === 'true') {
+      return;
+    }
+
     if (!hasInitialized) {
       hasInitialized = storage.init();
     }


### PR DESCRIPTION
## Description

Fixed migration CLI failing with MIGRATION_REQUIRED error during Mastra import. Added MASTRA_DISABLE_STORAGE_INIT environment variable to skip auto-initialization of storage, allowing the migration command to import user's Mastra config without triggering the migration check. Also improved the migration prompt display to show warning messages before the confirmation dialog.

## Related Issue(s)


## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed migration errors during Mastra configuration import by allowing storage auto-initialization to be skipped when requested.

* **Improvements**
  * Migration command can import an existing Mastra config without triggering migration checks.
  * Migration prompts now display warnings before confirmation and command output is tightened for clearer, more concise messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->