### PR TITLE
add docs on pool and update

### DIFF
--- a/docs/src/content/en/reference/storage/postgresql.mdx
+++ b/docs/src/content/en/reference/storage/postgresql.mdx
@@ -43,14 +43,63 @@ const storage = new PostgresStore({
       name: "connectionString",
       type: "string",
       description:
-        "PostgreSQL connection string (e.g., postgresql://user:pass@host:5432/dbname)",
-      isOptional: false,
+        "PostgreSQL connection string (e.g., postgresql://user:pass@host:5432/dbname). Required unless using `pool` or host-based config.",
+      isOptional: true,
+    },
+    {
+      name: "pool",
+      type: "pg.Pool",
+      description:
+        "Pre-configured pg.Pool instance. Use this to reuse an existing connection pool. When provided, Mastra will not create its own pool and will not close it when `store.close()` is called.",
+      isOptional: true,
     },
     {
       name: "schemaName",
       type: "string",
       description:
-        "The name of the schema you want the storage to use. Will use the default schema if not provided.",
+        "The name of the schema you want the storage to use. Defaults to 'public'.",
+      isOptional: true,
+    },
+    {
+      name: "ssl",
+      type: "boolean | ConnectionOptions",
+      description:
+        "SSL configuration for the connection. Can be `true` for default SSL, or a ConnectionOptions object for custom SSL settings.",
+      isOptional: true,
+    },
+    {
+      name: "max",
+      type: "number",
+      description:
+        "Maximum number of connections in the pool. Defaults to 20.",
+      isOptional: true,
+    },
+    {
+      name: "idleTimeoutMillis",
+      type: "number",
+      description:
+        "How long a connection can sit idle before being closed. Defaults to 30000 (30 seconds).",
+      isOptional: true,
+    },
+    {
+      name: "disableInit",
+      type: "boolean",
+      description:
+        "When true, automatic table creation/migrations are disabled. Useful for CI/CD pipelines where migrations are run separately.",
+      isOptional: true,
+    },
+    {
+      name: "skipDefaultIndexes",
+      type: "boolean",
+      description:
+        "When true, default indexes will not be created during initialization.",
+      isOptional: true,
+    },
+    {
+      name: "indexes",
+      type: "CreateIndexOptions[]",
+      description:
+        "Custom indexes to create during initialization.",
       isOptional: true,
     },
   ]}
@@ -62,22 +111,26 @@ You can instantiate `PostgresStore` in the following ways:
 
 ```ts
 import { PostgresStore } from "@mastra/pg";
+import { Pool } from "pg";
 
-// Using a connection string only
+// Using a connection string
 const store1 = new PostgresStore({
   id: 'pg-storage-1',
   connectionString: "postgresql://user:password@localhost:5432/mydb",
 });
 
-// Using a connection string with a custom schema name
+// Using a connection string with pool options
 const store2 = new PostgresStore({
   id: 'pg-storage-2',
   connectionString: "postgresql://user:password@localhost:5432/mydb",
-  schemaName: "custom_schema", // optional
+  schemaName: "custom_schema",
+  max: 30,                    // Max pool connections
+  idleTimeoutMillis: 60000,   // Idle timeout
+  ssl: { rejectUnauthorized: false },
 });
 
 // Using individual connection parameters
-const store4 = new PostgresStore({
+const store3 = new PostgresStore({
   id: 'pg-storage-3',
   host: "localhost",
   port: 5432,
@@ -86,14 +139,16 @@ const store4 = new PostgresStore({
   password: "password",
 });
 
-// Individual parameters with schemaName
-const store5 = new PostgresStore({
+// Using a pre-configured pg.Pool (recommended for pool reuse)
+const existingPool = new Pool({
+  connectionString: "postgresql://user:password@localhost:5432/mydb",
+  max: 20,
+  // ... your custom pool configuration
+});
+
+const store4 = new PostgresStore({
   id: 'pg-storage-4',
-  host: "localhost",
-  port: 5432,
-  database: "mydb",
-  user: "user",
-  password: "password",
+  pool: existingPool,
   schemaName: "custom_schema", // optional
 });
 ```
@@ -152,19 +207,74 @@ const thread = await memoryStore?.getThreadById({ threadId: "..." });
 If `init()` is not called, tables won't be created and storage operations will fail silently or throw errors.
 :::
 
-### Direct Database and Pool Access
+### Using an Existing Pool
 
-`PostgresStore` exposes both the underlying database object and the pg-promise instance as public fields:
+If you already have a `pg.Pool` in your application (e.g., shared with an ORM or for Row Level Security), you can pass it directly to `PostgresStore`:
 
 ```typescript
-store.db; // pg-promise database instance
-store.pgp; // pg-promise main instance
+import { Pool } from "pg";
+import { PostgresStore } from "@mastra/pg";
+
+// Your existing pool (shared across your application)
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  max: 20,
+});
+
+const storage = new PostgresStore({
+  id: "shared-storage",
+  pool: pool,
+});
 ```
 
-This enables direct queries and custom transaction management. When using these fields:
+**Pool lifecycle behavior:**
+
+- When you **provide a pool**: Mastra uses your pool but does **not** close it when `store.close()` is called. You manage the pool lifecycle.
+- When Mastra **creates a pool**: Mastra owns the pool and will close it when `store.close()` is called.
+
+### Direct Database and Pool Access
+
+`PostgresStore` exposes the underlying database client and pool for advanced use cases:
+
+```typescript
+store.db;   // DbClient - query interface with helpers (any, one, tx, etc.)
+store.pool; // pg.Pool - the underlying connection pool
+```
+
+**Using `store.db` for queries:**
+
+```typescript
+// Execute queries with helper methods
+const users = await store.db.any("SELECT * FROM users WHERE active = $1", [true]);
+const user = await store.db.one("SELECT * FROM users WHERE id = $1", [userId]);
+const maybeUser = await store.db.oneOrNone("SELECT * FROM users WHERE email = $1", [email]);
+
+// Use transactions
+const result = await store.db.tx(async (t) => {
+  await t.none("INSERT INTO logs (message) VALUES ($1)", ["Started"]);
+  const data = await t.any("SELECT * FROM items");
+  return data;
+});
+```
+
+**Using `store.pool` directly:**
+
+```typescript
+// Get a client for manual connection management
+const client = await store.pool.connect();
+try {
+  await client.query("SET LOCAL app.user_id = $1", [userId]);
+  const result = await client.query("SELECT * FROM protected_table");
+  return result.rows;
+} finally {
+  client.release();
+}
+```
+
+When using these fields:
 
 - You are responsible for proper connection and transaction handling.
-- Closing the store (`store.close()`) will destroy the associated connection pool.
+- Closing the store (`store.close()`) will destroy the pool only if Mastra created it.
 - Direct access bypasses any additional logic or validation provided by PostgresStore methods.
 
 This approach is intended for advanced scenarios where low-level access is required.

--- a/docs/src/content/en/reference/storage/postgresql.mdx
+++ b/docs/src/content/en/reference/storage/postgresql.mdx
@@ -43,7 +43,42 @@ const storage = new PostgresStore({
       name: "connectionString",
       type: "string",
       description:
-        "PostgreSQL connection string (e.g., postgresql://user:pass@host:5432/dbname). Required unless using `pool` or host-based config.",
+        "PostgreSQL connection string (e.g., postgresql://user:pass@host:5432/dbname). Required unless using `pool` or individual host-based parameters (`host`, `port`, `database`, `user`, `password`).",
+      isOptional: true,
+    },
+    {
+      name: "host",
+      type: "string",
+      description:
+        "Database server hostname or IP address. Used with other host-based parameters as an alternative to connectionString.",
+      isOptional: true,
+    },
+    {
+      name: "port",
+      type: "number",
+      description:
+        "Database server port number. Defaults to 5432 if not specified.",
+      isOptional: true,
+    },
+    {
+      name: "database",
+      type: "string",
+      description:
+        "Name of the database to connect to.",
+      isOptional: true,
+    },
+    {
+      name: "user",
+      type: "string",
+      description:
+        "Database user for authentication.",
+      isOptional: true,
+    },
+    {
+      name: "password",
+      type: "string",
+      description:
+        "Password for the database user.",
       isOptional: true,
     },
     {
@@ -64,7 +99,7 @@ const storage = new PostgresStore({
       name: "ssl",
       type: "boolean | ConnectionOptions",
       description:
-        "SSL configuration for the connection. Can be `true` for default SSL, or a ConnectionOptions object for custom SSL settings.",
+        "SSL configuration for the connection; set to true to use default SSL or provide a ConnectionOptions object for custom SSL settings.",
       isOptional: true,
     },
     {


### PR DESCRIPTION
## Description

Improved PostgreSQL storage documentation to better document pool configuration options. Added:
- `pool` parameter for passing a pre-configured `pg.Pool` instance
- Additional parameters: `ssl`, `max`, `idleTimeoutMillis`, `disableInit`, `skipDefaultIndexes`, `indexes`
- New "Using an Existing Pool" section explaining pool lifecycle behavior
- Updated "Direct Database and Pool Access" section with correct API (`store.db` and `store.pool`)
- Constructor examples showing pool reuse pattern

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added PostgreSQL configuration options: pool, ssl, max, idleTimeoutMillis, disableInit, skipDefaultIndexes, and indexes.
  * Clarified connectionString is optional when using a pool or host-based config; schemaName defaults to "public" and is optional.
  * Expanded guidance and examples for direct DB and pool access (store.db, store.pool), pool lifecycle behavior, using an existing Pool, queries/transactions, and manual connection management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->