### PR TITLE
feat(playground): add workspace selector UI and URL routing

### DIFF
--- a/examples/unified-workspace/agent-files/AGENT_README.md
+++ b/examples/unified-workspace/agent-files/AGENT_README.md
@@ -1,0 +1,3 @@
+# Agent Specific File
+
+This file is only in the agent workspace.

--- a/examples/unified-workspace/agent-files/agent-script.js
+++ b/examples/unified-workspace/agent-files/agent-script.js
@@ -1,0 +1,1 @@
+console.log('Agent script');

--- a/examples/unified-workspace/src/mastra/agents/index.ts
+++ b/examples/unified-workspace/src/mastra/agents/index.ts
@@ -7,3 +7,4 @@ export { automationAgent } from './automation-agent';
 export { scriptRunnerAgent } from './script-runner-agent';
 export { fsWriteApprovalAgent } from './fs-write-approval-agent';
 export { fsAllApprovalAgent } from './fs-all-approval-agent';
+export { testAgent } from './test-agent';

--- a/examples/unified-workspace/src/mastra/agents/test-agent.ts
+++ b/examples/unified-workspace/src/mastra/agents/test-agent.ts
@@ -1,0 +1,17 @@
+import { openai } from '@ai-sdk/openai';
+import { Agent } from '@mastra/core/agent';
+import { testAgentWorkspace } from '../workspaces';
+
+/**
+ * Test agent with a workspace that has a different filesystem basePath.
+ * Used to verify the UI shows different files for different workspaces.
+ */
+export const testAgent = new Agent({
+  id: 'test-agent',
+  name: 'Test Agent',
+  description: 'A test agent with its own isolated workspace filesystem.',
+  instructions: `You are a test agent with access to your own workspace.
+Your workspace contains files that are different from the global workspace.`,
+  model: openai('gpt-4o-mini'),
+  workspace: testAgentWorkspace,
+});

--- a/examples/unified-workspace/src/mastra/index.ts
+++ b/examples/unified-workspace/src/mastra/index.ts
@@ -8,6 +8,7 @@ import {
   editorAgent,
   automationAgent,
   scriptRunnerAgent,
+  testAgent,
 } from './agents';
 import { globalWorkspace } from './workspaces';
 
@@ -20,6 +21,7 @@ export {
   safeWriteWorkspace,
   supervisedSandboxWorkspace,
   commandApprovalWorkspace,
+  testAgentWorkspace,
 } from './workspaces';
 
 /**
@@ -51,6 +53,7 @@ export const mastra = new Mastra({
     editorAgent,
     automationAgent,
     scriptRunnerAgent,
+    testAgent,
   },
   workspace: globalWorkspace,
   storage,

--- a/examples/unified-workspace/src/mastra/workspaces.ts
+++ b/examples/unified-workspace/src/mastra/workspaces.ts
@@ -301,3 +301,17 @@ export const fsAllApprovalWorkspace = new Workspace({
     requireFilesystemApproval: 'all',
   },
 });
+
+/**
+ * Test workspace with a different filesystem basePath.
+ * Used to verify the UI shows different files for different workspaces.
+ */
+export const testAgentWorkspace = new Workspace({
+  id: 'test-agent-workspace',
+  name: 'Test Agent Workspace',
+  filesystem: new LocalFilesystem({
+    basePath: join(PROJECT_ROOT, 'agent-files'),
+  }),
+  bm25: true,
+  autoInit: true,
+});

--- a/examples/unified-workspace/src/mastra/workspaces.ts
+++ b/examples/unified-workspace/src/mastra/workspaces.ts
@@ -313,5 +313,6 @@ export const testAgentWorkspace = new Workspace({
     basePath: join(PROJECT_ROOT, 'agent-files'),
   }),
   bm25: true,
+  autoIndexPaths: ['/'],
   autoInit: true,
 });

--- a/packages/playground-ui/src/domains/workspace/components/skills-table.tsx
+++ b/packages/playground-ui/src/domains/workspace/components/skills-table.tsx
@@ -10,6 +10,7 @@ export interface SkillsTableProps {
   isLoading: boolean;
   isSkillsConfigured?: boolean;
   basePath?: string;
+  workspaceId?: string;
 }
 
 const columns = [
@@ -53,6 +54,7 @@ export function SkillsTable({
   isLoading,
   isSkillsConfigured = true,
   basePath = '/workspace/skills',
+  workspaceId,
 }: SkillsTableProps) {
   const { navigate } = useLinkComponent();
 
@@ -83,7 +85,10 @@ export function SkillsTable({
                   key={skill.name}
                   entry={entry}
                   columns={columns}
-                  onClick={() => navigate(`${basePath}/${encodeURIComponent(skill.name)}`)}
+                  onClick={() => {
+                    const url = `${basePath}/${encodeURIComponent(skill.name)}${workspaceId ? `?workspaceId=${encodeURIComponent(workspaceId)}` : ''}`;
+                    navigate(url);
+                  }}
                 >
                   <div className="flex items-center gap-3">
                     <div className="p-1.5 rounded bg-surface5">

--- a/packages/playground-ui/src/domains/workspace/hooks/index.ts
+++ b/packages/playground-ui/src/domains/workspace/hooks/index.ts
@@ -2,6 +2,8 @@
 export {
   type WorkspaceCapabilities,
   type WorkspaceInfo,
+  type WorkspaceItem,
+  type WorkspacesListResponse,
   type FileEntry,
   type FileReadResponse,
   type FileListResponse,
@@ -12,6 +14,7 @@ export {
   type SearchResult,
   type SearchResponse,
   useWorkspaceInfo,
+  useWorkspaces,
   useWorkspaceFiles,
   useWorkspaceFile,
   useWorkspaceFileStat,

--- a/packages/playground-ui/src/domains/workspace/hooks/use-workspace-skills.ts
+++ b/packages/playground-ui/src/domains/workspace/hooks/use-workspace-skills.ts
@@ -94,14 +94,19 @@ const skillsRequest = async <T>(baseUrl: string, path: string, options?: Request
 /**
  * Hook to list all discovered skills via workspace
  */
-export const useWorkspaceSkills = () => {
+export const useWorkspaceSkills = (options?: { workspaceId?: string }) => {
   const client = useMastraClient();
   const baseUrl = getBaseUrl(client);
 
   return useQuery({
-    queryKey: ['workspace', 'skills'],
+    queryKey: ['workspace', 'skills', options?.workspaceId],
     queryFn: async (): Promise<ListSkillsResponse> => {
-      return skillsRequest(baseUrl, '/api/workspace/skills');
+      const searchParams = new URLSearchParams();
+      if (options?.workspaceId) {
+        searchParams.set('workspaceId', options.workspaceId);
+      }
+      const query = searchParams.toString();
+      return skillsRequest(baseUrl, `/api/workspace/skills${query ? `?${query}` : ''}`);
     },
   });
 };
@@ -109,14 +114,22 @@ export const useWorkspaceSkills = () => {
 /**
  * Hook to get a specific skill's full details via workspace
  */
-export const useWorkspaceSkill = (skillName: string, options?: { enabled?: boolean }) => {
+export const useWorkspaceSkill = (skillName: string, options?: { enabled?: boolean; workspaceId?: string }) => {
   const client = useMastraClient();
   const baseUrl = getBaseUrl(client);
 
   return useQuery({
-    queryKey: ['workspace', 'skills', skillName],
+    queryKey: ['workspace', 'skills', skillName, options?.workspaceId],
     queryFn: async (): Promise<Skill> => {
-      return skillsRequest(baseUrl, `/api/workspace/skills/${encodeURIComponent(skillName)}`);
+      const searchParams = new URLSearchParams();
+      if (options?.workspaceId) {
+        searchParams.set('workspaceId', options.workspaceId);
+      }
+      const query = searchParams.toString();
+      return skillsRequest(
+        baseUrl,
+        `/api/workspace/skills/${encodeURIComponent(skillName)}${query ? `?${query}` : ''}`,
+      );
     },
     enabled: options?.enabled !== false && !!skillName,
   });
@@ -167,6 +180,7 @@ export interface SearchSkillsParams {
   minScore?: number;
   skillNames?: string[];
   includeReferences?: boolean;
+  workspaceId?: string;
 }
 
 /**
@@ -187,6 +201,9 @@ export const useSearchWorkspaceSkills = () => {
       }
       if (params.includeReferences !== undefined) {
         searchParams.set('includeReferences', String(params.includeReferences));
+      }
+      if (params.workspaceId) {
+        searchParams.set('workspaceId', params.workspaceId);
       }
 
       return skillsRequest(baseUrl, `/api/workspace/skills/search?${searchParams.toString()}`);

--- a/packages/playground-ui/src/domains/workspace/hooks/use-workspace-skills.ts
+++ b/packages/playground-ui/src/domains/workspace/hooks/use-workspace-skills.ts
@@ -138,14 +138,25 @@ export const useWorkspaceSkill = (skillName: string, options?: { enabled?: boole
 /**
  * Hook to list references for a skill via workspace
  */
-export const useWorkspaceSkillReferences = (skillName: string, options?: { enabled?: boolean }) => {
+export const useWorkspaceSkillReferences = (
+  skillName: string,
+  options?: { enabled?: boolean; workspaceId?: string },
+) => {
   const client = useMastraClient();
   const baseUrl = getBaseUrl(client);
 
   return useQuery({
-    queryKey: ['workspace', 'skills', skillName, 'references'],
+    queryKey: ['workspace', 'skills', skillName, 'references', options?.workspaceId],
     queryFn: async (): Promise<ListReferencesResponse> => {
-      return skillsRequest(baseUrl, `/api/workspace/skills/${encodeURIComponent(skillName)}/references`);
+      const searchParams = new URLSearchParams();
+      if (options?.workspaceId) {
+        searchParams.set('workspaceId', options.workspaceId);
+      }
+      const query = searchParams.toString();
+      return skillsRequest(
+        baseUrl,
+        `/api/workspace/skills/${encodeURIComponent(skillName)}/references${query ? `?${query}` : ''}`,
+      );
     },
     enabled: options?.enabled !== false && !!skillName,
   });
@@ -157,17 +168,22 @@ export const useWorkspaceSkillReferences = (skillName: string, options?: { enabl
 export const useWorkspaceSkillReference = (
   skillName: string,
   referencePath: string,
-  options?: { enabled?: boolean },
+  options?: { enabled?: boolean; workspaceId?: string },
 ) => {
   const client = useMastraClient();
   const baseUrl = getBaseUrl(client);
 
   return useQuery({
-    queryKey: ['workspace', 'skills', skillName, 'references', referencePath],
+    queryKey: ['workspace', 'skills', skillName, 'references', referencePath, options?.workspaceId],
     queryFn: async (): Promise<GetReferenceResponse> => {
+      const searchParams = new URLSearchParams();
+      if (options?.workspaceId) {
+        searchParams.set('workspaceId', options.workspaceId);
+      }
+      const query = searchParams.toString();
       return skillsRequest(
         baseUrl,
-        `/api/workspace/skills/${encodeURIComponent(skillName)}/references/${encodeURIComponent(referencePath)}`,
+        `/api/workspace/skills/${encodeURIComponent(skillName)}/references/${encodeURIComponent(referencePath)}${query ? `?${query}` : ''}`,
       );
     },
     enabled: options?.enabled !== false && !!skillName && !!referencePath,

--- a/packages/playground-ui/src/domains/workspace/hooks/use-workspace.ts
+++ b/packages/playground-ui/src/domains/workspace/hooks/use-workspace.ts
@@ -343,6 +343,7 @@ export interface SearchWorkspaceParams {
   topK?: number;
   mode?: 'bm25' | 'vector' | 'hybrid';
   minScore?: number;
+  workspaceId?: string;
 }
 
 export const useSearchWorkspace = () => {
@@ -356,6 +357,7 @@ export const useSearchWorkspace = () => {
       if (params.topK !== undefined) searchParams.set('topK', String(params.topK));
       if (params.mode) searchParams.set('mode', params.mode);
       if (params.minScore !== undefined) searchParams.set('minScore', String(params.minScore));
+      if (params.workspaceId) searchParams.set('workspaceId', params.workspaceId);
 
       return workspaceRequest(baseUrl, `/api/workspace/search?${searchParams.toString()}`);
     },

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -385,6 +385,7 @@ export default function Workspace() {
                 isLoading={isLoadingSkills}
                 isSkillsConfigured={isSkillsConfigured}
                 basePath="/workspace/skills"
+                workspaceId={effectiveWorkspaceId}
               />
             )}
 

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -292,7 +292,7 @@ export default function Workspace() {
                     Search Files
                   </h3>
                   <SearchWorkspacePanel
-                    onSearch={params => searchWorkspace.mutate(params)}
+                    onSearch={params => searchWorkspace.mutate({ ...params, workspaceId: effectiveWorkspaceId })}
                     isSearching={searchWorkspace.isPending}
                     searchResults={searchWorkspace.data}
                     canBM25={canBM25}
@@ -309,7 +309,7 @@ export default function Workspace() {
                     Search Skills
                   </h3>
                   <SearchSkillsPanel
-                    onSearch={params => searchSkills.mutate(params)}
+                    onSearch={params => searchSkills.mutate({ ...params, workspaceId: effectiveWorkspaceId })}
                     results={searchSkills.data?.results ?? []}
                     isSearching={searchSkills.isPending}
                   />

--- a/packages/playground/src/pages/workspace/skills/[skillName]/index.tsx
+++ b/packages/playground/src/pages/workspace/skills/[skillName]/index.tsx
@@ -14,17 +14,24 @@ import {
   useWorkspaceSkillReference,
 } from '@mastra/playground-ui';
 
-import { Link, useParams } from 'react-router';
+import { Link, useParams, useSearchParams } from 'react-router';
 import { Folder, Wand2 } from 'lucide-react';
 
 export default function WorkspaceSkillDetailPage() {
   const { skillName } = useParams<{ skillName: string }>();
+  const [searchParams] = useSearchParams();
   const decodedSkillName = skillName ? decodeURIComponent(skillName) : '';
+  const workspaceId = searchParams.get('workspaceId') ?? undefined;
+
+  // Build back link with workspaceId if present
+  const workspaceBackLink = workspaceId
+    ? `/workspace?workspaceId=${encodeURIComponent(workspaceId)}&tab=skills`
+    : '/workspace?tab=skills';
 
   const [viewingReference, setViewingReference] = useState<string | null>(null);
 
-  // Fetch skill details
-  const { data: skill, isLoading, error } = useWorkspaceSkill(decodedSkillName);
+  // Fetch skill details - pass workspaceId to fetch from correct workspace
+  const { data: skill, isLoading, error } = useWorkspaceSkill(decodedSkillName, { workspaceId });
 
   // Fetch reference content when viewing
   const { data: referenceData, isLoading: isLoadingReference } = useWorkspaceSkillReference(
@@ -32,6 +39,7 @@ export default function WorkspaceSkillDetailPage() {
     viewingReference ?? '',
     {
       enabled: !!viewingReference,
+      workspaceId,
     },
   );
 
@@ -40,13 +48,13 @@ export default function WorkspaceSkillDetailPage() {
       <MainContentLayout>
         <Header>
           <Breadcrumb>
-            <Crumb as={Link} to="/workspace">
+            <Crumb as={Link} to={workspaceBackLink}>
               <Icon>
                 <Folder className="h-4 w-4" />
               </Icon>
               Workspace
             </Crumb>
-            <Crumb as={Link} to="/workspace">
+            <Crumb as={Link} to={workspaceBackLink}>
               <Icon>
                 <Wand2 className="h-4 w-4" />
               </Icon>
@@ -69,13 +77,13 @@ export default function WorkspaceSkillDetailPage() {
       <MainContentLayout>
         <Header>
           <Breadcrumb>
-            <Crumb as={Link} to="/workspace">
+            <Crumb as={Link} to={workspaceBackLink}>
               <Icon>
                 <Folder className="h-4 w-4" />
               </Icon>
               Workspace
             </Crumb>
-            <Crumb as={Link} to="/workspace">
+            <Crumb as={Link} to={workspaceBackLink}>
               <Icon>
                 <Wand2 className="h-4 w-4" />
               </Icon>
@@ -100,13 +108,13 @@ export default function WorkspaceSkillDetailPage() {
     <MainContentLayout>
       <Header>
         <Breadcrumb>
-          <Crumb as={Link} to="/workspace">
+          <Crumb as={Link} to={workspaceBackLink}>
             <Icon>
               <Folder className="h-4 w-4" />
             </Icon>
             Workspace
           </Crumb>
-          <Crumb as={Link} to="/workspace">
+          <Crumb as={Link} to={workspaceBackLink}>
             <Icon>
               <Wand2 className="h-4 w-4" />
             </Icon>

--- a/packages/server/src/server/handlers/workspace.ts
+++ b/packages/server/src/server/handlers/workspace.ts
@@ -495,13 +495,13 @@ export const WORKSPACE_SEARCH_ROUTE = createRoute({
   summary: 'Search workspace content',
   description: 'Searches across indexed workspace content using BM25, vector, or hybrid search',
   tags: ['Workspace'],
-  handler: async ({ mastra, query, topK, mode, minScore }) => {
+  handler: async ({ mastra, query, topK, mode, minScore, workspaceId }) => {
     try {
       if (!query) {
         throw new HTTPException(400, { message: 'Search query is required' });
       }
 
-      const workspace = getWorkspace(mastra);
+      const workspace = await getWorkspaceById(mastra, workspaceId);
       if (!workspace) {
         return {
           results: [],

--- a/packages/server/src/server/schemas/workspace.ts
+++ b/packages/server/src/server/schemas/workspace.ts
@@ -24,21 +24,25 @@ export const fsPathParams = z.object({
 export const fsReadQuerySchema = z.object({
   path: z.string().describe('Path to the file to read'),
   encoding: z.string().optional().describe('Encoding for text files (default: utf-8)'),
+  workspaceId: z.string().optional().describe('Workspace ID (defaults to global workspace)'),
 });
 
 export const fsListQuerySchema = z.object({
   path: z.string().describe('Path to the directory to list'),
   recursive: z.coerce.boolean().optional().describe('Include subdirectories'),
+  workspaceId: z.string().optional().describe('Workspace ID (defaults to global workspace)'),
 });
 
 export const fsStatQuerySchema = z.object({
   path: z.string().describe('Path to get info about'),
+  workspaceId: z.string().optional().describe('Workspace ID (defaults to global workspace)'),
 });
 
 export const fsDeleteQuerySchema = z.object({
   path: z.string().describe('Path to delete'),
   recursive: z.coerce.boolean().optional().describe('Delete directories recursively'),
   force: z.coerce.boolean().optional().describe("Don't error if path doesn't exist"),
+  workspaceId: z.string().optional().describe('Workspace ID (defaults to global workspace)'),
 });
 
 // =============================================================================
@@ -50,11 +54,13 @@ export const fsWriteBodySchema = z.object({
   content: z.string().describe('Content to write (text or base64-encoded binary)'),
   encoding: z.enum(['utf-8', 'base64']).optional().default('utf-8').describe('Content encoding'),
   recursive: z.coerce.boolean().optional().describe('Create parent directories if needed'),
+  workspaceId: z.string().optional().describe('Workspace ID (defaults to global workspace)'),
 });
 
 export const fsMkdirBodySchema = z.object({
   path: z.string().describe('Directory path to create'),
   recursive: z.coerce.boolean().optional().describe('Create parent directories if needed'),
+  workspaceId: z.string().optional().describe('Workspace ID (defaults to global workspace)'),
 });
 
 // =============================================================================
@@ -178,6 +184,27 @@ export const workspaceInfoResponseSchema = z.object({
       hasSkills: z.boolean(),
     })
     .optional(),
+});
+
+const workspaceItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.string(),
+  source: z.enum(['mastra', 'agent']),
+  agentId: z.string().optional(),
+  agentName: z.string().optional(),
+  capabilities: z.object({
+    hasFilesystem: z.boolean(),
+    hasSandbox: z.boolean(),
+    canBM25: z.boolean(),
+    canVector: z.boolean(),
+    canHybrid: z.boolean(),
+    hasSkills: z.boolean(),
+  }),
+});
+
+export const listWorkspacesResponseSchema = z.object({
+  workspaces: z.array(workspaceItemSchema),
 });
 
 // =============================================================================

--- a/packages/server/src/server/schemas/workspace.ts
+++ b/packages/server/src/server/schemas/workspace.ts
@@ -119,6 +119,7 @@ export const searchQuerySchema = z.object({
   topK: z.coerce.number().optional().default(5).describe('Maximum number of results'),
   mode: z.enum(['bm25', 'vector', 'hybrid']).optional().describe('Search mode'),
   minScore: z.coerce.number().optional().describe('Minimum relevance score threshold'),
+  workspaceId: z.string().optional().describe('Workspace ID (defaults to global workspace)'),
 });
 
 export const searchResultSchema = z.object({

--- a/packages/server/src/server/schemas/workspace.ts
+++ b/packages/server/src/server/schemas/workspace.ts
@@ -223,12 +223,21 @@ export const skillReferencePathParams = skillNamePathParams.extend({
 // Skills Query Parameter Schemas
 // =============================================================================
 
+export const listSkillsQuerySchema = z.object({
+  workspaceId: z.string().optional().describe('Workspace ID (defaults to global workspace)'),
+});
+
+export const getSkillQuerySchema = z.object({
+  workspaceId: z.string().optional().describe('Workspace ID (defaults to global workspace)'),
+});
+
 export const searchSkillsQuerySchema = z.object({
   query: z.string().describe('Search query text'),
   topK: z.coerce.number().optional().default(5).describe('Maximum number of results'),
   minScore: z.coerce.number().optional().describe('Minimum relevance score threshold'),
   skillNames: z.string().optional().describe('Comma-separated list of skill names to search within'),
   includeReferences: z.coerce.boolean().optional().default(true).describe('Include reference files in search'),
+  workspaceId: z.string().optional().describe('Workspace ID (defaults to global workspace)'),
 });
 
 // =============================================================================

--- a/packages/server/src/server/server-adapter/routes/workspace.ts
+++ b/packages/server/src/server/server-adapter/routes/workspace.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  LIST_WORKSPACES_ROUTE,
   WORKSPACE_INFO_ROUTE,
   WORKSPACE_FS_ROUTES,
   WORKSPACE_SEARCH_ROUTES,
@@ -13,6 +14,9 @@ import {
 import type { ServerRoute } from '.';
 
 export const WORKSPACE_ROUTES: ServerRoute<any, any, any>[] = [
+  // List all workspaces route (at /api/workspaces - plural)
+  LIST_WORKSPACES_ROUTE,
+
   // Info route (must come first to avoid /api/workspace being matched by parameterized routes)
   WORKSPACE_INFO_ROUTE,
 


### PR DESCRIPTION
## Summary

- Add workspace selector dropdown in the Workspace page to switch between global and agent-specific workspaces
- Add URL-based state management for browser back/forward navigation
- Add workspace-specific skills support - each workspace now shows only its own skills

## Changes

### Workspace Selector UI
- Added dropdown to select between global workspace and agent workspaces
- Shows workspace capabilities (FS, Sandbox, Skills) as badges
- Shows agent name for agent-specific workspaces

### URL Routing
- Store `workspaceId`, `path`, `file`, and `tab` in URL params
- Browser back/forward buttons now work correctly
- State persists across page reloads

### Workspace-Specific Skills
- Added `workspaceId` parameter to all skills routes (list, get, references, search)
- Updated frontend hooks to pass `workspaceId` 
- Each workspace now correctly shows only its own skills

### Bug Fixes
- Fixed z-index issue where skills table overlapped workspace dropdown

## Test plan

- [x] Workspace selector dropdown shows all workspaces
- [x] Switching workspaces updates files and skills
- [x] URL updates when switching workspaces, navigating files, or changing tabs
- [x] Browser back/forward buttons work correctly
- [x] Each workspace shows only its own skills (e.g., Docs Agent shows brand-guidelines from docs-skills)
- [x] Dropdown appears above skills table (z-index fix)