### PR TITLE
feat(playground): show raw SKILL.md source with frontmatter

### DIFF
--- a/.changeset/violet-nights-create.md
+++ b/.changeset/violet-nights-create.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added raw SKILL.md source view in skill detail page. The 'Source' toggle now shows the full file contents including YAML frontmatter.

--- a/packages/playground-ui/src/domains/workspace/components/skill-detail.tsx
+++ b/packages/playground-ui/src/domains/workspace/components/skill-detail.tsx
@@ -19,6 +19,8 @@ import type { Skill, SkillSource } from '../types';
 
 export interface SkillDetailProps {
   skill: Skill;
+  /** Raw SKILL.md file contents to show in "Source" view. Falls back to skill.instructions if not provided. */
+  rawSkillMd?: string;
   onReferenceClick?: (referencePath: string) => void;
 }
 
@@ -45,7 +47,7 @@ function getSourceInfo(source: SkillSource): { icon: React.ReactNode; label: str
   }
 }
 
-export function SkillDetail({ skill, onReferenceClick }: SkillDetailProps) {
+export function SkillDetail({ skill, rawSkillMd, onReferenceClick }: SkillDetailProps) {
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set(['instructions']));
   const [showRawInstructions, setShowRawInstructions] = useState(false);
   const sourceInfo = getSourceInfo(skill.source);
@@ -118,7 +120,7 @@ export function SkillDetail({ skill, onReferenceClick }: SkillDetailProps) {
                 fontSize: '0.875rem',
               }}
             >
-              {skill.instructions}
+              {rawSkillMd ?? skill.instructions}
             </SyntaxHighlighter>
           </div>
         ) : (

--- a/packages/playground/src/pages/workspace/skills/[skillName]/index.tsx
+++ b/packages/playground/src/pages/workspace/skills/[skillName]/index.tsx
@@ -12,6 +12,7 @@ import {
   ReferenceViewerDialog,
   useWorkspaceSkill,
   useWorkspaceSkillReference,
+  useWorkspaceFile,
 } from '@mastra/playground-ui';
 
 import { Link, useParams, useSearchParams } from 'react-router';
@@ -37,6 +38,12 @@ export default function WorkspaceSkillDetailPage() {
 
   // Fetch skill details - pass workspaceId to fetch from correct workspace
   const { data: skill, isLoading, error } = useWorkspaceSkill(decodedSkillName, { workspaceId });
+
+  // Fetch raw SKILL.md file for "Source" view
+  const { data: rawSkillMdData } = useWorkspaceFile(skill?.path ? `${skill.path}/SKILL.md` : '', {
+    enabled: !!skill?.path,
+    workspaceId,
+  });
 
   // Fetch reference content when viewing
   const { data: referenceData, isLoading: isLoadingReference } = useWorkspaceSkillReference(
@@ -129,7 +136,7 @@ export default function WorkspaceSkillDetailPage() {
 
       <div className="grid overflow-y-auto overflow-x-hidden h-full">
         <div className="max-w-[100rem] px-[3rem] mx-auto py-8 h-full w-full overflow-x-hidden">
-          <SkillDetail skill={skill} onReferenceClick={setViewingReference} />
+          <SkillDetail skill={skill} rawSkillMd={rawSkillMdData?.content} onReferenceClick={setViewingReference} />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- Added `rawSkillMd` prop to `SkillDetail` component to display the full SKILL.md file contents including YAML frontmatter when toggling "Source" view
- Uses existing `useWorkspaceFile` hook to fetch the raw file content
- Falls back to `skill.instructions` (parsed body) if raw content is not available

## Test plan

- [x] Navigate to a skill detail page in the playground
- [x] Click the "Source" toggle button in the Instructions section
- [x] Verify the raw SKILL.md content is shown including the YAML frontmatter at the top

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a raw SKILL.md source view on skill detail pages, enabling users to toggle and view the complete source code including YAML frontmatter.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->