### PR TITLE
refactor(playground-ui): improve thread list UI styling

### DIFF
--- a/.changeset/cozy-rats-allow.md
+++ b/.changeset/cozy-rats-allow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved thread list UI with cleaner styling, truncated IDs, and shared empty state component

--- a/packages/playground-ui/src/domains/agents/components/chat-threads.tsx
+++ b/packages/playground-ui/src/domains/agents/components/chat-threads.tsx
@@ -124,7 +124,7 @@ function ThreadTitle({ title, id }: { title?: string; id?: string }) {
     return (
       <Txt variant="ui-sm" className="text-neutral3">
         Thread{' '}
-        <Truncate variant="ui-sm" className="text-neutral3" untilChar="-">
+        <Truncate variant="ui-sm" className="text-neutral3" untilChar="-" withTooltip={false}>
           {id ?? ''}
         </Truncate>
       </Txt>

--- a/packages/playground-ui/src/domains/agents/components/chat-threads.tsx
+++ b/packages/playground-ui/src/domains/agents/components/chat-threads.tsx
@@ -1,12 +1,11 @@
-import { ThreadDeleteButton, ThreadItem, ThreadLink, ThreadList, Threads } from '@/ds/components/Threads';
-import { Icon } from '@/ds/icons';
+import { NewThreadLink, ThreadDeleteButton, ThreadEmpty, ThreadItem, ThreadLink, ThreadList, Threads } from '@/ds/components/Threads';
 import { useLinkComponent } from '@/lib/framework';
-import { Plus } from 'lucide-react';
 import { StorageThreadType } from '@mastra/core/memory';
 import { AlertDialog } from '@/ds/components/AlertDialog';
 import { useState } from 'react';
 import { Skeleton } from '@/ds/components/Skeleton';
 import { Txt } from '@/ds/components/Txt/Txt';
+import { Truncate } from '@/ds/components/Truncate';
 
 export interface ChatThreadsProps {
   threads: StorageThreadType[];
@@ -33,20 +32,11 @@ export const ChatThreads = ({ threads, isLoading, threadId, onDelete, resourceId
       <Threads>
         <ThreadList>
           <ThreadItem>
-            <ThreadLink as={Link} to={newThreadLink}>
-              <span className="text-accent1 flex items-center gap-4">
-                <Icon className="bg-surface4 rounded-lg" size="lg">
-                  <Plus />
-                </Icon>
-                New Chat
-              </span>
-            </ThreadLink>
+            <NewThreadLink as={Link} to={newThreadLink} label="New Chat" />
           </ThreadItem>
 
           {threads.length === 0 && (
-            <Txt as="p" variant="ui-sm" className="text-neutral3 py-3 px-5">
-              Your conversations will appear here once you start chatting!
-            </Txt>
+            <ThreadEmpty>Your conversations will appear here once you start chatting!</ThreadEmpty>
           )}
 
           {threads.map(thread => {
@@ -59,9 +49,8 @@ export const ChatThreads = ({ threads, isLoading, threadId, onDelete, resourceId
 
             return (
               <ThreadItem isActive={isActive} key={thread.id}>
-                <ThreadLink as={Link} to={threadLink}>
+                <ThreadLink as={Link} to={threadLink} isActive={isActive}>
                   <ThreadTitle title={thread.title} id={thread.id} />
-                  <span>{formatDay(thread.createdAt)}</span>
                 </ThreadLink>
 
                 <ThreadDeleteButton onClick={() => setDeleteId(thread.id)} />
@@ -132,20 +121,19 @@ function ThreadTitle({ title, id }: { title?: string; id?: string }) {
   }
 
   if (isDefaultThreadName(title)) {
-    return <span className="text-neutral3">Thread {id ? id.substring(id.length - 5) : null}</span>;
+    return (
+      <Txt variant="ui-sm" className="text-neutral3">
+        Thread{' '}
+        <Truncate variant="ui-sm" className="text-neutral3" untilChar="-">
+          {id ?? ''}
+        </Truncate>
+      </Txt>
+    );
   }
 
-  return <span className="truncate max-w-[14rem] text-neutral3">{title}</span>;
+  return (
+    <Txt variant="ui-sm" className="text-neutral3 truncate max-w-[14rem]">
+      {title}
+    </Txt>
+  );
 }
-
-const formatDay = (date: Date) => {
-  const options: Intl.DateTimeFormatOptions = {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-    second: 'numeric',
-    hour12: true,
-  };
-  return new Date(date).toLocaleString('en-us', options).replace(',', ' at');
-};

--- a/packages/playground-ui/src/domains/workflows/runs/workflow-run-list.tsx
+++ b/packages/playground-ui/src/domains/workflows/runs/workflow-run-list.tsx
@@ -1,15 +1,13 @@
-import { Txt } from '@/ds/components/Txt';
 import { Icon } from '@/ds/icons';
 import { WorkflowRunStatus } from '@mastra/core/workflows';
-import { Check, CirclePause, CircleSlash, Clock, Plus, X } from 'lucide-react';
+import { Check, CirclePause, CircleSlash, Clock, X } from 'lucide-react';
 import { useDeleteWorkflowRun, useWorkflowRuns } from '@/hooks/use-workflow-runs';
-import { ThreadDeleteButton, ThreadItem, ThreadLink, ThreadList, Threads } from '@/ds/components/Threads';
+import { NewThreadLink, ThreadDeleteButton, ThreadEmpty, ThreadItem, ThreadLink, ThreadList, Threads } from '@/ds/components/Threads';
 import { useLinkComponent } from '@/lib/framework';
-import { formatDate } from 'date-fns';
+import { Truncate } from '@/ds/components/Truncate';
 import { Skeleton } from '@/ds/components/Skeleton';
 import { Badge } from '@/ds/components/Badge';
 import { Spinner } from '@/ds/components/Spinner';
-import { useInView } from '@/hooks';
 import { AlertDialog } from '@/ds/components/AlertDialog';
 import { useState } from 'react';
 
@@ -50,43 +48,30 @@ export const WorkflowRunList = ({ workflowId, runId }: WorkflowRunListProps) => 
       <Threads>
         <ThreadList>
           <ThreadItem>
-            <ThreadLink as={Link} to={paths.workflowLink(workflowId)}>
-              <span className="text-accent1 flex items-center gap-4">
-                <Icon className="bg-surface4 rounded-lg" size="lg">
-                  <Plus />
-                </Icon>
-                New workflow run
-              </span>
-            </ThreadLink>
+            <NewThreadLink as={Link} to={paths.workflowLink(workflowId)} label="New workflow run" />
           </ThreadItem>
 
           {actualRuns.length === 0 && (
-            <Txt variant="ui-md" className="text-neutral3 py-3 px-5">
-              Your run history will appear here once you run the workflow
-            </Txt>
+            <ThreadEmpty>Your run history will appear here once you run the workflow</ThreadEmpty>
           )}
 
-          {actualRuns.map(run => (
-            <ThreadItem isActive={run.runId === runId} key={run.runId} className="h-auto">
-              <ThreadLink as={Link} to={paths.workflowRunLink(workflowId, run.runId)}>
-                {typeof run?.snapshot === 'object' && (
-                  <div className="pb-1">
-                    <WorkflowRunStatusBadge status={run.snapshot.status} />
-                  </div>
-                )}
-                <span className="truncate max-w-32 text-neutral3">{run.runId}</span>
-                <span>
-                  {typeof run?.snapshot === 'string'
-                    ? ''
-                    : run?.snapshot?.timestamp
-                      ? formatDate(run?.snapshot?.timestamp, 'MMM d, yyyy h:mm a')
-                      : ''}
-                </span>
-              </ThreadLink>
+          {actualRuns.map(run => {
+            const isActive = run.runId === runId;
+            return (
+              <ThreadItem isActive={isActive} key={run.runId}>
+                <ThreadLink as={Link} to={paths.workflowRunLink(workflowId, run.runId)} isActive={isActive}>
+                  <span className="flex items-center gap-2">
+                    {typeof run?.snapshot === 'object' && <WorkflowRunStatusBadge status={run.snapshot.status} />}
+                    <Truncate variant="ui-sm" className="text-neutral3" untilChar="-">
+                      {run.runId}
+                    </Truncate>
+                  </span>
+                </ThreadLink>
 
-              <ThreadDeleteButton onClick={() => setDeleteRunId(run.runId)} />
-            </ThreadItem>
-          ))}
+                <ThreadDeleteButton onClick={() => setDeleteRunId(run.runId)} />
+              </ThreadItem>
+            );
+          })}
         </ThreadList>
       </Threads>
 
@@ -118,54 +103,30 @@ interface WorkflowRunStatusProps {
 
 const WorkflowRunStatusBadge = ({ status }: WorkflowRunStatusProps) => {
   if (status === 'running') {
-    return (
-      <Badge variant="default" icon={<Spinner />}>
-        {status}
-      </Badge>
-    );
+    return <Badge variant="default" icon={<Spinner />} />;
   }
 
   if (status === 'failed') {
-    return (
-      <Badge variant="default" icon={<X className="text-accent2" />}>
-        {status}
-      </Badge>
-    );
+    return <Badge variant="default" icon={<X className="text-accent2" />} />;
   }
 
   if (status === 'canceled') {
-    return (
-      <Badge variant="default" icon={<CircleSlash className="text-neutral3" />}>
-        {status}
-      </Badge>
-    );
+    return <Badge variant="default" icon={<CircleSlash className="text-neutral3" />} />;
   }
 
   if (status === 'pending' || status === 'waiting') {
-    return (
-      <Badge variant="default" icon={<Clock className="text-neutral3" />}>
-        {status}
-      </Badge>
-    );
+    return <Badge variant="default" icon={<Clock className="text-neutral3" />} />;
   }
 
   if (status === 'suspended') {
-    return (
-      <Badge variant="default" icon={<CirclePause className="text-accent3" />}>
-        {status}
-      </Badge>
-    );
+    return <Badge variant="default" icon={<CirclePause className="text-accent3" />} />;
   }
 
   if (status === 'success') {
-    return (
-      <Badge variant="default" icon={<Check className="text-accent1" />}>
-        {status}
-      </Badge>
-    );
+    return <Badge variant="default" icon={<Check className="text-accent1" />} />;
   }
 
-  return <Badge variant="default">{status}</Badge>;
+  return <Badge variant="default" />;
 };
 
 interface DeleteRunDialogProps {

--- a/packages/playground-ui/src/domains/workflows/runs/workflow-run-list.tsx
+++ b/packages/playground-ui/src/domains/workflows/runs/workflow-run-list.tsx
@@ -62,7 +62,7 @@ export const WorkflowRunList = ({ workflowId, runId }: WorkflowRunListProps) => 
                 <ThreadLink as={Link} to={paths.workflowRunLink(workflowId, run.runId)} isActive={isActive}>
                   <span className="flex items-center gap-2">
                     {typeof run?.snapshot === 'object' && <WorkflowRunStatusBadge status={run.snapshot.status} />}
-                    <Truncate variant="ui-sm" className="text-neutral3" untilChar="-">
+                    <Truncate variant="ui-sm" className="text-neutral3" untilChar="-" withTooltip={false}>
                       {run.runId}
                     </Truncate>
                   </span>

--- a/packages/playground-ui/src/ds/components/Threads/threads.tsx
+++ b/packages/playground-ui/src/ds/components/Threads/threads.tsx
@@ -1,6 +1,7 @@
-import { Button } from '@/ds/components/Button';
+import { IconButton } from '@/ds/components/IconButton';
 import { Icon } from '@/ds/icons/Icon';
-import { X } from 'lucide-react';
+import { Txt } from '@/ds/components/Txt';
+import { Plus, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ElementType } from 'react';
 import { transitions } from '@/ds/primitives/transitions';
@@ -10,7 +11,7 @@ export interface ThreadsProps {
 }
 
 export const Threads = ({ children }: ThreadsProps) => {
-  return <nav className="bg-surface2 min-h-full overflow-hidden">{children}</nav>;
+  return <nav className="bg-surface1 min-h-full overflow-hidden">{children}</nav>;
 };
 
 export interface ThreadLinkProps {
@@ -20,21 +21,63 @@ export interface ThreadLinkProps {
   className?: string;
   prefetch?: boolean;
   to?: string;
+  isActive?: boolean;
 }
 
-export const ThreadLink = ({ children, as: Component = 'a', href, className, prefetch, to }: ThreadLinkProps) => {
+export const ThreadLink = ({
+  children,
+  as: Component = 'a',
+  href,
+  className,
+  prefetch,
+  to,
+  isActive,
+}: ThreadLinkProps) => {
   return (
     <Component
       href={href}
       prefetch={prefetch}
       to={to}
       className={cn(
-        'text-ui-sm flex h-full w-full flex-col justify-center font-medium cursor-pointer',
+        'flex h-form-md w-full flex-col justify-center cursor-pointer rounded-lg px-2',
         transitions.colors,
+        'hover:bg-surface3 hover:text-neutral6',
+        isActive && 'bg-surface4',
         className,
       )}
     >
-      {children}
+      <Txt variant="ui-sm" className="text-neutral3">
+        {children}
+      </Txt>
+    </Component>
+  );
+};
+
+export interface NewThreadLinkProps {
+  as?: ElementType;
+  href?: string;
+  prefetch?: boolean;
+  to?: string;
+  label: string;
+}
+
+export const NewThreadLink = ({ as: Component = 'a', href, prefetch, to, label }: NewThreadLinkProps) => {
+  return (
+    <Component
+      href={href}
+      prefetch={prefetch}
+      to={to}
+      className={cn(
+        'text-ui-sm flex h-form-md w-full items-center gap-4 font-medium cursor-pointer rounded-lg px-2',
+        transitions.colors,
+        'hover:bg-surface3 hover:text-neutral6',
+        'text-neutral3',
+      )}
+    >
+      <Icon className="bg-surface4 rounded-lg text-neutral3" size="lg">
+        <Plus />
+      </Icon>
+      {label}
     </Component>
   );
 };
@@ -44,7 +87,7 @@ export interface ThreadListProps {
 }
 
 export const ThreadList = ({ children }: ThreadListProps) => {
-  return <ol data-testid="thread-list">{children}</ol>;
+  return <ol data-testid="thread-list" className="p-2 flex flex-col gap-2">{children}</ol>;
 };
 
 export interface ThreadItemProps {
@@ -56,13 +99,8 @@ export interface ThreadItemProps {
 export const ThreadItem = ({ children, isActive, className }: ThreadItemProps) => {
   return (
     <li
-      className={cn(
-        'border-b border-border1 group flex h-[54px] items-center justify-between gap-2 px-3 py-2',
-        transitions.colors,
-        'hover:bg-surface3',
-        isActive && 'bg-accent1Dark',
-        className,
-      )}
+      data-active={isActive}
+      className={cn('group relative flex items-center', className)}
     >
       {children}
     </li>
@@ -75,19 +113,30 @@ export interface ThreadDeleteButtonProps {
 
 export const ThreadDeleteButton = ({ onClick }: ThreadDeleteButtonProps) => {
   return (
-    <Button
+    <IconButton
+      tooltip="Delete thread"
       variant="ghost"
+      size="sm"
       className={cn(
-        'shrink-0 opacity-0',
+        'absolute right-2 opacity-0 border-transparent',
         transitions.all,
         'group-focus-within:opacity-100 group-hover:opacity-100',
-        'hover:bg-surface4 hover:text-accent2',
       )}
       onClick={onClick}
     >
-      <Icon>
-        <X aria-label="delete thread" className="text-neutral3 hover:text-accent2 transition-colors" />
-      </Icon>
-    </Button>
+      <X />
+    </IconButton>
+  );
+};
+
+export interface ThreadEmptyProps {
+  children: React.ReactNode;
+}
+
+export const ThreadEmpty = ({ children }: ThreadEmptyProps) => {
+  return (
+    <Txt as="p" variant="ui-sm" className="text-neutral3 p-2">
+      {children}
+    </Txt>
   );
 };


### PR DESCRIPTION
Cleaned up the thread list UI in the playground for both chat threads and workflow runs.

**Changes:**
- Removed date display from thread items
- Thread/run IDs now truncate at the first `-` with a tooltip showing the full ID
- Added shared `ThreadEmpty` and `NewThreadLink` components
- Delete button now uses `IconButton` with absolute positioning on hover
- Cleaner hover states and consistent styling across chat and workflow views