### PR TITLE
Fix security issue: exclude tracing credentials from error logs

### DIFF
--- a/.changeset/silver-rings-appear.md
+++ b/.changeset/silver-rings-appear.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a security issue where sensitive observability credentials (such as Langfuse API keys) could be exposed in tool execution error logs. The tracingContext is now properly excluded from logged data.

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -242,8 +242,17 @@ export class CoreToolBuilder extends MastraBase {
     logType?: 'tool' | 'toolset' | 'client-tool',
     processedSchema?: z.ZodTypeAny,
   ) {
-    // dont't add memory or mastra to logging
-    const { logger, mastra: _mastra, memory: _memory, requestContext, model, ...rest } = options;
+    // don't add memory, mastra, or tracing context to logging (tracingContext may contain sensitive observability credentials)
+    const {
+      logger,
+      mastra: _mastra,
+      memory: _memory,
+      requestContext,
+      model,
+      tracingContext: _tracingContext,
+      tracingPolicy: _tracingPolicy,
+      ...rest
+    } = options;
     const logModelObject = {
       modelId: model?.modelId,
       provider: model?.provider,
@@ -485,7 +494,7 @@ export class CoreToolBuilder extends MastraBase {
             domain: ErrorDomain.TOOL,
             category: ErrorCategory.USER,
             details: {
-              errorMessage: String(error),
+              errorMessage: String(err),
               argsJson: JSON.stringify(args),
               model: model?.modelId ?? '',
             },


### PR DESCRIPTION
## Description

This PR fixes a security vulnerability where sensitive observability credentials (such as Langfuse API keys) could be exposed in tool execution error logs. The `tracingContext` and `tracingPolicy` are now properly excluded from logged data.

Additionally, a bug fix is included where an undefined variable `error` was being referenced instead of the correct `err` variable in error handling.

## Issues

Fixes: #12644

## Changes Made

- Excluded `tracingContext` and `tracingPolicy` from tool execution logging to prevent exposure of sensitive observability credentials
- Fixed variable reference in error details from `error` to `err`
- Updated comment to clarify what is being excluded from logs

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Checklist

- [x] Changes address the security concern without breaking existing functionality
- [x] Variable reference bug has been corrected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability where sensitive observability credentials could be exposed in tool execution error logs. Sensitive data is now excluded from logged information to prevent credential leakage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->