### PR TITLE
refactor(workspace): inline constants for backwards compatibility

### DIFF
--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -12,8 +12,7 @@ The `Workspace` class combines a filesystem and sandbox to provide agents with f
 ## Usage Example
 
 ```typescript
-import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace';
-import { WORKSPACE_TOOLS } from '@mastra/core/workspace/constants';
+import { Workspace, LocalFilesystem, LocalSandbox, WORKSPACE_TOOLS } from '@mastra/core/workspace';
 
 const workspace = new Workspace({
   id: 'my-workspace',

--- a/examples/unified-workspace/src/mastra/workspaces.ts
+++ b/examples/unified-workspace/src/mastra/workspaces.ts
@@ -1,7 +1,6 @@
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace';
-import { WORKSPACE_TOOLS } from '@mastra/core/workspace/constants';
+import { Workspace, LocalFilesystem, LocalSandbox, WORKSPACE_TOOLS } from '@mastra/core/workspace';
 
 /**
  * Get the project root directory.

--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -43,6 +43,9 @@ export type { WorkspaceSandbox, ExecutionResult, CommandResult, ExecuteCommandOp
 export type { IsolationBackend, NativeSandboxConfig, SandboxDetectionResult } from './sandbox';
 export { detectIsolation, isIsolationAvailable, getRecommendedIsolation } from './sandbox';
 
+// Constants
+export { WORKSPACE_TOOLS_PREFIX, WORKSPACE_TOOLS, type WorkspaceToolName } from './constants';
+
 // Skills
 export type {
   SkillFormat,

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -50,7 +50,6 @@ export default defineConfig({
     'src/tools/is-vercel-tool.ts',
     'src/workflows/constants.ts',
     'src/storage/constants.ts',
-    'src/workspace/constants/index.ts',
     'src/workflows/evented/index.ts',
     'src/network/index.ts',
     'src/network/vNext/index.ts',

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
@@ -14,7 +14,7 @@ import { AgentIcon } from '@/ds/icons';
 import { GaugeIcon, Folder } from 'lucide-react';
 import { AgentMetadataModelList, AgentMetadataModelListProps } from './agent-metadata-model-list';
 import { LoadingBadge } from '@/lib/ai-ui/tools/badges/loading-badge';
-import { WORKSPACE_TOOLS_PREFIX } from '@mastra/core/workspace/constants';
+import { WORKSPACE_TOOLS_PREFIX } from '@/domains/workspace/constants';
 import { Alert, AlertTitle, AlertDescription } from '@/ds/components/Alert';
 import { PromptEnhancer } from '../agent-information/agent-instructions-enhancer';
 import { useReorderModelList, useUpdateModelInModelList } from '../../hooks/use-agents';

--- a/packages/playground-ui/src/domains/workspace/constants.ts
+++ b/packages/playground-ui/src/domains/workspace/constants.ts
@@ -1,18 +1,12 @@
+/**
+ * Workspace tool constants.
+ *
+ * Inlined from @mastra/core/workspace/constants to avoid import compatibility
+ * issues with older core versions that don't have the workspace module.
+ */
+
 export const WORKSPACE_TOOLS_PREFIX = 'mastra_workspace' as const;
 
-/**
- * Workspace tool name constants.
- * Use these to reference workspace tools by name.
- *
- * @example
- * ```typescript
- * import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
- *
- * if (toolName === WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND) {
- *   // Handle sandbox execution
- * }
- * ```
- */
 export const WORKSPACE_TOOLS = {
   FILESYSTEM: {
     READ_FILE: `${WORKSPACE_TOOLS_PREFIX}_read_file` as const,
@@ -32,9 +26,6 @@ export const WORKSPACE_TOOLS = {
   },
 } as const;
 
-/**
- * Type representing any workspace tool name.
- */
 export type WorkspaceToolName =
   | (typeof WORKSPACE_TOOLS.FILESYSTEM)[keyof typeof WORKSPACE_TOOLS.FILESYSTEM]
   | (typeof WORKSPACE_TOOLS.SEARCH)[keyof typeof WORKSPACE_TOOLS.SEARCH]

--- a/packages/playground-ui/src/lib/ai-ui/tools/badges/sandbox-execution-badge.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/badges/sandbox-execution-badge.tsx
@@ -1,5 +1,5 @@
 import { MastraUIMessage } from '@mastra/react';
-import { WORKSPACE_TOOLS } from '@mastra/core/workspace/constants';
+import { WORKSPACE_TOOLS } from '@/domains/workspace/constants';
 import { ToolApprovalButtons, ToolApprovalButtonsProps } from './tool-approval-buttons';
 import { useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';

--- a/packages/playground-ui/src/lib/ai-ui/tools/tool-fallback.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/tool-fallback.tsx
@@ -1,6 +1,6 @@
 import { ToolCallMessagePartProps } from '@assistant-ui/react';
 import { useEffect } from 'react';
-import { WORKSPACE_TOOLS } from '@mastra/core/workspace/constants';
+import { WORKSPACE_TOOLS } from '@/domains/workspace/constants';
 
 import { ToolBadge } from './badges/tool-badge';
 import { SandboxExecutionBadge } from './badges/sandbox-execution-badge';

--- a/packages/server/src/server/constants.ts
+++ b/packages/server/src/server/constants.ts
@@ -1,0 +1,86 @@
+/**
+ * Workspace tool constants and utilities.
+ *
+ * Inlined from @mastra/core/workspace to avoid import compatibility
+ * issues with older core versions that don't have the workspace module.
+ */
+
+export const WORKSPACE_TOOLS_PREFIX = 'mastra_workspace' as const;
+
+export const WORKSPACE_TOOLS = {
+  FILESYSTEM: {
+    READ_FILE: `${WORKSPACE_TOOLS_PREFIX}_read_file` as const,
+    WRITE_FILE: `${WORKSPACE_TOOLS_PREFIX}_write_file` as const,
+    EDIT_FILE: `${WORKSPACE_TOOLS_PREFIX}_edit_file` as const,
+    LIST_FILES: `${WORKSPACE_TOOLS_PREFIX}_list_files` as const,
+    DELETE: `${WORKSPACE_TOOLS_PREFIX}_delete` as const,
+    FILE_STAT: `${WORKSPACE_TOOLS_PREFIX}_file_stat` as const,
+    MKDIR: `${WORKSPACE_TOOLS_PREFIX}_mkdir` as const,
+  },
+  SANDBOX: {
+    EXECUTE_COMMAND: `${WORKSPACE_TOOLS_PREFIX}_execute_command` as const,
+  },
+  SEARCH: {
+    SEARCH: `${WORKSPACE_TOOLS_PREFIX}_search` as const,
+    INDEX: `${WORKSPACE_TOOLS_PREFIX}_index` as const,
+  },
+} as const;
+
+export type WorkspaceToolName =
+  | (typeof WORKSPACE_TOOLS.FILESYSTEM)[keyof typeof WORKSPACE_TOOLS.FILESYSTEM]
+  | (typeof WORKSPACE_TOOLS.SEARCH)[keyof typeof WORKSPACE_TOOLS.SEARCH]
+  | (typeof WORKSPACE_TOOLS.SANDBOX)[keyof typeof WORKSPACE_TOOLS.SANDBOX];
+
+/**
+ * Configuration for a single workspace tool.
+ */
+export interface WorkspaceToolConfig {
+  enabled?: boolean;
+  requireApproval?: boolean;
+  requireReadBeforeWrite?: boolean;
+}
+
+/**
+ * Configuration for workspace tools.
+ */
+export type WorkspaceToolsConfig = {
+  enabled?: boolean;
+  requireApproval?: boolean;
+} & Partial<Record<WorkspaceToolName, WorkspaceToolConfig>>;
+
+/**
+ * Resolve the effective configuration for a workspace tool.
+ * Inlined from @mastra/core/workspace for compatibility.
+ */
+export function resolveToolConfig(
+  toolsConfig: WorkspaceToolsConfig | undefined,
+  toolName: WorkspaceToolName,
+): { enabled: boolean; requireApproval: boolean; requireReadBeforeWrite?: boolean } {
+  let enabled = true;
+  let requireApproval = false;
+  let requireReadBeforeWrite: boolean | undefined;
+
+  if (toolsConfig) {
+    if (toolsConfig.enabled !== undefined) {
+      enabled = toolsConfig.enabled;
+    }
+    if (toolsConfig.requireApproval !== undefined) {
+      requireApproval = toolsConfig.requireApproval;
+    }
+
+    const perToolConfig = toolsConfig[toolName];
+    if (perToolConfig) {
+      if (perToolConfig.enabled !== undefined) {
+        enabled = perToolConfig.enabled;
+      }
+      if (perToolConfig.requireApproval !== undefined) {
+        requireApproval = perToolConfig.requireApproval;
+      }
+      if (perToolConfig.requireReadBeforeWrite !== undefined) {
+        requireReadBeforeWrite = perToolConfig.requireReadBeforeWrite;
+      }
+    }
+  }
+
+  return { enabled, requireApproval, requireReadBeforeWrite };
+}

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -11,11 +11,11 @@ import type {
 } from '@mastra/core/processors';
 import type { RequestContext } from '@mastra/core/request-context';
 import { zodToJsonSchema } from '@mastra/core/utils/zod-to-json';
-import { resolveToolConfig } from '@mastra/core/workspace';
-import { WORKSPACE_TOOLS } from '@mastra/core/workspace/constants';
-import type { WorkspaceToolName } from '@mastra/core/workspace/constants';
 import { stringify } from 'superjson';
+
 import { z } from 'zod';
+import { WORKSPACE_TOOLS, resolveToolConfig } from '../constants';
+import type { WorkspaceToolName } from '../constants';
 
 import { HTTPException } from '../http-exception';
 import {


### PR DESCRIPTION
## Summary

- Inline workspace constants in server and playground-ui packages to avoid import compatibility issues with older core versions that don't have the workspace module
- Consolidate constants export into main `@mastra/core/workspace` (remove separate `/constants` entry point)
- Remove redundant `TOOLS_NAMESPACE` alias

## Changes

| Package | Change |
|---------|--------|
| `core` | Added constants exports to main `workspace/index.ts` |
| `core` | Removed `/workspace/constants` entry from `tsup.config.ts` |
| `core` | Removed redundant `TOOLS_NAMESPACE` alias |
| `server` | Inlined constants in `server/constants.ts` |
| `playground-ui` | Moved constants to `domains/workspace/constants.ts` |
| `docs` | Updated to single import from `@mastra/core/workspace` |
| `examples` | Updated to single import from `@mastra/core/workspace` |

## Why

Server and playground-ui have peer dependencies on `@mastra/core` with wide version ranges (`>=1.0.0-0 <2.0.0-0`). Importing from `@mastra/core/workspace` would break for users with older core versions that don't have the workspace module.

By inlining the constants, these packages remain compatible with older core versions while still supporting the new workspace features.

## Test plan

- [x] Full build passes
- [x] No runtime imports from `@mastra/core/workspace/constants` in server or playground-ui

🤖 Generated with [Claude Code](https://claude.ai/code)