### PR TITLE
fix: use turbo task hash comparison for accurate RAG change detection

### DIFF
--- a/.github/workflows/secrets.test-rag.yml
+++ b/.github/workflows/secrets.test-rag.yml
@@ -43,34 +43,57 @@ jobs:
           set -e
           set -o pipefail
 
-          # Helper to extract JSON from turbo output (handles version line before JSON)
-          extract_json() {
-            sed -n '/^{/,/^}/p'
+          # Get task hash for @mastra/rag tasks
+          # Uses turbo's dry-run to get the computed hash based on task inputs
+          get_task_hash() {
+            local task=$1
+            pnpm turbo "$task" --filter='@mastra/rag' --dry-run=json 2>/dev/null | \
+              jq -r ".tasks[] | select(.package == \"@mastra/rag\" and .task == \"$task\") | .hash"
           }
 
-          # Check if build-related files changed
-          BUILD_PACKAGES=$(pnpm turbo build --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json | extract_json | jq -r '.packages | length')
+          # Save current ref to return to later
+          CURRENT_REF=$(git rev-parse HEAD)
 
-          # Validate jq output is a number
-          if ! [[ "$BUILD_PACKAGES" =~ ^[0-9]+$ ]]; then
-            echo "Error: BUILD_PACKAGES is not a valid number: $BUILD_PACKAGES"
-            exit 1
+          # Get current HEAD hashes
+          echo "Getting task hashes for HEAD..."
+          HEAD_BUILD_HASH=$(get_task_hash "build:lib")
+          HEAD_TEST_HASH=$(get_task_hash "test")
+
+          echo "HEAD build:lib hash: $HEAD_BUILD_HASH"
+          echo "HEAD test hash: $HEAD_TEST_HASH"
+
+          # Get main branch hashes
+          echo "Getting task hashes for origin/main..."
+          git checkout origin/main --quiet
+          MAIN_BUILD_HASH=$(get_task_hash "build:lib")
+          MAIN_TEST_HASH=$(get_task_hash "test")
+
+          echo "Main build:lib hash: $MAIN_BUILD_HASH"
+          echo "Main test hash: $MAIN_TEST_HASH"
+
+          # Return to original ref
+          git checkout "$CURRENT_REF" --quiet
+
+          # Compare hashes - if they differ, the task inputs changed
+          BUILD_CHANGED=false
+          TEST_CHANGED=false
+
+          if [ "$HEAD_BUILD_HASH" != "$MAIN_BUILD_HASH" ]; then
+            echo "Build inputs changed (hash mismatch)"
+            BUILD_CHANGED=true
+          else
+            echo "Build inputs unchanged (hash match)"
           fi
 
-          # Check if test-related files changed
-          TEST_PACKAGES=$(pnpm turbo test --filter='@mastra/rag...[origin/main...HEAD]' --dry-run=json | extract_json | jq -r '.packages | length')
-
-          # Validate jq output is a number
-          if ! [[ "$TEST_PACKAGES" =~ ^[0-9]+$ ]]; then
-            echo "Error: TEST_PACKAGES is not a valid number: $TEST_PACKAGES"
-            exit 1
+          if [ "$HEAD_TEST_HASH" != "$MAIN_TEST_HASH" ]; then
+            echo "Test inputs changed (hash mismatch)"
+            TEST_CHANGED=true
+          else
+            echo "Test inputs unchanged (hash match)"
           fi
 
-          echo "Build packages changed: $BUILD_PACKAGES"
-          echo "Test packages changed: $TEST_PACKAGES"
-
-          # Run tests if either build or test files changed
-          if [ "$BUILD_PACKAGES" -gt 0 ] || [ "$TEST_PACKAGES" -gt 0 ]; then
+          # Run tests if either build or test inputs changed
+          if [ "$BUILD_CHANGED" = true ] || [ "$TEST_CHANGED" = true ]; then
             echo "rag=true" >> $GITHUB_OUTPUT
           else
             echo "rag=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Replaces Turborepo's `[git-range]` filter with task hash comparison for accurate change detection in the RAG test workflow.

## Problem

Turborepo's `[git-range]` filter (e.g., `--filter='@mastra/rag...[origin/main...HEAD]'`) works at the **package level**, not the task level. This means even with task-specific `inputs` configured in `turbo.json` that exclude `*.md` files, any file change in the package (including README.md) would trigger tests.

## Solution

Compare turbo task hashes between `origin/main` and `HEAD`:
- Get `build:lib` and `test` task hashes for both refs
- If hashes differ → task inputs changed → run tests  
- If hashes match → no relevant changes → skip tests

This respects the `inputs` configuration in `packages/rag/turbo.json` which excludes `*.md` files from build and test task inputs.

## Testing

Verified locally:
- **README-only change**: Hashes match → correctly skips tests
- **Source file change**: Hashes differ → correctly runs tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD test workflow change detection with hash-based comparison logic. The workflow now efficiently determines which build and test tasks have changed between branches and conditionally triggers RAG output based on detected differences. Enhanced logging provides transparency into computations and comparison results for better debugging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->