### PR TITLE
fix(workflows): surface agent tool calls in streams

### DIFF
--- a/.changeset/empty-llamas-reply.md
+++ b/.changeset/empty-llamas-reply.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent tool calls not being surfaced in evented workflow streams. Added StreamChunkWriter abstraction and stream format configuration ('legacy' | 'vnext') to forward agent stream chunks through the workflow output stream.

--- a/packages/core/src/workflows/evented/step-executor.ts
+++ b/packages/core/src/workflows/evented/step-executor.ts
@@ -71,6 +71,7 @@ export class StepExecutor extends MastraBase {
     validateInputs?: boolean;
     abortController?: AbortController;
     perStep?: boolean;
+    format?: 'legacy' | 'vnext';
   }): Promise<StepResult<any, any, any, any>> {
     const { step, stepResults, runId, requestContext, retryCount = 0, perStep } = params;
 
@@ -202,7 +203,7 @@ export class StepExecutor extends MastraBase {
               abortController?.abort();
             },
             [PUBSUB_SYMBOL]: this.mastra!.pubsub,
-            [STREAM_FORMAT_SYMBOL]: undefined, // TODO
+            [STREAM_FORMAT_SYMBOL]: params.format,
             engine: {},
             abortSignal: abortController?.signal,
             // TODO

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -41,6 +41,7 @@ export type ProcessorArgs = {
   };
   retryCount?: number;
   perStep?: boolean;
+  format?: 'legacy' | 'vnext';
   state?: Record<string, any>;
   outputOptions?: {
     includeState?: boolean;
@@ -66,6 +67,7 @@ export class WorkflowEventProcessor extends EventProcessor {
   private abortControllers: Map<string, AbortController> = new Map();
   // Map of child runId -> parent runId for tracking nested workflows
   private parentChildRelationships: Map<string, string> = new Map();
+  private runFormats: Map<string, 'legacy' | 'vnext' | undefined> = new Map();
 
   constructor({ mastra }: { mastra: Mastra }) {
     super({ mastra });
@@ -109,6 +111,7 @@ export class WorkflowEventProcessor extends EventProcessor {
   private cleanupRun(runId: string): void {
     this.abortControllers.delete(runId);
     this.parentChildRelationships.delete(runId);
+    this.runFormats.delete(runId);
 
     // Clean up any orphaned child entries pointing to this run as their parent
     for (const [childRunId, parentRunId] of this.parentChildRelationships.entries()) {
@@ -198,12 +201,15 @@ export class WorkflowEventProcessor extends EventProcessor {
     stepResults,
     requestContext,
     perStep,
+    format,
     state,
     outputOptions,
     forEachIndex,
   }: ProcessorArgs & { initialState?: Record<string, any> }) {
     // Use initialState from event data if provided, otherwise use state from ProcessorArgs
     const initialState = (arguments[0] as any).initialState ?? state ?? {};
+    const resolvedFormat = format ?? this.runFormats.get(runId);
+    this.runFormats.set(runId, resolvedFormat);
     // Create abort controller for this workflow run
     this.getOrCreateAbortController(runId);
 
@@ -541,6 +547,7 @@ export class WorkflowEventProcessor extends EventProcessor {
     outputOptions,
     forEachIndex,
   }: ProcessorArgs) {
+    const streamFormat = this.runFormats.get(runId);
     // Get current state from stepResults.__state or from passed state
     const currentState = resolveCurrentState({ stepResults, state });
     let stepGraph: StepFlowEntry[] = workflow.stepGraph;
@@ -1070,6 +1077,7 @@ export class WorkflowEventProcessor extends EventProcessor {
       foreachIdx: step.type === 'foreach' ? executionPath[1] : undefined,
       validateInputs: workflow.options.validateInputs,
       abortController,
+      format: streamFormat,
       perStep,
     });
     requestContext = Object.fromEntries(rc.entries());

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -30,6 +30,7 @@ import { Workflow, Run } from '../../workflows';
 import type { AgentStepOptions } from '../../workflows';
 import type { ExecutionEngine, ExecutionGraph } from '../../workflows/execution-engine';
 import type { Step } from '../../workflows/step';
+import { forwardAgentStreamChunk, type StreamChunkWriter } from '../stream-utils';
 import type {
   SerializedStepFlowEntry,
   WorkflowConfig,
@@ -43,7 +44,7 @@ import type {
   DefaultEngineType,
   StepMetadata,
 } from '../../workflows/types';
-import { PUBSUB_SYMBOL } from '../constants';
+import { PUBSUB_SYMBOL, STREAM_FORMAT_SYMBOL } from '../constants';
 import { EventedExecutionEngine } from './execution-engine';
 import { isTripwireChunk, createTripWireFromChunk, getTextDeltaFromChunk } from './helpers';
 import type { TripwireChunk } from './helpers';
@@ -362,9 +363,11 @@ async function processAgentStream(params: {
   pubsub: { publish: (channel: string, data: any) => Promise<void> };
   runId: string;
   toolData: { name: string; args: unknown };
+  writer?: StreamChunkWriter;
+  streamFormat?: 'legacy' | 'vnext';
   logger?: { debug: (msg: string, data?: unknown) => void };
 }): Promise<{ tripwireChunk: TripwireChunk | null }> {
-  const { fullStream, isV2Model, pubsub, runId, toolData, logger } = params;
+  const { fullStream, isV2Model, pubsub, runId, toolData, logger, writer, streamFormat } = params;
 
   // Publish stream start event
   try {
@@ -402,6 +405,10 @@ async function processAgentStream(params: {
           logger?.debug('Failed to publish stream delta event', { runId, error: err });
         }
       }
+    }
+
+    if (streamFormat !== 'legacy') {
+      await forwardAgentStreamChunk({ writer, chunk });
     }
   }
 
@@ -470,9 +477,11 @@ function createStepFromAgent<TStepId extends string, TStepOutput>(
       runId,
       mastra,
       [PUBSUB_SYMBOL]: pubsub,
+      [STREAM_FORMAT_SYMBOL]: streamFormat,
       requestContext,
       abortSignal,
       abort,
+      writer,
       ...obsFields
     }) => {
       const observabilityContext = resolveObservabilityContext(obsFields);
@@ -550,6 +559,8 @@ function createStepFromAgent<TStepId extends string, TStepOutput>(
         runId,
         toolData,
         logger,
+        writer,
+        streamFormat,
       });
 
       // Handle tripwire if detected

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -30,7 +30,6 @@ import { Workflow, Run } from '../../workflows';
 import type { AgentStepOptions } from '../../workflows';
 import type { ExecutionEngine, ExecutionGraph } from '../../workflows/execution-engine';
 import type { Step } from '../../workflows/step';
-import { forwardAgentStreamChunk, type StreamChunkWriter } from '../stream-utils';
 import type {
   SerializedStepFlowEntry,
   WorkflowConfig,
@@ -45,6 +44,8 @@ import type {
   StepMetadata,
 } from '../../workflows/types';
 import { PUBSUB_SYMBOL, STREAM_FORMAT_SYMBOL } from '../constants';
+import { forwardAgentStreamChunk } from '../stream-utils';
+import type { StreamChunkWriter } from '../stream-utils';
 import { EventedExecutionEngine } from './execution-engine';
 import { isTripwireChunk, createTripWireFromChunk, getTextDeltaFromChunk } from './helpers';
 import type { TripwireChunk } from './helpers';

--- a/packages/core/src/workflows/stream-utils.ts
+++ b/packages/core/src/workflows/stream-utils.ts
@@ -1,0 +1,17 @@
+export type StreamChunkWriter = {
+  write: (chunk: unknown) => Promise<void>;
+};
+
+export async function forwardAgentStreamChunk({
+  writer,
+  chunk,
+}: {
+  writer?: StreamChunkWriter;
+  chunk: unknown;
+}): Promise<void> {
+  if (!writer) {
+    return;
+  }
+
+  await writer.write(chunk);
+}

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -40,7 +40,6 @@ import type { DynamicArgument } from '../types';
 import { PUBSUB_SYMBOL, STREAM_FORMAT_SYMBOL } from './constants';
 import { DefaultExecutionEngine } from './default';
 import type { ExecutionEngine, ExecutionGraph } from './execution-engine';
-import { forwardAgentStreamChunk } from './stream-utils';
 import type {
   ConditionFunction,
   ExecuteFunction,
@@ -49,6 +48,7 @@ import type {
   Step,
   SuspendOptions,
 } from './step';
+import { forwardAgentStreamChunk } from './stream-utils';
 import type {
   DefaultEngineType,
   DynamicMapping,

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -40,6 +40,7 @@ import type { DynamicArgument } from '../types';
 import { PUBSUB_SYMBOL, STREAM_FORMAT_SYMBOL } from './constants';
 import { DefaultExecutionEngine } from './default';
 import type { ExecutionEngine, ExecutionGraph } from './execution-engine';
+import { forwardAgentStreamChunk } from './stream-utils';
 import type {
   ConditionFunction,
   ExecuteFunction,
@@ -502,7 +503,7 @@ function createStepFromAgent<TStepId extends string, TStepOutput>(
         });
       } else {
         for await (const chunk of stream) {
-          await writer.write(chunk as any);
+          await forwardAgentStreamChunk({ writer, chunk });
           if (chunk.type === 'tripwire') {
             tripwireChunk = chunk;
             break;


### PR DESCRIPTION
## Summary
- propagate workflow stream format through the evented executor so steps know legacy vs vnext
- forward agent stream chunks into workflow step output for vnext runs, keeping legacy output unchanged
- add shared stream forwarding helper for workflow steps

## Test plan
- not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-run configurable stream format selection ('legacy' | 'vnext') for workflow runs
  * Stream chunk writer API to forward agent-produced streaming data to external consumers

* **Refactor**
  * Threaded stream format and writer through workflow execution so steps and agents honor per-run streaming behavior while preserving legacy handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->