### PR TITLE
fix(cli): use file-based LibSQL storage in create-mastra template

### DIFF
--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -505,7 +505,7 @@ export const mastra = new Mastra({
   storage: new LibSQLStore({
     id: "mastra-storage",
     // stores observability, scores, ... into memory storage, if it needs to persist, change to file:../mastra.db
-    url: ":memory:",
+    url: "file:./mastra.db",
   }),
   logger: new PinoLogger({
     name: 'Mastra',


### PR DESCRIPTION
## Summary

- Changes the default LibSQL storage URL from `:memory:` to `file:./mastra.db` in the create-mastra CLI template
- This ensures data persists across server restarts instead of being lost when the process ends

## Why

Using `:memory:` storage meant that observability data, scores, and other stored information would be lost every time the development server was restarted, which was confusing for users getting started with Mastra.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CLI initialization to use persistent file-based storage instead of temporary in-memory storage, ensuring data is preserved across sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->