### PR TITLE
perf(ci): skip pnpm install in check-changes jobs

### DIFF
--- a/.github/actions/turbo-changed/action.yaml
+++ b/.github/actions/turbo-changed/action.yaml
@@ -28,6 +28,14 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Install turbo
+      shell: bash
+      run: pnpm install -g turbo
+
+    - name: Disable turbo telemetry
+      shell: bash
+      run: turbo telemetry disable
+
     - name: Compare turbo task hashes
       id: compare
       shell: bash
@@ -59,7 +67,8 @@ runs:
           local filter_args=$2
           # Run turbo dry-run and extract all package/task/hash combinations
           # This automatically includes all transitive dependencies
-          pnpm turbo "$task" $filter_args --dry-run=json 2>/dev/null | \
+          # Note: Uses turbo directly (installed globally) - no pnpm install needed
+          turbo "$task" $filter_args --dry-run=json 2>/dev/null | \
             jq -r '.tasks[] | "\(.package)#\(.task)=\(.hash)"'
         }
 

--- a/.github/workflows/secrets.test-agent-builder.yml
+++ b/.github/workflows/secrets.test-agent-builder.yml
@@ -37,9 +37,8 @@ jobs:
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
-
-      - name: Disable turbo telemetry
-        run: pnpm turbo telemetry disable
+        with:
+          install-dependencies: 'false'
 
       - name: Check for agent-builder package changes using Turborepo
         id: changes

--- a/.github/workflows/secrets.test-auth.yml
+++ b/.github/workflows/secrets.test-auth.yml
@@ -37,9 +37,8 @@ jobs:
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
-
-      - name: Disable turbo telemetry
-        run: pnpm turbo telemetry disable
+        with:
+          install-dependencies: 'false'
 
       - name: Check for auth package changes using Turborepo
         id: changes

--- a/.github/workflows/secrets.test-core.yml
+++ b/.github/workflows/secrets.test-core.yml
@@ -37,9 +37,8 @@ jobs:
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
-
-      - name: Disable turbo telemetry
-        run: pnpm turbo telemetry disable
+        with:
+          install-dependencies: 'false'
 
       - name: Check for core package changes using Turborepo
         id: changes

--- a/.github/workflows/secrets.test-deployer.yml
+++ b/.github/workflows/secrets.test-deployer.yml
@@ -37,9 +37,8 @@ jobs:
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
-
-      - name: Disable turbo telemetry
-        run: pnpm turbo telemetry disable
+        with:
+          install-dependencies: 'false'
 
       - name: Check for Deployer package changes using Turborepo
         id: changes

--- a/.github/workflows/secrets.test-mcp.yml
+++ b/.github/workflows/secrets.test-mcp.yml
@@ -37,9 +37,8 @@ jobs:
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
-
-      - name: Disable turbo telemetry
-        run: pnpm turbo telemetry disable
+        with:
+          install-dependencies: 'false'
 
       - name: Check for MCP package changes using Turborepo
         id: changes

--- a/.github/workflows/secrets.test-memory.yml
+++ b/.github/workflows/secrets.test-memory.yml
@@ -37,9 +37,8 @@ jobs:
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
-
-      - name: Disable turbo telemetry
-        run: pnpm turbo telemetry disable
+        with:
+          install-dependencies: 'false'
 
       - name: Check for memory package changes using Turborepo
         id: changes

--- a/.github/workflows/secrets.test-observability.yml
+++ b/.github/workflows/secrets.test-observability.yml
@@ -37,9 +37,8 @@ jobs:
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
-
-      - name: Disable turbo telemetry
-        run: pnpm turbo telemetry disable
+        with:
+          install-dependencies: 'false'
 
       - name: Check for observability package changes using Turborepo
         id: changes

--- a/.github/workflows/secrets.test-rag.yml
+++ b/.github/workflows/secrets.test-rag.yml
@@ -37,9 +37,8 @@ jobs:
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
-
-      - name: Disable turbo telemetry
-        run: pnpm turbo telemetry disable
+        with:
+          install-dependencies: 'false'
 
       - name: Check for RAG package changes using Turborepo
         id: changes

--- a/.github/workflows/secrets.test-server.yml
+++ b/.github/workflows/secrets.test-server.yml
@@ -37,9 +37,8 @@ jobs:
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
-
-      - name: Disable turbo telemetry
-        run: pnpm turbo telemetry disable
+        with:
+          install-dependencies: 'false'
 
       - name: Check for Server package changes using Turborepo
         id: changes

--- a/.github/workflows/secrets.tool-builder-test.yml
+++ b/.github/workflows/secrets.tool-builder-test.yml
@@ -37,9 +37,8 @@ jobs:
 
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
-
-      - name: Disable turbo telemetry
-        run: pnpm turbo telemetry disable
+        with:
+          install-dependencies: 'false'
 
       - name: Check for tool-builder package changes using Turborepo
         id: changes


### PR DESCRIPTION
## Summary

Speed up the `check-changes` job in CI by skipping full `pnpm install` (~60s) and only installing turbo globally (~2s).

## Changes

1. **turbo-changed action is now self-contained** - Installs turbo globally and disables telemetry within the action itself
2. **Workflow files updated** - All 10 workflows using `turbo-changed` now use `install-dependencies: 'false'`
3. **Removed redundant step** - "Disable turbo telemetry" step removed from workflows (now handled by action)

## Why this works

Turbo can run `--dry-run=json` without `pnpm install` - it just reads the workspace configuration (`pnpm-workspace.yaml`, `package.json` files, `turbo.json` files). It doesn't need the actual dependencies installed to calculate task hashes.

## Expected Impact

- **Before**: `check-changes` job runs ~60-90s (checkout + pnpm install + turbo)
- **After**: `check-changes` job runs ~10-20s (checkout + turbo install + turbo)

## Files Changed

- `.github/actions/turbo-changed/action.yaml` - Now installs turbo and handles telemetry
- 10 workflow files - Use `install-dependencies: 'false'` and remove redundant turbo telemetry step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined GitHub Actions workflows by consolidating telemetry and dependency installation configuration into unified setup steps
  * Updated build tooling infrastructure to improve workflow efficiency and simplify CI/CD pipeline management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->