### PR TITLE
fix(lance): fix metadata round-trip for underscore keys

### DIFF
--- a/.changeset/young-peas-wash.md
+++ b/.changeset/young-peas-wash.md
@@ -1,0 +1,11 @@
+---
+'@mastra/lance': minor
+---
+
+Fixed metadata round-trip for keys containing underscores (e.g., resource_id, thread_id). New data is stored with a JSON column for lossless retrieval.
+
+**Note for existing data**
+
+Old data without the JSON column returns flat column names (e.g., `details_text` instead of `{ details: { text } }`). Re-insert data to get correct nested structure.
+
+Fixes #12500


### PR DESCRIPTION
## Description

Fixed metadata retrieval for keys containing underscores (resource_id, thread_id, message_id). New data is stored with a JSON column for lossless retrieval. Old data without JSON returns flat column names.

## Related Issue(s)

Fixes #12500

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata round-trip handling for keys containing underscores (e.g., resource_id, thread_id, message_id) to preserve correct structure during retrieval.

* **Upgrade Notes**
  * Existing metadata stored before this change will display with flattened column names. Re-insert data to restore the correct nested structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->