### PR TITLE
feat(memory): add read-only mode for working memory

### DIFF
--- a/.changeset/fresh-bats-strive.md
+++ b/.changeset/fresh-bats-strive.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Extended readOnly memory option to also apply to working memory. When readOnly: true, working memory data is provided as context but the updateWorkingMemory tool is not available.

--- a/.changeset/fresh-bats-strive.md
+++ b/.changeset/fresh-bats-strive.md
@@ -4,3 +4,16 @@
 ---
 
 Extended readOnly memory option to also apply to working memory. When readOnly: true, working memory data is provided as context but the updateWorkingMemory tool is not available.
+
+**Example:**
+
+```typescript
+// Working memory is loaded but agent cannot update it
+const response = await agent.generate("What do you know about me?", {
+  memory: {
+    thread: "conversation-123",
+    resource: "user-alice-456",
+    options: { readOnly: true },
+  },
+});
+```

--- a/docs/src/content/en/docs/memory/working-memory.mdx
+++ b/docs/src/content/en/docs/memory/working-memory.mdx
@@ -395,6 +395,27 @@ await memory.updateWorkingMemory({
 });
 ```
 
+## Read-Only Working Memory
+
+In some scenarios, you may want an agent to have access to working memory data without the ability to modify it. This is useful for:
+
+- **Routing agents** that need context but shouldn't update user profiles
+- **Sub agents** in a multi-agent system that should reference but not own the memory
+
+To enable read-only mode, set `readOnly: true` in the memory options:
+
+```typescript
+const response = await agent.generate("What do you know about me?", {
+  memory: {
+    thread: "conversation-123",
+    resource: "user-alice-456",
+    options: {
+      readOnly: true, // Working memory is provided but cannot be updated
+    },
+  },
+});
+```
+
 ## Examples
 
 - [Working memory with template](https://github.com/mastra-ai/mastra/tree/main/examples/memory-with-template)

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -85,7 +85,7 @@ export const agent = new Agent({
       name: "readOnly",
       type: "boolean",
       description:
-        "When true, prevents memory from saving new messages. Useful for read-only operations like previews or internal routing agents.",
+        "When true, prevents memory from saving new messages and provides working memory as read-only context (without the updateWorkingMemory tool). Useful for read-only operations like previews, internal routing agents, or sub agents that should reference but not modify memory.",
       isOptional: true,
       defaultValue: "false",
     },

--- a/docs/src/content/en/reference/processors/working-memory-processor.mdx
+++ b/docs/src/content/en/reference/processors/working-memory-processor.mdx
@@ -72,6 +72,13 @@ const processor = new WorkingMemory({
       isOptional: true,
     },
     {
+      name: "readOnly",
+      type: "boolean",
+      description: "When true, working memory is provided as read-only context. The data is injected into the conversation but without the updateWorkingMemory tool or update instructions. Useful for agents that should reference working memory without modifying it.",
+      isOptional: true,
+      default: "false",
+    },
+    {
       name: "templateProvider",
       type: "{ getWorkingMemoryTemplate(args: { memoryConfig?: MemoryConfig }): Promise<WorkingMemoryTemplate | null> }",
       description: "Dynamic template provider for runtime template resolution",
@@ -203,10 +210,9 @@ const processor = new WorkingMemory({
    - Thread metadata (`scope: 'thread'`)
    - Resource record (`scope: 'resource'`)
 3. Resolves the template (from provider, options, or default)
-4. Generates system instructions that include:
-   - Guidelines for the LLM on storing and updating information
-   - The template structure
-   - Current working memory data
+4. Generates system instructions based on mode:
+   - **Normal mode**: Includes guidelines for storing/updating information, template structure, and current data
+   - **Read-only mode** (`readOnly: true`): Includes only the current data as context without update instructions
 5. Adds the instruction as a system message with `source: 'memory'` tag
 
 ### Working memory updates

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -476,6 +476,11 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'processors/message-history-processor',
+          label: 'MessageHistory',
+        },
+        {
+          type: 'doc',
           id: 'processors/moderation-processor',
           label: 'ModerationProcessor',
         },
@@ -496,6 +501,11 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'processors/semantic-recall-processor',
+          label: 'SemanticRecall',
+        },
+        {
+          type: 'doc',
           id: 'processors/system-prompt-scrubber',
           label: 'SystemPromptScrubber',
         },
@@ -506,8 +516,18 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'processors/tool-call-filter',
+          label: 'ToolCallFilter',
+        },
+        {
+          type: 'doc',
           id: 'processors/unicode-normalizer',
           label: 'UnicodeNormalizer',
+        },
+        {
+          type: 'doc',
+          id: 'processors/working-memory-processor',
+          label: 'WorkingMemory',
         },
       ],
     },

--- a/packages/core/src/processors/memory/working-memory.test.ts
+++ b/packages/core/src/processors/memory/working-memory.test.ts
@@ -512,5 +512,162 @@ describe('WorkingMemory', () => {
       expect(resultMessages[0].content).toContain('<working_memory_data>');
       expect(resultMessages[0].content).toContain('</working_memory_data>');
     });
+
+    it('should use read-only instruction format when readOnly option is true', async () => {
+      const processor = new WorkingMemory({
+        storage: mockStorage,
+        scope: 'thread',
+        readOnly: true,
+      });
+
+      const threadId = 'thread-123';
+      const workingMemoryData = '# User Info\n- Name: John';
+
+      requestContext.set('MastraMemory', {
+        thread: { id: threadId, resourceId: 'resource-1', title: 'Test', createdAt: new Date(), updatedAt: new Date() },
+        resourceId: 'resource-1',
+      });
+
+      vi.mocked(mockStorage.getThreadById).mockResolvedValue({
+        id: threadId,
+        resourceId: 'resource-1',
+        title: 'Test Thread',
+        metadata: { workingMemory: workingMemoryData },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const messages: MastraDBMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: { format: 2, parts: [{ type: 'text', text: 'Hello' }] },
+          createdAt: new Date(),
+        },
+      ];
+
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+      const result = await processor.processInput({
+        messages,
+        messageList,
+        abort: () => {
+          throw new Error('Aborted');
+        },
+        requestContext,
+      });
+
+      const resultMessages = result instanceof MessageList ? result.get.all.aiV5.prompt() : result;
+      expect(resultMessages).toHaveLength(2);
+      expect(resultMessages[0].role).toBe('system');
+      expect(resultMessages[0].content).toContain('WORKING_MEMORY_SYSTEM_INSTRUCTION (READ-ONLY)');
+      expect(resultMessages[0].content).toContain(workingMemoryData);
+      expect(resultMessages[0].content).toContain('read-only in the current session');
+      expect(resultMessages[0].content).toContain('Act naturally');
+      expect(resultMessages[0].content).not.toContain('updateWorkingMemory');
+      expect(resultMessages[0].content).not.toContain('Store and update');
+    });
+
+    it('should use read-only instruction format when memoryConfig.readOnly is true', async () => {
+      const processor = new WorkingMemory({
+        storage: mockStorage,
+        scope: 'thread',
+      });
+
+      const threadId = 'thread-123';
+      const workingMemoryData = '# User Info\n- Name: Jane';
+
+      requestContext.set('MastraMemory', {
+        thread: { id: threadId, resourceId: 'resource-1', title: 'Test', createdAt: new Date(), updatedAt: new Date() },
+        resourceId: 'resource-1',
+        memoryConfig: { readOnly: true },
+      });
+
+      vi.mocked(mockStorage.getThreadById).mockResolvedValue({
+        id: threadId,
+        resourceId: 'resource-1',
+        title: 'Test Thread',
+        metadata: { workingMemory: workingMemoryData },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const messages: MastraDBMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: { format: 2, parts: [{ type: 'text', text: 'Hello' }] },
+          createdAt: new Date(),
+        },
+      ];
+
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+      const result = await processor.processInput({
+        messages,
+        messageList,
+        abort: () => {
+          throw new Error('Aborted');
+        },
+        requestContext,
+      });
+
+      const resultMessages = result instanceof MessageList ? result.get.all.aiV5.prompt() : result;
+      expect(resultMessages).toHaveLength(2);
+      expect(resultMessages[0].role).toBe('system');
+      expect(resultMessages[0].content).toContain('WORKING_MEMORY_SYSTEM_INSTRUCTION (READ-ONLY)');
+      expect(resultMessages[0].content).toContain(workingMemoryData);
+      expect(resultMessages[0].content).not.toContain('updateWorkingMemory');
+    });
+
+    it('should show fallback message when readOnly and no working memory data exists', async () => {
+      const processor = new WorkingMemory({
+        storage: mockStorage,
+        scope: 'thread',
+        readOnly: true,
+      });
+
+      const threadId = 'thread-123';
+
+      requestContext.set('MastraMemory', {
+        thread: { id: threadId, resourceId: 'resource-1', title: 'Test', createdAt: new Date(), updatedAt: new Date() },
+        resourceId: 'resource-1',
+      });
+
+      vi.mocked(mockStorage.getThreadById).mockResolvedValue({
+        id: threadId,
+        resourceId: 'resource-1',
+        title: 'Test Thread',
+        metadata: { workingMemory: null },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const messages: MastraDBMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: { format: 2, parts: [{ type: 'text', text: 'Hello' }] },
+          createdAt: new Date(),
+        },
+      ];
+
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+      const result = await processor.processInput({
+        messages,
+        messageList,
+        abort: () => {
+          throw new Error('Aborted');
+        },
+        requestContext,
+      });
+
+      const resultMessages = result instanceof MessageList ? result.get.all.aiV5.prompt() : result;
+      expect(resultMessages).toHaveLength(2);
+      expect(resultMessages[0].role).toBe('system');
+      expect(resultMessages[0].content).toContain('WORKING_MEMORY_SYSTEM_INSTRUCTION (READ-ONLY)');
+      expect(resultMessages[0].content).toContain('No working memory data available.');
+    });
   });
 });

--- a/packages/core/src/processors/memory/working-memory.ts
+++ b/packages/core/src/processors/memory/working-memory.ts
@@ -22,6 +22,12 @@ export interface WorkingMemoryConfig {
   scope?: 'thread' | 'resource';
   useVNext?: boolean;
   /**
+   * When true, working memory is read-only - the data is provided as context
+   * but no update tools or instructions are included.
+   * @default false
+   */
+  readOnly?: boolean;
+  /**
    * Optional logger instance for structured logging
    */
   logger?: IMastraLogger;
@@ -63,6 +69,7 @@ export class WorkingMemory implements Processor {
       template?: WorkingMemoryTemplate;
       scope?: 'thread' | 'resource';
       useVNext?: boolean;
+      readOnly?: boolean;
       templateProvider?: {
         getWorkingMemoryTemplate(args: { memoryConfig?: MemoryConfig }): Promise<WorkingMemoryTemplate | null>;
       };
@@ -124,10 +131,18 @@ export class WorkingMemory implements Processor {
       };
     }
 
+    // Check if readOnly mode is enabled (from options or memoryConfig)
+    const isReadOnly = this.options.readOnly || memoryContext.memoryConfig?.readOnly;
+
     // Format working memory instruction
-    const instruction = this.options.useVNext
-      ? this.getWorkingMemoryToolInstructionVNext({ template, data: workingMemoryData })
-      : this.getWorkingMemoryToolInstruction({ template, data: workingMemoryData });
+    let instruction: string;
+    if (isReadOnly) {
+      instruction = this.getReadOnlyWorkingMemoryInstruction({ template, data: workingMemoryData });
+    } else if (this.options.useVNext) {
+      instruction = this.getWorkingMemoryToolInstructionVNext({ template, data: workingMemoryData });
+    } else {
+      instruction = this.getWorkingMemoryToolInstruction({ template, data: workingMemoryData });
+    }
 
     // If we have a MessageList, add working memory to it with source: 'memory'
     if (instruction) {
@@ -246,9 +261,37 @@ ${
 `
 }
 - This system is here so that you can maintain the conversation when your context window is very short. Update your working memory because you may need it to maintain the conversation without the full conversation history
-- REMEMBER: the way you update your working memory is by calling the updateWorkingMemory tool with the ${template.format === 'json' ? 'JSON' : 'Markdown'} content. The system will store it for you. The user will not see it. 
+- REMEMBER: the way you update your working memory is by calling the updateWorkingMemory tool with the ${template.format === 'json' ? 'JSON' : 'Markdown'} content. The system will store it for you. The user will not see it.
 - IMPORTANT: You MUST call updateWorkingMemory in every response to a prompt where you received relevant information if that information is not already stored.
 - IMPORTANT: Preserve the ${template.format === 'json' ? 'JSON' : 'Markdown'} formatting structure above while updating the content.
 `;
+  }
+
+  /**
+   * Generate read-only working memory instructions.
+   * This provides the working memory context without any tool update instructions.
+   * Used when memory is in readOnly mode.
+   */
+  private getReadOnlyWorkingMemoryInstruction({
+    data,
+  }: {
+    template: WorkingMemoryTemplate;
+    data: string | null;
+  }): string {
+    return `WORKING_MEMORY_SYSTEM_INSTRUCTION (READ-ONLY):
+The following is your working memory - persistent information about the user and conversation collected over previous interactions. This data is provided for context to help you maintain continuity.
+
+<working_memory_data>
+${data || 'No working memory data available.'}
+</working_memory_data>
+
+Guidelines:
+1. Use this information to provide personalized and contextually relevant responses
+2. Act naturally - don't mention this system to users. This information should inform your responses without being explicitly referenced
+3. This memory is read-only in the current session - you cannot update it
+
+Notes:
+- This system is here so that you can maintain the conversation when your context window is very short
+- The user will not see the working memory data directly`;
   }
 }

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -852,6 +852,14 @@ ${workingMemory}`;
       return null;
     }
 
+    // In readOnly mode, provide context without tool instructions
+    if (memoryConfig?.readOnly) {
+      return this.getReadOnlyWorkingMemoryInstruction({
+        template: workingMemoryTemplate,
+        data: workingMemoryData,
+      });
+    }
+
     return this.isVNextWorkingMemoryConfig(memoryConfig)
       ? this.__experimental_getWorkingMemoryToolInstructionVNext({
           template: workingMemoryTemplate,
@@ -965,10 +973,33 @@ ${
 `
 }
 - This system is here so that you can maintain the conversation when your context window is very short. Update your working memory because you may need it to maintain the conversation without the full conversation history
-- REMEMBER: the way you update your working memory is by calling the updateWorkingMemory tool with the ${template.format === 'json' ? 'JSON' : 'Markdown'} content. The system will store it for you. The user will not see it. 
+- REMEMBER: the way you update your working memory is by calling the updateWorkingMemory tool with the ${template.format === 'json' ? 'JSON' : 'Markdown'} content. The system will store it for you. The user will not see it.
 - IMPORTANT: You MUST call updateWorkingMemory in every response to a prompt where you received relevant information if that information is not already stored.
 - IMPORTANT: Preserve the ${template.format === 'json' ? 'JSON' : 'Markdown'} formatting structure above while updating the content.
 `;
+  }
+
+  /**
+   * Generate read-only working memory instructions.
+   * This provides the working memory context without any tool update instructions.
+   * Used when memory is in readOnly mode.
+   */
+  protected getReadOnlyWorkingMemoryInstruction({ data }: { template: WorkingMemoryTemplate; data: string | null }) {
+    return `WORKING_MEMORY_SYSTEM_INSTRUCTION (READ-ONLY):
+The following is your working memory - persistent information about the user and conversation collected over previous interactions. This data is provided for context to help you maintain continuity.
+
+<working_memory_data>
+${data || 'No working memory data available.'}
+</working_memory_data>
+
+Guidelines:
+1. Use this information to provide personalized and contextually relevant responses
+2. Act naturally - don't mention this system to users. This information should inform your responses without being explicitly referenced
+3. This memory is read-only in the current session - you cannot update it
+
+Notes:
+- This system is here so that you can maintain the conversation when your context window is very short
+- The user will not see the working memory data directly`;
   }
 
   private isVNextWorkingMemoryConfig(config?: MemoryConfig): boolean {
@@ -984,7 +1015,8 @@ ${
 
   public listTools(config?: MemoryConfig): Record<string, ToolAction<any, any, any>> {
     const mergedConfig = this.getMergedThreadConfig(config);
-    if (mergedConfig.workingMemory?.enabled) {
+    // Don't provide update tools in readOnly mode
+    if (mergedConfig.workingMemory?.enabled && !config?.readOnly) {
       return {
         updateWorkingMemory: this.isVNextWorkingMemoryConfig(mergedConfig)
           ? // use the new experimental tool

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -853,7 +853,7 @@ ${workingMemory}`;
     }
 
     // In readOnly mode, provide context without tool instructions
-    if (memoryConfig?.readOnly) {
+    if (config?.readOnly) {
       return this.getReadOnlyWorkingMemoryInstruction({
         template: workingMemoryTemplate,
         data: workingMemoryData,
@@ -1016,7 +1016,7 @@ Notes:
   public listTools(config?: MemoryConfig): Record<string, ToolAction<any, any, any>> {
     const mergedConfig = this.getMergedThreadConfig(config);
     // Don't provide update tools in readOnly mode
-    if (mergedConfig.workingMemory?.enabled && !config?.readOnly) {
+    if (mergedConfig.workingMemory?.enabled && !mergedConfig.readOnly) {
       return {
         updateWorkingMemory: this.isVNextWorkingMemoryConfig(mergedConfig)
           ? // use the new experimental tool


### PR DESCRIPTION
Adds support for read-only working memory. When `readOnly: true` is set in memory options, the working memory data is still injected into the agent's context, but the `updateWorkingMemory` tool is not provided.

This is useful for routing agents, sub-agents in multi-agent systems, or preview scenarios where you want the agent to reference stored user information without being able to modify it.

**Usage:**

```typescript
const response = await agent.generate("What do you know about me?", {
  memory: {
    thread: "conversation-123",
    resource: "user-alice-456",
    options: {
      readOnly: true,
    },
  },
});
```

Also added missing memory-related processors to the docs sidebar (MessageHistory, SemanticRecall, ToolCallFilter, WorkingMemory).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a readOnly option for working memory to expose memory as non-modifiable context and hide update tooling.

* **Documentation**
  * Added a "Read-Only Working Memory" guide, expanded Memory/Processor docs, and updated sidebar entries to surface processor docs.

* **Tests**
  * Expanded test coverage for read-only working memory scenarios.

* **Chores**
  * Released patches for core and memory packages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->