### PR TITLE
docs: add redirect from /docs/scorers/overview to /docs/evals/overview

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -564,6 +564,11 @@
       "source": "/reference/memory/query",
       "destination": "/reference/memory/recall",
       "permanent": true
+    },
+    {
+      "source": "/docs/scorers/overview",
+      "destination": "/docs/evals/overview",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
## Description

Add a redirect from the old scorers documentation page to the new evals documentation page to maintain backward compatibility and prevent broken links.

## Type of Change

- [x] Documentation update

## Checklist

- [x] Changes are complete and ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation routing configuration to ensure users are directed to the correct evaluation documentation pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->