### PR TITLE
fix(core): allow processors to prevent tool calls and ensure final response

### DIFF
--- a/.changeset/busy-mammals-stand.md
+++ b/.changeset/busy-mammals-stand.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed processors returning `{ tools: {}, toolChoice: 'none' }` being ignored. Previously, when a processor returned empty tools with an explicit `toolChoice: 'none'` to prevent tool calls, the toolChoice was discarded and defaulted to 'auto'. This fix preserves the explicit 'none' value, enabling patterns like ensuring a final text response when `maxSteps` is reached.

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -228,6 +228,54 @@ The method can return any combination of:
 - `modelSettings`: Modify model settings
 - `structuredOutput`: Modify structured output configuration
 
+#### Ensuring a final response with maxSteps
+
+When using `maxSteps` to limit agent execution, the agent may return an empty response if it attempts a tool call on the final step. Use `processInputStep` to force a text response on the last step:
+
+```typescript title="src/mastra/processors/ensure-final-response.ts"
+import { Processor, ProcessInputStepArgs, ProcessInputStepResult } from "@mastra/core/processors";
+
+export class EnsureFinalResponseProcessor implements Processor {
+  readonly id = "ensure-final-response";
+
+  private maxSteps: number;
+
+  constructor(maxSteps: number) {
+    this.maxSteps = maxSteps;
+  }
+
+  async processInputStep({ stepNumber }: ProcessInputStepArgs): Promise<ProcessInputStepResult> {
+    // On the last step, prevent tool calls to guarantee a text response
+    if (stepNumber === this.maxSteps - 1) {
+      return { tools: {}, toolChoice: "none" };
+    }
+    return {};
+  }
+}
+```
+
+Use it with your agent:
+
+```typescript title="src/mastra/agents/bounded-agent.ts"
+import { Agent } from "@mastra/core/agent";
+import { EnsureFinalResponseProcessor } from "../processors/ensure-final-response";
+
+const MAX_STEPS = 5;
+
+const agent = new Agent({
+  id: "bounded-agent",
+  name: "Bounded Agent",
+  model: "openai/gpt-4o-mini",
+  tools: { /* your tools */ },
+  inputProcessors: [new EnsureFinalResponseProcessor(MAX_STEPS)],
+});
+
+// Pass maxSteps when calling generate/stream
+const result = await agent.generate("Your prompt", { maxSteps: MAX_STEPS });
+```
+
+This ensures that on the final allowed step (step 4 when `maxSteps` is 5, since steps are 0-indexed), the LLM generates text instead of attempting another tool call.
+
 #### Using prepareStep callback
 
 For simpler per-step logic, you can use the `prepareStep` callback on `generate()` or `stream()` instead of creating a full processor:

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -244,10 +244,21 @@ export class EnsureFinalResponseProcessor implements Processor {
     this.maxSteps = maxSteps;
   }
 
-  async processInputStep({ stepNumber }: ProcessInputStepArgs): Promise<ProcessInputStepResult> {
-    // On the last step, prevent tool calls to guarantee a text response
+  async processInputStep({ stepNumber, systemMessages }: ProcessInputStepArgs): Promise<ProcessInputStepResult> {
+    // On the last step, prevent tool calls and instruct the LLM to summarize
     if (stepNumber === this.maxSteps - 1) {
-      return { tools: {}, toolChoice: "none" };
+      return {
+        tools: {},
+        toolChoice: "none",
+        systemMessages: [
+          ...systemMessages,
+          {
+            role: "system",
+            content:
+              "You have reached the maximum number of steps. Summarize your progress so far and provide a best-effort response. If the task is incomplete, clearly indicate what remains to be done.",
+          },
+        ],
+      };
     }
     return {};
   }
@@ -274,7 +285,7 @@ const agent = new Agent({
 const result = await agent.generate("Your prompt", { maxSteps: MAX_STEPS });
 ```
 
-This ensures that on the final allowed step (step 4 when `maxSteps` is 5, since steps are 0-indexed), the LLM generates text instead of attempting another tool call.
+This ensures that on the final allowed step (step 4 when `maxSteps` is 5, since steps are 0-indexed), the LLM generates a summary instead of attempting another tool call, and clearly indicates if the task is incomplete.
 
 #### Using prepareStep callback
 

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
@@ -320,6 +320,28 @@ describe('prepareToolsAndToolChoice', () => {
       expect(result.tools).toBeUndefined();
       expect(result.toolChoice).toBeUndefined();
     });
+
+    it('should preserve toolChoice "none" when tools are empty', () => {
+      const result = prepareToolsAndToolChoice({
+        tools: {},
+        toolChoice: 'none',
+        activeTools: undefined,
+      });
+
+      expect(result.tools).toBeUndefined();
+      expect(result.toolChoice).toEqual({ type: 'none' });
+    });
+
+    it('should preserve toolChoice "none" when tools are undefined', () => {
+      const result = prepareToolsAndToolChoice({
+        tools: undefined,
+        toolChoice: 'none',
+        activeTools: undefined,
+      });
+
+      expect(result.tools).toBeUndefined();
+      expect(result.toolChoice).toEqual({ type: 'none' });
+    });
   });
 
   describe('default targetVersion', () => {

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
@@ -63,9 +63,10 @@ export function prepareToolsAndToolChoice<TOOLS extends Record<string, Tool>>({
   toolChoice: PreparedToolChoice | undefined;
 } {
   if (Object.keys(tools || {}).length === 0) {
+    // Preserve explicit 'none' toolChoice to tell the LLM not to attempt tool calls
     return {
       tools: undefined,
-      toolChoice: undefined,
+      toolChoice: toolChoice === 'none' ? { type: 'none' as const } : undefined,
     };
   }
 


### PR DESCRIPTION
When a processor returns `{ tools: {}, toolChoice: 'none' }` to prevent tool calls, the `toolChoice` was being discarded and defaulting to `'auto'`. This caused empty responses when using processors to force text output on the final step.

Fixes #12596

**Example use case** - ensuring a response when `maxSteps` is reached:

```typescript
class EnsureFinalResponseProcessor implements Processor {
  readonly id = "ensure-final-response";

  constructor(private maxSteps: number) {}

  async processInputStep({ stepNumber, systemMessages }: ProcessInputStepArgs): Promise<ProcessInputStepResult> {
    if (stepNumber === this.maxSteps - 1) {
      return {
        tools: {},
        toolChoice: "none",
        systemMessages: [
          ...systemMessages,
          {
            role: "system",
            content: "You have reached the maximum number of steps. Summarize your progress so far and provide a best-effort response. If the task is incomplete, clearly indicate what remains to be done.",
          },
        ],
      };
    }
    return {};
  }
}
```

Also added documentation for this pattern in the processors guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve an explicit toolChoice of "none" when no tools are available so the explicit choice is no longer ignored.

* **Documentation**
  * Added guidance and examples for ensuring a final text response when agents hit maxSteps, including a processor pattern and per-step handling to force a final summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->