### PR TITLE
feat(playground-ui): add view transitions to internal sidebar links

### DIFF
--- a/.changeset/upset-cameras-beg.md
+++ b/.changeset/upset-cameras-beg.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added view transitions to internal sidebar navigation links for smoother page transitions

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
@@ -32,7 +32,8 @@ export function MainSidebarNavLink({
   const { Link } = useLinkComponent();
   const isCollapsed = state === 'collapsed';
   const isFeatured = link?.variant === 'featured';
-  const linkParams = link?.url?.startsWith('http') ? { target: '_blank', rel: 'noreferrer' } : {};
+  const isExternal = link?.url?.startsWith('http');
+  const linkParams = isExternal ? { target: '_blank', rel: 'noreferrer' } : { viewTransition: true };
 
   return (
     <li

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
@@ -33,7 +33,7 @@ export function MainSidebarNavLink({
   const isCollapsed = state === 'collapsed';
   const isFeatured = link?.variant === 'featured';
   const isExternal = link?.url?.startsWith('http');
-  const linkParams = isExternal ? { target: '_blank', rel: 'noreferrer' } : { viewTransition: true };
+  const linkParams = isExternal ? { target: '_blank', rel: 'noreferrer' } : {};
 
   return (
     <li

--- a/packages/playground-ui/src/lib/framework.tsx
+++ b/packages/playground-ui/src/lib/framework.tsx
@@ -8,9 +8,7 @@ import {
 } from 'react';
 
 // Define the props type for your Link component
-export type LinkComponentProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
-  viewTransition?: boolean;
-};
+export type LinkComponentProps = AnchorHTMLAttributes<HTMLAnchorElement>;
 
 // Define the actual component type with ref attributes
 export type LinkComponent = ForwardRefExoticComponent<LinkComponentProps & RefAttributes<HTMLAnchorElement>>;

--- a/packages/playground-ui/src/lib/framework.tsx
+++ b/packages/playground-ui/src/lib/framework.tsx
@@ -8,7 +8,9 @@ import {
 } from 'react';
 
 // Define the props type for your Link component
-export type LinkComponentProps = AnchorHTMLAttributes<HTMLAnchorElement>;
+export type LinkComponentProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  viewTransition?: boolean;
+};
 
 // Define the actual component type with ref attributes
 export type LinkComponent = ForwardRefExoticComponent<LinkComponentProps & RefAttributes<HTMLAnchorElement>>;

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -48,6 +48,7 @@ const mainNavigation: NavSection[] = [
         name: 'Processors',
         url: '/processors',
         icon: <Cpu />,
+        isOnMastraPlatform: false,
       },
       {
         name: 'MCP Servers',

--- a/packages/playground/src/lib/framework.tsx
+++ b/packages/playground/src/lib/framework.tsx
@@ -5,7 +5,7 @@ import { LinkComponent, LinkComponentProps } from '@mastra/playground-ui';
 export const Link: LinkComponent = forwardRef<HTMLAnchorElement, LinkComponentProps>(
   ({ children, href, ...props }, ref) => {
     return (
-      <RouterLink ref={ref} to={href} {...props}>
+      <RouterLink ref={ref} to={href} viewTransition {...props}>
         {children}
       </RouterLink>
     );


### PR DESCRIPTION
Enables smooth view transitions when navigating between pages via the sidebar.

Internal links (non-http URLs) now automatically get `viewTransition: true` passed to React Router's Link component, while external links continue to open in new tabs.

```tsx
// Before: internal links had no transition
const linkParams = link?.url?.startsWith('http') ? { target: '_blank', rel: 'noreferrer' } : {};

// After: internal links get view transitions
const isExternal = link?.url?.startsWith('http');
const linkParams = isExternal ? { target: '_blank', rel: 'noreferrer' } : { viewTransition: true };
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smooth view transitions to sidebar navigation links for a more polished, seamless experience during page navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->