### PR TITLE
fix(lance): fix vector search failing with Memory semantic recall

### DIFF
--- a/.changeset/sparkly-sides-chew.md
+++ b/.changeset/sparkly-sides-chew.md
@@ -1,0 +1,5 @@
+---
+'@mastra/lance': patch
+---
+
+Fixed Lance vector store failing when used with Memory's semantic recall. Queries on empty tables with metadata filters (e.g. resource_id, thread_id) now return empty results instead of throwing a schema error. Also fixed metadata round-trip corruption where flat underscore keys like resource_id were incorrectly reconstructed as nested objects.


### PR DESCRIPTION
Fixes #12500

Two bugs were causing `@mastra/lance` to fail when used as the vector store for Memory's semantic recall:

**Query on empty table**: When `Memory.recall()` runs before any messages are saved, the table only has `{id, vector}` columns. The filter `{ resource_id: 'xxx' }` references `metadata_resource_id` which doesn't exist yet, causing a LanceDB schema error. Now validates filter columns against the table schema and returns empty results when columns are missing.

**Metadata round-trip corruption**: `unflattenObject` split on ALL underscores, so `resource_id` stored as `metadata_resource_id` came back as `{ resource: { id: 'xxx' } }` instead of `{ resource_id: 'xxx' }`. Now stores a `_metadata_json` column alongside flattened columns for lossless round-trip. Falls back to flat key extraction for legacy data.

```ts
// Before: first agent interaction throws
const agent = new Agent({
  memory: new Memory({
    vector: await LanceVectorStore.create(path),
    embedder: fastembed,
    options: { semanticRecall: { topK: 3, scope: "resource" } },
  }),
});
// Error: No field named metadata_resource_id

// After: works correctly, returns empty recall on first message
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed vector store failures when used with Memory's semantic recall feature
- Resolved schema errors when querying empty tables with metadata filters—now returns empty results as expected
- Corrected metadata corruption where underscore-prefixed keys were incorrectly reconstructed as nested objects during storage and retrieval operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->