### PR TITLE
fix(ci): handle turbo telemetry and version output in JSON parsing

### DIFF
--- a/.github/workflows/secrets.test-rag.yml
+++ b/.github/workflows/secrets.test-rag.yml
@@ -33,8 +33,9 @@ jobs:
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
-        with:
-          install-dependencies: 'false'
+
+      - name: Disable turbo telemetry
+        run: pnpm turbo telemetry disable
 
       - name: Check for RAG package changes using Turborepo
         id: changes
@@ -42,8 +43,13 @@ jobs:
           set -e
           set -o pipefail
 
+          # Helper to extract JSON from turbo output (handles version line before JSON)
+          extract_json() {
+            sed -n '/^{/,/^}/p'
+          }
+
           # Check if build-related files changed
-          BUILD_PACKAGES=$(pnpm dlx turbo build --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json | jq -r '.packages | length')
+          BUILD_PACKAGES=$(pnpm turbo build --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json | extract_json | jq -r '.packages | length')
 
           # Validate jq output is a number
           if ! [[ "$BUILD_PACKAGES" =~ ^[0-9]+$ ]]; then
@@ -52,7 +58,7 @@ jobs:
           fi
 
           # Check if test-related files changed
-          TEST_PACKAGES=$(pnpm dlx turbo test --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json | jq -r '.packages | length')
+          TEST_PACKAGES=$(pnpm turbo test --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json | extract_json | jq -r '.packages | length')
 
           # Validate jq output is a number
           if ! [[ "$TEST_PACKAGES" =~ ^[0-9]+$ ]]; then

--- a/.github/workflows/secrets.test-rag.yml
+++ b/.github/workflows/secrets.test-rag.yml
@@ -39,11 +39,29 @@ jobs:
       - name: Check for RAG package changes using Turborepo
         id: changes
         run: |
+          set -e
+          set -o pipefail
+
           # Check if build-related files changed
-          BUILD_PACKAGES=$(pnpm turbo build --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json 2>/dev/null | jq -r '.packages | length' || echo "0")
+          BUILD_PACKAGES=$(pnpm dlx turbo build --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json | jq -r '.packages | length')
+
+          # Validate jq output is a number
+          if ! [[ "$BUILD_PACKAGES" =~ ^[0-9]+$ ]]; then
+            echo "Error: BUILD_PACKAGES is not a valid number: $BUILD_PACKAGES"
+            exit 1
+          fi
 
           # Check if test-related files changed
-          TEST_PACKAGES=$(pnpm turbo test --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json 2>/dev/null | jq -r '.packages | length' || echo "0")
+          TEST_PACKAGES=$(pnpm dlx turbo test --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json | jq -r '.packages | length')
+
+          # Validate jq output is a number
+          if ! [[ "$TEST_PACKAGES" =~ ^[0-9]+$ ]]; then
+            echo "Error: TEST_PACKAGES is not a valid number: $TEST_PACKAGES"
+            exit 1
+          fi
+
+          echo "Build packages changed: $BUILD_PACKAGES"
+          echo "Test packages changed: $TEST_PACKAGES"
 
           # Run tests if either build or test files changed
           if [ "$BUILD_PACKAGES" -gt 0 ] || [ "$TEST_PACKAGES" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Fixes RAG test workflow incorrectly detecting changes due to turbo outputting telemetry/version text before JSON.

## Changes

1. **Disable turbo telemetry** - Adds a step to run `pnpm turbo telemetry disable` before the check
2. **Extract JSON properly** - Uses `sed -n '/^{/,/^}/p'` to extract only the JSON block from turbo output, filtering out:
   - Version line (`turbo 2.5.8`)
   - Telemetry notice
   - Any other non-JSON output

## Root Cause

Turbo outputs text before the JSON:
```
turbo 2.5.8

Attention:
Turborepo now collects completely anonymous telemetry...

{
  "packages": [...]
}
```

This caused `jq` to receive invalid input, and the validation was incorrectly passing with "1" (from parsing garbage).

## Testing

After this fix, the draft PRs should behave correctly:
- PR #12135 (source change) → RAG tests run
- PR #12136 (README only) → RAG tests skip