### PR TITLE
fix(playground-ui): prevent model combobox from auto-opening on mount

### DIFF
--- a/.changeset/eighty-mangos-lie.md
+++ b/.changeset/eighty-mangos-lie.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed model combobox auto-opening on mount. The model selector now only opens when explicitly changing providers, improving the initial page load experience.

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata-model-switcher.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata-model-switcher.tsx
@@ -156,9 +156,10 @@ export const AgentMetadataModelSwitcher = ({
     const cleanedId = cleanProviderId(providerId);
     setSelectedProvider(cleanedId);
 
-    // Only clear model selection when switching to a different provider
+    // Only clear model selection and open model combobox when switching to a different provider
     if (cleanedId !== currentModelProvider) {
       setSelectedModel('');
+      setModelOpen(true);
     }
   };
 
@@ -255,6 +256,8 @@ export const AgentMetadataModelSwitcher = ({
             emptyText="No providers found"
             variant="default"
             size="md"
+            open={providerOpen}
+            onOpenChange={setProviderOpen}
           />
         </div>
 
@@ -268,6 +271,8 @@ export const AgentMetadataModelSwitcher = ({
             emptyText="No models found"
             variant="default"
             size="md"
+            open={modelOpen}
+            onOpenChange={setModelOpen}
           />
         </div>
 

--- a/packages/playground-ui/src/domains/agents/components/composer-model-switcher.tsx
+++ b/packages/playground-ui/src/domains/agents/components/composer-model-switcher.tsx
@@ -23,6 +23,7 @@ export const ComposerModelSwitcher = ({ agentId }: ComposerModelSwitcherProps) =
 
   const [selectedModel, setSelectedModel] = useState(defaultModel);
   const [selectedProvider, setSelectedProvider] = useState(defaultProvider);
+  const [modelOpen, setModelOpen] = useState(false);
 
   const providers = dataProviders?.providers || [];
 
@@ -125,8 +126,10 @@ export const ComposerModelSwitcher = ({ agentId }: ComposerModelSwitcherProps) =
     const cleanedId = cleanProviderId(providerId);
     setSelectedProvider(cleanedId);
 
+    // Only clear model selection and open model combobox when switching to a different provider
     if (cleanedId !== currentModelProvider) {
       setSelectedModel('');
+      setModelOpen(true);
     }
   };
 
@@ -163,6 +166,9 @@ export const ComposerModelSwitcher = ({ agentId }: ComposerModelSwitcherProps) =
           searchPlaceholder="Search models..."
           emptyText="No models found"
           variant="light"
+          open={modelOpen}
+          onOpenChange={setModelOpen}
+          className="min-w-48"
         />
       </div>
       {showWarning && (

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
@@ -24,6 +24,8 @@ export type ComboboxProps = {
   disabled?: boolean;
   variant?: 'default' | 'light' | 'outline' | 'ghost';
   size?: FormElementSize;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 };
 
 export function Combobox({
@@ -37,6 +39,8 @@ export function Combobox({
   disabled = false,
   variant = 'default',
   size = 'md',
+  open,
+  onOpenChange,
 }: ComboboxProps) {
   const selectedOption = options.find(option => option.value === value) ?? null;
 
@@ -47,7 +51,14 @@ export function Combobox({
   };
 
   return (
-    <BaseCombobox.Root items={options} value={selectedOption} onValueChange={handleSelect} disabled={disabled}>
+    <BaseCombobox.Root
+      items={options}
+      value={selectedOption}
+      onValueChange={handleSelect}
+      disabled={disabled}
+      open={open}
+      onOpenChange={onOpenChange}
+    >
       <BaseCombobox.Trigger className={cn(buttonVariants({ variant, size }), 'w-full min-w-32 justify-between', className)}>
         <span className="truncate flex items-center gap-2">
           {selectedOption?.start}

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
@@ -48,15 +48,16 @@ export function Combobox({
 
   return (
     <BaseCombobox.Root items={options} value={selectedOption} onValueChange={handleSelect} disabled={disabled}>
-      <BaseCombobox.Trigger className={cn(buttonVariants({ variant, size }), 'w-full justify-between', className)}>
-        <span className="truncate">
+      <BaseCombobox.Trigger className={cn(buttonVariants({ variant, size }), 'w-full min-w-32 justify-between', className)}>
+        <span className="truncate flex items-center gap-2">
+          {selectedOption?.start}
           <BaseCombobox.Value placeholder={placeholder} />
         </span>
         <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
       </BaseCombobox.Trigger>
 
       <BaseCombobox.Portal>
-        <BaseCombobox.Positioner align="start" sideOffset={4}>
+        <BaseCombobox.Positioner align="start" sideOffset={4} className="z-50">
           <BaseCombobox.Popup
             className={cn(
               'min-w-[var(--anchor-width)] w-max rounded-md bg-surface3 text-neutral5',

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
@@ -59,7 +59,9 @@ export function Combobox({
       open={open}
       onOpenChange={onOpenChange}
     >
-      <BaseCombobox.Trigger className={cn(buttonVariants({ variant, size }), 'w-full min-w-32 justify-between', className)}>
+      <BaseCombobox.Trigger
+        className={cn(buttonVariants({ variant, size }), 'w-full min-w-32 justify-between', className)}
+      >
         <span className="truncate flex items-center gap-2">
           {selectedOption?.start}
           <BaseCombobox.Value placeholder={placeholder} />

--- a/packages/playground-ui/src/ds/components/IconButton/IconButton.tsx
+++ b/packages/playground-ui/src/ds/components/IconButton/IconButton.tsx
@@ -46,6 +46,7 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
           <button
             ref={ref}
             disabled={disabled}
+            aria-label={typeof tooltip === 'string' ? tooltip : undefined}
             className={cn(
               baseButtonStyles,
               formElementFocus,

--- a/packages/playground-ui/src/lib/ai-ui/thread.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/thread.tsx
@@ -92,7 +92,6 @@ interface ComposerProps {
 
 const Composer = ({ hasMemory, agentId, hasModelList }: ComposerProps) => {
   const { setThreadInput } = useThreadInput();
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
   return (
     <div className="mx-4">
       <ComposerPrimitive.Root>
@@ -100,17 +99,11 @@ const Composer = ({ hasMemory, agentId, hasModelList }: ComposerProps) => {
           <ComposerAttachments />
         </div>
 
-        <div
-          className="bg-surface3 rounded-lg border border-border1 py-4 mt-auto max-w-3xl w-full mx-auto px-4 focus-within:outline focus-within:outline-accent1 -outline-offset-2"
-          onClick={() => {
-            textareaRef.current?.focus();
-          }}
-        >
+        <div className="bg-surface3 rounded-lg border border-border1 py-4 mt-auto max-w-3xl w-full mx-auto px-4 focus-within:outline focus-within:outline-accent1 -outline-offset-2">
           <ComposerPrimitive.Input asChild className="w-full">
             <textarea
-              ref={textareaRef}
+              autoFocus
               className="text-ui-lg leading-ui-lg placeholder:text-neutral3 text-neutral6 bg-transparent focus:outline-none resize-none outline-none"
-              autoFocus={document.activeElement === document.body}
               placeholder="Enter your message..."
               name=""
               id=""


### PR DESCRIPTION
When mounting the agent chat, the model combobox was opening immediately because a `useEffect` was watching for provider changes and calling `setModelOpen(true)`. This couldn't distinguish between mount-time initialization vs actual user interaction.

Moved the auto-open logic from the effect into the `handleProviderSelect` handler so the model combobox only opens when the user explicitly changes providers. Also added controlled open/close props to the Combobox component and increased the model combobox width for better readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model selector no longer auto-opens on initial load; it now opens only when you switch providers.

* **User Interface**
  * Model dropdown trigger has improved sizing and shows model prefix for clearer selection.
  * Dropdown stacking improved to reduce overlap issues.

* **Accessibility / Focus**
  * Message input now auto-focuses by default.
  * Icon buttons set accessible labels when a text tooltip is provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->