### PR TITLE
fix(core): add missing id field to workflow snapshot schema

### DIFF
--- a/.changeset/quiet-wolves-march.md
+++ b/.changeset/quiet-wolves-march.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Convex storage adapter failing with schema validation error
+
+The workflow snapshot table schema was missing the `id` field, causing `@mastra/convex` to fail during initialization with: "the index 'by_record_id' is invalid because it references the field 'id' that does not exist."

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -107,6 +107,7 @@ export const AGENTS_SCHEMA: Record<string, StorageColumn> = {
 
 export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> = {
   [TABLE_WORKFLOW_SNAPSHOT]: {
+    id: { type: 'text', nullable: false, primaryKey: true },
     workflow_name: {
       type: 'text',
     },


### PR DESCRIPTION
## Summary

The `TABLE_WORKFLOW_SNAPSHOT` schema in `@mastra/core` is missing the `id` field that is required by the Convex storage adapter.

## Problem

The `@mastra/convex` package's `schema.ts` creates a `by_record_id` index on `['id']` for the workflow snapshots table:

```typescript
export const mastraWorkflowSnapshotsTable = defineTable(buildTableFromSchema(TABLE_SCHEMAS[TABLE_WORKFLOW_SNAPSHOT]))
  .index('by_record_id', ['id'])  // <-- References 'id' field
  // ...
```

However, `TABLE_SCHEMAS[TABLE_WORKFLOW_SNAPSHOT]` does not include an `id` field, causing Convex schema validation to fail:

```
SchemaDefinitionError: In table "mastra_workflow_snapshots" the index "by_record_id" 
is invalid because it references the field "id" that does not exist.
```

## Solution

Add the missing `id` field to the workflow snapshot schema:

```typescript
id: { type: 'text', nullable: false, primaryKey: true }
```

This is consistent with other tables like `TABLE_THREADS`, `TABLE_MESSAGES`, and `TABLE_RESOURCES` which all have an `id` field as primary key.

## Testing

Verified locally that after this fix:
1. The Convex schema validates successfully
2. The `mastra_workflow_snapshots` table is created with all indexes including `by_record_id`

## Checklist

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] The change is backward compatible
- [x] Verified the fix resolves the schema validation error

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal data storage schema to improve reliability and consistency of workflow record management.
  * Released a patch version to apply the storage initialization fix and ensure smoother startup behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->