### PR TITLE
docs: add notes about using absolute paths for shared database access

### DIFF
--- a/docs/src/content/en/docs/memory/storage.mdx
+++ b/docs/src/content/en/docs/memory/storage.mdx
@@ -32,7 +32,7 @@ export const mastra = new Mastra({
 When running `mastra dev` alongside your application (e.g., Next.js), use an absolute path to ensure both processes access the same database:
 
 ```typescript
-url: "file:/Users/yourname/project/mastra.db"
+url: "file:/absolute/path/to/your/project/mastra.db"
 ```
 
 Relative paths like `file:./mastra.db` resolve based on each process's working directory, which may differ.

--- a/docs/src/content/en/docs/memory/storage.mdx
+++ b/docs/src/content/en/docs/memory/storage.mdx
@@ -27,6 +27,17 @@ export const mastra = new Mastra({
   }),
 });
 ```
+
+:::tip[Sharing the database with Mastra Studio]
+When running `mastra dev` alongside your application (e.g., Next.js), use an absolute path to ensure both processes access the same database:
+
+```typescript
+url: "file:/Users/yourname/project/mastra.db"
+```
+
+Relative paths like `file:./mastra.db` resolve based on each process's working directory, which may differ.
+:::
+
 This configures instance-level storage, which all agents share by default. You can also configure [agent-level storage](#agent-level-storage) for isolated data boundaries.
 
 Mastra automatically creates the necessary tables on first interaction. See the [core schema](/reference/storage/overview#core-schema) for details on what gets created, including tables for messages, threads, resources, workflows, traces, and evaluation datasets.

--- a/docs/src/content/en/guides/getting-started/next-js.mdx
+++ b/docs/src/content/en/guides/getting-started/next-js.mdx
@@ -56,6 +56,16 @@ This creates a `src/mastra` folder with an example weather agent and the followi
 
 You'll call `weather-agent.ts` from your Next.js routes in the next steps.
 
+:::tip[Using Mastra Studio alongside Next.js]
+If you want to run `mastra dev` (Mastra Studio) alongside your Next.js app and have both share the same database, update the storage URL in `src/mastra/index.ts` to use an absolute path:
+
+```typescript
+url: "file:/absolute/path/to/your/project/mastra.db"
+```
+
+Relative paths resolve based on each process's working directory, which differs between `next dev` and `mastra dev`.
+:::
+
 ## Install AI SDK UI & AI Elements
 
 Install AI SDK UI along with the Mastra adapter:


### PR DESCRIPTION
When running `mastra dev` alongside a Next.js app, both processes need to access the same database file. Relative paths like `file:./mastra.db` resolve based on each process's working directory, which can differ.

Added tips to the storage docs and Next.js guide recommending absolute paths:

```typescript
url: "file:/absolute/path/to/your/project/mastra.db"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on sharing a database file between Mastra Studio and your app by using absolute file URLs in storage configuration.
  * Included Next.js-specific tips to ensure Mastra Studio and Next.js access the same database during development.
  * Clarified that relative paths resolve differently per process (dev servers may use different working directories).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->