### PR TITLE
ci: use contents:read permissions instead of empty block

### DIFF
--- a/.github/workflows/trigger-cloud-tests.yml
+++ b/.github/workflows/trigger-cloud-tests.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - main
       - 0.x
-      - fix-trigger
 
 jobs:
   trigger:

--- a/.github/workflows/trigger-cloud-tests.yml
+++ b/.github/workflows/trigger-cloud-tests.yml
@@ -1,6 +1,7 @@
 name: Trigger Cloud Integration Tests
 
-permissions: {}
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:
@@ -8,6 +9,7 @@ on:
     branches:
       - main
       - 0.x
+      - fix-trigger
 
 jobs:
   trigger:


### PR DESCRIPTION
## Summary
- Changed `permissions: {}` to `permissions: contents: read` for explicit least privilege
- Added `fix-trigger` branch to push triggers for testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)