### PR TITLE
refactor(cli): simplify agent tooling configuration

### DIFF
--- a/.changeset/cold-moles-sip.md
+++ b/.changeset/cold-moles-sip.md
@@ -1,0 +1,5 @@
+---
+'mastra': minor
+---
+
+Added skills installation support to create-mastra CLI. Users can now install official Mastra agent skills during project creation with an interactive multi-select prompt. The prompt shows 10 popular agents (Claude Code, Cursor, Windsurf, etc.) by default, with an option to expand and view all 40 supported agents. The new --skills flag accepts comma-separated agent names (e.g., `--skills claude-code,cursor`) for non-interactive setup.

--- a/packages/cli/src/commands/actions/create-project.ts
+++ b/packages/cli/src/commands/actions/create-project.ts
@@ -16,6 +16,7 @@ interface CreateProjectArgs {
   dir?: string;
   projectName?: string;
   mcp?: Editor;
+  skills?: string[];
   template?: string | boolean;
 }
 
@@ -33,6 +34,7 @@ export const createProject = async (projectNameArg: string | undefined, args: Cr
           addExample: true,
           timeout,
           mcpServer: args.mcp,
+          skills: args.skills,
           template: args.template,
         });
         return;
@@ -46,6 +48,7 @@ export const createProject = async (projectNameArg: string | undefined, args: Cr
         projectName,
         directory: args.dir,
         mcpServer: args.mcp,
+        skills: args.skills,
         template: args.template,
       });
     },

--- a/packages/cli/src/commands/actions/init-project.ts
+++ b/packages/cli/src/commands/actions/init-project.ts
@@ -38,6 +38,10 @@ export const initProject = async (args: InitArgs) => {
           llmApiKey: result?.llmApiKey as string,
           components: ['agents', 'tools', 'workflows'],
           addExample: true,
+          configureMastraToolingForCodingAgents: result?.configureMastraToolingForCodingAgents as
+            | { type: 'skills'; agents: string[] }
+            | Editor
+            | undefined,
           versionTag,
         });
         return;

--- a/packages/cli/src/commands/actions/init-project.ts
+++ b/packages/cli/src/commands/actions/init-project.ts
@@ -38,10 +38,8 @@ export const initProject = async (args: InitArgs) => {
           llmApiKey: result?.llmApiKey as string,
           components: ['agents', 'tools', 'workflows'],
           addExample: true,
-          configureMastraToolingForCodingAgents: result?.configureMastraToolingForCodingAgents as
-            | { type: 'skills'; agents: string[] }
-            | Editor
-            | undefined,
+          skills: result?.skills,
+          mcpServer: result?.mcpServer,
           versionTag,
         });
         return;
@@ -53,7 +51,7 @@ export const initProject = async (args: InitArgs) => {
           components: ['agents', 'tools', 'workflows'],
           llmProvider: 'openai',
           addExample: true,
-          configureEditorWithDocsMCP: args.mcp,
+          mcpServer: args.mcp,
           versionTag,
         });
         return;
@@ -65,7 +63,7 @@ export const initProject = async (args: InitArgs) => {
         llmProvider: args.llm,
         addExample: args.example,
         llmApiKey: args.llmApiKey,
-        configureEditorWithDocsMCP: args.mcp,
+        mcpServer: args.mcp,
         versionTag,
       });
       return;

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -28,6 +28,7 @@ export const create = async (args: {
   timeout?: number;
   directory?: string;
   mcpServer?: Editor;
+  skills?: string[];
   template?: string | boolean;
   analytics?: PosthogAnalytics;
 }) => {
@@ -54,6 +55,7 @@ export const create = async (args: {
     timeout: args?.timeout,
     llmProvider: args?.llmProvider,
     llmApiKey: args?.llmApiKey,
+    skills: args?.skills,
     needsInteractive,
   });
   const directory = args.directory || 'src/';
@@ -73,6 +75,10 @@ export const create = async (args: {
       llmApiKey: result?.llmApiKey as string | undefined,
       components: ['agents', 'tools', 'workflows', 'scorers'],
       addExample: true,
+      configureMastraToolingForCodingAgents:
+        (result?.configureMastraToolingForCodingAgents as { type: 'skills'; agents: string[] } | Editor | undefined) ||
+        (args.skills && args.skills.length > 0 ? { type: 'skills', agents: args.skills } : undefined),
+      configureEditorWithDocsMCP: undefined,
       versionTag: args.createVersionTag,
     });
     postCreate({ projectName });
@@ -96,6 +102,8 @@ export const create = async (args: {
     llmProvider,
     addExample,
     llmApiKey,
+    configureMastraToolingForCodingAgents:
+      args.skills && args.skills.length > 0 ? { type: 'skills', agents: args.skills } : undefined,
     configureEditorWithDocsMCP: args.mcpServer,
     versionTag: args.createVersionTag,
   });

--- a/packages/cli/src/commands/create/create.ts
+++ b/packages/cli/src/commands/create/create.ts
@@ -56,6 +56,7 @@ export const create = async (args: {
     llmProvider: args?.llmProvider,
     llmApiKey: args?.llmApiKey,
     skills: args?.skills,
+    mcpServer: args?.mcpServer,
     needsInteractive,
   });
   const directory = args.directory || 'src/';
@@ -75,10 +76,8 @@ export const create = async (args: {
       llmApiKey: result?.llmApiKey as string | undefined,
       components: ['agents', 'tools', 'workflows', 'scorers'],
       addExample: true,
-      configureMastraToolingForCodingAgents:
-        (result?.configureMastraToolingForCodingAgents as { type: 'skills'; agents: string[] } | Editor | undefined) ||
-        (args.skills && args.skills.length > 0 ? { type: 'skills', agents: args.skills } : undefined),
-      configureEditorWithDocsMCP: undefined,
+      skills: result?.skills || args.skills,
+      mcpServer: result?.mcpServer || args.mcpServer,
       versionTag: args.createVersionTag,
     });
     postCreate({ projectName });
@@ -102,9 +101,8 @@ export const create = async (args: {
     llmProvider,
     addExample,
     llmApiKey,
-    configureMastraToolingForCodingAgents:
-      args.skills && args.skills.length > 0 ? { type: 'skills', agents: args.skills } : undefined,
-    configureEditorWithDocsMCP: args.mcpServer,
+    skills: args.skills,
+    mcpServer: args.mcpServer,
     versionTag: args.createVersionTag,
   });
 

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -160,6 +160,7 @@ export const createMastraProject = async ({
   llmProvider,
   llmApiKey,
   skills,
+  mcpServer,
   needsInteractive,
 }: {
   projectName?: string;
@@ -168,6 +169,7 @@ export const createMastraProject = async ({
   llmProvider?: LLMProvider;
   llmApiKey?: string;
   skills?: string[];
+  mcpServer?: string;
   needsInteractive?: boolean;
 }) => {
   p.intro(color.inverse(' Mastra Create '));
@@ -199,7 +201,8 @@ export const createMastraProject = async ({
       skip: {
         llmProvider: llmProvider !== undefined,
         llmApiKey: llmApiKey !== undefined,
-        configureMastraToolingForCodingAgents: skills !== undefined && skills.length > 0,
+        skills: skills !== undefined && skills.length > 0,
+        mcpServer: mcpServer !== undefined,
       },
     });
   }

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -159,6 +159,7 @@ export const createMastraProject = async ({
   timeout,
   llmProvider,
   llmApiKey,
+  skills,
   needsInteractive,
 }: {
   projectName?: string;
@@ -166,6 +167,7 @@ export const createMastraProject = async ({
   timeout?: number;
   llmProvider?: LLMProvider;
   llmApiKey?: string;
+  skills?: string[];
   needsInteractive?: boolean;
 }) => {
   p.intro(color.inverse(' Mastra Create '));
@@ -194,7 +196,11 @@ export const createMastraProject = async ({
   if (needsInteractive) {
     result = await interactivePrompt({
       options: { showBanner: false },
-      skip: { llmProvider: llmProvider !== undefined, llmApiKey: llmApiKey !== undefined },
+      skip: {
+        llmProvider: llmProvider !== undefined,
+        llmApiKey: llmApiKey !== undefined,
+        configureMastraToolingForCodingAgents: skills !== undefined && skills.length > 0,
+      },
     });
   }
   const s = p.spinner();

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -18,8 +18,8 @@ export const init = async ({
   llmProvider = 'openai',
   llmApiKey,
   addExample = false,
-  configureEditorWithDocsMCP,
-  configureMastraToolingForCodingAgents,
+  skills,
+  mcpServer,
   versionTag,
   initGit = false,
 }: {
@@ -28,8 +28,8 @@ export const init = async ({
   llmProvider?: LLMProvider;
   llmApiKey?: string;
   addExample?: boolean;
-  configureEditorWithDocsMCP?: Editor;
-  configureMastraToolingForCodingAgents?: { type: 'skills'; agents: string[] } | Editor;
+  skills?: string[];
+  mcpServer?: Editor;
   versionTag?: string;
   initGit?: boolean;
 }) => {
@@ -99,17 +99,12 @@ export const init = async ({
     s.stop('Mastra initialized');
 
     // Install skills if selected
-    if (
-      configureMastraToolingForCodingAgents &&
-      typeof configureMastraToolingForCodingAgents === 'object' &&
-      'type' in configureMastraToolingForCodingAgents &&
-      configureMastraToolingForCodingAgents.type === 'skills'
-    ) {
+    if (skills && skills.length > 0) {
       try {
         s.start('Installing Mastra agent skills');
         const skillsResult = await installMastraSkills({
           directory: process.cwd(),
-          agents: configureMastraToolingForCodingAgents.agents,
+          agents: skills,
         });
         if (skillsResult.success) {
           // Format agent names nicely
@@ -134,16 +129,9 @@ export const init = async ({
     }
 
     // Install MCP if an editor was selected
-    const mcpEditor =
-      configureMastraToolingForCodingAgents &&
-      typeof configureMastraToolingForCodingAgents === 'string' &&
-      ['cursor', 'cursor-global', 'windsurf', 'vscode', 'antigravity'].includes(configureMastraToolingForCodingAgents)
-        ? (configureMastraToolingForCodingAgents as Editor)
-        : configureEditorWithDocsMCP;
-
-    if (mcpEditor) {
+    if (mcpServer) {
       await installMastraDocsMCPServer({
-        editor: mcpEditor,
+        editor: mcpServer,
         directory: process.cwd(),
         versionTag,
       });

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -105,26 +105,31 @@ export const init = async ({
       'type' in configureMastraToolingForCodingAgents &&
       configureMastraToolingForCodingAgents.type === 'skills'
     ) {
-      s.start('Installing Mastra agent skills');
-      const skillsResult = await installMastraSkills({
-        directory: process.cwd(),
-        agents: configureMastraToolingForCodingAgents.agents,
-      });
-      if (skillsResult.success) {
-        // Format agent names nicely
-        const agentNames = skillsResult.agents
-          .map(agent => {
-            // Convert kebab-case to Title Case
-            return agent
-              .split('-')
-              .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-              .join(' ');
-          })
-          .join(', ');
-        s.stop(`Mastra agent skills installed (in ${agentNames})`);
-      } else {
+      try {
+        s.start('Installing Mastra agent skills');
+        const skillsResult = await installMastraSkills({
+          directory: process.cwd(),
+          agents: configureMastraToolingForCodingAgents.agents,
+        });
+        if (skillsResult.success) {
+          // Format agent names nicely
+          const agentNames = skillsResult.agents
+            .map(agent => {
+              // Convert kebab-case to Title Case
+              return agent
+                .split('-')
+                .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+                .join(' ');
+            })
+            .join(', ');
+          s.stop(`Mastra agent skills installed (in ${agentNames})`);
+        } else {
+          s.stop('Skills installation failed');
+          console.warn(color.yellow(`\nWarning: ${skillsResult.error}`));
+        }
+      } catch (error) {
         s.stop('Skills installation failed');
-        console.warn(color.yellow(`\nWarning: ${skillsResult.error}`));
+        console.warn(color.yellow(`\nWarning: ${error instanceof Error ? error.message : 'Unknown error'}`));
       }
     }
 

--- a/packages/cli/src/commands/init/skills-install.ts
+++ b/packages/cli/src/commands/init/skills-install.ts
@@ -1,0 +1,27 @@
+import { execa } from 'execa';
+
+export async function installMastraSkills({
+  directory,
+  agents,
+}: {
+  directory: string;
+  agents: string[];
+}): Promise<{ success: boolean; error?: string; agents: string[] }> {
+  try {
+    // Build args: --agent takes space-separated agent names
+    const args = ['skills', 'add', 'mastra-ai/skills', '--agent', ...agents, '-y'];
+
+    await execa('npx', args, {
+      cwd: directory,
+      stdio: 'pipe', // Hide verbose output
+    });
+
+    return { success: true, agents };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      agents,
+    };
+  }
+}

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -669,6 +669,7 @@ interface InteractivePromptArgs {
     llmProvider?: boolean;
     llmApiKey?: boolean;
     gitInit?: boolean;
+    configureMastraToolingForCodingAgents?: boolean;
   };
 }
 
@@ -717,82 +718,181 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
         }
         return undefined;
       },
-      configureEditorWithDocsMCP: async () => {
-        const editor = await p.select({
-          message: `Make your IDE into a Mastra expert? (Installs Mastra's MCP server)`,
+      configureMastraToolingForCodingAgents: async () => {
+        if (skip?.configureMastraToolingForCodingAgents) return undefined;
+
+        const choice = await p.select({
+          message: `Configure Mastra tooling for coding agents?`,
           options: [
-            { value: 'skip', label: 'Skip for now', hint: 'default' },
-            {
-              value: 'cursor',
-              label: 'Cursor (project only)',
-            },
-            {
-              value: 'cursor-global',
-              label: 'Cursor (global, all projects)',
-            },
-            {
-              value: 'windsurf',
-              label: 'Windsurf',
-            },
-            {
-              value: 'vscode',
-              label: 'VSCode',
-            },
-            {
-              value: 'antigravity',
-              label: 'Antigravity',
-            },
-          ] satisfies { value: Editor | 'skip'; label: string; hint?: string }[],
+            { value: 'skills', label: 'Skills - Mastra agent skills', hint: 'recommended' },
+            { value: 'mcp', label: 'MCP Docs - IDE integration' },
+          ],
+          initialValue: 'skills',
         });
 
-        if (editor === `skip`) return undefined;
+        if (choice === 'skills') {
+          // Popular agents
+          const POPULAR_AGENTS: { value: string; label: string }[] = [
+            { value: 'claude-code', label: 'Claude Code' },
+            { value: 'cursor', label: 'Cursor' },
+            { value: 'windsurf', label: 'Windsurf' },
+            { value: 'github-copilot', label: 'GitHub Copilot' },
+            { value: 'cline', label: 'Cline' },
+            { value: 'continue', label: 'Continue' },
+            { value: 'gemini-cli', label: 'Gemini CLI' },
+            { value: 'opencode', label: 'OpenCode' },
+            { value: 'replit', label: 'Replit' },
+            { value: 'roo', label: 'Roo Code' },
+          ];
 
-        if (editor === `cursor`) {
-          p.log.message(
-            `\nNote: you will need to go into Cursor Settings -> MCP Settings and manually enable the installed Mastra MCP server.\n`,
-          );
-        }
+          // All agents (alphabetically)
+          const ALL_AGENTS: { value: string; label: string }[] = [
+            ...POPULAR_AGENTS,
+            { value: 'adal', label: 'AdaL' },
+            { value: 'amp', label: 'Amp' },
+            { value: 'antigravity', label: 'Antigravity' },
+            { value: 'augment', label: 'Augment' },
+            { value: 'codebuddy', label: 'CodeBuddy' },
+            { value: 'codex', label: 'Codex' },
+            { value: 'command-code', label: 'Command Code' },
+            { value: 'crush', label: 'Crush' },
+            { value: 'droid', label: 'Droid' },
+            { value: 'goose', label: 'Goose' },
+            { value: 'iflow-cli', label: 'iFlow CLI' },
+            { value: 'junie', label: 'Junie' },
+            { value: 'kilo', label: 'Kilo Code' },
+            { value: 'kimi-cli', label: 'Kimi Code CLI' },
+            { value: 'kiro-cli', label: 'Kiro CLI' },
+            { value: 'kode', label: 'Kode' },
+            { value: 'mcpjam', label: 'MCPJam' },
+            { value: 'mistral-vibe', label: 'Mistral Vibe' },
+            { value: 'mux', label: 'Mux' },
+            { value: 'neovate', label: 'Neovate' },
+            { value: 'openclaude', label: 'OpenClaude IDE' },
+            { value: 'openclaw', label: 'OpenClaw' },
+            { value: 'openhands', label: 'OpenHands' },
+            { value: 'pi', label: 'Pi' },
+            { value: 'pochi', label: 'Pochi' },
+            { value: 'qoder', label: 'Qoder' },
+            { value: 'qwen-code', label: 'Qwen Code' },
+            { value: 'trae', label: 'Trae' },
+            { value: 'trae-cn', label: 'Trae CN' },
+            { value: 'zencoder', label: 'Zencoder' },
+          ];
 
-        if (editor === `cursor-global`) {
-          const confirm = await p.select({
-            message: `Global install will add/update ${cursorGlobalMCPConfigPath} and make the Mastra docs MCP server available in all your Cursor projects. Continue?`,
-            options: [
-              { value: 'yes', label: 'Yes, I understand' },
-              { value: 'skip', label: 'No, skip for now' },
-            ],
+          // Show popular agents first with "Show all" option
+          const initialSelection = await p.multiselect({
+            message: 'Select agent(s) to install skills for:',
+            options: [...POPULAR_AGENTS, { value: '__show_all__', label: '+ Show all agents (30 more)' }],
+            required: true,
           });
-          if (confirm !== `yes`) {
+
+          if (p.isCancel(initialSelection)) {
             return undefined;
           }
-        }
 
-        if (editor === `windsurf`) {
-          const confirm = await p.select({
-            message: `Windsurf only supports a global MCP config (at ${windsurfGlobalMCPConfigPath}) is it ok to add/update that global config?\nThis means the Mastra docs MCP server will be available in all your Windsurf projects.`,
-            options: [
-              { value: 'yes', label: 'Yes, I understand' },
-              { value: 'skip', label: 'No, skip for now' },
-            ],
-          });
-          if (confirm !== `yes`) {
-            return undefined;
+          let selectedAgents = initialSelection as string[];
+
+          // If user selected "Show all", show full list
+          if (selectedAgents.includes('__show_all__')) {
+            // Remove the __show_all__ marker and use those as pre-selected
+            const preSelected = selectedAgents.filter(a => a !== '__show_all__');
+
+            const fullSelection = await p.multiselect({
+              message: 'Select agent(s) to install skills for:',
+              options: ALL_AGENTS,
+              initialValues: preSelected,
+              required: true,
+            });
+
+            if (p.isCancel(fullSelection)) {
+              return undefined;
+            }
+
+            selectedAgents = fullSelection as string[];
           }
+
+          return { type: 'skills' as const, agents: selectedAgents };
         }
 
-        if (editor === `antigravity`) {
-          const confirm = await p.select({
-            message: `Antigravity only supports a global MCP config (at ${antigravityGlobalMCPConfigPath}). Is it ok to add/update that global config?\nThis will make the Mastra docs MCP server available in all Antigravity projects.`,
+        // If MCP selected, show editor sub-selection
+        if (choice === 'mcp') {
+          const editor = await p.select({
+            message: `Which editor?`,
             options: [
-              { value: 'yes', label: 'Yes, I understand' },
-              { value: 'skip', label: 'No, skip for now' },
-            ],
+              {
+                value: 'cursor',
+                label: 'Cursor (project only)',
+              },
+              {
+                value: 'cursor-global',
+                label: 'Cursor (global, all projects)',
+              },
+              {
+                value: 'windsurf',
+                label: 'Windsurf',
+              },
+              {
+                value: 'vscode',
+                label: 'VSCode',
+              },
+              {
+                value: 'antigravity',
+                label: 'Antigravity',
+              },
+            ] satisfies { value: Editor; label: string }[],
           });
 
-          if (confirm !== `yes`) {
-            return undefined;
+          // Handle MCP editor selections with confirmations
+          if (editor === `cursor`) {
+            p.log.message(
+              `\nNote: you will need to go into Cursor Settings -> MCP Settings and manually enable the installed Mastra MCP server.\n`,
+            );
           }
+
+          if (editor === `cursor-global`) {
+            const confirm = await p.select({
+              message: `Global install will add/update ${cursorGlobalMCPConfigPath} and make the Mastra docs MCP server available in all your Cursor projects. Continue?`,
+              options: [
+                { value: 'yes', label: 'Yes, I understand' },
+                { value: 'no', label: 'No, cancel' },
+              ],
+            });
+            if (confirm !== `yes`) {
+              return undefined;
+            }
+          }
+
+          if (editor === `windsurf`) {
+            const confirm = await p.select({
+              message: `Windsurf only supports a global MCP config (at ${windsurfGlobalMCPConfigPath}) is it ok to add/update that global config?\nThis means the Mastra docs MCP server will be available in all your Windsurf projects.`,
+              options: [
+                { value: 'yes', label: 'Yes, I understand' },
+                { value: 'no', label: 'No, cancel' },
+              ],
+            });
+            if (confirm !== `yes`) {
+              return undefined;
+            }
+          }
+
+          if (editor === `antigravity`) {
+            const confirm = await p.select({
+              message: `Antigravity only supports a global MCP config (at ${antigravityGlobalMCPConfigPath}). Is it ok to add/update that global config?\nThis will make the Mastra docs MCP server available in all Antigravity projects.`,
+              options: [
+                { value: 'yes', label: 'Yes, I understand' },
+                { value: 'no', label: 'No, cancel' },
+              ],
+            });
+
+            if (confirm !== `yes`) {
+              return undefined;
+            }
+          }
+          return editor;
         }
-        return editor;
+
+        return undefined;
       },
       initGit: async () => {
         if (skip?.gitInit) return false;

--- a/packages/cli/src/commands/utils.ts
+++ b/packages/cli/src/commands/utils.ts
@@ -48,6 +48,14 @@ export function parseMcp(value: string) {
   return value;
 }
 
+export function parseSkills(value: string) {
+  // Skills flag accepts comma-separated agent names
+  return value
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
 export function parseComponents(value: string) {
   const parsedValue = value.split(',');
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,7 +17,7 @@ import { startDevServer } from './commands/actions/start-dev-server';
 import { startProject } from './commands/actions/start-project';
 import { COMPONENTS, LLMProvider } from './commands/init/utils';
 import { studio } from './commands/studio';
-import { parseComponents, parseLlmProvider, parseMcp } from './commands/utils';
+import { parseComponents, parseLlmProvider, parseMcp, parseSkills } from './commands/utils';
 
 const mastraPkg = pkgJson as PackageJson;
 export const version = mastraPkg.version;
@@ -71,6 +71,7 @@ program
     'MCP Server for code editor (cursor, cursor-global, windsurf, vscode, antigravity)',
     parseMcp,
   )
+  .option('--skills <agents>', 'Install Mastra agent skills for specified agents (comma-separated)', parseSkills)
   .option(
     '--template [template-name]',
     'Create project from a template (use template name, public GitHub URL, or leave blank to select from list)',

--- a/packages/cli/src/services/service.deps.ts
+++ b/packages/cli/src/services/service.deps.ts
@@ -51,7 +51,7 @@ export class DepsService {
     return execa(`${pm} ${installCommand} ${packageList}`, {
       all: true,
       shell: true,
-      stdio: 'inherit',
+      stdio: 'pipe',
     });
   }
 


### PR DESCRIPTION
## Summary

This PR refactors the CLI initialization flow to simplify agent tooling configuration and improve code maintainability.

### Changes

**Refactor: Simplify configuration parameters** (bf94fc4)
- Replace confusing union type `configureMastraToolingForCodingAgents` with two clear parameters:
  - `skills?: string[]` - Array of agent names for skills installation
  - `mcpServer?: Editor` - Editor type for MCP server installation
- Remove complex type guards (reduced from 8 lines to 1 line checks)
- Eliminate legacy `configureEditorWithDocsMCP` parameter
- Flatten interactive prompt return value for easier consumption
- Update terminology from "coding agents" to "agents"

**Bug fix: Wrap skills installation** (c94661e)
- Add try/catch around skills installation to prevent init failure
- Display warning message instead of crashing when skills installation fails

**Feature: Add skills installation** (2ee2060)
- Add interactive agent selection during project creation
- Support 40+ AI agents (Claude Code, Cursor, Windsurf, etc.)
- Install Mastra skills for selected agents

### Benefits

- **Clearer API**: Two simple parameters instead of complex union type
- **Better readability**: Eliminates type assertions and guards
- **Improved robustness**: Skills installation errors don't break project init
- **Easier maintenance**: Consistent parameter pattern across codebase

### Testing

- ✅ TypeScript type checks pass
- ✅ Build succeeds
- ✅ Pre-commit hooks (eslint, prettier) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skills installation support to create-mastra CLI with an interactive prompt displaying 10 popular agents by default and an option to view all 40 available agents.
  * Introduced a `--skills` flag for non-interactive setup, accepting comma-separated agent names.
  * Enhanced project initialization to support MCP server configuration during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->