### PR TITLE
fix(workspace): generate SQL-compatible search index names

### DIFF
--- a/.changeset/lucky-bees-serve.md
+++ b/.changeset/lucky-bees-serve.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workspace search index names to be compatible with SQL-based vector stores (PgVector, LibSQL). Index names now use underscores instead of hyphens, matching SQL identifier requirements.
+
+Added `searchIndexName` option to Workspace config for custom index names when needed.
+
+Fixes #12656

--- a/.changeset/lucky-bees-serve.md
+++ b/.changeset/lucky-bees-serve.md
@@ -2,8 +2,25 @@
 '@mastra/core': patch
 ---
 
-Fixed workspace search index names to be compatible with SQL-based vector stores (PgVector, LibSQL). Index names now use underscores instead of hyphens, matching SQL identifier requirements.
+**Fixed**
+Workspace search index names now use underscores so they work with SQL-based vector stores (PgVector, LibSQL).
 
-Added `searchIndexName` option to Workspace config for custom index names when needed.
+**Added**
+You can now set a custom index name with `searchIndexName`.
+
+**Why**
+Some SQL vector stores reject hyphens in index names.
+
+**Example**
+```ts
+// Before - would fail with PgVector
+new Workspace({ id: 'my-workspace', vectorStore, embedder });
+
+// After - works with all vector stores
+new Workspace({ id: 'my-workspace', vectorStore, embedder });
+
+// Or use a custom index name
+new Workspace({ vectorStore, embedder, searchIndexName: 'my_workspace_vectors' });
+```
 
 Fixes #12656

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -97,6 +97,19 @@ export interface WorkspaceConfig {
   bm25?: boolean | BM25Config;
 
   /**
+   * Custom index name for the vector store.
+   * If not provided, defaults to a sanitized version of `${id}_search`.
+   *
+   * Must be a valid SQL identifier for SQL-based stores (PgVector, LibSQL):
+   * - Start with a letter or underscore
+   * - Contain only letters, numbers, or underscores
+   * - Maximum 63 characters
+   *
+   * @example 'my_workspace_vectors'
+   */
+  searchIndexName?: string;
+
+  /**
    * Paths to auto-index on init().
    * Files in these directories will be indexed for search.
    * @example ['/docs', '/support']
@@ -291,7 +304,8 @@ export class Workspace {
             ? {
                 vectorStore: config.vectorStore,
                 embedder: config.embedder,
-                indexName: `${this.id}-search`,
+                // Use custom name or generate SQL-compatible default (no hyphens)
+                indexName: config.searchIndexName ?? `${this.id.replace(/-/g, '_')}_search`,
               }
             : undefined,
       });


### PR DESCRIPTION
## Description

Fixed workspace search index names to be compatible with SQL-based vector stores (PgVector, LibSQL). The generated index names now use underscores instead of hyphens, matching SQL identifier requirements.

Also added a `searchIndexName` config option to allow users to specify custom index names when needed.

## Related Issue(s)

Fixes #12656

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workspace setting to specify a custom search index name.

* **Bug Fixes**
  * Search index names now default to an underscore-safe format and are compatible with SQL-based vector stores.

* **Validation**
  * Index names are validated (must start with a letter/underscore, use only letters/numbers/underscores, max 63 chars); invalid names produce an error.

* **Tests**
  * Added tests covering name generation, sanitization, custom names, and validation errors.

* **Documentation**
  * Documented rationale, defaults, and examples for index naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->