### PR TITLE
fix(ci): add explicit inputs to composite build tasks in turbo.json

### DIFF
--- a/packages/auth/turbo.json
+++ b/packages/auth/turbo.json
@@ -23,7 +23,7 @@
     },
     "build": {
       "dependsOn": ["build:lib", "build:docs"],
-      "inputs": []
+      "inputs": ["package.json"]
     },
     "test": {
       "dependsOn": ["^build"],

--- a/packages/core/turbo.json
+++ b/packages/core/turbo.json
@@ -4,7 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["build:patch-commonjs", "build:lib", "build:docs"],
-      "inputs": []
+      "inputs": ["package.json"]
     },
     "build:patch-commonjs": {
       "dependsOn": ["build:lib"],

--- a/packages/deployer/turbo.json
+++ b/packages/deployer/turbo.json
@@ -23,7 +23,7 @@
     },
     "build": {
       "dependsOn": ["build:lib", "build:docs"],
-      "inputs": []
+      "inputs": ["package.json"]
     },
     "test": {
       "dependsOn": ["^build"],

--- a/packages/mcp/turbo.json
+++ b/packages/mcp/turbo.json
@@ -23,7 +23,7 @@
     },
     "build": {
       "dependsOn": ["build:lib", "build:docs"],
-      "inputs": []
+      "inputs": ["package.json"]
     },
     "test": {
       "dependsOn": ["^build"],

--- a/packages/memory/turbo.json
+++ b/packages/memory/turbo.json
@@ -23,7 +23,7 @@
     },
     "build": {
       "dependsOn": ["build:lib", "build:docs"],
-      "inputs": []
+      "inputs": ["package.json"]
     },
     "test": {
       "dependsOn": ["^build"],

--- a/packages/rag/turbo.json
+++ b/packages/rag/turbo.json
@@ -23,7 +23,7 @@
     },
     "build": {
       "dependsOn": ["build:lib", "build:docs"],
-      "inputs": []
+      "inputs": ["package.json"]
     },
     "test": {
       "dependsOn": ["^build"],

--- a/packages/server/turbo.json
+++ b/packages/server/turbo.json
@@ -27,7 +27,7 @@
     },
     "build": {
       "dependsOn": ["build:patch-commonjs", "build:lib", "build:docs"],
-      "inputs": []
+      "inputs": ["package.json"]
     },
     "test": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Problem

The turbo-changed action was detecting changes when only README.md files were modified, even though we intended to skip CI for markdown-only changes.

## Root Cause

The main `build` task in several package `turbo.json` files had:
```json
"build": {
  "dependsOn": ["build:lib", "build:docs"],
  "inputs": []
}
```

According to [Turborepo documentation](https://turbo.build/repo/docs/reference/configuration#inputs):
> **Default: `[]`, all files in the package that are checked into source control**

So `inputs: []` means **all files** are included, not "no files". This caused README.md changes to invalidate the build task hash.

## Solution

Since the composite `build` task doesn't process files directly - it only orchestrates sub-tasks (`build:lib`, `build:docs`, etc.) - we can use minimal inputs:

```json
"build": {
  "dependsOn": ["build:lib", "build:docs"],
  "inputs": ["package.json"]
}
```

The task hash will still change correctly when source files change because:
1. Source changes affect `build:lib` hash (which has proper inputs defined)
2. Turborepo includes dependent task hashes in the parent task's hash calculation
3. So `build` hash changes when `build:lib` hash changes

## Packages Fixed

- `@mastra/core`
- `@mastra/rag`
- `@mastra/memory`
- `@mastra/server`
- `@mastra/mcp`
- `@mastra/deployer`
- `@mastra/auth`

## Testing

After this fix, the turbo-changed action should correctly report `changed=false` when only markdown files are modified in a package.