### PR TITLE
fix(hono): skip permission check when auth is not configured

### DIFF
--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -343,7 +343,9 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
         };
 
         // Check route permission requirement (EE feature)
-        if (route.requiresPermission) {
+        // Only enforce permissions when auth is configured
+        const authConfig = this.mastra.getServer()?.auth;
+        if (route.requiresPermission && authConfig) {
           const userPermissions = c.get('requestContext').get('userPermissions') as string[] | undefined;
 
           if (!userPermissions || !hasPermission(userPermissions, route.requiresPermission)) {


### PR DESCRIPTION
## Summary
- Fixes 403 Forbidden errors on routes with `requiresPermission` when auth is not configured
- The `requiresPermission` feature was enforcing permissions even without an auth provider, causing apps without auth to fail

## Test plan
- [x] E2E tests pass (`pnpm --filter @internal/playground test:e2e`)
- [x] Verified API returns data instead of 403 when auth is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)