### PR TITLE
docs(workspace): clarify init() is optional

### DIFF
--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -83,7 +83,7 @@ export const myAgent = new Agent({
 
 ## Initialization
 
-Mastra automatically initializes workspaces when needed. Call `init()` manually when using a workspace outside of Mastra (standalone scripts, tests) or when you need to pre-provision resources before the first agent interaction.
+Calling `init()` is optional in most cases—some providers initialize on first operation. Call `init()` manually when using a workspace outside of Mastra (standalone scripts, tests) or when you need to pre-provision resources before the first agent interaction.
 
 ```typescript title="src/mastra/workspaces.ts"
 import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace';
@@ -93,6 +93,7 @@ const workspace = new Workspace({
   sandbox: new LocalSandbox({ workingDirectory: './workspace' }),
 });
 
+// Optional: pre-create directories and sandbox before first use
 await workspace.init();
 ```
 

--- a/docs/src/content/en/reference/workspace/local-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/local-filesystem.mdx
@@ -109,6 +109,10 @@ await filesystem.init();
 
 Called by `workspace.init()`.
 
+### Lazy initialization
+
+LocalFilesystem initializes on first operation if not already initialized, creating the base directory automatically. Calling `init()` explicitly is optional but can be useful to pre-create directories before the first operation.
+
 ### `destroy()`
 
 Clean up filesystem resources.

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -225,7 +225,7 @@ await workspace.init();
 
 Calling `init()` is optional in most cases:
 - **Sandbox**: Auto-starts on first `executeCommand()` call. Use `init()` to avoid first-command latency.
-- **Filesystem**: Only needed if the base directory doesn't exist yet.
+- **Filesystem**: Creates the base directory and runs any provider-specific setup. Some providers auto-create the directory on first operation.
 - **Search**: Required only if using `autoIndexPaths` for auto-indexing.
 
 Initialization performs:


### PR DESCRIPTION
## Description

Clarify that workspace `init()` is optional in most cases, and document lazy initialization behavior for providers.

## Related Issue(s)

Addresses feedback from internal discussion about workspace initialization docs being unclear.

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that initialization is optional in most cases, as some providers auto-create directories on first operation.
  * Updated examples to demonstrate optional initialization with guidance on when pre-creation may be beneficial.
  * Added details on lazy initialization behavior for workspace providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->