### PR TITLE
chore: Update templates

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -13,8 +13,8 @@ Your template folder **must** include the following files:
 ### a. `package.json`
 
 - Use `openai` as the LLM provider in your code/config.
-- All `@mastra/*` dependencies should be set to `"beta"` in the `dependencies` section.
-- `mastra` devDependency should be set to `"beta"` in the `devDependencies` section.
+- All `@mastra/*` dependencies should be set to `"latest"` in the `dependencies` section.
+- `mastra` devDependency should be set to `"latest"` in the `devDependencies` section.
 - The `description` field should clearly describe what the template does.
 
 **Example:**
@@ -33,13 +33,13 @@ Your template folder **must** include the following files:
     "dev": "mastra dev"
   },
   "dependencies": {
-    "@mastra/core": "beta",
+    "@mastra/core": "latest",
     "zod": "^3.25.67",
-    "@mastra/loggers": "beta"
+    "@mastra/loggers": "latest"
   },
   "devDependencies": {
     "@types/node": "^24.0.4",
-    "mastra": "beta",
+    "mastra": "latest",
     "typescript": "^5.8.3"
   }
 }

--- a/templates/template-ad-copy-from-content/package.json
+++ b/templates/template-ad-copy-from-content/package.json
@@ -19,18 +19,18 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",
     "@browserbasehq/stagehand": "^2.5.2",
-    "@mastra/core": "beta",
-    "@mastra/libsql": "beta",
-    "@mastra/loggers": "beta",
-    "@mastra/memory": "beta",
-    "@mastra/observability": "beta",
+    "@mastra/core": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/loggers": "latest",
+    "@mastra/memory": "latest",
+    "@mastra/observability": "latest",
     "ai": "^4.3.19",
     "@ai-sdk/openai": "^2.0.65",
     "pdf2json": "^3.1.3",
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "mastra": "beta",
+    "mastra": "latest",
     "@types/node": "22.13.17",
     "typescript": "^5.9.3"
   }

--- a/templates/template-ad-copy-from-content/package.json
+++ b/templates/template-ad-copy-from-content/package.json
@@ -24,7 +24,7 @@
     "@mastra/loggers": "latest",
     "@mastra/memory": "latest",
     "@mastra/observability": "latest",
-    "ai": "^4.3.19",
+    "ai": "^5.0.121",
     "@ai-sdk/openai": "^2.0.65",
     "pdf2json": "^3.1.3",
     "zod": "^3.25.76"

--- a/templates/template-ad-copy-from-content/src/mastra/tools/image-generator-tool.ts
+++ b/templates/template-ad-copy-from-content/src/mastra/tools/image-generator-tool.ts
@@ -64,7 +64,7 @@ export const imageGeneratorTool = createTool({
     }),
   }),
   execute: async input => {
-    const { prompt, style, platform, size } = input;
+    const { prompt, style, platform, size = '480x480' } = input;
 
     console.log(`🎨 Generating image with DALL-E 3 via AI package: "${prompt.substring(0, 50)}..."`);
 
@@ -94,7 +94,7 @@ export const imageGeneratorTool = createTool({
       const imageBuffer = Buffer.from(image.base64, 'base64');
 
       // Upload to cloud storage and get public URL
-      const publicImageUrl = await uploadImageToStorage(imageBuffer, image.mimeType);
+      const publicImageUrl = await uploadImageToStorage(imageBuffer, image.mediaType);
 
       return {
         imageUrl: publicImageUrl,

--- a/templates/template-ad-copy-from-content/src/mastra/workflows/ad-copy-generation-workflow.ts
+++ b/templates/template-ad-copy-from-content/src/mastra/workflows/ad-copy-generation-workflow.ts
@@ -61,7 +61,7 @@ const extractContentStep = createStep({
       })
       .optional(),
   }),
-  execute: async ({ inputData, requestContext, mastra }) => {
+  execute: async ({ inputData, requestContext, mastra, getInitData }) => {
     const { contentInput, inputType } = inputData;
 
     console.log(`📝 Processing ${inputType} content...`);
@@ -135,7 +135,7 @@ const extractContentStep = createStep({
 
       try {
         // Use the PDF content extractor tool
-        const extractionResult = await pdfContentExtractorTool.execute(
+        const extractionResult = await pdfContentExtractorTool.execute!(
           {
             pdfUrl: contentInput,
             focusAreas: ['benefits', 'features', 'value-proposition'],
@@ -219,7 +219,7 @@ const generateAdCopyStep = createStep({
     const finalTargetAudience = targetAudience || extractedData?.targetAudience || 'General audience';
 
     try {
-      const adCopyResults = await adCopyGeneratorTool.execute(
+      const adCopyResults = await adCopyGeneratorTool.execute!(
         {
           content: processedContent,
           platform: platform as 'facebook' | 'google' | 'instagram' | 'linkedin' | 'twitter' | 'tiktok' | 'generic',
@@ -298,7 +298,7 @@ const generateImageStep = createStep({
     try {
       const imagePrompt = `Professional promotional image for advertisement: ${headline}. ${body.substring(0, 100)}...`;
 
-      const imageResult = await imageGeneratorTool.execute(
+      const imageResult = await imageGeneratorTool.execute!(
         {
           prompt: imagePrompt,
           style: imageStyle as 'photographic' | 'digital_art' | 'illustration' | 'minimalist' | 'vintage' | 'modern',
@@ -333,6 +333,7 @@ export const adCopyGenerationWorkflow = createWorkflow({
   inputSchema,
   outputSchema,
 })
+  // @ts-expect-error - TODO: remove once z.enum().optional().default() type error is fixed
   .then(extractContentStep)
   .map({
     processedContent: {
@@ -348,35 +349,35 @@ export const adCopyGenerationWorkflow = createWorkflow({
     platform: {
       schema: z.string(),
       fn: async ({ getInitData }) => {
-        const initData = getInitData();
+        const initData = getInitData<z.infer<typeof inputSchema>>();
         return initData.platform;
       },
     },
     campaignType: {
       schema: z.string(),
       fn: async ({ getInitData }) => {
-        const initData = getInitData();
+        const initData = getInitData<z.infer<typeof inputSchema>>();
         return initData.campaignType;
       },
     },
     targetAudience: {
       schema: z.string().optional(),
       fn: async ({ getInitData }) => {
-        const initData = getInitData();
+        const initData = getInitData<z.infer<typeof inputSchema>>();
         return initData.targetAudience;
       },
     },
     tone: {
       schema: z.string(),
       fn: async ({ getInitData }) => {
-        const initData = getInitData();
+        const initData = getInitData<z.infer<typeof inputSchema>>();
         return initData.tone;
       },
     },
     productType: {
       schema: z.string().optional(),
       fn: async ({ getInitData }) => {
-        const initData = getInitData();
+        const initData = getInitData<z.infer<typeof inputSchema>>();
         return initData.productType;
       },
     },
@@ -386,21 +387,21 @@ export const adCopyGenerationWorkflow = createWorkflow({
     generateImages: {
       schema: z.boolean(),
       fn: async ({ getInitData }) => {
-        const initData = getInitData();
+        const initData = getInitData<z.infer<typeof inputSchema>>();
         return initData.generateImages;
       },
     },
     imageStyle: {
       schema: z.string().optional(),
       fn: async ({ getInitData }) => {
-        const initData = getInitData();
+        const initData = getInitData<z.infer<typeof inputSchema>>();
         return initData.imageStyle;
       },
     },
     platform: {
       schema: z.string(),
       fn: async ({ getInitData }) => {
-        const initData = getInitData();
+        const initData = getInitData<z.infer<typeof inputSchema>>();
         return initData.platform;
       },
     },
@@ -421,6 +422,7 @@ export const adCopyGenerationWorkflow = createWorkflow({
       step: generateAdCopyStep,
       path: '.',
     }),
+    // @ts-expect-error - TODO: remove once mapVariable type error is fixed
     imageUrl: mapVariable({
       step: generateImageStep,
       path: 'imageUrl',

--- a/templates/template-ad-copy-from-content/src/mastra/workflows/ad-copy-generation-workflow.ts
+++ b/templates/template-ad-copy-from-content/src/mastra/workflows/ad-copy-generation-workflow.ts
@@ -61,7 +61,7 @@ const extractContentStep = createStep({
       })
       .optional(),
   }),
-  execute: async ({ inputData, requestContext, mastra, getInitData }) => {
+  execute: async ({ inputData, requestContext, mastra }) => {
     const { contentInput, inputType } = inputData;
 
     console.log(`📝 Processing ${inputType} content...`);

--- a/templates/template-browsing-agent/package.json
+++ b/templates/template-browsing-agent/package.json
@@ -17,17 +17,17 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@mastra/core": "beta",
-    "@mastra/libsql": "beta",
-    "@mastra/loggers": "beta",
-    "@mastra/memory": "beta",
-    "@mastra/observability": "beta",
+    "@mastra/core": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/loggers": "latest",
+    "@mastra/memory": "latest",
+    "@mastra/observability": "latest",
     "@browserbasehq/stagehand": "^2.5.2",
     "zod": "^3.25.67"
   },
   "devDependencies": {
     "@types/node": "^24.0.4",
-    "mastra": "beta",
+    "mastra": "latest",
     "dotenv": "^16.4.5",
     "typescript": "^5.9.3"
   }

--- a/templates/template-coding-agent/package.json
+++ b/templates/template-coding-agent/package.json
@@ -19,19 +19,19 @@
   "dependencies": {
     "@daytonaio/sdk": "^0.120.0",
     "@e2b/code-interpreter": "^1.5.1",
-    "@mastra/core": "beta",
-    "@mastra/fastembed": "beta",
-    "@mastra/libsql": "beta",
-    "@mastra/loggers": "beta",
-    "@mastra/mcp": "beta",
-    "@mastra/memory": "beta",
-    "@mastra/observability": "beta",
+    "@mastra/core": "latest",
+    "@mastra/fastembed": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/loggers": "latest",
+    "@mastra/mcp": "latest",
+    "@mastra/memory": "latest",
+    "@mastra/observability": "latest",
     "supports-color": "^10.2.2",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^24.1.0",
-    "mastra": "beta",
+    "mastra": "latest",
     "typescript": "^5.9.3"
   }
 }

--- a/templates/template-csv-to-questions/package.json
+++ b/templates/template-csv-to-questions/package.json
@@ -23,7 +23,7 @@
     "@mastra/loggers": "latest",
     "@mastra/memory": "latest",
     "@mastra/observability": "latest",
-    "ai": "^4.3.19",
+    "ai": "^5.0.121",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/templates/template-csv-to-questions/package.json
+++ b/templates/template-csv-to-questions/package.json
@@ -18,18 +18,18 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@mastra/core": "beta",
-    "@mastra/libsql": "beta",
-    "@mastra/loggers": "beta",
-    "@mastra/memory": "beta",
-    "@mastra/observability": "beta",
+    "@mastra/core": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/loggers": "latest",
+    "@mastra/memory": "latest",
+    "@mastra/observability": "latest",
     "ai": "^4.3.19",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "22.13.17",
     "bun": "^1.3.5",
-    "mastra": "beta",
+    "mastra": "latest",
     "typescript": "^5.9.3"
   }
 }

--- a/templates/template-csv-to-questions/src/mastra/workflows/csv-to-questions-workflow.ts
+++ b/templates/template-csv-to-questions/src/mastra/workflows/csv-to-questions-workflow.ts
@@ -32,7 +32,7 @@ const downloadAndSummarizeCSVStep = createStep({
     console.log('Executing Step: download-and-summarize-csv');
     const { csvUrl } = inputData;
 
-    const result = await csvFetcherTool.execute(
+    const result = await csvFetcherTool.execute!(
       { csvUrl },
       {
         mastra,
@@ -69,7 +69,7 @@ const generateQuestionsFromSummaryStep = createStep({
     }
 
     try {
-      const result = await generateQuestionsFromTextTool.execute(
+      const result = await generateQuestionsFromTextTool.execute!(
         { extractedText: summary }, // Use summary as the text input
         {
           mastra,

--- a/templates/template-deep-research/package.json
+++ b/templates/template-deep-research/package.json
@@ -17,18 +17,18 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@mastra/core": "beta",
-    "@mastra/libsql": "beta",
-    "@mastra/loggers": "beta",
-    "@mastra/memory": "beta",
-    "@mastra/observability": "beta",
+    "@mastra/core": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/loggers": "latest",
+    "@mastra/memory": "latest",
+    "@mastra/observability": "latest",
     "ai": "^4.3.19",
     "exa-js": "^2.0.9",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^24.0.3",
-    "mastra": "beta",
+    "mastra": "latest",
     "typescript": "^5.9.3"
   }
 }

--- a/templates/template-deep-research/package.json
+++ b/templates/template-deep-research/package.json
@@ -22,7 +22,7 @@
     "@mastra/loggers": "latest",
     "@mastra/memory": "latest",
     "@mastra/observability": "latest",
-    "ai": "^4.3.19",
+    "ai": "^5.0.121",
     "exa-js": "^2.0.9",
     "zod": "^3.25.76"
   },

--- a/templates/template-deep-research/src/mastra/tools/webSearchTool.ts
+++ b/templates/template-deep-research/src/mastra/tools/webSearchTool.ts
@@ -23,8 +23,7 @@ export const webSearchTool = createTool({
       }
 
       console.log(`Searching web for: "${query}"`);
-      const { results } = await exa.searchAndContents(query, {
-        livecrawl: 'always',
+      const { results } = await exa.search(query, {
         numResults: 2,
       });
 

--- a/templates/template-docs-chatbot/apps/agent/package.json
+++ b/templates/template-docs-chatbot/apps/agent/package.json
@@ -22,16 +22,16 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@mastra/core": "beta",
-    "@mastra/libsql": "beta",
-    "@mastra/loggers": "beta",
-    "@mastra/mcp": "beta",
-    "@mastra/memory": "beta",
-    "@mastra/observability": "beta"
+    "@mastra/core": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/loggers": "latest",
+    "@mastra/mcp": "latest",
+    "@mastra/memory": "latest",
+    "@mastra/observability": "latest"
   },
   "devDependencies": {
     "@types/node": "^24.0.10",
-    "mastra": "beta",
+    "mastra": "latest",
     "tsx": "^4.20.3",
     "typescript": "^5.9.3",
     "dotenv": "^17.0.1",

--- a/templates/template-docs-chatbot/apps/mcp-server/package.json
+++ b/templates/template-docs-chatbot/apps/mcp-server/package.json
@@ -22,8 +22,8 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@mastra/core": "beta",
-    "@mastra/mcp": "beta",
+    "@mastra/core": "latest",
+    "@mastra/mcp": "latest",
     "zod": "^3.25.76",
     "dotenv": "^17.2.3"
   },

--- a/templates/template-flash-cards-from-pdf/package.json
+++ b/templates/template-flash-cards-from-pdf/package.json
@@ -23,7 +23,7 @@
     "@mastra/loggers": "latest",
     "@mastra/memory": "latest",
     "@mastra/observability": "latest",
-    "ai": "^4.3.19",
+    "ai": "^5.0.121",
     "@ai-sdk/openai": "^2.0.65",
     "pdf2json": "^3.1.3",
     "zod": "^3.25.76"

--- a/templates/template-flash-cards-from-pdf/package.json
+++ b/templates/template-flash-cards-from-pdf/package.json
@@ -18,11 +18,11 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",
-    "@mastra/core": "beta",
-    "@mastra/libsql": "beta",
-    "@mastra/loggers": "beta",
-    "@mastra/memory": "beta",
-    "@mastra/observability": "beta",
+    "@mastra/core": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/loggers": "latest",
+    "@mastra/memory": "latest",
+    "@mastra/observability": "latest",
     "ai": "^4.3.19",
     "@ai-sdk/openai": "^2.0.65",
     "pdf2json": "^3.1.3",
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/node": "22.13.17",
-    "mastra": "beta",
+    "mastra": "latest",
     "typescript": "^5.9.3"
   }
 }

--- a/templates/template-flash-cards-from-pdf/src/mastra/tools/educational-image-tool.ts
+++ b/templates/template-flash-cards-from-pdf/src/mastra/tools/educational-image-tool.ts
@@ -65,7 +65,7 @@ export const educationalImageTool = createTool({
     }),
   }),
   execute: async input => {
-    const { concept, subjectArea, style, complexity, size } = input;
+    const { concept, subjectArea, style, complexity, size = '1024x1024' } = input;
 
     console.log(`🎨 Generating educational image for concept: "${concept.substring(0, 50)}..."`);
 
@@ -103,7 +103,7 @@ export const educationalImageTool = createTool({
       const imageBuffer = Buffer.from(image.base64, 'base64');
 
       // Upload to cloud storage and get public URL
-      const publicImageUrl = await uploadImageToStorage(imageBuffer, image.mimeType);
+      const publicImageUrl = await uploadImageToStorage(imageBuffer, image.mediaType);
 
       return {
         imageUrl: publicImageUrl,

--- a/templates/template-flash-cards-from-pdf/src/mastra/tools/flash-card-generator-tool.ts
+++ b/templates/template-flash-cards-from-pdf/src/mastra/tools/flash-card-generator-tool.ts
@@ -34,7 +34,7 @@ export const flashCardGeneratorTool = createTool({
     subjectArea: z.string(),
   }),
   execute: async input => {
-    const { concepts, definitions, facts, numberOfCards, subjectArea } = input;
+    const { concepts, definitions, facts, numberOfCards = 10, subjectArea } = input;
 
     console.log(`🃏 Generating ${numberOfCards} flash cards for ${subjectArea}...`);
 

--- a/templates/template-flash-cards-from-pdf/src/mastra/workflows/flash-cards-generation-workflow.ts
+++ b/templates/template-flash-cards-from-pdf/src/mastra/workflows/flash-cards-generation-workflow.ts
@@ -69,7 +69,7 @@ const extractPdfContentStep = createStep({
 
     console.log('📄 Extracting content from PDF...');
 
-    const result = await pdfContentExtractorTool.execute(
+    const result = await pdfContentExtractorTool.execute!(
       {
         pdfUrl,
         pdfData,
@@ -135,7 +135,7 @@ const generateFlashCardsStep = createStep({
 
     console.log(`🃏 Generating ${numberOfCards} flash cards...`);
 
-    const result = await flashCardGeneratorTool.execute(
+    const result = await flashCardGeneratorTool.execute!(
       {
         concepts,
         definitions,
@@ -203,7 +203,7 @@ const generateImagesStep = createStep({
       // Generate image for the first 3 cards only
       if (i < 3 && generateImages) {
         try {
-          const imageResult = await educationalImageTool.execute(
+          const imageResult = await educationalImageTool.execute!(
             {
               concept: `${card.question} - ${card.answer}`,
               subjectArea,
@@ -245,6 +245,7 @@ export const flashCardsGenerationWorkflow = createWorkflow({
   inputSchema,
   outputSchema,
 })
+  // @ts-expect-error - TODO: remove once z.enum().optional().default() type error is fixed
   .then(extractPdfContentStep)
   .map({
     concepts: {
@@ -280,7 +281,7 @@ export const flashCardsGenerationWorkflow = createWorkflow({
     numberOfCards: {
       schema: z.number(),
       fn: async ({ getInitData }) => {
-        const initData = getInitData();
+        const initData = getInitData<z.infer<typeof inputSchema>>();
         return initData.numberOfCards;
       },
     },
@@ -302,7 +303,7 @@ export const flashCardsGenerationWorkflow = createWorkflow({
     generateImages: {
       schema: z.boolean(),
       fn: async ({ getInitData }) => {
-        const initData = getInitData();
+        const initData = getInitData<z.infer<typeof inputSchema>>();
         return initData.generateImages;
       },
     },
@@ -344,7 +345,7 @@ export const flashCardsGenerationWorkflow = createWorkflow({
         pagesCount: z.number(),
       }),
       fn: async ({ getInitData, getStepResult }) => {
-        const initData = getInitData();
+        const initData = getInitData<z.infer<typeof inputSchema>>();
         const pdfData = getStepResult(extractPdfContentStep);
         return {
           pdfUrl: initData.pdfUrl,

--- a/templates/template-google-sheets/package.json
+++ b/templates/template-google-sheets/package.json
@@ -19,19 +19,19 @@
   "dependencies": {
     "@composio/core": "^0.1.55",
     "@composio/mastra": "^0.1.56",
-    "@mastra/core": "beta",
-    "@mastra/fastembed": "beta",
-    "@mastra/libsql": "beta",
-    "@mastra/loggers": "beta",
-    "@mastra/mcp": "beta",
-    "@mastra/memory": "beta",
-    "@mastra/observability": "beta",
+    "@mastra/core": "latest",
+    "@mastra/fastembed": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/loggers": "latest",
+    "@mastra/mcp": "latest",
+    "@mastra/memory": "latest",
+    "@mastra/observability": "latest",
     "hono": "^4.11.3",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
-    "mastra": "beta",
+    "mastra": "latest",
     "prettier": "^3.6.2",
     "typescript": "^5.9.3"
   }

--- a/templates/template-meeting-scheduler/package.json
+++ b/templates/template-meeting-scheduler/package.json
@@ -18,17 +18,17 @@
   },
   "dependencies": {
     "@arcadeai/arcadejs": "^1.10.0",
-    "@mastra/core": "beta",
-    "@mastra/fastembed": "beta",
-    "@mastra/libsql": "beta",
-    "@mastra/loggers": "beta",
-    "@mastra/memory": "beta",
-    "@mastra/observability": "beta",
+    "@mastra/core": "latest",
+    "@mastra/fastembed": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/loggers": "latest",
+    "@mastra/memory": "latest",
+    "@mastra/observability": "latest",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
-    "mastra": "beta",
+    "mastra": "latest",
     "prettier": "^3.6.2",
     "typescript": "^5.9.3"
   }

--- a/templates/template-pdf-questions/package.json
+++ b/templates/template-pdf-questions/package.json
@@ -18,11 +18,11 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@mastra/core": "beta",
-    "@mastra/libsql": "beta",
-    "@mastra/loggers": "beta",
-    "@mastra/memory": "beta",
-    "@mastra/observability": "beta",
+    "@mastra/core": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/loggers": "latest",
+    "@mastra/memory": "latest",
+    "@mastra/observability": "latest",
     "ai": "^4.3.19",
     "pdf2json": "^3.1.3",
     "zod": "^3.25.76"
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/node": "22.13.17",
     "bun": "^1.3.5",
-    "mastra": "beta",
+    "mastra": "latest",
     "typescript": "^5.9.3"
   }
 }

--- a/templates/template-pdf-questions/package.json
+++ b/templates/template-pdf-questions/package.json
@@ -23,7 +23,7 @@
     "@mastra/loggers": "latest",
     "@mastra/memory": "latest",
     "@mastra/observability": "latest",
-    "ai": "^4.3.19",
+    "ai": "^5.0.121",
     "pdf2json": "^3.1.3",
     "zod": "^3.25.76"
   },

--- a/templates/template-pdf-questions/src/mastra/workflows/generate-questions-from-pdf-workflow.ts
+++ b/templates/template-pdf-questions/src/mastra/workflows/generate-questions-from-pdf-workflow.ts
@@ -31,7 +31,7 @@ const downloadAndSummarizePdfStep = createStep({
     console.log('Executing Step: download-and-summarize-pdf');
     const { pdfUrl } = inputData;
 
-    const result = await pdfFetcherTool.execute(
+    const result = await pdfFetcherTool.execute!(
       { pdfUrl },
       {
         mastra,
@@ -68,7 +68,7 @@ const generateQuestionsFromSummaryStep = createStep({
     }
 
     try {
-      const result = await generateQuestionsFromTextTool.execute(
+      const result = await generateQuestionsFromTextTool.execute!(
         { extractedText: summary }, // Use summary as the text input
         {
           mastra,

--- a/templates/template-pdf-to-audio/package.json
+++ b/templates/template-pdf-to-audio/package.json
@@ -24,7 +24,7 @@
     "@mastra/memory": "latest",
     "@mastra/observability": "latest",
     "@mastra/voice-openai": "latest",
-    "ai": "^4.3.19",
+    "ai": "^5.0.121",
     "pdf2json": "^3.1.3",
     "zod": "^3.25.76"
   },

--- a/templates/template-pdf-to-audio/package.json
+++ b/templates/template-pdf-to-audio/package.json
@@ -18,19 +18,19 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@mastra/core": "beta",
-    "@mastra/libsql": "beta",
-    "@mastra/loggers": "beta",
-    "@mastra/memory": "beta",
-    "@mastra/observability": "beta",
-    "@mastra/voice-openai": "beta",
+    "@mastra/core": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/loggers": "latest",
+    "@mastra/memory": "latest",
+    "@mastra/observability": "latest",
+    "@mastra/voice-openai": "latest",
     "ai": "^4.3.19",
     "pdf2json": "^3.1.3",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^24.1.0",
-    "mastra": "beta",
+    "mastra": "latest",
     "typescript": "^5.9.3"
   }
 }

--- a/templates/template-pdf-to-audio/src/mastra/tools/text-to-speech-tool.ts
+++ b/templates/template-pdf-to-audio/src/mastra/tools/text-to-speech-tool.ts
@@ -35,6 +35,7 @@ export const textToSpeechTool = createTool({
     speaker: z.string().describe('Voice speaker that was used for audio generation'),
     speed: z.number().describe('Speaking speed that was used for audio generation'),
   }),
+  // @ts-expect-error - TODO: remove once z.enum().optional().default() type error is fixed
   execute: async (inputData, context) => {
     const { extractedText, speaker, speed } = inputData;
 

--- a/templates/template-pdf-to-audio/src/mastra/workflows/pdf-to-audio-workflow.ts
+++ b/templates/template-pdf-to-audio/src/mastra/workflows/pdf-to-audio-workflow.ts
@@ -37,7 +37,7 @@ const downloadAndSummarizePdfStep = createStep({
     console.log('Executing Step: download-and-summarize-pdf');
     const { pdfUrl, speaker, speed } = inputData;
 
-    const result = await summarizePdfTool.execute(
+    const result = await summarizePdfTool.execute!(
       { pdfUrl },
       {
         mastra,
@@ -82,7 +82,7 @@ const generateAudioFromSummaryStep = createStep({
     }
 
     try {
-      const result = await textToSpeechTool.execute(
+      const result = await textToSpeechTool.execute!(
         {
           extractedText: summary, // Use summary as the text input
           speaker,
@@ -122,6 +122,7 @@ export const pdfToAudioWorkflow = createWorkflow({
   inputSchema: pdfInputSchema,
   outputSchema: audioSchema,
 })
+  // @ts-expect-error - TODO: remove once z.enum().optional().default() type error is fixed
   .then(downloadAndSummarizePdfStep)
   .then(generateAudioFromSummaryStep)
   .commit();

--- a/templates/template-slack-agent/package.json
+++ b/templates/template-slack-agent/package.json
@@ -17,16 +17,16 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@mastra/core": "beta",
-    "@mastra/libsql": "beta",
-    "@mastra/memory": "beta",
+    "@mastra/core": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/memory": "latest",
     "@slack/web-api": "^7.13.0",
     "supports-color": "^10.2.2",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^24.1.0",
-    "mastra": "beta",
+    "mastra": "latest",
     "typescript": "^5.9.3"
   }
 }

--- a/templates/template-text-to-sql/package.json
+++ b/templates/template-text-to-sql/package.json
@@ -17,11 +17,11 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@mastra/core": "beta",
-    "@mastra/libsql": "beta",
-    "@mastra/loggers": "beta",
-    "@mastra/memory": "beta",
-    "@mastra/observability": "beta",
+    "@mastra/core": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/loggers": "latest",
+    "@mastra/memory": "latest",
+    "@mastra/observability": "latest",
     "ai": "^5.0.111",
     "csv-parse": "^5.6.0",
     "dotenv": "^17.2.3",
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/node": "22.13.17",
     "@types/pg": "^8.16.0",
-    "mastra": "beta",
+    "mastra": "latest",
     "typescript": "^5.9.3"
   }
 }

--- a/templates/weather-agent/package.json
+++ b/templates/weather-agent/package.json
@@ -13,17 +13,17 @@
   "description": "One Agent, one Workflow, one Tool, and some Scorers to bring you the weather in your city.",
   "type": "module",
   "dependencies": {
-    "@mastra/core": "beta",
-    "@mastra/evals": "beta",
-    "@mastra/loggers": "beta",
-    "@mastra/libsql": "beta",
-    "@mastra/memory": "beta",
-    "@mastra/observability": "beta",
+    "@mastra/core": "latest",
+    "@mastra/evals": "latest",
+    "@mastra/loggers": "latest",
+    "@mastra/libsql": "latest",
+    "@mastra/memory": "latest",
+    "@mastra/observability": "latest",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^22.15.29",
-    "mastra": "beta",
+    "mastra": "latest",
     "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
## Description

Update version tag from beta to latest in templates

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated template dependency pins: Mastra packages moved from "beta" to "latest" across the template suite; several templates also bumped the AI package to a newer major version.

* **Documentation**
  * Updated template README and example package configuration to reflect "latest" dependency placeholders.

* **Behavior changes**
  * Image tools now default sizes when not provided and use mediaType for uploads; flash-card generator defaults to 10 cards; web search returns a smaller, focused result set.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> 
> Updates template ecosystem to current dependency guidance and aligns code with newer SDKs.
> 
> - Set all `@mastra/*` dependencies to `"latest"` and `mastra` devDependency to `"latest"` across templates; bump `ai` to `^5.0.121` where used
> - Update `templates/README.md` to require `"latest"` for Mastra deps
> 
> **Code adjustments**
> 
> - Image tools: add default sizes (`image-generator`/`educational-image-tool`), switch upload content type to `image.mediaType`
> - Workflows/tools: use `tool.execute!` non-null calls, add generics to `getInitData<...>`, and insert targeted `@ts-expect-error` comments for enum default typing issues
> - Deep research: `webSearchTool` now uses `exa.search` (drops `searchAndContents`/`livecrawl`) and summarizes results via agent
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf871d15662505ccf94e14b5d3d634b18f495779. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->