### PR TITLE
fix(llm): log streaming errors through Mastra logger

### DIFF
--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -290,6 +290,7 @@ export class MastraLLMV1 extends MastraBase {
         },
         e,
       );
+      this.logger?.trackException(mastraError);
       llmSpan?.error({ error: mastraError });
       throw mastraError;
     }
@@ -392,6 +393,7 @@ export class MastraLLMV1 extends MastraBase {
           },
           e,
         );
+        this.logger?.trackException(mastraError);
         llmSpan?.error({ error: mastraError });
         throw mastraError;
       }
@@ -621,6 +623,7 @@ export class MastraLLMV1 extends MastraBase {
         },
         e,
       );
+      this.logger?.trackException(mastraError);
       llmSpan?.error({ error: mastraError });
       throw mastraError;
     }
@@ -764,6 +767,7 @@ export class MastraLLMV1 extends MastraBase {
           },
           e,
         );
+        this.logger?.trackException(mastraError);
         llmSpan?.error({ error: mastraError });
         throw mastraError;
       }


### PR DESCRIPTION
## Description

Add `trackException()` calls in catch blocks for all LLM methods (`generateText`, `generateObject`, `streamText`, `streamObject`) to ensure all errors are consistently logged through the Mastra logger with structured context.

## Related Issue(s)

#12184 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in LLM operations with improved tracking and logging capabilities.

* **Tests**
  * Added comprehensive error-handling test coverage for text generation, object generation, and streaming operations, ensuring proper error propagation and context preservation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->