### PR TITLE
fix(core): resolve RequestContext type variance issue with IRequestContext interface

### DIFF
--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -27,7 +27,7 @@ import type { MastraMemory } from '../memory/memory';
 import type { MemoryConfig, StorageThreadType } from '../memory/types';
 import type { Span, SpanType, TracingContext, TracingOptions, TracingPolicy } from '../observability';
 import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '../processors/index';
-import type { RequestContext } from '../request-context';
+import type { IRequestContext, RequestContext } from '../request-context';
 import type { OutputSchema } from '../stream';
 import type { ModelManagerModelConfig } from '../stream/types';
 import type { ToolAction, VercelTool, VercelToolV5 } from '../tools';
@@ -117,7 +117,7 @@ type DynamicModel = ({
   requestContext,
   mastra,
 }: {
-  requestContext: RequestContext;
+  requestContext: IRequestContext;
   mastra?: Mastra;
 }) => Promise<MastraModelConfig> | MastraModelConfig;
 
@@ -132,7 +132,6 @@ export interface AgentConfig<
   TAgentId extends string = string,
   TTools extends ToolsInput = ToolsInput,
   TOutput = undefined,
-  TRequestContext extends Record<string, any> | unknown = unknown,
 > {
   /**
    * Identifier for the agent.
@@ -150,7 +149,7 @@ export interface AgentConfig<
    * Instructions that guide the agent's behavior. Can be a string, array of strings, system message object,
    * array of system messages, or a function that returns any of these types dynamically.
    */
-  instructions: DynamicArgument<AgentInstructions, TRequestContext>;
+  instructions: DynamicArgument<AgentInstructions>;
   /**
    * The language model used by the agent. Can be provided statically or resolved at runtime.
    */
@@ -163,7 +162,7 @@ export interface AgentConfig<
   /**
    * Tools that the agent can access. Can be provided statically or resolved dynamically.
    */
-  tools?: DynamicArgument<TTools, TRequestContext>;
+  tools?: DynamicArgument<TTools>;
   /**
    * Workflows that the agent can execute. Can be static or dynamically resolved.
    */
@@ -254,7 +253,7 @@ export interface AgentConfig<
    * When provided, the request context will be validated against this schema at the start of generate() and stream() calls.
    * If validation fails, an error is thrown.
    */
-  requestContextSchema?: ZodSchema<TRequestContext>;
+  requestContextSchema?: ZodSchema;
 }
 
 export type AgentMemoryOption = {

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -1735,7 +1735,7 @@ export async function networkLoop<OUTPUT = undefined>({
   networkName: string;
   requestContext: RequestContext;
   runId: string;
-  routingAgent: Agent<any, any, any, any>;
+  routingAgent: Agent<any, any, any>;
   routingAgentOptions?: AgentExecutionOptions<OUTPUT>;
   generateId: NetworkIdGenerator;
   maxIterations: number;

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -2,6 +2,7 @@ import type { ToolSet } from '@internal/ai-sdk-v5';
 import { zodToJsonSchema } from '@mastra/schema-compat/zod-to-json';
 import z from 'zod';
 import type { MastraDBMessage } from '../../../memory';
+import type { RequestContext } from '../../../request-context';
 import { ChunkFrom } from '../../../stream/types';
 import type { MastraToolInvocationOptions } from '../../../tools/types';
 import type { SuspendOptions } from '../../../workflows';
@@ -240,7 +241,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
       }
 
       try {
-        const requireToolApproval = requestContext.get('__mastra_requireToolApproval');
+        const requireToolApproval = (requestContext as RequestContext).get('__mastra_requireToolApproval');
 
         let resumeDataFromArgs: any = undefined;
         let args: any = inputData.args;

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -125,7 +125,7 @@ export abstract class MCPServerBase<TId extends string = string> extends MastraB
             // Use tool's intrinsic ID to avoid collisions across MCP servers
             const toolKey = typeof (tool as any).id === 'string' ? (tool as any).id : key;
             mastra.addTool(
-              tool as ToolAction<any, any, any, any, ToolExecutionContext<any, any, any>, string, unknown>,
+              tool as ToolAction<any, any, any, any, ToolExecutionContext<any, any, any>, string, any>,
               toolKey,
             );
           }

--- a/packages/core/src/tools/request-context-schema-types.test-d.ts
+++ b/packages/core/src/tools/request-context-schema-types.test-d.ts
@@ -45,10 +45,10 @@ describe('requestContextSchema type inference', () => {
       id: 'untyped-tool',
       description: 'A tool without request context schema',
       execute: async (input, context) => {
-        // Without schema, requestContext should be RequestContext<unknown>
-        expectTypeOf(context.requestContext).toEqualTypeOf<RequestContext<unknown> | undefined>();
+        // Without schema, requestContext defaults to Record<string, unknown>
+        expectTypeOf(context.requestContext).toEqualTypeOf<RequestContext<Record<string, unknown>> | undefined>();
 
-        // get() should return unknown
+        // get() returns unknown via the overload
         const value = context.requestContext?.get('anyKey');
         expectTypeOf(value).toEqualTypeOf<unknown>();
 

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -67,7 +67,7 @@ export class Tool<
     TResumeSchema
   >,
   TId extends string = string,
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 > implements ToolAction<TSchemaIn, TSchemaOut, TSuspendSchema, TResumeSchema, TContext, TId, TRequestContext> {
   /** Unique identifier for the tool */
   id: TId;
@@ -406,7 +406,7 @@ export function createTool<
   TSchemaOut = unknown,
   TSuspend = unknown,
   TResume = unknown,
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
   TContext extends ToolExecutionContext<TSuspend, TResume, TRequestContext> = ToolExecutionContext<
     TSuspend,
     TResume,

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -236,7 +236,7 @@ export type InternalCoreTool = {
 export interface ToolExecutionContext<
   TSuspend = unknown,
   TResume = unknown,
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 > {
   // ============ Common properties (available in all contexts) ============
   mastra?: MastraUnion;
@@ -267,7 +267,7 @@ export interface ToolAction<
   TResume = unknown,
   TContext extends ToolExecutionContext<TSuspend, TResume, any> = ToolExecutionContext<TSuspend, TResume>,
   TId extends string = string,
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 > {
   id: TId;
   description: string;

--- a/packages/core/src/types/dynamic-argument.ts
+++ b/packages/core/src/types/dynamic-argument.ts
@@ -1,15 +1,16 @@
 import type { Mastra } from '../mastra';
-import type { RequestContext } from '../request-context';
+import type { IRequestContext } from '../request-context';
 
-export type DynamicArgument<T, TRequestContext extends Record<string, any> | unknown = unknown> =
+/**
+ * A value that can be provided statically or resolved dynamically at runtime.
+ * When a function is provided, it receives the request context and Mastra instance.
+ *
+ * Uses IRequestContext (the interface) to allow any typed RequestContext<T>
+ * to be passed, avoiding TypeScript variance issues.
+ */
+export type DynamicArgument<T> =
   | T
-  | (({
-      requestContext,
-      mastra,
-    }: {
-      requestContext: RequestContext<TRequestContext>;
-      mastra?: Mastra;
-    }) => Promise<T> | T);
+  | (({ requestContext, mastra }: { requestContext: IRequestContext; mastra?: Mastra }) => Promise<T> | T);
 
 export type NonEmpty<T extends string> = T extends '' ? never : T;
 

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -202,7 +202,7 @@ export function createStep<
   TSchemaOut,
   TContext extends ToolExecutionContext<TSuspend, TResume, any>,
   TId extends string,
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 >(
   tool: Tool<TSchemaIn, TSchemaOut, TSuspend, TResume, TContext, TId, TRequestContext>,
   toolOptions?: { retries?: number; scorers?: DynamicArgument<MastraScorers> },

--- a/packages/core/src/workflows/step.ts
+++ b/packages/core/src/workflows/step.ts
@@ -27,7 +27,7 @@ export type ExecuteFunctionParams<
   TResume,
   TSuspend,
   EngineType,
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 > = {
   runId: string;
   resourceId?: string;
@@ -71,7 +71,7 @@ export type ConditionFunctionParams<
   TResumeSchema,
   TSuspendSchema,
   EngineType,
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 > = Omit<
   ExecuteFunctionParams<TState, TStepInput, TStepOutput, TResumeSchema, TSuspendSchema, EngineType, TRequestContext>,
   'setState' | 'suspend'
@@ -84,7 +84,7 @@ export type ExecuteFunction<
   TResumeSchema,
   TSuspendSchema,
   EngineType,
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 > = (
   params: ExecuteFunctionParams<
     TState,
@@ -104,7 +104,7 @@ export type ConditionFunction<
   TResumeSchema,
   TSuspendSchema,
   EngineType,
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 > = (
   params: ConditionFunctionParams<
     TState,
@@ -124,7 +124,7 @@ export type LoopConditionFunction<
   TResumeSchema,
   TSuspendSchema,
   EngineType,
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 > = (
   params: ConditionFunctionParams<
     TState,
@@ -148,7 +148,7 @@ export interface Step<
   TResume = unknown,
   TSuspend = unknown,
   TEngineType = any,
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 > {
   id: TStepId;
   description?: string;

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -523,7 +523,7 @@ export type SerializedStepFlowEntry =
       };
     };
 
-export type StepWithComponent = Step<string, any, any, any, any, any> & {
+export type StepWithComponent = Step<string, any, any, any, any, any, any, any> & {
   component?: string;
   steps?: Record<string, StepWithComponent>;
 };
@@ -578,7 +578,7 @@ export type StepParamsLegacy<
   TStepOutput,
   TResume,
   TSuspend,
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 > = {
   id: TStepId;
   description?: string;
@@ -720,7 +720,7 @@ export type WorkflowConfig<
   TInput,
   TOutput,
   TSteps extends Step[],
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 > = {
   mastra?: Mastra;
   id: TWorkflowId;

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -178,7 +178,7 @@ export function createStep<
   TResumeSchema extends z.ZodTypeAny ? z.infer<TResumeSchema> : unknown,
   TSuspendSchema extends z.ZodTypeAny ? z.infer<TSuspendSchema> : unknown,
   DefaultEngineType,
-  TRequestContextSchema extends z.ZodTypeAny ? z.infer<TRequestContextSchema> : unknown
+  TRequestContextSchema extends z.ZodTypeAny ? z.infer<TRequestContextSchema> : Record<string, unknown>
 >;
 
 /**
@@ -191,7 +191,16 @@ export function createStep<TStepId extends string>(
     retries?: number;
     scorers?: DynamicArgument<MastraScorers>;
   },
-): Step<TStepId, unknown, { prompt: string }, { text: string }, unknown, unknown, DefaultEngineType>;
+): Step<
+  TStepId,
+  unknown,
+  { prompt: string },
+  { text: string },
+  unknown,
+  unknown,
+  DefaultEngineType,
+  Record<string, unknown>
+>;
 
 /**
  * Creates a step from an agent with structured output
@@ -203,7 +212,16 @@ export function createStep<TStepId extends string, TStepOutput>(
     retries?: number;
     scorers?: DynamicArgument<MastraScorers>;
   },
-): Step<TStepId, unknown, { prompt: string }, TStepOutput, unknown, unknown, DefaultEngineType>;
+): Step<
+  TStepId,
+  unknown,
+  { prompt: string },
+  TStepOutput,
+  unknown,
+  unknown,
+  DefaultEngineType,
+  Record<string, unknown>
+>;
 
 /**
  * Creates a step from a tool
@@ -215,7 +233,7 @@ export function createStep<
   TSchemaOut,
   TContext extends ToolExecutionContext<TSuspend, TResume, any>,
   TId extends string,
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 >(
   tool: Tool<TSchemaIn, TSchemaOut, TSuspend, TResume, TContext, TId, TRequestContext>,
   toolOptions?: { retries?: number; scorers?: DynamicArgument<MastraScorers> },
@@ -240,7 +258,8 @@ export function createStep<TProcessorId extends string>(
   z.infer<typeof ProcessorStepOutputSchema>,
   unknown,
   unknown,
-  DefaultEngineType
+  DefaultEngineType,
+  Record<string, unknown>
 >;
 
 /**
@@ -274,14 +293,14 @@ export function createStep<
   TResumeSchema extends z.ZodTypeAny ? z.infer<TResumeSchema> : unknown,
   TSuspendSchema extends z.ZodTypeAny ? z.infer<TSuspendSchema> : unknown,
   DefaultEngineType,
-  TRequestContextSchema extends z.ZodTypeAny ? z.infer<TRequestContextSchema> : unknown
+  TRequestContextSchema extends z.ZodTypeAny ? z.infer<TRequestContextSchema> : Record<string, unknown>
 >;
 
 // ============================================
 // Implementation (uses type guards for clean logic)
 // ============================================
 
-export function createStep(params: any, agentOrToolOptions?: any): Step<any, any, any, any, any, any, any> {
+export function createStep(params: any, agentOrToolOptions?: any): Step<any, any, any, any, any, any, any, any> {
   // Type assertions are needed because each branch returns a different Step type,
   // but the overloads ensure type safety for consumers
   if (isAgent(params)) {
@@ -1165,7 +1184,7 @@ export function createWorkflow<
   TInput = unknown,
   TOutput = unknown,
   TSteps extends Step<string, any, any, any, any, any, DefaultEngineType>[] = Step[],
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 >(params: WorkflowConfig<TWorkflowId, TState, TInput, TOutput, TSteps, TRequestContext>) {
   return new Workflow<DefaultEngineType, TSteps, TWorkflowId, TState, TInput, TOutput, TInput, TRequestContext>(params);
 }
@@ -1219,7 +1238,7 @@ export class Workflow<
   TInput = unknown,
   TOutput = unknown,
   TPrevSchema = TInput,
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 >
   extends MastraBase
   implements Step<TWorkflowId, TState, TInput, TOutput | undefined, any, any, DefaultEngineType, TRequestContext>
@@ -2476,7 +2495,7 @@ export class Run<
   TState = unknown,
   TInput = unknown,
   TOutput = unknown,
-  TRequestContext extends Record<string, any> | unknown = unknown,
+  TRequestContext extends Record<string, unknown> = Record<string, unknown>,
 > {
   #abortController?: AbortController;
   protected pubsub: PubSub;


### PR DESCRIPTION
## Summary

Fixes TypeScript type variance issue where `RequestContext<{ userId: string }>` was not assignable to `RequestContext<Record<string, any>>`. This prevented typed RequestContexts from being passed to internal APIs that accept generic RequestContexts.

## Solution

Introduces an `IRequestContext` interface without generics that `RequestContext<T>` implements. This allows any `RequestContext<T>` to be assignable to `IRequestContext`, solving the variance problem while preserving type safety for users who define typed contexts.

## Changes

- Add `IRequestContext` interface without generics that `RequestContext<T>` implements
- Update `DynamicArgument` to use `IRequestContext` instead of generic `RequestContext`
- Remove `TRequestContext` generic from `Agent` and `AgentConfig`
- Standardize default generic from `unknown` to `Record<string, unknown>` across workflows, tools, and steps
- Add method overloads to preserve typed `get()`/`set()` for users with typed contexts

## Technical Details

The `IRequestContext` interface approach was chosen because:
- It preserves type safety for users defining typed `RequestContext<T>`
- It allows internal APIs to accept any context without variance issues
- `RequestContext<T>` implements `IRequestContext`, so typed contexts can be passed to functions expecting the interface
- Method overloads on `RequestContext<T>` provide typed `get()`/`set()` while the interface methods use `unknown`

## Testing

- All 2840 unit tests pass (40 failures are integration tests requiring API keys)
- TypeScript compilation passes with no errors
- Type-level tests verify the new interface behavior