### PR TITLE
docs(auth): add SimpleAuth and Custom Auth Provider documentation

### DIFF
--- a/docs/src/content/en/docs/server/auth/composite-auth.mdx
+++ b/docs/src/content/en/docs/server/auth/composite-auth.mdx
@@ -1,0 +1,241 @@
+---
+title: "CompositeAuth Class | Auth"
+description: "Documentation for the CompositeAuth class, which combines multiple authentication providers into a single auth handler."
+packages:
+  - "@mastra/core"
+---
+
+# CompositeAuth Class
+
+The `CompositeAuth` class allows you to combine multiple authentication providers into a single auth handler. It tries each provider in order until one succeeds.
+
+## Use Cases
+
+- Support both API keys and OAuth tokens
+- Migrate between auth providers without breaking existing clients
+- Allow multiple identity providers (e.g., Clerk for web, API keys for integrations)
+- Gradual rollout of new authentication methods
+
+## Installation
+
+CompositeAuth is included in `@mastra/core`, no additional packages required.
+
+```typescript
+import { CompositeAuth } from '@mastra/core/server';
+```
+
+## Usage Example
+
+Combine SimpleAuth (for API keys) with Clerk (for user sessions):
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core';
+import { CompositeAuth, SimpleAuth } from '@mastra/core/server';
+import { MastraAuthClerk } from '@mastra/auth-clerk';
+
+// API key users
+type ApiKeyUser = {
+  id: string;
+  name: string;
+  type: 'api-key';
+};
+
+const apiKeyAuth = new SimpleAuth<ApiKeyUser>({
+  tokens: {
+    'sk-integration-key-123': {
+      id: 'integration-1',
+      name: 'CI/CD Pipeline',
+      type: 'api-key',
+    },
+  },
+});
+
+// Clerk users (from web app)
+const clerkAuth = new MastraAuthClerk({
+  publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+  secretKey: process.env.CLERK_SECRET_KEY,
+  jwksUri: process.env.CLERK_JWKS_URI,
+});
+
+export const mastra = new Mastra({
+  server: {
+    auth: new CompositeAuth([apiKeyAuth, clerkAuth]),
+  },
+});
+```
+
+## How It Works
+
+When a request comes in, CompositeAuth:
+
+1. Extracts the token from the `Authorization` header
+2. Tries each provider's `authenticateToken()` method in order
+3. Returns the user from the first provider that succeeds
+4. Returns `null` (401 Unauthorized) if all providers fail
+
+For authorization, it calls each provider's `authorizeUser()` method until one returns `true`.
+
+```typescript
+// Pseudocode of CompositeAuth behavior
+async authenticateToken(token, request) {
+  for (const provider of this.providers) {
+    const user = await provider.authenticateToken(token, request);
+    if (user) return user;  // First match wins
+  }
+  return null;  // All providers failed
+}
+```
+
+## Provider Order
+
+The order of providers matters. Place the most common authentication method first for better performance:
+
+```typescript
+// If most requests use Clerk, put it first
+new CompositeAuth([
+  clerkAuth,      // Checked first (most common)
+  apiKeyAuth,     // Checked second (less common)
+]);
+
+// If most requests use API keys, put it first
+new CompositeAuth([
+  apiKeyAuth,     // Checked first (most common)
+  clerkAuth,      // Checked second (less common)
+]);
+```
+
+## Multiple OAuth Providers
+
+Support users from different identity providers:
+
+```typescript
+import { CompositeAuth } from '@mastra/core/server';
+import { MastraAuthClerk } from '@mastra/auth-clerk';
+import { MastraAuthAuth0 } from '@mastra/auth-auth0';
+
+const clerkAuth = new MastraAuthClerk({
+  publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+  secretKey: process.env.CLERK_SECRET_KEY,
+  jwksUri: process.env.CLERK_JWKS_URI,
+});
+
+const auth0Auth = new MastraAuthAuth0({
+  domain: process.env.AUTH0_DOMAIN,
+  audience: process.env.AUTH0_AUDIENCE,
+});
+
+export const mastra = new Mastra({
+  server: {
+    auth: new CompositeAuth([clerkAuth, auth0Auth]),
+  },
+});
+```
+
+## Migration Example
+
+Migrate from JWT to Clerk while maintaining backwards compatibility:
+
+```typescript
+import { CompositeAuth } from '@mastra/core/server';
+import { MastraJwtAuth } from '@mastra/auth';
+import { MastraAuthClerk } from '@mastra/auth-clerk';
+
+// Legacy JWT auth (existing clients)
+const legacyAuth = new MastraJwtAuth({
+  secret: process.env.JWT_SECRET,
+});
+
+// New Clerk auth (new clients)
+const clerkAuth = new MastraAuthClerk({
+  publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+  secretKey: process.env.CLERK_SECRET_KEY,
+  jwksUri: process.env.CLERK_JWKS_URI,
+});
+
+// Support both during migration
+export const mastra = new Mastra({
+  server: {
+    auth: new CompositeAuth([
+      clerkAuth,    // New auth method (preferred)
+      legacyAuth,   // Legacy support
+    ]),
+  },
+});
+```
+
+## With Custom Providers
+
+Combine built-in providers with custom implementations:
+
+```typescript
+import { CompositeAuth, SimpleAuth } from '@mastra/core/server';
+import { MyCustomAuth } from './my-custom-auth';
+
+const apiKeyAuth = new SimpleAuth({
+  tokens: {
+    'sk-key-123': { id: 'user-1', name: 'API User' },
+  },
+});
+
+const customAuth = new MyCustomAuth({
+  apiUrl: process.env.CUSTOM_AUTH_URL,
+});
+
+export const mastra = new Mastra({
+  server: {
+    auth: new CompositeAuth([apiKeyAuth, customAuth]),
+  },
+});
+```
+
+## Error Handling
+
+CompositeAuth silently catches errors from individual providers and moves to the next one. This prevents one failing provider from blocking authentication:
+
+```typescript
+// If clerkAuth throws an error, apiKeyAuth still gets tried
+new CompositeAuth([clerkAuth, apiKeyAuth]);
+```
+
+To debug authentication issues, add logging to your custom providers or check individual provider configurations.
+
+## Limitations
+
+- All providers share the same token from the `Authorization` header
+- User types may differ between providers (use discriminated unions if needed)
+- No built-in way to identify which provider authenticated a request
+
+### Handling Different User Types
+
+When providers return different user types, use a discriminated union:
+
+```typescript
+type ApiKeyUser = {
+  type: 'api-key';
+  id: string;
+  name: string;
+};
+
+type ClerkUser = {
+  type: 'clerk';
+  sub: string;
+  email: string;
+};
+
+type User = ApiKeyUser | ClerkUser;
+
+// In your application code
+function handleUser(user: User) {
+  if (user.type === 'api-key') {
+    console.log('API key user:', user.name);
+  } else {
+    console.log('Clerk user:', user.email);
+  }
+}
+```
+
+## Related
+
+- [Auth Overview](/docs/server/auth) - Authentication concepts
+- [Simple Auth](/docs/server/auth/simple-auth) - Token-to-user mapping
+- [Custom Auth Provider](/docs/server/auth/custom-auth-provider) - Build your own provider

--- a/docs/src/content/en/docs/server/auth/custom-auth-provider.mdx
+++ b/docs/src/content/en/docs/server/auth/custom-auth-provider.mdx
@@ -1,0 +1,521 @@
+---
+title: "Custom Auth Provider | Auth"
+description: "Create custom authentication providers for specialized identity systems"
+packages:
+  - "@mastra/core"
+  - "@mastra/auth"
+---
+
+# Custom Auth Providers
+
+Custom auth providers allow you to implement authentication for identity systems that aren't covered by the built-in providers. Extend the `MastraAuthProvider` base class to integrate with any authentication system.
+
+## Overview
+
+Auth providers handle authentication and authorization for incoming requests:
+
+- Token verification and user extraction
+- User authorization logic
+- Path-based access control (public/protected routes)
+
+Create custom auth providers to support:
+
+- Self-hosted identity systems
+- Custom token formats or verification logic
+- Specialized authorization rules
+- Enterprise SSO integrations
+
+## Creating a Custom Auth Provider
+
+Extend the `MastraAuthProvider` class and implement the required methods:
+
+```typescript
+import { MastraAuthProvider } from '@mastra/core/server';
+import type { MastraAuthProviderOptions } from '@mastra/core/server';
+import type { HonoRequest } from 'hono';
+
+// Define your user type
+type MyUser = {
+  id: string;
+  email: string;
+  roles: string[];
+};
+
+// Define options for your provider
+interface MyAuthOptions extends MastraAuthProviderOptions<MyUser> {
+  apiUrl?: string;
+  apiKey?: string;
+}
+
+export class MyAuthProvider extends MastraAuthProvider<MyUser> {
+  protected apiUrl: string;
+  protected apiKey: string;
+
+  constructor(options?: MyAuthOptions) {
+    // Call super with a name for logging/debugging
+    super({ name: options?.name ?? 'my-auth' });
+
+    const apiUrl = options?.apiUrl ?? process.env.MY_AUTH_API_URL;
+    const apiKey = options?.apiKey ?? process.env.MY_AUTH_API_KEY;
+
+    if (!apiUrl || !apiKey) {
+      throw new Error(
+        'Auth API URL and API key are required. Provide them in options or set MY_AUTH_API_URL and MY_AUTH_API_KEY environment variables.'
+      );
+    }
+
+    this.apiUrl = apiUrl;
+    this.apiKey = apiKey;
+
+    // Register any custom options (authorizeUser override, public/protected paths)
+    this.registerOptions(options);
+  }
+
+  /**
+   * Verify the token and return the user
+   * Return null if authentication fails
+   */
+  async authenticateToken(token: string, request: HonoRequest): Promise<MyUser | null> {
+    try {
+      const response = await fetch(`${this.apiUrl}/verify`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': this.apiKey,
+        },
+        body: JSON.stringify({ token }),
+      });
+
+      if (!response.ok) {
+        return null;
+      }
+
+      const user = await response.json();
+      return user;
+    } catch (error) {
+      console.error('Token verification failed:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Check if the authenticated user is authorized
+   * Return true to allow access, false to deny
+   */
+  async authorizeUser(user: MyUser, request: HonoRequest): Promise<boolean> {
+    // Basic authorization: user must exist and have an ID
+    return !!user?.id;
+  }
+}
+```
+
+## Required Methods
+
+### authenticateToken()
+
+Verify the incoming token and return the user object if valid, or `null` if authentication fails.
+
+```typescript
+async authenticateToken(token: string, request: HonoRequest): Promise<TUser | null>
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `token` | `string` | The bearer token extracted from the `Authorization` header |
+| `request` | `HonoRequest` | The incoming request object (access headers, cookies, etc.) |
+
+**Returns**: The user object if authentication succeeds, or `null` if it fails.
+
+The token is automatically extracted from the `Authorization: Bearer <token>` header. If you need to access other headers or cookies, use the `request` parameter.
+
+### authorizeUser()
+
+Determine if the authenticated user is allowed to access the resource.
+
+```typescript
+async authorizeUser(user: TUser, request: HonoRequest): Promise<boolean> | boolean
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `user` | `TUser` | The user object returned by `authenticateToken` |
+| `request` | `HonoRequest` | The incoming request object |
+
+**Returns**: `true` to allow access, `false` to deny (returns 403 Forbidden).
+
+## Configuration Options
+
+The `MastraAuthProviderOptions` interface supports these options:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `name` | `string` | Provider name for logging/debugging |
+| `authorizeUser` | `(user, request) => Promise<boolean> \| boolean` | Custom authorization function |
+| `protected` | `(RegExp \| string \| [string, Methods \| Methods[]])[]` | Paths that require authentication |
+| `public` | `(RegExp \| string \| [string, Methods \| Methods[]])[]` | Paths that bypass authentication |
+
+### Path Patterns
+
+Configure which paths require authentication using pattern matching:
+
+```typescript
+const auth = new MyAuthProvider({
+  // Paths that require authentication
+  protected: [
+    '/api/*',           // Wildcard: all /api routes
+    '/admin/*',         // Wildcard: all /admin routes
+    /^\/secure\/.*/,    // Regex pattern
+  ],
+
+  // Paths that bypass authentication
+  public: [
+    '/health',          // Exact match
+    '/api/status',      // Exact match
+    ['/api/webhook', 'POST'],  // Only POST requests to /api/webhook
+  ],
+});
+```
+
+## Using Your Auth Provider
+
+Register your custom auth provider with the Mastra instance:
+
+```typescript
+import { Mastra } from '@mastra/core';
+import { MyAuthProvider } from './my-auth-provider';
+
+export const mastra = new Mastra({
+  server: {
+    auth: new MyAuthProvider({
+      apiUrl: process.env.MY_AUTH_API_URL,
+      apiKey: process.env.MY_AUTH_API_KEY,
+    }),
+  },
+});
+```
+
+## Helper Utilities
+
+The `@mastra/auth` package provides utilities for common token verification patterns:
+
+### JWT Verification
+
+```typescript
+import { verifyHmac, verifyJwks, decodeToken, getTokenIssuer } from '@mastra/auth';
+
+// Verify HMAC-signed JWT
+const payload = await verifyHmac(token, 'your-secret-key');
+
+// Verify with JWKS (for OAuth providers)
+const payload = await verifyJwks(token, 'https://provider.com/.well-known/jwks.json');
+
+// Decode without verification (for inspection)
+const decoded = await decodeToken(token);
+
+// Get the issuer from a decoded token
+const issuer = getTokenIssuer(decoded);
+```
+
+### Example: JWKS-based Provider
+
+```typescript
+import { MastraAuthProvider } from '@mastra/core/server';
+import type { MastraAuthProviderOptions } from '@mastra/core/server';
+import { verifyJwks } from '@mastra/auth';
+import type { JwtPayload } from '@mastra/auth';
+
+type MyUser = JwtPayload;
+
+interface MyJwksAuthOptions extends MastraAuthProviderOptions<MyUser> {
+  jwksUri?: string;
+  issuer?: string;
+}
+
+export class MyJwksAuth extends MastraAuthProvider<MyUser> {
+  protected jwksUri: string;
+  protected issuer: string;
+
+  constructor(options?: MyJwksAuthOptions) {
+    super({ name: options?.name ?? 'my-jwks-auth' });
+
+    const jwksUri = options?.jwksUri ?? process.env.MY_JWKS_URI;
+    const issuer = options?.issuer ?? process.env.MY_AUTH_ISSUER;
+
+    if (!jwksUri) {
+      throw new Error('JWKS URI is required');
+    }
+
+    this.jwksUri = jwksUri;
+    this.issuer = issuer ?? '';
+
+    this.registerOptions(options);
+  }
+
+  async authenticateToken(token: string): Promise<MyUser | null> {
+    try {
+      const payload = await verifyJwks(token, this.jwksUri);
+
+      // Optionally validate issuer
+      if (this.issuer && payload.iss !== this.issuer) {
+        return null;
+      }
+
+      return payload;
+    } catch {
+      return null;
+    }
+  }
+
+  async authorizeUser(user: MyUser): Promise<boolean> {
+    // Check token hasn't expired
+    if (user.exp && user.exp * 1000 < Date.now()) {
+      return false;
+    }
+    return !!user.sub;
+  }
+}
+```
+
+## Custom Authorization Logic
+
+Override the default authorization by providing a custom `authorizeUser` function:
+
+```typescript
+const auth = new MyAuthProvider({
+  apiUrl: process.env.MY_AUTH_API_URL,
+  apiKey: process.env.MY_AUTH_API_KEY,
+
+  // Custom authorization: require admin role for all requests
+  async authorizeUser(user, request) {
+    return user.roles.includes('admin');
+  },
+});
+```
+
+### Role-based Authorization
+
+```typescript
+const auth = new MyAuthProvider({
+  async authorizeUser(user, request) {
+    const path = request.url;
+    const method = request.method;
+
+    // Admin routes require admin role
+    if (path.startsWith('/admin/')) {
+      return user.roles.includes('admin');
+    }
+
+    // Write operations require write role
+    if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
+      return user.roles.includes('write') || user.roles.includes('admin');
+    }
+
+    // Read operations allowed for all authenticated users
+    return true;
+  },
+});
+```
+
+## Testing Custom Auth Providers
+
+Example test structure using Vitest:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MyAuthProvider } from './my-auth-provider';
+
+// Mock fetch for API calls
+global.fetch = vi.fn();
+
+describe('MyAuthProvider', () => {
+  const mockOptions = {
+    apiUrl: 'https://auth.example.com',
+    apiKey: 'test-api-key',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('initialization', () => {
+    it('should initialize with provided options', () => {
+      const auth = new MyAuthProvider(mockOptions);
+      expect(auth).toBeInstanceOf(MyAuthProvider);
+    });
+
+    it('should throw error when required options are missing', () => {
+      expect(() => new MyAuthProvider({})).toThrow('Auth API URL and API key are required');
+    });
+  });
+
+  describe('authenticateToken', () => {
+    it('should return user when token is valid', async () => {
+      const mockUser = { id: 'user123', email: 'test@example.com', roles: ['read'] };
+      (fetch as any).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockUser),
+      });
+
+      const auth = new MyAuthProvider(mockOptions);
+      const result = await auth.authenticateToken('valid-token', {} as any);
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://auth.example.com/verify',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ token: 'valid-token' }),
+        })
+      );
+      expect(result).toEqual(mockUser);
+    });
+
+    it('should return null when token is invalid', async () => {
+      (fetch as any).mockResolvedValue({ ok: false });
+
+      const auth = new MyAuthProvider(mockOptions);
+      const result = await auth.authenticateToken('invalid-token', {} as any);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('authorizeUser', () => {
+    it('should return true when user has valid id', async () => {
+      const auth = new MyAuthProvider(mockOptions);
+      const result = await auth.authorizeUser(
+        { id: 'user123', email: 'test@example.com', roles: [] },
+        {} as any
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when user has no id', async () => {
+      const auth = new MyAuthProvider(mockOptions);
+      const result = await auth.authorizeUser(
+        { id: '', email: 'test@example.com', roles: [] },
+        {} as any
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('custom authorization', () => {
+    it('should use custom authorizeUser when provided', async () => {
+      const auth = new MyAuthProvider({
+        ...mockOptions,
+        authorizeUser: (user) => user.roles.includes('admin'),
+      });
+
+      const adminUser = { id: 'user123', email: 'admin@example.com', roles: ['admin'] };
+      const regularUser = { id: 'user456', email: 'user@example.com', roles: ['read'] };
+
+      expect(await auth.authorizeUser(adminUser, {} as any)).toBe(true);
+      expect(await auth.authorizeUser(regularUser, {} as any)).toBe(false);
+    });
+  });
+
+  describe('route configuration', () => {
+    it('should store public routes configuration', () => {
+      const publicRoutes = ['/health', '/api/status'];
+      const auth = new MyAuthProvider({
+        ...mockOptions,
+        public: publicRoutes,
+      });
+
+      expect(auth.public).toEqual(publicRoutes);
+    });
+
+    it('should store protected routes configuration', () => {
+      const protectedRoutes = ['/api/*', '/admin/*'];
+      const auth = new MyAuthProvider({
+        ...mockOptions,
+        protected: protectedRoutes,
+      });
+
+      expect(auth.protected).toEqual(protectedRoutes);
+    });
+  });
+});
+```
+
+## Error Handling
+
+Provide descriptive errors for common failure scenarios:
+
+```typescript
+export class MyAuthProvider extends MastraAuthProvider<MyUser> {
+  constructor(options?: MyAuthOptions) {
+    super({ name: options?.name ?? 'my-auth' });
+
+    const apiUrl = options?.apiUrl ?? process.env.MY_AUTH_API_URL;
+    const apiKey = options?.apiKey ?? process.env.MY_AUTH_API_KEY;
+
+    if (!apiUrl) {
+      throw new Error(
+        'Missing MY_AUTH_API_URL. Set the environment variable or pass apiUrl in options.'
+      );
+    }
+
+    if (!apiKey) {
+      throw new Error(
+        'Missing MY_AUTH_API_KEY. Set the environment variable or pass apiKey in options.'
+      );
+    }
+
+    this.apiUrl = apiUrl;
+    this.apiKey = apiKey;
+    this.registerOptions(options);
+  }
+
+  async authenticateToken(token: string): Promise<MyUser | null> {
+    if (!token || typeof token !== 'string') {
+      return null; // Immediate safe fail
+    }
+
+    try {
+      const response = await fetch(`${this.apiUrl}/verify`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': this.apiKey,
+        },
+        body: JSON.stringify({ token }),
+      });
+
+      if (!response.ok) {
+        return null;
+      }
+
+      return await response.json();
+    } catch (error) {
+      // Log error for debugging, but don't expose details to client
+      console.error('Auth verification error:', error);
+      return null;
+    }
+  }
+}
+```
+
+## Built-in Providers
+
+Mastra includes these auth providers as reference implementations:
+
+- **MastraJwtAuth**: Simple JWT verification with HMAC secrets (`@mastra/auth`)
+- **MastraAuthClerk**: Clerk authentication (`@mastra/auth-clerk`)
+- **MastraAuthAuth0**: Auth0 authentication (`@mastra/auth-auth0`)
+- **MastraAuthSupabase**: Supabase authentication (`@mastra/auth-supabase`)
+- **MastraAuthFirebase**: Firebase authentication (`@mastra/auth-firebase`)
+- **MastraAuthWorkOS**: WorkOS authentication (`@mastra/auth-workos`)
+- **MastraAuthBetterAuth**: Better Auth integration (`@mastra/auth-better-auth`)
+- **SimpleAuth**: Token-to-user mapping for development (`@mastra/core/server`)
+
+See the [source code](https://github.com/mastra-ai/mastra/tree/main/auth) for implementation details.
+
+## Related
+
+- [Auth Overview](/docs/server/auth) - Authentication concepts and configuration
+- [JWT Auth](/docs/server/auth/jwt) - Simple JWT authentication
+- [Clerk Auth](/docs/server/auth/clerk) - Clerk integration
+- [Custom API Routes](/docs/server/custom-api-routes) - Controlling authentication on custom endpoints

--- a/docs/src/content/en/docs/server/auth/index.mdx
+++ b/docs/src/content/en/docs/server/auth/index.mdx
@@ -25,9 +25,20 @@ See [Custom API Routes](/docs/server/custom-api-routes#authentication) for contr
 
 ## Available providers
 
-- [JSON Web Token (JWT)](/docs/server/auth/jwt)
+### Built-in
+
+- [Simple Auth](/docs/server/auth/simple-auth) - Token-to-user mapping for development and API keys
+- [JSON Web Token (JWT)](/docs/server/auth/jwt) - HMAC-signed JWT verification
+
+### Third-party integrations
+
 - [Clerk](/docs/server/auth/clerk)
 - [Supabase](/docs/server/auth/supabase)
 - [Firebase](/docs/server/auth/firebase)
 - [WorkOS](/docs/server/auth/workos)
 - [Auth0](/docs/server/auth/auth0)
+
+### Advanced
+
+- [Composite Auth](/docs/server/auth/composite-auth) - Combine multiple auth providers
+- [Custom Auth Provider](/docs/server/auth/custom-auth-provider) - Build your own provider

--- a/docs/src/content/en/docs/server/auth/simple-auth.mdx
+++ b/docs/src/content/en/docs/server/auth/simple-auth.mdx
@@ -1,0 +1,184 @@
+---
+title: "SimpleAuth Class | Auth"
+description: "Documentation for the SimpleAuth class, which provides token-to-user mapping authentication for development and simple API key scenarios."
+packages:
+  - "@mastra/core"
+---
+
+# SimpleAuth Class
+
+The `SimpleAuth` class provides token-based authentication using a simple token-to-user mapping. It's included in `@mastra/core/server` and is useful for development, testing, and simple API key authentication scenarios.
+
+## Use Cases
+
+- Local development and testing
+- Simple API key authentication
+- Prototyping before integrating a full identity provider
+- Internal services with static tokens
+
+## Installation
+
+SimpleAuth is included in `@mastra/core`, no additional packages required.
+
+```typescript
+import { SimpleAuth } from '@mastra/core/server';
+```
+
+## Usage Example
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core';
+import { SimpleAuth } from '@mastra/core/server';
+
+// Define your user type
+type User = {
+  id: string;
+  name: string;
+  role: 'admin' | 'user';
+};
+
+export const mastra = new Mastra({
+  server: {
+    auth: new SimpleAuth<User>({
+      tokens: {
+        'sk-admin-token-123': {
+          id: 'user-1',
+          name: 'Admin User',
+          role: 'admin',
+        },
+        'sk-user-token-456': {
+          id: 'user-2',
+          name: 'Regular User',
+          role: 'user',
+        },
+      },
+    }),
+  },
+});
+```
+
+## Configuration Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `tokens` | `Record<string, TUser>` | Yes | Map of tokens to user objects |
+| `headers` | `string \| string[]` | No | Additional headers to check for tokens |
+| `name` | `string` | No | Provider name for logging |
+| `authorizeUser` | `(user, request) => boolean` | No | Custom authorization function |
+| `protected` | `(RegExp \| string)[]` | No | Paths that require authentication |
+| `public` | `(RegExp \| string)[]` | No | Paths that bypass authentication |
+
+### Default Headers
+
+SimpleAuth checks these headers by default:
+- `Authorization` (with or without `Bearer` prefix)
+- `X-Playground-Access`
+
+Add custom headers using the `headers` option:
+
+```typescript
+new SimpleAuth({
+  tokens: { /* ... */ },
+  headers: ['X-API-Key', 'X-Custom-Auth'],
+});
+```
+
+## Making Authenticated Requests
+
+Include your token in the `Authorization` header:
+
+```bash
+curl -X POST http://localhost:4111/api/agents/myAgent/generate \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-admin-token-123" \
+  -d '{"messages": "Hello"}'
+```
+
+Or without the `Bearer` prefix:
+
+```bash
+curl -X POST http://localhost:4111/api/agents/myAgent/generate \
+  -H "Content-Type: application/json" \
+  -H "Authorization: sk-admin-token-123" \
+  -d '{"messages": "Hello"}'
+```
+
+## Custom Authorization
+
+Add role-based or custom authorization logic:
+
+```typescript
+new SimpleAuth<User>({
+  tokens: {
+    'sk-admin-token': { id: '1', name: 'Admin', role: 'admin' },
+    'sk-user-token': { id: '2', name: 'User', role: 'user' },
+  },
+  authorizeUser: (user, request) => {
+    // Only admins can access /admin routes
+    if (request.url.includes('/admin')) {
+      return user.role === 'admin';
+    }
+    return true;
+  },
+});
+```
+
+## Environment Variables
+
+For production-like setups, load tokens from environment variables:
+
+```typescript
+const tokens: Record<string, User> = {};
+
+// Load from environment
+const adminToken = process.env.ADMIN_API_KEY;
+if (adminToken) {
+  tokens[adminToken] = { id: 'admin', name: 'Admin', role: 'admin' };
+}
+
+const userToken = process.env.USER_API_KEY;
+if (userToken) {
+  tokens[userToken] = { id: 'user', name: 'User', role: 'user' };
+}
+
+export const mastra = new Mastra({
+  server: {
+    auth: new SimpleAuth({ tokens }),
+  },
+});
+```
+
+## With MastraClient
+
+Configure the client with your token:
+
+```typescript
+import { MastraClient } from '@mastra/client-js';
+
+const client = new MastraClient({
+  baseUrl: 'http://localhost:4111',
+  headers: {
+    Authorization: 'Bearer sk-admin-token-123',
+  },
+});
+
+const agent = client.getAgent('myAgent');
+const response = await agent.generate('Hello');
+```
+
+## Limitations
+
+SimpleAuth is designed for simplicity, not production security:
+
+- Tokens are stored in memory
+- No token expiration or refresh
+- No cryptographic verification
+- All tokens must be known at startup
+
+For production applications, consider using [JWT](/docs/server/auth/jwt), [Clerk](/docs/server/auth/clerk), [Auth0](/docs/server/auth/auth0), or another identity provider.
+
+## Related
+
+- [Auth Overview](/docs/server/auth) - Authentication concepts
+- [JWT Auth](/docs/server/auth/jwt) - JSON Web Token authentication
+- [Custom Auth Provider](/docs/server/auth/custom-auth-provider) - Build your own provider

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -357,6 +357,11 @@ const sidebars = {
             },
             {
               type: 'doc',
+              id: 'server/auth/composite-auth',
+              label: 'Composite Auth',
+            },
+            {
+              type: 'doc',
               id: 'server/auth/custom-auth-provider',
               label: 'Custom Auth Provider',
             },

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -322,6 +322,11 @@ const sidebars = {
             },
             {
               type: 'doc',
+              id: 'server/auth/simple-auth',
+              label: 'Simple Auth',
+            },
+            {
+              type: 'doc',
               id: 'server/auth/jwt',
               label: 'JSON Web Token',
             },
@@ -349,6 +354,11 @@ const sidebars = {
               type: 'doc',
               id: 'server/auth/auth0',
               label: 'Auth0',
+            },
+            {
+              type: 'doc',
+              id: 'server/auth/custom-auth-provider',
+              label: 'Custom Auth Provider',
             },
           ],
         },


### PR DESCRIPTION
## Summary

- Add documentation for **SimpleAuth**: built-in token-to-user mapping provider for development and simple API key authentication
- Add documentation for **CompositeAuth**: combine multiple auth providers into a single handler (e.g., support both API keys and OAuth)
- Add documentation for **Custom Auth Provider**: guide for creating custom authentication providers by extending `MastraAuthProvider`
- Update **Auth Overview** page to organize providers into categories (Built-in, Third-party, Advanced)
- Update sidebar to include all new documentation pages

These documentation gaps were identified during conversations with the team at Indeed.

## Test plan

- [ ] Verify docs build successfully
- [ ] Check SimpleAuth doc renders correctly at `/docs/server/auth/simple-auth`
- [ ] Check CompositeAuth doc renders correctly at `/docs/server/auth/composite-auth`
- [ ] Check Custom Auth Provider doc renders correctly at `/docs/server/auth/custom-auth-provider`
- [ ] Check Auth Overview shows organized provider categories at `/docs/server/auth`
- [ ] Verify sidebar navigation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guides for SimpleAuth and CompositeAuth authentication methods
  * Introduced documentation for implementing custom authentication providers
  * Reorganized authentication documentation into Built-in, Third-party integrations, and Advanced categories
  * Updated navigation to include new authentication documentation sections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->