### PR TITLE
docs(workspace): improve tool descriptions with usage guidance [COR-492]

### DIFF
--- a/.changeset/tricky-masks-appear.md
+++ b/.changeset/tricky-masks-appear.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Improved workspace tool descriptions with clearer usage guidance for read_file, edit_file, and execute_command tools.

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -101,7 +101,7 @@ export function createWorkspaceTools(workspace: Workspace) {
       tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE] = createTool({
         id: WORKSPACE_TOOLS.FILESYSTEM.READ_FILE,
         description:
-          'Read the contents of a file from the workspace filesystem. Supports reading specific line ranges using offset/limit parameters.',
+          'Read the contents of a file from the workspace filesystem. Use offset/limit parameters to read specific line ranges for large files.',
         requireApproval: readFileConfig.requireApproval,
         inputSchema: z.object({
           path: z.string().describe('The path to the file to read (e.g., "/data/config.json")'),
@@ -253,8 +253,13 @@ export function createWorkspaceTools(workspace: Workspace) {
     if (!isReadOnly && editFileConfig.enabled) {
       tools[WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE] = createTool({
         id: WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE,
-        description:
-          'Edit a file by replacing specific text. The old_string must match exactly and be unique in the file (unless using replace_all). You should read the file first to ensure you have the exact text to replace.',
+        description: `Edit a file by replacing specific text. The old_string must match exactly and be unique in the file.
+
+Usage:
+- Read the file first to get the exact text to replace.
+- By default, ${WORKSPACE_TOOLS.FILESYSTEM.READ_FILE} output includes line number prefixes (e.g., "     1→"). Ensure you preserve the exact indentation as it appears AFTER the arrow. Never include any part of the line number prefix in old_string or new_string.
+- Include enough surrounding context (multiple lines) to make old_string unique. If it still isn't unique, include more lines.
+- Use replace_all only when intentionally replacing all occurrences.`,
         requireApproval: editFileConfig.requireApproval,
         inputSchema: z.object({
           path: z.string().describe('The path to the file to edit'),
@@ -623,7 +628,13 @@ Examples:
     if (workspace.sandbox.executeCommand && executeCommandConfig.enabled) {
       tools[WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND] = createTool({
         id: WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND,
-        description: `Execute a shell command in the workspace sandbox. The output (stdout/stderr) is displayed to the user automatically in the tool result. ${pathInfo}`,
+        description: `Execute a shell command in the workspace sandbox.${pathInfo}
+
+Usage:
+- Verify parent directories exist before running commands that create files or directories.
+- Always quote file paths that contain spaces (e.g., cd "/path/with spaces").
+- Commands timeout after 30 seconds by default. Use the timeout parameter for longer operations.
+- Use cwd to set the working directory, or commands run from the sandbox default.`,
         requireApproval: executeCommandConfig.requireApproval,
         inputSchema: z.object({
           command: z.string().describe('The command to execute (e.g., "ls", "npm", "python")'),


### PR DESCRIPTION
## Summary
- Updated `read_file` tool description to clarify offset/limit usage for large files
- Improved `edit_file` tool description with usage guidance on line number prefixes, context matching, and replace_all
- Enhanced `execute_command` tool description with best practices for directory verification, path quoting, timeouts, and working directory

From [draft PR #12591](https://github.com/mastra-ai/mastra/pull/12591/files#diff-1fd2a1a8d81856d712b4142d0ab4876bbe5d22f3634812c80df978fbb3587cef) - shipping just the tool description updates.

## Test plan
- [x] Build passes (`pnpm build:core`)
- [x] Workspace tool tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced workspace tool descriptions with improved clarity and detailed usage guidance for file operations and command execution tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->