### PR TITLE
feat(playground-ui): add TracesTable component for Observability page

### DIFF
--- a/.changeset/icy-lies-wash.md
+++ b/.changeset/icy-lies-wash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added TracesTable component using TanStack Table for the Observability page. The new table includes keyboard navigation support (arrow keys and Enter to select), infinite scroll, and integrated filter tools. Also improved TracesTools styling with smaller form controls and consistent light variant appearance.

--- a/packages/playground-ui/src/domains/observability/components/index.ts
+++ b/packages/playground-ui/src/domains/observability/components/index.ts
@@ -5,6 +5,7 @@ export * from './shared';
 export * from './trace-dialog';
 export * from './traces-tools';
 export * from './traces-list';
+export * from './traces-table';
 export * from './span-score-list';
 export * from './span-scoring';
 export * from './span-tabs';

--- a/packages/playground-ui/src/domains/observability/components/traces-table/columns.tsx
+++ b/packages/playground-ui/src/domains/observability/components/traces-table/columns.tsx
@@ -1,0 +1,92 @@
+import { Cell, TxtCell, DateTimeCell } from '@/ds/components/Table';
+import { StatusBadge } from '@/ds/components/StatusBadge';
+import { getShortId } from '@/ds/components/Text';
+import { ColumnDef, Row } from '@tanstack/react-table';
+import { TraceTableColumn } from './types';
+
+const IdCell = ({ row }: { row: Row<TraceTableColumn> }) => {
+  const shortId = getShortId(row.original.traceId) || 'n/a';
+  return <TxtCell>{shortId}</TxtCell>;
+};
+
+const DateCell = ({ row }: { row: Row<TraceTableColumn> }) => {
+  const createdAt = new Date(row.original.createdAt);
+  return <DateTimeCell dateTime={createdAt} />;
+};
+
+const NameCell = ({ row }: { row: Row<TraceTableColumn> }) => {
+  return <TxtCell>{row.original.name}</TxtCell>;
+};
+
+const EntityCell = ({ row }: { row: Row<TraceTableColumn> }) => {
+  const entityName =
+    row.original.entityName ||
+    row.original.entityId ||
+    row.original.attributes?.agentId ||
+    row.original.attributes?.workflowId;
+  return <TxtCell>{entityName}</TxtCell>;
+};
+
+const StatusCell = ({ row }: { row: Row<TraceTableColumn> }) => {
+  const status = row.original.attributes?.status;
+
+  const getStatusVariant = (status: string | undefined) => {
+    switch (status) {
+      case 'success':
+      case 'ok':
+        return 'success';
+      case 'error':
+      case 'failed':
+        return 'error';
+      case 'pending':
+      case 'running':
+        return 'info';
+      default:
+        return 'neutral';
+    }
+  };
+
+  if (!status) {
+    return <TxtCell>-</TxtCell>;
+  }
+
+  return (
+    <Cell>
+      <StatusBadge variant={getStatusVariant(status)} size="sm" withDot>
+        {status}
+      </StatusBadge>
+    </Cell>
+  );
+};
+
+export const columns: ColumnDef<TraceTableColumn>[] = [
+  {
+    header: 'ID',
+    accessorKey: 'traceId',
+    cell: IdCell,
+    size: 100,
+  },
+  {
+    header: 'Date & Time',
+    accessorKey: 'createdAt',
+    cell: DateCell,
+    size: 140,
+  },
+  {
+    header: 'Name',
+    accessorKey: 'name',
+    cell: NameCell,
+  },
+  {
+    header: 'Entity',
+    accessorKey: 'entityId',
+    cell: EntityCell,
+    size: 160,
+  },
+  {
+    header: 'Status',
+    accessorKey: 'status',
+    cell: StatusCell,
+    size: 100,
+  },
+];

--- a/packages/playground-ui/src/domains/observability/components/traces-table/index.ts
+++ b/packages/playground-ui/src/domains/observability/components/traces-table/index.ts
@@ -1,0 +1,3 @@
+export * from './traces-table';
+export * from './types';
+export { columns as tracesTableColumns } from './columns';

--- a/packages/playground-ui/src/domains/observability/components/traces-table/traces-table.tsx
+++ b/packages/playground-ui/src/domains/observability/components/traces-table/traces-table.tsx
@@ -1,0 +1,235 @@
+import React from 'react';
+import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import { EyeOff, BookOpen } from 'lucide-react';
+
+import { Button } from '@/ds/components/Button';
+import { EmptyState } from '@/ds/components/EmptyState';
+import { Cell, Row, Table, Tbody, Th, Thead, useTableKeyboardNavigation } from '@/ds/components/Table';
+import { Icon } from '@/ds/icons/Icon';
+import { ScrollableContainer } from '@/ds/components/ScrollableContainer';
+import { Skeleton } from '@/ds/components/Skeleton';
+import { SearchbarWrapper } from '@/ds/components/Searchbar';
+
+import { TracesTools, EntityOptions } from '../traces-tools';
+import { columns } from './columns';
+import { TraceTableData } from './types';
+import type { TraceTableColumn } from './types';
+
+export interface TracesTableProps {
+  traces: TraceTableData[];
+  isLoading: boolean;
+  selectedTraceId?: string;
+  onTraceClick?: (id: string) => void;
+  errorMsg?: string;
+  filtersApplied?: boolean;
+  // Filter props
+  entityOptions: EntityOptions[];
+  selectedEntity?: EntityOptions;
+  onEntityChange: (option: EntityOptions | undefined) => void;
+  selectedDateFrom?: Date;
+  selectedDateTo?: Date;
+  onDateChange: (value: Date | undefined, type: 'from' | 'to') => void;
+  onReset: () => void;
+  isLoadingFilters?: boolean;
+  // Infinite scroll
+  setEndOfListElement?: (el: HTMLDivElement | null) => void;
+  isFetchingNextPage?: boolean;
+  hasNextPage?: boolean;
+}
+
+export function TracesTable({
+  traces,
+  isLoading,
+  selectedTraceId,
+  onTraceClick,
+  errorMsg,
+  filtersApplied,
+  entityOptions,
+  selectedEntity,
+  onEntityChange,
+  selectedDateFrom,
+  selectedDateTo,
+  onDateChange,
+  onReset,
+  isLoadingFilters,
+  setEndOfListElement,
+  isFetchingNextPage,
+  hasNextPage,
+}: TracesTableProps) {
+  const { activeIndex } = useTableKeyboardNavigation({
+    itemCount: traces.length,
+    global: true,
+    onSelect: index => {
+      const trace = traces[index];
+      if (trace) {
+        onTraceClick?.(trace.traceId);
+      }
+    },
+  });
+
+  const table = useReactTable({
+    data: traces,
+    columns: columns as ColumnDef<TraceTableColumn>[],
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  const ths = table.getHeaderGroups()[0];
+  const rows = table.getRowModel().rows;
+
+  const handleEntityChange = (option: EntityOptions) => {
+    onEntityChange(option);
+  };
+
+  return (
+    <div>
+      <SearchbarWrapper>
+        <TracesTools
+          onEntityChange={handleEntityChange}
+          onReset={onReset}
+          selectedEntity={selectedEntity}
+          entityOptions={entityOptions}
+          onDateChange={onDateChange}
+          selectedDateFrom={selectedDateFrom}
+          selectedDateTo={selectedDateTo}
+          isLoading={isLoadingFilters}
+        />
+      </SearchbarWrapper>
+
+      {isLoading ? (
+        <TracesTableSkeleton />
+      ) : errorMsg ? (
+        <EmptyTracesTable error={errorMsg} filtersApplied={false} />
+      ) : traces.length === 0 ? (
+        <EmptyTracesTable filtersApplied={Boolean(filtersApplied)} />
+      ) : (
+        <ScrollableContainer>
+          <Table size="small">
+            <Thead className="sticky top-0">
+              {ths.headers.map(header => (
+                <Th key={header.id} style={{ width: header.column.getSize() ?? 'auto' }}>
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                </Th>
+              ))}
+            </Thead>
+            <Tbody>
+              {rows.map((row, index) => (
+                <Row
+                  key={row.id}
+                  isActive={index === activeIndex}
+                  selected={selectedTraceId === row.original.traceId}
+                  onClick={() => onTraceClick?.(row.original.traceId)}
+                >
+                  {row.getVisibleCells().map(cell => (
+                    <React.Fragment key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </React.Fragment>
+                  ))}
+                </Row>
+              ))}
+            </Tbody>
+          </Table>
+          <InfiniteScrollSentinel
+            setEndOfListElement={setEndOfListElement}
+            isFetchingNextPage={isFetchingNextPage}
+            hasNextPage={hasNextPage}
+          />
+        </ScrollableContainer>
+      )}
+    </div>
+  );
+}
+
+const TracesTableSkeleton = () => (
+  <Table size="small">
+    <Thead>
+      <Th>ID</Th>
+      <Th>Date & Time</Th>
+      <Th>Name</Th>
+      <Th>Entity</Th>
+      <Th>Status</Th>
+    </Thead>
+    <Tbody>
+      {Array.from({ length: 5 }).map((_, index) => (
+        <Row key={index}>
+          <Cell>
+            <Skeleton className="h-4 w-16" />
+          </Cell>
+          <Cell>
+            <Skeleton className="h-4 w-24" />
+          </Cell>
+          <Cell>
+            <Skeleton className="h-4 w-32" />
+          </Cell>
+          <Cell>
+            <Skeleton className="h-4 w-20" />
+          </Cell>
+          <Cell>
+            <Skeleton className="h-4 w-16" />
+          </Cell>
+        </Row>
+      ))}
+    </Tbody>
+  </Table>
+);
+
+interface EmptyTracesTableProps {
+  filtersApplied: boolean;
+  error?: string;
+}
+
+const EmptyTracesTable = ({ filtersApplied, error }: EmptyTracesTableProps) => (
+  <div className="flex h-full items-center justify-center">
+    <EmptyState
+      iconSlot={<EyeOff className="w-10 h-10 text-neutral3" />}
+      titleSlot={error ? 'Error loading traces' : filtersApplied ? 'No traces found' : 'No Traces Yet'}
+      descriptionSlot={
+        error
+          ? error
+          : filtersApplied
+            ? 'No traces found for the applied filters. Try adjusting your filters.'
+            : 'Traces will appear here once your agents and workflows start running.'
+      }
+      actionSlot={
+        !error &&
+        !filtersApplied && (
+          <Button
+            size="lg"
+            variant="outline"
+            as="a"
+            href="https://mastra.ai/docs/observability"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Icon>
+              <BookOpen />
+            </Icon>
+            Documentation
+          </Button>
+        )
+      }
+    />
+  </div>
+);
+
+interface InfiniteScrollSentinelProps {
+  setEndOfListElement?: (el: HTMLDivElement | null) => void;
+  isFetchingNextPage?: boolean;
+  hasNextPage?: boolean;
+}
+
+const InfiniteScrollSentinel = ({
+  setEndOfListElement,
+  isFetchingNextPage,
+  hasNextPage,
+}: InfiniteScrollSentinelProps) => {
+  if (!setEndOfListElement) {
+    return null;
+  }
+
+  return (
+    <div ref={setEndOfListElement} className="text-ui-md text-neutral3 opacity-50 flex mt-8 justify-center">
+      {isFetchingNextPage && 'Loading more traces...'}
+      {!hasNextPage && !isFetchingNextPage && 'All traces loaded'}
+    </div>
+  );
+};

--- a/packages/playground-ui/src/domains/observability/components/traces-table/types.ts
+++ b/packages/playground-ui/src/domains/observability/components/traces-table/types.ts
@@ -1,0 +1,8 @@
+import { SpanRecord } from '@mastra/core/storage';
+
+export type TraceTableData = Pick<SpanRecord, 'traceId' | 'name' | 'entityType' | 'entityId' | 'entityName'> & {
+  attributes?: Record<string, any> | null;
+  createdAt: Date | string;
+};
+
+export type TraceTableColumn = TraceTableData;

--- a/packages/playground-ui/src/domains/observability/components/traces-tools.tsx
+++ b/packages/playground-ui/src/domains/observability/components/traces-tools.tsx
@@ -1,10 +1,12 @@
 import { SelectField } from '@/ds/components/FormFields';
 import { DateTimePicker } from '@/ds/components/DateTimePicker';
 import { Button } from '@/ds/components/Button/Button';
+import { IconButton } from '@/ds/components/IconButton/IconButton';
 import { cn } from '@/lib/utils';
-import { XIcon } from 'lucide-react';
+import { XIcon, CalendarIcon } from 'lucide-react';
 import { EntityType } from '@mastra/core/observability';
 import { Icon } from '@/ds/icons/Icon';
+import { format } from 'date-fns';
 
 // UI-specific entity options that map to API EntityType values
 // Using the enum values (lowercase strings) for the type field
@@ -48,36 +50,56 @@ export function TracesTools({
           }
         }}
         value={selectedEntity?.value || ''}
-        className="min-w-[20rem]"
+        className="min-w-[12rem] [&_button]:bg-surface3 [&_button]:hover:bg-surface5"
         disabled={isLoading}
+        size="sm"
       />
-      <div className={cn('flex gap-4 items-center flex-wrap')}>
-        <span className={cn('shrink-0 text-ui-md text-neutral3')}>Filter by Date & time range</span>
+      <div className={cn('flex gap-2 items-center flex-wrap')}>
+        <span className={cn('shrink-0 text-ui-sm text-neutral3')}>Filter by Date & time range</span>
         <DateTimePicker
           placeholder="From"
           value={selectedDateFrom}
           maxValue={selectedDateTo}
           onValueChange={date => onDateChange?.(date, 'from')}
-          className="min-w-32"
           defaultTimeStrValue="12:00 AM"
           disabled={isLoading}
-        />
+        >
+          <Button className="justify-start" variant="light" size="sm" disabled={isLoading}>
+            <Icon size="sm" className="mr-1">
+              <CalendarIcon />
+            </Icon>
+            {selectedDateFrom ? (
+              <span>{format(selectedDateFrom, 'PP p')}</span>
+            ) : (
+              <span className="text-neutral3">From</span>
+            )}
+          </Button>
+        </DateTimePicker>
         <DateTimePicker
           placeholder="To"
           value={selectedDateTo}
           minValue={selectedDateFrom}
           onValueChange={date => onDateChange?.(date, 'to')}
-          className="min-w-32"
           defaultTimeStrValue="11:59 PM"
           disabled={isLoading}
-        />
+        >
+          <Button className="justify-start" variant="light" size="sm" disabled={isLoading}>
+            <Icon size="sm" className="mr-1">
+              <CalendarIcon />
+            </Icon>
+            {selectedDateTo ? (
+              <span>{format(selectedDateTo, 'PP p')}</span>
+            ) : (
+              <span className="text-neutral3">To</span>
+            )}
+          </Button>
+        </DateTimePicker>
 
-        <Button variant="light" size="lg" className="min-w-32" onClick={onReset} disabled={isLoading}>
-          <Icon>
+        {(selectedDateFrom || selectedDateTo) && (
+          <IconButton variant="ghost" size="sm" onClick={onReset} disabled={isLoading} tooltip="Reset filters">
             <XIcon />
-          </Icon>
-          Reset
-        </Button>
+          </IconButton>
+        )}
       </div>
     </div>
   );

--- a/packages/playground/src/pages/observability/index.tsx
+++ b/packages/playground/src/pages/observability/index.tsx
@@ -1,20 +1,16 @@
-import { cn } from '@/lib/utils';
 import {
   HeaderTitle,
   Header,
   MainContentLayout,
-  TracesList,
-  tracesListColumns,
-  PageHeader,
+  MainContentContent,
+  TracesTable,
   EntityOptions,
-  TracesTools,
   TraceDialog,
   parseError,
   Icon,
   HeaderAction,
   Button,
   DocsIcon,
-  EntryListSkeleton,
   getToNextEntryFn,
   getToPreviousEntryFn,
   useAgents,
@@ -86,7 +82,7 @@ export default function Observability() {
     }
   }, [traceId]);
 
-  const agentOptions: EntityOptions[] = (Object.entries(agents) || []).map(([_, value]) => ({
+  const agentOptions: EntityOptions[] = (Object.entries(agents) || []).map(([, value]) => ({
     value: value.id,
     label: value.name,
     type: EntityType.AGENT,
@@ -131,7 +127,9 @@ export default function Observability() {
   };
 
   const handleSelectedEntityChange = (option: EntityOptions | undefined) => {
-    option?.value && setSearchParams({ entity: option?.value });
+    if (option?.value) {
+      setSearchParams({ entity: option.value });
+    }
   };
 
   const handleTraceClick = (id: string) => {
@@ -178,41 +176,27 @@ export default function Observability() {
           </HeaderAction>
         </Header>
 
-        <div className={cn(`grid overflow-y-auto h-full`)}>
-          <div className={cn('max-w-[100rem] px-12 mx-auto grid content-start gap-8 h-full')}>
-            <PageHeader
-              title="Observability"
-              description="Explore observability traces for your entities"
-              icon={<EyeIcon />}
-            />
-
-            <TracesTools
-              onEntityChange={handleSelectedEntityChange}
-              onReset={handleReset}
-              selectedEntity={selectedEntityOption}
-              entityOptions={entityOptions}
-              onDateChange={handleDataChange}
-              selectedDateFrom={selectedDateFrom}
-              selectedDateTo={selectedDateTo}
-              isLoading={isTracesLoading || isLoadingAgents || isLoadingWorkflows}
-            />
-
-            {isTracesLoading ? (
-              <EntryListSkeleton columns={tracesListColumns} />
-            ) : (
-              <TracesList
-                traces={traces}
-                selectedTraceId={selectedTraceId}
-                onTraceClick={handleTraceClick}
-                errorMsg={error?.error}
-                setEndOfListElement={setEndOfListElement}
-                filtersApplied={Boolean(filtersApplied)}
-                isFetchingNextPage={isFetchingNextPage}
-                hasNextPage={hasNextPage}
-              />
-            )}
-          </div>
-        </div>
+        <MainContentContent>
+          <TracesTable
+            traces={traces}
+            isLoading={isTracesLoading}
+            selectedTraceId={selectedTraceId}
+            onTraceClick={handleTraceClick}
+            errorMsg={error?.error}
+            filtersApplied={Boolean(filtersApplied)}
+            entityOptions={entityOptions}
+            selectedEntity={selectedEntityOption}
+            onEntityChange={handleSelectedEntityChange}
+            selectedDateFrom={selectedDateFrom}
+            selectedDateTo={selectedDateTo}
+            onDateChange={handleDataChange}
+            onReset={handleReset}
+            isLoadingFilters={isTracesLoading || isLoadingAgents || isLoadingWorkflows}
+            setEndOfListElement={setEndOfListElement}
+            isFetchingNextPage={isFetchingNextPage}
+            hasNextPage={hasNextPage}
+          />
+        </MainContentContent>
       </MainContentLayout>
       <TraceDialog
         traceSpans={Trace?.spans}


### PR DESCRIPTION
Refactored the Observability page to use TanStack Table (same pattern as AgentsTable). The new TracesTable component includes keyboard navigation (arrow keys, Enter), infinite scroll, integrated filter tools, small table row size, and a reset button that only appears when date filters are active.


<img width="3840" height="2160" alt="CleanShot 2026-01-30 at 13 39 28@2x" src="https://github.com/user-attachments/assets/a5bee305-f413-4e2f-8fa3-3b27c806e00a" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New traces table for the Observability page with keyboard navigation support (arrow keys and Enter to select rows) and infinite scrolling capability.
  * Integrated filter tools for searching and filtering traces directly within the interface.

* **Style**
  * Updated filter control styling with smaller form elements and refined visual appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->