### PR TITLE
fix(ci): prevent turbo cache contamination and OOM errors

### DIFF
--- a/.github/workflows/secrets.e2e.yml
+++ b/.github/workflows/secrets.e2e.yml
@@ -84,6 +84,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo
@@ -134,6 +135,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo
@@ -180,6 +182,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo
@@ -224,6 +227,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo
@@ -268,6 +272,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo
@@ -312,6 +317,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo
@@ -356,6 +362,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo
@@ -401,6 +408,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/secrets.test-agent-builder.yml
+++ b/.github/workflows/secrets.test-agent-builder.yml
@@ -87,12 +87,14 @@ jobs:
       - name: Build dependencies
         run: pnpm turbo build --filter "@mastra/agent-builder^..." --filter "./stores/*"
         env:
-          NODE_OPTIONS: '--max_old_space_size=8096'
+          NODE_OPTIONS: '--max_old_space_size=6144'
+          GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
       - name: Run Agent Builder unit tests
         run: pnpm --filter "@mastra/agent-builder" test
         env:
-          NODE_OPTIONS: '--max_old_space_size=8096'
+          NODE_OPTIONS: '--max_old_space_size=6144'
+          GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
       - name: Install integration test dependencies
         run: pnpm install --ignore-workspace
@@ -102,7 +104,8 @@ jobs:
         run: pnpm test
         working-directory: packages/agent-builder/integration-tests
         env:
-          NODE_OPTIONS: '--max_old_space_size=8096'
+          NODE_OPTIONS: '--max_old_space_size=6144'
+          GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
   test-success:

--- a/.github/workflows/secrets.test-agent-builder.yml
+++ b/.github/workflows/secrets.test-agent-builder.yml
@@ -86,6 +86,8 @@ jobs:
 
       - name: Build dependencies
         run: pnpm turbo build --filter "@mastra/agent-builder^..." --filter "./stores/*"
+        env:
+          NODE_OPTIONS: '--max_old_space_size=8096'
 
       - name: Run Agent Builder unit tests
         run: pnpm --filter "@mastra/agent-builder" test

--- a/.github/workflows/secrets.test-auth.yml
+++ b/.github/workflows/secrets.test-auth.yml
@@ -77,6 +77,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -88,7 +89,7 @@ jobs:
       - name: Build auth packages
         run: pnpm turbo --filter="./auth/*" --filter "mastra" build
         env:
-          NODE_OPTIONS: '--max_old_space_size=8096'
+          NODE_OPTIONS: '--max_old_space_size=6144'
 
       - name: Run Auth tests
         run: pnpm run test:auth

--- a/.github/workflows/secrets.test-combined-stores.yml
+++ b/.github/workflows/secrets.test-combined-stores.yml
@@ -112,6 +112,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - uses: actions/checkout@v5
@@ -128,7 +129,7 @@ jobs:
         run: pnpm test
         working-directory: stores/${{ matrix.store }}
         env:
-          NODE_OPTIONS: '--max_old_space_size=8096'
+          NODE_OPTIONS: '--max_old_space_size=6144'
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
           ASTRA_DB_ENDPOINT: ${{ secrets.ASTRA_DB_ENDPOINT }}
           ASTRA_DB_TOKEN: ${{ secrets.ASTRA_DB_TOKEN }}

--- a/.github/workflows/secrets.test-combined-stores.yml
+++ b/.github/workflows/secrets.test-combined-stores.yml
@@ -124,6 +124,8 @@ jobs:
 
       - name: Build combined storage packages
         run: pnpm turbo --filter "@mastra/${{ matrix.store }}" build
+        env:
+          NODE_OPTIONS: '--max_old_space_size=6144'
 
       - name: Run ${{ matrix.store }} tests
         run: pnpm test

--- a/.github/workflows/secrets.test-core.yml
+++ b/.github/workflows/secrets.test-core.yml
@@ -76,6 +76,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -93,7 +94,7 @@ jobs:
       - name: Run Core tests
         run: pnpm test:core
         env:
-          NODE_OPTIONS: '--max_old_space_size=8096'
+          NODE_OPTIONS: '--max_old_space_size=6144'
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/secrets.test-core.yml
+++ b/.github/workflows/secrets.test-core.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Build cli
         run: pnpm build:core
+        env:
+          NODE_OPTIONS: '--max_old_space_size=6144'
 
       - name: Run Zod compatibility checks
         run: pnpm test:core:zod

--- a/.github/workflows/secrets.test-deployer.yml
+++ b/.github/workflows/secrets.test-deployer.yml
@@ -76,6 +76,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -87,7 +88,7 @@ jobs:
       - name: Build Deployer package
         run: pnpm turbo --filter="./packages/deployer" --filter "mastra" build
         env:
-          NODE_OPTIONS: '--max_old_space_size=8096'
+          NODE_OPTIONS: '--max_old_space_size=6144'
 
       - name: Run Deployer tests
         run: pnpm run test:deployer

--- a/.github/workflows/secrets.test-mcp.yml
+++ b/.github/workflows/secrets.test-mcp.yml
@@ -76,6 +76,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -87,7 +88,7 @@ jobs:
       - name: Build @mastra/mcp
         run: pnpm turbo --filter="./packages/mcp" --filter "mastra" build
         env:
-          NODE_OPTIONS: '--max_old_space_size=8096'
+          NODE_OPTIONS: '--max_old_space_size=6144'
 
       - name: Run MCP server tests
         run: pnpm test:server

--- a/.github/workflows/secrets.test-memory.yml
+++ b/.github/workflows/secrets.test-memory.yml
@@ -109,6 +109,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - uses: actions/checkout@v5
@@ -133,7 +134,7 @@ jobs:
         run: pnpm run test:${{ matrix.suite }}
         working-directory: packages/memory/integration-tests
         env:
-          NODE_OPTIONS: '--max_old_space_size=8096'
+          NODE_OPTIONS: '--max_old_space_size=6144'
           DB_URL: 'postgresql://postgres:postgres@localhost:5432/mastra'
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}

--- a/.github/workflows/secrets.test-memory.yml
+++ b/.github/workflows/secrets.test-memory.yml
@@ -121,6 +121,8 @@ jobs:
 
       - name: Build vector+store packages
         run: pnpm turbo build --filter "./stores/*" --filter "mastra" --filter "@mastra/memory" --filter "@mastra/fastembed"
+        env:
+          NODE_OPTIONS: '--max_old_space_size=6144'
 
       - name: Install integration test dependencies
         run: pnpm install --ignore-workspace

--- a/.github/workflows/secrets.test-observability.yml
+++ b/.github/workflows/secrets.test-observability.yml
@@ -88,6 +88,8 @@ jobs:
 
       - name: Build observability packages
         run: pnpm build:observability
+        env:
+          NODE_OPTIONS: '--max_old_space_size=6144'
 
       - name: Run Observability tests
         run: pnpm test:observability

--- a/.github/workflows/secrets.test-observability.yml
+++ b/.github/workflows/secrets.test-observability.yml
@@ -77,6 +77,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -91,7 +92,7 @@ jobs:
       - name: Run Observability tests
         run: pnpm test:observability
         env:
-          NODE_OPTIONS: '--max_old_space_size=8096'
+          NODE_OPTIONS: '--max_old_space_size=6144'
 
   test-success:
     needs: [check-changes, test]

--- a/.github/workflows/secrets.test-rag.yml
+++ b/.github/workflows/secrets.test-rag.yml
@@ -76,6 +76,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
+      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -90,7 +91,7 @@ jobs:
       - name: Run RAG tests
         run: pnpm test:rag
         env:
-          NODE_OPTIONS: '--max_old_space_size=8096'
+          NODE_OPTIONS: '--max_old_space_size=6144'
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
 

--- a/.github/workflows/secrets.test-server.yml
+++ b/.github/workflows/secrets.test-server.yml
@@ -87,12 +87,14 @@ jobs:
       - name: Build Server package
         run: pnpm turbo --filter="./packages/server" --filter "mastra" build
         env:
-          NODE_OPTIONS: '--max_old_space_size=8096'
+          NODE_OPTIONS: '--max_old_space_size=6144'
+          GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
       - name: Run Server tests
         run: pnpm run test:server
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
   test-success:
     needs: [check-changes, test]

--- a/.github/workflows/secrets.tool-builder-test.yml
+++ b/.github/workflows/secrets.tool-builder-test.yml
@@ -86,6 +86,8 @@ jobs:
 
       - name: Build core
         run: pnpm build:core && pnpm build:deployer
+        env:
+          NODE_OPTIONS: '--max_old_space_size=8096'
 
       - name: Run tool-builder test
         run: pnpm test:tool-builder

--- a/.github/workflows/secrets.tool-builder-test.yml
+++ b/.github/workflows/secrets.tool-builder-test.yml
@@ -87,12 +87,14 @@ jobs:
       - name: Build core
         run: pnpm build:core && pnpm build:deployer
         env:
-          NODE_OPTIONS: '--max_old_space_size=8096'
+          NODE_OPTIONS: '--max_old_space_size=6144'
+          GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
       - name: Run tool-builder test
         run: pnpm test:tool-builder
         env:
-          NODE_OPTIONS: '--max_old_space_size=8096'
+          NODE_OPTIONS: '--max_old_space_size=6144'
+          GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
 

--- a/e2e-tests/client-js/_test-utils/src/server-setup.ts
+++ b/e2e-tests/client-js/_test-utils/src/server-setup.ts
@@ -116,7 +116,9 @@ export function createTestServerSetup(config: TestServerSetupConfig) {
           default: {
             serviceName,
             exporters: [
-              new DefaultExporter(), // Persists traces to storage
+              // Use realtime strategy for tests to ensure spans are persisted immediately
+              // (default batch strategy has 5 second flush interval which is too slow for tests)
+              new DefaultExporter({ strategy: 'realtime' }),
             ],
           },
         },

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalEnv": ["GITHUB_REF_NAME"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
Fixes CI test failures caused by:
1. Turbo remote cache contamination across branches
2. Insufficient memory allocation during build steps (OOM errors)
3. Client-js E2E tests timing issue with observability span persistence

## Problems & Solutions

### 1. Cache Contamination

**Problem:** Tests on `main` branch failed with unexpected `workspaceTools` field:

```
AssertionError: expected { 'test-agent': { …(19) } } to deeply equal { 'test-agent': { …(18) } }
- Expected
+ Received
+     "workspaceTools": [],
```

**Root cause:** The `workspaceTools` field was introduced in commit `9257c1a5a2` on `feat/unified-workspace` branch (not on `main`):

```bash
$ git branch -a --contains 9257c1a5a2
  remotes/origin/feat/unified-workspace
  remotes/origin/nikaiyer/cor-377-api-cleanup
# NOT on main
```

Turbo's remote cache served build artifacts from the feature branch to `main` CI runs because both branches had identical source file hashes for some packages, resulting in shared cache keys.

**Evidence of non-determinism** (same commit, different results within minutes):
```
575f1e74ec @ 21:11:30 → success (cache miss)
575f1e74ec @ 21:11:53 → failure (cache hit from feature branch)
575f1e74ec @ 21:12:22 → success (cache miss)
```

**Solution:** Added `GITHUB_REF_NAME` to `globalEnv` in `turbo.json` so each branch gets its own cache namespace. For `workflow_run` triggered workflows, explicitly set `GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}` since `GITHUB_REF_NAME` defaults to the default branch in that context.

### 2. OOM Errors

**Problem:** Build steps ran out of heap memory when building `@mastra/memory`:
```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
@mastra/memory#build:lib: command exited (134)
```

**Solution:** Added `NODE_OPTIONS: '--max_old_space_size=6144'` to build/test steps. Using 6GB (not 8GB) because ubuntu-latest runners have ~7GB RAM.

### 3. Client-js E2E Test Failures

**Problem:** The `DefaultExporter` batches spans with a 5 second flush interval (`maxBatchWaitMs: 5000`). Tests only waited 1 second after generating traces, so `listTraces()` returned empty because spans were still buffered.

**Solution:** Changed test server setup to use `DefaultExporter({ strategy: 'realtime' })` so spans are persisted immediately.

## Files Changed

### turbo.json
- Added `GITHUB_REF_NAME` to `globalEnv`

### Workflow files (all `workflow_run` triggered)
Added `GITHUB_REF_NAME` at job level and fixed `NODE_OPTIONS` to 6144MB:
- `secrets.e2e.yml` (8 jobs)
- `secrets.test-agent-builder.yml`
- `secrets.test-auth.yml`
- `secrets.test-combined-stores.yml`
- `secrets.test-core.yml`
- `secrets.test-deployer.yml`
- `secrets.test-mcp.yml`
- `secrets.test-memory.yml`
- `secrets.test-observability.yml`
- `secrets.test-rag.yml`
- `secrets.test-server.yml`
- `secrets.tool-builder-test.yml`

### e2e-tests/client-js/_test-utils/src/server-setup.ts
- Use `DefaultExporter({ strategy: 'realtime' })` for immediate span persistence

## Test plan
- [x] Local builds still work (`pnpm build`)
- [ ] CI passes on this PR
- [ ] Subsequent runs on `main` no longer show intermittent failures
- [ ] Client-js E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized memory allocation across CI/CD workflows, reducing Node.js heap size from 8GB to 6GB.
  * Added global branch reference tracking to build system for improved workflow tracking.

* **Changes**
  * Updated observability telemetry to use realtime persistence strategy, enabling faster feedback during testing instead of batched reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->