### PR TITLE
fix(server): pass requestContext to agent and workflow methods

### DIFF
--- a/.changeset/curly-places-lose.md
+++ b/.changeset/curly-places-lose.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed a bug introduced in PR #12251 where requestContext was not passed through to agent and workflow operations. This could cause tools and nested operations that rely on requestContext values to fail or behave incorrectly.

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -651,6 +651,7 @@ export const GENERATE_AGENT_ROUTE: ServerRoute<
         ...rest,
         memory: authorizedMemoryOption,
         abortSignal,
+        requestContext,
       });
 
       return result;
@@ -889,6 +890,7 @@ export const STREAM_GENERATE_ROUTE = createRoute({
         ...rest,
         memory: authorizedMemoryOption,
         abortSignal,
+        requestContext,
       });
 
       return streamResult.fullStream;

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -376,7 +376,7 @@ export const STREAM_WORKFLOW_ROUTE = createRoute({
       const serverCache = mastra.getServerCache();
 
       const run = await workflow.createRun({ runId, resourceId: effectiveResourceId });
-      const result = run.stream(params);
+      const result = run.stream({ ...params, requestContext });
       return result.fullStream.pipeThrough(
         new TransformStream<ChunkType, ChunkType>({
           transform(chunk, controller) {
@@ -435,7 +435,7 @@ export const RESUME_STREAM_WORKFLOW_ROUTE = createRoute({
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
       const serverCache = mastra.getServerCache();
 
-      const stream = _run.resumeStream(params).fullStream.pipeThrough(
+      const stream = _run.resumeStream({ ...params, requestContext }).fullStream.pipeThrough(
         new TransformStream<ChunkType, ChunkType>({
           transform(chunk, controller) {
             if (serverCache) {
@@ -483,7 +483,7 @@ export const START_ASYNC_WORKFLOW_ROUTE = createRoute({
       }
 
       const _run = await workflow.createRun({ runId, resourceId: effectiveResourceId });
-      const result = await _run.start(params);
+      const result = await _run.start({ ...params, requestContext });
       return result;
     } catch (error) {
       return handleError(error, 'Error starting async workflow');
@@ -532,6 +532,7 @@ export const START_WORKFLOW_RUN_ROUTE = createRoute({
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
       void _run.start({
         ...params,
+        requestContext,
       });
 
       return { message: 'Workflow run started' };
@@ -675,7 +676,7 @@ export const RESUME_ASYNC_WORKFLOW_ROUTE = createRoute({
       await validateRunOwnership(run, effectiveResourceId);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
-      const result = await _run.resume(params);
+      const result = await _run.resume({ ...params, requestContext });
 
       return result;
     } catch (error) {
@@ -724,7 +725,7 @@ export const RESUME_WORKFLOW_ROUTE = createRoute({
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
 
-      void _run.resume(params);
+      void _run.resume({ ...params, requestContext });
 
       return { message: 'Workflow run resumed' };
     } catch (error) {
@@ -772,7 +773,7 @@ export const RESTART_ASYNC_WORKFLOW_ROUTE = createRoute({
       await validateRunOwnership(run, effectiveResourceId);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
-      const result = await _run.restart(params);
+      const result = await _run.restart({ ...params, requestContext });
 
       return result;
     } catch (error) {
@@ -821,7 +822,7 @@ export const RESTART_WORKFLOW_ROUTE = createRoute({
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
 
-      void _run.restart(params);
+      void _run.restart({ ...params, requestContext });
 
       return { message: 'Workflow run restarted' };
     } catch (error) {
@@ -931,7 +932,7 @@ export const TIME_TRAVEL_ASYNC_WORKFLOW_ROUTE = createRoute({
       await validateRunOwnership(run, effectiveResourceId);
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
-      const result = await _run.timeTravel(params);
+      const result = await _run.timeTravel({ ...params, requestContext });
 
       return result;
     } catch (error) {
@@ -980,7 +981,7 @@ export const TIME_TRAVEL_WORKFLOW_ROUTE = createRoute({
 
       const _run = await workflow.createRun({ runId, resourceId: run.resourceId });
 
-      void _run.timeTravel(params);
+      void _run.timeTravel({ ...params, requestContext });
 
       return { message: 'Workflow run time travel started' };
     } catch (error) {
@@ -1028,7 +1029,7 @@ export const TIME_TRAVEL_STREAM_WORKFLOW_ROUTE = createRoute({
       const serverCache = mastra.getServerCache();
 
       const run = await workflow.createRun({ runId, resourceId: existingRun.resourceId });
-      const result = run.timeTravelStream(params);
+      const result = run.timeTravelStream({ ...params, requestContext });
       return result.fullStream.pipeThrough(
         new TransformStream<ChunkType, ChunkType>({
           transform(chunk, controller) {
@@ -1129,6 +1130,7 @@ export const STREAM_LEGACY_WORKFLOW_ROUTE = createRoute({
       const run = await workflow.createRun({ runId, resourceId: effectiveResourceId });
       const result = run.streamLegacy({
         ...params,
+        requestContext,
         onChunk: async chunk => {
           if (serverCache) {
             const cacheKey = runId;


### PR DESCRIPTION
PR #12251 added authorization handling but destructured `requestContext` from handler params without passing it through to downstream operations. This broke tools and workflows that depend on `requestContext` values.

**Fixed:**
- `GENERATE_AGENT_ROUTE` and `STREAM_GENERATE_ROUTE` now pass `requestContext` to `agent.generate()` / `agent.stream()`
- All workflow run methods (`stream`, `start`, `resume`, `restart`, `timeTravel`, etc.) now receive `requestContext`

Added tests to verify `requestContext` is properly passed through.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where request context was not properly propagated through agent and workflow operations, causing tools and nested operations to lose critical context information. Request context is now consistently maintained throughout all agent generation, streaming, and workflow execution operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->