### PR TITLE
fix(server): correct route prefix behavior to avoid double /api paths

### DIFF
--- a/.changeset/twelve-groups-rest.md
+++ b/.changeset/twelve-groups-rest.md
@@ -1,0 +1,9 @@
+---
+'@mastra/express': patch
+'@mastra/fastify': patch
+'@mastra/hono': patch
+'@mastra/koa': patch
+'@mastra/server': patch
+---
+
+Fixed route prefix behavior to correctly replace the default /api prefix instead of prepending to it. Previously, setting prefix: '/api/v2' resulted in routes at /api/v2/api/agents. Now routes correctly appear at /api/v2/agents as documented.

--- a/packages/server/src/server/handlers/agent-builder.ts
+++ b/packages/server/src/server/handlers/agent-builder.ts
@@ -508,7 +508,7 @@ export const STREAM_LEGACY_AGENT_BUILDER_ACTION_ROUTE = createRoute({
   responseSchema: streamResponseSchema,
   summary: '[DEPRECATED] Stream agent-builder action with legacy format',
   description:
-    'Legacy endpoint for streaming agent-builder action execution. Use /api/agent-builder/:actionId/stream instead.',
+    'Legacy endpoint for streaming agent-builder action execution. Use /agent-builder/:actionId/stream instead.',
   tags: ['Agent Builder', 'Legacy'],
   requiresAuth: true,
   handler: async ctx => {
@@ -546,7 +546,7 @@ export const OBSERVE_STREAM_LEGACY_AGENT_BUILDER_ACTION_ROUTE = createRoute({
   responseSchema: streamResponseSchema,
   summary: '[DEPRECATED] Observe agent-builder action stream with legacy format',
   description:
-    'Legacy endpoint for observing agent-builder action stream. Use /api/agent-builder/:actionId/observe instead.',
+    'Legacy endpoint for observing agent-builder action stream. Use /agent-builder/:actionId/observe instead.',
   tags: ['Agent Builder', 'Legacy'],
   requiresAuth: true,
   handler: async ctx => {

--- a/packages/server/src/server/handlers/agent-builder.ts
+++ b/packages/server/src/server/handlers/agent-builder.ts
@@ -30,7 +30,7 @@ import * as workflows from './workflows';
 
 export const LIST_AGENT_BUILDER_ACTIONS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/agent-builder',
+  path: '/agent-builder',
   responseType: 'json',
   responseSchema: listWorkflowsResponseSchema,
   summary: 'List agent-builder actions',
@@ -57,7 +57,7 @@ export const LIST_AGENT_BUILDER_ACTIONS_ROUTE = createRoute({
 
 export const GET_AGENT_BUILDER_ACTION_BY_ID_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/agent-builder/:actionId',
+  path: '/agent-builder/:actionId',
   responseType: 'json',
   pathParamSchema: actionIdPathParams,
   responseSchema: workflowInfoSchema,
@@ -91,7 +91,7 @@ export const GET_AGENT_BUILDER_ACTION_BY_ID_ROUTE = createRoute({
 
 export const LIST_AGENT_BUILDER_ACTION_RUNS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/agent-builder/:actionId/runs',
+  path: '/agent-builder/:actionId/runs',
   responseType: 'json',
   pathParamSchema: actionIdPathParams,
   queryParamSchema: listWorkflowRunsQuerySchema,
@@ -127,7 +127,7 @@ export const LIST_AGENT_BUILDER_ACTION_RUNS_ROUTE = createRoute({
 
 export const GET_AGENT_BUILDER_ACTION_RUN_BY_ID_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/agent-builder/:actionId/runs/:runId',
+  path: '/agent-builder/:actionId/runs/:runId',
   responseType: 'json',
   pathParamSchema: actionRunPathParams,
   queryParamSchema: workflowRunResultQuerySchema,
@@ -164,7 +164,7 @@ export const GET_AGENT_BUILDER_ACTION_RUN_BY_ID_ROUTE = createRoute({
 
 export const CREATE_AGENT_BUILDER_ACTION_RUN_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agent-builder/:actionId/create-run',
+  path: '/agent-builder/:actionId/create-run',
   responseType: 'json',
   pathParamSchema: actionIdPathParams,
   queryParamSchema: optionalRunIdSchema,
@@ -200,7 +200,7 @@ export const CREATE_AGENT_BUILDER_ACTION_RUN_ROUTE = createRoute({
 
 export const STREAM_AGENT_BUILDER_ACTION_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agent-builder/:actionId/stream',
+  path: '/agent-builder/:actionId/stream',
   responseType: 'stream',
   pathParamSchema: actionIdPathParams,
   queryParamSchema: runIdSchema,
@@ -238,7 +238,7 @@ export const STREAM_AGENT_BUILDER_ACTION_ROUTE = createRoute({
 
 export const START_ASYNC_AGENT_BUILDER_ACTION_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agent-builder/:actionId/start-async',
+  path: '/agent-builder/:actionId/start-async',
   responseType: 'json',
   pathParamSchema: actionIdPathParams,
   queryParamSchema: optionalRunIdSchema,
@@ -276,7 +276,7 @@ export const START_ASYNC_AGENT_BUILDER_ACTION_ROUTE = createRoute({
 
 export const START_AGENT_BUILDER_ACTION_RUN_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agent-builder/:actionId/start',
+  path: '/agent-builder/:actionId/start',
   responseType: 'json',
   pathParamSchema: actionIdPathParams,
   queryParamSchema: runIdSchema,
@@ -314,7 +314,7 @@ export const START_AGENT_BUILDER_ACTION_RUN_ROUTE = createRoute({
 
 export const OBSERVE_STREAM_AGENT_BUILDER_ACTION_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agent-builder/:actionId/observe',
+  path: '/agent-builder/:actionId/observe',
   responseType: 'stream',
   pathParamSchema: actionIdPathParams,
   queryParamSchema: runIdSchema,
@@ -350,7 +350,7 @@ export const OBSERVE_STREAM_AGENT_BUILDER_ACTION_ROUTE = createRoute({
 
 export const RESUME_ASYNC_AGENT_BUILDER_ACTION_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agent-builder/:actionId/resume-async',
+  path: '/agent-builder/:actionId/resume-async',
   responseType: 'json',
   pathParamSchema: actionIdPathParams,
   queryParamSchema: runIdSchema,
@@ -388,7 +388,7 @@ export const RESUME_ASYNC_AGENT_BUILDER_ACTION_ROUTE = createRoute({
 
 export const RESUME_AGENT_BUILDER_ACTION_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agent-builder/:actionId/resume',
+  path: '/agent-builder/:actionId/resume',
   responseType: 'json',
   pathParamSchema: actionIdPathParams,
   queryParamSchema: runIdSchema,
@@ -426,7 +426,7 @@ export const RESUME_AGENT_BUILDER_ACTION_ROUTE = createRoute({
 
 export const RESUME_STREAM_AGENT_BUILDER_ACTION_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agent-builder/:actionId/resume-stream',
+  path: '/agent-builder/:actionId/resume-stream',
   responseType: 'stream',
   pathParamSchema: actionIdPathParams,
   queryParamSchema: runIdSchema,
@@ -464,7 +464,7 @@ export const RESUME_STREAM_AGENT_BUILDER_ACTION_ROUTE = createRoute({
 
 export const CANCEL_AGENT_BUILDER_ACTION_RUN_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agent-builder/:actionId/runs/:runId/cancel',
+  path: '/agent-builder/:actionId/runs/:runId/cancel',
   responseType: 'json',
   pathParamSchema: actionRunPathParams,
   responseSchema: workflowControlResponseSchema,
@@ -500,7 +500,7 @@ export const CANCEL_AGENT_BUILDER_ACTION_RUN_ROUTE = createRoute({
 // Legacy routes (deprecated)
 export const STREAM_LEGACY_AGENT_BUILDER_ACTION_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agent-builder/:actionId/stream-legacy',
+  path: '/agent-builder/:actionId/stream-legacy',
   responseType: 'stream',
   pathParamSchema: actionIdPathParams,
   queryParamSchema: runIdSchema,
@@ -539,7 +539,7 @@ export const STREAM_LEGACY_AGENT_BUILDER_ACTION_ROUTE = createRoute({
 
 export const OBSERVE_STREAM_LEGACY_AGENT_BUILDER_ACTION_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agent-builder/:actionId/observe-stream-legacy',
+  path: '/agent-builder/:actionId/observe-stream-legacy',
   responseType: 'stream',
   pathParamSchema: actionIdPathParams,
   queryParamSchema: runIdSchema,

--- a/packages/server/src/server/handlers/agent-versions.ts
+++ b/packages/server/src/server/handlers/agent-versions.ts
@@ -326,7 +326,7 @@ export async function handleAutoVersioning<TAgent>(
  */
 export const LIST_AGENT_VERSIONS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/stored/agents/:agentId/versions',
+  path: '/stored/agents/:agentId/versions',
   responseType: 'json',
   pathParamSchema: agentVersionPathParams,
   queryParamSchema: listVersionsQuerySchema,
@@ -372,7 +372,7 @@ export const LIST_AGENT_VERSIONS_ROUTE = createRoute({
  */
 export const CREATE_AGENT_VERSION_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/stored/agents/:agentId/versions',
+  path: '/stored/agents/:agentId/versions',
   responseType: 'json',
   pathParamSchema: agentVersionPathParams,
   bodySchema: createVersionBodySchema,
@@ -436,7 +436,7 @@ export const CREATE_AGENT_VERSION_ROUTE = createRoute({
  */
 export const GET_AGENT_VERSION_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/stored/agents/:agentId/versions/:versionId',
+  path: '/stored/agents/:agentId/versions/:versionId',
   responseType: 'json',
   pathParamSchema: versionIdPathParams,
   responseSchema: getVersionResponseSchema,
@@ -479,7 +479,7 @@ export const GET_AGENT_VERSION_ROUTE = createRoute({
  */
 export const ACTIVATE_AGENT_VERSION_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/stored/agents/:agentId/versions/:versionId/activate',
+  path: '/stored/agents/:agentId/versions/:versionId/activate',
   responseType: 'json',
   pathParamSchema: versionIdPathParams,
   responseSchema: activateVersionResponseSchema,
@@ -536,7 +536,7 @@ export const ACTIVATE_AGENT_VERSION_ROUTE = createRoute({
  */
 export const RESTORE_AGENT_VERSION_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/stored/agents/:agentId/versions/:versionId/restore',
+  path: '/stored/agents/:agentId/versions/:versionId/restore',
   responseType: 'json',
   pathParamSchema: versionIdPathParams,
   responseSchema: restoreVersionResponseSchema,
@@ -638,7 +638,7 @@ export const RESTORE_AGENT_VERSION_ROUTE = createRoute({
  */
 export const DELETE_AGENT_VERSION_ROUTE = createRoute({
   method: 'DELETE',
-  path: '/api/stored/agents/:agentId/versions/:versionId',
+  path: '/stored/agents/:agentId/versions/:versionId',
   responseType: 'json',
   pathParamSchema: versionIdPathParams,
   responseSchema: deleteVersionResponseSchema,
@@ -697,7 +697,7 @@ export const DELETE_AGENT_VERSION_ROUTE = createRoute({
  */
 export const COMPARE_AGENT_VERSIONS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/stored/agents/:agentId/versions/compare',
+  path: '/stored/agents/:agentId/versions/compare',
   responseType: 'json',
   pathParamSchema: agentVersionPathParams,
   queryParamSchema: compareVersionsQuerySchema,

--- a/packages/server/src/server/handlers/agent-versions.ts
+++ b/packages/server/src/server/handlers/agent-versions.ts
@@ -322,7 +322,7 @@ export async function handleAutoVersioning<TAgent>(
 // ============================================================================
 
 /**
- * GET /api/stored/agents/:agentId/versions - List all versions for an agent
+ * GET /stored/agents/:agentId/versions - List all versions for an agent
  */
 export const LIST_AGENT_VERSIONS_ROUTE = createRoute({
   method: 'GET',
@@ -368,7 +368,7 @@ export const LIST_AGENT_VERSIONS_ROUTE = createRoute({
 });
 
 /**
- * POST /api/stored/agents/:agentId/versions - Create a new version snapshot
+ * POST /stored/agents/:agentId/versions - Create a new version snapshot
  */
 export const CREATE_AGENT_VERSION_ROUTE = createRoute({
   method: 'POST',
@@ -432,7 +432,7 @@ export const CREATE_AGENT_VERSION_ROUTE = createRoute({
 });
 
 /**
- * GET /api/stored/agents/:agentId/versions/:versionId - Get a specific version
+ * GET /stored/agents/:agentId/versions/:versionId - Get a specific version
  */
 export const GET_AGENT_VERSION_ROUTE = createRoute({
   method: 'GET',
@@ -475,7 +475,7 @@ export const GET_AGENT_VERSION_ROUTE = createRoute({
 });
 
 /**
- * POST /api/stored/agents/:agentId/versions/:versionId/activate - Set a version as active
+ * POST /stored/agents/:agentId/versions/:versionId/activate - Set a version as active
  */
 export const ACTIVATE_AGENT_VERSION_ROUTE = createRoute({
   method: 'POST',
@@ -532,7 +532,7 @@ export const ACTIVATE_AGENT_VERSION_ROUTE = createRoute({
 });
 
 /**
- * POST /api/stored/agents/:agentId/versions/:versionId/restore - Restore agent to a version
+ * POST /stored/agents/:agentId/versions/:versionId/restore - Restore agent to a version
  */
 export const RESTORE_AGENT_VERSION_ROUTE = createRoute({
   method: 'POST',
@@ -634,7 +634,7 @@ export const RESTORE_AGENT_VERSION_ROUTE = createRoute({
 });
 
 /**
- * DELETE /api/stored/agents/:agentId/versions/:versionId - Delete a version
+ * DELETE /stored/agents/:agentId/versions/:versionId - Delete a version
  */
 export const DELETE_AGENT_VERSION_ROUTE = createRoute({
   method: 'DELETE',
@@ -693,7 +693,7 @@ export const DELETE_AGENT_VERSION_ROUTE = createRoute({
 });
 
 /**
- * GET /api/stored/agents/:agentId/versions/compare - Compare two versions
+ * GET /stored/agents/:agentId/versions/compare - Compare two versions
  */
 export const COMPARE_AGENT_VERSIONS_ROUTE = createRoute({
   method: 'GET',

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -494,7 +494,7 @@ async function formatAgent({
 
 export const LIST_AGENTS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/agents',
+  path: '/agents',
   responseType: 'json',
   queryParamSchema: z.object({
     partial: z.string().optional(),
@@ -565,7 +565,7 @@ export const LIST_AGENTS_ROUTE = createRoute({
 
 export const GET_AGENT_BY_ID_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/agents/:agentId',
+  path: '/agents/:agentId',
   responseType: 'json',
   pathParamSchema: agentIdPathParams,
   responseSchema: serializedAgentSchema,
@@ -595,7 +595,7 @@ export const GENERATE_AGENT_ROUTE: ServerRoute<
   unknown
 > = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/generate',
+  path: '/agents/:agentId/generate',
   responseType: 'json',
   pathParamSchema: agentIdPathParams,
   bodySchema: agentExecutionBodySchema,
@@ -631,7 +631,7 @@ export const GENERATE_AGENT_ROUTE: ServerRoute<
 // Legacy routes (deprecated)
 export const GENERATE_LEGACY_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/generate-legacy',
+  path: '/agents/:agentId/generate-legacy',
   responseType: 'json' as const,
   pathParamSchema: agentIdPathParams,
   bodySchema: agentExecutionLegacyBodySchema,
@@ -674,7 +674,7 @@ export const GENERATE_LEGACY_ROUTE = createRoute({
 
 export const STREAM_GENERATE_LEGACY_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/stream-legacy',
+  path: '/agents/:agentId/stream-legacy',
   responseType: 'datastream-response' as const,
   pathParamSchema: agentIdPathParams,
   bodySchema: agentExecutionLegacyBodySchema,
@@ -734,7 +734,7 @@ export const STREAM_GENERATE_LEGACY_ROUTE = createRoute({
 
 export const GET_PROVIDERS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/agents/providers',
+  path: '/agents/providers',
   responseType: 'json',
   responseSchema: providersResponseSchema,
   summary: 'List AI providers',
@@ -767,7 +767,7 @@ export const GENERATE_AGENT_VNEXT_ROUTE: ServerRoute<
   unknown
 > = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/generate/vnext',
+  path: '/agents/:agentId/generate/vnext',
   responseType: 'json',
   pathParamSchema: agentIdPathParams,
   bodySchema: agentExecutionBodySchema,
@@ -781,7 +781,7 @@ export const GENERATE_AGENT_VNEXT_ROUTE: ServerRoute<
 
 export const STREAM_GENERATE_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/stream',
+  path: '/agents/:agentId/stream',
   responseType: 'stream' as const,
   streamFormat: 'sse' as const,
   pathParamSchema: agentIdPathParams,
@@ -816,7 +816,7 @@ export const STREAM_GENERATE_ROUTE = createRoute({
 
 export const STREAM_GENERATE_VNEXT_DEPRECATED_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/stream/vnext',
+  path: '/agents/:agentId/stream/vnext',
   responseType: 'stream',
   pathParamSchema: agentIdPathParams,
   bodySchema: agentExecutionBodySchema,
@@ -831,7 +831,7 @@ export const STREAM_GENERATE_VNEXT_DEPRECATED_ROUTE = createRoute({
 
 export const APPROVE_TOOL_CALL_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/approve-tool-call',
+  path: '/agents/:agentId/approve-tool-call',
   responseType: 'stream' as const,
   streamFormat: 'sse' as const,
   pathParamSchema: agentIdPathParams,
@@ -871,7 +871,7 @@ export const APPROVE_TOOL_CALL_ROUTE = createRoute({
 
 export const DECLINE_TOOL_CALL_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/decline-tool-call',
+  path: '/agents/:agentId/decline-tool-call',
   responseType: 'stream' as const,
   streamFormat: 'sse' as const,
   pathParamSchema: agentIdPathParams,
@@ -911,7 +911,7 @@ export const DECLINE_TOOL_CALL_ROUTE = createRoute({
 
 export const APPROVE_TOOL_CALL_GENERATE_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/approve-tool-call-generate',
+  path: '/agents/:agentId/approve-tool-call-generate',
   responseType: 'json' as const,
   pathParamSchema: agentIdPathParams,
   bodySchema: approveToolCallBodySchema,
@@ -950,7 +950,7 @@ export const APPROVE_TOOL_CALL_GENERATE_ROUTE = createRoute({
 
 export const DECLINE_TOOL_CALL_GENERATE_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/decline-tool-call-generate',
+  path: '/agents/:agentId/decline-tool-call-generate',
   responseType: 'json' as const,
   pathParamSchema: agentIdPathParams,
   bodySchema: declineToolCallBodySchema,
@@ -989,7 +989,7 @@ export const DECLINE_TOOL_CALL_GENERATE_ROUTE = createRoute({
 
 export const STREAM_NETWORK_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/network',
+  path: '/agents/:agentId/network',
   responseType: 'stream' as const,
   streamFormat: 'sse' as const,
   pathParamSchema: agentIdPathParams,
@@ -1022,7 +1022,7 @@ export const STREAM_NETWORK_ROUTE = createRoute({
 
 export const APPROVE_NETWORK_TOOL_CALL_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/approve-network-tool-call',
+  path: '/agents/:agentId/approve-network-tool-call',
   responseType: 'stream' as const,
   streamFormat: 'sse' as const,
   pathParamSchema: agentIdPathParams,
@@ -1057,7 +1057,7 @@ export const APPROVE_NETWORK_TOOL_CALL_ROUTE = createRoute({
 
 export const DECLINE_NETWORK_TOOL_CALL_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/decline-network-tool-call',
+  path: '/agents/:agentId/decline-network-tool-call',
   responseType: 'stream' as const,
   streamFormat: 'sse' as const,
   pathParamSchema: agentIdPathParams,
@@ -1092,7 +1092,7 @@ export const DECLINE_NETWORK_TOOL_CALL_ROUTE = createRoute({
 
 export const UPDATE_AGENT_MODEL_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/model',
+  path: '/agents/:agentId/model',
   responseType: 'json',
   pathParamSchema: agentIdPathParams,
   bodySchema: updateAgentModelBodySchema,
@@ -1122,7 +1122,7 @@ export const UPDATE_AGENT_MODEL_ROUTE = createRoute({
 
 export const RESET_AGENT_MODEL_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/model/reset',
+  path: '/agents/:agentId/model/reset',
   responseType: 'json',
   pathParamSchema: agentIdPathParams,
   responseSchema: modelManagementResponseSchema,
@@ -1145,7 +1145,7 @@ export const RESET_AGENT_MODEL_ROUTE = createRoute({
 
 export const REORDER_AGENT_MODEL_LIST_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/models/reorder',
+  path: '/agents/:agentId/models/reorder',
   responseType: 'json',
   pathParamSchema: agentIdPathParams,
   bodySchema: reorderAgentModelListBodySchema,
@@ -1174,7 +1174,7 @@ export const REORDER_AGENT_MODEL_LIST_ROUTE = createRoute({
 
 export const UPDATE_AGENT_MODEL_IN_MODEL_LIST_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/models/:modelConfigId',
+  path: '/agents/:agentId/models/:modelConfigId',
   responseType: 'json',
   pathParamSchema: modelConfigIdPathParams,
   bodySchema: updateAgentModelInModelListBodySchema,
@@ -1296,7 +1296,7 @@ type EnhanceInstructionsResponse = z.infer<typeof enhanceInstructionsResponseSch
 
 export const ENHANCE_INSTRUCTIONS_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/instructions/enhance',
+  path: '/agents/:agentId/instructions/enhance',
   responseType: 'json',
   pathParamSchema: agentIdPathParams,
   bodySchema: enhanceInstructionsBodySchema,
@@ -1345,7 +1345,7 @@ ${comment ? `User feedback: ${comment}` : ''}`,
 
 export const STREAM_VNEXT_DEPRECATED_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/streamVNext',
+  path: '/agents/:agentId/streamVNext',
   responseType: 'stream',
   pathParamSchema: agentIdPathParams,
   bodySchema: agentExecutionBodySchema,
@@ -1362,7 +1362,7 @@ export const STREAM_VNEXT_DEPRECATED_ROUTE = createRoute({
 
 export const STREAM_UI_MESSAGE_VNEXT_DEPRECATED_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/stream/vnext/ui',
+  path: '/agents/:agentId/stream/vnext/ui',
   responseType: 'stream',
   pathParamSchema: agentIdPathParams,
   bodySchema: agentExecutionBodySchema,
@@ -1389,7 +1389,7 @@ export const STREAM_UI_MESSAGE_VNEXT_DEPRECATED_ROUTE = createRoute({
 
 export const STREAM_UI_MESSAGE_DEPRECATED_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/stream/ui',
+  path: '/agents/:agentId/stream/ui',
   responseType: 'stream',
   pathParamSchema: agentIdPathParams,
   bodySchema: agentExecutionBodySchema,

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -637,7 +637,7 @@ export const GENERATE_LEGACY_ROUTE = createRoute({
   bodySchema: agentExecutionLegacyBodySchema,
   responseSchema: generateResponseSchema,
   summary: '[DEPRECATED] Generate with legacy format',
-  description: 'Legacy endpoint for generating agent responses. Use /api/agents/:agentId/generate instead.',
+  description: 'Legacy endpoint for generating agent responses. Use /agents/:agentId/generate instead.',
   tags: ['Agents', 'Legacy'],
   requiresAuth: true,
   handler: async ({ mastra, agentId, abortSignal, ...params }) => {
@@ -680,7 +680,7 @@ export const STREAM_GENERATE_LEGACY_ROUTE = createRoute({
   bodySchema: agentExecutionLegacyBodySchema,
   responseSchema: streamResponseSchema,
   summary: '[DEPRECATED] Stream with legacy format',
-  description: 'Legacy endpoint for streaming agent responses. Use /api/agents/:agentId/stream instead.',
+  description: 'Legacy endpoint for streaming agent responses. Use /agents/:agentId/stream instead.',
   tags: ['Agents', 'Legacy'],
   requiresAuth: true,
   handler: async ({ mastra, agentId, abortSignal, ...params }) => {

--- a/packages/server/src/server/handlers/logs.ts
+++ b/packages/server/src/server/handlers/logs.ts
@@ -10,7 +10,7 @@ import { parseFilters, validateBody } from './utils';
 
 export const LIST_LOG_TRANSPORTS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/logs/transports',
+  path: '/logs/transports',
   responseType: 'json',
   responseSchema: listLogTransportsResponseSchema,
   summary: 'List log transports',
@@ -33,7 +33,7 @@ export const LIST_LOG_TRANSPORTS_ROUTE = createRoute({
 
 export const LIST_LOGS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/logs',
+  path: '/logs',
   responseType: 'json',
   queryParamSchema: listLogsQuerySchema,
   responseSchema: listLogsResponseSchema,
@@ -68,7 +68,7 @@ export const LIST_LOGS_ROUTE = createRoute({
 
 export const LIST_LOGS_BY_RUN_ID_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/logs/:runId',
+  path: '/logs/:runId',
   responseType: 'json',
   pathParamSchema: runIdSchema,
   queryParamSchema: listLogsQuerySchema,

--- a/packages/server/src/server/handlers/mcp.test.ts
+++ b/packages/server/src/server/handlers/mcp.test.ts
@@ -158,7 +158,7 @@ describe('MCP Registry Handlers', () => {
         page: 0,
       });
 
-      expect(result.next).toBe('/api/mcp/v0/servers?perPage=1&page=1');
+      expect(result.next).toBe('/mcp/v0/servers?perPage=1&page=1');
     });
 
     it('should return null for next when no more results', async () => {

--- a/packages/server/src/server/handlers/mcp.ts
+++ b/packages/server/src/server/handlers/mcp.ts
@@ -22,7 +22,7 @@ import { createRoute } from '../server-adapter/routes/route-builder';
 
 export const LIST_MCP_SERVERS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/mcp/v0/servers',
+  path: '/mcp/v0/servers',
   responseType: 'json',
   queryParamSchema: listMcpServersQuerySchema,
   responseSchema: listMcpServersResponseSchema,
@@ -99,7 +99,7 @@ export const LIST_MCP_SERVERS_ROUTE = createRoute({
 
 export const GET_MCP_SERVER_DETAIL_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/mcp/v0/servers/:id',
+  path: '/mcp/v0/servers/:id',
   responseType: 'json',
   pathParamSchema: mcpServerDetailPathParams,
   queryParamSchema: getMcpServerDetailQuerySchema,
@@ -134,7 +134,7 @@ export const GET_MCP_SERVER_DETAIL_ROUTE = createRoute({
 
 export const LIST_MCP_SERVER_TOOLS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/mcp/:serverId/tools',
+  path: '/mcp/:serverId/tools',
   responseType: 'json',
   pathParamSchema: mcpServerIdPathParams,
   responseSchema: listMcpServerToolsResponseSchema,
@@ -163,7 +163,7 @@ export const LIST_MCP_SERVER_TOOLS_ROUTE = createRoute({
 
 export const GET_MCP_SERVER_TOOL_DETAIL_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/mcp/:serverId/tools/:toolId',
+  path: '/mcp/:serverId/tools/:toolId',
   responseType: 'json',
   pathParamSchema: mcpServerToolPathParams,
   responseSchema: mcpToolInfoSchema,
@@ -197,7 +197,7 @@ export const GET_MCP_SERVER_TOOL_DETAIL_ROUTE = createRoute({
 
 export const EXECUTE_MCP_SERVER_TOOL_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/mcp/:serverId/tools/:toolId/execute',
+  path: '/mcp/:serverId/tools/:toolId/execute',
   responseType: 'json',
   pathParamSchema: mcpServerToolPathParams,
   bodySchema: executeToolBodySchema,
@@ -256,7 +256,7 @@ export interface MCPSseTransportResult {
 
 export const MCP_HTTP_TRANSPORT_ROUTE = createRoute({
   method: 'ALL',
-  path: '/api/mcp/:serverId/mcp',
+  path: '/mcp/:serverId/mcp',
   responseType: 'mcp-http',
   pathParamSchema: mcpServerIdPathParams,
   summary: 'MCP HTTP Transport',
@@ -283,7 +283,7 @@ export const MCP_HTTP_TRANSPORT_ROUTE = createRoute({
 
 export const MCP_SSE_TRANSPORT_ROUTE = createRoute({
   method: 'ALL',
-  path: '/api/mcp/:serverId/sse',
+  path: '/mcp/:serverId/sse',
   responseType: 'mcp-sse',
   pathParamSchema: mcpServerIdPathParams,
   summary: 'MCP SSE Transport',
@@ -311,7 +311,7 @@ export const MCP_SSE_TRANSPORT_ROUTE = createRoute({
 
 export const MCP_SSE_MESSAGES_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/mcp/:serverId/messages',
+  path: '/mcp/:serverId/messages',
   responseType: 'mcp-sse',
   pathParamSchema: mcpServerIdPathParams,
   summary: 'MCP SSE Messages',

--- a/packages/server/src/server/handlers/mcp.ts
+++ b/packages/server/src/server/handlers/mcp.ts
@@ -79,9 +79,9 @@ export const LIST_MCP_SERVERS_ROUTE = createRoute({
         // Return next URL in same format as request (legacy limit/offset or page/perPage)
         if (useLegacyFormat) {
           const nextOffset = actualOffset + finalPerPage;
-          nextUrl = `/api/mcp/v0/servers?limit=${finalPerPage}&offset=${nextOffset}`;
+          nextUrl = `/mcp/v0/servers?limit=${finalPerPage}&offset=${nextOffset}`;
         } else {
-          nextUrl = `/api/mcp/v0/servers?perPage=${finalPerPage}&page=${nextPage}`;
+          nextUrl = `/mcp/v0/servers?perPage=${finalPerPage}&page=${nextPage}`;
         }
       }
     }
@@ -276,7 +276,7 @@ export const MCP_HTTP_TRANSPORT_ROUTE = createRoute({
 
     return {
       server,
-      httpPath: `/api/mcp/${serverId}/mcp`,
+      httpPath: `/mcp/${serverId}/mcp`,
     };
   },
 });
@@ -303,8 +303,8 @@ export const MCP_SSE_TRANSPORT_ROUTE = createRoute({
 
     return {
       server,
-      ssePath: `/api/mcp/${serverId}/sse`,
-      messagePath: `/api/mcp/${serverId}/messages`,
+      ssePath: `/mcp/${serverId}/sse`,
+      messagePath: `/mcp/${serverId}/messages`,
     };
   },
 });

--- a/packages/server/src/server/handlers/mcp.ts
+++ b/packages/server/src/server/handlers/mcp.ts
@@ -32,6 +32,7 @@ export const LIST_MCP_SERVERS_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({
     mastra,
+    routePrefix,
     page,
     perPage,
     limit,
@@ -77,11 +78,12 @@ export const LIST_MCP_SERVERS_ROUTE = createRoute({
       if (actualOffset + finalPerPage < totalCount) {
         const nextPage = (finalPage ?? 0) + 1;
         // Return next URL in same format as request (legacy limit/offset or page/perPage)
+        const prefix = routePrefix ?? '';
         if (useLegacyFormat) {
           const nextOffset = actualOffset + finalPerPage;
-          nextUrl = `/mcp/v0/servers?limit=${finalPerPage}&offset=${nextOffset}`;
+          nextUrl = `${prefix}/mcp/v0/servers?limit=${finalPerPage}&offset=${nextOffset}`;
         } else {
-          nextUrl = `/mcp/v0/servers?perPage=${finalPerPage}&page=${nextPage}`;
+          nextUrl = `${prefix}/mcp/v0/servers?perPage=${finalPerPage}&page=${nextPage}`;
         }
       }
     }

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -122,7 +122,7 @@ describe('Memory Handlers', () => {
    * https://github.com/mastra-ai/mastra/issues/11765
    *
    * When the playground UI loads messages for a sub-agent without memory configured,
-   * it calls GET /api/memory/threads/:threadId/messages?agentId=<subAgentId>.
+   * it calls GET /memory/threads/:threadId/messages?agentId=<subAgentId>.
    * This should return empty messages instead of throwing HTTPException(400).
    */
   describe('listMessagesHandler - Issue #11765', () => {

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -138,7 +138,7 @@ function getStorageFromContext({ mastra }: Pick<MemoryContext, 'mastra'>): Mastr
 
 export const GET_MEMORY_STATUS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/memory/status',
+  path: '/memory/status',
   responseType: 'json',
   queryParamSchema: getMemoryStatusQuerySchema,
   responseSchema: memoryStatusResponseSchema,
@@ -171,7 +171,7 @@ export const GET_MEMORY_STATUS_ROUTE = createRoute({
 
 export const GET_MEMORY_CONFIG_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/memory/config',
+  path: '/memory/config',
   responseType: 'json',
   queryParamSchema: getMemoryConfigQuerySchema,
   responseSchema: memoryConfigResponseSchema,
@@ -199,7 +199,7 @@ export const GET_MEMORY_CONFIG_ROUTE = createRoute({
 
 export const LIST_THREADS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/memory/threads',
+  path: '/memory/threads',
   responseType: 'json',
   queryParamSchema: listThreadsQuerySchema,
   responseSchema: listThreadsResponseSchema,
@@ -259,7 +259,7 @@ export const LIST_THREADS_ROUTE = createRoute({
 
 export const GET_THREAD_BY_ID_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/memory/threads/:threadId',
+  path: '/memory/threads/:threadId',
   responseType: 'json',
   pathParamSchema: threadIdPathParams,
   queryParamSchema: getThreadByIdQuerySchema,
@@ -305,7 +305,7 @@ export const GET_THREAD_BY_ID_ROUTE = createRoute({
 
 export const LIST_MESSAGES_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/memory/threads/:threadId/messages',
+  path: '/memory/threads/:threadId/messages',
   responseType: 'json',
   pathParamSchema: threadIdPathParams,
   queryParamSchema: listMessagesQuerySchema,
@@ -389,7 +389,7 @@ export const LIST_MESSAGES_ROUTE = createRoute({
 
 export const GET_WORKING_MEMORY_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/memory/threads/:threadId/working-memory',
+  path: '/memory/threads/:threadId/working-memory',
   responseType: 'json',
   pathParamSchema: threadIdPathParams,
   queryParamSchema: getWorkingMemoryQuerySchema,
@@ -425,7 +425,7 @@ export const GET_WORKING_MEMORY_ROUTE = createRoute({
 
 export const SAVE_MESSAGES_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/memory/save-messages',
+  path: '/memory/save-messages',
   responseType: 'json',
   queryParamSchema: agentIdQuerySchema,
   bodySchema: saveMessagesBodySchema,
@@ -474,7 +474,7 @@ export const SAVE_MESSAGES_ROUTE = createRoute({
 
 export const CREATE_THREAD_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/memory/threads',
+  path: '/memory/threads',
   responseType: 'json',
   queryParamSchema: agentIdQuerySchema,
   bodySchema: createThreadBodySchema,
@@ -508,7 +508,7 @@ export const CREATE_THREAD_ROUTE = createRoute({
 
 export const UPDATE_THREAD_ROUTE = createRoute({
   method: 'PATCH',
-  path: '/api/memory/threads/:threadId',
+  path: '/memory/threads/:threadId',
   responseType: 'json',
   pathParamSchema: threadIdPathParams,
   queryParamSchema: agentIdQuerySchema,
@@ -557,7 +557,7 @@ export const UPDATE_THREAD_ROUTE = createRoute({
 
 export const DELETE_THREAD_ROUTE = createRoute({
   method: 'DELETE',
-  path: '/api/memory/threads/:threadId',
+  path: '/memory/threads/:threadId',
   responseType: 'json',
   pathParamSchema: threadIdPathParams,
   queryParamSchema: agentIdQuerySchema,
@@ -590,7 +590,7 @@ export const DELETE_THREAD_ROUTE = createRoute({
 
 export const CLONE_THREAD_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/memory/threads/:threadId/clone',
+  path: '/memory/threads/:threadId/clone',
   responseType: 'json',
   pathParamSchema: threadIdPathParams,
   queryParamSchema: agentIdQuerySchema,
@@ -627,7 +627,7 @@ export const CLONE_THREAD_ROUTE = createRoute({
 
 export const UPDATE_WORKING_MEMORY_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/memory/threads/:threadId/working-memory',
+  path: '/memory/threads/:threadId/working-memory',
   responseType: 'json',
   pathParamSchema: threadIdPathParams,
   queryParamSchema: agentIdQuerySchema,
@@ -659,7 +659,7 @@ export const UPDATE_WORKING_MEMORY_ROUTE = createRoute({
 
 export const DELETE_MESSAGES_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/memory/messages/delete',
+  path: '/memory/messages/delete',
   responseType: 'json',
   queryParamSchema: agentIdQuerySchema,
   bodySchema: deleteMessagesBodySchema,
@@ -723,7 +723,7 @@ export const DELETE_MESSAGES_ROUTE = createRoute({
 
 export const SEARCH_MEMORY_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/memory/search',
+  path: '/memory/search',
   responseType: 'json',
   queryParamSchema: searchMemoryQuerySchema,
   responseSchema: searchMemoryResponseSchema,
@@ -895,7 +895,7 @@ export const SEARCH_MEMORY_ROUTE = createRoute({
 // Network routes (same handlers with /network/ prefix)
 export const GET_MEMORY_STATUS_NETWORK_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/memory/network/status',
+  path: '/memory/network/status',
   responseType: 'json',
   queryParamSchema: getMemoryStatusNetworkQuerySchema,
   responseSchema: memoryStatusResponseSchema,
@@ -908,7 +908,7 @@ export const GET_MEMORY_STATUS_NETWORK_ROUTE = createRoute({
 
 export const LIST_THREADS_NETWORK_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/memory/network/threads',
+  path: '/memory/network/threads',
   responseType: 'json',
   queryParamSchema: listThreadsNetworkQuerySchema,
   responseSchema: listThreadsResponseSchema,
@@ -921,7 +921,7 @@ export const LIST_THREADS_NETWORK_ROUTE = createRoute({
 
 export const GET_THREAD_BY_ID_NETWORK_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/memory/network/threads/:threadId',
+  path: '/memory/network/threads/:threadId',
   responseType: 'json',
   pathParamSchema: threadIdPathParams,
   queryParamSchema: getThreadByIdNetworkQuerySchema,
@@ -935,7 +935,7 @@ export const GET_THREAD_BY_ID_NETWORK_ROUTE = createRoute({
 
 export const LIST_MESSAGES_NETWORK_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/memory/network/threads/:threadId/messages',
+  path: '/memory/network/threads/:threadId/messages',
   responseType: 'json',
   pathParamSchema: threadIdPathParams,
   queryParamSchema: listMessagesNetworkQuerySchema,
@@ -949,7 +949,7 @@ export const LIST_MESSAGES_NETWORK_ROUTE = createRoute({
 
 export const SAVE_MESSAGES_NETWORK_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/memory/network/save-messages',
+  path: '/memory/network/save-messages',
   responseType: 'json',
   queryParamSchema: saveMessagesNetworkQuerySchema,
   bodySchema: saveMessagesBodySchema,
@@ -963,7 +963,7 @@ export const SAVE_MESSAGES_NETWORK_ROUTE = createRoute({
 
 export const CREATE_THREAD_NETWORK_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/memory/network/threads',
+  path: '/memory/network/threads',
   responseType: 'json',
   queryParamSchema: createThreadNetworkQuerySchema,
   bodySchema: createThreadBodySchema,
@@ -977,7 +977,7 @@ export const CREATE_THREAD_NETWORK_ROUTE = createRoute({
 
 export const UPDATE_THREAD_NETWORK_ROUTE = createRoute({
   method: 'PATCH',
-  path: '/api/memory/network/threads/:threadId',
+  path: '/memory/network/threads/:threadId',
   responseType: 'json',
   pathParamSchema: threadIdPathParams,
   queryParamSchema: updateThreadNetworkQuerySchema,
@@ -992,7 +992,7 @@ export const UPDATE_THREAD_NETWORK_ROUTE = createRoute({
 
 export const DELETE_THREAD_NETWORK_ROUTE = createRoute({
   method: 'DELETE',
-  path: '/api/memory/network/threads/:threadId',
+  path: '/memory/network/threads/:threadId',
   responseType: 'json',
   pathParamSchema: threadIdPathParams,
   queryParamSchema: deleteThreadNetworkQuerySchema,
@@ -1006,7 +1006,7 @@ export const DELETE_THREAD_NETWORK_ROUTE = createRoute({
 
 export const DELETE_MESSAGES_NETWORK_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/memory/network/messages/delete',
+  path: '/memory/network/messages/delete',
   responseType: 'json',
   queryParamSchema: deleteMessagesNetworkQuerySchema,
   bodySchema: deleteMessagesBodySchema,

--- a/packages/server/src/server/handlers/observability.ts
+++ b/packages/server/src/server/handlers/observability.ts
@@ -108,7 +108,7 @@ async function getScoresStore(mastra: Mastra): Promise<ScoresStorage> {
 
 export const LIST_TRACES_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/observability/traces',
+  path: '/observability/traces',
   responseType: 'json',
   queryParamSchema: wrapSchemaForQueryParams(
     tracesFilterSchema
@@ -141,7 +141,7 @@ export const LIST_TRACES_ROUTE = createRoute({
 
 export const GET_TRACE_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/observability/traces/:traceId',
+  path: '/observability/traces/:traceId',
   responseType: 'json',
   pathParamSchema: getTraceArgsSchema,
   responseSchema: getTraceResponseSchema,
@@ -167,7 +167,7 @@ export const GET_TRACE_ROUTE = createRoute({
 
 export const SCORE_TRACES_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/observability/traces/score',
+  path: '/observability/traces/score',
   responseType: 'json',
   bodySchema: scoreTracesRequestSchema,
   responseSchema: scoreTracesResponseSchema,
@@ -209,7 +209,7 @@ export const SCORE_TRACES_ROUTE = createRoute({
 
 export const LIST_SCORES_BY_SPAN_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/observability/traces/:traceId/:spanId/scores',
+  path: '/observability/traces/:traceId/:spanId/scores',
   responseType: 'json',
   pathParamSchema: spanIdsSchema,
   queryParamSchema: paginationArgsSchema,

--- a/packages/server/src/server/handlers/processors.ts
+++ b/packages/server/src/server/handlers/processors.ts
@@ -74,7 +74,7 @@ function detectProcessorPhases(processor: any): ProcessorPhase[] {
 
 export const LIST_PROCESSORS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/processors',
+  path: '/processors',
   responseType: 'json',
   responseSchema: listProcessorsResponseSchema,
   summary: 'List all processors',
@@ -134,7 +134,7 @@ export const LIST_PROCESSORS_ROUTE = createRoute({
 
 export const GET_PROCESSOR_BY_ID_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/processors/:processorId',
+  path: '/processors/:processorId',
   responseType: 'json',
   pathParamSchema: processorIdPathParams,
   responseSchema: serializedProcessorDetailSchema,
@@ -189,7 +189,7 @@ export const GET_PROCESSOR_BY_ID_ROUTE = createRoute({
 
 export const EXECUTE_PROCESSOR_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/processors/:processorId/execute',
+  path: '/processors/:processorId/execute',
   responseType: 'json',
   pathParamSchema: processorIdPathParams,
   bodySchema: executeProcessorBodySchema,

--- a/packages/server/src/server/handlers/scores.ts
+++ b/packages/server/src/server/handlers/scores.ts
@@ -143,7 +143,7 @@ function getTraceDetails(traceIdWithSpanId?: string) {
 
 export const LIST_SCORERS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/scores/scorers',
+  path: '/scores/scorers',
   responseType: 'json',
   responseSchema: listScorersResponseSchema,
   summary: 'List all scorers',
@@ -161,7 +161,7 @@ export const LIST_SCORERS_ROUTE = createRoute({
 
 export const GET_SCORER_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/scores/scorers/:scorerId',
+  path: '/scores/scorers/:scorerId',
   responseType: 'json',
   pathParamSchema: scorerIdPathParams,
   responseSchema: scorerEntrySchema.nullable(),
@@ -187,7 +187,7 @@ export const GET_SCORER_ROUTE = createRoute({
 
 export const LIST_SCORES_BY_RUN_ID_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/scores/run/:runId',
+  path: '/scores/run/:runId',
   responseType: 'json',
   pathParamSchema: runIdSchema,
   queryParamSchema: listScoresByRunIdQuerySchema,
@@ -220,7 +220,7 @@ export const LIST_SCORES_BY_RUN_ID_ROUTE = createRoute({
 
 export const LIST_SCORES_BY_SCORER_ID_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/scores/scorer/:scorerId',
+  path: '/scores/scorer/:scorerId',
   responseType: 'json',
   pathParamSchema: scorerIdPathParams,
   queryParamSchema: listScoresByScorerIdQuerySchema,
@@ -251,7 +251,7 @@ export const LIST_SCORES_BY_SCORER_ID_ROUTE = createRoute({
 
 export const LIST_SCORES_BY_ENTITY_ID_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/scores/entity/:entityType/:entityId',
+  path: '/scores/entity/:entityType/:entityId',
   responseType: 'json',
   pathParamSchema: entityPathParams,
   queryParamSchema: listScoresByEntityIdQuerySchema,
@@ -297,7 +297,7 @@ export const LIST_SCORES_BY_ENTITY_ID_ROUTE = createRoute({
 
 export const SAVE_SCORE_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/scores',
+  path: '/scores',
   responseType: 'json',
   bodySchema: saveScoreBodySchema,
   responseSchema: saveScoreResponseSchema,

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -24,7 +24,7 @@ import { handleError } from './error';
  */
 export const LIST_STORED_AGENTS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/stored/agents',
+  path: '/stored/agents',
   responseType: 'json',
   queryParamSchema: listStoredAgentsQuerySchema,
   responseSchema: listStoredAgentsResponseSchema,
@@ -65,7 +65,7 @@ export const LIST_STORED_AGENTS_ROUTE = createRoute({
  */
 export const GET_STORED_AGENT_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/stored/agents/:storedAgentId',
+  path: '/stored/agents/:storedAgentId',
   responseType: 'json',
   pathParamSchema: storedAgentIdPathParams,
   responseSchema: getStoredAgentResponseSchema,
@@ -105,7 +105,7 @@ export const GET_STORED_AGENT_ROUTE = createRoute({
  */
 export const CREATE_STORED_AGENT_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/stored/agents',
+  path: '/stored/agents',
   responseType: 'json',
   bodySchema: createStoredAgentBodySchema,
   responseSchema: createStoredAgentResponseSchema,
@@ -187,7 +187,7 @@ export const CREATE_STORED_AGENT_ROUTE = createRoute({
  */
 export const UPDATE_STORED_AGENT_ROUTE = createRoute({
   method: 'PATCH',
-  path: '/api/stored/agents/:storedAgentId',
+  path: '/stored/agents/:storedAgentId',
   responseType: 'json',
   pathParamSchema: storedAgentIdPathParams,
   bodySchema: updateStoredAgentBodySchema,
@@ -275,7 +275,7 @@ export const UPDATE_STORED_AGENT_ROUTE = createRoute({
  */
 export const DELETE_STORED_AGENT_ROUTE = createRoute({
   method: 'DELETE',
-  path: '/api/stored/agents/:storedAgentId',
+  path: '/stored/agents/:storedAgentId',
   responseType: 'json',
   pathParamSchema: storedAgentIdPathParams,
   responseSchema: deleteStoredAgentResponseSchema,

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -20,7 +20,7 @@ import { handleError } from './error';
 // ============================================================================
 
 /**
- * GET /api/stored/agents - List all stored agents
+ * GET /stored/agents - List all stored agents
  */
 export const LIST_STORED_AGENTS_ROUTE = createRoute({
   method: 'GET',
@@ -61,7 +61,7 @@ export const LIST_STORED_AGENTS_ROUTE = createRoute({
 });
 
 /**
- * GET /api/stored/agents/:storedAgentId - Get a stored agent by ID
+ * GET /stored/agents/:storedAgentId - Get a stored agent by ID
  */
 export const GET_STORED_AGENT_ROUTE = createRoute({
   method: 'GET',
@@ -101,7 +101,7 @@ export const GET_STORED_AGENT_ROUTE = createRoute({
 });
 
 /**
- * POST /api/stored/agents - Create a new stored agent
+ * POST /stored/agents - Create a new stored agent
  */
 export const CREATE_STORED_AGENT_ROUTE = createRoute({
   method: 'POST',
@@ -183,7 +183,7 @@ export const CREATE_STORED_AGENT_ROUTE = createRoute({
 });
 
 /**
- * PATCH /api/stored/agents/:storedAgentId - Update a stored agent
+ * PATCH /stored/agents/:storedAgentId - Update a stored agent
  */
 export const UPDATE_STORED_AGENT_ROUTE = createRoute({
   method: 'PATCH',
@@ -271,7 +271,7 @@ export const UPDATE_STORED_AGENT_ROUTE = createRoute({
 });
 
 /**
- * DELETE /api/stored/agents/:storedAgentId - Delete a stored agent
+ * DELETE /stored/agents/:storedAgentId - Delete a stored agent
  */
 export const DELETE_STORED_AGENT_ROUTE = createRoute({
   method: 'DELETE',

--- a/packages/server/src/server/handlers/system.ts
+++ b/packages/server/src/server/handlers/system.ts
@@ -7,7 +7,7 @@ import { handleError } from './error';
 
 export const GET_SYSTEM_PACKAGES_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/system/packages',
+  path: '/system/packages',
   responseType: 'json',
   responseSchema: systemPackagesResponseSchema,
   summary: 'Get installed Mastra packages',

--- a/packages/server/src/server/handlers/tools.ts
+++ b/packages/server/src/server/handlers/tools.ts
@@ -23,7 +23,7 @@ import { validateBody } from './utils';
 
 export const LIST_TOOLS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/tools',
+  path: '/tools',
   responseType: 'json',
   responseSchema: listToolsResponseSchema,
   summary: 'List all tools',
@@ -56,7 +56,7 @@ export const LIST_TOOLS_ROUTE = createRoute({
 
 export const GET_TOOL_BY_ID_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/tools/:toolId',
+  path: '/tools/:toolId',
   responseType: 'json',
   pathParamSchema: toolIdPathParams,
   responseSchema: serializedToolSchema,
@@ -94,7 +94,7 @@ export const GET_TOOL_BY_ID_ROUTE = createRoute({
 
 export const EXECUTE_TOOL_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/tools/:toolId/execute',
+  path: '/tools/:toolId/execute',
   responseType: 'json',
   pathParamSchema: toolIdPathParams,
   queryParamSchema: optionalRunIdSchema,
@@ -163,7 +163,7 @@ export const EXECUTE_TOOL_ROUTE = createRoute({
 
 export const GET_AGENT_TOOL_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/agents/:agentId/tools/:toolId',
+  path: '/agents/:agentId/tools/:toolId',
   responseType: 'json',
   pathParamSchema: agentToolPathParams,
   responseSchema: serializedToolSchema,
@@ -201,7 +201,7 @@ export const GET_AGENT_TOOL_ROUTE = createRoute({
 
 export const EXECUTE_AGENT_TOOL_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/tools/:toolId/execute',
+  path: '/agents/:agentId/tools/:toolId/execute',
   responseType: 'json',
   pathParamSchema: agentToolPathParams,
   bodySchema: executeToolBodySchema,

--- a/packages/server/src/server/handlers/vector.ts
+++ b/packages/server/src/server/handlers/vector.ts
@@ -189,7 +189,7 @@ export async function deleteIndex({
 
 export const UPSERT_VECTORS_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/vector/:vectorName/upsert',
+  path: '/vector/:vectorName/upsert',
   responseType: 'json',
   pathParamSchema: vectorNamePathParams,
   bodySchema: upsertVectorsBodySchema,
@@ -217,7 +217,7 @@ export const UPSERT_VECTORS_ROUTE = createRoute({
 
 export const CREATE_INDEX_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/vector/:vectorName/create-index',
+  path: '/vector/:vectorName/create-index',
   responseType: 'json',
   pathParamSchema: vectorNamePathParams,
   bodySchema: createIndexBodySchema,
@@ -251,7 +251,7 @@ export const CREATE_INDEX_ROUTE = createRoute({
 
 export const QUERY_VECTORS_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/vector/:vectorName/query',
+  path: '/vector/:vectorName/query',
   responseType: 'json',
   pathParamSchema: vectorNamePathParams,
   bodySchema: queryVectorsBodySchema,
@@ -281,7 +281,7 @@ export const QUERY_VECTORS_ROUTE = createRoute({
 
 export const LIST_INDEXES_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/vector/:vectorName/indexes',
+  path: '/vector/:vectorName/indexes',
   responseType: 'json',
   pathParamSchema: vectorNamePathParams,
   responseSchema: listIndexesResponseSchema,
@@ -302,7 +302,7 @@ export const LIST_INDEXES_ROUTE = createRoute({
 
 export const DESCRIBE_INDEX_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/vector/:vectorName/indexes/:indexName',
+  path: '/vector/:vectorName/indexes/:indexName',
   responseType: 'json',
   pathParamSchema: vectorIndexPathParams,
   responseSchema: describeIndexResponseSchema,
@@ -332,7 +332,7 @@ export const DESCRIBE_INDEX_ROUTE = createRoute({
 
 export const DELETE_INDEX_ROUTE = createRoute({
   method: 'DELETE',
-  path: '/api/vector/:vectorName/indexes/:indexName',
+  path: '/vector/:vectorName/indexes/:indexName',
   responseType: 'json',
   pathParamSchema: vectorIndexPathParams,
   responseSchema: deleteIndexResponseSchema,

--- a/packages/server/src/server/handlers/voice.ts
+++ b/packages/server/src/server/handlers/voice.ts
@@ -67,7 +67,7 @@ export const GET_SPEAKERS_DEPRECATED_ROUTE = createRoute({
   pathParamSchema: agentIdPathParams,
   responseSchema: voiceSpeakersResponseSchema,
   summary: 'Get available speakers for an agent',
-  description: '[DEPRECATED] Use /api/agents/:agentId/voice/speakers instead. Get available speakers for an agent',
+  description: '[DEPRECATED] Use /agents/:agentId/voice/speakers instead. Get available speakers for an agent',
   tags: ['Agents', 'Voice'],
   requiresAuth: true,
   handler: GET_SPEAKERS_ROUTE.handler,
@@ -134,7 +134,7 @@ export const GENERATE_SPEECH_DEPRECATED_ROUTE = createRoute({
   responseSchema: speakResponseSchema,
   summary: 'Convert text to speech',
   description:
-    "[DEPRECATED] Use /api/agents/:agentId/voice/speak instead. Convert text to speech using the agent's voice provider",
+    "[DEPRECATED] Use /agents/:agentId/voice/speak instead. Convert text to speech using the agent's voice provider",
   tags: ['Agents', 'Voice'],
   requiresAuth: true,
   handler: GENERATE_SPEECH_ROUTE.handler,
@@ -194,7 +194,7 @@ export const TRANSCRIBE_SPEECH_DEPRECATED_ROUTE = createRoute({
   responseSchema: transcribeSpeechResponseSchema,
   summary: 'Convert speech to text',
   description:
-    "[DEPRECATED] Use /api/agents/:agentId/voice/listen instead. Convert speech to text using the agent's voice provider. Additional provider-specific options can be passed as query parameters.",
+    "[DEPRECATED] Use /agents/:agentId/voice/listen instead. Convert speech to text using the agent's voice provider. Additional provider-specific options can be passed as query parameters.",
   tags: ['Agents', 'Voice'],
   requiresAuth: true,
   handler: TRANSCRIBE_SPEECH_ROUTE.handler,

--- a/packages/server/src/server/handlers/voice.ts
+++ b/packages/server/src/server/handlers/voice.ts
@@ -21,7 +21,7 @@ import { validateBody } from './utils';
 
 export const GET_SPEAKERS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/agents/:agentId/voice/speakers',
+  path: '/agents/:agentId/voice/speakers',
   responseType: 'json',
   pathParamSchema: agentIdPathParams,
   responseSchema: voiceSpeakersResponseSchema,
@@ -62,7 +62,7 @@ export const GET_SPEAKERS_ROUTE = createRoute({
 
 export const GET_SPEAKERS_DEPRECATED_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/agents/:agentId/speakers',
+  path: '/agents/:agentId/speakers',
   responseType: 'json',
   pathParamSchema: agentIdPathParams,
   responseSchema: voiceSpeakersResponseSchema,
@@ -75,7 +75,7 @@ export const GET_SPEAKERS_DEPRECATED_ROUTE = createRoute({
 
 export const GENERATE_SPEECH_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/voice/speak',
+  path: '/agents/:agentId/voice/speak',
   responseType: 'stream',
   pathParamSchema: agentIdPathParams,
   bodySchema: generateSpeechBodySchema,
@@ -127,7 +127,7 @@ export const GENERATE_SPEECH_ROUTE = createRoute({
 
 export const GENERATE_SPEECH_DEPRECATED_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/speak',
+  path: '/agents/:agentId/speak',
   responseType: 'stream',
   pathParamSchema: agentIdPathParams,
   bodySchema: generateSpeechBodySchema,
@@ -142,7 +142,7 @@ export const GENERATE_SPEECH_DEPRECATED_ROUTE = createRoute({
 
 export const TRANSCRIBE_SPEECH_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/voice/listen',
+  path: '/agents/:agentId/voice/listen',
   responseType: 'json',
   pathParamSchema: agentIdPathParams,
   bodySchema: transcribeSpeechBodySchema,
@@ -187,7 +187,7 @@ export const TRANSCRIBE_SPEECH_ROUTE = createRoute({
 
 export const TRANSCRIBE_SPEECH_DEPRECATED_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/agents/:agentId/listen',
+  path: '/agents/:agentId/listen',
   responseType: 'json',
   pathParamSchema: agentIdPathParams,
   bodySchema: transcribeSpeechBodySchema,
@@ -202,7 +202,7 @@ export const TRANSCRIBE_SPEECH_DEPRECATED_ROUTE = createRoute({
 
 export const GET_LISTENER_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/agents/:agentId/voice/listener',
+  path: '/agents/:agentId/voice/listener',
   responseType: 'json',
   pathParamSchema: agentIdPathParams,
   responseSchema: getListenerResponseSchema,

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -87,7 +87,7 @@ async function listWorkflowsFromSystem({ mastra, workflowId }: WorkflowContext) 
 
 export const LIST_WORKFLOWS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/workflows',
+  path: '/workflows',
   responseType: 'json',
   queryParamSchema: z.object({
     partial: z.string().optional(),
@@ -114,7 +114,7 @@ export const LIST_WORKFLOWS_ROUTE = createRoute({
 
 export const GET_WORKFLOW_BY_ID_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/workflows/:workflowId',
+  path: '/workflows/:workflowId',
   responseType: 'json',
   pathParamSchema: workflowIdPathParams,
   responseSchema: workflowInfoSchema,
@@ -137,7 +137,7 @@ export const GET_WORKFLOW_BY_ID_ROUTE = createRoute({
 
 export const LIST_WORKFLOW_RUNS_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/workflows/:workflowId/runs',
+  path: '/workflows/:workflowId/runs',
   responseType: 'json',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: listWorkflowRunsQuerySchema,
@@ -197,7 +197,7 @@ export const LIST_WORKFLOW_RUNS_ROUTE = createRoute({
 
 export const GET_WORKFLOW_RUN_BY_ID_ROUTE = createRoute({
   method: 'GET',
-  path: '/api/workflows/:workflowId/runs/:runId',
+  path: '/workflows/:workflowId/runs/:runId',
   responseType: 'json',
   pathParamSchema: workflowRunPathParams,
   queryParamSchema: workflowRunResultQuerySchema,
@@ -244,7 +244,7 @@ export const GET_WORKFLOW_RUN_BY_ID_ROUTE = createRoute({
 
 export const DELETE_WORKFLOW_RUN_BY_ID_ROUTE = createRoute({
   method: 'DELETE',
-  path: '/api/workflows/:workflowId/runs/:runId',
+  path: '/workflows/:workflowId/runs/:runId',
   responseType: 'json',
   pathParamSchema: workflowRunPathParams,
   responseSchema: workflowControlResponseSchema,
@@ -279,7 +279,7 @@ export const DELETE_WORKFLOW_RUN_BY_ID_ROUTE = createRoute({
 
 export const CREATE_WORKFLOW_RUN_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/create-run',
+  path: '/workflows/:workflowId/create-run',
   responseType: 'json',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: optionalRunIdSchema,
@@ -312,7 +312,7 @@ export const CREATE_WORKFLOW_RUN_ROUTE = createRoute({
 
 export const STREAM_WORKFLOW_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/stream',
+  path: '/workflows/:workflowId/stream',
   responseType: 'stream',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: runIdSchema,
@@ -359,7 +359,7 @@ export const STREAM_WORKFLOW_ROUTE = createRoute({
 
 export const RESUME_STREAM_WORKFLOW_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/resume-stream',
+  path: '/workflows/:workflowId/resume-stream',
   responseType: 'stream',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: runIdSchema,
@@ -416,7 +416,7 @@ export const RESUME_STREAM_WORKFLOW_ROUTE = createRoute({
 
 export const START_ASYNC_WORKFLOW_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/start-async',
+  path: '/workflows/:workflowId/start-async',
   responseType: 'json',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: optionalRunIdSchema,
@@ -449,7 +449,7 @@ export const START_ASYNC_WORKFLOW_ROUTE = createRoute({
 
 export const START_WORKFLOW_RUN_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/start',
+  path: '/workflows/:workflowId/start',
   responseType: 'json',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: runIdSchema,
@@ -495,7 +495,7 @@ export const START_WORKFLOW_RUN_ROUTE = createRoute({
 
 export const OBSERVE_STREAM_WORKFLOW_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/observe',
+  path: '/workflows/:workflowId/observe',
   responseType: 'stream',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: runIdSchema,
@@ -586,7 +586,7 @@ export const OBSERVE_STREAM_WORKFLOW_ROUTE = createRoute({
 
 export const RESUME_ASYNC_WORKFLOW_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/resume-async',
+  path: '/workflows/:workflowId/resume-async',
   responseType: 'json',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: runIdSchema,
@@ -630,7 +630,7 @@ export const RESUME_ASYNC_WORKFLOW_ROUTE = createRoute({
 
 export const RESUME_WORKFLOW_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/resume',
+  path: '/workflows/:workflowId/resume',
   responseType: 'json',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: runIdSchema,
@@ -675,7 +675,7 @@ export const RESUME_WORKFLOW_ROUTE = createRoute({
 
 export const RESTART_ASYNC_WORKFLOW_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/restart-async',
+  path: '/workflows/:workflowId/restart-async',
   responseType: 'json',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: runIdSchema,
@@ -719,7 +719,7 @@ export const RESTART_ASYNC_WORKFLOW_ROUTE = createRoute({
 
 export const RESTART_WORKFLOW_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/restart',
+  path: '/workflows/:workflowId/restart',
   responseType: 'json',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: runIdSchema,
@@ -764,7 +764,7 @@ export const RESTART_WORKFLOW_ROUTE = createRoute({
 
 export const RESTART_ALL_ACTIVE_WORKFLOW_RUNS_ASYNC_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/restart-all-active-workflow-runs-async',
+  path: '/workflows/:workflowId/restart-all-active-workflow-runs-async',
   responseType: 'json',
   pathParamSchema: workflowIdPathParams,
   responseSchema: workflowControlResponseSchema,
@@ -795,7 +795,7 @@ export const RESTART_ALL_ACTIVE_WORKFLOW_RUNS_ASYNC_ROUTE = createRoute({
 
 export const RESTART_ALL_ACTIVE_WORKFLOW_RUNS_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/restart-all-active-workflow-runs',
+  path: '/workflows/:workflowId/restart-all-active-workflow-runs',
   responseType: 'json',
   pathParamSchema: workflowIdPathParams,
   responseSchema: workflowControlResponseSchema,
@@ -826,7 +826,7 @@ export const RESTART_ALL_ACTIVE_WORKFLOW_RUNS_ROUTE = createRoute({
 
 export const TIME_TRAVEL_ASYNC_WORKFLOW_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/time-travel-async',
+  path: '/workflows/:workflowId/time-travel-async',
   responseType: 'json',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: runIdSchema,
@@ -870,7 +870,7 @@ export const TIME_TRAVEL_ASYNC_WORKFLOW_ROUTE = createRoute({
 
 export const TIME_TRAVEL_WORKFLOW_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/time-travel',
+  path: '/workflows/:workflowId/time-travel',
   responseType: 'json',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: runIdSchema,
@@ -915,7 +915,7 @@ export const TIME_TRAVEL_WORKFLOW_ROUTE = createRoute({
 
 export const TIME_TRAVEL_STREAM_WORKFLOW_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/time-travel-stream',
+  path: '/workflows/:workflowId/time-travel-stream',
   responseType: 'stream',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: runIdSchema,
@@ -962,7 +962,7 @@ export const TIME_TRAVEL_STREAM_WORKFLOW_ROUTE = createRoute({
 
 export const CANCEL_WORKFLOW_RUN_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/runs/:runId/cancel',
+  path: '/workflows/:workflowId/runs/:runId/cancel',
   responseType: 'json',
   pathParamSchema: workflowRunPathParams,
   responseSchema: workflowControlResponseSchema,
@@ -1006,7 +1006,7 @@ export const CANCEL_WORKFLOW_RUN_ROUTE = createRoute({
 // Legacy routes (deprecated)
 export const STREAM_LEGACY_WORKFLOW_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/stream-legacy',
+  path: '/workflows/:workflowId/stream-legacy',
   responseType: 'stream',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: runIdSchema,
@@ -1054,7 +1054,7 @@ export const STREAM_LEGACY_WORKFLOW_ROUTE = createRoute({
 
 export const OBSERVE_STREAM_LEGACY_WORKFLOW_ROUTE = createRoute({
   method: 'POST',
-  path: '/api/workflows/:workflowId/observe-stream-legacy',
+  path: '/workflows/:workflowId/observe-stream-legacy',
   responseType: 'stream',
   pathParamSchema: workflowIdPathParams,
   queryParamSchema: runIdSchema,

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -1013,7 +1013,7 @@ export const STREAM_LEGACY_WORKFLOW_ROUTE = createRoute({
   bodySchema: streamWorkflowBodySchema,
   responseSchema: streamResponseSchema,
   summary: '[DEPRECATED] Stream workflow with legacy format',
-  description: 'Legacy endpoint for streaming workflow execution. Use /api/workflows/:workflowId/stream instead.',
+  description: 'Legacy endpoint for streaming workflow execution. Use /workflows/:workflowId/stream instead.',
   tags: ['Workflows', 'Legacy'],
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId, ...params }) => {
@@ -1060,7 +1060,7 @@ export const OBSERVE_STREAM_LEGACY_WORKFLOW_ROUTE = createRoute({
   queryParamSchema: runIdSchema,
   responseSchema: streamResponseSchema,
   summary: '[DEPRECATED] Observe workflow stream with legacy format',
-  description: 'Legacy endpoint for observing workflow stream. Use /api/workflows/:workflowId/observe instead.',
+  description: 'Legacy endpoint for observing workflow stream. Use /workflows/:workflowId/observe instead.',
   tags: ['Workflows', 'Legacy'],
   requiresAuth: true,
   handler: async ({ mastra, workflowId, runId }) => {

--- a/packages/server/src/server/schemas/agent-versions.ts
+++ b/packages/server/src/server/schemas/agent-versions.ts
@@ -34,14 +34,14 @@ const versionOrderBySchema = z.object({
 });
 
 /**
- * GET /api/stored/agents/:agentId/versions - List versions query params
+ * GET /stored/agents/:agentId/versions - List versions query params
  */
 export const listVersionsQuerySchema = createPagePaginationSchema(20).extend({
   orderBy: versionOrderBySchema.optional(),
 });
 
 /**
- * GET /api/stored/agents/:agentId/versions/compare - Compare versions query params
+ * GET /stored/agents/:agentId/versions/compare - Compare versions query params
  */
 export const compareVersionsQuerySchema = z.object({
   from: z.string().describe('Version ID (UUID) to compare from'),
@@ -53,7 +53,7 @@ export const compareVersionsQuerySchema = z.object({
 // ============================================================================
 
 /**
- * POST /api/stored/agents/:agentId/versions - Create version body
+ * POST /stored/agents/:agentId/versions - Create version body
  */
 export const createVersionBodySchema = z.object({
   name: z.string().max(100).optional().describe('Optional vanity name for this version'),
@@ -79,24 +79,24 @@ export const agentVersionSchema = z.object({
 });
 
 /**
- * Response for GET /api/stored/agents/:agentId/versions
+ * Response for GET /stored/agents/:agentId/versions
  */
 export const listVersionsResponseSchema = paginationInfoSchema.extend({
   versions: z.array(agentVersionSchema),
 });
 
 /**
- * Response for GET /api/stored/agents/:agentId/versions/:versionId
+ * Response for GET /stored/agents/:agentId/versions/:versionId
  */
 export const getVersionResponseSchema = agentVersionSchema;
 
 /**
- * Response for POST /api/stored/agents/:agentId/versions
+ * Response for POST /stored/agents/:agentId/versions
  */
 export const createVersionResponseSchema = agentVersionSchema;
 
 /**
- * Response for POST /api/stored/agents/:agentId/versions/:versionId/activate
+ * Response for POST /stored/agents/:agentId/versions/:versionId/activate
  */
 export const activateVersionResponseSchema = z.object({
   success: z.boolean(),
@@ -105,14 +105,14 @@ export const activateVersionResponseSchema = z.object({
 });
 
 /**
- * Response for POST /api/stored/agents/:agentId/versions/:versionId/restore
+ * Response for POST /stored/agents/:agentId/versions/:versionId/restore
  */
 export const restoreVersionResponseSchema = agentVersionSchema.describe(
   'The newly created version from the restored snapshot',
 );
 
 /**
- * Response for DELETE /api/stored/agents/:agentId/versions/:versionId
+ * Response for DELETE /stored/agents/:agentId/versions/:versionId
  */
 export const deleteVersionResponseSchema = z.object({
   success: z.boolean(),
@@ -129,7 +129,7 @@ export const versionDiffEntrySchema = z.object({
 });
 
 /**
- * Response for GET /api/stored/agents/:agentId/versions/compare
+ * Response for GET /stored/agents/:agentId/versions/compare
  */
 export const compareVersionsResponseSchema = z.object({
   diffs: z.array(versionDiffEntrySchema).describe('List of differences between versions'),

--- a/packages/server/src/server/schemas/agents.ts
+++ b/packages/server/src/server/schemas/agents.ts
@@ -251,7 +251,7 @@ export const agentExecutionBodySchema = z
 
 /**
  * Legacy body schema for deprecated endpoints that still use threadId/resourceId
- * Used by /api/agents/:agentId/generate-legacy and /api/agents/:agentId/stream-legacy
+ * Used by /agents/:agentId/generate-legacy and /agents/:agentId/stream-legacy
  */
 export const agentExecutionLegacyBodySchema = agentExecutionBodySchema.extend({
   resourceId: z.string().optional(),

--- a/packages/server/src/server/schemas/memory.test.ts
+++ b/packages/server/src/server/schemas/memory.test.ts
@@ -31,7 +31,7 @@ describe('Memory Schema Query Parsing', () => {
       /**
        * Regression test for #11761: orderBy was failing when passed as a JSON string from URL query params.
        *
-       * Example URL: /api/memory/threads/abc/messages?orderBy={"field":"createdAt","direction":"ASC"}
+       * Example URL: /memory/threads/abc/messages?orderBy={"field":"createdAt","direction":"ASC"}
        */
       it('should parse orderBy when passed as a JSON string (from URL query params)', () => {
         const jsonString = JSON.stringify({ field: 'createdAt', direction: 'ASC' });
@@ -90,7 +90,7 @@ describe('Memory Schema Query Parsing', () => {
       /**
        * Regression test for #11761: include was failing when passed as a JSON string from URL query params.
        *
-       * Example URL: /api/memory/threads/abc/messages?include=[{"role":"user","withPreviousMessages":5}]
+       * Example URL: /memory/threads/abc/messages?include=[{"role":"user","withPreviousMessages":5}]
        */
       it('should parse include when passed as a JSON string (from URL query params)', () => {
         const jsonString = JSON.stringify([
@@ -133,7 +133,7 @@ describe('Memory Schema Query Parsing', () => {
       /**
        * Regression test for #11761: filter was failing when passed as a JSON string from URL query params.
        *
-       * Example URL: /api/memory/threads/abc/messages?filter={"roles":["user","assistant"]}
+       * Example URL: /memory/threads/abc/messages?filter={"roles":["user","assistant"]}
        */
       it('should parse filter when passed as a JSON string (from URL query params)', () => {
         const jsonString = JSON.stringify({ roles: ['user', 'assistant'] });

--- a/packages/server/src/server/schemas/memory.ts
+++ b/packages/server/src/server/schemas/memory.ts
@@ -166,17 +166,17 @@ const messageSchema = z.any();
 // ============================================================================
 
 /**
- * GET /api/memory/status
+ * GET /memory/status
  */
 export const getMemoryStatusQuerySchema = agentIdQuerySchema;
 
 /**
- * GET /api/memory/config
+ * GET /memory/config
  */
 export const getMemoryConfigQuerySchema = agentIdQuerySchema;
 
 /**
- * GET /api/memory/threads
+ * GET /memory/threads
  * agentId is optional - can use storage fallback when not provided
  * resourceId is optional - when omitted, returns all threads
  * metadata is optional - filters threads by metadata key-value pairs (AND logic)
@@ -202,13 +202,13 @@ export const listThreadsQuerySchema = createPagePaginationSchema(100).extend({
 });
 
 /**
- * GET /api/memory/threads/:threadId
+ * GET /memory/threads/:threadId
  * agentId is optional - can use storage fallback when not provided
  */
 export const getThreadByIdQuerySchema = optionalAgentIdQuerySchema;
 
 /**
- * GET /api/memory/threads/:threadId/messages
+ * GET /memory/threads/:threadId/messages
  * agentId is optional - can use storage fallback when not provided
  */
 export const listMessagesQuerySchema = createPagePaginationSchema(40).extend({
@@ -220,7 +220,7 @@ export const listMessagesQuerySchema = createPagePaginationSchema(40).extend({
 });
 
 /**
- * GET /api/memory/threads/:threadId/working-memory
+ * GET /memory/threads/:threadId/working-memory
  */
 export const getWorkingMemoryQuerySchema = z.object({
   agentId: z.string(),
@@ -233,12 +233,12 @@ export const getWorkingMemoryQuerySchema = z.object({
 // ============================================================================
 
 /**
- * GET /api/memory/network/status
+ * GET /memory/network/status
  */
 export const getMemoryStatusNetworkQuerySchema = agentIdQuerySchema;
 
 /**
- * GET /api/memory/network/threads
+ * GET /memory/network/threads
  * agentId is optional - can use storage fallback when not provided
  * resourceId is optional - when omitted, returns all threads
  * metadata is optional - filters threads by metadata key-value pairs (AND logic)
@@ -264,13 +264,13 @@ export const listThreadsNetworkQuerySchema = createPagePaginationSchema(100).ext
 });
 
 /**
- * GET /api/memory/network/threads/:threadId
+ * GET /memory/network/threads/:threadId
  * agentId is optional - can use storage fallback when not provided
  */
 export const getThreadByIdNetworkQuerySchema = optionalAgentIdQuerySchema;
 
 /**
- * GET /api/memory/network/threads/:threadId/messages
+ * GET /memory/network/threads/:threadId/messages
  * agentId is optional - can use storage fallback when not provided
  */
 export const listMessagesNetworkQuerySchema = createPagePaginationSchema(40).extend({
@@ -282,27 +282,27 @@ export const listMessagesNetworkQuerySchema = createPagePaginationSchema(40).ext
 });
 
 /**
- * POST /api/memory/network/save-messages
+ * POST /memory/network/save-messages
  */
 export const saveMessagesNetworkQuerySchema = agentIdQuerySchema;
 
 /**
- * POST /api/memory/network/threads
+ * POST /memory/network/threads
  */
 export const createThreadNetworkQuerySchema = agentIdQuerySchema;
 
 /**
- * PATCH /api/memory/network/threads/:threadId
+ * PATCH /memory/network/threads/:threadId
  */
 export const updateThreadNetworkQuerySchema = agentIdQuerySchema;
 
 /**
- * DELETE /api/memory/network/threads/:threadId
+ * DELETE /memory/network/threads/:threadId
  */
 export const deleteThreadNetworkQuerySchema = agentIdQuerySchema;
 
 /**
- * POST /api/memory/network/messages/delete
+ * POST /memory/network/messages/delete
  */
 export const deleteMessagesNetworkQuerySchema = agentIdQuerySchema;
 
@@ -311,14 +311,14 @@ export const deleteMessagesNetworkQuerySchema = agentIdQuerySchema;
 // ============================================================================
 
 /**
- * Response for GET /api/memory/status
+ * Response for GET /memory/status
  */
 export const memoryStatusResponseSchema = z.object({
   result: z.boolean(),
 });
 
 /**
- * Response for GET /api/memory/config
+ * Response for GET /memory/config
  * MemoryConfig is complex with many optional fields - using passthrough
  */
 export const memoryConfigResponseSchema = z.object({
@@ -330,19 +330,19 @@ export const memoryConfigResponseSchema = z.object({
 });
 
 /**
- * Response for GET /api/memory/threads
+ * Response for GET /memory/threads
  */
 export const listThreadsResponseSchema = paginationInfoSchema.extend({
   threads: z.array(threadSchema),
 });
 
 /**
- * Response for GET /api/memory/threads/:threadId
+ * Response for GET /memory/threads/:threadId
  */
 export const getThreadByIdResponseSchema = threadSchema;
 
 /**
- * Response for GET /api/memory/threads/:threadId/messages
+ * Response for GET /memory/threads/:threadId/messages
  */
 export const listMessagesResponseSchema = z.object({
   messages: z.array(messageSchema),
@@ -350,7 +350,7 @@ export const listMessagesResponseSchema = z.object({
 });
 
 /**
- * Response for GET /api/memory/threads/:threadId/working-memory
+ * Response for GET /memory/threads/:threadId/working-memory
  */
 export const getWorkingMemoryResponseSchema = z.object({
   workingMemory: z.unknown(), // Can be string or structured object depending on template
@@ -364,14 +364,14 @@ export const getWorkingMemoryResponseSchema = z.object({
 // ============================================================================
 
 /**
- * Body schema for POST /api/memory/messages
+ * Body schema for POST /memory/messages
  */
 export const saveMessagesBodySchema = z.object({
   messages: z.array(messageSchema),
 });
 
 /**
- * Body schema for POST /api/memory/threads
+ * Body schema for POST /memory/threads
  */
 export const createThreadBodySchema = z.object({
   resourceId: z.string(),
@@ -381,7 +381,7 @@ export const createThreadBodySchema = z.object({
 });
 
 /**
- * Body schema for PUT /api/memory/threads/:threadId
+ * Body schema for PUT /memory/threads/:threadId
  */
 export const updateThreadBodySchema = z.object({
   title: z.string().optional(),
@@ -390,7 +390,7 @@ export const updateThreadBodySchema = z.object({
 });
 
 /**
- * Body schema for PUT /api/memory/threads/:threadId/working-memory
+ * Body schema for PUT /memory/threads/:threadId/working-memory
  */
 export const updateWorkingMemoryBodySchema = z.object({
   workingMemory: z.string(),
@@ -399,7 +399,7 @@ export const updateWorkingMemoryBodySchema = z.object({
 });
 
 /**
- * Body schema for POST /api/memory/messages/delete
+ * Body schema for POST /memory/messages/delete
  * Accepts: string | string[] | { id: string } | { id: string }[]
  */
 export const deleteMessagesBodySchema = z.object({
@@ -412,7 +412,7 @@ export const deleteMessagesBodySchema = z.object({
 });
 
 /**
- * Query schema for GET /api/memory/search
+ * Query schema for GET /memory/search
  */
 export const searchMemoryQuerySchema = z.object({
   agentId: z.string(),
@@ -449,7 +449,7 @@ export const searchMemoryResponseSchema = z.object({
 });
 
 /**
- * Body schema for POST /api/memory/threads/:threadId/clone
+ * Body schema for POST /memory/threads/:threadId/clone
  */
 export const cloneThreadBodySchema = z.object({
   newThreadId: z.string().optional(),
@@ -471,7 +471,7 @@ export const cloneThreadBodySchema = z.object({
 });
 
 /**
- * Response schema for POST /api/memory/threads/:threadId/clone
+ * Response schema for POST /memory/threads/:threadId/clone
  */
 export const cloneThreadResponseSchema = z.object({
   thread: threadSchema,

--- a/packages/server/src/server/schemas/stored-agents.ts
+++ b/packages/server/src/server/schemas/stored-agents.ts
@@ -25,7 +25,7 @@ const storageOrderBySchema = z.object({
 });
 
 /**
- * GET /api/storage/agents - List stored agents
+ * GET /stored/agents - List stored agents
  */
 export const listStoredAgentsQuerySchema = createPagePaginationSchema(100).extend({
   orderBy: storageOrderBySchema.optional(),
@@ -75,14 +75,14 @@ const storedAgentBaseSchema = z.object({
 });
 
 /**
- * POST /api/storage/agents - Create stored agent body
+ * POST /stored/agents - Create stored agent body
  */
 export const createStoredAgentBodySchema = storedAgentBaseSchema.extend({
   id: z.string().describe('Unique identifier for the agent'),
 });
 
 /**
- * PATCH /api/storage/agents/:storedAgentId - Update stored agent body
+ * PATCH /stored/agents/:storedAgentId - Update stored agent body
  */
 export const updateStoredAgentBodySchema = storedAgentBaseSchema.partial();
 
@@ -101,29 +101,29 @@ export const storedAgentSchema = storedAgentBaseSchema.extend({
 });
 
 /**
- * Response for GET /api/storage/agents
+ * Response for GET /stored/agents
  */
 export const listStoredAgentsResponseSchema = paginationInfoSchema.extend({
   agents: z.array(storedAgentSchema),
 });
 
 /**
- * Response for GET /api/storage/agents/:storedAgentId
+ * Response for GET /stored/agents/:storedAgentId
  */
 export const getStoredAgentResponseSchema = storedAgentSchema;
 
 /**
- * Response for POST /api/storage/agents
+ * Response for POST /stored/agents
  */
 export const createStoredAgentResponseSchema = storedAgentSchema;
 
 /**
- * Response for PATCH /api/storage/agents/:storedAgentId
+ * Response for PATCH /stored/agents/:storedAgentId
  */
 export const updateStoredAgentResponseSchema = storedAgentSchema;
 
 /**
- * Response for DELETE /api/storage/agents/:storedAgentId
+ * Response for DELETE /stored/agents/:storedAgentId
  */
 export const deleteStoredAgentResponseSchema = z.object({
   success: z.boolean(),

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -106,7 +106,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     mastra,
     bodyLimitOptions,
     tools,
-    prefix = '',
+    prefix = '/api',
     openapiPath = '',
     taskStore,
     customRouteAuthConfig,

--- a/packages/server/src/server/server-adapter/routes/index.ts
+++ b/packages/server/src/server/server-adapter/routes/index.ts
@@ -32,6 +32,8 @@ export type ServerContext = {
   registeredTools?: ToolsInput;
   taskStore?: InMemoryTaskStore;
   abortSignal: AbortSignal;
+  /** The route prefix configured for the server (e.g., '/api') */
+  routePrefix?: string;
 };
 
 /**

--- a/packages/server/src/server/server-adapter/routes/route-builder.ts
+++ b/packages/server/src/server/server-adapter/routes/route-builder.ts
@@ -193,7 +193,7 @@ interface RouteConfig<
  * ```typescript
  * export const getAgentRoute = createRoute({
  *   method: 'GET',
- *   path: '/api/agents/:agentId',
+ *   path: '/agents/:agentId',
  *   responseType: 'json',
  *   pathParamSchema: z.object({ agentId: z.string() }),
  *   responseSchema: serializedAgentSchema,

--- a/packages/server/src/server/server-adapter/schema-consistency.test.ts
+++ b/packages/server/src/server/server-adapter/schema-consistency.test.ts
@@ -3,7 +3,7 @@ import { SERVER_ROUTES } from '../server-adapter/routes';
 
 /**
  * Extract path parameters from a path pattern
- * e.g., '/api/agents/:agentId/tools/:toolId' -> ['agentId', 'toolId']
+ * e.g., '/agents/:agentId/tools/:toolId' -> ['agentId', 'toolId']
  */
 export function extractPathParams(path: string): string[] {
   const matches = path.match(/:(\w+)/g);

--- a/server-adapters/_test-utils/src/index.ts
+++ b/server-adapters/_test-utils/src/index.ts
@@ -1,5 +1,11 @@
 export { createRouteAdapterTestSuite } from './route-adapter-test-suite';
-export type { AdapterTestSuiteConfig, AdapterTestContext, HttpRequest, HttpResponse } from './test-helpers';
+export type {
+  AdapterTestSuiteConfig,
+  AdapterTestContext,
+  AdapterSetupOptions,
+  HttpRequest,
+  HttpResponse,
+} from './test-helpers';
 export { createMCPRouteTestSuite } from './mcp-route-test-suite';
 export { createMCPTransportTestSuite, type MCPTransportTestConfig } from './mcp-transport-test-suite';
 export { createMultipartTestSuite, type MultipartTestSuiteConfig } from './multipart-test-suite';

--- a/server-adapters/_test-utils/src/multipart-test-suite.ts
+++ b/server-adapters/_test-utils/src/multipart-test-suite.ts
@@ -245,7 +245,8 @@ export function createMultipartTestSuite(config: MultipartTestSuiteConfig) {
           return {
             success: true,
             bodyKeys: Object.keys(params).filter(
-              k => !['mastra', 'requestContext', 'tools', 'taskStore', 'abortSignal', 'registeredTools'].includes(k),
+              k =>
+                !['mastra', 'requestContext', 'tools', 'taskStore', 'abortSignal', 'registeredTools', 'routePrefix'].includes(k),
             ),
           };
         },

--- a/server-adapters/_test-utils/src/multipart-test-suite.ts
+++ b/server-adapters/_test-utils/src/multipart-test-suite.ts
@@ -246,7 +246,15 @@ export function createMultipartTestSuite(config: MultipartTestSuiteConfig) {
             success: true,
             bodyKeys: Object.keys(params).filter(
               k =>
-                !['mastra', 'requestContext', 'tools', 'taskStore', 'abortSignal', 'registeredTools', 'routePrefix'].includes(k),
+                ![
+                  'mastra',
+                  'requestContext',
+                  'tools',
+                  'taskStore',
+                  'abortSignal',
+                  'registeredTools',
+                  'routePrefix',
+                ].includes(k),
             ),
           };
         },

--- a/server-adapters/_test-utils/src/route-adapter-test-suite.ts
+++ b/server-adapters/_test-utils/src/route-adapter-test-suite.ts
@@ -177,7 +177,7 @@ export function createRouteAdapterTestSuite(config: AdapterTestSuiteConfig) {
         }
 
         // MCP v0 server detail 404 test (uses :id instead of :serverId)
-        if (route.path.includes('/api/mcp/v0/servers/:id')) {
+        if (route.path.includes('/mcp/v0/servers/:id')) {
           it('should return 404 when MCP server not found (via :id)', async () => {
             const request = buildRouteRequest(route, {
               pathParams: { id: 'non-existent-server' },

--- a/server-adapters/_test-utils/src/route-adapter-test-suite.ts
+++ b/server-adapters/_test-utils/src/route-adapter-test-suite.ts
@@ -458,5 +458,38 @@ export function createRouteAdapterTestSuite(config: AdapterTestSuiteConfig) {
         });
       });
     });
+
+    // Route prefix tests
+    describe('Route Prefix', () => {
+      it('should register routes at prefixed paths without double /api', async () => {
+        // Create a new adapter with a custom prefix
+        const prefixedSetup = await setupAdapter(context, { prefix: '/v2' });
+        const prefixedApp = prefixedSetup.app;
+
+        // Request the expected path: /v2/agents (not /v2/api/agents)
+        const response = await executeHttpRequest(prefixedApp, {
+          method: 'GET',
+          path: '/v2/agents',
+        });
+
+        // Should succeed - routes should be at /v2/agents
+        expect(response.status).toBeLessThan(400);
+      });
+
+      it('should not have routes at double /api path when prefix is set', async () => {
+        // Create a new adapter with a custom prefix
+        const prefixedSetup = await setupAdapter(context, { prefix: '/v2' });
+        const prefixedApp = prefixedSetup.app;
+
+        // The buggy path /v2/api/agents should NOT work
+        const response = await executeHttpRequest(prefixedApp, {
+          method: 'GET',
+          path: '/v2/api/agents',
+        });
+
+        // Should return 404 - this path should not exist
+        expect(response.status).toBe(404);
+      });
+    });
   });
 }

--- a/server-adapters/_test-utils/src/test-helpers.ts
+++ b/server-adapters/_test-utils/src/test-helpers.ts
@@ -67,6 +67,14 @@ export interface HttpResponse {
 }
 
 /**
+ * Options for adapter setup
+ */
+export interface AdapterSetupOptions {
+  /** Route prefix (e.g., '/v2' or '/api/v2') */
+  prefix?: string;
+}
+
+/**
  * Configuration for adapter integration test suite
  */
 export interface AdapterTestSuiteConfig {
@@ -76,8 +84,13 @@ export interface AdapterTestSuiteConfig {
   /**
    * Setup adapter and app for testing
    * Called once before all tests
+   * @param context - Test context with Mastra instance
+   * @param options - Optional adapter options (e.g., prefix)
    */
-  setupAdapter: (context: AdapterTestContext) => { adapter: any; app: any } | Promise<{ adapter: any; app: any }>;
+  setupAdapter: (
+    context: AdapterTestContext,
+    options?: AdapterSetupOptions,
+  ) => { adapter: any; app: any } | Promise<{ adapter: any; app: any }>;
 
   /**
    * Execute HTTP request through the adapter's framework (Express/Hono)

--- a/server-adapters/_test-utils/src/test-helpers.ts
+++ b/server-adapters/_test-utils/src/test-helpers.ts
@@ -879,11 +879,14 @@ export interface RouteRequestOverrides {
   pathParams?: Record<string, string>;
   query?: Record<string, unknown>;
   body?: Record<string, unknown>;
+  /** Prefix to prepend to the route path (defaults to '/api') */
+  prefix?: string;
 }
 
 export function buildRouteRequest(route: ServerRoute, overrides: RouteRequestOverrides = {}): RouteRequestPayload {
   const method = route.method;
-  let path = route.path;
+  const prefix = overrides.prefix ?? '/api';
+  let path = `${prefix}${route.path}`;
 
   if (route.pathParamSchema) {
     const defaults = getDefaultValidPathParams(route);

--- a/server-adapters/express/src/__tests__/express-adapter.test.ts
+++ b/server-adapters/express/src/__tests__/express-adapter.test.ts
@@ -1,5 +1,10 @@
 import type { Server } from 'node:http';
-import type { AdapterTestContext, HttpRequest, HttpResponse } from '@internal/server-adapter-test-utils';
+import type {
+  AdapterTestContext,
+  AdapterSetupOptions,
+  HttpRequest,
+  HttpResponse,
+} from '@internal/server-adapter-test-utils';
 import {
   createRouteAdapterTestSuite,
   createDefaultTestContext,
@@ -18,7 +23,7 @@ describe('Express Server Adapter', () => {
   createRouteAdapterTestSuite({
     suiteName: 'Express Adapter Integration Tests',
 
-    setupAdapter: async (context: AdapterTestContext) => {
+    setupAdapter: async (context: AdapterTestContext, options?: AdapterSetupOptions) => {
       // Create Express app
       const app = express();
       app.use(express.json());
@@ -29,6 +34,7 @@ describe('Express Server Adapter', () => {
         mastra: context.mastra,
         taskStore: context.taskStore,
         customRouteAuthConfig: context.customRouteAuthConfig,
+        prefix: options?.prefix,
       });
 
       await adapter.init();

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -250,7 +250,7 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
       try {
         await server.startHTTP({
           url: new URL(request.url, `http://${request.headers.host}`),
-          httpPath,
+          httpPath: `${this.prefix ?? ''}${httpPath}`,
           req: request,
           res: response,
         });
@@ -276,8 +276,8 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
       try {
         await server.startSSE({
           url: new URL(request.url, `http://${request.headers.host}`),
-          ssePath,
-          messagePath,
+          ssePath: `${this.prefix ?? ''}${ssePath}`,
+          messagePath: `${this.prefix ?? ''}${messagePath}`,
           req: request,
           res: response,
         });
@@ -379,6 +379,7 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
           registeredTools: res.locals.registeredTools,
           taskStore: res.locals.taskStore,
           abortSignal: res.locals.abortSignal,
+          routePrefix: this.prefix,
         };
 
         try {

--- a/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
+++ b/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
@@ -1,4 +1,9 @@
-import type { AdapterTestContext, HttpRequest, HttpResponse } from '@internal/server-adapter-test-utils';
+import type {
+  AdapterTestContext,
+  AdapterSetupOptions,
+  HttpRequest,
+  HttpResponse,
+} from '@internal/server-adapter-test-utils';
 import {
   createRouteAdapterTestSuite,
   createDefaultTestContext,
@@ -17,7 +22,7 @@ describe('Fastify Server Adapter', () => {
   createRouteAdapterTestSuite({
     suiteName: 'Fastify Adapter Integration Tests',
 
-    setupAdapter: async (context: AdapterTestContext) => {
+    setupAdapter: async (context: AdapterTestContext, options?: AdapterSetupOptions) => {
       // Create Fastify app
       const app = Fastify();
 
@@ -27,6 +32,7 @@ describe('Fastify Server Adapter', () => {
         mastra: context.mastra,
         taskStore: context.taskStore,
         customRouteAuthConfig: context.customRouteAuthConfig,
+        prefix: options?.prefix,
       });
 
       await adapter.init();

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -276,7 +276,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
 
         await server.startHTTP({
           url: new URL(request.url, `http://${request.headers.host}`),
-          httpPath,
+          httpPath: `${this.prefix ?? ''}${httpPath}`,
           req: rawReq,
           res: reply.raw,
         });
@@ -316,8 +316,8 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
 
         await server.startSSE({
           url: new URL(request.url, `http://${request.headers.host}`),
-          ssePath,
-          messagePath,
+          ssePath: `${this.prefix ?? ''}${ssePath}`,
+          messagePath: `${this.prefix ?? ''}${messagePath}`,
           req: rawReq,
           res: reply.raw,
         });
@@ -397,6 +397,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
         tools: request.tools,
         taskStore: request.taskStore,
         abortSignal: request.abortSignal,
+        routePrefix: this.prefix,
       };
 
       try {

--- a/server-adapters/hono/src/__tests__/hono-adapter.test.ts
+++ b/server-adapters/hono/src/__tests__/hono-adapter.test.ts
@@ -1,6 +1,11 @@
 import type { Server } from 'node:http';
 import { serve } from '@hono/node-server';
-import type { AdapterTestContext, HttpRequest, HttpResponse } from '@internal/server-adapter-test-utils';
+import type {
+  AdapterTestContext,
+  AdapterSetupOptions,
+  HttpRequest,
+  HttpResponse,
+} from '@internal/server-adapter-test-utils';
 import {
   createRouteAdapterTestSuite,
   createDefaultTestContext,
@@ -18,7 +23,7 @@ describe('Hono Server Adapter', () => {
   createRouteAdapterTestSuite({
     suiteName: 'Hono Adapter Integration Tests',
 
-    setupAdapter: async (context: AdapterTestContext) => {
+    setupAdapter: async (context: AdapterTestContext, options?: AdapterSetupOptions) => {
       const app = new Hono();
 
       // Create Hono adapter
@@ -28,6 +33,7 @@ describe('Hono Server Adapter', () => {
         tools: context.tools,
         taskStore: context.taskStore,
         customRouteAuthConfig: context.customRouteAuthConfig,
+        prefix: options?.prefix,
       });
 
       await adapter.init();

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -228,7 +228,7 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
       try {
         await server.startHTTP({
           url: new URL(response.req.url),
-          httpPath,
+          httpPath: `${this.prefix ?? ''}${httpPath}`,
           req,
           res,
         });
@@ -254,8 +254,8 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
       try {
         return await server.startHonoSSE({
           url: new URL(response.req.url),
-          ssePath,
-          messagePath,
+          ssePath: `${this.prefix ?? ''}${ssePath}`,
+          messagePath: `${this.prefix ?? ''}${messagePath}`,
           context: response,
         });
       } catch {
@@ -351,6 +351,7 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
           registeredTools: c.get('registeredTools'),
           taskStore: c.get('taskStore'),
           abortSignal: c.get('abortSignal'),
+          routePrefix: this.prefix,
         };
 
         try {

--- a/server-adapters/koa/src/__tests__/koa-adapter.test.ts
+++ b/server-adapters/koa/src/__tests__/koa-adapter.test.ts
@@ -1,5 +1,10 @@
 import type { Server } from 'node:http';
-import type { AdapterTestContext, HttpRequest, HttpResponse } from '@internal/server-adapter-test-utils';
+import type {
+  AdapterTestContext,
+  AdapterSetupOptions,
+  HttpRequest,
+  HttpResponse,
+} from '@internal/server-adapter-test-utils';
 import {
   createRouteAdapterTestSuite,
   createDefaultTestContext,
@@ -18,7 +23,7 @@ describe('Koa Server Adapter', () => {
   createRouteAdapterTestSuite({
     suiteName: 'Koa Adapter Integration Tests',
 
-    setupAdapter: async (context: AdapterTestContext) => {
+    setupAdapter: async (context: AdapterTestContext, options?: AdapterSetupOptions) => {
       // Create Koa app
       const app = new Koa();
       app.use(bodyParser());
@@ -29,6 +34,7 @@ describe('Koa Server Adapter', () => {
         mastra: context.mastra,
         taskStore: context.taskStore,
         customRouteAuthConfig: context.customRouteAuthConfig,
+        prefix: options?.prefix,
       });
 
       await adapter.init();

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -276,7 +276,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
 
         await server.startHTTP({
           url: new URL(ctx.url, `http://${ctx.headers.host}`),
-          httpPath,
+          httpPath: `${this.prefix ?? ''}${httpPath}`,
           req: rawReq,
           res: ctx.res,
         });
@@ -309,8 +309,8 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
 
         await server.startSSE({
           url: new URL(ctx.url, `http://${ctx.headers.host}`),
-          ssePath,
-          messagePath,
+          ssePath: `${this.prefix ?? ''}${ssePath}`,
+          messagePath: `${this.prefix ?? ''}${messagePath}`,
           req: rawReq,
           res: ctx.res,
         });
@@ -422,6 +422,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
         tools: ctx.state.tools,
         taskStore: ctx.state.taskStore,
         abortSignal: ctx.state.abortSignal,
+        routePrefix: this.prefix,
       };
 
       try {


### PR DESCRIPTION
## Description

Fixed route prefix behavior to correctly replace the default `/api` prefix instead of prepending to it. 

Previously, setting `prefix: '/api/v2'` resulted in routes at `/api/v2/api/agents`. Now routes correctly appear at `/api/v2/agents` as documented.

**Changes:**
- Removed `/api` prefix from all 140 route definitions in `handlers/*.ts`
- Changed default prefix from `''` to `'/api'` in `server-adapter/index.ts`
- Updated `buildRouteRequest` in test utils to prepend prefix (default `/api`)
- Added Route Prefix integration tests to the shared test suite

## Related Issue(s)

Fixes #12157

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed route prefix issue: many endpoints moved from /api/... to root-level paths (agents, memory, workflows, mcp, scores, vector, logs, observability, etc.), preventing duplicated /api segments.

* **New Features**
  * Providers list now shows connectivity; version and stored-agent APIs accept/add extra fields.
  * Default server routing prefix adjusted to better support custom prefixes.

* **Tests**
  * Added/updated tests for route-prefix handling and expectations.

* **Documentation**
  * Public endpoint examples and comments updated to reflect new paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->