### PR TITLE
feat(memory): expose token usage from embedding operations

### DIFF
--- a/.changeset/shaky-coats-play.md
+++ b/.changeset/shaky-coats-play.md
@@ -1,0 +1,12 @@
+---
+'@mastra/memory': minor
+'@mastra/core': patch
+---
+
+Expose token usage from embedding operations
+
+- `saveMessages` now returns `usage: { tokens: number }` with aggregated token count from all embeddings
+- `recall` now returns `usage: { tokens: number }` from the vector search query embedding
+- Updated abstract method signatures in `MastraMemory` to include optional `usage` in return types
+
+This allows users to track embedding token usage when using the Memory class.

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -380,7 +380,7 @@ https://mastra.ai/en/docs/memory/overview`,
   abstract saveMessages(args: {
     messages: MastraDBMessage[];
     memoryConfig?: MemoryConfig | undefined;
-  }): Promise<{ messages: MastraDBMessage[] }>;
+  }): Promise<{ messages: MastraDBMessage[]; usage?: { tokens: number } }>;
 
   /**
    * Retrieves messages for a specific thread with optional semantic recall
@@ -395,7 +395,7 @@ https://mastra.ai/en/docs/memory/overview`,
       threadConfig?: MemoryConfig;
       vectorSearchString?: string;
     },
-  ): Promise<{ messages: MastraDBMessage[] }>;
+  ): Promise<{ messages: MastraDBMessage[]; usage?: { tokens: number } }>;
 
   /**
    * Helper method to create a new thread

--- a/packages/memory/src/memory-usage.test.ts
+++ b/packages/memory/src/memory-usage.test.ts
@@ -1,0 +1,166 @@
+import type { MastraDBMessage } from '@mastra/core/agent';
+import { InMemoryStore } from '@mastra/core/storage';
+import { describe, it, expect, vi } from 'vitest';
+import { Memory } from './index';
+
+// Mock embedMany for all AI SDK versions
+// v3 spec uses @internal/ai-v6
+vi.mock('@internal/ai-v6', () => ({
+  embedMany: vi.fn().mockResolvedValue({
+    embeddings: [[0.1, 0.2]],
+    usage: { tokens: 42 },
+  }),
+}));
+
+// v2 spec uses @internal/ai-sdk-v5
+vi.mock('@internal/ai-sdk-v5', () => ({
+  embedMany: vi.fn().mockResolvedValue({
+    embeddings: [[0.1, 0.2]],
+    usage: { tokens: 55 },
+  }),
+}));
+
+// v1 spec uses @internal/ai-sdk-v4
+vi.mock('@internal/ai-sdk-v4', () => ({
+  embedMany: vi.fn().mockResolvedValue({
+    embeddings: [[0.1, 0.2]],
+    usage: { tokens: 33 },
+  }),
+}));
+
+// Helper to create a Memory instance with specific embedder version
+function createMemoryWithEmbedder(specVersion: 'v1' | 'v2' | 'v3') {
+  return new Memory({
+    storage: new InMemoryStore(),
+    vector: {
+      upsert: vi.fn().mockResolvedValue('id'),
+      createIndex: vi.fn().mockResolvedValue({ indexName: 'test-index' }),
+      query: vi.fn().mockResolvedValue([]),
+      describeIndex: vi.fn(),
+    } as any,
+    embedder: {
+      specificationVersion: specVersion,
+      provider: 'test',
+      modelId: 'test-model',
+      doEmbed: vi.fn(),
+    } as any,
+    options: {
+      semanticRecall: true,
+    },
+  });
+}
+
+const testMessages: MastraDBMessage[] = [
+  {
+    id: 'msg-1',
+    threadId: 'thread-1',
+    role: 'user',
+    content: { format: 2, parts: [{ type: 'text', text: 'Hello usage' }] },
+    createdAt: new Date(),
+  },
+];
+
+describe('Memory Token Usage', () => {
+  describe('saveMessages usage tracking', () => {
+    it('should track usage with v3 spec embedder (ai-v6)', async () => {
+      const memory = createMemoryWithEmbedder('v3');
+      const result = await memory.saveMessages({
+        messages: testMessages,
+        memoryConfig: { semanticRecall: true },
+      });
+
+      expect(result.usage).toBeDefined();
+      expect(result.usage?.tokens).toBe(42);
+    });
+
+    it('should track usage with v2 spec embedder (ai-sdk-v5)', async () => {
+      const memory = createMemoryWithEmbedder('v2');
+      const result = await memory.saveMessages({
+        messages: testMessages,
+        memoryConfig: { semanticRecall: true },
+      });
+
+      expect(result.usage).toBeDefined();
+      expect(result.usage?.tokens).toBe(55);
+    });
+
+    it('should track usage with v1 spec embedder (ai-sdk-v4)', async () => {
+      const memory = createMemoryWithEmbedder('v1');
+      const result = await memory.saveMessages({
+        messages: testMessages,
+        memoryConfig: { semanticRecall: true },
+      });
+
+      expect(result.usage).toBeDefined();
+      expect(result.usage?.tokens).toBe(33);
+    });
+  });
+
+  describe('recall usage tracking', () => {
+    it('should track usage from recall with v3 spec', async () => {
+      const memory = createMemoryWithEmbedder('v3');
+      const result = await memory.recall({
+        threadId: 'thread-1',
+        vectorSearchString: 'search query',
+        threadConfig: {
+          semanticRecall: {
+            scope: 'thread',
+            topK: 10,
+            messageRange: 2,
+          },
+        },
+      });
+
+      expect(result.usage).toBeDefined();
+      expect(result.usage?.tokens).toBe(42);
+    });
+
+    it('should track usage from recall with v2 spec', async () => {
+      const memory = createMemoryWithEmbedder('v2');
+      const result = await memory.recall({
+        threadId: 'thread-1',
+        vectorSearchString: 'search query',
+        threadConfig: {
+          semanticRecall: {
+            scope: 'thread',
+            topK: 10,
+            messageRange: 2,
+          },
+        },
+      });
+
+      expect(result.usage).toBeDefined();
+      expect(result.usage?.tokens).toBe(55);
+    });
+
+    it('should track usage from recall with v1 spec', async () => {
+      const memory = createMemoryWithEmbedder('v1');
+      const result = await memory.recall({
+        threadId: 'thread-1',
+        vectorSearchString: 'search query',
+        threadConfig: {
+          semanticRecall: {
+            scope: 'thread',
+            topK: 10,
+            messageRange: 2,
+          },
+        },
+      });
+
+      expect(result.usage).toBeDefined();
+      expect(result.usage?.tokens).toBe(33);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return undefined usage when semanticRecall is disabled', async () => {
+      const memory = createMemoryWithEmbedder('v3');
+      const result = await memory.saveMessages({
+        messages: testMessages,
+        memoryConfig: { semanticRecall: false },
+      });
+
+      expect(result.usage).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Expose token usage from embedding operations in `@mastra/memory`.

## Changes
- [saveMessages](cci:1://file:///Users/sf/Develop/opensource/mastra/packages/memory/src/index.ts:603:2-711:3) now returns `usage: { tokens: number }` with aggregated token count from all embeddings
- [recall](cci:1://file:///Users/sf/Develop/opensource/mastra/packages/memory/src/index.ts:102:2-238:3) now returns `usage: { tokens: number }` from the vector search query embedding  
- Updated abstract method signatures in [MastraMemory](cci:2://file:///Users/sf/Develop/opensource/mastra/packages/core/src/memory/memory.ts:90:0-781:1) to include optional `usage` in return types

## Why
Previously, token usage from [embedMany](cci:1://file:///Users/sf/Develop/opensource/mastra/packages/_vendored/ai_v4/dist/index.d.ts:1630:0-1674:36) was discarded. Users had no way to track embedding costs when using semantic memory features. This change surfaces the data that was already being returned by the AI SDK.

## Testing
- Added unit tests in [packages/memory/src/memory-usage.test.ts](cci:7://file:///Users/sf/Develop/opensource/mastra/packages/memory/src/memory-usage.test.ts:0:0-0:0)
- Verified with simulated real request flow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Memory operations now expose token usage metrics from embeddings, providing visibility into token consumption for better cost tracking and performance analysis.
* Token usage information is available from memory save and recall operations, enabling detailed monitoring of embedding costs and resource utilization.
* Access token metrics to optimize embedding operations and manage costs more effectively within your applications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->