### PR TITLE
style(playground-ui): update Badge component styling

### DIFF
--- a/.changeset/fast-pandas-nail.md
+++ b/.changeset/fast-pandas-nail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Updated Badge component styling: increased height to 28px, changed to pill shape with rounded-full, added border, and increased padding for better visual appearance.

--- a/packages/playground-ui/src/ds/components/Badge/Badge.tsx
+++ b/packages/playground-ui/src/ds/components/Badge/Badge.tsx
@@ -31,9 +31,9 @@ export const Badge = ({ icon, variant = 'default', className, children, ...props
   return (
     <div
       className={cn(
-        'font-mono text-ui-sm gap-1 h-badge-default inline-flex items-center rounded-md shrink-0',
+        'font-mono text-ui-sm gap-1 h-badge-default inline-flex items-center rounded-full border border-border1 shrink-0',
         transitions.colors,
-        icon ? 'pl-1 pr-1.5' : 'px-1.5',
+        icon ? 'pl-2 pr-2.5' : 'px-2.5',
         variant === 'default' && icon ? 'bg-surface4 text-neutral5' : variantClasses[variant],
         className,
       )}

--- a/packages/playground-ui/src/ds/tokens/sizes.ts
+++ b/packages/playground-ui/src/ds/tokens/sizes.ts
@@ -9,7 +9,7 @@ export const Sizes = {
   'table-header': '28px',
   'table-row': '56px',
   'table-row-small': '40px',
-  'badge-default': '20px',
+  'badge-default': '28px',
   'avatar-sm': '24px',
   'avatar-md': '32px',
   'avatar-lg': '40px',


### PR DESCRIPTION
Updates the Badge component to look better:

- Height increased from 20px to 28px
- Pill shape with `rounded-full` instead of `rounded-md`
- Added border with `border border-border1`
- More padding (px-2.5 instead of px-1.5)

Before/after is a visual change - badges are now taller, rounder, and have a subtle border.

<img width="3840" height="2160" alt="CleanShot 2026-01-30 at 10 43 00@2x" src="https://github.com/user-attachments/assets/16d5892b-24e0-456c-9e3e-be633112790e" />

