### PR TITLE
chore(docs-0.x): noindex for ja locale

### DIFF
--- a/docs/src/theme/Layout/index.tsx
+++ b/docs/src/theme/Layout/index.tsx
@@ -33,7 +33,7 @@ export default function Layout(props: Props): ReactNode {
   useKeyboardNavigation();
 
   const location = useLocation();
-  const { siteConfig } = useDocusaurusContext();
+  const { siteConfig, i18n } = useDocusaurusContext();
   const cleanPath = location.pathname
     .replace(/^\/ja(\/|$)/, "/")
     .replace(/^\/([a-z]+)\/v0(\/|$)/, "/$1$2");
@@ -47,6 +47,10 @@ export default function Layout(props: Props): ReactNode {
         {/* If the current path is in the v0Urls list, do not set a canonical URL */}
         {!v0Urls.includes(location.pathname) && (
           <link rel="canonical" href={canonicalUrl} />
+        )}
+        {/* We don't want to index the ja locale */}
+        {i18n.currentLocale === "ja" && (
+          <meta name="robots" content="noindex" />
         )}
       </Head>
 


### PR DESCRIPTION
## Description

We don't want to index the outdated legacy 0.x Japanese docs

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
