### PR TITLE
feat(admin-pg): add comprehensive integration tests for PostgresAdminStorage

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3946,6 +3946,46 @@ importers:
         specifier: 'catalog:'
         version: 4.0.12(vitest@3.2.4)
 
+  stores/admin-pg:
+    dependencies:
+      async-mutex:
+        specifier: ^0.5.0
+        version: 0.5.0
+      pg:
+        specifier: ^8.16.3
+        version: 8.16.3
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/admin':
+        specifier: workspace:*
+        version: link:../../packages/admin
+      '@types/node':
+        specifier: 22.13.17
+        version: 22.13.17
+      '@types/pg':
+        specifier: ^8.16.0
+        version: 8.16.0
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.0.12(vitest@4.0.16)
+      eslint:
+        specifier: ^9.37.0
+        version: 9.39.2(jiti@2.6.1)
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@microsoft/api-extractor@7.55.2(@types/node@22.13.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.13.17)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.13.17)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+
   stores/astra:
     dependencies:
       '@datastax/astra-db-ts':

--- a/stores/admin-pg/.gitignore
+++ b/stores/admin-pg/.gitignore
@@ -1,0 +1,3 @@
+.env
+dist/
+node_modules/

--- a/stores/admin-pg/docker-compose.yml
+++ b/stores/admin-pg/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: 'admin-pg-test-db'
+    ports:
+      - '5433:5432'
+    environment:
+      POSTGRES_USER: mastra
+      POSTGRES_PASSWORD: mastra
+      POSTGRES_DB: mastra_admin_test
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U mastra -d mastra_admin_test']
+      interval: 2s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - admin_pgdata:/var/lib/postgresql/data
+
+volumes:
+  admin_pgdata:

--- a/stores/admin-pg/eslint.config.js
+++ b/stores/admin-pg/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/stores/admin-pg/package.json
+++ b/stores/admin-pg/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@mastra/admin-pg",
+  "version": "0.1.0",
+  "description": "PostgreSQL storage adapter for MastraAdmin",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "build": "pnpm build:lib",
+    "build:watch": "pnpm build:lib --watch",
+    "pretest": "docker compose up -d && (for i in $(seq 1 30); do docker compose exec -T postgres pg_isready -U mastra && break || (sleep 1; [ $i -eq 30 ] && exit 1); done)",
+    "test": "vitest run",
+    "posttest": "docker compose down -v",
+    "pretest:watch": "docker compose up -d",
+    "test:watch": "vitest watch",
+    "posttest:watch": "docker compose down -v",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "async-mutex": "^0.5.0",
+    "pg": "^8.16.3"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/admin": "workspace:*",
+    "@types/node": "22.13.17",
+    "@types/pg": "^8.16.0",
+    "@vitest/coverage-v8": "catalog:",
+    "eslint": "^9.37.0",
+    "tsup": "^8.5.0",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@mastra/admin": "workspace:*"
+  },
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "stores/admin-pg"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/stores/admin-pg/src/client.ts
+++ b/stores/admin-pg/src/client.ts
@@ -1,0 +1,184 @@
+import type { Pool, PoolClient, QueryResult, QueryResultRow } from 'pg';
+
+// Re-export pg types for consumers
+export type { Pool, PoolClient, QueryResult } from 'pg';
+
+/**
+ * Query parameter values
+ */
+export type QueryValues = unknown[] | Record<string, unknown>;
+
+/**
+ * Transaction client interface
+ */
+export interface TxClient {
+  readonly $pool: Pool;
+  none(query: string, values?: QueryValues): Promise<null>;
+  one<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<T>;
+  oneOrNone<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<T | null>;
+  any<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<T[]>;
+  manyOrNone<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<T[]>;
+  many<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<T[]>;
+  query<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<QueryResult<T>>;
+  batch<T>(promises: Promise<T>[]): Promise<T[]>;
+}
+
+/**
+ * Database client interface
+ */
+export interface DbClient extends Omit<TxClient, 'batch'> {
+  connect(): Promise<PoolClient>;
+  tx<T>(callback: (t: TxClient) => Promise<T>): Promise<T>;
+}
+
+/**
+ * Truncate a query string for error messages.
+ */
+function truncateQuery(query: string, maxLength = 100): string {
+  const normalized = query.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return normalized.slice(0, maxLength) + '...';
+}
+
+/**
+ * Pool adapter implementing DbClient
+ */
+export class PoolAdapter implements DbClient {
+  readonly $pool: Pool;
+
+  constructor(pool: Pool) {
+    this.$pool = pool;
+  }
+
+  async connect(): Promise<PoolClient> {
+    return this.$pool.connect();
+  }
+
+  async none(query: string, values?: QueryValues): Promise<null> {
+    await this.$pool.query(query, values as unknown[]);
+    return null;
+  }
+
+  async one<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<T> {
+    const result = await this.$pool.query<T>(query, values as unknown[]);
+    if (result.rowCount !== 1) {
+      if (result.rowCount === 0) {
+        throw new Error(`No data returned from query: ${truncateQuery(query)}`);
+      }
+      throw new Error(`Multiple rows returned when one was expected: ${truncateQuery(query)}`);
+    }
+    return result.rows[0]!;
+  }
+
+  async oneOrNone<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<T | null> {
+    const result = await this.$pool.query<T>(query, values as unknown[]);
+    if (result.rowCount === 0) return null;
+    if (result.rowCount === 1) return result.rows[0]!;
+    throw new Error(`Multiple rows returned when one or none was expected: ${truncateQuery(query)}`);
+  }
+
+  async any<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<T[]> {
+    const result = await this.$pool.query<T>(query, values as unknown[]);
+    return result.rows;
+  }
+
+  async manyOrNone<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<T[]> {
+    return this.any<T>(query, values);
+  }
+
+  async many<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<T[]> {
+    const result = await this.$pool.query<T>(query, values as unknown[]);
+    if (result.rowCount === 0) {
+      throw new Error(`No data returned from query: ${truncateQuery(query)}`);
+    }
+    return result.rows;
+  }
+
+  async query<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<QueryResult<T>> {
+    return this.$pool.query<T>(query, values as unknown[]);
+  }
+
+  async tx<T>(callback: (t: TxClient) => Promise<T>): Promise<T> {
+    const client = await this.$pool.connect();
+    try {
+      await client.query('BEGIN');
+      const txClient = new TransactionClient(client, this.$pool);
+      const result = await callback(txClient);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      try {
+        await client.query('ROLLBACK');
+      } catch (rollbackError) {
+        // Log rollback failure but throw original error
+        console.error('Transaction rollback failed:', rollbackError);
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+}
+
+/**
+ * Transaction client implementation
+ */
+class TransactionClient implements TxClient {
+  readonly $pool: Pool;
+  private client: PoolClient;
+
+  constructor(client: PoolClient, pool: Pool) {
+    this.client = client;
+    this.$pool = pool;
+  }
+
+  async none(query: string, values?: QueryValues): Promise<null> {
+    await this.client.query(query, values as unknown[]);
+    return null;
+  }
+
+  async one<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<T> {
+    const result = await this.client.query<T>(query, values as unknown[]);
+    if (result.rowCount !== 1) {
+      if (result.rowCount === 0) {
+        throw new Error(`No data returned from query: ${truncateQuery(query)}`);
+      }
+      throw new Error(`Multiple rows returned when one was expected: ${truncateQuery(query)}`);
+    }
+    return result.rows[0]!;
+  }
+
+  async oneOrNone<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<T | null> {
+    const result = await this.client.query<T>(query, values as unknown[]);
+    if (result.rowCount === 0) return null;
+    if (result.rowCount === 1) return result.rows[0]!;
+    throw new Error(`Multiple rows returned when one or none was expected: ${truncateQuery(query)}`);
+  }
+
+  async any<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<T[]> {
+    const result = await this.client.query<T>(query, values as unknown[]);
+    return result.rows;
+  }
+
+  async manyOrNone<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<T[]> {
+    return this.any<T>(query, values);
+  }
+
+  async many<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<T[]> {
+    const result = await this.client.query<T>(query, values as unknown[]);
+    if (result.rowCount === 0) {
+      throw new Error(`No data returned from query: ${truncateQuery(query)}`);
+    }
+    return result.rows;
+  }
+
+  async query<T extends QueryResultRow>(query: string, values?: QueryValues): Promise<QueryResult<T>> {
+    return this.client.query<T>(query, values as unknown[]);
+  }
+
+  async batch<T>(promises: Promise<T>[]): Promise<T[]> {
+    return Promise.all(promises);
+  }
+}

--- a/stores/admin-pg/src/db/index.ts
+++ b/stores/admin-pg/src/db/index.ts
@@ -1,0 +1,485 @@
+import { Mutex } from 'async-mutex';
+import type { DbClient } from '../client';
+import type { TableName } from '../migrations/001_initial';
+import { TABLES, TABLE_SCHEMAS, DEFAULT_INDEXES } from '../migrations/001_initial';
+import { parseSqlIdentifier } from '../shared/config';
+
+interface AdminPgDBConfig {
+  client: DbClient;
+  schemaName?: string;
+  skipDefaultIndexes?: boolean;
+}
+
+interface CreateIndexOptions {
+  name?: string;
+  table: string;
+  columns: string[];
+  unique?: boolean;
+  where?: string;
+}
+
+/**
+ * Core database layer for MastraAdmin PostgreSQL storage
+ */
+export class AdminPgDB {
+  private client: DbClient;
+  private schema: string;
+  private skipDefaultIndexes: boolean;
+
+  private static schemaSetupRegistry = new Map<string, Promise<void>>();
+  private static schemaSetupMutex = new Mutex();
+
+  constructor(config: AdminPgDBConfig) {
+    this.client = config.client;
+    this.schema = config.schemaName ? parseSqlIdentifier(config.schemaName, 'schema') : 'mastra_admin';
+    this.skipDefaultIndexes = config.skipDefaultIndexes ?? false;
+  }
+
+  /**
+   * Get qualified table name with schema
+   */
+  private qualifiedTable(table: TableName): string {
+    return `"${this.schema}"."${table}"`;
+  }
+
+  /**
+   * Setup schema if not public
+   */
+  private async setupSchema(): Promise<void> {
+    if (this.schema === 'public') return;
+
+    const poolOptions = this.client.$pool.options;
+    const host = poolOptions.host ?? 'localhost';
+    const port = poolOptions.port ?? 5432;
+    const key = `${host}:${port}:${this.schema}`;
+
+    const existingSetup = AdminPgDB.schemaSetupRegistry.get(key);
+    if (existingSetup) {
+      await existingSetup;
+      return;
+    }
+
+    const release = await AdminPgDB.schemaSetupMutex.acquire();
+    try {
+      const recheck = AdminPgDB.schemaSetupRegistry.get(key);
+      if (recheck) {
+        await recheck;
+        return;
+      }
+
+      const setupPromise = this.client.none(`CREATE SCHEMA IF NOT EXISTS "${this.schema}"`).then(() => {});
+      AdminPgDB.schemaSetupRegistry.set(key, setupPromise);
+      await setupPromise;
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * Initialize all tables
+   */
+  async init(): Promise<void> {
+    await this.setupSchema();
+
+    // Create tables in order (respecting foreign key constraints)
+    const tableOrder: TableName[] = [
+      TABLES.users,
+      TABLES.teams,
+      TABLES.team_members,
+      TABLES.team_invites,
+      TABLES.team_installations,
+      TABLES.projects,
+      TABLES.project_env_vars,
+      TABLES.project_api_tokens,
+      TABLES.deployments,
+      TABLES.builds,
+      TABLES.running_servers,
+      TABLES.routes,
+      TABLES.roles,
+      TABLES.role_assignments,
+    ];
+
+    for (const table of tableOrder) {
+      await this.createTable(table);
+    }
+
+    // Create default indexes
+    if (!this.skipDefaultIndexes) {
+      await this.createDefaultIndexes();
+    }
+
+    // Setup updated_at triggers
+    await this.setupUpdatedAtTriggers();
+  }
+
+  /**
+   * Create a single table
+   */
+  private async createTable(table: TableName): Promise<void> {
+    // Replace table references with schema-qualified names
+    let schema = TABLE_SCHEMAS[table];
+    for (const [, tableName] of Object.entries(TABLES)) {
+      schema = schema.replace(new RegExp(`REFERENCES ${tableName}\\(`, 'g'), `REFERENCES "${this.schema}"."${tableName}"(`);
+    }
+
+    const sql = `
+      CREATE TABLE IF NOT EXISTS ${this.qualifiedTable(table)} (
+        ${schema}
+      )
+    `;
+    await this.client.none(sql);
+  }
+
+  /**
+   * Create default indexes
+   */
+  private async createDefaultIndexes(): Promise<void> {
+    for (const index of DEFAULT_INDEXES) {
+      const name = index.unique
+        ? `${this.schema}_${index.table}_${index.columns.join('_')}_unique`
+        : `${this.schema}_${index.table}_${index.columns.join('_')}_idx`;
+
+      await this.createIndex({
+        name: name.toLowerCase().replace(/[^a-z0-9_]/g, '_'),
+        table: index.table,
+        columns: index.columns,
+        unique: index.unique,
+      });
+    }
+  }
+
+  /**
+   * Create an index
+   */
+  async createIndex(options: CreateIndexOptions): Promise<void> {
+    const { name, table, columns, unique, where } = options;
+    const indexName = name || `${this.schema}_${table}_${columns.join('_')}_idx`;
+    const uniqueStr = unique ? 'UNIQUE' : '';
+    const whereStr = where ? `WHERE ${where}` : '';
+    const columnsStr = columns
+      .map(c => {
+        // Handle DESC/ASC in column names
+        const parts = c.split(' ');
+        if (parts.length === 1) return `"${c}"`;
+        return `"${parts[0]}" ${parts.slice(1).join(' ')}`;
+      })
+      .join(', ');
+
+    const sql = `
+      CREATE ${uniqueStr} INDEX IF NOT EXISTS "${indexName}"
+      ON ${this.qualifiedTable(table as TableName)} (${columnsStr})
+      ${whereStr}
+    `;
+
+    try {
+      await this.client.none(sql);
+    } catch (error) {
+      // Ignore "already exists" errors
+      if (!(error instanceof Error && error.message.includes('already exists'))) {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Setup updated_at triggers
+   */
+  private async setupUpdatedAtTriggers(): Promise<void> {
+    // Create the trigger function
+    const functionSql = `
+      CREATE OR REPLACE FUNCTION "${this.schema}".update_updated_at_column()
+      RETURNS TRIGGER AS $$
+      BEGIN
+        NEW.updated_at = NOW();
+        RETURN NEW;
+      END;
+      $$ language 'plpgsql';
+    `;
+    await this.client.none(functionSql);
+
+    // Tables that have updated_at column
+    const tablesWithUpdatedAt: TableName[] = [
+      TABLES.users,
+      TABLES.teams,
+      TABLES.team_installations,
+      TABLES.projects,
+      TABLES.project_env_vars,
+      TABLES.deployments,
+      TABLES.routes,
+      TABLES.roles,
+    ];
+
+    for (const table of tablesWithUpdatedAt) {
+      const triggerName = `${table}_updated_at_trigger`;
+      const triggerSql = `
+        DROP TRIGGER IF EXISTS "${triggerName}" ON ${this.qualifiedTable(table)};
+        CREATE TRIGGER "${triggerName}"
+        BEFORE UPDATE ON ${this.qualifiedTable(table)}
+        FOR EACH ROW
+        EXECUTE FUNCTION "${this.schema}".update_updated_at_column();
+      `;
+      await this.client.none(triggerSql);
+    }
+  }
+
+  /**
+   * Insert a record
+   */
+  async insert<T extends Record<string, unknown>>(table: TableName, data: T): Promise<T & { id: string }> {
+    const keys = Object.keys(data);
+    const values = Object.values(data);
+    const placeholders = keys.map((_, i) => `$${i + 1}`);
+    const columns = keys.map(k => `"${this.toSnakeCase(k)}"`);
+
+    const sql = `
+      INSERT INTO ${this.qualifiedTable(table)} (${columns.join(', ')})
+      VALUES (${placeholders.join(', ')})
+      RETURNING *
+    `;
+
+    const row = await this.client.one(sql, values);
+    return this.transformRow<T & { id: string }>(row);
+  }
+
+  /**
+   * Batch insert records
+   */
+  async batchInsert<T extends Record<string, unknown>>(table: TableName, records: T[]): Promise<(T & { id: string })[]> {
+    if (records.length === 0) return [];
+
+    return this.client.tx(async tx => {
+      const results: (T & { id: string })[] = [];
+      for (const record of records) {
+        const keys = Object.keys(record);
+        const values = Object.values(record);
+        const placeholders = keys.map((_, i) => `$${i + 1}`);
+        const columns = keys.map(k => `"${this.toSnakeCase(k)}"`);
+
+        const sql = `
+          INSERT INTO ${this.qualifiedTable(table)} (${columns.join(', ')})
+          VALUES (${placeholders.join(', ')})
+          RETURNING *
+        `;
+
+        const row = await tx.one(sql, values);
+        results.push(this.transformRow<T & { id: string }>(row));
+      }
+      return results;
+    });
+  }
+
+  /**
+   * Update a record
+   */
+  async update<T extends Record<string, unknown>>(table: TableName, id: string, data: Partial<T>): Promise<(T & { id: string }) | null> {
+    const keys = Object.keys(data);
+    if (keys.length === 0) return null;
+
+    const values = Object.values(data);
+    const setClause = keys.map((k, i) => `"${this.toSnakeCase(k)}" = $${i + 1}`).join(', ');
+
+    const sql = `
+      UPDATE ${this.qualifiedTable(table)}
+      SET ${setClause}
+      WHERE id = $${keys.length + 1}
+      RETURNING *
+    `;
+
+    const row = await this.client.oneOrNone(sql, [...values, id]);
+    return row ? this.transformRow<T & { id: string }>(row) : null;
+  }
+
+  /**
+   * Delete a record
+   */
+  async delete(table: TableName, id: string): Promise<boolean> {
+    const sql = `DELETE FROM ${this.qualifiedTable(table)} WHERE id = $1`;
+    const result = await this.client.query(sql, [id]);
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  /**
+   * Find a record by ID
+   */
+  async findById<T>(table: TableName, id: string): Promise<(T & { id: string }) | null> {
+    const sql = `SELECT * FROM ${this.qualifiedTable(table)} WHERE id = $1`;
+    const row = await this.client.oneOrNone(sql, [id]);
+    return row ? this.transformRow<T & { id: string }>(row) : null;
+  }
+
+  /**
+   * Find records by condition
+   */
+  async findBy<T>(
+    table: TableName,
+    conditions: Record<string, unknown>,
+    options?: { limit?: number; offset?: number; orderBy?: string },
+  ): Promise<(T & { id: string })[]> {
+    const { where, values } = this.buildWhereClause(conditions);
+    let sql = `SELECT * FROM ${this.qualifiedTable(table)} ${where}`;
+
+    if (options?.orderBy) {
+      sql += ` ORDER BY ${options.orderBy}`;
+    }
+    if (options?.limit) {
+      sql += ` LIMIT ${options.limit}`;
+    }
+    if (options?.offset) {
+      sql += ` OFFSET ${options.offset}`;
+    }
+
+    const rows = await this.client.any(sql, values);
+    return rows.map(row => this.transformRow<T & { id: string }>(row));
+  }
+
+  /**
+   * Find one record by condition
+   */
+  async findOneBy<T>(table: TableName, conditions: Record<string, unknown>): Promise<(T & { id: string }) | null> {
+    const results = await this.findBy<T>(table, conditions, { limit: 1 });
+    return results[0] || null;
+  }
+
+  /**
+   * Count records
+   */
+  async count(table: TableName, conditions?: Record<string, unknown>): Promise<number> {
+    const { where, values } = conditions ? this.buildWhereClause(conditions) : { where: '', values: [] };
+
+    const sql = `SELECT COUNT(*) as count FROM ${this.qualifiedTable(table)} ${where}`;
+    const result = await this.client.one<{ count: string }>(sql, values);
+    return parseInt(result.count, 10);
+  }
+
+  /**
+   * Execute raw SQL
+   */
+  async query<T>(sql: string, values?: unknown[]): Promise<T[]> {
+    const rows = await this.client.any(sql, values);
+    return rows.map(row => this.transformRow<T>(row));
+  }
+
+  /**
+   * Execute in transaction
+   */
+  async transaction<T>(callback: (db: AdminPgDB) => Promise<T>): Promise<T> {
+    return this.client.tx(async () => {
+      return callback(this);
+    });
+  }
+
+  /**
+   * Build WHERE clause from conditions
+   */
+  private buildWhereClause(conditions: Record<string, unknown>): {
+    where: string;
+    values: unknown[];
+  } {
+    const keys = Object.keys(conditions);
+    if (keys.length === 0) return { where: '', values: [] };
+
+    const clauses: string[] = [];
+    const values: unknown[] = [];
+
+    for (const key of keys) {
+      const value = conditions[key];
+      const column = `"${this.toSnakeCase(key)}"`;
+
+      if (value === null) {
+        clauses.push(`${column} IS NULL`);
+      } else if (Array.isArray(value)) {
+        const placeholders = value.map((_, i) => `$${values.length + i + 1}`);
+        clauses.push(`${column} IN (${placeholders.join(', ')})`);
+        values.push(...value);
+      } else if (typeof value === 'object' && value !== null) {
+        // Handle operators like { gte: 5, lte: 10 }
+        const ops = value as Record<string, unknown>;
+        for (const [op, opValue] of Object.entries(ops)) {
+          values.push(opValue);
+          const placeholder = `$${values.length}`;
+          switch (op) {
+            case 'gte':
+              clauses.push(`${column} >= ${placeholder}`);
+              break;
+            case 'lte':
+              clauses.push(`${column} <= ${placeholder}`);
+              break;
+            case 'gt':
+              clauses.push(`${column} > ${placeholder}`);
+              break;
+            case 'lt':
+              clauses.push(`${column} < ${placeholder}`);
+              break;
+            case 'ne':
+              clauses.push(`${column} != ${placeholder}`);
+              break;
+            case 'like':
+              clauses.push(`${column} LIKE ${placeholder}`);
+              break;
+            case 'ilike':
+              clauses.push(`${column} ILIKE ${placeholder}`);
+              break;
+            default:
+              throw new Error(`Unknown operator: ${op}`);
+          }
+        }
+      } else {
+        values.push(value);
+        clauses.push(`${column} = $${values.length}`);
+      }
+    }
+
+    return { where: `WHERE ${clauses.join(' AND ')}`, values };
+  }
+
+  /**
+   * Transform database row to camelCase
+   */
+  private transformRow<T>(row: Record<string, unknown>): T {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(row)) {
+      const camelKey = this.toCamelCase(key);
+      // Parse JSONB columns
+      if (typeof value === 'string' && (value.startsWith('{') || value.startsWith('['))) {
+        try {
+          result[camelKey] = JSON.parse(value);
+        } catch {
+          result[camelKey] = value;
+        }
+      } else {
+        result[camelKey] = value;
+      }
+    }
+    return result as T;
+  }
+
+  /**
+   * Convert camelCase to snake_case
+   */
+  private toSnakeCase(str: string): string {
+    return str.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
+  }
+
+  /**
+   * Convert snake_case to camelCase
+   */
+  private toCamelCase(str: string): string {
+    return str.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+  }
+
+  /**
+   * Get the underlying client for direct access
+   */
+  get db(): DbClient {
+    return this.client;
+  }
+
+  /**
+   * Get schema name
+   */
+  get schemaName(): string {
+    return this.schema;
+  }
+}
+
+export { TABLES, type TableName };

--- a/stores/admin-pg/src/db/index.ts
+++ b/stores/admin-pg/src/db/index.ts
@@ -225,7 +225,7 @@ export class AdminPgDB {
   /**
    * Insert a record
    */
-  async insert<T extends Record<string, unknown>>(table: TableName, data: T): Promise<T & { id: string }> {
+  async insert<T>(table: TableName, data: Record<string, unknown>): Promise<T & { id: string }> {
     const keys = Object.keys(data);
     const values = Object.values(data);
     const placeholders = keys.map((_, i) => `$${i + 1}`);
@@ -244,7 +244,7 @@ export class AdminPgDB {
   /**
    * Batch insert records
    */
-  async batchInsert<T extends Record<string, unknown>>(table: TableName, records: T[]): Promise<(T & { id: string })[]> {
+  async batchInsert<T>(table: TableName, records: Record<string, unknown>[]): Promise<(T & { id: string })[]> {
     if (records.length === 0) return [];
 
     return this.client.tx(async tx => {
@@ -271,7 +271,7 @@ export class AdminPgDB {
   /**
    * Update a record
    */
-  async update<T extends Record<string, unknown>>(table: TableName, id: string, data: Partial<T>): Promise<(T & { id: string }) | null> {
+  async update<T>(table: TableName, id: string, data: Record<string, unknown>): Promise<(T & { id: string }) | null> {
     const keys = Object.keys(data);
     if (keys.length === 0) return null;
 

--- a/stores/admin-pg/src/domains/builds.ts
+++ b/stores/admin-pg/src/domains/builds.ts
@@ -1,0 +1,124 @@
+import type { Build, BuildStatus } from '@mastra/admin';
+import { AdminPgDB, TABLES } from '../db';
+import type { PgDomainConfig } from './utils';
+import { resolvePgConfig } from './utils';
+
+export class BuildsPG {
+  private db: AdminPgDB;
+
+  static readonly MANAGED_TABLES = [TABLES.builds] as const;
+
+  constructor(config: PgDomainConfig) {
+    const { client, schemaName, skipDefaultIndexes } = resolvePgConfig(config);
+    this.db = new AdminPgDB({ client, schemaName, skipDefaultIndexes });
+  }
+
+  async createBuild(data: Omit<Build, 'startedAt' | 'completedAt'>): Promise<Build> {
+    return this.db.insert<Omit<Build, 'id'>>(TABLES.builds, {
+      ...data,
+      startedAt: null,
+      completedAt: null,
+    } as unknown as Record<string, unknown>);
+  }
+
+  async getBuildById(id: string): Promise<Build | null> {
+    return this.db.findById<Build>(TABLES.builds, id);
+  }
+
+  async updateBuild(id: string, data: Partial<Omit<Build, 'id' | 'deploymentId' | 'queuedAt'>>): Promise<Build | null> {
+    return this.db.update<Omit<Build, 'id'>>(TABLES.builds, id, data as unknown as Record<string, unknown>);
+  }
+
+  async updateBuildStatus(id: string, status: BuildStatus, errorMessage?: string): Promise<Build | null> {
+    const updates: Partial<Build> = { status };
+
+    if (status === 'building') {
+      updates.startedAt = new Date();
+    } else if (['succeeded', 'failed', 'cancelled'].includes(status)) {
+      updates.completedAt = new Date();
+    }
+
+    if (errorMessage !== undefined) {
+      updates.errorMessage = errorMessage;
+    }
+
+    return this.updateBuild(id, updates);
+  }
+
+  async appendBuildLogs(id: string, logs: string): Promise<void> {
+    const sql = `
+      UPDATE "${this.db.schemaName}"."${TABLES.builds}"
+      SET logs = COALESCE(logs, '') || $1
+      WHERE id = $2
+    `;
+    await this.db.db.none(sql, [logs, id]);
+  }
+
+  async deleteBuild(id: string): Promise<boolean> {
+    return this.db.delete(TABLES.builds, id);
+  }
+
+  async listBuilds(
+    deploymentId: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<{ data: Build[]; total: number }> {
+    const total = await this.db.count(TABLES.builds, { deploymentId });
+    const data = await this.db.findBy<Build>(
+      TABLES.builds,
+      { deploymentId },
+      { ...options, orderBy: 'created_at DESC' },
+    );
+    return { data, total };
+  }
+
+  // Build queue operations
+
+  /**
+   * Dequeue the next build for processing.
+   * Uses FOR UPDATE SKIP LOCKED for concurrent-safe dequeue.
+   */
+  async dequeue(): Promise<Build | null> {
+    const sql = `
+      UPDATE "${this.db.schemaName}"."${TABLES.builds}"
+      SET status = 'building', started_at = NOW()
+      WHERE id = (
+        SELECT id FROM "${this.db.schemaName}"."${TABLES.builds}"
+        WHERE status = 'queued'
+        ORDER BY queued_at ASC
+        FOR UPDATE SKIP LOCKED
+        LIMIT 1
+      )
+      RETURNING *
+    `;
+    const rows = await this.db.query<Build>(sql);
+    return rows[0] || null;
+  }
+
+  async getQueuePosition(buildId: string): Promise<number> {
+    const build = await this.getBuildById(buildId);
+    if (!build || build.status !== 'queued') return -1;
+
+    const sql = `
+      SELECT COUNT(*) as position
+      FROM "${this.db.schemaName}"."${TABLES.builds}"
+      WHERE status = 'queued' AND queued_at < $1
+    `;
+    const result = await this.db.db.one<{ position: string }>(sql, [build.queuedAt]);
+    return parseInt(result.position, 10) + 1;
+  }
+
+  async getQueueLength(): Promise<number> {
+    return this.db.count(TABLES.builds, { status: 'queued' });
+  }
+
+  async cancelQueuedBuilds(deploymentId: string): Promise<number> {
+    const sql = `
+      UPDATE "${this.db.schemaName}"."${TABLES.builds}"
+      SET status = 'cancelled', completed_at = NOW()
+      WHERE deployment_id = $1 AND status = 'queued'
+      RETURNING id
+    `;
+    const result = await this.db.query<{ id: string }>(sql, [deploymentId]);
+    return result.length;
+  }
+}

--- a/stores/admin-pg/src/domains/deployments.ts
+++ b/stores/admin-pg/src/domains/deployments.ts
@@ -1,0 +1,81 @@
+import type { Deployment, DeploymentStatus } from '@mastra/admin';
+import { AdminPgDB, TABLES } from '../db';
+import type { PgDomainConfig } from './utils';
+import { resolvePgConfig } from './utils';
+
+export class DeploymentsPG {
+  private db: AdminPgDB;
+
+  static readonly MANAGED_TABLES = [TABLES.deployments] as const;
+
+  constructor(config: PgDomainConfig) {
+    const { client, schemaName, skipDefaultIndexes } = resolvePgConfig(config);
+    this.db = new AdminPgDB({ client, schemaName, skipDefaultIndexes });
+  }
+
+  async createDeployment(data: Omit<Deployment, 'createdAt' | 'updatedAt'>): Promise<Deployment> {
+    return this.db.insert<Omit<Deployment, 'id'>>(TABLES.deployments, data as unknown as Record<string, unknown>);
+  }
+
+  async getDeploymentById(id: string): Promise<Deployment | null> {
+    return this.db.findById<Deployment>(TABLES.deployments, id);
+  }
+
+  async getDeploymentBySlug(projectId: string, slug: string): Promise<Deployment | null> {
+    return this.db.findOneBy<Deployment>(TABLES.deployments, { projectId, slug });
+  }
+
+  async updateDeployment(id: string, data: Partial<Omit<Deployment, 'id' | 'projectId' | 'createdAt'>>): Promise<Deployment | null> {
+    return this.db.update<Omit<Deployment, 'id'>>(TABLES.deployments, id, data as unknown as Record<string, unknown>);
+  }
+
+  async updateDeploymentStatus(id: string, status: DeploymentStatus): Promise<Deployment | null> {
+    return this.updateDeployment(id, { status });
+  }
+
+  async setCurrentBuild(deploymentId: string, buildId: string | null): Promise<Deployment | null> {
+    return this.updateDeployment(deploymentId, { currentBuildId: buildId });
+  }
+
+  async deleteDeployment(id: string): Promise<boolean> {
+    return this.db.delete(TABLES.deployments, id);
+  }
+
+  async listDeployments(
+    projectId: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<{ data: Deployment[]; total: number }> {
+    const total = await this.db.count(TABLES.deployments, { projectId });
+    const data = await this.db.findBy<Deployment>(
+      TABLES.deployments,
+      { projectId },
+      { ...options, orderBy: 'created_at DESC' },
+    );
+    return { data, total };
+  }
+
+  async getProductionDeployment(projectId: string): Promise<Deployment | null> {
+    return this.db.findOneBy<Deployment>(TABLES.deployments, {
+      projectId,
+      type: 'production',
+    });
+  }
+
+  async listActiveDeployments(projectId: string): Promise<Deployment[]> {
+    return this.db.findBy<Deployment>(
+      TABLES.deployments,
+      { projectId, status: ['running', 'building', 'pending'] },
+      { orderBy: 'created_at DESC' },
+    );
+  }
+
+  async cleanupExpiredPreviews(): Promise<number> {
+    const sql = `
+      DELETE FROM "${this.db.schemaName}"."${TABLES.deployments}"
+      WHERE type = 'preview' AND expires_at < NOW()
+      RETURNING id
+    `;
+    const result = await this.db.query<{ id: string }>(sql);
+    return result.length;
+  }
+}

--- a/stores/admin-pg/src/domains/projects.ts
+++ b/stores/admin-pg/src/domains/projects.ts
@@ -144,7 +144,12 @@ export class ProjectsPG {
 
   // API token operations
   async createApiToken(data: Omit<ProjectApiToken, 'createdAt' | 'lastUsedAt'>): Promise<ProjectApiToken> {
-    return this.db.insert<Omit<ProjectApiToken, 'id'>>(TABLES.project_api_tokens, data as unknown as Record<string, unknown>);
+    // Serialize scopes array to JSON for JSONB column
+    const insertData = {
+      ...data,
+      scopes: JSON.stringify(data.scopes),
+    };
+    return this.db.insert<Omit<ProjectApiToken, 'id'>>(TABLES.project_api_tokens, insertData as unknown as Record<string, unknown>);
   }
 
   async getApiTokenById(id: string): Promise<ProjectApiToken | null> {

--- a/stores/admin-pg/src/domains/projects.ts
+++ b/stores/admin-pg/src/domains/projects.ts
@@ -1,0 +1,171 @@
+import type { Project, EncryptedEnvVar, ProjectApiToken } from '@mastra/admin';
+import { AdminPgDB, TABLES } from '../db';
+import type { PgDomainConfig } from './utils';
+import { resolvePgConfig } from './utils';
+
+export class ProjectsPG {
+  private db: AdminPgDB;
+
+  static readonly MANAGED_TABLES = [TABLES.projects, TABLES.project_env_vars, TABLES.project_api_tokens] as const;
+
+  constructor(config: PgDomainConfig) {
+    const { client, schemaName, skipDefaultIndexes } = resolvePgConfig(config);
+    this.db = new AdminPgDB({ client, schemaName, skipDefaultIndexes });
+  }
+
+  // Project operations
+  async createProject(data: Omit<Project, 'createdAt' | 'updatedAt'>): Promise<Project> {
+    // Store envVars separately in project_env_vars table, not in main project record
+    const { envVars, ...projectData } = data;
+
+    // Create project first
+    const project = await this.db.insert<Omit<Project, 'id' | 'envVars'>>(TABLES.projects, projectData as unknown as Record<string, unknown>);
+
+    // Insert env vars if provided
+    if (envVars && envVars.length > 0) {
+      for (const envVar of envVars) {
+        await this.setEnvVar(project.id, envVar);
+      }
+    }
+
+    // Return project with envVars
+    return {
+      ...project,
+      envVars: envVars || [],
+    };
+  }
+
+  async getProjectById(id: string): Promise<Project | null> {
+    const project = await this.db.findById<Omit<Project, 'envVars'>>(TABLES.projects, id);
+    if (!project) return null;
+
+    const envVars = await this.getEnvVars(id);
+    return { ...project, envVars };
+  }
+
+  async getProjectBySlug(teamId: string, slug: string): Promise<Project | null> {
+    const project = await this.db.findOneBy<Omit<Project, 'envVars'>>(TABLES.projects, { teamId, slug });
+    if (!project) return null;
+
+    const envVars = await this.getEnvVars(project.id);
+    return { ...project, envVars };
+  }
+
+  async updateProject(id: string, data: Partial<Omit<Project, 'id' | 'teamId' | 'createdAt' | 'envVars'>>): Promise<Project | null> {
+    const project = await this.db.update<Omit<Project, 'id' | 'envVars'>>(TABLES.projects, id, data as unknown as Record<string, unknown>);
+    if (!project) return null;
+
+    const envVars = await this.getEnvVars(id);
+    return { ...project, envVars };
+  }
+
+  async deleteProject(id: string): Promise<boolean> {
+    return this.db.delete(TABLES.projects, id);
+  }
+
+  async listProjects(
+    teamId: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<{ data: Project[]; total: number }> {
+    const total = await this.db.count(TABLES.projects, { teamId });
+    const projects = await this.db.findBy<Omit<Project, 'envVars'>>(TABLES.projects, { teamId }, { ...options, orderBy: 'name' });
+
+    // Load env vars for each project
+    const data = await Promise.all(
+      projects.map(async project => {
+        const envVars = await this.getEnvVars(project.id);
+        return { ...project, envVars };
+      }),
+    );
+
+    return { data, total };
+  }
+
+  // Environment variable operations
+  async setEnvVar(projectId: string, envVar: Omit<EncryptedEnvVar, 'createdAt' | 'updatedAt'>): Promise<EncryptedEnvVar> {
+    // Check if exists, if so update, otherwise insert
+    const existing = await this.db.findOneBy<EncryptedEnvVar & { projectId: string }>(TABLES.project_env_vars, {
+      projectId,
+      key: envVar.key,
+    });
+
+    if (existing) {
+      const updated = await this.db.update<EncryptedEnvVar & { projectId: string; id: string }>(TABLES.project_env_vars, existing.id, {
+        encryptedValue: envVar.encryptedValue,
+        isSecret: envVar.isSecret,
+      } as unknown as Record<string, unknown>);
+      if (!updated) throw new Error('Failed to update env var');
+      return {
+        key: updated.key,
+        encryptedValue: updated.encryptedValue,
+        isSecret: updated.isSecret,
+        createdAt: updated.createdAt,
+        updatedAt: updated.updatedAt,
+      };
+    }
+
+    const created = await this.db.insert<EncryptedEnvVar & { projectId: string }>(TABLES.project_env_vars, {
+      projectId,
+      ...envVar,
+    } as unknown as Record<string, unknown>);
+
+    return {
+      key: created.key,
+      encryptedValue: created.encryptedValue,
+      isSecret: created.isSecret,
+      createdAt: created.createdAt,
+      updatedAt: created.updatedAt,
+    };
+  }
+
+  async getEnvVars(projectId: string): Promise<EncryptedEnvVar[]> {
+    const results = await this.db.findBy<EncryptedEnvVar & { projectId: string }>(
+      TABLES.project_env_vars,
+      { projectId },
+      { orderBy: 'key' },
+    );
+    return results.map(r => ({
+      key: r.key,
+      encryptedValue: r.encryptedValue,
+      isSecret: r.isSecret,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+    }));
+  }
+
+  async deleteEnvVar(projectId: string, key: string): Promise<boolean> {
+    const envVar = await this.db.findOneBy<EncryptedEnvVar & { projectId: string }>(TABLES.project_env_vars, {
+      projectId,
+      key,
+    });
+    if (!envVar) return false;
+    return this.db.delete(TABLES.project_env_vars, envVar.id);
+  }
+
+  // API token operations
+  async createApiToken(data: Omit<ProjectApiToken, 'createdAt' | 'lastUsedAt'>): Promise<ProjectApiToken> {
+    return this.db.insert<Omit<ProjectApiToken, 'id'>>(TABLES.project_api_tokens, data as unknown as Record<string, unknown>);
+  }
+
+  async getApiTokenById(id: string): Promise<ProjectApiToken | null> {
+    return this.db.findById<ProjectApiToken>(TABLES.project_api_tokens, id);
+  }
+
+  async getApiTokenByHash(tokenHash: string): Promise<ProjectApiToken | null> {
+    return this.db.findOneBy<ProjectApiToken>(TABLES.project_api_tokens, { tokenHash });
+  }
+
+  async listApiTokens(projectId: string): Promise<ProjectApiToken[]> {
+    return this.db.findBy<ProjectApiToken>(TABLES.project_api_tokens, { projectId }, { orderBy: 'created_at DESC' });
+  }
+
+  async updateApiTokenLastUsed(id: string): Promise<void> {
+    await this.db.update<Omit<ProjectApiToken, 'id'>>(TABLES.project_api_tokens, id, {
+      lastUsedAt: new Date(),
+    } as unknown as Record<string, unknown>);
+  }
+
+  async deleteApiToken(id: string): Promise<boolean> {
+    return this.db.delete(TABLES.project_api_tokens, id);
+  }
+}

--- a/stores/admin-pg/src/domains/rbac.ts
+++ b/stores/admin-pg/src/domains/rbac.ts
@@ -1,0 +1,153 @@
+import type { TeamRole } from '@mastra/admin';
+import { AdminPgDB, TABLES } from '../db';
+import type { PgDomainConfig } from './utils';
+import { resolvePgConfig } from './utils';
+
+/**
+ * Permission mappings for team roles.
+ * These define what actions each role can perform.
+ */
+const ROLE_PERMISSIONS: Record<TeamRole, string[]> = {
+  owner: [
+    'team:read',
+    'team:update',
+    'team:delete',
+    'team:manage',
+    'member:read',
+    'member:create',
+    'member:update',
+    'member:delete',
+    'member:manage',
+    'invite:read',
+    'invite:create',
+    'invite:delete',
+    'project:read',
+    'project:create',
+    'project:update',
+    'project:delete',
+    'project:manage',
+    'deployment:read',
+    'deployment:create',
+    'deployment:update',
+    'deployment:delete',
+    'deployment:deploy',
+    'build:read',
+    'build:create',
+    'build:delete',
+    'env_var:read',
+    'env_var:create',
+    'env_var:update',
+    'env_var:delete',
+    'api_token:read',
+    'api_token:create',
+    'api_token:delete',
+  ],
+  admin: [
+    'team:read',
+    'team:update',
+    'member:read',
+    'member:create',
+    'member:update',
+    'member:delete',
+    'invite:read',
+    'invite:create',
+    'invite:delete',
+    'project:read',
+    'project:create',
+    'project:update',
+    'project:delete',
+    'deployment:read',
+    'deployment:create',
+    'deployment:update',
+    'deployment:delete',
+    'deployment:deploy',
+    'build:read',
+    'build:create',
+    'build:delete',
+    'env_var:read',
+    'env_var:create',
+    'env_var:update',
+    'env_var:delete',
+    'api_token:read',
+    'api_token:create',
+    'api_token:delete',
+  ],
+  developer: [
+    'team:read',
+    'member:read',
+    'project:read',
+    'project:create',
+    'project:update',
+    'deployment:read',
+    'deployment:create',
+    'deployment:update',
+    'deployment:deploy',
+    'build:read',
+    'build:create',
+    'env_var:read',
+    'env_var:create',
+    'env_var:update',
+    'api_token:read',
+    'api_token:create',
+  ],
+  viewer: ['team:read', 'member:read', 'project:read', 'deployment:read', 'build:read'],
+};
+
+export class RbacPG {
+  private db: AdminPgDB;
+
+  static readonly MANAGED_TABLES = [TABLES.roles, TABLES.role_assignments] as const;
+
+  constructor(config: PgDomainConfig) {
+    const { client, schemaName, skipDefaultIndexes } = resolvePgConfig(config);
+    this.db = new AdminPgDB({ client, schemaName, skipDefaultIndexes });
+  }
+
+  /**
+   * Get all permissions for a user in a team based on their role.
+   */
+  async getUserPermissionsForTeam(userId: string, teamId: string): Promise<string[]> {
+    // Get the user's membership in the team
+    const member = await this.db.findOneBy<{ role: TeamRole }>(TABLES.team_members, {
+      userId,
+      teamId,
+    });
+
+    if (!member) {
+      return [];
+    }
+
+    return ROLE_PERMISSIONS[member.role] || [];
+  }
+
+  /**
+   * Check if a user has a specific permission in a team.
+   */
+  async userHasPermission(userId: string, teamId: string, permission: string): Promise<boolean> {
+    const permissions = await this.getUserPermissionsForTeam(userId, teamId);
+    return permissions.includes(permission);
+  }
+
+  /**
+   * Check if a user has any of the specified permissions in a team.
+   */
+  async userHasAnyPermission(userId: string, teamId: string, permissions: string[]): Promise<boolean> {
+    const userPermissions = await this.getUserPermissionsForTeam(userId, teamId);
+    return permissions.some(p => userPermissions.includes(p));
+  }
+
+  /**
+   * Check if a user has all of the specified permissions in a team.
+   */
+  async userHasAllPermissions(userId: string, teamId: string, permissions: string[]): Promise<boolean> {
+    const userPermissions = await this.getUserPermissionsForTeam(userId, teamId);
+    return permissions.every(p => userPermissions.includes(p));
+  }
+
+  /**
+   * Get permissions for a role.
+   */
+  getPermissionsForRole(role: TeamRole): string[] {
+    return ROLE_PERMISSIONS[role] || [];
+  }
+}

--- a/stores/admin-pg/src/domains/routes.ts
+++ b/stores/admin-pg/src/domains/routes.ts
@@ -1,0 +1,113 @@
+import type { RouteInfo, RouteConfig, RouteStatus } from '@mastra/admin';
+import { AdminPgDB, TABLES } from '../db';
+import type { PgDomainConfig } from './utils';
+import { resolvePgConfig } from './utils';
+
+// Internal database representation
+interface RouteRecord {
+  id: string;
+  deploymentId: string;
+  projectId: string;
+  subdomain: string;
+  targetHost: string;
+  targetPort: number;
+  publicUrl: string;
+  status: RouteStatus;
+  tlsEnabled: boolean;
+  providerRouteId: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+  lastHealthCheck: Date | null;
+}
+
+export class RoutesPG {
+  private db: AdminPgDB;
+
+  static readonly MANAGED_TABLES = [TABLES.routes] as const;
+
+  constructor(config: PgDomainConfig) {
+    const { client, schemaName, skipDefaultIndexes } = resolvePgConfig(config);
+    this.db = new AdminPgDB({ client, schemaName, skipDefaultIndexes });
+  }
+
+  async createRoute(config: RouteConfig & { publicUrl: string }): Promise<RouteInfo> {
+    const record = await this.db.insert<Omit<RouteRecord, 'id'>>(TABLES.routes, {
+      deploymentId: config.deploymentId,
+      projectId: config.projectId,
+      subdomain: config.subdomain,
+      targetHost: config.targetHost,
+      targetPort: config.targetPort,
+      publicUrl: config.publicUrl,
+      status: 'pending',
+      tlsEnabled: config.tls ?? true,
+      providerRouteId: null,
+      metadata: {},
+    } as unknown as Record<string, unknown>);
+
+    return this.toRouteInfo(record);
+  }
+
+  async getRouteById(id: string): Promise<RouteInfo | null> {
+    const record = await this.db.findById<RouteRecord>(TABLES.routes, id);
+    return record ? this.toRouteInfo(record) : null;
+  }
+
+  async getRouteByDeployment(deploymentId: string): Promise<RouteInfo | null> {
+    const record = await this.db.findOneBy<RouteRecord>(TABLES.routes, { deploymentId });
+    return record ? this.toRouteInfo(record) : null;
+  }
+
+  async getRouteBySubdomain(subdomain: string): Promise<RouteInfo | null> {
+    const record = await this.db.findOneBy<RouteRecord>(TABLES.routes, { subdomain });
+    return record ? this.toRouteInfo(record) : null;
+  }
+
+  async updateRoute(id: string, data: Partial<RouteConfig>): Promise<RouteInfo | null> {
+    const record = await this.db.update<Omit<RouteRecord, 'id'>>(TABLES.routes, id, data as unknown as Record<string, unknown>);
+    return record ? this.toRouteInfo(record) : null;
+  }
+
+  async updateRouteStatus(id: string, status: RouteStatus): Promise<RouteInfo | null> {
+    const record = await this.db.update<Omit<RouteRecord, 'id'>>(TABLES.routes, id, { status } as unknown as Record<string, unknown>);
+    return record ? this.toRouteInfo(record) : null;
+  }
+
+  async updateRouteHealth(id: string, healthy: boolean): Promise<RouteInfo | null> {
+    const record = await this.db.update<Omit<RouteRecord, 'id'>>(TABLES.routes, id, {
+      status: healthy ? 'active' : 'unhealthy',
+      lastHealthCheck: new Date(),
+    } as unknown as Record<string, unknown>);
+    return record ? this.toRouteInfo(record) : null;
+  }
+
+  async setProviderRouteId(id: string, providerRouteId: string): Promise<RouteInfo | null> {
+    const record = await this.db.update<Omit<RouteRecord, 'id'>>(TABLES.routes, id, { providerRouteId } as unknown as Record<string, unknown>);
+    return record ? this.toRouteInfo(record) : null;
+  }
+
+  async deleteRoute(id: string): Promise<boolean> {
+    return this.db.delete(TABLES.routes, id);
+  }
+
+  async listRoutes(projectId: string): Promise<RouteInfo[]> {
+    const records = await this.db.findBy<RouteRecord>(TABLES.routes, { projectId }, { orderBy: 'created_at DESC' });
+    return records.map(r => this.toRouteInfo(r));
+  }
+
+  async listActiveRoutes(): Promise<RouteInfo[]> {
+    const records = await this.db.findBy<RouteRecord>(TABLES.routes, { status: 'active' }, { orderBy: 'subdomain' });
+    return records.map(r => this.toRouteInfo(r));
+  }
+
+  private toRouteInfo(record: RouteRecord): RouteInfo {
+    return {
+      routeId: record.id,
+      deploymentId: record.deploymentId,
+      publicUrl: record.publicUrl,
+      status: record.status,
+      createdAt: record.createdAt,
+      lastHealthCheck: record.lastHealthCheck ?? undefined,
+    };
+  }
+}

--- a/stores/admin-pg/src/domains/servers.ts
+++ b/stores/admin-pg/src/domains/servers.ts
@@ -1,0 +1,99 @@
+import type { RunningServer, HealthStatus } from '@mastra/admin';
+import { AdminPgDB, TABLES } from '../db';
+import type { PgDomainConfig } from './utils';
+import { resolvePgConfig } from './utils';
+
+export class RunningServersPG {
+  private db: AdminPgDB;
+
+  static readonly MANAGED_TABLES = [TABLES.running_servers] as const;
+
+  constructor(config: PgDomainConfig) {
+    const { client, schemaName, skipDefaultIndexes } = resolvePgConfig(config);
+    this.db = new AdminPgDB({ client, schemaName, skipDefaultIndexes });
+  }
+
+  async createRunningServer(data: Omit<RunningServer, 'stoppedAt'>): Promise<RunningServer> {
+    return this.db.insert<Omit<RunningServer, 'id'>>(TABLES.running_servers, {
+      ...data,
+      stoppedAt: null,
+    } as unknown as Record<string, unknown>);
+  }
+
+  async getServerById(id: string): Promise<RunningServer | null> {
+    return this.db.findById<RunningServer>(TABLES.running_servers, id);
+  }
+
+  async getServerForDeployment(deploymentId: string): Promise<RunningServer | null> {
+    return this.db.findOneBy<RunningServer>(TABLES.running_servers, {
+      deploymentId,
+      stoppedAt: null,
+    });
+  }
+
+  async updateServer(
+    id: string,
+    data: Partial<Omit<RunningServer, 'id' | 'deploymentId' | 'buildId' | 'startedAt'>>,
+  ): Promise<RunningServer | null> {
+    return this.db.update<Omit<RunningServer, 'id'>>(TABLES.running_servers, id, data as unknown as Record<string, unknown>);
+  }
+
+  async updateHealthStatus(
+    id: string,
+    status: HealthStatus,
+    metrics?: { memoryUsageMb?: number; cpuPercent?: number },
+  ): Promise<RunningServer | null> {
+    return this.updateServer(id, {
+      healthStatus: status,
+      lastHealthCheck: new Date(),
+      ...metrics,
+    });
+  }
+
+  async stopServer(id: string): Promise<RunningServer | null> {
+    return this.updateServer(id, {
+      healthStatus: 'stopping',
+      stoppedAt: new Date(),
+    });
+  }
+
+  async listRunningServers(): Promise<RunningServer[]> {
+    return this.db.findBy<RunningServer>(
+      TABLES.running_servers,
+      { stoppedAt: null },
+      { orderBy: 'started_at DESC' },
+    );
+  }
+
+  async listServersForDeployment(deploymentId: string, options?: { limit?: number }): Promise<RunningServer[]> {
+    return this.db.findBy<RunningServer>(
+      TABLES.running_servers,
+      { deploymentId },
+      { orderBy: 'started_at DESC', limit: options?.limit },
+    );
+  }
+
+  async getUnhealthyServers(thresholdMinutes: number = 5): Promise<RunningServer[]> {
+    const sql = `
+      SELECT * FROM "${this.db.schemaName}"."${TABLES.running_servers}"
+      WHERE stopped_at IS NULL
+        AND (
+          health_status = 'unhealthy'
+          OR (last_health_check IS NOT NULL AND last_health_check < NOW() - INTERVAL '${thresholdMinutes} minutes')
+        )
+      ORDER BY started_at DESC
+    `;
+    return this.db.query<RunningServer>(sql);
+  }
+
+  async cleanupStoppedServers(olderThanDays: number = 7): Promise<number> {
+    const sql = `
+      DELETE FROM "${this.db.schemaName}"."${TABLES.running_servers}"
+      WHERE stopped_at IS NOT NULL
+        AND stopped_at < NOW() - INTERVAL '${olderThanDays} days'
+      RETURNING id
+    `;
+    const result = await this.db.query<{ id: string }>(sql);
+    return result.length;
+  }
+}

--- a/stores/admin-pg/src/domains/teams.ts
+++ b/stores/admin-pg/src/domains/teams.ts
@@ -1,0 +1,162 @@
+import type { Team, TeamMember, TeamInvite, User, TeamRole } from '@mastra/admin';
+import { AdminPgDB, TABLES } from '../db';
+import type { PgDomainConfig } from './utils';
+import { resolvePgConfig } from './utils';
+
+export class TeamsPG {
+  private db: AdminPgDB;
+
+  static readonly MANAGED_TABLES = [TABLES.teams, TABLES.team_members, TABLES.team_invites, TABLES.team_installations] as const;
+
+  constructor(config: PgDomainConfig) {
+    const { client, schemaName, skipDefaultIndexes } = resolvePgConfig(config);
+    this.db = new AdminPgDB({ client, schemaName, skipDefaultIndexes });
+  }
+
+  // Team operations
+  async createTeam(data: Omit<Team, 'createdAt' | 'updatedAt'>): Promise<Team> {
+    return this.db.insert<Omit<Team, 'id'>>(TABLES.teams, data as unknown as Record<string, unknown>);
+  }
+
+  async getTeamById(id: string): Promise<Team | null> {
+    return this.db.findById<Team>(TABLES.teams, id);
+  }
+
+  async getTeamBySlug(slug: string): Promise<Team | null> {
+    return this.db.findOneBy<Team>(TABLES.teams, { slug });
+  }
+
+  async updateTeam(id: string, data: Partial<Omit<Team, 'id' | 'createdAt'>>): Promise<Team | null> {
+    return this.db.update<Omit<Team, 'id'>>(TABLES.teams, id, data as unknown as Record<string, unknown>);
+  }
+
+  async deleteTeam(id: string): Promise<boolean> {
+    return this.db.delete(TABLES.teams, id);
+  }
+
+  async listTeamsForUser(
+    userId: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<{ data: Team[]; total: number }> {
+    const countSql = `
+      SELECT COUNT(*) as count FROM "${this.db.schemaName}"."${TABLES.teams}" t
+      INNER JOIN "${this.db.schemaName}"."${TABLES.team_members}" tm ON t.id = tm.team_id
+      WHERE tm.user_id = $1
+    `;
+    const countResult = await this.db.db.one<{ count: string }>(countSql, [userId]);
+    const total = parseInt(countResult.count, 10);
+
+    let sql = `
+      SELECT t.* FROM "${this.db.schemaName}"."${TABLES.teams}" t
+      INNER JOIN "${this.db.schemaName}"."${TABLES.team_members}" tm ON t.id = tm.team_id
+      WHERE tm.user_id = $1
+      ORDER BY t.name
+    `;
+
+    if (options?.limit) {
+      sql += ` LIMIT ${options.limit}`;
+    }
+    if (options?.offset) {
+      sql += ` OFFSET ${options.offset}`;
+    }
+
+    const data = await this.db.query<Team>(sql, [userId]);
+    return { data, total };
+  }
+
+  // Team member operations
+  async addTeamMember(data: Omit<TeamMember, 'id' | 'createdAt' | 'updatedAt'>): Promise<TeamMember> {
+    return this.db.insert<Omit<TeamMember, 'id'>>(TABLES.team_members, data as unknown as Record<string, unknown>);
+  }
+
+  async removeTeamMember(teamId: string, userId: string): Promise<boolean> {
+    const member = await this.db.findOneBy<TeamMember>(TABLES.team_members, { teamId, userId });
+    if (!member) return false;
+    return this.db.delete(TABLES.team_members, member.id);
+  }
+
+  async getTeamMember(teamId: string, userId: string): Promise<TeamMember | null> {
+    return this.db.findOneBy<TeamMember>(TABLES.team_members, { teamId, userId });
+  }
+
+  async listTeamMembers(
+    teamId: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<{ data: (TeamMember & { user: User })[]; total: number }> {
+    const countSql = `
+      SELECT COUNT(*) as count FROM "${this.db.schemaName}"."${TABLES.team_members}"
+      WHERE team_id = $1
+    `;
+    const countResult = await this.db.db.one<{ count: string }>(countSql, [teamId]);
+    const total = parseInt(countResult.count, 10);
+
+    let sql = `
+      SELECT
+        tm.*,
+        u.id as "user_id",
+        u.email as "user_email",
+        u.name as "user_name",
+        u.avatar_url as "user_avatar_url",
+        u.created_at as "user_created_at",
+        u.updated_at as "user_updated_at"
+      FROM "${this.db.schemaName}"."${TABLES.team_members}" tm
+      INNER JOIN "${this.db.schemaName}"."${TABLES.users}" u ON tm.user_id = u.id
+      WHERE tm.team_id = $1
+      ORDER BY tm.created_at
+    `;
+
+    if (options?.limit) {
+      sql += ` LIMIT ${options.limit}`;
+    }
+    if (options?.offset) {
+      sql += ` OFFSET ${options.offset}`;
+    }
+
+    const rows = await this.db.db.any(sql, [teamId]);
+    const data = rows.map(row => ({
+      id: row.id,
+      teamId: row.team_id,
+      userId: row.user_id,
+      role: row.role as TeamRole,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      user: {
+        id: row.user_id,
+        email: row.user_email,
+        name: row.user_name,
+        avatarUrl: row.user_avatar_url,
+        createdAt: row.user_created_at,
+        updatedAt: row.user_updated_at,
+      },
+    }));
+
+    return { data, total };
+  }
+
+  async updateTeamMemberRole(teamId: string, userId: string, role: TeamRole): Promise<TeamMember | null> {
+    const member = await this.getTeamMember(teamId, userId);
+    if (!member) return null;
+    return this.db.update<Omit<TeamMember, 'id'>>(TABLES.team_members, member.id, { role });
+  }
+
+  // Team invite operations
+  async createInvite(data: Omit<TeamInvite, 'id' | 'createdAt'>): Promise<TeamInvite> {
+    return this.db.insert<Omit<TeamInvite, 'id'>>(TABLES.team_invites, data as unknown as Record<string, unknown>);
+  }
+
+  async getInviteById(id: string): Promise<TeamInvite | null> {
+    return this.db.findById<TeamInvite>(TABLES.team_invites, id);
+  }
+
+  async getInviteByEmail(teamId: string, email: string): Promise<TeamInvite | null> {
+    return this.db.findOneBy<TeamInvite>(TABLES.team_invites, { teamId, email });
+  }
+
+  async listPendingInvites(teamId: string): Promise<TeamInvite[]> {
+    return this.db.findBy<TeamInvite>(TABLES.team_invites, { teamId }, { orderBy: 'created_at DESC' });
+  }
+
+  async deleteInvite(id: string): Promise<boolean> {
+    return this.db.delete(TABLES.team_invites, id);
+  }
+}

--- a/stores/admin-pg/src/domains/users.ts
+++ b/stores/admin-pg/src/domains/users.ts
@@ -1,0 +1,39 @@
+import type { User } from '@mastra/admin';
+import { AdminPgDB, TABLES } from '../db';
+import type { PgDomainConfig } from './utils';
+import { resolvePgConfig } from './utils';
+
+export class UsersPG {
+  private db: AdminPgDB;
+
+  static readonly MANAGED_TABLES = [TABLES.users] as const;
+
+  constructor(config: PgDomainConfig) {
+    const { client, schemaName, skipDefaultIndexes } = resolvePgConfig(config);
+    this.db = new AdminPgDB({ client, schemaName, skipDefaultIndexes });
+  }
+
+  async createUser(data: Omit<User, 'createdAt' | 'updatedAt'>): Promise<User> {
+    return this.db.insert<Omit<User, 'id'>>(TABLES.users, data as unknown as Record<string, unknown>);
+  }
+
+  async getUserById(id: string): Promise<User | null> {
+    return this.db.findById<User>(TABLES.users, id);
+  }
+
+  async getUserByEmail(email: string): Promise<User | null> {
+    return this.db.findOneBy<User>(TABLES.users, { email });
+  }
+
+  async updateUser(id: string, data: Partial<Omit<User, 'id' | 'createdAt'>>): Promise<User | null> {
+    return this.db.update<Omit<User, 'id'>>(TABLES.users, id, data as unknown as Record<string, unknown>);
+  }
+
+  async deleteUser(id: string): Promise<boolean> {
+    return this.db.delete(TABLES.users, id);
+  }
+
+  async listUsers(options?: { limit?: number; offset?: number }): Promise<User[]> {
+    return this.db.findBy<User>(TABLES.users, {}, { ...options, orderBy: 'created_at DESC' });
+  }
+}

--- a/stores/admin-pg/src/domains/utils.ts
+++ b/stores/admin-pg/src/domains/utils.ts
@@ -1,0 +1,34 @@
+import type { Pool } from 'pg';
+import type { DbClient } from '../client';
+import { PoolAdapter } from '../client';
+
+export interface PgDomainConfig {
+  client?: DbClient;
+  pool?: Pool;
+  schemaName?: string;
+  skipDefaultIndexes?: boolean;
+}
+
+export function resolvePgConfig(config: PgDomainConfig): {
+  client: DbClient;
+  schemaName?: string;
+  skipDefaultIndexes?: boolean;
+} {
+  if (config.client) {
+    return {
+      client: config.client,
+      schemaName: config.schemaName,
+      skipDefaultIndexes: config.skipDefaultIndexes,
+    };
+  }
+
+  if (config.pool) {
+    return {
+      client: new PoolAdapter(config.pool),
+      schemaName: config.schemaName,
+      skipDefaultIndexes: config.skipDefaultIndexes,
+    };
+  }
+
+  throw new Error('Either client or pool must be provided');
+}

--- a/stores/admin-pg/src/index.ts
+++ b/stores/admin-pg/src/index.ts
@@ -1,5 +1,8 @@
 // @mastra/admin-pg - PostgreSQL storage adapter for MastraAdmin
 
+// Main storage class
+export { PostgresAdminStorage } from './storage';
+
 // Configuration types
 export type {
   PostgresAdminStorageConfig,

--- a/stores/admin-pg/src/index.ts
+++ b/stores/admin-pg/src/index.ts
@@ -14,3 +14,6 @@ export { isPoolConfig, isConnectionStringConfig, isHostConfig, validateConfig, p
 // Client types
 export type { DbClient, TxClient, QueryValues } from './client';
 export { PoolAdapter } from './client';
+
+// Migration schemas (for external tooling)
+export { TABLES, TABLE_SCHEMAS, DEFAULT_INDEXES, type TableName, type IndexDefinition } from './migrations/001_initial';

--- a/stores/admin-pg/src/index.ts
+++ b/stores/admin-pg/src/index.ts
@@ -20,3 +20,17 @@ export { TABLES, TABLE_SCHEMAS, DEFAULT_INDEXES, type TableName, type IndexDefin
 
 // Database utilities
 export { AdminPgDB } from './db';
+
+// Domain classes
+export { UsersPG } from './domains/users';
+export { TeamsPG } from './domains/teams';
+export { ProjectsPG } from './domains/projects';
+export { DeploymentsPG } from './domains/deployments';
+export { BuildsPG } from './domains/builds';
+export { RunningServersPG } from './domains/servers';
+export { RoutesPG } from './domains/routes';
+export { RbacPG } from './domains/rbac';
+
+// Domain utilities
+export type { PgDomainConfig } from './domains/utils';
+export { resolvePgConfig } from './domains/utils';

--- a/stores/admin-pg/src/index.ts
+++ b/stores/admin-pg/src/index.ts
@@ -17,3 +17,6 @@ export { PoolAdapter } from './client';
 
 // Migration schemas (for external tooling)
 export { TABLES, TABLE_SCHEMAS, DEFAULT_INDEXES, type TableName, type IndexDefinition } from './migrations/001_initial';
+
+// Database utilities
+export { AdminPgDB } from './db';

--- a/stores/admin-pg/src/index.ts
+++ b/stores/admin-pg/src/index.ts
@@ -1,4 +1,12 @@
 // @mastra/admin-pg - PostgreSQL storage adapter for MastraAdmin
-// This file will be populated with exports in Phase 8
 
-export {};
+// Configuration types
+export type {
+  PostgresAdminStorageConfig,
+  PostgresAdminBaseConfig,
+  PoolInstanceConfig,
+  ConnectionStringConfig,
+  HostConfig,
+} from './shared/config';
+
+export { isPoolConfig, isConnectionStringConfig, isHostConfig, validateConfig, parseSqlIdentifier } from './shared/config';

--- a/stores/admin-pg/src/index.ts
+++ b/stores/admin-pg/src/index.ts
@@ -1,0 +1,4 @@
+// @mastra/admin-pg - PostgreSQL storage adapter for MastraAdmin
+// This file will be populated with exports in Phase 8
+
+export {};

--- a/stores/admin-pg/src/index.ts
+++ b/stores/admin-pg/src/index.ts
@@ -10,3 +10,7 @@ export type {
 } from './shared/config';
 
 export { isPoolConfig, isConnectionStringConfig, isHostConfig, validateConfig, parseSqlIdentifier } from './shared/config';
+
+// Client types
+export type { DbClient, TxClient, QueryValues } from './client';
+export { PoolAdapter } from './client';

--- a/stores/admin-pg/src/migrations/001_initial.ts
+++ b/stores/admin-pg/src/migrations/001_initial.ts
@@ -1,0 +1,321 @@
+/**
+ * Initial database schema for MastraAdmin
+ *
+ * Tables:
+ * - users: User accounts
+ * - teams: Organizational units
+ * - team_members: User-team relationships
+ * - team_invites: Pending team invitations
+ * - team_installations: External service installations (GitHub App, etc.)
+ * - projects: Mastra project configurations
+ * - project_env_vars: Encrypted environment variables
+ * - project_api_tokens: API tokens for project access
+ * - deployments: Deployment instances (production, staging, preview)
+ * - builds: Build queue and history
+ * - running_servers: Active server instances
+ * - routes: Edge router registrations
+ * - roles: Custom RBAC roles
+ * - role_assignments: Role-user-resource mappings
+ */
+
+export const TABLES = {
+  users: 'admin_users',
+  teams: 'admin_teams',
+  team_members: 'admin_team_members',
+  team_invites: 'admin_team_invites',
+  team_installations: 'admin_team_installations',
+  projects: 'admin_projects',
+  project_env_vars: 'admin_project_env_vars',
+  project_api_tokens: 'admin_project_api_tokens',
+  deployments: 'admin_deployments',
+  builds: 'admin_builds',
+  running_servers: 'admin_running_servers',
+  routes: 'admin_routes',
+  roles: 'admin_roles',
+  role_assignments: 'admin_role_assignments',
+} as const;
+
+export type TableName = (typeof TABLES)[keyof typeof TABLES];
+
+/**
+ * Schema definitions for each table
+ */
+export const TABLE_SCHEMAS: Record<TableName, string> = {
+  // Users table
+  [TABLES.users]: `
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    external_id VARCHAR(255) UNIQUE,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    name VARCHAR(255),
+    avatar_url TEXT,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+  `,
+
+  // Teams table
+  [TABLES.teams]: `
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(255) NOT NULL,
+    slug VARCHAR(255) NOT NULL UNIQUE,
+    settings JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+  `,
+
+  // Team members table
+  [TABLES.team_members]: `
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id UUID NOT NULL REFERENCES ${TABLES.teams}(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES ${TABLES.users}(id) ON DELETE CASCADE,
+    role VARCHAR(50) NOT NULL DEFAULT 'member',
+    joined_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(team_id, user_id)
+  `,
+
+  // Team invites table
+  [TABLES.team_invites]: `
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id UUID NOT NULL REFERENCES ${TABLES.teams}(id) ON DELETE CASCADE,
+    email VARCHAR(255) NOT NULL,
+    role VARCHAR(50) NOT NULL DEFAULT 'member',
+    invited_by UUID NOT NULL REFERENCES ${TABLES.users}(id),
+    token VARCHAR(255) NOT NULL UNIQUE,
+    expires_at TIMESTAMPTZ NOT NULL,
+    accepted_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  `,
+
+  // Team installations table (GitHub App, etc.)
+  [TABLES.team_installations]: `
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id UUID NOT NULL REFERENCES ${TABLES.teams}(id) ON DELETE CASCADE,
+    provider VARCHAR(50) NOT NULL,
+    installation_id VARCHAR(255) NOT NULL,
+    account_name VARCHAR(255),
+    account_type VARCHAR(50),
+    permissions JSONB DEFAULT '{}',
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(team_id, provider, installation_id)
+  `,
+
+  // Projects table
+  [TABLES.projects]: `
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id UUID NOT NULL REFERENCES ${TABLES.teams}(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    slug VARCHAR(255) NOT NULL,
+    source_type VARCHAR(50) NOT NULL,
+    source_config JSONB NOT NULL,
+    default_branch VARCHAR(255) DEFAULT 'main',
+    settings JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(team_id, slug)
+  `,
+
+  // Project environment variables table
+  [TABLES.project_env_vars]: `
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES ${TABLES.projects}(id) ON DELETE CASCADE,
+    deployment_type VARCHAR(50),
+    key VARCHAR(255) NOT NULL,
+    encrypted_value TEXT NOT NULL,
+    is_secret BOOLEAN DEFAULT true,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(project_id, deployment_type, key)
+  `,
+
+  // Project API tokens table
+  [TABLES.project_api_tokens]: `
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES ${TABLES.projects}(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    token_hash VARCHAR(255) NOT NULL UNIQUE,
+    token_prefix VARCHAR(10) NOT NULL,
+    scopes JSONB DEFAULT '[]',
+    last_used_at TIMESTAMPTZ,
+    expires_at TIMESTAMPTZ,
+    created_by UUID NOT NULL REFERENCES ${TABLES.users}(id),
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  `,
+
+  // Deployments table
+  [TABLES.deployments]: `
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id UUID NOT NULL REFERENCES ${TABLES.projects}(id) ON DELETE CASCADE,
+    type VARCHAR(50) NOT NULL,
+    branch VARCHAR(255) NOT NULL,
+    slug VARCHAR(255) NOT NULL,
+    status VARCHAR(50) NOT NULL DEFAULT 'pending',
+    current_build_id UUID,
+    public_url TEXT,
+    internal_host VARCHAR(255),
+    internal_port INTEGER,
+    env_var_overrides JSONB DEFAULT '[]',
+    auto_shutdown BOOLEAN DEFAULT false,
+    expires_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(project_id, type, branch)
+  `,
+
+  // Builds table
+  [TABLES.builds]: `
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    deployment_id UUID NOT NULL REFERENCES ${TABLES.deployments}(id) ON DELETE CASCADE,
+    trigger VARCHAR(50) NOT NULL,
+    triggered_by VARCHAR(255) NOT NULL,
+    commit_sha VARCHAR(255),
+    commit_message TEXT,
+    status VARCHAR(50) NOT NULL DEFAULT 'queued',
+    logs TEXT DEFAULT '',
+    error_message TEXT,
+    queued_at TIMESTAMPTZ DEFAULT NOW(),
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+  `,
+
+  // Running servers table
+  [TABLES.running_servers]: `
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    deployment_id UUID NOT NULL REFERENCES ${TABLES.deployments}(id) ON DELETE CASCADE,
+    build_id UUID NOT NULL REFERENCES ${TABLES.builds}(id),
+    process_id INTEGER,
+    container_id VARCHAR(255),
+    host VARCHAR(255) NOT NULL,
+    port INTEGER NOT NULL,
+    health_status VARCHAR(50) NOT NULL DEFAULT 'starting',
+    last_health_check TIMESTAMPTZ,
+    memory_usage_mb REAL,
+    cpu_percent REAL,
+    started_at TIMESTAMPTZ DEFAULT NOW(),
+    stopped_at TIMESTAMPTZ
+  `,
+
+  // Routes table
+  [TABLES.routes]: `
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    deployment_id UUID NOT NULL REFERENCES ${TABLES.deployments}(id) ON DELETE CASCADE,
+    project_id UUID NOT NULL REFERENCES ${TABLES.projects}(id) ON DELETE CASCADE,
+    subdomain VARCHAR(255) NOT NULL,
+    target_host VARCHAR(255) NOT NULL,
+    target_port INTEGER NOT NULL,
+    public_url TEXT NOT NULL,
+    status VARCHAR(50) NOT NULL DEFAULT 'pending',
+    tls_enabled BOOLEAN DEFAULT true,
+    provider_route_id VARCHAR(255),
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    last_health_check TIMESTAMPTZ,
+    UNIQUE(subdomain)
+  `,
+
+  // Roles table
+  [TABLES.roles]: `
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    team_id UUID REFERENCES ${TABLES.teams}(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    permissions JSONB NOT NULL DEFAULT '[]',
+    is_system BOOLEAN DEFAULT false,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(team_id, name)
+  `,
+
+  // Role assignments table
+  [TABLES.role_assignments]: `
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    role_id UUID NOT NULL REFERENCES ${TABLES.roles}(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES ${TABLES.users}(id) ON DELETE CASCADE,
+    resource_type VARCHAR(50),
+    resource_id UUID,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(role_id, user_id, resource_type, resource_id)
+  `,
+};
+
+/**
+ * Index definition type
+ */
+export interface IndexDefinition {
+  table: TableName;
+  columns: string[];
+  unique?: boolean;
+}
+
+/**
+ * Default indexes for performance
+ */
+export const DEFAULT_INDEXES: IndexDefinition[] = [
+  // Users
+  { table: TABLES.users, columns: ['email'], unique: true },
+  { table: TABLES.users, columns: ['external_id'], unique: true },
+
+  // Teams
+  { table: TABLES.teams, columns: ['slug'], unique: true },
+
+  // Team members
+  { table: TABLES.team_members, columns: ['team_id'] },
+  { table: TABLES.team_members, columns: ['user_id'] },
+  { table: TABLES.team_members, columns: ['team_id', 'user_id'], unique: true },
+
+  // Team invites
+  { table: TABLES.team_invites, columns: ['team_id'] },
+  { table: TABLES.team_invites, columns: ['email'] },
+  { table: TABLES.team_invites, columns: ['token'], unique: true },
+
+  // Team installations
+  { table: TABLES.team_installations, columns: ['team_id'] },
+  { table: TABLES.team_installations, columns: ['provider', 'installation_id'] },
+
+  // Projects
+  { table: TABLES.projects, columns: ['team_id'] },
+  { table: TABLES.projects, columns: ['team_id', 'slug'], unique: true },
+
+  // Project env vars
+  { table: TABLES.project_env_vars, columns: ['project_id'] },
+  { table: TABLES.project_env_vars, columns: ['project_id', 'deployment_type', 'key'], unique: true },
+
+  // Project API tokens
+  { table: TABLES.project_api_tokens, columns: ['project_id'] },
+  { table: TABLES.project_api_tokens, columns: ['token_hash'], unique: true },
+
+  // Deployments
+  { table: TABLES.deployments, columns: ['project_id'] },
+  { table: TABLES.deployments, columns: ['project_id', 'type'] },
+  { table: TABLES.deployments, columns: ['status'] },
+  { table: TABLES.deployments, columns: ['project_id', 'type', 'branch'], unique: true },
+
+  // Builds
+  { table: TABLES.builds, columns: ['deployment_id'] },
+  { table: TABLES.builds, columns: ['status'] },
+  { table: TABLES.builds, columns: ['status', 'queued_at'] }, // For queue ordering
+  { table: TABLES.builds, columns: ['deployment_id', 'created_at DESC'] },
+
+  // Running servers
+  { table: TABLES.running_servers, columns: ['deployment_id'] },
+  { table: TABLES.running_servers, columns: ['health_status'] },
+  { table: TABLES.running_servers, columns: ['deployment_id', 'stopped_at'] },
+
+  // Routes
+  { table: TABLES.routes, columns: ['deployment_id'] },
+  { table: TABLES.routes, columns: ['project_id'] },
+  { table: TABLES.routes, columns: ['subdomain'], unique: true },
+  { table: TABLES.routes, columns: ['status'] },
+
+  // Roles
+  { table: TABLES.roles, columns: ['team_id'] },
+  { table: TABLES.roles, columns: ['team_id', 'name'], unique: true },
+
+  // Role assignments
+  { table: TABLES.role_assignments, columns: ['role_id'] },
+  { table: TABLES.role_assignments, columns: ['user_id'] },
+  { table: TABLES.role_assignments, columns: ['resource_type', 'resource_id'] },
+];

--- a/stores/admin-pg/src/shared/config.ts
+++ b/stores/admin-pg/src/shared/config.ts
@@ -1,0 +1,106 @@
+import type { Pool } from 'pg';
+
+/**
+ * Base configuration shared by all PostgresAdminStorage configs
+ */
+export interface PostgresAdminBaseConfig {
+  /** Unique identifier for this storage instance */
+  id?: string;
+  /** PostgreSQL schema name (default: 'mastra_admin') */
+  schemaName?: string;
+  /** Skip automatic table initialization */
+  disableInit?: boolean;
+  /** Skip creation of default indexes */
+  skipDefaultIndexes?: boolean;
+}
+
+/**
+ * Config using an existing pg.Pool instance
+ */
+export interface PoolInstanceConfig extends PostgresAdminBaseConfig {
+  pool: Pool;
+}
+
+/**
+ * Config using a connection string
+ */
+export interface ConnectionStringConfig extends PostgresAdminBaseConfig {
+  connectionString: string;
+}
+
+/**
+ * Config using explicit host/port/credentials
+ */
+export interface HostConfig extends PostgresAdminBaseConfig {
+  host: string;
+  port: number;
+  database: string;
+  user: string;
+  password: string;
+  ssl?: boolean | object;
+}
+
+/**
+ * Union of all valid config types
+ */
+export type PostgresAdminStorageConfig = PoolInstanceConfig | ConnectionStringConfig | HostConfig;
+
+/**
+ * Type guards for config discrimination
+ */
+export function isPoolConfig(config: PostgresAdminStorageConfig): config is PoolInstanceConfig {
+  return 'pool' in config && config.pool !== undefined;
+}
+
+export function isConnectionStringConfig(config: PostgresAdminStorageConfig): config is ConnectionStringConfig {
+  return 'connectionString' in config && typeof config.connectionString === 'string';
+}
+
+export function isHostConfig(config: PostgresAdminStorageConfig): config is HostConfig {
+  return 'host' in config && 'port' in config && 'database' in config;
+}
+
+/**
+ * Validate configuration
+ */
+export function validateConfig(config: PostgresAdminStorageConfig): void {
+  if (isPoolConfig(config)) {
+    if (!config.pool) {
+      throw new Error('PostgresAdminStorage: pool must be a valid pg.Pool instance');
+    }
+    return;
+  }
+
+  if (isConnectionStringConfig(config)) {
+    if (!config.connectionString || config.connectionString.trim() === '') {
+      throw new Error('PostgresAdminStorage: connectionString must be a non-empty string');
+    }
+    return;
+  }
+
+  if (isHostConfig(config)) {
+    if (!config.host || !config.database || !config.user) {
+      throw new Error('PostgresAdminStorage: host, database, and user are required');
+    }
+    if (typeof config.port !== 'number' || config.port <= 0) {
+      throw new Error('PostgresAdminStorage: port must be a positive number');
+    }
+    return;
+  }
+
+  throw new Error('PostgresAdminStorage: invalid configuration provided');
+}
+
+/**
+ * Parse SQL identifier to prevent SQL injection
+ */
+export function parseSqlIdentifier(value: string, label: string): string {
+  // Only allow alphanumeric and underscore
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
+    throw new Error(
+      `PostgresAdminStorage: ${label} contains invalid characters. ` +
+        'Only letters, numbers, and underscores are allowed.',
+    );
+  }
+  return value;
+}

--- a/stores/admin-pg/src/storage.test.ts
+++ b/stores/admin-pg/src/storage.test.ts
@@ -1,0 +1,2083 @@
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { AdminPgDB } from './db';
+import { PostgresAdminStorage } from './storage';
+
+/**
+ * Integration tests for PostgresAdminStorage
+ *
+ * These tests require a running PostgreSQL database.
+ * Use `docker compose up -d` to start the test database before running tests.
+ *
+ * Connection: localhost:5433, user: mastra, password: mastra, db: mastra_admin_test
+ */
+
+const TEST_CONNECTION_STRING = 'postgresql://mastra:mastra@localhost:5433/mastra_admin_test';
+
+// Helper to clear the static schema registry between tests
+function clearSchemaRegistry() {
+  // Access private static field via any cast - only for testing
+  (AdminPgDB as unknown as { schemaSetupRegistry: Map<string, unknown> }).schemaSetupRegistry.clear();
+}
+
+describe('PostgresAdminStorage', () => {
+  // Use a single storage instance for all tests to avoid schema setup race conditions
+  let storage: PostgresAdminStorage;
+  const testSchemaName = `test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+  beforeAll(async () => {
+    clearSchemaRegistry();
+    storage = new PostgresAdminStorage({
+      connectionString: TEST_CONNECTION_STRING,
+      schemaName: testSchemaName,
+    });
+    await storage.init();
+  });
+
+  afterAll(async () => {
+    if (storage) {
+      try {
+        await storage.db.none(`DROP SCHEMA IF EXISTS "${testSchemaName}" CASCADE`);
+      } catch {
+        // Ignore errors during cleanup
+      }
+      await storage.close();
+    }
+    clearSchemaRegistry();
+  });
+
+  // Helper to generate unique identifiers
+  const uniqueId = () => crypto.randomUUID();
+  const uniqueEmail = () => `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
+  const uniqueSlug = (prefix: string) => `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  // ============================================================================
+  // Initialization Tests
+  // ============================================================================
+
+  describe('initialization', () => {
+    it('should create storage with connection string', () => {
+      expect(storage).toBeDefined();
+      expect(storage.schemaName).toBe(testSchemaName);
+    });
+
+    it('should expose raw pool', () => {
+      expect(storage.rawPool).toBeInstanceOf(Pool);
+    });
+
+    it('should expose db client', () => {
+      expect(storage.db).toBeDefined();
+      expect(typeof storage.db.query).toBe('function');
+    });
+  });
+
+  describe('initialization variants', () => {
+    it('should create storage with host config', async () => {
+      clearSchemaRegistry();
+      const schemaName = `test_host_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const storageWithHost = new PostgresAdminStorage({
+        host: 'localhost',
+        port: 5433,
+        database: 'mastra_admin_test',
+        user: 'mastra',
+        password: 'mastra',
+        schemaName,
+      });
+
+      await storageWithHost.init();
+      expect(storageWithHost.schemaName).toBe(schemaName);
+
+      // Cleanup
+      await storageWithHost.db.none(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      await storageWithHost.close();
+    });
+
+    it('should create storage with existing pool', async () => {
+      clearSchemaRegistry();
+      const schemaName = `test_pool_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const pool = new Pool({ connectionString: TEST_CONNECTION_STRING });
+
+      const storageWithPool = new PostgresAdminStorage({
+        pool,
+        schemaName,
+      });
+
+      await storageWithPool.init();
+      expect(storageWithPool.schemaName).toBe(schemaName);
+      expect(storageWithPool.rawPool).toBe(pool);
+
+      // Cleanup - close storage but pool stays open (we don't own it)
+      await storageWithPool.db.none(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      await storageWithPool.close();
+      await pool.end();
+    });
+
+    it('should skip initialization when disableInit is true', async () => {
+      clearSchemaRegistry();
+      const schemaName = `test_noinit_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const storageNoInit = new PostgresAdminStorage({
+        connectionString: TEST_CONNECTION_STRING,
+        schemaName,
+        disableInit: true,
+      });
+
+      await storageNoInit.init();
+
+      // Schema should not exist
+      const result = await storageNoInit.db.oneOrNone(
+        `SELECT schema_name FROM information_schema.schemata WHERE schema_name = $1`,
+        [schemaName],
+      );
+      expect(result).toBeNull();
+
+      await storageNoInit.close();
+    });
+  });
+
+  // ============================================================================
+  // User Operations Tests
+  // ============================================================================
+
+  describe('user operations', () => {
+    it('should create a user', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Test User',
+        avatarUrl: 'https://example.com/avatar.png',
+      });
+
+      expect(user).toBeDefined();
+      expect(user.id).toBeDefined();
+      expect(user.name).toBe('Test User');
+      expect(user.createdAt).toBeInstanceOf(Date);
+      expect(user.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it('should get user by ID', async () => {
+      const created = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Get By ID',
+        avatarUrl: null,
+      });
+
+      const fetched = await storage.getUser(created.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.id).toBe(created.id);
+    });
+
+    it('should return null for non-existent user', async () => {
+      const fetched = await storage.getUser(uniqueId());
+      expect(fetched).toBeNull();
+    });
+
+    it('should get user by email', async () => {
+      const email = uniqueEmail();
+      await storage.createUser({
+        id: uniqueId(),
+        email,
+        name: 'Find By Email',
+        avatarUrl: null,
+      });
+
+      const fetched = await storage.getUserByEmail(email);
+      expect(fetched).toBeDefined();
+      expect(fetched!.email).toBe(email);
+    });
+
+    it('should update user', async () => {
+      const created = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Original Name',
+        avatarUrl: null,
+      });
+
+      const updated = await storage.updateUser(created.id, {
+        name: 'Updated Name',
+        avatarUrl: 'https://example.com/new-avatar.png',
+      });
+
+      expect(updated.name).toBe('Updated Name');
+      expect(updated.avatarUrl).toBe('https://example.com/new-avatar.png');
+    });
+
+    it('should throw when updating non-existent user', async () => {
+      await expect(storage.updateUser(uniqueId(), { name: 'New Name' })).rejects.toThrow(/User not found/);
+    });
+  });
+
+  // ============================================================================
+  // Team Operations Tests
+  // ============================================================================
+
+  describe('team operations', () => {
+    it('should create a team', async () => {
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Test Team',
+        slug: uniqueSlug('team'),
+        settings: { maxProjects: 10 },
+      });
+
+      expect(team).toBeDefined();
+      expect(team.id).toBeDefined();
+      expect(team.name).toBe('Test Team');
+      expect(team.settings).toEqual({ maxProjects: 10 });
+    });
+
+    it('should get team by ID', async () => {
+      const created = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Get By ID Team',
+        slug: uniqueSlug('get-id'),
+        settings: {},
+      });
+
+      const fetched = await storage.getTeam(created.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.id).toBe(created.id);
+    });
+
+    it('should get team by slug', async () => {
+      const slug = uniqueSlug('by-slug');
+      await storage.createTeam({
+        id: uniqueId(),
+        name: 'By Slug Team',
+        slug,
+        settings: {},
+      });
+
+      const fetched = await storage.getTeamBySlug(slug);
+      expect(fetched).toBeDefined();
+      expect(fetched!.slug).toBe(slug);
+    });
+
+    it('should update team', async () => {
+      const created = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Update Team',
+        slug: uniqueSlug('update'),
+        settings: {},
+      });
+
+      const updated = await storage.updateTeam(created.id, {
+        name: 'Updated Team Name',
+        settings: { maxProjects: 5 },
+      });
+
+      expect(updated.name).toBe('Updated Team Name');
+      expect(updated.settings).toEqual({ maxProjects: 5 });
+    });
+
+    it('should delete team', async () => {
+      const created = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Delete Team',
+        slug: uniqueSlug('delete'),
+        settings: {},
+      });
+
+      await storage.deleteTeam(created.id);
+
+      const fetched = await storage.getTeam(created.id);
+      expect(fetched).toBeNull();
+    });
+
+    it('should list teams for user', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Team List User',
+        avatarUrl: null,
+      });
+
+      const team1 = await storage.createTeam({
+        id: uniqueId(),
+        name: 'User Team 1',
+        slug: uniqueSlug('user-team-1'),
+        settings: {},
+      });
+
+      const team2 = await storage.createTeam({
+        id: uniqueId(),
+        name: 'User Team 2',
+        slug: uniqueSlug('user-team-2'),
+        settings: {},
+      });
+
+      await storage.addTeamMember({ teamId: team1.id, userId: user.id, role: 'owner' });
+      await storage.addTeamMember({ teamId: team2.id, userId: user.id, role: 'developer' });
+
+      const result = await storage.listTeamsForUser(user.id);
+      expect(result.data.length).toBe(2);
+      expect(result.total).toBe(2);
+    });
+  });
+
+  // ============================================================================
+  // Team Member Operations Tests
+  // ============================================================================
+
+  describe('team member operations', () => {
+    it('should add team member', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Member User',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Member Team',
+        slug: uniqueSlug('member'),
+        settings: {},
+      });
+
+      const member = await storage.addTeamMember({
+        teamId: team.id,
+        userId: user.id,
+        role: 'developer',
+      });
+
+      expect(member).toBeDefined();
+      expect(member.teamId).toBe(team.id);
+      expect(member.userId).toBe(user.id);
+      expect(member.role).toBe('developer');
+    });
+
+    it('should get team member', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Get Member User',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Get Member Team',
+        slug: uniqueSlug('get-member'),
+        settings: {},
+      });
+
+      await storage.addTeamMember({
+        teamId: team.id,
+        userId: user.id,
+        role: 'admin',
+      });
+
+      const fetched = await storage.getTeamMember(team.id, user.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.role).toBe('admin');
+    });
+
+    it('should list team members with user info', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'List Member User',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'List Member Team',
+        slug: uniqueSlug('list-member'),
+        settings: {},
+      });
+
+      await storage.addTeamMember({
+        teamId: team.id,
+        userId: user.id,
+        role: 'owner',
+      });
+
+      const result = await storage.listTeamMembers(team.id);
+      expect(result.data.length).toBe(1);
+      expect(result.data[0].user).toBeDefined();
+      expect(result.data[0].user.email).toBe(user.email);
+    });
+
+    it('should update team member role', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Update Role User',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Update Role Team',
+        slug: uniqueSlug('update-role'),
+        settings: {},
+      });
+
+      await storage.addTeamMember({
+        teamId: team.id,
+        userId: user.id,
+        role: 'viewer',
+      });
+
+      const updated = await storage.updateTeamMemberRole(team.id, user.id, 'admin');
+      expect(updated.role).toBe('admin');
+    });
+
+    it('should remove team member', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Remove Member User',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Remove Member Team',
+        slug: uniqueSlug('remove-member'),
+        settings: {},
+      });
+
+      await storage.addTeamMember({
+        teamId: team.id,
+        userId: user.id,
+        role: 'developer',
+      });
+
+      await storage.removeTeamMember(team.id, user.id);
+
+      const fetched = await storage.getTeamMember(team.id, user.id);
+      expect(fetched).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // Team Invite Operations Tests
+  // ============================================================================
+
+  describe('team invite operations', () => {
+    it('should create team invite', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Invite Creator',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Invite Team',
+        slug: uniqueSlug('invite'),
+        settings: {},
+      });
+
+      const invite = await storage.createTeamInvite({
+        teamId: team.id,
+        email: uniqueEmail(),
+        role: 'developer',
+        invitedBy: user.id,
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      expect(invite).toBeDefined();
+      expect(invite.role).toBe('developer');
+    });
+
+    it('should get invite by ID', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Get Invite Creator',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Get Invite Team',
+        slug: uniqueSlug('get-invite'),
+        settings: {},
+      });
+
+      const created = await storage.createTeamInvite({
+        teamId: team.id,
+        email: uniqueEmail(),
+        role: 'viewer',
+        invitedBy: user.id,
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      const fetched = await storage.getTeamInvite(created.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.id).toBe(created.id);
+    });
+
+    it('should get invite by email', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Email Invite Creator',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Email Invite Team',
+        slug: uniqueSlug('email-invite'),
+        settings: {},
+      });
+
+      const inviteEmail = uniqueEmail();
+      await storage.createTeamInvite({
+        teamId: team.id,
+        email: inviteEmail,
+        role: 'admin',
+        invitedBy: user.id,
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      const fetched = await storage.getTeamInviteByEmail(team.id, inviteEmail);
+      expect(fetched).toBeDefined();
+      expect(fetched!.email).toBe(inviteEmail);
+    });
+
+    it('should list team invites', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'List Invite Creator',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'List Invite Team',
+        slug: uniqueSlug('list-invite'),
+        settings: {},
+      });
+
+      await storage.createTeamInvite({
+        teamId: team.id,
+        email: uniqueEmail(),
+        role: 'developer',
+        invitedBy: user.id,
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      await storage.createTeamInvite({
+        teamId: team.id,
+        email: uniqueEmail(),
+        role: 'viewer',
+        invitedBy: user.id,
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      const invites = await storage.listTeamInvites(team.id);
+      expect(invites.length).toBe(2);
+    });
+
+    it('should delete team invite', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Delete Invite Creator',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Delete Invite Team',
+        slug: uniqueSlug('delete-invite'),
+        settings: {},
+      });
+
+      const invite = await storage.createTeamInvite({
+        teamId: team.id,
+        email: uniqueEmail(),
+        role: 'developer',
+        invitedBy: user.id,
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      await storage.deleteTeamInvite(invite.id);
+
+      const fetched = await storage.getTeamInvite(invite.id);
+      expect(fetched).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // Project Operations Tests
+  // ============================================================================
+
+  describe('project operations', () => {
+    it('should create a project', async () => {
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Project Team',
+        slug: uniqueSlug('project-team'),
+        settings: {},
+      });
+
+      const project = await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'Test Project',
+        slug: uniqueSlug('project'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path/to/project' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+
+      expect(project).toBeDefined();
+      expect(project.name).toBe('Test Project');
+      expect(project.sourceType).toBe('local');
+    });
+
+    it('should get project by ID', async () => {
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Get Project Team',
+        slug: uniqueSlug('get-project-team'),
+        settings: {},
+      });
+
+      const created = await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'Get By ID Project',
+        slug: uniqueSlug('get-id-project'),
+        sourceType: 'github',
+        sourceConfig: { repoFullName: 'owner/repo', installationId: '123', isPrivate: false },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+
+      const fetched = await storage.getProject(created.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.id).toBe(created.id);
+    });
+
+    it('should get project by slug', async () => {
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Slug Project Team',
+        slug: uniqueSlug('slug-project-team'),
+        settings: {},
+      });
+
+      const slug = uniqueSlug('by-slug-project');
+      await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'By Slug Project',
+        slug,
+        sourceType: 'local',
+        sourceConfig: { path: '/path' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+
+      const fetched = await storage.getProjectBySlug(team.id, slug);
+      expect(fetched).toBeDefined();
+      expect(fetched!.slug).toBe(slug);
+    });
+
+    it('should update project', async () => {
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Update Project Team',
+        slug: uniqueSlug('update-project-team'),
+        settings: {},
+      });
+
+      const created = await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'Update Project',
+        slug: uniqueSlug('update-project'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+
+      const updated = await storage.updateProject(created.id, {
+        name: 'Updated Project Name',
+        defaultBranch: 'develop',
+      });
+
+      expect(updated.name).toBe('Updated Project Name');
+      expect(updated.defaultBranch).toBe('develop');
+    });
+
+    it('should list projects for team', async () => {
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'List Project Team',
+        slug: uniqueSlug('list-project-team'),
+        settings: {},
+      });
+
+      await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'List Project 1',
+        slug: uniqueSlug('list-1'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path1' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+
+      await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'List Project 2',
+        slug: uniqueSlug('list-2'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path2' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+
+      const result = await storage.listProjectsForTeam(team.id);
+      expect(result.data.length).toBe(2);
+      expect(result.total).toBe(2);
+    });
+
+    it('should delete project', async () => {
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Delete Project Team',
+        slug: uniqueSlug('delete-project-team'),
+        settings: {},
+      });
+
+      const created = await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'Delete Project',
+        slug: uniqueSlug('delete-project'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+
+      await storage.deleteProject(created.id);
+
+      const fetched = await storage.getProject(created.id);
+      expect(fetched).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // Project Environment Variables Tests
+  // ============================================================================
+
+  describe('project environment variables', () => {
+    let testProject: Awaited<ReturnType<typeof storage.createProject>>;
+
+    beforeAll(async () => {
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Env Var Team',
+        slug: uniqueSlug('env-var-team'),
+        settings: {},
+      });
+
+      testProject = await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'Env Var Project',
+        slug: uniqueSlug('env-var-project'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+    });
+
+    it('should set environment variable', async () => {
+      const envVar = await storage.setProjectEnvVar(testProject.id, {
+        key: `API_KEY_${Date.now()}`,
+        encryptedValue: 'encrypted-value-123',
+        isSecret: true,
+      });
+
+      expect(envVar).toBeDefined();
+      expect(envVar.encryptedValue).toBe('encrypted-value-123');
+      expect(envVar.isSecret).toBe(true);
+    });
+
+    it('should get environment variables', async () => {
+      const key1 = `VAR_1_${Date.now()}`;
+      const key2 = `VAR_2_${Date.now()}`;
+
+      await storage.setProjectEnvVar(testProject.id, {
+        key: key1,
+        encryptedValue: 'value-1',
+        isSecret: false,
+      });
+
+      await storage.setProjectEnvVar(testProject.id, {
+        key: key2,
+        encryptedValue: 'value-2',
+        isSecret: true,
+      });
+
+      const envVars = await storage.getProjectEnvVars(testProject.id);
+      expect(envVars.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should update existing environment variable', async () => {
+      const key = `UPDATE_VAR_${Date.now()}`;
+
+      await storage.setProjectEnvVar(testProject.id, {
+        key,
+        encryptedValue: 'original-value',
+        isSecret: false,
+      });
+
+      await storage.setProjectEnvVar(testProject.id, {
+        key,
+        encryptedValue: 'updated-value',
+        isSecret: true,
+      });
+
+      const envVars = await storage.getProjectEnvVars(testProject.id);
+      const updateVar = envVars.find(v => v.key === key);
+      expect(updateVar).toBeDefined();
+      expect(updateVar!.encryptedValue).toBe('updated-value');
+      expect(updateVar!.isSecret).toBe(true);
+    });
+
+    it('should delete environment variable', async () => {
+      const key = `DELETE_VAR_${Date.now()}`;
+
+      await storage.setProjectEnvVar(testProject.id, {
+        key,
+        encryptedValue: 'delete-value',
+        isSecret: false,
+      });
+
+      await storage.deleteProjectEnvVar(testProject.id, key);
+
+      const envVars = await storage.getProjectEnvVars(testProject.id);
+      const deleted = envVars.find(v => v.key === key);
+      expect(deleted).toBeUndefined();
+    });
+  });
+
+  // ============================================================================
+  // Project API Token Tests
+  // ============================================================================
+
+  describe('project API tokens', () => {
+    let testProject: Awaited<ReturnType<typeof storage.createProject>>;
+    let tokenCreator: Awaited<ReturnType<typeof storage.createUser>>;
+
+    beforeAll(async () => {
+      tokenCreator = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Token Creator',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Token Team',
+        slug: uniqueSlug('token-team'),
+        settings: {},
+      });
+
+      testProject = await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'Token Project',
+        slug: uniqueSlug('token-project'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+    });
+
+    it('should create API token', async () => {
+      const token = await storage.createProjectApiToken({
+        id: uniqueId(),
+        projectId: testProject.id,
+        name: 'Test Token',
+        tokenPrefix: 'mst_',
+        tokenHash: `hash_${Date.now()}_${Math.random()}`,
+        scopes: ['read', 'write'],
+        expiresAt: null,
+        createdBy: tokenCreator.id,
+      } as Parameters<typeof storage.createProjectApiToken>[0]);
+
+      expect(token).toBeDefined();
+      expect(token.name).toBe('Test Token');
+      expect(token.tokenPrefix).toBe('mst_');
+      expect(token.scopes).toEqual(['read', 'write']);
+    });
+
+    it('should get token by ID', async () => {
+      const created = await storage.createProjectApiToken({
+        id: uniqueId(),
+        projectId: testProject.id,
+        name: 'Get Token',
+        tokenPrefix: 'mst_',
+        tokenHash: `hash_get_${Date.now()}_${Math.random()}`,
+        scopes: ['read'],
+        expiresAt: null,
+        createdBy: tokenCreator.id,
+      } as Parameters<typeof storage.createProjectApiToken>[0]);
+
+      const fetched = await storage.getProjectApiToken(created.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.id).toBe(created.id);
+    });
+
+    it('should get token by hash', async () => {
+      const tokenHash = `hash_by_hash_${Date.now()}_${Math.random()}`;
+      await storage.createProjectApiToken({
+        id: uniqueId(),
+        projectId: testProject.id,
+        name: 'Hash Token',
+        tokenPrefix: 'mst_',
+        tokenHash,
+        scopes: ['read'],
+        expiresAt: null,
+        createdBy: tokenCreator.id,
+      } as Parameters<typeof storage.createProjectApiToken>[0]);
+
+      const fetched = await storage.getProjectApiTokenByHash(tokenHash);
+      expect(fetched).toBeDefined();
+      expect(fetched!.tokenHash).toBe(tokenHash);
+    });
+
+    it('should list project tokens', async () => {
+      // Create a new project for this test to get accurate count
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'List Token Team',
+        slug: uniqueSlug('list-token-team'),
+        settings: {},
+      });
+
+      const project = await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'List Token Project',
+        slug: uniqueSlug('list-token-project'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+
+      await storage.createProjectApiToken({
+        id: uniqueId(),
+        projectId: project.id,
+        name: 'List Token 1',
+        tokenPrefix: 'mst_',
+        tokenHash: `hash_list_1_${Date.now()}_${Math.random()}`,
+        scopes: ['read'],
+        expiresAt: null,
+        createdBy: tokenCreator.id,
+      } as Parameters<typeof storage.createProjectApiToken>[0]);
+
+      await storage.createProjectApiToken({
+        id: uniqueId(),
+        projectId: project.id,
+        name: 'List Token 2',
+        tokenPrefix: 'mst_',
+        tokenHash: `hash_list_2_${Date.now()}_${Math.random()}`,
+        scopes: ['write'],
+        expiresAt: null,
+        createdBy: tokenCreator.id,
+      } as Parameters<typeof storage.createProjectApiToken>[0]);
+
+      const tokens = await storage.listProjectApiTokens(project.id);
+      expect(tokens.length).toBe(2);
+    });
+
+    it('should update token last used', async () => {
+      const created = await storage.createProjectApiToken({
+        id: uniqueId(),
+        projectId: testProject.id,
+        name: 'Update Token',
+        tokenPrefix: 'mst_',
+        tokenHash: `hash_update_${Date.now()}_${Math.random()}`,
+        scopes: ['read'],
+        expiresAt: null,
+        createdBy: tokenCreator.id,
+      } as Parameters<typeof storage.createProjectApiToken>[0]);
+
+      expect(created.lastUsedAt).toBeNull();
+
+      await storage.updateProjectApiTokenLastUsed(created.id);
+
+      const fetched = await storage.getProjectApiToken(created.id);
+      expect(fetched!.lastUsedAt).toBeInstanceOf(Date);
+    });
+
+    it('should delete token', async () => {
+      const created = await storage.createProjectApiToken({
+        id: uniqueId(),
+        projectId: testProject.id,
+        name: 'Delete Token',
+        tokenPrefix: 'mst_',
+        tokenHash: `hash_delete_${Date.now()}_${Math.random()}`,
+        scopes: ['read'],
+        expiresAt: null,
+        createdBy: tokenCreator.id,
+      } as Parameters<typeof storage.createProjectApiToken>[0]);
+
+      await storage.deleteProjectApiToken(created.id);
+
+      const fetched = await storage.getProjectApiToken(created.id);
+      expect(fetched).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // Deployment Operations Tests
+  // ============================================================================
+
+  describe('deployment operations', () => {
+    let testProject: Awaited<ReturnType<typeof storage.createProject>>;
+
+    beforeAll(async () => {
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Deployment Team',
+        slug: uniqueSlug('deployment-team'),
+        settings: {},
+      });
+
+      testProject = await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'Deployment Project',
+        slug: uniqueSlug('deployment-project'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+    });
+
+    it('should create deployment', async () => {
+      const deployment = await storage.createDeployment({
+        id: uniqueId(),
+        projectId: testProject.id,
+        type: 'production',
+        branch: 'main',
+        slug: uniqueSlug('deploy'),
+        status: 'pending',
+        currentBuildId: null,
+        publicUrl: null,
+        internalHost: null,
+        envVarOverrides: [],
+        autoShutdown: false,
+        expiresAt: null,
+      });
+
+      expect(deployment).toBeDefined();
+      expect(deployment.type).toBe('production');
+      expect(deployment.branch).toBe('main');
+      expect(deployment.status).toBe('pending');
+    });
+
+    it('should get deployment by ID', async () => {
+      const created = await storage.createDeployment({
+        id: uniqueId(),
+        projectId: testProject.id,
+        type: 'staging',
+        branch: 'develop',
+        slug: uniqueSlug('get-deploy'),
+        status: 'pending',
+        currentBuildId: null,
+        publicUrl: null,
+        internalHost: null,
+        envVarOverrides: [],
+        autoShutdown: false,
+        expiresAt: null,
+      });
+
+      const fetched = await storage.getDeployment(created.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.id).toBe(created.id);
+    });
+
+    it('should get deployment by slug', async () => {
+      const slug = uniqueSlug('preview');
+      await storage.createDeployment({
+        id: uniqueId(),
+        projectId: testProject.id,
+        type: 'preview',
+        branch: 'feature-x',
+        slug,
+        status: 'pending',
+        currentBuildId: null,
+        publicUrl: null,
+        internalHost: null,
+        envVarOverrides: [],
+        autoShutdown: true,
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      });
+
+      const fetched = await storage.getDeploymentBySlug(testProject.id, slug);
+      expect(fetched).toBeDefined();
+      expect(fetched!.slug).toBe(slug);
+    });
+
+    it('should update deployment', async () => {
+      const created = await storage.createDeployment({
+        id: uniqueId(),
+        projectId: testProject.id,
+        type: 'production',
+        branch: `update-branch-${Date.now()}`,
+        slug: uniqueSlug('update-deploy'),
+        status: 'pending',
+        currentBuildId: null,
+        publicUrl: null,
+        internalHost: null,
+        envVarOverrides: [],
+        autoShutdown: false,
+        expiresAt: null,
+      });
+
+      const updated = await storage.updateDeployment(created.id, {
+        publicUrl: 'https://example.com',
+        internalHost: 'localhost:3001',
+      });
+
+      expect(updated.publicUrl).toBe('https://example.com');
+      expect(updated.internalHost).toBe('localhost:3001');
+    });
+
+    it('should update deployment status', async () => {
+      const created = await storage.createDeployment({
+        id: uniqueId(),
+        projectId: testProject.id,
+        type: 'production',
+        branch: `status-branch-${Date.now()}`,
+        slug: uniqueSlug('status-deploy'),
+        status: 'pending',
+        currentBuildId: null,
+        publicUrl: null,
+        internalHost: null,
+        envVarOverrides: [],
+        autoShutdown: false,
+        expiresAt: null,
+      });
+
+      const updated = await storage.updateDeploymentStatus(created.id, 'running');
+      expect(updated.status).toBe('running');
+    });
+
+    it('should list deployments for project', async () => {
+      // Create a new project for accurate count
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'List Deploy Team',
+        slug: uniqueSlug('list-deploy-team'),
+        settings: {},
+      });
+
+      const project = await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'List Deploy Project',
+        slug: uniqueSlug('list-deploy-project'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+
+      await storage.createDeployment({
+        id: uniqueId(),
+        projectId: project.id,
+        type: 'production',
+        branch: 'main',
+        slug: uniqueSlug('list-prod'),
+        status: 'running',
+        currentBuildId: null,
+        publicUrl: null,
+        internalHost: null,
+        envVarOverrides: [],
+        autoShutdown: false,
+        expiresAt: null,
+      });
+
+      await storage.createDeployment({
+        id: uniqueId(),
+        projectId: project.id,
+        type: 'preview',
+        branch: 'feature',
+        slug: uniqueSlug('list-preview'),
+        status: 'pending',
+        currentBuildId: null,
+        publicUrl: null,
+        internalHost: null,
+        envVarOverrides: [],
+        autoShutdown: true,
+        expiresAt: null,
+      });
+
+      const result = await storage.listDeploymentsForProject(project.id);
+      expect(result.data.length).toBe(2);
+      expect(result.total).toBe(2);
+    });
+
+    it('should delete deployment', async () => {
+      const created = await storage.createDeployment({
+        id: uniqueId(),
+        projectId: testProject.id,
+        type: 'preview',
+        branch: 'delete-me',
+        slug: uniqueSlug('delete-deploy'),
+        status: 'stopped',
+        currentBuildId: null,
+        publicUrl: null,
+        internalHost: null,
+        envVarOverrides: [],
+        autoShutdown: true,
+        expiresAt: null,
+      });
+
+      await storage.deleteDeployment(created.id);
+
+      const fetched = await storage.getDeployment(created.id);
+      expect(fetched).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // Build Operations Tests
+  // ============================================================================
+
+  describe('build operations', () => {
+    let testDeployment: Awaited<ReturnType<typeof storage.createDeployment>>;
+
+    beforeAll(async () => {
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Build Team',
+        slug: uniqueSlug('build-team'),
+        settings: {},
+      });
+
+      const project = await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'Build Project',
+        slug: uniqueSlug('build-project'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+
+      testDeployment = await storage.createDeployment({
+        id: uniqueId(),
+        projectId: project.id,
+        type: 'production',
+        branch: 'main',
+        slug: uniqueSlug('build-deploy'),
+        status: 'pending',
+        currentBuildId: null,
+        publicUrl: null,
+        internalHost: null,
+        envVarOverrides: [],
+        autoShutdown: false,
+        expiresAt: null,
+      });
+    });
+
+    it('should create build', async () => {
+      const build = await storage.createBuild({
+        id: uniqueId(),
+        deploymentId: testDeployment.id,
+        trigger: 'manual',
+        triggeredBy: 'user-123',
+        commitSha: 'abc123',
+        commitMessage: 'Initial commit',
+        status: 'queued',
+        logs: '',
+        queuedAt: new Date(),
+        errorMessage: null,
+      });
+
+      expect(build).toBeDefined();
+      expect(build.status).toBe('queued');
+      expect(build.trigger).toBe('manual');
+      expect(build.startedAt).toBeNull();
+      expect(build.completedAt).toBeNull();
+    });
+
+    it('should get build by ID', async () => {
+      const created = await storage.createBuild({
+        id: uniqueId(),
+        deploymentId: testDeployment.id,
+        trigger: 'webhook',
+        triggeredBy: 'github',
+        commitSha: 'def456',
+        commitMessage: 'Feature commit',
+        status: 'queued',
+        logs: '',
+        queuedAt: new Date(),
+        errorMessage: null,
+      });
+
+      const fetched = await storage.getBuild(created.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.id).toBe(created.id);
+    });
+
+    it('should update build status', async () => {
+      const created = await storage.createBuild({
+        id: uniqueId(),
+        deploymentId: testDeployment.id,
+        trigger: 'manual',
+        triggeredBy: 'user',
+        commitSha: 'ghi789',
+        commitMessage: 'Test',
+        status: 'queued',
+        logs: '',
+        queuedAt: new Date(),
+        errorMessage: null,
+      });
+
+      // Start building
+      const building = await storage.updateBuildStatus(created.id, 'building');
+      expect(building.status).toBe('building');
+      expect(building.startedAt).toBeInstanceOf(Date);
+
+      // Complete successfully
+      const succeeded = await storage.updateBuildStatus(created.id, 'succeeded');
+      expect(succeeded.status).toBe('succeeded');
+      expect(succeeded.completedAt).toBeInstanceOf(Date);
+    });
+
+    it('should update build status with error message', async () => {
+      const created = await storage.createBuild({
+        id: uniqueId(),
+        deploymentId: testDeployment.id,
+        trigger: 'manual',
+        triggeredBy: 'user',
+        commitSha: 'error123',
+        commitMessage: 'Test error',
+        status: 'queued',
+        logs: '',
+        queuedAt: new Date(),
+        errorMessage: null,
+      });
+
+      const failed = await storage.updateBuildStatus(created.id, 'failed', 'Build failed: missing dependency');
+      expect(failed.status).toBe('failed');
+      expect(failed.errorMessage).toBe('Build failed: missing dependency');
+      expect(failed.completedAt).toBeInstanceOf(Date);
+    });
+
+    it('should append build logs', async () => {
+      const created = await storage.createBuild({
+        id: uniqueId(),
+        deploymentId: testDeployment.id,
+        trigger: 'manual',
+        triggeredBy: 'user',
+        commitSha: 'logs123',
+        commitMessage: 'Test logs',
+        status: 'building',
+        logs: '',
+        queuedAt: new Date(),
+        errorMessage: null,
+      });
+
+      await storage.appendBuildLogs(created.id, 'Step 1: Installing dependencies\n');
+      await storage.appendBuildLogs(created.id, 'Step 2: Building project\n');
+
+      const fetched = await storage.getBuild(created.id);
+      expect(fetched!.logs).toBe('Step 1: Installing dependencies\nStep 2: Building project\n');
+    });
+
+    it('should list builds for deployment', async () => {
+      // Create a new deployment for accurate count
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'List Build Team',
+        slug: uniqueSlug('list-build-team'),
+        settings: {},
+      });
+
+      const project = await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'List Build Project',
+        slug: uniqueSlug('list-build-project'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+
+      const deployment = await storage.createDeployment({
+        id: uniqueId(),
+        projectId: project.id,
+        type: 'production',
+        branch: 'main',
+        slug: uniqueSlug('list-build-deploy'),
+        status: 'pending',
+        currentBuildId: null,
+        publicUrl: null,
+        internalHost: null,
+        envVarOverrides: [],
+        autoShutdown: false,
+        expiresAt: null,
+      });
+
+      await storage.createBuild({
+        id: uniqueId(),
+        deploymentId: deployment.id,
+        trigger: 'manual',
+        triggeredBy: 'user',
+        commitSha: 'list1',
+        commitMessage: 'Build 1',
+        status: 'succeeded',
+        logs: '',
+        queuedAt: new Date(),
+        errorMessage: null,
+      });
+
+      await storage.createBuild({
+        id: uniqueId(),
+        deploymentId: deployment.id,
+        trigger: 'webhook',
+        triggeredBy: 'github',
+        commitSha: 'list2',
+        commitMessage: 'Build 2',
+        status: 'queued',
+        logs: '',
+        queuedAt: new Date(),
+        errorMessage: null,
+      });
+
+      const result = await storage.listBuildsForDeployment(deployment.id);
+      expect(result.data.length).toBe(2);
+      expect(result.total).toBe(2);
+    });
+  });
+
+  // ============================================================================
+  // Build Queue Tests
+  // ============================================================================
+
+  describe('build queue operations', () => {
+    it('should dequeue builds in FIFO order', async () => {
+      // Create fresh deployment for queue test
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Queue Team',
+        slug: uniqueSlug('queue-team'),
+        settings: {},
+      });
+
+      const project = await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'Queue Project',
+        slug: uniqueSlug('queue-project'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+
+      const deployment = await storage.createDeployment({
+        id: uniqueId(),
+        projectId: project.id,
+        type: 'production',
+        branch: 'main',
+        slug: uniqueSlug('queue-deploy'),
+        status: 'pending',
+        currentBuildId: null,
+        publicUrl: null,
+        internalHost: null,
+        envVarOverrides: [],
+        autoShutdown: false,
+        expiresAt: null,
+      });
+
+      // Create builds with different queued times
+      const build1 = await storage.createBuild({
+        id: uniqueId(),
+        deploymentId: deployment.id,
+        trigger: 'manual',
+        triggeredBy: 'user',
+        commitSha: 'fifo1',
+        commitMessage: 'First',
+        status: 'queued',
+        logs: '',
+        queuedAt: new Date(Date.now() - 2000),
+        errorMessage: null,
+      });
+
+      await storage.createBuild({
+        id: uniqueId(),
+        deploymentId: deployment.id,
+        trigger: 'manual',
+        triggeredBy: 'user',
+        commitSha: 'fifo2',
+        commitMessage: 'Second',
+        status: 'queued',
+        logs: '',
+        queuedAt: new Date(Date.now() - 1000),
+        errorMessage: null,
+      });
+
+      // First dequeue should get the oldest build
+      const dequeued1 = await storage.dequeueNextBuild();
+      expect(dequeued1).toBeDefined();
+      expect(dequeued1!.id).toBe(build1.id);
+      expect(dequeued1!.commitSha).toBe('fifo1');
+      expect(dequeued1!.status).toBe('building');
+      expect(dequeued1!.startedAt).toBeInstanceOf(Date);
+    });
+
+    it('should return null when no queued builds', async () => {
+      // Create a deployment with only non-queued builds
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Empty Queue Team',
+        slug: uniqueSlug('empty-queue-team'),
+        settings: {},
+      });
+
+      const project = await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'Empty Queue Project',
+        slug: uniqueSlug('empty-queue-project'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+
+      const deployment = await storage.createDeployment({
+        id: uniqueId(),
+        projectId: project.id,
+        type: 'production',
+        branch: 'main',
+        slug: uniqueSlug('empty-queue-deploy'),
+        status: 'pending',
+        currentBuildId: null,
+        publicUrl: null,
+        internalHost: null,
+        envVarOverrides: [],
+        autoShutdown: false,
+        expiresAt: null,
+      });
+
+      // Create a build that's already building
+      await storage.createBuild({
+        id: uniqueId(),
+        deploymentId: deployment.id,
+        trigger: 'manual',
+        triggeredBy: 'user',
+        commitSha: 'building1',
+        commitMessage: 'Already building',
+        status: 'building',
+        logs: '',
+        queuedAt: new Date(),
+        errorMessage: null,
+      });
+
+      // Dequeue all queued builds first (from other tests)
+      let dequeued = await storage.dequeueNextBuild();
+      while (dequeued) {
+        dequeued = await storage.dequeueNextBuild();
+      }
+
+      // Now queue should be empty
+      const result = await storage.dequeueNextBuild();
+      expect(result).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // Running Server Operations Tests
+  // ============================================================================
+
+  describe('running server operations', () => {
+    let testDeployment: Awaited<ReturnType<typeof storage.createDeployment>>;
+    let testBuild: Awaited<ReturnType<typeof storage.createBuild>>;
+
+    beforeAll(async () => {
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Server Team',
+        slug: uniqueSlug('server-team'),
+        settings: {},
+      });
+
+      const project = await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'Server Project',
+        slug: uniqueSlug('server-project'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+
+      testDeployment = await storage.createDeployment({
+        id: uniqueId(),
+        projectId: project.id,
+        type: 'production',
+        branch: 'main',
+        slug: uniqueSlug('server-deploy'),
+        status: 'running',
+        currentBuildId: null,
+        publicUrl: null,
+        internalHost: null,
+        envVarOverrides: [],
+        autoShutdown: false,
+        expiresAt: null,
+      });
+
+      testBuild = await storage.createBuild({
+        id: uniqueId(),
+        deploymentId: testDeployment.id,
+        trigger: 'manual',
+        triggeredBy: 'user',
+        commitSha: 'server123',
+        commitMessage: 'Server build',
+        status: 'succeeded',
+        logs: '',
+        queuedAt: new Date(),
+        errorMessage: null,
+      });
+    });
+
+    it('should create running server', async () => {
+      const server = await storage.createRunningServer({
+        id: uniqueId(),
+        deploymentId: testDeployment.id,
+        buildId: testBuild.id,
+        processId: 12345,
+        containerId: null,
+        host: 'localhost',
+        port: 3001,
+        healthStatus: 'starting',
+        lastHealthCheck: null,
+        memoryUsageMb: null,
+        cpuPercent: null,
+        startedAt: new Date(),
+      });
+
+      expect(server).toBeDefined();
+      expect(server.host).toBe('localhost');
+      expect(server.port).toBe(3001);
+      expect(server.healthStatus).toBe('starting');
+      expect(server.stoppedAt).toBeNull();
+    });
+
+    it('should get running server by ID', async () => {
+      const created = await storage.createRunningServer({
+        id: uniqueId(),
+        deploymentId: testDeployment.id,
+        buildId: testBuild.id,
+        processId: 12346,
+        containerId: null,
+        host: 'localhost',
+        port: 3002,
+        healthStatus: 'healthy',
+        lastHealthCheck: new Date(),
+        memoryUsageMb: 256,
+        cpuPercent: 5.5,
+        startedAt: new Date(),
+      });
+
+      const fetched = await storage.getRunningServer(created.id);
+      expect(fetched).toBeDefined();
+      expect(fetched!.id).toBe(created.id);
+    });
+
+    it('should update running server', async () => {
+      const created = await storage.createRunningServer({
+        id: uniqueId(),
+        deploymentId: testDeployment.id,
+        buildId: testBuild.id,
+        processId: 12348,
+        containerId: null,
+        host: 'localhost',
+        port: 3004,
+        healthStatus: 'starting',
+        lastHealthCheck: null,
+        memoryUsageMb: null,
+        cpuPercent: null,
+        startedAt: new Date(),
+      });
+
+      const updated = await storage.updateRunningServer(created.id, {
+        healthStatus: 'healthy',
+        lastHealthCheck: new Date(),
+        memoryUsageMb: 512,
+        cpuPercent: 10.0,
+      });
+
+      expect(updated.healthStatus).toBe('healthy');
+      expect(updated.memoryUsageMb).toBe(512);
+      expect(updated.cpuPercent).toBe(10.0);
+    });
+
+    it('should stop running server', async () => {
+      const created = await storage.createRunningServer({
+        id: uniqueId(),
+        deploymentId: testDeployment.id,
+        buildId: testBuild.id,
+        processId: 12349,
+        containerId: null,
+        host: 'localhost',
+        port: 3005,
+        healthStatus: 'healthy',
+        lastHealthCheck: new Date(),
+        memoryUsageMb: 256,
+        cpuPercent: 5.0,
+        startedAt: new Date(),
+      });
+
+      await storage.stopRunningServer(created.id);
+
+      const fetched = await storage.getRunningServer(created.id);
+      expect(fetched!.stoppedAt).toBeInstanceOf(Date);
+    });
+
+    it('should list running servers', async () => {
+      const servers = await storage.listRunningServers();
+      expect(Array.isArray(servers)).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // RBAC Operations Tests
+  // ============================================================================
+
+  describe('RBAC operations', () => {
+    it('should get permissions for owner role', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'RBAC Owner',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'RBAC Owner Team',
+        slug: uniqueSlug('rbac-owner'),
+        settings: {},
+      });
+
+      await storage.addTeamMember({
+        teamId: team.id,
+        userId: user.id,
+        role: 'owner',
+      });
+
+      const permissions = await storage.getUserPermissionsForTeam(user.id, team.id);
+      expect(permissions).toContain('team:delete');
+      expect(permissions).toContain('project:delete');
+      expect(permissions).toContain('member:manage');
+    });
+
+    it('should get permissions for admin role', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'RBAC Admin',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'RBAC Admin Team',
+        slug: uniqueSlug('rbac-admin'),
+        settings: {},
+      });
+
+      await storage.addTeamMember({
+        teamId: team.id,
+        userId: user.id,
+        role: 'admin',
+      });
+
+      const permissions = await storage.getUserPermissionsForTeam(user.id, team.id);
+      expect(permissions).toContain('team:update');
+      expect(permissions).toContain('project:delete');
+      expect(permissions).not.toContain('team:delete');
+      expect(permissions).not.toContain('team:manage');
+    });
+
+    it('should get permissions for developer role', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'RBAC Developer',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'RBAC Developer Team',
+        slug: uniqueSlug('rbac-dev'),
+        settings: {},
+      });
+
+      await storage.addTeamMember({
+        teamId: team.id,
+        userId: user.id,
+        role: 'developer',
+      });
+
+      const permissions = await storage.getUserPermissionsForTeam(user.id, team.id);
+      expect(permissions).toContain('project:create');
+      expect(permissions).toContain('deployment:deploy');
+      expect(permissions).not.toContain('project:delete');
+      expect(permissions).not.toContain('member:delete');
+    });
+
+    it('should get permissions for viewer role', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'RBAC Viewer',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'RBAC Viewer Team',
+        slug: uniqueSlug('rbac-viewer'),
+        settings: {},
+      });
+
+      await storage.addTeamMember({
+        teamId: team.id,
+        userId: user.id,
+        role: 'viewer',
+      });
+
+      const permissions = await storage.getUserPermissionsForTeam(user.id, team.id);
+      expect(permissions).toContain('team:read');
+      expect(permissions).toContain('project:read');
+      expect(permissions).not.toContain('project:create');
+      expect(permissions).not.toContain('deployment:deploy');
+    });
+
+    it('should return empty permissions for non-member', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Non-Member',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Non-Member Team',
+        slug: uniqueSlug('non-member'),
+        settings: {},
+      });
+
+      const permissions = await storage.getUserPermissionsForTeam(user.id, team.id);
+      expect(permissions).toEqual([]);
+    });
+
+    it('should check specific permission - has permission', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Has Permission User',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Has Permission Team',
+        slug: uniqueSlug('has-perm'),
+        settings: {},
+      });
+
+      await storage.addTeamMember({
+        teamId: team.id,
+        userId: user.id,
+        role: 'developer',
+      });
+
+      const hasPermission = await storage.userHasPermission(user.id, team.id, 'project:create');
+      expect(hasPermission).toBe(true);
+    });
+
+    it('should check specific permission - does not have permission', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'No Permission User',
+        avatarUrl: null,
+      });
+
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'No Permission Team',
+        slug: uniqueSlug('no-perm'),
+        settings: {},
+      });
+
+      await storage.addTeamMember({
+        teamId: team.id,
+        userId: user.id,
+        role: 'viewer',
+      });
+
+      const hasPermission = await storage.userHasPermission(user.id, team.id, 'project:create');
+      expect(hasPermission).toBe(false);
+    });
+  });
+
+  // ============================================================================
+  // Pagination Tests
+  // ============================================================================
+
+  describe('pagination', () => {
+    it('should paginate results correctly', async () => {
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Pagination User',
+        avatarUrl: null,
+      });
+
+      // Create 5 teams and add user to all
+      for (let i = 0; i < 5; i++) {
+        const team = await storage.createTeam({
+          id: uniqueId(),
+          name: `Pagination Team ${i}`,
+          slug: uniqueSlug(`pagination-${i}`),
+          settings: {},
+        });
+        await storage.addTeamMember({
+          teamId: team.id,
+          userId: user.id,
+          role: 'developer',
+        });
+      }
+
+      const page1 = await storage.listTeamsForUser(user.id, { page: 1, perPage: 2 });
+      expect(page1.data.length).toBe(2);
+      expect(page1.total).toBe(5);
+      expect(page1.page).toBe(1);
+      expect(page1.perPage).toBe(2);
+      expect(page1.hasMore).toBe(true);
+
+      const page2 = await storage.listTeamsForUser(user.id, { page: 2, perPage: 2 });
+      expect(page2.data.length).toBe(2);
+      expect(page2.page).toBe(2);
+      expect(page2.hasMore).toBe(true);
+
+      const page3 = await storage.listTeamsForUser(user.id, { page: 3, perPage: 2 });
+      expect(page3.data.length).toBe(1);
+      expect(page3.page).toBe(3);
+      expect(page3.hasMore).toBe(false);
+    });
+
+    it('should handle empty results', async () => {
+      const nonExistentUser = uniqueId();
+      const result = await storage.listTeamsForUser(nonExistentUser);
+      expect(result.data.length).toBe(0);
+      expect(result.total).toBe(0);
+      expect(result.hasMore).toBe(false);
+    });
+  });
+
+  // ============================================================================
+  // Error Handling Tests
+  // ============================================================================
+
+  describe('error handling', () => {
+    it('should throw on invalid config', () => {
+      expect(
+        () =>
+          new PostgresAdminStorage({
+            // @ts-expect-error - Testing invalid config
+            invalid: 'config',
+          }),
+      ).toThrow();
+    });
+
+    it('should throw on invalid schema name', () => {
+      expect(
+        () =>
+          new PostgresAdminStorage({
+            connectionString: TEST_CONNECTION_STRING,
+            schemaName: 'invalid-schema-name!',
+          }),
+      ).toThrow(/invalid characters/);
+    });
+
+    it('should cascade delete on team deletion', async () => {
+      const team = await storage.createTeam({
+        id: uniqueId(),
+        name: 'Cascade Team',
+        slug: uniqueSlug('cascade'),
+        settings: {},
+      });
+
+      const user = await storage.createUser({
+        id: uniqueId(),
+        email: uniqueEmail(),
+        name: 'Cascade User',
+        avatarUrl: null,
+      });
+
+      await storage.addTeamMember({
+        teamId: team.id,
+        userId: user.id,
+        role: 'owner',
+      });
+
+      const project = await storage.createProject({
+        id: uniqueId(),
+        teamId: team.id,
+        name: 'Cascade Project',
+        slug: uniqueSlug('cascade-project'),
+        sourceType: 'local',
+        sourceConfig: { path: '/path' },
+        defaultBranch: 'main',
+        envVars: [],
+      });
+
+      // Delete team should cascade to members and projects
+      await storage.deleteTeam(team.id);
+
+      // Team member should be deleted
+      const member = await storage.getTeamMember(team.id, user.id);
+      expect(member).toBeNull();
+
+      // Project should be deleted
+      const deletedProject = await storage.getProject(project.id);
+      expect(deletedProject).toBeNull();
+    });
+  });
+});

--- a/stores/admin-pg/src/storage.ts
+++ b/stores/admin-pg/src/storage.ts
@@ -1,0 +1,590 @@
+import type {
+  AdminStorage,
+  Build,
+  BuildStatus,
+  Deployment,
+  DeploymentStatus,
+  EncryptedEnvVar,
+  PaginatedResult,
+  PaginationParams,
+  Project,
+  ProjectApiToken,
+  RunningServer,
+  Team,
+  TeamInvite,
+  TeamMember,
+  TeamRole,
+  User,
+} from '@mastra/admin';
+import { Pool } from 'pg';
+
+import type { DbClient } from './client';
+import { PoolAdapter } from './client';
+import { AdminPgDB } from './db';
+import { BuildsPG } from './domains/builds';
+import { DeploymentsPG } from './domains/deployments';
+import { ProjectsPG } from './domains/projects';
+import { RbacPG } from './domains/rbac';
+import { RunningServersPG } from './domains/servers';
+import { TeamsPG } from './domains/teams';
+import { UsersPG } from './domains/users';
+import type { PostgresAdminStorageConfig } from './shared/config';
+import {
+  isConnectionStringConfig,
+  isHostConfig,
+  isPoolConfig,
+  parseSqlIdentifier,
+  validateConfig,
+} from './shared/config';
+
+/**
+ * PostgreSQL storage implementation for MastraAdmin.
+ * Implements the AdminStorage interface from @mastra/admin.
+ */
+export class PostgresAdminStorage implements AdminStorage {
+  private pool: Pool;
+  private client: DbClient;
+  private adminDb: AdminPgDB;
+  private ownsPool: boolean;
+  private schema: string;
+  private isInitialized = false;
+  private config: PostgresAdminStorageConfig;
+
+  // Domain stores (internal)
+  private readonly usersPg: UsersPG;
+  private readonly teamsPg: TeamsPG;
+  private readonly projectsPg: ProjectsPG;
+  private readonly deploymentsPg: DeploymentsPG;
+  private readonly buildsPg: BuildsPG;
+  private readonly serversPg: RunningServersPG;
+  private readonly rbacPg: RbacPG;
+
+  constructor(config: PostgresAdminStorageConfig) {
+    validateConfig(config);
+    this.config = config;
+
+    this.schema = config.schemaName ? parseSqlIdentifier(config.schemaName, 'schema') : 'mastra_admin';
+
+    // Create or wrap pool
+    if (isPoolConfig(config)) {
+      this.pool = config.pool;
+      this.ownsPool = false;
+    } else {
+      this.pool = this.createPool(config);
+      this.ownsPool = true;
+    }
+
+    this.client = new PoolAdapter(this.pool);
+
+    // Create domain config
+    const domainConfig = {
+      client: this.client,
+      schemaName: this.schema,
+      skipDefaultIndexes: config.skipDefaultIndexes,
+    };
+
+    // Initialize domain stores
+    this.usersPg = new UsersPG(domainConfig);
+    this.teamsPg = new TeamsPG(domainConfig);
+    this.projectsPg = new ProjectsPG(domainConfig);
+    this.deploymentsPg = new DeploymentsPG(domainConfig);
+    this.buildsPg = new BuildsPG(domainConfig);
+    this.serversPg = new RunningServersPG(domainConfig);
+    this.rbacPg = new RbacPG(domainConfig);
+
+    // Create admin db for initialization
+    this.adminDb = new AdminPgDB(domainConfig);
+  }
+
+  /**
+   * Create PostgreSQL connection pool
+   */
+  private createPool(config: PostgresAdminStorageConfig): Pool {
+    if (isConnectionStringConfig(config)) {
+      return new Pool({
+        connectionString: config.connectionString,
+        max: 20,
+        idleTimeoutMillis: 30000,
+      });
+    }
+
+    if (isHostConfig(config)) {
+      return new Pool({
+        host: config.host,
+        port: config.port,
+        database: config.database,
+        user: config.user,
+        password: config.password,
+        ssl: config.ssl,
+        max: 20,
+        idleTimeoutMillis: 30000,
+      });
+    }
+
+    throw new Error('Invalid configuration');
+  }
+
+  // ============================================================================
+  // Lifecycle
+  // ============================================================================
+
+  /**
+   * Initialize storage (create tables, run migrations).
+   */
+  async init(): Promise<void> {
+    if (this.isInitialized) return;
+    if (this.config.disableInit) {
+      this.isInitialized = true;
+      return;
+    }
+
+    await this.adminDb.init();
+    this.isInitialized = true;
+  }
+
+  /**
+   * Close the storage connection.
+   */
+  async close(): Promise<void> {
+    if (this.ownsPool) {
+      await this.pool.end();
+    }
+  }
+
+  // ============================================================================
+  // User Operations
+  // ============================================================================
+
+  async getUser(userId: string): Promise<User | null> {
+    return this.usersPg.getUserById(userId);
+  }
+
+  async getUserByEmail(email: string): Promise<User | null> {
+    return this.usersPg.getUserByEmail(email);
+  }
+
+  async createUser(user: Omit<User, 'createdAt' | 'updatedAt'>): Promise<User> {
+    return this.usersPg.createUser(user);
+  }
+
+  async updateUser(userId: string, updates: Partial<Omit<User, 'id' | 'createdAt'>>): Promise<User> {
+    const result = await this.usersPg.updateUser(userId, updates);
+    if (!result) {
+      throw new Error(`User not found: ${userId}`);
+    }
+    return result;
+  }
+
+  // ============================================================================
+  // Team Operations
+  // ============================================================================
+
+  async getTeam(teamId: string): Promise<Team | null> {
+    return this.teamsPg.getTeamById(teamId);
+  }
+
+  async getTeamBySlug(slug: string): Promise<Team | null> {
+    return this.teamsPg.getTeamBySlug(slug);
+  }
+
+  async listTeamsForUser(userId: string, pagination?: PaginationParams): Promise<PaginatedResult<Team>> {
+    const page = pagination?.page ?? 1;
+    const perPage = pagination?.perPage ?? 20;
+    const offset = (page - 1) * perPage;
+
+    const { data, total } = await this.teamsPg.listTeamsForUser(userId, { limit: perPage, offset });
+
+    return {
+      data,
+      total,
+      page,
+      perPage,
+      hasMore: offset + data.length < total,
+    };
+  }
+
+  async createTeam(team: Omit<Team, 'createdAt' | 'updatedAt'>): Promise<Team> {
+    return this.teamsPg.createTeam(team);
+  }
+
+  async updateTeam(teamId: string, updates: Partial<Omit<Team, 'id' | 'createdAt'>>): Promise<Team> {
+    const result = await this.teamsPg.updateTeam(teamId, updates);
+    if (!result) {
+      throw new Error(`Team not found: ${teamId}`);
+    }
+    return result;
+  }
+
+  async deleteTeam(teamId: string): Promise<void> {
+    const deleted = await this.teamsPg.deleteTeam(teamId);
+    if (!deleted) {
+      throw new Error(`Team not found: ${teamId}`);
+    }
+  }
+
+  // ============================================================================
+  // Team Member Operations
+  // ============================================================================
+
+  async getTeamMember(teamId: string, userId: string): Promise<TeamMember | null> {
+    return this.teamsPg.getTeamMember(teamId, userId);
+  }
+
+  async listTeamMembers(
+    teamId: string,
+    pagination?: PaginationParams,
+  ): Promise<PaginatedResult<TeamMember & { user: User }>> {
+    const page = pagination?.page ?? 1;
+    const perPage = pagination?.perPage ?? 20;
+    const offset = (page - 1) * perPage;
+
+    const { data, total } = await this.teamsPg.listTeamMembers(teamId, { limit: perPage, offset });
+
+    return {
+      data,
+      total,
+      page,
+      perPage,
+      hasMore: offset + data.length < total,
+    };
+  }
+
+  async addTeamMember(member: Omit<TeamMember, 'id' | 'createdAt' | 'updatedAt'>): Promise<TeamMember> {
+    return this.teamsPg.addTeamMember(member);
+  }
+
+  async updateTeamMemberRole(teamId: string, userId: string, role: TeamRole): Promise<TeamMember> {
+    const result = await this.teamsPg.updateTeamMemberRole(teamId, userId, role);
+    if (!result) {
+      throw new Error(`Team member not found: ${userId} in team ${teamId}`);
+    }
+    return result;
+  }
+
+  async removeTeamMember(teamId: string, userId: string): Promise<void> {
+    const removed = await this.teamsPg.removeTeamMember(teamId, userId);
+    if (!removed) {
+      throw new Error(`Team member not found: ${userId} in team ${teamId}`);
+    }
+  }
+
+  // ============================================================================
+  // Team Invite Operations
+  // ============================================================================
+
+  async getTeamInvite(inviteId: string): Promise<TeamInvite | null> {
+    return this.teamsPg.getInviteById(inviteId);
+  }
+
+  async getTeamInviteByEmail(teamId: string, email: string): Promise<TeamInvite | null> {
+    return this.teamsPg.getInviteByEmail(teamId, email);
+  }
+
+  async listTeamInvites(teamId: string): Promise<TeamInvite[]> {
+    return this.teamsPg.listPendingInvites(teamId);
+  }
+
+  async createTeamInvite(invite: Omit<TeamInvite, 'id' | 'createdAt'>): Promise<TeamInvite> {
+    return this.teamsPg.createInvite(invite);
+  }
+
+  async deleteTeamInvite(inviteId: string): Promise<void> {
+    const deleted = await this.teamsPg.deleteInvite(inviteId);
+    if (!deleted) {
+      throw new Error(`Team invite not found: ${inviteId}`);
+    }
+  }
+
+  // ============================================================================
+  // Project Operations
+  // ============================================================================
+
+  async getProject(projectId: string): Promise<Project | null> {
+    return this.projectsPg.getProjectById(projectId);
+  }
+
+  async getProjectBySlug(teamId: string, slug: string): Promise<Project | null> {
+    return this.projectsPg.getProjectBySlug(teamId, slug);
+  }
+
+  async listProjectsForTeam(teamId: string, pagination?: PaginationParams): Promise<PaginatedResult<Project>> {
+    const page = pagination?.page ?? 1;
+    const perPage = pagination?.perPage ?? 20;
+    const offset = (page - 1) * perPage;
+
+    const { data, total } = await this.projectsPg.listProjects(teamId, { limit: perPage, offset });
+
+    return {
+      data,
+      total,
+      page,
+      perPage,
+      hasMore: offset + data.length < total,
+    };
+  }
+
+  async createProject(project: Omit<Project, 'createdAt' | 'updatedAt'>): Promise<Project> {
+    return this.projectsPg.createProject(project);
+  }
+
+  async updateProject(
+    projectId: string,
+    updates: Partial<Omit<Project, 'id' | 'teamId' | 'createdAt'>>,
+  ): Promise<Project> {
+    // Filter out envVars from updates since they're handled separately
+    const { envVars: _envVars, ...projectUpdates } = updates as Partial<Project>;
+    const result = await this.projectsPg.updateProject(projectId, projectUpdates);
+    if (!result) {
+      throw new Error(`Project not found: ${projectId}`);
+    }
+    return result;
+  }
+
+  async deleteProject(projectId: string): Promise<void> {
+    const deleted = await this.projectsPg.deleteProject(projectId);
+    if (!deleted) {
+      throw new Error(`Project not found: ${projectId}`);
+    }
+  }
+
+  // ============================================================================
+  // Project Environment Variables
+  // ============================================================================
+
+  async getProjectEnvVars(projectId: string): Promise<EncryptedEnvVar[]> {
+    return this.projectsPg.getEnvVars(projectId);
+  }
+
+  async setProjectEnvVar(
+    projectId: string,
+    envVar: Omit<EncryptedEnvVar, 'createdAt' | 'updatedAt'>,
+  ): Promise<EncryptedEnvVar> {
+    return this.projectsPg.setEnvVar(projectId, envVar);
+  }
+
+  async deleteProjectEnvVar(projectId: string, key: string): Promise<void> {
+    const deleted = await this.projectsPg.deleteEnvVar(projectId, key);
+    if (!deleted) {
+      throw new Error(`Environment variable not found: ${key} in project ${projectId}`);
+    }
+  }
+
+  // ============================================================================
+  // Project API Tokens
+  // ============================================================================
+
+  async getProjectApiToken(tokenId: string): Promise<ProjectApiToken | null> {
+    return this.projectsPg.getApiTokenById(tokenId);
+  }
+
+  async getProjectApiTokenByHash(tokenHash: string): Promise<ProjectApiToken | null> {
+    return this.projectsPg.getApiTokenByHash(tokenHash);
+  }
+
+  async listProjectApiTokens(projectId: string): Promise<ProjectApiToken[]> {
+    return this.projectsPg.listApiTokens(projectId);
+  }
+
+  async createProjectApiToken(token: Omit<ProjectApiToken, 'createdAt' | 'lastUsedAt'>): Promise<ProjectApiToken> {
+    return this.projectsPg.createApiToken(token);
+  }
+
+  async updateProjectApiTokenLastUsed(tokenId: string): Promise<void> {
+    await this.projectsPg.updateApiTokenLastUsed(tokenId);
+  }
+
+  async deleteProjectApiToken(tokenId: string): Promise<void> {
+    const deleted = await this.projectsPg.deleteApiToken(tokenId);
+    if (!deleted) {
+      throw new Error(`API token not found: ${tokenId}`);
+    }
+  }
+
+  // ============================================================================
+  // Deployment Operations
+  // ============================================================================
+
+  async getDeployment(deploymentId: string): Promise<Deployment | null> {
+    return this.deploymentsPg.getDeploymentById(deploymentId);
+  }
+
+  async getDeploymentBySlug(projectId: string, slug: string): Promise<Deployment | null> {
+    return this.deploymentsPg.getDeploymentBySlug(projectId, slug);
+  }
+
+  async listDeploymentsForProject(
+    projectId: string,
+    pagination?: PaginationParams,
+  ): Promise<PaginatedResult<Deployment>> {
+    const page = pagination?.page ?? 1;
+    const perPage = pagination?.perPage ?? 20;
+    const offset = (page - 1) * perPage;
+
+    const { data, total } = await this.deploymentsPg.listDeployments(projectId, { limit: perPage, offset });
+
+    return {
+      data,
+      total,
+      page,
+      perPage,
+      hasMore: offset + data.length < total,
+    };
+  }
+
+  async createDeployment(deployment: Omit<Deployment, 'createdAt' | 'updatedAt'>): Promise<Deployment> {
+    return this.deploymentsPg.createDeployment(deployment);
+  }
+
+  async updateDeployment(
+    deploymentId: string,
+    updates: Partial<Omit<Deployment, 'id' | 'projectId' | 'createdAt'>>,
+  ): Promise<Deployment> {
+    const result = await this.deploymentsPg.updateDeployment(deploymentId, updates);
+    if (!result) {
+      throw new Error(`Deployment not found: ${deploymentId}`);
+    }
+    return result;
+  }
+
+  async updateDeploymentStatus(deploymentId: string, status: DeploymentStatus): Promise<Deployment> {
+    const result = await this.deploymentsPg.updateDeploymentStatus(deploymentId, status);
+    if (!result) {
+      throw new Error(`Deployment not found: ${deploymentId}`);
+    }
+    return result;
+  }
+
+  async deleteDeployment(deploymentId: string): Promise<void> {
+    const deleted = await this.deploymentsPg.deleteDeployment(deploymentId);
+    if (!deleted) {
+      throw new Error(`Deployment not found: ${deploymentId}`);
+    }
+  }
+
+  // ============================================================================
+  // Build Operations
+  // ============================================================================
+
+  async getBuild(buildId: string): Promise<Build | null> {
+    return this.buildsPg.getBuildById(buildId);
+  }
+
+  async listBuildsForDeployment(deploymentId: string, pagination?: PaginationParams): Promise<PaginatedResult<Build>> {
+    const page = pagination?.page ?? 1;
+    const perPage = pagination?.perPage ?? 20;
+    const offset = (page - 1) * perPage;
+
+    const { data, total } = await this.buildsPg.listBuilds(deploymentId, { limit: perPage, offset });
+
+    return {
+      data,
+      total,
+      page,
+      perPage,
+      hasMore: offset + data.length < total,
+    };
+  }
+
+  async createBuild(build: Omit<Build, 'startedAt' | 'completedAt'>): Promise<Build> {
+    return this.buildsPg.createBuild(build);
+  }
+
+  async updateBuild(buildId: string, updates: Partial<Omit<Build, 'id' | 'deploymentId' | 'queuedAt'>>): Promise<Build> {
+    const result = await this.buildsPg.updateBuild(buildId, updates);
+    if (!result) {
+      throw new Error(`Build not found: ${buildId}`);
+    }
+    return result;
+  }
+
+  async updateBuildStatus(buildId: string, status: BuildStatus, errorMessage?: string): Promise<Build> {
+    const result = await this.buildsPg.updateBuildStatus(buildId, status, errorMessage);
+    if (!result) {
+      throw new Error(`Build not found: ${buildId}`);
+    }
+    return result;
+  }
+
+  async appendBuildLogs(buildId: string, logs: string): Promise<void> {
+    await this.buildsPg.appendBuildLogs(buildId, logs);
+  }
+
+  async dequeueNextBuild(): Promise<Build | null> {
+    return this.buildsPg.dequeue();
+  }
+
+  // ============================================================================
+  // Running Server Operations
+  // ============================================================================
+
+  async getRunningServer(serverId: string): Promise<RunningServer | null> {
+    return this.serversPg.getServerById(serverId);
+  }
+
+  async getRunningServerForDeployment(deploymentId: string): Promise<RunningServer | null> {
+    return this.serversPg.getServerForDeployment(deploymentId);
+  }
+
+  async listRunningServers(): Promise<RunningServer[]> {
+    return this.serversPg.listRunningServers();
+  }
+
+  async createRunningServer(server: Omit<RunningServer, 'stoppedAt'>): Promise<RunningServer> {
+    return this.serversPg.createRunningServer(server);
+  }
+
+  async updateRunningServer(
+    serverId: string,
+    updates: Partial<Omit<RunningServer, 'id' | 'deploymentId' | 'buildId' | 'startedAt'>>,
+  ): Promise<RunningServer> {
+    const result = await this.serversPg.updateServer(serverId, updates);
+    if (!result) {
+      throw new Error(`Running server not found: ${serverId}`);
+    }
+    return result;
+  }
+
+  async stopRunningServer(serverId: string): Promise<void> {
+    const result = await this.serversPg.stopServer(serverId);
+    if (!result) {
+      throw new Error(`Running server not found: ${serverId}`);
+    }
+  }
+
+  // ============================================================================
+  // RBAC Operations
+  // ============================================================================
+
+  async getUserPermissionsForTeam(userId: string, teamId: string): Promise<string[]> {
+    return this.rbacPg.getUserPermissionsForTeam(userId, teamId);
+  }
+
+  async userHasPermission(userId: string, teamId: string, permission: string): Promise<boolean> {
+    return this.rbacPg.userHasPermission(userId, teamId, permission);
+  }
+
+  // ============================================================================
+  // Utility Accessors
+  // ============================================================================
+
+  /**
+   * Get raw database client for advanced operations.
+   */
+  get db(): DbClient {
+    return this.client;
+  }
+
+  /**
+   * Get raw pool for ORM integration.
+   */
+  get rawPool(): Pool {
+    return this.pool;
+  }
+
+  /**
+   * Get schema name.
+   */
+  get schemaName(): string {
+    return this.schema;
+  }
+}

--- a/stores/admin-pg/tsconfig.build.json
+++ b/stores/admin-pg/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/stores/admin-pg/tsconfig.json
+++ b/stores/admin-pg/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/stores/admin-pg/tsup.config.ts
+++ b/stores/admin-pg/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/stores/admin-pg/turbo.json
+++ b/stores/admin-pg/turbo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "build": {
+      "dependsOn": ["build:lib"]
+    }
+  }
+}

--- a/stores/admin-pg/vitest.config.ts
+++ b/stores/admin-pg/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Add 76 integration tests covering all `AdminStorage` interface methods
- Fix domain layer issues discovered during testing (JSONB serialization, auto-generate invite tokens, column name mismatch)
- All tests pass with Docker Compose PostgreSQL setup

## Test Coverage
- Storage initialization (connection string, host config, pool config)
- User operations (CRUD, find by email)
- Team operations (CRUD, list for user)
- Team member operations (add, get, list with user info, update role, remove)
- Team invite operations (CRUD, find by email, auto-generate tokens)
- Project operations (CRUD, list for team)
- Environment variables (set, get, update, delete)
- API tokens (CRUD, find by hash, update last used)
- Deployment operations (CRUD, status updates, list)
- Build operations (CRUD, status updates, log appending)
- Build queue operations (FIFO dequeue, empty queue handling)
- Running server operations (CRUD, health updates, stop)
- RBAC operations (permissions for all 4 roles, permission checks)
- Pagination and error handling tests

## Fixes Included
- Fix JSONB serialization for API token `scopes` array in `ProjectsPG`
- Add auto-generation of invite tokens in `TeamsPG`
- Fix column name mismatch in `listTeamMembers` (`joined_at` vs `created_at`)

## Test plan
- [x] Run `pnpm test` in `stores/admin-pg` - all 76 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)