### PR TITLE
Fix: inline deepEqual in server handlers instead of importing from core

### DIFF
--- a/.changeset/dry-knives-rhyme.md
+++ b/.changeset/dry-knives-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fix broken import for deepEqual by inlining the function into server.

--- a/packages/server/src/server/handlers/agent-versions.ts
+++ b/packages/server/src/server/handlers/agent-versions.ts
@@ -1,4 +1,3 @@
-import { deepEqual } from '@mastra/core/utils';
 import { HTTPException } from '../http-exception';
 import {
   agentVersionPathParams,
@@ -24,6 +23,48 @@ export const DEFAULT_MAX_VERSIONS_PER_AGENT = 50;
 // ============================================================================
 // Helper Functions (exported for use in stored-agents.ts)
 // ============================================================================
+
+/**
+ * Deep equality comparison for comparing two values.
+ * Handles primitives, arrays, objects, and Date instances.
+ * TODO: Move to a shared utils package that gets bundled into each package
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+  // Handle identical references and primitives
+  if (a === b) return true;
+
+  // Handle null/undefined
+  if (a == null || b == null) return a === b;
+
+  // Handle different types
+  if (typeof a !== typeof b) return false;
+
+  // Handle arrays
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((item, index) => deepEqual(item, b[index]));
+  }
+
+  // Handle dates (must check before generic objects since Date is also an object)
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+
+  // Handle objects (after Date check to avoid treating Dates as plain objects)
+  if (typeof a === 'object' && typeof b === 'object') {
+    const aObj = a as Record<string, unknown>;
+    const bObj = b as Record<string, unknown>;
+    const aKeys = Object.keys(aObj);
+    const bKeys = Object.keys(bObj);
+
+    if (aKeys.length !== bKeys.length) return false;
+
+    // Verify that bObj has the same keys as aObj before comparing values
+    return aKeys.every(key => Object.prototype.hasOwnProperty.call(bObj, key) && deepEqual(aObj[key], bObj[key]));
+  }
+
+  return false;
+}
 
 /**
  * Generates a unique ID for a version using crypto.randomUUID()


### PR DESCRIPTION
## Summary

Fixes a broken import issue where `@mastra/server` imports `deepEqual` from `@mastra/core/utils`, but older versions of `@mastra/core` don't export this function.

## Problem

PR #12038 introduced `deepEqual` to `@mastra/core/utils` and updated `@mastra/server` to import it. However, when a user's project resolves to an older version of `@mastra/core` (via peer dependencies), the server fails to start because the import doesn't exist.

## Solution

Inline the `deepEqual` function directly into `packages/server/src/server/handlers/agent-versions.ts` instead of importing it from core. This removes the dependency on core exporting this function, ensuring backwards compatibility with older core versions.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)