### PR TITLE
fix(server): resolve stored and sub-agents in all server handlers

### DIFF
--- a/.changeset/chilly-ears-shout.md
+++ b/.changeset/chilly-ears-shout.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed server handlers to find stored and sub-agents, not just registered agents. Agents created via the API or stored in the database are now correctly resolved in A2A, memory, scores, tools, and voice endpoints.

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -97,15 +97,27 @@ async function getMemoryFromContext({
     }
   }
   if (agentId && !agent) {
-    logger.debug('Agent not found, searching agents for agent', { agentId });
+    logger.debug('Agent not found in registered agents, trying stored agents', { agentId });
+    try {
+      const storedAgent = await mastra.getStoredAgentById(agentId);
+      if (storedAgent) {
+        agent = storedAgent;
+      }
+    } catch (error) {
+      logger.debug('Error getting stored agent', error);
+    }
+  }
+
+  if (agentId && !agent) {
+    logger.debug('Stored agent not found, searching sub-agents', { agentId });
     const agents = mastra.listAgents();
     if (Object.keys(agents || {}).length) {
       for (const [_, ag] of Object.entries(agents)) {
         try {
-          const agents = await ag.listAgents();
+          const subAgents = await ag.listAgents({ requestContext });
 
-          if (agents[agentId]) {
-            agent = agents[agentId];
+          if (subAgents[agentId]) {
+            agent = subAgents[agentId];
             break;
           }
         } catch (error) {

--- a/packages/server/src/server/handlers/scores.ts
+++ b/packages/server/src/server/handlers/scores.ts
@@ -17,6 +17,7 @@ import {
 } from '../schemas/scores';
 import { createRoute } from '../server-adapter/routes/route-builder';
 import type { Context } from '../types';
+import { getAgentFromSystem } from './agents';
 import { handleError } from './error';
 
 async function listScorersFromSystem({
@@ -266,7 +267,7 @@ export const LIST_SCORES_BY_ENTITY_ID_ROUTE = createRoute({
       let entityIdToUse = entityId;
 
       if (entityType === 'AGENT') {
-        const agent = mastra.getAgentById(entityId);
+        const agent = await getAgentFromSystem({ mastra, agentId: entityId });
         entityIdToUse = agent.id;
       } else if (entityType === 'WORKFLOW') {
         const workflow = mastra.getWorkflowById(entityId);

--- a/packages/server/src/server/handlers/tools.ts
+++ b/packages/server/src/server/handlers/tools.ts
@@ -14,6 +14,7 @@ import {
 import { optionalRunIdSchema } from '../schemas/common';
 import { createRoute } from '../server-adapter/routes/route-builder';
 
+import { getAgentFromSystem } from './agents';
 import { handleError } from './error';
 import { validateBody } from './utils';
 
@@ -181,10 +182,10 @@ export const GET_AGENT_TOOL_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, agentId, toolId, requestContext }) => {
     try {
-      const agent = agentId ? mastra.getAgentById(agentId) : null;
-      if (!agent) {
-        throw new HTTPException(404, { message: 'Agent not found' });
+      if (!agentId) {
+        throw new HTTPException(400, { message: 'Agent ID is required' });
       }
+      const agent = await getAgentFromSystem({ mastra, agentId });
 
       const agentTools = await agent.listTools({ requestContext });
 
@@ -223,10 +224,10 @@ export const EXECUTE_AGENT_TOOL_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, agentId, toolId, data, requestContext }) => {
     try {
-      const agent = agentId ? mastra.getAgentById(agentId) : null;
-      if (!agent) {
-        throw new HTTPException(404, { message: 'Agent not found' });
+      if (!agentId) {
+        throw new HTTPException(400, { message: 'Agent ID is required' });
       }
+      const agent = await getAgentFromSystem({ mastra, agentId });
 
       const agentTools = await agent.listTools({ requestContext });
 

--- a/packages/server/src/server/handlers/voice.ts
+++ b/packages/server/src/server/handlers/voice.ts
@@ -12,6 +12,7 @@ import {
 } from '../schemas/agents';
 import { createRoute } from '../server-adapter/routes/route-builder';
 
+import { getAgentFromSystem } from './agents';
 import { handleError } from './error';
 import { validateBody } from './utils';
 
@@ -35,11 +36,7 @@ export const GET_SPEAKERS_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'Agent ID is required' });
       }
 
-      const agent = mastra.getAgentById(agentId);
-
-      if (!agent) {
-        throw new HTTPException(404, { message: 'Agent not found' });
-      }
+      const agent = await getAgentFromSystem({ mastra, agentId });
 
       const voice = await agent.getVoice({ requestContext });
 
@@ -92,11 +89,7 @@ export const GENERATE_SPEECH_ROUTE = createRoute({
 
       validateBody({ text });
 
-      const agent = mastra.getAgentById(agentId);
-
-      if (!agent) {
-        throw new HTTPException(404, { message: 'Agent not found' });
-      }
+      const agent = await getAgentFromSystem({ mastra, agentId });
 
       const voice = await agent.getVoice({ requestContext });
 
@@ -161,11 +154,7 @@ export const TRANSCRIBE_SPEECH_ROUTE = createRoute({
         throw new HTTPException(400, { message: 'Audio data is required' });
       }
 
-      const agent = mastra.getAgentById(agentId);
-
-      if (!agent) {
-        throw new HTTPException(404, { message: 'Agent not found' });
-      }
+      const agent = await getAgentFromSystem({ mastra, agentId });
 
       const voice = await agent.getVoice({ requestContext });
 


### PR DESCRIPTION
Several server handlers (A2A, memory, scores, tools, voice) were using `mastra.getAgentById()` directly, which only finds agents registered in code. This meant agents created via the API or stored in the database weren't found by those endpoints.

This switches all handlers to use `getAgentFromSystem()`, which checks registered agents, sub-agents, and stored agents in that order. The memory handler also gets the stored agent fallback inline for its context resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent resolution to support agents created via API and stored agents across A2A, memory, scoring, tools, and voice features. These endpoints now correctly resolve all agent types, not just registered agents.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->