### PR TITLE
add convex id column

### DIFF
--- a/.changeset/fair-coats-dress.md
+++ b/.changeset/fair-coats-dress.md
@@ -1,0 +1,5 @@
+---
+'@mastra/convex': patch
+---
+
+Fixed Convex schema validation error where `mastra_workflow_snapshots` index `by_record_id` referenced a missing `id` field. The `id` field is now explicitly defined in the Convex workflow snapshots table schema. This enables successful `npx convex dev` deployments that were previously failing with SchemaDefinitionError.

--- a/stores/convex/src/schema.ts
+++ b/stores/convex/src/schema.ts
@@ -98,8 +98,24 @@ export const mastraResourcesTable = defineTable(buildTableFromSchema(TABLE_SCHEM
 /**
  * Workflow snapshots table - stores workflow execution state
  * Schema: TABLE_SCHEMAS[TABLE_WORKFLOW_SNAPSHOT]
+ *
+ * Note: The `id` field is added explicitly for Convex's by_record_id index.
+ * The core schema uses (workflow_name, run_id) as a composite key, but Convex
+ * requires a single-column index. The id value is generated at runtime as
+ * `${workflow_name}-${run_id}` by the Convex storage adapter's normalizeRecord().
+ *
+ * Fields are defined explicitly (not using buildTableFromSchema) because TypeScript's
+ * type inference doesn't work well with spread operators in Convex's defineTable.
  */
-export const mastraWorkflowSnapshotsTable = defineTable(buildTableFromSchema(TABLE_SCHEMAS[TABLE_WORKFLOW_SNAPSHOT]))
+export const mastraWorkflowSnapshotsTable = defineTable({
+  id: v.optional(v.string()), // Synthetic ID for Convex index, generated at runtime
+  workflow_name: v.string(),
+  run_id: v.string(),
+  resourceId: v.optional(v.string()),
+  snapshot: v.any(),
+  createdAt: v.string(),
+  updatedAt: v.string(),
+})
   .index('by_record_id', ['id'])
   .index('by_workflow_run', ['workflow_name', 'run_id'])
   .index('by_workflow', ['workflow_name'])

--- a/stores/convex/src/storage/index.test.ts
+++ b/stores/convex/src/storage/index.test.ts
@@ -153,6 +153,20 @@ describe('Convex Schema Sync', () => {
 
     expect(missingFields).toEqual([]);
   });
+
+  // Issue #12318: mastra_workflow_snapshots index references missing id field
+  // The Convex schema defines an index 'by_record_id' on ['id'] for the workflow snapshots table.
+  // The core TABLE_SCHEMAS[TABLE_WORKFLOW_SNAPSHOT] uses a composite key (workflow_name, run_id)
+  // and doesn't include an 'id' field. The Convex adapter adds 'id' explicitly to support the index,
+  // and generates the id value at runtime as `${workflow_name}-${run_id}` in normalizeRecord().
+  it('mastraWorkflowSnapshotsTable should include id field for by_record_id index', async () => {
+    const { mastraWorkflowSnapshotsTable } = await import('../schema');
+
+    // Verify the Convex table includes the id field (added explicitly in schema.ts)
+    const convexValidator = (mastraWorkflowSnapshotsTable as any).validator;
+    const convexFields = convexValidator ? Object.keys(convexValidator.fields || {}) : [];
+    expect(convexFields).toContain('id');
+  });
 });
 
 // Configuration validation tests (run even without credentials)


### PR DESCRIPTION
## Description

Fixes the Convex schema validation error where `mastra_workflow_snapshots` defines an index `by_record_id` on the `id` field, but the table definition didn't include an `id` field.

The fix adds the `id` field explicitly to the Convex workflow_snapshots table definition. The Convex adapter's `normalizeRecord()` already generates `id = ${workflowName}-${runId}` at runtime, so this just fixes the schema to match the runtime behavior.

### Why Convex-only?

The core `TABLE_SCHEMAS[TABLE_WORKFLOW_SNAPSHOT]` uses a composite key `(workflow_name, run_id)` which works fine for SQL-based adapters (PG, LibSQL, etc.). Only Convex needs a single-column `id` for its index system.

A broader fix was considered that would add `id` to the core schema, making it available to all adapters. This was deferred to minimize the blast radius of this fix. If desired in the future, that approach would:
- Add `id: { type: 'text', nullable: true }` to `TABLE_SCHEMAS[TABLE_WORKFLOW_SNAPSHOT]`
- Add `'id'` to `ifNotExists` in each adapter's `alterTable` migration
- Provide a more consistent schema across all storage adapters

## Related Issue(s)

Fixes #12318

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Workflow snapshot storage schema made explicit with defined fields and new indices for resource and creation-date queries.

* **Bug Fix**
  * Restored schema consistency by adding the record identifier required for index validation, fixing deployment-time schema errors.

* **Tests**
  * Added test coverage ensuring workflow snapshot records include the identifier used for indexing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->