### PR TITLE
fix(auth): add organizationId to WorkOS RBAC config in example

### DIFF
--- a/examples/agent/src/mastra/index.ts
+++ b/examples/agent/src/mastra/index.ts
@@ -100,6 +100,7 @@ const config = {
         provider: 'GoogleOAuth',
       },
       rbac: {
+        organizationId: process.env.WORKOS_ORGANIZATION_ID, // Required for RBAC to lookup memberships
         roleMapping: {
           admin: ['*'], // Full access
           member: ['agents:read', 'agents:execute', 'workflows:read', 'workflows:execute'],


### PR DESCRIPTION
## Summary
- Adds `organizationId` env var to WorkOS RBAC config in the example
- Without this config, users logging in via standalone OAuth (e.g., GoogleOAuth) always get the `viewer` role because the RBAC provider can't look up their organization membership

## Test plan
- [ ] Set `WORKOS_ORGANIZATION_ID` env var to your WorkOS organization ID
- [ ] Login via Google OAuth
- [ ] Verify `/api/auth/capabilities` returns correct role from organization membership instead of `viewer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)