### PR TITLE
fix(ci): install dependencies for turbo to read inputs config

### DIFF
--- a/.github/workflows/secrets.test-rag.yml
+++ b/.github/workflows/secrets.test-rag.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
-        with:
-          install-dependencies: 'false'
 
       - name: Check for RAG package changes using Turborepo
         id: changes
@@ -43,7 +41,7 @@ jobs:
           set -o pipefail
 
           # Check if build-related files changed
-          BUILD_PACKAGES=$(pnpm dlx turbo build --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json | jq -r '.packages | length')
+          BUILD_PACKAGES=$(pnpm turbo build --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json | jq -r '.packages | length')
 
           # Validate jq output is a number
           if ! [[ "$BUILD_PACKAGES" =~ ^[0-9]+$ ]]; then
@@ -52,7 +50,7 @@ jobs:
           fi
 
           # Check if test-related files changed
-          TEST_PACKAGES=$(pnpm dlx turbo test --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json | jq -r '.packages | length')
+          TEST_PACKAGES=$(pnpm turbo test --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json | jq -r '.packages | length')
 
           # Validate jq output is a number
           if ! [[ "$TEST_PACKAGES" =~ ^[0-9]+$ ]]; then

--- a/.github/workflows/secrets.test-rag.yml
+++ b/.github/workflows/secrets.test-rag.yml
@@ -39,11 +39,29 @@ jobs:
       - name: Check for RAG package changes using Turborepo
         id: changes
         run: |
+          set -e
+          set -o pipefail
+
           # Check if build-related files changed
-          BUILD_PACKAGES=$(pnpm turbo build --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json 2>/dev/null | jq -r '.packages | length' || echo "0")
+          BUILD_PACKAGES=$(pnpm dlx turbo build --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json | jq -r '.packages | length')
+
+          # Validate jq output is a number
+          if ! [[ "$BUILD_PACKAGES" =~ ^[0-9]+$ ]]; then
+            echo "Error: BUILD_PACKAGES is not a valid number: $BUILD_PACKAGES"
+            exit 1
+          fi
 
           # Check if test-related files changed
-          TEST_PACKAGES=$(pnpm turbo test --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json 2>/dev/null | jq -r '.packages | length' || echo "0")
+          TEST_PACKAGES=$(pnpm dlx turbo test --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json | jq -r '.packages | length')
+
+          # Validate jq output is a number
+          if ! [[ "$TEST_PACKAGES" =~ ^[0-9]+$ ]]; then
+            echo "Error: TEST_PACKAGES is not a valid number: $TEST_PACKAGES"
+            exit 1
+          fi
+
+          echo "Build packages changed: $BUILD_PACKAGES"
+          echo "Test packages changed: $TEST_PACKAGES"
 
           # Run tests if either build or test files changed
           if [ "$BUILD_PACKAGES" -gt 0 ] || [ "$TEST_PACKAGES" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Fixes the RAG test workflow failing with jq parse errors and incorrectly triggering tests.

## Changes

- Remove `install-dependencies: 'false'` - turbo needs to be installed locally to properly read the `inputs` configuration from `turbo.json`
- Use `pnpm turbo` instead of `pnpm dlx turbo` since turbo is now installed
- Keep strict error handling with `set -e` and `set -o pipefail`
- Validate jq output is a valid number before using it

## Root Cause

When `install-dependencies` was set to `false`, turbo wasn't installed locally. Using `pnpm dlx turbo` downloaded turbo but:
1. It still used a global version causing warning messages
2. It couldn't read the `inputs` configuration from `turbo.json` properly, causing all changes to be detected as needing tests

## Testing

After this fix:
- PRs with only README changes should skip RAG tests
- PRs with source file changes should run RAG tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved testing pipeline reliability with enhanced error handling and validation for build package detection, ensuring more robust automated testing workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->