### PR TITLE
refactor(playground-ui): simplify WorkflowTrigger component

### DIFF
--- a/.changeset/moody-goats-obey.md
+++ b/.changeset/moody-goats-obey.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Refactored WorkflowTrigger component into focused sub-components for better maintainability. Extracted WorkflowTriggerForm, WorkflowSuspendedSteps, WorkflowCancelButton, and WorkflowStepsStatus. Added useSuspendedSteps and useWorkflowSchemas hooks for memoized computations. No changes to public API.

--- a/packages/playground-ui/src/domains/workflows/workflow/use-workflow-trigger.ts
+++ b/packages/playground-ui/src/domains/workflows/workflow/use-workflow-trigger.ts
@@ -1,0 +1,50 @@
+import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
+import { useMemo } from 'react';
+import { parse } from 'superjson';
+import { z } from 'zod';
+
+import { resolveSerializedZodOutput } from '@/lib/form/utils';
+
+import type { GetWorkflowResponse } from '@mastra/client-js';
+import type { WorkflowRunStreamResult } from '../context/workflow-run-context';
+
+export interface SuspendedStep {
+  stepId: string;
+  runId: string;
+  suspendPayload: any;
+  workflow?: GetWorkflowResponse;
+  isLoading: boolean;
+}
+
+export function useSuspendedSteps(streamResult: WorkflowRunStreamResult | null, runId: string): SuspendedStep[] {
+  return useMemo(() => {
+    return Object.entries(streamResult?.steps || {})
+      .filter(([_, { status }]) => status === 'suspended')
+      .map(([stepId, { suspendPayload }]) => ({
+        stepId,
+        runId,
+        suspendPayload,
+        isLoading: false,
+      }));
+  }, [streamResult?.steps, runId]);
+}
+
+export function useWorkflowSchemas(workflow?: GetWorkflowResponse) {
+  return useMemo(() => {
+    const triggerSchema = workflow?.inputSchema;
+    const stateSchema = workflow?.stateSchema;
+
+    const zodInputSchema = triggerSchema ? resolveSerializedZodOutput(jsonSchemaToZod(parse(triggerSchema))) : null;
+    const zodStateSchema = stateSchema ? resolveSerializedZodOutput(jsonSchemaToZod(parse(stateSchema))) : null;
+
+    return {
+      zodSchemaToUse: zodStateSchema
+        ? z.object({
+            inputData: zodInputSchema,
+            initialState: zodStateSchema.optional(),
+          })
+        : zodInputSchema,
+      hasStateSchema: !!stateSchema,
+    };
+  }, [workflow?.inputSchema, workflow?.stateSchema]);
+}

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-cancel-button.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-cancel-button.tsx
@@ -1,0 +1,39 @@
+import { Loader2, StopCircle } from 'lucide-react';
+
+import { Button } from '@/ds/components/Button';
+import { Icon } from '@/ds/icons';
+
+export interface WorkflowCancelButtonProps {
+  status?: string;
+  cancelMessage: string | null;
+  isCancelling: boolean;
+  onCancel: () => void;
+}
+
+const DONE_STATUSES = ['success', 'failed', 'canceled', 'tripwire'];
+
+export function WorkflowCancelButton({ status, cancelMessage, isCancelling, onCancel }: WorkflowCancelButtonProps) {
+  if (status !== 'running') {
+    return null;
+  }
+
+  return (
+    <Button
+      variant="light"
+      className="w-full"
+      onClick={onCancel}
+      disabled={!!cancelMessage || isCancelling || (status && DONE_STATUSES.includes(status))}
+    >
+      {isCancelling ? (
+        <Icon>
+          <Loader2 className="animate-spin" />
+        </Icon>
+      ) : (
+        <Icon>
+          <StopCircle />
+        </Icon>
+      )}
+      {cancelMessage || 'Cancel Workflow Run'}
+    </Button>
+  );
+}

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-steps-status.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-steps-status.tsx
@@ -1,0 +1,84 @@
+import { Txt } from '@/ds/components/Txt';
+
+import type { WorkflowRunStreamResult } from '../context/workflow-run-context';
+import { WorkflowStatus } from './workflow-status';
+
+interface StepResult {
+  status: string;
+  output?: unknown;
+  suspendOutput?: unknown;
+  error?: unknown;
+  tripwire?: {
+    reason?: string;
+    retry?: boolean;
+    metadata?: unknown;
+    processorId?: string;
+  };
+  suspendPayload?: unknown;
+}
+
+export interface WorkflowStepsStatusProps {
+  steps: Record<string, StepResult>;
+  workflowResult?: WorkflowRunStreamResult | null;
+}
+
+export function WorkflowStepsStatus({ steps, workflowResult }: WorkflowStepsStatusProps) {
+  const filteredSteps = Object.entries(steps).filter(([key, _]) => key !== 'input' && !key.endsWith('.input'));
+
+  if (filteredSteps.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-2 pt-5 border-t border-border1">
+      <Txt variant="ui-xs" className="text-neutral3">
+        Status
+      </Txt>
+      <div className="flex flex-col gap-4">
+        {filteredSteps.map(([stepId, step]) => {
+          const { status } = step;
+          let output = undefined;
+          let suspendOutput = undefined;
+          let error = undefined;
+
+          if (step.status === 'suspended') {
+            suspendOutput = step.suspendOutput;
+          }
+          if (step.status === 'success') {
+            output = step.output;
+          }
+          if (step.status === 'failed') {
+            error = step.error;
+          }
+
+          // Build tripwire info from step or workflow-level result
+          // TripwireData is aligned with core schema: { reason, retry?, metadata?, processorId? }
+          const tripwireInfo =
+            step.status === 'failed' && step.tripwire
+              ? step.tripwire
+              : workflowResult?.status === 'tripwire'
+                ? {
+                    reason: workflowResult?.tripwire?.reason,
+                    retry: workflowResult?.tripwire?.retry,
+                    metadata: workflowResult?.tripwire?.metadata,
+                    processorId: workflowResult?.tripwire?.processorId,
+                  }
+                : undefined;
+
+          // Show tripwire status for failed steps with tripwire info
+          const displayStatus = step.status === 'failed' && step.tripwire ? 'tripwire' : status;
+
+          return (
+            <WorkflowStatus
+              key={stepId}
+              stepId={stepId}
+              status={displayStatus}
+              result={(output ?? suspendOutput ?? error ?? {}) as Record<string, unknown>}
+              tripwire={tripwireInfo}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-suspended-steps.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-suspended-steps.tsx
@@ -1,0 +1,78 @@
+import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
+import { parse } from 'superjson';
+import { z } from 'zod';
+
+import { resolveSerializedZodOutput } from '@/lib/form/utils';
+import { CodeEditor } from '@/ds/components/CodeEditor';
+import { Txt } from '@/ds/components/Txt';
+
+import type { GetWorkflowResponse } from '@mastra/client-js';
+import type { SuspendedStep } from './use-workflow-trigger';
+import { WorkflowInputData } from './workflow-input-data';
+
+export interface ResumeStepParams {
+  stepId: string | string[];
+  runId: string;
+  suspendPayload: any;
+  resumeData: any;
+  isLoading: boolean;
+}
+
+export interface WorkflowSuspendedStepsProps {
+  suspendedSteps: SuspendedStep[];
+  workflow: GetWorkflowResponse;
+  isStreaming: boolean;
+  onResume: (step: ResumeStepParams) => void;
+}
+
+export function WorkflowSuspendedSteps({
+  suspendedSteps,
+  workflow,
+  isStreaming,
+  onResume,
+}: WorkflowSuspendedStepsProps) {
+  if (isStreaming || suspendedSteps.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {suspendedSteps.map(step => {
+        const stepDefinition = workflow.allSteps[step.stepId];
+        if (!stepDefinition || stepDefinition.isWorkflow) return null;
+
+        const stepSchema = stepDefinition?.resumeSchema
+          ? resolveSerializedZodOutput(jsonSchemaToZod(parse(stepDefinition.resumeSchema)))
+          : z.record(z.string(), z.any());
+
+        return (
+          <div className="flex flex-col px-4" key={step.stepId}>
+            <Txt variant="ui-xs" className="text-neutral3">
+              {step.stepId}
+            </Txt>
+            {step.suspendPayload && (
+              <div data-testid="suspended-payload">
+                <CodeEditor data={step.suspendPayload} className="w-full overflow-x-auto p-2" showCopyButton={false} />
+              </div>
+            )}
+            <WorkflowInputData
+              schema={stepSchema}
+              isSubmitLoading={isStreaming}
+              submitButtonLabel="Resume workflow"
+              onSubmit={data => {
+                const stepIds = step.stepId?.split('.');
+                onResume({
+                  stepId: stepIds,
+                  runId: step.runId,
+                  suspendPayload: step.suspendPayload,
+                  resumeData: data,
+                  isLoading: false,
+                });
+              }}
+            />
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger-form.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger-form.tsx
@@ -1,0 +1,55 @@
+import { Loader2 } from 'lucide-react';
+import type { ZodSchema } from 'zod';
+
+import { Button } from '@/ds/components/Button';
+import { Icon } from '@/ds/icons';
+
+import { WorkflowInputData } from './workflow-input-data';
+
+export interface WorkflowTriggerFormProps {
+  zodSchema: ZodSchema | null;
+  isStreaming: boolean;
+  onExecute: (data: any) => void;
+  defaultValues?: any;
+  isViewingRun?: boolean;
+  isProcessorWorkflow?: boolean;
+}
+
+export function WorkflowTriggerForm({
+  zodSchema,
+  isStreaming,
+  onExecute,
+  defaultValues,
+  isViewingRun,
+  isProcessorWorkflow,
+}: WorkflowTriggerFormProps) {
+  if (zodSchema) {
+    return (
+      <WorkflowInputData
+        schema={zodSchema}
+        defaultValues={defaultValues}
+        isSubmitLoading={isStreaming}
+        submitButtonLabel="Run"
+        onSubmit={onExecute}
+        withoutSubmit={isViewingRun}
+        isProcessorWorkflow={isProcessorWorkflow}
+      />
+    );
+  }
+
+  if (isViewingRun) {
+    return null;
+  }
+
+  return (
+    <Button className="w-full" variant="light" disabled={isStreaming} onClick={() => onExecute(null)}>
+      {isStreaming ? (
+        <Icon>
+          <Loader2 className="animate-spin" />
+        </Icon>
+      ) : (
+        'Trigger'
+      )}
+    </Button>
+  );
+}

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
@@ -234,7 +234,7 @@ const WorkflowJsonDialog = ({ result }: { result: Record<string, unknown> }) => 
 
   return (
     <>
-      <Button variant="light" onClick={() => setOpen(true)} className="w-full">
+      <Button variant="light" onClick={() => setOpen(true)} className="w-full truncate">
         <Icon>
           <Braces className="text-neutral3" />
         </Icon>


### PR DESCRIPTION
Splits the 424-line WorkflowTrigger component into focused sub-components:

- **WorkflowTriggerForm** - handles form/button rendering
- **WorkflowSuspendedSteps** - handles suspended step display and resume
- **WorkflowCancelButton** - handles cancellation UI
- **WorkflowStepsStatus** - handles step status display

Also adds `useSuspendedSteps` and `useWorkflowSchemas` hooks to memoize computations that were previously inline.

No changes to external API - this is purely an internal refactor for maintainability. All E2E tests pass.