### PR TITLE
test: verify RAG workflow skips on README-only change (fresh)

### DIFF
--- a/packages/rag/README.md
+++ b/packages/rag/README.md
@@ -24,3 +24,7 @@ const doc = new MDocument({
 ```
 
 [Documentation](https://mastra.ai/reference/rag/document)
+
+<!-- Test: Should NOT trigger RAG tests - Wed Jan 21 16:45:19 CET 2026 -->
+
+<!-- Test: Should NOT trigger RAG tests - Wed Jan 21 16:45:32 CET 2026 -->


### PR DESCRIPTION
This PR makes a README-only change to the RAG package to verify that the hash-based change detection correctly skips tests when only markdown files are modified.

Expected behavior: RAG tests should be **skipped** because only README.md changed (which is excluded from task inputs in turbo.json).

This is a fresh branch from main to ensure proper hash comparison.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation with test markers and notes.

**Note:** This release contains no user-facing changes or new features. Updates are limited to internal documentation maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->