### PR TITLE
fix(core): handle models calling skill names directly as tools

### DIFF
--- a/.changeset/slimy-chicken-give.md
+++ b/.changeset/slimy-chicken-give.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed issue where some models incorrectly call skill names directly as tools instead of using skill-activate. Added clearer system instructions that explicitly state skills are NOT tools and must be activated via skill-activate with the skill name as the "name" parameter. Fixes #12654.

--- a/packages/core/src/processors/processors/skills.test.ts
+++ b/packages/core/src/processors/processors/skills.test.ts
@@ -630,4 +630,44 @@ describe('SkillsProcessor', () => {
       expect(result.tools).not.toHaveProperty('skill-activate');
     });
   });
+
+  describe('model calls skill name directly as tool (issue #12654)', () => {
+    it('should NOT expose skill names as callable tools', async () => {
+      // This test verifies that skill names are NOT available as tools
+      // The model should only be able to call 'skill-activate', not the skill name directly
+      const result = await processor.processInputStep({
+        messageList: mockMessageList as any,
+        tools: {},
+      });
+
+      // skill-activate should be available
+      expect(result.tools).toHaveProperty('skill-activate');
+
+      // Skill names should NOT be available as tools
+      expect(result.tools).not.toHaveProperty('code-review');
+      expect(result.tools).not.toHaveProperty('testing');
+    });
+
+    it('should provide clear instructions about how to use skills', async () => {
+      await processor.processInputStep({
+        messageList: mockMessageList as any,
+        tools: {},
+      });
+
+      // The system message should clearly explain that:
+      // 1. Skills are NOT tools themselves
+      // 2. Must use skill-activate to activate a skill
+      // 3. The skill name goes as a parameter to skill-activate
+      const systemCalls = mockMessageList.addSystem.mock.calls;
+      const allSystemContent = systemCalls.map((call: any) => call[0]?.content || call[0]).join('\n');
+
+      // Check that the instruction mentions skill-activate
+      expect(allSystemContent).toContain('skill-activate');
+
+      // The instruction should be clear enough that the model knows NOT to call skill names directly
+      expect(allSystemContent).toMatch(
+        /do not.*call.*skill.*directly|skill.*not.*tool|use.*skill-activate.*with.*name/i,
+      );
+    });
+  });
 });

--- a/packages/core/src/processors/processors/skills.ts
+++ b/packages/core/src/processors/processors/skills.ts
@@ -564,10 +564,13 @@ ${skillInstructions}`;
       }
 
       // Add instruction to activate skills proactively
+      // Be explicit that skills are NOT tools and must be activated via skill-activate
       messageList.addSystem({
         role: 'system',
         content:
-          'When a user asks about a topic covered by an available skill, activate that skill immediately using the skill-activate tool. Do not ask for permission - just activate the skill and use its instructions to answer the question.',
+          'IMPORTANT: Skills are NOT tools. Do not call skill names directly. ' +
+          'To use a skill, call the skill-activate tool with the skill name as the "name" parameter. ' +
+          'When a user asks about a topic covered by an available skill, activate it immediately without asking for permission.',
       });
     }
 


### PR DESCRIPTION
## Description

When an agent has workspace skills, some models (especially Qwen3-30B-A3B-Instruct-2507) incorrectly call the skill name directly as a tool (e.g., `code-review`) instead of using `skill-activate({ name: "code-review" })`. This produced cryptic "Tool not found" errors that were difficult to debug.

**Root cause**: The previous system instruction was ambiguous - it said "activate that skill immediately using the skill-activate tool" which some models interpreted as "call the skill directly."

**Fix**: Improved system instructions to be explicit that skills are NOT tools:
```
IMPORTANT: Skills are NOT tools. Do not call skill names directly.
To use a skill, call the skill-activate tool with the skill name as the "name" parameter.
When a user asks about a topic covered by an available skill, activate it immediately without asking for permission.
```

## Related Issue(s)

Fixes #12654

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skills are no longer exposed as direct callable tools; system instructions now require activation via the skill-activate mechanism with the skill name as the "name" parameter and preserve immediate activation when relevant. Messaging improved to guide correct usage.

* **Tests**
  * Added tests verifying skills are not callable as tools and that system instructions reference skill-activate.

* **Chores**
  * Added a changeset documenting the patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->