### PR TITLE
Remove deprecated text-embedding-004 model

### DIFF
--- a/.changeset/puny-candles-lose.md
+++ b/.changeset/puny-candles-lose.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Removed deprecated Google `text-embedding-004` embedding model from the model router. Google shut down this model on January 14, 2026. Use `google/gemini-embedding-001` instead.

--- a/docs/src/content/en/docs/memory/semantic-recall.mdx
+++ b/docs/src/content/en/docs/memory/semantic-recall.mdx
@@ -138,7 +138,7 @@ const agent = new Agent({
 Supported embedding models:
 
 - **OpenAI**: `text-embedding-3-small`, `text-embedding-3-large`, `text-embedding-ada-002`
-- **Google**: `gemini-embedding-001`, `text-embedding-004`
+- **Google**: `gemini-embedding-001`
 
 The model router automatically handles API key detection from environment variables (`OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`).
 

--- a/docs/src/content/en/docs/rag/vector-databases.mdx
+++ b/docs/src/content/en/docs/rag/vector-databases.mdx
@@ -400,7 +400,7 @@ The dimension size must match the output dimension of your chosen embedding mode
 
 - OpenAI text-embedding-3-small: 1536 dimensions (or custom, e.g., 256)
 - Cohere embed-multilingual-v3: 1024 dimensions
-- Google text-embedding-004: 768 dimensions (or custom)
+- Google gemini-embedding-001: 768 dimensions (or custom)
 
 :::warning
 Index dimensions cannot be changed after creation. To use a different model, delete and recreate the index with the new dimension size.

--- a/docs/src/content/en/models/embeddings.mdx
+++ b/docs/src/content/en/models/embeddings.mdx
@@ -36,8 +36,7 @@ const embedder = new ModelRouterEmbeddingModel("openai/text-embedding-3-small");
 
 ### Google
 
-- `gemini-embedding-001` - 768 dimensions (recommended), 2048 max tokens
-- `text-embedding-004` - 768 dimensions, 3072 max tokens
+- `gemini-embedding-001` - 768 dimensions, 2048 max tokens
 
 ```typescript
 const embedder = new ModelRouterEmbeddingModel("google/gemini-embedding-001");

--- a/packages/core/src/llm/model/embedding-router.integration.test.ts
+++ b/packages/core/src/llm/model/embedding-router.integration.test.ts
@@ -98,24 +98,12 @@ describe('ModelRouterEmbeddingModel Integration', () => {
         throw new Error('GOOGLE_GENERATIVE_AI_API_KEY is required for this test');
       }
 
-      const model = new ModelRouterEmbeddingModel('google/text-embedding-004');
+      const model = new ModelRouterEmbeddingModel('google/gemini-embedding-001');
       const result = await model.doEmbed({ values: ['hello world'] });
 
       expect(result.embeddings).toBeDefined();
       expect(result.embeddings.length).toBe(1);
       expect(result.embeddings[0].length).toBeGreaterThan(0);
-    });
-
-    it('should work with different Google models', async () => {
-      if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
-        throw new Error('GOOGLE_GENERATIVE_AI_API_KEY is required for this test');
-      }
-
-      const model = new ModelRouterEmbeddingModel('google/gemini-embedding-001');
-      const result = await model.doEmbed({ values: ['test'] });
-
-      expect(result.embeddings).toBeDefined();
-      expect(result.embeddings.length).toBe(1);
     });
   });
 

--- a/packages/core/src/llm/model/embedding-router.ts
+++ b/packages/core/src/llm/model/embedding-router.ts
@@ -52,13 +52,6 @@ export const EMBEDDING_MODELS: EmbeddingModelInfo[] = [
     maxInputTokens: 2048,
     description: 'Google gemini-embedding-001 model',
   },
-  {
-    id: 'text-embedding-004',
-    provider: 'google',
-    dimensions: 768,
-    maxInputTokens: 3072,
-    description: 'Google text-embedding-004 model',
-  },
 ];
 
 /**
@@ -68,8 +61,7 @@ export type EmbeddingModelId =
   | 'openai/text-embedding-3-small'
   | 'openai/text-embedding-3-large'
   | 'openai/text-embedding-ada-002'
-  | 'google/gemini-embedding-001'
-  | 'google/text-embedding-004';
+  | 'google/gemini-embedding-001';
 
 /**
  * Check if a model ID is a known embedding model


### PR DESCRIPTION
## Description

Removed the deprecated Google `text-embedding-004` embedding model from the model router. Google shut down this model on January 14, 2026. Users should migrate to `google/gemini-embedding-001`, which is the recommended replacement.

## Related Issue(s)

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the deprecated Google text-embedding-004 embedding model from the model router, as it's being discontinued by Google in January 2026. Migrate to Google Gemini Embedding model for continued compatibility.

* **Documentation**
  * Updated documentation to reflect the model removal and provide migration guidance to the supported Gemini embedding model.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->