### PR TITLE
fix(playground): prevent scorers page crash on direct URL navigation

### DIFF
--- a/.changeset/wet-hairs-sniff.md
+++ b/.changeset/wet-hairs-sniff.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed Studio scorers page crash when navigating directly to a scorer URL or reloading the page. The page would crash with 'Cannot read properties of undefined' due to a race condition between scorer and agents data loading.

--- a/packages/playground/src/pages/scorers/scorer/index.tsx
+++ b/packages/playground/src/pages/scorers/scorer/index.tsx
@@ -59,9 +59,11 @@ export default function Scorer() {
   });
 
   const agentOptions: EntityOptions[] =
-    scorer?.agentIds?.map(agentId => {
-      return { value: agentId, label: agents[agentId].name, type: 'AGENT' as const };
-    }) || [];
+    scorer?.agentIds
+      ?.filter(agentId => agents[agentId])
+      .map(agentId => {
+        return { value: agentId, label: agents[agentId].name, type: 'AGENT' as const };
+      }) || [];
 
   const workflowOptions: EntityOptions[] =
     scorer?.workflowIds?.map(workflowId => {
@@ -108,7 +110,7 @@ export default function Scorer() {
   if (isScorerLoading || scorerError || agentsError || workflowsError) return null;
 
   const scorerAgents =
-    scorer?.agentIds.map(agentId => {
+    scorer?.agentIds?.map(agentId => {
       return {
         name: agentId,
         id: Object.entries(agents).find(([_, value]) => value.name === agentId)?.[0],
@@ -116,7 +118,7 @@ export default function Scorer() {
     }) || [];
 
   const scorerWorkflows =
-    scorer?.workflowIds.map(workflowId => {
+    scorer?.workflowIds?.map(workflowId => {
       return {
         name: workflowId,
         id: Object.entries(workflows || {}).find(([_, value]) => value.name === workflowId)?.[0],


### PR DESCRIPTION
Fixes #12123

The scorers detail page was crashing when navigating directly via URL or reloading the page. This was caused by a race condition where `scorer.agentIds` was being mapped before `agents` data finished loading, causing `agents[agentId].name` to throw.

Added null checks to filter out agents that haven't loaded yet:

```tsx
// Before (crashes if agents[agentId] is undefined)
scorer?.agentIds?.map(agentId => {
  return { value: agentId, label: agents[agentId].name, type: 'AGENT' };
}) || [];

// After (safely handles loading state)
scorer?.agentIds
  ?.filter(agentId => agents[agentId])
  .map(agentId => {
    return { value: agentId, label: agents[agentId].name, type: 'AGENT' };
  }) || [];
```

Also added optional chaining to `scorer?.agentIds?.map()` and `scorer?.workflowIds?.map()` to prevent errors if these arrays are undefined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that occurred when navigating directly to a scorer or reloading the scorers page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->