### PR TITLE
fix(ci): publish prereleases with alpha tag instead of beta

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,7 +29,6 @@ on:
   push:
     branches:
       - main
-      - 0.x
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -75,14 +74,7 @@ jobs:
       - name: Determine publish tag
         id: determine-tag
         run: |
-          BRANCH_NAME="${{ github.ref_name }}"
-          if [[ "$BRANCH_NAME" == "main" ]]; then
-            echo "tag=beta" >> $GITHUB_OUTPUT
-          elif [[ "$BRANCH_NAME" == "0.x" ]]; then
-            echo "tag=v0" >> $GITHUB_OUTPUT
-          else
-            echo "tag=v0" >> $GITHUB_OUTPUT
-          fi
+          echo "tag=alpha" >> $GITHUB_OUTPUT
 
       - name: Publish packages
         run: pnpm publish -r --tag ${{ steps.determine-tag.outputs.tag }} --access public --no-git-checks
@@ -181,10 +173,6 @@ jobs:
       - name: Updated alpha versions
         if: ${{ !inputs.dry_run }}
         run: node .github/scripts/publish-alpha-tags.js alpha
-
-      - name: Updated beta versions
-        if: ${{ !inputs.dry_run }}
-        run: node .github/scripts/publish-alpha-tags.js beta
 
       - name: Publish packages - dry run
         if: ${{ inputs.dry_run }}

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - 0.x
 
 jobs:
   version:
@@ -46,13 +45,7 @@ jobs:
       - name: Determine prerelease tag
         id: determine-tag
         run: |
-          if [[ "${{ github.ref_name }}" == "main" ]]; then
-            echo "tag=beta" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.ref_name }}" == "0.x" ]]; then
-            echo "tag=alpha" >> $GITHUB_OUTPUT
-          else
-            echo "tag=alpha" >> $GITHUB_OUTPUT
-          fi
+          echo "tag=alpha" >> $GITHUB_OUTPUT
 
       - name: Bump mcp-docs-server prerelease version
         env:


### PR DESCRIPTION
## Summary
- Publish workflows had stale road-to-v1 tag mapping (`main→beta`, `0.x→alpha`). Post-1.0, main prereleases should use the `alpha` dist-tag.
- Changed tag determination in both `npm-publish.yml` and `version-packages.yml` to use `alpha` for main branch
- Removed `0.x` branch triggers (no longer used)
- Removed `publish-alpha-tags.js beta` step from stable job (no more beta dist-tag needed)

## Test plan
- [ ] Merge and verify next prerelease publishes with the `alpha` npm dist-tag
- [ ] Confirm `npm info @mastra/core dist-tags` shows `alpha` pointing to the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined release workflow by reducing monitored branches to main only.
  * Unified release tagging to consistently use "alpha" for all releases.
  * Removed beta release publishing step.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->