### PR TITLE
fix: require reading playground CLAUDE.md files before UI changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **IMPORTANT**: Unless explicitly mentioned in the user's prompt, do NOT check, search, read, or reference files in the `examples/` folder. Focus on core framework packages, integrations, and documentation. Only include examples when the user specifically asks about them.
 
-**UI Development**: When working on UI-related tasks, code modifications should be made in the `packages/playground/` and `packages/playground-ui/` packages. These packages contain the user interface components and follow specific development standards outlined in their respective CLAUDE.md files.
+**UI Development**: When working on UI-related tasks, or inside `packages/playground/` or `packages/playground-ui/`, you MUST read `packages/playground/CLAUDE.md` and `packages/playground-ui/CLAUDE.md` before making any changes.
 
 ## Development Commands
 


### PR DESCRIPTION
Strengthens the UI Development directive in the root CLAUDE.md so that working on playground packages requires reading their respective CLAUDE.md files first, rather than just suggesting it.

Before: "code modifications should be made in... These packages contain the user interface components and follow specific development standards outlined in their respective CLAUDE.md files."

After: "you MUST read `packages/playground/CLAUDE.md` and `packages/playground-ui/CLAUDE.md` before making any changes."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines and contributor documentation.

**Note:** This release contains no end-user facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->