### PR TITLE
docs: add Observational Memory documentation

### DIFF
--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -8,24 +8,7 @@ packages:
 
 # Observational Memory
 
-You don't remember every word of every conversation you've ever had. You observe what happened subconsciously, without choosing to. Over time, your brain reflects on those observations — reorganizing, combining, and condensing them into long-term memory.
-
-Observational Memory (OM) works the same way. Two background agents — an **Observer** and a **Reflector** — watch your agent's conversations and maintain a dense observation-based long-term memory.
-
-This solves two problems that agents face in long conversations:
-
-- **Context rot**: the more raw message history an agent carries, the worse it performs. Responses get less focused, instructions get ignored, and important details get lost in the noise.
-- **Context waste**: most of that history contains tokens which are no longer needed to keep the agent on task. Ten 50k-token tool call results can usually be represented as 500 tokens of observations instead of 500,000 tokens of raw output.
-
-On the [LongMemEval](https://github.com/xiaowu0162/LongMemEval) benchmark, gpt-4o answers questions correctly only 60.2% of the time when given all previous sessions directly. With OM, gpt-4o answers correctly 84% of the time across 57 million input tokens (with deafult settings) — and 95% when using gpt-5-mini. OM allows small context windows to behave like very large ones.
-
-### Example: browser automation
-
-Consider an agent using Playwright MCP to automate a browser. Each page snapshot might be 50,000 tokens. After a few pages, the context window is full of stale snapshots that actively hurt the agent's ability to follow instructions.
-
-With OM, when the snapshot comes in, the Observer watches the interaction and makes observations about what the page contained and what the agent did with it. The agent then continues with a concise understanding of what happened — not the raw 50k snapshot, but a few hundred tokens of observations about what was on the page and what actions were taken. The agent stays on task with full context of what it's seen, without carrying the weight of every raw snapshot.
-
-This applies to any token-heavy workflow: document analysis, coding sessions, research tasks, multi-step tool use.
+Observational Memory (OM) is Mastra's memory system for long-context agentic memory. Two background agents — an **Observer** and a **Reflector** — watch your agent's conversations and maintain a dense observation log that replaces raw message history as it grows.
 
 ## Quick Start
 
@@ -51,38 +34,47 @@ That's it. The agent now has humanlike long-term memory that persists across con
 
 ## How It Works
 
-Every time an agent responds, it sees a context window containing its system prompt, recent message history, and any injected context (tool results, semantic recall, working memory, etc). The context window is finite — even models with large token limits perform worse when the window is full.
+You don't remember every word of every conversation you've ever had. You observe what happened subconsciously, then your brain reflects — reorganizing, combining, and condensing into long-term memory. OM works the same way.
 
-### Message history as working memory
+Every time an agent responds, it sees a context window containing its system prompt, recent message history, and any injected context (tool results, semantic recall, working memory, etc). The context window is finite — even models with large token limits perform worse when the window is full. This causes two problems in long conversations:
 
-Raw message history is like human working memory — it's the space dedicated to the current task. It contains the exact back-and-forth of the conversation: what the user said, what the agent responded, tool calls and results.
+- **Context rot**: the more raw message history an agent carries, the worse it performs. Responses get less focused, instructions get ignored, and important details get lost in the noise.
+- **Context waste**: most of that history contains tokens which are no longer needed to keep the agent on task. Ten 50k-token tool call results can usually be represented as 500 tokens of observations instead of 500,000 tokens of raw output.
 
-> **Note:** This is different from Mastra's [Working Memory](/docs/memory/working-memory) feature, which is a structured scratchpad. OM is a successor to that approach for long-term memory.
+### Message history
 
-This is high-fidelity but expensive. A 50-message conversation might use 30,000+ tokens of context, most of which contain tokens no longer needed to keep the agent on task.
+Raw message history is the space dedicated to the current task. It contains the exact back-and-forth of the conversation: what the user said, what the agent responded, tool calls and results.
+
+This is high-fidelity but expensive. A 50-message conversation could use 100,000+ tokens of context, most of which contain tokens no longer needed to keep the agent on task.
 
 ### Observations as long-term memory
 
-When unobserved message tokens exceed a threshold (default: 30,000 tokens), the Observer is called. It watches the conversation and makes observations — a list of concise, dense notes about what actually happened:
+When message history tokens exceed a threshold (default: 30,000 tokens), the Observer is called. It watches the conversation and makes observations — a list of concise, dense notes about what actually happened:
 
 ```
-📅 2025-01-15
-🔴 User is building a Next.js app with Supabase auth
-🔴 App uses server components with client-side hydration
- User asked about middleware configuration for protected routes
-🔴 Agent provided middleware setup using createServerClient pattern
- User's app name is "Acme Dashboard"
+Date: 2026-01-15
+- 🔴 12:10 User is building a Next.js app with Supabase auth, due in 1 week (meaning January 22nd 2026 - 1 week from now)
+  - 🔴 12:10 App uses server components with client-side hydration
+  - 🟡 12:12 User asked about middleware configuration for protected routes
+  - 🟡 12:13 Agent provided middleware setup using createServerClient pattern
+  - 🔴 12:15 User stated the app name is "Acme Dashboard"
 ```
 
-New observations are appended to any previous observations, replacing the messages they observed. The compression is typically between 5x and 40x — instead of 30,000 tokens of back-and-forth, the agent sees a compact list of observations about what happened. 
+New observations are appended to any previous observations, replacing the messages they observed. The compression is typically between 5x and 40x — instead of 30,000 tokens of back-and-forth, the agent sees a compact list of observations about what happened. The more tool calls there are, the higher the compression ratio typically is.
 
-The system also injects temporal markers automatically. When the Observer references relative time (e.g., "the user plans to do X in a week"), the system converts it to an absolute date and adds context like "(meaning June 4th 2027 — 4 months from today)" or "(3 weeks ago)".
+#### Observation formatting
 
-The Observer also tracks a **current task** (what the agent is working on right now) and a **suggested response** (how the agent should respond next to maintain conversation continuity). These are injected into the agent's context alongside the observations, so the agent picks up where it left off even when large portions of the message history are replaced.
+Observations are output as raw appendable text. They're structured as a bullet point list, with indentation to represent grouped observations, emojis to represent information priority, and timestamps to indicate when the observations occurred.
+
+The system injects temporal markers automatically. When the Observer references relative time (e.g., "the user plans to do X in a week"), the system converts it to an absolute date and adds context like "(meaning June 4th 2027 — 4 months from today)" or "(meaning Jan 2025 - 1 year ago)".
+
+#### Task and response extraction
+
+The Observer tracks a **current task** (what the agent is working on right now) and a **suggested response** (how the agent should respond next to maintain conversation continuity, since message history is being replaced). These are injected into the agent's context alongside the observations, so the agent picks up where it left off even when large portions of the message history are replaced.
 
 ### Reflections
 
-As observations accumulate over time, they eventually hit their own threshold (default: 40,000 tokens). The Reflector then restructures them — combining related items, reflecting on overarching patterns, and condensing where possible. Reflections always completely replace all previous observations.
+As observations accumulate over time, they eventually hit their own threshold (default: 40,000 tokens). The Reflector then restructures them — combining related items, reflecting on overarching patterns, and condensing where possible. Reflections always completely replace all previous observations and are intended to condense the size of observations to save context window space.
 
 If the Reflector's output isn't smaller than the input, it's automatically run a second time with a tweaked prompt that instructs it to condense more aggressively.
 
@@ -90,9 +82,17 @@ The result is a three-tier system:
 
 1. **Recent messages** — exact conversation history for the current task
 2. **Observations** — a log of what the Observer has seen
-3. **Reflections** — condensed, reorganized observations after the Reflector runs
+3. **Reflections** — condensed, reorganized observations when memory becomes too long
 
-Each tier is progressively refined to drop context rot and waste. The agent always has access to all three, but the total context stays small and focused.
+Each tier is progressively refined to drop context rot/waste and gracefully degrade old irrelevant memories.
+
+### Example: browser automation
+
+Consider an agent using Playwright MCP to automate a browser. Each page snapshot might be 50,000+ tokens. After a few pages, the context window is full of stale snapshots that actively hurt the agent's ability to follow instructions.
+
+With OM, when the snapshot comes in, the Observer watches the interaction and makes observations about what the page contained and what the agent did with it. The agent then continues with a concise understanding of what happened — not the raw 50k snapshot, but a few hundred tokens of observations about what was on the page and what actions were taken. The agent stays on task with full context of what it's seen, without carrying the weight of every raw snapshot.
+
+This applies to any token-heavy workflow: document analysis, coding sessions, research tasks, multi-step tool use, even long text conversations.
 
 ## Scopes
 
@@ -103,9 +103,13 @@ Observational Memory supports two scopes:
 Observations are kept per-conversation. Each thread has its own observations. This is the simplest mode — each conversation is independent.
 
 ```typescript
-observationalMemory: {
-  scope: "thread",
-}
+const memory = new Memory({
+  options: {
+    observationalMemory: {
+      scope: "thread",
+    },
+  },
+});
 ```
 
 ### Resource scope (use carefully)
@@ -113,18 +117,24 @@ observationalMemory: {
 Observations are shared across all threads for a resource (typically a user). This enables cross-conversation memory — the agent remembers what happened in previous conversations with the same user.
 
 ```typescript
-observationalMemory: {
-  scope: "resource",
-}
+const memory = new Memory({
+  options: {
+    observationalMemory: {
+      scope: "resource",
+    },
+  },
+});
 ```
 
-**Understand what this does before enabling it.** In resource scope, the context window for each thread is a perspective on *all* threads simultaneously. Any unobserved messages across all threads are in context. When the total unobserved tokens across threads meets the threshold, observations are created (separated per thread).
+**Understand what this does before enabling it.** In resource scope, the context window for each thread is a perspective on *all* threads simultaneously. Any unobserved messages across all threads are in context. When the total unobserved tokens across threads meets the threshold, observations are created (separated by thread in context).
 
 This means if a user has 100 threads of unobserved messages, the first message sent will cause the Observer to block the response and iteratively chunk through every unobserved message across all threads until the context is small enough to fit. For users with many existing threads, this initial observation pass could take significant time.
 
+For existing apps, it will be easier to use thread scope.
+
 ## Token Budgets
 
-Observational Memory uses token thresholds to decide when to observe and when to reflect. The default values are based on the settings used to achieve our SOTA results using OM in [LongMemEval](https://github.com/xiaowu0162/LongMemEval).
+Observational Memory uses token thresholds to decide when to observe and when to reflect.
 
 ### Message tokens
 
@@ -132,30 +142,71 @@ Observational Memory uses token thresholds to decide when to observe and when to
 
 Lower values mean the Observer runs more frequently, but it also tends to capture more fine details since it's observing smaller batches of messages. This often leads to quicker reflection too, since more observations accumulate faster. Higher values let more raw history accumulate before observing.
 
+```typescript
+const memory = new Memory({
+  options: {
+    observationalMemory: {
+      observation: {
+        messageTokens: 15_000,
+      },
+    },
+  },
+});
+```
+
 ### Batch size
 
 `observation.maxTokensPerBatch` (default: 10,000) controls how many tokens the Observer processes at once when there are multiple threads in resource scope.
 
 This is independent of `messageTokens`. For example, you might want to observe at 20,000 message tokens but still use 5,000 token batches — the Observer will notice more details in each smaller batch rather than processing everything at once.
 
+```typescript
+const memory = new Memory({
+  options: {
+    observationalMemory: {
+      observation: {
+        messageTokens: 20_000,
+        maxTokensPerBatch: 5_000,
+      },
+    },
+  },
+});
+```
+
 ### Observation tokens
 
 `reflection.observationTokens` (default: 40,000) controls when the Reflector runs. When observation tokens exceed this value, the Reflector condenses them.
+
+```typescript
+const memory = new Memory({
+  options: {
+    observationalMemory: {
+      reflection: {
+        observationTokens: 20_000,
+      },
+    },
+  },
+});
+```
 
 ### Shared token budget
 
 By default, message tokens and observation tokens have independent thresholds. With `shareTokenBudget: true`, message history can borrow from the observation token budget:
 
 ```typescript
-observationalMemory: {
-  shareTokenBudget: true,
-  observation: {
-    messageTokens: 20_000,
+const memory = new Memory({
+  options: {
+    observationalMemory: {
+      shareTokenBudget: true,
+      observation: {
+        messageTokens: 20_000,
+      },
+      reflection: {
+        observationTokens: 44_000,
+      },
+    },
   },
-  reflection: {
-    observationTokens: 44_000,
-  },
-}
+});
 ```
 
 The total budget here is 64,000 tokens (20k + 44k). While observations are still small, message history can expand beyond its 20k threshold into the unused observation space. This lets you choose a rough max context window size and stay within it — if you want to stay under 64k tokens total, this configuration does that while still allowing longer message history when observations haven't accumulated yet.
@@ -171,26 +222,35 @@ The default is `google/gemini-2.5-flash`. This is what we've tested with the mos
 ### Alternative models
 
 We've also been testing the system with `deepseek`, `qwen3`, and `glm-4.7` for the Observer and they work well. For the Reflector, make sure the model's context window has enough headroom to fit all observations — Gemini Flash's 1M context window is a safe choice. If your `reflection.observationTokens` threshold is lower (e.g., 20k-40k), context window size matters less and smaller models work fine.
+Note that Claude 4.5 models currently do not work well as observer or reflector - something about their training seems to prevent them from fully observing all message history correctly.
 
 Set a single model for both agents:
 
 ```typescript
-observationalMemory: {
-  model: "deepseek/deepseek-reasoner",
-}
+const memory = new Memory({
+  options: {
+    observationalMemory: {
+      model: "deepseek/deepseek-reasoner",
+    },
+  },
+});
 ```
 
 Or use different models for each:
 
 ```typescript
-observationalMemory: {
-  observation: {
-    model: "deepseek/deepseek-chat",
+const memory = new Memory({
+  options: {
+    observationalMemory: {
+      observation: {
+        model: "deepseek/deepseek-chat",
+      },
+      reflection: {
+        model: "deepseek/deepseek-reasoner",
+      },
+    },
   },
-  reflection: {
-    model: "deepseek/deepseek-reasoner",
-  },
-}
+});
 ```
 
 ## Viewing in Mastra Studio

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -12,6 +12,8 @@ Observational Memory (OM) is Mastra's memory system for long-context agentic mem
 
 ## Quick Start
 
+Enable `observationalMemory` on the memory options:
+
 ```typescript title="src/mastra/agents/agent.ts"
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
@@ -22,6 +24,7 @@ export const agent = new Agent({
   model: "openai/gpt-5-mini",
   memory: new Memory({
     options: {
+      // highlight-next-line
       observationalMemory: true,
     },
   }),
@@ -30,7 +33,7 @@ export const agent = new Agent({
 
 That's it. The agent now has humanlike long-term memory that persists across conversations.
 
-> **Note:** Observational Memory currently only supports `@mastra/pg`, `@mastra/libsql`, and `@mastra/mongodb` storage adapters.
+> **Note:** OM currently only supports `@mastra/pg`, `@mastra/libsql`, and `@mastra/mongodb` storage adapters.
 
 ## How It Works
 
@@ -86,7 +89,7 @@ The result is a three-tier system:
 
 Each tier is progressively refined to drop context rot/waste and gracefully degrade old irrelevant memories.
 
-### Example: browser automation
+### Example: Browser automation
 
 Consider an agent using Playwright MCP to automate a browser. Each page snapshot might be 50,000+ tokens. After a few pages, the context window is full of stale snapshots that actively hurt the agent's ability to follow instructions.
 
@@ -126,7 +129,11 @@ const memory = new Memory({
 });
 ```
 
+:::warning
+
 **Understand what this does before enabling it.** In resource scope, the context window for each thread is a perspective on *all* threads simultaneously. Any unobserved messages across all threads are in context. When the total unobserved tokens across threads meets the threshold, observations are created (separated by thread in context).
+
+:::
 
 This means if a user has 100 threads of unobserved messages, the first message sent will cause the Observer to block the response and iteratively chunk through every unobserved message across all threads until the context is small enough to fit. For users with many existing threads, this initial observation pass could take significant time.
 

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -213,7 +213,7 @@ The total budget here is 64,000 tokens (20k + 44k). While observations are still
 
 ## Models
 
-The Observer and Reflector are agents that run in the background. Any model supported by the [Model Router](/reference/models/model-router) works.
+The Observer and Reflector are agents that run in the background. Any model that works with Mastra's model routing (e.g. `openai/...`, `google/...`, `deepseek/...`) can be used.
 
 ### Default model
 

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -33,7 +33,11 @@ export const agent = new Agent({
 
 That's it. The agent now has humanlike long-term memory that persists across conversations.
 
-> **Note:** OM currently only supports `@mastra/pg`, `@mastra/libsql`, and `@mastra/mongodb` storage adapters.
+:::note
+
+OM currently only supports `@mastra/pg`, `@mastra/libsql`, and `@mastra/mongodb` storage adapters.
+
+:::
 
 ## How It Works
 

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -54,6 +54,8 @@ Every time an agent responds, it sees a context window containing its system pro
 - **Context rot**: the more raw message history an agent carries, the worse it performs.
 - **Context waste**: most of that history contains tokens no longer needed to keep the agent on task.
 
+OM solves both problems by compressing old context into dense observations.
+
 ### Observations
 
 When message history tokens exceed a threshold (default: 30,000), the Observer creates observations — concise notes about what happened:

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -39,6 +39,20 @@ OM currently only supports `@mastra/pg`, `@mastra/libsql`, and `@mastra/mongodb`
 
 :::
 
+## Benefits of Observational Memory
+
+- **Prompt caching**: OM's context is stable — observations append over time rather than being dynamically retrieved each turn. This keeps the prompt prefix cacheable, which reduces costs.
+- **Compression**: Raw message history and tool results get compressed into a dense observation log. Smaller context means faster responses and longer coherent conversations.
+- **Zero context rot**: The agent sees relevant information instead of noisy tool calls and irrelevant tokens, so the agent stays on task over long sessions.
+
+### OM vs Working Memory and Message History
+
+- **[Message history](/docs/memory/message-history)** — high-fidelity record of the current conversation
+- **[Working memory](/docs/memory/working-memory)** — small, structured state (JSON or markdown) for user preferences, names, goals
+- **Observational Memory** — long-context agentic memory that compresses extended sessions
+
+If you're using working memory to store conversation summaries or ongoing state that grows over time, OM is a better fit. Working memory is for small, structured data; OM is for unbounded event logs.
+
 ## How It Works
 
 You don't remember every word of every conversation you've ever had. You observe what happened subconsciously, then your brain reflects — reorganizing, combining, and condensing into long-term memory. OM works the same way.
@@ -221,6 +235,17 @@ const memory = new Memory({
 ```
 
 The total budget here is 64,000 tokens (20k + 44k). While observations are still small, message history can expand beyond its 20k threshold into the unused observation space. This lets you choose a rough max context window size and stay within it — if you want to stay under 64k tokens total, this configuration does that while still allowing longer message history when observations haven't accumulated yet.
+
+## Migrating existing threads
+
+If you enable OM on an app that already has threads with message history, there's no manual migration step. OM reads existing messages from storage and observes them lazily when thresholds are exceeded.
+
+### First-run behavior
+
+- **Thread scope**: The first time a thread exceeds `observation.messageTokens`, the Observer processes the backlog.
+- **Resource scope**: All unobserved messages across all threads for a resource are processed together. For users with many existing threads, this initial pass can take significant time. Consider using thread scope for existing apps, or accept a one-time latency hit per resource.
+
+After the initial observation pass, subsequent messages are processed incrementally as usual.
 
 ## Models
 

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -168,9 +168,12 @@ Mastra Studio shows OM status in real time in the memory tab: token usage, which
 
 - **[Message history](/docs/memory/message-history)** — high-fidelity record of the current conversation
 - **[Working memory](/docs/memory/working-memory)** — small, structured state (JSON or markdown) for user preferences, names, goals
+- **[Semantic Recall](/docs/memory/semantic-recall)** — RAG-based retrieval of relevant past messages
 - **Observational Memory** — long-context agentic memory that compresses extended sessions
 
-If you're using working memory to store conversation summaries or ongoing state that grows over time, OM is a better fit. Working memory is for small, structured data; OM is for unbounded event logs.
+If you're using working memory to store conversation summaries or ongoing state that grows over time, OM is a better fit. Working memory is for small, structured data; OM is for long-running event logs. OM also manages message history automatically—the `messageTokens` setting controls how much raw history remains before observation runs.
+
+In practical terms, OM replaces both working memory and message history, and has greater accuracy (and lower cost) than Semantic Recall.
 
 ## Related
 

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -1,0 +1,212 @@
+---
+title: "Observational Memory | Memory"
+description: "Learn how Observational Memory keeps your agent's context window small while preserving long-term memory across conversations."
+packages:
+  - "@mastra/core"
+  - "@mastra/memory"
+---
+
+# Observational Memory
+
+You don't remember every word of every conversation you've ever had. You observe what happened subconsciously, without choosing to. Over time, your brain reflects on those observations — reorganizing, combining, and condensing them into long-term memory.
+
+Observational Memory (OM) works the same way. Two background agents — an **Observer** and a **Reflector** — watch your agent's conversations and maintain a dense observation-based long-term memory.
+
+This solves two problems that agents face in long conversations:
+
+- **Context rot**: the more raw message history an agent carries, the worse it performs. Responses get less focused, instructions get ignored, and important details get lost in the noise.
+- **Context waste**: most of that history contains tokens which are no longer needed to keep the agent on task. Ten 50k-token tool call results can usually be represented as 500 tokens of observations instead of 500,000 tokens of raw output.
+
+On the [LongMemEval](https://github.com/xiaowu0162/LongMemEval) benchmark, gpt-4o answers questions correctly only 60.2% of the time when given all previous sessions directly. With OM, gpt-4o answers correctly 84% of the time across 57 million input tokens (with deafult settings) — and 95% when using gpt-5-mini. OM allows small context windows to behave like very large ones.
+
+### Example: browser automation
+
+Consider an agent using Playwright MCP to automate a browser. Each page snapshot might be 50,000 tokens. After a few pages, the context window is full of stale snapshots that actively hurt the agent's ability to follow instructions.
+
+With OM, when the snapshot comes in, the Observer watches the interaction and makes observations about what the page contained and what the agent did with it. The agent then continues with a concise understanding of what happened — not the raw 50k snapshot, but a few hundred tokens of observations about what was on the page and what actions were taken. The agent stays on task with full context of what it's seen, without carrying the weight of every raw snapshot.
+
+This applies to any token-heavy workflow: document analysis, coding sessions, research tasks, multi-step tool use.
+
+## Quick Start
+
+```typescript title="src/mastra/agents/agent.ts"
+import { Memory } from "@mastra/memory";
+import { Agent } from "@mastra/core/agent";
+
+export const agent = new Agent({
+  name: "my-agent",
+  instructions: "You are a helpful assistant.",
+  model: "openai/gpt-5-mini",
+  memory: new Memory({
+    options: {
+      observationalMemory: true,
+    },
+  }),
+});
+```
+
+That's it. The agent now has humanlike long-term memory that persists across conversations.
+
+> **Note:** Observational Memory currently only supports `@mastra/pg`, `@mastra/libsql`, and `@mastra/mongodb` storage adapters.
+
+## How It Works
+
+Every time an agent responds, it sees a context window containing its system prompt, recent message history, and any injected context (tool results, semantic recall, working memory, etc). The context window is finite — even models with large token limits perform worse when the window is full.
+
+### Message history as working memory
+
+Raw message history is like human working memory — it's the space dedicated to the current task. It contains the exact back-and-forth of the conversation: what the user said, what the agent responded, tool calls and results.
+
+> **Note:** This is different from Mastra's [Working Memory](/docs/memory/working-memory) feature, which is a structured scratchpad. OM is a successor to that approach for long-term memory.
+
+This is high-fidelity but expensive. A 50-message conversation might use 30,000+ tokens of context, most of which contain tokens no longer needed to keep the agent on task.
+
+### Observations as long-term memory
+
+When unobserved message tokens exceed a threshold (default: 30,000 tokens), the Observer is called. It watches the conversation and makes observations — a list of concise, dense notes about what actually happened:
+
+```
+📅 2025-01-15
+🔴 User is building a Next.js app with Supabase auth
+🔴 App uses server components with client-side hydration
+ User asked about middleware configuration for protected routes
+🔴 Agent provided middleware setup using createServerClient pattern
+ User's app name is "Acme Dashboard"
+```
+
+New observations are appended to any previous observations, replacing the messages they observed. The compression is typically between 5x and 40x — instead of 30,000 tokens of back-and-forth, the agent sees a compact list of observations about what happened. 
+
+The system also injects temporal markers automatically. When the Observer references relative time (e.g., "the user plans to do X in a week"), the system converts it to an absolute date and adds context like "(meaning June 4th 2027 — 4 months from today)" or "(3 weeks ago)".
+
+The Observer also tracks a **current task** (what the agent is working on right now) and a **suggested response** (how the agent should respond next to maintain conversation continuity). These are injected into the agent's context alongside the observations, so the agent picks up where it left off even when large portions of the message history are replaced.
+
+### Reflections
+
+As observations accumulate over time, they eventually hit their own threshold (default: 40,000 tokens). The Reflector then restructures them — combining related items, reflecting on overarching patterns, and condensing where possible. Reflections always completely replace all previous observations.
+
+If the Reflector's output isn't smaller than the input, it's automatically run a second time with a tweaked prompt that instructs it to condense more aggressively.
+
+The result is a three-tier system:
+
+1. **Recent messages** — exact conversation history for the current task
+2. **Observations** — a log of what the Observer has seen
+3. **Reflections** — condensed, reorganized observations after the Reflector runs
+
+Each tier is progressively refined to drop context rot and waste. The agent always has access to all three, but the total context stays small and focused.
+
+## Scopes
+
+Observational Memory supports two scopes:
+
+### Thread scope (default)
+
+Observations are kept per-conversation. Each thread has its own observations. This is the simplest mode — each conversation is independent.
+
+```typescript
+observationalMemory: {
+  scope: "thread",
+}
+```
+
+### Resource scope (use carefully)
+
+Observations are shared across all threads for a resource (typically a user). This enables cross-conversation memory — the agent remembers what happened in previous conversations with the same user.
+
+```typescript
+observationalMemory: {
+  scope: "resource",
+}
+```
+
+**Understand what this does before enabling it.** In resource scope, the context window for each thread is a perspective on *all* threads simultaneously. Any unobserved messages across all threads are in context. When the total unobserved tokens across threads meets the threshold, observations are created (separated per thread).
+
+This means if a user has 100 threads of unobserved messages, the first message sent will cause the Observer to block the response and iteratively chunk through every unobserved message across all threads until the context is small enough to fit. For users with many existing threads, this initial observation pass could take significant time.
+
+## Token Budgets
+
+Observational Memory uses token thresholds to decide when to observe and when to reflect. The default values are based on the settings used to achieve our SOTA results using OM in [LongMemEval](https://github.com/xiaowu0162/LongMemEval).
+
+### Message tokens
+
+`observation.messageTokens` (default: 30,000) controls when the Observer runs. When unobserved message tokens exceed this value, the Observer is called.
+
+Lower values mean the Observer runs more frequently, but it also tends to capture more fine details since it's observing smaller batches of messages. This often leads to quicker reflection too, since more observations accumulate faster. Higher values let more raw history accumulate before observing.
+
+### Batch size
+
+`observation.maxTokensPerBatch` (default: 10,000) controls how many tokens the Observer processes at once when there are multiple threads in resource scope.
+
+This is independent of `messageTokens`. For example, you might want to observe at 20,000 message tokens but still use 5,000 token batches — the Observer will notice more details in each smaller batch rather than processing everything at once.
+
+### Observation tokens
+
+`reflection.observationTokens` (default: 40,000) controls when the Reflector runs. When observation tokens exceed this value, the Reflector condenses them.
+
+### Shared token budget
+
+By default, message tokens and observation tokens have independent thresholds. With `shareTokenBudget: true`, message history can borrow from the observation token budget:
+
+```typescript
+observationalMemory: {
+  shareTokenBudget: true,
+  observation: {
+    messageTokens: 20_000,
+  },
+  reflection: {
+    observationTokens: 44_000,
+  },
+}
+```
+
+The total budget here is 64,000 tokens (20k + 44k). While observations are still small, message history can expand beyond its 20k threshold into the unused observation space. This lets you choose a rough max context window size and stay within it — if you want to stay under 64k tokens total, this configuration does that while still allowing longer message history when observations haven't accumulated yet.
+
+## Models
+
+The Observer and Reflector are agents that run in the background. Any model supported by the [Model Router](/reference/models/model-router) works.
+
+### Default model
+
+The default is `google/gemini-2.5-flash`. This is what we've tested with the most internally and it works well for both observation and reflection. Gemini Flash's 1M token context window gives the Reflector headroom when reflecting on large amounts of observations.
+
+### Alternative models
+
+We've also been testing the system with `deepseek`, `qwen3`, and `glm-4.7` for the Observer and they work well. For the Reflector, make sure the model's context window has enough headroom to fit all observations — Gemini Flash's 1M context window is a safe choice. If your `reflection.observationTokens` threshold is lower (e.g., 20k-40k), context window size matters less and smaller models work fine.
+
+Set a single model for both agents:
+
+```typescript
+observationalMemory: {
+  model: "deepseek/deepseek-reasoner",
+}
+```
+
+Or use different models for each:
+
+```typescript
+observationalMemory: {
+  observation: {
+    model: "deepseek/deepseek-chat",
+  },
+  reflection: {
+    model: "deepseek/deepseek-reasoner",
+  },
+}
+```
+
+## Viewing in Mastra Studio
+
+Mastra Studio shows Observational Memory status in real time. When an observation or reflection is in progress, you'll see:
+
+- Token usage progress bars for messages and observations
+- Which model is running (Observer or Reflector)
+- The current observations and history of past reflections
+
+This is useful for understanding how OM is behaving and tuning thresholds for your use case.
+
+## Related
+
+- [Observational Memory Reference](/reference/memory/observational-memory) — configuration options and API
+- [Memory Overview](/docs/memory/overview)
+- [Message History](/docs/memory/message-history)
+- [Memory Processors](/docs/memory/memory-processors)
+- [Processors](/docs/agents/processors)

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -12,8 +12,6 @@ Observational Memory (OM) is Mastra's memory system for long-context agentic mem
 
 ## Quick Start
 
-Enable `observationalMemory` on the memory options:
-
 ```typescript title="src/mastra/agents/agent.ts"
 import { Memory } from "@mastra/memory";
 import { Agent } from "@mastra/core/agent";
@@ -24,7 +22,6 @@ export const agent = new Agent({
   model: "openai/gpt-5-mini",
   memory: new Memory({
     options: {
-      // highlight-next-line
       observationalMemory: true,
     },
   }),
@@ -33,234 +30,63 @@ export const agent = new Agent({
 
 That's it. The agent now has humanlike long-term memory that persists across conversations.
 
+See [configuration options](/reference/memory/observational-memory) for full API details.
+
 :::note
 
 OM currently only supports `@mastra/pg`, `@mastra/libsql`, and `@mastra/mongodb` storage adapters.
+It also uses background agents for managing memory. The default model (configurable) is `google/gemini-2.5-flash` as it's the one we've tested the most.
 
 :::
 
-## Benefits of Observational Memory
+## Benefits
 
 - **Prompt caching**: OM's context is stable — observations append over time rather than being dynamically retrieved each turn. This keeps the prompt prefix cacheable, which reduces costs.
 - **Compression**: Raw message history and tool results get compressed into a dense observation log. Smaller context means faster responses and longer coherent conversations.
 - **Zero context rot**: The agent sees relevant information instead of noisy tool calls and irrelevant tokens, so the agent stays on task over long sessions.
 
-### OM vs Working Memory and Message History
-
-- **[Message history](/docs/memory/message-history)** — high-fidelity record of the current conversation
-- **[Working memory](/docs/memory/working-memory)** — small, structured state (JSON or markdown) for user preferences, names, goals
-- **Observational Memory** — long-context agentic memory that compresses extended sessions
-
-If you're using working memory to store conversation summaries or ongoing state that grows over time, OM is a better fit. Working memory is for small, structured data; OM is for unbounded event logs.
-
 ## How It Works
 
 You don't remember every word of every conversation you've ever had. You observe what happened subconsciously, then your brain reflects — reorganizing, combining, and condensing into long-term memory. OM works the same way.
 
-Every time an agent responds, it sees a context window containing its system prompt, recent message history, and any injected context (tool results, semantic recall, working memory, etc). The context window is finite — even models with large token limits perform worse when the window is full. This causes two problems in long conversations:
+Every time an agent responds, it sees a context window containing its system prompt, recent message history, and any injected context. The context window is finite — even models with large token limits perform worse when the window is full. This causes two problems:
 
-- **Context rot**: the more raw message history an agent carries, the worse it performs. Responses get less focused, instructions get ignored, and important details get lost in the noise.
-- **Context waste**: most of that history contains tokens which are no longer needed to keep the agent on task. Ten 50k-token tool call results can usually be represented as 500 tokens of observations instead of 500,000 tokens of raw output.
+- **Context rot**: the more raw message history an agent carries, the worse it performs.
+- **Context waste**: most of that history contains tokens no longer needed to keep the agent on task.
 
-### Message history
+### Observations
 
-Raw message history is the space dedicated to the current task. It contains the exact back-and-forth of the conversation: what the user said, what the agent responded, tool calls and results.
-
-This is high-fidelity but expensive. A 50-message conversation could use 100,000+ tokens of context, most of which contain tokens no longer needed to keep the agent on task.
-
-### Observations as long-term memory
-
-When message history tokens exceed a threshold (default: 30,000 tokens), the Observer is called. It watches the conversation and makes observations — a list of concise, dense notes about what actually happened:
+When message history tokens exceed a threshold (default: 30,000), the Observer creates observations — concise notes about what happened:
 
 ```
 Date: 2026-01-15
-- 🔴 12:10 User is building a Next.js app with Supabase auth, due in 1 week (meaning January 22nd 2026 - 1 week from now)
+- 🔴 12:10 User is building a Next.js app with Supabase auth, due in 1 week (meaning January 22nd 2026)
   - 🔴 12:10 App uses server components with client-side hydration
   - 🟡 12:12 User asked about middleware configuration for protected routes
-  - 🟡 12:13 Agent provided middleware setup using createServerClient pattern
   - 🔴 12:15 User stated the app name is "Acme Dashboard"
 ```
 
-New observations are appended to any previous observations, replacing the messages they observed. The compression is typically between 5x and 40x — instead of 30,000 tokens of back-and-forth, the agent sees a compact list of observations about what happened. The more tool calls there are, the higher the compression ratio typically is.
+The compression is typically 5–40×. The Observer also tracks a **current task** and **suggested response** so the agent picks up where it left off.
 
-#### Observation formatting
-
-Observations are output as raw appendable text. They're structured as a bullet point list, with indentation to represent grouped observations, emojis to represent information priority, and timestamps to indicate when the observations occurred.
-
-The system injects temporal markers automatically. When the Observer references relative time (e.g., "the user plans to do X in a week"), the system converts it to an absolute date and adds context like "(meaning June 4th 2027 — 4 months from today)" or "(meaning Jan 2025 - 1 year ago)".
-
-#### Task and response extraction
-
-The Observer tracks a **current task** (what the agent is working on right now) and a **suggested response** (how the agent should respond next to maintain conversation continuity, since message history is being replaced). These are injected into the agent's context alongside the observations, so the agent picks up where it left off even when large portions of the message history are replaced.
+Example: an agent using Playwright MCP might see 50,000+ tokens per page snapshot. With OM, the Observer watches the interaction and creates a few hundred tokens of observations about what was on the page and what actions were taken. The agent stays on task without carrying every raw snapshot.
 
 ### Reflections
 
-As observations accumulate over time, they eventually hit their own threshold (default: 40,000 tokens). The Reflector then restructures them — combining related items, reflecting on overarching patterns, and condensing where possible. Reflections always completely replace all previous observations and are intended to condense the size of observations to save context window space.
-
-If the Reflector's output isn't smaller than the input, it's automatically run a second time with a tweaked prompt that instructs it to condense more aggressively.
+When observations exceed their threshold (default: 40,000 tokens), the Reflector condenses them — combining related items and reflecting on patterns.
 
 The result is a three-tier system:
 
 1. **Recent messages** — exact conversation history for the current task
 2. **Observations** — a log of what the Observer has seen
-3. **Reflections** — condensed, reorganized observations when memory becomes too long
-
-Each tier is progressively refined to drop context rot/waste and gracefully degrade old irrelevant memories.
-
-### Example: Browser automation
-
-Consider an agent using Playwright MCP to automate a browser. Each page snapshot might be 50,000+ tokens. After a few pages, the context window is full of stale snapshots that actively hurt the agent's ability to follow instructions.
-
-With OM, when the snapshot comes in, the Observer watches the interaction and makes observations about what the page contained and what the agent did with it. The agent then continues with a concise understanding of what happened — not the raw 50k snapshot, but a few hundred tokens of observations about what was on the page and what actions were taken. The agent stays on task with full context of what it's seen, without carrying the weight of every raw snapshot.
-
-This applies to any token-heavy workflow: document analysis, coding sessions, research tasks, multi-step tool use, even long text conversations.
-
-## Scopes
-
-Observational Memory supports two scopes:
-
-### Thread scope (default)
-
-Observations are kept per-conversation. Each thread has its own observations. This is the simplest mode — each conversation is independent.
-
-```typescript
-const memory = new Memory({
-  options: {
-    observationalMemory: {
-      scope: "thread",
-    },
-  },
-});
-```
-
-### Resource scope (use carefully)
-
-Observations are shared across all threads for a resource (typically a user). This enables cross-conversation memory — the agent remembers what happened in previous conversations with the same user.
-
-```typescript
-const memory = new Memory({
-  options: {
-    observationalMemory: {
-      scope: "resource",
-    },
-  },
-});
-```
-
-:::warning
-
-**Understand what this does before enabling it.** In resource scope, the context window for each thread is a perspective on *all* threads simultaneously. Any unobserved messages across all threads are in context. When the total unobserved tokens across threads meets the threshold, observations are created (separated by thread in context).
-
-:::
-
-This means if a user has 100 threads of unobserved messages, the first message sent will cause the Observer to block the response and iteratively chunk through every unobserved message across all threads until the context is small enough to fit. For users with many existing threads, this initial observation pass could take significant time.
-
-For existing apps, it will be easier to use thread scope.
-
-## Token Budgets
-
-Observational Memory uses token thresholds to decide when to observe and when to reflect.
-
-### Message tokens
-
-`observation.messageTokens` (default: 30,000) controls when the Observer runs. When unobserved message tokens exceed this value, the Observer is called.
-
-Lower values mean the Observer runs more frequently, but it also tends to capture more fine details since it's observing smaller batches of messages. This often leads to quicker reflection too, since more observations accumulate faster. Higher values let more raw history accumulate before observing.
-
-```typescript
-const memory = new Memory({
-  options: {
-    observationalMemory: {
-      observation: {
-        messageTokens: 15_000,
-      },
-    },
-  },
-});
-```
-
-### Batch size
-
-`observation.maxTokensPerBatch` (default: 10,000) controls how many tokens the Observer processes at once when there are multiple threads in resource scope.
-
-This is independent of `messageTokens`. For example, you might want to observe at 20,000 message tokens but still use 5,000 token batches — the Observer will notice more details in each smaller batch rather than processing everything at once.
-
-```typescript
-const memory = new Memory({
-  options: {
-    observationalMemory: {
-      observation: {
-        messageTokens: 20_000,
-        maxTokensPerBatch: 5_000,
-      },
-    },
-  },
-});
-```
-
-### Observation tokens
-
-`reflection.observationTokens` (default: 40,000) controls when the Reflector runs. When observation tokens exceed this value, the Reflector condenses them.
-
-```typescript
-const memory = new Memory({
-  options: {
-    observationalMemory: {
-      reflection: {
-        observationTokens: 20_000,
-      },
-    },
-  },
-});
-```
-
-### Shared token budget
-
-By default, message tokens and observation tokens have independent thresholds. With `shareTokenBudget: true`, message history can borrow from the observation token budget:
-
-```typescript
-const memory = new Memory({
-  options: {
-    observationalMemory: {
-      shareTokenBudget: true,
-      observation: {
-        messageTokens: 20_000,
-      },
-      reflection: {
-        observationTokens: 44_000,
-      },
-    },
-  },
-});
-```
-
-The total budget here is 64,000 tokens (20k + 44k). While observations are still small, message history can expand beyond its 20k threshold into the unused observation space. This lets you choose a rough max context window size and stay within it — if you want to stay under 64k tokens total, this configuration does that while still allowing longer message history when observations haven't accumulated yet.
-
-## Migrating existing threads
-
-If you enable OM on an app that already has threads with message history, there's no manual migration step. OM reads existing messages from storage and observes them lazily when thresholds are exceeded.
-
-### First-run behavior
-
-- **Thread scope**: The first time a thread exceeds `observation.messageTokens`, the Observer processes the backlog.
-- **Resource scope**: All unobserved messages across all threads for a resource are processed together. For users with many existing threads, this initial pass can take significant time. Consider using thread scope for existing apps, or accept a one-time latency hit per resource.
-
-After the initial observation pass, subsequent messages are processed incrementally as usual.
+3. **Reflections** — condensed observations when memory becomes too long
 
 ## Models
 
-The Observer and Reflector are agents that run in the background. Any model that works with Mastra's model routing (e.g. `openai/...`, `google/...`, `deepseek/...`) can be used.
+The Observer and Reflector run in the background. Any model that works with Mastra's model routing (e.g. `openai/...`, `google/...`, `deepseek/...`) can be used.
 
-### Default model
+The default is `google/gemini-2.5-flash` — it works well for both observation and reflection, and its 1M token context window gives the Reflector headroom.
 
-The default is `google/gemini-2.5-flash`. This is what we've tested with the most internally and it works well for both observation and reflection. Gemini Flash's 1M token context window gives the Reflector headroom when reflecting on large amounts of observations.
-
-### Alternative models
-
-We've also been testing the system with `deepseek`, `qwen3`, and `glm-4.7` for the Observer and they work well. For the Reflector, make sure the model's context window has enough headroom to fit all observations — Gemini Flash's 1M context window is a safe choice. If your `reflection.observationTokens` threshold is lower (e.g., 20k-40k), context window size matters less and smaller models work fine.
-Note that Claude 4.5 models currently do not work well as observer or reflector - something about their training seems to prevent them from fully observing all message history correctly.
-
-Set a single model for both agents:
+We've also tested `deepseek`, `qwen3`, and `glm-4.7` for the Observer. For the Reflector, make sure the model's context window can fit all observations. Note that Claude 4.5 models currently don't work well as observer or reflector.
 
 ```typescript
 const memory = new Memory({
@@ -272,32 +98,77 @@ const memory = new Memory({
 });
 ```
 
-Or use different models for each:
+See [model configuration](/reference/memory/observational-memory#models) for using different models per agent.
+
+## Scopes
+
+### Thread scope (default)
+
+Each thread has its own observations.
+
+```typescript
+observationalMemory: {
+  scope: "thread",
+}
+```
+
+### Resource scope
+
+Observations are shared across all threads for a resource (typically a user). Enables cross-conversation memory.
+
+```typescript
+observationalMemory: {
+  scope: "resource",
+}
+```
+
+:::warning
+
+In resource scope, unobserved messages across *all* threads are processed together. For users with many existing threads, this can be slow. Use thread scope for existing apps.
+
+:::
+
+## Token Budgets
+
+OM uses token thresholds to decide when to observe and reflect. See [token budget configuration](/reference/memory/observational-memory#token-budgets) for details.
 
 ```typescript
 const memory = new Memory({
   options: {
     observationalMemory: {
       observation: {
-        model: "deepseek/deepseek-chat",
+        // when to run the Observer (default: 30,000)
+        messageTokens: 30_000,
       },
       reflection: {
-        model: "deepseek/deepseek-reasoner",
+        // when to run the Reflector (default: 40,000)
+        observationTokens: 40_000,
       },
+      // let message history borrow from observation budget
+      shareTokenBudget: false,
     },
   },
 });
 ```
 
+## Migrating existing threads
+
+No manual migration needed. OM reads existing messages and observes them lazily when thresholds are exceeded.
+
+- **Thread scope**: The first time a thread exceeds `observation.messageTokens`, the Observer processes the backlog.
+- **Resource scope**: All unobserved messages across all threads for a resource are processed together. For users with many existing threads, this could take significant time.
+
 ## Viewing in Mastra Studio
 
-Mastra Studio shows Observational Memory status in real time. When an observation or reflection is in progress, you'll see:
+Mastra Studio shows OM status in real time in the memory tab: token usage, which model is running, current observations, and reflection history.
 
-- Token usage progress bars for messages and observations
-- Which model is running (Observer or Reflector)
-- The current observations and history of past reflections
+## Comparing OM with other memory features
 
-This is useful for understanding how OM is behaving and tuning thresholds for your use case.
+- **[Message history](/docs/memory/message-history)** — high-fidelity record of the current conversation
+- **[Working memory](/docs/memory/working-memory)** — small, structured state (JSON or markdown) for user preferences, names, goals
+- **Observational Memory** — long-context agentic memory that compresses extended sessions
+
+If you're using working memory to store conversation summaries or ongoing state that grows over time, OM is a better fit. Working memory is for small, structured data; OM is for unbounded event logs.
 
 ## Related
 
@@ -305,4 +176,3 @@ This is useful for understanding how OM is behaving and tuning thresholds for yo
 - [Memory Overview](/docs/memory/overview)
 - [Message History](/docs/memory/message-history)
 - [Memory Processors](/docs/memory/memory-processors)
-- [Processors](/docs/agents/processors)

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Memory overview | Memory"
-description: "Learn how Mastra's memory system works with working memory, message history, and semantic recall."
+description: "Learn how Mastra's memory system works with working memory, message history, semantic recall, and observational memory."
 packages:
   - "@mastra/core"
   - "@mastra/libsql"
@@ -11,11 +11,12 @@ packages:
 
 Memory enables your agent to remember user messages, agent replies, and tool results across interactions, giving it the context it needs to stay consistent, maintain conversation flow, and produce better answers over time.
 
-Mastra supports three complementary memory types:
+Mastra supports four complementary memory types:
 
 - [**Message history**](/docs/memory/message-history) - keeps recent messages from the current conversation so they can be rendered in the UI and used to maintain short-term continuity within the exchange.
 - [**Working memory**](/docs/memory/working-memory) - stores persistent, structured user data such as names, preferences, and goals.
 - [**Semantic recall**](/docs/memory/semantic-recall) - retrieves relevant messages from older conversations based on semantic meaning rather than exact keywords, mirroring how humans recall information by association. Requires a [vector database](/docs/memory/semantic-recall#storage-configuration) and an [embedding model](/docs/memory/semantic-recall#embedder-configuration).
+- [**Observational memory**](/docs/memory/observational-memory) - uses background Observer and Reflector agents to maintain a dense observation log that replaces raw message history as it grows, keeping the context window small while preserving long-term memory across conversations.
 
 If the combined memory exceeds the model's context limit, [memory processors](/docs/memory/memory-processors) can filter, trim, or prioritize content so the most relevant information is preserved.
 
@@ -26,6 +27,7 @@ Choose a memory option to get started:
 - [Message history](/docs/memory/message-history)
 - [Working memory](/docs/memory/working-memory)
 - [Semantic recall](/docs/memory/semantic-recall)
+- [Observational memory](/docs/memory/observational-memory)
 
 ## Storage
 
@@ -48,5 +50,5 @@ This visibility helps you understand why an agent made specific decisions and ve
 ## Next steps
 
 - Learn more about [Storage](/docs/memory/storage) providers and configuration options
-- Add [Message history](/docs/memory/message-history), [Working memory](/docs/memory/working-memory), or [Semantic recall](/docs/memory/semantic-recall)
+- Add [Message history](/docs/memory/message-history), [Working memory](/docs/memory/working-memory), [Semantic recall](/docs/memory/semantic-recall), or [Observational memory](/docs/memory/observational-memory)
 - Visit [Memory configuration reference](/reference/memory/memory-class) for all available options

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -264,6 +264,11 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'memory/observational-memory',
+          label: 'Observational Memory',
+        },
+        {
+          type: 'doc',
           id: 'memory/memory-processors',
           label: 'Memory Processors',
         },

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -266,6 +266,9 @@ const sidebars = {
           type: 'doc',
           id: 'memory/observational-memory',
           label: 'Observational Memory',
+          customProps: {
+            tags: ['new'],
+          },
         },
         {
           type: 'doc',

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -107,6 +107,14 @@ export const agent = new Agent({
         "{ enabled: false, template: '# User Information\\n- **First Name**:\\n- **Last Name**:\\n...' }",
     },
     {
+      name: "observationalMemory",
+      type: "boolean | ObservationalMemoryOptions",
+      description:
+        "Enable Observational Memory for long-term memory across conversations. Set to `true` for defaults, or pass a config object to customize thresholds, models, and scope. See [Observational Memory reference](/reference/memory/observational-memory) for configuration details.",
+      isOptional: true,
+      defaultValue: "false",
+    },
+    {
       name: "generateTitle",
       type: "boolean | { model: DynamicArgument<MastraLanguageModel>; instructions?: DynamicArgument<string> }",
       description:
@@ -213,6 +221,7 @@ export const agent = new Agent({
 - [Getting Started with Memory](/docs/memory/overview)
 - [Semantic Recall](/docs/memory/semantic-recall)
 - [Working Memory](/docs/memory/working-memory)
+- [Observational Memory](/docs/memory/observational-memory)
 - [Memory Processors](/docs/memory/memory-processors)
 - [createThread](/reference/memory/createThread)
 - [recall](/reference/memory/recall)

--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -110,7 +110,7 @@ export const agent = new Agent({
       name: "observationalMemory",
       type: "boolean | ObservationalMemoryOptions",
       description:
-        "Enable Observational Memory for long-term memory across conversations. Set to `true` for defaults, or pass a config object to customize thresholds, models, and scope. See [Observational Memory reference](/reference/memory/observational-memory) for configuration details.",
+        "Enable Observational Memory for long-context agentic memory. Set to `true` for defaults, or pass a config object to customize token budgets, models, and scope. See [Observational Memory reference](/reference/memory/observational-memory) for configuration details.",
       isOptional: true,
       defaultValue: "false",
     },

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -1,0 +1,356 @@
+---
+title: "Reference: Observational Memory | Memory"
+description: "API reference for Observational Memory in Mastra — a three-tier memory system that uses Observer and Reflector agents to maintain long-term memory across conversations."
+packages:
+  - "@mastra/core"
+  - "@mastra/memory"
+---
+
+# Observational Memory
+
+Observational Memory is a memory processor that maintains long-term memory across conversations. It uses two background agents — an Observer that watches conversations and makes observations, and a Reflector that restructures observations by combining related items, reflecting on overarching patterns, and condensing where possible.
+
+This keeps the agent's context window small while preserving what matters across long conversations.
+
+## Usage
+
+```typescript title="src/mastra/agents/agent.ts"
+import { Memory } from "@mastra/memory";
+import { Agent } from "@mastra/core/agent";
+
+export const agent = new Agent({
+  name: "my-agent",
+  instructions: "You are a helpful assistant.",
+  model: "openai/gpt-5-mini",
+  memory: new Memory({
+    options: {
+      observationalMemory: true,
+    },
+  }),
+});
+```
+
+## Configuration
+
+The `observationalMemory` option accepts `true`, `false`, or a configuration object.
+
+Setting `observationalMemory: true` enables it with all defaults. Setting `observationalMemory: false` or omitting it disables it.
+
+<PropertiesTable
+  content={[
+    {
+      name: "enabled",
+      type: "boolean",
+      description:
+        "Enable or disable Observational Memory. When omitted from a config object, defaults to `true`. Only `enabled: false` explicitly disables it.",
+      isOptional: true,
+      defaultValue: "true",
+    },
+    {
+      name: "model",
+      type: "string | LanguageModel | DynamicModel | ModelWithRetries[]",
+      description:
+        "Model for both the Observer and Reflector agents. Sets the model for both at once. Cannot be used together with `observation.model` or `reflection.model` — an error will be thrown if both are set.",
+      isOptional: true,
+      defaultValue: "'google/gemini-2.5-flash'",
+    },
+    {
+      name: "scope",
+      type: "'resource' | 'thread'",
+      description:
+        "Memory scope for observations. `'thread'` keeps observations per-thread. `'resource'` shares observations across all threads for a resource, enabling cross-conversation memory.",
+      isOptional: true,
+      defaultValue: "'thread'",
+    },
+    {
+      name: "shareTokenBudget",
+      type: "boolean",
+      description:
+        "Share the token budget between messages and observations. When enabled, the total budget is `observation.messageTokens + reflection.observationTokens`. Messages can use more space when observations are small, and vice versa. This maximizes context usage through flexible allocation.",
+      isOptional: true,
+      defaultValue: "false",
+    },
+    {
+      name: "observation",
+      type: "ObservationalMemoryObservationConfig",
+      description:
+        "Configuration for the observation step. Controls when the Observer agent runs and how it behaves.",
+      isOptional: true,
+    },
+    {
+      name: "reflection",
+      type: "ObservationalMemoryReflectionConfig",
+      description:
+        "Configuration for the reflection step. Controls when the Reflector agent runs and how it behaves.",
+      isOptional: true,
+    },
+  ]}
+/>
+
+### Observation config
+
+<PropertiesTable
+  content={[
+    {
+      name: "model",
+      type: "string | LanguageModel | DynamicModel | ModelWithRetries[]",
+      description:
+        "Model for the Observer agent. Cannot be set if a top-level `model` is also provided.",
+      isOptional: true,
+      defaultValue: "'google/gemini-2.5-flash'",
+    },
+    {
+      name: "messageTokens",
+      type: "number",
+      description:
+        "Token count of unobserved messages that triggers observation. When unobserved message tokens exceed this threshold, the Observer agent is called.",
+      isOptional: true,
+      defaultValue: "30000",
+    },
+    {
+      name: "maxTokensPerBatch",
+      type: "number",
+      description:
+        "Maximum tokens per batch when observing multiple threads in resource scope. Threads are chunked into batches of this size and processed in parallel. Lower values mean more parallelism but more API calls.",
+      isOptional: true,
+      defaultValue: "10000",
+    },
+    {
+      name: "modelSettings",
+      type: "ObservationalMemoryModelSettings",
+      description:
+        "Model settings for the Observer agent.",
+      isOptional: true,
+      defaultValue: "{ temperature: 0.3, maxOutputTokens: 100_000 }",
+    },
+  ]}
+/>
+
+### Reflection config
+
+<PropertiesTable
+  content={[
+    {
+      name: "model",
+      type: "string | LanguageModel | DynamicModel | ModelWithRetries[]",
+      description:
+        "Model for the Reflector agent. Cannot be set if a top-level `model` is also provided.",
+      isOptional: true,
+      defaultValue: "'google/gemini-2.5-flash'",
+    },
+    {
+      name: "observationTokens",
+      type: "number",
+      description:
+        "Token count of observations that triggers reflection. When observation tokens exceed this threshold, the Reflector agent is called to condense them.",
+      isOptional: true,
+      defaultValue: "40000",
+    },
+    {
+      name: "modelSettings",
+      type: "ObservationalMemoryModelSettings",
+      description:
+        "Model settings for the Reflector agent.",
+      isOptional: true,
+      defaultValue: "{ temperature: 0.3, maxOutputTokens: 100_000 }",
+    },
+  ]}
+/>
+
+### Model settings
+
+<PropertiesTable
+  content={[
+    {
+      name: "temperature",
+      type: "number",
+      description:
+        "Temperature for generation. Lower values produce more consistent output.",
+      isOptional: true,
+      defaultValue: "0.3",
+    },
+    {
+      name: "maxOutputTokens",
+      type: "number",
+      description:
+        "Maximum output tokens. Set high to prevent truncation of observations.",
+      isOptional: true,
+      defaultValue: "100000",
+    },
+  ]}
+/>
+
+## Examples
+
+### Resource scope with custom thresholds
+
+```typescript title="src/mastra/agents/agent.ts"
+import { Memory } from "@mastra/memory";
+import { Agent } from "@mastra/core/agent";
+
+export const agent = new Agent({
+  name: "my-agent",
+  instructions: "You are a helpful assistant.",
+  model: "openai/gpt-5-mini",
+  memory: new Memory({
+    options: {
+      observationalMemory: {
+        scope: "resource",
+        observation: {
+          messageTokens: 20_000,
+        },
+        reflection: {
+          observationTokens: 60_000,
+        },
+      },
+    },
+  }),
+});
+```
+
+### Shared token budget
+
+```typescript title="src/mastra/agents/agent.ts"
+import { Memory } from "@mastra/memory";
+import { Agent } from "@mastra/core/agent";
+
+export const agent = new Agent({
+  name: "my-agent",
+  instructions: "You are a helpful assistant.",
+  model: "openai/gpt-5-mini",
+  memory: new Memory({
+    options: {
+      observationalMemory: {
+        shareTokenBudget: true,
+        observation: {
+          messageTokens: 20_000,
+        },
+        reflection: {
+          observationTokens: 80_000,
+        },
+      },
+    },
+  }),
+});
+```
+
+When `shareTokenBudget` is enabled, the total budget is `messageTokens + observationTokens` (100k in this example). If observations only use 30k tokens, messages can expand to use up to 70k. If messages are short, observations have more room before triggering reflection.
+
+### Custom model
+
+```typescript title="src/mastra/agents/agent.ts"
+import { Memory } from "@mastra/memory";
+import { Agent } from "@mastra/core/agent";
+
+export const agent = new Agent({
+  name: "my-agent",
+  instructions: "You are a helpful assistant.",
+  model: "openai/gpt-5-mini",
+  memory: new Memory({
+    options: {
+      observationalMemory: {
+        model: "openai/gpt-4o-mini",
+      },
+    },
+  }),
+});
+```
+
+### Different models per agent
+
+```typescript title="src/mastra/agents/agent.ts"
+import { Memory } from "@mastra/memory";
+import { Agent } from "@mastra/core/agent";
+
+export const agent = new Agent({
+  name: "my-agent",
+  instructions: "You are a helpful assistant.",
+  model: "openai/gpt-5-mini",
+  memory: new Memory({
+    options: {
+      observationalMemory: {
+        observation: {
+          model: "google/gemini-2.5-flash",
+        },
+        reflection: {
+          model: "openai/gpt-4o-mini",
+        },
+      },
+    },
+  }),
+});
+```
+
+## Standalone usage
+
+Most users should use the `Memory` class above. Using `ObservationalMemory` directly is mainly useful for benchmarking, experimentation, or when you need to control processor ordering with other processors (like [guardrails](/docs/agents/guardrails)).
+
+```typescript title="src/mastra/agents/agent.ts"
+import { ObservationalMemory } from "@mastra/memory/processors";
+import { Agent } from "@mastra/core/agent";
+import { LibSQLStore } from "@mastra/libsql";
+
+const storage = new LibSQLStore({
+  id: "my-storage",
+  url: "file:./memory.db",
+});
+
+const om = new ObservationalMemory({
+  storage: storage.stores.memory,
+  model: "google/gemini-2.5-flash",
+  scope: "resource",
+  observation: {
+    messageTokens: 20_000,
+  },
+  reflection: {
+    observationTokens: 60_000,
+  },
+});
+
+export const agent = new Agent({
+  name: "my-agent",
+  instructions: "You are a helpful assistant.",
+  model: "openai/gpt-5-mini",
+  inputProcessors: [om],
+  outputProcessors: [om],
+});
+```
+
+### Standalone config
+
+The standalone `ObservationalMemory` class accepts all the same options as the `observationalMemory` config object above, plus the following:
+
+<PropertiesTable
+  content={[
+    {
+      name: "storage",
+      type: "MemoryStorage",
+      description:
+        "Storage adapter for persisting observations. Must be a MemoryStorage instance (from `MastraStorage.stores.memory`).",
+      isOptional: false,
+    },
+    {
+      name: "onDebugEvent",
+      type: "(event: ObservationDebugEvent) => void",
+      description:
+        "Debug callback for observation events. Called whenever observation-related events occur. Useful for debugging and understanding the observation flow.",
+      isOptional: true,
+    },
+    {
+      name: "obscureThreadIds",
+      type: "boolean",
+      description:
+        "When enabled, thread IDs are hashed before being included in observation context. This prevents the LLM from recognizing patterns in thread identifiers. Automatically enabled when using resource scope through the Memory class.",
+      isOptional: true,
+      defaultValue: "false",
+    },
+  ]}
+/>
+
+### Related
+
+- [Observational Memory](/docs/memory/observational-memory)
+- [Memory Overview](/docs/memory/overview)
+- [Memory Class](/reference/memory/memory-class)
+- [Memory Processors](/docs/memory/memory-processors)
+- [Processors](/docs/agents/processors)

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -8,9 +8,7 @@ packages:
 
 # Observational Memory
 
-Observational Memory is a memory processor that maintains long-term memory across conversations. It uses two background agents — an Observer that watches conversations and makes observations, and a Reflector that restructures observations by combining related items, reflecting on overarching patterns, and condensing where possible.
-
-This keeps the agent's context window small while preserving what matters across long conversations.
+Observational Memory (OM) is Mastra's memory system for long-context agentic memory. Two background agents — an **Observer** that watches conversations and creates observations, and a **Reflector** that restructures observations by combining related items, reflecting on overarching patterns, and condensing where possible — maintain an observation log that replaces raw message history as it grows.
 
 ## Usage
 
@@ -152,7 +150,7 @@ Setting `observationalMemory: true` enables it with all defaults. Setting `obser
       description:
         "Model settings for the Reflector agent.",
       isOptional: true,
-      defaultValue: "{ temperature: 0.3, maxOutputTokens: 100_000 }",
+      defaultValue: "{ temperature: 0, maxOutputTokens: 100_000 }",
     },
   ]}
 />
@@ -234,7 +232,7 @@ export const agent = new Agent({
 });
 ```
 
-When `shareTokenBudget` is enabled, the total budget is `messageTokens + observationTokens` (100k in this example). If observations only use 30k tokens, messages can expand to use up to 70k. If messages are short, observations have more room before triggering reflection.
+When `shareTokenBudget` is enabled, the total budget is `observation.messageTokens + reflection.observationTokens` (100k in this example). If observations only use 30k tokens, messages can expand to use up to 70k. If messages are short, observations have more room before triggering reflection.
 
 ### Custom model
 

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -312,6 +312,7 @@ const sidebars = {
       collapsed: true,
       items: [
         { type: 'doc', id: 'memory/memory-class', label: 'Memory Class' },
+        { type: 'doc', id: 'memory/observational-memory', label: 'Observational Memory' },
         { type: 'doc', id: 'memory/createThread', label: '.createThread()' },
         {
           type: 'doc',


### PR DESCRIPTION
Adds docs and API reference pages for Observational Memory.

New files:
- docs/memory/observational-memory.mdx — main docs page covering how OM works, scopes, token budgets, model config, and code examples
- reference/memory/observational-memory.mdx — API reference with all config options, defaults, and standalone usage

Small additions:
- observationalMemory option added to the Memory class reference
- Sidebar entries in both docs and reference

No code changes — just docs. Don't merge until obs-mem-core is released, then rebase onto main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Observational Memory docs covering concepts, Observer/Reflector agents, memory tiers, quick start, examples, configuration options, scopes, token budgets, thresholds, model guidance, migration notes, and supported storage adapters.
  * Updated memory overview to list Observational Memory as a new memory type.
  * Added Observational Memory entries to site navigation and reference sidebars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->