### PR TITLE
refactor(react): move useStreamWorkflow hook to @mastra/react

### DIFF
--- a/.changeset/solid-stamps-add.md
+++ b/.changeset/solid-stamps-add.md
@@ -1,0 +1,6 @@
+---
+'@mastra/react': minor
+'@mastra/playground-ui': patch
+---
+
+Added useStreamWorkflow hook to @mastra/react for streaming workflow execution. This hook supports streaming, observing, resuming, and time-traveling workflows. It accepts tracingOptions and onError as parameters for better customization.

--- a/client-sdks/react/src/workflows/hooks.ts
+++ b/client-sdks/react/src/workflows/hooks.ts
@@ -7,6 +7,8 @@ import type {
   CancelWorkflowRunResult,
 } from './types';
 
+export { useStreamWorkflow } from './use-stream-workflow';
+
 /**
  * Hook for creating workflow runs.
  * Returns a mutation for creating a new workflow run.

--- a/client-sdks/react/src/workflows/types.ts
+++ b/client-sdks/react/src/workflows/types.ts
@@ -1,4 +1,86 @@
+import type { TimeTravelParams } from '@mastra/client-js';
+import type { TracingOptions } from '@mastra/core/observability';
+import type { WorkflowStreamResult as CoreWorkflowStreamResult } from '@mastra/core/workflows';
 import type { MutationState } from '../lib/use-mutation';
+
+/**
+ * Workflow stream result type alias.
+ */
+export type WorkflowStreamResult = CoreWorkflowStreamResult<any, any, any, any>;
+
+/**
+ * Parameters for the useStreamWorkflow hook.
+ */
+export interface UseStreamWorkflowParams {
+  /** Whether to enable debug mode for per-step execution */
+  debugMode: boolean;
+  /** Optional tracing options for observability */
+  tracingOptions?: TracingOptions;
+  /** Optional error handler callback */
+  onError?: (error: Error, defaultMessage: string) => void;
+}
+
+/**
+ * Parameters for streaming a workflow.
+ */
+export interface StreamWorkflowParams {
+  /** The ID of the workflow */
+  workflowId: string;
+  /** The ID of the run */
+  runId: string;
+  /** Input data for the workflow */
+  inputData: Record<string, unknown>;
+  /** Optional initial state */
+  initialState?: Record<string, unknown>;
+  /** Request context to pass to the workflow */
+  requestContext: Record<string, unknown>;
+  /** Optional flag to enable per-step execution */
+  perStep?: boolean;
+}
+
+/**
+ * Parameters for observing a workflow stream.
+ */
+export interface ObserveWorkflowStreamParams {
+  /** The ID of the workflow */
+  workflowId: string;
+  /** The ID of the run */
+  runId: string;
+  /** Optional stored run result to resume from */
+  storeRunResult: WorkflowStreamResult | null;
+}
+
+/**
+ * Parameters for resuming a workflow stream.
+ */
+export interface ResumeWorkflowStreamParams {
+  /** The ID of the workflow */
+  workflowId: string;
+  /** The ID of the run */
+  runId: string;
+  /** The step or steps to resume */
+  step: string | string[];
+  /** Data to resume with */
+  resumeData: Record<string, unknown>;
+  /** Request context to pass to the workflow */
+  requestContext: Record<string, unknown>;
+  /** Optional flag to enable per-step execution */
+  perStep?: boolean;
+}
+
+/**
+ * Parameters for time-traveling a workflow stream.
+ */
+export interface TimeTravelWorkflowStreamParams extends Omit<TimeTravelParams, 'requestContext'> {
+  /** The ID of the workflow */
+  workflowId: string;
+  /** Request context to pass to the workflow */
+  requestContext: Record<string, unknown>;
+  /** Optional run ID */
+  runId?: string;
+  /** Optional flag to enable per-step execution */
+  perStep?: boolean;
+}
 
 /**
  * Parameters for creating a workflow run.

--- a/client-sdks/react/src/workflows/use-stream-workflow.ts
+++ b/client-sdks/react/src/workflows/use-stream-workflow.ts
@@ -1,18 +1,50 @@
 import { StreamVNextChunkType, TimeTravelParams } from '@mastra/client-js';
 import { RequestContext } from '@mastra/core/request-context';
 import { WorkflowStreamResult as CoreWorkflowStreamResult } from '@mastra/core/workflows';
-import { useMutation } from '@tanstack/react-query';
-import { useState, useRef, useEffect } from 'react';
-import { mapWorkflowStreamChunkToWatchResult, useMastraClient } from '@mastra/react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import type { ReadableStreamDefaultReader } from 'stream/web';
-import { toast } from '@/lib/toast';
-import { useTracingSettings } from '@/domains/observability/context/tracing-settings-context';
+import { useMastraClient } from '../mastra-client-context';
+import { useMutation } from '../lib/use-mutation';
+import { mapWorkflowStreamChunkToWatchResult } from '../lib/ai-sdk/utils/toUIMessage';
+import type {
+  UseStreamWorkflowParams,
+  WorkflowStreamResult,
+  StreamWorkflowParams,
+  ObserveWorkflowStreamParams,
+  ResumeWorkflowStreamParams,
+  TimeTravelWorkflowStreamParams,
+} from './types';
 
-type WorkflowStreamResult = CoreWorkflowStreamResult<any, any, any, any>;
-
-export const useStreamWorkflow = ({ debugMode }: { debugMode: boolean }) => {
+/**
+ * Hook for streaming workflow execution with support for observing, resuming, and time-travel.
+ *
+ * @example
+ * ```tsx
+ * const {
+ *   streamWorkflow,
+ *   streamResult,
+ *   isStreaming,
+ *   observeWorkflowStream,
+ *   closeStreamsAndReset,
+ *   resumeWorkflowStream,
+ *   timeTravelWorkflowStream,
+ * } = useStreamWorkflow({
+ *   debugMode: true,
+ *   tracingOptions: { enabled: true },
+ *   onError: (error, defaultMessage) => console.error(defaultMessage, error),
+ * });
+ *
+ * // Start streaming a workflow
+ * await streamWorkflow.mutateAsync({
+ *   workflowId: 'my-workflow',
+ *   runId: 'run-123',
+ *   inputData: { key: 'value' },
+ *   requestContext: {},
+ * });
+ * ```
+ */
+export function useStreamWorkflow({ debugMode, tracingOptions, onError }: UseStreamWorkflowParams) {
   const client = useMastraClient();
-  const { settings } = useTracingSettings();
   const [streamResult, setStreamResult] = useState<WorkflowStreamResult>({} as WorkflowStreamResult);
   const [isStreaming, setIsStreaming] = useState(false);
   const readerRef = useRef<ReadableStreamDefaultReader<StreamVNextChunkType> | null>(null);
@@ -61,17 +93,20 @@ export const useStreamWorkflow = ({ debugMode }: { debugMode: boolean }) => {
     };
   }, []);
 
-  const handleStreamError = (err: unknown, defaultMessage: string, setIsStreaming?: (isStreaming: boolean) => void) => {
-    // Expected error during cleanup - safe to ignore
-    if (err instanceof TypeError) {
-      return;
-    }
-    const errorMessage = err instanceof Error ? err.message : defaultMessage;
-    toast.error(errorMessage);
-    setIsStreaming?.(false);
-  };
+  const handleStreamError = useCallback(
+    (err: unknown, defaultMessage: string, setStreamingState?: (isStreaming: boolean) => void) => {
+      // Expected error during cleanup - safe to ignore
+      if (err instanceof TypeError) {
+        return;
+      }
+      const error = err instanceof Error ? err : new Error(defaultMessage);
+      onError?.(error, defaultMessage);
+      setStreamingState?.(false);
+    },
+    [onError],
+  );
 
-  const handleWorkflowFinish = (value: StreamVNextChunkType) => {
+  const handleWorkflowFinish = useCallback((value: StreamVNextChunkType) => {
     if (value.type === 'workflow-finish') {
       const streamStatus = value.payload?.workflowStatus;
       const metadata = value.payload?.metadata;
@@ -85,24 +120,10 @@ export const useStreamWorkflow = ({ debugMode }: { debugMode: boolean }) => {
       // Tripwire status is not an error - it's handled separately in the UI
       // Don't throw an error for tripwire status
     }
-  };
+  }, []);
 
-  const streamWorkflow = useMutation({
-    mutationFn: async ({
-      workflowId,
-      runId,
-      inputData,
-      initialState,
-      requestContext: playgroundRequestContext,
-      perStep,
-    }: {
-      workflowId: string;
-      runId: string;
-      inputData: Record<string, unknown>;
-      initialState?: Record<string, unknown>;
-      requestContext: Record<string, unknown>;
-      perStep?: boolean;
-    }) => {
+  const streamWorkflow = useMutation<void, Error, StreamWorkflowParams>(
+    async ({ workflowId, runId, inputData, initialState, requestContext: playgroundRequestContext, perStep }) => {
       // Clean up any existing reader before starting new stream
       if (readerRef.current) {
         readerRef.current.releaseLock();
@@ -123,7 +144,7 @@ export const useStreamWorkflow = ({ debugMode }: { debugMode: boolean }) => {
         initialState,
         requestContext,
         closeOnSuspend: true,
-        tracingOptions: settings?.tracingOptions,
+        tracingOptions,
         perStep: perStep ?? debugMode,
       });
 
@@ -174,18 +195,10 @@ export const useStreamWorkflow = ({ debugMode }: { debugMode: boolean }) => {
         }
       }
     },
-  });
+  );
 
-  const observeWorkflowStream = useMutation({
-    mutationFn: async ({
-      workflowId,
-      runId,
-      storeRunResult,
-    }: {
-      workflowId: string;
-      runId: string;
-      storeRunResult: WorkflowStreamResult | null;
-    }) => {
+  const observeWorkflowStream = useMutation<void, Error, ObserveWorkflowStreamParams>(
+    async ({ workflowId, runId, storeRunResult }) => {
       // Clean up any existing reader before starting new stream
       if (observerRef.current) {
         observerRef.current.releaseLock();
@@ -251,24 +264,10 @@ export const useStreamWorkflow = ({ debugMode }: { debugMode: boolean }) => {
         }
       }
     },
-  });
+  );
 
-  const resumeWorkflowStream = useMutation({
-    mutationFn: async ({
-      workflowId,
-      runId,
-      step,
-      resumeData,
-      requestContext: playgroundRequestContext,
-      perStep,
-    }: {
-      workflowId: string;
-      step: string | string[];
-      runId: string;
-      resumeData: Record<string, unknown>;
-      requestContext: Record<string, unknown>;
-      perStep?: boolean;
-    }) => {
+  const resumeWorkflowStream = useMutation<void, Error, ResumeWorkflowStreamParams>(
+    async ({ workflowId, runId, step, resumeData, requestContext: playgroundRequestContext, perStep }) => {
       // Clean up any existing reader before starting new stream
       if (resumeStreamRef.current) {
         resumeStreamRef.current.releaseLock();
@@ -287,7 +286,7 @@ export const useStreamWorkflow = ({ debugMode }: { debugMode: boolean }) => {
         step,
         resumeData,
         requestContext,
-        tracingOptions: settings?.tracingOptions,
+        tracingOptions,
         perStep: perStep ?? debugMode,
       });
 
@@ -338,20 +337,10 @@ export const useStreamWorkflow = ({ debugMode }: { debugMode: boolean }) => {
         }
       }
     },
-  });
+  );
 
-  const timeTravelWorkflowStream = useMutation({
-    mutationFn: async ({
-      workflowId,
-      requestContext: playgroundRequestContext,
-      runId,
-      perStep,
-      ...params
-    }: {
-      runId?: string;
-      workflowId: string;
-      requestContext: Record<string, unknown>;
-    } & Omit<TimeTravelParams, 'requestContext'>) => {
+  const timeTravelWorkflowStream = useMutation<void, Error, TimeTravelWorkflowStreamParams>(
+    async ({ workflowId, requestContext: playgroundRequestContext, runId, perStep, ...params }) => {
       // Clean up any existing reader before starting new stream
       if (timeTravelStreamRef.current) {
         timeTravelStreamRef.current.releaseLock();
@@ -370,7 +359,7 @@ export const useStreamWorkflow = ({ debugMode }: { debugMode: boolean }) => {
         ...params,
         perStep: perStep ?? debugMode,
         requestContext,
-        tracingOptions: settings?.tracingOptions,
+        tracingOptions,
       });
 
       if (!stream) {
@@ -420,9 +409,9 @@ export const useStreamWorkflow = ({ debugMode }: { debugMode: boolean }) => {
         }
       }
     },
-  });
+  );
 
-  const closeStreamsAndReset = () => {
+  const closeStreamsAndReset = useCallback(() => {
     setIsStreaming(false);
     setStreamResult({} as WorkflowStreamResult);
     if (readerRef.current) {
@@ -457,7 +446,7 @@ export const useStreamWorkflow = ({ debugMode }: { debugMode: boolean }) => {
       }
       timeTravelStreamRef.current = null;
     }
-  };
+  }, []);
 
   return {
     streamWorkflow,
@@ -468,4 +457,4 @@ export const useStreamWorkflow = ({ debugMode }: { debugMode: boolean }) => {
     resumeWorkflowStream,
     timeTravelWorkflowStream,
   };
-};
+}

--- a/packages/playground-ui/src/domains/workflows/context/workflow-run-context.tsx
+++ b/packages/playground-ui/src/domains/workflows/context/workflow-run-context.tsx
@@ -1,12 +1,13 @@
 import { WorkflowRunState, WorkflowStreamResult } from '@mastra/core/workflows';
 import { createContext, useEffect, useMemo, useState, type Dispatch, type SetStateAction, type ReactNode } from 'react';
 import { convertWorkflowRunStateToStreamResult } from '../utils';
-import { useCreateWorkflowRun, useCancelWorkflowRun } from '@mastra/react';
-import { useStreamWorkflow } from '../hooks';
+import { useCreateWorkflowRun, useCancelWorkflowRun, useStreamWorkflow } from '@mastra/react';
 import { WorkflowTriggerProps } from '../workflow/workflow-trigger';
 import { useWorkflow, useWorkflowRun } from '@/hooks';
 import { TimeTravelParams } from '@mastra/client-js';
 import { WorkflowStepDetailProvider } from './workflow-step-detail-context';
+import { useTracingSettings } from '@/domains/observability/context/tracing-settings-context';
+import { toast } from '@/lib/toast';
 
 export type WorkflowRunStreamResult = WorkflowStreamResult<any, any, any, any>;
 
@@ -97,6 +98,7 @@ export function WorkflowRunProvider({
   }, [runExecutionResult, initialRunId]);
 
   const { data: workflow, isLoading, error } = useWorkflow(workflowId);
+  const { settings } = useTracingSettings();
 
   const createWorkflowRun = useCreateWorkflowRun();
   const {
@@ -107,7 +109,11 @@ export function WorkflowRunProvider({
     closeStreamsAndReset,
     resumeWorkflowStream,
     timeTravelWorkflowStream,
-  } = useStreamWorkflow({ debugMode });
+  } = useStreamWorkflow({
+    debugMode,
+    tracingOptions: settings?.tracingOptions,
+    onError: error => toast.error(error.message),
+  });
   const cancelWorkflowRun = useCancelWorkflowRun();
 
   const clearData = () => {

--- a/packages/playground-ui/src/domains/workflows/hooks/index.ts
+++ b/packages/playground-ui/src/domains/workflows/hooks/index.ts
@@ -1,2 +1,1 @@
 export * from './use-workflows';
-export * from './use-workflows-actions';


### PR DESCRIPTION
Moves the `useStreamWorkflow` hook from `@mastra/playground-ui` to `@mastra/react` so it can be reused by other consumers.

The hook now accepts `tracingOptions` and `onError` as parameters instead of relying on context, making it more flexible:

```tsx
const { streamWorkflow, isStreaming } = useStreamWorkflow({
  debugMode: true,
  tracingOptions: { metadata: { env: 'dev' } },
  onError: (error) => toast.error(error.message),
});
```

**Changes:**
- Added `useStreamWorkflow` hook to `@mastra/react`
- Added corresponding types (`UseStreamWorkflowParams`, `StreamWorkflowParams`, etc.)
- Updated `@mastra/playground-ui` to use the hook from `@mastra/react`
- Removed the original hook file from playground-ui

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming workflow execution now available with capabilities to observe, resume, and time-travel through workflow runs.
  * Enhanced workflow debugging with improved error handling and tracing configuration options for better workflow visibility and troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->