### PR TITLE
Fix CloudFlare Workers compatibility in observability module

### DIFF
--- a/.changeset/fix-cloudflare-observability-init.md
+++ b/.changeset/fix-cloudflare-observability-init.md
@@ -1,0 +1,7 @@
+---
+'@mastra/observability': patch
+---
+
+Fix CloudFlare Workers deployment failure caused by `fileURLToPath` being called at module initialization time.
+
+Moved `SNAPSHOTS_DIR` calculation from top-level module code into a lazy getter function. In CloudFlare Workers (V8 runtime), `import.meta.url` is `undefined` during worker startup, causing the previous code to throw. The snapshot functionality is only used for testing, so deferring initialization has no impact on normal operation.

--- a/observability/mastra/src/exporters/json.ts
+++ b/observability/mastra/src/exporters/json.ts
@@ -23,8 +23,7 @@ function getSnapshotsDir(): string {
   if (!_snapshotsDir) {
     if (typeof import.meta.url !== 'string') {
       throw new Error(
-        'Snapshot functionality requires a Node.js environment. ' +
-          'import.meta.url is not available in this runtime.',
+        'Snapshot functionality requires a Node.js environment. ' + 'import.meta.url is not available in this runtime.',
       );
     }
     const __filename = fileURLToPath(import.meta.url);

--- a/observability/mastra/src/exporters/json.ts
+++ b/observability/mastra/src/exporters/json.ts
@@ -13,9 +13,26 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const SNAPSHOTS_DIR = join(__dirname, '..', '__snapshots__');
+/**
+ * Lazily compute the snapshots directory to avoid CloudFlare Workers compatibility issues.
+ * In non-Node.js environments (like CloudFlare Workers), import.meta.url may be undefined
+ * at module load time, causing fileURLToPath to throw.
+ */
+let _snapshotsDir: string | undefined;
+function getSnapshotsDir(): string {
+  if (!_snapshotsDir) {
+    if (typeof import.meta.url !== 'string') {
+      throw new Error(
+        'Snapshot functionality requires a Node.js environment. ' +
+          'import.meta.url is not available in this runtime.',
+      );
+    }
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    _snapshotsDir = join(__dirname, '..', '__snapshots__');
+  }
+  return _snapshotsDir;
+}
 
 import type {
   TracingEvent,
@@ -851,7 +868,7 @@ export class JsonExporter extends BaseExporter {
    */
   async assertMatchesSnapshot(snapshotName: string, options?: { updateSnapshot?: boolean }): Promise<void> {
     // Resolve snapshot path relative to the __snapshots__ directory
-    const snapshotPath = join(SNAPSHOTS_DIR, snapshotName);
+    const snapshotPath = join(getSnapshotsDir(), snapshotName);
     const normalizedTree = this.buildNormalizedTree();
     const structureGraph = this.generateStructureGraph(normalizedTree);
 


### PR DESCRIPTION
## Description

Fix CloudFlare Workers deployment failure in the observability module caused by `fileURLToPath` being called at module initialization time.

The issue occurs because in CloudFlare Workers (V8 runtime), `import.meta.url` is `undefined` during worker startup. The previous code attempted to resolve the snapshots directory at the top level of the module, causing the entire module to fail to load even when the snapshot functionality was never used.

**Solution:** Moved `SNAPSHOTS_DIR` calculation from top-level module code into a lazy getter function (`getSnapshotsDir()`). The snapshots directory path is now only computed when `assertMatchesSnapshot()` is actually called, which only happens during testing. This has no impact on normal operation in CloudFlare Workers or other environments.

## Related Issue(s)

Fixes #12536

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Changes Made

1. **observability/mastra/src/exporters/json.ts**
   - Removed top-level `fileURLToPath` and `dirname` calls
   - Added `getSnapshotsDir()` lazy getter function with proper error handling
   - Updated `assertMatchesSnapshot()` to use the lazy getter

2. **observability/mastra/src/exporters/json.test.ts**
   - Added comprehensive test suite for CloudFlare Workers compatibility
   - Verifies module loads without executing Node.js-specific code
   - Confirms all non-snapshot functionality works independently

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

https://claude.ai/code/session_01NgdcuQgwgRwXnNBWvqX6Sj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed CloudFlare Workers deployment failure in observability module by deferring snapshot directory initialization to runtime

* **Tests**
  * Added CloudFlare Workers compatibility test suite to verify module initialization in restricted environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->