### PR TITLE
Fix skill search dialog highlighting and installed badge bugs

### DIFF
--- a/.changeset/sweet-trams-roll.md
+++ b/.changeset/sweet-trams-roll.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Added source repository info to workspace skill listings so clients can distinguish identically named skills installed from different repos.

--- a/.changeset/tender-aliens-brush.md
+++ b/.changeset/tender-aliens-brush.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed skills search dialog to correctly identify individual skills. Selection now highlights only the clicked skill, and the Installed badge only shows for the exact skill that was installed (matching by source repository + name). Gracefully handles older server versions without source info by falling back to name-only matching.

--- a/packages/playground-ui/src/domains/workspace/types.ts
+++ b/packages/playground-ui/src/domains/workspace/types.ts
@@ -127,6 +127,12 @@ export type SkillSource =
   | { type: 'local'; projectPath: string }
   | { type: 'managed'; mastraPath: string };
 
+/** Source info for skills installed via skills.sh */
+export interface SkillsShSource {
+  owner: string;
+  repo: string;
+}
+
 export interface SkillMetadata {
   name: string;
   description: string;
@@ -135,6 +141,8 @@ export interface SkillMetadata {
   metadata?: Record<string, unknown>;
   /** Path to the skill directory */
   path: string;
+  /** Source info for skills installed via skills.sh (from .meta.json) */
+  skillsShSource?: SkillsShSource;
 }
 
 export interface Skill extends SkillMetadata {

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -628,7 +628,12 @@ export default function Workspace() {
           workspaceId={effectiveWorkspaceId}
           onInstall={handleInstallSkill}
           isInstalling={installSkill.isPending}
-          installedSkillNames={skills.map(s => s.name)}
+          // Pass precise IDs for skills with source info (format: owner/repo/name)
+          installedSkillIds={skills
+            .filter(s => s.skillsShSource)
+            .map(s => `${s.skillsShSource!.owner}/${s.skillsShSource!.repo}/${s.name}`)}
+          // Fallback to names for skills without source info
+          installedSkillNames={skills.filter(s => !s.skillsShSource).map(s => s.name)}
         />
       )}
     </MainContentLayout>

--- a/packages/server/src/server/schemas/workspace.ts
+++ b/packages/server/src/server/schemas/workspace.ts
@@ -255,8 +255,19 @@ export const skillSchema = skillMetadataSchema.extend({
   assets: z.array(z.string()),
 });
 
+/**
+ * Source info for skills installed via skills.sh
+ * Stored in .meta.json when a skill is installed
+ */
+export const skillsShSourceSchema = z.object({
+  owner: z.string().describe('GitHub owner/org'),
+  repo: z.string().describe('GitHub repository'),
+});
+
 export const skillMetadataWithPathSchema = skillMetadataSchema.extend({
   path: z.string().describe('Path to the skill directory'),
+  /** Source info for skills installed via skills.sh (from .meta.json) */
+  skillsShSource: skillsShSourceSchema.optional(),
 });
 
 export const listSkillsResponseSchema = z.object({


### PR DESCRIPTION
## Description

Fixed two bugs in the skills search dialog in Studio:

1. **Selection highlighting bug**: Clicking on a skill to select it would highlight all skills with the same name, even when they came from different repositories
2. **Installed badge bug**: After installing a skill, all skills with the same name showed as "Installed" even when they came from different repos

The root cause was that skills were being identified by name only, not considering their source repository. Now each skill is uniquely identified by its source (owner/repo) + name.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace skill listings now show source repository info so identically named skills can be distinguished.

* **Bug Fixes**
  * Skills search/add-skill dialog correctly identifies and highlights the clicked skill.
  * Installed badge now appears only for the exact installed skill (matched by repository + name).
  * Graceful fallback when server lacks source info (falls back to name-only matching).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->