### PR TITLE
Fixed token usage reporting for Langfuse and PostHog exporters

### DIFF
--- a/.changeset/fix-usage-token-counting.md
+++ b/.changeset/fix-usage-token-counting.md
@@ -3,4 +3,4 @@
 '@mastra/posthog': patch
 ---
 
-Fixed token usage reporting for Langfuse and PostHog exporters. The `input` token count now correctly excludes cached tokens, matching each platform's expected format for accurate cost calculation. Cache read and cache write tokens are now properly reported as separate fields (`cache_read_input_tokens`, `cache_creation_input_tokens`) rather than being included in the base input count.
+Fixed token usage reporting for Langfuse and PostHog exporters. The `input` token count now correctly excludes cached tokens, matching each platform's expected format for accurate cost calculation. Cache read and cache write tokens are now properly reported as separate fields (`cache_read_input_tokens`, `cache_creation_input_tokens`) rather than being included in the base input count. Added defensive clamping to ensure input tokens never go negative if cache values exceed the total.

--- a/.changeset/fix-usage-token-counting.md
+++ b/.changeset/fix-usage-token-counting.md
@@ -1,0 +1,6 @@
+---
+'@mastra/langfuse': patch
+'@mastra/posthog': patch
+---
+
+Fixed token usage reporting for Langfuse and PostHog exporters. The `input` token count now correctly excludes cached tokens, matching each platform's expected format for accurate cost calculation. Cache read and cache write tokens are now properly reported as separate fields (`cache_read_input_tokens`, `cache_creation_input_tokens`) rather than being included in the base input count.

--- a/observability/langfuse/src/metrics.test.ts
+++ b/observability/langfuse/src/metrics.test.ts
@@ -11,21 +11,43 @@ describe('formatUsageMetrics', () => {
     expect(result?.total).toBe(150);
   });
 
-  it('should extract cacheRead from inputDetails', () => {
+  it('should extract cacheRead from inputDetails and subtract from input', () => {
+    // inputTokens from usage.ts is the total (non-cached + cached)
+    // Langfuse expects 'input' to be NON-cached only
     const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheRead: 800 } };
     const result = formatUsageMetrics(usage);
     expect(result?.cache_read_input_tokens).toBe(800);
+    // input should be non-cached: 1000 - 800 = 200
+    expect(result?.input).toBe(200);
+    // total = input (200) + output (200) + cache_read (800) = 1200
+    expect(result?.total).toBe(1200);
   });
 
-  it('should extract cacheWrite from inputDetails', () => {
+  it('should extract cacheWrite from inputDetails and subtract from input', () => {
     const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheWrite: 500 } };
     const result = formatUsageMetrics(usage);
     expect(result?.cache_write_input_tokens).toBe(500);
-    // cacheWrite tokens are subtracted from input
+    // input should be non-cached: 1000 - 500 = 500
     expect(result?.input).toBe(500);
-    // total should include input (after subtraction) + output + cache_write_input_tokens
-    // total = 500 (input after subtraction) + 200 (output) + 500 (cache_write) = 1200
+    // total = input (500) + output (200) + cache_write (500) = 1200
     expect(result?.total).toBe(1200);
+  });
+
+  it('should handle both cacheRead and cacheWrite together', () => {
+    // Simulates Anthropic usage: inputTokens = non-cached + cacheRead + cacheWrite
+    // e.g., 5627 non-cached + 24440 cacheRead + 1000 cacheWrite = 31067 total
+    const usage: UsageStats = {
+      inputTokens: 31067,
+      outputTokens: 169,
+      inputDetails: { cacheRead: 24440, cacheWrite: 1000 },
+    };
+    const result = formatUsageMetrics(usage);
+    expect(result?.cache_read_input_tokens).toBe(24440);
+    expect(result?.cache_write_input_tokens).toBe(1000);
+    // input should be non-cached: 31067 - 24440 - 1000 = 5627
+    expect(result?.input).toBe(5627);
+    // total = input (5627) + output (169) + cache_read (24440) + cache_write (1000) = 31236
+    expect(result?.total).toBe(31236);
   });
 
   it('should extract reasoning from outputDetails', () => {

--- a/observability/langfuse/src/metrics.test.ts
+++ b/observability/langfuse/src/metrics.test.ts
@@ -55,4 +55,14 @@ describe('formatUsageMetrics', () => {
     const result = formatUsageMetrics(usage);
     expect(result?.reasoning).toBe(400);
   });
+
+  it('should clamp input tokens to zero if cache exceeds total', () => {
+    // Edge case: if cache tokens somehow exceed inputTokens, don't go negative
+    const usage: UsageStats = { inputTokens: 100, outputTokens: 50, inputDetails: { cacheRead: 150 } };
+    const result = formatUsageMetrics(usage);
+    expect(result?.cache_read_input_tokens).toBe(150);
+    expect(result?.input).toBe(0); // Clamped to 0, not -50
+    // total = input (0) + output (50) + cache_read (150) = 200
+    expect(result?.total).toBe(200);
+  });
 });

--- a/observability/langfuse/src/metrics.ts
+++ b/observability/langfuse/src/metrics.ts
@@ -36,6 +36,9 @@ export function formatUsageMetrics(usage?: UsageStats): LangfuseUsageMetrics {
       metrics.cache_write_input_tokens = usage.inputDetails.cacheWrite;
       metrics.input -= metrics.cache_write_input_tokens;
     }
+
+    // Defensive clamp: ensure input tokens is never negative
+    if (metrics.input < 0) metrics.input = 0;
   }
 
   if (usage.outputTokens !== undefined) {

--- a/observability/langfuse/src/metrics.ts
+++ b/observability/langfuse/src/metrics.ts
@@ -21,16 +21,21 @@ export function formatUsageMetrics(usage?: UsageStats): LangfuseUsageMetrics {
   const metrics: LangfuseUsageMetrics = {};
 
   if (usage.inputTokens !== undefined) {
+    // Start with total input tokens (which includes cached tokens from usage.ts)
     metrics.input = usage.inputTokens;
+
+    // Langfuse expects 'input' to be NON-cached tokens only.
+    // Subtract cache tokens to get the actual non-cached input count.
+    // See: https://langfuse.com/docs/observability/features/token-and-cost-tracking
+    if (usage.inputDetails?.cacheRead !== undefined) {
+      metrics.cache_read_input_tokens = usage.inputDetails.cacheRead;
+      metrics.input -= metrics.cache_read_input_tokens;
+    }
 
     if (usage.inputDetails?.cacheWrite !== undefined) {
       metrics.cache_write_input_tokens = usage.inputDetails.cacheWrite;
       metrics.input -= metrics.cache_write_input_tokens;
     }
-  }
-
-  if (usage.inputDetails?.cacheRead !== undefined) {
-    metrics.cache_read_input_tokens = usage.inputDetails.cacheRead;
   }
 
   if (usage.outputTokens !== undefined) {
@@ -41,9 +46,13 @@ export function formatUsageMetrics(usage?: UsageStats): LangfuseUsageMetrics {
     metrics.reasoning = usage.outputDetails.reasoning;
   }
 
+  // Calculate total: input + cache_read + cache_write + output
   // Use explicit null checks to handle zero values correctly
   if (metrics.input != null && metrics.output != null) {
     metrics.total = metrics.input + metrics.output;
+    if (metrics.cache_read_input_tokens != null) {
+      metrics.total += metrics.cache_read_input_tokens;
+    }
     if (metrics.cache_write_input_tokens != null) {
       metrics.total += metrics.cache_write_input_tokens;
     }

--- a/observability/langfuse/src/tracing.test.ts
+++ b/observability/langfuse/src/tracing.test.ts
@@ -1598,6 +1598,8 @@ describe('LangfuseExporter', () => {
     });
 
     it('should handle cached input tokens from inputDetails', async () => {
+      // inputTokens from usage.ts is the total (non-cached + cached)
+      // Langfuse expects 'input' to be NON-cached only
       const llmSpan = createMockSpan({
         id: 'llm-v5-cached-span',
         name: 'llm-generation-cached',
@@ -1607,7 +1609,7 @@ describe('LangfuseExporter', () => {
           model: 'claude-3-5-sonnet',
           provider: 'anthropic',
           usage: {
-            inputTokens: 150,
+            inputTokens: 150, // total: 50 non-cached + 100 cacheRead
             outputTokens: 75,
             inputDetails: { cacheRead: 100 },
           },
@@ -1623,9 +1625,11 @@ describe('LangfuseExporter', () => {
         expect.objectContaining({
           model: 'claude-3-5-sonnet',
           usageDetails: {
-            input: 150,
+            // input is non-cached: 150 - 100 = 50
+            input: 50,
             output: 75,
             cache_read_input_tokens: 100,
+            // total = input (50) + output (75) + cache_read (100) = 225
             total: 225,
           },
         }),

--- a/observability/posthog/src/tracing.ts
+++ b/observability/posthog/src/tracing.ts
@@ -45,6 +45,9 @@ export function formatUsageMetrics(usage?: UsageStats): PostHogUsageMetrics {
       props.$ai_cache_creation_input_tokens = usage.inputDetails.cacheWrite;
       props.$ai_input_tokens -= props.$ai_cache_creation_input_tokens;
     }
+
+    // Defensive clamp: ensure input tokens is never negative
+    if (props.$ai_input_tokens < 0) props.$ai_input_tokens = 0;
   }
 
   if (usage.outputTokens !== undefined) props.$ai_output_tokens = usage.outputTokens;

--- a/observability/posthog/src/usage.test.ts
+++ b/observability/posthog/src/usage.test.ts
@@ -10,16 +10,40 @@ describe('formatUsageMetrics', () => {
     expect(result.$ai_output_tokens).toBe(50);
   });
 
-  it('should extract cacheRead from inputDetails', () => {
+  it('should extract cacheRead from inputDetails and subtract from input', () => {
+    // inputTokens from usage.ts is the total (non-cached + cached)
+    // PostHog expects $ai_input_tokens to be NON-cached only for cost calculation
     const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheRead: 800 } };
     const result = formatUsageMetrics(usage);
     expect(result.$ai_cache_read_input_tokens).toBe(800);
+    // $ai_input_tokens should be non-cached: 1000 - 800 = 200
+    expect(result.$ai_input_tokens).toBe(200);
+    expect(result.$ai_output_tokens).toBe(200);
   });
 
-  it('should extract cacheWrite from inputDetails', () => {
+  it('should extract cacheWrite from inputDetails and subtract from input', () => {
     const usage: UsageStats = { inputTokens: 1000, outputTokens: 200, inputDetails: { cacheWrite: 500 } };
     const result = formatUsageMetrics(usage);
     expect(result.$ai_cache_creation_input_tokens).toBe(500);
+    // $ai_input_tokens should be non-cached: 1000 - 500 = 500
+    expect(result.$ai_input_tokens).toBe(500);
+    expect(result.$ai_output_tokens).toBe(200);
+  });
+
+  it('should handle both cacheRead and cacheWrite together', () => {
+    // Simulates Anthropic usage: inputTokens = non-cached + cacheRead + cacheWrite
+    // e.g., 5627 non-cached + 24440 cacheRead + 1000 cacheWrite = 31067 total
+    const usage: UsageStats = {
+      inputTokens: 31067,
+      outputTokens: 169,
+      inputDetails: { cacheRead: 24440, cacheWrite: 1000 },
+    };
+    const result = formatUsageMetrics(usage);
+    expect(result.$ai_cache_read_input_tokens).toBe(24440);
+    expect(result.$ai_cache_creation_input_tokens).toBe(1000);
+    // $ai_input_tokens should be non-cached: 31067 - 24440 - 1000 = 5627
+    expect(result.$ai_input_tokens).toBe(5627);
+    expect(result.$ai_output_tokens).toBe(169);
   });
 
   it('should return empty metrics for undefined usage', () => {

--- a/observability/posthog/src/usage.test.ts
+++ b/observability/posthog/src/usage.test.ts
@@ -50,4 +50,13 @@ describe('formatUsageMetrics', () => {
     const result = formatUsageMetrics(undefined);
     expect(result).toEqual({});
   });
+
+  it('should clamp input tokens to zero if cache exceeds total', () => {
+    // Edge case: if cache tokens somehow exceed inputTokens, don't go negative
+    const usage: UsageStats = { inputTokens: 100, outputTokens: 50, inputDetails: { cacheRead: 150 } };
+    const result = formatUsageMetrics(usage);
+    expect(result.$ai_cache_read_input_tokens).toBe(150);
+    expect(result.$ai_input_tokens).toBe(0); // Clamped to 0, not -50
+    expect(result.$ai_output_tokens).toBe(50);
+  });
 });


### PR DESCRIPTION
## Description

Fixed token usage reporting for Langfuse and PostHog exporters. The `input` token count now correctly excludes cached tokens, matching each platform's expected format for accurate cost calculation. Cache read and cache write tokens are now properly reported as separate fields (`cache_read_input_tokens`, `cache_creation_input_tokens`) rather than being included in the base input count.

## Related Issue(s)

Fixes: #12296

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Input token counts now exclude cached tokens; cache read and cache creation tokens are reported separately and totals clamp to zero when needed.

* **Tests**
  * Updated and added tests to validate non-cached input calculation, separate cache token reporting, combined cache scenarios, and clamping behavior.

* **Documentation**
  * Added a changelog entry describing the patch release and token-counting fix.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->