### PR TITLE
feat(playground-ui): add keyboard navigation to Table component

### DIFF
--- a/.changeset/quiet-berries-search.md
+++ b/.changeset/quiet-berries-search.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added keyboard navigation support to Table component with new `useTableKeyboardNavigation` hook and `isActive` prop on Row

--- a/packages/playground-ui/src/domains/mcps/components/mcp-table/mcp-table.tsx
+++ b/packages/playground-ui/src/domains/mcps/components/mcp-table/mcp-table.tsx
@@ -1,11 +1,11 @@
 import { McpServerListResponse } from '@mastra/client-js';
 import { Button } from '@/ds/components/Button';
 import { EmptyState } from '@/ds/components/EmptyState';
-import { Cell, Row, Table, Tbody, Th, Thead } from '@/ds/components/Table';
+import { Cell, Row, Table, Tbody, Th, Thead, useTableKeyboardNavigation } from '@/ds/components/Table';
 
 import { Icon } from '@/ds/icons/Icon';
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { ScrollableContainer } from '@/ds/components/ScrollableContainer';
 import { Skeleton } from '@/ds/components/Skeleton';
@@ -24,20 +24,35 @@ export interface MCPTableProps {
 export function MCPTable({ mcpServers, isLoading }: MCPTableProps) {
   const { navigate, paths } = useLinkComponent();
   const [search, setSearch] = useState('');
+
+  const filteredData = useMemo(
+    () => mcpServers.filter(server => server.name.toLowerCase().includes(search.toLowerCase())),
+    [mcpServers, search],
+  );
+
+  const { activeIndex } = useTableKeyboardNavigation({
+    itemCount: filteredData.length,
+    global: true,
+    onSelect: index => {
+      const server = filteredData[index];
+      if (server) {
+        navigate(paths.mcpServerLink(server.id));
+      }
+    },
+  });
+
   const table = useReactTable({
-    data: mcpServers,
+    data: filteredData,
     columns: columns as ColumnDef<McpServerListResponse['servers'][number]>[],
     getCoreRowModel: getCoreRowModel(),
   });
 
   const ths = table.getHeaderGroups()[0];
-  const rows = table.getRowModel().rows.concat();
+  const rows = table.getRowModel().rows;
 
-  if (rows.length === 0 && !isLoading) {
+  if (mcpServers.length === 0 && !isLoading) {
     return <EmptyMCPTable />;
   }
-
-  const filteredRows = rows.filter(row => row.original.name.toLowerCase().includes(search.toLowerCase()));
 
   return (
     <div>
@@ -59,8 +74,12 @@ export function MCPTable({ mcpServers, isLoading }: MCPTableProps) {
                 ))}
               </Thead>
               <Tbody>
-                {filteredRows.map(row => (
-                  <Row key={row.id} onClick={() => navigate(paths.mcpServerLink(row.original.id))}>
+                {rows.map((row, index) => (
+                  <Row
+                    key={row.id}
+                    isActive={index === activeIndex}
+                    onClick={() => navigate(paths.mcpServerLink(row.original.id))}
+                  >
                     {row.getVisibleCells().map(cell => (
                       <React.Fragment key={cell.id}>
                         {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/packages/playground-ui/src/domains/processors/components/processor-table/processor-table.tsx
+++ b/packages/playground-ui/src/domains/processors/components/processor-table/processor-table.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/ds/components/Button';
 import { EmptyState } from '@/ds/components/EmptyState';
-import { Cell, Row, Table, Tbody, Th, Thead } from '@/ds/components/Table';
+import { Cell, Row, Table, Tbody, Th, Thead, useTableKeyboardNavigation } from '@/ds/components/Table';
 import { Icon } from '@/ds/icons/Icon';
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import React, { useMemo, useState } from 'react';
@@ -30,25 +30,42 @@ export function ProcessorTable({ processors, isLoading }: ProcessorTableProps) {
     return Object.values(processors ?? {}).filter(p => p.phases && p.phases.length > 0);
   }, [processors]);
 
+  const filteredData = useMemo(() => {
+    const searchLower = search.toLowerCase();
+    return processorData.filter(p => {
+      const id = p.id.toLowerCase();
+      const name = (p.name || '').toLowerCase();
+      return id.includes(searchLower) || name.includes(searchLower);
+    });
+  }, [processorData, search]);
+
+  const { activeIndex } = useTableKeyboardNavigation({
+    itemCount: filteredData.length,
+    global: true,
+    onSelect: index => {
+      const processor = filteredData[index];
+      if (processor) {
+        if (processor.isWorkflow) {
+          navigate(paths.workflowLink(processor.id) + '/graph');
+        } else {
+          navigate(paths.processorLink(processor.id));
+        }
+      }
+    },
+  });
+
   const table = useReactTable({
-    data: processorData,
+    data: filteredData,
     columns: columns as ColumnDef<ProcessorRow>[],
     getCoreRowModel: getCoreRowModel(),
   });
 
   const ths = table.getHeaderGroups()[0];
-  const rows = table.getRowModel().rows.concat();
+  const rows = table.getRowModel().rows;
 
-  if (rows.length === 0 && !isLoading) {
+  if (processorData.length === 0 && !isLoading) {
     return <EmptyProcessorsTable />;
   }
-
-  const filteredRows = rows.filter(row => {
-    const id = row.original.id.toLowerCase();
-    const name = (row.original.name || '').toLowerCase();
-    const searchLower = search.toLowerCase();
-    return id.includes(searchLower) || name.includes(searchLower);
-  });
 
   return (
     <div>
@@ -69,27 +86,26 @@ export function ProcessorTable({ processors, isLoading }: ProcessorTableProps) {
                 ))}
               </Thead>
               <Tbody>
-                {filteredRows.map(row => {
-                  return (
-                    <Row
-                      key={row.id}
-                      onClick={() => {
-                        // Workflow processors should navigate to the workflow graph UI
-                        if (row.original.isWorkflow) {
-                          navigate(paths.workflowLink(row.original.id) + '/graph');
-                        } else {
-                          navigate(paths.processorLink(row.original.id));
-                        }
-                      }}
-                    >
-                      {row.getVisibleCells().map(cell => (
-                        <React.Fragment key={cell.id}>
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </React.Fragment>
-                      ))}
-                    </Row>
-                  );
-                })}
+                {rows.map((row, index) => (
+                  <Row
+                    key={row.id}
+                    isActive={index === activeIndex}
+                    onClick={() => {
+                      // Workflow processors should navigate to the workflow graph UI
+                      if (row.original.isWorkflow) {
+                        navigate(paths.workflowLink(row.original.id) + '/graph');
+                      } else {
+                        navigate(paths.processorLink(row.original.id));
+                      }
+                    }}
+                  >
+                    {row.getVisibleCells().map(cell => (
+                      <React.Fragment key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </React.Fragment>
+                    ))}
+                  </Row>
+                ))}
               </Tbody>
             </Table>
           </TooltipProvider>

--- a/packages/playground-ui/src/domains/scores/components/scorers-table/scorers-table.tsx
+++ b/packages/playground-ui/src/domains/scores/components/scorers-table/scorers-table.tsx
@@ -1,7 +1,7 @@
 import { GetScorerResponse } from '@mastra/client-js';
 import { Button } from '@/ds/components/Button';
 import { EmptyState } from '@/ds/components/EmptyState';
-import { Cell, Row, Table, Tbody, Th, Thead } from '@/ds/components/Table';
+import { Cell, Row, Table, Tbody, Th, Thead, useTableKeyboardNavigation } from '@/ds/components/Table';
 import { AgentCoinIcon } from '@/ds/icons/AgentCoinIcon';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
 import { Icon } from '@/ds/icons/Icon';
@@ -36,24 +36,38 @@ export function ScorersTable({ scorers, isLoading }: ScorersTableProps) {
     [scorers],
   );
 
+  const filteredData = useMemo(() => {
+    const searchLower = search.toLowerCase();
+    return scorersData.filter(
+      s =>
+        s.scorer.config?.id?.toLowerCase().includes(searchLower) ||
+        s.scorer.config?.name?.toLowerCase().includes(searchLower),
+    );
+  }, [scorersData, search]);
+
+  const { activeIndex } = useTableKeyboardNavigation({
+    itemCount: filteredData.length,
+    global: true,
+    onSelect: index => {
+      const scorer = filteredData[index];
+      if (scorer) {
+        navigate(paths.scorerLink(scorer.id));
+      }
+    },
+  });
+
   const table = useReactTable({
-    data: scorersData,
+    data: filteredData,
     columns: columns as ColumnDef<ScorerTableData>[],
     getCoreRowModel: getCoreRowModel(),
   });
 
   const ths = table.getHeaderGroups()[0];
-  const rows = table.getRowModel().rows.concat();
+  const rows = table.getRowModel().rows;
 
-  if (rows.length === 0 && !isLoading) {
+  if (scorersData.length === 0 && !isLoading) {
     return <EmptyScorersTable />;
   }
-
-  const filteredRows = rows.filter(
-    row =>
-      row.original.scorer.config?.id?.toLowerCase().includes(search.toLowerCase()) ||
-      row.original.scorer.config?.name?.toLowerCase().includes(search.toLowerCase()),
-  );
 
   return (
     <div>
@@ -73,8 +87,12 @@ export function ScorersTable({ scorers, isLoading }: ScorersTableProps) {
               ))}
             </Thead>
             <Tbody>
-              {filteredRows.map(row => (
-                <Row key={row.id} onClick={() => navigate(paths.scorerLink(row.original.id))}>
+              {rows.map((row, index) => (
+                <Row
+                  key={row.id}
+                  isActive={index === activeIndex}
+                  onClick={() => navigate(paths.scorerLink(row.original.id))}
+                >
                   {row.getVisibleCells().map(cell => (
                     <React.Fragment key={cell.id}>
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/packages/playground-ui/src/domains/tools/components/tool-table/tool-table.tsx
+++ b/packages/playground-ui/src/domains/tools/components/tool-table/tool-table.tsx
@@ -1,7 +1,7 @@
 import { GetAgentResponse, GetToolResponse } from '@mastra/client-js';
 import { Button } from '@/ds/components/Button';
 import { EmptyState } from '@/ds/components/EmptyState';
-import { Cell, Row, Table, Tbody, Th, Thead } from '@/ds/components/Table';
+import { Cell, Row, Table, Tbody, Th, Thead, useTableKeyboardNavigation } from '@/ds/components/Table';
 import { Icon } from '@/ds/icons/Icon';
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import React, { useMemo, useState } from 'react';
@@ -27,20 +27,34 @@ export function ToolTable({ tools, agents, isLoading }: ToolTableProps) {
   const { navigate, paths } = useLinkComponent();
   const toolData = useMemo(() => prepareToolsTable(tools, agents), [tools, agents]);
 
+  const filteredData = useMemo(
+    () => toolData.filter(tool => tool.id.toLowerCase().includes(search.toLowerCase())),
+    [toolData, search],
+  );
+
+  const { activeIndex } = useTableKeyboardNavigation({
+    itemCount: filteredData.length,
+    global: true,
+    onSelect: index => {
+      const tool = filteredData[index];
+      if (tool) {
+        navigate(paths.toolLink(tool.id));
+      }
+    },
+  });
+
   const table = useReactTable({
-    data: toolData,
+    data: filteredData,
     columns: columns as ColumnDef<ToolWithAgents>[],
     getCoreRowModel: getCoreRowModel(),
   });
 
   const ths = table.getHeaderGroups()[0];
-  const rows = table.getRowModel().rows.concat();
+  const rows = table.getRowModel().rows;
 
-  if (rows.length === 0 && !isLoading) {
+  if (toolData.length === 0 && !isLoading) {
     return <EmptyToolsTable />;
   }
-
-  const filteredRows = rows.filter(row => row.original.id.toLowerCase().includes(search.toLowerCase()));
 
   return (
     <div>
@@ -61,22 +75,19 @@ export function ToolTable({ tools, agents, isLoading }: ToolTableProps) {
                 ))}
               </Thead>
               <Tbody>
-                {filteredRows.map(row => {
-                  return (
-                    <Row
-                      key={row.id}
-                      onClick={() => {
-                        navigate(paths.toolLink(row.original.id));
-                      }}
-                    >
-                      {row.getVisibleCells().map(cell => (
-                        <React.Fragment key={cell.id}>
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </React.Fragment>
-                      ))}
-                    </Row>
-                  );
-                })}
+                {rows.map((row, index) => (
+                  <Row
+                    key={row.id}
+                    isActive={index === activeIndex}
+                    onClick={() => navigate(paths.toolLink(row.original.id))}
+                  >
+                    {row.getVisibleCells().map(cell => (
+                      <React.Fragment key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </React.Fragment>
+                    ))}
+                  </Row>
+                ))}
               </Tbody>
             </Table>
           </TooltipProvider>

--- a/packages/playground-ui/src/domains/workflows/components/workflow-table/workflow-table.tsx
+++ b/packages/playground-ui/src/domains/workflows/components/workflow-table/workflow-table.tsx
@@ -1,7 +1,7 @@
 import { GetWorkflowResponse } from '@mastra/client-js';
 import { Button } from '@/ds/components/Button';
 import { EmptyState } from '@/ds/components/EmptyState';
-import { Cell, Row, Table, Tbody, Th, Thead } from '@/ds/components/Table';
+import { Cell, Row, Table, Tbody, Th, Thead, useTableKeyboardNavigation } from '@/ds/components/Table';
 
 import { Icon } from '@/ds/icons/Icon';
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
@@ -36,20 +36,34 @@ export function WorkflowTable({ workflows, isLoading }: WorkflowTableProps) {
     return _workflowsData;
   }, [workflows]);
 
+  const filteredData = useMemo(
+    () => workflowData.filter(workflow => workflow.name.toLowerCase().includes(search.toLowerCase())),
+    [workflowData, search],
+  );
+
+  const { activeIndex } = useTableKeyboardNavigation({
+    itemCount: filteredData.length,
+    global: true,
+    onSelect: index => {
+      const workflow = filteredData[index];
+      if (workflow) {
+        navigate(paths.workflowLink(workflow.id));
+      }
+    },
+  });
+
   const table = useReactTable({
-    data: workflowData,
+    data: filteredData,
     columns: columns as ColumnDef<WorkflowTableData>[],
     getCoreRowModel: getCoreRowModel(),
   });
 
   const ths = table.getHeaderGroups()[0];
-  const rows = table.getRowModel().rows.concat();
+  const rows = table.getRowModel().rows;
 
-  if (rows.length === 0 && !isLoading) {
+  if (workflowData.length === 0 && !isLoading) {
     return <EmptyWorkflowsTable />;
   }
-
-  const filteredRows = rows.filter(row => row.original.name.toLowerCase().includes(search.toLowerCase()));
 
   return (
     <div>
@@ -70,8 +84,12 @@ export function WorkflowTable({ workflows, isLoading }: WorkflowTableProps) {
               ))}
             </Thead>
             <Tbody>
-              {filteredRows.map(row => (
-                <Row key={row.id} onClick={() => navigate(paths.workflowLink(row.original.id))}>
+              {rows.map((row, index) => (
+                <Row
+                  key={row.id}
+                  isActive={index === activeIndex}
+                  onClick={() => navigate(paths.workflowLink(row.original.id))}
+                >
                   {row.getVisibleCells().map(cell => (
                     <React.Fragment key={cell.id}>
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/packages/playground-ui/src/ds/components/Table/index.ts
+++ b/packages/playground-ui/src/ds/components/Table/index.ts
@@ -1,2 +1,7 @@
 export * from './Table';
 export * from './Cells';
+export { useTableKeyboardNavigation } from './use-table-keyboard-navigation';
+export type {
+  UseTableKeyboardNavigationOptions,
+  UseTableKeyboardNavigationReturn,
+} from './use-table-keyboard-navigation';

--- a/packages/playground-ui/src/ds/components/Table/use-table-keyboard-navigation.ts
+++ b/packages/playground-ui/src/ds/components/Table/use-table-keyboard-navigation.ts
@@ -1,0 +1,90 @@
+import { useState, useCallback } from 'react';
+
+export interface UseTableKeyboardNavigationOptions {
+  /** Number of items in the list */
+  itemCount: number;
+  /** Initial active index (-1 = none) */
+  initialIndex?: number;
+  /** Wrap around at boundaries */
+  wrap?: boolean;
+  /** Callback when Enter pressed on active row */
+  onSelect?: (index: number) => void;
+}
+
+export interface UseTableKeyboardNavigationReturn {
+  /** Currently active index (-1 if none) */
+  activeIndex: number;
+  /** Set active index programmatically */
+  setActiveIndex: React.Dispatch<React.SetStateAction<number>>;
+  /** Returns props to spread on the Tbody element */
+  getKeyboardProps: () => { onKeyDown: (e: React.KeyboardEvent) => void; tabIndex: number };
+}
+
+export function useTableKeyboardNavigation({
+  itemCount,
+  initialIndex = -1,
+  wrap = false,
+  onSelect,
+}: UseTableKeyboardNavigationOptions): UseTableKeyboardNavigationReturn {
+  const [activeIndex, setActiveIndex] = useState(initialIndex);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      // No-op for empty list
+      if (itemCount === 0) return;
+
+      switch (e.key) {
+        case 'ArrowDown': {
+          e.preventDefault();
+          setActiveIndex(prev => {
+            if (prev === -1) return 0;
+            if (prev >= itemCount - 1) {
+              return wrap ? 0 : itemCount - 1;
+            }
+            return prev + 1;
+          });
+          break;
+        }
+        case 'ArrowUp': {
+          e.preventDefault();
+          setActiveIndex(prev => {
+            if (prev === -1) return itemCount - 1;
+            if (prev <= 0) {
+              return wrap ? itemCount - 1 : 0;
+            }
+            return prev - 1;
+          });
+          break;
+        }
+        case 'Home': {
+          e.preventDefault();
+          setActiveIndex(0);
+          break;
+        }
+        case 'End': {
+          e.preventDefault();
+          setActiveIndex(itemCount - 1);
+          break;
+        }
+        case 'Enter': {
+          if (activeIndex >= 0 && onSelect) {
+            e.preventDefault();
+            onSelect(activeIndex);
+          }
+          break;
+        }
+      }
+    },
+    [itemCount, wrap, activeIndex, onSelect],
+  );
+
+  const getKeyboardProps = useCallback(() => {
+    return { onKeyDown: handleKeyDown, tabIndex: 0 };
+  }, [handleKeyDown]);
+
+  return {
+    activeIndex,
+    setActiveIndex,
+    getKeyboardProps,
+  };
+}


### PR DESCRIPTION
Adds keyboard navigation support to the Table component.

**New hook: `useTableKeyboardNavigation`**

```tsx
const { activeIndex, getKeyboardProps } = useTableKeyboardNavigation({
  itemCount: items.length,
  onSelect: (index) => handleClick(items[index]),
});

<Tbody {...getKeyboardProps()}>
  {items.map((item, i) => (
    <Row key={item.id} isActive={i === activeIndex}>...</Row>
  ))}
</Tbody>
```

Supports ArrowUp/Down navigation, Home/End keys, Enter to select, and optional wrapping at boundaries.

The `Row` component now accepts an `isActive` prop that auto-focuses and scrolls the row into view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard navigation support for tables throughout the playground UI using arrow keys, Home, End, and Enter to select items
  * Visual indication of the currently active row during keyboard navigation
  * Keyboard navigation integrates with search filtering across all table components (agents, MCPs, processors, scorers, tools, and workflows)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->