### PR TITLE
Peer dependencies compatibility

### DIFF
--- a/.changeset/dry-knives-rhyme.md
+++ b/.changeset/dry-knives-rhyme.md
@@ -1,5 +1,0 @@
----
-'@mastra/server': patch
----
-
-Fix broken import for deepEqual by inlining the function into server.

--- a/.changeset/peer-deps-cloudflare-fix.md
+++ b/.changeset/peer-deps-cloudflare-fix.md
@@ -12,11 +12,7 @@ Fix peer dependency compatibility issues and standardize on `fast-deep-equal`:
 
 - Update @mastra/cloudflare peer dependency from >=1.0.0-0 to >=1.1.0-0 to ensure compatibility with new agent versioning exports.
 
-- Add `getSchemas()`, `getSchema(tableName)`, and `hasSchema(tableName)` methods to `StorageDomain` base class. These provide a backwards-compatible way to access table schemas - packages can check for schema availability before using them, ensuring compatibility across different core versions.
-
-- Update storage adapters (pg, libsql, mongodb, cloudflare, clickhouse) to use local constants for `TABLE_AGENT_VERSIONS` instead of importing from core, avoiding import failures with older core versions.
-
-- Update storage adapters to use `#safeGetSchema()` helper in `init()` for backwards-compatible table creation that checks if `getSchema` method exists.
+- Add `getSchemas()`, `getSchema(tableName)`, and `hasSchema(tableName)` methods to `StorageDomain` base class. These provide a way to access table schemas dynamically.
 
 - Update server handlers to check if new Mastra methods exist before calling them:
   - `mastra.getStoredAgentById()` - check before calling in agent lookup
@@ -28,4 +24,4 @@ Fix peer dependency compatibility issues and standardize on `fast-deep-equal`:
 
 - Add graceful degradation in `handleAutoVersioning()` to skip versioning entirely when core version doesn't support versioning methods.
 
-- Standardize on `fast-deep-equal` package for deep equality comparisons instead of custom implementation. Remove custom `deepEqual` from core utils.ts and use `fast-deep-equal` in both core and server. This avoids backwards-compatibility issues and uses a well-tested library.
+- Standardize on `fast-deep-equal` package for deep equality comparisons instead of custom implementation. Remove custom `deepEqual` from core utils.ts and use `fast-deep-equal` in both core and server.

--- a/.changeset/peer-deps-cloudflare-fix.md
+++ b/.changeset/peer-deps-cloudflare-fix.md
@@ -1,0 +1,5 @@
+---
+'@mastra/cloudflare': patch
+---
+
+Update peer dependency for @mastra/core from >=1.0.0-0 to >=1.1.0-0 to ensure compatibility with new agent versioning exports (TABLE_AGENT_VERSIONS, AgentVersion) that were introduced in core 1.1.0.

--- a/.changeset/peer-deps-cloudflare-fix.md
+++ b/.changeset/peer-deps-cloudflare-fix.md
@@ -8,7 +8,7 @@
 '@mastra/server': patch
 ---
 
-Fix peer dependency compatibility issues:
+Fix peer dependency compatibility issues and standardize on `fast-deep-equal`:
 
 - Update @mastra/cloudflare peer dependency from >=1.0.0-0 to >=1.1.0-0 to ensure compatibility with new agent versioning exports.
 
@@ -27,3 +27,5 @@ Fix peer dependency compatibility issues:
 - Add `assertVersioningSupported()` helper to agent version routes that returns a 501 Not Implemented error with helpful message if versioning methods don't exist on the agents store.
 
 - Add graceful degradation in `handleAutoVersioning()` to skip versioning entirely when core version doesn't support versioning methods.
+
+- Standardize on `fast-deep-equal` package for deep equality comparisons instead of custom implementation. Remove custom `deepEqual` from core utils.ts and use `fast-deep-equal` in both core and server. This avoids backwards-compatibility issues and uses a well-tested library.

--- a/.changeset/peer-deps-cloudflare-fix.md
+++ b/.changeset/peer-deps-cloudflare-fix.md
@@ -15,7 +15,7 @@ Fix peer dependency compatibility issues and standardize on `fast-deep-equal`:
 
 - Add `getSchemas()`, `getSchema(tableName)`, and `hasSchema(tableName)` methods to `StorageDomain` base class. These provide a way to access table schemas dynamically.
 
-- Storage adapters now import `TABLE_AGENT_VERSIONS` and `toTraceSpans` directly from core. Peer dependency requirements (>=1.1.0-0) ensure these exports are available.
+- Storage adapters now use namespace imports (`import * as coreStorage`) with destructuring for cleaner access to core exports like `TABLE_AGENT_VERSIONS` and `toTraceSpans`. Peer dependency requirements (>=1.1.0-0) ensure these exports are available.
 
 - Update server handlers to check if new Mastra methods exist before calling them:
   - `mastra.getStoredAgentById()` - check before calling in agent lookup

--- a/.changeset/peer-deps-cloudflare-fix.md
+++ b/.changeset/peer-deps-cloudflare-fix.md
@@ -1,10 +1,18 @@
 ---
 '@mastra/cloudflare': patch
 '@mastra/core': patch
+'@mastra/pg': patch
+'@mastra/libsql': patch
+'@mastra/mongodb': patch
+'@mastra/clickhouse': patch
 ---
 
 Fix peer dependency compatibility issues:
 
-- Update @mastra/cloudflare peer dependency from >=1.0.0-0 to >=1.1.0-0 to ensure compatibility with new agent versioning exports (TABLE_AGENT_VERSIONS, AgentVersion) introduced in core 1.1.0.
+- Update @mastra/cloudflare peer dependency from >=1.0.0-0 to >=1.1.0-0 to ensure compatibility with new agent versioning exports.
 
 - Add `getSchemas()`, `getSchema(tableName)`, and `hasSchema(tableName)` methods to `StorageDomain` base class. These provide a backwards-compatible way to access table schemas - packages can check for schema availability before using them, ensuring compatibility across different core versions.
+
+- Update storage adapters (pg, libsql, mongodb, cloudflare, clickhouse) to use local constants for `TABLE_AGENT_VERSIONS` instead of importing from core, avoiding import failures with older core versions.
+
+- Update storage adapters to use `getSchema()` method in `init()` for backwards-compatible table creation.

--- a/.changeset/peer-deps-cloudflare-fix.md
+++ b/.changeset/peer-deps-cloudflare-fix.md
@@ -14,6 +14,8 @@ Fix peer dependency compatibility issues and standardize on `fast-deep-equal`:
 
 - Add `getSchemas()`, `getSchema(tableName)`, and `hasSchema(tableName)` methods to `StorageDomain` base class. These provide a way to access table schemas dynamically.
 
+- Storage adapters now use dynamic access for `TABLE_AGENT_VERSIONS` with fallback for backwards compatibility with older core versions.
+
 - Update server handlers to check if new Mastra methods exist before calling them:
   - `mastra.getStoredAgentById()` - check before calling in agent lookup
   - `mastra.listStoredAgents()` - check before calling in agent list and scorers

--- a/.changeset/peer-deps-cloudflare-fix.md
+++ b/.changeset/peer-deps-cloudflare-fix.md
@@ -14,7 +14,7 @@ Fix peer dependency compatibility issues and standardize on `fast-deep-equal`:
 
 - Add `getSchemas()`, `getSchema(tableName)`, and `hasSchema(tableName)` methods to `StorageDomain` base class. These provide a way to access table schemas dynamically.
 
-- Storage adapters now use dynamic access for `TABLE_AGENT_VERSIONS` with fallback for backwards compatibility with older core versions.
+- Storage adapters now use dynamic access for `TABLE_AGENT_VERSIONS` and `toTraceSpans` with fallback for backwards compatibility with older core versions.
 
 - Update server handlers to check if new Mastra methods exist before calling them:
   - `mastra.getStoredAgentById()` - check before calling in agent lookup

--- a/.changeset/peer-deps-cloudflare-fix.md
+++ b/.changeset/peer-deps-cloudflare-fix.md
@@ -1,5 +1,10 @@
 ---
 '@mastra/cloudflare': patch
+'@mastra/core': patch
 ---
 
-Update peer dependency for @mastra/core from >=1.0.0-0 to >=1.1.0-0 to ensure compatibility with new agent versioning exports (TABLE_AGENT_VERSIONS, AgentVersion) that were introduced in core 1.1.0.
+Fix peer dependency compatibility issues:
+
+- Update @mastra/cloudflare peer dependency from >=1.0.0-0 to >=1.1.0-0 to ensure compatibility with new agent versioning exports (TABLE_AGENT_VERSIONS, AgentVersion) introduced in core 1.1.0.
+
+- Add `getSchemas()`, `getSchema(tableName)`, and `hasSchema(tableName)` methods to `StorageDomain` base class. These provide a backwards-compatible way to access table schemas - packages can check for schema availability before using them, ensuring compatibility across different core versions.

--- a/.changeset/peer-deps-cloudflare-fix.md
+++ b/.changeset/peer-deps-cloudflare-fix.md
@@ -22,3 +22,8 @@ Fix peer dependency compatibility issues:
   - `mastra.getStoredAgentById()` - check before calling in agent lookup
   - `mastra.listStoredAgents()` - check before calling in agent list and scorers
   - `agentsStore.getAgentByIdResolved()` - fall back to `getAgentById()` if not available
+  - `mastra.clearStoredAgentCache()` - check before calling in stored agent update/delete
+
+- Add `assertVersioningSupported()` helper to agent version routes that returns a 501 Not Implemented error with helpful message if versioning methods don't exist on the agents store.
+
+- Add graceful degradation in `handleAutoVersioning()` to skip versioning entirely when core version doesn't support versioning methods.

--- a/.changeset/peer-deps-cloudflare-fix.md
+++ b/.changeset/peer-deps-cloudflare-fix.md
@@ -5,6 +5,7 @@
 '@mastra/libsql': patch
 '@mastra/mongodb': patch
 '@mastra/clickhouse': patch
+'@mastra/mssql': patch
 '@mastra/server': patch
 ---
 
@@ -14,7 +15,7 @@ Fix peer dependency compatibility issues and standardize on `fast-deep-equal`:
 
 - Add `getSchemas()`, `getSchema(tableName)`, and `hasSchema(tableName)` methods to `StorageDomain` base class. These provide a way to access table schemas dynamically.
 
-- Storage adapters now use dynamic access for `TABLE_AGENT_VERSIONS` and `toTraceSpans` with fallback for backwards compatibility with older core versions.
+- Storage adapters now import `TABLE_AGENT_VERSIONS` and `toTraceSpans` directly from core. Peer dependency requirements (>=1.1.0-0) ensure these exports are available.
 
 - Update server handlers to check if new Mastra methods exist before calling them:
   - `mastra.getStoredAgentById()` - check before calling in agent lookup

--- a/.changeset/peer-deps-cloudflare-fix.md
+++ b/.changeset/peer-deps-cloudflare-fix.md
@@ -5,6 +5,7 @@
 '@mastra/libsql': patch
 '@mastra/mongodb': patch
 '@mastra/clickhouse': patch
+'@mastra/server': patch
 ---
 
 Fix peer dependency compatibility issues:
@@ -15,4 +16,9 @@ Fix peer dependency compatibility issues:
 
 - Update storage adapters (pg, libsql, mongodb, cloudflare, clickhouse) to use local constants for `TABLE_AGENT_VERSIONS` instead of importing from core, avoiding import failures with older core versions.
 
-- Update storage adapters to use `getSchema()` method in `init()` for backwards-compatible table creation.
+- Update storage adapters to use `#safeGetSchema()` helper in `init()` for backwards-compatible table creation that checks if `getSchema` method exists.
+
+- Update server handlers to check if new Mastra methods exist before calling them:
+  - `mastra.getStoredAgentById()` - check before calling in agent lookup
+  - `mastra.listStoredAgents()` - check before calling in agent list and scorers
+  - `agentsStore.getAgentByIdResolved()` - fall back to `getAgentById()` if not available

--- a/packages/core/src/storage/domains/agents/inmemory.ts
+++ b/packages/core/src/storage/domains/agents/inmemory.ts
@@ -1,4 +1,4 @@
-import { deepEqual } from '../../../utils';
+import deepEqual from 'fast-deep-equal';
 import { normalizePerPage, calculatePagination } from '../../base';
 import type {
   StorageAgentType,

--- a/packages/core/src/storage/domains/base.ts
+++ b/packages/core/src/storage/domains/base.ts
@@ -1,4 +1,12 @@
 import { MastraBase } from '../../base';
+import { TABLE_SCHEMAS } from '../constants';
+import type { TABLE_NAMES } from '../constants';
+import type { StorageColumn } from '../types';
+
+/**
+ * Schema registry type - maps table names to their column schemas.
+ */
+export type SchemaRegistry = Record<TABLE_NAMES, Record<string, StorageColumn>>;
 
 /**
  * Base class for all storage domains.
@@ -20,4 +28,61 @@ export abstract class StorageDomain extends MastraBase {
    * Primarily used for testing.
    */
   abstract dangerouslyClearAll(): Promise<void>;
+
+  /**
+   * Returns all available table schemas from this version of core.
+   * This provides a backwards-compatible way to access schemas - the method
+   * exists in all versions, returning the schemas available in that version.
+   *
+   * Use this instead of directly importing TABLE_SCHEMAS to ensure compatibility
+   * with different versions of @mastra/core.
+   *
+   * @example
+   * ```typescript
+   * const schemas = this.getSchemas();
+   * if ('mastra_agent_versions' in schemas) {
+   *   // Agent versioning is supported in this core version
+   *   await db.createTable({ tableName: 'mastra_agent_versions', schema: schemas['mastra_agent_versions'] });
+   * }
+   * ```
+   */
+  getSchemas(): SchemaRegistry {
+    return TABLE_SCHEMAS;
+  }
+
+  /**
+   * Returns the schema for a specific table if it exists in this version of core.
+   * Returns undefined if the table schema is not available.
+   *
+   * @param tableName - The name of the table to get the schema for
+   * @returns The table schema or undefined if not available
+   *
+   * @example
+   * ```typescript
+   * const agentVersionsSchema = this.getSchema('mastra_agent_versions');
+   * if (agentVersionsSchema) {
+   *   await db.createTable({ tableName: 'mastra_agent_versions', schema: agentVersionsSchema });
+   * }
+   * ```
+   */
+  getSchema(tableName: string): Record<string, StorageColumn> | undefined {
+    return (TABLE_SCHEMAS as Record<string, Record<string, StorageColumn>>)[tableName];
+  }
+
+  /**
+   * Checks if a table schema is available in this version of core.
+   *
+   * @param tableName - The name of the table to check
+   * @returns true if the schema exists, false otherwise
+   *
+   * @example
+   * ```typescript
+   * if (this.hasSchema('mastra_agent_versions')) {
+   *   // Agent versioning is supported
+   * }
+   * ```
+   */
+  hasSchema(tableName: string): boolean {
+    return tableName in TABLE_SCHEMAS;
+  }
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -57,47 +57,6 @@ export function deepMerge<T extends object = object>(target: T, source: Partial<
   return output;
 }
 
-/**
- * Deep equality comparison for comparing two values.
- * Handles primitives, arrays, objects, and Date instances.
- */
-export function deepEqual(a: unknown, b: unknown): boolean {
-  // Handle identical references and primitives
-  if (a === b) return true;
-
-  // Handle null/undefined
-  if (a == null || b == null) return a === b;
-
-  // Handle different types
-  if (typeof a !== typeof b) return false;
-
-  // Handle arrays
-  if (Array.isArray(a) && Array.isArray(b)) {
-    if (a.length !== b.length) return false;
-    return a.every((item, index) => deepEqual(item, b[index]));
-  }
-
-  // Handle dates (must check before generic objects since Date is also an object)
-  if (a instanceof Date && b instanceof Date) {
-    return a.getTime() === b.getTime();
-  }
-
-  // Handle objects (after Date check to avoid treating Dates as plain objects)
-  if (typeof a === 'object' && typeof b === 'object') {
-    const aObj = a as Record<string, unknown>;
-    const bObj = b as Record<string, unknown>;
-    const aKeys = Object.keys(aObj);
-    const bKeys = Object.keys(bObj);
-
-    if (aKeys.length !== bKeys.length) return false;
-
-    // Verify that bObj has the same keys as aObj before comparing values
-    return aKeys.every(key => Object.prototype.hasOwnProperty.call(bObj, key) && deepEqual(aObj[key], bObj[key]));
-  }
-
-  return false;
-}
-
 export function generateEmptyFromSchema(schema: string) {
   try {
     const parsedSchema = JSON.parse(schema);

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -120,6 +120,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
+    "fast-deep-equal": "^3.1.3",
     "hono": "^4.11.3"
   }
 }

--- a/packages/server/src/server/handlers/agent-versions.ts
+++ b/packages/server/src/server/handlers/agent-versions.ts
@@ -43,7 +43,10 @@ function assertVersioningSupported(agentsStore: any): void {
 /**
  * Deep equality comparison for comparing two values.
  * Handles primitives, arrays, objects, and Date instances.
- * TODO: Move to a shared utils package that gets bundled into each package
+ *
+ * NOTE: This function is inlined rather than imported from @mastra/core/utils
+ * to ensure backwards compatibility with older core versions that don't export it.
+ * See: https://github.com/mastra-ai/mastra/pull/12446
  */
 function deepEqual(a: unknown, b: unknown): boolean {
   // Handle identical references and primitives

--- a/packages/server/src/server/handlers/agent-versions.ts
+++ b/packages/server/src/server/handlers/agent-versions.ts
@@ -1,3 +1,5 @@
+import deepEqual from 'fast-deep-equal';
+
 import { HTTPException } from '../http-exception';
 import {
   agentVersionPathParams,
@@ -39,51 +41,6 @@ function assertVersioningSupported(agentsStore: any): void {
 // ============================================================================
 // Helper Functions (exported for use in stored-agents.ts)
 // ============================================================================
-
-/**
- * Deep equality comparison for comparing two values.
- * Handles primitives, arrays, objects, and Date instances.
- *
- * NOTE: This function is inlined rather than imported from @mastra/core/utils
- * to ensure backwards compatibility with older core versions that don't export it.
- * See: https://github.com/mastra-ai/mastra/pull/12446
- */
-function deepEqual(a: unknown, b: unknown): boolean {
-  // Handle identical references and primitives
-  if (a === b) return true;
-
-  // Handle null/undefined
-  if (a == null || b == null) return a === b;
-
-  // Handle different types
-  if (typeof a !== typeof b) return false;
-
-  // Handle arrays
-  if (Array.isArray(a) && Array.isArray(b)) {
-    if (a.length !== b.length) return false;
-    return a.every((item, index) => deepEqual(item, b[index]));
-  }
-
-  // Handle dates (must check before generic objects since Date is also an object)
-  if (a instanceof Date && b instanceof Date) {
-    return a.getTime() === b.getTime();
-  }
-
-  // Handle objects (after Date check to avoid treating Dates as plain objects)
-  if (typeof a === 'object' && typeof b === 'object') {
-    const aObj = a as Record<string, unknown>;
-    const bObj = b as Record<string, unknown>;
-    const aKeys = Object.keys(aObj);
-    const bKeys = Object.keys(bObj);
-
-    if (aKeys.length !== bKeys.length) return false;
-
-    // Verify that bObj has the same keys as aObj before comparing values
-    return aKeys.every(key => Object.prototype.hasOwnProperty.call(bObj, key) && deepEqual(aObj[key], bObj[key]));
-  }
-
-  return false;
-}
 
 /**
  * Generates a unique ID for a version using crypto.randomUUID()

--- a/packages/server/src/server/handlers/agent-versions.ts
+++ b/packages/server/src/server/handlers/agent-versions.ts
@@ -20,6 +20,22 @@ import { handleError } from './error';
 // Default maximum versions per agent (can be made configurable in the future)
 export const DEFAULT_MAX_VERSIONS_PER_AGENT = 50;
 
+/**
+ * Checks if the agents store supports versioning methods.
+ * Used for backwards compatibility with older core versions that don't have versioning.
+ * @throws HTTPException 501 if versioning is not supported
+ */
+function assertVersioningSupported(agentsStore: any): void {
+  const requiredMethods = ['listVersions', 'createVersion', 'getVersion', 'deleteVersion', 'getLatestVersion'];
+  const missingMethods = requiredMethods.filter(method => typeof agentsStore[method] !== 'function');
+
+  if (missingMethods.length > 0) {
+    throw new HTTPException(501, {
+      message: 'Agent versioning is not supported by this core version. Please upgrade @mastra/core to 1.1.0 or later.',
+    });
+  }
+}
+
 // ============================================================================
 // Helper Functions (exported for use in stored-agents.ts)
 // ============================================================================
@@ -388,6 +404,9 @@ export const LIST_AGENT_VERSIONS_ROUTE = createRoute({
         throw new HTTPException(500, { message: 'Agents storage domain is not available' });
       }
 
+      // Check for versioning support (backwards compatibility with older core)
+      assertVersioningSupported(agentsStore);
+
       // Verify agent exists
       const agent = await agentsStore.getAgentById({ id: agentId });
       if (!agent) {
@@ -433,6 +452,9 @@ export const CREATE_AGENT_VERSION_ROUTE = createRoute({
       if (!agentsStore) {
         throw new HTTPException(500, { message: 'Agents storage domain is not available' });
       }
+
+      // Check for versioning support (backwards compatibility with older core)
+      assertVersioningSupported(agentsStore);
 
       // Get the current agent configuration
       const agent = await agentsStore.getAgentById({ id: agentId });
@@ -497,6 +519,9 @@ export const GET_AGENT_VERSION_ROUTE = createRoute({
         throw new HTTPException(500, { message: 'Agents storage domain is not available' });
       }
 
+      // Check for versioning support (backwards compatibility with older core)
+      assertVersioningSupported(agentsStore);
+
       const version = await agentsStore.getVersion(versionId);
 
       if (!version) {
@@ -539,6 +564,9 @@ export const ACTIVATE_AGENT_VERSION_ROUTE = createRoute({
       if (!agentsStore) {
         throw new HTTPException(500, { message: 'Agents storage domain is not available' });
       }
+
+      // Check for versioning support (backwards compatibility with older core)
+      assertVersioningSupported(agentsStore);
 
       // Verify agent exists
       const agent = await agentsStore.getAgentById({ id: agentId });
@@ -596,6 +624,9 @@ export const RESTORE_AGENT_VERSION_ROUTE = createRoute({
       if (!agentsStore) {
         throw new HTTPException(500, { message: 'Agents storage domain is not available' });
       }
+
+      // Check for versioning support (backwards compatibility with older core)
+      assertVersioningSupported(agentsStore);
 
       // Verify agent exists
       const agent = await agentsStore.getAgentById({ id: agentId });
@@ -699,6 +730,9 @@ export const DELETE_AGENT_VERSION_ROUTE = createRoute({
         throw new HTTPException(500, { message: 'Agents storage domain is not available' });
       }
 
+      // Check for versioning support (backwards compatibility with older core)
+      assertVersioningSupported(agentsStore);
+
       // Verify agent exists
       const agent = await agentsStore.getAgentById({ id: agentId });
       if (!agent) {
@@ -758,6 +792,9 @@ export const COMPARE_AGENT_VERSIONS_ROUTE = createRoute({
       if (!agentsStore) {
         throw new HTTPException(500, { message: 'Agents storage domain is not available' });
       }
+
+      // Check for versioning support (backwards compatibility with older core)
+      assertVersioningSupported(agentsStore);
 
       // Get both versions
       const fromVersion = await agentsStore.getVersion(from);

--- a/packages/server/src/server/handlers/agent-versions.ts
+++ b/packages/server/src/server/handlers/agent-versions.ts
@@ -346,6 +346,16 @@ export async function handleAutoVersioning<TAgent>(
   existingAgent: TAgent,
   updatedAgent: TAgent,
 ): Promise<{ agent: TAgent; versionCreated: boolean }> {
+  // Check for versioning support (backwards compatibility with older core)
+  // If versioning methods don't exist, skip versioning entirely
+  const requiredMethods = ['createVersion', 'getLatestVersion', 'listVersions', 'deleteVersion'];
+  const hasVersioningSupport = requiredMethods.every(method => typeof (agentsStore as any)[method] === 'function');
+
+  if (!hasVersioningSupport) {
+    // Gracefully degrade: just return the updated agent without versioning
+    return { agent: updatedAgent, versionCreated: false };
+  }
+
   // Calculate what fields changed
   const changedFields = calculateChangedFields(
     existingAgent as unknown as Record<string, unknown>,

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -380,7 +380,8 @@ export async function getAgentFromSystem({ mastra, agentId }: { mastra: Context[
   }
 
   // If still not found, try to get stored agent
-  if (!agent) {
+  // Check if method exists for backwards compatibility with older core versions
+  if (!agent && typeof mastra.getStoredAgentById === 'function') {
     logger.debug(`Agent ${agentId} not found in code-defined agents, looking in stored agents`);
     try {
       agent = await mastra.getStoredAgentById(agentId);
@@ -568,7 +569,11 @@ export const LIST_AGENTS_ROUTE = createRoute({
       );
 
       // Also fetch and include stored agents
+      // Check if method exists for backwards compatibility with older core versions
       try {
+        if (typeof mastra.listStoredAgents !== 'function') {
+          return serializedAgents;
+        }
         const storedAgentsResult = await mastra.listStoredAgents();
         if (storedAgentsResult?.agents) {
           // Process each agent individually to avoid one bad agent breaking the whole list

--- a/packages/server/src/server/handlers/scores.ts
+++ b/packages/server/src/server/handlers/scores.ts
@@ -69,15 +69,18 @@ async function listScorersFromSystem({
   }
 
   // Process stored agents (database-backed agents)
-  try {
-    const storedAgentsResult = await mastra.listStoredAgents();
-    if (storedAgentsResult?.agents) {
-      for (const storedAgent of storedAgentsResult.agents) {
-        await processAgentScorers(storedAgent);
+  // Check if method exists for backwards compatibility with older core versions
+  if (typeof mastra.listStoredAgents === 'function') {
+    try {
+      const storedAgentsResult = await mastra.listStoredAgents();
+      if (storedAgentsResult?.agents) {
+        for (const storedAgent of storedAgentsResult.agents) {
+          await processAgentScorers(storedAgent);
+        }
       }
+    } catch {
+      // Silently ignore if storage is not configured - not all setups have storage
     }
-  } catch {
-    // Silently ignore if storage is not configured - not all setups have storage
   }
 
   for (const [workflowId, workflow] of Object.entries(workflows)) {

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -87,7 +87,11 @@ export const GET_STORED_AGENT_ROUTE = createRoute({
       }
 
       // Use getAgentByIdResolved to automatically resolve from active version
-      const agent = await agentsStore.getAgentByIdResolved({ id: storedAgentId });
+      // Fall back to getAgentById for backwards compatibility with older core versions
+      const agent =
+        typeof agentsStore.getAgentByIdResolved === 'function'
+          ? await agentsStore.getAgentByIdResolved({ id: storedAgentId })
+          : await agentsStore.getAgentById({ id: storedAgentId });
 
       if (!agent) {
         throw new HTTPException(404, { message: `Stored agent with id ${storedAgentId} not found` });

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -265,7 +265,10 @@ export const UPDATE_STORED_AGENT_ROUTE = createRoute({
       const { agent } = await handleAutoVersioning(agentsStore, storedAgentId, existing, updatedAgent);
 
       // Clear the cached agent instance so the next request gets the updated config
-      mastra.clearStoredAgentCache(storedAgentId);
+      // Check if method exists for backwards compatibility with older core versions
+      if (typeof mastra.clearStoredAgentCache === 'function') {
+        mastra.clearStoredAgentCache(storedAgentId);
+      }
 
       return agent;
     } catch (error) {
@@ -309,7 +312,10 @@ export const DELETE_STORED_AGENT_ROUTE = createRoute({
       await agentsStore.deleteAgent({ id: storedAgentId });
 
       // Clear the cached agent instance
-      mastra.clearStoredAgentCache(storedAgentId);
+      // Check if method exists for backwards compatibility with older core versions
+      if (typeof mastra.clearStoredAgentCache === 'function') {
+        mastra.clearStoredAgentCache(storedAgentId);
+      }
 
       return { success: true, message: `Agent ${storedAgentId} deleted successfully` };
     } catch (error) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2976,16 +2976,16 @@ importers:
         version: 19.2.2(@types/react@19.2.2)
       '@vitejs/plugin-react':
         specifier: ^5.1.2
-        version: 5.1.2(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 5.1.2(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       autoprefixer:
         specifier: ^10.4.22
         version: 10.4.22(postcss@8.5.6)
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
-        version: 7.0.1(eslint@9.39.2(jiti@1.21.7))
+        version: 7.0.1(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-refresh:
         specifier: ^0.4.24
-        version: 0.4.24(eslint@9.39.2(jiti@1.21.7))
+        version: 0.4.24(eslint@9.39.2(jiti@2.6.1))
       globals:
         specifier: ^16.5.0
         version: 16.5.0
@@ -3003,10 +3003,10 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.51.0
-        version: 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+        version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^7.3.0
-        version: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/playground-ui:
     dependencies:
@@ -3214,10 +3214,10 @@ importers:
         version: link:../schema-compat
       '@storybook/addon-docs':
         specifier: ^9.1.16
-        version: 9.1.16(@types/react@19.2.2)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
+        version: 9.1.16(@types/react@19.2.2)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
       '@storybook/react-vite':
         specifier: ^9.1.16
-        version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.55.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.55.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       '@tailwindcss/container-queries':
         specifier: ^0.1.1
         version: 0.1.1(tailwindcss@3.4.18(tsx@4.21.0)(yaml@2.8.1))
@@ -3238,7 +3238,7 @@ importers:
         version: 7.7.1
       '@vitejs/plugin-react':
         specifier: ^5.1.2
-        version: 5.1.2(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 5.1.2(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       '@vitest/ui':
         specifier: 'catalog:'
         version: 4.0.12(vitest@4.0.16)
@@ -3259,7 +3259,7 @@ importers:
         version: 8.1.2(rollup@4.55.3)
       storybook:
         specifier: ^9.1.10
-        version: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -3271,16 +3271,16 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.0
-        version: 7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@22.19.7)(rollup@4.55.3)(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 4.5.4(@types/node@22.19.7)(rollup@4.55.3)(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       vite-plugin-lib-inject-css:
         specifier: ^2.2.2
-        version: 2.2.2(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 2.2.2(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/rag:
     dependencies:
@@ -3409,6 +3409,9 @@ importers:
 
   packages/server:
     dependencies:
+      fast-deep-equal:
+        specifier: ^3.1.3
+        version: 3.1.3
       hono:
         specifier: ^4.11.3
         version: 4.11.3
@@ -21421,11 +21424,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2(jiti@1.21.7))':
-    dependencies:
-      eslint: 9.39.2(jiti@1.21.7)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
@@ -21954,6 +21952,15 @@ snapshots:
       minipass: 7.1.2
 
   '@isaacs/ttlcache@2.1.4': {}
+
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      glob: 10.4.5
+      magic-string: 0.30.21
+      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
@@ -25102,18 +25109,25 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@9.1.16(@types/react@19.2.2)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))':
+  '@storybook/addon-docs@9.1.16(@types/react@19.2.2)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.2)(react@19.2.3)
-      '@storybook/csf-plugin': 9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
+      '@storybook/csf-plugin': 9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
       '@storybook/icons': 1.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@storybook/react-dom-shim': 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
+      '@storybook/react-dom-shim': 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
+
+  '@storybook/builder-vite@9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@storybook/csf-plugin': 9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
+      storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      ts-dedent: 2.2.0
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   '@storybook/builder-vite@9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
@@ -25121,6 +25135,11 @@ snapshots:
       storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       ts-dedent: 2.2.0
       vite: 7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+
+  '@storybook/csf-plugin@9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))':
+    dependencies:
+      storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      unplugin: 1.16.1
 
   '@storybook/csf-plugin@9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))':
     dependencies:
@@ -25134,11 +25153,37 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
+  '@storybook/react-dom-shim@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))':
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+
   '@storybook/react-dom-shim@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))':
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+
+  '@storybook/react-vite@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.55.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@rollup/pluginutils': 5.3.0(rollup@4.55.3)
+      '@storybook/builder-vite': 9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@storybook/react': 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(typescript@5.9.3)
+      find-up: 7.0.0
+      magic-string: 0.30.21
+      react: 19.2.3
+      react-docgen: 8.0.2
+      react-dom: 19.2.3(react@19.2.3)
+      resolve: 1.22.11
+      storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      tsconfig-paths: 4.2.0
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+      - typescript
 
   '@storybook/react-vite@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.55.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
@@ -25159,6 +25204,16 @@ snapshots:
       - rollup
       - supports-color
       - typescript
+
+  '@storybook/react@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(typescript@5.9.3)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@storybook/react@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(typescript@5.9.3)':
     dependencies:
@@ -25808,22 +25863,6 @@ snapshots:
     dependencies:
       '@types/node': 22.19.7
 
-  '@typescript-eslint/eslint-plugin@8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.51.0
-      '@typescript-eslint/type-utils': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.51.0
-      eslint: 9.39.2(jiti@1.21.7)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -25836,18 +25875,6 @@ snapshots:
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.51.0
-      '@typescript-eslint/types': 8.51.0
-      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.51.0
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -25882,18 +25909,6 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.51.0
-      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/type-utils@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.51.0
@@ -25919,17 +25934,6 @@ snapshots:
       semver: 7.7.3
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@1.21.7))
-      '@typescript-eslint/scope-manager': 8.51.0
-      '@typescript-eslint/types': 8.51.0
-      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -26174,6 +26178,15 @@ snapshots:
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
+  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.7(@types/node@22.19.7)(typescript@5.9.3)
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+
   '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -26182,6 +26195,15 @@ snapshots:
     optionalDependencies:
       msw: 2.12.7(@types/node@22.19.7)(typescript@5.9.3)
       vite: 7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+
+  '@vitest/mocker@4.0.16(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.0.16
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.7(@types/node@22.19.7)(typescript@5.9.3)
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   '@vitest/mocker@4.0.16(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
@@ -28078,17 +28100,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@1.21.7)):
-    dependencies:
-      '@babel/core': 7.28.6
-      '@babel/parser': 7.28.6
-      eslint: 9.39.2(jiti@1.21.7)
-      hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.28.6
@@ -28100,9 +28111,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-refresh@0.4.24(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-react-refresh@0.4.24(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
 
   eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
@@ -28174,47 +28185,6 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
-
-  eslint@9.39.2(jiti@1.21.7):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@1.21.7))
-      '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.21.1
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.39.2
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.7
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.6.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 1.21.7
-    transitivePeerDependencies:
-      - supports-color
 
   eslint@9.39.2(jiti@2.6.1):
     dependencies:
@@ -32394,6 +32364,30 @@ snapshots:
 
   stoppable@1.1.0: {}
 
+  storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/spy': 3.2.4
+      better-opn: 3.0.2
+      esbuild: 0.25.11
+      esbuild-register: 3.6.0(esbuild@0.25.11)
+      recast: 0.23.11
+      semver: 7.7.3
+      ws: 8.19.0
+    optionalDependencies:
+      prettier: 3.7.4
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - bufferutil
+      - msw
+      - supports-color
+      - utf-8-validate
+      - vite
+
   storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)):
     dependencies:
       '@storybook/global': 5.0.0
@@ -33007,17 +33001,6 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript-eslint@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   typescript-eslint@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
@@ -33298,6 +33281,25 @@ snapshots:
       - tsx
       - yaml
 
+  vite-plugin-dts@4.5.4(@types/node@22.19.7)(rollup@4.55.3)(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)):
+    dependencies:
+      '@microsoft/api-extractor': 7.55.2(@types/node@22.19.7)
+      '@rollup/pluginutils': 5.3.0(rollup@4.55.3)
+      '@volar/typescript': 2.4.23
+      '@vue/language-core': 2.2.0(typescript@5.9.3)
+      compare-versions: 6.1.1
+      debug: 4.4.3
+      kolorist: 1.8.0
+      local-pkg: 1.1.2
+      magic-string: 0.30.21
+      typescript: 5.9.3
+    optionalDependencies:
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - rollup
+      - supports-color
+
   vite-plugin-dts@4.5.4(@types/node@22.19.7)(rollup@4.55.3)(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)):
     dependencies:
       '@microsoft/api-extractor': 7.55.2(@types/node@22.19.7)
@@ -33317,12 +33319,12 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-lib-inject-css@2.2.2(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)):
+  vite-plugin-lib-inject-css@2.2.2(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)):
     dependencies:
       '@ast-grep/napi': 0.36.3
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
@@ -33467,6 +33469,46 @@ snapshots:
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
       vite: 7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.19.7
+      '@vitest/ui': 4.0.12(vitest@4.0.16)
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1):
+    dependencies:
+      '@vitest/expect': 4.0.16
+      '@vitest/mocker': 4.0.16(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.0.16
+      '@vitest/runner': 4.0.16
+      '@vitest/snapshot': 4.0.16
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0

--- a/stores/clickhouse/src/storage/db/utils.ts
+++ b/stores/clickhouse/src/storage/db/utils.ts
@@ -1,4 +1,5 @@
 import type { TABLE_NAMES, TABLE_SCHEMAS, StorageColumn } from '@mastra/core/storage';
+import * as coreStorage from '@mastra/core/storage';
 import {
   TABLE_MESSAGES,
   TABLE_RESOURCES,
@@ -6,10 +7,13 @@ import {
   TABLE_THREADS,
   TABLE_TRACES,
   TABLE_WORKFLOW_SNAPSHOT,
-  TABLE_AGENT_VERSIONS,
   safelyParseJSON,
   TABLE_SPANS,
 } from '@mastra/core/storage';
+
+// Use core's constant if available, otherwise fall back to local value for backwards compatibility
+const TABLE_AGENT_VERSIONS = ((coreStorage as Record<string, unknown>).TABLE_AGENT_VERSIONS ??
+  'mastra_agent_versions') as 'mastra_agent_versions';
 
 export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
   [TABLE_MESSAGES]: `MergeTree()`,

--- a/stores/clickhouse/src/storage/db/utils.ts
+++ b/stores/clickhouse/src/storage/db/utils.ts
@@ -1,5 +1,7 @@
 import type { TABLE_NAMES, TABLE_SCHEMAS, StorageColumn } from '@mastra/core/storage';
-import {
+import * as coreStorage from '@mastra/core/storage';
+
+const {
   TABLE_MESSAGES,
   TABLE_RESOURCES,
   TABLE_SCORERS,
@@ -9,7 +11,7 @@ import {
   TABLE_AGENT_VERSIONS,
   safelyParseJSON,
   TABLE_SPANS,
-} from '@mastra/core/storage';
+} = coreStorage;
 
 export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
   [TABLE_MESSAGES]: `MergeTree()`,

--- a/stores/clickhouse/src/storage/db/utils.ts
+++ b/stores/clickhouse/src/storage/db/utils.ts
@@ -8,8 +8,10 @@ import {
   TABLE_WORKFLOW_SNAPSHOT,
   safelyParseJSON,
   TABLE_SPANS,
-  TABLE_AGENT_VERSIONS,
 } from '@mastra/core/storage';
+
+// Local constant for agent versions table - avoids import issues with older core versions
+const TABLE_AGENT_VERSIONS = 'mastra_agent_versions';
 
 export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
   [TABLE_MESSAGES]: `MergeTree()`,

--- a/stores/clickhouse/src/storage/db/utils.ts
+++ b/stores/clickhouse/src/storage/db/utils.ts
@@ -1,5 +1,4 @@
 import type { TABLE_NAMES, TABLE_SCHEMAS, StorageColumn } from '@mastra/core/storage';
-import * as coreStorage from '@mastra/core/storage';
 import {
   TABLE_MESSAGES,
   TABLE_RESOURCES,
@@ -7,13 +6,10 @@ import {
   TABLE_THREADS,
   TABLE_TRACES,
   TABLE_WORKFLOW_SNAPSHOT,
+  TABLE_AGENT_VERSIONS,
   safelyParseJSON,
   TABLE_SPANS,
 } from '@mastra/core/storage';
-
-// Use core's constant if available, otherwise fall back to local value for backwards compatibility
-const TABLE_AGENT_VERSIONS = ((coreStorage as Record<string, unknown>).TABLE_AGENT_VERSIONS ??
-  'mastra_agent_versions') as 'mastra_agent_versions';
 
 export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
   [TABLE_MESSAGES]: `MergeTree()`,

--- a/stores/clickhouse/src/storage/db/utils.ts
+++ b/stores/clickhouse/src/storage/db/utils.ts
@@ -6,12 +6,10 @@ import {
   TABLE_THREADS,
   TABLE_TRACES,
   TABLE_WORKFLOW_SNAPSHOT,
+  TABLE_AGENT_VERSIONS,
   safelyParseJSON,
   TABLE_SPANS,
 } from '@mastra/core/storage';
-
-// Local constant for agent versions table - avoids import issues with older core versions
-const TABLE_AGENT_VERSIONS = 'mastra_agent_versions';
 
 export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
   [TABLE_MESSAGES]: `MergeTree()`,

--- a/stores/clickhouse/src/storage/domains/observability/index.ts
+++ b/stores/clickhouse/src/storage/domains/observability/index.ts
@@ -1,12 +1,12 @@
 import type { ClickHouseClient } from '@clickhouse/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import * as coreStorage from '@mastra/core/storage';
 import {
   createStorageErrorId,
   listTracesArgsSchema,
   ObservabilityStorage,
   SPAN_SCHEMA,
   TABLE_SPANS,
+  toTraceSpans,
   TraceStatus,
 } from '@mastra/core/storage';
 import type {
@@ -29,14 +29,6 @@ import type {
 import { ClickhouseDB, resolveClickhouseConfig } from '../../db';
 import type { ClickhouseDomainConfig } from '../../db';
 import { TABLE_ENGINES, transformRows } from '../../db/utils';
-
-// Use core's toTraceSpans if available, otherwise provide fallback for backwards compatibility
-const toTraceSpans = ((coreStorage as Record<string, unknown>).toTraceSpans ??
-  ((spans: SpanRecord[]) =>
-    spans.map(span => ({
-      ...span,
-      status: span.error != null ? TraceStatus.ERROR : span.endedAt == null ? TraceStatus.RUNNING : TraceStatus.SUCCESS,
-    })))) as (spans: SpanRecord[]) => (SpanRecord & { status: TraceStatus })[];
 
 export class ObservabilityStorageClickhouse extends ObservabilityStorage {
   protected client: ClickHouseClient;

--- a/stores/clickhouse/src/storage/domains/observability/index.ts
+++ b/stores/clickhouse/src/storage/domains/observability/index.ts
@@ -1,6 +1,8 @@
 import type { ClickHouseClient } from '@clickhouse/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
+import * as coreStorage from '@mastra/core/storage';
+
+const {
   createStorageErrorId,
   listTracesArgsSchema,
   ObservabilityStorage,
@@ -8,7 +10,7 @@ import {
   TABLE_SPANS,
   toTraceSpans,
   TraceStatus,
-} from '@mastra/core/storage';
+} = coreStorage;
 import type {
   SpanRecord,
   ListTracesArgs,

--- a/stores/clickhouse/src/storage/domains/observability/index.ts
+++ b/stores/clickhouse/src/storage/domains/observability/index.ts
@@ -1,12 +1,12 @@
 import type { ClickHouseClient } from '@clickhouse/client';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import * as coreStorage from '@mastra/core/storage';
 import {
   createStorageErrorId,
   listTracesArgsSchema,
   ObservabilityStorage,
   SPAN_SCHEMA,
   TABLE_SPANS,
-  toTraceSpans,
   TraceStatus,
 } from '@mastra/core/storage';
 import type {
@@ -29,6 +29,14 @@ import type {
 import { ClickhouseDB, resolveClickhouseConfig } from '../../db';
 import type { ClickhouseDomainConfig } from '../../db';
 import { TABLE_ENGINES, transformRows } from '../../db/utils';
+
+// Use core's toTraceSpans if available, otherwise provide fallback for backwards compatibility
+const toTraceSpans = ((coreStorage as Record<string, unknown>).toTraceSpans ??
+  ((spans: SpanRecord[]) =>
+    spans.map(span => ({
+      ...span,
+      status: span.error != null ? TraceStatus.ERROR : span.endedAt == null ? TraceStatus.RUNNING : TraceStatus.SUCCESS,
+    })))) as (spans: SpanRecord[]) => (SpanRecord & { status: TraceStatus })[];
 
 export class ObservabilityStorageClickhouse extends ObservabilityStorage {
   protected client: ClickHouseClient;

--- a/stores/cloudflare/package.json
+++ b/stores/cloudflare/package.json
@@ -50,7 +50,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.1.0-0 <2.0.0-0"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/stores/cloudflare/src/storage/types.ts
+++ b/stores/cloudflare/src/storage/types.ts
@@ -12,15 +12,13 @@ import type {
   TABLE_SCORERS,
   TABLE_SPANS,
   TABLE_AGENTS,
+  TABLE_AGENT_VERSIONS,
   SpanRecord,
   StorageAgentType,
 } from '@mastra/core/storage';
 import type { AgentVersion } from '@mastra/core/storage/domains/agents';
 import type { WorkflowRunState } from '@mastra/core/workflows';
 import type Cloudflare from 'cloudflare';
-
-// Local constant for agent versions table - avoids import issues with older core versions
-const TABLE_AGENT_VERSIONS = 'mastra_agent_versions' as const;
 
 /**
  * Base configuration options shared across Cloudflare configurations

--- a/stores/cloudflare/src/storage/types.ts
+++ b/stores/cloudflare/src/storage/types.ts
@@ -12,13 +12,15 @@ import type {
   TABLE_SCORERS,
   TABLE_SPANS,
   TABLE_AGENTS,
-  TABLE_AGENT_VERSIONS,
   SpanRecord,
   StorageAgentType,
 } from '@mastra/core/storage';
 import type { AgentVersion } from '@mastra/core/storage/domains/agents';
 import type { WorkflowRunState } from '@mastra/core/workflows';
 import type Cloudflare from 'cloudflare';
+
+// Local constant for agent versions table - avoids import issues with older core versions
+const TABLE_AGENT_VERSIONS = 'mastra_agent_versions' as const;
 
 /**
  * Base configuration options shared across Cloudflare configurations

--- a/stores/libsql/src/storage/domains/agents/index.ts
+++ b/stores/libsql/src/storage/domains/agents/index.ts
@@ -5,6 +5,7 @@ import {
   normalizePerPage,
   calculatePagination,
   TABLE_AGENTS,
+  TABLE_AGENT_VERSIONS,
 } from '@mastra/core/storage';
 import type {
   StorageAgentType,
@@ -16,13 +17,9 @@ import type {
   CreateVersionInput,
   ListVersionsInput,
   ListVersionsOutput,
-  StorageColumn,
 } from '@mastra/core/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
-
-// Local constant for agent versions table - avoids import issues with older core versions
-const TABLE_AGENT_VERSIONS = 'mastra_agent_versions';
 
 export class AgentsLibSQL extends AgentsStorage {
   #db: LibSQLDB;
@@ -33,26 +30,13 @@ export class AgentsLibSQL extends AgentsStorage {
     this.#db = new LibSQLDB({ client, maxRetries: config.maxRetries, initialBackoffMs: config.initialBackoffMs });
   }
 
-  /**
-   * Safely gets a schema, checking if getSchema method exists first.
-   * Returns undefined if the method doesn't exist or the schema isn't found.
-   */
-  #safeGetSchema(tableName: string): Record<string, StorageColumn> | undefined {
-    if (typeof this.getSchema === 'function') {
-      return this.getSchema(tableName);
-    }
-    return undefined;
-  }
-
   async init(): Promise<void> {
-    // Use getSchema() for backwards compatibility - schemas may not exist in older core versions
-    // Also check if getSchema exists (it may not in older core versions)
-    const agentsSchema = this.#safeGetSchema(TABLE_AGENTS);
+    const agentsSchema = this.getSchema(TABLE_AGENTS);
     if (agentsSchema) {
       await this.#db.createTable({ tableName: TABLE_AGENTS, schema: agentsSchema });
     }
 
-    const agentVersionsSchema = this.#safeGetSchema(TABLE_AGENT_VERSIONS);
+    const agentVersionsSchema = this.getSchema(TABLE_AGENT_VERSIONS);
     if (agentVersionsSchema) {
       await this.#db.createTable({ tableName: TABLE_AGENT_VERSIONS, schema: agentVersionsSchema });
     }

--- a/stores/libsql/src/storage/domains/agents/index.ts
+++ b/stores/libsql/src/storage/domains/agents/index.ts
@@ -1,16 +1,12 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import * as coreStorage from '@mastra/core/storage';
 import {
   AgentsStorage,
   createStorageErrorId,
   normalizePerPage,
   calculatePagination,
   TABLE_AGENTS,
+  TABLE_AGENT_VERSIONS,
 } from '@mastra/core/storage';
-
-// Use core's constant if available, otherwise fall back to local value for backwards compatibility
-const TABLE_AGENT_VERSIONS = ((coreStorage as Record<string, unknown>).TABLE_AGENT_VERSIONS ??
-  'mastra_agent_versions') as 'mastra_agent_versions';
 import type {
   StorageAgentType,
   StorageCreateAgentInput,

--- a/stores/libsql/src/storage/domains/agents/index.ts
+++ b/stores/libsql/src/storage/domains/agents/index.ts
@@ -1,12 +1,14 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
+import * as coreStorage from '@mastra/core/storage';
+
+const {
   AgentsStorage,
   createStorageErrorId,
   normalizePerPage,
   calculatePagination,
   TABLE_AGENTS,
   TABLE_AGENT_VERSIONS,
-} from '@mastra/core/storage';
+} = coreStorage;
 import type {
   StorageAgentType,
   StorageCreateAgentInput,

--- a/stores/libsql/src/storage/domains/agents/index.ts
+++ b/stores/libsql/src/storage/domains/agents/index.ts
@@ -1,12 +1,16 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import * as coreStorage from '@mastra/core/storage';
 import {
   AgentsStorage,
   createStorageErrorId,
   normalizePerPage,
   calculatePagination,
   TABLE_AGENTS,
-  TABLE_AGENT_VERSIONS,
 } from '@mastra/core/storage';
+
+// Use core's constant if available, otherwise fall back to local value for backwards compatibility
+const TABLE_AGENT_VERSIONS = ((coreStorage as Record<string, unknown>).TABLE_AGENT_VERSIONS ??
+  'mastra_agent_versions') as 'mastra_agent_versions';
 import type {
   StorageAgentType,
   StorageCreateAgentInput,

--- a/stores/libsql/src/storage/domains/observability/index.ts
+++ b/stores/libsql/src/storage/domains/observability/index.ts
@@ -1,11 +1,11 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import * as coreStorage from '@mastra/core/storage';
 import {
   createStorageErrorId,
   listTracesArgsSchema,
   ObservabilityStorage,
   SPAN_SCHEMA,
   TABLE_SPANS,
+  toTraceSpans,
   TraceStatus,
 } from '@mastra/core/storage';
 import type {
@@ -26,14 +26,6 @@ import type {
   GetTraceResponse,
 } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
-
-// Use core's toTraceSpans if available, otherwise provide fallback for backwards compatibility
-const toTraceSpans = ((coreStorage as Record<string, unknown>).toTraceSpans ??
-  ((spans: SpanRecord[]) =>
-    spans.map(span => ({
-      ...span,
-      status: span.error != null ? TraceStatus.ERROR : span.endedAt == null ? TraceStatus.RUNNING : TraceStatus.SUCCESS,
-    })))) as (spans: SpanRecord[]) => (SpanRecord & { status: TraceStatus })[];
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { transformFromSqlRow } from '../../db/utils';

--- a/stores/libsql/src/storage/domains/observability/index.ts
+++ b/stores/libsql/src/storage/domains/observability/index.ts
@@ -1,5 +1,7 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
+import * as coreStorage from '@mastra/core/storage';
+
+const {
   createStorageErrorId,
   listTracesArgsSchema,
   ObservabilityStorage,
@@ -7,7 +9,7 @@ import {
   TABLE_SPANS,
   toTraceSpans,
   TraceStatus,
-} from '@mastra/core/storage';
+} = coreStorage;
 import type {
   SpanRecord,
   ListTracesArgs,

--- a/stores/libsql/src/storage/domains/observability/index.ts
+++ b/stores/libsql/src/storage/domains/observability/index.ts
@@ -1,11 +1,11 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import * as coreStorage from '@mastra/core/storage';
 import {
   createStorageErrorId,
   listTracesArgsSchema,
   ObservabilityStorage,
   SPAN_SCHEMA,
   TABLE_SPANS,
-  toTraceSpans,
   TraceStatus,
 } from '@mastra/core/storage';
 import type {
@@ -26,6 +26,14 @@ import type {
   GetTraceResponse,
 } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
+
+// Use core's toTraceSpans if available, otherwise provide fallback for backwards compatibility
+const toTraceSpans = ((coreStorage as Record<string, unknown>).toTraceSpans ??
+  ((spans: SpanRecord[]) =>
+    spans.map(span => ({
+      ...span,
+      status: span.error != null ? TraceStatus.ERROR : span.endedAt == null ? TraceStatus.RUNNING : TraceStatus.SUCCESS,
+    })))) as (spans: SpanRecord[]) => (SpanRecord & { status: TraceStatus })[];
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
 import { transformFromSqlRow } from '../../db/utils';

--- a/stores/mongodb/src/storage/domains/agents/index.ts
+++ b/stores/mongodb/src/storage/domains/agents/index.ts
@@ -3,7 +3,6 @@ import {
   AgentsStorage,
   createStorageErrorId,
   TABLE_AGENTS,
-  TABLE_AGENT_VERSIONS,
   normalizePerPage,
   calculatePagination,
 } from '@mastra/core/storage';
@@ -23,6 +22,9 @@ import type {
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';
+
+// Local constant for agent versions table - avoids import issues with older core versions
+const TABLE_AGENT_VERSIONS = 'mastra_agent_versions';
 
 export class MongoDBAgentsStorage extends AgentsStorage {
   #connector: MongoDBConnector;

--- a/stores/mongodb/src/storage/domains/agents/index.ts
+++ b/stores/mongodb/src/storage/domains/agents/index.ts
@@ -1,12 +1,14 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
+import * as coreStorage from '@mastra/core/storage';
+
+const {
   AgentsStorage,
   createStorageErrorId,
   TABLE_AGENTS,
   TABLE_AGENT_VERSIONS,
   normalizePerPage,
   calculatePagination,
-} from '@mastra/core/storage';
+} = coreStorage;
 import type {
   StorageAgentType,
   StorageCreateAgentInput,

--- a/stores/mongodb/src/storage/domains/agents/index.ts
+++ b/stores/mongodb/src/storage/domains/agents/index.ts
@@ -1,16 +1,12 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import * as coreStorage from '@mastra/core/storage';
 import {
   AgentsStorage,
   createStorageErrorId,
   TABLE_AGENTS,
+  TABLE_AGENT_VERSIONS,
   normalizePerPage,
   calculatePagination,
 } from '@mastra/core/storage';
-
-// Use core's constant if available, otherwise fall back to local value for backwards compatibility
-const TABLE_AGENT_VERSIONS = ((coreStorage as Record<string, unknown>).TABLE_AGENT_VERSIONS ??
-  'mastra_agent_versions') as 'mastra_agent_versions';
 import type {
   StorageAgentType,
   StorageCreateAgentInput,

--- a/stores/mongodb/src/storage/domains/agents/index.ts
+++ b/stores/mongodb/src/storage/domains/agents/index.ts
@@ -1,12 +1,16 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import * as coreStorage from '@mastra/core/storage';
 import {
   AgentsStorage,
   createStorageErrorId,
   TABLE_AGENTS,
-  TABLE_AGENT_VERSIONS,
   normalizePerPage,
   calculatePagination,
 } from '@mastra/core/storage';
+
+// Use core's constant if available, otherwise fall back to local value for backwards compatibility
+const TABLE_AGENT_VERSIONS = ((coreStorage as Record<string, unknown>).TABLE_AGENT_VERSIONS ??
+  'mastra_agent_versions') as 'mastra_agent_versions';
 import type {
   StorageAgentType,
   StorageCreateAgentInput,

--- a/stores/mongodb/src/storage/domains/agents/index.ts
+++ b/stores/mongodb/src/storage/domains/agents/index.ts
@@ -3,6 +3,7 @@ import {
   AgentsStorage,
   createStorageErrorId,
   TABLE_AGENTS,
+  TABLE_AGENT_VERSIONS,
   normalizePerPage,
   calculatePagination,
 } from '@mastra/core/storage';
@@ -22,9 +23,6 @@ import type {
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';
-
-// Local constant for agent versions table - avoids import issues with older core versions
-const TABLE_AGENT_VERSIONS = 'mastra_agent_versions';
 
 export class MongoDBAgentsStorage extends AgentsStorage {
   #connector: MongoDBConnector;

--- a/stores/mongodb/src/storage/domains/observability/index.ts
+++ b/stores/mongodb/src/storage/domains/observability/index.ts
@@ -1,10 +1,10 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import * as coreStorage from '@mastra/core/storage';
 import {
   createStorageErrorId,
   listTracesArgsSchema,
   ObservabilityStorage,
   TABLE_SPANS,
+  toTraceSpans,
   TraceStatus,
 } from '@mastra/core/storage';
 import type {
@@ -28,14 +28,6 @@ import type {
 import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
 import { resolveMongoDBConfig } from '../../db';
 import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';
-
-// Use core's toTraceSpans if available, otherwise provide fallback for backwards compatibility
-const toTraceSpans = ((coreStorage as Record<string, unknown>).toTraceSpans ??
-  ((spans: SpanRecord[]) =>
-    spans.map(span => ({
-      ...span,
-      status: span.error != null ? TraceStatus.ERROR : span.endedAt == null ? TraceStatus.RUNNING : TraceStatus.SUCCESS,
-    })))) as (spans: SpanRecord[]) => (SpanRecord & { status: TraceStatus })[];
 
 export class ObservabilityMongoDB extends ObservabilityStorage {
   #connector: MongoDBConnector;

--- a/stores/mongodb/src/storage/domains/observability/index.ts
+++ b/stores/mongodb/src/storage/domains/observability/index.ts
@@ -1,12 +1,8 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
-  createStorageErrorId,
-  listTracesArgsSchema,
-  ObservabilityStorage,
-  TABLE_SPANS,
-  toTraceSpans,
-  TraceStatus,
-} from '@mastra/core/storage';
+import * as coreStorage from '@mastra/core/storage';
+
+const { createStorageErrorId, listTracesArgsSchema, ObservabilityStorage, TABLE_SPANS, toTraceSpans, TraceStatus } =
+  coreStorage;
 import type {
   SpanRecord,
   UpdateSpanRecord,

--- a/stores/mssql/src/storage/domains/observability/index.ts
+++ b/stores/mssql/src/storage/domains/observability/index.ts
@@ -1,5 +1,7 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
+import * as coreStorage from '@mastra/core/storage';
+
+const {
   createStorageErrorId,
   listTracesArgsSchema,
   ObservabilityStorage,
@@ -7,7 +9,7 @@ import {
   TABLE_SPANS,
   toTraceSpans,
   TraceStatus,
-} from '@mastra/core/storage';
+} = coreStorage;
 import type {
   SpanRecord,
   ListTracesArgs,

--- a/stores/mssql/src/storage/domains/observability/index.ts
+++ b/stores/mssql/src/storage/domains/observability/index.ts
@@ -1,11 +1,11 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import * as coreStorage from '@mastra/core/storage';
 import {
   createStorageErrorId,
   listTracesArgsSchema,
   ObservabilityStorage,
   SPAN_SCHEMA,
   TABLE_SPANS,
+  toTraceSpans,
   TraceStatus,
 } from '@mastra/core/storage';
 import type {
@@ -30,14 +30,6 @@ import type { ConnectionPool } from 'mssql';
 import { MssqlDB, resolveMssqlConfig } from '../../db';
 import type { MssqlDomainConfig } from '../../db';
 import { transformFromSqlRow, getTableName, getSchemaName } from '../utils';
-
-// Use core's toTraceSpans if available, otherwise provide fallback for backwards compatibility
-const toTraceSpans = ((coreStorage as Record<string, unknown>).toTraceSpans ??
-  ((spans: SpanRecord[]) =>
-    spans.map(span => ({
-      ...span,
-      status: span.error != null ? TraceStatus.ERROR : span.endedAt == null ? TraceStatus.RUNNING : TraceStatus.SUCCESS,
-    })))) as (spans: SpanRecord[]) => (SpanRecord & { status: TraceStatus })[];
 
 export class ObservabilityMSSQL extends ObservabilityStorage {
   public pool: ConnectionPool;

--- a/stores/pg/src/storage/domains/agents/index.ts
+++ b/stores/pg/src/storage/domains/agents/index.ts
@@ -1,16 +1,12 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import * as coreStorage from '@mastra/core/storage';
 import {
   AgentsStorage,
   createStorageErrorId,
   normalizePerPage,
   calculatePagination,
   TABLE_AGENTS,
+  TABLE_AGENT_VERSIONS,
 } from '@mastra/core/storage';
-
-// Use core's constant if available, otherwise fall back to local value for backwards compatibility
-const TABLE_AGENT_VERSIONS = ((coreStorage as Record<string, unknown>).TABLE_AGENT_VERSIONS ??
-  'mastra_agent_versions') as 'mastra_agent_versions';
 import type {
   StorageAgentType,
   StorageCreateAgentInput,

--- a/stores/pg/src/storage/domains/agents/index.ts
+++ b/stores/pg/src/storage/domains/agents/index.ts
@@ -5,6 +5,7 @@ import {
   normalizePerPage,
   calculatePagination,
   TABLE_AGENTS,
+  TABLE_AGENT_VERSIONS,
 } from '@mastra/core/storage';
 import type {
   StorageAgentType,
@@ -13,7 +14,6 @@ import type {
   StorageListAgentsInput,
   StorageListAgentsOutput,
   CreateIndexOptions,
-  StorageColumn,
 } from '@mastra/core/storage';
 import type {
   AgentVersion,
@@ -24,9 +24,6 @@ import type {
 import { PgDB, resolvePgConfig } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { getTableName, getSchemaName } from '../utils';
-
-// Local constant for agent versions table - avoids import issues with older core versions
-const TABLE_AGENT_VERSIONS = 'mastra_agent_versions';
 
 export class AgentsPG extends AgentsStorage {
   #db: PgDB;
@@ -66,26 +63,13 @@ export class AgentsPG extends AgentsStorage {
     // No default indexes for agents domain
   }
 
-  /**
-   * Safely gets a schema, checking if getSchema method exists first.
-   * Returns undefined if the method doesn't exist or the schema isn't found.
-   */
-  #safeGetSchema(tableName: string): Record<string, StorageColumn> | undefined {
-    if (typeof this.getSchema === 'function') {
-      return this.getSchema(tableName);
-    }
-    return undefined;
-  }
-
   async init(): Promise<void> {
-    // Use getSchema() for backwards compatibility - schemas may not exist in older core versions
-    // Also check if getSchema exists (it may not in older core versions)
-    const agentsSchema = this.#safeGetSchema(TABLE_AGENTS);
+    const agentsSchema = this.getSchema(TABLE_AGENTS);
     if (agentsSchema) {
       await this.#db.createTable({ tableName: TABLE_AGENTS, schema: agentsSchema });
     }
 
-    const agentVersionsSchema = this.#safeGetSchema(TABLE_AGENT_VERSIONS);
+    const agentVersionsSchema = this.getSchema(TABLE_AGENT_VERSIONS);
     if (agentVersionsSchema) {
       await this.#db.createTable({ tableName: TABLE_AGENT_VERSIONS, schema: agentVersionsSchema });
     }

--- a/stores/pg/src/storage/domains/agents/index.ts
+++ b/stores/pg/src/storage/domains/agents/index.ts
@@ -1,12 +1,14 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
+import * as coreStorage from '@mastra/core/storage';
+
+const {
   AgentsStorage,
   createStorageErrorId,
   normalizePerPage,
   calculatePagination,
   TABLE_AGENTS,
   TABLE_AGENT_VERSIONS,
-} from '@mastra/core/storage';
+} = coreStorage;
 import type {
   StorageAgentType,
   StorageCreateAgentInput,

--- a/stores/pg/src/storage/domains/agents/index.ts
+++ b/stores/pg/src/storage/domains/agents/index.ts
@@ -1,12 +1,16 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import * as coreStorage from '@mastra/core/storage';
 import {
   AgentsStorage,
   createStorageErrorId,
   normalizePerPage,
   calculatePagination,
   TABLE_AGENTS,
-  TABLE_AGENT_VERSIONS,
 } from '@mastra/core/storage';
+
+// Use core's constant if available, otherwise fall back to local value for backwards compatibility
+const TABLE_AGENT_VERSIONS = ((coreStorage as Record<string, unknown>).TABLE_AGENT_VERSIONS ??
+  'mastra_agent_versions') as 'mastra_agent_versions';
 import type {
   StorageAgentType,
   StorageCreateAgentInput,

--- a/stores/pg/src/storage/domains/observability/index.ts
+++ b/stores/pg/src/storage/domains/observability/index.ts
@@ -1,11 +1,11 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import * as coreStorage from '@mastra/core/storage';
 import {
   createStorageErrorId,
   listTracesArgsSchema,
   ObservabilityStorage,
   TABLE_SCHEMAS,
   TABLE_SPANS,
+  toTraceSpans,
   TraceStatus,
 } from '@mastra/core/storage';
 import type {
@@ -29,14 +29,6 @@ import type {
 import { PgDB, resolvePgConfig } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { transformFromSqlRow, getTableName, getSchemaName } from '../utils';
-
-// Use core's toTraceSpans if available, otherwise provide fallback for backwards compatibility
-const toTraceSpans = ((coreStorage as Record<string, unknown>).toTraceSpans ??
-  ((spans: SpanRecord[]) =>
-    spans.map(span => ({
-      ...span,
-      status: span.error != null ? TraceStatus.ERROR : span.endedAt == null ? TraceStatus.RUNNING : TraceStatus.SUCCESS,
-    })))) as (spans: SpanRecord[]) => (SpanRecord & { status: TraceStatus })[];
 
 export class ObservabilityPG extends ObservabilityStorage {
   #db: PgDB;

--- a/stores/pg/src/storage/domains/observability/index.ts
+++ b/stores/pg/src/storage/domains/observability/index.ts
@@ -1,5 +1,7 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import {
+import * as coreStorage from '@mastra/core/storage';
+
+const {
   createStorageErrorId,
   listTracesArgsSchema,
   ObservabilityStorage,
@@ -7,7 +9,7 @@ import {
   TABLE_SPANS,
   toTraceSpans,
   TraceStatus,
-} from '@mastra/core/storage';
+} = coreStorage;
 import type {
   SpanRecord,
   TracingStorageStrategy,

--- a/stores/pg/src/storage/domains/observability/index.ts
+++ b/stores/pg/src/storage/domains/observability/index.ts
@@ -1,11 +1,11 @@
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import * as coreStorage from '@mastra/core/storage';
 import {
   createStorageErrorId,
   listTracesArgsSchema,
   ObservabilityStorage,
   TABLE_SCHEMAS,
   TABLE_SPANS,
-  toTraceSpans,
   TraceStatus,
 } from '@mastra/core/storage';
 import type {
@@ -29,6 +29,14 @@ import type {
 import { PgDB, resolvePgConfig } from '../../db';
 import type { PgDomainConfig } from '../../db';
 import { transformFromSqlRow, getTableName, getSchemaName } from '../utils';
+
+// Use core's toTraceSpans if available, otherwise provide fallback for backwards compatibility
+const toTraceSpans = ((coreStorage as Record<string, unknown>).toTraceSpans ??
+  ((spans: SpanRecord[]) =>
+    spans.map(span => ({
+      ...span,
+      status: span.error != null ? TraceStatus.ERROR : span.endedAt == null ? TraceStatus.RUNNING : TraceStatus.SUCCESS,
+    })))) as (spans: SpanRecord[]) => (SpanRecord & { status: TraceStatus })[];
 
 export class ObservabilityPG extends ObservabilityStorage {
   #db: PgDB;


### PR DESCRIPTION
## Description

Updates `@mastra/cloudflare`'s peer dependency for `@mastra/core` to `>=1.1.0-0`. This ensures compatibility with new exports (e.g., `TABLE_AGENT_VERSIONS`, `AgentVersion`) introduced in `@mastra/core@1.1.0+` by PR #12038, preventing runtime errors when `@mastra/cloudflare` is used with older `@mastra/core` versions.

## Related Issue(s)

Addresses a peer dependency compatibility issue stemming from https://github.com/mastra-ai/mastra/pull/12038.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

---
<a href="https://cursor.com/background-agent?bcId=bc-5c38e4bc-e5ef-4454-bc4b-9d71ad286eae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5c38e4bc-e5ef-4454-bc4b-9d71ad286eae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

