### PR TITLE
fix(deployer-cloud): register vector store when cloud storage is enabled

### DIFF
--- a/.changeset/quiet-bees-swim.md
+++ b/.changeset/quiet-bees-swim.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer-cloud': patch
+---
+
+Added vector store registration when Mastra Cloud storage is enabled. The LibSQLVector instance is now added to the Mastra instance, enabling vector search capabilities for RAG workflows in cloud deployments.

--- a/deployers/cloud/src/index.ts
+++ b/deployers/cloud/src/index.ts
@@ -157,6 +157,7 @@ if (process.env.MASTRA_STORAGE_URL && process.env.MASTRA_STORAGE_AUTH_TOKEN) {
     authToken: process.env.MASTRA_STORAGE_AUTH_TOKEN,
   })
 
+  mastra?.addVector(vector);
   await storage.init()
   mastra?.setStorage(storage)
 } else if (mastra?.storage) {


### PR DESCRIPTION
The LibSQLVector instance was already being created when Mastra Cloud storage is enabled, but it wasn't being registered with the Mastra instance. This prevented vector search from working in cloud deployments.

```ts
// Now the vector store is registered alongside storage
mastra?.addVector(vector);
await storage.init();
mastra?.setStorage(storage);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vector search support for RAG workflows when Mastra Cloud storage is enabled, enhancing cloud-based AI applications with vector database capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->