### PR TITLE
fix(playground-ui): handle non-string compatibility and metadata in skill detail

### DIFF
--- a/.changeset/silly-eyes-own.md
+++ b/.changeset/silly-eyes-own.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed skill detail page crashing when skills have object-typed compatibility or metadata fields. Skills from skills.sh and other external sources now display correctly.

--- a/packages/playground-ui/src/domains/workspace/components/skill-detail.tsx
+++ b/packages/playground-ui/src/domains/workspace/components/skill-detail.tsx
@@ -79,7 +79,7 @@ export function SkillDetail({ skill, onReferenceClick }: SkillDetailProps) {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <MetadataCard label="Source" value={sourceInfo.label} icon={sourceInfo.icon} />
         {skill.license && <MetadataCard label="License" value={skill.license} />}
-        {skill.compatibility && <MetadataCard label="Compatibility" value={skill.compatibility} />}
+        {skill.compatibility != null && <MetadataCard label="Compatibility" value={skill.compatibility} />}
         <MetadataCard
           label="References"
           value={`${skill.references.length} files`}
@@ -194,13 +194,46 @@ export function SkillDetail({ skill, onReferenceClick }: SkillDetailProps) {
   );
 }
 
-function MetadataCard({ label, value, icon }: { label: string; value: string; icon?: React.ReactNode }) {
+/**
+ * Format a value for display, handling strings, objects, and arrays.
+ */
+function formatDisplayValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(v => (typeof v === 'string' ? v : JSON.stringify(v))).join(', ');
+  }
+  if (typeof value === 'object' && value !== null) {
+    // For objects, show a compact summary
+    const keys = Object.keys(value);
+    if (keys.length === 0) return '{}';
+    if (keys.length === 1) {
+      const key = keys[0];
+      const val = (value as Record<string, unknown>)[key];
+      if (Array.isArray(val)) {
+        return `${key}: ${val.join(', ')}`;
+      }
+      return `${key}: ${formatDisplayValue(val)}`;
+    }
+    return `{${keys.join(', ')}}`;
+  }
+  return String(value);
+}
+
+function MetadataCard({ label, value, icon }: { label: string; value: unknown; icon?: React.ReactNode }) {
+  const displayValue = formatDisplayValue(value);
   return (
     <div className="p-3 rounded-lg bg-surface3">
       <p className="text-xs text-icon3 mb-1">{label}</p>
       <div className="flex items-center gap-1.5">
         {icon && <span className="text-icon4">{icon}</span>}
-        <p className="text-sm font-medium text-icon5">{value}</p>
+        <p className="text-sm font-medium text-icon5 truncate" title={displayValue}>
+          {displayValue}
+        </p>
       </div>
     </div>
   );

--- a/packages/playground-ui/src/domains/workspace/types.ts
+++ b/packages/playground-ui/src/domains/workspace/types.ts
@@ -131,8 +131,8 @@ export interface SkillMetadata {
   name: string;
   description: string;
   license?: string;
-  compatibility?: string;
-  metadata?: Record<string, string>;
+  compatibility?: unknown;
+  metadata?: Record<string, unknown>;
 }
 
 export interface Skill extends SkillMetadata {


### PR DESCRIPTION
## Summary
- Update `SkillMetadata` types to use `unknown` for `compatibility` and `Record<string, unknown>` for `metadata` fields to match the updated core types from #12490
- Add `formatDisplayValue` helper to safely render objects and arrays in the `MetadataCard` component
- Fix React error 31 when viewing skills with object-typed compatibility (e.g., `{ agents: ["claude-code", ...] }`)

## Test plan
- [ ] View a skill with object compatibility (e.g., skill-search from skills.sh)
- [ ] Verify the compatibility field displays as "agents: claude-code, codex, ..." instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)