### PR TITLE
fix(playground-ui): redesign toast component

### DIFF
--- a/.changeset/every-cars-hope.md
+++ b/.changeset/every-cars-hope.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Redesigned toast component with outline circle icons, left-aligned layout, and consistent design system styling

--- a/.changeset/puny-views-change.md
+++ b/.changeset/puny-views-change.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed toast imports to use custom wrapper for consistent styling

--- a/packages/playground-ui/src/domains/agents/components/agent-information/agent-working-memory.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-information/agent-working-memory.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Button } from '@/ds/components/Button/Button';
 import { Skeleton } from '@/ds/components/Skeleton';
 import { RefreshCcwIcon, ExternalLink } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { cn } from '@/lib/utils';
 import { MarkdownRenderer } from '@/ds/components/MarkdownRenderer';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';

--- a/packages/playground-ui/src/domains/agents/components/request-context.tsx
+++ b/packages/playground-ui/src/domains/agents/components/request-context.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useEffect, useState } from 'react';
 import { Button } from '@/ds/components/Button';
 import { Icon } from '@/ds/icons/Icon';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Txt } from '@/ds/components/Txt';
 import { usePlaygroundStore } from '@/store/playground-store';
 import { useCodemirrorTheme } from '@/ds/components/CodeEditor';

--- a/packages/playground-ui/src/domains/agents/hooks/use-execute-agent-tool.ts
+++ b/packages/playground-ui/src/domains/agents/hooks/use-execute-agent-tool.ts
@@ -1,5 +1,5 @@
 import { RequestContext } from '@mastra/core/di';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { useMutation } from '@tanstack/react-query';
 import { useMastraClient } from '@mastra/react';
 

--- a/packages/playground-ui/src/domains/configuration/components/studio-config-form.tsx
+++ b/packages/playground-ui/src/domains/configuration/components/studio-config-form.tsx
@@ -5,7 +5,7 @@ import { StudioConfig } from '../types';
 import { Link2 } from 'lucide-react';
 import { Button } from '@/ds/components/Button/Button';
 import { Icon } from '@/ds/icons/Icon';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { InputField } from '@/ds/components/FormFields';
 
 export interface StudioConfigFormProps {

--- a/packages/playground-ui/src/domains/mcps/components/mcp-server-combobox.tsx
+++ b/packages/playground-ui/src/domains/mcps/components/mcp-server-combobox.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Combobox } from '@/ds/components/Combobox';
 import { useMCPServers } from '../hooks/use-mcp-servers';
 import { useLinkComponent } from '@/lib/framework';

--- a/packages/playground-ui/src/domains/memory/hooks/use-memory.ts
+++ b/packages/playground-ui/src/domains/memory/hooks/use-memory.ts
@@ -1,4 +1,4 @@
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type { MemorySearchParams } from '@/types/memory';

--- a/packages/playground-ui/src/domains/scores/hooks/use-scorers.tsx
+++ b/packages/playground-ui/src/domains/scores/hooks/use-scorers.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { GetScorerResponse } from '@mastra/client-js';
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';

--- a/packages/playground-ui/src/domains/tools/hooks/use-execute-tool.ts
+++ b/packages/playground-ui/src/domains/tools/hooks/use-execute-tool.ts
@@ -2,7 +2,7 @@ import { RequestContext } from '@mastra/core/di';
 
 import { useMutation } from '@tanstack/react-query';
 import { useMastraClient } from '@mastra/react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 
 export const useExecuteTool = () => {
   const client = useMastraClient();

--- a/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
+++ b/packages/playground-ui/src/domains/workflows/workflow/workflow-trigger.tsx
@@ -1,6 +1,6 @@
 import { Braces, Loader2 } from 'lucide-react';
 import { useState, useEffect, useContext } from 'react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 
 import { Button } from '@/ds/components/Button';
 import { ScrollArea } from '@/ds/components/ScrollArea';

--- a/packages/playground-ui/src/hooks/use-copy-to-clipboard.ts
+++ b/packages/playground-ui/src/hooks/use-copy-to-clipboard.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 
 type UseCopyToClipboardProps = {
   text: string;

--- a/packages/playground-ui/src/hooks/use-workflow-runs.ts
+++ b/packages/playground-ui/src/hooks/use-workflow-runs.ts
@@ -2,7 +2,7 @@ import { useMastraClient } from '@mastra/react';
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useInView } from './use-in-view';
 import { useEffect } from 'react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 
 const PER_PAGE = 20;
 

--- a/packages/playground-ui/src/lib/toast.stories.tsx
+++ b/packages/playground-ui/src/lib/toast.stories.tsx
@@ -1,0 +1,212 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { toast, Toaster } from './toast';
+import { Button } from '@/ds/components/Button';
+
+const meta: Meta = {
+  title: 'Feedback/Toast',
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <>
+        <Toaster position="bottom-right" />
+        <Story />
+      </>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => (
+    <Button variant="outline" onClick={() => toast('This is a default toast')}>
+      Show Default Toast
+    </Button>
+  ),
+};
+
+export const DefaultWithDescription: Story = {
+  render: () => (
+    <Button
+      variant="outline"
+      onClick={() =>
+        toast('Default Toast', {
+          description: 'This is a description for the default toast.',
+        })
+      }
+    >
+      Show Default Toast with Description
+    </Button>
+  ),
+};
+
+export const Success: Story = {
+  render: () => (
+    <Button variant="outline" onClick={() => toast.success('Operation completed successfully')}>
+      Show Success Toast
+    </Button>
+  ),
+};
+
+export const SuccessWithDescription: Story = {
+  render: () => (
+    <Button
+      variant="outline"
+      onClick={() =>
+        toast.success('Changes saved', {
+          description: 'Your changes have been saved successfully.',
+        })
+      }
+    >
+      Show Success Toast with Description
+    </Button>
+  ),
+};
+
+export const Error: Story = {
+  render: () => (
+    <Button variant="outline" onClick={() => toast.error('Something went wrong')}>
+      Show Error Toast
+    </Button>
+  ),
+};
+
+export const ErrorWithDescription: Story = {
+  render: () => (
+    <Button
+      variant="outline"
+      onClick={() =>
+        toast.error('Failed to save', {
+          description: 'An error occurred while saving your changes. Please try again.',
+        })
+      }
+    >
+      Show Error Toast with Description
+    </Button>
+  ),
+};
+
+export const Warning: Story = {
+  render: () => (
+    <Button variant="outline" onClick={() => toast.warning('Please review before continuing')}>
+      Show Warning Toast
+    </Button>
+  ),
+};
+
+export const WarningWithDescription: Story = {
+  render: () => (
+    <Button
+      variant="outline"
+      onClick={() =>
+        toast.warning('Unsaved changes', {
+          description: 'You have unsaved changes that will be lost if you leave.',
+        })
+      }
+    >
+      Show Warning Toast with Description
+    </Button>
+  ),
+};
+
+export const Info: Story = {
+  render: () => (
+    <Button variant="outline" onClick={() => toast.info('New update available')}>
+      Show Info Toast
+    </Button>
+  ),
+};
+
+export const InfoWithDescription: Story = {
+  render: () => (
+    <Button
+      variant="outline"
+      onClick={() =>
+        toast.info('Version 2.0 available', {
+          description: 'A new version is available. Please refresh to update.',
+        })
+      }
+    >
+      Show Info Toast with Description
+    </Button>
+  ),
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <Button variant="outline" onClick={() => toast('Default toast')}>
+          Default
+        </Button>
+        <Button variant="outline" onClick={() => toast.success('Success toast')}>
+          Success
+        </Button>
+        <Button variant="outline" onClick={() => toast.error('Error toast')}>
+          Error
+        </Button>
+        <Button variant="outline" onClick={() => toast.warning('Warning toast')}>
+          Warning
+        </Button>
+        <Button variant="outline" onClick={() => toast.info('Info toast')}>
+          Info
+        </Button>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="ghost"
+          onClick={() =>
+            toast('Default with description', {
+              description: 'This is a description.',
+            })
+          }
+        >
+          Default + Desc
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={() =>
+            toast.success('Success with description', {
+              description: 'This is a description.',
+            })
+          }
+        >
+          Success + Desc
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={() =>
+            toast.error('Error with description', {
+              description: 'This is a description.',
+            })
+          }
+        >
+          Error + Desc
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={() =>
+            toast.warning('Warning with description', {
+              description: 'This is a description.',
+            })
+          }
+        >
+          Warning + Desc
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={() =>
+            toast.info('Info with description', {
+              description: 'This is a description.',
+            })
+          }
+        >
+          Info + Desc
+        </Button>
+      </div>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/lib/toast.tsx
+++ b/packages/playground-ui/src/lib/toast.tsx
@@ -1,7 +1,8 @@
-import { X } from 'lucide-react';
+import { X, CircleCheck, CircleX, CircleAlert, Info } from 'lucide-react';
 import React from 'react';
 import { ExternalToast, toast as sonnerToast } from 'sonner';
 
+import { Icon } from '@/ds/icons';
 import { cn } from '@/lib/utils';
 
 export { Toaster } from 'sonner';
@@ -9,17 +10,21 @@ export { Toaster } from 'sonner';
 const defaultOptions: ExternalToast = {
   duration: 5000,
   cancel: {
-    label: <X size={'14'} />,
+    label: (
+      <Icon>
+        <X />
+      </Icon>
+    ),
     onClick: () => {},
   },
   unstyled: true,
   classNames: {
     toast:
-      'bg-surface2 w-full backdrop-accent h-auto rounded-lg gap-2 border border p-4 flex items-start justify-between rounded-lg pointer-events-auto',
-    title: 'text-white font-semibold text-xs mb-1 -mt-1',
-    description: '!text-text text-sm !font-light',
+      'bg-surface3 w-full h-auto rounded-lg gap-2 border border-border1 px-3 py-2 flex items-center justify-between pointer-events-auto shadow-card [&>[data-content]]:flex-1',
+    title: 'text-xs font-medium text-neutral5',
+    description: 'text-xs text-neutral3',
     cancelButton:
-      '!bg-transparent !p-0 flex items-center justify-center !text-text opacity-50 hover:opacity-100 ml-4 shrink-0',
+      '!bg-transparent hover:!bg-surface2 !border-none !rounded-md !p-1.5 !m-0 !text-neutral3 hover:!text-neutral6 shrink-0 transition-all',
     actionButton: '!bg-white flex items-center justify-center font-medium !text-black order-last hover:opacity-80',
   },
 };
@@ -62,14 +67,16 @@ export const toast = (message: string | string[] | React.ReactNode, options: Ext
 toast.success = (message: string | string[], options: ExternalToast = {}) => {
   const successOptions: ExternalToast = {
     ...options,
+    icon: (
+      <Icon className="text-accent1 shrink-0">
+        <CircleCheck />
+      </Icon>
+    ),
     classNames: {
       ...options.classNames,
-      toast: cn(
-        'bg-green-950/20 border-green-900/50 dark:bg-green-950/20 dark:border-green-900/50',
-        options.classNames?.toast,
-      ),
-      title: cn('text-green-200 dark:text-green-200', options.classNames?.title),
-      description: cn('text-green-300 dark:text-green-300', options.classNames?.description),
+      toast: cn('bg-accent1Darker border-accent1/30 border-l-[3px] border-l-accent1', options.classNames?.toast),
+      title: cn('text-xs text-neutral5', options.classNames?.title),
+      description: cn('text-xs text-neutral4', options.classNames?.description),
     },
   };
 
@@ -83,11 +90,16 @@ toast.success = (message: string | string[], options: ExternalToast = {}) => {
 toast.error = (message: string | string[], options: ExternalToast = {}) => {
   const errorOptions: ExternalToast = {
     ...options,
+    icon: (
+      <Icon className="text-accent2 shrink-0">
+        <CircleX />
+      </Icon>
+    ),
     classNames: {
       ...options.classNames,
-      toast: cn('bg-red-950/20 border-red-900/50 dark:bg-red-950/20 dark:border-red-900/50', options.classNames?.toast),
-      title: cn('text-red-200 dark:text-red-200', options.classNames?.title),
-      description: cn('text-red-300 dark:text-red-300', options.classNames?.description),
+      toast: cn('bg-accent2Darker border-accent2/30 border-l-[3px] border-l-accent2', options.classNames?.toast),
+      title: cn('text-xs text-neutral5', options.classNames?.title),
+      description: cn('text-xs text-neutral4', options.classNames?.description),
     },
   };
 
@@ -101,14 +113,16 @@ toast.error = (message: string | string[], options: ExternalToast = {}) => {
 toast.warning = (message: string | string[], options: ExternalToast = {}) => {
   const warningOptions: ExternalToast = {
     ...options,
+    icon: (
+      <Icon className="text-accent6 shrink-0">
+        <CircleAlert />
+      </Icon>
+    ),
     classNames: {
       ...options.classNames,
-      toast: cn(
-        'bg-yellow-950/20 border-yellow-900/50 dark:bg-yellow-950/20 dark:border-yellow-900/50',
-        options.classNames?.toast,
-      ),
-      title: cn('text-yellow-200 dark:text-yellow-200', options.classNames?.title),
-      description: cn('text-yellow-300 dark:text-yellow-300', options.classNames?.description),
+      toast: cn('bg-accent6Darker border-accent6/30 border-l-[3px] border-l-accent6', options.classNames?.toast),
+      title: cn('text-xs text-neutral5', options.classNames?.title),
+      description: cn('text-xs text-neutral4', options.classNames?.description),
     },
   };
 
@@ -122,14 +136,16 @@ toast.warning = (message: string | string[], options: ExternalToast = {}) => {
 toast.info = (message: string | string[], options: ExternalToast = {}) => {
   const infoOptions: ExternalToast = {
     ...options,
+    icon: (
+      <Icon className="text-accent3 shrink-0">
+        <Info />
+      </Icon>
+    ),
     classNames: {
       ...options.classNames,
-      toast: cn(
-        'bg-blue-950/20 border-blue-900/50 dark:bg-blue-950/20 dark:border-blue-900/50',
-        options.classNames?.toast,
-      ),
-      title: cn('text-blue-200 dark:text-blue-200', options.classNames?.title),
-      description: cn('text-blue-300 dark:text-blue-300', options.classNames?.description),
+      toast: cn('bg-accent3Darker border-accent3/30 border-l-[3px] border-l-accent3', options.classNames?.toast),
+      title: cn('text-xs text-neutral5', options.classNames?.title),
+      description: cn('text-xs text-neutral4', options.classNames?.description),
     },
   };
 


### PR DESCRIPTION
Redesigned the toast component to have a cleaner layout:

- Switched to outline circle icons (CircleCheck, CircleX, CircleAlert, Info) for semantic variants
- Fixed layout so content is left-aligned next to the icon with dismiss button on the far right
- Updated styling to use design system tokens instead of hardcoded colors
- Added left border accent for semantic variants (success, error, warning, info)

The key fix was targeting sonner's `[data-content]` wrapper with `flex-1` to ensure proper layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned toast component with outline circle icons, left-aligned layout, updated colors and sizing; applied consistently across the app.

* **Documentation**
  * Added Storybook documentation showcasing all toast variants (default, success, error, warning, info) with and without descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->