### PR TITLE
feat(playground): move header action buttons to right side

### DIFF
--- a/.changeset/header-actions-traces-button.md
+++ b/.changeset/header-actions-traces-button.md
@@ -1,0 +1,5 @@
+---
+"@mastra/playground": patch
+---
+
+Moved Traces button to the right side of the header next to documentation links. Removed Chat button from agent header.

--- a/.changeset/header-actions-traces-button.md
+++ b/.changeset/header-actions-traces-button.md
@@ -1,5 +1,0 @@
----
-"@mastra/playground": patch
----
-
-Moved Traces button to the right side of the header next to documentation links. Removed Chat button from agent header.

--- a/packages/playground/src/domains/agents/agent-header.tsx
+++ b/packages/playground/src/domains/agents/agent-header.tsx
@@ -1,12 +1,11 @@
+import { EyeIcon } from 'lucide-react';
 import { Link } from 'react-router';
 
 import {
   Header,
   Breadcrumb,
   Crumb,
-  HeaderGroup,
   Button,
-  DividerIcon,
   HeaderAction,
   Icon,
   DocsIcon,
@@ -14,7 +13,7 @@ import {
   AgentCombobox,
 } from '@mastra/playground-ui';
 
-export function AgentHeader({ agentName, agentId }: { agentName: string; agentId: string }) {
+export function AgentHeader({ agentId }: { agentId: string }) {
   return (
     <Header>
       <Breadcrumb>
@@ -29,19 +28,14 @@ export function AgentHeader({ agentName, agentId }: { agentName: string; agentId
         </Crumb>
       </Breadcrumb>
 
-      <HeaderGroup>
-        <Button as={Link} to={`/agents/${agentId}/chat`}>
-          Chat
-        </Button>
-
-        <DividerIcon />
-
+      <HeaderAction>
         <Button as={Link} to={`/observability?entity=${agentId}`}>
+          <Icon>
+            <EyeIcon />
+          </Icon>
           Traces
         </Button>
-      </HeaderGroup>
 
-      <HeaderAction>
         <Button as={Link} to="https://mastra.ai/en/docs/agents/overview" target="_blank">
           <Icon>
             <DocsIcon />

--- a/packages/playground/src/domains/agents/agent-layout.tsx
+++ b/packages/playground/src/domains/agents/agent-layout.tsx
@@ -5,7 +5,7 @@ import { HeaderTitle, Header, MainContentLayout, useAgent, Skeleton } from '@mas
 
 export const AgentLayout = ({ children }: { children: React.ReactNode }) => {
   const { agentId } = useParams();
-  const { data: agent, isLoading: isAgentLoading } = useAgent(agentId!);
+  const { isLoading: isAgentLoading } = useAgent(agentId!);
   return (
     <MainContentLayout>
       {isAgentLoading ? (
@@ -15,7 +15,7 @@ export const AgentLayout = ({ children }: { children: React.ReactNode }) => {
           </HeaderTitle>
         </Header>
       ) : (
-        <AgentHeader agentName={agent?.name!} agentId={agentId!} />
+        <AgentHeader agentId={agentId!} />
       )}
       {children}
     </MainContentLayout>

--- a/packages/playground/src/domains/workflows/workflow-header.tsx
+++ b/packages/playground/src/domains/workflows/workflow-header.tsx
@@ -1,3 +1,4 @@
+import { EyeIcon } from 'lucide-react';
 import { Link } from 'react-router';
 
 import {
@@ -47,13 +48,16 @@ export function WorkflowHeader({
               <DividerIcon />
             </>
           )}
-
-          <Button as={Link} to={`/observability?entity=${workflowName}`}>
-            Traces
-          </Button>
         </HeaderGroup>
 
         <HeaderAction>
+          <Button as={Link} to={`/observability?entity=${workflowName}`}>
+            <Icon>
+              <EyeIcon />
+            </Icon>
+            Traces
+          </Button>
+
           <Button as={Link} target="_blank" to="/swagger-ui">
             <Icon>
               <ApiIcon />


### PR DESCRIPTION
Moved the Traces button from the center section of the header to the right side, next to the docs button. Also removed the Chat button from the agent header since it's redundant.

Before: `[Breadcrumb] [Combobox] / [Chat] / [Traces] ... [Docs]`
After: `[Breadcrumb] [Combobox] ... [Traces] [Docs]`

The Traces button now uses the EyeIcon to match the Observability item in the sidebar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned the Traces button to the right side of the agent header, aligning it with documentation links for a cleaner layout.
  * Removed the Chat button from the agent header interface.
  * Enhanced the Traces button with a new icon for improved visual identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->