### PR TITLE
chore(docs): Document workspace in config ref

### DIFF
--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -106,40 +106,6 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Workspace',
-      customProps: {
-        tags: ['new'],
-      },
-      items: [
-        {
-          type: 'doc',
-          id: 'workspace/overview',
-          label: 'Overview',
-        },
-        {
-          type: 'doc',
-          id: 'workspace/filesystem',
-          label: 'Filesystem',
-        },
-        {
-          type: 'doc',
-          id: 'workspace/sandbox',
-          label: 'Sandbox',
-        },
-        {
-          type: 'doc',
-          id: 'workspace/skills',
-          label: 'Skills',
-        },
-        {
-          type: 'doc',
-          id: 'workspace/search',
-          label: 'Search and Indexing',
-        },
-      ],
-    },
-    {
-      type: 'category',
       label: 'Workflows',
       items: [
         {
@@ -297,6 +263,40 @@ const sidebars = {
           type: 'doc',
           id: 'rag/graph-rag',
           label: 'GraphRAG',
+        },
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Workspace',
+      customProps: {
+        tags: ['new'],
+      },
+      items: [
+        {
+          type: 'doc',
+          id: 'workspace/overview',
+          label: 'Overview',
+        },
+        {
+          type: 'doc',
+          id: 'workspace/filesystem',
+          label: 'Filesystem',
+        },
+        {
+          type: 'doc',
+          id: 'workspace/sandbox',
+          label: 'Sandbox',
+        },
+        {
+          type: 'doc',
+          id: 'workspace/skills',
+          label: 'Skills',
+        },
+        {
+          type: 'doc',
+          id: 'workspace/search',
+          label: 'Search and Indexing',
         },
       ],
     },

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -58,7 +58,6 @@ const workspace = new Workspace({
 
 const mastra = new Mastra({
   workspace,
-  agents: { myAgent },
 });
 ```
 

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -428,6 +428,27 @@ export const mastra = new Mastra({
 });
 ```
 
+### workspace
+
+**Type:** `Workspace`
+
+A Mastra workspace gives agents a persistent environment for storing files and executing commands. Agents inherit the global workspace on the `Mastra` class unless the have their own workspace configured.
+
+Visit the [Workspace documentation](/docs/workspace/overview) to learn more.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core';
+import { Workspace, LocalFilesystem } from '@mastra/core/workspace';
+
+const workspace = new Workspace({
+  filesystem: new LocalFilesystem({ basePath: './workspace' }),
+});
+
+const mastra = new Mastra({
+  workspace,
+});
+```
+
 ## Bundler options
 
 ### bundler.externals

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -432,10 +432,9 @@ export const mastra = new Mastra({
 
 **Type:** `Workspace`
 
-A Mastra workspace gives agents a persistent environment for storing files and executing commands. Agents inherit the global workspace on the `Mastra` class unless the have their own workspace configured.
+A Mastra workspace gives agents a persistent environment for storing files and executing commands. Agents inherit the global workspace on the `Mastra` class unless they have their own workspace configured.
 
-Visit the [Workspace documentation](/docs/workspace/overview) to learn more.
-
+See the [Workspace documentation](/docs/workspace/overview) for implementation details.
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core';
 import { Workspace, LocalFilesystem } from '@mastra/core/workspace';


### PR DESCRIPTION
## Description

Document `workspace` key of the Mastra class in the configuration reference. Also move workspace in the sidebar below memory and RAG

## Related Issue(s)

Fixes GRWTH-1395

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mastra now accepts a workspace configuration option, letting you attach a persistent Workspace (for example, LocalFilesystem) at initialization.

* **Documentation**
  * Configuration guide updated with examples for creating and wiring a Workspace into Mastra.
  * Workspace overview examples simplified by removing preset agents from constructor snippets.
  * Docs sidebar reorganized: Workspace section moved after RAG without content changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->