### PR TITLE
feat(workspace): add skills runtime refresh with staleness check

### DIFF
--- a/examples/unified-workspace/src/mastra/agents/developer-agent.ts
+++ b/examples/unified-workspace/src/mastra/agents/developer-agent.ts
@@ -1,5 +1,5 @@
-import { openai } from '@ai-sdk/openai';
 import { Agent } from '@mastra/core/agent';
+import { Memory } from '@mastra/memory';
 
 /**
  * Developer agent - inherits globalWorkspace from Mastra instance.
@@ -23,5 +23,10 @@ When helping with code or design:
 3. Be specific and provide examples
 4. Use workspace tools to read, write, and execute code as needed`,
 
-  model: openai('gpt-4o-mini'),
+  model: 'openai/gpt-5.1',
+  memory: new Memory({
+    options: {
+      lastMessages: 10,
+    },
+  }),
 });

--- a/packages/core/src/processors/processors/skills.test.ts
+++ b/packages/core/src/processors/processors/skills.test.ts
@@ -74,6 +74,7 @@ function createMockWorkspaceSkills(): WorkspaceSkills {
     get: vi.fn().mockImplementation((name: string) => Promise.resolve(skills.get(name) || null)),
     has: vi.fn().mockImplementation((name: string) => Promise.resolve(skills.has(name))),
     refresh: vi.fn().mockResolvedValue(undefined),
+    maybeRefresh: vi.fn().mockResolvedValue(undefined),
     search: vi.fn().mockResolvedValue([]),
     create: vi.fn(),
     update: vi.fn(),

--- a/packages/core/src/processors/processors/skills.ts
+++ b/packages/core/src/processors/processors/skills.ts
@@ -28,7 +28,7 @@ import { createTool } from '../../tools';
 import { extractLines } from '../../workspace/line-utils';
 import type { Skill, SkillFormat, WorkspaceSkills } from '../../workspace/skills';
 import type { Workspace } from '../../workspace/workspace';
-import type { ProcessInputStepArgs, Processor } from '../index';
+import type { ProcessInputArgs, ProcessInputStepArgs, Processor } from '../index';
 
 // =============================================================================
 // Configuration
@@ -585,12 +585,18 @@ ${skillInstructions}`;
   // ===========================================================================
 
   /**
+   * Process input - refresh skills if needed (runs once at start of agent call)
+   */
+  async processInput({ messageList }: ProcessInputArgs) {
+    // Refresh skills if any skillsPaths have been modified since last discovery
+    await this.skills?.maybeRefresh();
+    return messageList;
+  }
+
+  /**
    * Process input step - inject available skills and provide skill tools
    */
   async processInputStep({ messageList, tools }: ProcessInputStepArgs) {
-    // Refresh skills if any skillsPaths have been modified since last discovery
-    await this.skills?.maybeRefresh();
-
     const skillsList = await this.skills?.list();
     const hasSkills = skillsList && skillsList.length > 0;
 

--- a/packages/core/src/processors/processors/skills.ts
+++ b/packages/core/src/processors/processors/skills.ts
@@ -588,6 +588,9 @@ ${skillInstructions}`;
    * Process input step - inject available skills and provide skill tools
    */
   async processInputStep({ messageList, tools }: ProcessInputStepArgs) {
+    // Refresh skills if any skillsPaths have been modified since last discovery
+    await this.skills?.maybeRefresh();
+
     const skillsList = await this.skills?.list();
     const hasSkills = skillsList && skillsList.length > 0;
 

--- a/packages/core/src/processors/processors/skills.ts
+++ b/packages/core/src/processors/processors/skills.ts
@@ -28,7 +28,7 @@ import { createTool } from '../../tools';
 import { extractLines } from '../../workspace/line-utils';
 import type { Skill, SkillFormat, WorkspaceSkills } from '../../workspace/skills';
 import type { Workspace } from '../../workspace/workspace';
-import type { ProcessInputArgs, ProcessInputStepArgs, Processor } from '../index';
+import type { ProcessInputStepArgs, Processor } from '../index';
 
 // =============================================================================
 // Configuration
@@ -585,18 +585,13 @@ ${skillInstructions}`;
   // ===========================================================================
 
   /**
-   * Process input - refresh skills if needed (runs once at start of agent call)
-   */
-  async processInput({ messageList }: ProcessInputArgs) {
-    // Refresh skills if any skillsPaths have been modified since last discovery
-    await this.skills?.maybeRefresh();
-    return messageList;
-  }
-
-  /**
    * Process input step - inject available skills and provide skill tools
    */
-  async processInputStep({ messageList, tools }: ProcessInputStepArgs) {
+  async processInputStep({ messageList, tools, stepNumber }: ProcessInputStepArgs) {
+    // Refresh skills on first step only (not every step in the agentic loop)
+    if (stepNumber === 0) {
+      await this.skills?.maybeRefresh();
+    }
     const skillsList = await this.skills?.list();
     const hasSkills = skillsList && skillsList.length > 0;
 

--- a/packages/core/src/workspace/skills/types.ts
+++ b/packages/core/src/workspace/skills/types.ts
@@ -157,6 +157,15 @@ export interface WorkspaceSkills {
    */
   refresh(): Promise<void>;
 
+  /**
+   * Conditionally refresh skills if the skillsPaths have been modified.
+   * Uses a staleness check to avoid unnecessary re-discovery on every call.
+   *
+   * Call this in processInput before each agent turn to catch newly
+   * added skills without the overhead of a full refresh every time.
+   */
+  maybeRefresh(): Promise<void>;
+
   // ===========================================================================
   // Search
   // ===========================================================================


### PR DESCRIPTION
## Summary

- Adds `maybeRefresh()` method to `WorkspaceSkills` interface for conditional skill refresh
- Implements staleness check that compares skillsPaths directory mtime against last discovery time  
- Calls `maybeRefresh()` in `SkillsProcessor.processInputStep` when `stepNumber === 0` (first step only)
- Skills created at runtime are now discovered on the next agent turn without process restart

## Test plan

- [x] All workspace tests pass (483 tests)
- [x] All processors tests pass (433 tests)
- [x] Manual testing confirms newly created skills are discovered after maybeRefresh

🤖 Generated with [Claude Code](https://claude.ai/code)