### PR TITLE
feat(playground): add workflow run ID to breadcrumbs

### DIFF
--- a/.changeset/lazy-parks-try.md
+++ b/.changeset/lazy-parks-try.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added workflow run ID to breadcrumbs with truncation and copy functionality

--- a/packages/playground-ui/src/ds/components/Truncate/index.ts
+++ b/packages/playground-ui/src/ds/components/Truncate/index.ts
@@ -1,0 +1,1 @@
+export * from './truncate';

--- a/packages/playground-ui/src/ds/components/Truncate/truncate.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Truncate/truncate.stories.tsx
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Truncate } from './truncate';
+import { TooltipProvider } from '../Tooltip';
+
+const meta: Meta<typeof Truncate> = {
+  title: 'Elements/Truncate',
+  component: Truncate,
+  decorators: [
+    Story => (
+      <TooltipProvider>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Truncate>;
+
+export const Default: Story = {
+  args: {
+    children: 'Short text',
+  },
+};
+
+export const TruncateByCharCount: Story = {
+  args: {
+    children: 'This is a very long text that should be truncated after a certain number of characters',
+    charCount: 20,
+  },
+};
+
+export const TruncateByDelimiter: Story = {
+  args: {
+    children: 'workflow-run-abc123-def456-ghi789',
+    untilChar: '-',
+  },
+};
+
+export const WithCopyButton: Story = {
+  args: {
+    children: 'This is a very long text that should be truncated',
+    charCount: 15,
+    copy: true,
+  },
+};
+
+export const LongTextWithTooltip: Story = {
+  args: {
+    children:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+    charCount: 30,
+  },
+};
+
+export const UUIDTruncation: Story = {
+  args: {
+    children: '550e8400-e29b-41d4-a716-446655440000',
+    charCount: 8,
+    copy: true,
+  },
+};
+
+export const NoTruncationNeeded: Story = {
+  args: {
+    children: 'Short',
+    charCount: 100,
+  },
+};
+
+export const DelimiterNotFound: Story = {
+  args: {
+    children: 'no-delimiter-present',
+    untilChar: '@',
+  },
+};
+
+export const WithMonoFont: Story = {
+  args: {
+    children: '550e8400-e29b-41d4-a716-446655440000',
+    charCount: 8,
+    font: 'mono',
+    copy: true,
+  },
+};
+
+export const WithVariant: Story = {
+  args: {
+    children: 'This is a header that gets truncated',
+    charCount: 20,
+    variant: 'header-md',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <span className="text-neutral4 text-sm w-32">No truncation:</span>
+        <Truncate>Short text</Truncate>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-neutral4 text-sm w-32">By char count:</span>
+        <Truncate charCount={20}>This is a very long text that needs truncation</Truncate>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-neutral4 text-sm w-32">By delimiter:</span>
+        <Truncate untilChar="-">workflow-run-12345</Truncate>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-neutral4 text-sm w-32">With copy:</span>
+        <Truncate charCount={10} copy>
+          Copy this long text
+        </Truncate>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-neutral4 text-sm w-32">Mono font:</span>
+        <Truncate charCount={8} font="mono" copy>
+          550e8400-e29b-41d4
+        </Truncate>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-neutral4 text-sm w-32">Header variant:</span>
+        <Truncate charCount={15} variant="header-sm">
+          Large header text truncated
+        </Truncate>
+      </div>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Truncate/truncate.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Truncate/truncate.stories.tsx
@@ -49,6 +49,23 @@ export const WithCopyButton: Story = {
   },
 };
 
+export const WithoutTooltip: Story = {
+  args: {
+    children: 'This is a very long text that should be truncated',
+    charCount: 15,
+    withTooltip: false,
+  },
+};
+
+export const WithoutTooltipWithCopy: Story = {
+  args: {
+    children: 'This is a very long text that should be truncated',
+    charCount: 15,
+    withTooltip: false,
+    copy: true,
+  },
+};
+
 export const LongTextWithTooltip: Story = {
   args: {
     children:

--- a/packages/playground-ui/src/ds/components/Truncate/truncate.tsx
+++ b/packages/playground-ui/src/ds/components/Truncate/truncate.tsx
@@ -10,15 +10,7 @@ export interface TruncateProps extends Omit<TxtProps, 'children'> {
   copy?: boolean;
 }
 
-export function Truncate({
-  children,
-  untilChar,
-  charCount,
-  copy,
-  className,
-  as = 'span',
-  ...txtProps
-}: TruncateProps) {
+export function Truncate({ children, untilChar, charCount, copy, className, as = 'span', ...txtProps }: TruncateProps) {
   const fullText = children;
 
   let truncatedText = fullText;
@@ -53,7 +45,9 @@ export function Truncate({
         </TooltipTrigger>
         <TooltipContent>{fullText}</TooltipContent>
       </Tooltip>
-      {copy && <CopyButton content={fullText} iconSize="sm" className="opacity-0 group-hover:opacity-100 transition-opacity" />}
+      {copy && (
+        <CopyButton content={fullText} iconSize="sm" className="opacity-0 group-hover:opacity-100 transition-opacity" />
+      )}
     </Txt>
   );
 }

--- a/packages/playground-ui/src/ds/components/Truncate/truncate.tsx
+++ b/packages/playground-ui/src/ds/components/Truncate/truncate.tsx
@@ -1,0 +1,59 @@
+import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/ds/components/Tooltip';
+import { CopyButton } from '@/ds/components/CopyButton';
+import { Txt, TxtProps } from '@/ds/components/Txt';
+
+export interface TruncateProps extends Omit<TxtProps, 'children'> {
+  children: string;
+  untilChar?: string;
+  charCount?: number;
+  copy?: boolean;
+}
+
+export function Truncate({
+  children,
+  untilChar,
+  charCount,
+  copy,
+  className,
+  as = 'span',
+  ...txtProps
+}: TruncateProps) {
+  const fullText = children;
+
+  let truncatedText = fullText;
+  let isTruncated = false;
+
+  if (untilChar !== undefined) {
+    const index = fullText.indexOf(untilChar);
+    if (index !== -1) {
+      truncatedText = fullText.slice(0, index);
+      isTruncated = true;
+    }
+  } else if (charCount !== undefined && fullText.length > charCount) {
+    truncatedText = fullText.slice(0, charCount);
+    isTruncated = true;
+  }
+
+  if (!isTruncated) {
+    return (
+      <Txt as={as} className={className} {...txtProps}>
+        {fullText}
+      </Txt>
+    );
+  }
+
+  return (
+    <Txt as={as} className={cn('group inline-flex items-center gap-1', className)} {...txtProps}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Txt as="span" className="cursor-default" variant={txtProps.variant} font={txtProps.font}>
+            {truncatedText}...
+          </Txt>
+        </TooltipTrigger>
+        <TooltipContent>{fullText}</TooltipContent>
+      </Tooltip>
+      {copy && <CopyButton content={fullText} iconSize="sm" className="opacity-0 group-hover:opacity-100 transition-opacity" />}
+    </Txt>
+  );
+}

--- a/packages/playground-ui/src/ds/components/Truncate/truncate.tsx
+++ b/packages/playground-ui/src/ds/components/Truncate/truncate.tsx
@@ -8,9 +8,19 @@ export interface TruncateProps extends Omit<TxtProps, 'children'> {
   untilChar?: string;
   charCount?: number;
   copy?: boolean;
+  withTooltip?: boolean;
 }
 
-export function Truncate({ children, untilChar, charCount, copy, className, as = 'span', ...txtProps }: TruncateProps) {
+export function Truncate({
+  children,
+  untilChar,
+  charCount,
+  copy,
+  withTooltip = true,
+  className,
+  as = 'span',
+  ...txtProps
+}: TruncateProps) {
   const fullText = children;
 
   let truncatedText = fullText;
@@ -35,16 +45,22 @@ export function Truncate({ children, untilChar, charCount, copy, className, as =
     );
   }
 
+  const truncatedContent = (
+    <Txt as="span" className="cursor-default" variant={txtProps.variant} font={txtProps.font}>
+      {truncatedText}...
+    </Txt>
+  );
+
   return (
     <Txt as={as} className={cn('group inline-flex items-center gap-1', className)} {...txtProps}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Txt as="span" className="cursor-default" variant={txtProps.variant} font={txtProps.font}>
-            {truncatedText}...
-          </Txt>
-        </TooltipTrigger>
-        <TooltipContent>{fullText}</TooltipContent>
-      </Tooltip>
+      {withTooltip ? (
+        <Tooltip>
+          <TooltipTrigger asChild>{truncatedContent}</TooltipTrigger>
+          <TooltipContent>{fullText}</TooltipContent>
+        </Tooltip>
+      ) : (
+        truncatedContent
+      )}
       {copy && (
         <CopyButton content={fullText} iconSize="sm" className="opacity-0 group-hover:opacity-100 transition-opacity" />
       )}

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -48,6 +48,7 @@ export * from './ds/components/Slider';
 export * from './ds/components/Spinner';
 export * from './ds/components/Switch';
 export * from './ds/components/Tooltip';
+export * from './ds/components/Truncate';
 
 // DS Components - Migrated Containers
 export * from './ds/components/ButtonsGroup';

--- a/packages/playground/src/domains/workflows/workflow-header.tsx
+++ b/packages/playground/src/domains/workflows/workflow-header.tsx
@@ -11,9 +11,8 @@ import {
   ApiIcon,
   WorkflowIcon,
   DocsIcon,
-  DividerIcon,
   WorkflowCombobox,
-  Badge,
+  Truncate,
 } from '@mastra/playground-ui';
 import { EyeIcon } from 'lucide-react';
 
@@ -36,19 +35,19 @@ export function WorkflowHeader({
             </Icon>
             Workflows
           </Crumb>
-          <Crumb as="span" to="" isCurrent>
+          <Crumb as="span" to="" isCurrent={!runId}>
             <WorkflowCombobox value={workflowId} variant="ghost" />
           </Crumb>
+          {runId && (
+            <Crumb as={Link} to={`/workflows/${workflowId}/graph/${runId}`} isCurrent>
+              <Truncate untilChar="-" copy>
+                {runId}
+              </Truncate>
+            </Crumb>
+          )}
         </Breadcrumb>
 
         <HeaderGroup>
-          {runId && (
-            <>
-              <Badge variant="default">Run: {runId}</Badge>
-              <DividerIcon />
-            </>
-          )}
-
           <Button as={Link} to={`/observability?entity=${workflowName}`}>
             <Icon>
               <EyeIcon />


### PR DESCRIPTION
Moves the workflow run ID from the Badge in the header to the breadcrumbs for better navigation context.

The run ID now shows truncated (up to the first `-`) with a copy button to get the full ID:

```
Workflows / my-workflow / abc123...
```

Before: Run ID was displayed in a Badge next to the Traces button.
After: Run ID appears as the third breadcrumb using the `Truncate` component.

<img width="3840" height="2160" alt="CleanShot 2026-01-28 at 10 15 09@2x" src="https://github.com/user-attachments/assets/002a0ad6-df0e-4ef3-8fcb-34cd6c6c306f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable text truncation component with tooltip preview and optional copy-to-clipboard support; supports truncation by character count or delimiter.
  * Added Storybook examples demonstrating truncation variants and behaviors.
  * Updated workflow header breadcrumbs to display run IDs using the new truncation and copy behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->