### PR TITLE
test: verify RAG workflow skips on markdown-only change

### DIFF
--- a/packages/rag/README.md
+++ b/packages/rag/README.md
@@ -24,3 +24,5 @@ const doc = new MDocument({
 ```
 
 [Documentation](https://mastra.ai/reference/rag/document)
+
+<!-- Test change Wed Jan 21 09:09:03 CET 2026 -->


### PR DESCRIPTION
This PR tests that the new Turborepo-based change detection correctly skips RAG tests when only markdown files change.

**Expected**: RAG tests should be skipped (status set to success with 'RAG package unchanged' message).