### PR TITLE
Fix: quote provider names starting with digits in provider-types.generated.d.ts

### DIFF
--- a/.changeset/fix-provider-types-digit-identifier.md
+++ b/.changeset/fix-provider-types-digit-identifier.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fix provider-types.generated.d.ts producing invalid TypeScript for provider IDs starting with digits (e.g., 302ai)

--- a/.changeset/fix-provider-types-digit-identifier.md
+++ b/.changeset/fix-provider-types-digit-identifier.md
@@ -1,5 +1,0 @@
----
-"@mastra/core": patch
----
-
-Fix provider-types.generated.d.ts producing invalid TypeScript for provider IDs starting with digits (e.g., 302ai)

--- a/.changeset/shy-owls-fly.md
+++ b/.changeset/shy-owls-fly.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed generated provider types so IDs starting with digits no longer break TypeScript builds

--- a/packages/core/src/llm/model/registry-generator.test.ts
+++ b/packages/core/src/llm/model/registry-generator.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { generateTypesContent } from './registry-generator.js';
+
+describe('registry-generator', () => {
+  describe('generateTypesContent', () => {
+    it('should not quote valid JS identifiers', () => {
+      const models = {
+        openai: ['gpt-4'],
+        _private: ['model-1'],
+        $provider: ['model-2'],
+        provider123: ['model-3'],
+      };
+
+      const content = generateTypesContent(models);
+
+      expect(content).toContain('readonly openai:');
+      expect(content).toContain('readonly _private:');
+      expect(content).toContain('readonly $provider:');
+      expect(content).toContain('readonly provider123:');
+    });
+
+    it('should quote provider names with special characters', () => {
+      const models = {
+        'fireworks-ai': ['llama-v3-70b'],
+      };
+
+      const content = generateTypesContent(models);
+
+      expect(content).toContain("readonly 'fireworks-ai':");
+    });
+
+    it('should quote provider names starting with digits', () => {
+      const models = {
+        '302ai': ['model-1'],
+      };
+
+      const content = generateTypesContent(models);
+
+      expect(content).toContain("readonly '302ai':");
+      expect(content).not.toMatch(/readonly\s+\d/);
+    });
+  });
+});

--- a/packages/core/src/llm/model/registry-generator.ts
+++ b/packages/core/src/llm/model/registry-generator.ts
@@ -115,8 +115,9 @@ export function generateTypesContent(models: Record<string, string[]>): string {
     .map(([provider, modelList]) => {
       const modelsList = modelList.map(m => `'${m}'`);
 
-      // Only quote provider key if it contains special characters (like dashes)
-      const needsQuotes = /[^a-zA-Z0-9_$]/.test(provider);
+      // Quote provider key if it's not a valid JavaScript identifier
+      // Valid identifiers must start with a letter, underscore, or dollar sign
+      const needsQuotes = !/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(provider);
       const providerKey = needsQuotes ? `'${provider}'` : provider;
 
       // Format array based on length (prettier printWidth: 120)


### PR DESCRIPTION
## Description

Fixed the `generateTypesContent` function in `registry-generator.ts` to properly quote provider names that start with digits. JavaScript identifiers cannot start with digits, so provider IDs like `302ai` must be quoted to produce valid TypeScript.

## Related Issue(s)

Fixes #12402

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generation of provider type declarations for IDs starting with digits (e.g., 302ai), preventing invalid TypeScript output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->