### PR TITLE
feat: add convention-based permission derivation for routes

### DIFF
--- a/packages/server/src/server/handlers/auth.ts
+++ b/packages/server/src/server/handlers/auth.ts
@@ -30,7 +30,7 @@ import {
   credentialsSignInBodySchema,
   credentialsSignUpBodySchema,
 } from '../schemas/auth';
-import { createRoute } from '../server-adapter/routes/route-builder';
+import { createPublicRoute } from '../server-adapter/routes/route-builder';
 import { handleError } from './error';
 
 /**
@@ -68,7 +68,7 @@ function implementsInterface<T>(auth: unknown, method: keyof T): auth is T {
 // GET /auth/capabilities
 // ============================================================================
 
-export const GET_AUTH_CAPABILITIES_ROUTE = createRoute({
+export const GET_AUTH_CAPABILITIES_ROUTE = createPublicRoute({
   method: 'GET',
   path: '/auth/capabilities',
   responseType: 'json',
@@ -97,7 +97,7 @@ export const GET_AUTH_CAPABILITIES_ROUTE = createRoute({
 // GET /auth/me
 // ============================================================================
 
-export const GET_CURRENT_USER_ROUTE = createRoute({
+export const GET_CURRENT_USER_ROUTE = createPublicRoute({
   method: 'GET',
   path: '/auth/me',
   responseType: 'json',
@@ -149,7 +149,7 @@ export const GET_CURRENT_USER_ROUTE = createRoute({
 // GET /auth/sso/login
 // ============================================================================
 
-export const GET_SSO_LOGIN_ROUTE = createRoute({
+export const GET_SSO_LOGIN_ROUTE = createPublicRoute({
   method: 'GET',
   path: '/auth/sso/login',
   responseType: 'json',
@@ -190,7 +190,7 @@ export const GET_SSO_LOGIN_ROUTE = createRoute({
 // GET /auth/sso/callback
 // ============================================================================
 
-export const GET_SSO_CALLBACK_ROUTE = createRoute({
+export const GET_SSO_CALLBACK_ROUTE = createPublicRoute({
   method: 'GET',
   path: '/auth/sso/callback',
   responseType: 'datastream-response',
@@ -263,7 +263,7 @@ export const GET_SSO_CALLBACK_ROUTE = createRoute({
 // POST /auth/logout
 // ============================================================================
 
-export const POST_LOGOUT_ROUTE = createRoute({
+export const POST_LOGOUT_ROUTE = createPublicRoute({
   method: 'POST',
   path: '/auth/logout',
   responseType: 'datastream-response',
@@ -325,7 +325,7 @@ export const POST_LOGOUT_ROUTE = createRoute({
 // POST /auth/credentials/sign-in
 // ============================================================================
 
-export const POST_CREDENTIALS_SIGN_IN_ROUTE = createRoute({
+export const POST_CREDENTIALS_SIGN_IN_ROUTE = createPublicRoute({
   method: 'POST',
   path: '/auth/credentials/sign-in',
   responseType: 'datastream-response',
@@ -381,7 +381,7 @@ export const POST_CREDENTIALS_SIGN_IN_ROUTE = createRoute({
 // POST /auth/credentials/sign-up
 // ============================================================================
 
-export const POST_CREDENTIALS_SIGN_UP_ROUTE = createRoute({
+export const POST_CREDENTIALS_SIGN_UP_ROUTE = createPublicRoute({
   method: 'POST',
   path: '/auth/credentials/sign-up',
   responseType: 'datastream-response',

--- a/packages/server/src/server/server-adapter/routes/index.ts
+++ b/packages/server/src/server/server-adapter/routes/index.ts
@@ -122,5 +122,8 @@ export const SERVER_ROUTES: ServerRoute<any, any, any>[] = [
 ];
 
 // Export route builder and OpenAPI utilities
-export { createRoute, pickParams, jsonQueryParam, wrapSchemaForQueryParams } from './route-builder';
+export { createRoute, createPublicRoute, pickParams, jsonQueryParam, wrapSchemaForQueryParams } from './route-builder';
 export { generateOpenAPIDocument } from '../openapi-utils';
+
+// Export permission utilities
+export { derivePermission, extractResource, deriveAction, getEffectivePermission } from './permissions';

--- a/packages/server/src/server/server-adapter/routes/permissions.ts
+++ b/packages/server/src/server/server-adapter/routes/permissions.ts
@@ -1,0 +1,184 @@
+/**
+ * Permission derivation utilities for automatic route permission assignment.
+ *
+ * This module provides convention-based permission derivation from route paths and methods,
+ * reducing the need to manually specify permissions on each route.
+ *
+ * Convention: `{resource}:{action}`
+ * - resource: First path segment after common prefixes (e.g., 'agents', 'workflows', 'memory')
+ * - action: Derived from HTTP method (GET→read, POST→write/execute, DELETE→delete, etc.)
+ */
+
+import type { ServerRoute } from './index';
+
+/**
+ * Map HTTP methods to permission actions.
+ * POST is context-dependent (write for data, execute for operations).
+ */
+const METHOD_TO_ACTION: Record<string, string> = {
+  GET: 'read',
+  POST: 'write', // Default for POST, may be overridden to 'execute'
+  PUT: 'write',
+  PATCH: 'write',
+  DELETE: 'delete',
+};
+
+/**
+ * Path patterns that indicate an "execute" action rather than "write" for POST requests.
+ * These are typically operation endpoints rather than data creation endpoints.
+ */
+const EXECUTE_PATTERNS = [
+  '/generate',
+  '/stream',
+  '/execute',
+  '/start',
+  '/resume',
+  '/restart',
+  '/cancel',
+  '/approve',
+  '/decline',
+  '/speak',
+  '/listen',
+  '/query',
+  '/search',
+  '/observe',
+  '/time-travel',
+  '/enhance',
+  '/clone',
+];
+
+/**
+ * Known resource prefixes in the API.
+ * Used to extract the primary resource from route paths.
+ */
+const KNOWN_RESOURCES = [
+  'agents',
+  'workflows',
+  'memory',
+  'tools',
+  'vector',
+  'vectors',
+  'mcp',
+  'logs',
+  'observability',
+  'scores',
+  'processors',
+  'stored',
+  'agent-builder',
+  'workspaces',
+  'a2a',
+  'system',
+];
+
+/**
+ * Extracts the primary resource name from a route path.
+ *
+ * @param path - The route path (e.g., '/agents/:agentId/generate')
+ * @returns The resource name (e.g., 'agents') or null if not identifiable
+ *
+ * @example
+ * extractResource('/agents/:agentId') // → 'agents'
+ * extractResource('/memory/threads/:threadId') // → 'memory'
+ * extractResource('/stored/agents/:agentId') // → 'stored-agents'
+ */
+export function extractResource(path: string): string | null {
+  // Remove leading slash and split by segments
+  const segments = path.replace(/^\//, '').split('/');
+
+  if (segments.length === 0) {
+    return null;
+  }
+
+  const firstSegment = segments[0];
+
+  // Handle special case: /stored/agents → 'stored-agents'
+  if (firstSegment === 'stored' && segments[1] === 'agents') {
+    return 'stored-agents';
+  }
+
+  // Check if first segment is a known resource
+  if (firstSegment && KNOWN_RESOURCES.includes(firstSegment)) {
+    return firstSegment;
+  }
+
+  // Check for .well-known paths (A2A)
+  if (firstSegment === '.well-known') {
+    return 'a2a';
+  }
+
+  return firstSegment || null;
+}
+
+/**
+ * Determines the action based on HTTP method and path context.
+ *
+ * @param method - HTTP method (GET, POST, PUT, DELETE, etc.)
+ * @param path - The route path for context
+ * @returns The action string (read, write, execute, delete)
+ */
+export function deriveAction(method: string, path: string): string {
+  const upperMethod = method.toUpperCase();
+
+  // For POST requests, check if it's an execute operation
+  if (upperMethod === 'POST') {
+    const isExecuteOperation = EXECUTE_PATTERNS.some(pattern => path.includes(pattern));
+    return isExecuteOperation ? 'execute' : 'write';
+  }
+
+  return METHOD_TO_ACTION[upperMethod] || 'read';
+}
+
+/**
+ * Derives a permission string from a route's path and method.
+ *
+ * Uses convention: `{resource}:{action}`
+ *
+ * @param route - The server route to derive permission for
+ * @returns The derived permission string, or null if cannot be derived
+ *
+ * @example
+ * derivePermission({ path: '/agents', method: 'GET' }) // → 'agents:read'
+ * derivePermission({ path: '/agents/:id/generate', method: 'POST' }) // → 'agents:execute'
+ * derivePermission({ path: '/workflows/:id', method: 'DELETE' }) // → 'workflows:delete'
+ */
+export function derivePermission(route: Pick<ServerRoute, 'path' | 'method'>): string | null {
+  // Skip for ALL method (typically MCP transports)
+  if (route.method === 'ALL') {
+    return null;
+  }
+
+  const resource = extractResource(route.path);
+  if (!resource) {
+    return null;
+  }
+
+  const action = deriveAction(route.method, route.path);
+
+  return `${resource}:${action}`;
+}
+
+/**
+ * Gets the effective permission for a route.
+ *
+ * Priority:
+ * 1. Explicit requiresPermission on the route
+ * 2. Derived permission from path/method convention
+ * 3. null (no permission required - should only happen for public routes)
+ *
+ * @param route - The server route
+ * @returns The permission string or null
+ */
+export function getEffectivePermission(route: ServerRoute): string | null {
+  // If route is explicitly public, no permission needed
+  if (route.requiresAuth === false) {
+    return null;
+  }
+
+  // Use explicit permission if set
+  if (route.requiresPermission) {
+    return route.requiresPermission;
+  }
+
+  // Derive permission from convention
+  return derivePermission(route);
+}

--- a/packages/server/src/server/server-adapter/routes/route-builder.ts
+++ b/packages/server/src/server/server-adapter/routes/route-builder.ts
@@ -186,6 +186,27 @@ interface RouteConfig<
 /**
  * Creates a server route with auto-generated OpenAPI specification and type-safe handler inference.
  *
+ * ## Permission System
+ *
+ * Routes use a convention-based permission system. Permissions are automatically derived
+ * from the route path and method using the format: `{resource}:{action}`
+ *
+ * - **resource**: First path segment (e.g., 'agents', 'workflows', 'memory')
+ * - **action**: Derived from HTTP method:
+ *   - GET → 'read'
+ *   - POST → 'write' (or 'execute' for operation endpoints like /generate, /stream)
+ *   - PUT/PATCH → 'write'
+ *   - DELETE → 'delete'
+ *
+ * ### Examples:
+ * - `GET /agents/:id` → `agents:read`
+ * - `POST /agents/:id/generate` → `agents:execute`
+ * - `DELETE /workflows/:id` → `workflows:delete`
+ *
+ * ### Overriding:
+ * - Use `requiresPermission` to explicitly set a custom permission
+ * - Use `createPublicRoute()` for routes that should bypass auth entirely
+ *
  * The handler parameters are automatically inferred from the provided schemas:
  * - pathParamSchema: Infers path parameter types (e.g., :agentId)
  * - queryParamSchema: Infers query parameter types
@@ -197,6 +218,7 @@ interface RouteConfig<
  *
  * @example
  * ```typescript
+ * // Protected route (default) - permission auto-derived as 'agents:read'
  * export const getAgentRoute = createRoute({
  *   method: 'GET',
  *   path: '/agents/:agentId',
@@ -204,13 +226,19 @@ interface RouteConfig<
  *   pathParamSchema: z.object({ agentId: z.string() }),
  *   responseSchema: serializedAgentSchema,
  *   handler: async ({ agentId, mastra, requestContext }) => {
- *     // agentId is typed as string
- *     // mastra, requestContext, tools, taskStore are always available
  *     return mastra.getAgentById(agentId);
  *   },
  *   summary: 'Get agent by ID',
- *   description: 'Returns details for a specific agent',
  *   tags: ['Agents'],
+ * });
+ *
+ * // Protected route with explicit permission override
+ * export const adminRoute = createRoute({
+ *   method: 'POST',
+ *   path: '/agents/:agentId/admin-action',
+ *   responseType: 'json',
+ *   requiresPermission: 'agents:admin', // Override derived 'agents:write'
+ *   handler: async (ctx) => { ... },
  * });
  * ```
  */
@@ -254,4 +282,59 @@ export function createRoute<
     requiresAuth,
     requiresPermission,
   };
+}
+
+/**
+ * Creates a public server route that bypasses authentication and authorization.
+ *
+ * Use this for routes that must be accessible without authentication, such as:
+ * - Auth endpoints (login, logout, OAuth callbacks)
+ * - Health checks
+ * - Public API endpoints
+ *
+ * This is equivalent to calling `createRoute({ ...config, requiresAuth: false })`.
+ *
+ * @param config - Route configuration (same as createRoute, but requiresAuth is forced to false)
+ * @returns Complete ServerRoute marked as public
+ *
+ * @example
+ * ```typescript
+ * // Public route - no authentication required
+ * export const healthCheckRoute = createPublicRoute({
+ *   method: 'GET',
+ *   path: '/health',
+ *   responseType: 'json',
+ *   handler: async () => ({ status: 'ok' }),
+ *   summary: 'Health check',
+ *   tags: ['System'],
+ * });
+ *
+ * // Auth callback - must be public for OAuth flow
+ * export const ssoCallbackRoute = createPublicRoute({
+ *   method: 'GET',
+ *   path: '/auth/sso/callback',
+ *   responseType: 'datastream-response',
+ *   handler: async (ctx) => { ... },
+ *   summary: 'Handle SSO callback',
+ *   tags: ['Auth'],
+ * });
+ * ```
+ */
+export function createPublicRoute<
+  TPathSchema extends z.ZodTypeAny | undefined = undefined,
+  TQuerySchema extends z.ZodTypeAny | undefined = undefined,
+  TBodySchema extends z.ZodTypeAny | undefined = undefined,
+  TResponseSchema extends z.ZodTypeAny | undefined = undefined,
+  TResponseType extends ResponseType = 'json',
+>(
+  config: Omit<RouteConfig<TPathSchema, TQuerySchema, TBodySchema, TResponseSchema, TResponseType>, 'requiresAuth'>,
+): ServerRoute<
+  InferParams<TPathSchema, TQuerySchema, TBodySchema>,
+  TResponseSchema extends z.ZodTypeAny ? z.infer<TResponseSchema> : unknown,
+  TResponseType
+> {
+  return createRoute({
+    ...config,
+    requiresAuth: false,
+  });
 }

--- a/server-adapters/express/src/__tests__/rbac-permissions.test.ts
+++ b/server-adapters/express/src/__tests__/rbac-permissions.test.ts
@@ -374,14 +374,15 @@ describe('Express RBAC Permission Enforcement', () => {
   });
 
   describe('Routes Without Permission Requirements', () => {
-    it('should allow access to routes without requiresPermission when authenticated', async () => {
+    it('should allow access to routes with requiresAuth: false', async () => {
       const { app, adapter } = await setupAuthAdapter(context);
 
-      // Route without requiresPermission
+      // Route explicitly marked as public with requiresAuth: false
       const publicRoute: ServerRoute<any, any, any> = {
         method: 'GET',
         path: '/api/public',
         responseType: 'json',
+        requiresAuth: false,
         handler: async () => ({ public: true }),
       };
 
@@ -395,6 +396,34 @@ describe('Express RBAC Permission Enforcement', () => {
       });
 
       expect(status).toBe(200);
+    });
+
+    it('should derive permissions from route path/method when not explicitly set', async () => {
+      const { app, adapter } = await setupAuthAdapter(context);
+
+      // Route without explicit requiresPermission - will derive 'agents:read'
+      const derivedRoute: ServerRoute<any, any, any> = {
+        method: 'GET',
+        path: '/agents/test',
+        responseType: 'json',
+        handler: async () => ({ derived: true }),
+      };
+
+      await adapter.registerRoute(app, derivedRoute, { prefix: '' });
+
+      server = await startServer(app);
+
+      // Viewer has 'agents:read' permission, should have access
+      const { status: viewerStatus } = await makeRequest(server, '/agents/test', {
+        headers: { Authorization: 'Bearer viewer' },
+      });
+      expect(viewerStatus).toBe(200);
+
+      // _default role has no permissions, should be denied
+      const { status: defaultStatus } = await makeRequest(server, '/agents/test', {
+        headers: { Authorization: 'Bearer _default' },
+      });
+      expect(defaultStatus).toBe(403);
     });
   });
 });

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -441,15 +441,17 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
         };
 
         // Check route permission requirement (EE feature)
-        // Only enforce permissions when auth is configured
+        // Uses convention-based permission derivation: permissions are auto-derived
+        // from route path/method unless explicitly set or route is public
         const authConfig = this.mastra.getServer()?.auth;
-        if (route.requiresPermission && authConfig) {
+        if (authConfig) {
           const userPermissions = res.locals.requestContext.get('userPermissions') as string[] | undefined;
+          const permissionError = this.checkRoutePermission(route, userPermissions, hasPermission);
 
-          if (!userPermissions || !hasPermission(userPermissions, route.requiresPermission)) {
-            return res.status(403).json({
-              error: 'Forbidden',
-              message: `Missing required permission: ${route.requiresPermission}`,
+          if (permissionError) {
+            return res.status(permissionError.status).json({
+              error: permissionError.error,
+              message: permissionError.message,
             });
           }
         }


### PR DESCRIPTION
## Summary

- Implements automatic permission derivation from route path and HTTP method, reducing the need to manually specify `requiresPermission` on each route
- Adds `createPublicRoute()` for routes that should bypass authentication entirely
- Updates server adapters (Hono, Koa) to use the new `checkRoutePermission()` method

## Convention

Permissions are derived using the format: `{resource}:{action}`

| HTTP Method | Path Example | Derived Permission |
|-------------|--------------|-------------------|
| GET | `/agents/:id` | `agents:read` |
| POST | `/agents/:id/generate` | `agents:execute` |
| POST | `/agents` | `agents:write` |
| DELETE | `/workflows/:id` | `workflows:delete` |

## Key Changes

- **New**: `permissions.ts` - Utility functions for permission derivation
- **New**: `createPublicRoute()` - Route builder for public routes
- **Updated**: Server adapters use `checkRoutePermission()` instead of inline checks
- **Updated**: Auth routes now use `createPublicRoute()`
- **Updated**: RBAC tests verify derived permissions work correctly

## Test plan

- [x] All existing RBAC permission tests pass
- [x] New test for derived permissions added
- [x] TypeScript compiles without errors
- [x] Build succeeds for server, hono, and koa packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)