### PR TITLE
fix(core): support Zod .transform() on createTool outputSchema

### DIFF
--- a/.changeset/true-dryers-arrive.md
+++ b/.changeset/true-dryers-arrive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed createTool to accept Zod schemas with .transform() on outputSchema without requiring `as any`. The execute function now correctly expects the pre-transform (input) type, while validation still applies the transform before returning the post-transform result to callers.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2412,7 +2412,6 @@ export class Agent<
           mastra: this.#mastra,
           // manually wrap workflow tools with tracing, so that we can pass the
           // current tool span onto the workflow to maintain continuity of the trace
-          // @ts-expect-error - context type mismatch in workflow tool
           execute: async (inputData, context) => {
             try {
               const { initialState, inputData: workflowInputData, suspendedToolRunId } = inputData as any;

--- a/packages/core/src/tools/__tests__/transform-output-typing.test-d.ts
+++ b/packages/core/src/tools/__tests__/transform-output-typing.test-d.ts
@@ -1,0 +1,102 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { z } from 'zod';
+
+import type { ZodLikeSchema, InferZodLikeSchemaInput } from '../../types/zod-compat';
+import { createTool } from '../tool';
+
+/**
+ * Type-level tests for GitHub Issue #12426
+ * https://github.com/mastra-ai/mastra/issues/12426
+ *
+ * Verifies that createTool correctly accepts Zod schemas with .transform()
+ * on outputSchema, and that execute() can return the pre-transform (input) type.
+ *
+ * The runtime flow is:
+ *   execute() returns pre-transform data → schema.safeParse() → post-transform data
+ */
+describe('Issue #12426 - outputSchema .transform() type-level tests', () => {
+  const transformSchema = z.object({ raw: z.string() }).transform(v => ({ processed: v.raw.toUpperCase() }));
+
+  type PreTransform = z.input<typeof transformSchema>; // { raw: string }
+  type PostTransform = z.output<typeof transformSchema>; // { processed: string }
+
+  it('prerequisite: pre-transform and post-transform types are different', () => {
+    expectTypeOf<PreTransform>().not.toEqualTypeOf<PostTransform>();
+  });
+
+  it('prerequisite: InferZodLikeSchemaInput extracts PreTransform (input type)', () => {
+    type InferredInput = InferZodLikeSchemaInput<typeof transformSchema>;
+    expectTypeOf<InferredInput>().toEqualTypeOf<PreTransform>();
+  });
+
+  it('ZodEffects matches ZodLikeSchema after relaxing _input constraint', () => {
+    expectTypeOf<typeof transformSchema>().toMatchTypeOf<ZodLikeSchema<PostTransform>>();
+  });
+
+  it('createTool with transformed outputSchema compiles — execute accepts pre-transform return', () => {
+    createTool({
+      id: 'transform-tool',
+      description: 'Tool with transform on outputSchema',
+      outputSchema: transformSchema,
+      execute: async () => {
+        return { raw: 'hello' }; // pre-transform (correct at runtime)
+      },
+    });
+  });
+
+  it('issue reproduction — API response with transform compiles without as any', () => {
+    const apiResponseSchema = z
+      .object({
+        data: z.array(
+          z.object({
+            user_id: z.string(),
+            f_name: z.string(),
+            l_name: z.string(),
+            acc_status: z.string(),
+          }),
+        ),
+      })
+      .transform(response => ({
+        activeUsers: response.data
+          .filter(u => u.acc_status === 'A')
+          .map(user => ({
+            userId: user.user_id,
+            fullName: `${user.f_name} ${user.l_name}`,
+            accountStatus: 'Active' as const,
+          })),
+      }));
+
+    createTool({
+      id: 'list-users',
+      description: 'Get active users with LLM-friendly output',
+      outputSchema: apiResponseSchema,
+      execute: async () => {
+        return {
+          data: [
+            { user_id: '123', f_name: 'John', l_name: 'Doe', acc_status: 'A' },
+            { user_id: '456', f_name: 'Jane', l_name: 'Smith', acc_status: 'I' },
+          ],
+        };
+      },
+    });
+  });
+
+  it('non-transformed outputSchema is backwards compatible', () => {
+    const plainSchema = z.object({ name: z.string(), count: z.number() });
+
+    type PlainInput = z.input<typeof plainSchema>;
+    type PlainOutput = z.output<typeof plainSchema>;
+    expectTypeOf<PlainInput>().toEqualTypeOf<PlainOutput>();
+
+    expectTypeOf<typeof plainSchema>().toMatchTypeOf<ZodLikeSchema<PlainOutput>>();
+
+    createTool({
+      id: 'plain-test',
+      description: 'Non-transformed schema (always works)',
+      outputSchema: plainSchema,
+      execute: async () => {
+        return { name: 'test', count: 42 };
+      },
+    });
+  });
+});

--- a/packages/core/src/tools/__tests__/transform-output-typing.test.ts
+++ b/packages/core/src/tools/__tests__/transform-output-typing.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import { z } from 'zod';
+
+import { createTool } from '../tool';
+
+/**
+ * Runtime tests for GitHub Issue #12426
+ * https://github.com/mastra-ai/mastra/issues/12426
+ *
+ * Verifies that Zod transforms on outputSchema work correctly at runtime:
+ * execute() returns pre-transform data, and validation applies the transform
+ * via schema.safeParse() before the result reaches the caller.
+ */
+describe('Issue #12426 - createTool outputSchema with .transform() runtime', () => {
+  const formatHeight = (inches: number) => {
+    const feet = Math.floor(inches / 12);
+    const remainingInches = inches % 12;
+    return `${feet}'${remainingInches}"`;
+  };
+
+  const apiResponseSchema = z
+    .object({
+      data: z.array(
+        z.object({
+          user_id: z.string(),
+          f_name: z.string(),
+          l_name: z.string(),
+          acc_status: z.string(),
+        }),
+      ),
+    })
+    .transform(response => ({
+      activeUsers: response.data
+        .filter(u => u.acc_status === 'A')
+        .map(user => ({
+          userId: user.user_id,
+          fullName: `${user.f_name} ${user.l_name}`,
+          accountStatus: 'Active' as const,
+        })),
+    }));
+
+  type ApiInput = z.input<typeof apiResponseSchema>;
+  type ApiOutput = z.output<typeof apiResponseSchema>;
+
+  it('pre-transform and post-transform types are different', () => {
+    expectTypeOf<ApiInput>().not.toEqualTypeOf<ApiOutput>();
+  });
+
+  it('transform is applied during output validation', async () => {
+    const tool = createTool({
+      id: 'list-users',
+      description: 'Get active users',
+      outputSchema: apiResponseSchema,
+      execute: async () => {
+        // No `as any` needed — execute accepts pre-transform type
+        return {
+          data: [
+            { user_id: '123', f_name: 'John', l_name: 'Doe', acc_status: 'A' },
+            { user_id: '456', f_name: 'Jane', l_name: 'Smith', acc_status: 'I' },
+          ],
+        };
+      },
+    });
+
+    const result = await tool.execute!({});
+
+    // After validation+transform, output is the post-transform shape
+    expect(result).toEqual({
+      activeUsers: [
+        {
+          userId: '123',
+          fullName: 'John Doe',
+          accountStatus: 'Active',
+        },
+      ],
+    });
+  });
+
+  it('simple transform applied correctly', async () => {
+    const rawDataSchema = z.object({
+      firstName: z.string(),
+      lastName: z.string(),
+      heightInches: z.number(),
+    });
+
+    const transformedSchema = rawDataSchema.transform(v => ({
+      fullName: `${v.firstName} ${v.lastName}`,
+      height: formatHeight(v.heightInches),
+    }));
+
+    const tool = createTool({
+      id: 'get-data',
+      description: 'Get formatted data',
+      outputSchema: transformedSchema,
+      execute: async () => {
+        return {
+          firstName: 'John',
+          lastName: 'Doe',
+          heightInches: 74,
+        };
+      },
+    });
+
+    const result = await tool.execute!({});
+
+    expect(result).toEqual({
+      fullName: 'John Doe',
+      height: '6\'2"',
+    });
+  });
+
+  it('transform with array output', async () => {
+    const rawDataSchema = z.object({
+      firstName: z.string(),
+      lastName: z.string(),
+      heightInches: z.number(),
+    });
+
+    const transformedSchema = rawDataSchema
+      .transform(v => ({
+        fullName: `${v.firstName} ${v.lastName}`,
+        height: formatHeight(v.heightInches),
+      }))
+      .array();
+
+    const tool = createTool({
+      id: 'get-data-array',
+      description: 'Get formatted data as array',
+      outputSchema: transformedSchema,
+      execute: async () => {
+        return [
+          { firstName: 'John', lastName: 'Doe', heightInches: 74 },
+          { firstName: 'Jane', lastName: 'Smith', heightInches: 65 },
+        ];
+      },
+    });
+
+    const result = await tool.execute!({});
+
+    expect(result).toEqual([
+      { fullName: 'John Doe', height: '6\'2"' },
+      { fullName: 'Jane Smith', height: '5\'5"' },
+    ]);
+  });
+
+  it('non-transformed outputSchema continues working', async () => {
+    const plainSchema = z.object({
+      name: z.string(),
+      count: z.number(),
+    });
+
+    const tool = createTool({
+      id: 'plain-test',
+      description: 'Test plain schema',
+      outputSchema: plainSchema,
+      execute: async () => {
+        return { name: 'test', count: 42 };
+      },
+    });
+
+    const result = await tool.execute!({});
+
+    if ('error' in result && result.error) {
+      throw new Error('Unexpected validation error');
+    }
+
+    expect(result.name).toBe('test');
+    expect(result.count).toBe(42);
+  });
+});

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -404,6 +404,7 @@ export function createTool<
   TId extends string = string,
   TSchemaIn = unknown,
   TSchemaOut = unknown,
+  TSchemaOutInput = TSchemaOut,
   TSuspend = unknown,
   TResume = unknown,
   TRequestContext extends Record<string, any> | unknown = unknown,
@@ -413,7 +414,9 @@ export function createTool<
     TRequestContext
   >,
 >(
-  opts: ToolAction<TSchemaIn, TSchemaOut, TSuspend, TResume, TContext, TId, TRequestContext>,
+  opts: ToolAction<TSchemaIn, TSchemaOut, TSuspend, TResume, TContext, TId, TRequestContext, TSchemaOutInput>,
 ): Tool<TSchemaIn, TSchemaOut, TSuspend, TResume, TContext, TId, TRequestContext> {
-  return new Tool(opts);
+  return new Tool(
+    opts as unknown as ToolAction<TSchemaIn, TSchemaOut, TSuspend, TResume, TContext, TId, TRequestContext>,
+  );
 }

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -268,6 +268,7 @@ export interface ToolAction<
   TContext extends ToolExecutionContext<TSuspend, TResume, any> = ToolExecutionContext<TSuspend, TResume>,
   TId extends string = string,
   TRequestContext extends Record<string, any> | unknown = unknown,
+  TSchemaOutInput = TSchemaOut,
 > {
   id: TId;
   description: string;
@@ -291,9 +292,9 @@ export interface ToolAction<
   // Second parameter: unified execution context with all metadata
   // Returns: The expected output OR a validation error if input validation fails
   // Note: When no outputSchema is provided, returns any to allow property access
-  // Note: For outputSchema, we use the input type because Zod transforms are applied during validation
+  // Note: TSchemaOutInput is the pre-transform type of outputSchema — Zod transforms are applied during validation
   // Note: { error?: never } enables inline type narrowing with 'error' in result checks
-  execute?: (inputData: TSchemaIn, context: TContext) => Promise<TSchemaOut | ValidationError>;
+  execute?: (inputData: TSchemaIn, context: TContext) => Promise<TSchemaOutInput | ValidationError>;
   mastra?: Mastra;
   requireApproval?: boolean;
   /**

--- a/packages/core/src/types/zod-compat.ts
+++ b/packages/core/src/types/zod-compat.ts
@@ -9,7 +9,7 @@ import type { z as zv4 } from 'zod/v4';
  * from both versions by checking for the presence of key methods rather
  * than relying on exact type matching.
  */
-export type ZodLikeSchema<T = any> = z.ZodType<T> | zv4.ZodType<T, any>;
+export type ZodLikeSchema<T = any> = z.ZodType<T, any, any> | zv4.ZodType<T, any>;
 
 /**
  * Helper type for extracting the inferred type from a Zod-like schema after parsing


### PR DESCRIPTION
Fixes #12426

When using `createTool` with a Zod `.transform()` on `outputSchema`, TypeScript was forcing `execute()` to return the post-transform type — requiring `as any` to compile. The runtime was already correct (transforms are applied via `safeParse` during validation), so this was purely a typing issue.

**Before:**
```ts
const tool = createTool({
  id: 'list-users',
  outputSchema: z.object({ data: z.array(...) }).transform(resp => ({
    activeUsers: resp.data.filter(u => u.acc_status === 'A')
  })),
  execute: async () => {
    return { data: [...] } as any; // required to avoid type error
  },
});
```

**After:**
```ts
const tool = createTool({
  id: 'list-users',
  outputSchema: z.object({ data: z.array(...) }).transform(resp => ({
    activeUsers: resp.data.filter(u => u.acc_status === 'A')
  })),
  execute: async () => {
    return { data: [...] }; // works — execute accepts pre-transform type
  },
});
```

Two changes make this work: relaxed `ZodLikeSchema` to accept `ZodEffects` (from `.transform()`), and added a `TSchemaOutInput` type parameter to `ToolAction` so `execute()` independently infers the pre-transform return type. Non-transformed schemas are unaffected since input and output types are identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved issue where createTool required type assertions for Zod schemas with .transform() on outputSchema.
  * Enhanced type inference for tool execution to correctly handle pre-transform and post-transform type differences.

* **Tests**
  * Added comprehensive test coverage for output schema transformations, including both type-level and runtime validation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->