### PR TITLE
feat(source-local): add @mastra/source-local package

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "build:schema-compat": "pnpm turbo build --filter ./packages/schema-compat",
     "build:auth": "pnpm turbo build --filter \"./auth/*\" --filter \"./packages/auth\"",
     "build:observability": "pnpm turbo build --filter \"./observability/*\"",
+    "build:sources": "pnpm turbo build --filter \"./sources/*\"",
     "dev:playground": "pnpm turbo run dev --filter ./packages/playground-ui --filter ./packages/playground --filter ./client-sdks/react",
     "generate:integration": "pnpx tsx ./integration-generator/index.ts",
     "generate:docs": "pnpx tsx ./scripts/generate-package-docs.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3930,6 +3930,49 @@ importers:
         specifier: ^3.25.0
         version: 3.25.76
 
+  sources/local:
+    dependencies:
+      chokidar:
+        specifier: ^4.0.0
+        version: 4.0.3
+      fast-glob:
+        specifier: ^3.3.0
+        version: 3.3.3
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/admin':
+        specifier: workspace:*
+        version: link:../../packages/admin
+      '@types/node':
+        specifier: 22.13.17
+        version: 22.13.17
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.0.12(vitest@4.0.16)
+      '@vitest/ui':
+        specifier: 'catalog:'
+        version: 4.0.12(vitest@4.0.16)
+      eslint:
+        specifier: ^9.37.0
+        version: 9.39.2(jiti@2.6.1)
+      memfs:
+        specifier: ^4.0.0
+        version: 4.51.1
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@microsoft/api-extractor@7.55.2(@types/node@22.13.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.13.17)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.13.17)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+
   stores/_test-utils:
     dependencies:
       vitest:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ packages:
   - examples/dane
   - auth/*
   - observability/*
+  - sources/*
   - explorations/longmemeval
   - explorations/agent-builder-gh-repro
   - e2e-tests/client-js/_test-utils

--- a/sources/local/CHANGELOG.md
+++ b/sources/local/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @mastra/source-local
+
+## 1.0.0
+
+### Features
+
+- Initial release
+- `LocalProjectSource` implementing `ProjectSourceProvider` interface
+- Automatic Mastra project discovery via `MastraProjectDetector`
+- File watching support for development hot-reload
+- Support for npm, pnpm, yarn, and bun package managers

--- a/sources/local/eslint.config.js
+++ b/sources/local/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/sources/local/package.json
+++ b/sources/local/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@mastra/source-local",
+  "version": "1.0.0",
+  "description": "Local filesystem project source provider for MastraAdmin",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "build:docs": "pnpx tsx ../../scripts/generate-package-docs.ts sources/local",
+    "build:watch": "pnpm build:lib --watch",
+    "test": "vitest run",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "chokidar": "^4.0.0",
+    "fast-glob": "^3.3.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/admin": "workspace:*",
+    "@types/node": "22.13.17",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "eslint": "^9.37.0",
+    "memfs": "^4.0.0",
+    "tsup": "^8.5.0",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@mastra/admin": ">=1.0.0-0 <2.0.0-0"
+  },
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "sources/local"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/sources/local/src/detector.test.ts
+++ b/sources/local/src/detector.test.ts
@@ -1,0 +1,295 @@
+import * as fs from 'node:fs/promises';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MastraProjectDetector } from './detector';
+
+// Mock fs module
+vi.mock('node:fs/promises');
+
+describe('MastraProjectDetector', () => {
+  let detector: MastraProjectDetector;
+
+  beforeEach(() => {
+    detector = new MastraProjectDetector();
+    vi.clearAllMocks();
+  });
+
+  describe('isMastraProject', () => {
+    it('should return false if no package.json exists', async () => {
+      vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT'));
+
+      const result = await detector.isMastraProject('/test/project');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true if project has @mastra/core dependency', async () => {
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          name: 'test-project',
+          dependencies: {
+            '@mastra/core': '^1.0.0',
+          },
+        }),
+      );
+
+      const result = await detector.isMastraProject('/test/project');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true if project has mastra.config.ts', async () => {
+      vi.mocked(fs.access).mockImplementation(async filePath => {
+        // package.json exists
+        if (String(filePath).endsWith('package.json')) return;
+        // mastra.config.ts exists
+        if (String(filePath).endsWith('mastra.config.ts')) return;
+        throw new Error('ENOENT');
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          name: 'test-project',
+          dependencies: {},
+        }),
+      );
+
+      const result = await detector.isMastraProject('/test/project');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if no Mastra indicators present', async () => {
+      vi.mocked(fs.access).mockImplementation(async filePath => {
+        if (String(filePath).endsWith('package.json')) return;
+        throw new Error('ENOENT');
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          name: 'test-project',
+          dependencies: {
+            express: '^4.0.0',
+          },
+        }),
+      );
+
+      const result = await detector.isMastraProject('/test/project');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true if project has mastra dependency', async () => {
+      vi.mocked(fs.access).mockImplementation(async filePath => {
+        if (String(filePath).endsWith('package.json')) return;
+        throw new Error('ENOENT');
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          name: 'test-project',
+          dependencies: {
+            mastra: '^1.0.0',
+          },
+        }),
+      );
+
+      const result = await detector.isMastraProject('/test/project');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true if project has @mastra/cli devDependency', async () => {
+      vi.mocked(fs.access).mockImplementation(async filePath => {
+        if (String(filePath).endsWith('package.json')) return;
+        throw new Error('ENOENT');
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          name: 'test-project',
+          devDependencies: {
+            '@mastra/cli': '^1.0.0',
+          },
+        }),
+      );
+
+      const result = await detector.isMastraProject('/test/project');
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('getProjectMetadata', () => {
+    it('should return complete metadata for a Mastra project', async () => {
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readFile).mockImplementation(async filePath => {
+        if (String(filePath).endsWith('package.json')) {
+          return JSON.stringify({
+            name: 'my-mastra-app',
+            version: '1.0.0',
+            description: 'A Mastra application',
+            main: 'dist/index.js',
+            dependencies: {
+              '@mastra/core': '^1.0.0',
+              '@mastra/server': '^1.0.0',
+            },
+          });
+        }
+        throw new Error('ENOENT');
+      });
+
+      const metadata = await detector.getProjectMetadata('/test/project');
+
+      expect(metadata.name).toBe('my-mastra-app');
+      expect(metadata.version).toBe('1.0.0');
+      expect(metadata.mastraDependencies).toContain('@mastra/core');
+      expect(metadata.mastraDependencies).toContain('@mastra/server');
+    });
+
+    it('should detect package manager from lock file', async () => {
+      vi.mocked(fs.access).mockImplementation(async filePath => {
+        if (String(filePath).endsWith('package.json') || String(filePath).endsWith('pnpm-lock.yaml')) {
+          return;
+        }
+        throw new Error('ENOENT');
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          name: 'test',
+          dependencies: { '@mastra/core': '*' },
+        }),
+      );
+
+      const metadata = await detector.getProjectMetadata('/test/project');
+
+      expect(metadata.packageManager).toBe('pnpm');
+    });
+
+    it('should detect yarn package manager', async () => {
+      vi.mocked(fs.access).mockImplementation(async filePath => {
+        if (String(filePath).endsWith('package.json') || String(filePath).endsWith('yarn.lock')) {
+          return;
+        }
+        throw new Error('ENOENT');
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          name: 'test',
+          dependencies: { '@mastra/core': '*' },
+        }),
+      );
+
+      const metadata = await detector.getProjectMetadata('/test/project');
+
+      expect(metadata.packageManager).toBe('yarn');
+    });
+
+    it('should detect bun package manager', async () => {
+      vi.mocked(fs.access).mockImplementation(async filePath => {
+        if (String(filePath).endsWith('package.json') || String(filePath).endsWith('bun.lockb')) {
+          return;
+        }
+        throw new Error('ENOENT');
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          name: 'test',
+          dependencies: { '@mastra/core': '*' },
+        }),
+      );
+
+      const metadata = await detector.getProjectMetadata('/test/project');
+
+      expect(metadata.packageManager).toBe('bun');
+    });
+
+    it('should default to npm if no lock file found', async () => {
+      vi.mocked(fs.access).mockImplementation(async filePath => {
+        if (String(filePath).endsWith('package.json')) return;
+        throw new Error('ENOENT');
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          name: 'test',
+          dependencies: { '@mastra/core': '*' },
+        }),
+      );
+
+      const metadata = await detector.getProjectMetadata('/test/project');
+
+      expect(metadata.packageManager).toBe('npm');
+    });
+
+    it('should detect TypeScript project', async () => {
+      vi.mocked(fs.access).mockImplementation(async filePath => {
+        if (
+          String(filePath).endsWith('package.json') ||
+          String(filePath).endsWith('tsconfig.json') ||
+          String(filePath).endsWith('pnpm-lock.yaml')
+        ) {
+          return;
+        }
+        throw new Error('ENOENT');
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          name: 'test',
+          dependencies: { '@mastra/core': '*' },
+        }),
+      );
+
+      const metadata = await detector.getProjectMetadata('/test/project');
+
+      expect(metadata.isTypeScript).toBe(true);
+    });
+
+    it('should throw if no package.json found', async () => {
+      vi.mocked(fs.readFile).mockRejectedValue(new Error('ENOENT'));
+
+      await expect(detector.getProjectMetadata('/test/project')).rejects.toThrow('No package.json found');
+    });
+
+    it('should throw if not a valid Mastra project', async () => {
+      vi.mocked(fs.access).mockImplementation(async filePath => {
+        if (String(filePath).endsWith('package.json')) return;
+        throw new Error('ENOENT');
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          name: 'test',
+          dependencies: { express: '*' },
+        }),
+      );
+
+      await expect(detector.getProjectMetadata('/test/project')).rejects.toThrow('is not a valid Mastra project');
+    });
+  });
+
+  describe('detectPackageManager', () => {
+    it('should detect from packageManager field in package.json', async () => {
+      vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT')); // No lock files
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          name: 'test',
+          packageManager: 'pnpm@8.0.0',
+        }),
+      );
+
+      const pm = await detector.detectPackageManager('/test/project');
+
+      expect(pm).toBe('pnpm');
+    });
+
+    it('should detect yarn from packageManager field', async () => {
+      vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT'));
+      vi.mocked(fs.readFile).mockResolvedValue(
+        JSON.stringify({
+          name: 'test',
+          packageManager: 'yarn@4.0.0',
+        }),
+      );
+
+      const pm = await detector.detectPackageManager('/test/project');
+
+      expect(pm).toBe('yarn');
+    });
+  });
+});

--- a/sources/local/src/detector.ts
+++ b/sources/local/src/detector.ts
@@ -1,0 +1,212 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import type { PackageManager, ProjectMetadata } from './types';
+
+/**
+ * Filenames that indicate a Mastra configuration.
+ */
+const MASTRA_CONFIG_FILES = [
+  'mastra.config.ts',
+  'mastra.config.js',
+  'mastra.config.mjs',
+  'src/mastra/index.ts',
+  'src/mastra/index.js',
+];
+
+/**
+ * Package names that indicate a Mastra project.
+ */
+const MASTRA_PACKAGES = ['@mastra/core', 'mastra', '@mastra/cli', '@mastra/server'];
+
+/**
+ * Lock files and their corresponding package managers.
+ */
+const LOCK_FILES: Record<string, PackageManager> = {
+  'pnpm-lock.yaml': 'pnpm',
+  'yarn.lock': 'yarn',
+  'bun.lockb': 'bun',
+  'package-lock.json': 'npm',
+};
+
+/**
+ * Detects whether a directory contains a valid Mastra project
+ * and extracts project metadata.
+ */
+export class MastraProjectDetector {
+  /**
+   * Check if a directory is a valid Mastra project.
+   *
+   * A directory is considered a Mastra project if:
+   * 1. It has a package.json file
+   * 2. It has @mastra/core or mastra as a dependency
+   *    OR it has a mastra.config file
+   *
+   * @param dir - Absolute path to the directory
+   * @returns True if the directory is a Mastra project
+   */
+  async isMastraProject(dir: string): Promise<boolean> {
+    try {
+      // Check for package.json
+      const packageJsonPath = path.join(dir, 'package.json');
+      const packageJsonExists = await this.fileExists(packageJsonPath);
+      if (!packageJsonExists) {
+        return false;
+      }
+
+      // Check for Mastra config file
+      const hasMastraConfig = await this.findMastraConfig(dir);
+      if (hasMastraConfig) {
+        return true;
+      }
+
+      // Check for Mastra dependencies in package.json
+      const packageJson = await this.readPackageJson(dir);
+      if (!packageJson) {
+        return false;
+      }
+
+      const allDeps = {
+        ...packageJson.dependencies,
+        ...packageJson.devDependencies,
+      };
+
+      return MASTRA_PACKAGES.some(pkg => pkg in allDeps);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Get metadata about a Mastra project.
+   *
+   * @param dir - Absolute path to the project directory
+   * @returns Project metadata
+   * @throws Error if not a valid Mastra project
+   */
+  async getProjectMetadata(dir: string): Promise<ProjectMetadata> {
+    const packageJson = await this.readPackageJson(dir);
+    if (!packageJson) {
+      throw new Error(`No package.json found in ${dir}`);
+    }
+
+    const isValid = await this.isMastraProject(dir);
+    if (!isValid) {
+      throw new Error(`Directory ${dir} is not a valid Mastra project`);
+    }
+
+    const packageManager = await this.detectPackageManager(dir);
+    const mastraConfigPath = await this.findMastraConfig(dir);
+    const isTypeScript = await this.detectTypeScript(dir);
+
+    const allDeps = {
+      ...packageJson.dependencies,
+      ...packageJson.devDependencies,
+    };
+
+    const mastraDependencies = MASTRA_PACKAGES.filter(pkg => pkg in allDeps);
+
+    return {
+      name: packageJson.name || path.basename(dir),
+      version: packageJson.version,
+      description: packageJson.description,
+      packageManager,
+      hasMastraConfig: !!mastraConfigPath,
+      mastraConfigPath: mastraConfigPath || undefined,
+      entryPoint: packageJson.main || packageJson.module,
+      isTypeScript,
+      mastraDependencies,
+    };
+  }
+
+  /**
+   * Detect the package manager used by the project.
+   */
+  async detectPackageManager(dir: string): Promise<PackageManager> {
+    // Check for lock files in order of preference
+    for (const [lockFile, manager] of Object.entries(LOCK_FILES)) {
+      const lockPath = path.join(dir, lockFile);
+      if (await this.fileExists(lockPath)) {
+        return manager;
+      }
+    }
+
+    // Check packageManager field in package.json
+    const packageJson = await this.readPackageJson(dir);
+    if (packageJson?.packageManager) {
+      const pmField = packageJson.packageManager;
+      if (pmField.startsWith('pnpm')) return 'pnpm';
+      if (pmField.startsWith('yarn')) return 'yarn';
+      if (pmField.startsWith('bun')) return 'bun';
+      if (pmField.startsWith('npm')) return 'npm';
+    }
+
+    // Default to npm
+    return 'npm';
+  }
+
+  /**
+   * Find the Mastra config file path if it exists.
+   */
+  private async findMastraConfig(dir: string): Promise<string | null> {
+    for (const configFile of MASTRA_CONFIG_FILES) {
+      const configPath = path.join(dir, configFile);
+      if (await this.fileExists(configPath)) {
+        return configPath;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Detect if the project uses TypeScript.
+   */
+  private async detectTypeScript(dir: string): Promise<boolean> {
+    const tsconfigPath = path.join(dir, 'tsconfig.json');
+    return this.fileExists(tsconfigPath);
+  }
+
+  /**
+   * Read and parse package.json from a directory.
+   */
+  private async readPackageJson(dir: string): Promise<PackageJson | null> {
+    try {
+      const packageJsonPath = path.join(dir, 'package.json');
+      const content = await fs.readFile(packageJsonPath, 'utf-8');
+      return JSON.parse(content) as PackageJson;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Check if a file exists.
+   */
+  private async fileExists(filePath: string): Promise<boolean> {
+    try {
+      await fs.access(filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Simplified package.json type.
+ */
+interface PackageJson {
+  name?: string;
+  version?: string;
+  description?: string;
+  main?: string;
+  module?: string;
+  packageManager?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+/**
+ * Singleton instance for convenience.
+ */
+export const detector = new MastraProjectDetector();

--- a/sources/local/src/index.ts
+++ b/sources/local/src/index.ts
@@ -1,4 +1,28 @@
-// Placeholder for @mastra/source-local package
-// Implementation will be added in subsequent phases
+// Main provider
+export { LocalProjectSource } from './provider';
 
-export {};
+// Detector
+export { MastraProjectDetector, detector } from './detector';
+
+// Scanner
+export { DirectoryScanner, scanner } from './scanner';
+
+// Watcher
+export { ProjectWatcher } from './watcher';
+export type { WatcherOptions } from './watcher';
+
+// Types
+export type {
+  LocalProjectSourceConfig,
+  PackageManager,
+  ProjectMetadata,
+  LocalProjectSource as LocalProjectSourceType,
+  ScanOptions,
+  ScanResult,
+  ScanError,
+  ProjectSource,
+  ChangeEvent,
+} from './types';
+
+// Utilities
+export { generateProjectId, isPathAccessible, isDirectory, resolvePath, getProjectNameFromPath } from './utils';

--- a/sources/local/src/index.ts
+++ b/sources/local/src/index.ts
@@ -1,0 +1,4 @@
+// Placeholder for @mastra/source-local package
+// Implementation will be added in subsequent phases
+
+export {};

--- a/sources/local/src/provider.test.ts
+++ b/sources/local/src/provider.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MastraProjectDetector } from './detector';
+import { LocalProjectSource } from './provider';
+import type { DirectoryScanner } from './scanner';
+
+describe('LocalProjectSource', () => {
+  let provider: LocalProjectSource;
+  let mockDetector: MastraProjectDetector;
+  let mockScanner: DirectoryScanner;
+
+  beforeEach(() => {
+    mockDetector = {
+      isMastraProject: vi.fn().mockResolvedValue(true),
+      getProjectMetadata: vi.fn().mockResolvedValue({
+        name: 'test-project',
+        packageManager: 'pnpm',
+        hasMastraConfig: true,
+        isTypeScript: true,
+        mastraDependencies: ['@mastra/core'],
+      }),
+    } as unknown as MastraProjectDetector;
+
+    mockScanner = {
+      scan: vi.fn(),
+      scanMultiple: vi.fn().mockResolvedValue({
+        projects: [
+          {
+            id: 'local_abc123',
+            name: 'test-project',
+            type: 'local',
+            path: '/test/project',
+            metadata: {
+              name: 'test-project',
+              packageManager: 'pnpm',
+            },
+          },
+        ],
+        skipped: [],
+        errors: [],
+      }),
+    } as unknown as DirectoryScanner;
+
+    provider = new LocalProjectSource({ basePaths: ['/test'] }, mockDetector, mockScanner);
+  });
+
+  describe('constructor', () => {
+    it('should throw if no base paths provided', () => {
+      expect(() => new LocalProjectSource({ basePaths: [] })).toThrow(
+        'LocalProjectSource requires at least one base path',
+      );
+    });
+
+    it('should accept valid configuration', () => {
+      const source = new LocalProjectSource({
+        basePaths: ['/test'],
+        maxDepth: 3,
+        watchChanges: true,
+      });
+
+      const config = source.getConfig();
+      expect(config.maxDepth).toBe(3);
+      expect(config.watchChanges).toBe(true);
+    });
+  });
+
+  describe('listProjects', () => {
+    it('should return discovered projects', async () => {
+      const projects = await provider.listProjects('team-1');
+
+      expect(projects).toHaveLength(1);
+      expect(projects[0].name).toBe('test-project');
+    });
+
+    it('should use cache on subsequent calls', async () => {
+      await provider.listProjects('team-1');
+      await provider.listProjects('team-1');
+
+      expect(mockScanner.scanMultiple).toHaveBeenCalledTimes(1);
+    });
+
+    it('should pass correct options to scanner', async () => {
+      await provider.listProjects('team-1');
+
+      expect(mockScanner.scanMultiple).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          include: ['*'],
+          exclude: expect.arrayContaining(['node_modules', '.git']),
+          maxDepth: 2,
+        }),
+      );
+    });
+  });
+
+  describe('getProject', () => {
+    it('should return cached project', async () => {
+      await provider.listProjects('team-1'); // Populate cache
+      const project = await provider.getProject('local_abc123');
+
+      expect(project.name).toBe('test-project');
+    });
+
+    it('should throw if project not found', async () => {
+      await expect(provider.getProject('nonexistent')).rejects.toThrow('Project not found');
+    });
+
+    it('should refresh cache if project not found initially', async () => {
+      // First call will populate cache
+      await provider.listProjects('team-1');
+
+      // Clear scanner mock call count and clear cache to force rescan
+      vi.mocked(mockScanner.scanMultiple).mockClear();
+      provider.clearCache();
+
+      // Request a non-existent project - should trigger rescan
+      await expect(provider.getProject('nonexistent')).rejects.toThrow('Project not found');
+
+      // Should have called scanMultiple again after cache clear
+      expect(mockScanner.scanMultiple).toHaveBeenCalled();
+    });
+  });
+
+  describe('validateAccess', () => {
+    it('should return false for non-local source type', async () => {
+      const result = await provider.validateAccess({
+        id: '123',
+        name: 'test',
+        type: 'github',
+        path: '/test',
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('watchChanges', () => {
+    it('should return no-op if watching is disabled', () => {
+      const cleanup = provider.watchChanges({ id: '1', name: 'test', type: 'local', path: '/test' }, () => {});
+
+      expect(typeof cleanup).toBe('function');
+    });
+
+    it('should warn when watching is disabled', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      provider.watchChanges({ id: '1', name: 'test', type: 'local', path: '/test' }, () => {});
+
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('watchChanges is disabled'));
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('addProject', () => {
+    it('should add a valid project to cache', async () => {
+      const project = await provider.addProject('/new/project');
+
+      expect(project.type).toBe('local');
+      expect(project.name).toBe('test-project');
+      expect(project.id).toMatch(/^local_[a-f0-9]+$/);
+    });
+
+    it('should throw for invalid project', async () => {
+      vi.mocked(mockDetector.isMastraProject).mockResolvedValueOnce(false);
+
+      await expect(provider.addProject('/invalid/project')).rejects.toThrow('Not a valid Mastra project');
+    });
+  });
+
+  describe('removeProject', () => {
+    it('should remove project from cache', async () => {
+      await provider.listProjects('team-1');
+      provider.removeProject('local_abc123');
+
+      // Clear mock to check if rescan is triggered
+      vi.mocked(mockScanner.scanMultiple).mockClear();
+
+      // Getting the project should trigger rescan since it's not in cache
+      await provider.getProject('local_abc123');
+      expect(mockScanner.scanMultiple).toHaveBeenCalled();
+    });
+  });
+
+  describe('clearCache', () => {
+    it('should force rescan on next listProjects call', async () => {
+      await provider.listProjects('team-1');
+
+      provider.clearCache();
+
+      // Clear mock call count
+      vi.mocked(mockScanner.scanMultiple).mockClear();
+
+      await provider.listProjects('team-1');
+
+      expect(mockScanner.scanMultiple).toHaveBeenCalled();
+    });
+  });
+
+  describe('getConfig', () => {
+    it('should return current configuration', () => {
+      const config = provider.getConfig();
+
+      expect(config.basePaths).toBeDefined();
+      expect(config.maxDepth).toBe(2);
+      expect(config.watchChanges).toBe(false);
+    });
+
+    it('should return readonly config (not modifying original)', () => {
+      const config1 = provider.getConfig();
+      const config2 = provider.getConfig();
+
+      expect(config1).not.toBe(config2);
+      expect(config1).toEqual(config2);
+    });
+  });
+});

--- a/sources/local/src/provider.ts
+++ b/sources/local/src/provider.ts
@@ -1,0 +1,253 @@
+import type { ChangeEvent, ProjectSource, ProjectSourceProvider } from '@mastra/admin';
+
+import type { MastraProjectDetector } from './detector';
+import { detector as defaultDetector } from './detector';
+import { DirectoryScanner } from './scanner';
+import type { LocalProjectSource as LocalProjectSourceType, LocalProjectSourceConfig } from './types';
+import { generateProjectId, isDirectory, isPathAccessible, resolvePath } from './utils';
+import { ProjectWatcher } from './watcher';
+
+/**
+ * Default configuration values.
+ */
+const DEFAULT_CONFIG: Required<Omit<LocalProjectSourceConfig, 'basePaths'>> = {
+  include: ['*'],
+  exclude: ['node_modules', '.git', 'dist', 'build', '.next', '.turbo'],
+  maxDepth: 2,
+  watchChanges: false,
+  watchDebounceMs: 300,
+};
+
+/**
+ * Local filesystem project source provider.
+ *
+ * Discovers Mastra projects from configured directories on the local filesystem.
+ * Ideal for development and self-hosted deployments.
+ *
+ * @example
+ * ```typescript
+ * const source = new LocalProjectSource({
+ *   basePaths: ['/home/user/projects'],
+ *   watchChanges: true, // Enable for dev mode
+ * });
+ *
+ * // List all discovered projects
+ * const projects = await source.listProjects('team-1');
+ *
+ * // Get a specific project
+ * const project = await source.getProject('local_abc123');
+ *
+ * // Watch for changes
+ * const cleanup = source.watchChanges(project, (event) => {
+ *   console.log('File changed:', event.path);
+ * });
+ * ```
+ */
+export class LocalProjectSource implements ProjectSourceProvider {
+  readonly type = 'local' as const;
+
+  private readonly config: Required<LocalProjectSourceConfig>;
+  private readonly detector: MastraProjectDetector;
+  private readonly scanner: DirectoryScanner;
+  private projectCache: Map<string, LocalProjectSourceType> = new Map();
+  private lastScanTime: number = 0;
+  private readonly cacheTTL = 30000; // 30 seconds
+
+  constructor(config: LocalProjectSourceConfig, detector?: MastraProjectDetector, scanner?: DirectoryScanner) {
+    // Validate and resolve base paths
+    if (!config.basePaths || config.basePaths.length === 0) {
+      throw new Error('LocalProjectSource requires at least one base path');
+    }
+
+    this.config = {
+      ...DEFAULT_CONFIG,
+      ...config,
+      basePaths: config.basePaths.map(resolvePath),
+    };
+
+    this.detector = detector ?? defaultDetector;
+    this.scanner = scanner ?? new DirectoryScanner(this.detector);
+  }
+
+  /**
+   * List available projects from configured base paths.
+   *
+   * @param _teamId - Team ID (not used for local source, included for interface compatibility)
+   * @returns List of discovered project sources
+   */
+  async listProjects(_teamId: string): Promise<ProjectSource[]> {
+    // Check if cache is still valid
+    const now = Date.now();
+    if (now - this.lastScanTime < this.cacheTTL && this.projectCache.size > 0) {
+      return Array.from(this.projectCache.values());
+    }
+
+    // Scan all configured paths
+    const result = await this.scanner.scanMultiple(this.config.basePaths, {
+      include: this.config.include,
+      exclude: this.config.exclude,
+      maxDepth: this.config.maxDepth,
+    });
+
+    // Update cache
+    this.projectCache.clear();
+    for (const project of result.projects) {
+      this.projectCache.set(project.id, project);
+    }
+    this.lastScanTime = now;
+
+    // Log any errors (non-fatal)
+    if (result.errors.length > 0) {
+      console.warn(`LocalProjectSource: ${result.errors.length} errors during scan:`, result.errors);
+    }
+
+    return result.projects;
+  }
+
+  /**
+   * Get a specific project by ID.
+   *
+   * @param projectId - Project ID (generated from path hash)
+   * @returns Project source details
+   * @throws Error if project not found
+   */
+  async getProject(projectId: string): Promise<ProjectSource> {
+    // Check cache first
+    if (this.projectCache.has(projectId)) {
+      const cached = this.projectCache.get(projectId)!;
+      // Verify the project still exists
+      if (await isDirectory(cached.path)) {
+        return cached;
+      }
+      // Remove stale cache entry
+      this.projectCache.delete(projectId);
+    }
+
+    // Refresh cache and try again
+    await this.listProjects(''); // teamId not used
+
+    const project = this.projectCache.get(projectId);
+    if (!project) {
+      throw new Error(`Project not found: ${projectId}`);
+    }
+
+    return project;
+  }
+
+  /**
+   * Validate that a project source is accessible.
+   *
+   * @param source - Project source to validate
+   * @returns True if the project path exists and is accessible
+   */
+  async validateAccess(source: ProjectSource): Promise<boolean> {
+    if (source.type !== 'local') {
+      return false;
+    }
+
+    // Check path exists and is accessible
+    if (!(await isPathAccessible(source.path))) {
+      return false;
+    }
+
+    // Check it's still a valid Mastra project
+    return this.detector.isMastraProject(source.path);
+  }
+
+  /**
+   * Get the local path to the project.
+   * For local sources, returns the path directly (no copying needed).
+   *
+   * @param source - Project source
+   * @param _targetDir - Target directory (ignored for local source)
+   * @returns Local filesystem path
+   */
+  async getProjectPath(source: ProjectSource, _targetDir: string): Promise<string> {
+    // For local source, just return the path directly
+    // Runners use the project in-place
+    if (!(await this.validateAccess(source))) {
+      throw new Error(`Project path is not accessible: ${source.path}`);
+    }
+
+    return source.path;
+  }
+
+  /**
+   * Watch for file changes in a project.
+   *
+   * @param source - Project source to watch
+   * @param callback - Callback for change events
+   * @returns Cleanup function to stop watching
+   */
+  watchChanges(source: ProjectSource, callback: (event: ChangeEvent) => void): () => void {
+    if (!this.config.watchChanges) {
+      console.warn('LocalProjectSource: watchChanges is disabled in config');
+      return () => {}; // No-op cleanup
+    }
+
+    const watcher = new ProjectWatcher({
+      debounceMs: this.config.watchDebounceMs,
+    });
+
+    return watcher.watch(source as LocalProjectSourceType, callback);
+  }
+
+  /**
+   * Manually add a project path to the source.
+   * Useful for adding projects outside the configured base paths.
+   *
+   * @param projectPath - Absolute path to the project
+   * @returns Added project source
+   * @throws Error if not a valid Mastra project
+   */
+  async addProject(projectPath: string): Promise<LocalProjectSourceType> {
+    const resolvedPath = resolvePath(projectPath);
+
+    // Verify it's a valid Mastra project
+    const isValid = await this.detector.isMastraProject(resolvedPath);
+    if (!isValid) {
+      throw new Error(`Not a valid Mastra project: ${resolvedPath}`);
+    }
+
+    // Get metadata
+    const metadata = await this.detector.getProjectMetadata(resolvedPath);
+
+    const project: LocalProjectSourceType = {
+      id: generateProjectId(resolvedPath),
+      name: metadata.name,
+      type: 'local',
+      path: resolvedPath,
+      metadata,
+    };
+
+    // Add to cache
+    this.projectCache.set(project.id, project);
+
+    return project;
+  }
+
+  /**
+   * Remove a project from the cache.
+   * Does not delete the actual project files.
+   *
+   * @param projectId - Project ID to remove
+   */
+  removeProject(projectId: string): void {
+    this.projectCache.delete(projectId);
+  }
+
+  /**
+   * Clear the project cache, forcing a rescan on next listProjects call.
+   */
+  clearCache(): void {
+    this.projectCache.clear();
+    this.lastScanTime = 0;
+  }
+
+  /**
+   * Get the current configuration.
+   */
+  getConfig(): Readonly<Required<LocalProjectSourceConfig>> {
+    return { ...this.config };
+  }
+}

--- a/sources/local/src/scanner.test.ts
+++ b/sources/local/src/scanner.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MastraProjectDetector } from './detector';
+import { DirectoryScanner } from './scanner';
+
+describe('DirectoryScanner', () => {
+  let scanner: DirectoryScanner;
+  let mockDetector: MastraProjectDetector;
+
+  beforeEach(() => {
+    mockDetector = {
+      isMastraProject: vi.fn(),
+      getProjectMetadata: vi.fn(),
+    } as unknown as MastraProjectDetector;
+
+    scanner = new DirectoryScanner(mockDetector);
+  });
+
+  describe('scan', () => {
+    it('should return empty results for non-existent path', async () => {
+      const result = await scanner.scan({
+        basePath: '/nonexistent/path',
+        include: ['*'],
+        exclude: [],
+        maxDepth: 2,
+      });
+
+      expect(result.projects).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].code).toBe('ACCESS_ERROR');
+    });
+
+    it('should include ACCESS_ERROR code when path cannot be accessed', async () => {
+      const result = await scanner.scan({
+        basePath: '/nonexistent/definitely/not/real',
+        include: ['*'],
+        exclude: [],
+        maxDepth: 2,
+      });
+
+      expect(result.errors[0]).toMatchObject({
+        path: '/nonexistent/definitely/not/real',
+        code: 'ACCESS_ERROR',
+      });
+      expect(result.errors[0].error).toContain('Cannot access path');
+    });
+  });
+
+  describe('scanMultiple', () => {
+    it('should return empty results for multiple non-existent paths', async () => {
+      const result = await scanner.scanMultiple(['/nonexistent/path1', '/nonexistent/path2'], {
+        include: ['*'],
+        exclude: [],
+        maxDepth: 2,
+      });
+
+      expect(result.projects).toHaveLength(0);
+      expect(result.errors).toHaveLength(2);
+    });
+
+    it('should deduplicate projects found in overlapping paths', async () => {
+      // This tests the deduplication logic even if paths don't exist
+      // The seenPaths Set ensures uniqueness
+      const result = await scanner.scanMultiple(['/same/path', '/same/path'], {
+        include: ['*'],
+        exclude: [],
+        maxDepth: 2,
+      });
+
+      // Both will fail, but that's ok - we're testing the structure
+      expect(result.errors).toHaveLength(2);
+    });
+  });
+});

--- a/sources/local/src/scanner.ts
+++ b/sources/local/src/scanner.ts
@@ -1,0 +1,182 @@
+import * as fs from 'node:fs/promises';
+
+import fg from 'fast-glob';
+
+import { MastraProjectDetector } from './detector';
+import type { LocalProjectSource, ScanError, ScanOptions, ScanResult } from './types';
+import { generateProjectId } from './utils';
+
+/**
+ * Scans directories to discover Mastra projects.
+ */
+export class DirectoryScanner {
+  private readonly detector: MastraProjectDetector;
+
+  constructor(detector?: MastraProjectDetector) {
+    this.detector = detector ?? new MastraProjectDetector();
+  }
+
+  /**
+   * Scan a base path for Mastra projects.
+   *
+   * @param options - Scan options
+   * @returns Scan result with discovered projects
+   */
+  async scan(options: ScanOptions): Promise<ScanResult> {
+    const { basePath, include, exclude, maxDepth } = options;
+
+    const projects: LocalProjectSource[] = [];
+    const skipped: string[] = [];
+    const errors: ScanError[] = [];
+
+    // Verify base path exists
+    try {
+      const stats = await fs.stat(basePath);
+      if (!stats.isDirectory()) {
+        errors.push({
+          path: basePath,
+          error: 'Path is not a directory',
+          code: 'NOT_DIRECTORY',
+        });
+        return { projects, skipped, errors };
+      }
+    } catch (error) {
+      errors.push({
+        path: basePath,
+        error: `Cannot access path: ${(error as Error).message}`,
+        code: 'ACCESS_ERROR',
+      });
+      return { projects, skipped, errors };
+    }
+
+    // Generate glob patterns for scanning
+    const patterns = this.generatePatterns(include, maxDepth);
+    const ignorePatterns = this.generateIgnorePatterns(exclude);
+
+    // Find all directories matching the patterns
+    const directories = await fg(patterns, {
+      cwd: basePath,
+      onlyDirectories: true,
+      absolute: true,
+      ignore: ignorePatterns,
+      deep: maxDepth,
+      followSymbolicLinks: false,
+    });
+
+    // Also check the base path itself
+    const directoriesToCheck = [basePath, ...directories];
+
+    // Check each directory for Mastra projects
+    for (const dir of directoriesToCheck) {
+      try {
+        const isMastraProject = await this.detector.isMastraProject(dir);
+
+        if (isMastraProject) {
+          const metadata = await this.detector.getProjectMetadata(dir);
+          const projectSource: LocalProjectSource = {
+            id: generateProjectId(dir),
+            name: metadata.name,
+            type: 'local',
+            path: dir,
+            defaultBranch: undefined, // Local projects don't have branches
+            metadata,
+          };
+          projects.push(projectSource);
+        } else if (dir !== basePath) {
+          // Only record as skipped if it's not the base path
+          skipped.push(dir);
+        }
+      } catch (error) {
+        errors.push({
+          path: dir,
+          error: (error as Error).message,
+        });
+      }
+    }
+
+    return { projects, skipped, errors };
+  }
+
+  /**
+   * Scan multiple base paths and merge results.
+   *
+   * @param basePaths - Array of base paths to scan
+   * @param options - Common scan options (exclude, maxDepth, etc.)
+   * @returns Combined scan result
+   */
+  async scanMultiple(basePaths: string[], options: Omit<ScanOptions, 'basePath'>): Promise<ScanResult> {
+    const allProjects: LocalProjectSource[] = [];
+    const allSkipped: string[] = [];
+    const allErrors: ScanError[] = [];
+
+    // Use a Set to track unique project paths (avoid duplicates)
+    const seenPaths = new Set<string>();
+
+    for (const basePath of basePaths) {
+      const result = await this.scan({
+        basePath,
+        ...options,
+      });
+
+      // Add unique projects
+      for (const project of result.projects) {
+        if (!seenPaths.has(project.path)) {
+          seenPaths.add(project.path);
+          allProjects.push(project);
+        }
+      }
+
+      allSkipped.push(...result.skipped);
+      allErrors.push(...result.errors);
+    }
+
+    return {
+      projects: allProjects,
+      skipped: allSkipped,
+      errors: allErrors,
+    };
+  }
+
+  /**
+   * Generate glob patterns from include patterns.
+   */
+  private generatePatterns(include: string[], maxDepth: number): string[] {
+    if (include.length === 0) {
+      // Default: scan immediate subdirectories
+      return ['*'];
+    }
+
+    // Expand patterns to account for depth
+    const patterns: string[] = [];
+    for (const pattern of include) {
+      patterns.push(pattern);
+      // Add depth-based patterns if not already a glob
+      if (!pattern.includes('**')) {
+        for (let depth = 1; depth < maxDepth; depth++) {
+          const depthPrefix = Array(depth).fill('*').join('/');
+          patterns.push(`${depthPrefix}/${pattern}`);
+        }
+      }
+    }
+
+    return patterns;
+  }
+
+  /**
+   * Generate ignore patterns from exclude patterns.
+   */
+  private generateIgnorePatterns(exclude: string[]): string[] {
+    return exclude.map(pattern => {
+      // Ensure patterns work at any depth
+      if (pattern.startsWith('**/')) {
+        return pattern;
+      }
+      return `**/${pattern}`;
+    });
+  }
+}
+
+/**
+ * Singleton instance for convenience.
+ */
+export const scanner = new DirectoryScanner();

--- a/sources/local/src/types.ts
+++ b/sources/local/src/types.ts
@@ -1,0 +1,142 @@
+import type { ChangeEvent, ProjectSource } from '@mastra/admin';
+
+/**
+ * Configuration for the local project source provider.
+ */
+export interface LocalProjectSourceConfig {
+  /**
+   * Base directories to scan for Mastra projects.
+   * All paths should be absolute.
+   * @example ['/home/user/projects', '/opt/mastra-apps']
+   */
+  basePaths: string[];
+
+  /**
+   * Glob patterns to include when scanning for projects.
+   * Relative to each base path.
+   * @default ['*']
+   */
+  include?: string[];
+
+  /**
+   * Glob patterns to exclude from scanning.
+   * Useful for ignoring node_modules, .git, etc.
+   * @default ['node_modules', '.git', 'dist', 'build', '.next']
+   */
+  exclude?: string[];
+
+  /**
+   * Maximum depth to scan for projects.
+   * @default 2
+   */
+  maxDepth?: number;
+
+  /**
+   * Whether to watch for file changes.
+   * Only enable in development mode.
+   * @default false
+   */
+  watchChanges?: boolean;
+
+  /**
+   * Debounce interval for file change events (ms).
+   * @default 300
+   */
+  watchDebounceMs?: number;
+}
+
+/**
+ * Supported package managers for Mastra projects.
+ */
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
+
+/**
+ * Metadata about a detected Mastra project.
+ */
+export interface ProjectMetadata {
+  /** Project name from package.json */
+  name: string;
+
+  /** Project version from package.json */
+  version?: string;
+
+  /** Description from package.json */
+  description?: string;
+
+  /** Detected package manager */
+  packageManager: PackageManager;
+
+  /** Whether the project has a mastra.config file */
+  hasMastraConfig: boolean;
+
+  /** Path to the mastra config file (if found) */
+  mastraConfigPath?: string;
+
+  /** Main entry point from package.json */
+  entryPoint?: string;
+
+  /** Whether the project uses TypeScript */
+  isTypeScript: boolean;
+
+  /** Dependencies that indicate this is a Mastra project */
+  mastraDependencies: string[];
+
+  /** Allow additional custom metadata fields */
+  [key: string]: unknown;
+}
+
+/**
+ * Extended project source with local-specific metadata.
+ */
+export interface LocalProjectSource extends ProjectSource {
+  type: 'local';
+  /** Absolute path to the project directory */
+  path: string;
+  /** Detected project metadata */
+  metadata: ProjectMetadata & Record<string, unknown>;
+}
+
+/**
+ * Options for scanning directories.
+ */
+export interface ScanOptions {
+  /** Base path to scan */
+  basePath: string;
+
+  /** Include patterns */
+  include: string[];
+
+  /** Exclude patterns */
+  exclude: string[];
+
+  /** Maximum depth */
+  maxDepth: number;
+}
+
+/**
+ * Result of scanning a directory.
+ */
+export interface ScanResult {
+  /** Discovered Mastra projects */
+  projects: LocalProjectSource[];
+
+  /** Directories that were scanned but not valid Mastra projects */
+  skipped: string[];
+
+  /** Errors encountered during scanning */
+  errors: ScanError[];
+}
+
+/**
+ * Error encountered during scanning.
+ */
+export interface ScanError {
+  path: string;
+  error: string;
+  code?: string;
+}
+
+/**
+ * Re-export core types for convenience.
+ */
+export type { ProjectSource, ChangeEvent };

--- a/sources/local/src/utils.ts
+++ b/sources/local/src/utils.ts
@@ -1,0 +1,69 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+/**
+ * Generate a stable project ID from a path.
+ * Uses a hash of the normalized absolute path.
+ *
+ * @param projectPath - Absolute path to the project
+ * @returns Stable project ID
+ */
+export function generateProjectId(projectPath: string): string {
+  const normalized = path.normalize(projectPath);
+  const hash = crypto.createHash('sha256').update(normalized).digest('hex');
+  // Use first 12 characters for a shorter ID
+  return `local_${hash.substring(0, 12)}`;
+}
+
+/**
+ * Check if a path is accessible (readable).
+ *
+ * @param targetPath - Path to check
+ * @returns True if accessible
+ */
+export async function isPathAccessible(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath, fs.constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a path exists and is a directory.
+ *
+ * @param targetPath - Path to check
+ * @returns True if exists and is a directory
+ */
+export async function isDirectory(targetPath: string): Promise<boolean> {
+  try {
+    const stats = await fs.stat(targetPath);
+    return stats.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve and normalize a path.
+ * Handles relative paths by making them absolute.
+ *
+ * @param inputPath - Path to resolve
+ * @returns Resolved absolute path
+ */
+export function resolvePath(inputPath: string): string {
+  return path.resolve(path.normalize(inputPath));
+}
+
+/**
+ * Get the project name from a path.
+ * Uses the directory name as a fallback.
+ *
+ * @param projectPath - Path to the project
+ * @returns Project name
+ */
+export function getProjectNameFromPath(projectPath: string): string {
+  return path.basename(projectPath);
+}

--- a/sources/local/src/watcher.ts
+++ b/sources/local/src/watcher.ts
@@ -1,0 +1,153 @@
+import * as path from 'node:path';
+
+import type { FSWatcher } from 'chokidar';
+import chokidar from 'chokidar';
+
+import type { ChangeEvent, LocalProjectSource } from './types';
+
+/**
+ * Options for the file watcher.
+ */
+export interface WatcherOptions {
+  /**
+   * Debounce interval for events (ms).
+   * @default 300
+   */
+  debounceMs?: number;
+
+  /**
+   * Patterns to ignore when watching.
+   */
+  ignored?: (string | RegExp)[];
+
+  /**
+   * Use polling instead of native events.
+   * Useful for network mounts or containers.
+   * @default false
+   */
+  usePolling?: boolean;
+
+  /**
+   * Polling interval (ms) when usePolling is true.
+   * @default 1000
+   */
+  pollInterval?: number;
+}
+
+/**
+ * Default patterns to ignore when watching.
+ */
+const DEFAULT_IGNORED = [
+  '**/node_modules/**',
+  '**/.git/**',
+  '**/dist/**',
+  '**/build/**',
+  '**/.next/**',
+  '**/.turbo/**',
+  '**/coverage/**',
+  '**/*.log',
+];
+
+/**
+ * Watches for file changes in a project directory.
+ */
+export class ProjectWatcher {
+  private watcher: FSWatcher | null = null;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingEvents: Map<string, ChangeEvent> = new Map();
+
+  constructor(private readonly options: WatcherOptions = {}) {}
+
+  /**
+   * Start watching a project for file changes.
+   *
+   * @param source - Project source to watch
+   * @param callback - Callback for change events
+   * @returns Cleanup function to stop watching
+   */
+  watch(source: LocalProjectSource, callback: (event: ChangeEvent) => void): () => void {
+    const { debounceMs = 300, ignored = [], usePolling = false, pollInterval = 1000 } = this.options;
+
+    // Combine default ignored patterns with custom ones
+    const allIgnored = [...DEFAULT_IGNORED, ...ignored];
+
+    this.watcher = chokidar.watch(source.path, {
+      ignored: allIgnored,
+      persistent: true,
+      ignoreInitial: true,
+      usePolling,
+      interval: pollInterval,
+      awaitWriteFinish: {
+        stabilityThreshold: 100,
+        pollInterval: 100,
+      },
+    });
+
+    // Handler for file events
+    const handleEvent = (eventType: 'add' | 'change' | 'unlink', filePath: string) => {
+      const relativePath = path.relative(source.path, filePath);
+
+      // Skip if the file is in ignored directories (double check)
+      if (this.shouldIgnore(relativePath)) {
+        return;
+      }
+
+      const event: ChangeEvent = {
+        type: eventType,
+        path: relativePath,
+        timestamp: new Date(),
+      };
+
+      // Use the file path as key to dedupe rapid events on the same file
+      this.pendingEvents.set(relativePath, event);
+
+      // Debounce: collect events and emit them after the debounce period
+      if (this.debounceTimer) {
+        clearTimeout(this.debounceTimer);
+      }
+
+      this.debounceTimer = setTimeout(() => {
+        // Emit all pending events
+        for (const pendingEvent of this.pendingEvents.values()) {
+          callback(pendingEvent);
+        }
+        this.pendingEvents.clear();
+      }, debounceMs);
+    };
+
+    this.watcher
+      .on('add', filePath => handleEvent('add', filePath))
+      .on('change', filePath => handleEvent('change', filePath))
+      .on('unlink', filePath => handleEvent('unlink', filePath));
+
+    // Return cleanup function
+    return () => {
+      this.stop();
+    };
+  }
+
+  /**
+   * Stop watching.
+   */
+  stop(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+
+    if (this.watcher) {
+      void this.watcher.close();
+      this.watcher = null;
+    }
+
+    this.pendingEvents.clear();
+  }
+
+  /**
+   * Check if a path should be ignored.
+   */
+  private shouldIgnore(relativePath: string): boolean {
+    const segments = relativePath.split(path.sep);
+    return segments.some(segment => ['node_modules', '.git', 'dist', 'build', '.next', '.turbo'].includes(segment));
+  }
+}

--- a/sources/local/tsconfig.build.json
+++ b/sources/local/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/sources/local/tsconfig.json
+++ b/sources/local/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/sources/local/tsup.config.ts
+++ b/sources/local/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/sources/local/turbo.json
+++ b/sources/local/turbo.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "!dist/docs/**"]
+    },
+    "build:docs": {
+      "dependsOn": ["build:lib"],
+      "outputs": ["dist/docs/**"]
+    },
+    "build": {
+      "dependsOn": ["build:lib", "build:docs"]
+    }
+  }
+}

--- a/sources/local/vitest.config.ts
+++ b/sources/local/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
Adds the `@mastra/source-local` package for scanning local filesystem for Mastra projects.

The package provides:
- Project detection (identifies Mastra projects by checking for package dependencies and config files)
- Directory scanning (recursively finds all Mastra projects under a given path)
- File watching (monitors for project changes using chokidar)
- Source provider interface implementation for the admin system

```ts
import { LocalProjectSource } from '@mastra/source-local';

const source = new LocalProjectSource({
  basePath: '/path/to/projects',
  watchEnabled: true,
});

const projects = await source.listProjects();
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)