### PR TITLE
refactor(core): rename skillsPaths to skills in workspace config

### DIFF
--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -122,12 +122,12 @@ A skill is a folder containing a `SKILL.md` file with metadata and instructions,
       lint.ts         # Executable scripts
 ```
 
-Configure `skillsPaths` to enable skill discovery:
+Configure `skills` to enable skill discovery:
 
 ```typescript
 const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: './workspace' }),
-  skillsPaths: ['/skills'],
+  skills: ['/skills'],
 });
 ```
 

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -93,7 +93,7 @@ await workspace.init();
       isOptional: true,
     },
     {
-      name: "skillsPaths",
+      name: "skills",
       type: "string[]",
       description: "Paths where SKILL.md files are located",
       isOptional: true,
@@ -345,7 +345,7 @@ A workspace provides tools to agents based on what is configured:
 
 **Search** - When BM25 or vector search is configured, agents receive tools for searching and indexing workspace content.
 
-**Skills** - When `skillsPaths` is configured, the workspace provides access to SKILL.md files for skill discovery and activation.
+**Skills** - When `skills` is configured, the workspace provides access to SKILL.md files for skill discovery and activation.
 
 ## Related
 

--- a/examples/unified-workspace/src/mastra/workspaces.ts
+++ b/examples/unified-workspace/src/mastra/workspaces.ts
@@ -39,7 +39,7 @@ const PROJECT_ROOT = getProjectRoot();
  * - Skills discovery from SKILL.md files
  * - BM25 search across indexed content
  *
- * Skills are discovered from the configured skillsPaths and are:
+ * Skills are discovered from the configured skills and are:
  * - Visible in the Workspace UI (/workspace page, Skills tab)
  * - Available to agents via workspace.skills
  * - Searchable via workspace.skills.search()
@@ -71,7 +71,7 @@ export const globalWorkspace = new Workspace({
   // Auto-index support FAQ content for search
   autoIndexPaths: ['/.mastra-knowledge/knowledge/support/default'],
   // Discover skills from these paths (global skills only)
-  skillsPaths: ['/skills'],
+  skills: ['/skills'],
   // Auto-initialize on construction (needed for mastra dev)
   autoInit: true,
 });
@@ -105,7 +105,7 @@ export const docsAgentWorkspace = new Workspace({
   // Enable BM25 search
   bm25: true,
   // Inherit global skills + add agent-specific skills
-  skillsPaths: ['/skills', '/docs-skills'],
+  skills: ['/skills', '/docs-skills'],
   // Auto-initialize on construction
   autoInit: true,
 });
@@ -136,7 +136,7 @@ export const isolatedDocsWorkspace = new Workspace({
   // Auto-index support FAQ content for search
   autoIndexPaths: ['/.mastra-knowledge/knowledge/support/default'],
   // Only agent-specific skills, no global skills
-  skillsPaths: ['/docs-skills'],
+  skills: ['/docs-skills'],
   // Auto-initialize on construction
   autoInit: true,
 });
@@ -158,7 +158,7 @@ export const readonlyWorkspace = new Workspace({
     },
   }),
   bm25: true,
-  skillsPaths: ['/skills'],
+  skills: ['/skills'],
   autoInit: true,
 });
 
@@ -191,7 +191,7 @@ export const safeWriteWorkspace = new Workspace({
     },
   },
   bm25: true,
-  skillsPaths: ['/skills'],
+  skills: ['/skills'],
   autoInit: true,
 });
 
@@ -219,7 +219,7 @@ export const supervisedSandboxWorkspace = new Workspace({
     },
   },
   bm25: true,
-  skillsPaths: ['/skills'],
+  skills: ['/skills'],
   autoInit: true,
 });
 
@@ -249,7 +249,7 @@ export const fsWriteApprovalWorkspace = new Workspace({
     [WORKSPACE_TOOLS.SEARCH.INDEX]: { requireApproval: true },
   },
   bm25: true,
-  skillsPaths: ['/skills'],
+  skills: ['/skills'],
   autoInit: true,
 });
 
@@ -278,7 +278,7 @@ export const fsAllApprovalWorkspace = new Workspace({
     [WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]: { requireApproval: false },
   },
   bm25: true,
-  skillsPaths: ['/skills'],
+  skills: ['/skills'],
   autoInit: true,
 });
 
@@ -301,7 +301,7 @@ export const testAgentWorkspace = new Workspace({
  * Skills-only workspace - no filesystem or sandbox, just skills.
  *
  * This demonstrates the minimal workspace configuration:
- * - Only skillsPaths is provided
+ * - Only skills is provided
  * - Skills are loaded read-only via LocalSkillSource (using Node.js fs/promises)
  * - No filesystem tools (workspace_read_file, workspace_write_file, etc.)
  * - No sandbox tools (execute_command)
@@ -318,7 +318,7 @@ export const skillsOnlyWorkspace = new Workspace({
   // No filesystem - skills loaded read-only from disk via LocalSkillSource
   // No sandbox - no code execution capability
   // Only skills from the configured paths
-  skillsPaths: [join(PROJECT_ROOT, 'skills'), join(PROJECT_ROOT, 'docs-skills')],
+  skills: [join(PROJECT_ROOT, 'skills'), join(PROJECT_ROOT, 'docs-skills')],
   // Note: BM25/vector search not available without filesystem
   // Skills are still searchable via workspace.skills.search() using simple text matching
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -295,7 +295,7 @@ export class Agent<
   }
 
   /**
-   * Gets the skills processors to add to input processors when workspace has skillsPaths.
+   * Gets the skills processors to add to input processors when workspace has skills.
    * @internal
    */
   private async getSkillsProcessors(

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -222,7 +222,7 @@ export interface AgentConfig<
    */
   memory?: DynamicArgument<MastraMemory>;
   /**
-   * Format for skill information injection when workspace has skillsPaths.
+   * Format for skill information injection when workspace has skills.
    * @default 'xml'
    */
   skillsFormat?: SkillFormat;

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -218,7 +218,7 @@ export interface Config<
   /**
    * Global workspace for file storage, skills, and code execution.
    * Agents inherit this workspace unless they have their own configured.
-   * Skills are accessed via workspace.skills when skillsPaths is configured.
+   * Skills are accessed via workspace.skills when skills is configured.
    */
   workspace?: Workspace;
 

--- a/packages/core/src/processors/processors/skills.ts
+++ b/packages/core/src/processors/processors/skills.ts
@@ -6,11 +6,11 @@
  *
  * @example
  * ```typescript
- * // Auto-created by Agent when workspace has skillsPaths
+ * // Auto-created by Agent when workspace has skills
  * const agent = new Agent({
  *   workspace: new Workspace({
  *     filesystem: new LocalFilesystem({ basePath: './data' }),
- *     skillsPaths: ['/skills'],
+ *     skills: ['/skills'],
  *   }),
  * });
  *

--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -206,8 +206,8 @@ export type {
   CreateSkillInput,
   UpdateSkillInput,
   WorkspaceSkills,
-  SkillsPathsResolver,
-  SkillsPathsContext,
+  SkillsResolver,
+  SkillsContext,
 } from './skills';
 
 // =============================================================================

--- a/packages/core/src/workspace/skills/index.ts
+++ b/packages/core/src/workspace/skills/index.ts
@@ -2,7 +2,7 @@
  * Skills Module
  *
  * Provides types, schemas, and implementation for Skills following the Agent Skills specification.
- * Skills are SKILL.md files discovered from workspace skillsPaths.
+ * Skills are SKILL.md files discovered from workspace skills paths.
  *
  * @see https://github.com/anthropics/skills
  */
@@ -21,8 +21,8 @@ export type {
   CreateSkillInput,
   UpdateSkillInput,
   WorkspaceSkills,
-  SkillsPathsResolver,
-  SkillsPathsContext,
+  SkillsResolver,
+  SkillsContext,
 } from './types';
 
 // =============================================================================

--- a/packages/core/src/workspace/skills/local-skill-source.ts
+++ b/packages/core/src/workspace/skills/local-skill-source.ts
@@ -10,10 +10,10 @@
  *   basePath: process.cwd(),
  * });
  *
- * // skillsPaths are relative to basePath
- * const skills = new WorkspaceSkillsImpl({
+ * // skills paths are relative to basePath
+ * const skillsImpl = new WorkspaceSkillsImpl({
  *   source,
- *   skillsPaths: ['./skills', './node_modules/@company/skills'],
+ *   skills: ['./skills', './node_modules/@company/skills'],
  * });
  * ```
  */

--- a/packages/core/src/workspace/skills/types.ts
+++ b/packages/core/src/workspace/skills/types.ts
@@ -1,6 +1,6 @@
 /**
  * Types for Skills following the Agent Skills specification.
- * Skills are SKILL.md files discovered from workspace skillsPaths.
+ * Skills are SKILL.md files discovered from workspace skills paths.
  *
  * @see https://github.com/anthropics/skills
  */
@@ -9,20 +9,20 @@ import type { BaseSearchResult, BaseSearchOptions, ContentSource } from '../../a
 import type { RequestContext } from '../../request-context';
 
 // =============================================================================
-// Skills Paths Types
+// Skills Types
 // =============================================================================
 
 /**
- * Context passed to skillsPaths resolver function.
+ * Context passed to skills resolver function.
  * Contains request-scoped information for dynamic path resolution.
  */
-export interface SkillsPathsContext {
+export interface SkillsContext {
   /** Request context with user/thread information */
   requestContext?: RequestContext;
 }
 
 /**
- * Resolver for skillsPaths - can be static array or dynamic function.
+ * Resolver for skills - can be static array of paths or dynamic function.
  *
  * Static: A fixed array of paths to scan for skills.
  * Dynamic: A function that returns paths based on context (e.g., user tier, tenant).
@@ -30,14 +30,14 @@ export interface SkillsPathsContext {
  * @example Static paths
  * ```typescript
  * const workspace = new Workspace({
- *   skillsPaths: ['/skills', '/node_modules/@myorg/skills'],
+ *   skills: ['/skills', '/node_modules/@myorg/skills'],
  * });
  * ```
  *
  * @example Dynamic paths based on user tier
  * ```typescript
  * const workspace = new Workspace({
- *   skillsPaths: (ctx) => {
+ *   skills: (ctx) => {
  *     const tier = ctx.requestContext?.get('userTier');
  *     if (tier === 'premium') {
  *       return ['/skills/basic', '/skills/premium'];
@@ -47,7 +47,7 @@ export interface SkillsPathsContext {
  * });
  * ```
  */
-export type SkillsPathsResolver = string[] | ((context: SkillsPathsContext) => string[] | Promise<string[]>);
+export type SkillsResolver = string[] | ((context: SkillsContext) => string[] | Promise<string[]>);
 
 /**
  * Skill source types indicating where the skill comes from and its access level.
@@ -148,14 +148,14 @@ export interface UpdateSkillInput {
  * Interface for skills accessed via workspace.skills.
  * Provides discovery, search, and CRUD operations for skills in the workspace.
  *
- * Skills are SKILL.md files discovered from configured skillsPaths.
+ * Skills are SKILL.md files discovered from configured skills.
  * All operations are async because they use the workspace filesystem.
  *
  * @example
  * ```typescript
  * const workspace = new Workspace({
  *   filesystem: new LocalFilesystem({ basePath: './data' }),
- *   skillsPaths: ['/skills'],
+ *   skills: ['/skills'],
  * });
  *
  * // List all skills
@@ -199,15 +199,15 @@ export interface WorkspaceSkills {
   has(name: string): Promise<boolean>;
 
   /**
-   * Refresh skills from filesystem (re-scan skillsPaths)
+   * Refresh skills from filesystem (re-scan skills)
    */
   refresh(): Promise<void>;
 
   /**
-   * Conditionally refresh skills if the skillsPaths have been modified.
+   * Conditionally refresh skills if the skills have been modified.
    * Uses a staleness check to avoid unnecessary re-discovery on every call.
    *
-   * When skillsPaths is a dynamic function, pass context to resolve paths.
+   * When skills is a dynamic function, pass context to resolve paths.
    * If paths have changed, triggers a full refresh.
    *
    * Call this in processInput before each agent turn to catch newly
@@ -215,7 +215,7 @@ export interface WorkspaceSkills {
    *
    * @param context - Optional context for dynamic path resolution
    */
-  maybeRefresh(context?: SkillsPathsContext): Promise<void>;
+  maybeRefresh(context?: SkillsContext): Promise<void>;
 
   // ===========================================================================
   // Search

--- a/packages/core/src/workspace/skills/workspace-skills.test.ts
+++ b/packages/core/src/workspace/skills/workspace-skills.test.ts
@@ -225,7 +225,7 @@ describe('WorkspaceSkillsImpl', () => {
       const filesystem = createMockFilesystem({});
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const result = await skills.list();
@@ -240,7 +240,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const result = await skills.list();
@@ -256,7 +256,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const result = await skills.list();
@@ -267,7 +267,7 @@ describe('WorkspaceSkillsImpl', () => {
       });
     });
 
-    it('should discover skills from multiple skillsPaths', async () => {
+    it('should discover skills from multiple paths', async () => {
       const filesystem = createMockFilesystem({
         '/skills/test-skill/SKILL.md': VALID_SKILL_MD,
         '/custom-skills/api-skill/SKILL.md': VALID_SKILL_MD_WITH_TOOLS,
@@ -275,7 +275,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills', '/custom-skills'],
+        skills: ['/skills', '/custom-skills'],
       });
 
       const result = await skills.list();
@@ -288,7 +288,7 @@ describe('WorkspaceSkillsImpl', () => {
       const filesystem = createMockFilesystem({});
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const result = await skills.get('non-existent');
@@ -302,7 +302,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const result = await skills.get('test-skill');
@@ -323,7 +323,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const result = await skills.get('test-skill');
@@ -338,7 +338,7 @@ describe('WorkspaceSkillsImpl', () => {
       const filesystem = createMockFilesystem({});
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const result = await skills.has('non-existent');
@@ -352,7 +352,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const result = await skills.has('test-skill');
@@ -368,7 +368,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       // Initial discovery
@@ -398,7 +398,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const results = await skills.search('API');
@@ -415,7 +415,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
         searchEngine,
       });
 
@@ -435,7 +435,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const results = await skills.search('skill', { skillNames: ['test-skill'] });
@@ -451,7 +451,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const results = await skills.search('test', { topK: 2 });
@@ -465,7 +465,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const newSkill = await skills.create({
@@ -491,7 +491,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       await expect(
@@ -510,7 +510,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       await skills.create({
@@ -539,7 +539,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const updated = await skills.update('test-skill', {
@@ -559,7 +559,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const updated = await skills.update('test-skill', {
@@ -574,7 +574,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       await expect(
@@ -593,7 +593,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       expect(await skills.has('test-skill')).toBe(true);
@@ -609,7 +609,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       await expect(skills.delete('non-existent')).rejects.toThrow('not found');
@@ -625,7 +625,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const content = await skills.getReference('test-skill', 'doc.md');
@@ -639,7 +639,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const content = await skills.getReference('test-skill', 'non-existent.md');
@@ -651,7 +651,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const content = await skills.getReference('non-existent', 'doc.md');
@@ -668,7 +668,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const content = await skills.getScript('test-skill', 'run.sh');
@@ -686,7 +686,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const content = await skills.getAsset('test-skill', 'logo.png');
@@ -706,7 +706,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const refs = await skills.listReferences('test-skill');
@@ -722,7 +722,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const refs = await skills.listReferences('test-skill');
@@ -740,7 +740,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const scripts = await skills.listScripts('test-skill');
@@ -759,7 +759,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const assets = await skills.listAssets('test-skill');
@@ -776,7 +776,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
         validateOnLoad: true,
       });
 
@@ -792,7 +792,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
         validateOnLoad: false,
       });
 
@@ -807,7 +807,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
         validateOnLoad: true,
       });
 
@@ -825,7 +825,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const skill = await skills.get('test-skill');
@@ -839,7 +839,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/node_modules/@company/skills'],
+        skills: ['/node_modules/@company/skills'],
       });
 
       const skill = await skills.get('test-skill');
@@ -853,7 +853,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/.mastra/skills'],
+        skills: ['/.mastra/skills'],
       });
 
       const skill = await skills.get('test-skill');
@@ -869,7 +869,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       // Call list() concurrently
@@ -903,7 +903,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       // First call initializes
@@ -934,7 +934,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       // First call initializes
@@ -968,7 +968,7 @@ describe('WorkspaceSkillsImpl', () => {
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       // Initial discovery
@@ -1084,7 +1084,7 @@ Instructions for the new skill.`;
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       expect(skills.isWritable).toBe(true);
@@ -1097,7 +1097,7 @@ Instructions for the new skill.`;
 
       const skills = new WorkspaceSkillsImpl({
         source,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       expect(skills.isWritable).toBe(false);
@@ -1111,7 +1111,7 @@ Instructions for the new skill.`;
 
       const skills = new WorkspaceSkillsImpl({
         source,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const result = await skills.list();
@@ -1128,7 +1128,7 @@ Instructions for the new skill.`;
 
       const skills = new WorkspaceSkillsImpl({
         source,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const skill = await skills.get('test-skill');
@@ -1145,7 +1145,7 @@ Instructions for the new skill.`;
 
       const skills = new WorkspaceSkillsImpl({
         source,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const results = await skills.search('API');
@@ -1158,7 +1158,7 @@ Instructions for the new skill.`;
 
       const skills = new WorkspaceSkillsImpl({
         source,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       await expect(
@@ -1176,7 +1176,7 @@ Instructions for the new skill.`;
 
       const skills = new WorkspaceSkillsImpl({
         source,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       await expect(
@@ -1193,7 +1193,7 @@ Instructions for the new skill.`;
 
       const skills = new WorkspaceSkillsImpl({
         source,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       await expect(skills.delete('test-skill')).rejects.toThrow('read-only');
@@ -1205,7 +1205,7 @@ Instructions for the new skill.`;
       // Use new 'source' config instead of deprecated 'filesystem'
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       // Create should work
@@ -1230,7 +1230,7 @@ Instructions for the new skill.`;
     });
   });
 
-  describe('dynamic skillsPaths', () => {
+  describe('dynamic skills paths', () => {
     const BASIC_SKILL_MD = `---
 name: basic-skill
 description: A basic skill
@@ -1251,14 +1251,14 @@ description: A premium skill
 Premium instructions.
 `;
 
-    it('should accept a function as skillsPaths', async () => {
+    it('should accept a function for skills config', async () => {
       const filesystem = createMockFilesystem({
         '/skills/basic/basic-skill/SKILL.md': BASIC_SKILL_MD,
       });
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: () => ['/skills/basic'],
+        skills: () => ['/skills/basic'],
       });
 
       const result = await skills.list();
@@ -1266,14 +1266,14 @@ Premium instructions.
       expect(result[0]?.name).toBe('basic-skill');
     });
 
-    it('should accept an async function as skillsPaths', async () => {
+    it('should accept an async function for skills config', async () => {
       const filesystem = createMockFilesystem({
         '/skills/basic/basic-skill/SKILL.md': BASIC_SKILL_MD,
       });
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: async () => {
+        skills: async () => {
           // Simulate async operation (e.g., fetching config)
           await new Promise(resolve => setTimeout(resolve, 10));
           return ['/skills/basic'];
@@ -1285,7 +1285,7 @@ Premium instructions.
       expect(result[0]?.name).toBe('basic-skill');
     });
 
-    it('should pass context to skillsPaths function', async () => {
+    it('should pass context to skills function', async () => {
       const filesystem = createMockFilesystem({
         '/skills/basic/basic-skill/SKILL.md': BASIC_SKILL_MD,
         '/skills/premium/premium-skill/SKILL.md': PREMIUM_SKILL_MD,
@@ -1295,7 +1295,7 @@ Premium instructions.
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ctx => {
+        skills: ctx => {
           capturedContext = ctx;
           return ['/skills/basic'];
         },
@@ -1329,7 +1329,7 @@ Premium instructions.
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: ctx => {
+        skills: ctx => {
           const tier = (ctx.requestContext as ReturnType<typeof createMockRequestContext>)?.get?.('userTier');
           if (tier === 'premium') {
             return ['/skills/basic', '/skills/premium'];
@@ -1364,7 +1364,7 @@ Premium instructions.
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: () => [currentPath],
+        skills: () => [currentPath],
       });
 
       // Initial list
@@ -1398,7 +1398,7 @@ Premium instructions.
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: pathsResolver,
+        skills: pathsResolver,
       });
 
       // Initial list
@@ -1423,7 +1423,7 @@ Premium instructions.
 
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
-        skillsPaths: () => [],
+        skills: () => [],
       });
 
       const result = await skills.list();
@@ -1441,7 +1441,7 @@ Premium instructions.
       const skills = new WorkspaceSkillsImpl({
         source: filesystem,
         // Return paths in different order but same content
-        skillsPaths: () => {
+        skills: () => {
           callCount++;
           return callCount % 2 === 0 ? ['/skills/b', '/skills/a'] : ['/skills/a', '/skills/b'];
         },

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -76,8 +76,8 @@ describe('Workspace', () => {
       expect(workspace.name).toBe('Custom Workspace');
     });
 
-    it('should throw when neither filesystem nor sandbox nor skillsPaths provided', () => {
-      expect(() => new Workspace({})).toThrow('Workspace requires at least a filesystem, sandbox, or skillsPaths');
+    it('should throw when neither filesystem nor sandbox nor skills provided', () => {
+      expect(() => new Workspace({})).toThrow('Workspace requires at least a filesystem, sandbox, or skills');
     });
 
     it('should auto-initialize when autoInit is true', async () => {
@@ -284,7 +284,7 @@ Line 3 conclusion`;
   // Skills
   // ===========================================================================
   describe('skills', () => {
-    it('should return undefined when no skillsPaths configured', () => {
+    it('should return undefined when no skills configured', () => {
       const filesystem = new LocalFilesystem({ basePath: tempDir });
       const workspace = new Workspace({ filesystem });
       expect(workspace.skills).toBeUndefined();
@@ -294,7 +294,7 @@ Line 3 conclusion`;
       const sandbox = new LocalSandbox({ workingDirectory: tempDir });
       const workspace = new Workspace({
         sandbox,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       // Skills should be available via LocalSkillSource (read-only)
@@ -302,17 +302,17 @@ Line 3 conclusion`;
       expect(workspace.skills?.isWritable).toBe(false);
     });
 
-    it('should return undefined when no skillsPaths configured', () => {
+    it('should return undefined when no skills configured', () => {
       const sandbox = new LocalSandbox({ workingDirectory: tempDir });
       const workspace = new Workspace({ sandbox });
       expect(workspace.skills).toBeUndefined();
     });
 
-    it('should return skills instance when skillsPaths and filesystem configured', () => {
+    it('should return skills instance when skills and filesystem configured', () => {
       const filesystem = new LocalFilesystem({ basePath: tempDir });
       const workspace = new Workspace({
         filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
       expect(workspace.skills).toBeDefined();
     });
@@ -321,7 +321,7 @@ Line 3 conclusion`;
       const filesystem = new LocalFilesystem({ basePath: tempDir });
       const workspace = new Workspace({
         filesystem,
-        skillsPaths: ['/skills'],
+        skills: ['/skills'],
       });
 
       const skills1 = workspace.skills;

--- a/server-adapters/_test-utils/src/test-helpers.ts
+++ b/server-adapters/_test-utils/src/test-helpers.ts
@@ -685,7 +685,7 @@ Follow these instructions for the test skill.
   const filesystem = new LocalFilesystem({ basePath: tempDir });
   const workspace = new Workspace({
     filesystem,
-    skillsPaths: ['/skills'],
+    skills: ['/skills'],
     bm25: true, // Enable BM25 search for index/unindex operations
     autoInit: true,
   });


### PR DESCRIPTION
## Summary

- Renames `workspace.skillsPaths` config property to `workspace.skills`
- Renames `SkillsPathsResolver` → `SkillsResolver`
- Renames `SkillsPathsContext` → `SkillsContext`
- The accessor `workspace.skills` (which returns `WorkspaceSkills`) remains unchanged

## Usage

```typescript
const workspace = new Workspace({
  skills: ['/skills', '/node_modules/@myorg/skills'],
});

// Access skills
const allSkills = await workspace.skills?.list();
const skill = await workspace.skills?.get('my-skill');
```

## Test plan

- [x] Core package builds successfully
- [x] All workspace tests pass (95 tests)