### PR TITLE
chore(docs): Remove /llms.txt from internal links

### DIFF
--- a/docs/src/plugins/docusaurus-plugin-llms-txt/link-handler.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/link-handler.ts
@@ -88,11 +88,10 @@ export function createLinkHandler(options: LinkHandlerOptions) {
       }
     }
 
-    // Convert internal links to llms.txt URLs
     let finalHref = href || ''
     if (isInternalLink(href) && !(options.excludeRoutes && isExcludedRoute(href, options.excludeRoutes))) {
       const route = normalizeRoute(href!)
-      finalHref = `${options.siteUrl}${route}/llms.txt`
+      finalHref = `${options.siteUrl}${route}`
     }
 
     return {

--- a/docs/src/plugins/docusaurus-plugin-llms-txt/output-generator.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/output-generator.ts
@@ -61,7 +61,7 @@ Each section contains detailed docs that provide comprehensive information about
 
 These are the most popular starting points:
 
-- [Getting Started](https://mastra.ai/docs/getting-started/start/llms.txt): Create a new project with the \`create mastra\` CLI or use one of the framework quickstart guides
-- [Agent Overview](https://mastra.ai/docs/agents/overview/llms.txt): Agents use LLMs and tools to solve open-ended tasks. They reason about goals, decide which tools to use, retain conversation memory, and iterate internally until the model emits a final answer or an optional stop condition is met.
-- [Workflows Overview](https://mastra.ai/docs/workflows/overview/llms.txt): Workflows let you define complex sequences of tasks using clear, structured steps rather than relying on the reasoning of a single agent.
-- [Memory Overview](https://mastra.ai/docs/memory/overview/llms.txt): Memory gives your agent coherence across interactions and allows it to improve over time by retaining relevant information from past conversations.`
+- [Getting Started](https://mastra.ai/docs/getting-started/start): Create a new project with the \`create mastra\` CLI or use one of the framework quickstart guides
+- [Agent Overview](https://mastra.ai/docs/agents/overview): Agents use LLMs and tools to solve open-ended tasks. They reason about goals, decide which tools to use, retain conversation memory, and iterate internally until the model emits a final answer or an optional stop condition is met.
+- [Workflows Overview](https://mastra.ai/docs/workflows/overview): Workflows let you define complex sequences of tasks using clear, structured steps rather than relying on the reasoning of a single agent.
+- [Memory Overview](https://mastra.ai/docs/memory/overview): Memory gives your agent coherence across interactions and allows it to improve over time by retaining relevant information from past conversations.`

--- a/docs/src/plugins/docusaurus-plugin-llms-txt/sidebars-handler.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/sidebars-handler.ts
@@ -104,14 +104,6 @@ function findCategoryOverviewUrl(items: SidebarItem[], baseUrl: string): string 
   return null
 }
 
-function addLlmsPostfix(url: string): string {
-  if (url.endsWith('/')) {
-    return `${url}llms.txt`
-  } else {
-    return `${url}/llms.txt`
-  }
-}
-
 /**
  * Generate markdown list for sidebar items recursively
  */
@@ -130,14 +122,14 @@ export function generateMarkdownList(
 
     if (typeof item === 'string' || item.type === 'doc') {
       // It's a doc item - create a link
-      const url = docId === 'index' ? addLlmsPostfix(baseUrl) : addLlmsPostfix(`${baseUrl}/${docId}`)
+      const url = docId === 'index' ? baseUrl : `${baseUrl}/${docId}`
       output += `${indent}- [${label}](${url})\n`
     } else if (item.type === 'category') {
       // Check if this category should be condensed to just its overview link
       if (condensedCategories.includes(label)) {
         const overviewUrl = findCategoryOverviewUrl(item.items, baseUrl)
         if (overviewUrl) {
-          output += `${indent}- [${label}](${addLlmsPostfix(overviewUrl)})\n`
+          output += `${indent}- [${label}](${overviewUrl})\n`
         } else {
           // Fallback: just show category name without link
           output += `${indent}- ${label}\n`


### PR DESCRIPTION
## Description

Since I've added content negotiation for llms.txt files, the links in the generated llms.txt should point to the actual pages, not to the llms.txt versions of those pages. This PR removes the addition of the /llms.txt postfix to internal links in the llms.txt files.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated link generation in the LLMS documentation plugin. Navigation links throughout the documentation now point directly to their destination pages without trailing file extensions, improving navigation accuracy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->