### PR TITLE
fix(playground-ui): fix sidebar tooltip styling in collapsed mode

### DIFF
--- a/.changeset/smooth-swans-hammer.md
+++ b/.changeset/smooth-swans-hammer.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed sidebar tooltip styling in collapsed mode by removing hardcoded color overrides

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
@@ -73,7 +73,7 @@ export function MainSidebarNavLink({
                   {isCollapsed ? <VisuallyHidden>{link.name}</VisuallyHidden> : link.name} {children}
                 </Link>
               </TooltipTrigger>
-              <TooltipContent side="right" align="center" className="bg-border1 text-neutral6 ml-4">
+              <TooltipContent side="right" align="center" className="ml-4">
                 {link.tooltipMsg ? (
                   <>
                     {isCollapsed && `${link.name} | `} {link.tooltipMsg}


### PR DESCRIPTION
The collapsed sidebar tooltips had hardcoded color classes (`bg-border1 text-neutral6`) that overrode the default tooltip styling, causing visual inconsistency.

Removed the overrides so tooltips now use the design system's default styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar tooltip styling in collapsed mode by removing hardcoded color overrides. Tooltips now display with improved visual consistency while maintaining proper positioning and alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->