### PR TITLE
fix(playground-ui): stop keyboard event propagation in command palette

### DIFF
--- a/.changeset/cold-rockets-cheat.md
+++ b/.changeset/cold-rockets-cheat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed keyboard events in command palette propagating to underlying page elements like tables

--- a/packages/playground-ui/src/ds/components/Command/command.tsx
+++ b/packages/playground-ui/src/ds/components/Command/command.tsx
@@ -41,6 +41,12 @@ const CommandDialog = ({
     return matches ? 1 : 0;
   }, []);
 
+  // Stop propagation to prevent keyboard events from reaching
+  // global document-level listeners (e.g., table keyboard nav)
+  const handleKeyDown = React.useCallback((e: React.KeyboardEvent) => {
+    e.stopPropagation();
+  }, []);
+
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0">
@@ -48,6 +54,7 @@ const CommandDialog = ({
         <DialogDescription className="sr-only">{description}</DialogDescription>
         <Command
           filter={filter}
+          onKeyDown={handleKeyDown}
           className={cn(
             '[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-neutral3',
             '[&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2',


### PR DESCRIPTION
When the command palette is open over a table, keyboard events (arrow keys, Enter, etc.) were propagating to the table's global keyboard listeners, causing unintended row navigation.

Added `stopPropagation()` to the `CommandDialog` component's `onKeyDown` handler to contain keyboard events within the dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard events in the command palette from propagating to underlying page elements, preventing unintended interactions with tables and other components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->