### PR TITLE
fix(fastify): preserve plugin headers on stream responses

### DIFF
--- a/.changeset/four-squids-begin.md
+++ b/.changeset/four-squids-begin.md
@@ -2,4 +2,4 @@
 '@mastra/fastify': patch
 ---
 
-Fixed CORS headers not being included in stream responses when using the Fastify adapter. Headers set by plugins (like @fastify/cors) are now preserved when streaming.
+Fixed missing cross-origin headers on streaming responses when using the Fastify adapter. Headers set by plugins (like @fastify/cors) are now preserved when streaming. See https://github.com/mastra-ai/mastra/issues/12622

--- a/.changeset/four-squids-begin.md
+++ b/.changeset/four-squids-begin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/fastify': patch
+---
+
+Fixed CORS headers not being included in stream responses when using the Fastify adapter. Headers set by plugins (like @fastify/cors) are now preserved when streaming.

--- a/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
+++ b/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
@@ -478,4 +478,118 @@ describe('Fastify Server Adapter', () => {
       app.addHook('preHandler', middleware);
     },
   });
+
+  describe('Plugin Headers on Stream Responses', () => {
+    let context: AdapterTestContext;
+    let app: FastifyInstance | null = null;
+
+    beforeEach(async () => {
+      context = await createDefaultTestContext();
+    });
+
+    afterEach(async () => {
+      if (app) {
+        await app.close();
+        app = null;
+      }
+    });
+
+    it('should preserve headers set by plugins/hooks on stream responses', async () => {
+      app = Fastify();
+
+      // Simulate what a CORS plugin does: set headers in an onRequest hook
+      // This tests that headers set before the route handler are preserved
+      // when using reply.hijack() for streaming
+      app.addHook('onRequest', async (_request, reply) => {
+        reply.header('access-control-allow-origin', 'https://example.com');
+        reply.header('access-control-allow-credentials', 'true');
+        reply.header('x-custom-header', 'custom-value');
+      });
+
+      const adapter = new MastraServer({
+        app,
+        mastra: context.mastra,
+      });
+
+      // Create a test route that returns a stream
+      const testRoute: ServerRoute<any, any, any> = {
+        method: 'POST',
+        path: '/test/stream',
+        responseType: 'stream',
+        streamFormat: 'sse',
+        handler: async () => createStreamWithSensitiveData('v2'),
+      };
+
+      app.addHook('preHandler', adapter.createContextMiddleware());
+      await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+      // Start server
+      const address = await app.listen({ port: 0 });
+
+      const response = await fetch(`${address}/test/stream`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(200);
+
+      // Headers set by the hook should be preserved on stream responses
+      expect(response.headers.get('access-control-allow-origin')).toBe('https://example.com');
+      expect(response.headers.get('access-control-allow-credentials')).toBe('true');
+      expect(response.headers.get('x-custom-header')).toBe('custom-value');
+
+      // Consume the stream to avoid hanging
+      await consumeSSEStream(response.body);
+    });
+
+    it('should preserve headers set by plugins/hooks on non-stream (JSON) responses', async () => {
+      app = Fastify();
+
+      // Simulate what a CORS plugin does: set headers in an onRequest hook
+      app.addHook('onRequest', async (_request, reply) => {
+        reply.header('access-control-allow-origin', 'https://example.com');
+        reply.header('access-control-allow-credentials', 'true');
+        reply.header('x-custom-header', 'custom-value');
+      });
+
+      const adapter = new MastraServer({
+        app,
+        mastra: context.mastra,
+      });
+
+      // Create a test route that returns JSON (not a stream)
+      const testRoute: ServerRoute<any, any, any> = {
+        method: 'POST',
+        path: '/test/json',
+        responseType: 'json',
+        handler: async () => ({ message: 'hello' }),
+      };
+
+      app.addHook('preHandler', adapter.createContextMiddleware());
+      await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+      // Start server
+      const address = await app.listen({ port: 0 });
+
+      const response = await fetch(`${address}/test/json`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(200);
+
+      // Headers should be present on JSON responses (this already works without the fix)
+      expect(response.headers.get('access-control-allow-origin')).toBe('https://example.com');
+      expect(response.headers.get('access-control-allow-credentials')).toBe('true');
+      expect(response.headers.get('x-custom-header')).toBe('custom-value');
+
+      await response.json();
+    });
+  });
 });

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -97,7 +97,14 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
     // Capture headers set by plugins (e.g., @fastify/cors) BEFORE hijacking
     // reply.hijack() bypasses Fastify's response handling, so we need to preserve
     // any headers that were set by hooks/plugins and manually include them
-    const existingHeaders = reply.getHeaders();
+    const rawHeaders = reply.getHeaders();
+    // Filter out undefined values to satisfy OutgoingHttpHeaders type
+    const existingHeaders: Record<string, string | number | string[]> = {};
+    for (const [key, value] of Object.entries(rawHeaders)) {
+      if (value !== undefined) {
+        existingHeaders[key] = value;
+      }
+    }
 
     // Hijack the reply to take control of the response
     // This is required when writing directly to reply.raw


### PR DESCRIPTION
Fixes #12622

When using the Fastify adapter with plugins like `@fastify/cors`, headers were missing from stream responses. This happened because `reply.hijack()` bypasses Fastify's normal response handling, so headers set by plugins were never included.

The fix captures headers before hijacking and includes them in the raw response:

```typescript
const rawHeaders = reply.getHeaders();
const existingHeaders: Record<string, string | number | string[]> = {};
for (const [key, value] of Object.entries(rawHeaders)) {
  if (value === undefined) continue;
  const lowerKey = key.toLowerCase();
  // Filter out headers that conflict with chunked streaming (RFC 7230)
  if (lowerKey === 'content-length' || lowerKey === 'transfer-encoding') continue;
  existingHeaders[key] = value;
}

reply.hijack();
reply.raw.writeHead(200, {
  ...existingHeaders,  // now includes CORS headers
  'Content-Type': 'text/plain',
  'Transfer-Encoding': 'chunked',
});
```

Added tests that simulate plugin behavior by setting headers in an `onRequest` hook.