### PR TITLE
feat(codemod): add workflow-get-init-data codemod

### DIFF
--- a/.changeset/workflow-get-init-data-codemod.md
+++ b/.changeset/workflow-get-init-data-codemod.md
@@ -1,0 +1,35 @@
+---
+"@mastra/codemod": patch
+---
+
+Added `workflow-get-init-data` codemod that transforms `getInitData()` calls to `getInitData<any>()`.
+
+This codemod helps migrate code after the `getInitData` return type changed from `any` to `unknown`. Adding the explicit `<any>` type parameter restores the previous behavior while maintaining type safety.
+
+**Usage:**
+
+```bash
+npx @mastra/codemod@latest v1/workflow-get-init-data .
+```
+
+**Before:**
+
+```typescript
+createStep({
+  execute: async ({ getInitData }) => {
+    const initData = getInitData();
+    if (initData.key === 'value') {}
+  },
+});
+```
+
+**After:**
+
+```typescript
+createStep({
+  execute: async ({ getInitData }) => {
+    const initData = getInitData<any>();
+    if (initData.key === 'value') {}
+  },
+});
+```

--- a/docs/src/content/en/docs/workflows/control-flow.mdx
+++ b/docs/src/content/en/docs/workflows/control-flow.mdx
@@ -327,7 +327,7 @@ The `.map()` method provides additional helper functions for more complex mappin
 **Available helper functions:**
 
 - [`getStepResult()`](/reference/workflows/workflow-methods/map#using-getstepresult): Access a specific step's full output
-- [`getInitData()`](/reference/workflows/workflow-methods/map#using-getinitdata): Access the workflow's initial input data
+- [`getInitData<any>()`](/reference/workflows/workflow-methods/map#using-getinitdata): Access the workflow's initial input data
 - [`mapVariable()`](/reference/workflows/workflow-methods/map#using-mapvariable): Use declarative object syntax to extract and rename fields
 
 ### Parallel and Branch outputs

--- a/docs/src/content/en/docs/workflows/error-handling.mdx
+++ b/docs/src/content/en/docs/workflows/error-handling.mdx
@@ -101,7 +101,7 @@ The `onFinish` callback receives:
 - `runId` - The unique identifier for this workflow run
 - `workflowId` - The workflow's identifier
 - `resourceId` - Optional resource identifier (if provided when creating the run)
-- `getInitData()` - Function that returns the initial input data
+- `getInitData<any>()` - Function that returns the initial input data
 - `mastra` - The Mastra instance (if workflow is registered with Mastra)
 - `requestContext` - Request-scoped context data
 - `logger` - The workflow's logger instance
@@ -140,7 +140,7 @@ The `onError` callback receives:
 - `runId` - The unique identifier for this workflow run
 - `workflowId` - The workflow's identifier
 - `resourceId` - Optional resource identifier (if provided when creating the run)
-- `getInitData()` - Function that returns the initial input data
+- `getInitData<any>()` - Function that returns the initial input data
 - `mastra` - The Mastra instance (if workflow is registered with Mastra)
 - `requestContext` - Request-scoped context data
 - `logger` - The workflow's logger instance

--- a/docs/src/content/en/docs/workflows/input-data-mapping.mdx
+++ b/docs/src/content/en/docs/workflows/input-data-mapping.mdx
@@ -58,14 +58,14 @@ Use `getStepResult` to access the full output of a specific step by referencing 
   })
 ```
 
-## Using `getInitData()`
+## Using `getInitData<any>()`
 
-Use `getInitData` to access the initial input data provided to the workflow:
+Use `getInitData<any>` to access the initial input data provided to the workflow:
 
 ```typescript {3} title="src/mastra/workflows/test-workflow.ts"
   .then(step1)
   .map(async ({ getInitData }) => {
-      console.log(getInitData());
+      console.log(getInitData<any>());
   })
 ```
 

--- a/docs/src/content/en/guides/guide/whatsapp-chat-bot.mdx
+++ b/docs/src/content/en/guides/guide/whatsapp-chat-bot.mdx
@@ -280,7 +280,7 @@ export const chatWorkflow = createWorkflow({
   .then(breakIntoMessages)
   .map(async ({ inputData, getInitData }) => {
     // Parse the original stringified input to get user phone
-    const initData = getInitData();
+    const initData = getInitData<typeof chatWorkflow>();
     const webhookData = JSON.parse(initData.userMessage);
     const userPhone =
       webhookData.entry?.[0]?.changes?.[0]?.value?.messages?.[0]?.from ||

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/workflows.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/workflows.mdx
@@ -103,6 +103,32 @@ npx @mastra/codemod@latest v1/workflow-run-count .
 
 :::
 
+### `getInitData` returns unknown
+
+The `getInitData` function in the execute function now returns unknown instead of any. You'll need to type it yourself.
+To simply migrate, change `getInitData()` into `getInitData<any>()`
+
+```diff
+  createStep({
+    execute: async ({ getInitData }) => {
+-     const initData = getInitData();
+-     if (initData.key === 'value') {}
++     const initData = getInitData<any>();
++     if (initData.key === 'value') {}
+    },
+  });
+```
+
+:::tip[Codemod]
+
+You can use Mastra's codemod CLI to update your code automatically:
+
+```bash
+npx @mastra/codemod@latest v1/workflow-get-init-data .
+```
+
+:::
+
 ### `getWorkflowRuns` to `listWorkflowRuns`
 
 The `getWorkflowRuns()` method has been renamed to `listWorkflowRuns()`. This change aligns with the convention that `list*` methods return collections.

--- a/docs/src/content/en/reference/workflows/workflow-methods/map.mdx
+++ b/docs/src/content/en/reference/workflows/workflow-methods/map.mdx
@@ -65,7 +65,7 @@ Use `getStepResult()` to access the full output of a specific step by referencin
 
 ## Using `getInitData()`
 
-Use `getInitData()` to access the initial input data provided to the workflow.
+Use `getInitData<typeof workflow>()` to access the initial input data provided to the workflow.
 
 ```typescript {3} filename="src/mastra/workflows/test-workflow.ts"
   .then(step1)

--- a/packages/codemod/src/codemods/v1/workflow-get-init-data.ts
+++ b/packages/codemod/src/codemods/v1/workflow-get-init-data.ts
@@ -1,0 +1,55 @@
+import { createTransformer } from '../lib/create-transformer';
+
+/**
+ * Transforms getInitData() calls to getInitData<any>() to add explicit type parameter.
+ * This ensures type safety when accessing the initial workflow data.
+ *
+ * Before:
+ * createStep({
+ *   execute: async ({ getInitData }) => {
+ *     const initData = getInitData();
+ *     if (initData.key === 'value') {}
+ *   },
+ * });
+ *
+ * After:
+ * createStep({
+ *   execute: async ({ getInitData }) => {
+ *     const initData = getInitData<any>();
+ *     if (initData.key === 'value') {}
+ *   },
+ * });
+ */
+export default createTransformer((fileInfo, api, options, context) => {
+  const { j, root } = context;
+
+  // Find all call expressions where the callee is 'getInitData'
+  root
+    .find(j.CallExpression, {
+      callee: {
+        type: 'Identifier',
+        name: 'getInitData',
+      },
+    })
+    .forEach(path => {
+      const callExpr = path.value;
+      // Skip if already has type arguments
+      if (callExpr.typeArguments) {
+        return;
+      }
+
+      // Create the type argument <any>
+      const anyType = j.tsTypeReference(j.identifier('any'));
+      const typeParameterInstantiation = j.tsTypeParameterInstantiation([anyType]);
+
+      // Add type arguments to the call expression
+      // @ts-expect-error - jscodeshift's type system is not compatible with the type arguments we're adding
+      callExpr.typeArguments = typeParameterInstantiation;
+
+      context.hasChanges = true;
+    });
+
+  if (context.hasChanges) {
+    context.messages.push('Transformed getInitData() calls to getInitData<any>()');
+  }
+});

--- a/packages/codemod/src/lib/bundle.ts
+++ b/packages/codemod/src/lib/bundle.ts
@@ -26,6 +26,7 @@ export const BUNDLE = [
   'v1/workflow-run-count',
   'v1/workflow-list-runs',
   'v1/workflow-stream-vnext',
+  'v1/workflow-get-init-data',
   'v1/memory-query-to-recall',
   'v1/memory-vector-search-param',
   'v1/memory-message-v2-type',

--- a/packages/codemod/src/test/__fixtures__/workflow-get-init-data.input.ts
+++ b/packages/codemod/src/test/__fixtures__/workflow-get-init-data.input.ts
@@ -1,0 +1,62 @@
+// @ts-nocheck
+import { createStep, createWorkflow } from '@mastra/core/workflows';
+
+// Should transform - getInitData() in createStep execute
+const step1 = createStep({
+  id: 'step-1',
+  execute: async ({ getInitData }) => {
+    const initData = getInitData();
+    if (initData.key === 'value') {
+      console.log('matched');
+    }
+    return { result: initData.key };
+  },
+});
+
+// Should transform - getInitData() in workflow .map()
+const workflow = createWorkflow({
+  id: 'my-workflow',
+})
+  .then(step1)
+  .map(async ({ getInitData }) => {
+    console.log(getInitData());
+  });
+
+// Should transform - multiple getInitData() calls
+const step2 = createStep({
+  id: 'step-2',
+  execute: async ({ getInitData, inputData }) => {
+    const data1 = getInitData();
+    const data2 = getInitData();
+    return { combined: data1.a + data2.b };
+  },
+});
+
+// Should transform - getInitData() with property access
+const step3 = createStep({
+  id: 'step-3',
+  execute: async ({ getInitData }) => {
+    return { name: getInitData().name };
+  },
+});
+
+// Should NOT transform - already has type parameter
+const step4 = createStep({
+  id: 'step-4',
+  execute: async ({ getInitData }) => {
+    const initData = getInitData<{ key: string }>();
+    return { result: initData.key };
+  },
+});
+
+// Should NOT transform - different function name
+const step5 = createStep({
+  id: 'step-5',
+  execute: async ({ getStepResult }) => {
+    const result = getStepResult('other-step');
+    return { result };
+  },
+});
+
+// Should NOT transform - getInitData as a variable assignment (not a call)
+const getInitDataAlias = (fn: () => any) => fn;

--- a/packages/codemod/src/test/__fixtures__/workflow-get-init-data.output.ts
+++ b/packages/codemod/src/test/__fixtures__/workflow-get-init-data.output.ts
@@ -1,0 +1,62 @@
+// @ts-nocheck
+import { createStep, createWorkflow } from '@mastra/core/workflows';
+
+// Should transform - getInitData() in createStep execute
+const step1 = createStep({
+  id: 'step-1',
+  execute: async ({ getInitData }) => {
+    const initData = getInitData<any>();
+    if (initData.key === 'value') {
+      console.log('matched');
+    }
+    return { result: initData.key };
+  },
+});
+
+// Should transform - getInitData() in workflow .map()
+const workflow = createWorkflow({
+  id: 'my-workflow',
+})
+  .then(step1)
+  .map(async ({ getInitData }) => {
+    console.log(getInitData<any>());
+  });
+
+// Should transform - multiple getInitData() calls
+const step2 = createStep({
+  id: 'step-2',
+  execute: async ({ getInitData, inputData }) => {
+    const data1 = getInitData<any>();
+    const data2 = getInitData<any>();
+    return { combined: data1.a + data2.b };
+  },
+});
+
+// Should transform - getInitData() with property access
+const step3 = createStep({
+  id: 'step-3',
+  execute: async ({ getInitData }) => {
+    return { name: getInitData<any>().name };
+  },
+});
+
+// Should NOT transform - already has type parameter
+const step4 = createStep({
+  id: 'step-4',
+  execute: async ({ getInitData }) => {
+    const initData = getInitData<{ key: string }>();
+    return { result: initData.key };
+  },
+});
+
+// Should NOT transform - different function name
+const step5 = createStep({
+  id: 'step-5',
+  execute: async ({ getStepResult }) => {
+    const result = getStepResult('other-step');
+    return { result };
+  },
+});
+
+// Should NOT transform - getInitData as a variable assignment (not a call)
+const getInitDataAlias = (fn: () => any) => fn;

--- a/packages/codemod/src/test/workflow-get-init-data.test.ts
+++ b/packages/codemod/src/test/workflow-get-init-data.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from 'vitest';
+import transformer from '../codemods/v1/workflow-get-init-data';
+import { testTransform } from './test-utils';
+
+describe('workflow-get-init-data', () => {
+  it('transforms correctly', () => {
+    testTransform(transformer, 'workflow-get-init-data');
+  });
+});


### PR DESCRIPTION
## Summary

- Added `workflow-get-init-data` codemod that transforms `getInitData()` calls to `getInitData<any>()`
- Updated documentation to use the new `getInitData<any>()` syntax
- Added migration guide section for the `getInitData` return type change

## Details

The `getInitData` function return type changed from `any` to `unknown`. This codemod helps users migrate their code by adding an explicit `<any>` type parameter to restore the previous behavior.

### Codemod transformation:

**Before:**
```typescript
createStep({
  execute: async ({ getInitData }) => {
    const initData = getInitData();
    if (initData.key === 'value') {}
  },
});
```

**After:**
```typescript
createStep({
  execute: async ({ getInitData }) => {
    const initData = getInitData<any>();
    if (initData.key === 'value') {}
  },
});
```

### Usage:
```bash
npx @mastra/codemod@latest v1/workflow-get-init-data .
```

## Test Plan

- [x] Added unit tests for the codemod
- [x] All existing codemod tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new codemod tool to automatically transform `getInitData()` calls to the properly typed format.

* **Documentation**
  * Updated API reference and migration documentation across workflow guides to reflect updated `getInitData()` usage patterns, including before and after examples and codemod guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->