### PR TITLE
fix(core): improve JSON parsing in agent network for malformed LLM output

### DIFF
--- a/.changeset/yummy-nights-return.md
+++ b/.changeset/yummy-nights-return.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed JSON parsing in agent network to handle malformed LLM output. Uses parsePartialJson from AI SDK to recover truncated JSON, missing braces, and unescaped control characters instead of failing immediately. This reduces unnecessary retry round-trips when the routing agent generates slightly malformed JSON for tool/workflow prompts. Fixes #12519.


### PR DESCRIPTION
## Description

This improves upon #12486.

Fixed JSON parsing in the agent network to handle malformed LLM output. Uses `parsePartialJson` from AI SDK to recover truncated JSON, missing braces, and unescaped control characters instead of failing immediately. This reduces unnecessary retry round-trips when the routing agent generates slightly malformed JSON for tool/workflow prompts.

This matches the pattern used in `client-js` and `output-format-handlers`.

## Related Issue(s)

Fixes #12519

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works