### PR TITLE
fix(cli): handle prerelease versions in peer dependency check

### DIFF
--- a/.changeset/chubby-ads-prove.md
+++ b/.changeset/chubby-ads-prove.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed peer dependency checker to correctly validate prerelease versions (e.g., 1.1.0-alpha.1 now satisfies >=1.0.0-0 <2.0.0-0)

--- a/packages/cli/src/utils/check-peer-deps.ts
+++ b/packages/cli/src/utils/check-peer-deps.ts
@@ -56,7 +56,8 @@ export async function checkMastraPeerDeps(packages: MastraPackageInfo[]): Promis
         }
 
         // Check if the installed version satisfies the peer dep range
-        if (!satisfies(installedVersion, requiredRange)) {
+        // includePrerelease: true so that 1.1.0-alpha.1 satisfies >=1.0.0-0 <2.0.0-0
+        if (!satisfies(installedVersion, requiredRange, { includePrerelease: true })) {
           mismatches.push({
             package: pkg.name,
             packageVersion: pkg.version,


### PR DESCRIPTION
## Summary
- Add `includePrerelease: true` to `semver.satisfies()` call in peer dependency checker
- Fixes false warnings where `1.1.0-alpha.1` doesn't satisfy `>=1.0.0-0 <2.0.0-0`

## Problem
When running `mastra dev` with alpha versions, users see spurious warnings:
```
⚠ Peer dependency version mismatch detected:
  • @mastra/evals@1.0.0-beta.5 requires @mastra/core >=1.0.0-0 <2.0.0-0
    but found @mastra/core@1.1.0-alpha.1
```

`1.1.0-alpha.1` should satisfy `>=1.0.0-0 <2.0.0-0` but semver's default behavior excludes prereleases.

## Test plan
- [x] Existing tests pass
- [x] `mastra dev` no longer shows false peer dep warnings for alpha versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer dependency validation to correctly recognize and accept prerelease versions (e.g., 1.1.0-alpha.1) when evaluating whether installed packages satisfy specified version ranges. This reduces false mismatch warnings and improves compatibility checks for projects that rely on prerelease package versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->