### PR TITLE
fix(playground): add missing MASTRA_API_PREFIX replacement in vite dev mode

### DIFF
--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -382,6 +382,7 @@ export async function createHonoServer(
       const experimentalFeatures = process.env.EXPERIMENTAL_FEATURES === 'true' ? 'true' : 'false';
       indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_HOST%%'`, `'${host}'`);
       indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_PORT%%'`, `'${port}'`);
+      indexHtml = indexHtml.replace(`'%%MASTRA_API_PREFIX%%'`, `'${serverOptions?.apiPrefix ?? '/api'}'`);
       indexHtml = indexHtml.replace(`'%%MASTRA_HIDE_CLOUD_CTA%%'`, `'${hideCloudCta}'`);
       indexHtml = indexHtml.replace(`'%%MASTRA_SERVER_PROTOCOL%%'`, `'${protocol}'`);
       indexHtml = indexHtml.replace(`'%%MASTRA_CLOUD_API_ENDPOINT%%'`, `'${cloudApiEndpoint}'`);

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -8,6 +8,7 @@ const studioStandalonePlugin = (targetPort: string, targetHost: string): PluginO
     return html
       .replace(/%%MASTRA_SERVER_HOST%%/g, targetHost)
       .replace(/%%MASTRA_SERVER_PORT%%/g, targetPort)
+      .replace(/%%MASTRA_API_PREFIX%%/g, '/api')
       .replace(/%%MASTRA_HIDE_CLOUD_CTA%%/g, 'true')
       .replace(/%%MASTRA_STUDIO_BASE_PATH%%/g, '')
       .replace(/%%MASTRA_SERVER_PROTOCOL%%/g, 'http')


### PR DESCRIPTION
## Summary

- Add missing `%%MASTRA_API_PREFIX%%` replacement in `packages/playground/vite.config.ts` for dev mode
- Add missing `%%MASTRA_API_PREFIX%%` replacement in `packages/deployer/src/server/index.ts` using `serverOptions.apiPrefix`
- Both default to `/api` to match the CLI default and App.tsx fallback

## Test plan

- [ ] Run `pnpm dev:playground` and verify `window.MASTRA_API_PREFIX` is `/api` (not the literal placeholder string)
- [ ] Test deployer with custom `apiPrefix` in server options

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made the API prefix configurable and accessible to the frontend, allowing flexible API endpoint routing across deployment environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->