### PR TITLE
docs: mcp req ctx to agent

### DIFF
--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1389,6 +1389,35 @@ execute: async (inputData, context) => {
 };
 ```
 
+### Passing `RequestContext` through to agent
+
+```typescript
+execute: async (inputData, context) => {
+  // Access the auth data you set in middleware
+  const authInfo = context?.mcp?.extra?.authInfo;
+
+  const requestContext = context.requestContext || new RequestContext().set('someKey', authInfo)
+
+  if (!authInfo?.extra?.userId) {
+    return { error: "Authentication required" };
+  }
+
+  // Use the auth data
+  console.log("User ID:", authInfo.extra.userId);
+  console.log("Email:", authInfo.extra.email);
+
+  const agent = context?.mastra?.getAgentById('some-agent-id');
+
+  if (!agent) {
+    return { error: "Agent 'some-agent-id' not found" }
+  }
+
+  const response = await agent.generate(prompt, { requestContext })
+
+  return response.text
+};
+```
+
 ### The `extra` Object
 
 The full `context.mcp.extra` object contains:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new docs section showing how to pass `RequestContext` from a tool to an agent.
> 
> - New "Passing `RequestContext` through to agent" example demonstrates extracting auth from `context.mcp.extra`, creating/using `requestContext`, retrieving an agent via `context.mastra.getAgentById`, and calling `agent.generate(prompt, { requestContext })` with basic error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd3be5eb323d9d4bc6ab7f32ea7f5ef3bc19b8e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide with TypeScript example demonstrating how to pass RequestContext through to agents, including authentication validation and agent retrieval patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->