### PR TITLE
feat(cli): set default agent selections for skills installation

### DIFF
--- a/.changeset/default-skill-selections.md
+++ b/.changeset/default-skill-selections.md
@@ -1,0 +1,5 @@
+---
+'mastra': minor
+---
+
+Pre-select Claude Code, Codex, OpenCode, and Cursor as default agents when users choose to install Mastra skills during project creation. Codex has been promoted to the popular agents list for better visibility.

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -740,12 +740,13 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
           const POPULAR_AGENTS: { value: string; label: string }[] = [
             { value: 'claude-code', label: 'Claude Code' },
             { value: 'cursor', label: 'Cursor' },
+            { value: 'codex', label: 'Codex' },
+            { value: 'opencode', label: 'OpenCode' },
             { value: 'windsurf', label: 'Windsurf' },
             { value: 'github-copilot', label: 'GitHub Copilot' },
             { value: 'cline', label: 'Cline' },
             { value: 'continue', label: 'Continue' },
             { value: 'gemini-cli', label: 'Gemini CLI' },
-            { value: 'opencode', label: 'OpenCode' },
             { value: 'replit', label: 'Replit' },
             { value: 'roo', label: 'Roo Code' },
           ];
@@ -758,7 +759,6 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
             { value: 'antigravity', label: 'Antigravity' },
             { value: 'augment', label: 'Augment' },
             { value: 'codebuddy', label: 'CodeBuddy' },
-            { value: 'codex', label: 'Codex' },
             { value: 'command-code', label: 'Command Code' },
             { value: 'crush', label: 'Crush' },
             { value: 'droid', label: 'Droid' },
@@ -788,7 +788,8 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
           // Show popular agents first with "Show all" option
           const initialSelection = await p.multiselect({
             message: 'Select agent(s) to install skills for:',
-            options: [...POPULAR_AGENTS, { value: '__show_all__', label: '+ Show all agents (30 more)' }],
+            options: [...POPULAR_AGENTS, { value: '__show_all__', label: '+ Show all agents (29 more)' }],
+            initialValues: ['claude-code', 'codex', 'opencode', 'cursor'],
             required: true,
           });
 


### PR DESCRIPTION
## Summary

Pre-select Claude Code, Codex, OpenCode, and Cursor as default agents when users choose to install Mastra skills during project creation.

## Changes

1. **Added default selections**: Set `initialValues` to pre-select `['claude-code', 'codex', 'opencode', 'cursor']` in the skills multiselect prompt
2. **Promoted Codex to popular agents**: Moved Codex from the "Show all" list to the popular agents list for better visibility
3. **Updated count**: Changed "Show all agents (30 more)" to "(29 more)" to reflect the correct count

## Benefits

- **Better UX**: Users get sensible defaults pre-selected based on the most commonly used coding agents
- **Faster onboarding**: Users can simply press Enter to accept the recommended agents
- **Consistency**: All pre-selected agents are visible in the initial list (not hidden in "Show all")

## Testing

- ✅ TypeScript type checks pass
- ✅ Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex and OpenCode to the interactive CLI agent list.
  * Pre-filled initial agent selection with Claude Code, Codex, OpenCode, and Cursor.

* **Improvements**
  * Removed a duplicate agent entry and adjusted the "Show all agents" counter to reflect the current total.

* **Documentation**
  * Added a changeset documenting the default agent selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->