### PR TITLE
chore: force alpha bump for evals, loggers, observability, memory

### DIFF
--- a/.changeset/force-alpha-bump-evals-loggers.md
+++ b/.changeset/force-alpha-bump-evals-loggers.md
@@ -1,0 +1,8 @@
+---
+'@mastra/evals': patch
+'@mastra/loggers': patch
+'@mastra/observability': patch
+'@mastra/memory': patch
+---
+
+Force alpha version bump for @mastra/evals, @mastra/loggers, @mastra/observability, and @mastra/memory


### PR DESCRIPTION
## Summary
- Force alpha version bump for `@mastra/evals`, `@mastra/loggers`, `@mastra/observability`, and `@mastra/memory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)