### PR TITLE
chore: replace @ts-ignore with @ts-expect-error

### DIFF
--- a/client-sdks/client-js/src/example.ts
+++ b/client-sdks/client-js/src/example.ts
@@ -13,7 +13,7 @@ import { MastraClient } from './client';
   try {
     const agent = client.getAgent('weatherAgent');
     const response = await agent.stream('what is the weather in new york?', {
-      // @ts-ignore - TODO: fix this
+      // @ts-expect-error - TODO: fix this
       structuredOutput: {
         schema: z.object({
           weather: z.string(),

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -283,7 +283,7 @@ export class Agent extends BaseResource {
               ],
             },
           ];
-          // @ts-ignore
+          // @ts-expect-error
           return this.generate({
             ...params,
             messages: updatedMessages,
@@ -1214,7 +1214,7 @@ export class Agent extends BaseResource {
 
                 if (toolInvocation) {
                   toolInvocation.state = 'result';
-                  // @ts-ignore
+                  // @ts-expect-error
                   toolInvocation.result = result;
                 }
 
@@ -1728,7 +1728,7 @@ export class Agent extends BaseResource {
 
                 if (toolInvocation) {
                   toolInvocation.state = 'result';
-                  // @ts-ignore
+                  // @ts-expect-error
                   toolInvocation.result = result;
                 }
 

--- a/deployers/cloud/src/index.test.ts
+++ b/deployers/cloud/src/index.test.ts
@@ -87,7 +87,7 @@ describe('CloudDeployer', () => {
 
     deployer = new CloudDeployer();
 
-    // @ts-ignore - accessing protected method for testing
+    // @ts-expect-error - accessing protected method for testing
     deployer._bundle = mockBundle;
 
     vi.mocked(installDeps).mockResolvedValue(undefined);
@@ -111,25 +111,25 @@ describe('CloudDeployer', () => {
 
     it('should default studio to false when not provided', () => {
       const d = new CloudDeployer();
-      // @ts-ignore - accessing private property for testing
+      // @ts-expect-error - accessing private property for testing
       expect(d.studio).toBe(false);
     });
 
     it('should default studio to false when empty options provided', () => {
       const d = new CloudDeployer({});
-      // @ts-ignore - accessing private property for testing
+      // @ts-expect-error - accessing private property for testing
       expect(d.studio).toBe(false);
     });
 
     it('should set studio to true when provided', () => {
       const d = new CloudDeployer({ studio: true });
-      // @ts-ignore - accessing private property for testing
+      // @ts-expect-error - accessing private property for testing
       expect(d.studio).toBe(true);
     });
 
     it('should set studio to false when explicitly provided', () => {
       const d = new CloudDeployer({ studio: false });
-      // @ts-ignore - accessing private property for testing
+      // @ts-expect-error - accessing private property for testing
       expect(d.studio).toBe(false);
     });
   });
@@ -182,7 +182,7 @@ describe('CloudDeployer', () => {
       const outputDirectory = '/test/output';
       const rootDir = '/test/root';
 
-      // @ts-ignore - accessing protected method for testing
+      // @ts-expect-error - accessing protected method for testing
       await deployer.installDependencies(outputDirectory, rootDir);
 
       expect(installDeps).toHaveBeenCalledWith({
@@ -194,7 +194,7 @@ describe('CloudDeployer', () => {
     it('should use process.cwd() as default rootDir', async () => {
       const outputDirectory = '/test/output';
 
-      // @ts-ignore - accessing protected method for testing
+      // @ts-expect-error - accessing protected method for testing
       await deployer.installDependencies(outputDirectory);
 
       expect(installDeps).toHaveBeenCalledWith({
@@ -248,7 +248,7 @@ describe('CloudDeployer', () => {
 
   describe('getEntry', () => {
     it('should generate correct server entry code', () => {
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       // Check for essential imports
@@ -290,7 +290,7 @@ describe('CloudDeployer', () => {
     });
 
     it('should include readiness logs', () => {
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       expect(entry).toContain('Server starting');
@@ -301,7 +301,7 @@ describe('CloudDeployer', () => {
 
     it('should include studio: true when studio is enabled', () => {
       const studioDeployer = new CloudDeployer({ studio: true });
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = studioDeployer.getEntry();
 
       expect(entry).toContain('studio: true');
@@ -310,7 +310,7 @@ describe('CloudDeployer', () => {
 
     it('should include studio: false when studio is disabled', () => {
       const studioDeployer = new CloudDeployer({ studio: false });
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = studioDeployer.getEntry();
 
       expect(entry).toContain('studio: false');
@@ -334,7 +334,7 @@ describe('CloudDeployer', () => {
 
       vi.mocked(installDeps).mockRejectedValue(new Error('Install failed'));
 
-      // @ts-ignore - accessing protected method for testing
+      // @ts-expect-error - accessing protected method for testing
       await expect(deployer.installDependencies(outputDirectory)).rejects.toThrow('Install failed');
     });
   });

--- a/deployers/cloud/src/integration.test.ts
+++ b/deployers/cloud/src/integration.test.ts
@@ -56,7 +56,7 @@ describe('CloudDeployer Integration Tests', () => {
       // Create some existing files to ensure clean preparation
       await writeFile(join(outputDir, 'old-file.txt'), 'old content');
 
-      // @ts-ignore - accessing protected method for testing
+      // @ts-expect-error - accessing protected method for testing
       await deployer.prepare(outputDir);
 
       // Verify output directories are created
@@ -125,7 +125,7 @@ describe('CloudDeployer Integration Tests', () => {
     });
 
     it('should generate valid entry code for server', () => {
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       // Basic validation that it's valid JavaScript
@@ -169,7 +169,7 @@ describe('CloudDeployer Integration Tests', () => {
 
     it('should maintain correct entry code structure even with special characters in constants', () => {
       // This tests that the template literals are properly escaped
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       // The regex needs to account for multiline JSON objects
@@ -199,7 +199,7 @@ describe('CloudDeployer Integration Tests', () => {
       let capturedEntry: string = '';
       let capturedToolsPaths: any[] = [];
 
-      // @ts-ignore - accessing protected method for testing
+      // @ts-expect-error - accessing protected method for testing
       deployer._bundle = async (entry: string, mastraFile: string, output: string, toolsPaths: any[]) => {
         capturedEntry = entry;
         capturedToolsPaths = toolsPaths;

--- a/deployers/cloud/src/server-runtime.test.ts
+++ b/deployers/cloud/src/server-runtime.test.ts
@@ -46,7 +46,7 @@ describe('CloudDeployer Server Runtime', () => {
 
   describe('Server Entry Code Generation', () => {
     it('should generate valid server initialization code', () => {
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       // Validate it's valid JavaScript/TypeScript
@@ -63,7 +63,7 @@ describe('CloudDeployer Server Runtime', () => {
     });
 
     it('should handle environment variables correctly', () => {
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       // Check environment variable handling
@@ -77,7 +77,7 @@ describe('CloudDeployer Server Runtime', () => {
     });
 
     it('should setup logging correctly', () => {
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       // Verify logger setup
@@ -90,7 +90,7 @@ describe('CloudDeployer Server Runtime', () => {
     });
 
     it('should configure HTTP transport when endpoint is provided', () => {
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       expect(entry).toContain('new HttpTransport({');
@@ -99,7 +99,7 @@ describe('CloudDeployer Server Runtime', () => {
     });
 
     it('should setup storage and vector stores correctly', () => {
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       // Check storage initialization
@@ -120,7 +120,7 @@ describe('CloudDeployer Server Runtime', () => {
     });
 
     it('should create node server with correct configuration', () => {
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       // Default: studio disabled
@@ -131,7 +131,7 @@ describe('CloudDeployer Server Runtime', () => {
 
     it('should create node server with studio enabled when studio is true', () => {
       const studioDeployer = new CloudDeployer({ studio: true });
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = studioDeployer.getEntry();
 
       expect(entry).toContain('studio: true');
@@ -140,14 +140,14 @@ describe('CloudDeployer Server Runtime', () => {
 
     it('should create node server with studio disabled when studio is false', () => {
       const studioDeployer = new CloudDeployer({ studio: false });
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = studioDeployer.getEntry();
 
       expect(entry).toContain('studio: false');
     });
 
     it('should include readiness logging with correct metadata', () => {
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       // Check server starting log
@@ -171,14 +171,14 @@ describe('CloudDeployer Server Runtime', () => {
     });
 
     it('should include auth entrypoint', () => {
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       expect(entry).toContain('// Mock auth entrypoint');
     });
 
     it('should handle success entrypoint', () => {
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       // The successEntrypoint should be included but we don't have its content mocked
@@ -189,7 +189,7 @@ describe('CloudDeployer Server Runtime', () => {
 
   describe('Runtime Error Scenarios', () => {
     it('should handle missing mastra instance gracefully', () => {
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       // Check optional chaining for mastra
@@ -199,7 +199,7 @@ describe('CloudDeployer Server Runtime', () => {
     });
 
     it('should skip HTTP transport in CI environment', () => {
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       expect(entry).toContain("if (process.env.CI !== 'true') {");
@@ -207,7 +207,7 @@ describe('CloudDeployer Server Runtime', () => {
     });
 
     it('should only setup cloud storage when credentials are present', () => {
-      // @ts-ignore - accessing private method for testing
+      // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
       expect(entry).toContain('if (process.env.MASTRA_STORAGE_URL && process.env.MASTRA_STORAGE_AUTH_TOKEN) {');

--- a/docs/src/utils/disableTransitions.ts
+++ b/docs/src/utils/disableTransitions.ts
@@ -16,7 +16,7 @@ export function disableTransitions(): () => void {
   document.head.appendChild(css);
 
   return () => {
-    // @ts-ignore
+    // @ts-expect-error
     const _ = window.getComputedStyle(css).opacity;
     document.head.removeChild(css);
   };

--- a/observability/otel-exporter/src/tracing.ts
+++ b/observability/otel-exporter/src/tracing.ts
@@ -102,7 +102,6 @@ export class OtelExporter extends BaseExporter {
         // Dynamically import @grpc/grpc-js to create metadata
         let metadata: any;
         try {
-          // @ts-ignore - Dynamic import for optional dependency
           const grpcModule = await import('@grpc/grpc-js');
           metadata = new grpcModule.Metadata();
           Object.entries(headers).forEach(([key, value]) => {

--- a/packages/cli/src/commands/build/BuildBundler.ts
+++ b/packages/cli/src/commands/build/BuildBundler.ts
@@ -77,12 +77,12 @@ export class BuildBundler extends Bundler {
 
   protected getEntry(): string {
     return `
-    // @ts-ignore
+    // @ts-expect-error
     import { scoreTracesWorkflow } from '@mastra/core/evals/scoreTraces';
     import { mastra } from '#mastra';
     import { createNodeServer, getToolExports } from '#server';
     import { tools } from '#tools';
-    // @ts-ignore
+    // @ts-expect-error
     await createNodeServer(mastra, { tools: getToolExports(tools), studio: ${this.studio} });
 
     if (mastra.getStorage()) {

--- a/packages/core/src/agent/__tests__/stream.test.ts
+++ b/packages/core/src/agent/__tests__/stream.test.ts
@@ -46,9 +46,9 @@ function runStreamTest(version: 'v1' | 'v2' | 'v3') {
       let saveCallCount = 0;
       let savedMessages: any[] = [];
 
-      // // @ts-ignore
+      // // @ts-expect-error
       // const original = mockMemory._storage.stores.memory.saveMessages;
-      // // @ts-ignore
+      // // @ts-expect-error
       // mockMemory._storage.stores.memory.saveMessages = async function (...args) {
       //   saveCallCount++;
       //   return original.apply(this, args);
@@ -430,9 +430,9 @@ function runStreamTest(version: 'v1' | 'v2' | 'v3') {
       const mockMemory = new MockMemory();
       let saveCallCount = 0;
 
-      // @ts-ignore
+      // @ts-expect-error
       const original = mockMemory._storage.stores.memory.saveMessages;
-      // @ts-ignore
+      // @ts-expect-error
       mockMemory._storage.stores.memory.saveMessages = async function (...args) {
         saveCallCount++;
         return original.apply(this, args);
@@ -476,9 +476,9 @@ function runStreamTest(version: 'v1' | 'v2' | 'v3') {
       const mockMemory = new MockMemory();
       let saveCallCount = 0;
 
-      // @ts-ignore
+      // @ts-expect-error
       const original = mockMemory._storage.stores.memory.saveMessages;
-      // @ts-ignore
+      // @ts-expect-error
       mockMemory._storage.stores.memory.saveMessages = async function (...args) {
         saveCallCount++;
         return original.apply(this, args);

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -293,7 +293,7 @@ export class AgentLegacyHandler {
           threadId,
           resourceId,
           generateMessageId: this.capabilities.mastra?.generateId?.bind(this.capabilities.mastra),
-          // @ts-ignore Flag for agent network messages
+          // @ts-expect-error Flag for agent network messages
           _agentNetworkAppend: this.capabilities._agentNetworkAppend,
         })
           .addSystem(instructions || (await this.capabilities.getInstructions({ requestContext })))
@@ -455,7 +455,7 @@ export class AgentLegacyHandler {
           threadId,
           resourceId,
           generateMessageId: this.capabilities.mastra?.generateId?.bind(this.capabilities.mastra),
-          // @ts-ignore Flag for agent network messages
+          // @ts-expect-error Flag for agent network messages
           _agentNetworkAppend: this.capabilities._agentNetworkAppend,
         })
           .add(result.response.messages, 'response')

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -7484,9 +7484,9 @@ describe('Agent Tests', () => {
 //       expect((agent.listTools() as Agent['tools']).vercelTool).toBeDefined();
 
 //       // Verify both tools can be executed
-//       // @ts-ignore
+//       // @ts-expect-error
 //       await (agent.listTools() as Agent['tools']).mastraTool.execute!({ name: 'test' });
-//       // @ts-ignore
+//       // @ts-expect-error
 //       await (agent.listTools() as Agent['tools']).vercelTool.execute!({ name: 'test' });
 
 //       expect(mastraExecute).toHaveBeenCalled();

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -272,7 +272,7 @@ export class Agent<
       this.#maxProcessorRetries = config.maxProcessorRetries;
     }
 
-    // @ts-ignore Flag for agent network messages
+    // @ts-expect-error Flag for agent network messages
     this._agentNetworkAppend = config._agentNetworkAppend || false;
   }
 
@@ -2159,7 +2159,7 @@ export class Agent<
           mastra: this.#mastra,
           // manually wrap workflow tools with tracing, so that we can pass the
           // current tool span onto the workflow to maintain continuity of the trace
-          // @ts-ignore
+          // @ts-expect-error
           execute: async (inputData, context) => {
             try {
               const { initialState, inputData: workflowInputData, suspendedToolRunId } = inputData as any;

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -94,7 +94,7 @@ export class MessageList {
     threadId,
     resourceId,
     generateMessageId,
-    // @ts-ignore Flag for agent network messages
+    // @ts-expect-error Flag for agent network messages
     _agentNetworkAppend,
   }: { threadId?: string; resourceId?: string; generateMessageId?: (context?: IdGeneratorContext) => string } = {}) {
     if (threadId) {

--- a/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-to-mastra-v1.ts
@@ -25,8 +25,7 @@ const makePushOrCombine = (v1Messages: MastraMessageV1[]) => {
       (msg.role !== `assistant` || (msg.role === `assistant` && msg.content.at(-1)?.type !== `tool-call`))
     ) {
       for (const part of msg.content) {
-        // @ts-ignore needs type gymnastics? msg.content and previousMessage.content are the same type here since both are arrays
-        // I'm not sure what's adding `never` to the union but this code definitely works..
+        // @ts-expect-error needs type gymnastics? msg.content and previousMessage.content are the same type here since both are arrays
         previousMessage.content.push(part);
       }
     } else {
@@ -96,7 +95,7 @@ export function convertToV1Messages(messages: Array<MastraDBMessage>) {
             role: 'user',
             ...fields,
             type: 'text',
-            // @ts-ignore
+            // @ts-expect-error
             content: userContent,
           });
         } else {

--- a/packages/core/src/agent/message-list/tests/message-list.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list.test.ts
@@ -2010,7 +2010,7 @@ describe('MessageList', () => {
       ];
       const newUIMessages5 = appendResponseMessages({
         messages: newUIMessages3,
-        // @ts-ignore
+        // @ts-expect-error
         responseMessages: responseMessages2,
       });
 

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -113,7 +113,7 @@ export function createMapResultsStep<OUTPUT = undefined>({
         messageList: memoryData.messageList,
       });
 
-      // @ts-ignore - TODO: types are wrong here, maybe wrong in general?
+      // @ts-expect-error - TODO: types are wrong here, maybe wrong in general?
       return bail(modelOutput);
     }
 

--- a/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/prepare-memory-step.ts
@@ -67,7 +67,7 @@ export function createPrepareMemoryStep<OUTPUT = undefined>({
         threadId: thread?.id,
         resourceId,
         generateMessageId: capabilities.generateMessageId,
-        // @ts-ignore Flag for agent network messages
+        // @ts-expect-error Flag for agent network messages
         _agentNetworkAppend: capabilities._agentNetworkAppend,
       });
 

--- a/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/stream-step.ts
@@ -50,7 +50,6 @@ export function createStreamStep<OUTPUT = undefined>({
 }: StreamStepOptions) {
   return createStep({
     id: 'stream-text-step',
-    // @ts-ignore
     inputSchema: z.any(), // tried to type this in various ways but it's too complex
     outputSchema: z.instanceof(MastraModelOutput<OUTPUT>),
     execute: async ({ inputData, tracingContext }) => {

--- a/packages/core/src/evals/scoreTraces/utils.test.ts
+++ b/packages/core/src/evals/scoreTraces/utils.test.ts
@@ -388,7 +388,7 @@ describe('Transformer Functions', () => {
       expect(result.output[0]?.content.toolInvocations?.[0]?.toolName).toBe('weatherAPI');
       expect(result.output[0]?.content.toolInvocations?.[0]?.args).toEqual({ location: 'Seattle' });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.output[0]?.content.toolInvocations?.[0]?.result).toEqual({ temperature: 72, condition: 'sunny' });
     });
 

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -145,7 +145,7 @@ export async function getRoutingAgent({
     instructions,
     model: model,
     memory: memoryToUse,
-    // @ts-ignore
+    // @ts-expect-error
     _agentNetworkAppend: true,
   });
 }

--- a/packages/core/src/loop/test-utils/streamObject.ts
+++ b/packages/core/src/loop/test-utils/streamObject.ts
@@ -367,7 +367,7 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
 
           pipeTextStreamToResponse({
             response: mockResponse,
-            // @ts-ignore
+            // @ts-expect-error
             textStream: result.textStream,
           });
 

--- a/packages/core/src/loop/workflows/agentic-loop/index.ts
+++ b/packages/core/src/loop/workflows/agentic-loop/index.ts
@@ -138,7 +138,7 @@ export function createAgenticLoopWorkflow<Tools extends ToolSet = ToolSet, OUTPU
             type: 'step-finish',
             runId,
             from: ChunkFrom.AGENT,
-            // @ts-ignore TODO: Look into the proper types for this
+            // @ts-expect-error TODO: Look into the proper types for this
             payload: typedInputData,
           });
         }

--- a/packages/core/src/stream/RunOutput.ts
+++ b/packages/core/src/stream/RunOutput.ts
@@ -128,7 +128,6 @@ export class WorkflowRunOutput<
                     }
                   : {},
                 output: {
-                  // @ts-ignore
                   usage: self.#usageCount,
                 },
                 // Include tripwire data when status is 'tripwire'
@@ -301,7 +300,6 @@ export class WorkflowRunOutput<
                     }
                   : {},
                 output: {
-                  // @ts-ignore
                   usage: self.#usageCount,
                 },
                 // Include tripwire data when status is 'tripwire'

--- a/packages/core/src/stream/aisdk/v4/input.ts
+++ b/packages/core/src/stream/aisdk/v4/input.ts
@@ -19,7 +19,7 @@ export class AISDKV4InputStream extends MastraModelInput {
     controller: ReadableStreamDefaultController<ChunkType>;
   }) {
     // ReadableStream throws TS errors, if imported not imported. What an annoying thing.
-    //@ts-ignore
+    //@ts-expect-error
     for await (const chunk of stream) {
       const transformedChunk = convertFullStreamChunkToMastra(chunk, { runId });
       if (transformedChunk) {

--- a/packages/core/src/stream/aisdk/v5/compat/media.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/media.ts
@@ -114,13 +114,13 @@ export const audioMediaTypeSignatures = [
 const stripID3 = (data: Uint8Array | string) => {
   const bytes = typeof data === 'string' ? convertBase64ToUint8Array(data) : data;
   const id3Size =
-    // @ts-ignore
+    // @ts-expect-error
     ((bytes[6] & 0x7f) << 21) |
-    // @ts-ignore
+    // @ts-expect-error
     ((bytes[7] & 0x7f) << 14) |
-    // @ts-ignore
+    // @ts-expect-error
     ((bytes[8] & 0x7f) << 7) |
-    // @ts-ignore
+    // @ts-expect-error
     (bytes[9] & 0x7f);
 
   // The raw MP3 starts here

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
@@ -100,7 +100,7 @@ export function prepareToolsAndToolChoice<TOOLS extends Record<string, Tool>>({
           if ('inputSchema' in tool) {
             inputSchema = tool.inputSchema;
           } else if ('parameters' in tool) {
-            // @ts-ignore tool is not part
+            // @ts-expect-error tool is not part
             inputSchema = tool.parameters;
           }
 

--- a/packages/core/src/stream/aisdk/v5/input.ts
+++ b/packages/core/src/stream/aisdk/v5/input.ts
@@ -48,7 +48,7 @@ export class AISDKV5InputStream extends MastraModelInput {
     const idMap = new Map<string, string>();
 
     // ReadableStream throws TS errors, if imported not imported. What an annoying thing.
-    //@ts-ignore
+    //@ts-expect-error
     for await (const chunk of stream) {
       const rawChunk = chunk as StreamPart;
 

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -476,9 +476,9 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               self.#toolCalls.push(chunk);
               self.#bufferedByStep.toolCalls.push(chunk);
               const toolCallPayload = chunk.payload;
-              // @ts-ignore TODO: What does this mean??? Why is there a nested output, what is the type supposed to be
+              // @ts-expect-error TODO: What does this mean??? Why is there a nested output, what is the type supposed to be
               if (toolCallPayload?.output?.from === 'AGENT' && toolCallPayload?.output?.type === 'finish') {
-                // @ts-ignore TODO: What does this mean??? Why is there a nested output, what is the type supposed to be
+                // @ts-expect-error TODO: What does this mean??? Why is there a nested output, what is the type supposed to be
                 const finishPayload = toolCallPayload.output.payload;
                 if (finishPayload?.usage) {
                   self.updateUsageCount(finishPayload.usage);

--- a/packages/core/src/test-utils/llm-mock.ts
+++ b/packages/core/src/test-utils/llm-mock.ts
@@ -185,31 +185,29 @@ export class MockProvider extends MastraLLMV1 {
     super({ model: mockModel });
   }
 
-  // @ts-ignore
+  // @ts-expect-error
   stream(...args: any): PromiseLike<StreamReturn<any, any, any>> {
-    // @ts-ignore
+    // @ts-expect-error
     const result = super.stream(...args);
 
     return {
       ...result,
-      // @ts-ignore on await read the stream
       then: (onfulfilled, onrejected) => {
-        // @ts-ignore
+        // @ts-expect-error
         return result.baseStream.pipeTo(new WritableStream()).then(onfulfilled, onrejected);
       },
     };
   }
 
-  // @ts-ignore
+  // @ts-expect-error
   __streamObject(...args): PromiseLike<StreamObjectResult<any>> {
-    // @ts-ignore
+    // @ts-expect-error
     const result = super.__streamObject(...args);
 
     return {
       ...result,
-      // @ts-ignore on await read the stream
       then: (onfulfilled, onrejected) => {
-        // @ts-ignore
+        // @ts-expect-error
         return result.baseStream.pipeTo(new WritableStream()).then(onfulfilled, onrejected);
       },
     };

--- a/packages/core/src/workflows/evented/evented-workflow.test.ts
+++ b/packages/core/src/workflows/evented/evented-workflow.test.ts
@@ -4875,9 +4875,9 @@ describe('Workflow', () => {
 
       expect(increment).toHaveBeenCalledTimes(12);
       expect(final).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.result).toEqual({ finalValue: 12 });
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.increment.output).toEqual({ value: 12 });
     });
 
@@ -4951,9 +4951,9 @@ describe('Workflow', () => {
 
       expect(increment).toHaveBeenCalledTimes(12);
       expect(final).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.result).toEqual({ finalValue: 12 });
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.increment.output).toEqual({ value: 12 });
 
       await mastra.stopEventEngine();
@@ -5310,9 +5310,9 @@ describe('Workflow', () => {
       expect(start).toHaveBeenCalledTimes(1);
       expect(other).toHaveBeenCalledTimes(0);
       expect(final).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.finalIf.output).toEqual({ finalValue: 2 });
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.start.output).toEqual({ newValue: 2 });
 
       await mastra.stopEventEngine();
@@ -5433,9 +5433,9 @@ describe('Workflow', () => {
       expect(start).toHaveBeenCalledTimes(1);
       expect(other).toHaveBeenCalledTimes(1);
       expect(final).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['else-branch'].output).toEqual({ finalValue: 26 + 6 + 1 });
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.start.output).toEqual({ newValue: 7 });
     });
   });
@@ -5805,7 +5805,7 @@ describe('Workflow', () => {
         outputSchema: z.object({ name: z.string() }),
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       const toolAction = vi.fn().mockImplementation(async (input: { name: string }) => {
         return { name: input.name };
       });
@@ -5824,7 +5824,7 @@ describe('Workflow', () => {
         outputSchema: z.object({ name: z.string() }),
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       workflow.then(step1).then(createStep(randomTool)).commit();
 
       const mastra = new Mastra({
@@ -5839,7 +5839,7 @@ describe('Workflow', () => {
 
       expect(step1Action).toHaveBeenCalled();
       expect(toolAction).toHaveBeenCalled();
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.step1).toEqual({
         status: 'success',
         output: { name: 'step1' },
@@ -5847,7 +5847,7 @@ describe('Workflow', () => {
         startedAt: expect.any(Number),
         endedAt: expect.any(Number),
       });
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['random-tool']).toEqual({
         status: 'success',
         output: { name: 'step1' },
@@ -6373,7 +6373,7 @@ describe('Workflow', () => {
       const firstResumeResult = await run.resume({ step: 'promptAgent', resumeData: newCtx });
       expect(promptAgentAction).toHaveBeenCalledTimes(2);
       expect(firstResumeResult.steps.requestContextAction.status).toBe('success');
-      // @ts-ignore
+      // @ts-expect-error
       expect(firstResumeResult.steps.requestContextAction.output).toEqual(['first message', 'promptAgentAction']);
 
       await mastra.stopEventEngine();
@@ -6449,7 +6449,7 @@ describe('Workflow', () => {
       const firstResumeResult = await run.resume({ step: 'promptAgent', resumeData: newCtx, requestContext });
       expect(promptAgentAction).toHaveBeenCalledTimes(2);
       expect(firstResumeResult.steps.requestContextAction.status).toBe('success');
-      // @ts-ignore
+      // @ts-expect-error
       expect(firstResumeResult.steps.requestContextAction.output).toEqual(['first message', 'promptAgentAction']);
 
       await mastra.stopEventEngine();
@@ -9983,12 +9983,12 @@ describe('Workflow', () => {
       expect(other).toHaveBeenCalledTimes(1);
       expect(final).toHaveBeenCalledTimes(2);
       expect(last).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-a'].output).toEqual({
         finalValue: 26 + 1,
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-b'].output).toEqual({
         finalValue: 1,
       });
@@ -10094,12 +10094,12 @@ describe('Workflow', () => {
       expect(start).toHaveBeenCalledTimes(1);
       expect(other).toHaveBeenCalledTimes(1);
       expect(final).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-a'].output).toEqual({
         newValue: 1,
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-b'].output).toEqual({
         finalValue: 28,
       });
@@ -10213,12 +10213,12 @@ describe('Workflow', () => {
       expect(other).toHaveBeenCalledTimes(1);
       expect(final).toHaveBeenCalledTimes(2);
       expect(last).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-a-clone'].output).toEqual({
         finalValue: 26 + 1,
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-b'].output).toEqual({
         finalValue: 1,
       });
@@ -10313,7 +10313,7 @@ describe('Workflow', () => {
         .then(startStep)
         .branch([
           [async () => false, otherStep],
-          // @ts-ignore
+          // @ts-expect-error
           [async () => true, finalStep],
         ])
         .map({
@@ -10352,12 +10352,12 @@ describe('Workflow', () => {
       expect(other).toHaveBeenCalledTimes(1);
       expect(final).toHaveBeenCalledTimes(2);
       expect(last).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-a'].output).toEqual({
         finalValue: 26 + 1,
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-b'].output).toEqual({
         finalValue: 1,
       });
@@ -10495,7 +10495,7 @@ describe('Workflow', () => {
         expect(final).toHaveBeenCalledTimes(1);
         expect(first).toHaveBeenCalledTimes(1);
         expect(last).toHaveBeenCalledTimes(1);
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-a'].output).toEqual({
           finalValue: 26 + 1,
         });
@@ -10643,7 +10643,7 @@ describe('Workflow', () => {
         expect(first).toHaveBeenCalledTimes(1);
         expect(last).toHaveBeenCalledTimes(1);
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-b'].output).toEqual({
           finalValue: 1,
         });
@@ -10830,7 +10830,7 @@ describe('Workflow', () => {
         expect(first).toHaveBeenCalledTimes(1);
         expect(last).toHaveBeenCalledTimes(1);
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-b'].output).toEqual({
           finalValue: 1,
         });
@@ -10976,12 +10976,12 @@ describe('Workflow', () => {
           status: 'suspended',
         });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['last-step']).toEqual(undefined);
 
         const resumedResults = await run.resume({ step: [wfA, otherStep], resumeData: { newValue: 0 } });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(resumedResults.steps['nested-workflow-a'].output).toEqual({
           finalValue: 26 + 1,
         });
@@ -11099,7 +11099,7 @@ describe('Workflow', () => {
         expect(final).toHaveBeenCalledTimes(1);
         expect(last).toHaveBeenCalledTimes(1);
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(results['nested-workflow-a']).toMatchObject({
           status: 'success',
           output: {
@@ -11270,7 +11270,7 @@ describe('Workflow', () => {
         },
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['last-step']).toEqual(undefined);
 
       if (result.status !== 'suspended') {
@@ -11279,7 +11279,7 @@ describe('Workflow', () => {
       expect(result.suspended[0]).toEqual(['nested-workflow-c', 'nested-workflow-b', 'nested-workflow-a', 'other']);
       const resumedResults = await run.resume({ step: result.suspended[0], resumeData: { newValue: 0 } });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(resumedResults.steps['nested-workflow-c'].output).toEqual({
         finalValue: 26 + 1,
       });
@@ -11592,7 +11592,7 @@ describe('Workflow', () => {
       const run = await workflow.createRun();
       const result = await run.start({ requestContext });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.step1.output.injectedValue).toBe(testValue);
 
       await mastra.stopEventEngine();
@@ -11650,7 +11650,7 @@ describe('Workflow', () => {
         requestContext: resumerequestContext,
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result?.steps.step1.output.injectedValue).toBe(testValue + '2');
 
       await mastra.stopEventEngine();

--- a/packages/core/src/workflows/evented/step-executor.ts
+++ b/packages/core/src/workflows/evented/step-executor.ts
@@ -164,7 +164,7 @@ export class StepExecutor extends MastraBase {
       } else if (bailed) {
         finalResult = {
           ...stepInfo,
-          // @ts-ignore
+          // @ts-expect-error
           status: 'bailed',
           endedAt,
           output: bailed.payload,

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -724,7 +724,6 @@ export class WorkflowEventProcessor extends EventProcessor {
           perStep,
         });
 
-        // @ts-ignore
         const nestedPrevStep = getStep(step.step, timeTravelParams.executionPath);
         const nestedPrevResult = timeTravelParams.stepResults[nestedPrevStep?.id ?? 'input'];
 
@@ -853,9 +852,9 @@ export class WorkflowEventProcessor extends EventProcessor {
     });
     requestContext = Object.fromEntries(rc.entries());
 
-    // @ts-ignore
+    // @ts-expect-error
     if (stepResult.status === 'bailed') {
-      // @ts-ignore
+      // @ts-expect-error
       stepResult.status = 'success';
 
       await this.endWorkflow({
@@ -1204,7 +1203,7 @@ export class WorkflowEventProcessor extends EventProcessor {
             const res = stepResults?.[step.step.id];
             if (res && res.status === 'success') {
               acc[step.step.id] = res?.output;
-              // @ts-ignore
+              // @ts-expect-error
             } else if (res?.status === 'skipped') {
               skippedCount++;
             }

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -1103,7 +1103,6 @@ export class EventedWorkflow<
           waitingPaths: {},
           result: undefined,
           error: undefined,
-          // @ts-ignore
           timestamp: Date.now(),
         },
       });

--- a/packages/core/src/workflows/handlers/control-flow.ts
+++ b/packages/core/src/workflows/handlers/control-flow.ts
@@ -199,7 +199,6 @@ export async function executeParallel(
       status: 'success',
       output: results.reduce((acc: Record<string, any>, result, index) => {
         if (result.status === 'success') {
-          // @ts-ignore
           acc[entry.steps[index]!.step.id] = result.output;
         }
 
@@ -498,7 +497,6 @@ export async function executeConditional(
       status: 'success',
       output: results.reduce((acc: Record<string, any>, result, index) => {
         if (result.status === 'success') {
-          // @ts-ignore
           acc[stepsToRun[index]!.step.id] = result.output;
         }
 
@@ -1027,7 +1025,6 @@ export async function executeForeach(
     ...stepInfo,
     status: 'success',
     output: results,
-    //@ts-ignore
     endedAt: Date.now(),
   } as StepSuccess<any, any, any, any>;
 }

--- a/packages/core/src/workflows/handlers/entry.ts
+++ b/packages/core/src/workflows/handlers/entry.ts
@@ -78,7 +78,6 @@ export async function persistStepUpdate(
         result,
         error,
         requestContext: requestContextObj,
-        // @ts-ignore
         timestamp: Date.now(),
       },
     });

--- a/packages/core/src/workflows/handlers/step.ts
+++ b/packages/core/src/workflows/handlers/step.ts
@@ -365,7 +365,6 @@ export async function executeStep(
             ? {
                 steps: resume?.steps?.slice(1) || [],
                 resumePayload: resume?.resumePayload,
-                // @ts-ignore
                 runId: stepResults[step.id]?.suspendPayload?.__workflow_meta?.runId,
                 label: resume?.label,
                 forEachIndex: resume?.forEachIndex,

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -193,8 +193,7 @@ export type PathsToStringProps<T> =
       ? {
           [K in keyof T]: T[K] extends object
             ? K extends string
-              ? // @ts-ignore
-                  K | `${K}.${PathsToStringProps<T[K]>}`
+              ? K | `${K}.${PathsToStringProps<T[K]>}`
               : never
             : K extends string
               ? K

--- a/packages/core/src/workflows/workflow.test.ts
+++ b/packages/core/src/workflows/workflow.test.ts
@@ -7523,9 +7523,9 @@ describe('Workflow', () => {
 
       expect(increment).toHaveBeenCalledTimes(12);
       expect(final).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.result).toEqual({ finalValue: 12 });
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.increment.output).toEqual({ value: 12 });
     });
 
@@ -7596,9 +7596,9 @@ describe('Workflow', () => {
 
       expect(increment).toHaveBeenCalledTimes(12);
       expect(final).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.result).toEqual({ finalValue: 12 });
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.increment.output).toEqual({ value: 12 });
     });
   });
@@ -8515,9 +8515,9 @@ describe('Workflow', () => {
       expect(start).toHaveBeenCalledTimes(1);
       expect(other).toHaveBeenCalledTimes(0);
       expect(final).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.finalIf.output).toEqual({ finalValue: 2 });
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.start.output).toEqual({ newValue: 2 });
     });
 
@@ -8629,9 +8629,9 @@ describe('Workflow', () => {
       expect(start).toHaveBeenCalledTimes(1);
       expect(other).toHaveBeenCalledTimes(1);
       expect(final).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['else-branch'].output).toEqual({ finalValue: 26 + 6 + 1 });
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.start.output).toEqual({ newValue: 7 });
     });
   });
@@ -8796,7 +8796,7 @@ describe('Workflow', () => {
         endedAt: expect.any(Number),
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.result).toEqual({ required: 'test', nested: { value: 1 } });
     });
 
@@ -9470,14 +9470,14 @@ describe('Workflow', () => {
       expect(other).toHaveBeenCalledTimes(1);
       expect(final).toHaveBeenCalledTimes(1);
       expect(last).toHaveBeenCalledTimes(0);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-a'].error).toBeInstanceOf(Error);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-a'].error.message).toContain(
         'Step input validation failed: \n- newValue: Required',
       );
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-b'].output).toEqual({
         finalValue: 1,
       });
@@ -9760,7 +9760,7 @@ describe('Workflow', () => {
 
       const step1 = createStep({
         id: 'step1',
-        // @ts-ignore
+        // @ts-expect-error
         execute: vi.fn().mockResolvedValue({ result: 'success' }),
         inputSchema: zv4.object({
           required: zv4.string(),
@@ -9773,7 +9773,7 @@ describe('Workflow', () => {
         }),
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       const step2 = createStep({
         id: 'step2',
         execute: vi.fn().mockResolvedValue({ result: 'step2 success' }),
@@ -9790,7 +9790,7 @@ describe('Workflow', () => {
 
       const step3 = createStep({
         id: 'step3',
-        // @ts-ignore
+        // @ts-expect-error
         execute: vi.fn().mockResolvedValue({ result: 'step3 success' }),
         inputSchema: zv4.object({
           required: zv4.string(),
@@ -9805,9 +9805,9 @@ describe('Workflow', () => {
 
       const workflow = createWorkflow({
         id: 'test-workflow',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: triggerSchema,
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({
           result: zv4.string(),
         }),
@@ -9817,14 +9817,14 @@ describe('Workflow', () => {
 
       const parallelWorkflow = createWorkflow({
         id: 'parallel-workflow',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: zv4.object({
           required: zv4.string(),
           nested: zv4.object({
             value: zv4.number(),
           }),
         }),
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({
           result: zv4.string(),
         }),
@@ -9882,7 +9882,7 @@ describe('Workflow', () => {
 
       const step1 = createStep({
         id: 'step1',
-        // @ts-ignore
+        // @ts-expect-error
         execute: async ({ inputData }) => {
           return inputData;
         },
@@ -9892,9 +9892,9 @@ describe('Workflow', () => {
 
       const workflow = createWorkflow({
         id: 'test-workflow',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: triggerSchema,
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: triggerSchema,
         steps: [step1],
         options: { validateInputs: true },
@@ -9918,7 +9918,7 @@ describe('Workflow', () => {
         endedAt: expect.any(Number),
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.result).toEqual({ required: 'test', nested: { value: 1 } });
     });
 
@@ -9929,7 +9929,7 @@ describe('Workflow', () => {
 
       const step1 = createStep({
         id: 'step1',
-        // @ts-ignore
+        // @ts-expect-error
         execute: successAction,
         inputSchema: zv4.object({
           start: zv4.string(),
@@ -9941,7 +9941,7 @@ describe('Workflow', () => {
 
       const step2 = createStep({
         id: 'step2',
-        // @ts-ignore
+        // @ts-expect-error
         execute: successAction,
         inputSchema: zv4.object({
           start: zv4.string(),
@@ -9953,11 +9953,11 @@ describe('Workflow', () => {
 
       const workflow = createWorkflow({
         id: 'test-workflow',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: zv4.object({
           start: zv4.string(),
         }),
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({
           result: zv4.string(),
         }),
@@ -10022,7 +10022,7 @@ describe('Workflow', () => {
 
       const step1 = createStep({
         id: 'step1',
-        // @ts-ignore
+        // @ts-expect-error
         execute: async () => {
           return {};
         },
@@ -10036,7 +10036,7 @@ describe('Workflow', () => {
 
       const step2 = createStep({
         id: 'step2',
-        // @ts-ignore
+        // @ts-expect-error
         execute: successAction,
         inputSchema: zv4.object({
           start: zv4.string().optional().default('test'),
@@ -10048,11 +10048,11 @@ describe('Workflow', () => {
 
       const workflow = createWorkflow({
         id: 'test-workflow',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: zv4.object({
           start: zv4.string(),
         }),
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({
           result: zv4.string(),
         }),
@@ -10062,7 +10062,7 @@ describe('Workflow', () => {
       workflow
         .then(step1)
         .map({
-          // @ts-ignore
+          // @ts-expect-error
           start: mapVariable({
             step: step1,
             path: 'start',
@@ -10109,7 +10109,7 @@ describe('Workflow', () => {
 
       const step1 = createStep({
         id: 'step1',
-        // @ts-ignore
+        // @ts-expect-error
         execute: async ({ inputData }) => {
           return { start: inputData.start };
         },
@@ -10123,7 +10123,7 @@ describe('Workflow', () => {
 
       const step2 = createStep({
         id: 'step2',
-        // @ts-ignore
+        // @ts-expect-error
         execute: successAction,
         inputSchema: zv4.object({
           start: zv4.string(),
@@ -10135,11 +10135,11 @@ describe('Workflow', () => {
 
       const workflow = createWorkflow({
         id: 'test-workflow',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: zv4.object({
           start: zv4.number(),
         }),
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({
           result: zv4.string(),
         }),
@@ -10208,13 +10208,13 @@ describe('Workflow', () => {
     it('should throw error when you try to resume a workflow step with invalid resume data', async () => {
       const resumeStep = createStep({
         id: 'resume',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: zv4.object({ value: zv4.number() }),
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({ value: zv4.number() }),
-        // @ts-ignore
+        // @ts-expect-error
         resumeSchema: zv4.object({ value: zv4.number() }),
-        // @ts-ignore
+        // @ts-expect-error
         suspendSchema: zv4.object({ message: zv4.string() }),
         execute: async ({ inputData, resumeData, suspend }) => {
           const finalValue = (resumeData?.value ?? 0) + inputData.value;
@@ -10229,11 +10229,11 @@ describe('Workflow', () => {
 
       const incrementStep = createStep({
         id: 'increment',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: zv4.object({
           value: zv4.number(),
         }),
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({
           value: zv4.number(),
         }),
@@ -10246,9 +10246,9 @@ describe('Workflow', () => {
 
       const incrementWorkflow = createWorkflow({
         id: 'increment-workflow',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: zv4.object({ value: zv4.number() }),
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({ value: zv4.number() }),
         options: { validateInputs: true },
       })
@@ -10257,9 +10257,9 @@ describe('Workflow', () => {
         .then(
           createStep({
             id: 'final',
-            // @ts-ignore
+            // @ts-expect-error
             inputSchema: zv4.object({ value: zv4.number() }),
-            // @ts-ignore
+            // @ts-expect-error
             outputSchema: zv4.object({ value: zv4.number() }),
             execute: async ({ inputData }) => ({ value: inputData.value }),
           }),
@@ -10300,13 +10300,13 @@ describe('Workflow', () => {
     it('should use default value from resumeSchema when resuming a workflow', async () => {
       const resumeStep = createStep({
         id: 'resume',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: zv4.object({ value: zv4.number() }),
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({ value: zv4.number() }),
-        // @ts-ignore
+        // @ts-expect-error
         resumeSchema: zv4.object({ value: zv4.number().optional().default(21) }),
-        // @ts-ignore
+        // @ts-expect-error
         suspendSchema: zv4.object({ message: zv4.string() }),
         execute: async ({ inputData, resumeData, suspend }) => {
           const finalValue = (resumeData?.value ?? 0) + inputData.value;
@@ -10321,11 +10321,11 @@ describe('Workflow', () => {
 
       const incrementStep = createStep({
         id: 'increment',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: zv4.object({
           value: zv4.number(),
         }),
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({
           value: zv4.number(),
         }),
@@ -10338,9 +10338,9 @@ describe('Workflow', () => {
 
       const incrementWorkflow = createWorkflow({
         id: 'increment-workflow',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: zv4.object({ value: zv4.number() }),
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({ value: zv4.number() }),
         options: { validateInputs: true },
       })
@@ -10349,9 +10349,9 @@ describe('Workflow', () => {
         .then(
           createStep({
             id: 'final',
-            // @ts-ignore
+            // @ts-expect-error
             inputSchema: zv4.object({ value: zv4.number() }),
-            // @ts-ignore
+            // @ts-expect-error
             outputSchema: zv4.object({ value: zv4.number() }),
             execute: async ({ inputData }) => ({ value: inputData.value }),
           }),
@@ -10400,9 +10400,9 @@ describe('Workflow', () => {
       });
       const startStep = createStep({
         id: 'start',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: zv4.object({ startValue: zv4.number() }),
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({
           newValue: zv4.number(),
         }),
@@ -10414,9 +10414,9 @@ describe('Workflow', () => {
       });
       const otherStep = createStep({
         id: 'other',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: zv4.object({ newValue: zv4.number() }),
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({ newValue: zv4.number(), other: zv4.number() }),
         execute: other,
       });
@@ -10431,20 +10431,20 @@ describe('Workflow', () => {
       });
       const finalStep = createStep({
         id: 'final',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: zv4.object({ newValue: zv4.number(), other: zv4.number() }),
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({ success: zv4.boolean() }),
         execute: final,
       });
 
       const counterWorkflow = createWorkflow({
         id: 'counter-workflow',
-        // @ts-ignore
+        // @ts-expect-error
         inputSchema: zv4.object({
           startValue: zv4.number(),
         }),
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({
           success: zv4.boolean(),
         }),
@@ -10454,7 +10454,7 @@ describe('Workflow', () => {
       const wfA = createWorkflow({
         id: 'nested-workflow-a',
         inputSchema: counterWorkflow.inputSchema,
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({ finalValue: zv4.number() }),
       })
         .then(startStep)
@@ -10464,17 +10464,17 @@ describe('Workflow', () => {
       const wfB = createWorkflow({
         id: 'nested-workflow-b',
         inputSchema: counterWorkflow.inputSchema,
-        // @ts-ignore
+        // @ts-expect-error
         outputSchema: zv4.object({ finalValue: zv4.number() }),
       })
         .then(startStep)
         .map({
-          // @ts-ignore
+          // @ts-expect-error
           other: mapVariable({
             step: startStep,
             path: 'newValue',
           }),
-          // @ts-ignore
+          // @ts-expect-error
           newValue: mapVariable({
             step: startStep,
             path: 'newValue',
@@ -10485,10 +10485,10 @@ describe('Workflow', () => {
       counterWorkflow
         .parallel([wfA, wfB])
         .then(
-          // @ts-ignore
+          // @ts-expect-error
           createStep({
             id: 'last-step',
-            // @ts-ignore
+            // @ts-expect-error
             execute: last,
             inputSchema: zv4.object({
               'nested-workflow-a': zv4.object({ finalValue: zv4.number() }),
@@ -10508,14 +10508,14 @@ describe('Workflow', () => {
       expect(other).toHaveBeenCalledTimes(1);
       expect(final).toHaveBeenCalledTimes(1);
       expect(last).toHaveBeenCalledTimes(0);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-a'].error).toBeInstanceOf(Error);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-a'].error.message).toContain(
         'Step input validation failed: \n- newValue: Invalid input: expected number, received undefined',
       );
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-b'].output).toEqual({
         finalValue: 1,
       });
@@ -10807,7 +10807,7 @@ describe('Workflow', () => {
         outputSchema: z.object({ name: z.string() }),
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       const toolAction = vi.fn().mockImplementation(async (input, _context) => {
         return { name: input.name };
       });
@@ -10835,7 +10835,7 @@ describe('Workflow', () => {
 
       expect(step1Action).toHaveBeenCalled();
       expect(toolAction).toHaveBeenCalled();
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.step1).toEqual({
         status: 'success',
         output: { name: 'step1' },
@@ -10843,7 +10843,7 @@ describe('Workflow', () => {
         startedAt: expect.any(Number),
         endedAt: expect.any(Number),
       });
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['random-tool']).toEqual({
         status: 'success',
         output: { name: 'step1' },
@@ -11720,7 +11720,7 @@ describe('Workflow', () => {
       const firstResumeResult = await run.resume({ step: 'promptAgent', resumeData: newCtx });
       expect(promptAgentAction).toHaveBeenCalledTimes(2);
       expect(firstResumeResult.steps.requestContextAction.status).toBe('success');
-      // @ts-ignore
+      // @ts-expect-error
       expect(firstResumeResult.steps.requestContextAction.output).toEqual(['first message', 'promptAgentAction']);
     });
 
@@ -11791,7 +11791,7 @@ describe('Workflow', () => {
       const firstResumeResult = await run.resume({ step: 'promptAgent', resumeData: newCtx, requestContext });
       expect(promptAgentAction).toHaveBeenCalledTimes(2);
       expect(firstResumeResult.steps.requestContextAction.status).toBe('success');
-      // @ts-ignore
+      // @ts-expect-error
       expect(firstResumeResult.steps.requestContextAction.output).toEqual(['first message', 'promptAgentAction']);
     });
 
@@ -17476,12 +17476,12 @@ describe('Workflow', () => {
       expect(other).toHaveBeenCalledTimes(1);
       expect(final).toHaveBeenCalledTimes(2);
       expect(last).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-a'].output).toEqual({
         finalValue: 26 + 1,
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-b'].output).toEqual({
         finalValue: 1,
       });
@@ -17604,12 +17604,12 @@ describe('Workflow', () => {
       expect(other).toHaveBeenCalledTimes(1);
       expect(final).toHaveBeenCalledTimes(2);
       expect(last).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-a-clone'].output).toEqual({
         finalValue: 26 + 1,
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-b'].output).toEqual({
         finalValue: 1,
       });
@@ -17702,7 +17702,7 @@ describe('Workflow', () => {
         .then(startStep)
         .branch([
           [async () => false, otherStep],
-          // @ts-ignore
+          // @ts-expect-error
           [async () => true, finalStep],
         ])
         .map({
@@ -17734,12 +17734,12 @@ describe('Workflow', () => {
       expect(other).toHaveBeenCalledTimes(1);
       expect(final).toHaveBeenCalledTimes(2);
       expect(last).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-a'].output).toEqual({
         finalValue: 26 + 1,
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-b'].output).toEqual({
         finalValue: 1,
       });
@@ -17880,7 +17880,7 @@ describe('Workflow', () => {
         expect(final).toHaveBeenCalledTimes(1);
         expect(first).toHaveBeenCalledTimes(1);
         expect(last).toHaveBeenCalledTimes(1);
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-a'].output).toEqual({
           finalValue: 26 + 1,
         });
@@ -18025,7 +18025,7 @@ describe('Workflow', () => {
         expect(first).toHaveBeenCalledTimes(1);
         expect(last).toHaveBeenCalledTimes(1);
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-b'].output).toEqual({
           finalValue: 1,
         });
@@ -18206,7 +18206,7 @@ describe('Workflow', () => {
         expect(first).toHaveBeenCalledTimes(1);
         expect(last).toHaveBeenCalledTimes(1);
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-b'].output).toEqual({
           finalValue: 1,
         });
@@ -18348,12 +18348,12 @@ describe('Workflow', () => {
           status: 'suspended',
         });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['last-step']).toEqual(undefined);
 
         const resumedResults = await run.resume({ step: [wfA, otherStep], resumeData: { newValue: 0 } });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(resumedResults.steps['nested-workflow-a'].output).toEqual({
           finalValue: 26 + 1,
         });
@@ -18475,12 +18475,12 @@ describe('Workflow', () => {
           status: 'suspended',
         });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['last-step']).toEqual(undefined);
 
         const resumedResults = await run.resume({ step: 'nested-workflow-a', resumeData: { newValue: 0 } });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(resumedResults.steps['nested-workflow-a'].output).toEqual({
           finalValue: 26 + 1,
         });
@@ -18813,7 +18813,7 @@ describe('Workflow', () => {
         expect(final).toHaveBeenCalledTimes(1);
         expect(last).toHaveBeenCalledTimes(1);
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(results['nested-workflow-a']).toMatchObject({
           status: 'success',
           output: {
@@ -18979,7 +18979,7 @@ describe('Workflow', () => {
         },
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['last-step']).toEqual(undefined);
 
       if (result.status !== 'suspended') {
@@ -18988,7 +18988,7 @@ describe('Workflow', () => {
       expect(result.suspended[0]).toEqual(['nested-workflow-c', 'nested-workflow-b', 'nested-workflow-a', 'other']);
       const resumedResults = await run.resume({ step: result.suspended[0], resumeData: { newValue: 0 } });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(resumedResults.steps['nested-workflow-c'].output).toEqual({
         finalValue: 26 + 1,
       });
@@ -19547,7 +19547,7 @@ describe('Workflow', () => {
       const run = await workflow.createRun();
       const result = await run.start({ requestContext });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.step1.output.injectedValue).toBe(testValue);
     });
 
@@ -19601,7 +19601,7 @@ describe('Workflow', () => {
         requestContext: resumerequestContext,
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result?.steps.step1.output.injectedValue).toBe(testValue + '2');
     });
 

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1444,7 +1444,6 @@ export class Workflow<
   ): Workflow<TEngineType, TSteps, TWorkflowId, TState, TInput, TOutput, any> {
     // Create an implicit step that handles the mapping
     if (typeof mappingConfig === 'function') {
-      // @ts-ignore
       const mappingStep: any = createStep({
         id:
           stepOptions?.id ||
@@ -1628,7 +1627,6 @@ export class Workflow<
     this.stepFlow.push({
       type: 'conditional',
       steps: steps.map(([_cond, step]) => ({ type: 'step', step: step as any })),
-      // @ts-ignore
       conditions: steps.map(([cond]) => cond),
       serializedConditions: steps.map(([cond, _step]) => ({ id: `${_step.id}-condition`, fn: cond.toString() })),
     });
@@ -1679,7 +1677,6 @@ export class Workflow<
     this.stepFlow.push({
       type: 'loop',
       step: step as any,
-      // @ts-ignore
       condition,
       loopType: 'dowhile',
       serializedCondition: { id: `${step.id}-condition`, fn: condition.toString() },
@@ -1707,7 +1704,6 @@ export class Workflow<
     this.stepFlow.push({
       type: 'loop',
       step: step as any,
-      // @ts-ignore
       condition,
       loopType: 'dountil',
       serializedCondition: { id: `${step.id}-condition`, fn: condition.toString() },
@@ -1872,7 +1868,7 @@ export class Workflow<
           runId: runIdToUse,
           status: 'pending',
           value: {},
-          // @ts-ignore
+          // @ts-expect-error
           context: this.#nestedWorkflowInput ? { input: this.#nestedWorkflowInput } : {},
           activePaths: [],
           activeStepsPath: {},
@@ -1882,7 +1878,6 @@ export class Workflow<
           waitingPaths: {},
           result: undefined,
           error: undefined,
-          // @ts-ignore
           timestamp: Date.now(),
         },
       });
@@ -2077,7 +2072,7 @@ export class Workflow<
 
     if (suspendedSteps?.length) {
       for (const [stepName, stepResult] of suspendedSteps) {
-        // @ts-ignore
+        // @ts-expect-error
         const suspendPath: string[] = [stepName, ...(stepResult?.suspendPayload?.__workflow_meta?.path ?? [])];
         await suspend(
           {
@@ -2981,7 +2976,6 @@ export class Run<
     const stream = new ReadableStream<WorkflowStreamEvent>({
       async start(controller) {
         // TODO: fix this, watch doesn't have a type
-        // @ts-ignore
         const unwatch = self.watch(async (event: any) => {
           const { type, from = ChunkFrom.WORKFLOW, payload, data, ...rest } = event;
           // Check if this is a custom event (has 'data' property instead of 'payload')
@@ -3108,7 +3102,6 @@ export class Run<
     const stream = new ReadableStream<WorkflowStreamEvent>({
       async start(controller) {
         // TODO: fix this, watch doesn't have a type
-        // @ts-ignore
         const unwatch = self.watch(async (event: any) => {
           const { type, from = ChunkFrom.WORKFLOW, payload, data, ...rest } = event;
           // Check if this is a custom event (has 'data' property instead of 'payload')
@@ -3441,7 +3434,7 @@ export class Run<
           steps,
           stepResults,
           resumePayload: resumeDataToUse,
-          // @ts-ignore
+          // @ts-expect-error
           resumePath: snapshot?.suspendedPaths?.[steps?.[0]] as any,
           forEachIndex: params.forEachIndex ?? snapshotResumeLabel?.foreachIndex,
           label: params.label,
@@ -3777,7 +3770,6 @@ export class Run<
     const stream = new ReadableStream<WorkflowStreamEvent>({
       async start(controller) {
         // TODO: fix this, watch doesn't have a type
-        // @ts-ignore
         const unwatch = self.watch(async ({ type, from = ChunkFrom.WORKFLOW, payload }) => {
           controller.enqueue({
             type,

--- a/packages/deployer/src/build/bundler.ts
+++ b/packages/deployer/src/build/bundler.ts
@@ -138,11 +138,11 @@ export async function getInputOptions(
       // for debugging
       // {
       //   name: 'logger',
-      //   //@ts-ignore
+      //   //@ts-expect-error
       //   resolveId(id, ...args) {
       //     console.log({ id, args });
       //   },
-      //   // @ts-ignore
+      //   // @ts-expect-error
       // transform(code, id) {
       //   if (code.includes('class Duplexify ')) {
       //     console.log({ duplex: id });

--- a/packages/deployer/src/build/plugins/node-modules-extension-resolver.test.ts
+++ b/packages/deployer/src/build/plugins/node-modules-extension-resolver.test.ts
@@ -81,9 +81,9 @@ describe('nodeModulesExtensionResolver', () => {
 
     it('imports with an extension that have exports mapping', async () => {
       const pkgJson = { name: 'hono', exports: { 'hono/utils/mime.js': './dist/utils/mime.js' } };
-      // @ts-ignore parital is fine
+      // @ts-expect-error parital is fine
       vi.mocked(getPackageInfo).mockResolvedValue({ name: 'hono', rootPath: '/project/node_modules/hono' });
-      // @ts-ignore  type should be correct
+      // @ts-expect-error  type should be correct
       vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
       const result = await resolveId('hono/utils/mime.js', '/project/src/index.ts');
@@ -95,9 +95,9 @@ describe('nodeModulesExtensionResolver', () => {
   describe('imports with JS extension', () => {
     it('It will resolve the import to the correct path if no exports present', async () => {
       const pkgJson = { name: 'lodash' };
-      // @ts-ignore parital is fine
+      // @ts-expect-error parital is fine
       vi.mocked(getPackageInfo).mockResolvedValue({ name: 'lodash', rootPath: '/project/node_modules/lodash' });
-      // @ts-ignore  type should be correct
+      // @ts-expect-error  type should be correct
       vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
       mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/lodash/fp/get.js' });
@@ -112,9 +112,9 @@ describe('nodeModulesExtensionResolver', () => {
 
     it('handles .mjs extension', async () => {
       const pkgJson = { name: 'lodash' };
-      // @ts-ignore parital is fine
+      // @ts-expect-error parital is fine
       vi.mocked(getPackageInfo).mockResolvedValue({ name: 'lodash', rootPath: '/project/node_modules/lodash' });
-      // @ts-ignore  type should be correct
+      // @ts-expect-error  type should be correct
       vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
       mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/lodash/fp/get.mjs' });
@@ -129,9 +129,9 @@ describe('nodeModulesExtensionResolver', () => {
 
     it('handles .cjs extension', async () => {
       const pkgJson = { name: 'lodash' };
-      // @ts-ignore parital is fine
+      // @ts-expect-error parital is fine
       vi.mocked(getPackageInfo).mockResolvedValue({ name: 'lodash', rootPath: '/project/node_modules/lodash' });
-      // @ts-ignore  type should be correct
+      // @ts-expect-error  type should be correct
       vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
       mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/lodash/fp/get.cjs' });
@@ -148,9 +148,9 @@ describe('nodeModulesExtensionResolver', () => {
   describe('imports without extension', () => {
     it('resolves the import to the correct path if no exports present', async () => {
       const pkgJson = { name: 'lodash' };
-      // @ts-ignore parital is fine
+      // @ts-expect-error parital is fine
       vi.mocked(getPackageInfo).mockResolvedValue({ name: 'lodash', rootPath: '/project/node_modules/lodash' });
-      // @ts-ignore  type should be correct
+      // @ts-expect-error  type should be correct
       vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
       mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/lodash/fp/get.cjs' });
@@ -175,9 +175,9 @@ describe('nodeModulesExtensionResolver', () => {
   describe('scoped packages', () => {
     it('handles scoped package subpath imports with exports', async () => {
       const pkgJson = { name: '@my/lodash', exports: {} };
-      // @ts-ignore parital is fine
+      // @ts-expect-error parital is fine
       vi.mocked(getPackageInfo).mockResolvedValue({ name: '@my/lodash', rootPath: '/project/node_modules/@my/lodash' });
-      // @ts-ignore  type should be correct
+      // @ts-expect-error  type should be correct
       vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
 
       mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/@my/lodash/fp/get.cjs' });
@@ -189,11 +189,11 @@ describe('nodeModulesExtensionResolver', () => {
 
     it('adds extension for scoped package without exports', async () => {
       const pkgJson = { name: '@my/lodash' };
-      // @ts-ignore parital is fine
+      // @ts-expect-error parital is fine
       vi.mocked(getPackageInfo).mockResolvedValue({ name: '@my/lodash', rootPath: '/project/node_modules/@my/lodash' });
-      // @ts-ignore  type should be correct
+      // @ts-expect-error  type should be correct
       vi.mocked(readFile).mockResolvedValue(JSON.stringify(pkgJson));
-      // @ts-ignore Partial input is fine
+      // @ts-expect-error Partial input is fine
       mockNodeResolveHandler.mockResolvedValue({ id: '/project/node_modules/@my/lodash/utils.cjs' });
 
       const result = await resolveId('@my/lodash/utils', '/project/src/index.ts');
@@ -205,7 +205,7 @@ describe('nodeModulesExtensionResolver', () => {
   describe('edge cases', () => {
     it('handles package.json read failure gracefully', async () => {
       const pkgJson = { name: '@my/lodash' };
-      // @ts-ignore parital is fine
+      // @ts-expect-error parital is fine
       vi.mocked(getPackageInfo).mockResolvedValue({ name: '@my/lodash', rootPath: '/project/node_modules/@my/lodash' });
 
       vi.mocked(readFile).mockImplementation(() => {

--- a/packages/mcp/src/server/server.test.ts
+++ b/packages/mcp/src/server/server.test.ts
@@ -158,20 +158,20 @@ describe('MCPServer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // @ts-ignore - Mocking Date completely
+    // @ts-expect-error - Mocking Date completely
     // Must use a regular function (not arrow function) to support `new Date()` constructor calls
     global.Date = vi.fn(function (this: any, ...args: any[]) {
       if (args.length === 0) {
         // new Date()
         return mockDate;
       }
-      // @ts-ignore
+      // @ts-expect-error
       return new OriginalDate(...args); // new Date('some-string') or new Date(timestamp)
     }) as any;
 
-    // @ts-ignore
+    // @ts-expect-error
     global.Date.now = vi.fn(() => mockDate.getTime());
-    // @ts-ignore
+    // @ts-expect-error
     global.Date.prototype = OriginalDate.prototype;
   });
 
@@ -248,7 +248,7 @@ describe('MCPServer', () => {
       const sdkServer = server.getServer();
 
       // Check that the SDK Server was initialized with instructions
-      // @ts-ignore - accessing private property for testing
+      // @ts-expect-error - accessing private property for testing
       expect(sdkServer._instructions).toBe(instructions);
     });
   });
@@ -1146,7 +1146,7 @@ describe('MCPServer', () => {
 
       const serverInstance = server.getServer();
 
-      // @ts-ignore - this is a private property, but we need to access it to test the request handler
+      // @ts-expect-error - this is a private property, but we need to access it to test the request handler
       const requestHandlers = serverInstance._requestHandlers;
       const callToolHandler = requestHandlers.get('tools/call');
 
@@ -1658,7 +1658,7 @@ describe('MCPServer - Agent to Tool Conversion', () => {
     });
 
     const serverInstance = server.getServer();
-    // @ts-ignore
+    // @ts-expect-error
     const requestHandlers = serverInstance._requestHandlers;
     const callToolHandler = requestHandlers.get('tools/call');
 
@@ -1789,7 +1789,7 @@ describe('MCPServer - Agent to Tool Conversion', () => {
     });
 
     const serverInstance2 = server.getServer();
-    // @ts-ignore
+    // @ts-expect-error
     const requestHandlers2 = serverInstance2._requestHandlers;
     const callToolHandler2 = requestHandlers2.get('tools/call');
 
@@ -2006,7 +2006,7 @@ describe('MCPServer - Workflow to Tool Conversion', () => {
     });
 
     const serverInstance = server.getServer();
-    // @ts-ignore - accessing private property for testing
+    // @ts-expect-error - accessing private property for testing
     const requestHandlers = serverInstance._requestHandlers;
     const callToolHandler = requestHandlers.get('tools/call');
 

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -497,7 +497,7 @@ export class MCPServer extends MCPServerBase {
             elicitation: sessionElicitation,
             extra,
           },
-          // @ts-ignore this is to let people know that the elicitation and extra keys are now nested under mcp.elicitation and mcp.extra in tool arguments
+          // @ts-expect-error this is to let people know that the elicitation and extra keys are now nested under mcp.elicitation and mcp.extra in tool arguments
           get elicitation() {
             throw new Error(`The "elicitation" key is now nested under "mcp.elicitation" in tool arguments`);
           },

--- a/packages/memory/integration-tests/src/shared/output-processor-memory.ts
+++ b/packages/memory/integration-tests/src/shared/output-processor-memory.ts
@@ -43,7 +43,7 @@ export function getOutputProcessorMemoryTests(config: OutputProcessorTestConfig)
     });
 
     afterEach(async () => {
-      //@ts-ignore
+      //@ts-expect-error
       await storage.client?.close();
     });
 

--- a/packages/memory/integration-tests/src/shared/processors.ts
+++ b/packages/memory/integration-tests/src/shared/processors.ts
@@ -69,9 +69,9 @@ export function getProcessorsTests(config: ProcessorsTestConfig) {
     });
 
     afterEach(async () => {
-      //@ts-ignore
+      //@ts-expect-error
       await storage.client.close();
-      //@ts-ignore
+      //@ts-expect-error
       await vector.turso.close();
     });
 
@@ -727,9 +727,9 @@ export function getProcessorsTests(config: ProcessorsTestConfig) {
     });
 
     afterEach(async () => {
-      //@ts-ignore
+      //@ts-expect-error
       await storage.client.close();
-      //@ts-ignore
+      //@ts-expect-error
       await vector.turso.close();
     });
 

--- a/packages/memory/integration-tests/src/shared/useChat.ts
+++ b/packages/memory/integration-tests/src/shared/useChat.ts
@@ -22,7 +22,7 @@ const dom = new JSDOM('<!doctype html><html><body></body></html>', {
   resources: 'usable',
 });
 
-// @ts-ignore - JSDOM types don't match exactly but this works for testing
+// @ts-expect-error - JSDOM types don't match exactly but this works for testing
 (globalThis as any).window = dom.window;
 (globalThis as any).document = dom.window.document;
 Object.defineProperty(globalThis, 'navigator', {

--- a/packages/memory/integration-tests/src/shared/working-memory-additive.ts
+++ b/packages/memory/integration-tests/src/shared/working-memory-additive.ts
@@ -107,7 +107,7 @@ You only need to include the fields that have new information - existing data is
       });
 
       afterEach(async () => {
-        // @ts-ignore
+        // @ts-expect-error
         await storage.client.close();
       });
 
@@ -212,7 +212,7 @@ You only need to include fields that have changed - existing data is automatical
       });
 
       afterEach(async () => {
-        // @ts-ignore
+        // @ts-expect-error
         await storage.client.close();
       });
 
@@ -380,7 +380,7 @@ Schema structure reminder:
       });
 
       afterEach(async () => {
-        // @ts-ignore
+        // @ts-expect-error
         await storage.client.close();
       });
 

--- a/packages/memory/integration-tests/src/shared/working-memory.ts
+++ b/packages/memory/integration-tests/src/shared/working-memory.ts
@@ -161,9 +161,9 @@ export function getWorkingMemoryTests(model: MastraModelConfig) {
       });
 
       afterEach(async () => {
-        //@ts-ignore
+        //@ts-expect-error
         await storage.client.close();
-        //@ts-ignore
+        //@ts-expect-error
         await vector.turso.close();
       });
 
@@ -701,9 +701,9 @@ export function getWorkingMemoryTests(model: MastraModelConfig) {
         });
 
         afterEach(async () => {
-          //@ts-ignore
+          //@ts-expect-error
           await storage.client.close();
-          //@ts-ignore
+          //@ts-expect-error
           await vector.turso.close();
         });
 
@@ -891,9 +891,9 @@ export function getWorkingMemoryTests(model: MastraModelConfig) {
       });
 
       afterEach(async () => {
-        //@ts-ignore
+        //@ts-expect-error
         await storage.client.close();
-        //@ts-ignore
+        //@ts-expect-error
         await vector.turso.close();
       });
 
@@ -1107,9 +1107,9 @@ export function getWorkingMemoryTests(model: MastraModelConfig) {
       });
 
       afterEach(async () => {
-        //@ts-ignore
+        //@ts-expect-error
         await storage.client.close();
-        //@ts-ignore
+        //@ts-expect-error
         await vector.turso.close();
       });
 
@@ -1461,9 +1461,9 @@ export function getWorkingMemoryTests(model: MastraModelConfig) {
       });
 
       afterEach(async () => {
-        //@ts-ignore
+        //@ts-expect-error
         await storage.client.close();
-        //@ts-ignore
+        //@ts-expect-error
         await vector.turso.close();
       });
 
@@ -1579,9 +1579,9 @@ export function getWorkingMemoryTests(model: MastraModelConfig) {
       });
 
       afterEach(async () => {
-        //@ts-ignore
+        //@ts-expect-error
         await storage.client.close();
-        //@ts-ignore
+        //@ts-expect-error
         await vector.turso.close();
       });
 

--- a/packages/memory/integration-tests/src/update-messages-vector-sync.test.ts
+++ b/packages/memory/integration-tests/src/update-messages-vector-sync.test.ts
@@ -68,9 +68,9 @@ describe('updateMessages should sync vector database (Issue #6195)', () => {
 
   afterEach(async () => {
     try {
-      // @ts-ignore - accessing internal client for cleanup
+      // @ts-expect-error - accessing internal client for cleanup
       await storage.client?.close();
-      // @ts-ignore - accessing internal client for cleanup
+      // @ts-expect-error - accessing internal client for cleanup
       await vector.turso?.close();
     } catch {
       // Ignore cleanup errors
@@ -104,7 +104,7 @@ describe('updateMessages should sync vector database (Issue #6195)', () => {
     expect(vectorIdBefore).toBeDefined();
 
     // Verify original content has HIGH score for physics query
-    // @ts-ignore - accessing protected method
+    // @ts-expect-error - accessing protected method
     const { embeddings: physicsEmbeddings } = await memory.embedMessageContent(
       'quantum physics subatomic particles wave functions',
     );
@@ -151,7 +151,7 @@ describe('updateMessages should sync vector database (Issue #6195)', () => {
     expect(physicsScoreAfter).toBeLessThan(0.6); // Low similarity - fix is working!
 
     // Step 6: Verify "cooking" query has HIGH score (matches pasta content)
-    // @ts-ignore - accessing protected method
+    // @ts-expect-error - accessing protected method
     const { embeddings: cookingEmbeddings } = await memory.embedMessageContent(
       'Italian pasta recipes carbonara bolognese cooking',
     );
@@ -283,9 +283,9 @@ describe('updateMessages should sync vector database (Issue #6195)', () => {
     expect(messageIds).toContain(message2.id);
 
     // Verify message1 now matches "space" query better than "marine" query
-    // @ts-ignore - accessing protected method
+    // @ts-expect-error - accessing protected method
     const { embeddings: spaceEmbeddings } = await memory.embedMessageContent('space exploration rockets');
-    // @ts-ignore - accessing protected method
+    // @ts-expect-error - accessing protected method
     const { embeddings: marineEmbeddings } = await memory.embedMessageContent('marine biology ocean underwater');
 
     const spaceResults = await vector.query({

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -578,7 +578,7 @@ ${workingMemory}`;
     const promise = embedFn({
       values: chunks,
       maxRetries: 3,
-      // @ts-ignore
+      // @ts-expect-error
       model: this.embedder,
       ...(this.embedderOptions || {}),
     });

--- a/packages/playground-ui/src/lib/form/utils.ts
+++ b/packages/playground-ui/src/lib/form/utils.ts
@@ -3,7 +3,7 @@ import { FieldTypes } from './auto-form';
 import { FieldConfig } from '@autoform/core';
 import { z } from 'zod';
 
-// @ts-ignore
+// @ts-expect-error
 export const fieldConfig: FieldConfig = buildZodFieldConfig<
   FieldTypes,
   {

--- a/packages/playground/src/lib/analytics.tsx
+++ b/packages/playground/src/lib/analytics.tsx
@@ -9,7 +9,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    // @ts-ignore - window is always defined in the browser and we don't want to type this out.
+    // @ts-expect-error - window is always defined in the browser and we don't want to type this out.
     if (window.MASTRA_TELEMETRY_DISABLED) {
       console.info('[Analytics]: Telemetry is disabled.');
       return;

--- a/pubsub/google-cloud-pubsub/src/index.test.ts
+++ b/pubsub/google-cloud-pubsub/src/index.test.ts
@@ -3093,9 +3093,9 @@ describe.sequential(
 
         expect(increment).toHaveBeenCalledTimes(12);
         expect(final).toHaveBeenCalledTimes(1);
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.result).toEqual({ finalValue: 12 });
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps.increment.output).toEqual({ value: 12 });
         await mastra.stopEventEngine();
       });
@@ -3171,9 +3171,9 @@ describe.sequential(
 
         expect(increment).toHaveBeenCalledTimes(12);
         expect(final).toHaveBeenCalledTimes(1);
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.result).toEqual({ finalValue: 12 });
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps.increment.output).toEqual({ value: 12 });
         await mastra.stopEventEngine();
       });
@@ -3376,9 +3376,9 @@ describe.sequential(
         expect(start).toHaveBeenCalledTimes(1);
         expect(other).toHaveBeenCalledTimes(0);
         expect(final).toHaveBeenCalledTimes(1);
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps.finalIf.output).toEqual({ finalValue: 2 });
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps.start.output).toEqual({ newValue: 2 });
         await mastra.stopEventEngine();
       });
@@ -3500,9 +3500,9 @@ describe.sequential(
         expect(start).toHaveBeenCalledTimes(1);
         expect(other).toHaveBeenCalledTimes(1);
         expect(final).toHaveBeenCalledTimes(1);
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['else-branch'].output).toEqual({ finalValue: 26 + 6 + 1 });
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps.start.output).toEqual({ newValue: 7 });
         await mastra.stopEventEngine();
       });
@@ -3743,7 +3743,7 @@ describe.sequential(
           outputSchema: z.object({ name: z.string() }),
         });
 
-        // @ts-ignore
+        // @ts-expect-error
         const toolAction = vi.fn<any>().mockImplementation(async ({ context }) => {
           return { name: context.name };
         });
@@ -3778,7 +3778,7 @@ describe.sequential(
 
         expect(step1Action).toHaveBeenCalled();
         expect(toolAction).toHaveBeenCalled();
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps.step1).toEqual({
           status: 'success',
           output: { name: 'step1' },
@@ -3786,7 +3786,7 @@ describe.sequential(
           startedAt: expect.any(Number),
           endedAt: expect.any(Number),
         });
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['random-tool']).toEqual({
           status: 'success',
           output: { name: 'step1' },
@@ -4153,7 +4153,7 @@ describe.sequential(
         const firstResumeResult = await run.resume({ step: 'promptAgent', resumeData: newCtx });
         expect(promptAgentAction).toHaveBeenCalledTimes(2);
         expect(firstResumeResult.steps.requestContextAction.status).toBe('success');
-        // @ts-ignore
+        // @ts-expect-error
         expect(firstResumeResult.steps.requestContextAction.output).toEqual(['first message', 'promptAgentAction']);
         await mastra.stopEventEngine();
       });
@@ -4229,7 +4229,7 @@ describe.sequential(
         const firstResumeResult = await run.resume({ step: 'promptAgent', resumeData: newCtx, requestContext });
         expect(promptAgentAction).toHaveBeenCalledTimes(2);
         expect(firstResumeResult.steps.requestContextAction.status).toBe('success');
-        // @ts-ignore
+        // @ts-expect-error
         expect(firstResumeResult.steps.requestContextAction.output).toEqual(['first message', 'promptAgentAction']);
         await mastra.stopEventEngine();
       });
@@ -5107,12 +5107,12 @@ describe.sequential(
         expect(other).toHaveBeenCalledTimes(1);
         expect(final).toHaveBeenCalledTimes(2);
         expect(last).toHaveBeenCalledTimes(1);
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-a'].output).toEqual({
           finalValue: 26 + 1,
         });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-b'].output).toEqual({
           finalValue: 1,
         });
@@ -5216,12 +5216,12 @@ describe.sequential(
         expect(start).toHaveBeenCalledTimes(1);
         expect(other).toHaveBeenCalledTimes(1);
         expect(final).toHaveBeenCalledTimes(1);
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-a'].output).toEqual({
           newValue: 1,
         });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-b'].output).toEqual({
           finalValue: 28,
         });
@@ -5333,12 +5333,12 @@ describe.sequential(
         expect(other).toHaveBeenCalledTimes(1);
         expect(final).toHaveBeenCalledTimes(2);
         expect(last).toHaveBeenCalledTimes(1);
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-a-clone'].output).toEqual({
           finalValue: 26 + 1,
         });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-b'].output).toEqual({
           finalValue: 1,
         });
@@ -5429,7 +5429,7 @@ describe.sequential(
           .then(startStep)
           .branch([
             [async () => false, otherStep],
-            // @ts-ignore
+            // @ts-expect-error
             [async () => true, finalStep],
           ])
           .map({
@@ -5470,12 +5470,12 @@ describe.sequential(
         expect(other).toHaveBeenCalledTimes(1);
         expect(final).toHaveBeenCalledTimes(2);
         expect(last).toHaveBeenCalledTimes(1);
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-a'].output).toEqual({
           finalValue: 26 + 1,
         });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-b'].output).toEqual({
           finalValue: 1,
         });
@@ -5613,7 +5613,7 @@ describe.sequential(
           expect(final).toHaveBeenCalledTimes(1);
           expect(first).toHaveBeenCalledTimes(1);
           expect(last).toHaveBeenCalledTimes(1);
-          // @ts-ignore
+          // @ts-expect-error
           expect(result.steps['nested-workflow-a'].output).toEqual({
             finalValue: 26 + 1,
           });
@@ -5759,7 +5759,7 @@ describe.sequential(
           expect(first).toHaveBeenCalledTimes(1);
           expect(last).toHaveBeenCalledTimes(1);
 
-          // @ts-ignore
+          // @ts-expect-error
           expect(result.steps['nested-workflow-b'].output).toEqual({
             finalValue: 1,
           });
@@ -5942,7 +5942,7 @@ describe.sequential(
           expect(first).toHaveBeenCalledTimes(1);
           expect(last).toHaveBeenCalledTimes(1);
 
-          // @ts-ignore
+          // @ts-expect-error
           expect(result.steps['nested-workflow-b'].output).toEqual({
             finalValue: 1,
           });
@@ -6087,12 +6087,12 @@ describe.sequential(
             status: 'suspended',
           });
 
-          // @ts-ignore
+          // @ts-expect-error
           expect(result.steps['last-step']).toEqual(undefined);
 
           const resumedResults = await run.resume({ step: [wfA, otherStep], resumeData: { newValue: 0 } });
 
-          // @ts-ignore
+          // @ts-expect-error
           expect(resumedResults.steps['nested-workflow-a'].output).toEqual({
             finalValue: 26 + 1,
           });
@@ -6209,7 +6209,7 @@ describe.sequential(
           expect(final).toHaveBeenCalledTimes(1);
           expect(last).toHaveBeenCalledTimes(1);
 
-          // @ts-ignore
+          // @ts-expect-error
           expect(results['nested-workflow-a']).toMatchObject({
             status: 'success',
             output: {
@@ -6376,7 +6376,7 @@ describe.sequential(
           },
         });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['last-step']).toEqual(undefined);
 
         if (result.status !== 'suspended') {
@@ -6385,7 +6385,7 @@ describe.sequential(
         expect(result.suspended[0]).toEqual(['nested-workflow-c', 'nested-workflow-b', 'nested-workflow-a', 'other']);
         const resumedResults = await run.resume({ step: result.suspended[0], resumeData: { newValue: 0 } });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(resumedResults.steps['nested-workflow-c'].output).toEqual({
           finalValue: 26 + 1,
         });
@@ -6429,7 +6429,7 @@ describe.sequential(
         const run = workflow.createRun();
         const result = await run.start({ requestContext });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps.step1.output.injectedValue).toBe(testValue);
         await mastra.stopEventEngine();
       });
@@ -6487,7 +6487,7 @@ describe.sequential(
           requestContext: resumerequestContext,
         });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result?.steps.step1.output.injectedValue).toBe(testValue + '2');
         await mastra.stopEventEngine();
       });

--- a/stores/chroma/src/vector/index.test.ts
+++ b/stores/chroma/src/vector/index.test.ts
@@ -452,7 +452,7 @@ describe('ChromaVector Integration Tests', () => {
           vectorDB.query({
             indexName: testIndexName3,
             queryVector: [1, 0, 0],
-            // @ts-ignore
+            // @ts-expect-error
             documentFilter: {},
           }),
         ).rejects.toThrow();

--- a/templates/template-pdf-questions/src/mastra/lib/util.ts
+++ b/templates/template-pdf-questions/src/mastra/lib/util.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error
 import PDFParser from 'pdf2json';
 
 // Simple function to extract text from PDF using pure JavaScript

--- a/templates/template-pdf-to-audio/src/mastra/lib/util.ts
+++ b/templates/template-pdf-to-audio/src/mastra/lib/util.ts
@@ -1,4 +1,4 @@
-// @ts-ignore
+// @ts-expect-error
 import PDFParser from 'pdf2json';
 
 // Simple function to extract text from PDF using pure JavaScript

--- a/workflows/inngest/src/index.test.ts
+++ b/workflows/inngest/src/index.test.ts
@@ -3650,9 +3650,9 @@ describe('MastraInngestWorkflow', () => {
 
       expect(increment).toHaveBeenCalledTimes(12);
       expect(final).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.result).toMatchObject({ finalValue: 12 });
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.increment.output).toMatchObject({ value: 12 });
       expect(totalCount).toBe(12);
 
@@ -3757,9 +3757,9 @@ describe('MastraInngestWorkflow', () => {
 
       expect(increment).toHaveBeenCalledTimes(12);
       expect(final).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.result).toMatchObject({ finalValue: 12 });
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.increment.output).toMatchObject({ value: 12 });
       expect(totalCount).toBe(12);
       srv.close();
@@ -4127,9 +4127,9 @@ describe('MastraInngestWorkflow', () => {
       expect(start).toHaveBeenCalledTimes(1);
       expect(other).toHaveBeenCalledTimes(0);
       expect(final).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.finalIf.output).toMatchObject({ finalValue: 2 });
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.start.output).toMatchObject({ newValue: 2 });
 
       srv.close();
@@ -4281,9 +4281,9 @@ describe('MastraInngestWorkflow', () => {
       expect(start).toHaveBeenCalledTimes(1);
       expect(other).toHaveBeenCalledTimes(1);
       expect(final).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['else-branch'].output).toMatchObject({ finalValue: 26 + 6 + 1 });
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.start.output).toMatchObject({ newValue: 7 });
     });
   });
@@ -4702,7 +4702,7 @@ describe('MastraInngestWorkflow', () => {
         outputSchema: z.object({ name: z.string() }),
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       const toolAction = vi.fn().mockImplementation(async ({ name }) => {
         return { name };
       });
@@ -9084,12 +9084,12 @@ describe('MastraInngestWorkflow', () => {
       expect(other).toHaveBeenCalledTimes(1);
       expect(final).toHaveBeenCalledTimes(2);
       expect(last).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-a'].output).toMatchObject({
         finalValue: 26 + 1,
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-b'].output).toMatchObject({
         finalValue: 1,
       });
@@ -9179,7 +9179,7 @@ describe('MastraInngestWorkflow', () => {
         .then(startStep)
         .branch([
           [async () => false, otherStep],
-          // @ts-ignore
+          // @ts-expect-error
           [async () => true, finalStep],
         ])
         .map({
@@ -9240,12 +9240,12 @@ describe('MastraInngestWorkflow', () => {
       expect(other).toHaveBeenCalledTimes(1);
       expect(final).toHaveBeenCalledTimes(2);
       expect(last).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-a'].output).toMatchObject({
         finalValue: 26 + 1,
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-b'].output).toMatchObject({
         finalValue: 1,
       });
@@ -9405,7 +9405,7 @@ describe('MastraInngestWorkflow', () => {
         expect(final).toHaveBeenCalledTimes(1);
         expect(first).toHaveBeenCalledTimes(1);
         expect(last).toHaveBeenCalledTimes(1);
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-a'].output).toMatchObject({
           finalValue: 26 + 1,
         });
@@ -9570,7 +9570,7 @@ describe('MastraInngestWorkflow', () => {
         expect(first).toHaveBeenCalledTimes(1);
         expect(last).toHaveBeenCalledTimes(1);
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-b'].output).toMatchObject({
           finalValue: 1,
         });
@@ -9772,7 +9772,7 @@ describe('MastraInngestWorkflow', () => {
         // expect(first).toHaveBeenCalledTimes(1);
         // expect(last).toHaveBeenCalledTimes(1);
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['nested-workflow-b'].output).toMatchObject({
           finalValue: 1,
         });
@@ -9930,12 +9930,12 @@ describe('MastraInngestWorkflow', () => {
           status: 'suspended',
         });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(result.steps['last-step']).toMatchObject(undefined);
 
         const resumedResults = await run.resume({ step: [wfA, otherStep], resumeData: { newValue: 0 } });
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(resumedResults.steps['nested-workflow-a'].output).toMatchObject({
           finalValue: 26 + 1,
         });
@@ -10083,7 +10083,7 @@ describe('MastraInngestWorkflow', () => {
         expect(final).toHaveBeenCalledTimes(1);
         expect(last).toHaveBeenCalledTimes(1);
 
-        // @ts-ignore
+        // @ts-expect-error
         expect(results['nested-workflow-a']).toMatchObject({
           status: 'success',
           output: {
@@ -10274,7 +10274,7 @@ describe('MastraInngestWorkflow', () => {
         },
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['last-step']).toMatchObject(undefined);
 
       if (result.status !== 'suspended') {
@@ -10290,7 +10290,7 @@ describe('MastraInngestWorkflow', () => {
 
       srv.close();
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(resumedResults.steps['nested-workflow-c'].output).toMatchObject({
         finalValue: 26 + 1,
       });
@@ -10436,12 +10436,12 @@ describe('MastraInngestWorkflow', () => {
       expect(other).toHaveBeenCalledTimes(1);
       expect(final).toHaveBeenCalledTimes(2);
       expect(last).toHaveBeenCalledTimes(1);
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-a-clone'].output).toMatchObject({
         finalValue: 26 + 1,
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps['nested-workflow-b'].output).toMatchObject({
         finalValue: 1,
       });
@@ -10516,7 +10516,7 @@ describe('MastraInngestWorkflow', () => {
 
       srv.close();
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result.steps.step1.output.injectedValue).toBe(testValue);
     });
 
@@ -10579,7 +10579,7 @@ describe('MastraInngestWorkflow', () => {
         requestContext: resumerequestContext,
       });
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result?.steps.step1.output.injectedValue).toBe(testValue + '2');
     });
 
@@ -10859,7 +10859,7 @@ describe('MastraInngestWorkflow', () => {
 
       srv.close();
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(result?.steps.step1.output.hasEngine).toBe(true);
     });
   });
@@ -13135,7 +13135,7 @@ describe('MastraInngestWorkflow', () => {
 
       srv.close();
 
-      // @ts-ignore
+      // @ts-expect-error
       expect(agentEvents.map(event => event?.payload?.output?.type)).toEqual([
         'start',
         'step-start',

--- a/workflows/inngest/src/run.ts
+++ b/workflows/inngest/src/run.ts
@@ -656,9 +656,8 @@ export class InngestRun<
 
     const writer = writable.getWriter();
     void writer.write({
-      // @ts-ignore
+      // @ts-expect-error
       type: 'start',
-      // @ts-ignore
       payload: { runId: this.runId },
     });
 
@@ -681,7 +680,7 @@ export class InngestRun<
     this.closeStreamAction = async () => {
       await writer.write({
         type: 'finish',
-        // @ts-ignore
+        // @ts-expect-error
         payload: { runId: this.runId },
       });
       unwatch();
@@ -740,7 +739,6 @@ export class InngestRun<
     const stream = new ReadableStream<WorkflowStreamEvent>({
       async start(controller) {
         // TODO: fix this, watch doesn't have a type
-        // @ts-ignore
         const unwatch = self.watch(async ({ type, from = ChunkFrom.WORKFLOW, payload }) => {
           controller.enqueue({
             type,
@@ -843,7 +841,6 @@ export class InngestRun<
     const stream = new ReadableStream<WorkflowStreamEvent>({
       async start(controller) {
         // TODO: fix this, watch doesn't have a type
-        // @ts-ignore
         const unwatch = self.watch(async ({ type, from = ChunkFrom.WORKFLOW, payload }) => {
           controller.enqueue({
             type,

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -190,7 +190,7 @@ export class InngestWorkflow<
       { cron: this.cronConfig?.cron ?? '' },
       async () => {
         const run = await this.createRun();
-        // @ts-ignore
+        // @ts-expect-error
         const result = await run.start({
           inputData: this.cronConfig?.inputData,
           initialState: this.cronConfig?.initialState,


### PR DESCRIPTION
## Summary
- Replace all `@ts-ignore` comments with `@ts-expect-error` across 59 files
- `@ts-expect-error` provides stricter type checking by failing if the suppressed error no longer exists
- Helps catch stale type suppressions during future TypeScript updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript type-checking directives throughout the codebase to enforce stricter compile-time validation. No functional changes to features or behavior—this is an internal code quality improvement that enhances type safety during development.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->