### PR TITLE
fix(agent-builder): fix file naming conversion in template merger

### DIFF
--- a/.changeset/gentle-mugs-shop.md
+++ b/.changeset/gentle-mugs-shop.md
@@ -2,4 +2,4 @@
 '@mastra/agent-builder': patch
 ---
 
-Fixed file naming conversion when merging templates into projects with camelCase conventions. Kebab-case filenames like `csv-to-questions-workflow.ts` were incorrectly converted to all-lowercase (`csvtoquestionsworkflow.ts`) instead of proper camelCase (`csvToQuestionsWorkflow.ts`). The same issue affected PascalCase conversion.
+Fixed file naming conversion when merging templates. Kebab-case filenames like `csv-to-questions-workflow.ts` were incorrectly converted to all-lowercase (`csvtoquestionsworkflow.ts`) instead of proper camelCase (`csvToQuestionsWorkflow.ts`). PascalCase and acronym-boundary conversions are also fixed.

--- a/.changeset/gentle-mugs-shop.md
+++ b/.changeset/gentle-mugs-shop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/agent-builder': patch
+---
+
+Fixed file naming conversion when merging templates into projects with camelCase conventions. Kebab-case filenames like `csv-to-questions-workflow.ts` were incorrectly converted to all-lowercase (`csvtoquestionsworkflow.ts`) instead of proper camelCase (`csvToQuestionsWorkflow.ts`). The same issue affected PascalCase conversion.

--- a/packages/agent-builder/integration-tests/src/template-integration.test.ts
+++ b/packages/agent-builder/integration-tests/src/template-integration.test.ts
@@ -142,7 +142,9 @@ describe('Template Workflow Integration Tests', () => {
       { dir: 'src/mastra/agents', patterns: ['csvQuestionAgent.ts', 'csv-question-agent.ts'] },
       {
         dir: 'src/mastra/tools',
-        patterns: ['csvFetcherTool.ts', 'csv-fetcher-tool.ts', 'download-csv-tool.ts'],
+        // AI discovery may return export name (csvFetcherTool) or filename-based ID (download-csv-tool),
+        // and convertNaming then adapts to the target project's convention
+        patterns: ['csvFetcherTool.ts', 'csv-fetcher-tool.ts', 'download-csv-tool.ts', 'downloadCsvTool.ts'],
       },
       {
         dir: 'src/mastra/workflows',

--- a/packages/agent-builder/src/workflows/template-builder/template-builder.ts
+++ b/packages/agent-builder/src/workflows/template-builder/template-builder.ts
@@ -565,12 +565,16 @@ const programmaticFileCopyStep = createStep({
 
         // Helper: split a name into words by hyphens, underscores, or camelCase boundaries
         const toWords = (s: string): string[] => {
-          return s
-            .replace(/[-_]/g, ' ')
-            .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-            .split(/\s+/)
-            .filter(Boolean)
-            .map(w => w.toLowerCase());
+          return (
+            s
+              .replace(/[-_]/g, ' ')
+              // split "HTTPServer" -> "HTTP Server"
+              .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+              .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+              .split(/\s+/)
+              .filter(Boolean)
+              .map(w => w.toLowerCase())
+          );
         };
 
         const words = toWords(baseName);

--- a/packages/agent-builder/src/workflows/template-builder/template-builder.ts
+++ b/packages/agent-builder/src/workflows/template-builder/template-builder.ts
@@ -563,27 +563,27 @@ const programmaticFileCopyStep = createStep({
         const baseName = basename(name, extname(name));
         const ext = extname(name);
 
+        // Helper: split a name into words by hyphens, underscores, or camelCase boundaries
+        const toWords = (s: string): string[] => {
+          return s
+            .replace(/[-_]/g, ' ')
+            .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+            .split(/\s+/)
+            .filter(Boolean)
+            .map(w => w.toLowerCase());
+        };
+
+        const words = toWords(baseName);
+
         switch (convention) {
           case 'camelCase':
-            return (
-              baseName
-                .replace(/[-_]/g, '')
-                .replace(/([A-Z])/g, (match, p1, offset) => (offset === 0 ? p1.toLowerCase() : p1)) + ext
-            );
+            return words.map((w, i) => (i === 0 ? w : w.charAt(0).toUpperCase() + w.slice(1))).join('') + ext;
           case 'snake_case':
-            return (
-              baseName
-                .replace(/[-]/g, '_')
-                .replace(/([A-Z])/g, (match, p1, offset) => (offset === 0 ? '' : '_') + p1.toLowerCase()) + ext
-            );
+            return words.join('_') + ext;
           case 'kebab-case':
-            return (
-              baseName
-                .replace(/[_]/g, '-')
-                .replace(/([A-Z])/g, (match, p1, offset) => (offset === 0 ? '' : '-') + p1.toLowerCase()) + ext
-            );
+            return words.join('-') + ext;
           case 'PascalCase':
-            return baseName.replace(/[-_]/g, '').replace(/^[a-z]/, match => match.toUpperCase()) + ext;
+            return words.map(w => w.charAt(0).toUpperCase() + w.slice(1)).join('') + ext;
           default:
             return name;
         }


### PR DESCRIPTION
## Description

Fixed a bug in the `convertNaming` function that incorrectly converted kebab-case filenames to all-lowercase when merging templates into projects with camelCase conventions. The function was stripping hyphens and underscores without properly capitalizing the following letters, causing names like `csv-to-questions-workflow` to become `csvtoquestionsworkflow` instead of `csvToQuestionsWorkflow`.

This fix rewrites the conversion logic to properly decompose names into words first (splitting on hyphens, underscores, and camelCase boundaries), then reassembles them according to the target naming convention. The same issue affected PascalCase and snake_case conversions, which are now also fixed.

- **OLD** `convertNaming`: `csv-to-questions-workflow.ts` → `csvtoquestionsworkflow.ts` — doesn’t match either accepted pattern → FAIL

- **NEW** `convertNaming`: `csv-to-questions-workflow.ts` → `csvToQuestionsWorkflow.ts` — matches the first accepted pattern → PASS

The old code stripped hyphens without capitalizing the following letters, producing all-lowercase. The fix properly splits into words and capitalizes each word boundary.

## Related Issue(s)

Fixes #21451308580 (CI test failure)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved original filename casing and word boundaries when applying template file naming conventions (kebab, snake, camel, Pascal, acronyms), preventing unintended mangling.
  * No changes to public interfaces or exported declarations.

* **Tests**
  * Expanded integration test patterns to cover additional file-naming variants.

* **Chores**
  * Added a patch changelog entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->