### PR TITLE
fix(docs): Improve llms.txt output

### DIFF
--- a/docs/src/components/CardItems.tsx
+++ b/docs/src/components/CardItems.tsx
@@ -31,8 +31,6 @@ export function CardItems({ titles, items }: CardItemsProps) {
     setActiveTab(sluggify(tab))
   }
 
-  const currentItems = items[titles.find(tab => sluggify(tab) === activeTab) ?? ''] ?? []
-
   return (
     <div className="card__grid">
       <div className="mt-6 flex flex-wrap items-center gap-2">
@@ -49,20 +47,33 @@ export function CardItems({ titles, items }: CardItemsProps) {
           </button>
         ))}
       </div>
-      <div className="mt-6 grid w-full gap-3 md:grid-cols-2 lg:grid-cols-3">
-        {currentItems.map(item => (
-          <Link
-            key={`${item.title}-${item.href}`}
-            to={item.href}
-            style={{
-              textDecoration: 'none',
-            }}
-            className="group mb-0 min-w-0 rounded-[10px] border-[0.5px] border-(--border) bg-(--mastra-surface-3) p-2 px-4 text-center text-sm wrap-break-word transition-opacity hover:opacity-80 dark:border-[#343434]"
+      {/* Render all tab panels, hide inactive ones with CSS for llms.txt extraction */}
+      {titles.map(title => {
+        const tabSlug = sluggify(title)
+        const tabItems = items[title] ?? []
+        const isActive = activeTab === tabSlug
+
+        return (
+          <div
+            key={tabSlug}
+            className={cn('mt-6 grid w-full gap-3 md:grid-cols-2 lg:grid-cols-3', !isActive && 'hidden')}
+            data-tab={tabSlug}
           >
-            {item.title}
-          </Link>
-        ))}
-      </div>
+            {tabItems.map(item => (
+              <Link
+                key={`${item.title}-${item.href}`}
+                to={item.href}
+                style={{
+                  textDecoration: 'none',
+                }}
+                className="group mb-0 min-w-0 rounded-[10px] border-[0.5px] border-(--border) bg-(--mastra-surface-3) p-2 px-4 text-center text-sm wrap-break-word transition-opacity hover:opacity-80 dark:border-[#343434]"
+              >
+                {item.title}
+              </Link>
+            ))}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/docs/src/components/ReferenceCards.tsx
+++ b/docs/src/components/ReferenceCards.tsx
@@ -2,6 +2,17 @@ import React from 'react'
 import { CardItems } from './CardItems'
 import sidebars from '@site/src/content/en/reference/sidebars'
 
+/**
+ * Convert a doc id to an href, handling index pages
+ * e.g., "deployer/index" -> "/reference/deployer"
+ *       "agents/agent" -> "/reference/agents/agent"
+ */
+function docIdToHref(docId: string): string {
+  // Strip /index suffix since those are served at the parent path
+  const cleanId = docId.replace(/\/index$/, '')
+  return `/reference/${cleanId}`
+}
+
 // Extract reference sections from sidebar config
 function extractReferenceSections() {
   const sections: Record<string, Array<{ title: string; href: string }>> = {}
@@ -31,7 +42,7 @@ function extractReferenceSections() {
           if (subItem.type === 'doc') {
             sections[label].push({
               title: subItem.label,
-              href: `/reference/${subItem.id}`,
+              href: docIdToHref(subItem.id),
             })
           } else if (subItem.type === 'category') {
             // Handle nested categories by including their items
@@ -40,7 +51,7 @@ function extractReferenceSections() {
                 if (nestedItem.type === 'doc') {
                   sections[label].push({
                     title: nestedItem.label,
-                    href: `/reference/${nestedItem.id}`,
+                    href: docIdToHref(nestedItem.id),
                   })
                 }
               })

--- a/docs/src/content/en/reference/deployer/index.mdx
+++ b/docs/src/content/en/reference/deployer/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Reference: Deployer | Deployer"
 description: Documentation for the Deployer abstract class, which handles packaging and deployment of Mastra applications.
-asIndexPage: true
 packages:
   - "@mastra/deployer"
 ---

--- a/docs/src/content/en/reference/observability/tracing/instances.mdx
+++ b/docs/src/content/en/reference/observability/tracing/instances.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Reference: Tracing | Observability"
 description: Core Tracing classes and methods
-asIndexPage: true
 packages:
   - "@mastra/core"
 ---

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -230,7 +230,7 @@ const sidebars = {
       collapsed: true,
       items: [
         { type: 'doc', id: 'deployer/cloudflare', label: 'Cloudflare' },
-        { type: 'doc', id: 'deployer/deployer', label: 'Deployer' },
+        { type: 'doc', id: 'deployer/index', label: 'Deployer' },
         { type: 'doc', id: 'deployer/netlify', label: 'Netlify' },
         { type: 'doc', id: 'deployer/vercel', label: 'Vercel' },
       ],

--- a/docs/src/pages/kitchen-sink.mdx
+++ b/docs/src/pages/kitchen-sink.mdx
@@ -9,6 +9,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Steps from "@site/src/components/Steps";
 import StepItem from "@site/src/components/StepItem";
+import { CardGrid, CardGridItem } from "@site/src/components/cards/card-grid";
+import YouTube from "@site/src/components/YouTube-player";
+import { ReferenceCards } from "@site/src/components/ReferenceCards";
 
 # Kitchen Sink
 
@@ -136,6 +139,100 @@ Some **content** with _Markdown_ `syntax`. Check [this `api`](#).
 Some **content** with _Markdown_ `syntax`. Check [this `api`](#).
 
 :::
+
+## Card Grid
+
+<CardGrid>
+  <CardGridItem
+    title="Gateways"
+    href="/models/gateways"
+  >
+    <div className="space-y-3">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2 text-sm">
+          <img src="https://models.dev/logos/openrouter.svg" alt="OpenRouter" className="w-4 h-4 object-contain dark:invert dark:brightness-0 dark:contrast-200" />
+          <span>OpenRouter</span>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <NetlifyLogo className="w-4 h-4" />
+          <span>Netlify</span>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <img src="https://models.dev/logos/vercel.svg" alt="Vercel" className="w-4 h-4 object-contain dark:invert dark:brightness-0 dark:contrast-200" />
+          <span>Vercel</span>
+        </div>
+      </div>
+      <div className="text-sm text-gray-600 dark:text-gray-400 mt-3">+ 1 more</div>
+    </div>
+  </CardGridItem>
+  <CardGridItem
+    title="Providers"
+    href="/models/providers"
+  >
+    <div className="space-y-3">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2 text-sm">
+          <img src="https://models.dev/logos/openai.svg" alt="OpenAI" className="w-4 h-4 object-contain dark:invert dark:brightness-0 dark:contrast-200" />
+          <span>OpenAI</span>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <img src="https://models.dev/logos/anthropic.svg" alt="Anthropic" className="w-4 h-4 object-contain dark:invert dark:brightness-0 dark:contrast-200" />
+          <span>Anthropic</span>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <img src="https://models.dev/logos/google.svg" alt="Google" className="w-4 h-4 object-contain dark:invert dark:brightness-0 dark:contrast-200" />
+          <span>Google</span>
+        </div>
+      </div>
+      <div className="text-sm text-gray-600 dark:text-gray-400 mt-3">+ 68 more</div>
+    </div>
+  </CardGridItem>
+</CardGrid>
+
+## YouTube
+
+<YouTube id="1qnmnRICX50" />
+
+## Reference Cards
+
+<ReferenceCards />
+
+## Properties Table
+
+<PropertiesTable
+  content={[
+    {
+      name: "domain",
+      type: "string",
+      description:
+        "Your Auth0 domain (e.g., your-tenant.auth0.com). This is used to verify JWT tokens issued by your Auth0 tenant.",
+      isOptional: true,
+      defaultValue: "process.env.AUTH0_DOMAIN",
+    },
+    {
+      name: "audience",
+      type: "string",
+      description:
+        "Your Auth0 API identifier/audience. This ensures tokens are intended for your specific API.",
+      isOptional: true,
+      defaultValue: "process.env.AUTH0_AUDIENCE",
+    },
+    {
+      name: "name",
+      type: "string",
+      description: "Custom name for the auth provider instance.",
+      isOptional: true,
+      defaultValue: '"auth0"',
+    },
+    {
+      name: "authorizeUser",
+      type: "(user: Auth0User) => Promise<boolean> | boolean",
+      description:
+        "Custom authorization function to determine if a user should be granted access. Called after token verification. By default, allows all authenticated users with valid tokens.",
+      isOptional: true,
+    },
+  ]}
+/>
 
 ## Markdown Kitchen Sink
 

--- a/docs/src/pages/kitchen-sink.mdx
+++ b/docs/src/pages/kitchen-sink.mdx
@@ -114,6 +114,14 @@ console.log(add(2, 3));
 
 Some **content** with _Markdown_ `syntax`. Check [this `api`](#).
 
+Some other second line goes here.
+
+:::
+
+:::note[With Custom Title]
+
+Some **content** with _Markdown_ `syntax`. Check [this `api`](#).
+
 :::
 
 :::tip

--- a/docs/src/pages/kitchen-sink.mdx
+++ b/docs/src/pages/kitchen-sink.mdx
@@ -1,0 +1,323 @@
+---
+title: Kitchen Sink
+description: An example showing every possible component and feature in one page.
+slug: /kitchen-sink
+draft: true
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import Steps from "@site/src/components/Steps";
+import StepItem from "@site/src/components/StepItem";
+
+# Kitchen Sink
+
+On this page you'll find every possible combination or usage we could have in the docs site, all in one place.
+
+## Basic Markdown Formatting
+
+Some text to introduce the section.
+
+> Now a quote block
+
+Or **bold** text, or _italic_ text, or even `inline code`.
+
+You can also place additional information into `<details>` blocks:
+
+<details>
+  <summary>Toggle me!</summary>
+
+  This is the detailed content
+
+  ```js
+  console.log("Markdown features including the code block are available");
+  ```
+
+  You can use Markdown here including **bold** and _italic_ text, and [inline link](https://docusaurus.io)
+  <details>
+    <summary>Nested toggle! Some surprise inside...</summary>
+
+    😲😲😲😲😲
+  </details>
+</details>
+
+We also have images:
+
+![Image alt text](https://images.unsplash.com/photo-1634129366530-61d3e56a84fb?q=80&w=2532&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D)
+
+## Tabs
+
+<Tabs>
+  <TabItem value="apple" label="Apple" default>
+    This is an apple 🍎
+  </TabItem>
+  <TabItem value="orange" label="Orange">
+    This is an orange 🍊
+  </TabItem>
+  <TabItem value="banana" label="Banana">
+    This is a banana 🍌
+  </TabItem>
+</Tabs>
+
+## Steps
+
+<Steps>
+  <StepItem>
+
+Content of step one. Can also contain code blocks or admonitions.
+
+```typescript {7-11} title="src/mastra/agents/memory-agent.ts"
+code goes here
+```
+
+:::info
+
+Visit stuff for a full list of configuration options.
+
+:::
+
+  </StepItem>
+
+  <StepItem>
+
+step content
+
+  </StepItem>
+</Steps>
+
+## Code Blocks
+
+A normal `inline code` block.
+
+An example with only language:
+
+```typescript
+const greeting: string = "Hello, world!";
+console.log(greeting);
+```
+
+An example with title and highlighted lines:
+
+```typescript {4} title="src/example.ts"
+function add(a: number, b: number): number {
+  return a + b;
+}
+console.log(add(2, 3));
+```
+
+## Admonitions
+
+:::note
+
+Some **content** with _Markdown_ `syntax`. Check [this `api`](#).
+
+:::
+
+:::tip
+
+Some **content** with _Markdown_ `syntax`. Check [this `api`](#).
+
+:::
+
+:::info
+
+Some **content** with _Markdown_ `syntax`. Check [this `api`](#).
+
+:::
+
+:::warning
+
+Some **content** with _Markdown_ `syntax`. Check [this `api`](#).
+
+:::
+
+:::danger
+
+Some **content** with _Markdown_ `syntax`. Check [this `api`](#).
+
+:::
+
+## Markdown Kitchen Sink
+
+What follows from here is just a bunch of absolute nonsense I've written to dogfood the plugin itself. It includes every sensible typographic element I could think of, like **bold text**, unordered lists, ordered lists, code blocks, block quotes, _and even italics_.
+
+It's important to cover all of these use cases for a few reasons:
+
+1. We want everything to look good out of the box.
+2. Really just the first reason, that's the whole point of the plugin.
+3. Here's a third pretend reason though a list with three items looks more realistic than a list with two items.
+
+Now we're going to try out another header style.
+
+### Typography should be easy
+
+So that's a header for you — with any luck if we've done our job correctly that will look pretty reasonable.
+
+Something a wise person once told me about typography is:
+
+> Typography is pretty important if you don't want your stuff to look like trash. Make it good then it won't be bad.
+
+It's probably important that images look okay here by default as well:
+
+<figure>
+  <img
+    src="https://images.unsplash.com/photo-1556740758-90de374c12ad?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80"
+    alt=""
+  />
+  <figcaption>
+    Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of
+    classical Latin literature from 45 BC, making it over 2000 years old.
+  </figcaption>
+</figure>
+
+Now I'm going to show you an example of an unordered list to make sure that looks good, too:
+
+- So here is the first item in this list.
+- In this example we're keeping the items short.
+- Later, we'll use longer, more complex list items.
+
+And that's the end of this section.
+
+### We should make sure that looks good, too.
+
+Sometimes you have headings directly underneath each other. In those cases you often have to undo the top margin on the second heading because it usually looks better for the headings to be closer together than a paragraph followed by a heading should be.
+
+### When a heading comes after a paragraph …
+
+When a heading comes after a paragraph, we need a bit more space, like I already mentioned above. Now let's see what a more complex list would look like.
+
+- **I often do this thing where list items have headings.**
+
+  For some reason I think this looks cool which is unfortunate because it's pretty annoying to get the styles right.
+
+  I often have two or three paragraphs in these list items, too, so the hard part is getting the spacing between the paragraphs, list item heading, and separate list items to all make sense. Pretty tough honestly, you could make a strong argument that you just shouldn't write this way.
+
+- **Since this is a list, I need at least two items.**
+
+  I explained what I'm doing already in the previous list item, but a list wouldn't be a list if it only had one item, and we really want this to look realistic. That's why I've added this second list item so I actually have something to look at when writing the styles.
+
+- **It's not a bad idea to add a third item either.**
+
+  I think it probably would've been fine to just use two items but three is definitely not worse, and since I seem to be having no trouble making up arbitrary things to type, I might as well include it. I'm going to press <kbd>Enter</kbd> now.
+
+After this sort of list I usually have a closing statement or paragraph, because it kinda looks weird jumping right to a heading.
+
+### Code should look okay by default.
+
+I think most people are going to use [highlight.js](https://highlightjs.org/) or [Prism](https://prismjs.com/) or something if they want to style their code blocks but it wouldn't hurt to make them look _okay_ out of the box, even with no syntax highlighting.
+
+Here's what a default `tailwind.config.js` file looks like at the time of writing:
+
+```js
+module.exports = {
+  purge: [],
+  theme: {
+    extend: {},
+  },
+  variants: {},
+  plugins: [],
+}
+```
+
+Hopefully that looks good enough to you.
+
+### What about nested lists?
+
+Nested lists basically always look bad which is why editors like Medium don't even let you do it, but I guess since some of you goofballs are going to do it we have to carry the burden of at least making it work.
+
+1. **Nested lists are rarely a good idea.**
+   - You might feel like you are being really "organized" or something but you are just creating a gross shape on the screen that is hard to read.
+   - Nested navigation in UIs is a bad idea too, keep things as flat as possible.
+   - Nesting tons of folders in your source code is also not helpful.
+2. **Since we need to have more items, here's another one.**
+   - I'm not sure if we'll bother styling more than two levels deep.
+   - Two is already too much, three is guaranteed to be a bad idea.
+   - If you nest four levels deep you belong in prison.
+3. **Two items isn't really a list, three is good though.**
+   - Again please don't nest lists if you want people to actually read your content.
+   - Nobody wants to look at this.
+   - I'm upset that we even have to bother styling this.
+
+The most annoying thing about lists in Markdown is that `<li>` elements aren't given a child `<p>` tag unless there are multiple paragraphs in the list item. That means I have to worry about styling that annoying situation too.
+
+- **For example, here's another nested list.**
+
+  But this time with a second paragraph.
+
+  - These list items won't have `<p>` tags
+  - Because they are only one line each
+
+- **But in this second top-level list item, they will.**
+
+  This is especially annoying because of the spacing on this paragraph.
+
+  - As you can see here, because I've added a second line, this list item now has a `<p>` tag.
+
+    This is the second line I'm talking about by the way.
+
+  - Finally here's another list item so it's more like a list.
+
+- A closing list item, but with no nested list, because why not?
+
+And finally a sentence to close off this section.
+
+### We didn't forget about description lists
+
+Well, that's not exactly true, we first released this plugin back in 2020 and it took three years before we added description lists. But they're here now, so let's just be happy about that&hellip;okay? They can be great for things like FAQs.
+
+<dl>
+  <dt>Why do you never see elephants hiding in trees?</dt>
+  <dd>
+    Because they're so good at it. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quas
+    cupiditate laboriosam fugiat.
+  </dd>
+  <dt>What do you call someone with no body and no nose?</dt>
+  <dd>
+    Nobody knows. Lorem ipsum dolor sit amet consectetur adipisicing elit. Culpa, voluptas ipsa quia
+    excepturi, quibusdam natus exercitationem sapiente tempore labore voluptatem.
+  </dd>
+  <dt>Why can't you hear a pterodactyl go to the bathroom?</dt>
+  <dd>
+    Because the pee is silent. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsam, quas
+    voluptatibus ex culpa ipsum, aspernatur blanditiis fugiat ullam magnam suscipit deserunt illum
+    natus facilis atque vero consequatur! Quisquam, debitis error.
+  </dd>
+</dl>
+
+### There are other elements we need to style
+
+I almost forgot to mention links, like [this link to the Tailwind CSS website](https://tailwindcss.com). We almost made them blue but that's so yesterday, so we went with dark gray, feels edgier.
+
+We even included table styles, check it out:
+
+| Wrestler                | Origin       | Finisher           |
+| ----------------------- | ------------ | ------------------ |
+| Bret "The Hitman" Hart  | Calgary, AB  | Sharpshooter       |
+| Stone Cold Steve Austin | Austin, TX   | Stone Cold Stunner |
+| Randy Savage            | Sarasota, FL | Elbow Drop         |
+| Vader                   | Boulder, CO  | Vader Bomb         |
+| Razor Ramon             | Chuluota, FL | Razor's Edge       |
+
+We also need to make sure inline code looks good, like if I wanted to talk about `<span>` elements or tell you the good news about `@tailwindcss/typography`.
+
+### Sometimes I even use `code` in headings
+
+Even though it's probably a bad idea, and historically I've had a hard time making it look good. This _"wrap the code blocks in backticks"_ trick works pretty well though really.
+
+Another thing I've done in the past is put a `code` tag inside of a link, like if I wanted to tell you about the [`tailwindcss/docs`](https://github.com/tailwindcss/docs) repository. I don't love that there is an underline below the backticks but it is absolutely not worth the madness it would require to avoid it.
+
+#### We haven't used an `h4` yet
+
+But now we have. Please don't use `h5` or `h6` in your content, Medium only supports two heading levels for a reason, you animals. I honestly considered using a `before` pseudo-element to scream at you if you use an `h5` or `h6`.
+
+We don't style them at all out of the box because `h4` elements are already so small that they are the same size as the body copy. What are we supposed to do with an `h5`, make it _smaller_ than the body copy? No thanks.
+
+### We still need to think about stacked headings though.
+
+#### Let's make sure we don't screw that up with `h4` elements, either.
+
+Phew, with any luck we have styled the headings above this text and they look pretty good.
+
+Let's add a closing paragraph here so things end with a decently sized block of text. I can't explain why I want things to end that way but I have to assume it's because I think things will look weird or unbalanced if there is a heading too close to the end of the document.
+
+What I've written here is probably long enough, but adding this final sentence can't hurt.

--- a/docs/src/plugins/docusaurus-plugin-llms-txt/admonition-handler.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/admonition-handler.ts
@@ -16,8 +16,13 @@ import type { BlockContent, DefinitionContent } from 'mdast'
 import type { State } from 'hast-util-to-mdast'
 
 /**
- * Find an element with a specific data-testid attribute recursively
+ * Find an element with a specific data-testid attribute within a limited depth
+ * This prevents false positives when ancestor divs contain deeply nested admonitions
+ * The admonition structure has data-testid="admonition-title" at depth 2 from the container:
+ *   admonition div (0) > title row div (1) > span[data-testid] (2)
  */
+const MAX_ADMONITION_SEARCH_DEPTH = 2
+
 function findByTestId(node: ElementContent, testId: string, depth = 0): Element | null {
   if (node.type !== 'element') return null
 
@@ -27,6 +32,11 @@ function findByTestId(node: ElementContent, testId: string, depth = 0): Element 
 
   if (dataTestId === testId) {
     return node
+  }
+
+  // Limit search depth to avoid matching ancestor divs that contain admonitions
+  if (depth >= MAX_ADMONITION_SEARCH_DEPTH) {
+    return null
   }
 
   for (const child of node.children || []) {

--- a/docs/src/plugins/docusaurus-plugin-llms-txt/admonition-handler.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/admonition-handler.ts
@@ -1,0 +1,131 @@
+/**
+ * Custom handler for admonitions to preserve type/title information
+ *
+ * Admonitions in Docusaurus render as divs with a specific structure:
+ * <div class="...">
+ *   <div class="...">
+ *     <span class="..."><svg>icon</svg></span>
+ *     <span data-testid="admonition-title">note</span>
+ *   </div>
+ *   <div class="...">content</div>
+ * </div>
+ */
+
+import type { Element, ElementContent } from 'hast'
+import type { BlockContent, DefinitionContent } from 'mdast'
+import type { State } from 'hast-util-to-mdast'
+
+/**
+ * Find an element with a specific data-testid attribute recursively
+ */
+function findByTestId(node: ElementContent, testId: string, depth = 0): Element | null {
+  if (node.type !== 'element') return null
+
+  // Check various property name formats
+  const props = node.properties
+  const dataTestId = props?.dataTestid ?? props?.['data-testid'] ?? props?.['dataTestId']
+
+  if (dataTestId === testId) {
+    return node
+  }
+
+  for (const child of node.children || []) {
+    const found = findByTestId(child, testId, depth + 1)
+    if (found) return found
+  }
+
+  return null
+}
+
+/**
+ * Get text content from an element recursively
+ */
+function getTextContent(node: ElementContent): string {
+  if (node.type === 'text') {
+    return node.value
+  }
+
+  if (node.type === 'element') {
+    return node.children.map(getTextContent).join('')
+  }
+
+  return ''
+}
+
+/**
+ * Find the content div in an admonition (the div after the title row)
+ */
+function findAdmonitionContent(node: Element): Element | null {
+  // The content is typically in the last child div
+  const divChildren = node.children.filter(
+    (child): child is Element => child.type === 'element' && child.tagName === 'div',
+  )
+
+  // Return the last div which should contain the content
+  if (divChildren.length >= 2) {
+    return divChildren[divChildren.length - 1]
+  }
+
+  return null
+}
+
+/**
+ * Check if an element is an admonition by looking for data-testid="admonition-title"
+ */
+export function isAdmonition(node: Element): boolean {
+  return findByTestId(node, 'admonition-title') !== null
+}
+
+/**
+ * Handle admonition elements
+ * Converts to blockquote format: > **Note:** content
+ */
+export function handleAdmonition(state: State, node: Element): BlockContent | Array<BlockContent | DefinitionContent> {
+  // Find the title element
+  const titleElement = findByTestId(node, 'admonition-title')
+  const title = titleElement ? getTextContent(titleElement).trim() : 'Note'
+
+  // Capitalize first letter for display
+  const displayTitle = title.charAt(0).toUpperCase() + title.slice(1)
+
+  // Find the content div
+  const contentDiv = findAdmonitionContent(node)
+
+  // Process content children
+  const contentChildren: Array<BlockContent | DefinitionContent> = []
+
+  if (contentDiv) {
+    for (const child of contentDiv.children) {
+      const result = state.one(child, contentDiv)
+      if (result) {
+        if (Array.isArray(result)) {
+          contentChildren.push(...(result as Array<BlockContent | DefinitionContent>))
+        } else {
+          contentChildren.push(result as BlockContent | DefinitionContent)
+        }
+      }
+    }
+  }
+
+  // If we have paragraph content, prepend the title to the first paragraph
+  if (contentChildren.length > 0 && contentChildren[0].type === 'paragraph') {
+    const firstPara = contentChildren[0]
+    firstPara.children = [
+      { type: 'strong', children: [{ type: 'text', value: `${displayTitle}:` }] },
+      { type: 'text', value: ' ' },
+      ...firstPara.children,
+    ]
+  } else {
+    // Add a title paragraph if no content or first child isn't a paragraph
+    contentChildren.unshift({
+      type: 'paragraph',
+      children: [{ type: 'strong', children: [{ type: 'text', value: `${displayTitle}:` }] }],
+    })
+  }
+
+  // Return as blockquote
+  return {
+    type: 'blockquote',
+    children: contentChildren,
+  }
+}

--- a/docs/src/plugins/docusaurus-plugin-llms-txt/code-block-handler.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/code-block-handler.ts
@@ -1,7 +1,9 @@
 /**
  * Custom handler for code blocks to preserve language hints
  *
- * Docusaurus places language classes on <pre> elements (e.g., <pre class="language-typescript">), not on <code> elements. The default rehype-remark handler only checks <code> elements, so we need a custom handler to extract the language from the <pre> element.
+ * Docusaurus places language classes on <pre> elements (e.g., <pre class="language-typescript">),
+ * not on <code> elements. The default rehype-remark handler only checks <code> elements,
+ * so we need a custom handler to extract the language from the <pre> element.
  */
 
 import type { Element, Text } from 'hast'
@@ -69,9 +71,6 @@ export function handleCodeBlock(_state: State, node: Element): Code {
     const codeClassNames = codeElement.properties?.className as string[] | undefined
     lang = extractLanguage(codeClassNames)
   }
-
-  // Also check parent div for language class (Docusaurus sometimes puts it there)
-  // This is handled at a higher level, so we don't need to worry about it here
 
   // Extract code content
   const code = codeElement ? extractTextContent(codeElement) : extractTextContent(node)

--- a/docs/src/plugins/docusaurus-plugin-llms-txt/component-handlers.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/component-handlers.ts
@@ -1,0 +1,545 @@
+/**
+ * Custom handlers for Docusaurus components (tabs, details, etc.)
+ */
+
+import type { Element, ElementContent } from 'hast'
+import type { BlockContent, DefinitionContent, Paragraph, Text, Strong } from 'mdast'
+import type { State } from 'hast-util-to-mdast'
+
+/**
+ * Get text content from an element recursively
+ */
+function getTextContent(node: ElementContent): string {
+  if (node.type === 'text') return node.value
+  if (node.type === 'element') {
+    return node.children.map(getTextContent).join('')
+  }
+  return ''
+}
+
+/**
+ * Check if a class name matches a pattern (handles hashed class names)
+ */
+function classMatches(className: string, pattern: string): boolean {
+  return className === pattern || className.startsWith(pattern + '_') || className.startsWith(pattern + '-')
+}
+
+/**
+ * Check if an element has a class matching the pattern
+ */
+function hasClass(node: Element, pattern: string): boolean {
+  const classNames = node.properties?.className as string[] | undefined
+  if (!classNames) return false
+  return classNames.some(cls => classMatches(cls, pattern))
+}
+
+// ============================================
+// TABS HANDLER
+// ============================================
+
+/**
+ * Check if an element is a tabs container
+ * Structure:
+ * <div class="theme-tabs-container">
+ *   <ul role="tablist" class="tabs">
+ *     <li role="tab" class="tabs__item">Tab 1</li>
+ *     <li role="tab" class="tabs__item">Tab 2</li>
+ *   </ul>
+ *   <div>
+ *     <div role="tabpanel">Content 1</div>
+ *     <div role="tabpanel" hidden>Content 2</div>
+ *   </div>
+ * </div>
+ */
+export function isTabsContainer(node: Element): boolean {
+  return hasClass(node, 'theme-tabs-container') || hasClass(node, 'tabs-container')
+}
+
+/**
+ * Handle tabs container - convert to labeled sections
+ */
+export function handleTabsContainer(
+  state: State,
+  node: Element,
+): BlockContent | Array<BlockContent | DefinitionContent> {
+  const result: Array<BlockContent | DefinitionContent> = []
+
+  // Find the tab list (ul with role="tablist")
+  const tabList = findElementByRole(node, 'tablist')
+  const tabLabels: string[] = []
+
+  if (tabList) {
+    // Extract tab labels from li elements
+    for (const child of tabList.children) {
+      if (child.type === 'element' && child.tagName === 'li') {
+        tabLabels.push(getTextContent(child).trim())
+      }
+    }
+  }
+
+  // Find tab panels (divs with role="tabpanel")
+  const tabPanels = findAllElementsByRole(node, 'tabpanel')
+
+  // Generate output: pair labels with content
+  for (let i = 0; i < tabPanels.length; i++) {
+    const label = tabLabels[i] || `Tab ${i + 1}`
+    const panel = tabPanels[i]
+
+    // Add label as bold text
+    const labelPara: Paragraph = {
+      type: 'paragraph',
+      children: [
+        { type: 'strong', children: [{ type: 'text', value: label }] } as Strong,
+        { type: 'text', value: ':' } as Text,
+      ],
+    }
+    result.push(labelPara)
+
+    // Process panel content
+    for (const child of panel.children) {
+      const processed = state.one(child, panel)
+      if (processed) {
+        if (Array.isArray(processed)) {
+          result.push(...(processed as Array<BlockContent | DefinitionContent>))
+        } else {
+          result.push(processed as BlockContent | DefinitionContent)
+        }
+      }
+    }
+  }
+
+  return result
+}
+
+// ============================================
+// DETAILS HANDLER
+// ============================================
+
+/**
+ * Check if an element is a details element
+ */
+export function isDetails(node: Element): boolean {
+  return node.tagName === 'details'
+}
+
+/**
+ * Handle details element - convert to collapsible format
+ * Output format:
+ * <details>
+ * **Summary text**
+ *
+ * Content here...
+ * </details>
+ */
+export function handleDetails(state: State, node: Element): BlockContent | Array<BlockContent | DefinitionContent> {
+  const result: Array<BlockContent | DefinitionContent> = []
+
+  // Find summary element
+  let summaryText = 'Details'
+  const summary = node.children.find(
+    (child): child is Element => child.type === 'element' && child.tagName === 'summary',
+  )
+  if (summary) {
+    summaryText = getTextContent(summary).trim()
+  }
+
+  // Add opening marker with summary as bold
+  result.push({
+    type: 'paragraph',
+    children: [
+      { type: 'html', value: '<details>' },
+      { type: 'text', value: '\n' },
+      { type: 'strong', children: [{ type: 'text', value: summaryText }] } as Strong,
+    ],
+  } as Paragraph)
+
+  // Process content (skip the summary element)
+  for (const child of node.children) {
+    if (child.type === 'element' && child.tagName === 'summary') continue
+
+    const processed = state.one(child, node)
+    if (processed) {
+      if (Array.isArray(processed)) {
+        result.push(...(processed as Array<BlockContent | DefinitionContent>))
+      } else {
+        result.push(processed as BlockContent | DefinitionContent)
+      }
+    }
+  }
+
+  // Add closing marker
+  result.push({
+    type: 'paragraph',
+    children: [{ type: 'html', value: '</details>' }],
+  } as Paragraph)
+
+  return result
+}
+
+// ============================================
+// CARD GRID HANDLER (Reference Cards - card__grid class)
+// ============================================
+
+/**
+ * Check if an element is a card grid (Reference Cards component with card__grid class)
+ */
+export function isCardGrid(node: Element): boolean {
+  return hasClass(node, 'card__grid')
+}
+
+/**
+ * Handle card grid - format links on separate lines
+ * The card__grid contains:
+ * - Filter buttons (skip these)
+ * - Grid of links (format as bullet list)
+ */
+export function handleCardGrid(_state: State, node: Element): BlockContent | Array<BlockContent | DefinitionContent> {
+  const result: Array<BlockContent | DefinitionContent> = []
+
+  // Find all links in the card grid
+  const links = findAllElementsByTag(node, 'a')
+
+  if (links.length > 0) {
+    // Create a list of links
+    const listItems = links.map(link => {
+      const href = link.properties?.href as string | undefined
+      const text = getTextContent(link).trim()
+
+      // Skip empty links
+      if (!text || !href) return null
+
+      return {
+        type: 'listItem' as const,
+        spread: false,
+        children: [
+          {
+            type: 'paragraph' as const,
+            children: [
+              {
+                type: 'link' as const,
+                url: href.startsWith('/') ? `https://mastra.ai${href}` : href,
+                children: [{ type: 'text' as const, value: text }],
+              },
+            ],
+          },
+        ],
+      }
+    })
+
+    const validItems = listItems.filter(item => item !== null)
+
+    if (validItems.length > 0) {
+      result.push({
+        type: 'list',
+        ordered: false,
+        spread: false,
+        children: validItems,
+      })
+    }
+  }
+
+  return result
+}
+
+// ============================================
+// CARD GRID ITEMS HANDLER (CardGrid component - grid layout with data-slot=card)
+// ============================================
+
+/**
+ * Check if an element is a CardGrid items container (grid with card items)
+ * Structure: <div class="grid grid-cols-1 ..."><a><div data-slot="card">...</div></a>...</div>
+ */
+export function isCardGridItems(node: Element): boolean {
+  const classNames = node.properties?.className as string[] | undefined
+  if (!classNames) return false
+
+  // Check for grid layout class
+  const hasGridClass = classNames.some(cls => cls.startsWith('grid') && cls !== 'card__grid')
+  if (!hasGridClass) return false
+
+  // Check if it contains card items (a > div[data-slot=card])
+  for (const child of node.children) {
+    if (child.type === 'element' && child.tagName === 'a') {
+      for (const grandchild of child.children) {
+        if (grandchild.type === 'element' && grandchild.properties?.dataSlot === 'card') {
+          return true
+        }
+      }
+    }
+  }
+
+  return false
+}
+
+/**
+ * Handle CardGrid items - extract card titles and links
+ */
+export function handleCardGridItems(
+  _state: State,
+  node: Element,
+): BlockContent | Array<BlockContent | DefinitionContent> {
+  const result: Array<BlockContent | DefinitionContent> = []
+  const listItems: Array<{
+    type: 'listItem'
+    spread: boolean
+    children: Array<{
+      type: 'paragraph'
+      children: Array<{ type: 'link'; url: string; children: Array<{ type: 'text'; value: string }> }>
+    }>
+  }> = []
+
+  // Find all card links
+  for (const child of node.children) {
+    if (child.type === 'element' && child.tagName === 'a') {
+      const href = child.properties?.href as string | undefined
+      if (!href) continue
+
+      // Find the card title
+      const cardTitle = findElementByDataSlot(child, 'card-title')
+      const title = cardTitle ? getTextContent(cardTitle).trim() : ''
+
+      if (title) {
+        listItems.push({
+          type: 'listItem',
+          spread: false,
+          children: [
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  type: 'link',
+                  url: href.startsWith('/') ? `https://mastra.ai${href}` : href,
+                  children: [{ type: 'text', value: title }],
+                },
+              ],
+            },
+          ],
+        })
+      }
+    }
+  }
+
+  if (listItems.length > 0) {
+    result.push({
+      type: 'list',
+      ordered: false,
+      spread: false,
+      children: listItems,
+    })
+  }
+
+  return result
+}
+
+// ============================================
+// PROPERTIES TABLE HANDLER
+// ============================================
+
+/**
+ * Check if an element is a PropertiesTable container
+ * Structure: <div class="flex flex-col"><div id="propName" class="... border-b ...">...</div>...</div>
+ */
+export function isPropertiesTable(node: Element): boolean {
+  // Check if this is a flex flex-col container
+  const classNames = node.properties?.className as string[] | undefined
+  if (!classNames) return false
+
+  const hasFlexCol =
+    classNames.includes('flex') && classNames.some(cls => cls === 'flex-col' || cls.startsWith('flex-col'))
+
+  if (!hasFlexCol) return false
+
+  // Check if children have id attributes and border-b class (property rows)
+  let propertyRowCount = 0
+  for (const child of node.children) {
+    if (child.type === 'element' && child.properties?.id && hasClass(child, 'border-b')) {
+      propertyRowCount++
+    }
+  }
+
+  return propertyRowCount >= 1
+}
+
+/**
+ * Handle PropertiesTable - format as definition-style list
+ */
+export function handlePropertiesTable(
+  _state: State,
+  node: Element,
+): BlockContent | Array<BlockContent | DefinitionContent> {
+  const result: Array<BlockContent | DefinitionContent> = []
+
+  for (const child of node.children) {
+    if (child.type !== 'element') continue
+
+    const propId = child.properties?.id as string | undefined
+    if (!propId) continue
+
+    // Find the h3 with property name
+    const h3 = findElementByTag(child, 'h3')
+    const propName = h3 ? getTextContent(h3).trim() : propId
+
+    // Find type and default value in the first row div
+    let propType = ''
+    let defaultValue = ''
+    let description = ''
+
+    // Structure: div > (div.group[h3, div(type), div(default)], div(description))
+    const divChildren = child.children.filter((c): c is Element => c.type === 'element' && c.tagName === 'div')
+
+    if (divChildren.length >= 1) {
+      // First div contains h3, type, and default
+      const headerDiv = divChildren[0]
+      const headerDivChildren = headerDiv.children.filter(
+        (c): c is Element => c.type === 'element' && c.tagName === 'div',
+      )
+
+      // Extract type (first div after h3)
+      if (headerDivChildren.length >= 1) {
+        propType = getTextContent(headerDivChildren[0]).trim()
+      }
+
+      // Extract default value (second div after h3, starts with "=")
+      if (headerDivChildren.length >= 2) {
+        const defaultText = getTextContent(headerDivChildren[1]).trim()
+        if (defaultText.startsWith('=')) {
+          defaultValue = defaultText.slice(1).trim()
+        }
+      }
+    }
+
+    // Last div is the description
+    if (divChildren.length >= 2) {
+      description = getTextContent(divChildren[divChildren.length - 1]).trim()
+    }
+
+    // Format as: **propName** (`type`): description (Default: value)
+    const children: Array<{ type: string; value?: string; children?: Array<{ type: string; value: string }> }> = []
+
+    // Property name in bold
+    children.push({
+      type: 'strong',
+      children: [{ type: 'text', value: propName }],
+    })
+
+    // Type in code
+    if (propType) {
+      children.push({ type: 'text', value: ' (' })
+      children.push({ type: 'inlineCode', value: propType })
+      children.push({ type: 'text', value: ')' })
+    }
+
+    // Description
+    if (description) {
+      children.push({ type: 'text', value: ': ' + description })
+    }
+
+    // Default value
+    if (defaultValue) {
+      children.push({ type: 'text', value: ' (Default: ' })
+      children.push({ type: 'inlineCode', value: defaultValue })
+      children.push({ type: 'text', value: ')' })
+    }
+
+    result.push({
+      type: 'paragraph',
+      children: children as Paragraph['children'],
+    })
+  }
+
+  return result
+}
+
+// ============================================
+// HELPER FUNCTIONS
+// ============================================
+
+/**
+ * Find an element by role attribute recursively
+ */
+function findElementByRole(node: Element, role: string): Element | null {
+  for (const child of node.children) {
+    if (child.type === 'element') {
+      if (child.properties?.role === role) {
+        return child
+      }
+      const found = findElementByRole(child, role)
+      if (found) return found
+    }
+  }
+  return null
+}
+
+/**
+ * Find all elements by role attribute recursively
+ */
+function findAllElementsByRole(node: Element, role: string): Element[] {
+  const results: Element[] = []
+
+  function search(el: Element) {
+    for (const child of el.children) {
+      if (child.type === 'element') {
+        if (child.properties?.role === role) {
+          results.push(child)
+        }
+        search(child)
+      }
+    }
+  }
+
+  search(node)
+  return results
+}
+
+/**
+ * Find all elements by tag name recursively
+ */
+function findAllElementsByTag(node: Element, tagName: string): Element[] {
+  const results: Element[] = []
+
+  function search(el: Element) {
+    for (const child of el.children) {
+      if (child.type === 'element') {
+        if (child.tagName === tagName) {
+          results.push(child)
+        }
+        search(child)
+      }
+    }
+  }
+
+  search(node)
+  return results
+}
+
+/**
+ * Find an element by tag name recursively (first match)
+ */
+function findElementByTag(node: Element, tagName: string): Element | null {
+  for (const child of node.children) {
+    if (child.type === 'element') {
+      if (child.tagName === tagName) {
+        return child
+      }
+      const found = findElementByTag(child, tagName)
+      if (found) return found
+    }
+  }
+  return null
+}
+
+/**
+ * Find an element by data-slot attribute recursively
+ */
+function findElementByDataSlot(node: Element, slotName: string): Element | null {
+  for (const child of node.children) {
+    if (child.type === 'element') {
+      if (child.properties?.dataSlot === slotName) {
+        return child
+      }
+      const found = findElementByDataSlot(child, slotName)
+      if (found) return found
+    }
+  }
+  return null
+}

--- a/docs/src/plugins/docusaurus-plugin-llms-txt/content-extractor.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/content-extractor.ts
@@ -101,17 +101,16 @@ const CLASS_PATTERNS_TO_REMOVE = [
   /hash-link/,
   /sr-only/,
   /codeBlockTitle/,
-  /^tabs$/,
-  /tabs__item/,
-  /font-mono.*font-bold.*capitalize/,
+  // Note: tabs/tabs__item preserved for tab label extraction
+  // Note: font-mono.*font-bold.*capitalize removed - was catching admonition titles
   /tocCollapsible/,
 ]
 
 // Pre-compiled aria-label patterns
 const ARIA_LABEL_PATTERNS_TO_REMOVE = [/^breadcrumbs$/, /^Direct link to/]
 
-// Pre-compiled role patterns
-const ROLES_TO_REMOVE = new Set(['tablist', 'tab'])
+// Pre-compiled role patterns - tablist/tab preserved for tabs handling
+const ROLES_TO_REMOVE = new Set<string>([])
 
 /**
  * Check if an element should be removed based on its properties

--- a/docs/src/theme/Admonition/Layout/index.tsx
+++ b/docs/src/theme/Admonition/Layout/index.tsx
@@ -56,7 +56,11 @@ function AdmonitionIconType({ title, type }: Pick<Props, 'title' | 'type'>) {
   return (
     <div className="flex items-center gap-1.5">
       <span className="size-3 shrink-0">{TypeToEmoji[type]}</span>
-      {title ? <span className="font-mono text-sm font-bold tracking-tight capitalize">{title}</span> : null}
+      {title ? (
+        <span className="font-mono text-sm font-bold tracking-tight capitalize" data-testid="admonition-title">
+          {title}
+        </span>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
## Description

- Improve caching of llms.txt by invalidating cache when plugin files change
- Improve parsing of admonitions with custom titles and multiple paragraphs
- Improve parsing of other custom MDX components
- Add a kitchen-sink page to test all components and features

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Kitchen Sink" docs page demonstrating many components, formatting and embeds.

* **Documentation**
  * Improved handling and rendering of tabs, details, admonitions, card grids, properties tables and code blocks for richer docs output.
  * Centralized reference link generation and adjusted sidebar/index metadata entries for clearer reference paths.

* **Bug Fixes / Chores**
  * Cache now invalidates when plugin code changes to ensure up-to-date documentation rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->