### PR TITLE
fix(rag): set empty inputs for build task orchestrator

### DIFF
--- a/packages/rag/turbo.json
+++ b/packages/rag/turbo.json
@@ -22,7 +22,8 @@
       "outputs": ["dist/docs/**"]
     },
     "build": {
-      "dependsOn": ["build:lib", "build:docs"]
+      "dependsOn": ["build:lib", "build:docs"],
+      "inputs": []
     },
     "test": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

Fixes RAG test workflow incorrectly detecting changes when only README.md is modified.

## Problem

The `build` task in `packages/rag/turbo.json` didn't have `inputs` specified, so turbo was using the default which includes **all files** (including README.md, CHANGELOG.md, etc.).

From the turbo dry-run output:
```json
"inputs": {
  "README.md": "b8128dbc6d203ba3859ce46feb6586627583bbcb",
  "CHANGELOG.md": "d175ec9b0b7f7574374f4560054ea8218242e468",
  ...
}
```

## Solution

Set `inputs: []` for the `build` task since it only orchestrates `build:lib` and `build:docs` - it doesn't process files directly. This means:
- The `build` task hash only changes when its dependencies (`build:lib`, `build:docs`) change
- `build:lib` and `build:docs` already have proper `inputs` that exclude `.md` files

## Result

After this fix:
- Changes to README.md → no rebuild, no test trigger
- Changes to src files → rebuild triggers, tests run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to explicitly declare task inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->