### PR TITLE
refactor(workspace): add shared Lifecycle interface for providers

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,7 +36,7 @@ export {
   type ExecutionResult,
   type CommandResult,
   type ExecuteCommandOptions,
-  type SandboxStatus,
+  type ProviderStatus,
   type SandboxInfo,
   // Built-in providers
   LocalFilesystem,

--- a/packages/core/src/workspace/filesystem.ts
+++ b/packages/core/src/workspace/filesystem.ts
@@ -19,6 +19,8 @@
  * ```
  */
 
+import type { Lifecycle, ProviderStatus } from './lifecycle';
+
 // =============================================================================
 // Core Types
 // =============================================================================
@@ -90,6 +92,36 @@ export interface CopyOptions {
 }
 
 // =============================================================================
+// Filesystem Info
+// =============================================================================
+
+/**
+ * Information about a filesystem provider's current state.
+ */
+export interface FilesystemInfo {
+  /** Unique identifier */
+  id: string;
+  /** Human-readable name */
+  name: string;
+  /** Provider type */
+  provider: string;
+  /** Current status (for stateful providers) */
+  status?: ProviderStatus;
+  /** Whether filesystem is read-only */
+  readOnly?: boolean;
+  /** Base path (for local filesystems) */
+  basePath?: string;
+  /** Storage usage (if available) */
+  storage?: {
+    totalBytes?: number;
+    usedBytes?: number;
+    availableBytes?: number;
+  };
+  /** Provider-specific metadata */
+  metadata?: Record<string, unknown>;
+}
+
+// =============================================================================
 // Filesystem Interface
 // =============================================================================
 
@@ -101,8 +133,16 @@ export interface CopyOptions {
  *
  * All paths are absolute within the filesystem's namespace.
  * Implementations handle path normalization.
+ *
+ * Lifecycle methods (from Lifecycle interface) are all optional:
+ * - init(): One-time setup (create directories, tables)
+ * - start(): Begin operation (establish connections)
+ * - stop(): Pause operation (close connections)
+ * - destroy(): Clean up resources
+ * - isReady(): Check if ready for operations
+ * - getInfo(): Get status and metadata
  */
-export interface WorkspaceFilesystem {
+export interface WorkspaceFilesystem extends Lifecycle<FilesystemInfo> {
   /** Unique identifier for this filesystem instance */
   readonly id: string;
 
@@ -204,20 +244,6 @@ export interface WorkspaceFilesystem {
    * @throws {FileNotFoundError} if path doesn't exist
    */
   stat(path: string): Promise<FileStat>;
-
-  // ---------------------------------------------------------------------------
-  // Lifecycle
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Initialize the filesystem (create tables, connect, etc.)
-   */
-  init?(): Promise<void>;
-
-  /**
-   * Clean up resources.
-   */
-  destroy?(): Promise<void>;
 }
 
 // =============================================================================

--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -37,8 +37,8 @@
  * });
  *
  * await workspace.init();
- * await workspace.writeFile('/hello.txt', 'Hello World!');
- * const result = await workspace.executeCommand('cat', ['/hello.txt']);
+ * await workspace.filesystem?.writeFile('/hello.txt', 'Hello World!');
+ * const result = await workspace.sandbox?.executeCommand?.('cat', ['/hello.txt']);
  * ```
  *
  * @packageDocumentation
@@ -146,6 +146,18 @@ export {
 } from './constants';
 
 // =============================================================================
+// PROVIDER INTERFACE - Lifecycle
+// =============================================================================
+
+/**
+ * Shared lifecycle interface for workspace providers.
+ * Both filesystem and sandbox providers extend this interface.
+ *
+ * @public
+ */
+export type { Lifecycle, ProviderStatus } from './lifecycle';
+
+// =============================================================================
 // PROVIDER INTERFACE - Filesystem
 // =============================================================================
 
@@ -160,6 +172,7 @@ export type {
   FileContent,
   FileStat,
   FileEntry,
+  FilesystemInfo,
   ReadOptions,
   WriteOptions,
   ListOptions,
@@ -177,14 +190,7 @@ export type {
  *
  * @public
  */
-export type {
-  WorkspaceSandbox,
-  ExecutionResult,
-  CommandResult,
-  ExecuteCommandOptions,
-  SandboxStatus,
-  SandboxInfo,
-} from './sandbox';
+export type { WorkspaceSandbox, ExecutionResult, CommandResult, ExecuteCommandOptions, SandboxInfo } from './sandbox';
 
 // =============================================================================
 // PROVIDER INTERFACE - Skills

--- a/packages/core/src/workspace/lifecycle.ts
+++ b/packages/core/src/workspace/lifecycle.ts
@@ -1,0 +1,128 @@
+/**
+ * Shared Lifecycle Interface
+ *
+ * Defines common lifecycle methods for workspace providers (filesystem, sandbox).
+ * All methods are optional - implementations provide what they need.
+ */
+
+// =============================================================================
+// Lifecycle Interface
+// =============================================================================
+
+/**
+ * Common lifecycle interface for workspace providers.
+ *
+ * Both filesystem and sandbox providers can implement any of these methods
+ * based on their requirements. The Workspace class will call available
+ * methods in the appropriate order.
+ *
+ * @typeParam TInfo - The type returned by getInfo() (e.g., FilesystemInfo, SandboxInfo)
+ *
+ * @example
+ * ```typescript
+ * // A simple local provider might only implement init
+ * class LocalFilesystem implements WorkspaceFilesystem {
+ *   async init() {
+ *     await fs.mkdir(this.basePath, { recursive: true });
+ *   }
+ * }
+ *
+ * // A cloud provider might implement the full lifecycle
+ * class CloudSandbox implements WorkspaceSandbox {
+ *   async init() { // provision template }
+ *   async start() { // spin up instance }
+ *   async stop() { // pause instance }
+ *   async destroy() { // terminate instance }
+ *   async isReady() { return this.status === 'running'; }
+ *   async getInfo() { return { ...metadata }; }
+ * }
+ * ```
+ */
+export interface Lifecycle<TInfo = unknown> {
+  /**
+   * One-time setup operations.
+   *
+   * Called once when the workspace is first initialized.
+   * Use for operations like:
+   * - Creating base directories
+   * - Setting up database tables
+   * - Provisioning cloud resources
+   * - Installing dependencies
+   */
+  init?(): Promise<void>;
+
+  /**
+   * Begin active operation.
+   *
+   * Called to transition from initialized to running state.
+   * Use for operations like:
+   * - Establishing connection pools
+   * - Spinning up cloud instances
+   * - Starting background processes
+   * - Warming up caches
+   */
+  start?(): Promise<void>;
+
+  /**
+   * Pause operation, keeping state for potential restart.
+   *
+   * Called to temporarily stop without full cleanup.
+   * Use for operations like:
+   * - Closing connections (but keeping config)
+   * - Pausing cloud instances
+   * - Flushing buffers
+   */
+  stop?(): Promise<void>;
+
+  /**
+   * Clean up all resources.
+   *
+   * Called when the workspace is being permanently shut down.
+   * Use for operations like:
+   * - Terminating cloud instances
+   * - Closing all connections
+   * - Cleaning up temporary files
+   */
+  destroy?(): Promise<void>;
+
+  /**
+   * Check if ready for operations.
+   *
+   * Returns true if the provider is ready to handle requests.
+   * Use for checking:
+   * - Connection health
+   * - Instance status
+   * - Resource availability
+   */
+  isReady?(): Promise<boolean>;
+
+  /**
+   * Get status and metadata.
+   *
+   * Returns information about the current state of the provider.
+   */
+  getInfo?(): Promise<TInfo>;
+}
+
+// =============================================================================
+// Status Types
+// =============================================================================
+
+/**
+ * Common status values for stateful providers.
+ *
+ * Not all providers need status tracking - local/stateless providers
+ * may not use this. But providers with connection pools or cloud
+ * instances can use these states.
+ */
+export type ProviderStatus =
+  | 'pending' // Created but not initialized
+  | 'initializing' // Running init()
+  | 'ready' // Initialized, waiting to start (or stateless and ready)
+  | 'starting' // Running start()
+  | 'running' // Active and accepting requests
+  | 'stopping' // Running stop()
+  | 'stopped' // Stopped but can restart
+  | 'destroying' // Running destroy()
+  | 'destroyed' // Fully cleaned up
+  | 'error'; // Something went wrong

--- a/packages/core/src/workspace/local-sandbox.ts
+++ b/packages/core/src/workspace/local-sandbox.ts
@@ -10,7 +10,8 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
-import type { WorkspaceSandbox, SandboxStatus, SandboxInfo, ExecuteCommandOptions, CommandResult } from './sandbox';
+import type { ProviderStatus } from './lifecycle';
+import type { WorkspaceSandbox, SandboxInfo, ExecuteCommandOptions, CommandResult } from './sandbox';
 import { SandboxNotReadyError } from './sandbox';
 
 const execFile = promisify(childProcess.execFile);
@@ -122,7 +123,7 @@ export class LocalSandbox implements WorkspaceSandbox {
   readonly name = 'LocalSandbox';
   readonly provider = 'local';
 
-  private _status: SandboxStatus = 'stopped';
+  private _status: ProviderStatus = 'stopped';
   private readonly _workingDirectory: string;
   private readonly env: Record<string, string>;
   private readonly _inheritEnv: boolean;
@@ -165,7 +166,7 @@ export class LocalSandbox implements WorkspaceSandbox {
     return { ...this.env, ...additionalEnv };
   }
 
-  get status(): SandboxStatus {
+  get status(): ProviderStatus {
     return this._status;
   }
 

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -557,7 +557,7 @@ export class Workspace {
         await this._fs.init();
       }
 
-      if (this._sandbox) {
+      if (this._sandbox?.start) {
         await this._sandbox.start();
       }
 
@@ -580,7 +580,7 @@ export class Workspace {
     this._status = 'destroying';
 
     try {
-      if (this._sandbox) {
+      if (this._sandbox?.destroy) {
         await this._sandbox.destroy();
       }
 
@@ -618,11 +618,11 @@ export class Workspace {
     }
 
     if (this._sandbox) {
-      const sandboxInfo = await this._sandbox.getInfo();
+      const sandboxInfo = await this._sandbox.getInfo?.();
       info.sandbox = {
         provider: this._sandbox.provider,
-        status: sandboxInfo.status,
-        resources: sandboxInfo.resources,
+        status: sandboxInfo?.status ?? this._sandbox.status,
+        resources: sandboxInfo?.resources,
       };
     }
 


### PR DESCRIPTION
## Summary

- Create shared `Lifecycle<TInfo>` interface that both filesystem and sandbox providers extend
- All lifecycle methods are now optional - providers implement what they need:
  - `init()` - one-time setup
  - `start()` - begin operation  
  - `stop()` - pause operation
  - `destroy()` - clean up resources
  - `isReady()` - check readiness
  - `getInfo()` - get status/metadata
- Add `ProviderStatus` type with comprehensive state machine (replaces `SandboxStatus`)
- Add `FilesystemInfo` type for filesystem `getInfo()` return value

## Related

- Follow-up to #12386 (filesystem interface review)
- Addresses MASTRA-4317 (lifecycle methods review)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)