### PR TITLE
fix(core): strip null values from tool inputs before validation

### DIFF
--- a/.changeset/red-birds-reply.md
+++ b/.changeset/red-birds-reply.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed tool input validation failing when LLMs send null for optional fields. Zod's .optional() only accepts undefined, not null, causing validation errors with Gemini and other LLMs. Now null values in object properties are stripped before validation, treating them as 'not provided'.
+Fixed tool input validation failing when LLMs send null for optional fields. Zod's .optional() only accepts undefined, not null, causing validation errors with Gemini and other LLMs. Validation now retries with null values stripped when the initial attempt fails, so .optional() fields accept null while .nullable() fields continue to work correctly.

--- a/.changeset/red-birds-reply.md
+++ b/.changeset/red-birds-reply.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed tool input validation failing when LLMs send null for optional fields. Zod's .optional() only accepts undefined, not null, causing validation errors with Gemini and other LLMs. Validation now retries with null values stripped when the initial attempt fails, so .optional() fields accept null while .nullable() fields continue to work correctly.
+Fixed tool input validation failing when LLMs send null for optional fields (#12362). Zod's .optional() only accepts undefined, not null, causing validation errors with Gemini and other LLMs. Validation now retries with null values stripped when the initial attempt fails, so .optional() fields accept null while .nullable() fields continue to work correctly.

--- a/.changeset/red-birds-reply.md
+++ b/.changeset/red-birds-reply.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed tool input validation failing when LLMs send null for optional fields. Zod's .optional() only accepts undefined, not null, causing validation errors with Gemini and other LLMs. Now null values in object properties are stripped before validation, treating them as 'not provided'.

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -107,18 +107,19 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Recursively strips null and undefined values from objects.
- * This handles LLMs (Claude, Gemini) that send null for optional fields,
+ * Recursively strips null and undefined values from object properties.
+ * This handles LLMs (e.g. Gemini) that send null for optional fields,
  * since Zod's .optional() only accepts undefined, not null. (GitHub #12362)
- *
- * Also strips explicit undefined values from object properties to prevent
- * convertUndefinedToNull from converting them to null later in the pipeline.
  *
  * When a property value is null or undefined, it is omitted from the result
  * object entirely, which is equivalent to "not provided" for Zod validation.
  *
  * Only recurses into plain objects to preserve class instances and built-in objects
  * like Date, Map, URL, etc.
+ *
+ * NOTE: This function should NOT be called unconditionally because it breaks
+ * schemas that use .nullable() (where null is a valid value). It is used as
+ * a fallback when initial validation fails. See validateToolInput for usage.
  *
  * @param input The input to process
  * @returns The processed input with null/undefined values stripped
@@ -214,31 +215,49 @@ export function validateToolInput<T = any>(
     return { data: input };
   }
 
-  // Strip null/undefined values from input (GitHub #12362)
-  // LLMs like Claude and Gemini often send null for optional fields, but Zod's
-  // .optional() only accepts undefined, not null. By stripping nullish values,
-  // we treat them as "not provided" which matches user intent.
-  let normalizedInput = stripNullishValues(input);
+  // Validation pipeline:
+  //
+  // 1. normalizeNullishInput: Convert top-level null/undefined to {} or [] based on schema type.
+  //    Handles LLMs that send undefined instead of {} or [] for all-optional parameters.
+  //
+  // 2. convertUndefinedToNull: Convert undefined values to null in object properties.
+  //    Needed for OpenAI compat layers that convert .optional() to .nullable() for
+  //    strict mode compliance. The schema's transform converts null back to undefined.
+  //    (GitHub #11457)
+  //
+  // 3. First validation attempt with null values preserved. This handles .nullable()
+  //    schemas correctly (where null is a valid value).
+  //
+  // 4. If validation fails, retry with null values stripped from object properties.
+  //    This handles LLMs (e.g. Gemini) that send null for .optional() fields, where
+  //    Zod expects undefined, not null. (GitHub #12362)
 
-  // Normalize undefined/null input to appropriate default for the schema type
-  // This handles LLMs that send undefined instead of {} or [] for optional parameters
-  normalizedInput = normalizeNullishInput(schema, normalizedInput);
+  // Step 1: Normalize top-level null/undefined to appropriate default
+  let normalizedInput = normalizeNullishInput(schema, input);
 
-  // Convert undefined values to null recursively (GitHub #11457)
-  // This is needed because OpenAI compat layers convert .optional() to .nullable()
-  // for strict mode compliance. When fields are omitted (undefined), we convert them
-  // to null so the schema validation passes. The schema's transform will then convert
-  // null back to undefined to match the original .optional() semantics.
+  // Step 2: Convert undefined values to null recursively (GitHub #11457)
   normalizedInput = convertUndefinedToNull(normalizedInput);
 
-  // Validate the normalized input
+  // Step 3: Try validation with null values preserved
   const validation = schema.safeParse(normalizedInput);
-
   if (validation.success) {
     return { data: validation.data };
   }
 
-  // Validation failed, return error
+  // Step 4: Retry with null values stripped (GitHub #12362)
+  // LLMs like Gemini send null for optional fields, but Zod's .optional() only
+  // accepts undefined, not null. By stripping nullish values and retrying, we
+  // handle this case without breaking .nullable() schemas that passed in step 3.
+  const strippedInput = stripNullishValues(input);
+  const normalizedStripped = normalizeNullishInput(schema, strippedInput);
+  const retryValidation = schema.safeParse(normalizedStripped);
+
+  if (retryValidation.success) {
+    return { data: retryValidation.data };
+  }
+
+  // Both attempts failed - return the original (non-stripped) error since it's
+  // more informative about what the schema actually expects
   const errorMessages = validation.error.issues.map(e => `- ${e.path?.join('.') || 'root'}: ${e.message}`).join('\n');
 
   const error: ValidationError<T> = {


### PR DESCRIPTION
## Description

LLMs like Gemini send `null` for optional fields, but Zod's `.optional()` only accepts `undefined`, not `null`. This caused validation errors like:

```
Tool input validation failed: Expected number, received null
```

Validation now uses a try-then-retry strategy: first validates with null preserved (for `.nullable()` schemas), then retries with null values stripped (for `.optional()` schemas). This ensures `.nullable()` fields continue to work correctly while `.optional()` fields accept null from LLMs.

**Before:** `{ category: "electronics", minPrice: null }` → validation error
**After:** `{ category: "electronics", minPrice: null }` → `{ category: "electronics" }` → success

## Related Issue(s)

Fixes #12362

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed input validation when LLMs return null for optional fields: validation now retries with nulls stripped so optional parameters are accepted while nullable fields continue to behave correctly.

* **Tests**
  * Added comprehensive tests for null/undefined handling across nested and mixed optional/nullable scenarios.

* **Documentation**
  * Added a changelog entry describing the patch release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->