### PR TITLE
feat(playground-ui): add markdown support with variable highlighting to CodeEditor

### DIFF
--- a/.changeset/fuzzy-moose-occur.md
+++ b/.changeset/fuzzy-moose-occur.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added markdown language support to CodeEditor with syntax highlighting for headings, emphasis, links, and code blocks. New `language` prop accepts 'json' (default) or 'markdown'. Added variable highlighting extension that visually distinguishes `{{variableName}}` patterns with orange styling when `highlightVariables` prop is enabled.

--- a/packages/playground-ui/src/ds/components/CodeEditor/__tests__/variable-highlight-extension.test.ts
+++ b/packages/playground-ui/src/ds/components/CodeEditor/__tests__/variable-highlight-extension.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { VARIABLE_PATTERN } from '../variable-highlight-extension';
+
+describe('VARIABLE_PATTERN', () => {
+  const matchAll = (text: string): string[] => {
+    const matches: string[] = [];
+    let match: RegExpExecArray | null;
+    const pattern = new RegExp(VARIABLE_PATTERN.source, VARIABLE_PATTERN.flags);
+    while ((match = pattern.exec(text)) !== null) {
+      matches.push(match[0]);
+    }
+    return matches;
+  };
+
+  it('should match simple variable names', () => {
+    const text = '{{userName}}';
+    expect(matchAll(text)).toEqual(['{{userName}}']);
+  });
+
+  it('should match variables starting with underscore', () => {
+    const text = '{{_privateVar}}';
+    expect(matchAll(text)).toEqual(['{{_privateVar}}']);
+  });
+
+  it('should match variables with numbers', () => {
+    const text = '{{user1Name}}';
+    expect(matchAll(text)).toEqual(['{{user1Name}}']);
+  });
+
+  it('should match multiple variables in text', () => {
+    const text = 'Hello {{userName}}, welcome to {{companyName}}!';
+    expect(matchAll(text)).toEqual(['{{userName}}', '{{companyName}}']);
+  });
+
+  it('should not match variables starting with numbers', () => {
+    const text = '{{1invalid}}';
+    expect(matchAll(text)).toEqual([]);
+  });
+
+  it('should not match empty braces', () => {
+    const text = '{{}}';
+    expect(matchAll(text)).toEqual([]);
+  });
+
+  it('should not match single braces', () => {
+    const text = '{singleBrace}';
+    expect(matchAll(text)).toEqual([]);
+  });
+
+  it('should not match variables with spaces', () => {
+    const text = '{{user name}}';
+    expect(matchAll(text)).toEqual([]);
+  });
+
+  it('should not match variables with special characters', () => {
+    const text = '{{user-name}}';
+    expect(matchAll(text)).toEqual([]);
+  });
+
+  it('should match in markdown context', () => {
+    const text = `# Instructions
+
+You are helping {{userName}} at {{companyName}}.
+
+## Context
+- Role: {{userRole}}
+- Language: {{preferredLanguage}}`;
+
+    expect(matchAll(text)).toEqual(['{{userName}}', '{{companyName}}', '{{userRole}}', '{{preferredLanguage}}']);
+  });
+});

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.stories.tsx
@@ -1,15 +1,30 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CodeEditor } from './code-editor';
+import { TooltipProvider } from '../Tooltip';
 
 const meta: Meta<typeof CodeEditor> = {
   title: 'Composite/CodeEditor',
   component: CodeEditor,
+  decorators: [
+    Story => (
+      <TooltipProvider>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
   parameters: {
     layout: 'centered',
   },
   tags: ['autodocs'],
   argTypes: {
     showCopyButton: {
+      control: { type: 'boolean' },
+    },
+    language: {
+      control: { type: 'select' },
+      options: ['json', 'markdown'],
+    },
+    highlightVariables: {
       control: { type: 'boolean' },
     },
   },
@@ -104,5 +119,54 @@ export const LargeContent: Story = {
       },
     },
     className: 'w-[600px] max-h-[400px] overflow-auto',
+  },
+};
+
+export const MarkdownWithVariables: Story = {
+  args: {
+    value: `# Agent Instructions
+
+You are a helpful assistant for {{companyName}}.
+
+## Context
+- User: {{userName}}
+- Role: {{userRole}}
+
+## Guidelines
+
+1. Always greet the user by their name: {{userName}}
+2. Use the company context: {{companyContext}}
+3. Respond in the user's preferred language: {{preferredLanguage}}
+
+## Example Response
+
+Hello {{userName}}, welcome to {{companyName}}! How can I help you today?`,
+    language: 'markdown',
+    highlightVariables: true,
+    className: 'w-[600px]',
+  },
+};
+
+export const MarkdownWithoutVariables: Story = {
+  args: {
+    value: `# Simple Markdown
+
+This is a markdown editor without variable highlighting.
+
+## Features
+
+- Syntax highlighting for markdown
+- Code blocks support
+- Line wrapping enabled
+
+\`\`\`javascript
+const greeting = "Hello, World!";
+console.log(greeting);
+\`\`\`
+
+Regular text continues here.`,
+    language: 'markdown',
+    highlightVariables: false,
+    className: 'w-[600px]',
   },
 };

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
@@ -28,7 +28,11 @@ export const useCodemirrorTheme = (): Extension => {
         // JSON styles
         { tag: [t.className, t.propertyName] },
         // Markdown styles
-        { tag: [t.heading1, t.heading2, t.heading3, t.heading4, t.heading5, t.heading6], color: '#BD93F9', fontWeight: 'bold' },
+        {
+          tag: [t.heading1, t.heading2, t.heading3, t.heading4, t.heading5, t.heading6],
+          color: '#BD93F9',
+          fontWeight: 'bold',
+        },
         { tag: t.emphasis, fontStyle: 'italic', color: '#F1FA8C' },
         { tag: t.strong, fontWeight: 'bold', color: '#FFB86C' },
         { tag: t.link, color: '#8BE9FD', textDecoration: 'underline' },

--- a/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
+++ b/packages/playground-ui/src/ds/components/CodeEditor/code-editor.tsx
@@ -1,4 +1,6 @@
 import { jsonLanguage } from '@codemirror/lang-json';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { languages } from '@codemirror/language-data';
 import { EditorView } from '@codemirror/view';
 import { tags as t } from '@lezer/highlight';
 import { draculaInit } from '@uiw/codemirror-theme-dracula';
@@ -9,6 +11,7 @@ import { cn } from '@/lib/utils';
 import type { Extension } from '@codemirror/state';
 
 import { CopyButton } from '@/ds/components/CopyButton';
+import { variableHighlight } from './variable-highlight-extension';
 
 export const useCodemirrorTheme = (): Extension => {
   return useMemo(() => {
@@ -21,7 +24,21 @@ export const useCodemirrorTheme = (): Extension => {
         gutterForeground: '#939393',
         background: 'transparent',
       },
-      styles: [{ tag: [t.className, t.propertyName] }],
+      styles: [
+        // JSON styles
+        { tag: [t.className, t.propertyName] },
+        // Markdown styles
+        { tag: [t.heading1, t.heading2, t.heading3, t.heading4, t.heading5, t.heading6], color: '#BD93F9', fontWeight: 'bold' },
+        { tag: t.emphasis, fontStyle: 'italic', color: '#F1FA8C' },
+        { tag: t.strong, fontWeight: 'bold', color: '#FFB86C' },
+        { tag: t.link, color: '#8BE9FD', textDecoration: 'underline' },
+        { tag: t.url, color: '#8BE9FD' },
+        { tag: t.strikethrough, textDecoration: 'line-through' },
+        { tag: t.quote, color: '#6272A4', fontStyle: 'italic' },
+        { tag: t.monospace, color: '#50FA7B' },
+        { tag: [t.processingInstruction, t.inserted], color: '#50FA7B' },
+        { tag: t.contentSeparator, color: '#6272A4' },
+      ],
     });
 
     const customLineNumberTheme = EditorView.theme({
@@ -44,11 +61,39 @@ export type CodeEditorProps = {
   onChange?: (value: string) => void;
   showCopyButton?: boolean;
   className?: string;
+  language?: 'json' | 'markdown';
+  highlightVariables?: boolean;
 } & Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>;
 
-export const CodeEditor = ({ data, value, onChange, showCopyButton = true, className, ...props }: CodeEditorProps) => {
+export const CodeEditor = ({
+  data,
+  value,
+  onChange,
+  showCopyButton = true,
+  className,
+  language = 'json',
+  highlightVariables = false,
+  ...props
+}: CodeEditorProps) => {
   const theme = useCodemirrorTheme();
   const formattedCode = data ? JSON.stringify(data, null, 2) : (value ?? '');
+
+  const extensions = useMemo(() => {
+    const exts: Extension[] = [];
+
+    if (language === 'json') {
+      exts.push(jsonLanguage);
+    } else if (language === 'markdown') {
+      exts.push(markdown({ base: markdownLanguage, codeLanguages: languages }));
+      exts.push(EditorView.lineWrapping);
+    }
+
+    if (highlightVariables && language === 'markdown') {
+      exts.push(variableHighlight);
+    }
+
+    return exts;
+  }, [language, highlightVariables]);
 
   return (
     <div className={cn('rounded-md bg-surface4 p-1 font-mono relative', className)} {...props}>
@@ -56,7 +101,7 @@ export const CodeEditor = ({ data, value, onChange, showCopyButton = true, class
       <CodeMirror
         value={formattedCode}
         theme={theme}
-        extensions={[jsonLanguage]}
+        extensions={extensions}
         onChange={onChange}
         aria-label="Code editor"
       />

--- a/packages/playground-ui/src/ds/components/CodeEditor/index.ts
+++ b/packages/playground-ui/src/ds/components/CodeEditor/index.ts
@@ -1,1 +1,2 @@
 export * from './code-editor';
+export { variableHighlight, VARIABLE_PATTERN } from './variable-highlight-extension';

--- a/packages/playground-ui/src/ds/components/CodeEditor/variable-highlight-extension.ts
+++ b/packages/playground-ui/src/ds/components/CodeEditor/variable-highlight-extension.ts
@@ -1,0 +1,41 @@
+import { Decoration, DecorationSet, EditorView, MatchDecorator, ViewPlugin, ViewUpdate } from '@codemirror/view';
+
+/**
+ * Regex pattern to match variable placeholders like {{variableName}}
+ * Matches: {{ followed by a valid identifier (letter/underscore, then alphanumeric/underscore), then }}
+ */
+export const VARIABLE_PATTERN = /\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}/g;
+
+const variableDecoration = Decoration.mark({
+  attributes: {
+    style: 'color: #F59E0B !important; font-weight: 500 !important;',
+  },
+});
+
+const variableMatcher = new MatchDecorator({
+  regexp: VARIABLE_PATTERN,
+  decoration: () => variableDecoration,
+});
+
+const variableHighlightPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+      this.decorations = variableMatcher.createDeco(view);
+    }
+
+    update(update: ViewUpdate) {
+      this.decorations = variableMatcher.updateDeco(update, this.decorations);
+    }
+  },
+  {
+    decorations: v => v.decorations,
+  },
+);
+
+/**
+ * CodeMirror extension that highlights {{variableName}} patterns
+ * with orange color and semibold weight
+ */
+export const variableHighlight = variableHighlightPlugin;


### PR DESCRIPTION
The CodeEditor component now supports markdown in addition to JSON. It also highlights `{{variableName}}` patterns when enabled.

**New props:**

```tsx
<CodeEditor
  language="markdown"  // 'json' (default) | 'markdown'
  highlightVariables   // highlights {{varName}} patterns in orange
  value={`Hello {{userName}}, welcome to {{companyName}}!`}
/>
```

The markdown mode includes syntax highlighting for headings, emphasis, links, code blocks, and more. Line wrapping is automatically enabled for markdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown support in the CodeEditor with syntax highlighting for headings, emphasis, links, and code blocks.
  * Variable highlighting for {{variableName}} patterns.
  * New language prop ('json' default | 'markdown') and highlightVariables boolean prop.

* **Tests**
  * Added unit tests covering variable highlighting patterns and edge cases.

* **Documentation**
  * Storybook stories demonstrating Markdown with and without variable highlighting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->