### PR TITLE
docs: clarify workspace init() is optional

### DIFF
--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -39,7 +39,7 @@ const workspace = new Workspace({
 
 ## Initialization
 
-Call `init()` to initialize the workspace and prepare resources:
+You can optionally call `init()` to initialize the workspace before use:
 
 ```typescript
 const workspace = new Workspace({

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -223,6 +223,11 @@ Initialize the workspace and prepare resources.
 await workspace.init();
 ```
 
+Calling `init()` is optional in most cases:
+- **Sandbox**: Auto-starts on first `executeCommand()` call. Use `init()` to avoid first-command latency.
+- **Filesystem**: Only needed if the base directory doesn't exist yet.
+- **Search**: Required only if using `autoIndexPaths` for auto-indexing.
+
 Initialization performs:
 - Starts the filesystem provider (creates base directory if needed)
 - Starts the sandbox provider (creates working directory, sets up isolation if configured)


### PR DESCRIPTION
## Summary
- Updated workspace overview and reference docs to clarify that `init()` is optional
- Removed language that made `init()` seem like a requirement
- Generalized references from "LocalFilesystem"/"LocalSandbox" to "Filesystem"/"Sandbox"

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workspace initialization guidance to clarify optional vs. required initialization scenarios.
  * Added detailed notes on when `init()` is needed for sandbox, filesystem, and search functionality.
  * Documented that initialization now includes auto-indexing files for search and that sandbox auto-starts on first command execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->