### PR TITLE
fix(core,server): replace custom deepEqual with fast-deep-equal

### DIFF
--- a/.changeset/replace-deep-equal.md
+++ b/.changeset/replace-deep-equal.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/server': patch
+---
+
+Replaced custom deepEqual implementations with fast-deep-equal.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -231,7 +231,8 @@
     "p-map": "^7.0.3",
     "p-retry": "^7.1.0",
     "radash": "^12.1.1",
-    "xxhash-wasm": "^1.1.0"
+    "xxhash-wasm": "^1.1.0",
+    "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {
     "zod": "^3.25.0 || ^4.0.0"
@@ -268,7 +269,6 @@
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
     "eslint": "^9.37.0",
-    "fast-deep-equal": "^3.1.3",
     "globby": "^14.1.0",
     "rollup": "^4.55.2",
     "ts-morph": "^27.0.2",

--- a/packages/core/src/storage/domains/agents/inmemory.ts
+++ b/packages/core/src/storage/domains/agents/inmemory.ts
@@ -1,4 +1,4 @@
-import { deepEqual } from '../../../utils';
+import deepEqual from 'fast-deep-equal';
 import { normalizePerPage, calculatePagination } from '../../base';
 import type {
   StorageAgentType,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -57,47 +57,6 @@ export function deepMerge<T extends object = object>(target: T, source: Partial<
   return output;
 }
 
-/**
- * Deep equality comparison for comparing two values.
- * Handles primitives, arrays, objects, and Date instances.
- */
-export function deepEqual(a: unknown, b: unknown): boolean {
-  // Handle identical references and primitives
-  if (a === b) return true;
-
-  // Handle null/undefined
-  if (a == null || b == null) return a === b;
-
-  // Handle different types
-  if (typeof a !== typeof b) return false;
-
-  // Handle arrays
-  if (Array.isArray(a) && Array.isArray(b)) {
-    if (a.length !== b.length) return false;
-    return a.every((item, index) => deepEqual(item, b[index]));
-  }
-
-  // Handle dates (must check before generic objects since Date is also an object)
-  if (a instanceof Date && b instanceof Date) {
-    return a.getTime() === b.getTime();
-  }
-
-  // Handle objects (after Date check to avoid treating Dates as plain objects)
-  if (typeof a === 'object' && typeof b === 'object') {
-    const aObj = a as Record<string, unknown>;
-    const bObj = b as Record<string, unknown>;
-    const aKeys = Object.keys(aObj);
-    const bKeys = Object.keys(bObj);
-
-    if (aKeys.length !== bKeys.length) return false;
-
-    // Verify that bObj has the same keys as aObj before comparing values
-    return aKeys.every(key => Object.prototype.hasOwnProperty.call(bObj, key) && deepEqual(aObj[key], bObj[key]));
-  }
-
-  return false;
-}
-
 export function generateEmptyFromSchema(schema: string) {
   try {
     const parsedSchema = JSON.parse(schema);

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -120,6 +120,7 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
+    "fast-deep-equal": "^3.1.3",
     "hono": "^4.11.3"
   }
 }

--- a/packages/server/src/server/handlers/agent-versions.ts
+++ b/packages/server/src/server/handlers/agent-versions.ts
@@ -1,3 +1,4 @@
+import deepEqual from 'fast-deep-equal';
 import { HTTPException } from '../http-exception';
 import {
   agentVersionPathParams,
@@ -23,48 +24,6 @@ export const DEFAULT_MAX_VERSIONS_PER_AGENT = 50;
 // ============================================================================
 // Helper Functions (exported for use in stored-agents.ts)
 // ============================================================================
-
-/**
- * Deep equality comparison for comparing two values.
- * Handles primitives, arrays, objects, and Date instances.
- * TODO: Move to a shared utils package that gets bundled into each package
- */
-function deepEqual(a: unknown, b: unknown): boolean {
-  // Handle identical references and primitives
-  if (a === b) return true;
-
-  // Handle null/undefined
-  if (a == null || b == null) return a === b;
-
-  // Handle different types
-  if (typeof a !== typeof b) return false;
-
-  // Handle arrays
-  if (Array.isArray(a) && Array.isArray(b)) {
-    if (a.length !== b.length) return false;
-    return a.every((item, index) => deepEqual(item, b[index]));
-  }
-
-  // Handle dates (must check before generic objects since Date is also an object)
-  if (a instanceof Date && b instanceof Date) {
-    return a.getTime() === b.getTime();
-  }
-
-  // Handle objects (after Date check to avoid treating Dates as plain objects)
-  if (typeof a === 'object' && typeof b === 'object') {
-    const aObj = a as Record<string, unknown>;
-    const bObj = b as Record<string, unknown>;
-    const aKeys = Object.keys(aObj);
-    const bKeys = Object.keys(bObj);
-
-    if (aKeys.length !== bKeys.length) return false;
-
-    // Verify that bObj has the same keys as aObj before comparing values
-    return aKeys.every(key => Object.prototype.hasOwnProperty.call(bObj, key) && deepEqual(aObj[key], bObj[key]));
-  }
-
-  return false;
-}
 
 /**
  * Generates a unique ID for a version using crypto.randomUUID()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2147,6 +2147,9 @@ importers:
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
+      fast-deep-equal:
+        specifier: ^3.1.3
+        version: 3.1.3
       hono:
         specifier: ^4.11.3
         version: 4.11.3
@@ -2268,9 +2271,6 @@ importers:
       eslint:
         specifier: ^9.37.0
         version: 9.39.2(jiti@2.6.1)
-      fast-deep-equal:
-        specifier: ^3.1.3
-        version: 3.1.3
       globby:
         specifier: ^14.1.0
         version: 14.1.0
@@ -3418,6 +3418,9 @@ importers:
 
   packages/server:
     dependencies:
+      fast-deep-equal:
+        specifier: ^3.1.3
+        version: 3.1.3
       hono:
         specifier: ^4.11.3
         version: 4.11.3


### PR DESCRIPTION
We had a custom `deepEqual` implementation inlined in `@mastra/server` and `@mastra/core`. We already depend on `fast-deep-equal` — this just uses it directly instead.

- Removed custom `deepEqual` from `packages/core/src/utils.ts`
- Removed inlined `deepEqual` from `packages/server/src/server/handlers/agent-versions.ts`
- Moved `fast-deep-equal` from devDependencies to dependencies in `@mastra/core`
- Added `fast-deep-equal` as a direct dependency of `@mastra/server`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized deep equality comparison logic for improved performance and package efficiency.
  * Updated dependency structure to align runtime and development package requirements across core and server modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->