### PR TITLE
Increase default serialization limits for AI tracing

### DIFF
--- a/.changeset/afraid-doors-tap.md
+++ b/.changeset/afraid-doors-tap.md
@@ -1,0 +1,14 @@
+---
+'@mastra/observability': minor
+---
+
+Increased default serialization limits for AI tracing. The maxStringLength is now 128KB (previously 1KB) and maxDepth is 8 (previously 6). These changes prevent truncation of large LLM prompts and responses during tracing.
+
+To restore the previous behavior, set `serializationOptions` in your observability config:
+
+```ts
+serializationOptions: {
+  maxStringLength: 1024,
+  maxDepth: 6,
+}
+```

--- a/observability/mastra/src/spans/base.test.ts
+++ b/observability/mastra/src/spans/base.test.ts
@@ -629,15 +629,16 @@ describe('Span', () => {
         exporters: [testExporter],
       });
 
-      const longString = 'a'.repeat(2000);
+      // Default maxStringLength is 128KB - create a string longer than that
+      const longString = 'a'.repeat(150 * 1024);
       const span = tracing.startSpan({
         type: SpanType.GENERIC,
         name: 'test',
         input: { data: longString },
       });
 
-      // Default maxStringLength is 1024
-      expect(span.input.data.length).toBeLessThanOrEqual(1024 + 15);
+      // Default maxStringLength is 128 * 1024 (128KB)
+      expect(span.input.data.length).toBeLessThanOrEqual(128 * 1024 + 15);
       expect(span.input.data).toContain('[truncated]');
       span.end();
     });

--- a/observability/mastra/src/spans/serialization.ts
+++ b/observability/mastra/src/spans/serialization.ts
@@ -52,8 +52,8 @@ export const DEFAULT_DEEP_CLEAN_OPTIONS: DeepCleanOptions = Object.freeze({
   keysToStrip: DEFAULT_KEYS_TO_STRIP,
   maxDepth: 8,
   maxStringLength: 128 * 1024, // 128KB - sufficient for large LLM prompts/responses
-  maxArrayLength: 100, // Supports longer conversation histories
-  maxObjectKeys: 100,
+  maxArrayLength: 50,
+  maxObjectKeys: 50,
 });
 
 /**

--- a/observability/mastra/src/spans/serialization.ts
+++ b/observability/mastra/src/spans/serialization.ts
@@ -50,10 +50,10 @@ export interface DeepCleanOptions {
 
 export const DEFAULT_DEEP_CLEAN_OPTIONS: DeepCleanOptions = Object.freeze({
   keysToStrip: DEFAULT_KEYS_TO_STRIP,
-  maxDepth: 6,
-  maxStringLength: 1024,
-  maxArrayLength: 50,
-  maxObjectKeys: 50,
+  maxDepth: 8,
+  maxStringLength: 128 * 1024, // 128KB - sufficient for large LLM prompts/responses
+  maxArrayLength: 100, // Supports longer conversation histories
+  maxObjectKeys: 100,
 });
 
 /**


### PR DESCRIPTION
## Description

Increased default serialization limits in the observability module to prevent truncation of large LLM prompts and responses during tracing. This change improves the ability to capture complete AI interactions without data loss.

### Changes Made:
- **maxStringLength**: Increased from 1KB to 128KB
- **maxDepth**: Increased from 6 to 8 levels

These limits are now more appropriate for typical LLM use cases where prompts and responses can be quite large, and conversation histories may contain many messages.

### Testing:
Updated the serialization test to verify the new 128KB string length limit is properly enforced.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [X] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [X] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased default serialization limits for AI tracing observability: string length limits expanded to 128KB (from 1KB) and nesting depth limits to 8 (from 6). Users can configure custom limits to restore previous behavior if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->