### PR TITLE
docs for dynamic prompting with request context

### DIFF
--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -120,6 +120,16 @@ Visit [Agent reference](/reference/agents/agent) for more information.
 
 :::
 
+### Dynamic instructions
+
+Instructions can be provided as an async function, allowing you to resolve prompts at runtime. This enables patterns like personalizing instructions based on user context, fetching prompts from external registry services, and running A/B tests with different variants.
+
+:::info
+
+See [Dynamic instructions](/docs/server/request-context#dynamic-instructions) for examples.
+
+:::
+
 ### Registering an agent
 
 Register your agent in the Mastra instance to make it available throughout your application. Once registered, it can be called from workflows, tools, or other agents, and has access to shared resources such as memory, logging, and observability features:

--- a/docs/src/content/en/docs/server/request-context.mdx
+++ b/docs/src/content/en/docs/server/request-context.mdx
@@ -130,6 +130,68 @@ export const weatherAgent = new Agent({
 
 You can also use `requestContext` with other options like `agents`, `workflows`, `scorers`, `inputProcessors`, and `outputProcessors`.
 
+### Dynamic instructions
+
+Agent instructions can be provided as an async function, enabling you to resolve prompts dynamically at runtime. Combined with `requestContext`, this unlocks powerful patterns:
+
+- **Personalization**: Tailor instructions based on user attributes, preferences, or tier
+- **Localization**: Adjust tone, language, or behavior based on locale
+- **A/B testing**: Serve different prompt variants for experimentation
+- **External prompt management**: Fetch prompts from registry services without redeploying
+
+```typescript title="src/mastra/agents/dynamic-agent.ts"
+import { Agent } from "@mastra/core/agent";
+
+export const dynamicAgent = new Agent({
+  id: "dynamic-agent",
+  name: "Dynamic Agent",
+  instructions: async ({ requestContext }) => {
+    const userTier = requestContext?.get("user-tier");
+    const locale = requestContext?.get("locale");
+
+    // Personalize based on user tier
+    const basePrompt = userTier === "enterprise"
+      ? "You are a premium support agent. Provide detailed, thorough responses with technical depth."
+      : "You are a helpful assistant. Be concise and friendly.";
+
+    // Localize behavior
+    const localeInstructions = locale === "ja"
+      ? "Respond in Japanese using formal keigo."
+      : "";
+
+    return `${basePrompt} ${localeInstructions}`.trim();
+  },
+  model: "openai/gpt-5.1",
+});
+```
+
+#### Fetching from a prompt registry
+
+If your organization uses a prompt registry service for central prompt management, you can fetch instructions at runtime. This allows you to update prompts without redeploying, run experiments with variants, and track prompt usage across your agents.
+
+```typescript title="src/mastra/agents/registry-agent.ts"
+import { Agent } from "@mastra/core/agent";
+
+// Your prompt registry client
+import { promptRegistry } from "../lib/prompt-registry";
+
+export const registryAgent = new Agent({
+  id: "registry-agent",
+  name: "Registry Agent",
+  instructions: async ({ requestContext }) => {
+    const prompt = await promptRegistry.getPrompt({
+      promptId: "customer-support-agent",
+      // Pass context for variant selection or tracking
+      variant: requestContext?.get("experiment-variant"),
+      userId: requestContext?.get("user-id"),
+    });
+
+    return prompt.content;
+  },
+  model: "openai/gpt-5.1",
+});
+```
+
 :::info
 
 Visit [Agent](/reference/agents/agent) for a full list of configuration options.

--- a/docs/src/content/en/docs/server/request-context.mdx
+++ b/docs/src/content/en/docs/server/request-context.mdx
@@ -132,7 +132,7 @@ You can also use `requestContext` with other options like `agents`, `workflows`,
 
 ### Dynamic instructions
 
-Agent instructions can be provided as an async function, enabling you to resolve prompts dynamically at runtime. Combined with `requestContext`, this unlocks powerful patterns:
+Agent instructions can be provided as an async function, enabling you to resolve prompts dynamically at runtime. Combined with `requestContext`, this enables patterns like:
 
 - **Personalization**: Tailor instructions based on user attributes, preferences, or tier
 - **Localization**: Adjust tone, language, or behavior based on locale


### PR DESCRIPTION
## Description

Adds documentation for dynamic instructions in agents, a pattern that allows resolving prompts at runtime using async functions. This enables use cases like:
- Personalizing instructions based on user attributes
- Fetching prompts from external registry services
- Running A/B tests with prompt variants
- Updating prompts without redeploying

Changes:
- Added comprehensive "Dynamic instructions" section to request-context docs with full examples
- Added "Fetching from a prompt registry" subsection for the registry-specific pattern
- Added brief callout in agents overview linking to the full examples

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive "Dynamic instructions" guidance showing how instructions can be provided as async functions resolved at runtime.
  * Documented practical use cases: personalization, localization, A/B testing, and external prompt management.
  * Included multiple implementation examples and a prompt-registry pattern demonstrating runtime prompt retrieval and centralized prompt management.
  * Integrated new sections into agent and server request-context docs for easier discovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->