### PR TITLE
docs: add authorization middleware documentation

### DIFF
--- a/docs/src/content/en/docs/memory/storage.mdx
+++ b/docs/src/content/en/docs/memory/storage.mdx
@@ -164,7 +164,7 @@ but resource <resource_b> was queried
 
 Note that while each thread has one owner, messages within that thread can have different `resourceId` values. This is used for message attribution and filtering (e.g., distinguishing between different agents in a multi-agent system, or filtering messages for analytics).
 
-**Security:** Memory is a storage layer, not an authorization layer. Your application must implement access control before calling memory APIs. The `resourceId` parameter controls both validation and filtering - provide it to validate ownership and filter messages, or omit it for server-side access without validation.
+**Security:** Memory is a storage layer, not an authorization layer. Your application must implement access control before calling memory APIs. The `resourceId` parameter controls both validation and filtering - provide it to validate ownership and filter messages, or omit it for server-side access without validation. See [Authorization middleware](/docs/server/middleware#authorization-user-isolation) for how to implement user isolation using reserved context keys.
 
 To avoid accidentally reusing thread IDs across different owners, use UUIDs: `crypto.randomUUID()`
 

--- a/docs/src/content/en/docs/server/middleware.mdx
+++ b/docs/src/content/en/docs/server/middleware.mdx
@@ -112,6 +112,100 @@ export const mastra = new Mastra({
 }
 ```
 
+### Authorization (User Isolation)
+
+Authentication verifies who the user is. Authorization controls what they can access. Without authorization middleware, an authenticated user could access other users' threads by guessing IDs or manipulating the `resourceId` parameter.
+
+Mastra provides reserved context keys that, when set by middleware, take precedence over client-provided values:
+
+```typescript
+import { Mastra } from "@mastra/core";
+import { MASTRA_RESOURCE_ID_KEY } from "@mastra/core/request-context";
+
+export const mastra = new Mastra({
+  server: {
+    auth: {
+      authenticateToken: async (token) => {
+        // Your auth logic returns the user
+        return verifyToken(token); // { id: 'user-123', ... }
+      },
+    },
+    middleware: [
+      {
+        path: '/api/memory/*',
+        handler: async (c, next) => {
+          const requestContext = c.get('requestContext');
+          const user = requestContext.get('user');
+
+          if (!user) {
+            return c.json({ error: 'Unauthorized' }, 401);
+          }
+
+          // Force all memory operations to use this user's ID
+          // This takes precedence over any client-provided resourceId
+          requestContext.set(MASTRA_RESOURCE_ID_KEY, user.id);
+
+          return next();
+        },
+      },
+    ],
+  },
+});
+```
+
+With this middleware:
+- **Thread listing** returns only threads where `resourceId` matches the user's ID
+- **Thread creation** forces the new thread's `resourceId` to be the user's ID
+- **Message operations** are scoped to threads owned by the user
+
+Even if a client passes `?resourceId=other-user-id`, the middleware-set value takes precedence.
+
+#### Thread ownership validation
+
+For additional security, validate thread ownership before allowing access:
+
+```typescript
+import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from "@mastra/core/request-context";
+
+{
+  path: '/api/memory/*',
+  handler: async (c, next) => {
+    const requestContext = c.get('requestContext');
+    const user = requestContext.get('user');
+
+    if (!user) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, user.id);
+
+    // Validate thread ownership if accessing a specific thread
+    const path = c.req.path;
+    const threadMatch = path.match(/\/memory\/(?:network\/)?threads\/([^\/]+)/);
+
+    if (threadMatch) {
+      const threadId = threadMatch[1];
+      const storage = c.get('mastra').getStorage();
+
+      if (storage) {
+        const memoryStore = await storage.getStore('memory');
+        const thread = await memoryStore?.getThreadById({ threadId });
+
+        if (thread && thread.resourceId !== user.id) {
+          return c.json({ error: 'Access denied' }, 403);
+        }
+
+        if (thread) {
+          requestContext.set(MASTRA_THREAD_ID_KEY, threadId);
+        }
+      }
+    }
+
+    return next();
+  },
+}
+```
+
 ### CORS support
 
 ```typescript
@@ -177,3 +271,4 @@ be inspected by middleware to tailor behavior:
 # Related
 
 - [Request Context](/docs/server/request-context)
+- [Reserved Keys](/docs/server/request-context#reserved-keys)

--- a/docs/src/content/en/docs/server/request-context.mdx
+++ b/docs/src/content/en/docs/server/request-context.mdx
@@ -248,6 +248,30 @@ Visit [createTool()](/reference/tools/create-tool) for a full list of configurat
 
 :::
 
+## Reserved keys
+
+Mastra reserves special context keys for security purposes. When set by middleware, these keys take precedence over client-provided values, preventing users from accessing other users' data.
+
+```typescript
+import {
+  MASTRA_RESOURCE_ID_KEY,
+  MASTRA_THREAD_ID_KEY,
+} from "@mastra/core/request-context";
+
+// In middleware: force memory operations to use authenticated user's ID
+requestContext.set(MASTRA_RESOURCE_ID_KEY, user.id);
+
+// In middleware: set validated thread ID
+requestContext.set(MASTRA_THREAD_ID_KEY, threadId);
+```
+
+| Key | Purpose |
+|-----|---------|
+| `MASTRA_RESOURCE_ID_KEY` | Forces all memory operations to use this resource ID, overriding client-provided values |
+| `MASTRA_THREAD_ID_KEY` | Forces thread operations to use this thread ID, overriding client-provided values |
+
+These keys are used to implement user isolation in multi-tenant applications. See [Authorization middleware](/docs/server/middleware#authorization-user-isolation) for usage examples.
+
 ## TypeScript support
 
 When you provide a type parameter to `RequestContext`, all methods are fully typed:
@@ -295,3 +319,4 @@ for (const [key, value] of ctx.entries()) {
 - [Agent Request Context](/docs/agents/overview#using-requestcontext)
 - [Workflow Request Context](../workflows/overview#using-requestcontext)
 - [Server Middleware](/docs/server/middleware)
+- [Authorization Middleware](/docs/server/middleware#authorization-user-isolation)


### PR DESCRIPTION
The existing auth docs cover authentication but not authorization. Users could still access other users' threads by manipulating the `resourceId` parameter.

This adds documentation for:

- **middleware.mdx**: New "Authorization (User Isolation)" section showing how to use `MASTRA_RESOURCE_ID_KEY` to force memory operations to the authenticated user's ID
- **request-context.mdx**: New "Reserved keys" section documenting `MASTRA_RESOURCE_ID_KEY` and `MASTRA_THREAD_ID_KEY`
- **storage.mdx**: Links to the authorization docs from the security note

Example usage:

```typescript
import { MASTRA_RESOURCE_ID_KEY } from "@mastra/core/request-context";

middleware: [
  {
    path: '/api/memory/*',
    handler: async (c, next) => {
      const user = c.get('requestContext').get('user');
      if (!user) {
        return c.json({ error: 'Unauthorized' }, 401);
      }
      // Forces all memory operations to this user's ID
      c.get('requestContext').set(MASTRA_RESOURCE_ID_KEY, user.id);
      return next();
    },
  },
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive authorization and user isolation guidance with implementation examples.
  * Documented reserved security keys for enforcing user-scoped access in multi-tenant scenarios.
  * Added cross-referenced documentation for authorization middleware patterns and thread ownership validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->