### PR TITLE
refactor(playground-ui): use EntryCell icon prop for agent source indicator

### DIFF
--- a/.changeset/afraid-dodos-hunt.md
+++ b/.changeset/afraid-dodos-hunt.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Use EntryCell icon prop for source indicator in agent table

--- a/packages/playground-ui/src/domains/agents/components/agent-table/agent-table.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-table/agent-table.tsx
@@ -66,7 +66,7 @@ export function AgentsTable({ agents, isLoading, onCreateClick }: AgentsTablePro
       </SearchbarWrapper>
 
       {isLoading ? (
-        <AgentsTableSkeleton showSourceColumn={experimentalFeaturesEnabled} />
+        <AgentsTableSkeleton />
       ) : (
         <ScrollableContainer>
           <TooltipProvider>
@@ -101,11 +101,10 @@ export function AgentsTable({ agents, isLoading, onCreateClick }: AgentsTablePro
   );
 }
 
-const AgentsTableSkeleton = ({ showSourceColumn }: { showSourceColumn: boolean }) => (
+const AgentsTableSkeleton = () => (
   <Table>
     <Thead>
       <Th>Name</Th>
-      {showSourceColumn && <Th>Source</Th>}
       <Th>Model</Th>
       <Th>Attached entities</Th>
     </Thead>
@@ -115,11 +114,6 @@ const AgentsTableSkeleton = ({ showSourceColumn }: { showSourceColumn: boolean }
           <Cell>
             <Skeleton className="h-4 w-1/2" />
           </Cell>
-          {showSourceColumn && (
-            <Cell>
-              <Skeleton className="h-4 w-16" />
-            </Cell>
-          )}
           <Cell>
             <Skeleton className="h-4 w-1/2" />
           </Cell>

--- a/packages/playground-ui/src/domains/agents/components/agent-table/columns.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-table/columns.tsx
@@ -21,28 +21,28 @@ const NameCell = ({ row, showSourceIcon }: { row: Row<AgentTableColumn>; showSou
   const { Link, paths } = useLinkComponent();
   const isStored = row.original.source === 'stored';
 
+  const sourceIcon = showSourceIcon ? (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {isStored ? (
+          <Database className="w-3.5 h-3.5 text-accent6 shrink-0" />
+        ) : (
+          <Code2 className="w-3.5 h-3.5 text-accent3 shrink-0" />
+        )}
+      </TooltipTrigger>
+      <TooltipContent>
+        {isStored ? 'Stored in database - can be edited in UI' : 'Defined in code - read-only in UI'}
+      </TooltipContent>
+    </Tooltip>
+  ) : undefined;
+
   return (
     <EntryCell
+      icon={sourceIcon}
       name={
-        <div className="flex items-center gap-2">
-          {showSourceIcon && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                {isStored ? (
-                  <Database className="w-3.5 h-3.5 text-accent6 shrink-0" />
-                ) : (
-                  <Code2 className="w-3.5 h-3.5 text-accent3 shrink-0" />
-                )}
-              </TooltipTrigger>
-              <TooltipContent>
-                {isStored ? 'Stored in database - can be edited in UI' : 'Defined in code - read-only in UI'}
-              </TooltipContent>
-            </Tooltip>
-          )}
-          <Link className="w-full" href={paths.agentLink(row.original.id)}>
-            {row.original.name}
-          </Link>
-        </div>
+        <Link className="w-full" href={paths.agentLink(row.original.id)}>
+          {row.original.name}
+        </Link>
       }
       description={extractPrompt(row.original.instructions)}
     />

--- a/packages/playground-ui/src/domains/agents/components/agent-table/columns.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-table/columns.tsx
@@ -17,161 +17,137 @@ export type AgentTableColumn = {
   id: string;
 } & AgentTableData;
 
-const NameCell = ({ row }: { row: Row<AgentTableColumn> }) => {
+const NameCell = ({ row, showSourceIcon }: { row: Row<AgentTableColumn>; showSourceIcon?: boolean }) => {
   const { Link, paths } = useLinkComponent();
+  const isStored = row.original.source === 'stored';
 
   return (
     <EntryCell
       name={
-        <Link className="w-full" href={paths.agentLink(row.original.id)}>
-          {row.original.name}
-        </Link>
+        <div className="flex items-center gap-2">
+          {showSourceIcon && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                {isStored ? (
+                  <Database className="w-3.5 h-3.5 text-accent6 shrink-0" />
+                ) : (
+                  <Code2 className="w-3.5 h-3.5 text-accent3 shrink-0" />
+                )}
+              </TooltipTrigger>
+              <TooltipContent>
+                {isStored ? 'Stored in database - can be edited in UI' : 'Defined in code - read-only in UI'}
+              </TooltipContent>
+            </Tooltip>
+          )}
+          <Link className="w-full" href={paths.agentLink(row.original.id)}>
+            {row.original.name}
+          </Link>
+        </div>
       }
       description={extractPrompt(row.original.instructions)}
     />
   );
 };
 
-const SourceCell = ({ row }: { row: Row<AgentTableColumn> }) => {
-  const isStored = row.original.source === 'stored';
-
-  return (
-    <Cell>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="inline-flex items-center gap-1.5 text-sm">
-            {isStored ? (
-              <>
-                <Database className="w-3.5 h-3.5 text-accent6" />
-                <span className="text-text2">Storage</span>
-              </>
-            ) : (
-              <>
-                <Code2 className="w-3.5 h-3.5 text-accent3" />
-                <span className="text-text2">Code</span>
-              </>
-            )}
-          </div>
-        </TooltipTrigger>
-        <TooltipContent>
-          {isStored ? 'Stored in database - can be edited in UI' : 'Defined in code - read-only in UI'}
-        </TooltipContent>
-      </Tooltip>
-    </Cell>
-  );
-};
-
-const sourceColumn: ColumnDef<AgentTableColumn> = {
-  header: 'Source',
-  accessorKey: 'source',
-  cell: SourceCell,
-  size: 100,
-};
-
-const baseColumns: ColumnDef<AgentTableColumn>[] = [
-  {
-    header: 'Name',
-    accessorKey: 'name',
-    cell: NameCell,
+const modelColumn: ColumnDef<AgentTableColumn> = {
+  header: 'Model',
+  accessorKey: 'model',
+  cell: ({ row }) => {
+    return (
+      <Cell>
+        <Badge
+          variant="default"
+          icon={providerMapToIcon[row.original.provider as keyof typeof providerMapToIcon] || <OpenAIIcon />}
+          className="truncate"
+        >
+          {row.original.modelId || 'N/A'}
+        </Badge>
+        {row.original.modelList && row.original.modelList.length > 1 ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Badge variant="info" className="ml-2">
+                + {row.original.modelList.length - 1} more
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent className="bg-surface5 flex flex-col gap-2">
+              {row.original.modelList.slice(1).map(mdl => (
+                <div key={mdl.id}>
+                  <Badge
+                    variant="default"
+                    icon={providerMapToIcon[mdl.model.provider as keyof typeof providerMapToIcon]}
+                  >
+                    {mdl.model.modelId}
+                  </Badge>
+                </div>
+              ))}
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
+      </Cell>
+    );
   },
-  {
-    header: 'Model',
-    accessorKey: 'model',
-    cell: ({ row }) => {
-      return (
-        <Cell>
-          <Badge
-            variant="default"
-            icon={providerMapToIcon[row.original.provider as keyof typeof providerMapToIcon] || <OpenAIIcon />}
-            className="truncate"
-          >
-            {row.original.modelId || 'N/A'}
+};
+
+const attachedEntitiesColumn: ColumnDef<AgentTableColumn> = {
+  header: 'Attached entities',
+  accessorKey: 'attachedEntities',
+  cell: ({ row }) => {
+    const agent = row.original;
+
+    const agentsCount = Object.keys(agent.agents || {}).length;
+    const toolsCount = Object.keys(agent.tools || {}).length;
+    const workflowsCount = Object.keys(agent.workflows || {}).length;
+    const inputProcessorsCount = (agent.inputProcessors || []).length;
+    const outputProcessorsCount = (agent.outputProcessors || []).length;
+
+    return (
+      <Cell>
+        <span className="flex flex-row gap-2 w-full items-center flex-wrap">
+          <Badge variant="default" icon={<AgentIcon className="text-accent1" />}>
+            {agentsCount} agent{agentsCount !== 1 ? 's' : ''}
           </Badge>
-          {row.original.modelList && row.original.modelList.length > 1 ? (
+          <Badge variant="default" icon={<ToolsIcon className="text-accent6" />}>
+            {toolsCount} tool{toolsCount !== 1 ? 's' : ''}
+          </Badge>
+          <Badge variant="default" icon={<WorkflowIcon className="text-accent3" />}>
+            {workflowsCount} workflow{workflowsCount !== 1 ? 's' : ''}
+          </Badge>
+          {(inputProcessorsCount > 0 || outputProcessorsCount > 0) && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <Badge variant="info" className="ml-2">
-                  + {row.original.modelList.length - 1} more
-                </Badge>
+                <Badge variant="default" icon={<ProcessorIcon className="text-accent4" />} />
               </TooltipTrigger>
-              <TooltipContent className="bg-surface5 flex flex-col gap-2">
-                {row.original.modelList.slice(1).map(mdl => (
-                  <div key={mdl.id}>
-                    <Badge
-                      variant="default"
-                      icon={providerMapToIcon[mdl.model.provider as keyof typeof providerMapToIcon]}
-                    >
-                      {mdl.model.modelId}
-                    </Badge>
-                  </div>
-                ))}
+              <TooltipContent className="flex flex-col gap-1">
+                <a
+                  href="https://mastra.ai/docs/agents/processors"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-accent1 hover:underline"
+                >
+                  Processors
+                </a>
+                <span className="text-icon3">
+                  {[inputProcessorsCount > 0 && 'input', outputProcessorsCount > 0 && 'output']
+                    .filter(Boolean)
+                    .join(', ')}
+                </span>
               </TooltipContent>
             </Tooltip>
-          ) : null}
-        </Cell>
-      );
-    },
+          )}
+        </span>
+      </Cell>
+    );
   },
-  {
-    header: 'Attached entities',
-    accessorKey: 'attachedEntities',
-    cell: ({ row }) => {
-      const agent = row.original;
-
-      const agentsCount = Object.keys(agent.agents || {}).length;
-      const toolsCount = Object.keys(agent.tools || {}).length;
-      const workflowsCount = Object.keys(agent.workflows || {}).length;
-      const inputProcessorsCount = (agent.inputProcessors || []).length;
-      const outputProcessorsCount = (agent.outputProcessors || []).length;
-
-      return (
-        <Cell>
-          <span className="flex flex-row gap-2 w-full items-center flex-wrap">
-            <Badge variant="default" icon={<AgentIcon className="text-accent1" />}>
-              {agentsCount} agent{agentsCount !== 1 ? 's' : ''}
-            </Badge>
-            <Badge variant="default" icon={<ToolsIcon className="text-accent6" />}>
-              {toolsCount} tool{toolsCount !== 1 ? 's' : ''}
-            </Badge>
-            <Badge variant="default" icon={<WorkflowIcon className="text-accent3" />}>
-              {workflowsCount} workflow{workflowsCount !== 1 ? 's' : ''}
-            </Badge>
-            {(inputProcessorsCount > 0 || outputProcessorsCount > 0) && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Badge variant="default" icon={<ProcessorIcon className="text-accent4" />} />
-                </TooltipTrigger>
-                <TooltipContent className="flex flex-col gap-1">
-                  <a
-                    href="https://mastra.ai/docs/agents/processors"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-accent1 hover:underline"
-                  >
-                    Processors
-                  </a>
-                  <span className="text-icon3">
-                    {[inputProcessorsCount > 0 && 'input', outputProcessorsCount > 0 && 'output']
-                      .filter(Boolean)
-                      .join(', ')}
-                  </span>
-                </TooltipContent>
-              </Tooltip>
-            )}
-          </span>
-        </Cell>
-      );
-    },
-  },
-];
-
-/** @deprecated Use getColumns() instead for conditional column support */
-export const columns = baseColumns;
+};
 
 export const getColumns = (experimentalFeaturesEnabled: boolean): ColumnDef<AgentTableColumn>[] => {
-  if (experimentalFeaturesEnabled) {
-    // Insert source column after Name column
-    return [baseColumns[0], sourceColumn, ...baseColumns.slice(1)];
-  }
-  return baseColumns;
+  return [
+    {
+      header: 'Name',
+      accessorKey: 'name',
+      cell: ({ row }) => <NameCell row={row} showSourceIcon={experimentalFeaturesEnabled} />,
+    },
+    modelColumn,
+    attachedEntitiesColumn,
+  ];
 };


### PR DESCRIPTION
Moves the source indicator icon (database/code) from being nested inside the `name` prop to using the dedicated `icon` prop on `EntryCell`.

This gives proper layout alignment - the icon sits to the left of the name/description block, and the description stays aligned with the name.

```tsx
// Before: icon wrapped inside name prop
<EntryCell
  name={
    <div className="flex items-center gap-2">
      {sourceIcon}
      <Link>...</Link>
    </div>
  }
/>

// After: using the icon prop
<EntryCell
  icon={sourceIcon}
  name={<Link>...</Link>}
/>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Model column to agent table displaying model ID with provider icon.
  * Added Attached Entities column showing counts of connected agents, tools, workflows, and processors.
  * Moved source indicator to name cell as an icon for cleaner layout.

* **Bug Fixes**
  * Removed conditional Source column rendering logic from table skeleton.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->