### PR TITLE
fix(convex): use correct subpath export for storage constants import

### DIFF
--- a/.changeset/whole-candies-report.md
+++ b/.changeset/whole-candies-report.md
@@ -1,0 +1,5 @@
+---
+'@mastra/convex': patch
+---
+
+Fixed import path for storage constants in Convex server storage to use the correct @mastra/core/storage/constants subpath export

--- a/stores/convex/src/server/storage.ts
+++ b/stores/convex/src/server/storage.ts
@@ -4,7 +4,7 @@ import {
   TABLE_THREADS,
   TABLE_RESOURCES,
   TABLE_SCORERS,
-} from '@mastra/core/storage';
+} from '@mastra/core/storage/constants';
 import type { GenericMutationCtx as MutationCtx } from 'convex/server';
 import { mutationGeneric } from 'convex/server';
 


### PR DESCRIPTION
The Convex server storage was importing `TABLE_THREADS`, `TABLE_RESOURCES`, and `TABLE_SCORERS` from `@mastra/core/storage`, but that subpath isn't exported in `@mastra/core`'s package.json. The actual export is `@mastra/core/storage/constants`.

```diff
- import { ... } from '@mastra/core/storage';
+ import { ... } from '@mastra/core/storage/constants';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes https://github.com/mastra-ai/mastra/issues/12551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed import resolution for Convex server storage constants, ensuring storage functionality operates correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->