### PR TITLE
feat(lint): add ESLint rule to disallow @ts-ignore in favor of @ts-expect-error

### DIFF
--- a/packages/_config/src/eslint.js
+++ b/packages/_config/src/eslint.js
@@ -176,6 +176,17 @@ export const createConfig = async () =>
 
             '@typescript-eslint/no-floating-promises': 'error',
 
+            '@typescript-eslint/ban-ts-comment': [
+              ERROR,
+              {
+                'ts-expect-error': 'allow-with-description',
+                'ts-ignore': true,
+                'ts-nocheck': true,
+                'ts-check': false,
+                minimumDescriptionLength: 3,
+              },
+            ],
+
             // here are rules we've decided to not enable. Commented out rather
             // than setting them to disabled to avoid them being referenced at all
             // when config resolution happens.


### PR DESCRIPTION
## Summary
- Adds `@typescript-eslint/ban-ts-comment` rule to the shared ESLint config
- Disallows `@ts-ignore` comments (requires migration to `@ts-expect-error`)
- Requires `@ts-expect-error` comments to include a description (min 3 characters)
- Also disallows `@ts-nocheck` comments

## Why
`@ts-expect-error` is preferred over `@ts-ignore` because:
- It errors when the suppressed error is fixed (preventing stale suppressions)
- Requires documentation of why the suppression is needed
- Helps maintain type safety over time

## Breaking Change
Existing `@ts-ignore` usages will need to be migrated to `@ts-expect-error` with descriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced TypeScript linting rules to enforce stricter use of TypeScript comment directives with mandatory descriptions, improving code quality standards and discouraging problematic practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->