### PR TITLE
docs: add requestContextSchema documentation

### DIFF
--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -336,6 +336,12 @@ See [Request Context](/docs/server/request-context) for more information.
 
 :::
 
+:::tip
+
+For type-safe request context schema validation, see [Schema Validation](/docs/server/request-context#schema-validation).
+
+:::
+
 ## Testing with Studio
 
 Use [Studio](/docs/getting-started/studio) to test agents with different messages, inspect tool calls and responses, and debug agent behavior.

--- a/docs/src/content/en/docs/server/request-context.mdx
+++ b/docs/src/content/en/docs/server/request-context.mdx
@@ -314,6 +314,169 @@ for (const [key, value] of ctx.entries()) {
 }
 ```
 
+## Schema validation
+
+Use `requestContextSchema` to define a Zod schema that validates request context values at runtime. This catches missing or invalid context values early, provides clear error messages, and gives you type inference within your component.
+
+### Agent schema validation
+
+When you define `requestContextSchema` on an agent, the context is validated at the start of `generate()` or `stream()`. If validation fails, the agent throws a `MastraError` before any LLM calls are made.
+
+```typescript title="src/mastra/agents/validated-agent.ts"
+import { Agent } from "@mastra/core/agent";
+import { z } from "zod";
+
+export const validatedAgent = new Agent({
+  id: "validated-agent",
+  name: "Validated Agent",
+  requestContextSchema: z.object({
+    userId: z.string(),
+    apiKey: z.string(),
+  }),
+  instructions: ({ requestContext }) => {
+    // Access all values as a typed object
+    const { userId, apiKey } = requestContext.all;
+    // { userId: string; apiKey: string }
+
+    // Or retrieve individual values with .get()
+    const id = requestContext.get("userId");
+    // string
+
+    return `You are helping user ${userId}`;
+  },
+  model: "openai/gpt-4o",
+});
+```
+
+When validation fails, the error includes the agent ID and details about which fields failed:
+
+```
+Request context validation failed for agent 'validated-agent':
+- apiKey: Required
+```
+
+### Tool schema validation
+
+When you define `requestContextSchema` on a tool, the context is validated before `execute()` runs. Unlike agents, tools return a validation error object instead of throwing:
+
+```typescript title="src/mastra/tools/validated-tool.ts"
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+export const validatedTool = createTool({
+  id: "validated-tool",
+  description: "A tool that requires authenticated context",
+  inputSchema: z.object({
+    query: z.string(),
+  }),
+  requestContextSchema: z.object({
+    userId: z.string(),
+  }),
+  execute: async (inputData, { requestContext }) => {
+    // Access all values as a typed object
+    const { userId } = requestContext.all;
+    // { userId: string }
+
+    // Or retrieve individual values with .get()
+    const id = requestContext.get("userId");
+    // string
+
+    return { result: `Processed for ${userId}` };
+  },
+});
+```
+
+When validation fails, the tool returns an error object instead of throwing:
+
+```json
+{
+  "error": true,
+  "message": "Request context validation failed for validated-tool. Please fix the following errors and try again:\n- userId: Required\n\nProvided context: {}"
+}
+```
+
+### Workflow schema validation
+
+When you define `requestContextSchema` on a workflow, the context is validated at the start of `run.start()`. If validation fails, the workflow throws an error before any steps execute.
+
+```typescript title="src/mastra/workflows/validated-workflow.ts"
+import { createWorkflow, createStep } from "@mastra/core/workflows";
+import { z } from "zod";
+
+const step1 = createStep({
+  id: "step-1",
+  inputSchema: z.object({ message: z.string() }),
+  outputSchema: z.object({ result: z.string() }),
+  execute: async ({ inputData, requestContext }) => {
+    // Access all values as a typed object
+    const { tenantId } = requestContext.all;
+    // { tenantId: string }
+
+    // Or retrieve individual values with .get()
+    const id = requestContext.get("tenantId");
+    // string
+
+    return { result: `Processed for tenant ${tenantId}` };
+  },
+});
+
+export const validatedWorkflow = createWorkflow({
+  id: "validated-workflow",
+  inputSchema: z.object({ message: z.string() }),
+  outputSchema: z.object({ result: z.string() }),
+  requestContextSchema: z.object({
+    tenantId: z.string(),
+  }),
+})
+  .then(step1)
+  .commit();
+```
+
+When validation fails, the workflow throws an error:
+
+```
+Request context validation failed for workflow 'validated-workflow':
+- tenantId: Required
+```
+
+Steps can also define their own `requestContextSchema` for step-level validation. Step validation runs before the step's `execute()` function.
+
+### Validation behavior
+
+| Component | Property | Validation timing | On failure |
+|-----------|----------|-------------------|------------|
+| Agent | `requestContextSchema` | Start of `generate()` / `stream()` | Throws `MastraError` |
+| Tool | `requestContextSchema` | Before `execute()` | Returns error object |
+| Workflow | `requestContextSchema` | Start of `run.start()` | Throws `Error` |
+| Step | `requestContextSchema` | Before step `execute()` | Step fails with error |
+
+### Best practices
+
+**Match your middleware**: Define the same required fields in your schema that your middleware sets. This ensures the contract between middleware and components is explicit and validated.
+
+```typescript
+// Middleware sets these fields
+requestContext.set("userId", user.id);
+requestContext.set("tenantId", tenant.id);
+
+// Schema validates they exist
+requestContextSchema: z.object({
+  userId: z.string(),
+  tenantId: z.string(),
+})
+```
+
+**Use optional fields for conditional context**: Use `.optional()` for values that may not always be present.
+
+```typescript
+requestContextSchema: z.object({
+  userId: z.string(),               // Always required
+  experimentVariant: z.string().optional(), // May not be set
+})
+```
+
+**Handle tool validation errors**: Since tools return error objects instead of throwing, check for errors in your agent or workflow logic when tool execution is critical.
+
 ## Related
 
 - [Agent Request Context](/docs/agents/overview#using-requestcontext)

--- a/docs/src/content/en/docs/server/request-context.mdx
+++ b/docs/src/content/en/docs/server/request-context.mdx
@@ -372,14 +372,14 @@ export const validatedTool = createTool({
   requestContextSchema: z.object({
     userId: z.string(),
   }),
-  execute: async (inputData, { requestContext }) => {
+  execute: async (inputData, context) => {
     // Access all values as a typed object
-    const { userId } = requestContext.all;
+    const { userId } = context.requestContext?.all ?? {};
     // { userId: string }
 
     // Or retrieve individual values with .get()
-    const id = requestContext.get("userId");
-    // string
+    const id = context.requestContext?.get("userId");
+    // string | undefined
 
     return { result: `Processed for ${userId}` };
   },
@@ -403,10 +403,17 @@ When you define `requestContextSchema` on a workflow, the context is validated a
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
 
+// Define schema once and share between workflow and steps
+const workflowContextSchema = z.object({
+  tenantId: z.string(),
+});
+
 const step1 = createStep({
   id: "step-1",
   inputSchema: z.object({ message: z.string() }),
   outputSchema: z.object({ result: z.string() }),
+  // Add schema to step for type inference
+  requestContextSchema: workflowContextSchema,
   execute: async ({ inputData, requestContext }) => {
     // Access all values as a typed object
     const { tenantId } = requestContext.all;
@@ -424,9 +431,7 @@ export const validatedWorkflow = createWorkflow({
   id: "validated-workflow",
   inputSchema: z.object({ message: z.string() }),
   outputSchema: z.object({ result: z.string() }),
-  requestContextSchema: z.object({
-    tenantId: z.string(),
-  }),
+  requestContextSchema: workflowContextSchema,
 })
   .then(step1)
   .commit();

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -388,6 +388,12 @@ Visit [Request Context](/docs/server/request-context) for more information.
 
 :::
 
+:::tip
+
+For type-safe request context schema validation, see [Schema Validation](/docs/server/request-context#schema-validation).
+
+:::
+
 ## Testing with Studio
 
 Use [Studio](/docs/getting-started/studio) to easily run workflows with different inputs, visualize the execution lifecycle, see the inputs and outputs for each step, and inspect each part of the workflow in more detail.

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -227,6 +227,13 @@ export const agent = new Agent({
       description:
         "Maximum number of times a processor can request retrying the LLM step.",
     },
+    {
+      name: "requestContextSchema",
+      type: "z.ZodType<any>",
+      isOptional: true,
+      description:
+        "Zod schema for validating request context values. When provided, the context is validated at the start of generate() or stream(), throwing a MastraError if validation fails.",
+    },
   ]}
 />
 

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -131,6 +131,13 @@ export const weatherTool = createTool({
       isOptional: true,
     },
     {
+      name: "requestContextSchema",
+      type: "Zod schema",
+      description:
+        "A Zod schema for validating request context values. When provided, the context is validated before execute() runs, returning an error object if validation fails.",
+      isOptional: true,
+    },
+    {
       name: "execute",
       type: "function",
       description:

--- a/docs/src/content/en/reference/workflows/step.mdx
+++ b/docs/src/content/en/reference/workflows/step.mdx
@@ -133,6 +133,13 @@ const agentStep = createStep(testAgent, {
       required: false,
     },
     {
+      name: "requestContextSchema",
+      type: "z.ZodType<any>",
+      description:
+        "Zod schema for validating request context values. When provided, the context is validated before the step's execute() runs, failing the step if validation fails.",
+      required: false,
+    },
+    {
       name: "execute",
       type: "(params: ExecuteParams) => Promise<any>",
       description: "Async function containing step logic",

--- a/docs/src/content/en/reference/workflows/workflow.mdx
+++ b/docs/src/content/en/reference/workflows/workflow.mdx
@@ -53,6 +53,13 @@ export const workflow = createWorkflow({
       isOptional: true,
     },
     {
+      name: "requestContextSchema",
+      type: "z.ZodType<any>",
+      description:
+        "Zod schema for validating request context values. When provided, the context is validated at the start of run.start(), throwing an error if validation fails.",
+      isOptional: true,
+    },
+    {
       name: "options",
       type: "WorkflowOptions",
       description: "Optional options for the workflow",


### PR DESCRIPTION
Adds documentation for the `requestContextSchema` feature, which allows Zod-based validation of request context values in agents, tools, and workflows.

**Changes:**
- New "Schema Validation" section in `/docs/server/request-context` with examples for agents, tools, and workflows
- Shows both `.all` and `.get()` methods for accessing typed context values
- Includes error message examples so users know what to expect when validation fails
- Adds `requestContextSchema` to reference docs for Agent, createTool, Workflow, and Step
- Tips in overview pages linking to the new section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Schema Validation guide for request context with patterns, error behaviors, validation timing, and best practices; linked from multiple request-context and workflow pages.
* **New Features**
  * Documented new optional requestContextSchema option for Agents, Tools, Workflows, and Steps to enable runtime request-context validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->