### PR TITLE
fix(ci): add concurrency control to workflow_run triggered workflows

### DIFF
--- a/.github/workflows/secrets.e2e.yml
+++ b/.github/workflows/secrets.e2e.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   check-changes:
     if: ${{ github.repository == 'mastra-ai/mastra' }}

--- a/.github/workflows/secrets.test-agent-builder.yml
+++ b/.github/workflows/secrets.test-agent-builder.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   check-changes:
     if: ${{ github.repository == 'mastra-ai/mastra' }}

--- a/.github/workflows/secrets.test-auth.yml
+++ b/.github/workflows/secrets.test-auth.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   check-changes:
     if: ${{ github.repository == 'mastra-ai/mastra' }}

--- a/.github/workflows/secrets.test-combined-stores.yml
+++ b/.github/workflows/secrets.test-combined-stores.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   check-changes:
     if: ${{ github.repository == 'mastra-ai/mastra' }}

--- a/.github/workflows/secrets.test-core.yml
+++ b/.github/workflows/secrets.test-core.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   check-changes:
     if: ${{ github.repository == 'mastra-ai/mastra' }}

--- a/.github/workflows/secrets.test-deployer.yml
+++ b/.github/workflows/secrets.test-deployer.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   check-changes:
     if: ${{ github.repository == 'mastra-ai/mastra' }}

--- a/.github/workflows/secrets.test-mcp.yml
+++ b/.github/workflows/secrets.test-mcp.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   check-changes:
     if: ${{ github.repository == 'mastra-ai/mastra' }}

--- a/.github/workflows/secrets.test-memory.yml
+++ b/.github/workflows/secrets.test-memory.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   check-changes:
     if: ${{ github.repository == 'mastra-ai/mastra' }}

--- a/.github/workflows/secrets.test-observability.yml
+++ b/.github/workflows/secrets.test-observability.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   check-changes:
     if: ${{ github.repository == 'mastra-ai/mastra' }}

--- a/.github/workflows/secrets.test-rag.yml
+++ b/.github/workflows/secrets.test-rag.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   check-changes:
     if: ${{ github.repository == 'mastra-ai/mastra' }}

--- a/.github/workflows/secrets.test-server.yml
+++ b/.github/workflows/secrets.test-server.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   check-changes:
     if: ${{ github.repository == 'mastra-ai/mastra' }}

--- a/.github/workflows/secrets.tool-builder-test.yml
+++ b/.github/workflows/secrets.tool-builder-test.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   check-changes:
     if: ${{ github.repository == 'mastra-ai/mastra' }}


### PR DESCRIPTION
## Problem

When multiple PRs trigger the Quality assurance workflow around the same time, the downstream `workflow_run` triggered workflows (Core Tests, Memory Tests, etc.) can race against each other. This can cause:

1. Wasted CI resources running outdated checks
2. Multiple workflows trying to set status checks on the same commit
3. Confusing status check results

## Solution

Added concurrency control to all 12 `workflow_run` triggered workflows:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha }}
  cancel-in-progress: true
```

This ensures:
- Only one run per workflow per commit SHA runs at a time
- New pushes to the same branch cancel any in-progress runs
- CI resources are freed up faster

## Workflows Updated

- `secrets.e2e.yml`
- `secrets.test-agent-builder.yml`
- `secrets.test-auth.yml`
- `secrets.test-combined-stores.yml`
- `secrets.test-core.yml`
- `secrets.test-deployer.yml`
- `secrets.test-mcp.yml`
- `secrets.test-memory.yml`
- `secrets.test-observability.yml`
- `secrets.test-rag.yml`
- `secrets.test-server.yml`
- `secrets.tool-builder-test.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to prevent concurrent test runs, ensuring only the latest workflow execution processes while canceling earlier redundant runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->