### PR TITLE
fix(deployer-cloudflare): Prevent TypeScript bundling exceeding size limits

### DIFF
--- a/.changeset/few-lemons-stay.md
+++ b/.changeset/few-lemons-stay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer-cloudflare': patch
+---
+
+Fixed Cloudflare Workers exceeding the 3MB size limit due to TypeScript being bundled. The deployer now stubs out TypeScript (~10MB) since the agent-builder gracefully falls back to basic validation when it's unavailable.

--- a/deployers/cloudflare/src/index.test.ts
+++ b/deployers/cloudflare/src/index.test.ts
@@ -1,0 +1,68 @@
+import { mkdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { CloudflareDeployer } from './index.js';
+
+describe('CloudflareDeployer', () => {
+  let deployer: CloudflareDeployer;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `cloudflare-deployer-test-${Date.now()}`);
+    // Create the output directory that writeFiles expects
+    await mkdir(join(tempDir, 'output'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('writeFiles', () => {
+    describe('TypeScript stub for bundle size optimization', () => {
+      it('should create typescript-stub.mjs and configure wrangler alias', async () => {
+        deployer = new CloudflareDeployer({ name: 'test-worker' });
+        vi.spyOn(deployer, 'loadEnvVars').mockResolvedValue(new Map());
+
+        await deployer.writeFiles(tempDir);
+
+        // Verify stub file is created with expected exports
+        const stubPath = join(tempDir, 'output', 'typescript-stub.mjs');
+        const stub = await import(stubPath);
+
+        expect(stub.default).toEqual({});
+        expect(stub.createSourceFile()).toBeNull();
+        expect(stub.createProgram()).toBeNull();
+        expect(stub.ScriptTarget.Latest).toBe(99);
+        expect(stub.DiagnosticCategory.Error).toBe(1);
+
+        // Verify wrangler config uses the stub
+        const wranglerConfigPath = join(tempDir, 'output', 'wrangler.json');
+        const wranglerConfig = JSON.parse(await readFile(wranglerConfigPath, 'utf-8'));
+
+        expect(wranglerConfig.alias.typescript).toBe('./typescript-stub.mjs');
+      });
+
+      it('should allow user to override the TypeScript alias', async () => {
+        deployer = new CloudflareDeployer({
+          name: 'test-worker',
+          alias: {
+            typescript: './custom-typescript-stub.js',
+            'other-module': './other.js',
+          },
+        });
+        vi.spyOn(deployer, 'loadEnvVars').mockResolvedValue(new Map());
+
+        await deployer.writeFiles(tempDir);
+
+        const wranglerConfigPath = join(tempDir, 'output', 'wrangler.json');
+        const wranglerConfig = JSON.parse(await readFile(wranglerConfigPath, 'utf-8'));
+
+        // User's alias should override the default, other aliases preserved
+        expect(wranglerConfig.alias.typescript).toBe('./custom-typescript-stub.js');
+        expect(wranglerConfig.alias['other-module']).toBe('./other.js');
+      });
+    });
+  });
+});

--- a/deployers/cloudflare/src/index.ts
+++ b/deployers/cloudflare/src/index.ts
@@ -61,11 +61,37 @@ export class CloudflareDeployer extends Deployer {
   }
 
   async writeFiles(outputDirectory: string): Promise<void> {
-    const { vars: userVars, ...userConfig } = this.userConfig;
+    const { vars: userVars, alias: userAlias, ...userConfig } = this.userConfig;
     const loadedEnvVars = await this.loadEnvVars();
 
     // Merge env vars from .env files with user-provided vars
     const envsAsObject = Object.assign({}, Object.fromEntries(loadedEnvVars.entries()), userVars);
+
+    // Write TypeScript stub to prevent bundling the full TypeScript library (~10MB)
+    // The agent-builder package dynamically imports TypeScript for code validation,
+    // but gracefully falls back to basic validation when TypeScript is unavailable.
+    // This stub ensures the import doesn't fail while keeping the bundle small.
+    const typescriptStubPath = 'typescript-stub.mjs';
+    const typescriptStub = `// Stub for TypeScript - not available at runtime in Cloudflare Workers
+// The @mastra/agent-builder package will fall back to basic validation
+export default {};
+export const createSourceFile = () => null;
+export const createProgram = () => null;
+export const findConfigFile = () => null;
+export const readConfigFile = () => ({ error: new Error('TypeScript not available') });
+export const parseJsonConfigFileContent = () => ({ errors: [new Error('TypeScript not available')], fileNames: [], options: {} });
+export const flattenDiagnosticMessageText = (message) => typeof message === 'string' ? message : message?.messageText || '';
+export const ScriptTarget = { Latest: 99 };
+export const ModuleKind = { ESNext: 99 };
+export const JsxEmit = { ReactJSX: 4 };
+export const DiagnosticCategory = { Warning: 0, Error: 1, Suggestion: 2, Message: 3 };
+export const sys = {
+  fileExists: () => false,
+  readFile: () => undefined,
+};
+`;
+
+    await writeFile(join(outputDirectory, this.outputDir, typescriptStubPath), typescriptStub);
 
     const wranglerConfig: Unstable_RawConfig = {
       name: 'mastra',
@@ -79,6 +105,11 @@ export class CloudflareDeployer extends Deployer {
       ...userConfig,
       main: './index.mjs',
       vars: envsAsObject,
+      // Alias TypeScript to stub to prevent wrangler from bundling the full library
+      alias: {
+        typescript: `./${typescriptStubPath}`,
+        ...userAlias,
+      },
     };
 
     await writeFile(join(outputDirectory, this.outputDir, 'wrangler.json'), JSON.stringify(wranglerConfig));


### PR DESCRIPTION
## Description

Fixed Cloudflare Workers deployments failing due to exceeding the 3MB size limit. The deployer now automatically stubs out the TypeScript module to prevent wrangler from bundling the full TypeScript library (~10MB).

## Related Issue(s)

Fixes #11449

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Cloudflare Workers deployments exceeded the 3MB size limit by optimizing TypeScript handling when agent-builder is unavailable, enabling successful fallback validation.

* **Tests**
  * Added test suite for Cloudflare deployer configuration and file generation, including validation of user-provided overrides.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->