### PR TITLE
fix(core): use absolute path in local sandbox cwd test

### DIFF
--- a/packages/core/src/workspace/sandbox/local-sandbox.test.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.test.ts
@@ -159,7 +159,7 @@ describe('LocalSandbox', () => {
       await fs.mkdir(subDir);
       await fs.writeFile(path.join(subDir, 'subfile.txt'), 'content');
 
-      const result = await sandbox.executeCommand('ls', ['-1'], { cwd: 'subdir' });
+      const result = await sandbox.executeCommand('ls', ['-1'], { cwd: subDir });
 
       expect(result.success).toBe(true);
       expect(result.stdout).toContain('subfile.txt');


### PR DESCRIPTION
## Summary
- Fix failing test `should support custom cwd option` in local-sandbox.test.ts
- The test was passing a relative path `'subdir'` but `cwd` works like `child_process.spawn` - relative paths resolve from `process.cwd()`, not the sandbox working directory

## Test plan
- [x] `pnpm test src/workspace/sandbox/local-sandbox.test.ts` passes (41/41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed test execution context to ensure commands run in the correct directory path, improving test reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->