### PR TITLE
ci: add major version check workflow

### DIFF
--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -14,8 +14,10 @@ permissions:
 jobs:
   check-major-bump:
     runs-on: ubuntu-latest
-    # Only run on PR events or issue comments that are on PRs (not regular issues)
-    if: github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+    # Only run on canonical repo (secrets unavailable for forks) and for PR events or PR comments
+    if: |
+      github.repository == 'mastra-ai/mastra' &&
+      (github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request))
     steps:
       - name: Check for major changesets
         id: check_major
@@ -50,10 +52,14 @@ jobs:
               return;
             }
 
-            // Get PR head SHA - use context if available, otherwise fetch
-            const headSha = context.payload.pull_request?.head?.sha || (
+            // Get PR data - use context if available, otherwise fetch
+            const pr = context.payload.pull_request || (
               await github.rest.pulls.get({ owner, repo, pull_number: prNumber })
-            ).data.head.sha;
+            ).data;
+
+            const headSha = pr.head.sha;
+            // Output base SHA for checkout step (to prevent malicious PR from modifying local action)
+            core.setOutput('base_sha', pr.base.sha);
 
             // Regex to check for major in frontmatter
             const majorRegex = /:\s*["']?major["']?/;
@@ -83,6 +89,8 @@ jobs:
         if: steps.check_major.outputs.has_major_changeset == 'true'
         uses: actions/checkout@v4
         with:
+          # Pin to PR base SHA to prevent malicious PRs from modifying the local action
+          ref: ${{ steps.check_major.outputs.base_sha }}
           sparse-checkout: .github/actions
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   issues: read
   pull-requests: read
+  checks: write
 
 jobs:
   check-major-bump:
@@ -58,6 +59,8 @@ jobs:
             ).data;
 
             const headSha = pr.head.sha;
+            // Output SHAs for downstream steps
+            core.setOutput('head_sha', headSha);
             // Output base SHA for checkout step (to prevent malicious PR from modifying local action)
             core.setOutput('base_sha', pr.base.sha);
 
@@ -111,6 +114,27 @@ jobs:
           script: |
             const prNumber = context.payload?.pull_request?.number || context.payload?.issue?.number;
             const { owner, repo } = context.repo;
+            const headSha = '${{ steps.check_major.outputs.head_sha }}';
+            const isCommentEvent = context.eventName === 'issue_comment';
+            const checkName = 'Major Version Check';
+
+            // Helper to create/update check run on PR head SHA
+            const reportCheckResult = async (conclusion, title, summary) => {
+              // For issue_comment events, we need to create a check run on the PR head SHA
+              // because the workflow runs on the default branch, not the PR
+              if (isCommentEvent) {
+                await github.rest.checks.create({
+                  owner,
+                  repo,
+                  name: checkName,
+                  head_sha: headSha,
+                  status: 'completed',
+                  conclusion,
+                  output: { title, summary },
+                });
+                console.log(`Created check run on ${headSha}: ${conclusion}`);
+              }
+            };
 
             // Get all comments on the PR (paginated to handle PRs with many comments)
             const comments = await github.paginate(github.rest.issues.listComments, {
@@ -125,7 +149,9 @@ jobs:
             );
 
             if (approvalComments.length === 0) {
-              core.setFailed('Major version bump requires approval from an organization member by commenting "!allow-major" on the PR.');
+              const msg = 'Major version bump requires approval from an organization member by commenting "!allow-major" on the PR.';
+              await reportCheckResult('failure', 'Approval Required', msg);
+              core.setFailed(msg);
               return;
             }
 
@@ -147,9 +173,9 @@ jobs:
               } catch (error) {
                 // 403: Token lacks org:read permission - this is a configuration error
                 if (error.status === 403) {
-                  core.setFailed(
-                    `Permission denied checking org membership. Ensure the GitHub App has "Organization members: Read" permission. Error: ${error.message}`
-                  );
+                  const msg = `Permission denied checking org membership. Ensure the GitHub App has "Organization members: Read" permission. Error: ${error.message}`;
+                  await reportCheckResult('failure', 'Permission Error', msg);
+                  core.setFailed(msg);
                   throw error;
                 }
                 // 404: User is not a member of the org - this is expected for non-members
@@ -158,7 +184,9 @@ jobs:
                   return false;
                 }
                 // Other errors (network issues, rate limits, etc.) - rethrow to fail loudly
-                core.setFailed(`Unexpected error checking org membership for ${username}: ${error.message}`);
+                const msg = `Unexpected error checking org membership for ${username}: ${error.message}`;
+                await reportCheckResult('failure', 'Unexpected Error', msg);
+                core.setFailed(msg);
                 throw error;
               }
             };
@@ -166,9 +194,13 @@ jobs:
             // Check membership for all approval comment authors
             for (const comment of approvalComments) {
               if (await checkMembership(comment.user.login)) {
-                console.log(`Major version bump approved by organization member: ${comment.user.login}`);
+                const msg = `Major version bump approved by organization member: ${comment.user.login}`;
+                await reportCheckResult('success', 'Approved', msg);
+                console.log(msg);
                 return;
               }
             }
 
-            core.setFailed('Major version bump requires approval from an organization member by commenting "!allow-major" on the PR.');
+            const msg = 'Major version bump requires approval from an organization member by commenting "!allow-major" on the PR.';
+            await reportCheckResult('failure', 'Approval Required', msg);
+            core.setFailed(msg);

--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -1,0 +1,137 @@
+name: Major Version Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  check-major-bump:
+    runs-on: ubuntu-latest
+    # Only run on PR events or issue comments that are on PRs (not regular issues)
+    if: github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+    steps:
+      - name: Check for major changesets
+        id: check_major
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload?.pull_request?.number || context.payload?.issue?.number;
+
+            if (!prNumber) {
+              core.setOutput('has_major_changeset', false);
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+
+            // Get list of files changed in the PR
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            // Filter to only changeset files early
+            const changesetFiles = files.filter(
+              file => file.filename.startsWith('.changeset/') && 
+                      file.filename.endsWith('.md') &&
+                      file.status !== 'removed'
+            );
+
+            if (changesetFiles.length === 0) {
+              core.setOutput('has_major_changeset', false);
+              return;
+            }
+
+            // Get PR head SHA - use context if available, otherwise fetch
+            const headSha = context.payload.pull_request?.head?.sha || (
+              await github.rest.pulls.get({ owner, repo, pull_number: prNumber })
+            ).data.head.sha;
+
+            // Regex to check for major in frontmatter
+            const majorRegex = /:\s*["']?major["']?/;
+
+            // Fetch all changeset contents in parallel
+            const contentPromises = changesetFiles.map(async (file) => {
+              const { data } = await github.rest.repos.getContent({
+                owner,
+                repo,
+                path: file.filename,
+                ref: headSha,
+              });
+              return Buffer.from(data.content, data.encoding).toString();
+            });
+
+            const contents = await Promise.all(contentPromises);
+
+            // Check if any changeset has a major bump in frontmatter
+            const hasMajorChangeset = contents.some(content => {
+              const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/m);
+              return frontmatterMatch && majorRegex.test(frontmatterMatch[1]);
+            });
+
+            core.setOutput('has_major_changeset', hasMajorChangeset);
+
+      - name: Check if major version bump is allowed
+        if: steps.check_major.outputs.has_major_changeset == 'true'
+        id: check_approval
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload?.pull_request?.number || context.payload?.issue?.number;
+            const { owner, repo } = context.repo;
+
+            // Get all comments on the PR
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: prNumber,
+            });
+
+            // Filter to only approval comments first
+            const approvalComments = comments.filter(
+              comment => comment.body.trim().toLowerCase() === '!allow-major'
+            );
+
+            if (approvalComments.length === 0) {
+              core.setFailed('Major version bump requires approval from an organization member by commenting "!allow-major" on the PR.');
+              return;
+            }
+
+            // Cache membership results to avoid duplicate API calls
+            const membershipCache = new Map();
+
+            const checkMembership = async (username) => {
+              if (membershipCache.has(username)) {
+                return membershipCache.get(username);
+              }
+
+              try {
+                await github.rest.orgs.checkMembershipForUser({
+                  org: owner,
+                  username,
+                });
+                membershipCache.set(username, true);
+                return true;
+              } catch {
+                membershipCache.set(username, false);
+                return false;
+              }
+            };
+
+            // Check membership for all approval comment authors
+            for (const comment of approvalComments) {
+              if (await checkMembership(comment.user.login)) {
+                console.log(`Major version bump approved by organization member: ${comment.user.login}`);
+                return;
+              }
+            }
+
+            core.setFailed('Major version bump requires approval from an organization member by commenting "!allow-major" on the PR.');

--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -79,16 +79,25 @@ jobs:
 
             core.setOutput('has_major_changeset', hasMajorChangeset);
 
+      - name: Generate GitHub App token
+        if: steps.check_major.outputs.has_major_changeset == 'true'
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ORG_MEMBERSHIP_APP_ID }}
+          private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
+
       - name: Check if major version bump is allowed
         if: steps.check_major.outputs.has_major_changeset == 'true'
         id: check_approval
         uses: actions/github-script@v7
         with:
+          github-token: ${{ steps.app_token.outputs.token }}
           script: |
             const prNumber = context.payload?.pull_request?.number || context.payload?.issue?.number;
             const { owner, repo } = context.repo;
 
-            // Get all comments on the PR
+            // Get all comments on the PR (use default token for this - no special perms needed)
             const { data: comments } = await github.rest.issues.listComments({
               owner,
               repo,
@@ -120,9 +129,22 @@ jobs:
                 });
                 membershipCache.set(username, true);
                 return true;
-              } catch {
-                membershipCache.set(username, false);
-                return false;
+              } catch (error) {
+                // 403: Token lacks org:read permission - this is a configuration error
+                if (error.status === 403) {
+                  core.setFailed(
+                    `Permission denied checking org membership. Ensure the GitHub App has "Organization members: Read" permission. Error: ${error.message}`
+                  );
+                  throw error;
+                }
+                // 404: User is not a member of the org - this is expected for non-members
+                if (error.status === 404) {
+                  membershipCache.set(username, false);
+                  return false;
+                }
+                // Other errors (network issues, rate limits, etc.) - rethrow to fail loudly
+                core.setFailed(`Unexpected error checking org membership for ${username}: ${error.message}`);
+                throw error;
               }
             };
 

--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -31,8 +31,8 @@ jobs:
 
             const { owner, repo } = context.repo;
 
-            // Get list of files changed in the PR
-            const { data: files } = await github.rest.pulls.listFiles({
+            // Get all files changed in the PR (paginated to handle large PRs)
+            const files = await github.paginate(github.rest.pulls.listFiles, {
               owner,
               repo,
               pull_number: prNumber,
@@ -104,8 +104,8 @@ jobs:
             const prNumber = context.payload?.pull_request?.number || context.payload?.issue?.number;
             const { owner, repo } = context.repo;
 
-            // Get all comments on the PR (use default token for this - no special perms needed)
-            const { data: comments } = await github.rest.issues.listComments({
+            // Get all comments on the PR (paginated to handle PRs with many comments)
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner,
               repo,
               issue_number: prNumber,

--- a/.github/workflows/major-version-check.yml
+++ b/.github/workflows/major-version-check.yml
@@ -79,13 +79,20 @@ jobs:
 
             core.setOutput('has_major_changeset', hasMajorChangeset);
 
+      - name: Checkout for local action
+        if: steps.check_major.outputs.has_major_changeset == 'true'
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+
       - name: Generate GitHub App token
         if: steps.check_major.outputs.has_major_changeset == 'true'
         id: app_token
-        uses: actions/create-github-app-token@v1
+        uses: ./.github/actions/app-auth
         with:
-          app-id: ${{ secrets.ORG_MEMBERSHIP_APP_ID }}
-          private-key: ${{ secrets.ORG_MEMBERSHIP_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.DANE_APP_ID }}
+          private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
 
       - name: Check if major version bump is allowed
         if: steps.check_major.outputs.has_major_changeset == 'true'


### PR DESCRIPTION
## Summary

- Adds a GitHub workflow that detects major version bumps in `.changeset/*.md` files
- Requires approval from an organization member by commenting `!allow-major` on the PR before merging
- Optimized implementation with parallel file fetching and membership caching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated "Major Version Check" workflow that detects proposed major-version changes in pull requests, requires an exact "!allow-major" approval from an authorized organization member, validates approver membership, and provides clear failure messages when approvals or required permissions are missing.
  * Prevents merging of PRs with unapproved major-version changes until a valid approval is present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->