### PR TITLE
fix(e2e): fix client-js observability tests

### DIFF
--- a/e2e-tests/client-js/_test-utils/src/observability-tests.ts
+++ b/e2e-tests/client-js/_test-utils/src/observability-tests.ts
@@ -59,7 +59,8 @@ export function createObservabilityTests(config: ObservabilityTestConfig = {}) {
         await agent.generate([{ role: 'user', content: 'Hello, just testing!' }]);
 
         // Wait a bit for the trace to be persisted
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        // The batch-with-updates strategy has a 5 second flush interval
+        await new Promise(resolve => setTimeout(resolve, 5000));
       } catch (e) {
         console.warn('Could not generate agent trace, some tests may fail:', e);
       }

--- a/e2e-tests/client-js/_test-utils/src/server-setup.ts
+++ b/e2e-tests/client-js/_test-utils/src/server-setup.ts
@@ -101,7 +101,7 @@ export function createTestServerSetup(config: TestServerSetupConfig) {
 
     // Create a simple test agent
     const testAgent = new Agent({
-      id: 'test-agent',
+      id: 'testAgent',
       name: 'testAgent',
       instructions: 'You are a helpful test assistant.',
       model: 'openai/gpt-4.1-mini',


### PR DESCRIPTION
Fixes the client-js e2e tests that were failing:
- **zod-v3**: 12/15 tests failed (no traces returned)
- **zod-v4**: 2/15 tests failed (entityId filter tests)

Two issues fixed:

1. The test agent had `id: 'test-agent'` but `name: 'testAgent'`. When filtering by `entityId`, the tests used the name but spans record the id. Changed id to match name.

2. The 1s wait wasn't enough for the batch-with-updates strategy (5s flush interval) to persist traces. Increased to 5s.

All 15 tests now pass in both zod-v3 and zod-v4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure timing and configuration to improve test reliability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->