### PR TITLE
fix(arize): map mastra span types to correct OpenInference span kinds

### DIFF
--- a/.changeset/wise-impalas-scream.md
+++ b/.changeset/wise-impalas-scream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/arize': patch
+---
+
+Fixed incorrect span kind mapping in @mastra/arize. Workflow spans now correctly map to CHAIN, agent spans to AGENT, and tool spans to TOOL instead of defaulting to LLM.

--- a/observability/arize/src/openInferenceOTLPExporter.ts
+++ b/observability/arize/src/openInferenceOTLPExporter.ts
@@ -52,17 +52,10 @@ const MASTRA_SPAN_TYPE = 'mastra.span.type';
  * The @arizeai/openinference-genai library defaults all spans to LLM kind,
  * which is incorrect for workflow, agent, tool, and other non-LLM spans.
  * This mapping overrides the span kind based on the mastra.span.type attribute.
+ *
+ * Only non-CHAIN types are mapped here - all other span types default to CHAIN.
  */
 const SPAN_TYPE_TO_KIND: Record<string, OpenInferenceSpanKind> = {
-  // Workflow spans -> CHAIN
-  workflow_run: OpenInferenceSpanKind.CHAIN,
-  workflow_step: OpenInferenceSpanKind.CHAIN,
-  workflow_conditional: OpenInferenceSpanKind.CHAIN,
-  workflow_conditional_eval: OpenInferenceSpanKind.CHAIN,
-  workflow_parallel: OpenInferenceSpanKind.CHAIN,
-  workflow_loop: OpenInferenceSpanKind.CHAIN,
-  workflow_sleep: OpenInferenceSpanKind.CHAIN,
-  workflow_wait_event: OpenInferenceSpanKind.CHAIN,
   // Model spans -> LLM
   model_generation: OpenInferenceSpanKind.LLM,
   model_step: OpenInferenceSpanKind.LLM,
@@ -72,9 +65,6 @@ const SPAN_TYPE_TO_KIND: Record<string, OpenInferenceSpanKind> = {
   mcp_tool_call: OpenInferenceSpanKind.TOOL,
   // Agent spans -> AGENT
   agent_run: OpenInferenceSpanKind.AGENT,
-  // Other spans -> CHAIN
-  processor_run: OpenInferenceSpanKind.CHAIN,
-  generic: OpenInferenceSpanKind.CHAIN,
 };
 
 /**
@@ -250,10 +240,11 @@ export class OpenInferenceOTLPTraceExporter extends OTLPTraceExporter {
 
         // Override span kind based on mastra.span.type
         // The @arizeai/openinference-genai library incorrectly defaults all spans to LLM kind.
-        // We need to map based on the actual Mastra span type.
+        // We need to map based on the actual Mastra span type, defaulting to CHAIN.
         const spanType = mastraOther[MASTRA_SPAN_TYPE];
-        if (typeof spanType === 'string' && SPAN_TYPE_TO_KIND[spanType]) {
-          mutableSpan.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] = SPAN_TYPE_TO_KIND[spanType];
+        if (typeof spanType === 'string') {
+          mutableSpan.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] =
+            SPAN_TYPE_TO_KIND[spanType] ?? OpenInferenceSpanKind.CHAIN;
         }
       }
 

--- a/observability/arize/src/openInferenceOTLPExporter.ts
+++ b/observability/arize/src/openInferenceOTLPExporter.ts
@@ -47,11 +47,7 @@ const MASTRA_MODEL_CHUNK_OUTPUT = 'mastra.model_chunk.output';
 const MASTRA_SPAN_TYPE = 'mastra.span.type';
 
 /**
- * Maps Mastra span types to OpenInference span kinds.
- *
- * The @arizeai/openinference-genai library defaults all spans to LLM kind,
- * which is incorrect for workflow, agent, tool, and other non-LLM spans.
- * This mapping overrides the span kind based on the mastra.span.type attribute.
+ * Maps Mastra span types to OpenInference span kinds for proper trace categorization.
  *
  * Only non-CHAIN types are mapped here - all other span types default to CHAIN.
  */
@@ -238,9 +234,7 @@ export class OpenInferenceOTLPTraceExporter extends OTLPTraceExporter {
 
         mutableSpan.attributes = { ...processedAttributes, ...mastraOther };
 
-        // Override span kind based on mastra.span.type
-        // The @arizeai/openinference-genai library incorrectly defaults all spans to LLM kind.
-        // We need to map based on the actual Mastra span type, defaulting to CHAIN.
+        // Set span kind based on mastra.span.type for proper trace categorization
         const spanType = mastraOther[MASTRA_SPAN_TYPE];
         if (typeof spanType === 'string') {
           mutableSpan.attributes[SemanticConventions.OPENINFERENCE_SPAN_KIND] =

--- a/observability/arize/src/tracing.test.ts
+++ b/observability/arize/src/tracing.test.ts
@@ -533,6 +533,230 @@ describe('ArizeExporter', () => {
     });
   });
 
+  describe('Span Kind Mapping', () => {
+    it('maps workflow_run spans to CHAIN span kind', async () => {
+      exporter = new ArizeExporter({
+        endpoint: 'http://localhost:4318/v1/traces',
+      });
+
+      const workflowRunSpan: Mutable<AnyExportedSpan> = {
+        id: 'workflow-run-span',
+        traceId: 'trace-workflow-run',
+        type: SpanType.WORKFLOW_RUN,
+        name: 'Data Processing Workflow',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: true,
+        input: { data: [1, 2, 3] },
+        output: { processed: true, count: 3 },
+        attributes: {},
+      } as unknown as AnyExportedSpan;
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan: workflowRunSpan,
+      });
+
+      expect(exportedSpans.length).toBe(1);
+      const attrs = exportedSpans[0].attributes;
+
+      // Workflow spans should be mapped to CHAIN span kind, not LLM
+      expect(attrs[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe('CHAIN');
+    });
+
+    it('maps workflow_step spans to CHAIN span kind', async () => {
+      exporter = new ArizeExporter({
+        endpoint: 'http://localhost:4318/v1/traces',
+      });
+
+      const workflowStepSpan: Mutable<AnyExportedSpan> = {
+        id: 'workflow-step-span',
+        traceId: 'trace-workflow-step',
+        parentSpanId: 'parent-workflow',
+        type: SpanType.WORKFLOW_STEP,
+        name: 'Process Data Step',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: false,
+        input: { item: 1 },
+        output: { result: 'processed' },
+        attributes: {},
+      } as unknown as AnyExportedSpan;
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan: workflowStepSpan,
+      });
+
+      expect(exportedSpans.length).toBe(1);
+      const attrs = exportedSpans[0].attributes;
+
+      // Workflow step spans should be mapped to CHAIN span kind
+      expect(attrs[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe('CHAIN');
+    });
+
+    it('maps agent_run spans to AGENT span kind', async () => {
+      exporter = new ArizeExporter({
+        endpoint: 'http://localhost:4318/v1/traces',
+      });
+
+      const agentRunSpan: Mutable<AnyExportedSpan> = {
+        id: 'agent-run-span',
+        traceId: 'trace-agent-run',
+        type: SpanType.AGENT_RUN,
+        name: 'Customer Support Agent',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: true,
+        input: { prompt: 'Hello' },
+        output: { response: 'Hi there!' },
+        attributes: {
+          agentId: 'support-agent',
+        },
+      } as unknown as AnyExportedSpan;
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan: agentRunSpan,
+      });
+
+      expect(exportedSpans.length).toBe(1);
+      const attrs = exportedSpans[0].attributes;
+
+      // Agent spans should be mapped to AGENT span kind
+      expect(attrs[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe('AGENT');
+    });
+
+    it('maps model_generation spans to LLM span kind', async () => {
+      exporter = new ArizeExporter({
+        endpoint: 'http://localhost:4318/v1/traces',
+      });
+
+      const modelGenerationSpan: Mutable<AnyExportedSpan> = {
+        id: 'model-gen-span',
+        traceId: 'trace-model-gen',
+        parentSpanId: 'parent-agent',
+        type: SpanType.MODEL_GENERATION,
+        name: 'gpt-4 generation',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: false,
+        input: { messages: [{ role: 'user', content: 'Hello' }] },
+        output: { text: 'Hi!' },
+        attributes: {
+          model: 'gpt-4',
+          provider: 'openai',
+        },
+      } as unknown as AnyExportedSpan;
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan: modelGenerationSpan,
+      });
+
+      expect(exportedSpans.length).toBe(1);
+      const attrs = exportedSpans[0].attributes;
+
+      // Model generation spans should be mapped to LLM span kind
+      expect(attrs[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe('LLM');
+    });
+
+    it('maps processor_run spans to CHAIN span kind', async () => {
+      exporter = new ArizeExporter({
+        endpoint: 'http://localhost:4318/v1/traces',
+      });
+
+      const processorRunSpan: Mutable<AnyExportedSpan> = {
+        id: 'processor-run-span',
+        traceId: 'trace-processor-run',
+        parentSpanId: 'parent-agent',
+        type: SpanType.PROCESSOR_RUN,
+        name: 'Input Processor',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: false,
+        input: { raw: 'input data' },
+        output: { processed: 'transformed data' },
+        attributes: {},
+      } as unknown as AnyExportedSpan;
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan: processorRunSpan,
+      });
+
+      expect(exportedSpans.length).toBe(1);
+      const attrs = exportedSpans[0].attributes;
+
+      // Processor spans should be mapped to CHAIN span kind
+      expect(attrs[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe('CHAIN');
+    });
+
+    it('maps generic spans to CHAIN span kind', async () => {
+      exporter = new ArizeExporter({
+        endpoint: 'http://localhost:4318/v1/traces',
+      });
+
+      const genericSpan: Mutable<AnyExportedSpan> = {
+        id: 'generic-span',
+        traceId: 'trace-generic',
+        parentSpanId: 'parent-workflow',
+        type: SpanType.GENERIC,
+        name: 'Custom Operation',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: false,
+        input: { data: 'some input' },
+        output: { result: 'some output' },
+        attributes: {},
+      } as unknown as AnyExportedSpan;
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan: genericSpan,
+      });
+
+      expect(exportedSpans.length).toBe(1);
+      const attrs = exportedSpans[0].attributes;
+
+      // Generic spans should be mapped to CHAIN span kind
+      expect(attrs[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe('CHAIN');
+    });
+
+    it('maps mcp_tool_call spans to TOOL span kind', async () => {
+      exporter = new ArizeExporter({
+        endpoint: 'http://localhost:4318/v1/traces',
+      });
+
+      const mcpToolCallSpan: Mutable<AnyExportedSpan> = {
+        id: 'mcp-tool-span',
+        traceId: 'trace-mcp-tool',
+        parentSpanId: 'parent-agent',
+        type: SpanType.MCP_TOOL_CALL,
+        name: 'execute_tool filesystem.readFile',
+        startTime: new Date(),
+        endTime: new Date(),
+        isRootSpan: false,
+        input: { path: '/tmp/file.txt' },
+        output: { content: 'file contents' },
+        attributes: {
+          mcpServer: 'filesystem-server',
+        },
+      } as unknown as AnyExportedSpan;
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan: mcpToolCallSpan,
+      });
+
+      expect(exportedSpans.length).toBe(1);
+      const attrs = exportedSpans[0].attributes;
+
+      // MCP tool call spans should be mapped to TOOL span kind
+      expect(attrs[SemanticConventions.OPENINFERENCE_SPAN_KIND]).toBe('TOOL');
+    });
+  });
+
   describe('Tool Call Span Support', () => {
     it('maps tool call input/output to OpenInference INPUT_VALUE/OUTPUT_VALUE', async () => {
       exporter = new ArizeExporter({


### PR DESCRIPTION
Fixes #12404
Fixes #12397

When exporting traces to Phoenix/Arize, Mastra span types need to be mapped to the appropriate OpenInference span kinds for proper categorization.

This adds a mapping from `mastra.span.type` to `openinference.span.kind`. Only non-CHAIN types are explicitly mapped - all other span types (including future ones) default to `CHAIN`:

| Span Type | OpenInference Kind |
|-----------|-------------------|
| `model_generation`, `model_step`, `model_chunk` | `LLM` |
| `tool_call`, `mcp_tool_call` | `TOOL` |
| `agent_run` | `AGENT` |
| Everything else | `CHAIN` (default) |

This ensures model spans are always classified as `LLM` (enabling cost calculation in Phoenix), even when they inherit `gen_ai.agent.*` attributes from parent agent spans.

Added tests covering all span type mappings plus a test for unknown types defaulting to CHAIN.