### PR TITLE
feat(observability-clickhouse): implement @mastra/observability-clickhouse package

### DIFF
--- a/observability/clickhouse/CHANGELOG.md
+++ b/observability/clickhouse/CHANGELOG.md
@@ -2,4 +2,12 @@
 
 ## 0.0.1
 
+### Features
+
 - Initial release
+- ClickHouse schema for traces, spans, logs, metrics, scores
+- Materialized views for hourly aggregations
+- `IngestionWorker` for processing JSONL files into ClickHouse
+- `ClickHouseQueryProvider` for querying observability data
+- CLI for running ingestion worker standalone
+- Migration support with `migrate` command

--- a/observability/clickhouse/CHANGELOG.md
+++ b/observability/clickhouse/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @mastra/observability-clickhouse
+
+## 0.0.1
+
+- Initial release

--- a/observability/clickhouse/README.md
+++ b/observability/clickhouse/README.md
@@ -166,6 +166,50 @@ For efficient aggregation queries:
 - `mastra_admin_metrics_hourly_stats`
 - `mastra_admin_scores_hourly_stats`
 
+## Development
+
+### Running Tests
+
+```bash
+# Run unit tests
+pnpm test
+
+# Run tests in watch mode
+pnpm test:watch
+
+# Run integration tests (requires Docker)
+pnpm docker:up
+pnpm test:integration
+pnpm docker:down
+```
+
+### Docker Compose
+
+A Docker Compose setup is provided for running integration tests locally:
+
+```bash
+# Start ClickHouse
+docker compose up -d
+
+# ClickHouse will be available at:
+# - HTTP API: http://localhost:8123
+# - Native protocol: localhost:9000
+
+# Stop ClickHouse
+docker compose down
+
+# Stop and remove data
+docker compose down -v
+```
+
+### Environment Variables
+
+The following environment variables can be used to configure the integration tests:
+
+- `CLICKHOUSE_URL` - ClickHouse HTTP URL (default: `http://localhost:8123`)
+- `CLICKHOUSE_USER` - ClickHouse username (default: `default`)
+- `CLICKHOUSE_PASSWORD` - ClickHouse password (default: empty)
+
 ## Related Packages
 
 - `@mastra/admin` - Core types and interfaces

--- a/observability/clickhouse/README.md
+++ b/observability/clickhouse/README.md
@@ -1,0 +1,173 @@
+# @mastra/observability-clickhouse
+
+ClickHouse storage and ingestion worker for MastraAdmin observability data.
+
+## Installation
+
+```bash
+npm install @mastra/observability-clickhouse
+```
+
+## Prerequisites
+
+- Node.js >= 22.13.0
+- ClickHouse server
+- A `FileStorageProvider` implementation (e.g., `@mastra/observability-file-local`)
+
+## Usage
+
+### Running the Ingestion Worker
+
+The ingestion worker polls file storage for JSONL files and ingests them into ClickHouse.
+
+#### Via CLI
+
+```bash
+# Run continuously
+npx @mastra/observability-clickhouse ingest \
+  --file-storage-type local \
+  --file-storage-path /var/mastra/observability \
+  --clickhouse-url http://localhost:8123 \
+  --poll-interval 10000
+
+# Run once (for cron)
+npx @mastra/observability-clickhouse ingest \
+  --file-storage-type local \
+  --file-storage-path /var/mastra/observability \
+  --clickhouse-url http://localhost:8123 \
+  --once
+```
+
+#### Programmatically
+
+```typescript
+import { IngestionWorker } from '@mastra/observability-clickhouse';
+import { LocalFileStorage } from '@mastra/observability-file-local';
+
+const worker = new IngestionWorker({
+  fileStorage: new LocalFileStorage({ baseDir: '/var/mastra/observability' }),
+  clickhouse: {
+    url: 'http://localhost:8123',
+    username: 'default',
+    password: '',
+  },
+  pollIntervalMs: 10000,
+  batchSize: 10,
+});
+
+await worker.init(); // Run migrations
+await worker.start(); // Start polling
+
+// Later...
+await worker.stop();
+```
+
+### Querying Data
+
+```typescript
+import { ClickHouseQueryProvider } from '@mastra/observability-clickhouse';
+
+const queryProvider = new ClickHouseQueryProvider({
+  clickhouse: {
+    url: 'http://localhost:8123',
+    username: 'default',
+    password: '',
+  },
+});
+
+await queryProvider.init();
+
+// List traces
+const { traces, pagination } = await queryProvider.listTraces({
+  projectId: 'proj_123',
+  timeRange: {
+    start: new Date('2025-01-01'),
+    end: new Date('2025-01-31'),
+  },
+  pagination: { page: 0, perPage: 50 },
+});
+
+// Get spans for a trace
+const spans = await queryProvider.getSpansForTrace('trace_123');
+
+// Get error rate over time
+const errorRate = await queryProvider.getErrorRateTimeSeries({
+  projectId: 'proj_123',
+  intervalSeconds: 3600, // 1 hour buckets
+  timeRange: {
+    start: new Date('2025-01-01'),
+    end: new Date('2025-01-31'),
+  },
+});
+```
+
+### Running Migrations
+
+```bash
+# Run migrations
+npx @mastra/observability-clickhouse migrate \
+  --clickhouse-url http://localhost:8123
+
+# Check migration status
+npx @mastra/observability-clickhouse migrate \
+  --clickhouse-url http://localhost:8123 \
+  --check
+```
+
+## CLI Reference
+
+### `ingest` Command
+
+```
+Options:
+  --clickhouse-url <url>         ClickHouse server URL (required)
+  --clickhouse-username <user>   ClickHouse username (default: "default")
+  --clickhouse-password <pass>   ClickHouse password (default: "")
+  --clickhouse-database <db>     ClickHouse database name
+  --file-storage-type <type>     File storage type: local (required)
+  --file-storage-path <path>     Base path for local file storage
+  --base-path <path>             Base path for observability files (default: "observability")
+  --poll-interval <ms>           Poll interval in milliseconds (default: 10000)
+  --batch-size <count>           Files to process per batch (default: 10)
+  --delete-after-process         Delete files instead of moving to processed/
+  --project-id <id>              Only process files for specific project
+  --once                         Process files once and exit
+  --debug                        Enable debug logging
+```
+
+### `migrate` Command
+
+```
+Options:
+  --clickhouse-url <url>         ClickHouse server URL (required)
+  --clickhouse-username <user>   ClickHouse username (default: "default")
+  --clickhouse-password <pass>   ClickHouse password (default: "")
+  --clickhouse-database <db>     ClickHouse database name
+  --check                        Only check status, don't run migrations
+```
+
+## ClickHouse Schema
+
+### Tables
+
+- `mastra_admin_traces` - Trace records
+- `mastra_admin_spans` - Span records
+- `mastra_admin_logs` - Log records
+- `mastra_admin_metrics` - Metric records
+- `mastra_admin_scores` - Score records
+
+### Materialized Views
+
+For efficient aggregation queries:
+
+- `mastra_admin_traces_hourly_stats`
+- `mastra_admin_spans_hourly_stats`
+- `mastra_admin_logs_hourly_stats`
+- `mastra_admin_metrics_hourly_stats`
+- `mastra_admin_scores_hourly_stats`
+
+## Related Packages
+
+- `@mastra/admin` - Core types and interfaces
+- `@mastra/observability-writer` - Writes observability events to file storage
+- `@mastra/observability-file-local` - Local filesystem storage adapter

--- a/observability/clickhouse/docker-compose.yaml
+++ b/observability/clickhouse/docker-compose.yaml
@@ -1,0 +1,23 @@
+services:
+  clickhouse:
+    image: clickhouse/clickhouse-server:latest
+    container_name: 'observability-clickhouse-test'
+    ports:
+      - '8123:8123'
+      - '9000:9000'
+    environment:
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+      CLICKHOUSE_USER: ${CLICKHOUSE_USER:-default}
+      CLICKHOUSE_PASSWORD: ${CLICKHOUSE_PASSWORD:-}
+      CLICKHOUSE_DB: ${CLICKHOUSE_DB:-mastra_observability}
+    volumes:
+      - clickhouse_data:/var/lib/clickhouse
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8123/ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+volumes:
+  clickhouse_data:

--- a/observability/clickhouse/eslint.config.js
+++ b/observability/clickhouse/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default config;

--- a/observability/clickhouse/package.json
+++ b/observability/clickhouse/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@mastra/observability-clickhouse",
+  "version": "0.0.1",
+  "description": "ClickHouse storage and ingestion worker for MastraAdmin observability data",
+  "type": "module",
+  "license": "Apache-2.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "mastra-observability-clickhouse": "./dist/cli/index.js"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./cli": {
+      "import": {
+        "types": "./dist/cli/index.d.ts",
+        "default": "./dist/cli/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "build:watch": "pnpm build:lib --watch",
+    "check": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@clickhouse/client": "^1.12.1",
+    "commander": "^14.0.2"
+  },
+  "peerDependencies": {
+    "@mastra/admin": "workspace:*"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/admin": "workspace:*",
+    "@mastra/observability-writer": "workspace:*",
+    "@mastra/observability-file-local": "workspace:*",
+    "@types/node": "22.13.17",
+    "@vitest/coverage-v8": "catalog:",
+    "tsup": "^8.3.5",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "observability/clickhouse"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  }
+}

--- a/observability/clickhouse/package.json
+++ b/observability/clickhouse/package.json
@@ -37,8 +37,11 @@
     "build:watch": "pnpm build:lib --watch",
     "check": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
-    "test:watch": "vitest watch",
+    "test": "vitest run --exclude src/integration.test.ts",
+    "test:watch": "vitest watch --exclude src/integration.test.ts",
+    "test:integration": "RUN_INTEGRATION_TESTS=1 vitest run src/integration.test.ts",
+    "docker:up": "docker compose up -d",
+    "docker:down": "docker compose down",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/observability/clickhouse/src/cli/commands/ingest.ts
+++ b/observability/clickhouse/src/cli/commands/ingest.ts
@@ -1,0 +1,107 @@
+/**
+ * Ingest command - runs the ingestion worker
+ */
+
+import { Command } from 'commander';
+import { IngestionWorker } from '../../ingestion/worker.js';
+
+export const ingestCommand = new Command('ingest')
+  .description('Run the ingestion worker to process JSONL files into ClickHouse')
+  .requiredOption('--clickhouse-url <url>', 'ClickHouse server URL (e.g., http://localhost:8123)')
+  .option('--clickhouse-username <username>', 'ClickHouse username', 'default')
+  .option('--clickhouse-password <password>', 'ClickHouse password', '')
+  .option('--clickhouse-database <database>', 'ClickHouse database name')
+  .requiredOption('--file-storage-type <type>', 'File storage type (local)', 'local')
+  .option('--file-storage-path <path>', 'Base path for file storage (required for local)')
+  .option('--base-path <path>', 'Base path within file storage for observability files', 'observability')
+  .option('--poll-interval <ms>', 'Poll interval in milliseconds', '10000')
+  .option('--batch-size <count>', 'Number of files to process per batch', '10')
+  .option('--delete-after-process', 'Delete files after processing instead of moving to processed/')
+  .option('--project-id <id>', 'Only process files for a specific project')
+  .option('--once', 'Process files once and exit (for cron-based execution)')
+  .option('--debug', 'Enable debug logging')
+  .action(async options => {
+    try {
+      // Validate file storage options
+      if (options.fileStorageType === 'local' && !options.fileStoragePath) {
+        console.error('Error: --file-storage-path is required when --file-storage-type is local');
+        process.exit(1);
+      }
+
+      // Create file storage
+      let fileStorage;
+      if (options.fileStorageType === 'local') {
+        const { LocalFileStorage } = await import('@mastra/observability-file-local');
+        fileStorage = new LocalFileStorage({
+          baseDir: options.fileStoragePath,
+        });
+      } else {
+        console.error(`Error: Unsupported file storage type: ${options.fileStorageType}`);
+        process.exit(1);
+      }
+
+      // Create worker
+      const worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: {
+          url: options.clickhouseUrl,
+          username: options.clickhouseUsername,
+          password: options.clickhousePassword,
+          database: options.clickhouseDatabase,
+        },
+        basePath: options.basePath,
+        pollIntervalMs: parseInt(options.pollInterval, 10),
+        batchSize: parseInt(options.batchSize, 10),
+        deleteAfterProcess: options.deleteAfterProcess ?? false,
+        projectId: options.projectId,
+        debug: options.debug ?? false,
+      });
+
+      // Initialize (run migrations)
+      console.info('Initializing ClickHouse schema...');
+      await worker.init();
+      console.info('Schema initialized');
+
+      if (options.once) {
+        // Process once and exit
+        console.info('Processing files once...');
+        const result = await worker.processOnce();
+        console.info(`Processed ${result.filesProcessed} files, ${result.eventsIngested} events`);
+        if (result.errors.length > 0) {
+          console.error(`Errors: ${result.errors.length}`);
+          for (const error of result.errors) {
+            console.error(`  - ${error.filePath}: ${error.message}`);
+          }
+        }
+        process.exit(result.errors.length > 0 ? 1 : 0);
+      } else {
+        // Run continuously
+        console.info('Starting ingestion worker...');
+        console.info(`  ClickHouse URL: ${options.clickhouseUrl}`);
+        console.info(`  File storage: ${options.fileStorageType} (${options.fileStoragePath || 'n/a'})`);
+        console.info(`  Poll interval: ${options.pollInterval}ms`);
+        console.info(`  Batch size: ${options.batchSize}`);
+
+        // Handle shutdown signals
+        const shutdown = async () => {
+          console.info('\nShutting down...');
+          await worker.stop();
+          const status = worker.getStatus();
+          console.info(`Total files processed: ${status.totalFilesProcessed}`);
+          console.info(`Total events ingested: ${status.totalEventsIngested}`);
+          process.exit(0);
+        };
+
+        process.on('SIGINT', shutdown);
+        process.on('SIGTERM', shutdown);
+
+        await worker.start();
+
+        // Keep the process running
+        await new Promise(() => {}); // Never resolves
+      }
+    } catch (error) {
+      console.error('Fatal error:', error);
+      process.exit(1);
+    }
+  });

--- a/observability/clickhouse/src/cli/commands/migrate.ts
+++ b/observability/clickhouse/src/cli/commands/migrate.ts
@@ -1,0 +1,56 @@
+/**
+ * Migrate command - runs schema migrations
+ */
+
+import { createClient } from '@clickhouse/client';
+import { Command } from 'commander';
+
+import { runMigrations, checkSchemaStatus } from '../../schema/migrations.js';
+
+export const migrateCommand = new Command('migrate')
+  .description('Run ClickHouse schema migrations')
+  .requiredOption('--clickhouse-url <url>', 'ClickHouse server URL (e.g., http://localhost:8123)')
+  .option('--clickhouse-username <username>', 'ClickHouse username', 'default')
+  .option('--clickhouse-password <password>', 'ClickHouse password', '')
+  .option('--clickhouse-database <database>', 'ClickHouse database name')
+  .option('--check', 'Only check migration status, do not run migrations')
+  .action(async options => {
+    try {
+      const client = createClient({
+        url: options.clickhouseUrl,
+        username: options.clickhouseUsername,
+        password: options.clickhousePassword,
+        database: options.clickhouseDatabase,
+      });
+
+      if (options.check) {
+        console.info('Checking schema status...');
+        const status = await checkSchemaStatus(client);
+
+        if (status.isInitialized) {
+          console.info('Schema is up to date');
+        } else {
+          console.info('Schema needs migration');
+          if (status.missingTables.length > 0) {
+            console.info(`  Missing tables: ${status.missingTables.join(', ')}`);
+          }
+          if (status.missingViews.length > 0) {
+            console.info(`  Missing views: ${status.missingViews.join(', ')}`);
+          }
+        }
+
+        await client.close();
+        process.exit(status.isInitialized ? 0 : 1);
+      }
+
+      console.info('Running migrations...');
+      await runMigrations(client);
+      console.info('Migrations complete');
+
+      await client.close();
+      process.exit(0);
+    } catch (error) {
+      console.error('Migration error:', error);
+      process.exit(1);
+    }
+  });

--- a/observability/clickhouse/src/cli/index.ts
+++ b/observability/clickhouse/src/cli/index.ts
@@ -1,34 +1,20 @@
 #!/usr/bin/env node
 /**
- * CLI entry point for @mastra/observability-clickhouse.
- *
- * Provides commands for:
- * - migrate: Run ClickHouse schema migrations
- * - ingest: Start or run the ingestion worker
+ * CLI for @mastra/observability-clickhouse
  */
 
 import { Command } from 'commander';
+import { ingestCommand } from './commands/ingest.js';
+import { migrateCommand } from './commands/migrate.js';
 
 const program = new Command();
 
 program
   .name('mastra-observability-clickhouse')
-  .description('ClickHouse tools for MastraAdmin observability')
+  .description('ClickHouse ingestion worker and utilities for MastraAdmin observability')
   .version('0.0.1');
 
-// Placeholder commands - will be implemented in later phases
-program
-  .command('migrate')
-  .description('Run ClickHouse schema migrations')
-  .action(() => {
-    console.info('Migration command - to be implemented');
-  });
+program.addCommand(ingestCommand);
+program.addCommand(migrateCommand);
 
-program
-  .command('ingest')
-  .description('Start the ingestion worker')
-  .action(() => {
-    console.info('Ingest command - to be implemented');
-  });
-
-program.parse();
+program.parse(process.argv);

--- a/observability/clickhouse/src/cli/index.ts
+++ b/observability/clickhouse/src/cli/index.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * CLI entry point for @mastra/observability-clickhouse.
+ *
+ * Provides commands for:
+ * - migrate: Run ClickHouse schema migrations
+ * - ingest: Start or run the ingestion worker
+ */
+
+import { Command } from 'commander';
+
+const program = new Command();
+
+program
+  .name('mastra-observability-clickhouse')
+  .description('ClickHouse tools for MastraAdmin observability')
+  .version('0.0.1');
+
+// Placeholder commands - will be implemented in later phases
+program
+  .command('migrate')
+  .description('Run ClickHouse schema migrations')
+  .action(() => {
+    console.info('Migration command - to be implemented');
+  });
+
+program
+  .command('ingest')
+  .description('Start the ingestion worker')
+  .action(() => {
+    console.info('Ingest command - to be implemented');
+  });
+
+program.parse();

--- a/observability/clickhouse/src/index.ts
+++ b/observability/clickhouse/src/index.ts
@@ -76,5 +76,9 @@ export {
 
 export type { TableName } from './schema/index.js';
 
+// Ingestion worker
+export { IngestionWorker, processFile, listPendingFiles, bulkInsert } from './ingestion/index.js';
+export type { FileProcessingResult, ParsedEvent } from './ingestion/index.js';
+
 // Version
 export const VERSION = '0.0.1';

--- a/observability/clickhouse/src/index.ts
+++ b/observability/clickhouse/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @mastra/observability-clickhouse
+ *
+ * ClickHouse storage and ingestion worker for MastraAdmin observability data.
+ * Provides schema management, query capabilities, and an ingestion worker
+ * for processing JSONL observability files into ClickHouse.
+ *
+ * @packageDocumentation
+ */
+
+// Placeholder exports - will be expanded in later phases
+export const VERSION = '0.0.1';

--- a/observability/clickhouse/src/index.ts
+++ b/observability/clickhouse/src/index.ts
@@ -48,5 +48,33 @@ export type {
   AggregationOptions,
 } from './types.js';
 
+// Schema
+export {
+  // Table definitions
+  TRACES_TABLE_SQL,
+  SPANS_TABLE_SQL,
+  LOGS_TABLE_SQL,
+  METRICS_TABLE_SQL,
+  SCORES_TABLE_SQL,
+  ALL_TABLES_SQL,
+  TABLE_NAMES,
+
+  // Materialized view definitions
+  TRACES_HOURLY_STATS_VIEW_SQL,
+  SPANS_HOURLY_STATS_VIEW_SQL,
+  LOGS_HOURLY_STATS_VIEW_SQL,
+  METRICS_HOURLY_STATS_VIEW_SQL,
+  SCORES_HOURLY_STATS_VIEW_SQL,
+  ALL_MATERIALIZED_VIEWS_SQL,
+  VIEW_NAMES,
+
+  // Migration utilities
+  runMigrations,
+  checkSchemaStatus,
+  dropAllTables,
+} from './schema/index.js';
+
+export type { TableName } from './schema/index.js';
+
 // Version
 export const VERSION = '0.0.1';

--- a/observability/clickhouse/src/index.ts
+++ b/observability/clickhouse/src/index.ts
@@ -8,5 +8,45 @@
  * @packageDocumentation
  */
 
-// Placeholder exports - will be expanded in later phases
+// Types
+export type {
+  // Re-exported from @mastra/admin
+  Trace,
+  Span,
+  Log,
+  Metric,
+  Score,
+  ObservabilityEvent,
+  FileStorageProvider,
+  FileInfo,
+  ObservabilityQueryProvider,
+
+  // Re-exported from @mastra/observability-writer
+  ObservabilityEventType,
+
+  // ClickHouse configuration
+  ClickHouseConfig,
+
+  // Ingestion worker types
+  IngestionWorkerConfig,
+  ProcessingResult,
+  ProcessingError,
+  WorkerStatus,
+
+  // Query provider types
+  QueryProviderConfig,
+  TimeRangeFilter,
+  PaginationOptions,
+  PaginationInfo,
+  ObservabilityFilters,
+  TraceQueryOptions,
+  SpanQueryOptions,
+  LogQueryOptions,
+  MetricQueryOptions,
+  ScoreQueryOptions,
+  TimeBucket,
+  AggregationOptions,
+} from './types.js';
+
+// Version
 export const VERSION = '0.0.1';

--- a/observability/clickhouse/src/index.ts
+++ b/observability/clickhouse/src/index.ts
@@ -80,5 +80,8 @@ export type { TableName } from './schema/index.js';
 export { IngestionWorker, processFile, listPendingFiles, bulkInsert } from './ingestion/index.js';
 export type { FileProcessingResult, ParsedEvent } from './ingestion/index.js';
 
+// Query provider
+export { ClickHouseQueryProvider } from './query-provider/index.js';
+
 // Version
 export const VERSION = '0.0.1';

--- a/observability/clickhouse/src/ingestion/bulk-inserter.test.ts
+++ b/observability/clickhouse/src/ingestion/bulk-inserter.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { bulkInsert } from './bulk-inserter.js';
+import { TABLE_NAMES } from '../schema/tables.js';
+import type { ObservabilityEvent } from '../types.js';
+
+// Mock ClickHouse client
+function createMockClickHouseClient() {
+  const insertCalls: Array<{
+    table: string;
+    values: Record<string, unknown>[];
+    format: string;
+  }> = [];
+
+  return {
+    insertCalls,
+    async insert(options: { table: string; values: Record<string, unknown>[]; format: string }) {
+      insertCalls.push(options);
+    },
+  };
+}
+
+describe('bulkInsert', () => {
+  let client: ReturnType<typeof createMockClickHouseClient>;
+
+  beforeEach(() => {
+    client = createMockClickHouseClient();
+  });
+
+  describe('basic functionality', () => {
+    it('should insert a single trace event', async () => {
+      const event: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't1',
+          projectId: 'p1',
+          deploymentId: 'd1',
+          name: 'test-trace',
+          status: 'ok',
+          startTime: new Date('2025-01-23T12:00:00.000Z'),
+          endTime: new Date('2025-01-23T12:00:01.000Z'),
+          durationMs: 1000,
+          metadata: { key: 'value' },
+        },
+      };
+
+      const result = await bulkInsert(client as unknown as import('@clickhouse/client').ClickHouseClient, [
+        { type: 'trace', data: event },
+      ]);
+
+      expect(client.insertCalls).toHaveLength(1);
+      expect(client.insertCalls[0]?.table).toBe(TABLE_NAMES.TRACES);
+      expect(client.insertCalls[0]?.format).toBe('JSONEachRow');
+      expect(result.insertedByType).toEqual({ trace: 1 });
+
+      const insertedRow = client.insertCalls[0]?.values[0];
+      expect(insertedRow?.trace_id).toBe('t1');
+      expect(insertedRow?.project_id).toBe('p1');
+      expect(insertedRow?.deployment_id).toBe('d1');
+      expect(insertedRow?.name).toBe('test-trace');
+      expect(insertedRow?.status).toBe('ok');
+    });
+
+    it('should insert a single span event', async () => {
+      const event: ObservabilityEvent = {
+        type: 'span',
+        data: {
+          spanId: 's1',
+          traceId: 't1',
+          parentSpanId: null,
+          projectId: 'p1',
+          deploymentId: 'd1',
+          name: 'test-span',
+          kind: 'server',
+          status: 'ok',
+          startTime: new Date('2025-01-23T12:00:00.000Z'),
+          endTime: new Date('2025-01-23T12:00:01.000Z'),
+          durationMs: 1000,
+          attributes: { http_method: 'GET' },
+          events: [],
+        },
+      };
+
+      const result = await bulkInsert(client as unknown as import('@clickhouse/client').ClickHouseClient, [
+        { type: 'span', data: event },
+      ]);
+
+      expect(client.insertCalls).toHaveLength(1);
+      expect(client.insertCalls[0]?.table).toBe(TABLE_NAMES.SPANS);
+      expect(result.insertedByType).toEqual({ span: 1 });
+
+      const insertedRow = client.insertCalls[0]?.values[0];
+      expect(insertedRow?.span_id).toBe('s1');
+      expect(insertedRow?.trace_id).toBe('t1');
+      expect(insertedRow?.kind).toBe('server');
+      expect(insertedRow?.attributes).toBe('{"http_method":"GET"}');
+    });
+
+    it('should insert a single log event', async () => {
+      const event: ObservabilityEvent = {
+        type: 'log',
+        data: {
+          id: 'l1',
+          projectId: 'p1',
+          deploymentId: 'd1',
+          traceId: 't1',
+          spanId: 's1',
+          level: 'error',
+          message: 'Something went wrong',
+          timestamp: new Date('2025-01-23T12:00:00.000Z'),
+          attributes: { error_code: 500 },
+        },
+      };
+
+      const result = await bulkInsert(client as unknown as import('@clickhouse/client').ClickHouseClient, [
+        { type: 'log', data: event },
+      ]);
+
+      expect(client.insertCalls).toHaveLength(1);
+      expect(client.insertCalls[0]?.table).toBe(TABLE_NAMES.LOGS);
+      expect(result.insertedByType).toEqual({ log: 1 });
+
+      const insertedRow = client.insertCalls[0]?.values[0];
+      expect(insertedRow?.id).toBe('l1');
+      expect(insertedRow?.level).toBe('error');
+      expect(insertedRow?.message).toBe('Something went wrong');
+    });
+
+    it('should insert a single metric event', async () => {
+      const event: ObservabilityEvent = {
+        type: 'metric',
+        data: {
+          id: 'm1',
+          projectId: 'p1',
+          deploymentId: 'd1',
+          name: 'cpu_usage',
+          type: 'gauge',
+          value: 0.75,
+          unit: 'percent',
+          timestamp: new Date('2025-01-23T12:00:00.000Z'),
+          labels: { host: 'server-1' },
+        },
+      };
+
+      const result = await bulkInsert(client as unknown as import('@clickhouse/client').ClickHouseClient, [
+        { type: 'metric', data: event },
+      ]);
+
+      expect(client.insertCalls).toHaveLength(1);
+      expect(client.insertCalls[0]?.table).toBe(TABLE_NAMES.METRICS);
+      expect(result.insertedByType).toEqual({ metric: 1 });
+
+      const insertedRow = client.insertCalls[0]?.values[0];
+      expect(insertedRow?.id).toBe('m1');
+      expect(insertedRow?.name).toBe('cpu_usage');
+      expect(insertedRow?.type).toBe('gauge');
+      expect(insertedRow?.value).toBe(0.75);
+      expect(insertedRow?.unit).toBe('percent');
+    });
+
+    it('should insert a single score event', async () => {
+      const event: ObservabilityEvent = {
+        type: 'score',
+        data: {
+          id: 'sc1',
+          projectId: 'p1',
+          deploymentId: 'd1',
+          traceId: 't1',
+          name: 'quality_score',
+          value: 0.95,
+          normalizedValue: 95,
+          comment: 'High quality',
+          timestamp: new Date('2025-01-23T12:00:00.000Z'),
+          metadata: { evaluator: 'gpt-4' },
+        },
+      };
+
+      const result = await bulkInsert(client as unknown as import('@clickhouse/client').ClickHouseClient, [
+        { type: 'score', data: event },
+      ]);
+
+      expect(client.insertCalls).toHaveLength(1);
+      expect(client.insertCalls[0]?.table).toBe(TABLE_NAMES.SCORES);
+      expect(result.insertedByType).toEqual({ score: 1 });
+
+      const insertedRow = client.insertCalls[0]?.values[0];
+      expect(insertedRow?.id).toBe('sc1');
+      expect(insertedRow?.name).toBe('quality_score');
+      expect(insertedRow?.value).toBe(0.95);
+      expect(insertedRow?.normalized_value).toBe(95);
+      expect(insertedRow?.comment).toBe('High quality');
+    });
+  });
+
+  describe('grouping by type', () => {
+    it('should group events by type and insert into correct tables', async () => {
+      const events: Array<{ type: import('../types.js').ObservabilityEventType; data: ObservabilityEvent }> = [
+        {
+          type: 'trace',
+          data: {
+            type: 'trace',
+            data: {
+              traceId: 't1',
+              projectId: 'p1',
+              name: 'trace1',
+              status: 'ok',
+              startTime: new Date(),
+              endTime: null,
+              durationMs: null,
+              metadata: {},
+            },
+          },
+        },
+        {
+          type: 'trace',
+          data: {
+            type: 'trace',
+            data: {
+              traceId: 't2',
+              projectId: 'p1',
+              name: 'trace2',
+              status: 'ok',
+              startTime: new Date(),
+              endTime: null,
+              durationMs: null,
+              metadata: {},
+            },
+          },
+        },
+        {
+          type: 'span',
+          data: {
+            type: 'span',
+            data: {
+              spanId: 's1',
+              traceId: 't1',
+              projectId: 'p1',
+              name: 'span1',
+              kind: 'internal',
+              status: 'ok',
+              startTime: new Date(),
+              endTime: null,
+              durationMs: null,
+              attributes: {},
+              events: [],
+            },
+          },
+        },
+        {
+          type: 'log',
+          data: {
+            type: 'log',
+            data: {
+              id: 'l1',
+              projectId: 'p1',
+              level: 'info',
+              message: 'test',
+              timestamp: new Date(),
+              attributes: {},
+            },
+          },
+        },
+      ];
+
+      const result = await bulkInsert(client as unknown as import('@clickhouse/client').ClickHouseClient, events);
+
+      expect(client.insertCalls).toHaveLength(3);
+
+      const traceInsert = client.insertCalls.find(c => c.table === TABLE_NAMES.TRACES);
+      const spanInsert = client.insertCalls.find(c => c.table === TABLE_NAMES.SPANS);
+      const logInsert = client.insertCalls.find(c => c.table === TABLE_NAMES.LOGS);
+
+      expect(traceInsert?.values).toHaveLength(2);
+      expect(spanInsert?.values).toHaveLength(1);
+      expect(logInsert?.values).toHaveLength(1);
+
+      expect(result.insertedByType).toEqual({
+        trace: 2,
+        span: 1,
+        log: 1,
+      });
+    });
+
+    it('should handle empty events array', async () => {
+      const result = await bulkInsert(client as unknown as import('@clickhouse/client').ClickHouseClient, []);
+
+      expect(client.insertCalls).toHaveLength(0);
+      expect(result.insertedByType).toEqual({});
+    });
+  });
+
+  describe('data transformation', () => {
+    it('should serialize JSON fields correctly', async () => {
+      const event: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't1',
+          projectId: 'p1',
+          name: 'test',
+          status: 'ok',
+          startTime: new Date('2025-01-23T12:00:00.000Z'),
+          endTime: null,
+          durationMs: null,
+          metadata: {
+            nested: {
+              value: 123,
+              array: [1, 2, 3],
+            },
+          },
+        },
+      };
+
+      await bulkInsert(client as unknown as import('@clickhouse/client').ClickHouseClient, [
+        { type: 'trace', data: event },
+      ]);
+
+      const insertedRow = client.insertCalls[0]?.values[0];
+      expect(insertedRow?.metadata).toBe('{"nested":{"value":123,"array":[1,2,3]}}');
+    });
+
+    it('should handle null optional fields', async () => {
+      const event: ObservabilityEvent = {
+        type: 'span',
+        data: {
+          spanId: 's1',
+          traceId: 't1',
+          parentSpanId: null,
+          projectId: 'p1',
+          name: 'test',
+          kind: 'internal',
+          status: 'ok',
+          startTime: new Date(),
+          endTime: null,
+          durationMs: null,
+          attributes: {},
+          events: [],
+        },
+      };
+
+      await bulkInsert(client as unknown as import('@clickhouse/client').ClickHouseClient, [
+        { type: 'span', data: event },
+      ]);
+
+      const insertedRow = client.insertCalls[0]?.values[0];
+      expect(insertedRow?.parent_span_id).toBeNull();
+      expect(insertedRow?.end_time).toBeNull();
+      expect(insertedRow?.duration_ms).toBeNull();
+    });
+
+    it('should use default values for missing optional fields', async () => {
+      const event: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't1',
+          projectId: 'p1',
+          name: 'test',
+          status: 'ok',
+          startTime: new Date(),
+          endTime: null,
+          durationMs: null,
+          metadata: {},
+        },
+      };
+
+      await bulkInsert(client as unknown as import('@clickhouse/client').ClickHouseClient, [
+        { type: 'trace', data: event },
+      ]);
+
+      const insertedRow = client.insertCalls[0]?.values[0];
+      expect(insertedRow?.deployment_id).toBe('');
+      expect(insertedRow?.metadata).toBe('{}');
+    });
+
+    it('should add recorded_at timestamp', async () => {
+      const beforeInsert = new Date();
+
+      const event: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't1',
+          projectId: 'p1',
+          name: 'test',
+          status: 'ok',
+          startTime: new Date(),
+          endTime: null,
+          durationMs: null,
+          metadata: {},
+        },
+      };
+
+      await bulkInsert(client as unknown as import('@clickhouse/client').ClickHouseClient, [
+        { type: 'trace', data: event },
+      ]);
+
+      const insertedRow = client.insertCalls[0]?.values[0];
+      expect(insertedRow?.recorded_at).toBeDefined();
+
+      const recordedAt = new Date(insertedRow?.recorded_at as string);
+      expect(recordedAt.getTime()).toBeGreaterThanOrEqual(beforeInsert.getTime());
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw error for unknown event type', async () => {
+      const event = {
+        type: 'unknown_type' as import('../types.js').ObservabilityEventType,
+        data: { type: 'unknown_type', data: {} } as ObservabilityEvent,
+      };
+
+      await expect(
+        bulkInsert(client as unknown as import('@clickhouse/client').ClickHouseClient, [event]),
+      ).rejects.toThrow('Unknown event type: unknown_type');
+    });
+  });
+});

--- a/observability/clickhouse/src/ingestion/bulk-inserter.ts
+++ b/observability/clickhouse/src/ingestion/bulk-inserter.ts
@@ -1,0 +1,185 @@
+/**
+ * Bulk inserter for ClickHouse.
+ */
+
+import type { ClickHouseClient } from '@clickhouse/client';
+import { TABLE_NAMES } from '../schema/tables.js';
+import type { ObservabilityEvent, ObservabilityEventType, Trace, Span, Log, Metric, Score } from '../types.js';
+
+/**
+ * Transform a trace event to ClickHouse row format.
+ */
+function transformTrace(trace: Trace, recordedAt: string): Record<string, unknown> {
+  return {
+    trace_id: trace.traceId,
+    project_id: trace.projectId,
+    deployment_id: trace.deploymentId || '',
+    name: trace.name,
+    status: trace.status || 'unset',
+    start_time: trace.startTime,
+    end_time: trace.endTime || null,
+    duration_ms: trace.durationMs || null,
+    input: '', // Not in base Trace type
+    output: '', // Not in base Trace type
+    metadata: trace.metadata ? JSON.stringify(trace.metadata) : '{}',
+    recorded_at: recordedAt,
+  };
+}
+
+/**
+ * Transform a span event to ClickHouse row format.
+ */
+function transformSpan(span: Span, recordedAt: string): Record<string, unknown> {
+  return {
+    span_id: span.spanId,
+    trace_id: span.traceId,
+    parent_span_id: span.parentSpanId || null,
+    project_id: span.projectId,
+    deployment_id: span.deploymentId || '',
+    name: span.name,
+    kind: span.kind || 'internal',
+    status: span.status || 'unset',
+    start_time: span.startTime,
+    end_time: span.endTime || null,
+    duration_ms: span.durationMs || null,
+    attributes: span.attributes ? JSON.stringify(span.attributes) : '{}',
+    events: span.events ? JSON.stringify(span.events) : '[]',
+    recorded_at: recordedAt,
+  };
+}
+
+/**
+ * Transform a log event to ClickHouse row format.
+ */
+function transformLog(log: Log, recordedAt: string): Record<string, unknown> {
+  return {
+    id: log.id,
+    project_id: log.projectId,
+    deployment_id: log.deploymentId || '',
+    trace_id: log.traceId || null,
+    span_id: log.spanId || null,
+    level: log.level,
+    message: log.message,
+    timestamp: log.timestamp,
+    attributes: log.attributes ? JSON.stringify(log.attributes) : '{}',
+    recorded_at: recordedAt,
+  };
+}
+
+/**
+ * Transform a metric event to ClickHouse row format.
+ */
+function transformMetric(metric: Metric, recordedAt: string): Record<string, unknown> {
+  return {
+    id: metric.id,
+    project_id: metric.projectId,
+    deployment_id: metric.deploymentId || '',
+    name: metric.name,
+    type: metric.type || 'gauge',
+    value: metric.value,
+    unit: metric.unit || null,
+    timestamp: metric.timestamp,
+    labels: metric.labels ? JSON.stringify(metric.labels) : '{}',
+    recorded_at: recordedAt,
+  };
+}
+
+/**
+ * Transform a score event to ClickHouse row format.
+ */
+function transformScore(score: Score, recordedAt: string): Record<string, unknown> {
+  return {
+    id: score.id,
+    project_id: score.projectId,
+    deployment_id: score.deploymentId || '',
+    trace_id: score.traceId || null,
+    name: score.name,
+    value: score.value,
+    normalized_value: score.normalizedValue || null,
+    comment: score.comment || null,
+    timestamp: score.timestamp,
+    metadata: score.metadata ? JSON.stringify(score.metadata) : '{}',
+    recorded_at: recordedAt,
+  };
+}
+
+/**
+ * Transform an event to ClickHouse row format.
+ */
+function transformEvent(event: ObservabilityEvent): Record<string, unknown> {
+  const recordedAt = new Date().toISOString();
+
+  switch (event.type) {
+    case 'trace':
+      return transformTrace(event.data, recordedAt);
+    case 'span':
+      return transformSpan(event.data, recordedAt);
+    case 'log':
+      return transformLog(event.data, recordedAt);
+    case 'metric':
+      return transformMetric(event.data, recordedAt);
+    case 'score':
+      return transformScore(event.data, recordedAt);
+    default:
+      throw new Error(`Unknown event type: ${(event as { type: string }).type}`);
+  }
+}
+
+/**
+ * Get the table name for an event type.
+ */
+function getTableForType(type: ObservabilityEventType): string {
+  switch (type) {
+    case 'trace':
+      return TABLE_NAMES.TRACES;
+    case 'span':
+      return TABLE_NAMES.SPANS;
+    case 'log':
+      return TABLE_NAMES.LOGS;
+    case 'metric':
+      return TABLE_NAMES.METRICS;
+    case 'score':
+      return TABLE_NAMES.SCORES;
+    default:
+      throw new Error(`Unknown event type: ${type}`);
+  }
+}
+
+/**
+ * Bulk insert events into ClickHouse.
+ * Groups events by type and inserts into appropriate tables.
+ */
+export async function bulkInsert(
+  client: ClickHouseClient,
+  events: Array<{ type: ObservabilityEventType; data: ObservabilityEvent }>,
+): Promise<{ insertedByType: Record<string, number> }> {
+  // Group events by type
+  const eventsByType = new Map<ObservabilityEventType, ObservabilityEvent[]>();
+
+  for (const event of events) {
+    const existing = eventsByType.get(event.type) || [];
+    existing.push(event.data);
+    eventsByType.set(event.type, existing);
+  }
+
+  const insertedByType: Record<string, number> = {};
+
+  // Insert each type into its table
+  for (const [type, typeEvents] of eventsByType) {
+    const tableName = getTableForType(type);
+    const rows = typeEvents.map(transformEvent);
+
+    await client.insert({
+      table: tableName,
+      values: rows,
+      format: 'JSONEachRow',
+      clickhouse_settings: {
+        date_time_input_format: 'best_effort',
+      },
+    });
+
+    insertedByType[type] = typeEvents.length;
+  }
+
+  return { insertedByType };
+}

--- a/observability/clickhouse/src/ingestion/file-processor.test.ts
+++ b/observability/clickhouse/src/ingestion/file-processor.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { processFile, listPendingFiles, type FileProcessingResult } from './file-processor.js';
+import { describe, it, expect, beforeEach } from 'vitest';
+
 import type { FileStorageProvider, FileInfo, ObservabilityEvent } from '../types.js';
+
+import { processFile, listPendingFiles } from './file-processor.js';
 
 // Mock file storage
 function createMockFileStorage(): FileStorageProvider & {

--- a/observability/clickhouse/src/ingestion/file-processor.test.ts
+++ b/observability/clickhouse/src/ingestion/file-processor.test.ts
@@ -1,0 +1,513 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { processFile, listPendingFiles, type FileProcessingResult } from './file-processor.js';
+import type { FileStorageProvider, FileInfo, ObservabilityEvent } from '../types.js';
+
+// Mock file storage
+function createMockFileStorage(): FileStorageProvider & {
+  files: Map<string, Buffer>;
+  setFile: (path: string, content: string) => void;
+} {
+  const files = new Map<string, Buffer>();
+
+  return {
+    type: 'mock' as const,
+    files,
+    setFile: (path: string, content: string) => {
+      files.set(path, Buffer.from(content, 'utf-8'));
+    },
+
+    async write(path: string, content: Buffer | string): Promise<void> {
+      const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf-8');
+      files.set(path, buffer);
+    },
+
+    async read(path: string): Promise<Buffer> {
+      const content = files.get(path);
+      if (!content) {
+        throw new Error(`File not found: ${path}`);
+      }
+      return content;
+    },
+
+    async list(prefix: string): Promise<FileInfo[]> {
+      const result: FileInfo[] = [];
+      for (const [path, content] of files) {
+        if (path.startsWith(prefix) && !path.includes('/processed/')) {
+          result.push({
+            path,
+            size: content.length,
+            lastModified: new Date(),
+          });
+        }
+      }
+      return result;
+    },
+
+    async delete(path: string): Promise<void> {
+      files.delete(path);
+    },
+
+    async move(from: string, to: string): Promise<void> {
+      const content = files.get(from);
+      if (content) {
+        files.set(to, content);
+        files.delete(from);
+      }
+    },
+
+    async exists(path: string): Promise<boolean> {
+      return files.has(path);
+    },
+  };
+}
+
+describe('processFile', () => {
+  let fileStorage: ReturnType<typeof createMockFileStorage>;
+
+  beforeEach(() => {
+    fileStorage = createMockFileStorage();
+  });
+
+  describe('valid JSONL files', () => {
+    it('should parse a single trace event', async () => {
+      const traceEvent: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 'trace_1',
+          projectId: 'proj_1',
+          name: 'test-trace',
+          status: 'ok',
+          startTime: '2025-01-23T12:00:00.000Z',
+          endTime: '2025-01-23T12:00:01.000Z',
+          durationMs: 1000,
+          metadata: {},
+        },
+      };
+      const filePath = 'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl';
+      fileStorage.setFile(filePath, JSON.stringify(traceEvent) + '\n');
+
+      const result = await processFile(fileStorage, filePath);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0]?.type).toBe('trace');
+      // Data is stored as parsed JSON, so Date objects become strings
+      expect(result.events[0]?.data.type).toBe('trace');
+      expect((result.events[0]?.data as ObservabilityEvent).data.traceId).toBe('trace_1');
+      expect(result.events[0]?.line).toBe(1);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should parse multiple events from a single file', async () => {
+      const events: ObservabilityEvent[] = [
+        {
+          type: 'trace',
+          data: {
+            traceId: 't1',
+            projectId: 'p1',
+            name: 'test1',
+            status: 'ok',
+            startTime: new Date(),
+            endTime: null,
+            durationMs: null,
+            metadata: {},
+          },
+        },
+        {
+          type: 'span',
+          data: {
+            spanId: 's1',
+            traceId: 't1',
+            projectId: 'p1',
+            name: 'span1',
+            kind: 'internal',
+            status: 'ok',
+            startTime: new Date(),
+            endTime: null,
+            durationMs: null,
+            attributes: {},
+            events: [],
+          },
+        },
+        {
+          type: 'log',
+          data: {
+            id: 'l1',
+            projectId: 'p1',
+            level: 'info',
+            message: 'test log',
+            timestamp: new Date(),
+            attributes: {},
+          },
+        },
+      ];
+      const content = events.map(e => JSON.stringify(e)).join('\n') + '\n';
+      const filePath = 'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl';
+      fileStorage.setFile(filePath, content);
+
+      const result = await processFile(fileStorage, filePath);
+
+      expect(result.events).toHaveLength(3);
+      expect(result.events[0]?.type).toBe('trace');
+      expect(result.events[1]?.type).toBe('span');
+      expect(result.events[2]?.type).toBe('log');
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should parse all event types correctly', async () => {
+      const events: ObservabilityEvent[] = [
+        {
+          type: 'trace',
+          data: {
+            traceId: 't1',
+            projectId: 'p1',
+            name: 'trace',
+            status: 'ok',
+            startTime: new Date(),
+            endTime: null,
+            durationMs: null,
+            metadata: {},
+          },
+        },
+        {
+          type: 'span',
+          data: {
+            spanId: 's1',
+            traceId: 't1',
+            projectId: 'p1',
+            name: 'span',
+            kind: 'server',
+            status: 'ok',
+            startTime: new Date(),
+            endTime: null,
+            durationMs: null,
+            attributes: {},
+            events: [],
+          },
+        },
+        {
+          type: 'log',
+          data: {
+            id: 'l1',
+            projectId: 'p1',
+            level: 'error',
+            message: 'error log',
+            timestamp: new Date(),
+            attributes: {},
+          },
+        },
+        {
+          type: 'metric',
+          data: {
+            id: 'm1',
+            projectId: 'p1',
+            name: 'cpu_usage',
+            type: 'gauge',
+            value: 0.75,
+            timestamp: new Date(),
+            labels: {},
+          },
+        },
+        {
+          type: 'score',
+          data: {
+            id: 'sc1',
+            projectId: 'p1',
+            name: 'quality_score',
+            value: 0.95,
+            timestamp: new Date(),
+            metadata: {},
+          },
+        },
+      ];
+      const content = events.map(e => JSON.stringify(e)).join('\n') + '\n';
+      const filePath = 'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl';
+      fileStorage.setFile(filePath, content);
+
+      const result = await processFile(fileStorage, filePath);
+
+      expect(result.events).toHaveLength(5);
+      expect(result.events.map(e => e.type)).toEqual(['trace', 'span', 'log', 'metric', 'score']);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should skip empty lines', async () => {
+      const event: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't1',
+          projectId: 'p1',
+          name: 'test',
+          status: 'ok',
+          startTime: new Date(),
+          endTime: null,
+          durationMs: null,
+          metadata: {},
+        },
+      };
+      const content = '\n' + JSON.stringify(event) + '\n\n\n';
+      const filePath = 'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl';
+      fileStorage.setFile(filePath, content);
+
+      const result = await processFile(fileStorage, filePath);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should skip whitespace-only lines', async () => {
+      const event: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't1',
+          projectId: 'p1',
+          name: 'test',
+          status: 'ok',
+          startTime: new Date(),
+          endTime: null,
+          durationMs: null,
+          metadata: {},
+        },
+      };
+      const content = '   \n' + JSON.stringify(event) + '\n  \t  \n';
+      const filePath = 'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl';
+      fileStorage.setFile(filePath, content);
+
+      const result = await processFile(fileStorage, filePath);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  describe('metadata extraction', () => {
+    it('should extract metadata from file path', async () => {
+      const event: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't1',
+          projectId: 'p1',
+          name: 'test',
+          status: 'ok',
+          startTime: new Date(),
+          endTime: null,
+          durationMs: null,
+          metadata: {},
+        },
+      };
+      const filePath = 'observability/trace/proj_123/20250123T120000Z_abc123def456.jsonl';
+      fileStorage.setFile(filePath, JSON.stringify(event) + '\n');
+
+      const result = await processFile(fileStorage, filePath);
+
+      expect(result.metadata).not.toBeNull();
+      expect(result.metadata?.type).toBe('trace');
+      expect(result.metadata?.projectId).toBe('proj_123');
+      expect(result.metadata?.timestamp).toBe('20250123T120000Z');
+    });
+
+    it('should return null metadata for invalid file paths', async () => {
+      const event: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't1',
+          projectId: 'p1',
+          name: 'test',
+          status: 'ok',
+          startTime: new Date(),
+          endTime: null,
+          durationMs: null,
+          metadata: {},
+        },
+      };
+      const filePath = 'invalid/path/file.jsonl';
+      fileStorage.setFile(filePath, JSON.stringify(event) + '\n');
+
+      const result = await processFile(fileStorage, filePath);
+
+      expect(result.metadata).toBeNull();
+    });
+  });
+
+  describe('error handling', () => {
+    it('should record error for invalid JSON', async () => {
+      const filePath = 'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl';
+      fileStorage.setFile(filePath, 'not valid json\n');
+
+      const result = await processFile(fileStorage, filePath);
+
+      expect(result.events).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.line).toBe(1);
+      expect(result.errors[0]?.error).toContain('Unexpected token');
+    });
+
+    it('should record error for missing event type', async () => {
+      const filePath = 'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl';
+      fileStorage.setFile(filePath, '{"data": {"traceId": "t1"}}\n');
+
+      const result = await processFile(fileStorage, filePath);
+
+      expect(result.events).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.error).toContain('Invalid or missing event type');
+    });
+
+    it('should record error for invalid event type', async () => {
+      const filePath = 'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl';
+      fileStorage.setFile(filePath, '{"type": "invalid_type", "data": {}}\n');
+
+      const result = await processFile(fileStorage, filePath);
+
+      expect(result.events).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.error).toContain('Invalid or missing event type');
+    });
+
+    it('should record error for missing data field', async () => {
+      const filePath = 'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl';
+      fileStorage.setFile(filePath, '{"type": "trace"}\n');
+
+      const result = await processFile(fileStorage, filePath);
+
+      expect(result.events).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.error).toContain('Missing event data field');
+    });
+
+    it('should continue processing after encountering errors', async () => {
+      const validEvent: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't1',
+          projectId: 'p1',
+          name: 'test',
+          status: 'ok',
+          startTime: new Date(),
+          endTime: null,
+          durationMs: null,
+          metadata: {},
+        },
+      };
+      const content = 'invalid json\n' + JSON.stringify(validEvent) + '\n{"type": "bad"}\n';
+      const filePath = 'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl';
+      fileStorage.setFile(filePath, content);
+
+      const result = await processFile(fileStorage, filePath);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.errors).toHaveLength(2);
+      expect(result.errors[0]?.line).toBe(1);
+      expect(result.errors[1]?.line).toBe(3);
+    });
+
+    it('should track correct line numbers for errors', async () => {
+      const content = '\n\n{"type": "invalid"}\n\n{"also": "invalid"}\n';
+      const filePath = 'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl';
+      fileStorage.setFile(filePath, content);
+
+      const result = await processFile(fileStorage, filePath);
+
+      expect(result.errors).toHaveLength(2);
+      expect(result.errors[0]?.line).toBe(3);
+      expect(result.errors[1]?.line).toBe(5);
+    });
+  });
+});
+
+describe('listPendingFiles', () => {
+  let fileStorage: ReturnType<typeof createMockFileStorage>;
+
+  beforeEach(() => {
+    fileStorage = createMockFileStorage();
+  });
+
+  it('should return empty array when no files exist', async () => {
+    const files = await listPendingFiles(fileStorage, 'observability');
+
+    expect(files).toHaveLength(0);
+  });
+
+  it('should list pending JSONL files', async () => {
+    fileStorage.setFile('observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl', '{}');
+    fileStorage.setFile('observability/trace/proj_1/20250123T120100Z_xyz789ghi012.jsonl', '{}');
+
+    const files = await listPendingFiles(fileStorage, 'observability');
+
+    expect(files).toHaveLength(2);
+    expect(files.every(f => f.endsWith('.jsonl'))).toBe(true);
+  });
+
+  it('should exclude processed files', async () => {
+    fileStorage.setFile('observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl', '{}');
+    fileStorage.setFile('observability/trace/proj_1/processed/20250123T120100Z_xyz789.jsonl', '{}');
+
+    const files = await listPendingFiles(fileStorage, 'observability');
+
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain('20250123T120000Z');
+    expect(files[0]).not.toContain('processed');
+  });
+
+  it('should respect limit option', async () => {
+    for (let i = 0; i < 10; i++) {
+      fileStorage.setFile(`observability/trace/proj_1/20250123T12000${i}Z_abc${i}xyz.jsonl`, '{}');
+    }
+
+    const files = await listPendingFiles(fileStorage, 'observability', { limit: 5 });
+
+    expect(files).toHaveLength(5);
+  });
+
+  it('should filter by event type', async () => {
+    fileStorage.setFile('observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl', '{}');
+    fileStorage.setFile('observability/span/proj_1/20250123T120100Z_xyz789ghi012.jsonl', '{}');
+    fileStorage.setFile('observability/log/proj_1/20250123T120200Z_mno345pqr678.jsonl', '{}');
+
+    const files = await listPendingFiles(fileStorage, 'observability', { eventType: 'trace' });
+
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain('/trace/');
+  });
+
+  it('should filter by project ID', async () => {
+    fileStorage.setFile('observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl', '{}');
+    fileStorage.setFile('observability/trace/proj_2/20250123T120100Z_xyz789ghi012.jsonl', '{}');
+    fileStorage.setFile('observability/span/proj_1/20250123T120200Z_mno345pqr678.jsonl', '{}');
+
+    const files = await listPendingFiles(fileStorage, 'observability', { projectId: 'proj_1' });
+
+    expect(files).toHaveLength(2);
+    expect(files.every(f => f.includes('/proj_1/'))).toBe(true);
+  });
+
+  it('should filter by both event type and project ID', async () => {
+    fileStorage.setFile('observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl', '{}');
+    fileStorage.setFile('observability/trace/proj_2/20250123T120100Z_xyz789ghi012.jsonl', '{}');
+    fileStorage.setFile('observability/span/proj_1/20250123T120200Z_mno345pqr678.jsonl', '{}');
+
+    const files = await listPendingFiles(fileStorage, 'observability', {
+      eventType: 'trace',
+      projectId: 'proj_1',
+    });
+
+    expect(files).toHaveLength(1);
+    expect(files[0]).toContain('/trace/');
+    expect(files[0]).toContain('/proj_1/');
+  });
+
+  it('should handle basePath with trailing slash', async () => {
+    fileStorage.setFile('observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl', '{}');
+
+    const files = await listPendingFiles(fileStorage, 'observability/');
+
+    expect(files).toHaveLength(1);
+  });
+
+  it('should handle basePath without trailing slash', async () => {
+    fileStorage.setFile('observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl', '{}');
+
+    const files = await listPendingFiles(fileStorage, 'observability');
+
+    expect(files).toHaveLength(1);
+  });
+});

--- a/observability/clickhouse/src/ingestion/file-processor.ts
+++ b/observability/clickhouse/src/ingestion/file-processor.ts
@@ -1,0 +1,144 @@
+/**
+ * JSONL file processor for observability data.
+ */
+
+import { parseFilePath, isPendingFile } from '@mastra/observability-writer';
+import type { FileStorageProvider, ObservabilityEvent, ObservabilityEventType } from '../types.js';
+
+/**
+ * Parsed event from a JSONL file
+ */
+export interface ParsedEvent {
+  type: ObservabilityEventType;
+  data: ObservabilityEvent;
+  line: number;
+}
+
+/**
+ * Result of processing a single file
+ */
+export interface FileProcessingResult {
+  filePath: string;
+  events: ParsedEvent[];
+  errors: Array<{ line: number; error: string }>;
+  metadata: {
+    type: string;
+    projectId: string;
+    timestamp: string;
+  } | null;
+}
+
+const VALID_EVENT_TYPES: readonly ObservabilityEventType[] = ['trace', 'span', 'log', 'metric', 'score'];
+
+/**
+ * Process a JSONL file and extract events.
+ */
+export async function processFile(fileStorage: FileStorageProvider, filePath: string): Promise<FileProcessingResult> {
+  const result: FileProcessingResult = {
+    filePath,
+    events: [],
+    errors: [],
+    metadata: null,
+  };
+
+  // Parse file path to extract metadata
+  const pathInfo = parseFilePath(filePath);
+  if (pathInfo) {
+    result.metadata = {
+      type: pathInfo.type,
+      projectId: pathInfo.projectId,
+      timestamp: pathInfo.timestamp,
+    };
+  }
+
+  // Read file content
+  const content = await fileStorage.read(filePath);
+  const lines = content.toString('utf-8').split('\n');
+
+  // Parse each line
+  for (let i = 0; i < lines.length; i++) {
+    const rawLine = lines[i];
+    if (!rawLine) continue; // Skip undefined entries
+    const line = rawLine.trim();
+    if (!line) continue; // Skip empty lines
+
+    try {
+      const event = JSON.parse(line) as ObservabilityEvent;
+
+      // Validate event has required type field
+      if (!event.type || !VALID_EVENT_TYPES.includes(event.type)) {
+        result.errors.push({
+          line: i + 1,
+          error: `Invalid or missing event type: ${(event as { type?: unknown }).type}`,
+        });
+        continue;
+      }
+
+      // Validate event has data field
+      if (!event.data) {
+        result.errors.push({
+          line: i + 1,
+          error: 'Missing event data field',
+        });
+        continue;
+      }
+
+      result.events.push({
+        type: event.type,
+        data: event,
+        line: i + 1,
+      });
+    } catch (error) {
+      result.errors.push({
+        line: i + 1,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * List pending JSONL files from file storage.
+ * Returns files sorted by lastModified (oldest first) for FIFO processing.
+ */
+export async function listPendingFiles(
+  fileStorage: FileStorageProvider,
+  basePath: string,
+  options?: {
+    projectId?: string;
+    eventType?: ObservabilityEventType;
+    limit?: number;
+  },
+): Promise<string[]> {
+  // Build the prefix for listing
+  let prefix = basePath.endsWith('/') ? basePath : `${basePath}/`;
+
+  if (options?.eventType) {
+    prefix = `${prefix}${options.eventType}/`;
+    if (options?.projectId) {
+      prefix = `${prefix}${options.projectId}/`;
+    }
+  } else if (options?.projectId) {
+    // If only projectId is specified, we need to list all event type directories
+    const eventTypes: readonly ObservabilityEventType[] = ['trace', 'span', 'log', 'metric', 'score'];
+    const allFiles: string[] = [];
+
+    for (const type of eventTypes) {
+      const typePrefix = `${prefix}${type}/${options.projectId}/`;
+      const files = await fileStorage.list(typePrefix);
+      const pendingFiles = files.filter(f => isPendingFile(f.path)).map(f => f.path);
+      allFiles.push(...pendingFiles);
+    }
+
+    // Sort by lastModified would require re-fetching file info
+    // For simplicity, rely on the individual list calls being sorted
+    return options?.limit ? allFiles.slice(0, options.limit) : allFiles;
+  }
+
+  const files = await fileStorage.list(prefix);
+  const pendingFiles = files.filter(f => isPendingFile(f.path)).map(f => f.path);
+
+  return options?.limit ? pendingFiles.slice(0, options.limit) : pendingFiles;
+}

--- a/observability/clickhouse/src/ingestion/index.ts
+++ b/observability/clickhouse/src/ingestion/index.ts
@@ -1,0 +1,4 @@
+export { IngestionWorker } from './worker.js';
+export { processFile, listPendingFiles } from './file-processor.js';
+export type { FileProcessingResult, ParsedEvent } from './file-processor.js';
+export { bulkInsert } from './bulk-inserter.js';

--- a/observability/clickhouse/src/ingestion/worker.test.ts
+++ b/observability/clickhouse/src/ingestion/worker.test.ts
@@ -1,0 +1,595 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { IngestionWorker } from './worker.js';
+import type { FileStorageProvider, FileInfo, ObservabilityEvent } from '../types.js';
+
+// Mock file storage
+function createMockFileStorage(): FileStorageProvider & {
+  files: Map<string, Buffer>;
+  setFile: (path: string, content: string) => void;
+} {
+  const files = new Map<string, Buffer>();
+
+  return {
+    type: 'mock' as const,
+    files,
+    setFile: (path: string, content: string) => {
+      files.set(path, Buffer.from(content, 'utf-8'));
+    },
+
+    async write(path: string, content: Buffer | string): Promise<void> {
+      const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf-8');
+      files.set(path, buffer);
+    },
+
+    async read(path: string): Promise<Buffer> {
+      const content = files.get(path);
+      if (!content) {
+        throw new Error(`File not found: ${path}`);
+      }
+      return content;
+    },
+
+    async list(prefix: string): Promise<FileInfo[]> {
+      const result: FileInfo[] = [];
+      for (const [path, content] of files) {
+        if (path.startsWith(prefix) && !path.includes('/processed/')) {
+          result.push({
+            path,
+            size: content.length,
+            lastModified: new Date(),
+          });
+        }
+      }
+      return result;
+    },
+
+    async delete(path: string): Promise<void> {
+      files.delete(path);
+    },
+
+    async move(from: string, to: string): Promise<void> {
+      const content = files.get(from);
+      if (content) {
+        files.set(to, content);
+        files.delete(from);
+      }
+    },
+
+    async exists(path: string): Promise<boolean> {
+      return files.has(path);
+    },
+  };
+}
+
+// Mock ClickHouse client
+function createMockClickHouseClient() {
+  const insertedRows: Record<string, unknown>[] = [];
+  const commands: string[] = [];
+
+  return {
+    insertedRows,
+    commands,
+    async insert(options: { table: string; values: Record<string, unknown>[]; format: string }) {
+      insertedRows.push(...options.values);
+    },
+    async query(options: { query: string }) {
+      // Return empty result for schema checks
+      return {
+        async json() {
+          return [];
+        },
+      };
+    },
+    async command(options: { query: string }) {
+      commands.push(options.query);
+    },
+    async close() {},
+  };
+}
+
+describe('IngestionWorker', () => {
+  let fileStorage: ReturnType<typeof createMockFileStorage>;
+  let clickhouseClient: ReturnType<typeof createMockClickHouseClient>;
+  let worker: IngestionWorker;
+
+  beforeEach(() => {
+    fileStorage = createMockFileStorage();
+    clickhouseClient = createMockClickHouseClient();
+  });
+
+  afterEach(async () => {
+    if (worker) {
+      await worker.stop();
+    }
+  });
+
+  describe('constructor', () => {
+    it('should create worker with valid config using client', () => {
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        debug: false,
+      });
+
+      expect(worker).toBeInstanceOf(IngestionWorker);
+    });
+
+    it('should apply default config values', () => {
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      const status = worker.getStatus();
+      expect(status.isRunning).toBe(false);
+      expect(status.isProcessing).toBe(false);
+    });
+  });
+
+  describe('getStatus', () => {
+    it('should return initial status', () => {
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        debug: false,
+      });
+
+      const status = worker.getStatus();
+
+      expect(status.isRunning).toBe(false);
+      expect(status.isProcessing).toBe(false);
+      expect(status.totalFilesProcessed).toBe(0);
+      expect(status.totalEventsIngested).toBe(0);
+      expect(status.startedAt).toBeNull();
+      expect(status.lastProcessedAt).toBeNull();
+      expect(status.currentErrors).toHaveLength(0);
+      expect(status.totalEventsByType).toEqual({});
+    });
+  });
+
+  describe('processOnce', () => {
+    it('should return empty result when no files', async () => {
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        debug: false,
+      });
+
+      const result = await worker.processOnce();
+
+      expect(result.filesProcessed).toBe(0);
+      expect(result.eventsIngested).toBe(0);
+      expect(result.errors).toHaveLength(0);
+      expect(result.eventsByType).toEqual({});
+    });
+
+    it('should process JSONL files and insert events', async () => {
+      // Add a test file with a trace event
+      const traceEvent: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 'trace_1',
+          projectId: 'proj_1',
+          deploymentId: 'dep_1',
+          name: 'test-trace',
+          status: 'ok',
+          startTime: new Date('2025-01-23T12:00:00.000Z'),
+          endTime: new Date('2025-01-23T12:00:01.000Z'),
+          durationMs: 1000,
+          metadata: {},
+        },
+      };
+      fileStorage.setFile(
+        'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl',
+        JSON.stringify(traceEvent) + '\n',
+      );
+
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        debug: false,
+      });
+
+      const result = await worker.processOnce();
+
+      expect(result.filesProcessed).toBe(1);
+      expect(result.eventsIngested).toBe(1);
+      expect(result.eventsByType.trace).toBe(1);
+      expect(clickhouseClient.insertedRows).toHaveLength(1);
+    });
+
+    it('should move processed files to processed directory', async () => {
+      const filePath = 'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl';
+      const traceEvent: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't1',
+          projectId: 'p1',
+          name: 'test',
+          status: 'ok',
+          startTime: new Date(),
+          endTime: null,
+          durationMs: null,
+          metadata: {},
+        },
+      };
+      fileStorage.setFile(filePath, JSON.stringify(traceEvent) + '\n');
+
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        deleteAfterProcess: false,
+        debug: false,
+      });
+
+      await worker.processOnce();
+
+      // Original file should be gone
+      expect(await fileStorage.exists(filePath)).toBe(false);
+      // Processed file should exist
+      expect(
+        await fileStorage.exists('observability/trace/proj_1/processed/20250123T120000Z_abc123def456.jsonl'),
+      ).toBe(true);
+    });
+
+    it('should delete files after processing when deleteAfterProcess is true', async () => {
+      const filePath = 'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl';
+      const traceEvent: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't1',
+          projectId: 'p1',
+          name: 'test',
+          status: 'ok',
+          startTime: new Date(),
+          endTime: null,
+          durationMs: null,
+          metadata: {},
+        },
+      };
+      fileStorage.setFile(filePath, JSON.stringify(traceEvent) + '\n');
+
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        deleteAfterProcess: true,
+        debug: false,
+      });
+
+      await worker.processOnce();
+
+      // Original file should be deleted
+      expect(await fileStorage.exists(filePath)).toBe(false);
+      // Processed file should NOT exist
+      expect(
+        await fileStorage.exists('observability/trace/proj_1/processed/20250123T120000Z_abc123def456.jsonl'),
+      ).toBe(false);
+    });
+
+    it('should process multiple event types in a single file', async () => {
+      const events: ObservabilityEvent[] = [
+        {
+          type: 'trace',
+          data: {
+            traceId: 't1',
+            projectId: 'p1',
+            name: 'test',
+            status: 'ok',
+            startTime: new Date(),
+            endTime: null,
+            durationMs: null,
+            metadata: {},
+          },
+        },
+        {
+          type: 'span',
+          data: {
+            spanId: 's1',
+            traceId: 't1',
+            projectId: 'p1',
+            name: 'span-test',
+            kind: 'internal',
+            status: 'ok',
+            startTime: new Date(),
+            endTime: null,
+            durationMs: null,
+            attributes: {},
+            events: [],
+          },
+        },
+      ];
+
+      fileStorage.setFile(
+        'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl',
+        events.map(e => JSON.stringify(e)).join('\n') + '\n',
+      );
+
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        debug: false,
+      });
+
+      const result = await worker.processOnce();
+
+      expect(result.filesProcessed).toBe(1);
+      expect(result.eventsIngested).toBe(2);
+      expect(result.eventsByType.trace).toBe(1);
+      expect(result.eventsByType.span).toBe(1);
+    });
+
+    it('should update statistics after processing', async () => {
+      const traceEvent: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't1',
+          projectId: 'p1',
+          name: 'test',
+          status: 'ok',
+          startTime: new Date(),
+          endTime: null,
+          durationMs: null,
+          metadata: {},
+        },
+      };
+      fileStorage.setFile(
+        'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl',
+        JSON.stringify(traceEvent) + '\n',
+      );
+
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        debug: false,
+      });
+
+      await worker.processOnce();
+
+      const status = worker.getStatus();
+      expect(status.totalFilesProcessed).toBe(1);
+      expect(status.totalEventsIngested).toBe(1);
+      expect(status.totalEventsByType.trace).toBe(1);
+      expect(status.lastProcessedAt).not.toBeNull();
+    });
+
+    it('should accumulate statistics across multiple processOnce calls', async () => {
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        debug: false,
+      });
+
+      // First batch
+      const traceEvent1: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't1',
+          projectId: 'p1',
+          name: 'test1',
+          status: 'ok',
+          startTime: new Date(),
+          endTime: null,
+          durationMs: null,
+          metadata: {},
+        },
+      };
+      fileStorage.setFile(
+        'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl',
+        JSON.stringify(traceEvent1) + '\n',
+      );
+      await worker.processOnce();
+
+      // Second batch
+      const traceEvent2: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't2',
+          projectId: 'p1',
+          name: 'test2',
+          status: 'ok',
+          startTime: new Date(),
+          endTime: null,
+          durationMs: null,
+          metadata: {},
+        },
+      };
+      fileStorage.setFile(
+        'observability/trace/proj_1/20250123T120100Z_xyz789ghi012.jsonl',
+        JSON.stringify(traceEvent2) + '\n',
+      );
+      await worker.processOnce();
+
+      const status = worker.getStatus();
+      expect(status.totalFilesProcessed).toBe(2);
+      expect(status.totalEventsIngested).toBe(2);
+      expect(status.totalEventsByType.trace).toBe(2);
+    });
+  });
+
+  describe('start and stop', () => {
+    it('should start and stop the worker', async () => {
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        pollIntervalMs: 100,
+        debug: false,
+      });
+
+      await worker.start();
+      let status = worker.getStatus();
+      expect(status.isRunning).toBe(true);
+      expect(status.startedAt).not.toBeNull();
+
+      await worker.stop();
+      status = worker.getStatus();
+      expect(status.isRunning).toBe(false);
+    });
+
+    it('should not start if already running', async () => {
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        pollIntervalMs: 100,
+        debug: false,
+      });
+
+      await worker.start();
+      const startedAt = worker.getStatus().startedAt;
+
+      // Try to start again
+      await worker.start();
+
+      // Started at should be the same (not restarted)
+      expect(worker.getStatus().startedAt).toBe(startedAt);
+
+      await worker.stop();
+    });
+
+    it('should not fail if stopped when not running', async () => {
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        debug: false,
+      });
+
+      // Should not throw
+      await worker.stop();
+      expect(worker.getStatus().isRunning).toBe(false);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should record errors for files that fail to process', async () => {
+      // Create a mock that throws on insert
+      const failingClient = {
+        ...clickhouseClient,
+        async insert() {
+          throw new Error('ClickHouse connection failed');
+        },
+      };
+
+      const traceEvent: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't1',
+          projectId: 'p1',
+          name: 'test',
+          status: 'ok',
+          startTime: new Date(),
+          endTime: null,
+          durationMs: null,
+          metadata: {},
+        },
+      };
+      fileStorage.setFile(
+        'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl',
+        JSON.stringify(traceEvent) + '\n',
+      );
+
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: failingClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        retryAttempts: 1,
+        retryDelayMs: 10,
+        debug: false,
+      });
+
+      const result = await worker.processOnce();
+
+      expect(result.filesProcessed).toBe(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.message).toBe('ClickHouse connection failed');
+      expect(result.errors[0]?.filePath).toContain('20250123T120000Z_abc123def456.jsonl');
+    });
+
+    it('should retry failed operations', async () => {
+      let attempts = 0;
+      const retriableClient = {
+        ...clickhouseClient,
+        async insert(options: { table: string; values: Record<string, unknown>[] }) {
+          attempts++;
+          if (attempts < 3) {
+            throw new Error('Transient error');
+          }
+          clickhouseClient.insertedRows.push(...options.values);
+        },
+      };
+
+      const traceEvent: ObservabilityEvent = {
+        type: 'trace',
+        data: {
+          traceId: 't1',
+          projectId: 'p1',
+          name: 'test',
+          status: 'ok',
+          startTime: new Date(),
+          endTime: null,
+          durationMs: null,
+          metadata: {},
+        },
+      };
+      fileStorage.setFile(
+        'observability/trace/proj_1/20250123T120000Z_abc123def456.jsonl',
+        JSON.stringify(traceEvent) + '\n',
+      );
+
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: retriableClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        retryAttempts: 3,
+        retryDelayMs: 10,
+        debug: false,
+      });
+
+      const result = await worker.processOnce();
+
+      expect(attempts).toBe(3);
+      expect(result.filesProcessed).toBe(1);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  describe('batch processing', () => {
+    it('should respect batchSize limit', async () => {
+      // Add 5 files
+      for (let i = 0; i < 5; i++) {
+        const traceEvent: ObservabilityEvent = {
+          type: 'trace',
+          data: {
+            traceId: `t${i}`,
+            projectId: 'p1',
+            name: `test${i}`,
+            status: 'ok',
+            startTime: new Date(),
+            endTime: null,
+            durationMs: null,
+            metadata: {},
+          },
+        };
+        fileStorage.setFile(
+          `observability/trace/proj_1/20250123T12000${i}Z_abc${i}def456xyz.jsonl`,
+          JSON.stringify(traceEvent) + '\n',
+        );
+      }
+
+      worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        batchSize: 2,
+        debug: false,
+      });
+
+      // First batch should process 2 files
+      const result1 = await worker.processOnce();
+      expect(result1.filesProcessed).toBe(2);
+
+      // Second batch should process 2 more
+      const result2 = await worker.processOnce();
+      expect(result2.filesProcessed).toBe(2);
+
+      // Third batch should process the remaining 1
+      const result3 = await worker.processOnce();
+      expect(result3.filesProcessed).toBe(1);
+    });
+  });
+});

--- a/observability/clickhouse/src/ingestion/worker.test.ts
+++ b/observability/clickhouse/src/ingestion/worker.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { IngestionWorker } from './worker.js';
+import type { ClickHouseClient } from '@clickhouse/client';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
 import type { FileStorageProvider, FileInfo, ObservabilityEvent } from '../types.js';
+
+import { IngestionWorker } from './worker.js';
 
 // Mock file storage
 function createMockFileStorage(): FileStorageProvider & {
@@ -72,7 +76,7 @@ function createMockClickHouseClient() {
     async insert(options: { table: string; values: Record<string, unknown>[]; format: string }) {
       insertedRows.push(...options.values);
     },
-    async query(options: { query: string }) {
+    async query(_options: { query: string }) {
       // Return empty result for schema checks
       return {
         async json() {
@@ -107,7 +111,7 @@ describe('IngestionWorker', () => {
     it('should create worker with valid config using client', () => {
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: clickhouseClient as unknown as ClickHouseClient },
         debug: false,
       });
 
@@ -117,7 +121,7 @@ describe('IngestionWorker', () => {
     it('should apply default config values', () => {
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: clickhouseClient as unknown as ClickHouseClient },
       });
 
       const status = worker.getStatus();
@@ -130,7 +134,7 @@ describe('IngestionWorker', () => {
     it('should return initial status', () => {
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: clickhouseClient as unknown as ClickHouseClient },
         debug: false,
       });
 
@@ -151,7 +155,7 @@ describe('IngestionWorker', () => {
     it('should return empty result when no files', async () => {
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: clickhouseClient as unknown as ClickHouseClient },
         debug: false,
       });
 
@@ -186,7 +190,7 @@ describe('IngestionWorker', () => {
 
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: clickhouseClient as unknown as ClickHouseClient },
         debug: false,
       });
 
@@ -217,7 +221,7 @@ describe('IngestionWorker', () => {
 
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: clickhouseClient as unknown as ClickHouseClient },
         deleteAfterProcess: false,
         debug: false,
       });
@@ -251,7 +255,7 @@ describe('IngestionWorker', () => {
 
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: clickhouseClient as unknown as ClickHouseClient },
         deleteAfterProcess: true,
         debug: false,
       });
@@ -306,7 +310,7 @@ describe('IngestionWorker', () => {
 
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: clickhouseClient as unknown as ClickHouseClient },
         debug: false,
       });
 
@@ -339,7 +343,7 @@ describe('IngestionWorker', () => {
 
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: clickhouseClient as unknown as ClickHouseClient },
         debug: false,
       });
 
@@ -355,7 +359,7 @@ describe('IngestionWorker', () => {
     it('should accumulate statistics across multiple processOnce calls', async () => {
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: clickhouseClient as unknown as ClickHouseClient },
         debug: false,
       });
 
@@ -410,7 +414,7 @@ describe('IngestionWorker', () => {
     it('should start and stop the worker', async () => {
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: clickhouseClient as unknown as ClickHouseClient },
         pollIntervalMs: 100,
         debug: false,
       });
@@ -428,7 +432,7 @@ describe('IngestionWorker', () => {
     it('should not start if already running', async () => {
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: clickhouseClient as unknown as ClickHouseClient },
         pollIntervalMs: 100,
         debug: false,
       });
@@ -448,7 +452,7 @@ describe('IngestionWorker', () => {
     it('should not fail if stopped when not running', async () => {
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: clickhouseClient as unknown as ClickHouseClient },
         debug: false,
       });
 
@@ -488,7 +492,7 @@ describe('IngestionWorker', () => {
 
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: failingClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: failingClient as unknown as ClickHouseClient },
         retryAttempts: 1,
         retryDelayMs: 10,
         debug: false,
@@ -535,7 +539,7 @@ describe('IngestionWorker', () => {
 
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: retriableClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: retriableClient as unknown as ClickHouseClient },
         retryAttempts: 3,
         retryDelayMs: 10,
         debug: false,
@@ -574,7 +578,7 @@ describe('IngestionWorker', () => {
 
       worker = new IngestionWorker({
         fileStorage,
-        clickhouse: { client: clickhouseClient as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: clickhouseClient as unknown as ClickHouseClient },
         batchSize: 2,
         debug: false,
       });

--- a/observability/clickhouse/src/ingestion/worker.ts
+++ b/observability/clickhouse/src/ingestion/worker.ts
@@ -1,0 +1,338 @@
+/**
+ * Ingestion worker for processing JSONL files into ClickHouse.
+ */
+
+import type { ClickHouseClient } from '@clickhouse/client';
+import { createClient } from '@clickhouse/client';
+import { getProcessedFilePath } from '@mastra/observability-writer';
+import { runMigrations } from '../schema/migrations.js';
+import type {
+  IngestionWorkerConfig,
+  ProcessingResult,
+  ProcessingError,
+  WorkerStatus,
+  FileStorageProvider,
+} from '../types.js';
+import { bulkInsert } from './bulk-inserter.js';
+import { processFile, listPendingFiles } from './file-processor.js';
+
+/**
+ * Default configuration values
+ */
+const DEFAULT_POLL_INTERVAL_MS = 10000;
+const DEFAULT_BATCH_SIZE = 10;
+const DEFAULT_INSERT_BATCH_SIZE = 10000;
+const DEFAULT_BASE_PATH = 'observability';
+const DEFAULT_RETRY_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY_MS = 1000;
+
+/**
+ * IngestionWorker continuously polls file storage for new JSONL files
+ * and ingests them into ClickHouse.
+ */
+export class IngestionWorker {
+  private readonly fileStorage: FileStorageProvider;
+  private readonly client: ClickHouseClient;
+  private readonly config: Required<
+    Omit<IngestionWorkerConfig, 'fileStorage' | 'clickhouse' | 'projectId'> & {
+      projectId: string | undefined;
+    }
+  >;
+
+  private isRunning = false;
+  private isProcessing = false;
+  private pollTimeout: ReturnType<typeof setTimeout> | null = null;
+  private shutdownPromise: Promise<void> | null = null;
+
+  // Statistics
+  private startedAt: Date | null = null;
+  private lastProcessedAt: Date | null = null;
+  private totalFilesProcessed = 0;
+  private totalEventsIngested = 0;
+  private totalEventsByType: Record<string, number> = {};
+  private currentErrors: ProcessingError[] = [];
+
+  constructor(config: IngestionWorkerConfig) {
+    this.fileStorage = config.fileStorage;
+
+    // Create or use provided ClickHouse client
+    if ('client' in config.clickhouse) {
+      this.client = config.clickhouse.client;
+    } else {
+      this.client = createClient({
+        url: config.clickhouse.url,
+        username: config.clickhouse.username,
+        password: config.clickhouse.password,
+        database: config.clickhouse.database,
+        ...config.clickhouse.options,
+        clickhouse_settings: {
+          date_time_input_format: 'best_effort',
+          date_time_output_format: 'iso',
+        },
+      });
+    }
+
+    this.config = {
+      pollIntervalMs: config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+      batchSize: config.batchSize ?? DEFAULT_BATCH_SIZE,
+      insertBatchSize: config.insertBatchSize ?? DEFAULT_INSERT_BATCH_SIZE,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      deleteAfterProcess: config.deleteAfterProcess ?? false,
+      retryAttempts: config.retryAttempts ?? DEFAULT_RETRY_ATTEMPTS,
+      retryDelayMs: config.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS,
+      projectId: config.projectId,
+      debug: config.debug ?? false,
+    };
+  }
+
+  /**
+   * Initialize the worker (run migrations).
+   */
+  async init(): Promise<void> {
+    await runMigrations(this.client);
+  }
+
+  /**
+   * Start the worker. It will continuously poll for files.
+   */
+  async start(): Promise<void> {
+    if (this.isRunning) {
+      return;
+    }
+
+    this.isRunning = true;
+    this.startedAt = new Date();
+    this.currentErrors = [];
+
+    if (this.config.debug) {
+      console.info('[IngestionWorker] Starting...');
+    }
+
+    // Start the poll loop
+    this.schedulePoll();
+  }
+
+  /**
+   * Stop the worker gracefully.
+   * Waits for any in-progress processing to complete.
+   */
+  async stop(): Promise<void> {
+    if (!this.isRunning) {
+      return;
+    }
+
+    if (this.config.debug) {
+      console.info('[IngestionWorker] Stopping...');
+    }
+
+    this.isRunning = false;
+
+    // Clear any pending poll
+    if (this.pollTimeout) {
+      clearTimeout(this.pollTimeout);
+      this.pollTimeout = null;
+    }
+
+    // Wait for in-progress processing
+    if (this.isProcessing && !this.shutdownPromise) {
+      this.shutdownPromise = new Promise(resolve => {
+        const checkInterval = setInterval(() => {
+          if (!this.isProcessing) {
+            clearInterval(checkInterval);
+            resolve();
+          }
+        }, 100);
+      });
+    }
+
+    if (this.shutdownPromise) {
+      await this.shutdownPromise;
+    }
+
+    if (this.config.debug) {
+      console.info('[IngestionWorker] Stopped');
+    }
+  }
+
+  /**
+   * Process files once (for manual/cron-based execution).
+   */
+  async processOnce(): Promise<ProcessingResult> {
+    return this.runProcessingCycle();
+  }
+
+  /**
+   * Get current worker status.
+   */
+  getStatus(): WorkerStatus {
+    return {
+      isRunning: this.isRunning,
+      isProcessing: this.isProcessing,
+      lastProcessedAt: this.lastProcessedAt,
+      totalFilesProcessed: this.totalFilesProcessed,
+      totalEventsIngested: this.totalEventsIngested,
+      totalEventsByType: { ...this.totalEventsByType },
+      currentErrors: [...this.currentErrors],
+      startedAt: this.startedAt,
+    };
+  }
+
+  /**
+   * Schedule the next poll.
+   */
+  private schedulePoll(): void {
+    if (!this.isRunning) {
+      return;
+    }
+
+    this.pollTimeout = setTimeout(async () => {
+      try {
+        await this.runProcessingCycle();
+      } catch (error) {
+        if (this.config.debug) {
+          console.error('[IngestionWorker] Processing cycle error:', error);
+        }
+      }
+      this.schedulePoll();
+    }, this.config.pollIntervalMs);
+  }
+
+  /**
+   * Run a single processing cycle.
+   */
+  private async runProcessingCycle(): Promise<ProcessingResult> {
+    if (this.isProcessing) {
+      return {
+        filesProcessed: 0,
+        eventsIngested: 0,
+        eventsByType: {},
+        errors: [],
+        durationMs: 0,
+      };
+    }
+
+    this.isProcessing = true;
+    const startTime = Date.now();
+    const result: ProcessingResult = {
+      filesProcessed: 0,
+      eventsIngested: 0,
+      eventsByType: {},
+      errors: [],
+      durationMs: 0,
+    };
+
+    try {
+      // List pending files
+      const files = await listPendingFiles(this.fileStorage, this.config.basePath, {
+        projectId: this.config.projectId,
+        limit: this.config.batchSize,
+      });
+
+      if (files.length === 0) {
+        if (this.config.debug) {
+          console.info('[IngestionWorker] No pending files');
+        }
+        return result;
+      }
+
+      if (this.config.debug) {
+        console.info(`[IngestionWorker] Found ${files.length} pending files`);
+      }
+
+      // Process each file
+      for (const filePath of files) {
+        await this.processFileWithRetry(filePath, result);
+      }
+
+      // Update statistics
+      this.totalFilesProcessed += result.filesProcessed;
+      this.totalEventsIngested += result.eventsIngested;
+      for (const [type, count] of Object.entries(result.eventsByType)) {
+        this.totalEventsByType[type] = (this.totalEventsByType[type] || 0) + count;
+      }
+      this.lastProcessedAt = new Date();
+
+      // Clear errors on successful processing
+      if (result.errors.length === 0) {
+        this.currentErrors = [];
+      } else {
+        this.currentErrors = result.errors;
+      }
+    } finally {
+      this.isProcessing = false;
+      result.durationMs = Date.now() - startTime;
+    }
+
+    if (this.config.debug) {
+      console.info(
+        `[IngestionWorker] Processed ${result.filesProcessed} files, ` +
+          `${result.eventsIngested} events in ${result.durationMs}ms`,
+      );
+    }
+
+    return result;
+  }
+
+  /**
+   * Process a single file with retry logic.
+   */
+  private async processFileWithRetry(filePath: string, result: ProcessingResult): Promise<void> {
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt < this.config.retryAttempts; attempt++) {
+      try {
+        // Process the file
+        const fileResult = await processFile(this.fileStorage, filePath);
+
+        if (fileResult.errors.length > 0 && this.config.debug) {
+          console.warn(`[IngestionWorker] ${fileResult.errors.length} parse errors in ${filePath}`);
+        }
+
+        if (fileResult.events.length > 0) {
+          // Insert events into ClickHouse
+          const { insertedByType } = await bulkInsert(
+            this.client,
+            fileResult.events.map(e => ({ type: e.type, data: e.data })),
+          );
+
+          result.eventsIngested += fileResult.events.length;
+          for (const [type, count] of Object.entries(insertedByType)) {
+            result.eventsByType[type] = (result.eventsByType[type] || 0) + count;
+          }
+        }
+
+        // Move or delete the file
+        if (this.config.deleteAfterProcess) {
+          await this.fileStorage.delete(filePath);
+        } else {
+          const processedPath = getProcessedFilePath(filePath);
+          await this.fileStorage.move(filePath, processedPath);
+        }
+
+        result.filesProcessed += 1;
+        return; // Success, exit retry loop
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+
+        if (attempt < this.config.retryAttempts - 1) {
+          if (this.config.debug) {
+            console.warn(`[IngestionWorker] Retry ${attempt + 1}/${this.config.retryAttempts} for ${filePath}`);
+          }
+          await this.delay(this.config.retryDelayMs);
+        }
+      }
+    }
+
+    // All retries failed
+    result.errors.push({
+      filePath,
+      message: lastError?.message || 'Unknown error',
+      error: lastError || new Error('Unknown error'),
+      retryCount: this.config.retryAttempts,
+    });
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+}

--- a/observability/clickhouse/src/integration.test.ts
+++ b/observability/clickhouse/src/integration.test.ts
@@ -1,0 +1,609 @@
+/**
+ * Integration tests for @mastra/observability-clickhouse.
+ *
+ * These tests require a running ClickHouse instance.
+ * Start it with: docker compose up -d
+ *
+ * Run these tests with: pnpm test:integration
+ */
+
+import type { ClickHouseClient } from '@clickhouse/client';
+import { createClient } from '@clickhouse/client';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { IngestionWorker } from './ingestion/worker.js';
+import { ClickHouseQueryProvider } from './query-provider/index.js';
+import { runMigrations, dropAllTables, checkSchemaStatus } from './schema/migrations.js';
+import type { FileStorageProvider, FileInfo } from './types.js';
+
+// Skip integration tests if CLICKHOUSE_URL is not set
+const CLICKHOUSE_URL = process.env['CLICKHOUSE_URL'] || 'http://localhost:8123';
+const CLICKHOUSE_USER = process.env['CLICKHOUSE_USER'] || 'default';
+const CLICKHOUSE_PASSWORD = process.env['CLICKHOUSE_PASSWORD'] || '';
+
+// Helper to check if ClickHouse is available
+async function isClickHouseAvailable(): Promise<boolean> {
+  try {
+    const client = createClient({
+      url: CLICKHOUSE_URL,
+      username: CLICKHOUSE_USER,
+      password: CLICKHOUSE_PASSWORD,
+    });
+    await client.ping();
+    await client.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// In-memory file storage for testing
+function createMemoryFileStorage(): FileStorageProvider & {
+  files: Map<string, Buffer>;
+  setFile: (path: string, content: string) => void;
+} {
+  const files = new Map<string, Buffer>();
+
+  return {
+    type: 'memory' as const,
+    files,
+    setFile: (path: string, content: string) => {
+      files.set(path, Buffer.from(content, 'utf-8'));
+    },
+
+    async write(path: string, content: Buffer | string): Promise<void> {
+      const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf-8');
+      files.set(path, buffer);
+    },
+
+    async read(path: string): Promise<Buffer> {
+      const content = files.get(path);
+      if (!content) {
+        throw new Error(`File not found: ${path}`);
+      }
+      return content;
+    },
+
+    async list(prefix: string): Promise<FileInfo[]> {
+      const result: FileInfo[] = [];
+      for (const [path, content] of files) {
+        if (path.startsWith(prefix) && !path.includes('/processed/')) {
+          result.push({
+            path,
+            size: content.length,
+            lastModified: new Date(),
+          });
+        }
+      }
+      return result;
+    },
+
+    async delete(path: string): Promise<void> {
+      files.delete(path);
+    },
+
+    async move(from: string, to: string): Promise<void> {
+      const content = files.get(from);
+      if (content) {
+        files.set(to, content);
+        files.delete(from);
+      }
+    },
+
+    async exists(path: string): Promise<boolean> {
+      return files.has(path);
+    },
+  };
+}
+
+describe.skipIf(!process.env['RUN_INTEGRATION_TESTS'])('Integration Tests', () => {
+  let client: ClickHouseClient;
+  let fileStorage: ReturnType<typeof createMemoryFileStorage>;
+
+  beforeAll(async () => {
+    const available = await isClickHouseAvailable();
+    if (!available) {
+      console.warn('ClickHouse not available, skipping integration tests');
+      return;
+    }
+
+    client = createClient({
+      url: CLICKHOUSE_URL,
+      username: CLICKHOUSE_USER,
+      password: CLICKHOUSE_PASSWORD,
+    });
+
+    // Ensure clean state
+    await dropAllTables(client);
+    await runMigrations(client);
+  });
+
+  afterAll(async () => {
+    if (client) {
+      await dropAllTables(client);
+      await client.close();
+    }
+  });
+
+  beforeEach(() => {
+    fileStorage = createMemoryFileStorage();
+  });
+
+  describe('Schema Migrations', () => {
+    it('should create all tables and views', async () => {
+      const status = await checkSchemaStatus(client);
+      expect(status.isInitialized).toBe(true);
+      expect(status.missingTables).toHaveLength(0);
+      expect(status.missingViews).toHaveLength(0);
+    });
+  });
+
+  describe('End-to-End Ingestion and Query', () => {
+    it('should ingest traces and query them back', async () => {
+      // Create test trace data
+      const traceEvent = {
+        type: 'trace',
+        id: 'trace_integration_1',
+        projectId: 'proj_integration',
+        deploymentId: 'dep_1',
+        name: 'integration-test-trace',
+        status: 'ok',
+        startTime: new Date().toISOString(),
+        endTime: new Date(Date.now() + 1000).toISOString(),
+        durationMs: 1000,
+        recordedAt: new Date().toISOString(),
+      };
+
+      fileStorage.setFile(
+        'observability/trace/proj_integration/20250123T120000Z_test123.jsonl',
+        JSON.stringify(traceEvent) + '\n',
+      );
+
+      // Create and run worker
+      const worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client },
+        debug: false,
+      });
+
+      const result = await worker.processOnce();
+      expect(result.filesProcessed).toBe(1);
+      expect(result.eventsIngested).toBe(1);
+      expect(result.eventsByType['trace']).toBe(1);
+
+      // Query back
+      const queryProvider = new ClickHouseQueryProvider({
+        clickhouse: { client },
+      });
+
+      const { traces, pagination } = await queryProvider.listTraces({
+        projectId: 'proj_integration',
+      });
+
+      expect(traces).toHaveLength(1);
+      expect(traces[0].id).toBe('trace_integration_1');
+      expect(traces[0].name).toBe('integration-test-trace');
+      expect(pagination.total).toBe(1);
+    });
+
+    it('should ingest spans and query them for a trace', async () => {
+      // Create trace and spans
+      const traceId = 'trace_integration_2';
+      const events = [
+        {
+          type: 'trace',
+          id: traceId,
+          projectId: 'proj_integration',
+          deploymentId: 'dep_1',
+          name: 'parent-trace',
+          status: 'ok',
+          startTime: new Date().toISOString(),
+          endTime: new Date(Date.now() + 2000).toISOString(),
+          durationMs: 2000,
+          recordedAt: new Date().toISOString(),
+        },
+        {
+          type: 'span',
+          id: 'span_1',
+          traceId,
+          projectId: 'proj_integration',
+          deploymentId: 'dep_1',
+          name: 'child-span-1',
+          kind: 'internal',
+          status: 'ok',
+          startTime: new Date().toISOString(),
+          endTime: new Date(Date.now() + 500).toISOString(),
+          durationMs: 500,
+          recordedAt: new Date().toISOString(),
+        },
+        {
+          type: 'span',
+          id: 'span_2',
+          traceId,
+          parentSpanId: 'span_1',
+          projectId: 'proj_integration',
+          deploymentId: 'dep_1',
+          name: 'child-span-2',
+          kind: 'client',
+          status: 'ok',
+          startTime: new Date(Date.now() + 100).toISOString(),
+          endTime: new Date(Date.now() + 400).toISOString(),
+          durationMs: 300,
+          recordedAt: new Date().toISOString(),
+        },
+      ];
+
+      fileStorage.setFile(
+        'observability/trace/proj_integration/20250123T130000Z_test456.jsonl',
+        events.map(e => JSON.stringify(e)).join('\n') + '\n',
+      );
+
+      // Ingest
+      const worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client },
+        debug: false,
+      });
+
+      const result = await worker.processOnce();
+      expect(result.eventsIngested).toBe(3);
+
+      // Query spans for trace
+      const queryProvider = new ClickHouseQueryProvider({
+        clickhouse: { client },
+      });
+
+      const spans = await queryProvider.getSpansForTrace(traceId);
+      expect(spans).toHaveLength(2);
+
+      const span1 = spans.find(s => s.id === 'span_1');
+      const span2 = spans.find(s => s.id === 'span_2');
+
+      expect(span1).toBeDefined();
+      expect(span1?.name).toBe('child-span-1');
+      expect(span2).toBeDefined();
+      expect(span2?.parentSpanId).toBe('span_1');
+    });
+
+    it('should ingest logs and filter by level', async () => {
+      const logs = [
+        {
+          type: 'log',
+          id: 'log_1',
+          projectId: 'proj_integration',
+          deploymentId: 'dep_1',
+          level: 'info',
+          message: 'Application started',
+          timestamp: new Date().toISOString(),
+          recordedAt: new Date().toISOString(),
+        },
+        {
+          type: 'log',
+          id: 'log_2',
+          projectId: 'proj_integration',
+          deploymentId: 'dep_1',
+          level: 'error',
+          message: 'Something went wrong',
+          timestamp: new Date().toISOString(),
+          recordedAt: new Date().toISOString(),
+        },
+        {
+          type: 'log',
+          id: 'log_3',
+          projectId: 'proj_integration',
+          deploymentId: 'dep_1',
+          level: 'info',
+          message: 'Request handled',
+          timestamp: new Date().toISOString(),
+          recordedAt: new Date().toISOString(),
+        },
+      ];
+
+      fileStorage.setFile(
+        'observability/log/proj_integration/20250123T140000Z_logs.jsonl',
+        logs.map(e => JSON.stringify(e)).join('\n') + '\n',
+      );
+
+      const worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client },
+        debug: false,
+      });
+
+      await worker.processOnce();
+
+      const queryProvider = new ClickHouseQueryProvider({
+        clickhouse: { client },
+      });
+
+      // Query error logs only
+      const { logs: errorLogs } = await queryProvider.listLogs({
+        projectId: 'proj_integration',
+        level: 'error',
+      });
+
+      expect(errorLogs).toHaveLength(1);
+      expect(errorLogs[0].message).toBe('Something went wrong');
+
+      // Query all logs
+      const { logs: allLogs, pagination } = await queryProvider.listLogs({
+        projectId: 'proj_integration',
+      });
+
+      expect(allLogs.length).toBeGreaterThanOrEqual(3);
+      expect(pagination.total).toBeGreaterThanOrEqual(3);
+    });
+
+    it('should ingest metrics and query by name', async () => {
+      const metrics = [
+        {
+          type: 'metric',
+          id: 'metric_1',
+          projectId: 'proj_integration',
+          deploymentId: 'dep_1',
+          name: 'request_latency',
+          metricType: 'histogram',
+          value: 150,
+          unit: 'ms',
+          timestamp: new Date().toISOString(),
+          recordedAt: new Date().toISOString(),
+        },
+        {
+          type: 'metric',
+          id: 'metric_2',
+          projectId: 'proj_integration',
+          deploymentId: 'dep_1',
+          name: 'request_count',
+          metricType: 'counter',
+          value: 100,
+          timestamp: new Date().toISOString(),
+          recordedAt: new Date().toISOString(),
+        },
+      ];
+
+      fileStorage.setFile(
+        'observability/metric/proj_integration/20250123T150000Z_metrics.jsonl',
+        metrics.map(e => JSON.stringify(e)).join('\n') + '\n',
+      );
+
+      const worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client },
+        debug: false,
+      });
+
+      await worker.processOnce();
+
+      const queryProvider = new ClickHouseQueryProvider({
+        clickhouse: { client },
+      });
+
+      const { metrics: latencyMetrics } = await queryProvider.listMetrics({
+        projectId: 'proj_integration',
+        name: 'request_latency',
+      });
+
+      expect(latencyMetrics).toHaveLength(1);
+      expect(latencyMetrics[0].value).toBe(150);
+      expect(latencyMetrics[0].unit).toBe('ms');
+    });
+
+    it('should ingest scores and query by value range', async () => {
+      const scores = [
+        {
+          type: 'score',
+          id: 'score_1',
+          projectId: 'proj_integration',
+          deploymentId: 'dep_1',
+          name: 'accuracy',
+          value: 0.95,
+          normalizedValue: 0.95,
+          timestamp: new Date().toISOString(),
+          recordedAt: new Date().toISOString(),
+        },
+        {
+          type: 'score',
+          id: 'score_2',
+          projectId: 'proj_integration',
+          deploymentId: 'dep_1',
+          name: 'accuracy',
+          value: 0.72,
+          normalizedValue: 0.72,
+          timestamp: new Date().toISOString(),
+          recordedAt: new Date().toISOString(),
+        },
+        {
+          type: 'score',
+          id: 'score_3',
+          projectId: 'proj_integration',
+          deploymentId: 'dep_1',
+          name: 'accuracy',
+          value: 0.88,
+          normalizedValue: 0.88,
+          timestamp: new Date().toISOString(),
+          recordedAt: new Date().toISOString(),
+        },
+      ];
+
+      fileStorage.setFile(
+        'observability/score/proj_integration/20250123T160000Z_scores.jsonl',
+        scores.map(e => JSON.stringify(e)).join('\n') + '\n',
+      );
+
+      const worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client },
+        debug: false,
+      });
+
+      await worker.processOnce();
+
+      const queryProvider = new ClickHouseQueryProvider({
+        clickhouse: { client },
+      });
+
+      // Query high scores (>= 0.85)
+      const { scores: highScores } = await queryProvider.listScores({
+        projectId: 'proj_integration',
+        name: 'accuracy',
+        minValue: 0.85,
+      });
+
+      expect(highScores).toHaveLength(2);
+      expect(highScores.every(s => s.value >= 0.85)).toBe(true);
+    });
+  });
+
+  describe('Time Series Aggregations', () => {
+    it('should calculate trace count over time', async () => {
+      const queryProvider = new ClickHouseQueryProvider({
+        clickhouse: { client },
+      });
+
+      const timeSeries = await queryProvider.getTraceCountTimeSeries({
+        projectId: 'proj_integration',
+        intervalSeconds: 3600,
+        timeRange: {
+          start: new Date(Date.now() - 24 * 60 * 60 * 1000), // 24 hours ago
+          end: new Date(),
+        },
+      });
+
+      // Should have some buckets from previous tests
+      expect(timeSeries.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should calculate error rate over time', async () => {
+      // First, add some error traces
+      const errorTraces = [
+        {
+          type: 'trace',
+          id: 'trace_error_1',
+          projectId: 'proj_integration',
+          deploymentId: 'dep_1',
+          name: 'failed-trace',
+          status: 'error',
+          startTime: new Date().toISOString(),
+          endTime: new Date(Date.now() + 100).toISOString(),
+          durationMs: 100,
+          recordedAt: new Date().toISOString(),
+        },
+        {
+          type: 'trace',
+          id: 'trace_error_2',
+          projectId: 'proj_integration',
+          deploymentId: 'dep_1',
+          name: 'another-failed-trace',
+          status: 'error',
+          startTime: new Date().toISOString(),
+          endTime: new Date(Date.now() + 200).toISOString(),
+          durationMs: 200,
+          recordedAt: new Date().toISOString(),
+        },
+      ];
+
+      fileStorage.setFile(
+        'observability/trace/proj_integration/20250123T170000Z_errors.jsonl',
+        errorTraces.map(e => JSON.stringify(e)).join('\n') + '\n',
+      );
+
+      const worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client },
+        debug: false,
+      });
+
+      await worker.processOnce();
+
+      const queryProvider = new ClickHouseQueryProvider({
+        clickhouse: { client },
+      });
+
+      const errorRate = await queryProvider.getErrorRateTimeSeries({
+        projectId: 'proj_integration',
+        intervalSeconds: 3600,
+        timeRange: {
+          start: new Date(Date.now() - 24 * 60 * 60 * 1000),
+          end: new Date(),
+        },
+      });
+
+      // Should have buckets with error counts
+      expect(errorRate.length).toBeGreaterThanOrEqual(0);
+      if (errorRate.length > 0) {
+        expect(errorRate[0].values).toBeDefined();
+      }
+    });
+  });
+
+  describe('Worker Lifecycle', () => {
+    it('should track worker status correctly', async () => {
+      const worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client },
+        debug: false,
+      });
+
+      // Initial status
+      let status = worker.getStatus();
+      expect(status.isRunning).toBe(false);
+      expect(status.isProcessing).toBe(false);
+      expect(status.totalFilesProcessed).toBe(0);
+
+      // Add a file and process
+      fileStorage.setFile(
+        'observability/trace/proj_status/20250123T180000Z_status.jsonl',
+        JSON.stringify({
+          type: 'trace',
+          id: 'trace_status',
+          projectId: 'proj_status',
+          name: 'status-test',
+          status: 'ok',
+          startTime: new Date().toISOString(),
+          endTime: new Date().toISOString(),
+        }) + '\n',
+      );
+
+      await worker.processOnce();
+
+      // Status after processing
+      status = worker.getStatus();
+      expect(status.totalFilesProcessed).toBe(1);
+      expect(status.totalEventsIngested).toBe(1);
+      expect(status.lastProcessedAt).toBeDefined();
+    });
+
+    it('should handle file deletion after processing when configured', async () => {
+      const worker = new IngestionWorker({
+        fileStorage,
+        clickhouse: { client },
+        deleteAfterProcess: true,
+        debug: false,
+      });
+
+      const filePath = 'observability/trace/proj_delete/20250123T190000Z_delete.jsonl';
+      fileStorage.setFile(
+        filePath,
+        JSON.stringify({
+          type: 'trace',
+          id: 'trace_delete',
+          projectId: 'proj_delete',
+          name: 'delete-test',
+          status: 'ok',
+          startTime: new Date().toISOString(),
+          endTime: new Date().toISOString(),
+        }) + '\n',
+      );
+
+      expect(await fileStorage.exists(filePath)).toBe(true);
+
+      await worker.processOnce();
+
+      // File should be deleted
+      expect(await fileStorage.exists(filePath)).toBe(false);
+      // No processed file should exist either
+      expect(await fileStorage.exists(filePath.replace('trace/proj_delete/', 'trace/proj_delete/processed/'))).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/observability/clickhouse/src/query-provider/index.test.ts
+++ b/observability/clickhouse/src/query-provider/index.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { ClickHouseQueryProvider } from './index.js';
+import type { ClickHouseClient } from '@clickhouse/client';
+
+import { describe, it, expect, vi } from 'vitest';
+
 import { TABLE_NAMES } from '../schema/tables.js';
+
+import { ClickHouseQueryProvider } from './index.js';
 
 // Mock ClickHouse client that returns configurable results
 function createMockClickHouseClient(mockData: {
@@ -74,7 +78,7 @@ describe('ClickHouseQueryProvider', () => {
     it('should create provider with client config', () => {
       const client = createMockClickHouseClient();
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       expect(provider).toBeInstanceOf(ClickHouseQueryProvider);
@@ -85,7 +89,7 @@ describe('ClickHouseQueryProvider', () => {
     it('should run migrations if schema is not initialized', async () => {
       const client = createMockClickHouseClient({ tables: [] });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       await provider.init();
@@ -109,7 +113,7 @@ describe('ClickHouseQueryProvider', () => {
         ],
       });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       await provider.init();
@@ -122,7 +126,7 @@ describe('ClickHouseQueryProvider', () => {
     it('should return empty result when no traces', async () => {
       const client = createMockClickHouseClient({ traces: [] });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       const result = await provider.listTraces();
@@ -148,7 +152,7 @@ describe('ClickHouseQueryProvider', () => {
       ];
       const client = createMockClickHouseClient({ traces: mockTraces });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       const result = await provider.listTraces();
@@ -168,7 +172,7 @@ describe('ClickHouseQueryProvider', () => {
     it('should apply filters correctly', async () => {
       const client = createMockClickHouseClient({ traces: [] });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       await provider.listTraces({
@@ -206,7 +210,7 @@ describe('ClickHouseQueryProvider', () => {
       }));
       const client = createMockClickHouseClient({ traces: mockTraces });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       const result = await provider.listTraces({
@@ -224,7 +228,7 @@ describe('ClickHouseQueryProvider', () => {
     it('should return null when trace not found', async () => {
       const client = createMockClickHouseClient({ traces: [] });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       const result = await provider.getTrace('nonexistent');
@@ -248,7 +252,7 @@ describe('ClickHouseQueryProvider', () => {
       ];
       const client = createMockClickHouseClient({ traces: mockTraces });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       const result = await provider.getTrace('t1');
@@ -279,7 +283,7 @@ describe('ClickHouseQueryProvider', () => {
       ];
       const client = createMockClickHouseClient({ spans: mockSpans });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       const result = await provider.listSpans();
@@ -296,7 +300,7 @@ describe('ClickHouseQueryProvider', () => {
     it('should apply span-specific filters', async () => {
       const client = createMockClickHouseClient({ spans: [] });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       await provider.listSpans({
@@ -350,7 +354,7 @@ describe('ClickHouseQueryProvider', () => {
       ];
       const client = createMockClickHouseClient({ spans: mockSpans });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       const result = await provider.getSpansForTrace('t1');
@@ -378,7 +382,7 @@ describe('ClickHouseQueryProvider', () => {
       ];
       const client = createMockClickHouseClient({ logs: mockLogs });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       const result = await provider.listLogs();
@@ -395,7 +399,7 @@ describe('ClickHouseQueryProvider', () => {
     it('should apply log-specific filters', async () => {
       const client = createMockClickHouseClient({ logs: [] });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       await provider.listLogs({
@@ -430,7 +434,7 @@ describe('ClickHouseQueryProvider', () => {
       ];
       const client = createMockClickHouseClient({ metrics: mockMetrics });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       const result = await provider.listMetrics();
@@ -447,7 +451,7 @@ describe('ClickHouseQueryProvider', () => {
     it('should apply metric-specific filters', async () => {
       const client = createMockClickHouseClient({ metrics: [] });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       await provider.listMetrics({
@@ -479,7 +483,7 @@ describe('ClickHouseQueryProvider', () => {
       ];
       const client = createMockClickHouseClient({ scores: mockScores });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       const result = await provider.listScores();
@@ -497,7 +501,7 @@ describe('ClickHouseQueryProvider', () => {
     it('should apply score-specific filters', async () => {
       const client = createMockClickHouseClient({ scores: [] });
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       await provider.listScores({
@@ -527,7 +531,7 @@ describe('ClickHouseQueryProvider', () => {
       });
 
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       const result = await provider.getTraceCountTimeSeries({
@@ -557,7 +561,7 @@ describe('ClickHouseQueryProvider', () => {
       });
 
       const provider = new ClickHouseQueryProvider({
-        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+        clickhouse: { client: client as unknown as ClickHouseClient },
       });
 
       const result = await provider.getErrorRateTimeSeries({

--- a/observability/clickhouse/src/query-provider/index.test.ts
+++ b/observability/clickhouse/src/query-provider/index.test.ts
@@ -1,0 +1,578 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ClickHouseQueryProvider } from './index.js';
+import { TABLE_NAMES } from '../schema/tables.js';
+
+// Mock ClickHouse client that returns configurable results
+function createMockClickHouseClient(mockData: {
+  traces?: Record<string, unknown>[];
+  spans?: Record<string, unknown>[];
+  logs?: Record<string, unknown>[];
+  metrics?: Record<string, unknown>[];
+  scores?: Record<string, unknown>[];
+  tables?: string[];
+} = {}) {
+  const queries: Array<{ query: string; params: Record<string, unknown> }> = [];
+  const commands: string[] = [];
+
+  return {
+    queries,
+    commands,
+    async query(options: { query: string; query_params?: Record<string, unknown>; format?: string }) {
+      queries.push({ query: options.query, params: options.query_params || {} });
+
+      // Return count result
+      if (options.query.includes('count()')) {
+        const tableMatch = options.query.match(/FROM\s+(\w+)/);
+        const table = tableMatch?.[1];
+        let count = 0;
+        if (table === TABLE_NAMES.TRACES) count = mockData.traces?.length || 0;
+        if (table === TABLE_NAMES.SPANS) count = mockData.spans?.length || 0;
+        if (table === TABLE_NAMES.LOGS) count = mockData.logs?.length || 0;
+        if (table === TABLE_NAMES.METRICS) count = mockData.metrics?.length || 0;
+        if (table === TABLE_NAMES.SCORES) count = mockData.scores?.length || 0;
+
+        return {
+          async json() {
+            return [{ total: count }];
+          },
+        };
+      }
+
+      // Return table list for schema check
+      if (options.query.includes('system.tables')) {
+        return {
+          async json() {
+            return (mockData.tables || []).map(name => ({ name }));
+          },
+        };
+      }
+
+      // Return data based on table
+      const tableMatch = options.query.match(/FROM\s+(\w+)/);
+      const table = tableMatch?.[1];
+
+      return {
+        async json() {
+          if (table === TABLE_NAMES.TRACES) return mockData.traces || [];
+          if (table === TABLE_NAMES.SPANS) return mockData.spans || [];
+          if (table === TABLE_NAMES.LOGS) return mockData.logs || [];
+          if (table === TABLE_NAMES.METRICS) return mockData.metrics || [];
+          if (table === TABLE_NAMES.SCORES) return mockData.scores || [];
+          return [];
+        },
+      };
+    },
+    async command(options: { query: string }) {
+      commands.push(options.query);
+    },
+    async close() {},
+  };
+}
+
+describe('ClickHouseQueryProvider', () => {
+  describe('constructor', () => {
+    it('should create provider with client config', () => {
+      const client = createMockClickHouseClient();
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      expect(provider).toBeInstanceOf(ClickHouseQueryProvider);
+    });
+  });
+
+  describe('init', () => {
+    it('should run migrations if schema is not initialized', async () => {
+      const client = createMockClickHouseClient({ tables: [] });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      await provider.init();
+
+      expect(client.commands.length).toBeGreaterThan(0);
+    });
+
+    it('should skip migrations if schema is already initialized', async () => {
+      const client = createMockClickHouseClient({
+        tables: [
+          'mastra_admin_traces',
+          'mastra_admin_spans',
+          'mastra_admin_logs',
+          'mastra_admin_metrics',
+          'mastra_admin_scores',
+          'mastra_admin_traces_hourly_stats',
+          'mastra_admin_spans_hourly_stats',
+          'mastra_admin_logs_hourly_stats',
+          'mastra_admin_metrics_hourly_stats',
+          'mastra_admin_scores_hourly_stats',
+        ],
+      });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      await provider.init();
+
+      expect(client.commands.length).toBe(0);
+    });
+  });
+
+  describe('listTraces', () => {
+    it('should return empty result when no traces', async () => {
+      const client = createMockClickHouseClient({ traces: [] });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      const result = await provider.listTraces();
+
+      expect(result.traces).toHaveLength(0);
+      expect(result.pagination.total).toBe(0);
+      expect(result.pagination.hasMore).toBe(false);
+    });
+
+    it('should return traces with correct transformation', async () => {
+      const mockTraces = [
+        {
+          trace_id: 't1',
+          project_id: 'p1',
+          deployment_id: 'd1',
+          name: 'test-trace',
+          status: 'ok',
+          start_time: '2025-01-23T12:00:00.000Z',
+          end_time: '2025-01-23T12:00:01.000Z',
+          duration_ms: 1000,
+          metadata: '{"key":"value"}',
+        },
+      ];
+      const client = createMockClickHouseClient({ traces: mockTraces });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      const result = await provider.listTraces();
+
+      expect(result.traces).toHaveLength(1);
+      expect(result.traces[0]?.traceId).toBe('t1');
+      expect(result.traces[0]?.projectId).toBe('p1');
+      expect(result.traces[0]?.deploymentId).toBe('d1');
+      expect(result.traces[0]?.name).toBe('test-trace');
+      expect(result.traces[0]?.status).toBe('ok');
+      expect(result.traces[0]?.startTime).toBeInstanceOf(Date);
+      expect(result.traces[0]?.endTime).toBeInstanceOf(Date);
+      expect(result.traces[0]?.durationMs).toBe(1000);
+      expect(result.traces[0]?.metadata).toEqual({ key: 'value' });
+    });
+
+    it('should apply filters correctly', async () => {
+      const client = createMockClickHouseClient({ traces: [] });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      await provider.listTraces({
+        projectId: 'p1',
+        deploymentId: 'd1',
+        status: 'error',
+        name: 'test',
+        timeRange: {
+          start: new Date('2025-01-01'),
+          end: new Date('2025-01-31'),
+        },
+      });
+
+      // Check that queries include the filter conditions
+      const listQuery = client.queries.find(q => !q.query.includes('count()'));
+      expect(listQuery?.query).toContain('project_id =');
+      expect(listQuery?.query).toContain('deployment_id =');
+      expect(listQuery?.query).toContain('status =');
+      expect(listQuery?.query).toContain('name LIKE');
+      expect(listQuery?.query).toContain('start_time >=');
+      expect(listQuery?.query).toContain('start_time <=');
+    });
+
+    it('should apply pagination correctly', async () => {
+      const mockTraces = Array.from({ length: 100 }, (_, i) => ({
+        trace_id: `t${i}`,
+        project_id: 'p1',
+        deployment_id: 'd1',
+        name: `trace-${i}`,
+        status: 'ok',
+        start_time: '2025-01-23T12:00:00.000Z',
+        end_time: null,
+        duration_ms: null,
+        metadata: '{}',
+      }));
+      const client = createMockClickHouseClient({ traces: mockTraces });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      const result = await provider.listTraces({
+        pagination: { page: 0, perPage: 10 },
+      });
+
+      expect(result.pagination.page).toBe(0);
+      expect(result.pagination.perPage).toBe(10);
+      expect(result.pagination.total).toBe(100);
+      expect(result.pagination.hasMore).toBe(true);
+    });
+  });
+
+  describe('getTrace', () => {
+    it('should return null when trace not found', async () => {
+      const client = createMockClickHouseClient({ traces: [] });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      const result = await provider.getTrace('nonexistent');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return trace when found', async () => {
+      const mockTraces = [
+        {
+          trace_id: 't1',
+          project_id: 'p1',
+          deployment_id: 'd1',
+          name: 'test-trace',
+          status: 'ok',
+          start_time: '2025-01-23T12:00:00.000Z',
+          end_time: null,
+          duration_ms: null,
+          metadata: '{}',
+        },
+      ];
+      const client = createMockClickHouseClient({ traces: mockTraces });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      const result = await provider.getTrace('t1');
+
+      expect(result).not.toBeNull();
+      expect(result?.traceId).toBe('t1');
+    });
+  });
+
+  describe('listSpans', () => {
+    it('should return spans with correct transformation', async () => {
+      const mockSpans = [
+        {
+          span_id: 's1',
+          trace_id: 't1',
+          parent_span_id: null,
+          project_id: 'p1',
+          deployment_id: 'd1',
+          name: 'test-span',
+          kind: 'server',
+          status: 'ok',
+          start_time: '2025-01-23T12:00:00.000Z',
+          end_time: '2025-01-23T12:00:01.000Z',
+          duration_ms: 1000,
+          attributes: '{"http.method":"GET"}',
+          events: '[]',
+        },
+      ];
+      const client = createMockClickHouseClient({ spans: mockSpans });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      const result = await provider.listSpans();
+
+      expect(result.spans).toHaveLength(1);
+      expect(result.spans[0]?.spanId).toBe('s1');
+      expect(result.spans[0]?.traceId).toBe('t1');
+      expect(result.spans[0]?.parentSpanId).toBeNull();
+      expect(result.spans[0]?.kind).toBe('server');
+      expect(result.spans[0]?.attributes).toEqual({ 'http.method': 'GET' });
+      expect(result.spans[0]?.events).toEqual([]);
+    });
+
+    it('should apply span-specific filters', async () => {
+      const client = createMockClickHouseClient({ spans: [] });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      await provider.listSpans({
+        traceId: 't1',
+        spanId: 's1',
+        parentSpanId: 'ps1',
+        kind: 'server',
+      });
+
+      const listQuery = client.queries.find(q => !q.query.includes('count()'));
+      expect(listQuery?.query).toContain('trace_id =');
+      expect(listQuery?.query).toContain('span_id =');
+      expect(listQuery?.query).toContain('parent_span_id =');
+      expect(listQuery?.query).toContain('kind =');
+    });
+  });
+
+  describe('getSpansForTrace', () => {
+    it('should return all spans for a trace', async () => {
+      const mockSpans = [
+        {
+          span_id: 's1',
+          trace_id: 't1',
+          parent_span_id: null,
+          project_id: 'p1',
+          deployment_id: 'd1',
+          name: 'root-span',
+          kind: 'server',
+          status: 'ok',
+          start_time: '2025-01-23T12:00:00.000Z',
+          end_time: '2025-01-23T12:00:01.000Z',
+          duration_ms: 1000,
+          attributes: '{}',
+          events: '[]',
+        },
+        {
+          span_id: 's2',
+          trace_id: 't1',
+          parent_span_id: 's1',
+          project_id: 'p1',
+          deployment_id: 'd1',
+          name: 'child-span',
+          kind: 'internal',
+          status: 'ok',
+          start_time: '2025-01-23T12:00:00.100Z',
+          end_time: '2025-01-23T12:00:00.500Z',
+          duration_ms: 400,
+          attributes: '{}',
+          events: '[]',
+        },
+      ];
+      const client = createMockClickHouseClient({ spans: mockSpans });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      const result = await provider.getSpansForTrace('t1');
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.spanId).toBe('s1');
+      expect(result[1]?.spanId).toBe('s2');
+    });
+  });
+
+  describe('listLogs', () => {
+    it('should return logs with correct transformation', async () => {
+      const mockLogs = [
+        {
+          id: 'l1',
+          project_id: 'p1',
+          deployment_id: 'd1',
+          trace_id: 't1',
+          span_id: 's1',
+          level: 'error',
+          message: 'Something went wrong',
+          timestamp: '2025-01-23T12:00:00.000Z',
+          attributes: '{"error_code":500}',
+        },
+      ];
+      const client = createMockClickHouseClient({ logs: mockLogs });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      const result = await provider.listLogs();
+
+      expect(result.logs).toHaveLength(1);
+      expect(result.logs[0]?.id).toBe('l1');
+      expect(result.logs[0]?.level).toBe('error');
+      expect(result.logs[0]?.message).toBe('Something went wrong');
+      expect(result.logs[0]?.traceId).toBe('t1');
+      expect(result.logs[0]?.spanId).toBe('s1');
+      expect(result.logs[0]?.attributes).toEqual({ error_code: 500 });
+    });
+
+    it('should apply log-specific filters', async () => {
+      const client = createMockClickHouseClient({ logs: [] });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      await provider.listLogs({
+        level: 'error',
+        traceId: 't1',
+        spanId: 's1',
+        message: 'error',
+      });
+
+      const listQuery = client.queries.find(q => !q.query.includes('count()'));
+      expect(listQuery?.query).toContain('level =');
+      expect(listQuery?.query).toContain('trace_id =');
+      expect(listQuery?.query).toContain('span_id =');
+      expect(listQuery?.query).toContain('message LIKE');
+    });
+  });
+
+  describe('listMetrics', () => {
+    it('should return metrics with correct transformation', async () => {
+      const mockMetrics = [
+        {
+          id: 'm1',
+          project_id: 'p1',
+          deployment_id: 'd1',
+          name: 'cpu_usage',
+          type: 'gauge',
+          value: 0.75,
+          unit: 'percent',
+          timestamp: '2025-01-23T12:00:00.000Z',
+          labels: '{"host":"server-1"}',
+        },
+      ];
+      const client = createMockClickHouseClient({ metrics: mockMetrics });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      const result = await provider.listMetrics();
+
+      expect(result.metrics).toHaveLength(1);
+      expect(result.metrics[0]?.id).toBe('m1');
+      expect(result.metrics[0]?.name).toBe('cpu_usage');
+      expect(result.metrics[0]?.type).toBe('gauge');
+      expect(result.metrics[0]?.value).toBe(0.75);
+      expect(result.metrics[0]?.unit).toBe('percent');
+      expect(result.metrics[0]?.labels).toEqual({ host: 'server-1' });
+    });
+
+    it('should apply metric-specific filters', async () => {
+      const client = createMockClickHouseClient({ metrics: [] });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      await provider.listMetrics({
+        name: 'cpu_usage',
+        type: 'gauge',
+      });
+
+      const listQuery = client.queries.find(q => !q.query.includes('count()'));
+      expect(listQuery?.query).toContain('name =');
+      expect(listQuery?.query).toContain('type =');
+    });
+  });
+
+  describe('listScores', () => {
+    it('should return scores with correct transformation', async () => {
+      const mockScores = [
+        {
+          id: 'sc1',
+          project_id: 'p1',
+          deployment_id: 'd1',
+          trace_id: 't1',
+          name: 'quality_score',
+          value: 0.95,
+          normalized_value: 95,
+          comment: 'High quality',
+          timestamp: '2025-01-23T12:00:00.000Z',
+          metadata: '{"evaluator":"gpt-4"}',
+        },
+      ];
+      const client = createMockClickHouseClient({ scores: mockScores });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      const result = await provider.listScores();
+
+      expect(result.scores).toHaveLength(1);
+      expect(result.scores[0]?.id).toBe('sc1');
+      expect(result.scores[0]?.name).toBe('quality_score');
+      expect(result.scores[0]?.value).toBe(0.95);
+      expect(result.scores[0]?.normalizedValue).toBe(95);
+      expect(result.scores[0]?.comment).toBe('High quality');
+      expect(result.scores[0]?.traceId).toBe('t1');
+      expect(result.scores[0]?.metadata).toEqual({ evaluator: 'gpt-4' });
+    });
+
+    it('should apply score-specific filters', async () => {
+      const client = createMockClickHouseClient({ scores: [] });
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      await provider.listScores({
+        name: 'quality',
+        traceId: 't1',
+        minValue: 0.5,
+        maxValue: 1.0,
+      });
+
+      const listQuery = client.queries.find(q => !q.query.includes('count()'));
+      expect(listQuery?.query).toContain('name =');
+      expect(listQuery?.query).toContain('trace_id =');
+      expect(listQuery?.query).toContain('value >=');
+      expect(listQuery?.query).toContain('value <=');
+    });
+  });
+
+  describe('getTraceCountTimeSeries', () => {
+    it('should return time series data', async () => {
+      const client = createMockClickHouseClient({ traces: [] });
+      // Override query to return time series data
+      client.query = vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue([
+          { timestamp: '2025-01-23T12:00:00.000Z', count: 10 },
+          { timestamp: '2025-01-23T13:00:00.000Z', count: 15 },
+        ]),
+      });
+
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      const result = await provider.getTraceCountTimeSeries({
+        intervalSeconds: 3600,
+        timeRange: {
+          start: new Date('2025-01-23T00:00:00.000Z'),
+          end: new Date('2025-01-23T23:59:59.999Z'),
+        },
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.count).toBe(10);
+      expect(result[1]?.count).toBe(15);
+      expect(result[0]?.timestamp).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('getErrorRateTimeSeries', () => {
+    it('should return error rate time series data', async () => {
+      const client = createMockClickHouseClient({ traces: [] });
+      // Override query to return time series data
+      client.query = vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue([
+          { timestamp: '2025-01-23T12:00:00.000Z', count: 100, error_count: 5, error_rate: 0.05 },
+          { timestamp: '2025-01-23T13:00:00.000Z', count: 200, error_count: 20, error_rate: 0.1 },
+        ]),
+      });
+
+      const provider = new ClickHouseQueryProvider({
+        clickhouse: { client: client as unknown as import('@clickhouse/client').ClickHouseClient },
+      });
+
+      const result = await provider.getErrorRateTimeSeries({
+        intervalSeconds: 3600,
+        timeRange: {
+          start: new Date('2025-01-23T00:00:00.000Z'),
+          end: new Date('2025-01-23T23:59:59.999Z'),
+        },
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.count).toBe(100);
+      expect(result[0]?.values?.errorCount).toBe(5);
+      expect(result[0]?.values?.errorRate).toBe(0.05);
+      expect(result[1]?.values?.errorRate).toBe(0.1);
+    });
+  });
+});

--- a/observability/clickhouse/src/query-provider/index.ts
+++ b/observability/clickhouse/src/query-provider/index.ts
@@ -4,6 +4,9 @@
 
 import type { ClickHouseClient } from '@clickhouse/client';
 import { createClient } from '@clickhouse/client';
+
+import { TABLE_NAMES } from '../schema/index.js';
+import { runMigrations, checkSchemaStatus } from '../schema/migrations.js';
 import type {
   QueryProviderConfig,
   TraceQueryOptions,
@@ -20,8 +23,6 @@ import type {
   Metric,
   Score,
 } from '../types.js';
-import { TABLE_NAMES } from '../schema/index.js';
-import { runMigrations, checkSchemaStatus } from '../schema/migrations.js';
 
 /**
  * Default pagination values

--- a/observability/clickhouse/src/query-provider/index.ts
+++ b/observability/clickhouse/src/query-provider/index.ts
@@ -1,0 +1,795 @@
+/**
+ * ClickHouse query provider for observability data.
+ */
+
+import type { ClickHouseClient } from '@clickhouse/client';
+import { createClient } from '@clickhouse/client';
+import type {
+  QueryProviderConfig,
+  TraceQueryOptions,
+  SpanQueryOptions,
+  LogQueryOptions,
+  MetricQueryOptions,
+  ScoreQueryOptions,
+  PaginationInfo,
+  TimeBucket,
+  AggregationOptions,
+  Trace,
+  Span,
+  Log,
+  Metric,
+  Score,
+} from '../types.js';
+import { TABLE_NAMES } from '../schema/index.js';
+import { runMigrations, checkSchemaStatus } from '../schema/migrations.js';
+
+/**
+ * Default pagination values
+ */
+const DEFAULT_PAGE = 0;
+const DEFAULT_PER_PAGE = 50;
+
+/**
+ * ClickHouseQueryProvider provides read access to observability data.
+ * Implements the ObservabilityQueryProvider interface from @mastra/admin.
+ */
+export class ClickHouseQueryProvider {
+  private readonly client: ClickHouseClient;
+  private readonly debug: boolean;
+
+  constructor(config: QueryProviderConfig) {
+    // Create or use provided ClickHouse client
+    if ('client' in config.clickhouse) {
+      this.client = config.clickhouse.client;
+    } else {
+      this.client = createClient({
+        url: config.clickhouse.url,
+        username: config.clickhouse.username,
+        password: config.clickhouse.password,
+        database: config.clickhouse.database,
+        ...config.clickhouse.options,
+        clickhouse_settings: {
+          date_time_input_format: 'best_effort',
+          date_time_output_format: 'iso',
+          use_client_time_zone: 1,
+        },
+      });
+    }
+
+    this.debug = config.debug ?? false;
+  }
+
+  /**
+   * Initialize the query provider (ensures schema exists).
+   */
+  async init(): Promise<void> {
+    const status = await checkSchemaStatus(this.client);
+    if (!status.isInitialized) {
+      await runMigrations(this.client);
+    }
+  }
+
+  // ============================================================
+  // Trace Queries
+  // ============================================================
+
+  /**
+   * List traces with filtering and pagination.
+   */
+  async listTraces(options: TraceQueryOptions = {}): Promise<{ traces: Trace[]; pagination: PaginationInfo }> {
+    const { conditions, params } = this.buildTraceConditions(options);
+    const page = options.pagination?.page ?? DEFAULT_PAGE;
+    const perPage = options.pagination?.perPage ?? DEFAULT_PER_PAGE;
+
+    // Get total count
+    const countQuery = `
+      SELECT count() as total
+      FROM ${TABLE_NAMES.TRACES} FINAL
+      ${conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''}
+    `;
+    const countResult = await this.client.query({
+      query: countQuery,
+      query_params: params,
+      format: 'JSONEachRow',
+    });
+    const countRows = await countResult.json<{ total: number }>();
+    const total = countRows[0]?.total ?? 0;
+
+    // Get paginated results
+    const query = `
+      SELECT *
+      FROM ${TABLE_NAMES.TRACES} FINAL
+      ${conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''}
+      ORDER BY start_time DESC
+      LIMIT {limit:UInt32} OFFSET {offset:UInt32}
+    `;
+
+    const result = await this.client.query({
+      query,
+      query_params: { ...params, limit: perPage, offset: page * perPage },
+      format: 'JSONEachRow',
+    });
+
+    const rows = await result.json<Record<string, unknown>>();
+    const traces = rows.map(row => this.transformTrace(row as Record<string, unknown>));
+
+    return {
+      traces,
+      pagination: {
+        total,
+        page,
+        perPage,
+        hasMore: (page + 1) * perPage < total,
+      },
+    };
+  }
+
+  /**
+   * Get a single trace by ID.
+   */
+  async getTrace(traceId: string): Promise<Trace | null> {
+    const query = `
+      SELECT * FROM ${TABLE_NAMES.TRACES} FINAL
+      WHERE trace_id = {traceId:String}
+      LIMIT 1
+    `;
+
+    const result = await this.client.query({
+      query,
+      query_params: { traceId },
+      format: 'JSONEachRow',
+    });
+
+    const rows = await result.json<Record<string, unknown>>();
+    const firstRow = rows[0];
+    return firstRow ? this.transformTrace(firstRow) : null;
+  }
+
+  // ============================================================
+  // Span Queries
+  // ============================================================
+
+  /**
+   * List spans with filtering and pagination.
+   */
+  async listSpans(options: SpanQueryOptions = {}): Promise<{ spans: Span[]; pagination: PaginationInfo }> {
+    const { conditions, params } = this.buildSpanConditions(options);
+    const page = options.pagination?.page ?? DEFAULT_PAGE;
+    const perPage = options.pagination?.perPage ?? DEFAULT_PER_PAGE;
+
+    // Get total count
+    const countQuery = `
+      SELECT count() as total
+      FROM ${TABLE_NAMES.SPANS} FINAL
+      ${conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''}
+    `;
+    const countResult = await this.client.query({
+      query: countQuery,
+      query_params: params,
+      format: 'JSONEachRow',
+    });
+    const countRows = await countResult.json<{ total: number }>();
+    const total = countRows[0]?.total ?? 0;
+
+    // Get paginated results
+    const query = `
+      SELECT *
+      FROM ${TABLE_NAMES.SPANS} FINAL
+      ${conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''}
+      ORDER BY start_time DESC
+      LIMIT {limit:UInt32} OFFSET {offset:UInt32}
+    `;
+
+    const result = await this.client.query({
+      query,
+      query_params: { ...params, limit: perPage, offset: page * perPage },
+      format: 'JSONEachRow',
+    });
+
+    const rows = await result.json<Record<string, unknown>>();
+    const spans = rows.map(row => this.transformSpan(row as Record<string, unknown>));
+
+    return {
+      spans,
+      pagination: {
+        total,
+        page,
+        perPage,
+        hasMore: (page + 1) * perPage < total,
+      },
+    };
+  }
+
+  /**
+   * Get spans for a trace.
+   */
+  async getSpansForTrace(traceId: string): Promise<Span[]> {
+    const query = `
+      SELECT * FROM ${TABLE_NAMES.SPANS} FINAL
+      WHERE trace_id = {traceId:String}
+      ORDER BY start_time ASC
+    `;
+
+    const result = await this.client.query({
+      query,
+      query_params: { traceId },
+      format: 'JSONEachRow',
+    });
+
+    const rows = await result.json<Record<string, unknown>>();
+    return rows.map(row => this.transformSpan(row as Record<string, unknown>));
+  }
+
+  // ============================================================
+  // Log Queries
+  // ============================================================
+
+  /**
+   * List logs with filtering and pagination.
+   */
+  async listLogs(options: LogQueryOptions = {}): Promise<{ logs: Log[]; pagination: PaginationInfo }> {
+    const { conditions, params } = this.buildLogConditions(options);
+    const page = options.pagination?.page ?? DEFAULT_PAGE;
+    const perPage = options.pagination?.perPage ?? DEFAULT_PER_PAGE;
+
+    // Get total count
+    const countQuery = `
+      SELECT count() as total
+      FROM ${TABLE_NAMES.LOGS}
+      ${conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''}
+    `;
+    const countResult = await this.client.query({
+      query: countQuery,
+      query_params: params,
+      format: 'JSONEachRow',
+    });
+    const countRows = await countResult.json<{ total: number }>();
+    const total = countRows[0]?.total ?? 0;
+
+    // Get paginated results
+    const query = `
+      SELECT *
+      FROM ${TABLE_NAMES.LOGS}
+      ${conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''}
+      ORDER BY timestamp DESC
+      LIMIT {limit:UInt32} OFFSET {offset:UInt32}
+    `;
+
+    const result = await this.client.query({
+      query,
+      query_params: { ...params, limit: perPage, offset: page * perPage },
+      format: 'JSONEachRow',
+    });
+
+    const rows = await result.json<Record<string, unknown>>();
+    const logs = rows.map(row => this.transformLog(row as Record<string, unknown>));
+
+    return {
+      logs,
+      pagination: {
+        total,
+        page,
+        perPage,
+        hasMore: (page + 1) * perPage < total,
+      },
+    };
+  }
+
+  // ============================================================
+  // Metric Queries
+  // ============================================================
+
+  /**
+   * List metrics with filtering and pagination.
+   */
+  async listMetrics(options: MetricQueryOptions = {}): Promise<{ metrics: Metric[]; pagination: PaginationInfo }> {
+    const { conditions, params } = this.buildMetricConditions(options);
+    const page = options.pagination?.page ?? DEFAULT_PAGE;
+    const perPage = options.pagination?.perPage ?? DEFAULT_PER_PAGE;
+
+    // Get total count
+    const countQuery = `
+      SELECT count() as total
+      FROM ${TABLE_NAMES.METRICS}
+      ${conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''}
+    `;
+    const countResult = await this.client.query({
+      query: countQuery,
+      query_params: params,
+      format: 'JSONEachRow',
+    });
+    const countRows = await countResult.json<{ total: number }>();
+    const total = countRows[0]?.total ?? 0;
+
+    // Get paginated results
+    const query = `
+      SELECT *
+      FROM ${TABLE_NAMES.METRICS}
+      ${conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''}
+      ORDER BY timestamp DESC
+      LIMIT {limit:UInt32} OFFSET {offset:UInt32}
+    `;
+
+    const result = await this.client.query({
+      query,
+      query_params: { ...params, limit: perPage, offset: page * perPage },
+      format: 'JSONEachRow',
+    });
+
+    const rows = await result.json<Record<string, unknown>>();
+    const metrics = rows.map(row => this.transformMetric(row as Record<string, unknown>));
+
+    return {
+      metrics,
+      pagination: {
+        total,
+        page,
+        perPage,
+        hasMore: (page + 1) * perPage < total,
+      },
+    };
+  }
+
+  // ============================================================
+  // Score Queries
+  // ============================================================
+
+  /**
+   * List scores with filtering and pagination.
+   */
+  async listScores(options: ScoreQueryOptions = {}): Promise<{ scores: Score[]; pagination: PaginationInfo }> {
+    const { conditions, params } = this.buildScoreConditions(options);
+    const page = options.pagination?.page ?? DEFAULT_PAGE;
+    const perPage = options.pagination?.perPage ?? DEFAULT_PER_PAGE;
+
+    // Get total count
+    const countQuery = `
+      SELECT count() as total
+      FROM ${TABLE_NAMES.SCORES}
+      ${conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''}
+    `;
+    const countResult = await this.client.query({
+      query: countQuery,
+      query_params: params,
+      format: 'JSONEachRow',
+    });
+    const countRows = await countResult.json<{ total: number }>();
+    const total = countRows[0]?.total ?? 0;
+
+    // Get paginated results
+    const query = `
+      SELECT *
+      FROM ${TABLE_NAMES.SCORES}
+      ${conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''}
+      ORDER BY timestamp DESC
+      LIMIT {limit:UInt32} OFFSET {offset:UInt32}
+    `;
+
+    const result = await this.client.query({
+      query,
+      query_params: { ...params, limit: perPage, offset: page * perPage },
+      format: 'JSONEachRow',
+    });
+
+    const rows = await result.json<Record<string, unknown>>();
+    const scores = rows.map(row => this.transformScore(row as Record<string, unknown>));
+
+    return {
+      scores,
+      pagination: {
+        total,
+        page,
+        perPage,
+        hasMore: (page + 1) * perPage < total,
+      },
+    };
+  }
+
+  // ============================================================
+  // Analytics / Aggregation Queries
+  // ============================================================
+
+  /**
+   * Get trace count over time.
+   */
+  async getTraceCountTimeSeries(
+    options: AggregationOptions & { projectId?: string; deploymentId?: string },
+  ): Promise<TimeBucket[]> {
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {
+      intervalSeconds: options.intervalSeconds,
+    };
+
+    if (options.timeRange?.start) {
+      conditions.push('start_time >= {startTime:DateTime64(3)}');
+      params.startTime = options.timeRange.start.getTime();
+    }
+    if (options.timeRange?.end) {
+      conditions.push('start_time <= {endTime:DateTime64(3)}');
+      params.endTime = options.timeRange.end.getTime();
+    }
+    if (options.projectId) {
+      conditions.push('project_id = {projectId:String}');
+      params.projectId = options.projectId;
+    }
+    if (options.deploymentId) {
+      conditions.push('deployment_id = {deploymentId:String}');
+      params.deploymentId = options.deploymentId;
+    }
+
+    const query = `
+      SELECT
+        toStartOfInterval(start_time, INTERVAL {intervalSeconds:UInt32} SECOND) AS timestamp,
+        count() AS count
+      FROM ${TABLE_NAMES.TRACES} FINAL
+      ${conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''}
+      GROUP BY timestamp
+      ORDER BY timestamp ASC
+    `;
+
+    const result = await this.client.query({
+      query,
+      query_params: params,
+      format: 'JSONEachRow',
+    });
+
+    const rows = await result.json<{ timestamp: string; count: number }>();
+    return rows.map(r => ({
+      timestamp: new Date(r.timestamp),
+      count: r.count,
+    }));
+  }
+
+  /**
+   * Get error rate over time.
+   */
+  async getErrorRateTimeSeries(
+    options: AggregationOptions & { projectId?: string; deploymentId?: string },
+  ): Promise<TimeBucket[]> {
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {
+      intervalSeconds: options.intervalSeconds,
+    };
+
+    if (options.timeRange?.start) {
+      conditions.push('start_time >= {startTime:DateTime64(3)}');
+      params.startTime = options.timeRange.start.getTime();
+    }
+    if (options.timeRange?.end) {
+      conditions.push('start_time <= {endTime:DateTime64(3)}');
+      params.endTime = options.timeRange.end.getTime();
+    }
+    if (options.projectId) {
+      conditions.push('project_id = {projectId:String}');
+      params.projectId = options.projectId;
+    }
+    if (options.deploymentId) {
+      conditions.push('deployment_id = {deploymentId:String}');
+      params.deploymentId = options.deploymentId;
+    }
+
+    const query = `
+      SELECT
+        toStartOfInterval(start_time, INTERVAL {intervalSeconds:UInt32} SECOND) AS timestamp,
+        count() AS count,
+        countIf(status = 'error') AS error_count,
+        error_count / count AS error_rate
+      FROM ${TABLE_NAMES.TRACES} FINAL
+      ${conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''}
+      GROUP BY timestamp
+      ORDER BY timestamp ASC
+    `;
+
+    const result = await this.client.query({
+      query,
+      query_params: params,
+      format: 'JSONEachRow',
+    });
+
+    const rows = await result.json<{
+      timestamp: string;
+      count: number;
+      error_count: number;
+      error_rate: number;
+    }>();
+
+    return rows.map(r => ({
+      timestamp: new Date(r.timestamp),
+      count: r.count,
+      values: {
+        errorCount: r.error_count,
+        errorRate: r.error_rate,
+      },
+    }));
+  }
+
+  // ============================================================
+  // Condition Builders
+  // ============================================================
+
+  private buildTraceConditions(options: TraceQueryOptions): {
+    conditions: string[];
+    params: Record<string, unknown>;
+  } {
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {};
+
+    if (options.projectId) {
+      conditions.push('project_id = {projectId:String}');
+      params.projectId = options.projectId;
+    }
+    if (options.deploymentId) {
+      conditions.push('deployment_id = {deploymentId:String}');
+      params.deploymentId = options.deploymentId;
+    }
+    if (options.traceId) {
+      conditions.push('trace_id = {traceId:String}');
+      params.traceId = options.traceId;
+    }
+    if (options.status) {
+      conditions.push('status = {status:String}');
+      params.status = options.status;
+    }
+    if (options.name) {
+      conditions.push('name LIKE {name:String}');
+      params.name = `%${options.name}%`;
+    }
+    if (options.timeRange?.start) {
+      conditions.push('start_time >= {startTime:DateTime64(3)}');
+      params.startTime = options.timeRange.start.getTime();
+    }
+    if (options.timeRange?.end) {
+      conditions.push('start_time <= {endTime:DateTime64(3)}');
+      params.endTime = options.timeRange.end.getTime();
+    }
+
+    return { conditions, params };
+  }
+
+  private buildSpanConditions(options: SpanQueryOptions): {
+    conditions: string[];
+    params: Record<string, unknown>;
+  } {
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {};
+
+    if (options.projectId) {
+      conditions.push('project_id = {projectId:String}');
+      params.projectId = options.projectId;
+    }
+    if (options.deploymentId) {
+      conditions.push('deployment_id = {deploymentId:String}');
+      params.deploymentId = options.deploymentId;
+    }
+    if (options.traceId) {
+      conditions.push('trace_id = {traceId:String}');
+      params.traceId = options.traceId;
+    }
+    if (options.spanId) {
+      conditions.push('span_id = {spanId:String}');
+      params.spanId = options.spanId;
+    }
+    if (options.parentSpanId) {
+      conditions.push('parent_span_id = {parentSpanId:String}');
+      params.parentSpanId = options.parentSpanId;
+    }
+    if (options.kind) {
+      conditions.push('kind = {kind:String}');
+      params.kind = options.kind;
+    }
+    if (options.name) {
+      conditions.push('name LIKE {name:String}');
+      params.name = `%${options.name}%`;
+    }
+    if (options.timeRange?.start) {
+      conditions.push('start_time >= {startTime:DateTime64(3)}');
+      params.startTime = options.timeRange.start.getTime();
+    }
+    if (options.timeRange?.end) {
+      conditions.push('start_time <= {endTime:DateTime64(3)}');
+      params.endTime = options.timeRange.end.getTime();
+    }
+
+    return { conditions, params };
+  }
+
+  private buildLogConditions(options: LogQueryOptions): {
+    conditions: string[];
+    params: Record<string, unknown>;
+  } {
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {};
+
+    if (options.projectId) {
+      conditions.push('project_id = {projectId:String}');
+      params.projectId = options.projectId;
+    }
+    if (options.deploymentId) {
+      conditions.push('deployment_id = {deploymentId:String}');
+      params.deploymentId = options.deploymentId;
+    }
+    if (options.level) {
+      conditions.push('level = {level:String}');
+      params.level = options.level;
+    }
+    if (options.traceId) {
+      conditions.push('trace_id = {traceId:String}');
+      params.traceId = options.traceId;
+    }
+    if (options.spanId) {
+      conditions.push('span_id = {spanId:String}');
+      params.spanId = options.spanId;
+    }
+    if (options.message) {
+      conditions.push('message LIKE {message:String}');
+      params.message = `%${options.message}%`;
+    }
+    if (options.timeRange?.start) {
+      conditions.push('timestamp >= {startTime:DateTime64(3)}');
+      params.startTime = options.timeRange.start.getTime();
+    }
+    if (options.timeRange?.end) {
+      conditions.push('timestamp <= {endTime:DateTime64(3)}');
+      params.endTime = options.timeRange.end.getTime();
+    }
+
+    return { conditions, params };
+  }
+
+  private buildMetricConditions(options: MetricQueryOptions): {
+    conditions: string[];
+    params: Record<string, unknown>;
+  } {
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {};
+
+    if (options.projectId) {
+      conditions.push('project_id = {projectId:String}');
+      params.projectId = options.projectId;
+    }
+    if (options.deploymentId) {
+      conditions.push('deployment_id = {deploymentId:String}');
+      params.deploymentId = options.deploymentId;
+    }
+    if (options.name) {
+      conditions.push('name = {name:String}');
+      params.name = options.name;
+    }
+    if (options.type) {
+      conditions.push('type = {type:String}');
+      params.type = options.type;
+    }
+    if (options.timeRange?.start) {
+      conditions.push('timestamp >= {startTime:DateTime64(3)}');
+      params.startTime = options.timeRange.start.getTime();
+    }
+    if (options.timeRange?.end) {
+      conditions.push('timestamp <= {endTime:DateTime64(3)}');
+      params.endTime = options.timeRange.end.getTime();
+    }
+
+    return { conditions, params };
+  }
+
+  private buildScoreConditions(options: ScoreQueryOptions): {
+    conditions: string[];
+    params: Record<string, unknown>;
+  } {
+    const conditions: string[] = [];
+    const params: Record<string, unknown> = {};
+
+    if (options.projectId) {
+      conditions.push('project_id = {projectId:String}');
+      params.projectId = options.projectId;
+    }
+    if (options.deploymentId) {
+      conditions.push('deployment_id = {deploymentId:String}');
+      params.deploymentId = options.deploymentId;
+    }
+    if (options.name) {
+      conditions.push('name = {name:String}');
+      params.name = options.name;
+    }
+    if (options.traceId) {
+      conditions.push('trace_id = {traceId:String}');
+      params.traceId = options.traceId;
+    }
+    if (options.minValue !== undefined) {
+      conditions.push('value >= {minValue:Float64}');
+      params.minValue = options.minValue;
+    }
+    if (options.maxValue !== undefined) {
+      conditions.push('value <= {maxValue:Float64}');
+      params.maxValue = options.maxValue;
+    }
+    if (options.timeRange?.start) {
+      conditions.push('timestamp >= {startTime:DateTime64(3)}');
+      params.startTime = options.timeRange.start.getTime();
+    }
+    if (options.timeRange?.end) {
+      conditions.push('timestamp <= {endTime:DateTime64(3)}');
+      params.endTime = options.timeRange.end.getTime();
+    }
+
+    return { conditions, params };
+  }
+
+  // ============================================================
+  // Transform Functions
+  // ============================================================
+
+  private transformTrace(row: Record<string, unknown>): Trace {
+    return {
+      traceId: row.trace_id as string,
+      projectId: row.project_id as string,
+      deploymentId: row.deployment_id as string,
+      name: row.name as string,
+      status: row.status as 'ok' | 'error' | 'unset',
+      startTime: new Date(row.start_time as string),
+      endTime: row.end_time ? new Date(row.end_time as string) : null,
+      durationMs: row.duration_ms as number | null,
+      metadata: row.metadata ? JSON.parse(row.metadata as string) : {},
+    };
+  }
+
+  private transformSpan(row: Record<string, unknown>): Span {
+    return {
+      spanId: row.span_id as string,
+      traceId: row.trace_id as string,
+      parentSpanId: (row.parent_span_id as string) || null,
+      projectId: row.project_id as string,
+      deploymentId: row.deployment_id as string,
+      name: row.name as string,
+      kind: row.kind as 'internal' | 'server' | 'client' | 'producer' | 'consumer',
+      status: row.status as 'ok' | 'error' | 'unset',
+      startTime: new Date(row.start_time as string),
+      endTime: row.end_time ? new Date(row.end_time as string) : null,
+      durationMs: row.duration_ms as number | null,
+      attributes: row.attributes ? JSON.parse(row.attributes as string) : {},
+      events: row.events ? JSON.parse(row.events as string) : [],
+    };
+  }
+
+  private transformLog(row: Record<string, unknown>): Log {
+    return {
+      id: row.id as string,
+      projectId: row.project_id as string,
+      deploymentId: row.deployment_id as string,
+      traceId: (row.trace_id as string) || null,
+      spanId: (row.span_id as string) || null,
+      level: row.level as 'debug' | 'info' | 'warn' | 'error',
+      message: row.message as string,
+      timestamp: new Date(row.timestamp as string),
+      attributes: row.attributes ? JSON.parse(row.attributes as string) : {},
+    };
+  }
+
+  private transformMetric(row: Record<string, unknown>): Metric {
+    return {
+      id: row.id as string,
+      projectId: row.project_id as string,
+      deploymentId: row.deployment_id as string,
+      name: row.name as string,
+      type: row.type as 'counter' | 'gauge' | 'histogram',
+      value: row.value as number,
+      unit: (row.unit as string) || null,
+      timestamp: new Date(row.timestamp as string),
+      labels: row.labels ? JSON.parse(row.labels as string) : {},
+    };
+  }
+
+  private transformScore(row: Record<string, unknown>): Score {
+    return {
+      id: row.id as string,
+      projectId: row.project_id as string,
+      deploymentId: row.deployment_id as string,
+      traceId: (row.trace_id as string) || null,
+      name: row.name as string,
+      value: row.value as number,
+      normalizedValue: row.normalized_value as number | null,
+      comment: (row.comment as string) || null,
+      timestamp: new Date(row.timestamp as string),
+      metadata: row.metadata ? JSON.parse(row.metadata as string) : {},
+    };
+  }
+}

--- a/observability/clickhouse/src/schema/index.ts
+++ b/observability/clickhouse/src/schema/index.ts
@@ -1,0 +1,3 @@
+export * from './tables.js';
+export * from './materialized-views.js';
+export * from './migrations.js';

--- a/observability/clickhouse/src/schema/materialized-views.ts
+++ b/observability/clickhouse/src/schema/materialized-views.ts
@@ -1,0 +1,130 @@
+/**
+ * Materialized views for efficient aggregation queries.
+ */
+
+import { TABLE_NAMES } from './tables.js';
+
+/**
+ * Hourly trace statistics per project/deployment
+ */
+export const TRACES_HOURLY_STATS_VIEW_SQL = `
+CREATE MATERIALIZED VIEW IF NOT EXISTS mastra_admin_traces_hourly_stats
+ENGINE = SummingMergeTree()
+PARTITION BY toYYYYMM(hour)
+ORDER BY (project_id, deployment_id, hour, status)
+AS SELECT
+  project_id,
+  deployment_id,
+  toStartOfHour(start_time) AS hour,
+  status,
+  count() AS count,
+  sum(duration_ms) AS total_duration_ms,
+  avg(duration_ms) AS avg_duration_ms
+FROM ${TABLE_NAMES.TRACES}
+GROUP BY project_id, deployment_id, hour, status
+`;
+
+/**
+ * Hourly span statistics per project/deployment
+ */
+export const SPANS_HOURLY_STATS_VIEW_SQL = `
+CREATE MATERIALIZED VIEW IF NOT EXISTS mastra_admin_spans_hourly_stats
+ENGINE = SummingMergeTree()
+PARTITION BY toYYYYMM(hour)
+ORDER BY (project_id, deployment_id, hour, kind, status)
+AS SELECT
+  project_id,
+  deployment_id,
+  toStartOfHour(start_time) AS hour,
+  kind,
+  status,
+  count() AS count,
+  sum(duration_ms) AS total_duration_ms,
+  avg(duration_ms) AS avg_duration_ms
+FROM ${TABLE_NAMES.SPANS}
+GROUP BY project_id, deployment_id, hour, kind, status
+`;
+
+/**
+ * Hourly log level counts per project/deployment
+ */
+export const LOGS_HOURLY_STATS_VIEW_SQL = `
+CREATE MATERIALIZED VIEW IF NOT EXISTS mastra_admin_logs_hourly_stats
+ENGINE = SummingMergeTree()
+PARTITION BY toYYYYMM(hour)
+ORDER BY (project_id, deployment_id, hour, level)
+AS SELECT
+  project_id,
+  deployment_id,
+  toStartOfHour(timestamp) AS hour,
+  level,
+  count() AS count
+FROM ${TABLE_NAMES.LOGS}
+GROUP BY project_id, deployment_id, hour, level
+`;
+
+/**
+ * Hourly metric aggregations per project/deployment/metric name
+ */
+export const METRICS_HOURLY_STATS_VIEW_SQL = `
+CREATE MATERIALIZED VIEW IF NOT EXISTS mastra_admin_metrics_hourly_stats
+ENGINE = SummingMergeTree()
+PARTITION BY toYYYYMM(hour)
+ORDER BY (project_id, deployment_id, name, hour)
+AS SELECT
+  project_id,
+  deployment_id,
+  name,
+  toStartOfHour(timestamp) AS hour,
+  count() AS count,
+  sum(value) AS sum_value,
+  avg(value) AS avg_value,
+  min(value) AS min_value,
+  max(value) AS max_value
+FROM ${TABLE_NAMES.METRICS}
+GROUP BY project_id, deployment_id, name, hour
+`;
+
+/**
+ * Hourly score aggregations per project/deployment/score name
+ */
+export const SCORES_HOURLY_STATS_VIEW_SQL = `
+CREATE MATERIALIZED VIEW IF NOT EXISTS mastra_admin_scores_hourly_stats
+ENGINE = SummingMergeTree()
+PARTITION BY toYYYYMM(hour)
+ORDER BY (project_id, deployment_id, name, hour)
+AS SELECT
+  project_id,
+  deployment_id,
+  name,
+  toStartOfHour(timestamp) AS hour,
+  count() AS count,
+  sum(value) AS sum_value,
+  avg(value) AS avg_value,
+  min(value) AS min_value,
+  max(value) AS max_value
+FROM ${TABLE_NAMES.SCORES}
+GROUP BY project_id, deployment_id, name, hour
+`;
+
+/**
+ * All materialized view creation SQL statements
+ */
+export const ALL_MATERIALIZED_VIEWS_SQL = [
+  TRACES_HOURLY_STATS_VIEW_SQL,
+  SPANS_HOURLY_STATS_VIEW_SQL,
+  LOGS_HOURLY_STATS_VIEW_SQL,
+  METRICS_HOURLY_STATS_VIEW_SQL,
+  SCORES_HOURLY_STATS_VIEW_SQL,
+];
+
+/**
+ * Materialized view names
+ */
+export const VIEW_NAMES = {
+  TRACES_HOURLY: 'mastra_admin_traces_hourly_stats',
+  SPANS_HOURLY: 'mastra_admin_spans_hourly_stats',
+  LOGS_HOURLY: 'mastra_admin_logs_hourly_stats',
+  METRICS_HOURLY: 'mastra_admin_metrics_hourly_stats',
+  SCORES_HOURLY: 'mastra_admin_scores_hourly_stats',
+} as const;

--- a/observability/clickhouse/src/schema/migrations.test.ts
+++ b/observability/clickhouse/src/schema/migrations.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { runMigrations, checkSchemaStatus, dropAllTables } from './migrations.js';
+import { ALL_TABLES_SQL } from './tables.js';
+import { ALL_MATERIALIZED_VIEWS_SQL } from './materialized-views.js';
+
+// Mock ClickHouse client
+function createMockClickHouseClient(existingTables: string[] = []) {
+  const commands: string[] = [];
+  const tables = new Set(existingTables);
+
+  return {
+    commands,
+    tables,
+    async command(options: { query: string }) {
+      commands.push(options.query);
+
+      // Handle CREATE TABLE IF NOT EXISTS
+      const createMatch = options.query.match(/CREATE\s+(?:TABLE|MATERIALIZED\s+VIEW)\s+IF\s+NOT\s+EXISTS\s+(\w+)/i);
+      if (createMatch?.[1]) {
+        tables.add(createMatch[1]);
+      }
+
+      // Handle DROP TABLE IF EXISTS
+      const dropMatch = options.query.match(/DROP\s+TABLE\s+IF\s+EXISTS\s+(\w+)/i);
+      if (dropMatch?.[1]) {
+        tables.delete(dropMatch[1]);
+      }
+    },
+    async query(options: { query: string; format?: string }) {
+      // Return existing tables for schema check
+      if (options.query.includes('system.tables')) {
+        return {
+          async json() {
+            return Array.from(tables).map(name => ({ name }));
+          },
+        };
+      }
+      return {
+        async json() {
+          return [];
+        },
+      };
+    },
+  };
+}
+
+describe('runMigrations', () => {
+  it('should create all tables and views', async () => {
+    const client = createMockClickHouseClient();
+
+    await runMigrations(client as unknown as import('@clickhouse/client').ClickHouseClient);
+
+    // Should have run commands for all tables and views
+    const expectedCount = ALL_TABLES_SQL.length + ALL_MATERIALIZED_VIEWS_SQL.length;
+    expect(client.commands.length).toBe(expectedCount);
+
+    // Verify all tables were created
+    expect(client.tables.has('mastra_admin_traces')).toBe(true);
+    expect(client.tables.has('mastra_admin_spans')).toBe(true);
+    expect(client.tables.has('mastra_admin_logs')).toBe(true);
+    expect(client.tables.has('mastra_admin_metrics')).toBe(true);
+    expect(client.tables.has('mastra_admin_scores')).toBe(true);
+
+    // Verify all views were created
+    expect(client.tables.has('mastra_admin_traces_hourly_stats')).toBe(true);
+    expect(client.tables.has('mastra_admin_spans_hourly_stats')).toBe(true);
+    expect(client.tables.has('mastra_admin_logs_hourly_stats')).toBe(true);
+    expect(client.tables.has('mastra_admin_metrics_hourly_stats')).toBe(true);
+    expect(client.tables.has('mastra_admin_scores_hourly_stats')).toBe(true);
+  });
+
+  it('should be safe to run multiple times (idempotent)', async () => {
+    const client = createMockClickHouseClient();
+
+    // Run migrations twice
+    await runMigrations(client as unknown as import('@clickhouse/client').ClickHouseClient);
+    const firstRunCount = client.commands.length;
+
+    await runMigrations(client as unknown as import('@clickhouse/client').ClickHouseClient);
+    const secondRunCount = client.commands.length;
+
+    // Both runs should execute the same number of commands
+    expect(secondRunCount).toBe(firstRunCount * 2);
+
+    // But we should still only have the expected tables
+    expect(client.tables.size).toBe(10);
+  });
+
+  it('should create tables in correct order (tables before views)', async () => {
+    const client = createMockClickHouseClient();
+
+    await runMigrations(client as unknown as import('@clickhouse/client').ClickHouseClient);
+
+    // Find indices of table and view creation commands
+    const tracesTableIdx = client.commands.findIndex(c => c.includes('CREATE TABLE') && c.includes('mastra_admin_traces'));
+    const tracesViewIdx = client.commands.findIndex(c => c.includes('CREATE MATERIALIZED VIEW') && c.includes('mastra_admin_traces_hourly_stats'));
+
+    // Tables should be created before views
+    expect(tracesTableIdx).toBeLessThan(tracesViewIdx);
+  });
+});
+
+describe('checkSchemaStatus', () => {
+  it('should return not initialized when no tables exist', async () => {
+    const client = createMockClickHouseClient([]);
+
+    const status = await checkSchemaStatus(client as unknown as import('@clickhouse/client').ClickHouseClient);
+
+    expect(status.isInitialized).toBe(false);
+    expect(status.missingTables).toContain('mastra_admin_traces');
+    expect(status.missingTables).toContain('mastra_admin_spans');
+    expect(status.missingTables).toContain('mastra_admin_logs');
+    expect(status.missingTables).toContain('mastra_admin_metrics');
+    expect(status.missingTables).toContain('mastra_admin_scores');
+    expect(status.missingViews).toContain('mastra_admin_traces_hourly_stats');
+  });
+
+  it('should return initialized when all tables and views exist', async () => {
+    const client = createMockClickHouseClient([
+      'mastra_admin_traces',
+      'mastra_admin_spans',
+      'mastra_admin_logs',
+      'mastra_admin_metrics',
+      'mastra_admin_scores',
+      'mastra_admin_traces_hourly_stats',
+      'mastra_admin_spans_hourly_stats',
+      'mastra_admin_logs_hourly_stats',
+      'mastra_admin_metrics_hourly_stats',
+      'mastra_admin_scores_hourly_stats',
+    ]);
+
+    const status = await checkSchemaStatus(client as unknown as import('@clickhouse/client').ClickHouseClient);
+
+    expect(status.isInitialized).toBe(true);
+    expect(status.missingTables).toHaveLength(0);
+    expect(status.missingViews).toHaveLength(0);
+  });
+
+  it('should return not initialized when some tables are missing', async () => {
+    const client = createMockClickHouseClient([
+      'mastra_admin_traces',
+      'mastra_admin_spans',
+      // missing logs, metrics, scores
+    ]);
+
+    const status = await checkSchemaStatus(client as unknown as import('@clickhouse/client').ClickHouseClient);
+
+    expect(status.isInitialized).toBe(false);
+    expect(status.missingTables).toContain('mastra_admin_logs');
+    expect(status.missingTables).toContain('mastra_admin_metrics');
+    expect(status.missingTables).toContain('mastra_admin_scores');
+  });
+
+  it('should return not initialized when some views are missing', async () => {
+    const client = createMockClickHouseClient([
+      'mastra_admin_traces',
+      'mastra_admin_spans',
+      'mastra_admin_logs',
+      'mastra_admin_metrics',
+      'mastra_admin_scores',
+      'mastra_admin_traces_hourly_stats',
+      // missing other views
+    ]);
+
+    const status = await checkSchemaStatus(client as unknown as import('@clickhouse/client').ClickHouseClient);
+
+    expect(status.isInitialized).toBe(false);
+    expect(status.missingTables).toHaveLength(0);
+    expect(status.missingViews).toContain('mastra_admin_spans_hourly_stats');
+    expect(status.missingViews).toContain('mastra_admin_logs_hourly_stats');
+  });
+});
+
+describe('dropAllTables', () => {
+  it('should drop all tables and views', async () => {
+    const client = createMockClickHouseClient([
+      'mastra_admin_traces',
+      'mastra_admin_spans',
+      'mastra_admin_logs',
+      'mastra_admin_metrics',
+      'mastra_admin_scores',
+      'mastra_admin_traces_hourly_stats',
+      'mastra_admin_spans_hourly_stats',
+      'mastra_admin_logs_hourly_stats',
+      'mastra_admin_metrics_hourly_stats',
+      'mastra_admin_scores_hourly_stats',
+    ]);
+
+    await dropAllTables(client as unknown as import('@clickhouse/client').ClickHouseClient);
+
+    // All tables should be dropped
+    expect(client.tables.size).toBe(0);
+    expect(client.commands.length).toBe(10);
+  });
+
+  it('should drop views before tables', async () => {
+    const client = createMockClickHouseClient([
+      'mastra_admin_traces',
+      'mastra_admin_traces_hourly_stats',
+    ]);
+
+    await dropAllTables(client as unknown as import('@clickhouse/client').ClickHouseClient);
+
+    // Find indices of drop commands
+    const dropViewIdx = client.commands.findIndex(c => c.includes('mastra_admin_traces_hourly_stats'));
+    const dropTableIdx = client.commands.findIndex(c => c.includes('DROP TABLE') && c.includes('mastra_admin_traces') && !c.includes('hourly'));
+
+    // Views should be dropped before tables
+    expect(dropViewIdx).toBeLessThan(dropTableIdx);
+  });
+
+  it('should be safe to run when tables do not exist', async () => {
+    const client = createMockClickHouseClient([]);
+
+    // Should not throw
+    await dropAllTables(client as unknown as import('@clickhouse/client').ClickHouseClient);
+
+    expect(client.commands.length).toBe(10); // Still executes DROP IF EXISTS
+  });
+});

--- a/observability/clickhouse/src/schema/migrations.test.ts
+++ b/observability/clickhouse/src/schema/migrations.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import type { ClickHouseClient } from '@clickhouse/client';
+
+import { describe, it, expect } from 'vitest';
+
+import { ALL_MATERIALIZED_VIEWS_SQL } from './materialized-views.js';
 import { runMigrations, checkSchemaStatus, dropAllTables } from './migrations.js';
 import { ALL_TABLES_SQL } from './tables.js';
-import { ALL_MATERIALIZED_VIEWS_SQL } from './materialized-views.js';
 
 // Mock ClickHouse client
 function createMockClickHouseClient(existingTables: string[] = []) {
@@ -48,7 +51,7 @@ describe('runMigrations', () => {
   it('should create all tables and views', async () => {
     const client = createMockClickHouseClient();
 
-    await runMigrations(client as unknown as import('@clickhouse/client').ClickHouseClient);
+    await runMigrations(client as unknown as ClickHouseClient);
 
     // Should have run commands for all tables and views
     const expectedCount = ALL_TABLES_SQL.length + ALL_MATERIALIZED_VIEWS_SQL.length;
@@ -73,10 +76,10 @@ describe('runMigrations', () => {
     const client = createMockClickHouseClient();
 
     // Run migrations twice
-    await runMigrations(client as unknown as import('@clickhouse/client').ClickHouseClient);
+    await runMigrations(client as unknown as ClickHouseClient);
     const firstRunCount = client.commands.length;
 
-    await runMigrations(client as unknown as import('@clickhouse/client').ClickHouseClient);
+    await runMigrations(client as unknown as ClickHouseClient);
     const secondRunCount = client.commands.length;
 
     // Both runs should execute the same number of commands
@@ -89,7 +92,7 @@ describe('runMigrations', () => {
   it('should create tables in correct order (tables before views)', async () => {
     const client = createMockClickHouseClient();
 
-    await runMigrations(client as unknown as import('@clickhouse/client').ClickHouseClient);
+    await runMigrations(client as unknown as ClickHouseClient);
 
     // Find indices of table and view creation commands
     const tracesTableIdx = client.commands.findIndex(c => c.includes('CREATE TABLE') && c.includes('mastra_admin_traces'));
@@ -104,7 +107,7 @@ describe('checkSchemaStatus', () => {
   it('should return not initialized when no tables exist', async () => {
     const client = createMockClickHouseClient([]);
 
-    const status = await checkSchemaStatus(client as unknown as import('@clickhouse/client').ClickHouseClient);
+    const status = await checkSchemaStatus(client as unknown as ClickHouseClient);
 
     expect(status.isInitialized).toBe(false);
     expect(status.missingTables).toContain('mastra_admin_traces');
@@ -129,7 +132,7 @@ describe('checkSchemaStatus', () => {
       'mastra_admin_scores_hourly_stats',
     ]);
 
-    const status = await checkSchemaStatus(client as unknown as import('@clickhouse/client').ClickHouseClient);
+    const status = await checkSchemaStatus(client as unknown as ClickHouseClient);
 
     expect(status.isInitialized).toBe(true);
     expect(status.missingTables).toHaveLength(0);
@@ -143,7 +146,7 @@ describe('checkSchemaStatus', () => {
       // missing logs, metrics, scores
     ]);
 
-    const status = await checkSchemaStatus(client as unknown as import('@clickhouse/client').ClickHouseClient);
+    const status = await checkSchemaStatus(client as unknown as ClickHouseClient);
 
     expect(status.isInitialized).toBe(false);
     expect(status.missingTables).toContain('mastra_admin_logs');
@@ -162,7 +165,7 @@ describe('checkSchemaStatus', () => {
       // missing other views
     ]);
 
-    const status = await checkSchemaStatus(client as unknown as import('@clickhouse/client').ClickHouseClient);
+    const status = await checkSchemaStatus(client as unknown as ClickHouseClient);
 
     expect(status.isInitialized).toBe(false);
     expect(status.missingTables).toHaveLength(0);
@@ -186,7 +189,7 @@ describe('dropAllTables', () => {
       'mastra_admin_scores_hourly_stats',
     ]);
 
-    await dropAllTables(client as unknown as import('@clickhouse/client').ClickHouseClient);
+    await dropAllTables(client as unknown as ClickHouseClient);
 
     // All tables should be dropped
     expect(client.tables.size).toBe(0);
@@ -199,7 +202,7 @@ describe('dropAllTables', () => {
       'mastra_admin_traces_hourly_stats',
     ]);
 
-    await dropAllTables(client as unknown as import('@clickhouse/client').ClickHouseClient);
+    await dropAllTables(client as unknown as ClickHouseClient);
 
     // Find indices of drop commands
     const dropViewIdx = client.commands.findIndex(c => c.includes('mastra_admin_traces_hourly_stats'));
@@ -213,7 +216,7 @@ describe('dropAllTables', () => {
     const client = createMockClickHouseClient([]);
 
     // Should not throw
-    await dropAllTables(client as unknown as import('@clickhouse/client').ClickHouseClient);
+    await dropAllTables(client as unknown as ClickHouseClient);
 
     expect(client.commands.length).toBe(10); // Still executes DROP IF EXISTS
   });

--- a/observability/clickhouse/src/schema/migrations.ts
+++ b/observability/clickhouse/src/schema/migrations.ts
@@ -1,0 +1,89 @@
+/**
+ * Schema migration utilities for ClickHouse.
+ */
+
+import type { ClickHouseClient } from '@clickhouse/client';
+
+import { ALL_MATERIALIZED_VIEWS_SQL } from './materialized-views.js';
+import { ALL_TABLES_SQL } from './tables.js';
+
+/**
+ * Run all migrations to set up the schema.
+ * Safe to call multiple times - uses CREATE IF NOT EXISTS.
+ */
+export async function runMigrations(client: ClickHouseClient): Promise<void> {
+  // Create tables
+  for (const sql of ALL_TABLES_SQL) {
+    await client.command({ query: sql });
+  }
+
+  // Create materialized views
+  for (const sql of ALL_MATERIALIZED_VIEWS_SQL) {
+    await client.command({ query: sql });
+  }
+}
+
+/**
+ * Check if the schema is up to date.
+ * Returns true if all tables and views exist.
+ */
+export async function checkSchemaStatus(client: ClickHouseClient): Promise<{
+  isInitialized: boolean;
+  missingTables: string[];
+  missingViews: string[];
+}> {
+  const expectedTables = [
+    'mastra_admin_traces',
+    'mastra_admin_spans',
+    'mastra_admin_logs',
+    'mastra_admin_metrics',
+    'mastra_admin_scores',
+  ];
+
+  const expectedViews = [
+    'mastra_admin_traces_hourly_stats',
+    'mastra_admin_spans_hourly_stats',
+    'mastra_admin_logs_hourly_stats',
+    'mastra_admin_metrics_hourly_stats',
+    'mastra_admin_scores_hourly_stats',
+  ];
+
+  // Query existing tables
+  const tablesResult = await client.query({
+    query: `SELECT name FROM system.tables WHERE database = currentDatabase() AND name LIKE 'mastra_admin_%'`,
+    format: 'JSONEachRow',
+  });
+  const existingTables = new Set((await tablesResult.json<{ name: string }>()).map(r => r.name));
+
+  const missingTables = expectedTables.filter(t => !existingTables.has(t));
+  const missingViews = expectedViews.filter(v => !existingTables.has(v));
+
+  return {
+    isInitialized: missingTables.length === 0 && missingViews.length === 0,
+    missingTables,
+    missingViews,
+  };
+}
+
+/**
+ * Drop all tables and views (for testing/reset).
+ * WARNING: This deletes all data!
+ */
+export async function dropAllTables(client: ClickHouseClient): Promise<void> {
+  const tables = [
+    'mastra_admin_traces_hourly_stats',
+    'mastra_admin_spans_hourly_stats',
+    'mastra_admin_logs_hourly_stats',
+    'mastra_admin_metrics_hourly_stats',
+    'mastra_admin_scores_hourly_stats',
+    'mastra_admin_traces',
+    'mastra_admin_spans',
+    'mastra_admin_logs',
+    'mastra_admin_metrics',
+    'mastra_admin_scores',
+  ];
+
+  for (const table of tables) {
+    await client.command({ query: `DROP TABLE IF EXISTS ${table}` });
+  }
+}

--- a/observability/clickhouse/src/schema/tables.ts
+++ b/observability/clickhouse/src/schema/tables.ts
@@ -1,0 +1,199 @@
+/**
+ * ClickHouse table definitions for observability data.
+ *
+ * Uses MergeTree engine family for efficient time-series storage.
+ * Tables are partitioned by month for efficient data management.
+ */
+
+/**
+ * SQL for creating the traces table.
+ * Traces represent complete request/operation lifecycles.
+ */
+export const TRACES_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS mastra_admin_traces (
+  -- Identity
+  trace_id String,
+  project_id String,
+  deployment_id String,
+
+  -- Trace info
+  name String,
+  status Enum8('ok' = 1, 'error' = 2, 'unset' = 0),
+
+  -- Timing
+  start_time DateTime64(3),
+  end_time Nullable(DateTime64(3)),
+  duration_ms Nullable(Int64),
+
+  -- Data
+  input String DEFAULT '',
+  output String DEFAULT '',
+  metadata String DEFAULT '{}',
+
+  -- Ingestion metadata
+  recorded_at DateTime64(3),
+  ingested_at DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(start_time)
+ORDER BY (project_id, deployment_id, start_time, trace_id)
+TTL start_time + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192
+`;
+
+/**
+ * SQL for creating the spans table.
+ * Spans represent individual operations within a trace.
+ */
+export const SPANS_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS mastra_admin_spans (
+  -- Identity
+  span_id String,
+  trace_id String,
+  parent_span_id Nullable(String),
+  project_id String,
+  deployment_id String,
+
+  -- Span info
+  name String,
+  kind Enum8('internal' = 0, 'server' = 1, 'client' = 2, 'producer' = 3, 'consumer' = 4),
+  status Enum8('ok' = 1, 'error' = 2, 'unset' = 0),
+
+  -- Timing
+  start_time DateTime64(3),
+  end_time Nullable(DateTime64(3)),
+  duration_ms Nullable(Int64),
+
+  -- Data
+  attributes String DEFAULT '{}',
+  events String DEFAULT '[]',
+
+  -- Ingestion metadata
+  recorded_at DateTime64(3),
+  ingested_at DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(start_time)
+ORDER BY (project_id, deployment_id, trace_id, span_id)
+TTL start_time + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192
+`;
+
+/**
+ * SQL for creating the logs table.
+ * Logs capture textual information with severity levels.
+ */
+export const LOGS_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS mastra_admin_logs (
+  -- Identity
+  id String,
+  project_id String,
+  deployment_id String,
+
+  -- Correlation
+  trace_id Nullable(String),
+  span_id Nullable(String),
+
+  -- Log info
+  level Enum8('debug' = 0, 'info' = 1, 'warn' = 2, 'error' = 3),
+  message String,
+  timestamp DateTime64(3),
+
+  -- Data
+  attributes String DEFAULT '{}',
+
+  -- Ingestion metadata
+  recorded_at DateTime64(3),
+  ingested_at DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (project_id, deployment_id, timestamp, id)
+TTL timestamp + INTERVAL 30 DAY
+SETTINGS index_granularity = 8192
+`;
+
+/**
+ * SQL for creating the metrics table.
+ * Metrics capture numeric measurements.
+ */
+export const METRICS_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS mastra_admin_metrics (
+  -- Identity
+  id String,
+  project_id String,
+  deployment_id String,
+
+  -- Metric info
+  name String,
+  type Enum8('counter' = 0, 'gauge' = 1, 'histogram' = 2),
+  value Float64,
+  unit Nullable(String),
+  timestamp DateTime64(3),
+
+  -- Labels (for grouping/filtering)
+  labels String DEFAULT '{}',
+
+  -- Ingestion metadata
+  recorded_at DateTime64(3),
+  ingested_at DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (project_id, deployment_id, name, timestamp, id)
+TTL timestamp + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192
+`;
+
+/**
+ * SQL for creating the scores table.
+ * Scores capture evaluation results.
+ */
+export const SCORES_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS mastra_admin_scores (
+  -- Identity
+  id String,
+  project_id String,
+  deployment_id String,
+
+  -- Correlation
+  trace_id Nullable(String),
+
+  -- Score info
+  name String,
+  value Float64,
+  normalized_value Nullable(Float64),
+  comment Nullable(String),
+  timestamp DateTime64(3),
+
+  -- Data
+  metadata String DEFAULT '{}',
+
+  -- Ingestion metadata
+  recorded_at DateTime64(3),
+  ingested_at DateTime64(3) DEFAULT now64(3)
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (project_id, deployment_id, name, timestamp, id)
+TTL timestamp + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192
+`;
+
+/**
+ * All table creation SQL statements
+ */
+export const ALL_TABLES_SQL = [TRACES_TABLE_SQL, SPANS_TABLE_SQL, LOGS_TABLE_SQL, METRICS_TABLE_SQL, SCORES_TABLE_SQL];
+
+/**
+ * Table names
+ */
+export const TABLE_NAMES = {
+  TRACES: 'mastra_admin_traces',
+  SPANS: 'mastra_admin_spans',
+  LOGS: 'mastra_admin_logs',
+  METRICS: 'mastra_admin_metrics',
+  SCORES: 'mastra_admin_scores',
+} as const;
+
+export type TableName = (typeof TABLE_NAMES)[keyof typeof TABLE_NAMES];

--- a/observability/clickhouse/src/types.ts
+++ b/observability/clickhouse/src/types.ts
@@ -1,0 +1,338 @@
+/**
+ * Types for @mastra/observability-clickhouse
+ */
+
+import type { ClickHouseClient, ClickHouseClientConfigOptions } from '@clickhouse/client';
+import type {
+  Trace,
+  Span,
+  Log,
+  Metric,
+  Score,
+  ObservabilityEvent,
+  FileStorageProvider,
+  FileInfo,
+  ObservabilityQueryProvider,
+} from '@mastra/admin';
+import type { ObservabilityEventType } from '@mastra/observability-writer';
+
+// Re-export types from @mastra/admin
+export type {
+  Trace,
+  Span,
+  Log,
+  Metric,
+  Score,
+  ObservabilityEvent,
+  FileStorageProvider,
+  FileInfo,
+  ObservabilityQueryProvider,
+};
+
+// Re-export ObservabilityEventType from @mastra/observability-writer
+export type { ObservabilityEventType };
+
+/**
+ * ClickHouse connection configuration.
+ * Accepts either a pre-configured client or connection credentials.
+ */
+export type ClickHouseConfig =
+  | {
+      /** Pre-configured ClickHouse client */
+      client: ClickHouseClient;
+    }
+  | {
+      /** ClickHouse server URL */
+      url: string;
+      /** ClickHouse username */
+      username: string;
+      /** ClickHouse password */
+      password: string;
+      /** Database name */
+      database?: string;
+      /** Additional client options */
+      options?: Omit<ClickHouseClientConfigOptions, 'url' | 'username' | 'password' | 'database'>;
+    };
+
+/**
+ * Configuration for the IngestionWorker
+ */
+export interface IngestionWorkerConfig {
+  /**
+   * File storage provider to read JSONL files from.
+   */
+  fileStorage: FileStorageProvider;
+
+  /**
+   * ClickHouse connection configuration.
+   */
+  clickhouse: ClickHouseConfig;
+
+  /**
+   * Interval in milliseconds between polling for new files.
+   * @default 10000 (10 seconds)
+   */
+  pollIntervalMs?: number;
+
+  /**
+   * Maximum number of files to process in a single batch.
+   * @default 10
+   */
+  batchSize?: number;
+
+  /**
+   * Maximum number of events to insert in a single ClickHouse batch.
+   * @default 10000
+   */
+  insertBatchSize?: number;
+
+  /**
+   * Base path in file storage where observability files are stored.
+   * @default 'observability'
+   */
+  basePath?: string;
+
+  /**
+   * Whether to delete files after processing instead of moving to processed/.
+   * @default false
+   */
+  deleteAfterProcess?: boolean;
+
+  /**
+   * Number of retry attempts for failed operations.
+   * @default 3
+   */
+  retryAttempts?: number;
+
+  /**
+   * Delay in milliseconds between retry attempts.
+   * @default 1000
+   */
+  retryDelayMs?: number;
+
+  /**
+   * Project ID to filter files by (optional).
+   * If not specified, processes files for all projects.
+   */
+  projectId?: string;
+
+  /**
+   * Enable debug logging.
+   * @default false
+   */
+  debug?: boolean;
+}
+
+/**
+ * Result of a single processing cycle
+ */
+export interface ProcessingResult {
+  /** Number of files processed */
+  filesProcessed: number;
+  /** Number of events ingested into ClickHouse */
+  eventsIngested: number;
+  /** Breakdown by event type */
+  eventsByType: Record<string, number>;
+  /** Errors encountered during processing */
+  errors: ProcessingError[];
+  /** Duration of processing in milliseconds */
+  durationMs: number;
+}
+
+/**
+ * Error encountered during file processing
+ */
+export interface ProcessingError {
+  /** File path that failed */
+  filePath: string;
+  /** Error message */
+  message: string;
+  /** Error details */
+  error: Error;
+  /** Retry count at time of failure */
+  retryCount: number;
+}
+
+/**
+ * Worker status information
+ */
+export interface WorkerStatus {
+  /** Whether the worker is currently running */
+  isRunning: boolean;
+  /** Whether the worker is currently processing files */
+  isProcessing: boolean;
+  /** Timestamp of last successful processing */
+  lastProcessedAt: Date | null;
+  /** Total files processed since worker started */
+  totalFilesProcessed: number;
+  /** Total events ingested since worker started */
+  totalEventsIngested: number;
+  /** Breakdown of total events by type */
+  totalEventsByType: Record<string, number>;
+  /** Current error count (resets on successful processing) */
+  currentErrors: ProcessingError[];
+  /** Worker start time */
+  startedAt: Date | null;
+}
+
+/**
+ * Configuration for ClickHouseQueryProvider
+ */
+export interface QueryProviderConfig {
+  /**
+   * ClickHouse connection configuration.
+   */
+  clickhouse: ClickHouseConfig;
+
+  /**
+   * Enable debug logging.
+   * @default false
+   */
+  debug?: boolean;
+}
+
+/**
+ * Time range filter for queries
+ */
+export interface TimeRangeFilter {
+  /** Start of time range (inclusive) */
+  start?: Date;
+  /** End of time range (inclusive) */
+  end?: Date;
+}
+
+/**
+ * Pagination options for list queries
+ */
+export interface PaginationOptions {
+  /** Page number (0-indexed) */
+  page?: number;
+  /** Number of items per page */
+  perPage?: number;
+}
+
+/**
+ * Pagination info returned with list queries
+ */
+export interface PaginationInfo {
+  /** Total number of items */
+  total: number;
+  /** Current page number */
+  page: number;
+  /** Items per page */
+  perPage: number;
+  /** Whether there are more pages */
+  hasMore: boolean;
+}
+
+/**
+ * Common filter options for observability queries
+ */
+export interface ObservabilityFilters {
+  /** Filter by project ID */
+  projectId?: string;
+  /** Filter by deployment ID */
+  deploymentId?: string;
+  /** Filter by time range */
+  timeRange?: TimeRangeFilter;
+}
+
+/**
+ * Query options for traces
+ */
+export interface TraceQueryOptions extends ObservabilityFilters {
+  /** Filter by trace ID */
+  traceId?: string;
+  /** Filter by trace status */
+  status?: 'ok' | 'error' | 'unset';
+  /** Filter by trace name (partial match) */
+  name?: string;
+  /** Pagination options */
+  pagination?: PaginationOptions;
+}
+
+/**
+ * Query options for spans
+ */
+export interface SpanQueryOptions extends ObservabilityFilters {
+  /** Filter by trace ID */
+  traceId?: string;
+  /** Filter by span ID */
+  spanId?: string;
+  /** Filter by parent span ID */
+  parentSpanId?: string;
+  /** Filter by span kind */
+  kind?: 'internal' | 'server' | 'client' | 'producer' | 'consumer';
+  /** Filter by span name (partial match) */
+  name?: string;
+  /** Pagination options */
+  pagination?: PaginationOptions;
+}
+
+/**
+ * Query options for logs
+ */
+export interface LogQueryOptions extends ObservabilityFilters {
+  /** Filter by log level */
+  level?: 'debug' | 'info' | 'warn' | 'error';
+  /** Filter by trace ID */
+  traceId?: string;
+  /** Filter by span ID */
+  spanId?: string;
+  /** Filter by message content (partial match) */
+  message?: string;
+  /** Pagination options */
+  pagination?: PaginationOptions;
+}
+
+/**
+ * Query options for metrics
+ */
+export interface MetricQueryOptions extends ObservabilityFilters {
+  /** Filter by metric name */
+  name?: string;
+  /** Filter by metric type */
+  type?: 'counter' | 'gauge' | 'histogram';
+  /** Pagination options */
+  pagination?: PaginationOptions;
+}
+
+/**
+ * Query options for scores
+ */
+export interface ScoreQueryOptions extends ObservabilityFilters {
+  /** Filter by score name */
+  name?: string;
+  /** Filter by trace ID */
+  traceId?: string;
+  /** Minimum score value */
+  minValue?: number;
+  /** Maximum score value */
+  maxValue?: number;
+  /** Pagination options */
+  pagination?: PaginationOptions;
+}
+
+/**
+ * Aggregation bucket for time-series data
+ */
+export interface TimeBucket {
+  /** Bucket start time */
+  timestamp: Date;
+  /** Count of items in bucket */
+  count: number;
+  /** Additional aggregated values */
+  values?: Record<string, number>;
+}
+
+/**
+ * Aggregation options
+ */
+export interface AggregationOptions {
+  /** Bucket interval in seconds */
+  intervalSeconds: number;
+  /** Time range for aggregation */
+  timeRange: TimeRangeFilter;
+  /** Group by fields */
+  groupBy?: string[];
+}

--- a/observability/clickhouse/tsconfig.build.json
+++ b/observability/clickhouse/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/observability/clickhouse/tsconfig.json
+++ b/observability/clickhouse/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/observability/clickhouse/tsup.config.ts
+++ b/observability/clickhouse/tsup.config.ts
@@ -1,0 +1,15 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/cli/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: { preset: 'smallest' },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/observability/clickhouse/vitest.config.ts
+++ b/observability/clickhouse/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    passWithNoTests: true,
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+    testTimeout: 30000, // ClickHouse operations may take longer
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1093,6 +1093,46 @@ importers:
         specifier: 'catalog:'
         version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.13.17)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.13.17)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
+  observability/clickhouse:
+    dependencies:
+      '@clickhouse/client':
+        specifier: ^1.12.1
+        version: 1.12.1
+      commander:
+        specifier: ^14.0.2
+        version: 14.0.2
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/admin':
+        specifier: workspace:*
+        version: link:../../packages/admin
+      '@mastra/observability-file-local':
+        specifier: workspace:*
+        version: link:../file-local
+      '@mastra/observability-writer':
+        specifier: workspace:*
+        version: link:../writer
+      '@types/node':
+        specifier: 22.13.17
+        version: 22.13.17
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.0.12(vitest@4.0.16)
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(@microsoft/api-extractor@7.55.2(@types/node@22.13.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.13.17)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.13.17)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+
   observability/datadog:
     dependencies:
       '@mastra/observability':


### PR DESCRIPTION
## Summary

- Implements `@mastra/observability-clickhouse` package for ClickHouse-based observability storage
- Adds ClickHouse schema with 5 tables (traces, spans, logs, metrics, scores) and 5 materialized views for hourly aggregations
- Implements `IngestionWorker` for processing JSONL files from file storage into ClickHouse
- Implements `ClickHouseQueryProvider` for querying observability data with filtering and pagination
- Adds CLI with `ingest` and `migrate` commands for standalone operation

## Features

- **Schema Management**: Tables with proper partitioning (monthly), TTL policies (30-90 days), and ReplacingMergeTree for deduplication
- **Ingestion Worker**: Polls file storage, parses JSONL, bulk inserts to ClickHouse, moves processed files
- **Query Provider**: Full query support for traces/spans/logs/metrics/scores with time-range filtering, pagination, and analytics
- **CLI**: `mastra-observability-clickhouse ingest` and `migrate` commands with comprehensive options
- **Docker Compose**: Setup for integration testing with ClickHouse

## Test plan

- [x] Build passes: `pnpm build:lib`
- [x] TypeScript passes: `pnpm typecheck`
- [x] 80 unit tests pass: `pnpm test`
- [x] Lint passes: `pnpm lint`
- [ ] Integration tests with Docker: `docker compose up -d && pnpm test:integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)