### PR TITLE
docs: add storage size limits and large attachment handling guide

### DIFF
--- a/docs/src/content/en/docs/memory/storage.mdx
+++ b/docs/src/content/en/docs/memory/storage.mdx
@@ -257,9 +257,8 @@ Some storage providers enforce record size limits that can be exceeded when stor
 | [DynamoDB](/reference/storage/dynamodb) | 400 KB |
 | [Convex](/reference/storage/convex) | 1 MiB |
 | [Cloudflare D1](/reference/storage/cloudflare-d1) | 1 MiB |
-| [NeonDB](/reference/storage/postgresql) | ~5 MiB |
 
-Other providers like PostgreSQL (self-hosted), MongoDB, and libSQL have significantly higher limits and are generally not affected.
+Other providers like PostgreSQL, MongoDB, and libSQL have significantly higher limits and are generally not affected.
 
 ### Solution: Upload attachments to external storage
 

--- a/docs/src/content/en/docs/memory/storage.mdx
+++ b/docs/src/content/en/docs/memory/storage.mdx
@@ -246,3 +246,74 @@ We support all popular vector providers including [Pinecone](/reference/vectors/
 
 For more information on configuring semantic recall, see the [Semantic Recall](./semantic-recall) documentation.
 
+## Handling large attachments
+
+Some storage providers enforce record size limits that can be exceeded when storing messages with base64-encoded attachments (such as images). When an attachment is embedded directly in the message content, the total record size may exceed the provider's limit.
+
+### Affected providers
+
+| Provider | Record size limit |
+| -------- | ----------------- |
+| [DynamoDB](/reference/storage/dynamodb) | 400 KB |
+| [Convex](/reference/storage/convex) | 1 MiB |
+| [Cloudflare D1](/reference/storage/cloudflare-d1) | 1 MiB |
+| [NeonDB](/reference/storage/postgresql) | ~5 MiB |
+
+Other providers like PostgreSQL (self-hosted), MongoDB, and libSQL have significantly higher limits and are generally not affected.
+
+### Solution: Upload attachments to external storage
+
+The recommended approach is to use an input processor that uploads large attachments to external storage and replaces them with URL references before the message is persisted. This works with any file storage service—S3, Cloudflare R2, Google Cloud Storage, [Convex file storage](https://docs.convex.dev/file-storage), or your own server.
+
+```typescript title="src/mastra/processors/attachment-uploader.ts"
+import type { Processor, MastraDBMessage } from "@mastra/core";
+
+export class AttachmentUploader implements Processor {
+  id = "attachment-uploader";
+
+  async processInput({ messages }: { messages: MastraDBMessage[] }) {
+    return Promise.all(messages.map((msg) => this.processMessage(msg)));
+  }
+
+  async processMessage(msg: MastraDBMessage) {
+    const attachments = msg.content.experimental_attachments;
+    if (!attachments?.length) return msg;
+
+    const uploaded = await Promise.all(
+      attachments.map(async (att) => {
+        // Skip if already a URL
+        if (!att.url?.startsWith("data:")) return att;
+
+        // Upload base64 data and replace with URL
+        const url = await this.upload(att.url, att.contentType);
+        return { ...att, url };
+      })
+    );
+
+    return { ...msg, content: { ...msg.content, experimental_attachments: uploaded } };
+  }
+
+  async upload(dataUri: string, contentType?: string): Promise<string> {
+    const base64 = dataUri.split(",")[1];
+    const buffer = Buffer.from(base64, "base64");
+
+    // Replace with your storage provider (S3, R2, GCS, Convex, etc.)
+    // return await s3.upload(buffer, contentType);
+    throw new Error("Implement upload() with your storage provider");
+  }
+}
+```
+
+Use the processor with your agent:
+
+```typescript
+import { Agent } from "@mastra/core/agent";
+import { Memory } from "@mastra/memory";
+import { AttachmentUploader } from "./processors/attachment-uploader";
+
+const agent = new Agent({
+  id: "my-agent",
+  memory: new Memory({ storage: yourStorage }),
+  inputProcessors: [new AttachmentUploader()],
+});
+```

--- a/docs/src/content/en/docs/memory/storage.mdx
+++ b/docs/src/content/en/docs/memory/storage.mdx
@@ -266,7 +266,8 @@ Other providers like PostgreSQL (self-hosted), MongoDB, and libSQL have signific
 The recommended approach is to use an input processor that uploads large attachments to external storage and replaces them with URL references before the message is persisted. This works with any file storage service—S3, Cloudflare R2, Google Cloud Storage, [Convex file storage](https://docs.convex.dev/file-storage), or your own server.
 
 ```typescript title="src/mastra/processors/attachment-uploader.ts"
-import type { Processor, MastraDBMessage } from "@mastra/core";
+import type { Processor } from "@mastra/core/processors";
+import type { MastraDBMessage } from "@mastra/core/memory";
 
 export class AttachmentUploader implements Processor {
   id = "attachment-uploader";

--- a/docs/src/content/en/reference/storage/cloudflare-d1.mdx
+++ b/docs/src/content/en/reference/storage/cloudflare-d1.mdx
@@ -14,6 +14,10 @@ The Cloudflare D1 storage implementation provides a serverless SQL database solu
 Cloudflare D1 storage **does not support the observability domain**. Traces from the `DefaultExporter` cannot be persisted to D1, and Mastra Studio's observability features won't work with D1 as your only storage provider. To enable observability, use [composite storage](/reference/storage/composite#specialized-storage-for-observability-recommended-for-production) to route observability data to a supported provider like ClickHouse or PostgreSQL.
 :::
 
+:::warning[Row Size Limit]
+Cloudflare D1 enforces a **1 MiB maximum row size**. This limit can be exceeded when storing messages with base64-encoded attachments such as images. See [Handling large attachments](/docs/memory/storage#handling-large-attachments) for workarounds including uploading attachments to external storage.
+:::
+
 ## Installation
 
 ```bash npm2yarn

--- a/docs/src/content/en/reference/storage/convex.mdx
+++ b/docs/src/content/en/reference/storage/convex.mdx
@@ -13,6 +13,10 @@ The Convex storage implementation provides a serverless storage solution using [
 Convex storage **does not support the observability domain**. Traces from the `DefaultExporter` cannot be persisted to Convex, and Mastra Studio's observability features won't work with Convex as your only storage provider. To enable observability, use [composite storage](/reference/storage/composite#specialized-storage-for-observability-recommended-for-production) to route observability data to a supported provider like ClickHouse or PostgreSQL.
 :::
 
+:::warning[Record Size Limit]
+Convex enforces a **1 MiB maximum record size**. This limit can be exceeded when storing messages with base64-encoded attachments such as images. See [Handling large attachments](/docs/memory/storage#handling-large-attachments) for workarounds including uploading attachments to external storage like S3, Cloudflare R2, or [Convex file storage](https://docs.convex.dev/file-storage).
+:::
+
 ## Installation
 
 ```bash npm2yarn

--- a/docs/src/content/en/reference/storage/dynamodb.mdx
+++ b/docs/src/content/en/reference/storage/dynamodb.mdx
@@ -16,6 +16,10 @@ The DynamoDB storage implementation provides a scalable and performant NoSQL dat
 DynamoDB storage **does not support the observability domain**. Traces from the `DefaultExporter` cannot be persisted to DynamoDB, and Mastra Studio's observability features won't work with DynamoDB as your only storage provider. To enable observability, use [composite storage](/reference/storage/composite#specialized-storage-for-observability-recommended-for-production) to route observability data to a supported provider like ClickHouse or PostgreSQL.
 :::
 
+:::warning[Item Size Limit]
+DynamoDB enforces a **400 KB maximum item size**. This limit can be exceeded when storing messages with base64-encoded attachments such as images. See [Handling large attachments](/docs/memory/storage#handling-large-attachments) for workarounds including uploading attachments to external storage.
+:::
+
 ## Features
 
 - Efficient single-table design for all Mastra storage needs


### PR DESCRIPTION
## Description

Documents storage provider record size limits and provides a workaround pattern for handling large base64-encoded attachments (like images) that exceed these limits.

**Changes:**
- Added central documentation section "Handling large attachments" to memory storage docs with:
  - Table of affected providers and their limits (DynamoDB 400KB, Convex 1MiB, D1 1MiB, NeonDB ~5MiB)
  - Example `AttachmentUploader` processor that uploads base64 data to external storage and replaces with URLs
- Added "Record Size Limit" / "Item Size Limit" warnings to affected storage provider reference pages:
  - Convex
  - DynamoDB  
  - Cloudflare D1

## Related Issue(s)

Fixes #12341

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance on handling large attachments in memory/storage systems.
  * Documented provider row/record/item size limits and added warning notes for Cloudflare D1 (1 MiB), Convex (1 MiB), and DynamoDB (400 KB).
  * Provided patterns and example guidance for uploading large attachments to external storage and replacing them with URL references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->