### PR TITLE
fix(core): preserve workspace skills when custom inputProcessors are used

### DIFF
--- a/.changeset/great-chefs-go.md
+++ b/.changeset/great-chefs-go.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workspace skills being removed when custom inputProcessors are passed to generate() or stream() options. Previously, passing inputProcessors to these methods would completely replace the auto-derived processors (including SkillsProcessor), causing skill tools like skill-activate and skill-search to be unavailable. Now, custom inputProcessors correctly override only user-configured processors while preserving implicit processors for memory and skills. Fixes #12612.

--- a/.changeset/great-chefs-go.md
+++ b/.changeset/great-chefs-go.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed workspace skills being removed when custom inputProcessors are passed to generate() or stream() options. Previously, passing inputProcessors to these methods would completely replace the auto-derived processors (including SkillsProcessor), causing skill tools like skill-activate and skill-search to be unavailable. Now, custom inputProcessors correctly override only user-configured processors while preserving implicit processors for memory and skills. Fixes #12612.
+Fixed custom input processors from disabling workspace skill tools in generate() and stream(). Custom processors now replace only the processors you configured, while memory and skills remain available. Fixes #12612.

--- a/packages/core/src/agent/__tests__/skills-with-custom-processors.test.ts
+++ b/packages/core/src/agent/__tests__/skills-with-custom-processors.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for GitHub Issue #12612
+ * Verifies that SkillsProcessor is preserved when custom inputProcessors are used.
+ *
+ * Two scenarios:
+ * 1. inputProcessors on Agent constructor - should merge with skills (WORKS)
+ * 2. inputProcessors on generate()/stream() options - should merge with skills (CURRENTLY BROKEN)
+ */
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Processor, ProcessInputArgs } from '../../processors/index';
+import type { Skill, SkillMetadata, WorkspaceSkills } from '../../workspace/skills';
+import type { Workspace } from '../../workspace/workspace';
+import { Agent } from '../index';
+
+// =============================================================================
+// Mock Helpers
+// =============================================================================
+
+// Simple passthrough processor that doesn't modify messages
+// This simulates a user adding a custom processor like ModerationProcessor
+class PassthroughProcessor implements Processor<'passthrough'> {
+  readonly id = 'passthrough' as const;
+  readonly name = 'Passthrough Processor';
+
+  async processInput(args: ProcessInputArgs) {
+    // Just return messages unchanged
+    return args.messages;
+  }
+}
+
+// Mock skill data
+const mockSkill: Skill = {
+  name: 'test-skill',
+  description: 'A test skill',
+  instructions: '# Test Skill\n\nThis is a test skill.',
+  path: '/skills/test-skill',
+  source: { type: 'local', projectPath: '/skills/test-skill' },
+  references: [],
+  scripts: [],
+  assets: [],
+};
+
+const mockSkillMetadata: SkillMetadata = {
+  name: mockSkill.name,
+  description: mockSkill.description,
+};
+
+// Create mock WorkspaceSkills
+function createMockWorkspaceSkills(): WorkspaceSkills {
+  const skills = new Map<string, Skill>([[mockSkill.name, mockSkill]]);
+
+  return {
+    list: vi.fn().mockResolvedValue([mockSkillMetadata]),
+    get: vi.fn().mockImplementation((name: string) => Promise.resolve(skills.get(name) || null)),
+    has: vi.fn().mockImplementation((name: string) => Promise.resolve(skills.has(name))),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    maybeRefresh: vi.fn().mockResolvedValue(undefined),
+    search: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getReference: vi.fn().mockResolvedValue(null),
+    getScript: vi.fn().mockResolvedValue(null),
+    getAsset: vi.fn().mockResolvedValue(null),
+    listReferences: vi.fn().mockResolvedValue([]),
+    listScripts: vi.fn().mockResolvedValue([]),
+    listAssets: vi.fn().mockResolvedValue([]),
+  };
+}
+
+// Create mock Workspace with skills
+function createMockWorkspace(): Workspace {
+  return {
+    skills: createMockWorkspaceSkills(),
+    getToolsConfig: () => undefined,
+    filesystem: undefined,
+    sandbox: undefined,
+  } as unknown as Workspace;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+// Helper to extract tool names from the tools passed to the model
+function getToolNames(tools: unknown): string[] {
+  if (!tools) return [];
+  if (Array.isArray(tools)) {
+    return tools.map((t: any) => t.name).filter(Boolean);
+  }
+  if (typeof tools === 'object') {
+    return Object.keys(tools);
+  }
+  return [];
+}
+
+describe('Skills with Custom Processors (Issue #12612)', () => {
+  let mockModel: MockLanguageModelV2;
+  let mockWorkspace: Workspace;
+  let capturedTools: unknown;
+
+  beforeEach(() => {
+    capturedTools = undefined;
+
+    mockModel = new MockLanguageModelV2({
+      doGenerate: async ({ prompt, tools }) => {
+        // Capture the tools that were passed to the model
+        capturedTools = tools;
+
+        return {
+          content: [{ type: 'text', text: 'response' }],
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+          rawCall: { rawPrompt: prompt, rawSettings: {} },
+          warnings: [],
+        };
+      },
+      doStream: async ({ prompt, tools }) => {
+        // Capture the tools that were passed to the model
+        capturedTools = tools;
+
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'response' },
+            { type: 'text-end', id: 'text-1' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            },
+          ]),
+          rawCall: { rawPrompt: prompt, rawSettings: {} },
+          warnings: [],
+        };
+      },
+    });
+
+    mockWorkspace = createMockWorkspace();
+  });
+
+  describe('Scenario 1: inputProcessors on Agent constructor', () => {
+    it('should include skill tools when custom processor is on Agent constructor', async () => {
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'You are a test agent',
+        model: mockModel,
+        workspace: mockWorkspace,
+        inputProcessors: [new PassthroughProcessor()],
+      });
+
+      await agent.generate('Hello');
+
+      // Verify that skill tools are available
+      const toolNames = getToolNames(capturedTools);
+      expect(toolNames).toContain('skill-activate');
+      expect(toolNames).toContain('skill-search');
+    });
+
+    it('should include skill tools when using stream() with custom processor on Agent constructor', async () => {
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'You are a test agent',
+        model: mockModel,
+        workspace: mockWorkspace,
+        inputProcessors: [new PassthroughProcessor()],
+      });
+
+      const result = await agent.stream('Hello');
+      // Consume the stream to trigger processing
+      for await (const _ of result.fullStream) {
+        // Just consume
+      }
+
+      // Verify that skill tools are available
+      const toolNames = getToolNames(capturedTools);
+      expect(toolNames).toContain('skill-activate');
+      expect(toolNames).toContain('skill-search');
+    });
+  });
+
+  describe('Scenario 2: inputProcessors on generate()/stream() options', () => {
+    it('should include skill tools when custom processor is passed to generate() options', async () => {
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'You are a test agent',
+        model: mockModel,
+        workspace: mockWorkspace,
+      });
+
+      await agent.generate('Hello', {
+        inputProcessors: [new PassthroughProcessor()],
+      });
+
+      // Verify that skill tools are available
+      // THIS TEST WILL FAIL with current code - skills get replaced by the override
+      const toolNames = getToolNames(capturedTools);
+      expect(toolNames).toContain('skill-activate');
+      expect(toolNames).toContain('skill-search');
+    });
+
+    it('should include skill tools when custom processor is passed to stream() options', async () => {
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'You are a test agent',
+        model: mockModel,
+        workspace: mockWorkspace,
+      });
+
+      const result = await agent.stream('Hello', {
+        inputProcessors: [new PassthroughProcessor()],
+      });
+      // Consume the stream to trigger processing
+      for await (const _ of result.fullStream) {
+        // Just consume
+      }
+
+      // Verify that skill tools are available
+      // THIS TEST WILL FAIL with current code - skills get replaced by the override
+      const toolNames = getToolNames(capturedTools);
+      expect(toolNames).toContain('skill-activate');
+      expect(toolNames).toContain('skill-search');
+    });
+  });
+
+  describe('Baseline: Agent with workspace but no custom processors', () => {
+    it('should include skill tools by default', async () => {
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'You are a test agent',
+        model: mockModel,
+        workspace: mockWorkspace,
+      });
+
+      await agent.generate('Hello');
+
+      // Verify that skill tools are available
+      const toolNames = getToolNames(capturedTools);
+      expect(toolNames).toContain('skill-activate');
+      expect(toolNames).toContain('skill-search');
+    });
+  });
+});

--- a/packages/core/src/agent/__tests__/skills-with-custom-processors.test.ts
+++ b/packages/core/src/agent/__tests__/skills-with-custom-processors.test.ts
@@ -1,10 +1,10 @@
 /**
  * Tests for GitHub Issue #12612
- * Verifies that SkillsProcessor is preserved when custom inputProcessors are used.
+ * Verifies that skill tools are preserved when custom inputProcessors are used.
  *
  * Two scenarios:
- * 1. inputProcessors on Agent constructor - should merge with skills (WORKS)
- * 2. inputProcessors on generate()/stream() options - should merge with skills (CURRENTLY BROKEN)
+ * 1. inputProcessors on Agent constructor - should merge with skills
+ * 2. inputProcessors on generate()/stream() options - should merge with skills
  */
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -200,7 +200,6 @@ describe('Skills with Custom Processors (Issue #12612)', () => {
       });
 
       // Verify that skill tools are available
-      // THIS TEST WILL FAIL with current code - skills get replaced by the override
       const toolNames = getToolNames(capturedTools);
       expect(toolNames).toContain('skill-activate');
       expect(toolNames).toContain('skill-search');
@@ -224,7 +223,6 @@ describe('Skills with Custom Processors (Issue #12612)', () => {
       }
 
       // Verify that skill tools are available
-      // THIS TEST WILL FAIL with current code - skills get replaced by the override
       const toolNames = getToolNames(capturedTools);
       expect(toolNames).toContain('skill-activate');
       expect(toolNames).toContain('skill-search');

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -417,8 +417,8 @@ export class Agent<
     outputProcessorOverrides?: OutputProcessorOrWorkflow[];
     processorStates?: Map<string, ProcessorState>;
   }): Promise<ProcessorRunner> {
-    // Use overrides if provided, otherwise resolve from agent config + memory
-    const inputProcessors = inputProcessorOverrides ?? (await this.listResolvedInputProcessors(requestContext));
+    // Resolve input processors - overrides replace user-configured but auto-derived (memory, skills) are kept
+    const inputProcessors = await this.listResolvedInputProcessors(requestContext, inputProcessorOverrides);
 
     const outputProcessors = outputProcessorOverrides ?? (await this.listResolvedOutputProcessors(requestContext));
 
@@ -544,13 +544,19 @@ export class Agent<
    * All processors are combined into a single workflow for consistency.
    * @internal
    */
-  private async listResolvedInputProcessors(requestContext?: RequestContext): Promise<InputProcessorOrWorkflow[]> {
-    // Get configured input processors
-    const configuredProcessors = this.#inputProcessors
-      ? typeof this.#inputProcessors === 'function'
-        ? await this.#inputProcessors({ requestContext: requestContext || new RequestContext() })
-        : this.#inputProcessors
-      : [];
+  private async listResolvedInputProcessors(
+    requestContext?: RequestContext,
+    configuredProcessorOverrides?: InputProcessorOrWorkflow[],
+  ): Promise<InputProcessorOrWorkflow[]> {
+    // Get configured input processors - use overrides if provided (from generate/stream options),
+    // otherwise use agent constructor processors
+    const configuredProcessors = configuredProcessorOverrides
+      ? configuredProcessorOverrides
+      : this.#inputProcessors
+        ? typeof this.#inputProcessors === 'function'
+          ? await this.#inputProcessors({ requestContext: requestContext || new RequestContext() })
+          : this.#inputProcessors
+        : [];
 
     // Get memory input processors (with deduplication)
     // Use getMemory() to ensure storage is injected from Mastra if not explicitly configured
@@ -3191,8 +3197,13 @@ export class Agent<
       getMemoryMessages: this.getMemoryMessages.bind(this),
       runInputProcessors: this.__runInputProcessors.bind(this),
       executeOnFinish: this.#executeOnFinish.bind(this),
-      inputProcessors: async ({ requestContext }: { requestContext: RequestContext }) =>
-        this.listResolvedInputProcessors(requestContext),
+      inputProcessors: async ({
+        requestContext,
+        overrides,
+      }: {
+        requestContext: RequestContext;
+        overrides?: InputProcessorOrWorkflow[];
+      }) => this.listResolvedInputProcessors(requestContext, overrides),
       outputProcessors: async ({ requestContext }: { requestContext: RequestContext }) =>
         this.listResolvedOutputProcessors(requestContext),
       llm,

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -142,16 +142,15 @@ export function createMapResultsStep<OUTPUT = undefined>({
         : [structuredProcessor];
     }
 
-    // Resolve input processors from options override or agent capability
-    const effectiveInputProcessors =
-      options.inputProcessors ||
-      (capabilities.inputProcessors
-        ? typeof capabilities.inputProcessors === 'function'
-          ? await capabilities.inputProcessors({
-              requestContext: result.requestContext!,
-            })
-          : capabilities.inputProcessors
-        : []);
+    // Resolve input processors - overrides replace user-configured but auto-derived (memory, skills) are kept
+    const effectiveInputProcessors = capabilities.inputProcessors
+      ? typeof capabilities.inputProcessors === 'function'
+        ? await capabilities.inputProcessors({
+            requestContext: result.requestContext!,
+            overrides: options.inputProcessors,
+          })
+        : capabilities.inputProcessors
+      : options.inputProcessors || [];
 
     const messageList = memoryData.messageList!;
 

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -120,15 +120,15 @@ export function createMapResultsStep<OUTPUT = undefined>({
       return bail(modelOutput);
     }
 
-    let effectiveOutputProcessors =
-      options.outputProcessors ||
-      (capabilities.outputProcessors
-        ? typeof capabilities.outputProcessors === 'function'
-          ? await capabilities.outputProcessors({
-              requestContext: result.requestContext!,
-            })
-          : capabilities.outputProcessors
-        : []);
+    // Resolve output processors - overrides replace user-configured but auto-derived (memory) are kept
+    let effectiveOutputProcessors = capabilities.outputProcessors
+      ? typeof capabilities.outputProcessors === 'function'
+        ? await capabilities.outputProcessors({
+            requestContext: result.requestContext!,
+            overrides: options.outputProcessors,
+          })
+        : options.outputProcessors || capabilities.outputProcessors
+      : options.outputProcessors || [];
 
     // Handle structuredOutput option by creating an StructuredOutputProcessor
     // Only create the processor if a model is explicitly provided

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -149,7 +149,7 @@ export function createMapResultsStep<OUTPUT = undefined>({
             requestContext: result.requestContext!,
             overrides: options.inputProcessors,
           })
-        : capabilities.inputProcessors
+        : options.inputProcessors || capabilities.inputProcessors
       : options.inputProcessors || [];
 
     const messageList = memoryData.messageList!;

--- a/packages/core/src/agent/workflows/prepare-stream/schema.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/schema.ts
@@ -4,7 +4,6 @@ import type { MastraLLMVNext } from '../../../llm/model/model.loop';
 import type { Mastra } from '../../../mastra';
 import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow, ProcessorState } from '../../../processors';
 import type { RequestContext } from '../../../request-context';
-import type { DynamicArgument } from '../../../types';
 import type { Agent } from '../../agent';
 import { MessageList } from '../../message-list';
 import type { AgentExecuteOnFinishOptions } from '../../types';
@@ -20,7 +19,12 @@ export type AgentCapabilities = {
   convertTools: Agent['convertTools'];
   runInputProcessors: Agent['__runInputProcessors'];
   executeOnFinish: (args: AgentExecuteOnFinishOptions) => Promise<void>;
-  outputProcessors?: DynamicArgument<OutputProcessorOrWorkflow[]>;
+  outputProcessors?:
+    | OutputProcessorOrWorkflow[]
+    | ((args: {
+        requestContext: RequestContext;
+        overrides?: OutputProcessorOrWorkflow[];
+      }) => Promise<OutputProcessorOrWorkflow[]> | OutputProcessorOrWorkflow[]);
   inputProcessors?:
     | InputProcessorOrWorkflow[]
     | ((args: {

--- a/packages/core/src/agent/workflows/prepare-stream/schema.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/schema.ts
@@ -3,6 +3,7 @@ import type { MastraBase } from '../../../base';
 import type { MastraLLMVNext } from '../../../llm/model/model.loop';
 import type { Mastra } from '../../../mastra';
 import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow, ProcessorState } from '../../../processors';
+import type { RequestContext } from '../../../request-context';
 import type { DynamicArgument } from '../../../types';
 import type { Agent } from '../../agent';
 import { MessageList } from '../../message-list';
@@ -20,7 +21,12 @@ export type AgentCapabilities = {
   runInputProcessors: Agent['__runInputProcessors'];
   executeOnFinish: (args: AgentExecuteOnFinishOptions) => Promise<void>;
   outputProcessors?: DynamicArgument<OutputProcessorOrWorkflow[]>;
-  inputProcessors?: DynamicArgument<InputProcessorOrWorkflow[]>;
+  inputProcessors?:
+    | InputProcessorOrWorkflow[]
+    | ((args: {
+        requestContext: RequestContext;
+        overrides?: InputProcessorOrWorkflow[];
+      }) => Promise<InputProcessorOrWorkflow[]> | InputProcessorOrWorkflow[]);
   llm: MastraLLMVNext;
 };
 


### PR DESCRIPTION
## Description

When users passed `inputProcessors` to `generate()`/`stream()` options, the auto-derived processors (memory, skills) were completely replaced instead of being merged. This caused skill tools (`skill-activate`, `skill-search`) to be unavailable.

The fix ensures that custom `inputProcessors` override only user-configured processors (from Agent constructor) while preserving implicit processors for memory and skills.

## Related Issue(s)

Fixes #12612

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom input processors passed to generate()/stream() now override only user-configured processors while preserving implicit processors (memory and skills), restoring expected tool availability.

* **Tests**
  * Added tests confirming skill-related tools remain available when custom input processors are supplied via agent configuration or per-call options (including streaming).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->