### PR TITLE
fix(playground): improve workspace dropdown and skill activation UI

### DIFF
--- a/.changeset/khaki-bears-create.md
+++ b/.changeset/khaki-bears-create.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed workspace UI issues: removed confusing 'pending' status from workspace dropdown, and improved skill activation styling with cleaner badge appearance and dark-themed tooltip on hover.

--- a/.changeset/khaki-bears-create.md
+++ b/.changeset/khaki-bears-create.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Fixed workspace UI issues: removed confusing 'pending' status from workspace dropdown, and improved skill activation styling with cleaner badge appearance and dark-themed tooltip on hover.
+Improved skill activation styling with cleaner badge appearance and dark-themed tooltip on hover.

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
@@ -326,23 +326,28 @@ export const AgentMetadataSkillList = ({ skills, agentId, workspaceId }: AgentMe
             variant={isActivated ? 'success' : 'default'}
           >
             {skill.name}
+            {isActivated && <span className="sr-only">Active</span>}
           </Badge>
         );
 
         return (
           <AgentMetadataListItem key={skill.name}>
-            <Link href={paths.agentSkillLink(agentId, skill.name, workspaceId)} data-testid="skill-badge">
-              {isActivated ? (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>{badge}</TooltipTrigger>
-                    <TooltipContent className="bg-surface3 text-icon6 border border-border1">Active</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              ) : (
-                badge
-              )}
-            </Link>
+            {isActivated ? (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Link href={paths.agentSkillLink(agentId, skill.name, workspaceId)} data-testid="skill-badge">
+                      {badge}
+                    </Link>
+                  </TooltipTrigger>
+                  <TooltipContent className="bg-surface3 text-icon6 border border-border1">Active</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : (
+              <Link href={paths.agentSkillLink(agentId, skill.name, workspaceId)} data-testid="skill-badge">
+                {badge}
+              </Link>
+            )}
           </AgentMetadataListItem>
         );
       })}

--- a/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-metadata/agent-metadata.tsx
@@ -1,4 +1,5 @@
 import { Badge } from '@/ds/components/Badge';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/ds/components/Tooltip';
 import { ToolsIcon } from '@/ds/icons/ToolsIcon';
 import { SkillIcon } from '@/ds/icons/SkillIcon';
 import { MemoryIcon } from '@/ds/icons/MemoryIcon';
@@ -319,22 +320,29 @@ export const AgentMetadataSkillList = ({ skills, agentId, workspaceId }: AgentMe
     <AgentMetadataList>
       {skills.map(skill => {
         const isActivated = isSkillActivated(skill.name);
-        return (
-          <AgentMetadataListItem
-            key={skill.name}
-            className={`flex-col items-start gap-1 ${isActivated ? 'bg-green-500/10 rounded-md p-1 -m-1' : ''}`}
+        const badge = (
+          <Badge
+            icon={<SkillIcon className={isActivated ? 'text-green-400' : 'text-accent2'} />}
+            variant={isActivated ? 'success' : 'default'}
           >
-            <div className="flex items-center gap-2">
-              <Link href={paths.agentSkillLink(agentId, skill.name, workspaceId)} data-testid="skill-badge">
-                <Badge
-                  icon={<SkillIcon className={isActivated ? 'text-green-400' : 'text-accent2'} />}
-                  variant={isActivated ? 'success' : 'default'}
-                >
-                  {skill.name}
-                </Badge>
-              </Link>
-              {isActivated && <span className="text-[10px] text-green-400 font-medium">Active</span>}
-            </div>
+            {skill.name}
+          </Badge>
+        );
+
+        return (
+          <AgentMetadataListItem key={skill.name}>
+            <Link href={paths.agentSkillLink(agentId, skill.name, workspaceId)} data-testid="skill-badge">
+              {isActivated ? (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>{badge}</TooltipTrigger>
+                    <TooltipContent className="bg-surface3 text-icon6 border border-border1">Active</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              ) : (
+                badge
+              )}
+            </Link>
           </AgentMetadataListItem>
         );
       })}

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -317,8 +317,6 @@ export default function Workspace() {
                         <div className="text-sm font-medium text-icon6 truncate">{workspace.name}</div>
                         <div className="text-xs text-icon4 truncate">
                           {workspace.source === 'agent' ? `Agent: ${workspace.agentName}` : 'Global workspace'}
-                          {' · '}
-                          {workspace.status}
                         </div>
                       </div>
                       <div className="flex gap-1 flex-shrink-0">
@@ -356,8 +354,6 @@ export default function Workspace() {
               {selectedWorkspace.source === 'agent' && selectedWorkspace.agentName && (
                 <span className="text-icon3">({selectedWorkspace.agentName})</span>
               )}
-              <span className="text-icon3">·</span>
-              <span className="text-icon3">{selectedWorkspace.status}</span>
               {isReadOnly && (
                 <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400">Read-only</span>
               )}


### PR DESCRIPTION
## Description

Fixed two UI issues in the workspace and agent pages:

1. **Workspace dropdown**: Removed the confusing 'pending' status that was showing for all workspaces. Since workspaces use lazy initialization (init() is only called on first use), the 'pending' status was not meaningful to users.

2. **Skill activation styling**: Cleaned up the active skill badge appearance by removing the double background effect (outer green tint + badge background). Added a dark-themed tooltip that shows "Active" on hover instead of inline text.

## Related Issue(s)

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed confusing workspace status indicator and separator from workspace listings.

* **Style / UI Improvements**
  * Refined active-skill appearance with a cleaner badge and adjusted icon coloring.
  * Added a dark-themed tooltip that appears when hovering over activated skills.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->