### PR TITLE
Fix #12477: Handle invalid JSON prompts gracefully in agent network

### DIFF
--- a/.changeset/many-deer-win.md
+++ b/.changeset/many-deer-win.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent network crashing with 'Invalid task input' error when routing agent returns malformed JSON for tool/workflow prompts. The error is now fed back to the routing agent, allowing it to retry with valid JSON on the next iteration.


### PR DESCRIPTION
## Description

Fixed agent network crashing with 'Invalid task input' error when the routing agent returns malformed JSON for tool/workflow prompts. Instead of throwing an error that halts execution, the error is now fed back to the routing agent as a result string with `isComplete: false`, allowing it to retry on the next iteration.

**Pattern:** This follows the existing error handling pattern used in the regular agent tool execution flow:
- [`tool-call-step.ts` (lines 423-428)](https://github.com/mastra-ai/mastra/blob/main/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts#L423-L428) - catches tool errors and returns them as results instead of throwing
- [`llm-mapping-step.ts` (lines 94-128)](https://github.com/mastra-ai/mastra/blob/main/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts#L94-L128) - converts error results to messages the LLM can see and respond to

## Related Issue(s)

Fixes #12477

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works