### PR TITLE
feat(runner-local): implement @mastra/runner-local package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3772,6 +3772,55 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1
 
+  runners/local:
+    dependencies:
+      get-port:
+        specifier: ^7.1.0
+        version: 7.1.0
+      pidusage:
+        specifier: ^3.0.2
+        version: 3.0.2
+      tree-kill:
+        specifier: ^1.2.2
+        version: 1.2.2
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/admin':
+        specifier: workspace:*
+        version: link:../../packages/admin
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@types/node':
+        specifier: 22.13.17
+        version: 22.13.17
+      '@types/pidusage':
+        specifier: ^2.0.5
+        version: 2.0.5
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.0.12(vitest@4.0.16)
+      '@vitest/ui':
+        specifier: 'catalog:'
+        version: 4.0.12(vitest@4.0.16)
+      eslint:
+        specifier: ^9.37.0
+        version: 9.39.2(jiti@2.6.1)
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(@microsoft/api-extractor@7.55.2(@types/node@22.13.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.13.17)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.13.17)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+
   server-adapters/_test-utils:
     dependencies:
       vitest:
@@ -12259,6 +12308,9 @@ packages:
   '@types/phoenix@1.6.6':
     resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
 
+  '@types/pidusage@2.0.5':
+    resolution: {integrity: sha512-MIiyZI4/MK9UGUXWt0jJcCZhVw7YdhBuTOuqP/BjuLDLZ2PmmViMIQgZiWxtaMicQfAz/kMrZ5T7PKxFSkTeUA==}
+
   '@types/prismjs@1.26.5':
     resolution: {integrity: sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==}
 
@@ -17072,6 +17124,10 @@ packages:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
     hasBin: true
+
+  pidusage@3.0.2:
+    resolution: {integrity: sha512-g0VU+y08pKw5M8EZ2rIGiEBaB8wrQMjYGFfW2QVIfyT8V+fq8YFLkvlz4bz5ljvFDJYNFCWT3PWqcRr2FKO81w==}
+    engines: {node: '>=10'}
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -27032,6 +27088,8 @@ snapshots:
 
   '@types/phoenix@1.6.6': {}
 
+  '@types/pidusage@2.0.5': {}
+
   '@types/prismjs@1.26.5': {}
 
   '@types/pumpify@1.4.4':
@@ -32830,6 +32888,10 @@ snapshots:
   picomatch@4.0.3: {}
 
   pidtree@0.6.0: {}
+
+  pidusage@3.0.2:
+    dependencies:
+      safe-buffer: 5.2.1
 
   pify@2.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ packages:
   - observability/*
   - sources/*
   - routers/*
+  - runners/*
   - explorations/longmemeval
   - explorations/agent-builder-gh-repro
   - e2e-tests/client-js/_test-utils

--- a/runners/local/README.md
+++ b/runners/local/README.md
@@ -1,0 +1,170 @@
+# @mastra/runner-local
+
+Local process runner for MastraAdmin. This package enables building Mastra projects and running them as child processes, suitable for local development and self-hosted deployments.
+
+## Installation
+
+```bash
+pnpm add @mastra/runner-local
+```
+
+## Usage
+
+```typescript
+import { LocalProcessRunner } from '@mastra/runner-local';
+import { LocalProjectSource } from '@mastra/source-local';
+
+// Create and configure the runner
+const runner = new LocalProcessRunner({
+  portRange: { start: 4111, end: 4200 },
+  healthCheck: {
+    timeoutMs: 5000,
+    retryIntervalMs: 1000,
+    maxRetries: 30,
+  },
+});
+
+// Set the project source provider
+const source = new LocalProjectSource({ basePaths: ['/path/to/projects'] });
+runner.setSource(source);
+
+// Build a project
+const buildResult = await runner.build(project, build, {
+  envVars: { API_KEY: 'xxx' },
+});
+
+// Deploy and start a server
+const server = await runner.deploy(project, deployment, build);
+
+// Check server health
+const health = await runner.healthCheck(server);
+
+// Get logs
+const logs = await runner.getLogs(server, { tail: 100 });
+
+// Stop the server
+await runner.stop(server);
+
+// Shutdown the runner (stops all processes)
+await runner.shutdown();
+```
+
+## Configuration
+
+```typescript
+interface LocalProcessRunnerConfig {
+  /** Port range for server allocation. @default { start: 4111, end: 4200 } */
+  portRange?: { start: number; end: number };
+
+  /** Maximum concurrent builds. @default 3 */
+  maxConcurrentBuilds?: number;
+
+  /** Default build timeout in milliseconds. @default 600000 (10 minutes) */
+  defaultBuildTimeoutMs?: number;
+
+  /** Health check configuration */
+  healthCheck?: {
+    timeoutMs?: number; // @default 5000
+    retryIntervalMs?: number; // @default 1000
+    maxRetries?: number; // @default 30
+    endpoint?: string; // @default '/health'
+  };
+
+  /** Number of log lines to retain per server. @default 10000 */
+  logRetentionLines?: number;
+
+  /** Working directory for build artifacts. @default '.mastra/builds' */
+  buildDir?: string;
+
+  /** Environment variables to inject into all builds */
+  globalEnvVars?: Record<string, string>;
+}
+```
+
+## Features
+
+### Build Process
+
+- Automatic package manager detection (npm, pnpm, yarn, bun)
+- Dependency installation with appropriate flags per package manager
+- Build script execution with real-time log streaming
+- Build output verification
+
+### Process Management
+
+- Child process spawning with stdout/stderr capture
+- Process tree termination (kills all child processes)
+- Graceful shutdown with SIGTERM/SIGKILL fallback
+
+### Port Allocation
+
+- Automatic port allocation within configured range
+- Port conflict detection using `get-port`
+- Port tracking and release on process termination
+
+### Health Checks
+
+- HTTP health check with configurable timeout
+- Retry mechanism with configurable interval
+- Deployment fails if health check times out
+
+### Log Collection
+
+- Circular buffer (ring buffer) for memory-efficient log storage
+- Tail and since-based log queries
+- Real-time log streaming via callbacks
+
+### Resource Monitoring
+
+- CPU usage monitoring via `pidusage`
+- Memory usage monitoring via `pidusage`
+- Graceful fallback on monitoring errors
+
+### Subdomain Generation
+
+- Production: `{project-slug}`
+- Staging: `staging--{project-slug}`
+- Preview: `{branch}--{project-slug}`
+
+## Exported Components
+
+For advanced use cases, individual components can be imported:
+
+```typescript
+import {
+  // Main runner
+  LocalProcessRunner,
+
+  // Components
+  PortAllocator,
+  HealthChecker,
+  ProcessManager,
+  ProjectBuilder,
+  SubdomainGenerator,
+  LogCollectorImpl,
+  RingBuffer,
+
+  // Utilities
+  detectPackageManager,
+  getInstallArgs,
+  getBuildArgs,
+  hasBuildScript,
+  createBuildLogStream,
+  createMultiLogStream,
+  createFilteredLogStream,
+  spawnCommand,
+  runCommand,
+  getProcessResourceUsage,
+  cleanupResourceMonitor,
+} from '@mastra/runner-local';
+```
+
+## Requirements
+
+- Node.js >= 22.13.0
+- `@mastra/admin` >= 1.0.0
+- `@mastra/core` >= 0.1.0
+
+## License
+
+Apache-2.0

--- a/runners/local/eslint.config.js
+++ b/runners/local/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default config;

--- a/runners/local/package.json
+++ b/runners/local/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@mastra/runner-local",
+  "version": "0.1.0",
+  "description": "Local process runner for MastraAdmin",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "build:docs": "pnpx tsx ../../scripts/generate-package-docs.ts runners/local",
+    "build:watch": "pnpm build:lib --watch",
+    "test": "vitest run",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "get-port": "^7.1.0",
+    "pidusage": "^3.0.2",
+    "tree-kill": "^1.2.2"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/admin": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "@types/node": "22.13.17",
+    "@types/pidusage": "^2.0.5",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "eslint": "^9.37.0",
+    "tsup": "^8.5.0",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@mastra/admin": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/core": ">=0.1.0-0 <1.0.0-0"
+  },
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "runners/local"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/runners/local/src/build/builder.test.ts
+++ b/runners/local/src/build/builder.test.ts
@@ -1,0 +1,331 @@
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as fs from 'node:fs/promises';
+import type { Build, Project } from '@mastra/admin';
+import { BuildStatus } from '@mastra/admin';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ProjectBuilder } from './builder';
+
+// Mock the spawner module
+vi.mock('../process/spawner', () => ({
+  runCommand: vi.fn(),
+}));
+
+describe('ProjectBuilder', () => {
+  let testDir: string;
+  let builder: ProjectBuilder;
+  let mockProject: Project;
+  let mockBuild: Build;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'builder-test-'));
+    builder = new ProjectBuilder();
+
+    mockProject = {
+      id: 'project-1',
+      name: 'test-project',
+      slug: 'test-project',
+      sourceType: 'local',
+      sourceConfig: { path: testDir },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as Project;
+
+    mockBuild = {
+      id: 'build-1',
+      projectId: 'project-1',
+      status: BuildStatus.BUILDING,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as Build;
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('constructor', () => {
+    it('should use default configuration', () => {
+      const b = new ProjectBuilder();
+      expect(b).toBeDefined();
+    });
+
+    it('should merge custom configuration', () => {
+      const b = new ProjectBuilder({
+        defaultTimeoutMs: 300000,
+        buildDir: '/custom/build',
+        globalEnvVars: { CUSTOM: 'value' },
+      });
+      expect(b).toBeDefined();
+    });
+  });
+
+  describe('build', () => {
+    it('should detect package manager and run install', async () => {
+      const { runCommand } = await import('../process/spawner');
+
+      // Create package.json with pnpm lock file
+      await fs.writeFile(path.join(testDir, 'package.json'), JSON.stringify({ name: 'test' }));
+      await fs.writeFile(path.join(testDir, 'pnpm-lock.yaml'), '');
+
+      // Create output directory with entry point
+      const outputDir = path.join(testDir, '.mastra/output');
+      await fs.mkdir(outputDir, { recursive: true });
+      await fs.writeFile(path.join(outputDir, 'index.mjs'), 'export default {}');
+
+      (runCommand as ReturnType<typeof vi.fn>).mockResolvedValue({ exitCode: 0, output: [] });
+
+      const logs: string[] = [];
+      const result = await builder.build(mockProject, mockBuild, testDir, undefined, log => logs.push(log));
+
+      expect(result.status).toBe(BuildStatus.SUCCEEDED);
+      expect(runCommand).toHaveBeenCalledWith(
+        'pnpm',
+        expect.arrayContaining(['install']),
+        expect.objectContaining({ cwd: testDir }),
+      );
+    });
+
+    it('should skip install when skipInstall is true', async () => {
+      const { runCommand } = await import('../process/spawner');
+
+      // Create package.json without build script
+      await fs.writeFile(path.join(testDir, 'package.json'), JSON.stringify({ name: 'test' }));
+
+      // Create output directory with entry point
+      const outputDir = path.join(testDir, '.mastra/output');
+      await fs.mkdir(outputDir, { recursive: true });
+      await fs.writeFile(path.join(outputDir, 'index.mjs'), 'export default {}');
+
+      (runCommand as ReturnType<typeof vi.fn>).mockResolvedValue({ exitCode: 0, output: [] });
+
+      const result = await builder.build(mockProject, mockBuild, testDir, { skipInstall: true });
+
+      expect(result.status).toBe(BuildStatus.SUCCEEDED);
+      // Should not have called runCommand for install
+      expect(runCommand).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.arrayContaining(['install']),
+        expect.anything(),
+      );
+    });
+
+    it('should run build script when present', async () => {
+      const { runCommand } = await import('../process/spawner');
+
+      // Create package.json with build script
+      await fs.writeFile(
+        path.join(testDir, 'package.json'),
+        JSON.stringify({ name: 'test', scripts: { build: 'tsc' } }),
+      );
+
+      // Create output directory with entry point
+      const outputDir = path.join(testDir, '.mastra/output');
+      await fs.mkdir(outputDir, { recursive: true });
+      await fs.writeFile(path.join(outputDir, 'index.mjs'), 'export default {}');
+
+      (runCommand as ReturnType<typeof vi.fn>).mockResolvedValue({ exitCode: 0, output: [] });
+
+      const result = await builder.build(mockProject, mockBuild, testDir);
+
+      expect(result.status).toBe(BuildStatus.SUCCEEDED);
+      expect(runCommand).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.arrayContaining(['run', 'build']),
+        expect.anything(),
+      );
+    });
+
+    it('should skip build step when no build script', async () => {
+      const { runCommand } = await import('../process/spawner');
+
+      // Create package.json without build script
+      await fs.writeFile(path.join(testDir, 'package.json'), JSON.stringify({ name: 'test' }));
+
+      // Create output directory with entry point
+      const outputDir = path.join(testDir, '.mastra/output');
+      await fs.mkdir(outputDir, { recursive: true });
+      await fs.writeFile(path.join(outputDir, 'index.mjs'), 'export default {}');
+
+      (runCommand as ReturnType<typeof vi.fn>).mockResolvedValue({ exitCode: 0, output: [] });
+
+      const logs: string[] = [];
+      const result = await builder.build(mockProject, mockBuild, testDir, undefined, log => logs.push(log));
+
+      expect(result.status).toBe(BuildStatus.SUCCEEDED);
+      expect(logs.some(l => l.includes('No build script found'))).toBe(true);
+    });
+
+    it('should fail when install fails', async () => {
+      const { runCommand } = await import('../process/spawner');
+
+      await fs.writeFile(path.join(testDir, 'package.json'), JSON.stringify({ name: 'test' }));
+
+      (runCommand as ReturnType<typeof vi.fn>).mockResolvedValue({ exitCode: 1, output: ['Error'] });
+
+      const result = await builder.build(mockProject, mockBuild, testDir);
+
+      expect(result.status).toBe(BuildStatus.FAILED);
+      expect(result.errorMessage).toContain('Dependency installation failed');
+    });
+
+    it('should fail when build script fails', async () => {
+      const { runCommand } = await import('../process/spawner');
+
+      await fs.writeFile(
+        path.join(testDir, 'package.json'),
+        JSON.stringify({ name: 'test', scripts: { build: 'exit 1' } }),
+      );
+
+      // First call (install) succeeds, second call (build) fails
+      (runCommand as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ exitCode: 0, output: [] })
+        .mockResolvedValueOnce({ exitCode: 1, output: ['Build error'] });
+
+      const result = await builder.build(mockProject, mockBuild, testDir);
+
+      expect(result.status).toBe(BuildStatus.FAILED);
+      expect(result.errorMessage).toContain('Build failed with exit code');
+    });
+
+    it('should fail when output directory does not exist', async () => {
+      const { runCommand } = await import('../process/spawner');
+
+      await fs.writeFile(path.join(testDir, 'package.json'), JSON.stringify({ name: 'test' }));
+
+      (runCommand as ReturnType<typeof vi.fn>).mockResolvedValue({ exitCode: 0, output: [] });
+
+      const result = await builder.build(mockProject, mockBuild, testDir);
+
+      expect(result.status).toBe(BuildStatus.FAILED);
+      expect(result.errorMessage).toContain('Build output not found');
+    });
+
+    it('should fail when entry point does not exist', async () => {
+      const { runCommand } = await import('../process/spawner');
+
+      await fs.writeFile(path.join(testDir, 'package.json'), JSON.stringify({ name: 'test' }));
+
+      // Create output directory but no entry point
+      const outputDir = path.join(testDir, '.mastra/output');
+      await fs.mkdir(outputDir, { recursive: true });
+
+      (runCommand as ReturnType<typeof vi.fn>).mockResolvedValue({ exitCode: 0, output: [] });
+
+      const result = await builder.build(mockProject, mockBuild, testDir);
+
+      expect(result.status).toBe(BuildStatus.FAILED);
+      expect(result.errorMessage).toContain('Build output not found');
+    });
+
+    it('should pass environment variables', async () => {
+      const { runCommand } = await import('../process/spawner');
+
+      await fs.writeFile(path.join(testDir, 'package.json'), JSON.stringify({ name: 'test' }));
+
+      // Create output directory with entry point
+      const outputDir = path.join(testDir, '.mastra/output');
+      await fs.mkdir(outputDir, { recursive: true });
+      await fs.writeFile(path.join(outputDir, 'index.mjs'), 'export default {}');
+
+      (runCommand as ReturnType<typeof vi.fn>).mockResolvedValue({ exitCode: 0, output: [] });
+
+      await builder.build(mockProject, mockBuild, testDir, { envVars: { CUSTOM_VAR: 'value' } });
+
+      expect(runCommand).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          env: expect.objectContaining({
+            CUSTOM_VAR: 'value',
+            NODE_ENV: 'production',
+          }),
+        }),
+      );
+    });
+
+    it('should set completedAt on success', async () => {
+      const { runCommand } = await import('../process/spawner');
+
+      await fs.writeFile(path.join(testDir, 'package.json'), JSON.stringify({ name: 'test' }));
+
+      // Create output directory with entry point
+      const outputDir = path.join(testDir, '.mastra/output');
+      await fs.mkdir(outputDir, { recursive: true });
+      await fs.writeFile(path.join(outputDir, 'index.mjs'), 'export default {}');
+
+      (runCommand as ReturnType<typeof vi.fn>).mockResolvedValue({ exitCode: 0, output: [] });
+
+      const before = new Date();
+      const result = await builder.build(mockProject, mockBuild, testDir);
+      const after = new Date();
+
+      expect(result.completedAt).toBeDefined();
+      expect(result.completedAt!.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(result.completedAt!.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+
+    it('should set completedAt on failure', async () => {
+      const { runCommand } = await import('../process/spawner');
+
+      await fs.writeFile(path.join(testDir, 'package.json'), JSON.stringify({ name: 'test' }));
+
+      (runCommand as ReturnType<typeof vi.fn>).mockResolvedValue({ exitCode: 1, output: [] });
+
+      const result = await builder.build(mockProject, mockBuild, testDir);
+
+      expect(result.completedAt).toBeDefined();
+    });
+
+    it('should stream logs to callback', async () => {
+      const { runCommand } = await import('../process/spawner');
+
+      await fs.writeFile(path.join(testDir, 'package.json'), JSON.stringify({ name: 'test' }));
+
+      // Create output directory with entry point
+      const outputDir = path.join(testDir, '.mastra/output');
+      await fs.mkdir(outputDir, { recursive: true });
+      await fs.writeFile(path.join(outputDir, 'index.mjs'), 'export default {}');
+
+      (runCommand as ReturnType<typeof vi.fn>).mockResolvedValue({ exitCode: 0, output: [] });
+
+      const logs: string[] = [];
+      await builder.build(mockProject, mockBuild, testDir, undefined, log => logs.push(log));
+
+      expect(logs.length).toBeGreaterThan(0);
+      expect(logs.some(l => l.includes('Detected package manager'))).toBe(true);
+      expect(logs.some(l => l.includes('Installing dependencies'))).toBe(true);
+    });
+
+    it('should use global env vars from config', async () => {
+      const { runCommand } = await import('../process/spawner');
+
+      const customBuilder = new ProjectBuilder({
+        globalEnvVars: { GLOBAL_VAR: 'global-value' },
+      });
+
+      await fs.writeFile(path.join(testDir, 'package.json'), JSON.stringify({ name: 'test' }));
+
+      // Create output directory with entry point
+      const outputDir = path.join(testDir, '.mastra/output');
+      await fs.mkdir(outputDir, { recursive: true });
+      await fs.writeFile(path.join(outputDir, 'index.mjs'), 'export default {}');
+
+      (runCommand as ReturnType<typeof vi.fn>).mockResolvedValue({ exitCode: 0, output: [] });
+
+      await customBuilder.build(mockProject, mockBuild, testDir);
+
+      expect(runCommand).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          env: expect.objectContaining({
+            GLOBAL_VAR: 'global-value',
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/runners/local/src/build/builder.ts
+++ b/runners/local/src/build/builder.ts
@@ -1,0 +1,153 @@
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import type { Build, Project, BuildOptions, LogStreamCallback } from '@mastra/admin';
+import { BuildStatus } from '@mastra/admin';
+import { detectPackageManager, getInstallArgs, getBuildArgs, hasBuildScript } from './package-manager';
+import { runCommand } from '../process/spawner';
+import type { BuildContext, PackageManager } from '../types';
+
+export interface BuilderConfig {
+  /** Default build timeout (ms) */
+  defaultTimeoutMs: number;
+  /** Working directory for builds */
+  buildDir: string;
+  /** Global env vars to inject */
+  globalEnvVars: Record<string, string>;
+}
+
+const DEFAULT_CONFIG: BuilderConfig = {
+  defaultTimeoutMs: 600000, // 10 minutes
+  buildDir: '.mastra/builds',
+  globalEnvVars: {},
+};
+
+/**
+ * Builds Mastra projects by running install and build commands.
+ */
+export class ProjectBuilder {
+  private readonly config: BuilderConfig;
+
+  constructor(config: Partial<BuilderConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Build a project.
+   */
+  async build(
+    _project: Project,
+    build: Build,
+    projectPath: string,
+    options?: BuildOptions,
+    onLog?: LogStreamCallback,
+  ): Promise<Build> {
+    const startTime = Date.now();
+    const log = (message: string) => onLog?.(`[${new Date().toISOString()}] ${message}`);
+
+    try {
+      // Detect package manager
+      const packageManager = await detectPackageManager(projectPath);
+      log(`Detected package manager: ${packageManager}`);
+
+      // Prepare environment
+      const envVars = {
+        ...this.config.globalEnvVars,
+        ...options?.envVars,
+        NODE_ENV: 'production',
+      };
+
+      // Build context
+      const context: BuildContext = {
+        projectPath,
+        outputDir: path.join(projectPath, '.mastra/output'),
+        packageManager,
+        envVars,
+      };
+
+      // Step 1: Install dependencies (unless skipped)
+      if (!options?.skipInstall) {
+        log('Installing dependencies...');
+        await this.installDependencies(context, onLog);
+        log('Dependencies installed successfully');
+      }
+
+      // Step 2: Run build
+      if (await hasBuildScript(projectPath)) {
+        log('Running build script...');
+        await this.runBuild(context, onLog);
+        log('Build completed successfully');
+      } else {
+        log('No build script found, skipping build step');
+      }
+
+      // Verify output exists
+      const outputExists = await this.verifyOutput(context.outputDir);
+      if (!outputExists) {
+        throw new Error(`Build output not found at ${context.outputDir}`);
+      }
+
+      const duration = Date.now() - startTime;
+      log(`Build completed in ${Math.round(duration / 1000)}s`);
+
+      return {
+        ...build,
+        status: BuildStatus.SUCCEEDED as Build['status'],
+        completedAt: new Date(),
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log(`Build failed: ${message}`);
+
+      return {
+        ...build,
+        status: BuildStatus.FAILED as Build['status'],
+        completedAt: new Date(),
+        errorMessage: message,
+      };
+    }
+  }
+
+  private async installDependencies(context: BuildContext, onLog?: LogStreamCallback): Promise<void> {
+    const args = getInstallArgs(context.packageManager);
+
+    const result = await runCommand(context.packageManager, args, {
+      cwd: context.projectPath,
+      env: context.envVars,
+      onOutput: onLog,
+    });
+
+    if (result.exitCode !== 0) {
+      throw new Error(`Dependency installation failed with exit code ${result.exitCode}`);
+    }
+  }
+
+  private async runBuild(context: BuildContext, onLog?: LogStreamCallback): Promise<void> {
+    const args = getBuildArgs(context.packageManager);
+
+    const result = await runCommand(context.packageManager, args, {
+      cwd: context.projectPath,
+      env: context.envVars,
+      onOutput: onLog,
+    });
+
+    if (result.exitCode !== 0) {
+      throw new Error(`Build failed with exit code ${result.exitCode}`);
+    }
+  }
+
+  private async verifyOutput(outputDir: string): Promise<boolean> {
+    try {
+      const stats = await fs.stat(outputDir);
+      if (!stats.isDirectory()) {
+        return false;
+      }
+
+      // Check for index.mjs entry point
+      const entryPoint = path.join(outputDir, 'index.mjs');
+      await fs.access(entryPoint);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/runners/local/src/build/index.ts
+++ b/runners/local/src/build/index.ts
@@ -1,0 +1,2 @@
+export { detectPackageManager, getInstallArgs, getBuildArgs, hasBuildScript } from './package-manager';
+export { ProjectBuilder, type BuilderConfig } from './builder';

--- a/runners/local/src/build/index.ts
+++ b/runners/local/src/build/index.ts
@@ -1,2 +1,9 @@
 export { detectPackageManager, getInstallArgs, getBuildArgs, hasBuildScript } from './package-manager';
 export { ProjectBuilder, type BuilderConfig } from './builder';
+export {
+  createBuildLogStream,
+  createMultiLogStream,
+  createFilteredLogStream,
+  formatLogLine,
+  type BuildLogStreamConfig,
+} from './log-stream';

--- a/runners/local/src/build/log-stream.ts
+++ b/runners/local/src/build/log-stream.ts
@@ -1,0 +1,149 @@
+import type { LogStreamCallback } from '@mastra/admin';
+
+/**
+ * Build log stream configuration.
+ */
+export interface BuildLogStreamConfig {
+  /** Whether to include timestamps. @default true */
+  includeTimestamp?: boolean;
+  /** Prefix for log lines (e.g., build step name). */
+  prefix?: string;
+  /** Whether to buffer lines before flushing. @default false */
+  buffered?: boolean;
+  /** Buffer flush interval in ms. @default 100 */
+  flushIntervalMs?: number;
+}
+
+const DEFAULT_CONFIG: Required<BuildLogStreamConfig> = {
+  includeTimestamp: true,
+  prefix: '',
+  buffered: false,
+  flushIntervalMs: 100,
+};
+
+/**
+ * Creates a wrapped log stream callback with formatting options.
+ *
+ * @example
+ * ```typescript
+ * const logStream = createBuildLogStream(onLog, { prefix: '[install]' });
+ * logStream('Installing dependencies...');
+ * // Output: [2025-01-23T12:00:00.000Z] [install] Installing dependencies...
+ * ```
+ */
+export function createBuildLogStream(
+  callback: LogStreamCallback | undefined,
+  config: BuildLogStreamConfig = {},
+): LogStreamCallback {
+  if (!callback) {
+    return () => {};
+  }
+
+  const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+
+  if (mergedConfig.buffered) {
+    return createBufferedLogStream(callback, mergedConfig);
+  }
+
+  return (line: string) => {
+    const formatted = formatLogLine(line, mergedConfig);
+    callback(formatted);
+  };
+}
+
+/**
+ * Format a log line with timestamp and prefix.
+ */
+export function formatLogLine(line: string, config: BuildLogStreamConfig = {}): string {
+  const parts: string[] = [];
+
+  if (config.includeTimestamp !== false) {
+    parts.push(`[${new Date().toISOString()}]`);
+  }
+
+  if (config.prefix) {
+    parts.push(config.prefix);
+  }
+
+  parts.push(line);
+
+  return parts.join(' ');
+}
+
+/**
+ * Creates a buffered log stream that batches lines before sending.
+ * Useful for high-frequency log output to reduce callback overhead.
+ */
+function createBufferedLogStream(
+  callback: LogStreamCallback,
+  config: Required<BuildLogStreamConfig>,
+): LogStreamCallback {
+  let buffer: string[] = [];
+  let flushTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  const flush = () => {
+    if (buffer.length > 0) {
+      const lines = buffer.join('\n');
+      buffer = [];
+      callback(lines);
+    }
+    flushTimeout = null;
+  };
+
+  return (line: string) => {
+    const formatted = formatLogLine(line, config);
+    buffer.push(formatted);
+
+    if (!flushTimeout) {
+      flushTimeout = setTimeout(flush, config.flushIntervalMs);
+    }
+  };
+}
+
+/**
+ * Creates a multi-destination log stream that sends to multiple callbacks.
+ */
+export function createMultiLogStream(...callbacks: (LogStreamCallback | undefined)[]): LogStreamCallback {
+  const validCallbacks: LogStreamCallback[] = [];
+  for (const cb of callbacks) {
+    if (cb !== undefined) {
+      validCallbacks.push(cb);
+    }
+  }
+
+  if (validCallbacks.length === 0) {
+    return () => {};
+  }
+
+  if (validCallbacks.length === 1) {
+    return validCallbacks[0]!;
+  }
+
+  return (line: string) => {
+    for (const callback of validCallbacks) {
+      try {
+        callback(line);
+      } catch {
+        // Ignore callback errors to prevent one failing callback from blocking others
+      }
+    }
+  };
+}
+
+/**
+ * Creates a log stream that filters lines based on a predicate.
+ */
+export function createFilteredLogStream(
+  callback: LogStreamCallback | undefined,
+  predicate: (line: string) => boolean,
+): LogStreamCallback {
+  if (!callback) {
+    return () => {};
+  }
+
+  return (line: string) => {
+    if (predicate(line)) {
+      callback(line);
+    }
+  };
+}

--- a/runners/local/src/build/package-manager.test.ts
+++ b/runners/local/src/build/package-manager.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  detectPackageManager,
+  getInstallArgs,
+  getBuildArgs,
+  hasBuildScript,
+} from './package-manager';
+
+describe('package-manager', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pm-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('detectPackageManager', () => {
+    it('should detect pnpm from lock file', async () => {
+      await fs.writeFile(path.join(testDir, 'pnpm-lock.yaml'), '');
+      await fs.writeFile(path.join(testDir, 'package.json'), '{}');
+
+      expect(await detectPackageManager(testDir)).toBe('pnpm');
+    });
+
+    it('should detect yarn from lock file', async () => {
+      await fs.writeFile(path.join(testDir, 'yarn.lock'), '');
+      await fs.writeFile(path.join(testDir, 'package.json'), '{}');
+
+      expect(await detectPackageManager(testDir)).toBe('yarn');
+    });
+
+    it('should detect npm from lock file', async () => {
+      await fs.writeFile(path.join(testDir, 'package-lock.json'), '{}');
+      await fs.writeFile(path.join(testDir, 'package.json'), '{}');
+
+      expect(await detectPackageManager(testDir)).toBe('npm');
+    });
+
+    it('should detect bun from lock file', async () => {
+      await fs.writeFile(path.join(testDir, 'bun.lockb'), '');
+      await fs.writeFile(path.join(testDir, 'package.json'), '{}');
+
+      expect(await detectPackageManager(testDir)).toBe('bun');
+    });
+
+    it('should detect from packageManager field in package.json', async () => {
+      await fs.writeFile(
+        path.join(testDir, 'package.json'),
+        JSON.stringify({ packageManager: 'pnpm@8.0.0' }),
+      );
+
+      expect(await detectPackageManager(testDir)).toBe('pnpm');
+    });
+
+    it('should default to npm when no indicators found', async () => {
+      await fs.writeFile(path.join(testDir, 'package.json'), '{}');
+
+      expect(await detectPackageManager(testDir)).toBe('npm');
+    });
+
+    it('should default to npm when no package.json exists', async () => {
+      expect(await detectPackageManager(testDir)).toBe('npm');
+    });
+  });
+
+  describe('getInstallArgs', () => {
+    it('should return correct args for npm', () => {
+      const args = getInstallArgs('npm');
+      expect(args).toContain('install');
+      expect(args).toContain('--audit=false');
+    });
+
+    it('should return correct args for pnpm', () => {
+      const args = getInstallArgs('pnpm');
+      expect(args).toContain('install');
+      expect(args).toContain('--ignore-workspace');
+    });
+
+    it('should return correct args for yarn', () => {
+      const args = getInstallArgs('yarn');
+      expect(args).toContain('install');
+      expect(args).toContain('--silent');
+    });
+
+    it('should return correct args for bun', () => {
+      const args = getInstallArgs('bun');
+      expect(args).toContain('install');
+      expect(args).toContain('--silent');
+    });
+  });
+
+  describe('getBuildArgs', () => {
+    it('should return run build for all package managers', () => {
+      for (const pm of ['npm', 'pnpm', 'yarn', 'bun'] as const) {
+        const args = getBuildArgs(pm);
+        expect(args).toEqual(['run', 'build']);
+      }
+    });
+  });
+
+  describe('hasBuildScript', () => {
+    it('should return true when build script exists', async () => {
+      await fs.writeFile(
+        path.join(testDir, 'package.json'),
+        JSON.stringify({ scripts: { build: 'tsc' } }),
+      );
+
+      expect(await hasBuildScript(testDir)).toBe(true);
+    });
+
+    it('should return false when no build script', async () => {
+      await fs.writeFile(
+        path.join(testDir, 'package.json'),
+        JSON.stringify({ scripts: { test: 'vitest' } }),
+      );
+
+      expect(await hasBuildScript(testDir)).toBe(false);
+    });
+
+    it('should return false when no scripts field', async () => {
+      await fs.writeFile(path.join(testDir, 'package.json'), JSON.stringify({ name: 'test' }));
+
+      expect(await hasBuildScript(testDir)).toBe(false);
+    });
+
+    it('should return false when no package.json', async () => {
+      expect(await hasBuildScript(testDir)).toBe(false);
+    });
+  });
+});

--- a/runners/local/src/build/package-manager.ts
+++ b/runners/local/src/build/package-manager.ts
@@ -1,0 +1,97 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { PackageManager } from '../types';
+
+/**
+ * Lock files and their corresponding package managers.
+ */
+const LOCK_FILES: Record<string, PackageManager> = {
+  'pnpm-lock.yaml': 'pnpm',
+  'yarn.lock': 'yarn',
+  'bun.lockb': 'bun',
+  'package-lock.json': 'npm',
+};
+
+/**
+ * Install command flags by package manager.
+ */
+const INSTALL_FLAGS: Record<PackageManager, string[]> = {
+  npm: ['install', '--audit=false', '--fund=false', '--loglevel=error', '--progress=false'],
+  pnpm: ['install', '--ignore-workspace', '--loglevel=error'],
+  yarn: ['install', '--silent'],
+  bun: ['install', '--silent'],
+};
+
+/**
+ * Build command (run scripts.build) by package manager.
+ */
+const BUILD_COMMANDS: Record<PackageManager, string[]> = {
+  npm: ['run', 'build'],
+  pnpm: ['run', 'build'],
+  yarn: ['run', 'build'],
+  bun: ['run', 'build'],
+};
+
+/**
+ * Detect package manager from lock files or package.json.
+ */
+export async function detectPackageManager(projectPath: string): Promise<PackageManager> {
+  // Check for lock files
+  for (const [lockFile, manager] of Object.entries(LOCK_FILES)) {
+    const lockPath = path.join(projectPath, lockFile);
+    try {
+      await fs.access(lockPath);
+      return manager;
+    } catch {
+      // Lock file doesn't exist, continue
+    }
+  }
+
+  // Check packageManager field in package.json
+  try {
+    const packageJsonPath = path.join(projectPath, 'package.json');
+    const content = await fs.readFile(packageJsonPath, 'utf-8');
+    const packageJson = JSON.parse(content) as { packageManager?: string };
+
+    if (packageJson.packageManager) {
+      const pmField = packageJson.packageManager;
+      if (pmField.startsWith('pnpm')) return 'pnpm';
+      if (pmField.startsWith('yarn')) return 'yarn';
+      if (pmField.startsWith('bun')) return 'bun';
+      if (pmField.startsWith('npm')) return 'npm';
+    }
+  } catch {
+    // No package.json or parse error
+  }
+
+  // Default to npm
+  return 'npm';
+}
+
+/**
+ * Get install command arguments for a package manager.
+ */
+export function getInstallArgs(pm: PackageManager): string[] {
+  return INSTALL_FLAGS[pm] ?? INSTALL_FLAGS.npm;
+}
+
+/**
+ * Get build command arguments for a package manager.
+ */
+export function getBuildArgs(pm: PackageManager): string[] {
+  return BUILD_COMMANDS[pm] ?? BUILD_COMMANDS.npm;
+}
+
+/**
+ * Check if a build script exists in package.json.
+ */
+export async function hasBuildScript(projectPath: string): Promise<boolean> {
+  try {
+    const packageJsonPath = path.join(projectPath, 'package.json');
+    const content = await fs.readFile(packageJsonPath, 'utf-8');
+    const packageJson = JSON.parse(content) as { scripts?: { build?: string } };
+    return !!packageJson.scripts?.build;
+  } catch {
+    return false;
+  }
+}

--- a/runners/local/src/health/checker.test.ts
+++ b/runners/local/src/health/checker.test.ts
@@ -1,0 +1,168 @@
+import type { Server, IncomingMessage, ServerResponse } from 'node:http';
+import { createServer } from 'node:http';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { HealthChecker } from './checker';
+
+describe('HealthChecker', () => {
+  let server: Server;
+  let port: number;
+  let shouldFail: boolean;
+  let statusCode: number;
+
+  beforeAll(async () => {
+    shouldFail = false;
+    statusCode = 200;
+
+    server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      if (req.url === '/health') {
+        if (shouldFail) {
+          res.writeHead(statusCode);
+          res.end('Error');
+        } else {
+          res.writeHead(200);
+          res.end('OK');
+        }
+      } else {
+        res.writeHead(404);
+        res.end('Not Found');
+      }
+    });
+
+    await new Promise<void>(resolve => {
+      server.listen(0, () => {
+        const address = server.address();
+        port = typeof address === 'object' && address ? address.port : 0;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  describe('check', () => {
+    it('should return healthy for successful health check', async () => {
+      shouldFail = false;
+      const checker = new HealthChecker();
+
+      const result = await checker.check('localhost', port);
+
+      expect(result.healthy).toBe(true);
+      expect(result.message).toBeUndefined();
+    });
+
+    it('should return unhealthy for failed health check', async () => {
+      shouldFail = true;
+      statusCode = 500;
+      const checker = new HealthChecker();
+
+      const result = await checker.check('localhost', port);
+
+      expect(result.healthy).toBe(false);
+      expect(result.message).toContain('500');
+    });
+
+    it('should return unhealthy for connection errors', async () => {
+      const checker = new HealthChecker({ timeoutMs: 1000 });
+
+      const result = await checker.check('localhost', 1); // Port 1 should not be accessible
+
+      expect(result.healthy).toBe(false);
+      expect(result.message).toContain('Health check failed');
+    });
+
+    it('should use custom endpoint', async () => {
+      const checker = new HealthChecker({ endpoint: '/custom-health' });
+
+      const result = await checker.check('localhost', port);
+
+      // Server returns 404 for non-/health endpoints
+      expect(result.healthy).toBe(false);
+    });
+
+    it('should timeout when server is slow', async () => {
+      const checker = new HealthChecker({ timeoutMs: 10 });
+
+      // Connect to a port that won't respond quickly
+      const result = await checker.check('localhost', 1);
+
+      expect(result.healthy).toBe(false);
+    });
+  });
+
+  describe('waitForHealthy', () => {
+    it('should succeed when server is healthy', async () => {
+      shouldFail = false;
+      const checker = new HealthChecker({
+        retryIntervalMs: 10,
+        maxRetries: 3,
+      });
+
+      await expect(checker.waitForHealthy('localhost', port)).resolves.toBeUndefined();
+    });
+
+    it('should fail after max retries when server is unhealthy', async () => {
+      shouldFail = true;
+      statusCode = 500;
+      const checker = new HealthChecker({
+        retryIntervalMs: 10,
+        maxRetries: 3,
+      });
+
+      await expect(checker.waitForHealthy('localhost', port)).rejects.toThrow(
+        /failed to become healthy after 3 attempts/,
+      );
+    });
+
+    it('should retry until server becomes healthy', async () => {
+      let attempts = 0;
+      const checkSpy = vi.fn();
+
+      shouldFail = true;
+      statusCode = 503;
+
+      // After 2 attempts, server becomes healthy
+      const originalFetch = global.fetch;
+      global.fetch = vi.fn(async (url: string | URL | Request) => {
+        attempts++;
+        checkSpy();
+        if (attempts >= 3) {
+          shouldFail = false;
+        }
+        return originalFetch(url);
+      }) as typeof fetch;
+
+      const checker = new HealthChecker({
+        retryIntervalMs: 10,
+        maxRetries: 10,
+      });
+
+      try {
+        await checker.waitForHealthy('localhost', port);
+        expect(checkSpy).toHaveBeenCalled();
+      } finally {
+        global.fetch = originalFetch;
+        shouldFail = false;
+      }
+    });
+  });
+
+  describe('configuration', () => {
+    it('should use default configuration', () => {
+      const checker = new HealthChecker();
+
+      // Can't directly inspect config, but we can verify behavior
+      expect(checker).toBeDefined();
+    });
+
+    it('should merge partial configuration with defaults', () => {
+      const checker = new HealthChecker({
+        timeoutMs: 1000,
+        // Other values should use defaults
+      });
+
+      expect(checker).toBeDefined();
+    });
+  });
+});

--- a/runners/local/src/health/checker.ts
+++ b/runners/local/src/health/checker.ts
@@ -1,0 +1,93 @@
+export interface HealthCheckConfig {
+  /** Timeout for each request (ms) */
+  timeoutMs: number;
+  /** Interval between retries (ms) */
+  retryIntervalMs: number;
+  /** Maximum retry attempts */
+  maxRetries: number;
+  /** Health check endpoint */
+  endpoint: string;
+}
+
+const DEFAULT_CONFIG: HealthCheckConfig = {
+  timeoutMs: 5000,
+  retryIntervalMs: 1000,
+  maxRetries: 30,
+  endpoint: '/health',
+};
+
+/**
+ * HTTP health checker for running servers.
+ */
+export class HealthChecker {
+  private readonly config: HealthCheckConfig;
+
+  constructor(config: Partial<HealthCheckConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Check health of a server once.
+   */
+  async check(host: string, port: number): Promise<{ healthy: boolean; message?: string }> {
+    const url = `http://${host}:${port}${this.config.endpoint}`;
+
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), this.config.timeoutMs);
+
+      const response = await fetch(url, {
+        method: 'GET',
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (response.ok) {
+        return { healthy: true };
+      }
+
+      return {
+        healthy: false,
+        message: `Health check returned status ${response.status}`,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        healthy: false,
+        message: `Health check failed: ${message}`,
+      };
+    }
+  }
+
+  /**
+   * Wait for server to become healthy with retries.
+   */
+  async waitForHealthy(host: string, port: number): Promise<void> {
+    let lastError: string | undefined;
+
+    for (let attempt = 1; attempt <= this.config.maxRetries; attempt++) {
+      const result = await this.check(host, port);
+
+      if (result.healthy) {
+        return;
+      }
+
+      lastError = result.message;
+
+      // Wait before retry (except on last attempt)
+      if (attempt < this.config.maxRetries) {
+        await this.sleep(this.config.retryIntervalMs);
+      }
+    }
+
+    throw new Error(
+      `Server failed to become healthy after ${this.config.maxRetries} attempts. ` +
+        `Last error: ${lastError ?? 'unknown'}`,
+    );
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+}

--- a/runners/local/src/health/index.ts
+++ b/runners/local/src/health/index.ts
@@ -1,0 +1,1 @@
+export { HealthChecker, type HealthCheckConfig } from './checker';

--- a/runners/local/src/index.ts
+++ b/runners/local/src/index.ts
@@ -2,13 +2,7 @@
 export { LocalProcessRunner } from './runner';
 
 // Types
-export type {
-  LocalProcessRunnerConfig,
-  TrackedProcess,
-  BuildContext,
-  PackageManager,
-  LogCollector,
-} from './types';
+export type { LocalProcessRunnerConfig, TrackedProcess, BuildContext, PackageManager, LogCollector } from './types';
 
 // Components (for advanced use cases)
 export { PortAllocator } from './port/allocator';
@@ -21,5 +15,12 @@ export { RingBuffer, type LogEntry } from './logs/ring-buffer';
 
 // Utilities
 export { detectPackageManager, getInstallArgs, getBuildArgs, hasBuildScript } from './build/package-manager';
+export {
+  createBuildLogStream,
+  createMultiLogStream,
+  createFilteredLogStream,
+  formatLogLine,
+  type BuildLogStreamConfig,
+} from './build/log-stream';
 export { spawnCommand, runCommand, type SpawnOptions } from './process/spawner';
 export { getProcessResourceUsage, cleanupResourceMonitor, type ResourceUsage } from './process/resource-monitor';

--- a/runners/local/src/index.ts
+++ b/runners/local/src/index.ts
@@ -1,0 +1,25 @@
+// Main runner
+export { LocalProcessRunner } from './runner';
+
+// Types
+export type {
+  LocalProcessRunnerConfig,
+  TrackedProcess,
+  BuildContext,
+  PackageManager,
+  LogCollector,
+} from './types';
+
+// Components (for advanced use cases)
+export { PortAllocator } from './port/allocator';
+export { HealthChecker, type HealthCheckConfig } from './health/checker';
+export { ProcessManager } from './process/manager';
+export { ProjectBuilder, type BuilderConfig } from './build/builder';
+export { SubdomainGenerator } from './subdomain/generator';
+export { LogCollector as LogCollectorImpl } from './logs/collector';
+export { RingBuffer, type LogEntry } from './logs/ring-buffer';
+
+// Utilities
+export { detectPackageManager, getInstallArgs, getBuildArgs, hasBuildScript } from './build/package-manager';
+export { spawnCommand, runCommand, type SpawnOptions } from './process/spawner';
+export { getProcessResourceUsage, cleanupResourceMonitor, type ResourceUsage } from './process/resource-monitor';

--- a/runners/local/src/logs/collector.test.ts
+++ b/runners/local/src/logs/collector.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { LogCollector } from './collector';
+
+describe('LogCollector', () => {
+  let collector: LogCollector;
+
+  beforeEach(() => {
+    collector = new LogCollector(100);
+  });
+
+  describe('append', () => {
+    it('should append single log lines', () => {
+      collector.append('line 1');
+      collector.append('line 2');
+
+      expect(collector.getAll()).toBe('line 1\nline 2');
+    });
+
+    it('should append multiple lines at once', () => {
+      collector.appendMultiple(['line 1', 'line 2', 'line 3']);
+
+      expect(collector.getAll()).toBe('line 1\nline 2\nline 3');
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return empty string for empty collector', () => {
+      expect(collector.getAll()).toBe('');
+    });
+
+    it('should return all lines joined by newlines', () => {
+      collector.append('first');
+      collector.append('second');
+      collector.append('third');
+
+      expect(collector.getAll()).toBe('first\nsecond\nthird');
+    });
+  });
+
+  describe('getTail', () => {
+    it('should return last n lines', () => {
+      collector.appendMultiple(['1', '2', '3', '4', '5']);
+
+      expect(collector.getTail(3)).toBe('3\n4\n5');
+      expect(collector.getTail(1)).toBe('5');
+    });
+
+    it('should return all lines if n is greater than line count', () => {
+      collector.append('only line');
+
+      expect(collector.getTail(100)).toBe('only line');
+    });
+  });
+
+  describe('getSince', () => {
+    it('should return logs since a timestamp', async () => {
+      collector.append('before');
+
+      // Small delay to ensure timestamp difference
+      await new Promise(resolve => setTimeout(resolve, 10));
+      const since = new Date();
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      collector.append('after 1');
+      collector.append('after 2');
+
+      const result = collector.getSince(since);
+      expect(result).toBe('after 1\nafter 2');
+    });
+
+    it('should return empty string if no logs since timestamp', () => {
+      collector.append('before');
+
+      const future = new Date(Date.now() + 10000);
+      expect(collector.getSince(future)).toBe('');
+    });
+  });
+
+  describe('stream', () => {
+    it('should stream new lines to callback', () => {
+      const callback = vi.fn();
+      const cleanup = collector.stream(callback);
+
+      collector.append('line 1');
+      collector.append('line 2');
+
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback).toHaveBeenNthCalledWith(1, 'line 1');
+      expect(callback).toHaveBeenNthCalledWith(2, 'line 2');
+
+      cleanup();
+    });
+
+    it('should stop streaming after cleanup', () => {
+      const callback = vi.fn();
+      const cleanup = collector.stream(callback);
+
+      collector.append('line 1');
+      cleanup();
+      collector.append('line 2');
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith('line 1');
+    });
+
+    it('should support multiple listeners', () => {
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+
+      const cleanup1 = collector.stream(callback1);
+      const cleanup2 = collector.stream(callback2);
+
+      collector.append('line');
+
+      expect(callback1).toHaveBeenCalledWith('line');
+      expect(callback2).toHaveBeenCalledWith('line');
+
+      cleanup1();
+      cleanup2();
+    });
+
+    it('should handle callback errors gracefully', () => {
+      const errorCallback = vi.fn(() => {
+        throw new Error('Callback error');
+      });
+      const goodCallback = vi.fn();
+
+      collector.stream(errorCallback);
+      collector.stream(goodCallback);
+
+      // Should not throw
+      expect(() => collector.append('line')).not.toThrow();
+
+      // Good callback should still be called
+      expect(goodCallback).toHaveBeenCalledWith('line');
+    });
+  });
+
+  describe('clear', () => {
+    it('should clear all logs', () => {
+      collector.appendMultiple(['1', '2', '3']);
+      expect(collector.getLineCount()).toBe(3);
+
+      collector.clear();
+      expect(collector.getLineCount()).toBe(0);
+      expect(collector.getAll()).toBe('');
+    });
+  });
+
+  describe('getLineCount', () => {
+    it('should return correct line count', () => {
+      expect(collector.getLineCount()).toBe(0);
+
+      collector.append('line');
+      expect(collector.getLineCount()).toBe(1);
+
+      collector.appendMultiple(['a', 'b', 'c']);
+      expect(collector.getLineCount()).toBe(4);
+    });
+  });
+
+  describe('capacity', () => {
+    it('should respect max lines limit', () => {
+      const smallCollector = new LogCollector(5);
+
+      for (let i = 1; i <= 10; i++) {
+        smallCollector.append(`line ${i}`);
+      }
+
+      expect(smallCollector.getLineCount()).toBe(5);
+      expect(smallCollector.getAll()).toBe('line 6\nline 7\nline 8\nline 9\nline 10');
+    });
+  });
+});

--- a/runners/local/src/logs/collector.ts
+++ b/runners/local/src/logs/collector.ts
@@ -1,0 +1,102 @@
+import type { LogStreamCallback } from '@mastra/admin';
+import type { LogCollector as ILogCollector } from '../types';
+import { RingBuffer  } from './ring-buffer';
+import type {LogEntry} from './ring-buffer';
+
+/**
+ * Collects and manages logs for a running process.
+ */
+export class LogCollector implements ILogCollector {
+  private readonly buffer: RingBuffer<LogEntry>;
+  private readonly listeners: Set<LogStreamCallback> = new Set();
+
+  constructor(maxLines: number = 10000) {
+    this.buffer = new RingBuffer<LogEntry>(maxLines);
+  }
+
+  /**
+   * Append a log line with timestamp.
+   */
+  append(line: string): void {
+    const entry: LogEntry = {
+      timestamp: new Date(),
+      line,
+    };
+    this.buffer.push(entry);
+
+    // Notify all listeners
+    for (const callback of this.listeners) {
+      try {
+        callback(line);
+      } catch {
+        // Ignore callback errors
+      }
+    }
+  }
+
+  /**
+   * Append multiple lines at once.
+   */
+  appendMultiple(lines: string[]): void {
+    for (const line of lines) {
+      this.append(line);
+    }
+  }
+
+  /**
+   * Get all logs as a single string.
+   */
+  getAll(): string {
+    return this.buffer
+      .toArray()
+      .map(entry => entry.line)
+      .join('\n');
+  }
+
+  /**
+   * Get the last n lines.
+   */
+  getTail(lines: number): string {
+    return this.buffer
+      .getTail(lines)
+      .map(entry => entry.line)
+      .join('\n');
+  }
+
+  /**
+   * Get logs since a timestamp.
+   */
+  getSince(since: Date): string {
+    return this.buffer
+      .toArray()
+      .filter(entry => entry.timestamp >= since)
+      .map(entry => entry.line)
+      .join('\n');
+  }
+
+  /**
+   * Stream logs to a callback.
+   * Returns cleanup function.
+   */
+  stream(callback: LogStreamCallback): () => void {
+    this.listeners.add(callback);
+
+    return () => {
+      this.listeners.delete(callback);
+    };
+  }
+
+  /**
+   * Clear all logs.
+   */
+  clear(): void {
+    this.buffer.clear();
+  }
+
+  /**
+   * Get number of stored lines.
+   */
+  getLineCount(): number {
+    return this.buffer.getSize();
+  }
+}

--- a/runners/local/src/logs/index.ts
+++ b/runners/local/src/logs/index.ts
@@ -1,0 +1,2 @@
+export { LogCollector } from './collector';
+export { RingBuffer, type LogEntry } from './ring-buffer';

--- a/runners/local/src/logs/ring-buffer.test.ts
+++ b/runners/local/src/logs/ring-buffer.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { RingBuffer } from './ring-buffer';
+
+describe('RingBuffer', () => {
+  let buffer: RingBuffer<number>;
+
+  beforeEach(() => {
+    buffer = new RingBuffer<number>(5);
+  });
+
+  it('should add items and return them in order', () => {
+    buffer.push(1);
+    buffer.push(2);
+    buffer.push(3);
+
+    expect(buffer.toArray()).toEqual([1, 2, 3]);
+  });
+
+  it('should report correct size', () => {
+    expect(buffer.getSize()).toBe(0);
+
+    buffer.push(1);
+    expect(buffer.getSize()).toBe(1);
+
+    buffer.push(2);
+    buffer.push(3);
+    expect(buffer.getSize()).toBe(3);
+  });
+
+  it('should overwrite oldest items when at capacity', () => {
+    buffer.push(1);
+    buffer.push(2);
+    buffer.push(3);
+    buffer.push(4);
+    buffer.push(5);
+
+    // Buffer is now full
+    expect(buffer.toArray()).toEqual([1, 2, 3, 4, 5]);
+
+    // Add one more - should overwrite 1
+    buffer.push(6);
+    expect(buffer.toArray()).toEqual([2, 3, 4, 5, 6]);
+
+    // Add two more
+    buffer.push(7);
+    buffer.push(8);
+    expect(buffer.toArray()).toEqual([4, 5, 6, 7, 8]);
+  });
+
+  it('should maintain capacity after overwrites', () => {
+    for (let i = 1; i <= 10; i++) {
+      buffer.push(i);
+    }
+
+    expect(buffer.getSize()).toBe(5);
+    expect(buffer.toArray()).toEqual([6, 7, 8, 9, 10]);
+  });
+
+  it('should get tail items (newest)', () => {
+    buffer.push(1);
+    buffer.push(2);
+    buffer.push(3);
+    buffer.push(4);
+    buffer.push(5);
+
+    expect(buffer.getTail(3)).toEqual([3, 4, 5]);
+    expect(buffer.getTail(1)).toEqual([5]);
+    expect(buffer.getTail(5)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('should handle getTail when requesting more than available', () => {
+    buffer.push(1);
+    buffer.push(2);
+
+    expect(buffer.getTail(10)).toEqual([1, 2]);
+  });
+
+  it('should clear the buffer', () => {
+    buffer.push(1);
+    buffer.push(2);
+    buffer.push(3);
+
+    buffer.clear();
+
+    expect(buffer.getSize()).toBe(0);
+    expect(buffer.toArray()).toEqual([]);
+  });
+
+  it('should work with objects', () => {
+    const objectBuffer = new RingBuffer<{ id: number }>(3);
+
+    objectBuffer.push({ id: 1 });
+    objectBuffer.push({ id: 2 });
+    objectBuffer.push({ id: 3 });
+    objectBuffer.push({ id: 4 });
+
+    expect(objectBuffer.toArray()).toEqual([{ id: 2 }, { id: 3 }, { id: 4 }]);
+  });
+
+  it('should work with capacity of 1', () => {
+    const singleBuffer = new RingBuffer<string>(1);
+
+    singleBuffer.push('a');
+    expect(singleBuffer.toArray()).toEqual(['a']);
+
+    singleBuffer.push('b');
+    expect(singleBuffer.toArray()).toEqual(['b']);
+  });
+});

--- a/runners/local/src/logs/ring-buffer.ts
+++ b/runners/local/src/logs/ring-buffer.ts
@@ -1,0 +1,78 @@
+/**
+ * Timestamped log entry.
+ */
+export interface LogEntry {
+  timestamp: Date;
+  line: string;
+}
+
+/**
+ * Circular buffer for efficient log retention.
+ */
+export class RingBuffer<T> {
+  private buffer: (T | undefined)[];
+  private head: number = 0;
+  private tail: number = 0;
+  private size: number = 0;
+
+  constructor(private readonly capacity: number) {
+    this.buffer = new Array(capacity);
+  }
+
+  /**
+   * Add an item to the buffer.
+   * Overwrites oldest item if at capacity.
+   */
+  push(item: T): void {
+    this.buffer[this.tail] = item;
+    this.tail = (this.tail + 1) % this.capacity;
+
+    if (this.size < this.capacity) {
+      this.size++;
+    } else {
+      this.head = (this.head + 1) % this.capacity;
+    }
+  }
+
+  /**
+   * Get all items in order (oldest first).
+   */
+  toArray(): T[] {
+    const result: T[] = [];
+    for (let i = 0; i < this.size; i++) {
+      const index = (this.head + i) % this.capacity;
+      result.push(this.buffer[index]!);
+    }
+    return result;
+  }
+
+  /**
+   * Get the last n items (newest).
+   */
+  getTail(n: number): T[] {
+    const count = Math.min(n, this.size);
+    const result: T[] = [];
+    for (let i = this.size - count; i < this.size; i++) {
+      const index = (this.head + i) % this.capacity;
+      result.push(this.buffer[index]!);
+    }
+    return result;
+  }
+
+  /**
+   * Get current size.
+   */
+  getSize(): number {
+    return this.size;
+  }
+
+  /**
+   * Clear the buffer.
+   */
+  clear(): void {
+    this.buffer = new Array(this.capacity);
+    this.head = 0;
+    this.tail = 0;
+    this.size = 0;
+  }
+}

--- a/runners/local/src/port/allocator.test.ts
+++ b/runners/local/src/port/allocator.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PortAllocator } from './allocator';
+
+describe('PortAllocator', () => {
+  let allocator: PortAllocator;
+  // Use high ephemeral ports less likely to conflict with other services
+  const PORT_START = 49200;
+  const PORT_END = 49210;
+
+  beforeEach(() => {
+    allocator = new PortAllocator({ start: PORT_START, end: PORT_END });
+  });
+
+  it('should allocate a port within range', async () => {
+    const port = await allocator.allocate();
+    expect(port).toBeGreaterThanOrEqual(PORT_START);
+    expect(port).toBeLessThanOrEqual(PORT_END);
+  });
+
+  it('should track allocated ports', async () => {
+    const port = await allocator.allocate();
+    expect(allocator.isAllocated(port)).toBe(true);
+  });
+
+  it('should release ports', async () => {
+    const port = await allocator.allocate();
+    allocator.release(port);
+    expect(allocator.isAllocated(port)).toBe(false);
+  });
+
+  it('should respect preferred port when available', async () => {
+    const preferredPort = PORT_START + 5;
+    const port = await allocator.allocate(preferredPort);
+    expect(port).toBe(preferredPort);
+  });
+
+  it('should not allocate the same port twice', async () => {
+    const port1 = await allocator.allocate();
+    const port2 = await allocator.allocate();
+    expect(port1).not.toBe(port2);
+    expect(allocator.getAllocatedPorts()).toContain(port1);
+    expect(allocator.getAllocatedPorts()).toContain(port2);
+  });
+
+  it('should return correct available count', async () => {
+    const totalPorts = PORT_END - PORT_START + 1; // 11 ports
+    expect(allocator.getAvailableCount()).toBe(totalPorts);
+
+    await allocator.allocate();
+    expect(allocator.getAvailableCount()).toBe(totalPorts - 1);
+
+    await allocator.allocate();
+    expect(allocator.getAvailableCount()).toBe(totalPorts - 2);
+  });
+
+  it('should return all allocated ports', async () => {
+    const port1 = await allocator.allocate();
+    const port2 = await allocator.allocate();
+
+    const allocated = allocator.getAllocatedPorts();
+    expect(allocated).toHaveLength(2);
+    expect(allocated).toContain(port1);
+    expect(allocated).toContain(port2);
+  });
+
+  it('should allow re-allocating a released port', async () => {
+    const port1 = await allocator.allocate();
+    allocator.release(port1);
+
+    // After release, the port should no longer be tracked as allocated
+    expect(allocator.isAllocated(port1)).toBe(false);
+
+    // The port should be available for allocation again (tracked by allocator)
+    // Note: OS port availability is separate from allocator tracking
+    const allocatedAfterRelease = allocator.getAllocatedPorts().length;
+    expect(allocatedAfterRelease).toBe(0);
+  });
+
+  it('should use default port range if not specified', () => {
+    const defaultAllocator = new PortAllocator();
+    const totalPorts = 4200 - 4111 + 1; // 90 ports
+    expect(defaultAllocator.getAvailableCount()).toBe(totalPorts);
+  });
+});

--- a/runners/local/src/port/allocator.ts
+++ b/runners/local/src/port/allocator.ts
@@ -1,0 +1,92 @@
+import getPort from 'get-port';
+
+/**
+ * Manages port allocation for running servers.
+ * Tracks used ports and ensures no collisions.
+ */
+export class PortAllocator {
+  private readonly portRange: { start: number; end: number };
+  private readonly allocatedPorts: Set<number> = new Set();
+
+  constructor(portRange: { start: number; end: number } = { start: 4111, end: 4200 }) {
+    this.portRange = portRange;
+  }
+
+  /**
+   * Allocate an available port.
+   *
+   * @param preferred - Preferred port (if available)
+   * @returns Allocated port number
+   * @throws Error if no ports available
+   */
+  async allocate(preferred?: number): Promise<number> {
+    // Try preferred port first
+    if (preferred && this.isInRange(preferred) && !this.allocatedPorts.has(preferred)) {
+      const available = await this.isPortAvailable(preferred);
+      if (available) {
+        this.allocatedPorts.add(preferred);
+        return preferred;
+      }
+    }
+
+    // Generate port list within range
+    const portList: number[] = [];
+    for (let port = this.portRange.start; port <= this.portRange.end; port++) {
+      if (!this.allocatedPorts.has(port)) {
+        portList.push(port);
+      }
+    }
+
+    if (portList.length === 0) {
+      throw new Error(`No available ports in range ${this.portRange.start}-${this.portRange.end}`);
+    }
+
+    // Use get-port to find an available port
+    const port = await getPort({ port: portList });
+
+    if (!this.isInRange(port)) {
+      throw new Error(`Allocated port ${port} is outside configured range`);
+    }
+
+    this.allocatedPorts.add(port);
+    return port;
+  }
+
+  /**
+   * Release a previously allocated port.
+   */
+  release(port: number): void {
+    this.allocatedPorts.delete(port);
+  }
+
+  /**
+   * Check if a port is currently allocated by this allocator.
+   */
+  isAllocated(port: number): boolean {
+    return this.allocatedPorts.has(port);
+  }
+
+  /**
+   * Get all currently allocated ports.
+   */
+  getAllocatedPorts(): number[] {
+    return Array.from(this.allocatedPorts);
+  }
+
+  /**
+   * Get number of available ports.
+   */
+  getAvailableCount(): number {
+    const total = this.portRange.end - this.portRange.start + 1;
+    return total - this.allocatedPorts.size;
+  }
+
+  private isInRange(port: number): boolean {
+    return port >= this.portRange.start && port <= this.portRange.end;
+  }
+
+  private async isPortAvailable(port: number): Promise<boolean> {
+    const allocated = await getPort({ port: [port] });
+    return allocated === port;
+  }
+}

--- a/runners/local/src/port/index.ts
+++ b/runners/local/src/port/index.ts
@@ -1,0 +1,1 @@
+export { PortAllocator } from './allocator';

--- a/runners/local/src/process/index.ts
+++ b/runners/local/src/process/index.ts
@@ -1,0 +1,3 @@
+export { ProcessManager } from './manager';
+export { spawnCommand, runCommand, type SpawnOptions } from './spawner';
+export { getProcessResourceUsage, cleanupResourceMonitor, type ResourceUsage } from './resource-monitor';

--- a/runners/local/src/process/manager.test.ts
+++ b/runners/local/src/process/manager.test.ts
@@ -1,0 +1,247 @@
+import type { ChildProcess } from 'node:child_process';
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import type { LogCollector } from '../types';
+import { ProcessManager } from './manager';
+
+// Mock tree-kill
+vi.mock('tree-kill', () => ({
+  default: vi.fn((pid: number, signal: string, callback: (err?: Error) => void) => {
+    callback();
+  }),
+}));
+
+describe('ProcessManager', () => {
+  let manager: ProcessManager;
+  let mockProcess: ChildProcess;
+  let mockLogCollector: LogCollector;
+
+  beforeEach(() => {
+    manager = new ProcessManager();
+    vi.clearAllMocks();
+
+    // Create mock process
+    mockProcess = {
+      pid: 12345,
+      killed: false,
+      exitCode: null,
+      on: vi.fn(),
+    } as unknown as ChildProcess;
+
+    // Create mock log collector
+    mockLogCollector = {
+      append: vi.fn(),
+      getAll: vi.fn(() => ''),
+      getTail: vi.fn(() => ''),
+      getSince: vi.fn(() => ''),
+      stream: vi.fn(() => () => {}),
+      clear: vi.fn(),
+    };
+  });
+
+  describe('track', () => {
+    it('should track a new process', () => {
+      manager.track('server-1', 'deployment-1', mockProcess, 4111, mockLogCollector);
+
+      const tracked = manager.get('server-1');
+      expect(tracked).toBeDefined();
+      expect(tracked?.serverId).toBe('server-1');
+      expect(tracked?.deploymentId).toBe('deployment-1');
+      expect(tracked?.port).toBe(4111);
+      expect(tracked?.process).toBe(mockProcess);
+      expect(tracked?.logCollector).toBe(mockLogCollector);
+    });
+
+    it('should set startedAt to current time', () => {
+      const before = new Date();
+      manager.track('server-1', 'deployment-1', mockProcess, 4111, mockLogCollector);
+      const after = new Date();
+
+      const tracked = manager.get('server-1');
+      expect(tracked?.startedAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(tracked?.startedAt.getTime()).toBeLessThanOrEqual(after.getTime());
+    });
+
+    it('should set up exit handler to remove process', () => {
+      manager.track('server-1', 'deployment-1', mockProcess, 4111, mockLogCollector);
+
+      // Verify exit handler was registered
+      expect(mockProcess.on).toHaveBeenCalledWith('exit', expect.any(Function));
+
+      // Simulate exit
+      const exitHandler = (mockProcess.on as ReturnType<typeof vi.fn>).mock.calls.find(
+        call => call[0] === 'exit',
+      )?.[1];
+      exitHandler?.();
+
+      // Process should be removed
+      expect(manager.get('server-1')).toBeUndefined();
+    });
+  });
+
+  describe('get', () => {
+    it('should return undefined for non-existent server', () => {
+      expect(manager.get('non-existent')).toBeUndefined();
+    });
+
+    it('should return tracked process by server ID', () => {
+      manager.track('server-1', 'deployment-1', mockProcess, 4111, mockLogCollector);
+
+      const tracked = manager.get('server-1');
+      expect(tracked?.serverId).toBe('server-1');
+    });
+  });
+
+  describe('getByDeploymentId', () => {
+    it('should return undefined for non-existent deployment', () => {
+      expect(manager.getByDeploymentId('non-existent')).toBeUndefined();
+    });
+
+    it('should return tracked process by deployment ID', () => {
+      manager.track('server-1', 'deployment-123', mockProcess, 4111, mockLogCollector);
+
+      const tracked = manager.getByDeploymentId('deployment-123');
+      expect(tracked?.deploymentId).toBe('deployment-123');
+      expect(tracked?.serverId).toBe('server-1');
+    });
+
+    it('should search through all processes', () => {
+      const mockProcess2 = { ...mockProcess, pid: 12346, on: vi.fn() } as unknown as ChildProcess;
+
+      manager.track('server-1', 'deployment-1', mockProcess, 4111, mockLogCollector);
+      manager.track('server-2', 'deployment-2', mockProcess2, 4112, mockLogCollector);
+
+      expect(manager.getByDeploymentId('deployment-2')?.serverId).toBe('server-2');
+    });
+  });
+
+  describe('kill', () => {
+    it('should do nothing for non-existent server', async () => {
+      await expect(manager.kill('non-existent')).resolves.toBeUndefined();
+    });
+
+    it('should remove process without pid', async () => {
+      const noPidProcess = { pid: undefined, killed: false, exitCode: null, on: vi.fn() } as unknown as ChildProcess;
+      manager.track('server-1', 'deployment-1', noPidProcess, 4111, mockLogCollector);
+
+      await manager.kill('server-1');
+
+      expect(manager.get('server-1')).toBeUndefined();
+    });
+
+    it('should kill process with tree-kill', async () => {
+      const treeKill = (await import('tree-kill')).default;
+      manager.track('server-1', 'deployment-1', mockProcess, 4111, mockLogCollector);
+
+      await manager.kill('server-1');
+
+      expect(treeKill).toHaveBeenCalledWith(12345, 'SIGTERM', expect.any(Function));
+      expect(manager.get('server-1')).toBeUndefined();
+    });
+
+    it('should try SIGKILL on SIGTERM failure', async () => {
+      const treeKill = (await import('tree-kill')).default;
+      let callCount = 0;
+      (treeKill as ReturnType<typeof vi.fn>).mockImplementation(
+        (pid: number, signal: string, callback: (err?: Error) => void) => {
+          callCount++;
+          if (callCount === 1) {
+            // First call (SIGTERM) fails
+            callback(new Error('SIGTERM failed'));
+          } else {
+            // Second call (SIGKILL) succeeds
+            callback();
+          }
+        },
+      );
+
+      manager.track('server-1', 'deployment-1', mockProcess, 4111, mockLogCollector);
+
+      await manager.kill('server-1');
+
+      expect(treeKill).toHaveBeenCalledWith(12345, 'SIGTERM', expect.any(Function));
+      expect(treeKill).toHaveBeenCalledWith(12345, 'SIGKILL', expect.any(Function));
+      expect(manager.get('server-1')).toBeUndefined();
+    });
+  });
+
+  describe('isRunning', () => {
+    it('should return false for non-existent server', () => {
+      expect(manager.isRunning('non-existent')).toBe(false);
+    });
+
+    it('should return true for running process', () => {
+      manager.track('server-1', 'deployment-1', mockProcess, 4111, mockLogCollector);
+
+      expect(manager.isRunning('server-1')).toBe(true);
+    });
+
+    it('should return false for killed process', () => {
+      const killedProcess = { ...mockProcess, killed: true, on: vi.fn() } as unknown as ChildProcess;
+      manager.track('server-1', 'deployment-1', killedProcess, 4111, mockLogCollector);
+
+      expect(manager.isRunning('server-1')).toBe(false);
+    });
+
+    it('should return false for exited process', () => {
+      const exitedProcess = { ...mockProcess, exitCode: 0, on: vi.fn() } as unknown as ChildProcess;
+      manager.track('server-1', 'deployment-1', exitedProcess, 4111, mockLogCollector);
+
+      expect(manager.isRunning('server-1')).toBe(false);
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return empty array when no processes', () => {
+      expect(manager.getAll()).toEqual([]);
+    });
+
+    it('should return all tracked processes', () => {
+      const mockProcess2 = { ...mockProcess, pid: 12346, on: vi.fn() } as unknown as ChildProcess;
+
+      manager.track('server-1', 'deployment-1', mockProcess, 4111, mockLogCollector);
+      manager.track('server-2', 'deployment-2', mockProcess2, 4112, mockLogCollector);
+
+      const all = manager.getAll();
+      expect(all).toHaveLength(2);
+      expect(all.map(p => p.serverId)).toContain('server-1');
+      expect(all.map(p => p.serverId)).toContain('server-2');
+    });
+  });
+
+  describe('getRunningCount', () => {
+    it('should return 0 when no processes', () => {
+      expect(manager.getRunningCount()).toBe(0);
+    });
+
+    it('should count only running processes', () => {
+      const runningProcess = { ...mockProcess, on: vi.fn() } as unknown as ChildProcess;
+      const killedProcess = { ...mockProcess, pid: 12346, killed: true, on: vi.fn() } as unknown as ChildProcess;
+      const exitedProcess = { ...mockProcess, pid: 12347, exitCode: 1, on: vi.fn() } as unknown as ChildProcess;
+
+      manager.track('server-1', 'deployment-1', runningProcess, 4111, mockLogCollector);
+      manager.track('server-2', 'deployment-2', killedProcess, 4112, mockLogCollector);
+      manager.track('server-3', 'deployment-3', exitedProcess, 4113, mockLogCollector);
+
+      expect(manager.getRunningCount()).toBe(1);
+    });
+  });
+
+  describe('killAll', () => {
+    it('should do nothing when no processes', async () => {
+      await expect(manager.killAll()).resolves.toBeUndefined();
+    });
+
+    it('should kill all tracked processes', async () => {
+      const mockProcess2 = { ...mockProcess, pid: 12346, on: vi.fn() } as unknown as ChildProcess;
+
+      manager.track('server-1', 'deployment-1', mockProcess, 4111, mockLogCollector);
+      manager.track('server-2', 'deployment-2', mockProcess2, 4112, mockLogCollector);
+
+      await manager.killAll();
+
+      expect(manager.getAll()).toHaveLength(0);
+    });
+  });
+});

--- a/runners/local/src/process/manager.ts
+++ b/runners/local/src/process/manager.ts
@@ -1,0 +1,129 @@
+import type { ChildProcess } from 'node:child_process';
+import treeKill from 'tree-kill';
+import type { TrackedProcess, LogCollector } from '../types';
+
+// tree-kill types
+type TreeKillCallback = (error?: Error) => void;
+
+/**
+ * Manages running server processes.
+ */
+export class ProcessManager {
+  private readonly processes: Map<string, TrackedProcess> = new Map();
+
+  /**
+   * Track a new process.
+   */
+  track(
+    serverId: string,
+    deploymentId: string,
+    process: ChildProcess,
+    port: number,
+    logCollector: LogCollector,
+  ): void {
+    const tracked: TrackedProcess = {
+      serverId,
+      deploymentId,
+      process,
+      port,
+      startedAt: new Date(),
+      logCollector,
+    };
+
+    this.processes.set(serverId, tracked);
+
+    // Clean up on exit
+    process.on('exit', () => {
+      this.processes.delete(serverId);
+    });
+  }
+
+  /**
+   * Get a tracked process by server ID.
+   */
+  get(serverId: string): TrackedProcess | undefined {
+    return this.processes.get(serverId);
+  }
+
+  /**
+   * Get process by deployment ID.
+   */
+  getByDeploymentId(deploymentId: string): TrackedProcess | undefined {
+    for (const tracked of this.processes.values()) {
+      if (tracked.deploymentId === deploymentId) {
+        return tracked;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Kill a process and remove from tracking.
+   */
+  async kill(serverId: string): Promise<void> {
+    const tracked = this.processes.get(serverId);
+    if (!tracked) {
+      return;
+    }
+
+    const pid = tracked.process.pid;
+    if (!pid) {
+      this.processes.delete(serverId);
+      return;
+    }
+
+    return new Promise(resolve => {
+      // Use tree-kill to kill process and all children
+      treeKill(pid, 'SIGTERM', ((err: Error | undefined) => {
+        if (err) {
+          // Try SIGKILL as fallback
+          treeKill(pid, 'SIGKILL', (() => {
+            this.processes.delete(serverId);
+            resolve();
+          }) as TreeKillCallback);
+        } else {
+          this.processes.delete(serverId);
+          resolve();
+        }
+      }) as TreeKillCallback);
+    });
+  }
+
+  /**
+   * Check if a process is running.
+   */
+  isRunning(serverId: string): boolean {
+    const tracked = this.processes.get(serverId);
+    if (!tracked) return false;
+
+    return !tracked.process.killed && tracked.process.exitCode === null;
+  }
+
+  /**
+   * Get all tracked processes.
+   */
+  getAll(): TrackedProcess[] {
+    return Array.from(this.processes.values());
+  }
+
+  /**
+   * Get count of running processes.
+   */
+  getRunningCount(): number {
+    let count = 0;
+    for (const tracked of this.processes.values()) {
+      if (this.isRunning(tracked.serverId)) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Kill all processes (for shutdown).
+   */
+  async killAll(): Promise<void> {
+    const killPromises = Array.from(this.processes.keys()).map(id => this.kill(id));
+    await Promise.all(killPromises);
+  }
+}

--- a/runners/local/src/process/resource-monitor.test.ts
+++ b/runners/local/src/process/resource-monitor.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getProcessResourceUsage, cleanupResourceMonitor } from './resource-monitor';
+
+// Mock pidusage
+vi.mock('pidusage', () => ({
+  default: vi.fn(),
+}));
+
+describe('resource-monitor', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getProcessResourceUsage', () => {
+    it('should return resource usage for a valid process', async () => {
+      const pidusage = (await import('pidusage')).default;
+      (pidusage as ReturnType<typeof vi.fn>).mockResolvedValue({
+        memory: 104857600, // 100 MB
+        cpu: 25.5,
+      });
+
+      const result = await getProcessResourceUsage(12345);
+
+      expect(pidusage).toHaveBeenCalledWith(12345);
+      expect(result.memoryUsageMb).toBe(100);
+      expect(result.cpuPercent).toBe(25.5);
+    });
+
+    it('should round memory usage to nearest MB', async () => {
+      const pidusage = (await import('pidusage')).default;
+      (pidusage as ReturnType<typeof vi.fn>).mockResolvedValue({
+        memory: 157286400, // ~150 MB
+        cpu: 10,
+      });
+
+      const result = await getProcessResourceUsage(12345);
+
+      expect(result.memoryUsageMb).toBe(150);
+    });
+
+    it('should round CPU to 2 decimal places', async () => {
+      const pidusage = (await import('pidusage')).default;
+      (pidusage as ReturnType<typeof vi.fn>).mockResolvedValue({
+        memory: 1048576,
+        cpu: 33.3333333,
+      });
+
+      const result = await getProcessResourceUsage(12345);
+
+      expect(result.cpuPercent).toBe(33.33);
+    });
+
+    it('should return null values when memory is not available', async () => {
+      const pidusage = (await import('pidusage')).default;
+      (pidusage as ReturnType<typeof vi.fn>).mockResolvedValue({
+        memory: 0,
+        cpu: 10,
+      });
+
+      const result = await getProcessResourceUsage(12345);
+
+      expect(result.memoryUsageMb).toBeNull();
+      expect(result.cpuPercent).toBe(10);
+    });
+
+    it('should handle CPU being exactly 0', async () => {
+      const pidusage = (await import('pidusage')).default;
+      (pidusage as ReturnType<typeof vi.fn>).mockResolvedValue({
+        memory: 1048576,
+        cpu: 0,
+      });
+
+      const result = await getProcessResourceUsage(12345);
+
+      expect(result.cpuPercent).toBe(0);
+    });
+
+    it('should return null values on error', async () => {
+      const pidusage = (await import('pidusage')).default;
+      (pidusage as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Process not found'));
+
+      const result = await getProcessResourceUsage(12345);
+
+      expect(result.memoryUsageMb).toBeNull();
+      expect(result.cpuPercent).toBeNull();
+    });
+
+    it('should handle undefined cpu value', async () => {
+      const pidusage = (await import('pidusage')).default;
+      (pidusage as ReturnType<typeof vi.fn>).mockResolvedValue({
+        memory: 1048576,
+        cpu: undefined,
+      });
+
+      const result = await getProcessResourceUsage(12345);
+
+      expect(result.memoryUsageMb).toBe(1);
+      expect(result.cpuPercent).toBeNull();
+    });
+  });
+
+  describe('cleanupResourceMonitor', () => {
+    it('should call pidusage.clear()', async () => {
+      const pidusage = (await import('pidusage')).default;
+      (pidusage as ReturnType<typeof vi.fn> & { clear: ReturnType<typeof vi.fn> }).clear = vi.fn();
+
+      cleanupResourceMonitor();
+
+      expect(
+        (pidusage as ReturnType<typeof vi.fn> & { clear: ReturnType<typeof vi.fn> }).clear,
+      ).toHaveBeenCalled();
+    });
+  });
+});

--- a/runners/local/src/process/resource-monitor.ts
+++ b/runners/local/src/process/resource-monitor.ts
@@ -1,0 +1,32 @@
+import pidusage from 'pidusage';
+
+export interface ResourceUsage {
+  memoryUsageMb: number | null;
+  cpuPercent: number | null;
+}
+
+/**
+ * Get resource usage for a process.
+ */
+export async function getProcessResourceUsage(pid: number): Promise<ResourceUsage> {
+  try {
+    const stats = await pidusage(pid);
+
+    return {
+      memoryUsageMb: stats.memory ? Math.round(stats.memory / 1024 / 1024) : null,
+      cpuPercent: stats.cpu !== undefined ? Math.round(stats.cpu * 100) / 100 : null,
+    };
+  } catch {
+    return {
+      memoryUsageMb: null,
+      cpuPercent: null,
+    };
+  }
+}
+
+/**
+ * Cleanup pidusage monitoring.
+ */
+export function cleanupResourceMonitor(): void {
+  pidusage.clear();
+}

--- a/runners/local/src/process/spawner.test.ts
+++ b/runners/local/src/process/spawner.test.ts
@@ -1,0 +1,185 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { spawnCommand, runCommand } from './spawner';
+
+describe('spawner', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spawner-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('spawnCommand', () => {
+    it('should spawn a command and return child process', () => {
+      const proc = spawnCommand('node', ['--version'], {
+        cwd: testDir,
+        env: {},
+      });
+
+      expect(proc).toBeDefined();
+      expect(proc.pid).toBeDefined();
+
+      // Clean up
+      proc.kill();
+    });
+
+    it('should stream stdout to callback', async () => {
+      const lines: string[] = [];
+      const onOutput = vi.fn((line: string) => lines.push(line));
+
+      const proc = spawnCommand('node', ['-e', 'console.log("hello")'], {
+        cwd: testDir,
+        env: {},
+        onOutput,
+      });
+
+      await new Promise<void>(resolve => {
+        proc.on('close', () => resolve());
+      });
+
+      expect(onOutput).toHaveBeenCalled();
+      expect(lines.some(l => l.includes('hello'))).toBe(true);
+    });
+
+    it('should stream stderr to callback with [stderr] prefix', async () => {
+      const lines: string[] = [];
+      const onOutput = vi.fn((line: string) => lines.push(line));
+
+      const proc = spawnCommand('node', ['-e', 'console.error("error message")'], {
+        cwd: testDir,
+        env: {},
+        onOutput,
+      });
+
+      await new Promise<void>(resolve => {
+        proc.on('close', () => resolve());
+      });
+
+      expect(onOutput).toHaveBeenCalled();
+      expect(lines.some(l => l.includes('[stderr]') && l.includes('error message'))).toBe(true);
+    });
+
+    it('should pass environment variables', async () => {
+      const lines: string[] = [];
+      const onOutput = vi.fn((line: string) => lines.push(line));
+
+      const proc = spawnCommand('node', ['-e', 'console.log(process.env.TEST_VAR)'], {
+        cwd: testDir,
+        env: { TEST_VAR: 'test-value-123' },
+        onOutput,
+      });
+
+      await new Promise<void>(resolve => {
+        proc.on('close', () => resolve());
+      });
+
+      expect(lines.some(l => l.includes('test-value-123'))).toBe(true);
+    });
+
+    it('should use specified working directory', async () => {
+      const lines: string[] = [];
+      const onOutput = vi.fn((line: string) => lines.push(line));
+
+      const proc = spawnCommand('node', ['-e', 'console.log(process.cwd())'], {
+        cwd: testDir,
+        env: {},
+        onOutput,
+      });
+
+      await new Promise<void>(resolve => {
+        proc.on('close', () => resolve());
+      });
+
+      expect(lines.some(l => l.includes(testDir))).toBe(true);
+    });
+  });
+
+  describe('runCommand', () => {
+    it('should run a command and return exit code', async () => {
+      const result = await runCommand('node', ['--version'], {
+        cwd: testDir,
+        env: {},
+      });
+
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('should capture output', async () => {
+      const result = await runCommand('node', ['-e', 'console.log("output line")'], {
+        cwd: testDir,
+        env: {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.output.some(l => l.includes('output line'))).toBe(true);
+    });
+
+    it('should call onOutput callback', async () => {
+      const onOutput = vi.fn();
+
+      const result = await runCommand('node', ['-e', 'console.log("callback test")'], {
+        cwd: testDir,
+        env: {},
+        onOutput,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(onOutput).toHaveBeenCalled();
+    });
+
+    it('should return non-zero exit code on failure', async () => {
+      const result = await runCommand('node', ['-e', 'process.exit(42)'], {
+        cwd: testDir,
+        env: {},
+      });
+
+      expect(result.exitCode).toBe(42);
+    });
+
+    it('should reject on spawn error', async () => {
+      await expect(
+        runCommand('nonexistent-command-that-does-not-exist', [], {
+          cwd: testDir,
+          env: {},
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('should capture multiple output lines', async () => {
+      const result = await runCommand(
+        'node',
+        ['-e', 'console.log("line1"); console.log("line2"); console.log("line3")'],
+        {
+          cwd: testDir,
+          env: {},
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.output.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('should capture both stdout and stderr', async () => {
+      const result = await runCommand(
+        'node',
+        ['-e', 'console.log("stdout"); console.error("stderr")'],
+        {
+          cwd: testDir,
+          env: {},
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.output.some(l => l.includes('stdout'))).toBe(true);
+      expect(result.output.some(l => l.includes('[stderr]') && l.includes('stderr'))).toBe(true);
+    });
+  });
+});

--- a/runners/local/src/process/spawner.ts
+++ b/runners/local/src/process/spawner.ts
@@ -1,0 +1,77 @@
+import { spawn  } from 'node:child_process';
+import type {ChildProcess} from 'node:child_process';
+import type { LogStreamCallback } from '@mastra/admin';
+
+export interface SpawnOptions {
+  /** Working directory */
+  cwd: string;
+  /** Environment variables */
+  env: Record<string, string>;
+  /** Callback for stdout/stderr */
+  onOutput?: LogStreamCallback;
+}
+
+/**
+ * Spawn a command and return the process.
+ */
+export function spawnCommand(command: string, args: string[], options: SpawnOptions): ChildProcess {
+  const proc = spawn(command, args, {
+    cwd: options.cwd,
+    env: {
+      ...process.env,
+      ...options.env,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  // Stream stdout
+  if (proc.stdout && options.onOutput) {
+    proc.stdout.on('data', (data: Buffer) => {
+      const lines = data.toString().split('\n').filter(Boolean);
+      for (const line of lines) {
+        options.onOutput!(line);
+      }
+    });
+  }
+
+  // Stream stderr
+  if (proc.stderr && options.onOutput) {
+    proc.stderr.on('data', (data: Buffer) => {
+      const lines = data.toString().split('\n').filter(Boolean);
+      for (const line of lines) {
+        options.onOutput!(`[stderr] ${line}`);
+      }
+    });
+  }
+
+  return proc;
+}
+
+/**
+ * Run a command and wait for completion.
+ */
+export async function runCommand(
+  command: string,
+  args: string[],
+  options: SpawnOptions,
+): Promise<{ exitCode: number; output: string[] }> {
+  return new Promise((resolve, reject) => {
+    const output: string[] = [];
+
+    const proc = spawnCommand(command, args, {
+      ...options,
+      onOutput: (line: string) => {
+        output.push(line);
+        options.onOutput?.(line);
+      },
+    });
+
+    proc.on('close', code => {
+      resolve({ exitCode: code ?? 0, output });
+    });
+
+    proc.on('error', err => {
+      reject(err);
+    });
+  });
+}

--- a/runners/local/src/runner.test.ts
+++ b/runners/local/src/runner.test.ts
@@ -1,0 +1,273 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { Build, Project, ProjectSourceProvider, EdgeRouterProvider } from '@mastra/admin';
+import { BuildStatus, DeploymentType, HealthStatus } from '@mastra/admin';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { LocalProcessRunner } from './runner';
+
+describe('LocalProcessRunner', () => {
+  let runner: LocalProcessRunner;
+  let testDir: string;
+  let mockProject: Project;
+  let mockBuild: Build;
+  let mockSourceProvider: ProjectSourceProvider;
+  let mockRouterProvider: EdgeRouterProvider;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'runner-test-'));
+
+    // Create output directory with entry point
+    const outputDir = path.join(testDir, '.mastra/output');
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(path.join(outputDir, 'index.mjs'), 'export default {}');
+
+    // Create package.json for build
+    await fs.writeFile(path.join(testDir, 'package.json'), JSON.stringify({ name: 'test' }));
+
+    mockProject = {
+      id: 'project-1',
+      name: 'test-project',
+      slug: 'test-project',
+      sourceType: 'local',
+      sourceConfig: { path: testDir },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as Project;
+
+    mockBuild = {
+      id: 'build-1',
+      projectId: 'project-1',
+      status: BuildStatus.SUCCEEDED,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as Build;
+
+    // Mock deployment kept for future deploy tests
+    // (currently unused but setup for integration testing)
+    void DeploymentType.PRODUCTION; // Reference to keep import
+
+    mockSourceProvider = {
+      type: 'local',
+      getProjectPath: vi.fn().mockResolvedValue(testDir),
+      validateSource: vi.fn().mockResolvedValue({ valid: true }),
+    };
+
+    mockRouterProvider = {
+      type: 'local',
+      registerRoute: vi.fn().mockResolvedValue({
+        publicUrl: 'https://test-project.localhost',
+        subdomain: 'test-project',
+      }),
+      removeRoute: vi.fn().mockResolvedValue(undefined),
+      getRoute: vi.fn(),
+    };
+
+    runner = new LocalProcessRunner({
+      portRange: { start: 49300, end: 49310 },
+    });
+    runner.setSource(mockSourceProvider);
+    runner.setRouter(mockRouterProvider);
+  });
+
+  afterEach(async () => {
+    if (runner) {
+      try {
+        await runner.shutdown();
+      } catch {
+        // Ignore shutdown errors in cleanup
+      }
+    }
+    try {
+      await fs.rm(testDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe('constructor', () => {
+    it('should create runner with default config', () => {
+      const r = new LocalProcessRunner();
+      expect(r.type).toBe('local');
+    });
+
+    it('should create runner with custom config', () => {
+      const r = new LocalProcessRunner({
+        portRange: { start: 5000, end: 5100 },
+        maxConcurrentBuilds: 5,
+        logRetentionLines: 5000,
+      });
+      expect(r.type).toBe('local');
+    });
+  });
+
+  describe('setSource', () => {
+    it('should set the source provider', () => {
+      const r = new LocalProcessRunner();
+      r.setSource(mockSourceProvider);
+      expect(r).toBeDefined();
+    });
+  });
+
+  describe('setRouter', () => {
+    it('should set the router provider', () => {
+      const r = new LocalProcessRunner();
+      r.setRouter(mockRouterProvider);
+      expect(r).toBeDefined();
+    });
+  });
+
+  describe('build', () => {
+    it('should throw if source provider not set', async () => {
+      const r = new LocalProcessRunner();
+
+      await expect(r.build(mockProject, mockBuild)).rejects.toThrow('Project source provider not configured');
+    });
+
+    it('should get project path from source provider', async () => {
+      await runner.build(mockProject, mockBuild, { skipInstall: true });
+
+      expect(mockSourceProvider.getProjectPath).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'project-1',
+          name: 'test-project',
+          type: 'local',
+          path: testDir,
+        }),
+        expect.any(String),
+      );
+    });
+
+    it('should stream logs to callback', async () => {
+      const logs: string[] = [];
+      await runner.build(mockProject, mockBuild, { skipInstall: true }, log => logs.push(log));
+
+      expect(logs.length).toBeGreaterThan(0);
+      expect(logs.some(l => l.includes('Detected package manager'))).toBe(true);
+    });
+
+    it('should return build result', async () => {
+      const result = await runner.build(mockProject, mockBuild, { skipInstall: true });
+
+      expect(result).toBeDefined();
+      expect(result.status).toBeDefined();
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return initial stats', () => {
+      const stats = runner.getStats();
+
+      expect(stats.runningProcesses).toBe(0);
+      expect(stats.allocatedPorts).toEqual([]);
+      expect(stats.availablePorts).toBe(11); // 49300-49310 = 11 ports
+    });
+  });
+
+  describe('shutdown', () => {
+    it('should not throw when no processes running', async () => {
+      await expect(runner.shutdown()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getLogs', () => {
+    it('should return empty string if server not found', async () => {
+      const fakeServer = {
+        id: 'non-existent',
+        deploymentId: 'dep-1',
+        buildId: 'build-1',
+        processId: null,
+        containerId: null,
+        host: 'localhost',
+        port: 4111,
+        healthStatus: HealthStatus.HEALTHY,
+        lastHealthCheck: new Date(),
+        memoryUsageMb: null,
+        cpuPercent: null,
+        startedAt: new Date(),
+        stoppedAt: null,
+      };
+
+      const logs = await runner.getLogs(fakeServer);
+
+      expect(logs).toBe('');
+    });
+  });
+
+  describe('streamLogs', () => {
+    it('should return noop function if server not found', () => {
+      const fakeServer = {
+        id: 'non-existent',
+        deploymentId: 'dep-1',
+        buildId: 'build-1',
+        processId: null,
+        containerId: null,
+        host: 'localhost',
+        port: 4111,
+        healthStatus: HealthStatus.HEALTHY,
+        lastHealthCheck: new Date(),
+        memoryUsageMb: null,
+        cpuPercent: null,
+        startedAt: new Date(),
+        stoppedAt: null,
+      };
+
+      const cleanup = runner.streamLogs(fakeServer, vi.fn());
+
+      expect(typeof cleanup).toBe('function');
+      cleanup(); // Should not throw
+    });
+  });
+
+  describe('getResourceUsage', () => {
+    it('should return null values if no processId', async () => {
+      const fakeServer = {
+        id: 'test',
+        deploymentId: 'dep-1',
+        buildId: 'build-1',
+        processId: null,
+        containerId: null,
+        host: 'localhost',
+        port: 4111,
+        healthStatus: HealthStatus.HEALTHY,
+        lastHealthCheck: new Date(),
+        memoryUsageMb: null,
+        cpuPercent: null,
+        startedAt: new Date(),
+        stoppedAt: null,
+      };
+
+      const usage = await runner.getResourceUsage(fakeServer);
+
+      expect(usage.memoryUsageMb).toBeNull();
+      expect(usage.cpuPercent).toBeNull();
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('should return unhealthy if server not tracked', async () => {
+      const fakeServer = {
+        id: 'non-existent',
+        deploymentId: 'dep-1',
+        buildId: 'build-1',
+        processId: 12345,
+        containerId: null,
+        host: 'localhost',
+        port: 4111,
+        healthStatus: HealthStatus.HEALTHY,
+        lastHealthCheck: new Date(),
+        memoryUsageMb: null,
+        cpuPercent: null,
+        startedAt: new Date(),
+        stoppedAt: null,
+      };
+
+      const result = await runner.healthCheck(fakeServer);
+
+      expect(result.healthy).toBe(false);
+      expect(result.message).toContain('Process is not running');
+    });
+  });
+});

--- a/runners/local/src/runner.ts
+++ b/runners/local/src/runner.ts
@@ -1,0 +1,438 @@
+import * as path from 'node:path';
+import type {
+  ProjectRunner,
+  Build,
+  Deployment,
+  Project,
+  RunningServer,
+  BuildOptions,
+  RunOptions,
+  LogStreamCallback,
+  ProjectSourceProvider,
+  EdgeRouterProvider,
+} from '@mastra/admin';
+import { HealthStatus } from '@mastra/admin';
+import { ProjectBuilder } from './build/builder';
+import { HealthChecker } from './health/checker';
+import { LogCollector } from './logs/collector';
+import { PortAllocator } from './port/allocator';
+import { ProcessManager } from './process/manager';
+import { getProcessResourceUsage, cleanupResourceMonitor } from './process/resource-monitor';
+import { spawnCommand } from './process/spawner';
+import { SubdomainGenerator } from './subdomain/generator';
+import type { LocalProcessRunnerConfig } from './types';
+
+/**
+ * Simple logger interface for LocalProcessRunner.
+ */
+interface Logger {
+  debug(message: string, data?: Record<string, unknown>): void;
+  info(message: string, data?: Record<string, unknown>): void;
+  warn(message: string, data?: Record<string, unknown>): void;
+  error(message: string, data?: Record<string, unknown>): void;
+}
+
+/**
+ * Default console logger.
+ */
+class ConsoleLogger implements Logger {
+  private readonly name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  private format(level: string, message: string, data?: Record<string, unknown>): string {
+    const timestamp = new Date().toISOString();
+    const dataStr = data ? ` ${JSON.stringify(data)}` : '';
+    return `[${timestamp}] [${level}] [${this.name}] ${message}${dataStr}`;
+  }
+
+  debug(message: string, data?: Record<string, unknown>): void {
+    console.info(this.format('DEBUG', message, data));
+  }
+
+  info(message: string, data?: Record<string, unknown>): void {
+    console.info(this.format('INFO', message, data));
+  }
+
+  warn(message: string, data?: Record<string, unknown>): void {
+    console.warn(this.format('WARN', message, data));
+  }
+
+  error(message: string, data?: Record<string, unknown>): void {
+    console.error(this.format('ERROR', message, data));
+  }
+}
+
+interface RequiredHealthCheckConfig {
+  timeoutMs: number;
+  retryIntervalMs: number;
+  maxRetries: number;
+  endpoint: string;
+}
+
+interface ResolvedConfig {
+  portRange: { start: number; end: number };
+  maxConcurrentBuilds: number;
+  defaultBuildTimeoutMs: number;
+  healthCheck: RequiredHealthCheckConfig;
+  logRetentionLines: number;
+  buildDir: string;
+  globalEnvVars: Record<string, string>;
+}
+
+const DEFAULT_HEALTH_CHECK: RequiredHealthCheckConfig = {
+  timeoutMs: 5000,
+  retryIntervalMs: 1000,
+  maxRetries: 30,
+  endpoint: '/health',
+};
+
+const DEFAULT_CONFIG: Omit<ResolvedConfig, 'globalEnvVars'> = {
+  portRange: { start: 4111, end: 4200 },
+  maxConcurrentBuilds: 3,
+  defaultBuildTimeoutMs: 600000,
+  healthCheck: DEFAULT_HEALTH_CHECK,
+  logRetentionLines: 10000,
+  buildDir: '.mastra/builds',
+};
+
+/**
+ * LocalProcessRunner builds Mastra projects and runs them as child processes.
+ *
+ * @example
+ * ```typescript
+ * const runner = new LocalProcessRunner({
+ *   portRange: { start: 4111, end: 4200 },
+ * });
+ *
+ * // Build a project
+ * const buildResult = await runner.build(project, build, { envVars });
+ *
+ * // Deploy and start server
+ * const server = await runner.deploy(project, deployment, build);
+ *
+ * // Stop server
+ * await runner.stop(server);
+ * ```
+ */
+export class LocalProcessRunner implements ProjectRunner {
+  readonly type = 'local' as const;
+
+  private readonly config: ResolvedConfig;
+
+  private readonly portAllocator: PortAllocator;
+  private readonly healthChecker: HealthChecker;
+  private readonly processManager: ProcessManager;
+  private readonly projectBuilder: ProjectBuilder;
+  private readonly subdomainGenerator: SubdomainGenerator;
+  private readonly logger: Logger;
+
+  // Injected providers
+  private source?: ProjectSourceProvider;
+  private router?: EdgeRouterProvider;
+
+  constructor(config: LocalProcessRunnerConfig = {}) {
+    this.config = {
+      ...DEFAULT_CONFIG,
+      ...config,
+      healthCheck: { ...DEFAULT_HEALTH_CHECK, ...config.healthCheck },
+      globalEnvVars: config.globalEnvVars ?? {},
+    };
+
+    this.portAllocator = new PortAllocator(this.config.portRange);
+    this.healthChecker = new HealthChecker(this.config.healthCheck);
+    this.processManager = new ProcessManager();
+    this.projectBuilder = new ProjectBuilder({
+      defaultTimeoutMs: this.config.defaultBuildTimeoutMs,
+      buildDir: this.config.buildDir,
+      globalEnvVars: this.config.globalEnvVars,
+    });
+    this.subdomainGenerator = new SubdomainGenerator();
+    this.logger = new ConsoleLogger('LocalProcessRunner');
+
+    this.logger.info('LocalProcessRunner initialized', {
+      portRange: this.config.portRange,
+      maxConcurrentBuilds: this.config.maxConcurrentBuilds,
+    });
+  }
+
+  /**
+   * Set the project source provider.
+   * Called by MastraAdmin during initialization.
+   */
+  setSource(source: ProjectSourceProvider): void {
+    this.source = source;
+  }
+
+  /**
+   * Set the edge router provider.
+   * Called by MastraAdmin during initialization.
+   */
+  setRouter(router: EdgeRouterProvider): void {
+    this.router = router;
+  }
+
+  /**
+   * Build a project from source.
+   */
+  async build(
+    project: Project,
+    build: Build,
+    options?: BuildOptions,
+    onLog?: LogStreamCallback,
+  ): Promise<Build> {
+    this.logger.info('Starting build', { projectId: project.id, buildId: build.id });
+
+    // Get project path from source provider
+    const projectPath = await this.getProjectPath(project);
+
+    // Run the build
+    const result = await this.projectBuilder.build(project, build, projectPath, options, onLog);
+
+    this.logger.info('Build completed', {
+      projectId: project.id,
+      buildId: build.id,
+      status: result.status,
+    });
+
+    return result;
+  }
+
+  /**
+   * Deploy and start a server for a deployment.
+   */
+  async deploy(
+    project: Project,
+    deployment: Deployment,
+    build: Build,
+    options?: RunOptions,
+  ): Promise<RunningServer> {
+    this.logger.info('Starting deployment', {
+      projectId: project.id,
+      deploymentId: deployment.id,
+      buildId: build.id,
+    });
+
+    // Get project path
+    const projectPath = await this.getProjectPath(project);
+    const outputDir = path.join(projectPath, '.mastra/output');
+
+    // Allocate port
+    const port = await this.portAllocator.allocate(options?.port);
+    this.logger.debug('Allocated port', { port });
+
+    // Prepare environment
+    const envVars = {
+      ...this.config.globalEnvVars,
+      ...options?.envVars,
+      NODE_ENV: 'production',
+      PORT: String(port),
+      MASTRA_DEPLOYMENT_ID: deployment.id,
+      MASTRA_PROJECT_ID: project.id,
+    };
+
+    // Create log collector
+    const logCollector = new LogCollector(this.config.logRetentionLines);
+
+    // Start the server process
+    const entryPoint = path.join(outputDir, 'index.mjs');
+    const proc = spawnCommand(process.execPath, [entryPoint], {
+      cwd: outputDir,
+      env: envVars,
+      onOutput: (line: string) => logCollector.append(line),
+    });
+
+    // Generate server ID
+    const serverId = crypto.randomUUID();
+
+    // Track the process
+    this.processManager.track(serverId, deployment.id, proc, port, logCollector);
+
+    // Wait for health check
+    try {
+      const healthTimeoutMs =
+        options?.healthCheckTimeoutMs ??
+        this.config.healthCheck.maxRetries * this.config.healthCheck.retryIntervalMs;
+
+      this.logger.debug('Waiting for server health', { port, timeoutMs: healthTimeoutMs });
+      await this.healthChecker.waitForHealthy('localhost', port);
+      this.logger.info('Server is healthy', { port });
+    } catch (error) {
+      // Kill process on health check failure
+      await this.processManager.kill(serverId);
+      this.portAllocator.release(port);
+      throw error;
+    }
+
+    // Register route with edge router
+    let publicUrl: string | null = null;
+    if (this.router) {
+      const subdomain = this.subdomainGenerator.generate(project, deployment);
+      const routeInfo = await this.router.registerRoute({
+        deploymentId: deployment.id,
+        projectId: project.id,
+        subdomain,
+        targetHost: 'localhost',
+        targetPort: port,
+      });
+      publicUrl = routeInfo.publicUrl;
+      this.logger.info('Route registered', { subdomain, publicUrl });
+    }
+
+    const server: RunningServer = {
+      id: serverId,
+      deploymentId: deployment.id,
+      buildId: build.id,
+      processId: proc.pid ?? null,
+      containerId: null,
+      host: 'localhost',
+      port,
+      healthStatus: HealthStatus.HEALTHY as RunningServer['healthStatus'],
+      lastHealthCheck: new Date(),
+      memoryUsageMb: null,
+      cpuPercent: null,
+      startedAt: new Date(),
+      stoppedAt: null,
+    };
+
+    this.logger.info('Deployment complete', { serverId, port, publicUrl });
+
+    return server;
+  }
+
+  /**
+   * Stop a running server.
+   */
+  async stop(server: RunningServer): Promise<void> {
+    this.logger.info('Stopping server', { serverId: server.id, port: server.port });
+
+    // Remove route first
+    if (this.router) {
+      try {
+        await this.router.removeRoute(server.deploymentId);
+        this.logger.debug('Route removed', { deploymentId: server.deploymentId });
+      } catch (error) {
+        this.logger.warn('Failed to remove route', { error: String(error) });
+      }
+    }
+
+    // Kill the process
+    await this.processManager.kill(server.id);
+
+    // Release the port
+    this.portAllocator.release(server.port);
+
+    this.logger.info('Server stopped', { serverId: server.id });
+  }
+
+  /**
+   * Check health of a running server.
+   */
+  async healthCheck(server: RunningServer): Promise<{ healthy: boolean; message?: string }> {
+    // First check if process is still running
+    if (!this.processManager.isRunning(server.id)) {
+      return { healthy: false, message: 'Process is not running' };
+    }
+
+    return this.healthChecker.check(server.host, server.port);
+  }
+
+  /**
+   * Get logs from a running server.
+   */
+  async getLogs(
+    server: RunningServer,
+    options?: { tail?: number; since?: Date },
+  ): Promise<string> {
+    const tracked = this.processManager.get(server.id);
+    if (!tracked) {
+      return '';
+    }
+
+    if (options?.since) {
+      return tracked.logCollector.getSince(options.since);
+    }
+
+    if (options?.tail) {
+      return tracked.logCollector.getTail(options.tail);
+    }
+
+    return tracked.logCollector.getAll();
+  }
+
+  /**
+   * Stream logs from a running server.
+   */
+  streamLogs(server: RunningServer, callback: LogStreamCallback): () => void {
+    const tracked = this.processManager.get(server.id);
+    if (!tracked) {
+      return () => {};
+    }
+
+    return tracked.logCollector.stream(callback);
+  }
+
+  /**
+   * Get resource usage for a running server.
+   */
+  async getResourceUsage(server: RunningServer): Promise<{
+    memoryUsageMb: number | null;
+    cpuPercent: number | null;
+  }> {
+    if (!server.processId) {
+      return { memoryUsageMb: null, cpuPercent: null };
+    }
+
+    return getProcessResourceUsage(server.processId);
+  }
+
+  /**
+   * Shutdown the runner (stop all processes).
+   */
+  async shutdown(): Promise<void> {
+    this.logger.info('Shutting down LocalProcessRunner');
+
+    await this.processManager.killAll();
+    cleanupResourceMonitor();
+
+    this.logger.info('LocalProcessRunner shutdown complete');
+  }
+
+  /**
+   * Get stats about the runner.
+   */
+  getStats(): {
+    runningProcesses: number;
+    allocatedPorts: number[];
+    availablePorts: number;
+  } {
+    return {
+      runningProcesses: this.processManager.getRunningCount(),
+      allocatedPorts: this.portAllocator.getAllocatedPorts(),
+      availablePorts: this.portAllocator.getAvailableCount(),
+    };
+  }
+
+  /**
+   * Get project path from source provider.
+   */
+  private async getProjectPath(project: Project): Promise<string> {
+    if (!this.source) {
+      throw new Error('Project source provider not configured');
+    }
+
+    // For local source, this returns the path directly
+    // For GitHub source (future), this would clone the repo
+    return this.source.getProjectPath(
+      {
+        id: project.id,
+        name: project.name,
+        type: project.sourceType,
+        path: (project.sourceConfig as { path: string }).path,
+      },
+      this.config.buildDir,
+    );
+  }
+}

--- a/runners/local/src/subdomain/generator.test.ts
+++ b/runners/local/src/subdomain/generator.test.ts
@@ -1,0 +1,121 @@
+import type { Project, Deployment } from '@mastra/admin';
+import { DeploymentType } from '@mastra/admin';
+import { describe, it, expect } from 'vitest';
+import { SubdomainGenerator } from './generator';
+
+describe('SubdomainGenerator', () => {
+  const generator = new SubdomainGenerator();
+
+  const createMockProject = (slug: string): Project =>
+    ({
+      id: 'project-1',
+      slug,
+      name: 'Test Project',
+      sourceType: 'local',
+      sourceConfig: { path: '/test' },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }) as Project;
+
+  const createMockDeployment = (type: DeploymentType, extra: Partial<Deployment> = {}): Deployment =>
+    ({
+      id: 'deployment-1',
+      projectId: 'project-1',
+      buildId: 'build-1',
+      type,
+      slug: `deployment-${type}`,
+      branch: 'main',
+      status: 'running',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...extra,
+    }) as Deployment;
+
+  describe('generate', () => {
+    it('should generate production subdomain as project slug', () => {
+      const project = createMockProject('my-project');
+      const deployment = createMockDeployment(DeploymentType.PRODUCTION);
+
+      expect(generator.generate(project, deployment)).toBe('my-project');
+    });
+
+    it('should generate staging subdomain with staging prefix', () => {
+      const project = createMockProject('my-project');
+      const deployment = createMockDeployment(DeploymentType.STAGING);
+
+      expect(generator.generate(project, deployment)).toBe('staging--my-project');
+    });
+
+    it('should generate preview subdomain with branch prefix', () => {
+      const project = createMockProject('my-project');
+      const deployment = createMockDeployment(DeploymentType.PREVIEW, { branch: 'feature-new-ui' });
+
+      expect(generator.generate(project, deployment)).toBe('feature-new-ui--my-project');
+    });
+
+    it('should sanitize special characters in project slug', () => {
+      const project = createMockProject('My_Project 123!');
+      const deployment = createMockDeployment(DeploymentType.PRODUCTION);
+
+      expect(generator.generate(project, deployment)).toBe('my-project-123');
+    });
+
+    it('should sanitize branch names with slashes', () => {
+      const project = createMockProject('api');
+      const deployment = createMockDeployment(DeploymentType.PREVIEW, { branch: 'feature/auth/oauth2' });
+
+      expect(generator.generate(project, deployment)).toBe('featureauthoauth2--api');
+    });
+
+    it('should handle uppercase letters in project slug', () => {
+      const project = createMockProject('MyAwesomeProject');
+      const deployment = createMockDeployment(DeploymentType.PRODUCTION);
+
+      expect(generator.generate(project, deployment)).toBe('myawesomeproject');
+    });
+
+    it('should collapse multiple hyphens', () => {
+      const project = createMockProject('my---project');
+      const deployment = createMockDeployment(DeploymentType.PRODUCTION);
+
+      expect(generator.generate(project, deployment)).toBe('my-project');
+    });
+
+    it('should trim leading and trailing hyphens', () => {
+      const project = createMockProject('-my-project-');
+      const deployment = createMockDeployment(DeploymentType.PRODUCTION);
+
+      expect(generator.generate(project, deployment)).toBe('my-project');
+    });
+  });
+
+  describe('parse', () => {
+    it('should parse production subdomain', () => {
+      const result = generator.parse('my-project');
+
+      expect(result.projectSlug).toBe('my-project');
+      expect(result.deploymentSlug).toBeUndefined();
+    });
+
+    it('should parse staging subdomain', () => {
+      const result = generator.parse('staging--my-project');
+
+      expect(result.projectSlug).toBe('my-project');
+      expect(result.deploymentSlug).toBe('staging');
+    });
+
+    it('should parse preview subdomain with branch', () => {
+      const result = generator.parse('feature-new-ui--my-project');
+
+      expect(result.projectSlug).toBe('my-project');
+      expect(result.deploymentSlug).toBe('feature-new-ui');
+    });
+
+    it('should handle multiple double-dash separators', () => {
+      const result = generator.parse('some-prefix--another--my-project');
+
+      expect(result.projectSlug).toBe('my-project');
+      expect(result.deploymentSlug).toBe('some-prefix--another');
+    });
+  });
+});

--- a/runners/local/src/subdomain/generator.ts
+++ b/runners/local/src/subdomain/generator.ts
@@ -1,0 +1,73 @@
+import type { Project, Deployment } from '@mastra/admin';
+import { DeploymentType } from '@mastra/admin';
+
+/**
+ * Generates subdomain strings for deployments.
+ *
+ * Patterns:
+ * - production: "{project-slug}"
+ * - staging: "staging--{project-slug}"
+ * - preview: "{branch}--{project-slug}"
+ */
+export class SubdomainGenerator {
+  /**
+   * Generate subdomain for a deployment.
+   */
+  generate(project: Project, deployment: Deployment): string {
+    const projectSlug = this.sanitizeSlug(project.slug);
+
+    switch (deployment.type) {
+      case DeploymentType.PRODUCTION:
+        return projectSlug;
+
+      case DeploymentType.STAGING:
+        return `staging--${projectSlug}`;
+
+      case DeploymentType.PREVIEW: {
+        const branchSlug = this.sanitizeSlug(deployment.branch);
+        return `${branchSlug}--${projectSlug}`;
+      }
+
+      default: {
+        // For any custom deployment types
+        const typeSlug = this.sanitizeSlug(deployment.slug);
+        return `${typeSlug}--${projectSlug}`;
+      }
+    }
+  }
+
+  /**
+   * Parse a subdomain to extract project slug and deployment type.
+   */
+  parse(subdomain: string): { projectSlug: string; deploymentSlug?: string } {
+    const parts = subdomain.split('--');
+
+    if (parts.length === 1) {
+      // Production deployment
+      return { projectSlug: parts[0]! };
+    }
+
+    // Non-production deployment
+    return {
+      projectSlug: parts[parts.length - 1]!,
+      deploymentSlug: parts.slice(0, -1).join('--'),
+    };
+  }
+
+  /**
+   * Sanitize a string for use in a subdomain.
+   * - Lowercase
+   * - Replace spaces and underscores with hyphens
+   * - Remove invalid characters
+   * - Collapse multiple hyphens
+   * - Trim hyphens from start/end
+   */
+  private sanitizeSlug(input: string): string {
+    return input
+      .toLowerCase()
+      .replace(/[\s_]/g, '-')
+      .replace(/[^a-z0-9-]/g, '')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '');
+  }
+}

--- a/runners/local/src/subdomain/index.ts
+++ b/runners/local/src/subdomain/index.ts
@@ -1,0 +1,1 @@
+export { SubdomainGenerator } from './generator';

--- a/runners/local/src/types.ts
+++ b/runners/local/src/types.ts
@@ -1,0 +1,114 @@
+import type { ChildProcess } from 'node:child_process';
+import type { LogStreamCallback } from '@mastra/admin';
+
+/**
+ * Package manager types supported by the runner.
+ */
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
+
+/**
+ * Configuration for LocalProcessRunner.
+ */
+export interface LocalProcessRunnerConfig {
+  /**
+   * Port range for server allocation.
+   * @default { start: 4111, end: 4200 }
+   */
+  portRange?: {
+    start: number;
+    end: number;
+  };
+
+  /**
+   * Maximum concurrent builds.
+   * @default 3
+   */
+  maxConcurrentBuilds?: number;
+
+  /**
+   * Default build timeout in milliseconds.
+   * @default 600000 (10 minutes)
+   */
+  defaultBuildTimeoutMs?: number;
+
+  /**
+   * Health check configuration.
+   */
+  healthCheck?: {
+    /** Timeout for health check request (ms). @default 5000 */
+    timeoutMs?: number;
+    /** Interval between health check retries (ms). @default 1000 */
+    retryIntervalMs?: number;
+    /** Maximum retries before giving up. @default 30 */
+    maxRetries?: number;
+    /** Health check endpoint path. @default '/health' */
+    endpoint?: string;
+  };
+
+  /**
+   * Number of log lines to retain per server.
+   * @default 10000
+   */
+  logRetentionLines?: number;
+
+  /**
+   * Working directory for build artifacts.
+   * @default '.mastra/builds'
+   */
+  buildDir?: string;
+
+  /**
+   * Environment variables to inject into all builds.
+   */
+  globalEnvVars?: Record<string, string>;
+}
+
+/**
+ * Tracked running process information.
+ */
+export interface TrackedProcess {
+  /** Server ID */
+  serverId: string;
+  /** Deployment ID */
+  deploymentId: string;
+  /** Node.js child process */
+  process: ChildProcess;
+  /** Allocated port */
+  port: number;
+  /** Process start time */
+  startedAt: Date;
+  /** Log collector reference */
+  logCollector: LogCollector;
+}
+
+/**
+ * Build context with resolved paths.
+ */
+export interface BuildContext {
+  /** Project source path */
+  projectPath: string;
+  /** Build output directory */
+  outputDir: string;
+  /** Detected package manager */
+  packageManager: PackageManager;
+  /** Environment variables for build */
+  envVars: Record<string, string>;
+}
+
+/**
+ * Log collector interface.
+ */
+export interface LogCollector {
+  /** Append a log line */
+  append(line: string): void;
+  /** Get all logs */
+  getAll(): string;
+  /** Get tail of logs */
+  getTail(lines: number): string;
+  /** Get logs since timestamp */
+  getSince(since: Date): string;
+  /** Stream logs with callback */
+  stream(callback: LogStreamCallback): () => void;
+  /** Clear all logs */
+  clear(): void;
+}

--- a/runners/local/tsconfig.build.json
+++ b/runners/local/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/runners/local/tsconfig.json
+++ b/runners/local/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/runners/local/tsup.config.ts
+++ b/runners/local/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/runners/local/vitest.config.ts
+++ b/runners/local/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Implements the `@mastra/runner-local` package - a LocalProcess runner that builds Mastra projects and runs them as child processes
- This is the primary runner for MVP, enabling local development and self-hosted deployments
- Follows the implementation plan in `thoughts/shared/plans/2025-01-23-runner-local.md`

## Features

### Build Process
- Automatic package manager detection (npm, pnpm, yarn, bun) from lock files
- Dependency installation with appropriate flags per package manager
- Build script execution with real-time log streaming
- Build output verification

### Process Management
- Child process spawning with stdout/stderr capture
- Process tree termination using `tree-kill` (kills all child processes)
- Graceful shutdown with SIGTERM/SIGKILL fallback

### Port Allocation
- Automatic port allocation within configured range (default: 4111-4200)
- Port conflict detection using `get-port`
- Port tracking and release on process termination

### Health Checks
- HTTP health check with configurable timeout
- Retry mechanism with configurable interval
- Deployment fails if health check times out

### Log Collection
- Circular buffer (ring buffer) for memory-efficient log storage
- Tail and since-based log queries
- Real-time log streaming via callbacks

### Resource Monitoring
- CPU/memory usage monitoring via `pidusage`
- Graceful fallback on monitoring errors

### Subdomain Generation
- Production: `{project-slug}`
- Staging: `staging--{project-slug}`
- Preview: `{branch}--{project-slug}`

## Test plan

- [x] All 142 unit tests pass (`pnpm test`)
- [x] TypeScript compiles without errors (`pnpm typecheck`)
- [x] Linting passes (`pnpm lint`)
- [ ] Integration testing with MastraAdmin (requires LANE 12 router-local)

## Files Changed

- `runners/local/` - New package with all source files
- `pnpm-workspace.yaml` - Added runners/local to workspace
- `thoughts/shared/plans/2025-01-23-runner-local.md` - Updated with resolved Open Questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)