### PR TITLE
docs(migration): add section on direct tool execution

### DIFF
--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/tools.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/tools.mdx
@@ -183,3 +183,11 @@ Alternatively, update the `outputSchema` to match your actual output, or remove 
 
 The `tool.execute` property is optional in the type system to support client-side tool definitions where execution logic is handled separately. When calling `execute` directly on a tool instance (rather than through agents or workflows), use optional chaining or non-null assertion:
 
+```typescript
+// Optional chaining (recommended)
+const result = await weatherTool.execute?.({ location: 'New York' }, {});
+
+// Non-null assertion (when you know execute exists)
+const result = await weatherTool.execute!({ location: 'New York' }, {});
+```
+

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/tools.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/tools.mdx
@@ -178,3 +178,15 @@ console.log(result.id, result.name, result.email);
 ```
 
 Alternatively, update the `outputSchema` to match your actual output, or remove `outputSchema` entirely if you don't need validation.
+
+### Direct tool execution
+
+For people doing direct tool execution, the `tool.execute` property is optional to support client-side tool definitions. Use optional chaining or non-null assertion when calling execute:
+
+```typescript
+// Optional chaining (recommended)
+const result = await weatherTool.execute?.({ location: 'New York' }, {});
+
+// Non-null assertion (when you know execute exists)
+const result = await weatherTool.execute!({ location: 'New York' }, {});
+```

--- a/docs/src/content/en/guides/migrations/upgrade-to-v1/tools.mdx
+++ b/docs/src/content/en/guides/migrations/upgrade-to-v1/tools.mdx
@@ -181,12 +181,5 @@ Alternatively, update the `outputSchema` to match your actual output, or remove 
 
 ### Direct tool execution
 
-For people doing direct tool execution, the `tool.execute` property is optional to support client-side tool definitions. Use optional chaining or non-null assertion when calling execute:
+The `tool.execute` property is optional in the type system to support client-side tool definitions where execution logic is handled separately. When calling `execute` directly on a tool instance (rather than through agents or workflows), use optional chaining or non-null assertion:
 
-```typescript
-// Optional chaining (recommended)
-const result = await weatherTool.execute?.({ location: 'New York' }, {});
-
-// Non-null assertion (when you know execute exists)
-const result = await weatherTool.execute!({ location: 'New York' }, {});
-```


### PR DESCRIPTION
## Summary

Adds a section to the v1 tools migration guide explaining that `tool.execute` is now optional.
## Changes

- Added "Direct tool execution" section explaining optional `tool.execute`
- Documents using optional chaining or non-null assertion when calling execute directly
- Clarifies this is relevant for people doing direct tool execution

## Example

```typescript
// Optional chaining (recommended)
const result = await weatherTool.execute?.({ location: 'New York' }, {});

// Non-null assertion (when you know execute exists)
const result = await weatherTool.execute!({ location: 'New York' }, {});
```

## Context

The `tool.execute` property is intentionally optional in the type system to support client-side tool definitions where execution logic is handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new subsection explaining optional direct execution of tools and providing guidance and TypeScript examples for safely invoking tool instances during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->