### PR TITLE
docs(playground): add react and tailwind best-practices skills to agent checklist

### DIFF
--- a/packages/playground-ui/AGENTS.md
+++ b/packages/playground-ui/AGENTS.md
@@ -46,6 +46,10 @@ Standards and conventions for building components in `packages/playground-ui`.
 - Minimize side effects and state management
 - Use TanStack Query for all server state
 
-## E2E Testing (MUST DO)
+## MUST DO EVERY SINGLE TIME
 
-On every change to this package, you MUST use the `e2e-frontend-validation` skill
+On every change to this package, you MUST ALWAYS follow these instructions:
+
+- use `e2e-frontend-validation` skill
+- use `react-best-practices` skill
+- use `tailwind-best-practices` skill

--- a/packages/playground-ui/CLAUDE.md
+++ b/packages/playground-ui/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+Always read and follow the instructions in AGENTS.md in this directory before working on this package.  

--- a/packages/playground/AGENTS.md
+++ b/packages/playground/AGENTS.md
@@ -37,6 +37,10 @@ Standards and conventions for building the local studio in `packages/playground`
 - Pages should be thin wrappers around `playground-ui` components
 - When in doubt, add functionality to `playground-ui` instead
 
-## E2E Testing (MUST DO)
+## MUST DO EVERY SINGLE TIME
 
-On every change to this package, you MUST use the `e2e-frontend-validation` skill
+On every change to this package, you MUST ALWAYS follow these instructions:
+
+- use `e2e-frontend-validation` skill
+- use `react-best-practices` skill
+- use `tailwind-best-practices` skill

--- a/packages/playground/CLAUDE.md
+++ b/packages/playground/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+Always read and follow the instructions in AGENTS.md in this directory before working on this package.  


### PR DESCRIPTION
Updates the MUST DO checklist in both `packages/playground` and `packages/playground-ui` to require running `react-best-practices` and `tailwind-best-practices` skills alongside the existing `e2e-frontend-validation` skill on every change.

Also makes `CLAUDE.md` in both packages more explicit about reading `AGENTS.md` instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer guidelines across multiple packages to emphasize consistent validation and best practices requirements.
  * Enhanced instructions to make compliance steps explicit and repeatable across all development cycles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->