### PR TITLE
fix(deployer): fix lint errors

### DIFF
--- a/.changeset/fruity-pets-invent.md
+++ b/.changeset/fruity-pets-invent.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed lint errors in deployer package

--- a/packages/deployer/eslint.config.js
+++ b/packages/deployer/eslint.config.js
@@ -3,4 +3,9 @@ import { createConfig } from '@internal/lint/eslint';
 const config = await createConfig();
 
 /** @type {import("eslint").Linter.Config[]} */
-export default [...config];
+export default [
+  {
+    ignores: ['**/__fixtures__/**'],
+  },
+  ...config,
+];

--- a/packages/deployer/src/build/__fixtures__/no-bundler.js
+++ b/packages/deployer/src/build/__fixtures__/no-bundler.js
@@ -1,7 +1,7 @@
-import { Mastra } from '@mastra/core/mastra';
 import { createLogger } from '@mastra/core/logger';
-import { weatherAgent } from '@/agents';
+import { Mastra } from '@mastra/core/mastra';
 import { TestDeployer } from '@mastra/deployer/test';
+import { weatherAgent } from '@/agents';
 
 export const mastra = new Mastra({
   agents: { weatherAgent },

--- a/packages/deployer/src/build/__fixtures__/no-server.js
+++ b/packages/deployer/src/build/__fixtures__/no-server.js
@@ -1,7 +1,6 @@
-import { Mastra } from '@mastra/core/mastra';
 import { createLogger } from '@mastra/core/logger';
+import { Mastra } from '@mastra/core/mastra';
 import { weatherAgent } from '@/agents';
-import { TestDeployer } from '@mastra/deployer/test';
 
 export const mastra = new Mastra({
   agents: { weatherAgent },

--- a/packages/deployer/src/build/__fixtures__/no-telemetry.js
+++ b/packages/deployer/src/build/__fixtures__/no-telemetry.js
@@ -1,7 +1,6 @@
-import { Mastra } from '@mastra/core/mastra';
 import { createLogger } from '@mastra/core/logger';
+import { Mastra } from '@mastra/core/mastra';
 import { weatherAgent } from '@/agents';
-import { TestDeployer } from '@mastra/deployer/test';
 
 export const mastra = new Mastra({
   agents: { weatherAgent },

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -1,20 +1,21 @@
-import type { IMastraLogger } from '@mastra/core/logger';
-import * as babel from '@babel/core';
 import { existsSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
+import { basename, join, relative } from 'node:path';
+import * as babel from '@babel/core';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import type { IMastraLogger } from '@mastra/core/logger';
 import type { OutputAsset, OutputChunk } from 'rollup';
-import { basename, join, parse, relative } from 'node:path';
+import * as stackTraceParser from 'stacktrace-parser';
+import { getWorkspaceInformation } from '../bundler/workspaceDependencies';
+import type { WorkspacePackageInfo } from '../bundler/workspaceDependencies';
 import { validate, ValidationError } from '../validator/validate';
-import { getBundlerOptions } from './bundlerOptions';
-import { checkConfigExport } from './babel/check-config-export';
-import { getWorkspaceInformation, type WorkspacePackageInfo } from '../bundler/workspaceDependencies';
-import type { BundlerOptions, DependencyMetadata, ExternalDependencyInfo } from './types';
 import { analyzeEntry } from './analyze/analyzeEntry';
 import { bundleExternals } from './analyze/bundleExternals';
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
-import { getPackageName, isBuiltinModule, isDependencyPartOfPackage, type BundlerPlatform } from './utils';
 import { GLOBAL_EXTERNALS } from './analyze/constants';
-import * as stackTraceParser from 'stacktrace-parser';
+import { checkConfigExport } from './babel/check-config-export';
+import type { BundlerOptions, DependencyMetadata, ExternalDependencyInfo } from './types';
+import { getPackageName, isBuiltinModule, isDependencyPartOfPackage } from './utils';
+import type { BundlerPlatform } from './utils';
 
 type ErrorId =
   | 'DEPLOYER_ANALYZE_MODULE_NOT_FOUND'
@@ -314,7 +315,7 @@ export async function analyzeBundle(
 export const mastra = new Mastra({
   // your options
 })
-  
+
 If you think your configuration is valid, please open an issue.`);
   }
 

--- a/packages/deployer/src/build/analyze/analyzeEntry.test.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.test.ts
@@ -1,22 +1,24 @@
-import { analyzeEntry } from './analyzeEntry';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { readFile } from 'fs-extra';
 import { join } from 'node:path';
 import { noopLogger } from '@mastra/core/logger';
+import { readFile } from 'fs-extra';
 import { resolveModule } from 'local-pkg';
-import type { WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
+import type * as LocalPkgModule from 'local-pkg';
 import { rollup } from 'rollup';
+import type * as RollupModule from 'rollup';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
+import { analyzeEntry } from './analyzeEntry';
 
 vi.spyOn(process, 'cwd').mockReturnValue(join(import.meta.dirname, '__fixtures__', 'default'));
 vi.mock('local-pkg', async () => {
-  const actual = await vi.importActual<typeof import('local-pkg')>('local-pkg');
+  const actual = await vi.importActual<typeof LocalPkgModule>('local-pkg');
   return {
     ...actual,
     resolveModule: vi.fn(),
   };
 });
 vi.mock('rollup', async () => {
-  const actual = await vi.importActual<typeof import('rollup')>('rollup');
+  const actual = await vi.importActual<typeof RollupModule>('rollup');
   return {
     ...actual,
     rollup: vi.fn(actual.rollup),
@@ -128,13 +130,13 @@ describe('analyzeEntry', () => {
   it('should handle dynamic imports', async () => {
     const entryWithDynamicImport = `
       import { Mastra } from '@mastra/core/mastra';
-      
+
       export async function loadAgent() {
         const { Agent } = await import('@mastra/core/agent');
         const externalModule = await import('lodash');
         return new Agent();
       }
-      
+
       export const mastra = new Mastra({});
     `;
 
@@ -179,11 +181,11 @@ describe('analyzeEntry', () => {
   it('should handle entry with no external dependencies', async () => {
     const entryWithNoDeps = `
       const message = "Hello World";
-      
+
       function greet(name) {
         return message + ", " + name + "!";
       }
-      
+
       export { greet };
     `;
 

--- a/packages/deployer/src/build/analyze/analyzeEntry.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.ts
@@ -1,20 +1,22 @@
-import { noopLogger, type IMastraLogger } from '@mastra/core/logger';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { noopLogger  } from '@mastra/core/logger';
+import type {IMastraLogger} from '@mastra/core/logger';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import virtual from '@rollup/plugin-virtual';
-import { fileURLToPath, pathToFileURL } from 'node:url';
-import { rollup, type OutputChunk, type Plugin, type SourceMap } from 'rollup';
-import { resolveModule } from 'local-pkg';
 import { readJSON } from 'fs-extra/esm';
-import { esbuild } from '../plugins/esbuild';
+import { resolveModule } from 'local-pkg';
+import { rollup    } from 'rollup';
+import type {OutputChunk, Plugin, SourceMap} from 'rollup';
+import type {WorkspacePackageInfo} from '../../bundler/workspaceDependencies';
 import { isNodeBuiltin } from '../isNodeBuiltin';
-import { tsConfigPaths } from '../plugins/tsconfig-paths';
-import { getPackageName, slash } from '../utils';
 import { getPackageRootPath } from '../package-info';
-import { type WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
-import type { DependencyMetadata } from '../types';
-import { DEPS_TO_IGNORE } from './constants';
+import { esbuild } from '../plugins/esbuild';
 import { removeDeployer } from '../plugins/remove-deployer';
+import { tsConfigPaths } from '../plugins/tsconfig-paths';
+import type { DependencyMetadata } from '../types';
+import { getPackageName, slash } from '../utils';
+import { DEPS_TO_IGNORE } from './constants';
 
 /**
  * Configures and returns the Rollup plugins needed for analyzing entry files.

--- a/packages/deployer/src/build/analyze/bundleExternals.test.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.test.ts
@@ -1,14 +1,15 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createVirtualDependencies, bundleExternals } from './bundleExternals';
-import type { DependencyMetadata } from '../types';
-import type { WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ensureDir, remove, pathExists, writeFile } from 'fs-extra';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
+import type { DependencyMetadata } from '../types';
+import type * as UtilsModule from '../utils';
+import { createVirtualDependencies, bundleExternals } from './bundleExternals';
 
 // Mock the utilities that bundleExternals depends on
 vi.mock('../utils', async importOriginal => {
-  const actual = await importOriginal<typeof import('../utils')>();
+  const actual = await importOriginal<typeof UtilsModule>();
   return {
     ...actual,
     getCompiledDepCachePath: vi.fn((rootPath: string, fileName: string) =>

--- a/packages/deployer/src/build/analyze/bundleExternals.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.ts
@@ -1,27 +1,28 @@
+import { readFile } from 'node:fs/promises';
+import * as path from 'node:path';
+import { basename } from 'node:path/posix';
+import { ErrorCategory, ErrorDomain, MastraBaseError } from '@mastra/core/error';
 import type { Config } from '@mastra/core/mastra';
+import { optimizeLodashImports } from '@optimize-lodash/rollup-plugin';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import virtual from '@rollup/plugin-virtual';
-import { esmShim } from '../plugins/esm-shim';
-import { basename } from 'node:path/posix';
-import * as path from 'node:path';
-import { rollup, type OutputChunk, type OutputAsset, type Plugin } from 'rollup';
-import { esbuild } from '../plugins/esbuild';
-import { aliasHono } from '../plugins/hono-alias';
-import { getCompiledDepCachePath, isDependencyPartOfPackage, rollupSafeName, slash } from '../utils';
-import { getPackageRootPath } from '../package-info';
-import { type WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
-import type { DependencyMetadata } from '../types';
-import { DEPS_TO_IGNORE, GLOBAL_EXTERNALS, DEPRECATED_EXTERNALS } from './constants';
-import * as resolve from 'resolve.exports';
-import { optimizeLodashImports } from '@optimize-lodash/rollup-plugin';
-import { readFile } from 'node:fs/promises';
 import { getPackageInfo } from 'local-pkg';
-import { ErrorCategory, ErrorDomain, MastraBaseError } from '@mastra/core/error';
+import * as resolve from 'resolve.exports';
+import { rollup } from 'rollup';
+import type { OutputChunk, OutputAsset, Plugin } from 'rollup';
+import type { WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
+import { getPackageRootPath } from '../package-info';
+import { esbuild } from '../plugins/esbuild';
+import { esmShim } from '../plugins/esm-shim';
+import { aliasHono } from '../plugins/hono-alias';
+import { moduleResolveMap } from '../plugins/module-resolve-map';
 import { nodeGypDetector } from '../plugins/node-gyp-detector';
 import { subpathExternalsResolver } from '../plugins/subpath-externals-resolver';
-import { moduleResolveMap } from '../plugins/module-resolve-map';
+import type { DependencyMetadata } from '../types';
+import { getCompiledDepCachePath, isDependencyPartOfPackage, rollupSafeName, slash } from '../utils';
+import { DEPS_TO_IGNORE, GLOBAL_EXTERNALS, DEPRECATED_EXTERNALS } from './constants';
 
 type VirtualDependency = {
   name: string;
@@ -247,9 +248,9 @@ async function getInputPlugins(
               packageName,
             },
             text: `We found a possible binary dependency in your bundle. ${id} was not found when imported at ${importer}.
-            
+
 Please consider adding \`${packageName}\` to your externals, or updating this import to not end with ".node".
-  
+
 export const mastra = new Mastra({
   bundler: {
     externals: ["${packageName}"],

--- a/packages/deployer/src/build/babel/check-config-export.test.ts
+++ b/packages/deployer/src/build/babel/check-config-export.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
 import { transformSync } from '@babel/core';
+import { describe, it, expect } from 'vitest';
 import { checkConfigExport } from './check-config-export';
 
 describe('checkConfigExport Babel plugin', () => {

--- a/packages/deployer/src/build/babel/remove-all-options-except.ts
+++ b/packages/deployer/src/build/babel/remove-all-options-except.ts
@@ -1,7 +1,7 @@
 import babel from '@babel/core';
 import type { NodePath, types } from '@babel/core';
-import type { Config as MastraConfig } from '@mastra/core/mastra';
 import type { IMastraLogger } from '@mastra/core/logger';
+import type { Config as MastraConfig } from '@mastra/core/mastra';
 
 export function removeAllOptionsFromMastraExcept(
   result: { hasCustomConfig: boolean },

--- a/packages/deployer/src/build/bundler.ts
+++ b/packages/deployer/src/build/bundler.ts
@@ -1,20 +1,21 @@
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { optimizeLodashImports } from '@optimize-lodash/rollup-plugin';
 import alias from '@rollup/plugin-alias';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';
-import { esmShim } from './plugins/esm-shim';
-import { fileURLToPath, pathToFileURL } from 'node:url';
-import { rollup, type InputOptions, type OutputOptions, type Plugin } from 'rollup';
+import { rollup } from 'rollup';
+import type { InputOptions, OutputOptions, Plugin } from 'rollup';
+import type { analyzeBundle } from './analyze';
 import { esbuild } from './plugins/esbuild';
-import { optimizeLodashImports } from '@optimize-lodash/rollup-plugin';
-import { analyzeBundle } from './analyze';
-import { removeAllOptionsFromMastraExceptPlugin } from './plugins/remove-all-except';
-import { tsConfigPaths } from './plugins/tsconfig-paths';
-import { join } from 'node:path';
-import { slash, type BundlerPlatform } from './utils';
-import { subpathExternalsResolver } from './plugins/subpath-externals-resolver';
+import { esmShim } from './plugins/esm-shim';
 import { nodeModulesExtensionResolver } from './plugins/node-modules-extension-resolver';
 import { removeDeployer } from './plugins/remove-deployer';
+import { subpathExternalsResolver } from './plugins/subpath-externals-resolver';
+import { tsConfigPaths } from './plugins/tsconfig-paths';
+import { slash } from './utils';
+import type { BundlerPlatform } from './utils';
 
 export async function getInputOptions(
   entryFile: string,

--- a/packages/deployer/src/build/bundlerOptions.test.ts
+++ b/packages/deployer/src/build/bundlerOptions.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
 import { getBundlerOptionsBundler } from './bundlerOptions';
 
 describe('getBundlerOptionsConfig', () => {

--- a/packages/deployer/src/build/bundlerOptions.ts
+++ b/packages/deployer/src/build/bundlerOptions.ts
@@ -1,6 +1,6 @@
+import type { IMastraLogger } from '@mastra/core/logger';
 import type { Config } from '@mastra/core/mastra';
 import { extractMastraOption, extractMastraOptionBundler } from './shared/extract-mastra-option';
-import type { IMastraLogger } from '@mastra/core/logger';
 
 export function getBundlerOptionsBundler(
   entryFile: string,

--- a/packages/deployer/src/build/deployer.test.ts
+++ b/packages/deployer/src/build/deployer.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
 import { getDeployerBundler } from './deployer';
 
 describe('getDeployer', () => {

--- a/packages/deployer/src/build/deployer.ts
+++ b/packages/deployer/src/build/deployer.ts
@@ -1,6 +1,6 @@
+import type { IMastraLogger } from '@mastra/core/logger';
 import type { Config } from '@mastra/core/mastra';
 import { extractMastraOption, extractMastraOptionBundler } from './shared/extract-mastra-option';
-import type { IMastraLogger } from '@mastra/core/logger';
 
 export function getDeployerBundler(
   entryFile: string,

--- a/packages/deployer/src/build/package-info.ts
+++ b/packages/deployer/src/build/package-info.ts
@@ -3,8 +3,8 @@
  * It is in a separate file to avoid including local-pkg in runtime code.
  */
 
-import { getPackageInfo } from 'local-pkg';
 import { pathToFileURL } from 'node:url';
+import { getPackageInfo } from 'local-pkg';
 
 /**
  * Get package root path
@@ -26,7 +26,7 @@ export async function getPackageRootPath(packageName: string, parentPath?: strin
 
     const pkg = await getPackageInfo(packageName, options);
     rootPath = pkg?.rootPath ?? null;
-  } catch (e) {
+  } catch {
     rootPath = null;
   }
 

--- a/packages/deployer/src/build/plugins/__fixtures__/basic-with-bundler.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/basic-with-bundler.js
@@ -1,7 +1,7 @@
-import { Mastra } from '@mastra/core/mastra';
 import { createLogger } from '@mastra/core/logger';
-import { weatherAgent } from '@/agents';
+import { Mastra } from '@mastra/core/mastra';
 import { TestDeployer } from '@mastra/deployer/test';
+import { weatherAgent } from '@/agents';
 
 export const mastra = new Mastra({
   agents: { weatherAgent },

--- a/packages/deployer/src/build/plugins/__fixtures__/basic-with-const.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/basic-with-const.js
@@ -1,8 +1,8 @@
-import { Mastra } from '@mastra/core/mastra';
 import { createLogger } from '@mastra/core/logger';
+import { Mastra } from '@mastra/core/mastra';
 import { createApiRoute } from '@mastra/core/server';
-import { weatherAgent } from '@/agents';
 import { TestDeployer } from '@mastra/deployer/test';
+import { weatherAgent } from '@/agents';
 
 const testDeployer = new TestDeployer();
 

--- a/packages/deployer/src/build/plugins/__fixtures__/basic-with-function.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/basic-with-function.js
@@ -1,8 +1,8 @@
-import { Mastra } from '@mastra/core/mastra';
 import { createLogger } from '@mastra/core/logger';
+import { Mastra } from '@mastra/core/mastra';
 import { createApiRoute } from '@mastra/core/server';
-import { weatherAgent } from '@/agents';
 import { testDeployer } from '@mastra/deployer/test';
+import { weatherAgent } from '@/agents';
 
 function getDeployer() {
   return testDeployer;

--- a/packages/deployer/src/build/plugins/__fixtures__/basic-with-import.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/basic-with-import.js
@@ -1,9 +1,9 @@
-import { Mastra } from '@mastra/core/mastra';
 import { createLogger } from '@mastra/core/logger';
-import { weatherAgent } from '@/agents';
+import { Mastra } from '@mastra/core/mastra';
 import { testDeployer } from '@mastra/deployer/test';
-import { telemetryConfig } from '@/telemetry';
+import { weatherAgent } from '@/agents';
 import { serverOptions } from '@/server';
+import { telemetryConfig } from '@/telemetry';
 
 export const mastra = new Mastra({
   agents: { weatherAgent },

--- a/packages/deployer/src/build/plugins/__fixtures__/basic-with-json.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/basic-with-json.js
@@ -1,5 +1,5 @@
-import { Mastra } from '@mastra/core/mastra';
 import { createLogger } from '@mastra/core/logger';
+import { Mastra } from '@mastra/core/mastra';
 import { TestDeployer } from '@mastra/deployer/test';
 import { name } from './example.json';
 

--- a/packages/deployer/src/build/plugins/__fixtures__/basic-with-spread.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/basic-with-spread.js
@@ -1,5 +1,5 @@
-import { Mastra } from '@mastra/core/mastra';
 import { createLogger } from '@mastra/core/logger';
+import { Mastra } from '@mastra/core/mastra';
 import { TestDeployer } from '@mastra/deployer/test';
 
 const configLogger = {

--- a/packages/deployer/src/build/plugins/__fixtures__/basic.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/basic.js
@@ -1,8 +1,8 @@
-import { Mastra } from '@mastra/core/mastra';
 import { createLogger } from '@mastra/core/logger';
-import { weatherAgent } from '@/agents';
-import { TestDeployer } from '@mastra/deployer/test';
+import { Mastra } from '@mastra/core/mastra';
 import { createApiRoute } from '@mastra/core/server';
+import { TestDeployer } from '@mastra/deployer/test';
+import { weatherAgent } from '@/agents';
 export const mastra = new Mastra({
   agents: { weatherAgent },
   logger: createLogger({

--- a/packages/deployer/src/build/plugins/__fixtures__/esm-shim-only-dirname.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/esm-shim-only-dirname.js
@@ -1,6 +1,6 @@
 // Fixture: User declares only __dirname (issue #10054 scenario 3)
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/packages/deployer/src/build/plugins/__fixtures__/esm-shim-only-filename.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/esm-shim-only-filename.js
@@ -1,5 +1,5 @@
 // Fixture: User declares only __filename (issue #10054 scenario 2)
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 

--- a/packages/deployer/src/build/plugins/__fixtures__/esm-shim-user-declared.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/esm-shim-user-declared.js
@@ -1,6 +1,6 @@
 // Fixture: User declares their own __filename and __dirname (like in issue #10054)
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/packages/deployer/src/build/plugins/__fixtures__/mastra-with-extra-code.js
+++ b/packages/deployer/src/build/plugins/__fixtures__/mastra-with-extra-code.js
@@ -1,10 +1,10 @@
 import { openai } from '@ai-sdk/openai';
-import { Mastra } from '@mastra/core/mastra';
 import { Agent } from '@mastra/core/agent';
+import { Mastra } from '@mastra/core/mastra';
+import { testDeployer } from '@mastra/deployer/test';
 import { PgVector } from '@mastra/pg';
 import { createVectorQueryTool, MDocument } from '@mastra/rag';
 import { embedMany } from 'ai';
-import { testDeployer } from '@mastra/deployer/test';
 
 function getDeployer() {
   return testDeployer;

--- a/packages/deployer/src/build/plugins/__snapshots__/remove-deployer.test.ts.snap
+++ b/packages/deployer/src/build/plugins/__snapshots__/remove-deployer.test.ts.snap
@@ -1,10 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Remove deployer > should remove the deployer from ./__fixtures__/basic.js 1`] = `
-"import { Mastra } from '@mastra/core/mastra';
-import { createLogger } from '@mastra/core/logger';
-import { weatherAgent } from '@/agents';
+"import { createLogger } from '@mastra/core/logger';
+import { Mastra } from '@mastra/core/mastra';
 import { createApiRoute } from '@mastra/core/server';
+import { weatherAgent } from '@/agents';
 
 const mastra = new Mastra({
   agents: {
@@ -41,8 +41,8 @@ export { mastra };
 `;
 
 exports[`Remove deployer > should remove the deployer from ./__fixtures__/basic-with-const.js 1`] = `
-"import { Mastra } from '@mastra/core/mastra';
-import { createLogger } from '@mastra/core/logger';
+"import { createLogger } from '@mastra/core/logger';
+import { Mastra } from '@mastra/core/mastra';
 import { createApiRoute } from '@mastra/core/server';
 import { weatherAgent } from '@/agents';
 
@@ -83,8 +83,8 @@ export { mastra };
 `;
 
 exports[`Remove deployer > should remove the deployer from ./__fixtures__/basic-with-function.js 1`] = `
-"import { Mastra } from '@mastra/core/mastra';
-import { createLogger } from '@mastra/core/logger';
+"import { createLogger } from '@mastra/core/logger';
+import { Mastra } from '@mastra/core/mastra';
 import { createApiRoute } from '@mastra/core/server';
 import { weatherAgent } from '@/agents';
 
@@ -129,11 +129,11 @@ export { mastra };
 `;
 
 exports[`Remove deployer > should remove the deployer from ./__fixtures__/basic-with-import.js 1`] = `
-"import { Mastra } from '@mastra/core/mastra';
-import { createLogger } from '@mastra/core/logger';
+"import { createLogger } from '@mastra/core/logger';
+import { Mastra } from '@mastra/core/mastra';
 import { weatherAgent } from '@/agents';
-import { telemetryConfig } from '@/telemetry';
 import { serverOptions } from '@/server';
+import { telemetryConfig } from '@/telemetry';
 
 const mastra = new Mastra({
   agents: {
@@ -152,8 +152,8 @@ export { mastra };
 `;
 
 exports[`Remove deployer > should remove the deployer from ./__fixtures__/basic-with-spread.js 1`] = `
-"import { Mastra } from '@mastra/core/mastra';
-import { createLogger } from '@mastra/core/logger';
+"import { createLogger } from '@mastra/core/logger';
+import { Mastra } from '@mastra/core/mastra';
 
 const configLogger = {
   logger: createLogger({

--- a/packages/deployer/src/build/plugins/esm-shim.test.ts
+++ b/packages/deployer/src/build/plugins/esm-shim.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { rollup } from 'rollup';
 import esbuild from 'rollup-plugin-esbuild';
+import { describe, it, expect } from 'vitest';
 import { esmShim } from './esm-shim';
 
 async function buildWithEsmShim(fixturePath: string) {

--- a/packages/deployer/src/build/plugins/module-resolve-map.ts
+++ b/packages/deployer/src/build/plugins/module-resolve-map.ts
@@ -1,7 +1,7 @@
-import type { Plugin } from 'rollup';
-import { isDependencyPartOfPackage, slash } from '../utils';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import type { Plugin } from 'rollup';
+import { isDependencyPartOfPackage, slash } from '../utils';
 
 export function moduleResolveMap(externals: string[], projectRoot: string): Plugin {
   const importMap = new Map<string, string>();

--- a/packages/deployer/src/build/plugins/node-gyp-detector.ts
+++ b/packages/deployer/src/build/plugins/node-gyp-detector.ts
@@ -1,5 +1,5 @@
-import type { Plugin } from 'rollup';
 import { getPackageInfo } from 'local-pkg';
+import type { Plugin } from 'rollup';
 
 export function nodeGypDetector(): Plugin {
   const modulesToTrack = new Set<string>();

--- a/packages/deployer/src/build/plugins/node-modules-extension-resolver.test.ts
+++ b/packages/deployer/src/build/plugins/node-modules-extension-resolver.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Plugin, PluginContext } from 'rollup';
-import { getPackageInfo } from 'local-pkg';
 import { readFile } from 'node:fs/promises';
+import { getPackageInfo } from 'local-pkg';
+import type { Plugin, PluginContext } from 'rollup';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockNodeResolveHandler = vi.fn();
 
@@ -204,7 +204,8 @@ describe('nodeModulesExtensionResolver', () => {
 
   describe('edge cases', () => {
     it('handles package.json read failure gracefully', async () => {
-      const pkgJson = { name: '@my/lodash' };
+      // ts-expect-error @typescript-eslint/no-unused-vars
+      const _pkgJson = { name: '@my/lodash' };
       // @ts-expect-error parital is fine
       vi.mocked(getPackageInfo).mockResolvedValue({ name: '@my/lodash', rootPath: '/project/node_modules/@my/lodash' });
 

--- a/packages/deployer/src/build/plugins/node-modules-extension-resolver.ts
+++ b/packages/deployer/src/build/plugins/node-modules-extension-resolver.ts
@@ -1,10 +1,10 @@
-import { join, isAbsolute } from 'node:path';
 import { readFile } from 'node:fs/promises';
-import type { Plugin } from 'rollup';
+import { join, isAbsolute } from 'node:path';
 import nodeResolve from '@rollup/plugin-node-resolve';
-import { getPackageName, isBuiltinModule } from '../utils';
-import { getPackageRootPath } from '../package-info';
+import type { Plugin } from 'rollup';
 import type { PackageJson } from 'type-fest';
+import { getPackageRootPath } from '../package-info';
+import { getPackageName, isBuiltinModule } from '../utils';
 
 /**
  * Check if a package has an exports field in its package.json.

--- a/packages/deployer/src/build/plugins/pino.ts
+++ b/packages/deployer/src/build/plugins/pino.ts
@@ -1,9 +1,6 @@
-import path from 'node:path';
 import type { OutputChunk, Plugin } from 'rollup';
 
 export function pino() {
-  let emittedChunks = new Map();
-
   const workerFiles = [
     {
       id: 'thread-stream-worker',

--- a/packages/deployer/src/build/plugins/remove-all-deployer.test.ts
+++ b/packages/deployer/src/build/plugins/remove-all-deployer.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { removeAllOptionsFromMastraExceptPlugin } from './remove-all-except';
-import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { rollup } from 'rollup';
 import esbuild from 'rollup-plugin-esbuild';
+import { describe, it, expect } from 'vitest';
+import { removeAllOptionsFromMastraExceptPlugin } from './remove-all-except';
 
 describe('Remove deployer', () => {
   const _dirname = dirname(fileURLToPath(import.meta.url));

--- a/packages/deployer/src/build/plugins/remove-all-except.ts
+++ b/packages/deployer/src/build/plugins/remove-all-except.ts
@@ -1,8 +1,8 @@
 import * as babel from '@babel/core';
-import type { Plugin } from 'rollup';
-import type { Config as MastraConfig } from '@mastra/core/mastra';
-import { removeAllOptionsFromMastraExcept } from '../babel/remove-all-options-except';
 import type { IMastraLogger } from '@mastra/core/logger';
+import type { Config as MastraConfig } from '@mastra/core/mastra';
+import type { Plugin } from 'rollup';
+import { removeAllOptionsFromMastraExcept } from '../babel/remove-all-options-except';
 
 export function removeAllOptionsFromMastraExceptPlugin(
   mastraEntry: string,

--- a/packages/deployer/src/build/plugins/remove-deployer.test.ts
+++ b/packages/deployer/src/build/plugins/remove-deployer.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { removeDeployer } from './remove-deployer';
-import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { rollup } from 'rollup';
 import esbuild from 'rollup-plugin-esbuild';
+import { describe, it, expect } from 'vitest';
+import { removeDeployer } from './remove-deployer';
 
 describe('Remove deployer', () => {
   const _dirname = dirname(fileURLToPath(import.meta.url));

--- a/packages/deployer/src/build/plugins/tsconfig-paths.test.ts
+++ b/packages/deployer/src/build/plugins/tsconfig-paths.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
-import { tsConfigPaths, hasPaths } from './tsconfig-paths';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { rollup } from 'rollup';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { tsConfigPaths, hasPaths } from './tsconfig-paths';
 
 describe('tsconfig-paths plugin', () => {
   const _dirname = dirname(fileURLToPath(import.meta.url));

--- a/packages/deployer/src/build/plugins/tsconfig-paths.ts
+++ b/packages/deployer/src/build/plugins/tsconfig-paths.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path, { normalize } from 'node:path';
-import resolveFrom from 'resolve-from';
 import type { Plugin } from 'rollup';
 import stripJsonComments from 'strip-json-comments';
 import type { RegisterOptions } from 'typescript-paths';

--- a/packages/deployer/src/build/serverOptions.test.ts
+++ b/packages/deployer/src/build/serverOptions.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
 import { getServerOptionsBundler } from './serverOptions';
 
 describe('getServerOptionsConfig', () => {

--- a/packages/deployer/src/build/serverOptions.ts
+++ b/packages/deployer/src/build/serverOptions.ts
@@ -1,6 +1,6 @@
+import type { IMastraLogger } from '@mastra/core/logger';
 import type { Config } from '@mastra/core/mastra';
 import { extractMastraOption, extractMastraOptionBundler } from './shared/extract-mastra-option';
-import type { IMastraLogger } from '@mastra/core/logger';
 
 export function getServerOptionsBundler(
   entryFile: string,

--- a/packages/deployer/src/build/shared/extract-mastra-option.test.ts
+++ b/packages/deployer/src/build/shared/extract-mastra-option.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
-import { mkdir, rm } from 'node:fs/promises';
-import { extractMastraOption } from './extract-mastra-option';
 import { existsSync } from 'node:fs';
+import { mkdir, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { extractMastraOption } from './extract-mastra-option';
 
 describe('Extract Mastra option', () => {
   const _dirname = dirname(fileURLToPath(import.meta.url));
@@ -28,7 +28,7 @@ describe('Extract Mastra option', () => {
       ['../plugins/__fixtures__/basic-with-spread.js'],
       ['../plugins/__fixtures__/basic-with-function.js'],
     ])('should extract the %s option from %s', async ([fileName]) => {
-      const file = join(_dirname, fileName);
+      const _file = join(_dirname, fileName);
 
       await mkdir(testOutputDir, { recursive: true });
 

--- a/packages/deployer/src/build/shared/extract-mastra-option.ts
+++ b/packages/deployer/src/build/shared/extract-mastra-option.ts
@@ -1,16 +1,15 @@
-import * as babel from '@babel/core';
-import { rollup, type RollupOutput } from 'rollup';
-import { esbuild } from '../plugins/esbuild';
-import commonjs from '@rollup/plugin-commonjs';
-import { tsConfigPaths } from '../plugins/tsconfig-paths';
-import { recursiveRemoveNonReferencedNodes } from '../plugins/remove-unused-references';
-import { optimizeLodashImports } from '@optimize-lodash/rollup-plugin';
-import json from '@rollup/plugin-json';
-import type { IMastraLogger } from '@mastra/core/logger';
 import { pathToFileURL } from 'node:url';
-import { removeAllOptionsFromMastraExceptPlugin } from '../plugins/remove-all-except';
-
+import type { IMastraLogger } from '@mastra/core/logger';
 import type { Config as MastraConfig } from '@mastra/core/mastra';
+import { optimizeLodashImports } from '@optimize-lodash/rollup-plugin';
+import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
+import { rollup } from 'rollup';
+import type { RollupOutput } from 'rollup';
+import { esbuild } from '../plugins/esbuild';
+import { removeAllOptionsFromMastraExceptPlugin } from '../plugins/remove-all-except';
+import { recursiveRemoveNonReferencedNodes } from '../plugins/remove-unused-references';
+import { tsConfigPaths } from '../plugins/tsconfig-paths';
 
 export function extractMastraOptionBundler(
   name: keyof MastraConfig,

--- a/packages/deployer/src/build/utils.ts
+++ b/packages/deployer/src/build/utils.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync, mkdirSync } from 'node:fs';
-import { basename, join, relative } from 'node:path';
 import { builtinModules } from 'node:module';
+import { basename, join, relative } from 'node:path';
 
 /** The detected JavaScript runtime environment */
 export type RuntimePlatform = 'node' | 'bun';

--- a/packages/deployer/src/build/watcher.ts
+++ b/packages/deployer/src/build/watcher.ts
@@ -1,15 +1,16 @@
+import { dirname, posix } from 'node:path';
+import { noopLogger } from '@mastra/core/logger';
+import * as pkg from 'empathic/package';
 import type { InputOptions, OutputOptions, Plugin } from 'rollup';
 import { watch } from 'rollup';
-import { dirname, posix } from 'node:path';
-import * as pkg from 'empathic/package';
+import { getWorkspaceInformation } from '../bundler/workspaceDependencies';
+import { analyzeBundle } from './analyze';
 import { getInputOptions as getBundlerInputOptions } from './bundler';
 import { aliasHono } from './plugins/hono-alias';
 import { nodeModulesExtensionResolver } from './plugins/node-modules-extension-resolver';
 import { tsConfigPaths } from './plugins/tsconfig-paths';
-import { noopLogger } from '@mastra/core/logger';
-import { getWorkspaceInformation } from '../bundler/workspaceDependencies';
-import { analyzeBundle } from './analyze';
-import { getPackageName, slash, type BundlerPlatform } from './utils';
+import { getPackageName, slash  } from './utils';
+import type {BundlerPlatform} from './utils';
 
 export async function getInputOptions(
   entryFile: string,


### PR DESCRIPTION
Fixes lint errors in the deployer package:

- Added ESLint ignores for `__fixtures__` directories (they're excluded from tsconfig but ESLint was still trying to parse them)
- Replaced inline `typeof import()` with proper type namespace imports to satisfy `@typescript-eslint/consistent-type-imports`
- Removed unused variables and cleaned up empty catch bindings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed lint errors in the deployer package
  * Improved error handling and messaging for external dependency resolution and deployment analysis

* **Chores**
  * Optimized import organization and removed unused dependencies across the codebase

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->