### PR TITLE
feat(playground-ui): add ContentBlocks drag-and-drop component

### DIFF
--- a/.changeset/empty-beers-switch.md
+++ b/.changeset/empty-beers-switch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added ContentBlocks, a reusable drag-and-drop component for building ordered lists of editable content. Also includes AgentCMSBlocks, a ready-to-use implementation for agent system prompts with add, delete, and reorder functionality.

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { GripVertical, Trash2 } from 'lucide-react';
+import type { DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
+
+import { ContentBlock, useContentBlock } from '@/ds/components/ContentBlocks';
+import { cn } from '@/lib/utils';
+import { IconButton } from '@/ds/components/IconButton';
+import { Textarea } from '@/components/ui/textarea';
+import { Icon } from '@/ds/icons';
+
+export interface AgentCMSBlockProps {
+  index: number;
+  onDelete?: (index: number) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+interface AgentCMSBlockContentProps {
+  placeholder?: string;
+  dragHandleProps?: DraggableProvidedDragHandleProps | null;
+  onDelete?: () => void;
+}
+
+const AgentCMSBlockContent = ({ placeholder, dragHandleProps, onDelete }: AgentCMSBlockContentProps) => {
+  const [item, setItem] = useContentBlock();
+
+  return (
+    <div className="border border-border1 rounded-md w-full bg-surface2">
+      <div className="flex items-center justify-between p-2 border-b border-border1">
+        <div {...dragHandleProps} className="text-neutral3 hover:text-neutral6">
+          <Icon>
+            <GripVertical />
+          </Icon>
+        </div>
+
+        {onDelete && (
+          <IconButton variant="ghost" size="sm" onClick={onDelete} tooltip="Delete block">
+            <Trash2 />
+          </IconButton>
+        )}
+      </div>
+
+      <Textarea
+        value={item}
+        onChange={e => setItem(e.target.value)}
+        placeholder={placeholder}
+        className="border-none rounded-none text-neutral6"
+      />
+    </div>
+  );
+};
+
+export const AgentCMSBlock = ({ index, onDelete, placeholder, className }: AgentCMSBlockProps) => {
+  return (
+    <ContentBlock index={index} className={className}>
+      {(dragHandleProps: DraggableProvidedDragHandleProps | null) => (
+        <AgentCMSBlockContent
+          placeholder={placeholder}
+          dragHandleProps={dragHandleProps}
+          onDelete={onDelete ? () => onDelete(index) : undefined}
+        />
+      )}
+    </ContentBlock>
+  );
+};

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-blocks/agent-cms-blocks.stories.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-blocks/agent-cms-blocks.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+import { AgentCMSBlocks } from './agent-cms-blocks';
+import { TooltipProvider } from '@/ds/components/Tooltip';
+
+const meta: Meta<typeof AgentCMSBlocks> = {
+  title: 'Domain/Agents/AgentCMSBlocks',
+  component: AgentCMSBlocks,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof AgentCMSBlocks>;
+
+const InteractiveExample = () => {
+  const [items, setItems] = useState<Array<string>>([
+    'You are a helpful assistant that answers questions about programming.',
+    'Always be polite and professional in your responses.',
+  ]);
+
+  return (
+    <div className="w-[500px]">
+      <TooltipProvider>
+        <AgentCMSBlocks items={items} onChange={setItems} placeholder="Enter content..." />
+      </TooltipProvider>
+
+      <div className="mt-4 p-3 bg-surface2 rounded-lg">
+        <p className="text-xs text-icon3 mb-2">Current state:</p>
+        <pre className="text-xs text-icon5 whitespace-pre-wrap">{JSON.stringify(items, null, 2)}</pre>
+      </div>
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: () => <InteractiveExample />,
+};
+
+const EmptyExample = () => {
+  const [items, setItems] = useState<Array<string>>([]);
+
+  return (
+    <div className="w-[500px]">
+      <TooltipProvider>
+        <AgentCMSBlocks items={items} onChange={setItems} placeholder="Add your first content block..." />
+      </TooltipProvider>
+    </div>
+  );
+};
+
+export const Empty: Story = {
+  render: () => <EmptyExample />,
+};
+
+const SingleBlockExample = () => {
+  const [items, setItems] = useState<Array<string>>(['Single content block with some text.']);
+
+  return (
+    <div className="w-[500px]">
+      <TooltipProvider>
+        <AgentCMSBlocks items={items} onChange={setItems} placeholder="Enter content..." />
+      </TooltipProvider>
+    </div>
+  );
+};
+
+export const SingleBlock: Story = {
+  render: () => <SingleBlockExample />,
+};

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-blocks/agent-cms-blocks.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-blocks/agent-cms-blocks.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { Plus } from 'lucide-react';
+
+import { ContentBlocks } from '@/ds/components/ContentBlocks';
+import { cn } from '@/lib/utils';
+
+import { AgentCMSBlock } from './agent-cms-block';
+
+export interface AgentCMSBlocksProps {
+  items: Array<string>;
+  onChange: (items: Array<string>) => void;
+  className?: string;
+  placeholder?: string;
+}
+
+export const AgentCMSBlocks = ({ items, onChange, className, placeholder }: AgentCMSBlocksProps) => {
+  const handleDelete = (index: number) => {
+    const newItems = items.filter((_, idx) => idx !== index);
+    onChange(newItems);
+  };
+
+  const handleAdd = () => {
+    onChange([...items, '']);
+  };
+
+  return (
+    <div className={cn('flex flex-col gap-4 w-full', className)}>
+      <ContentBlocks items={items} onChange={onChange} className="flex flex-col gap-2 w-full">
+        {items.map((_, index) => (
+          <AgentCMSBlock key={index} index={index} onDelete={handleDelete} placeholder={placeholder} />
+        ))}
+      </ContentBlocks>
+
+      <button
+        type="button"
+        onClick={handleAdd}
+        className={cn(
+          'border border-border1 text-neutral6 text-ui-sm py-2 rounded-md bg-surface1 hover:bg-surface2 active:bg-surface3',
+        )}
+      >
+        Add content block
+      </button>
+    </div>
+  );
+};

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-blocks/index.ts
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-blocks/index.ts
@@ -1,0 +1,2 @@
+export * from './agent-cms-blocks';
+export * from './agent-cms-block';

--- a/packages/playground-ui/src/domains/agents/index.tsx
+++ b/packages/playground-ui/src/domains/agents/index.tsx
@@ -20,3 +20,4 @@ export * from './components/agent-information/agent-memory';
 export * from './components/agent-layout';
 export * from './components/create-agent/create-agent-dialog';
 export * from './components/create-agent/edit-agent-dialog';
+export * from './components/agent-cms-blocks';

--- a/packages/playground-ui/src/ds/components/ContentBlocks/content-block.tsx
+++ b/packages/playground-ui/src/ds/components/ContentBlocks/content-block.tsx
@@ -1,9 +1,13 @@
-import { Draggable, DraggableStyle } from '@hello-pangea/dnd';
+import { Draggable, DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
 import { ContentBlockContext, ContentBlocksContext } from './content-blocks.context';
 import { useContext } from 'react';
 
+export type ContentBlockChildren =
+  | React.ReactNode
+  | ((dragHandleProps: DraggableProvidedDragHandleProps | null) => React.ReactNode);
+
 export interface ContentBlockProps {
-  children: React.ReactNode;
+  children: ContentBlockChildren;
   index: number;
   className?: string;
 }
@@ -18,6 +22,8 @@ export const ContentBlock = ({ children, index, className }: ContentBlockProps) 
     onChange(newItems);
   };
 
+  const isRenderProp = typeof children === 'function';
+
   return (
     <ContentBlockContext.Provider value={{ item, modifyAtIndex }}>
       <Draggable draggableId={`draggable-content-block-${index}`} index={index}>
@@ -25,11 +31,11 @@ export const ContentBlock = ({ children, index, className }: ContentBlockProps) 
           <div
             ref={provided.innerRef}
             {...provided.draggableProps}
-            {...provided.dragHandleProps}
+            {...(isRenderProp ? {} : provided.dragHandleProps)}
             className={className}
-            style={{ backgroundColor: snapshot.isDragging ? 'lightgray' : 'white', ...provided.draggableProps.style }}
+            style={provided.draggableProps.style}
           >
-            {children}
+            {isRenderProp ? children(provided.dragHandleProps) : children}
           </div>
         )}
       </Draggable>

--- a/packages/playground-ui/src/ds/components/ContentBlocks/content-block.tsx
+++ b/packages/playground-ui/src/ds/components/ContentBlocks/content-block.tsx
@@ -1,0 +1,38 @@
+import { Draggable, DraggableStyle } from '@hello-pangea/dnd';
+import { ContentBlockContext, ContentBlocksContext } from './content-blocks.context';
+import { useContext } from 'react';
+
+export interface ContentBlockProps {
+  children: React.ReactNode;
+  index: number;
+  className?: string;
+}
+
+export const ContentBlock = ({ children, index, className }: ContentBlockProps) => {
+  const { items, onChange } = useContext(ContentBlocksContext);
+
+  const item = items[index];
+  const modifyAtIndex = (newItem: string) => {
+    const newItems = items.map((item, idx) => (idx === index ? newItem : item));
+
+    onChange(newItems);
+  };
+
+  return (
+    <ContentBlockContext.Provider value={{ item, modifyAtIndex }}>
+      <Draggable draggableId={`draggable-content-block-${index}`} index={index}>
+        {(provided, snapshot) => (
+          <div
+            ref={provided.innerRef}
+            {...provided.draggableProps}
+            {...provided.dragHandleProps}
+            className={className}
+            style={{ backgroundColor: snapshot.isDragging ? 'lightgray' : 'white', ...provided.draggableProps.style }}
+          >
+            {children}
+          </div>
+        )}
+      </Draggable>
+    </ContentBlockContext.Provider>
+  );
+};

--- a/packages/playground-ui/src/ds/components/ContentBlocks/content-blocks.context.tsx
+++ b/packages/playground-ui/src/ds/components/ContentBlocks/content-blocks.context.tsx
@@ -1,0 +1,27 @@
+import { createContext, useContext } from 'react';
+
+export type ContentBlocksContextType = {
+  items: Array<string>;
+  onChange: (items: Array<string>) => void;
+};
+
+export const ContentBlocksContext = createContext<ContentBlocksContextType>({
+  items: [],
+  onChange: () => {},
+});
+
+export type ContextBlockContextType = {
+  item: string;
+  modifyAtIndex: (item: string) => void;
+};
+
+export const ContentBlockContext = createContext<ContextBlockContextType>({
+  item: '',
+  modifyAtIndex: () => {},
+});
+
+export const useContentBlock = () => {
+  const { item, modifyAtIndex } = useContext(ContentBlockContext);
+
+  return [item, modifyAtIndex] as const;
+};

--- a/packages/playground-ui/src/ds/components/ContentBlocks/content-blocks.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ContentBlocks/content-blocks.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { ContentBlocks } from './content-blocks';
+import { ContentBlock } from './content-block';
+import { useState } from 'react';
+import { useContentBlock } from './content-blocks.context';
+
+const meta: Meta<typeof ContentBlocks> = {
+  title: 'Composite/ContentBlocks',
+  component: ContentBlocks,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ContentBlocks>;
+
+const CustomBlock = () => {
+  const [item, setItem] = useContentBlock();
+
+  return (
+    <div>
+      <input type="text" value={item} onChange={e => setItem(e.target.value)} />
+    </div>
+  );
+};
+
+const Components = () => {
+  const [items, setItems] = useState<Array<string>>([]);
+
+  const addButton = () => {
+    setItems(state => [...state, `item content number ${state.length + 1}`]);
+  };
+
+  return (
+    <div>
+      <ContentBlocks items={items} onChange={setItems}>
+        {items.map((item, index) => (
+          <ContentBlock index={index} key={index}>
+            <CustomBlock />
+          </ContentBlock>
+        ))}
+      </ContentBlocks>
+
+      <button onClick={addButton} style={{ backgroundColor: 'white' }}>
+        Add item
+      </button>
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: () => <Components />,
+};

--- a/packages/playground-ui/src/ds/components/ContentBlocks/content-blocks.tsx
+++ b/packages/playground-ui/src/ds/components/ContentBlocks/content-blocks.tsx
@@ -25,22 +25,12 @@ export const ContentBlocks = ({ children, items, onChange, className }: ContentB
     onChange(nextItems);
   };
 
-  const getListStyle = (isDraggingOver: boolean) => ({
-    background: isDraggingOver ? 'lightblue' : 'lightgrey',
-    width: 250,
-  });
-
   return (
     <ContentBlocksContext.Provider value={{ items, onChange }}>
       <DragDropContext onDragEnd={handleDragEnd}>
         <Droppable droppableId="droppable">
           {(provided, snapshot) => (
-            <div
-              {...provided.droppableProps}
-              ref={provided.innerRef}
-              style={getListStyle(snapshot.isDraggingOver)}
-              className={className}
-            >
+            <div {...provided.droppableProps} ref={provided.innerRef} className={className}>
               {children}
               {provided.placeholder}
             </div>

--- a/packages/playground-ui/src/ds/components/ContentBlocks/content-blocks.tsx
+++ b/packages/playground-ui/src/ds/components/ContentBlocks/content-blocks.tsx
@@ -1,0 +1,52 @@
+import { DragDropContext, Droppable, DropResult } from '@hello-pangea/dnd';
+import { ContentBlocksContext } from './content-blocks.context';
+
+export interface ContentBlocksProps {
+  children: React.ReactNode;
+  items: Array<string>;
+  onChange: (items: Array<string>) => void;
+  className?: string;
+}
+
+const reorder = (list: Array<string>, startIndex: number, endIndex: number) => {
+  const result = Array.from(list);
+  const [removed] = result.splice(startIndex, 1);
+  result.splice(endIndex, 0, removed);
+
+  return result;
+};
+
+export const ContentBlocks = ({ children, items, onChange, className }: ContentBlocksProps) => {
+  const handleDragEnd = (result: DropResult) => {
+    if (!result.destination) return;
+
+    const nextItems = reorder(items, result.source.index, result.destination.index);
+
+    onChange(nextItems);
+  };
+
+  const getListStyle = (isDraggingOver: boolean) => ({
+    background: isDraggingOver ? 'lightblue' : 'lightgrey',
+    width: 250,
+  });
+
+  return (
+    <ContentBlocksContext.Provider value={{ items, onChange }}>
+      <DragDropContext onDragEnd={handleDragEnd}>
+        <Droppable droppableId="droppable">
+          {(provided, snapshot) => (
+            <div
+              {...provided.droppableProps}
+              ref={provided.innerRef}
+              style={getListStyle(snapshot.isDraggingOver)}
+              className={className}
+            >
+              {children}
+              {provided.placeholder}
+            </div>
+          )}
+        </Droppable>
+      </DragDropContext>
+    </ContentBlocksContext.Provider>
+  );
+};

--- a/packages/playground-ui/src/ds/components/ContentBlocks/index.ts
+++ b/packages/playground-ui/src/ds/components/ContentBlocks/index.ts
@@ -1,2 +1,3 @@
 export * from './content-blocks';
 export * from './content-block';
+export { useContentBlock } from './content-blocks.context';

--- a/packages/playground-ui/src/ds/components/ContentBlocks/index.ts
+++ b/packages/playground-ui/src/ds/components/ContentBlocks/index.ts
@@ -1,0 +1,2 @@
+export * from './content-blocks';
+export * from './content-block';

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -72,6 +72,7 @@ export * from './ds/components/Steps';
 export * from './ds/components/Tabs';
 export * from './ds/components/Text';
 export * from './ds/components/JSONSchemaForm';
+export * from './ds/components/ContentBlocks';
 
 // Form utilities (AutoForm)
 export * from './lib/form';


### PR DESCRIPTION
Adds a reusable drag-and-drop content blocks system built on @hello-pangea/dnd.

**ContentBlocks** - A generic drag-and-drop container with context for managing ordered string arrays:

```tsx
<ContentBlocks items={items} onChange={setItems}>
  {items.map((_, index) => (
    <ContentBlock key={index} index={index}>
      {(dragHandleProps) => <MyContent dragHandleProps={dragHandleProps} />}
    </ContentBlock>
  ))}
</ContentBlocks>
```

**AgentCMSBlocks** - A ready-to-use implementation for agent system prompts with add, delete, and reorder:

```tsx
<AgentCMSBlocks
  items={systemPrompts}
  onChange={setSystemPrompts}
  placeholder="Enter system prompt..."
/>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop component for managing and reordering lists of editable content blocks
  * Introduced ready-to-use CMS block component with add, delete, and reorder functionality for agent system prompts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->