### PR TITLE
docs(workspace): update docs to match actual implementation

### DIFF
--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -9,18 +9,18 @@ packages:
 
 A workspace gives agents a persistent environment for storing files and executing commands. Agents use workspace tools to read and write files, run shell commands, and search indexed content.
 
-## How workspaces work
+## How Workspaces Work
 
 A workspace combines two components:
 
 - **Filesystem provider** - Handles file storage (read, write, list, delete)
 - **Sandbox provider** - Handles command execution (shell commands)
 
-When you assign a workspace to an agent, Mastra automatically adds workspace tools to the agent's toolset. The agent can then use these tools to interact with files and execute code as part of its task.
+When you assign a workspace to an agent, Mastra automatically adds workspace tools to the agent's toolset. The agent can then use these tools to interact with files and execute commands as part of its task.
 
-You can create a workspace with just a filesystem (file storage only), just a sandbox (code execution only), or both. The agent receives only the tools relevant to the configured providers.
+You can create a workspace with just a filesystem (file storage only), just a sandbox (command execution only), or both. The agent receives only the tools relevant to the configured providers.
 
-## Filesystem providers
+## Filesystem Providers
 
 Filesystem providers determine where files are stored. All file operations go through the provider, which handles the actual storage.
 
@@ -38,7 +38,7 @@ All file paths are relative to `basePath`. A path like `/docs/guide.md` maps to 
 
 See [Filesystem Reference](/reference/workspace/filesystem) for the full API.
 
-## Sandbox providers
+## Sandbox Providers
 
 Sandbox providers execute shell commands.
 
@@ -58,7 +58,7 @@ const sandbox = new LocalSandbox({
 
 See [Sandbox Reference](/reference/workspace/sandbox) for the full API.
 
-## Creating a workspace
+## Creating a Workspace
 
 Combine providers into a workspace:
 
@@ -79,7 +79,7 @@ await workspace.init();
 
 The `init()` call starts the sandbox and indexes any files in `autoIndexPaths` if search is configured.
 
-## Global workspace
+## Global Workspace
 
 Set a workspace on the Mastra instance. All agents inherit this workspace unless they define their own:
 
@@ -92,7 +92,7 @@ const mastra = new Mastra({
 });
 ```
 
-## Agent-scoped workspace
+## Agent-scoped Workspace
 
 Assign a workspace directly to an agent to override the global workspace:
 
@@ -110,7 +110,7 @@ export const myAgent = new Agent({
 
 Skills are reusable instructions that teach agents how to perform specific tasks. They follow the [Agent Skills specification](https://agentskills.io) - an open standard for packaging agent capabilities.
 
-A skill is a folder containing a `SKILL.md` file with metadata and instructions, plus optional reference files, scripts, and assets. When an agent activates a skill, the instructions are injected into its context.
+A skill is a folder containing a `SKILL.md` file with metadata and instructions, plus optional reference files, scripts, and assets:
 
 ```
 /skills
@@ -131,87 +131,90 @@ const workspace = new Workspace({
 });
 ```
 
-When skills are configured, agents receive a `SkillsProcessor` that:
-- Injects available skills into the system message
-- Provides tools for activating skills (`skill-activate`)
-- Provides tools for searching skill content (`skill-search`)
-- Provides tools for reading references, scripts, and assets
+When skills are configured, agents receive a `SkillsProcessor` that injects available skills into the system message and allows agents to activate skills during conversation.
 
-## Agent tools and processors
+## Agent Tools
 
-A workspace provides tools and processors to agents based on what is configured:
+A workspace provides tools to agents based on what is configured:
 
-- **Filesystem** - Tools for reading, writing, editing, listing, and deleting files
-- **Sandbox** - Tools for executing shell commands
-- **Search** - Tools for searching and indexing workspace content
-- **Skills** - A processor that injects skill instructions into the system message, plus tools for activating and reading skills
+**Filesystem tools** (when filesystem is configured):
+- `mastra_workspace_read_file` - Read file contents
+- `mastra_workspace_write_file` - Write file contents
+- `mastra_workspace_edit_file` - Edit file by replacing text
+- `mastra_workspace_list_files` - List directory contents
+- `mastra_workspace_delete` - Delete files or directories
+- `mastra_workspace_file_stat` - Get file metadata
+- `mastra_workspace_mkdir` - Create directories
+
+**Sandbox tools** (when sandbox is configured):
+- `mastra_workspace_execute_command` - Execute shell commands
+
+**Search tools** (when BM25 or vector search is configured):
+- `mastra_workspace_search` - Search indexed content
+- `mastra_workspace_index` - Index content for search
 
 Only the relevant tools are added. A workspace with only a filesystem won't have command execution tools.
 
 See [Workspace Class Reference](/reference/workspace/workspace-class) for details.
 
-## Safety
+## Tool Configuration
 
-Safety is configured on the provider instances (LocalFilesystem, LocalSandbox), not on the Workspace directly.
+Configure tool behavior through the `tools` option on the Workspace. This controls which tools are enabled and their safety settings.
 
 ```typescript
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+
 const workspace = new Workspace({
-  filesystem: new LocalFilesystem({
-    basePath: './workspace',
-    safety: {
-      readOnly: false,
+  filesystem: new LocalFilesystem({ basePath: './workspace' }),
+  sandbox: new LocalSandbox({ workingDirectory: './workspace' }),
+  tools: {
+    // Global defaults
+    enabled: true,
+    requireApproval: false,
+
+    // Per-tool overrides
+    [WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]: {
+      requireApproval: true,
       requireReadBeforeWrite: true,
-      requireApproval: 'none',
     },
-  }),
-  sandbox: new LocalSandbox({
-    workingDirectory: './workspace',
-    safety: {
-      requireApproval: 'all',
+    [WORKSPACE_TOOLS.FILESYSTEM.DELETE]: {
+      enabled: false,
     },
-  }),
+    [WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]: {
+      requireApproval: true,
+    },
+  },
 });
 ```
 
-### Filesystem safety
+### Tool Options
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `readOnly` | `false` | Block all write operations |
-| `requireReadBeforeWrite` | `true` | Require reading files before writing |
-| `requireApproval` | `'none'` | Approval for filesystem ops: `'all'`, `'write'`, or `'none'` |
+| Option | Type | Description |
+|--------|------|-------------|
+| `enabled` | `boolean` | Whether the tool is available (default: `true`) |
+| `requireApproval` | `boolean` | Whether the tool requires user approval before execution (default: `false`) |
+| `requireReadBeforeWrite` | `boolean` | For write tools: require reading the file first (default: `false`) |
 
 ### Read-before-write
 
-When enabled (default), agents must read a file before writing to it. This prevents overwriting files the agent hasn't seen. The workspace tracks:
+When `requireReadBeforeWrite` is enabled on write tools, agents must read a file before writing to it. This prevents overwriting files the agent hasn't seen:
 
 - **New files** - Can be written without reading (they don't exist yet)
 - **Existing files** - Must be read first
 - **Externally modified files** - If a file changed since the agent read it, the write fails
 
-### Sandbox safety
+### Read-only Mode
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `requireApproval` | `'all'` | Approval for sandbox ops: `'all'`, `'commands'`, or `'none'` |
+To make a filesystem read-only, set `readOnly: true` on the LocalFilesystem:
 
-Controls when sandbox operations require user approval:
+```typescript
+const filesystem = new LocalFilesystem({
+  basePath: './workspace',
+  readOnly: true,
+});
+```
 
-| Value | `execute_command` |
-|-------|-------------------|
-| `'none'` | No approval |
-| `'commands'` | Requires approval |
-| `'all'` | Requires approval |
-
-### Filesystem approval
-
-Controls when filesystem operations require user approval:
-
-| Value | Read ops | Write ops |
-|-------|----------|-----------|
-| `'none'` | No approval | No approval |
-| `'write'` | No approval | Requires approval |
-| `'all'` | Requires approval | Requires approval |
+When read-only, write tools (`write_file`, `edit_file`, `delete`, `mkdir`) are not added to the agent's toolset.
 
 ## Search
 
@@ -231,4 +234,3 @@ const workspace = new Workspace({
 - [Workspace Class Reference](/reference/workspace/workspace-class)
 - [Filesystem Reference](/reference/workspace/filesystem)
 - [Sandbox Reference](/reference/workspace/sandbox)
-- [Agent Approval](/docs/agents/agent-approval)

--- a/docs/src/content/en/docs/workspace/search.mdx
+++ b/docs/src/content/en/docs/workspace/search.mdx
@@ -104,9 +104,10 @@ With options:
 
 ```typescript
 const results = await workspace.search('authentication flow', {
-  topK: 10,         // Maximum results (default: 5)
-  mode: 'hybrid',   // 'bm25' | 'vector' | 'hybrid'
-  threshold: 0.5,   // Minimum score threshold
+  topK: 10,           // Maximum results (default: 5)
+  mode: 'hybrid',     // 'bm25' | 'vector' | 'hybrid'
+  minScore: 0.5,      // Minimum score threshold
+  vectorWeight: 0.5,  // Weight for vector scores in hybrid (0-1)
 });
 ```
 
@@ -118,12 +119,12 @@ const results = await workspace.search('authentication flow', {
 | `vector` | Conceptual queries, natural language questions |
 | `hybrid` | General search combining both approaches |
 
-## Agent tools
+## Agent Tools
 
 Agents with a search-enabled workspace receive:
 
-- `workspace_search` - Search indexed content
-- `workspace_index` - Index new content
+- `mastra_workspace_search` - Search indexed content
+- `mastra_workspace_index` - Index new content
 
 ## Related
 

--- a/docs/src/content/en/reference/workspace/filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/filesystem.mdx
@@ -23,7 +23,7 @@ const filesystem = new LocalFilesystem({
 });
 ```
 
-### Constructor parameters
+### Constructor Parameters
 
 <PropertiesTable
   content={[
@@ -33,10 +33,25 @@ const filesystem = new LocalFilesystem({
       description: "Root directory for the filesystem. All paths are relative to this directory.",
     },
     {
-      name: "safety",
-      type: "FilesystemSafetyOptions",
-      description: "Safety configuration for filesystem operations",
+      name: "id",
+      type: "string",
+      description: "Unique identifier for this filesystem instance",
       isOptional: true,
+      defaultValue: "Auto-generated",
+    },
+    {
+      name: "sandbox",
+      type: "boolean",
+      description: "Restrict operations to basePath (prevents path traversal)",
+      isOptional: true,
+      defaultValue: "true",
+    },
+    {
+      name: "readOnly",
+      type: "boolean",
+      description: "Block all write operations. When true, write tools are not added to agents.",
+      isOptional: true,
+      defaultValue: "false",
     },
   ]}
 />
@@ -46,6 +61,16 @@ const filesystem = new LocalFilesystem({
 <PropertiesTable
   content={[
     {
+      name: "id",
+      type: "string",
+      description: "Filesystem instance identifier",
+    },
+    {
+      name: "name",
+      type: "string",
+      description: "Provider name ('LocalFilesystem')",
+    },
+    {
       name: "provider",
       type: "string",
       description: "Provider identifier ('local')",
@@ -53,12 +78,17 @@ const filesystem = new LocalFilesystem({
     {
       name: "basePath",
       type: "string",
-      description: "The configured base path",
+      description: "The absolute base path on disk",
+    },
+    {
+      name: "readOnly",
+      type: "boolean | undefined",
+      description: "Whether the filesystem is in read-only mode",
     },
   ]}
 />
 
-## WorkspaceFilesystem interface
+## WorkspaceFilesystem Interface
 
 All filesystem providers implement this interface.
 
@@ -123,6 +153,13 @@ await filesystem.writeFile('/nested/path/file.md', content, { recursive: true })
       description: "Create parent directories if they don't exist",
       isOptional: true,
       defaultValue: "false",
+    },
+    {
+      name: "options.overwrite",
+      type: "boolean",
+      description: "Overwrite existing file",
+      isOptional: true,
+      defaultValue: "true",
     },
   ]}
 />
@@ -228,6 +265,13 @@ await filesystem.rmdir('/docs/nested', { recursive: true });
       isOptional: true,
       defaultValue: "false",
     },
+    {
+      name: "options.force",
+      type: "boolean",
+      description: "Don't throw if directory doesn't exist",
+      isOptional: true,
+      defaultValue: "false",
+    },
   ]}
 />
 
@@ -247,7 +291,7 @@ Get file or directory metadata.
 
 ```typescript
 const stat = await filesystem.stat('/docs/guide.md');
-// { type: 'file', size: 1234, modifiedAt: Date, createdAt: Date }
+// { type: 'file', size: 1234, modifiedAt: Date, createdAt: Date, path: '/docs/guide.md' }
 ```
 
 **Returns:** `Promise<FileStat>`
@@ -258,10 +302,11 @@ interface FileStat {
   size: number;
   modifiedAt: Date;
   createdAt: Date;
+  path: string;
 }
 ```
 
-### Optional methods
+### Optional Methods
 
 #### `init()`
 
@@ -299,13 +344,33 @@ Common error codes:
 - `EISDIR` - Expected a file
 - `EACCES` - Permission denied
 
+### FileNotFoundError
+
+Thrown when a file or directory does not exist.
+
+```typescript
+class FileNotFoundError extends FilesystemError {
+  code: 'ENOENT';
+}
+```
+
 ### FileReadRequiredError
 
-Thrown when `requireReadBeforeWrite` is enabled and a write is attempted without reading first.
+Thrown when `requireReadBeforeWrite` is enabled on a tool and a write is attempted without reading first.
 
 ```typescript
 class FileReadRequiredError extends FilesystemError {
   code: 'EREAD_REQUIRED';
+}
+```
+
+### WorkspaceReadOnlyError
+
+Thrown when a write operation is attempted on a read-only filesystem.
+
+```typescript
+class WorkspaceReadOnlyError extends WorkspaceError {
+  code: 'READ_ONLY';
 }
 ```
 

--- a/docs/src/content/en/reference/workspace/sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/sandbox.mdx
@@ -26,10 +26,17 @@ const sandbox = new LocalSandbox({
 });
 ```
 
-### Constructor parameters
+### Constructor Parameters
 
 <PropertiesTable
   content={[
+    {
+      name: "id",
+      type: "string",
+      description: "Unique identifier for this sandbox instance",
+      isOptional: true,
+      defaultValue: "Auto-generated",
+    },
     {
       name: "workingDirectory",
       type: "string",
@@ -42,6 +49,13 @@ const sandbox = new LocalSandbox({
       type: "NodeJS.ProcessEnv",
       description: "Environment variables to set. PATH is included by default unless overridden.",
       isOptional: true,
+    },
+    {
+      name: "timeout",
+      type: "number",
+      description: "Default timeout for operations in milliseconds",
+      isOptional: true,
+      defaultValue: "30000",
     },
     {
       name: "isolation",
@@ -104,14 +118,55 @@ Configuration options for native OS sandboxing (used with `isolation: 'seatbelt'
 <PropertiesTable
   content={[
     {
+      name: "id",
+      type: "string",
+      description: "Sandbox instance identifier",
+    },
+    {
+      name: "name",
+      type: "string",
+      description: "Provider name ('LocalSandbox')",
+    },
+    {
       name: "provider",
       type: "string",
       description: "Provider identifier ('local')",
     },
+    {
+      name: "status",
+      type: "ProviderStatus",
+      description: "'starting' | 'running' | 'stopped' | 'error'",
+    },
+    {
+      name: "workingDirectory",
+      type: "string",
+      description: "The configured working directory",
+    },
   ]}
 />
 
-## WorkspaceSandbox interface
+### Static Methods
+
+#### `detectIsolation()`
+
+Detect the best available isolation backend for the current platform.
+
+```typescript
+const detection = LocalSandbox.detectIsolation();
+// { backend: 'seatbelt', available: true, message: 'Seatbelt available on macOS' }
+```
+
+**Returns:** `SandboxDetectionResult`
+
+```typescript
+interface SandboxDetectionResult {
+  backend: IsolationBackend;
+  available: boolean;
+  message: string;
+}
+```
+
+## WorkspaceSandbox Interface
 
 All sandbox providers implement this interface.
 
@@ -183,6 +238,18 @@ const result = await sandbox.executeCommand('npm', ['install', 'lodash']);
       description: "Additional environment variables",
       isOptional: true,
     },
+    {
+      name: "options.onStdout",
+      type: "(data: string) => void",
+      description: "Callback for stdout streaming",
+      isOptional: true,
+    },
+    {
+      name: "options.onStderr",
+      type: "(data: string) => void",
+      description: "Callback for stderr streaming",
+      isOptional: true,
+    },
   ]}
 />
 
@@ -194,7 +261,7 @@ interface CommandResult {
   stdout: string;
   stderr: string;
   exitCode: number;
-  duration: number;
+  executionTimeMs: number;
 }
 ```
 
@@ -223,7 +290,7 @@ interface SandboxInfo {
 }
 ```
 
-## Environment isolation
+## Environment Isolation
 
 By default, `LocalSandbox` only includes `PATH` in the environment. This allows commands to run while preventing accidental exposure of API keys and secrets.
 
@@ -249,7 +316,7 @@ const devSandbox = new LocalSandbox({
 });
 ```
 
-## Native OS sandboxing
+## Native OS Sandboxing
 
 `LocalSandbox` supports native OS-level sandboxing for additional security:
 
@@ -278,6 +345,60 @@ When isolation is enabled:
 - File reads are allowed everywhere (needed for system binaries)
 - Network access is blocked by default
 - Process isolation prevents affecting the host system
+
+## Errors
+
+### SandboxError
+
+Base error for sandbox operations.
+
+```typescript
+class SandboxError extends Error {
+  code: string;
+}
+```
+
+### SandboxNotReadyError
+
+Thrown when attempting to execute commands before the sandbox is started.
+
+```typescript
+class SandboxNotReadyError extends SandboxError {
+  code: 'SANDBOX_NOT_READY';
+}
+```
+
+### SandboxExecutionError
+
+Thrown when a command fails to execute.
+
+```typescript
+class SandboxExecutionError extends SandboxError {
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+}
+```
+
+### SandboxTimeoutError
+
+Thrown when a command exceeds its timeout.
+
+```typescript
+class SandboxTimeoutError extends SandboxError {
+  code: 'TIMEOUT';
+}
+```
+
+### IsolationUnavailableError
+
+Thrown when the requested isolation backend is not available on the current platform.
+
+```typescript
+class IsolationUnavailableError extends SandboxError {
+  code: 'ISOLATION_UNAVAILABLE';
+}
+```
 
 ## Related
 

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -7,36 +7,39 @@ packages:
 
 # Workspace Class
 
-The `Workspace` class combines a filesystem and sandbox to provide agents with file storage and code execution capabilities. It also supports BM25 and vector search for indexed content.
+The `Workspace` class combines a filesystem and sandbox to provide agents with file storage and command execution capabilities. It also supports BM25 and vector search for indexed content.
 
-## Usage example
+## Usage Example
 
 ```typescript
-import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace';
+import { Workspace, LocalFilesystem, LocalSandbox, WORKSPACE_TOOLS } from '@mastra/core/workspace';
 
 const workspace = new Workspace({
   id: 'my-workspace',
   name: 'My Workspace',
   filesystem: new LocalFilesystem({
     basePath: './workspace',
-    safety: {
-      requireReadBeforeWrite: true,
-    },
   }),
   sandbox: new LocalSandbox({
     workingDirectory: './workspace',
-    safety: {
-      requireApproval: 'all',
-    },
   }),
   bm25: true,
   autoIndexPaths: ['/docs'],
+  tools: {
+    [WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]: {
+      requireApproval: true,
+      requireReadBeforeWrite: true,
+    },
+    [WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]: {
+      requireApproval: true,
+    },
+  },
 });
 
 await workspace.init();
 ```
 
-## Constructor parameters
+## Constructor Parameters
 
 <PropertiesTable
   content={[
@@ -57,13 +60,13 @@ await workspace.init();
     {
       name: "filesystem",
       type: "WorkspaceFilesystem",
-      description: "Filesystem provider instance (LocalFilesystem)",
+      description: "Filesystem provider instance (e.g., LocalFilesystem)",
       isOptional: true,
     },
     {
       name: "sandbox",
       type: "WorkspaceSandbox",
-      description: "Sandbox provider instance (LocalSandbox)",
+      description: "Sandbox provider instance (e.g., LocalSandbox)",
       isOptional: true,
     },
     {
@@ -93,10 +96,15 @@ await workspace.init();
     },
     {
       name: "skills",
-      type: "string[]",
-      description: "Paths where SKILL.md files are located",
+      type: "string[] | ((context) => string[])",
+      description: "Paths where SKILL.md files are located. Can be static array or dynamic function.",
       isOptional: true,
-      defaultValue: "['/skills']",
+    },
+    {
+      name: "tools",
+      type: "WorkspaceToolsConfig",
+      description: "Per-tool configuration for enabling tools and setting safety options",
+      isOptional: true,
     },
     {
       name: "autoInit",
@@ -114,48 +122,56 @@ await workspace.init();
   ]}
 />
 
-## Safety configuration
+## Tool Configuration
 
-Safety is configured on the provider instances (LocalFilesystem, LocalSandbox), not on the Workspace directly. The Workspace reads these settings from the providers.
+The `tools` option controls which workspace tools are enabled and their safety settings.
 
-### Filesystem safety (LocalFilesystem)
+```typescript
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+
+const workspace = new Workspace({
+  filesystem: new LocalFilesystem({ basePath: './workspace' }),
+  tools: {
+    // Global defaults apply to all tools
+    enabled: true,
+    requireApproval: false,
+
+    // Per-tool overrides
+    [WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]: {
+      requireApproval: true,
+      requireReadBeforeWrite: true,
+    },
+    [WORKSPACE_TOOLS.FILESYSTEM.DELETE]: {
+      enabled: false,
+    },
+  },
+});
+```
+
+### WorkspaceToolConfig
 
 <PropertiesTable
   content={[
     {
-      name: "readOnly",
+      name: "enabled",
       type: "boolean",
-      description: "Block all write operations",
+      description: "Whether the tool is available to agents",
+      isOptional: true,
+      defaultValue: "true",
+    },
+    {
+      name: "requireApproval",
+      type: "boolean",
+      description: "Whether the tool requires user approval before execution",
       isOptional: true,
       defaultValue: "false",
     },
     {
       name: "requireReadBeforeWrite",
       type: "boolean",
-      description: "Require files to be read before writing. Prevents overwrites of externally modified files.",
+      description: "For write tools: require reading the file first to prevent overwrites",
       isOptional: true,
-      defaultValue: "true",
-    },
-    {
-      name: "requireApproval",
-      type: "'all' | 'write' | 'none'",
-      description: "Require approval for filesystem operations",
-      isOptional: true,
-      defaultValue: "'none'",
-    },
-  ]}
-/>
-
-### Sandbox safety (LocalSandbox)
-
-<PropertiesTable
-  content={[
-    {
-      name: "requireApproval",
-      type: "'all' | 'commands' | 'none'",
-      description: "Require approval for sandbox operations",
-      isOptional: true,
-      defaultValue: "'all'",
+      defaultValue: "false",
     },
   ]}
 />
@@ -195,11 +211,6 @@ Safety is configured on the provider instances (LocalFilesystem, LocalSandbox), 
       description: "Skills interface for accessing SKILL.md files",
     },
     {
-      name: "readOnly",
-      type: "boolean",
-      description: "Whether the workspace is in read-only mode",
-    },
-    {
       name: "canBM25",
       type: "boolean",
       description: "Whether BM25 search is available",
@@ -237,55 +248,7 @@ Destroy the workspace and clean up resources.
 await workspace.destroy();
 ```
 
-### Filesystem operations
-
-#### `readFile(path, options?)`
-
-Read a file from the workspace filesystem.
-
-```typescript
-const content = await workspace.readFile('/docs/guide.md');
-const buffer = await workspace.readFile('/data/image.png', { encoding: 'binary' });
-```
-
-#### `writeFile(path, content, options?)`
-
-Write a file to the workspace filesystem.
-
-```typescript
-await workspace.writeFile('/docs/new.md', '# New Document');
-await workspace.writeFile('/docs/nested/file.md', content, { recursive: true });
-```
-
-#### `readdir(path, options?)`
-
-List directory contents.
-
-```typescript
-const entries = await workspace.readdir('/docs');
-// [{ name: 'guide.md', type: 'file' }, { name: 'api', type: 'directory' }]
-```
-
-#### `exists(path)`
-
-Check if a path exists.
-
-```typescript
-const exists = await workspace.exists('/docs/guide.md');
-```
-
-### Sandbox operations
-
-#### `executeCommand(command, args?, options?)`
-
-Execute a shell command.
-
-```typescript
-const result = await workspace.executeCommand('ls', ['-la']);
-console.log(result.stdout);
-```
-
-### Search operations
+### Search Operations
 
 #### `index(path, content, options?)`
 
@@ -326,27 +289,39 @@ const context = workspace.getPathContext();
 // { type, filesystem?, sandbox?, requiresSync, instructions }
 ```
 
-#### `getSafetyConfig()`
+#### `getToolsConfig()`
 
-Get the safety configuration.
+Get the tools configuration.
 
 ```typescript
-const config = workspace.getSafetyConfig();
+const config = workspace.getToolsConfig();
 ```
 
-## Agent tools
+## Agent Tools
 
 A workspace provides tools to agents based on what is configured:
 
-**Filesystem** - When a filesystem provider is configured, agents receive tools for file operations: reading, writing, editing, listing, and deleting files.
+**Filesystem tools** (when filesystem is configured):
+- `mastra_workspace_read_file` - Read file contents with optional line range
+- `mastra_workspace_write_file` - Write content to a file
+- `mastra_workspace_edit_file` - Edit file by replacing text
+- `mastra_workspace_list_files` - List directory contents as a tree
+- `mastra_workspace_delete` - Delete files or directories
+- `mastra_workspace_file_stat` - Get file/directory metadata
+- `mastra_workspace_mkdir` - Create directories
 
-**Sandbox** - When a sandbox provider is configured, agents receive tools for executing shell commands.
+**Sandbox tools** (when sandbox is configured):
+- `mastra_workspace_execute_command` - Execute shell commands
 
-**Search** - When BM25 or vector search is configured, agents receive tools for searching and indexing workspace content.
+**Search tools** (when BM25 or vector search is configured):
+- `mastra_workspace_search` - Search indexed content
+- `mastra_workspace_index` - Index content for search
 
-**Skills** - When `skills` is configured, the workspace provides access to SKILL.md files for skill discovery and activation.
+Write tools (`write_file`, `edit_file`, `delete`, `mkdir`, `index`) are excluded when the filesystem is in read-only mode.
 
 ## Related
 
 - [Workspace Overview](/docs/workspace/overview)
 - [Search and Indexing](/docs/workspace/search)
+- [Filesystem Reference](/reference/workspace/filesystem)
+- [Sandbox Reference](/reference/workspace/sandbox)


### PR DESCRIPTION
## Summary

- Fix tool names to use `mastra_workspace_` prefix throughout all workspace docs
- Update tools config to use `WorkspaceToolsConfig` on Workspace (not provider-level safety config)
- Remove non-existent `safety` config from filesystem/sandbox providers
- Document `readOnly` option on `LocalFilesystem`
- Add missing sandbox static methods (`detectIsolation()`) and error types
- Fix search option from `threshold` to `minScore`
- Add `vectorWeight` option documentation
- Update skills section to describe `SkillsProcessor` pattern

## Test plan

- [ ] Verify docs build successfully
- [ ] Review each doc page for accuracy against implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)