### PR TITLE
chore(docs): Subagents, "Added in"

### DIFF
--- a/docs/src/content/en/docs/agents/network-approval.mdx
+++ b/docs/src/content/en/docs/agents/network-approval.mdx
@@ -9,7 +9,7 @@ packages:
 
 # Network Approval
 
-Agent networks can require the same [human-in-the-loop](/docs/workflows/human-in-the-loop) oversight used in individual agents and workflows. When a tool, sub-agent, or workflow within a network requires approval or suspends execution, the network pauses and emits events that allow your application to collect user input before resuming.
+Agent networks can require the same [human-in-the-loop](/docs/workflows/human-in-the-loop) oversight used in individual agents and workflows. When a tool, subagent, or workflow within a network requires approval or suspends execution, the network pauses and emits events that allow your application to collect user input before resuming.
 
 ## Storage
 

--- a/docs/src/content/en/docs/agents/networks.mdx
+++ b/docs/src/content/en/docs/agents/networks.mdx
@@ -9,7 +9,7 @@ packages:
 
 # Agent Networks
 
-Agent networks in Mastra coordinate multiple agents, workflows, and tools to handle tasks that aren't clearly defined upfront but can be inferred from the user's message or context. A top-level **routing agent** (a Mastra agent with other agents, workflows, and tools configured) uses an LLM to interpret the request and decide which primitives (sub-agents, workflows, or tools) to call, in what order, and with what data.
+Agent networks in Mastra coordinate multiple agents, workflows, and tools to handle tasks that aren't clearly defined upfront but can be inferred from the user's message or context. A top-level **routing agent** (a Mastra agent with other agents, workflows, and tools configured) uses an LLM to interpret the request and decide which primitives (subagents, workflows, or tools) to call, in what order, and with what data.
 
 ## When to use networks
 
@@ -25,7 +25,7 @@ Mastra agent networks operate using these principles:
 
 ## Creating an agent network
 
-An agent network is built around a top-level routing agent that delegates tasks to agents, workflows, and tools defined in its configuration. Memory is configured on the routing agent using the `memory` option, and `instructions` define the agent's routing behavior.
+An agent network is built around a top-level routing agent that delegates tasks to subagents, workflows, and tools defined in its configuration. Memory is configured on the routing agent using the `memory` option, and `instructions` define the agent's routing behavior.
 
 ```typescript {22-23,26,29} title="src/mastra/agents/routing-agent.ts"
 import { Agent } from "@mastra/core/agent";
@@ -73,7 +73,7 @@ When configuring a Mastra agent network, each primitive (agent, workflow, or too
 
 #### Agent descriptions
 
-Each agent in a network should include a clear `description` that explains what the agent does.
+Each subagent in a network should include a clear `description` that explains what the agent does.
 
 ```typescript title="src/mastra/agents/research-agent.ts"
 export const researchAgent = new Agent({

--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -143,6 +143,14 @@ export const mastra = new Mastra({
 });
 ```
 
+### Registering subagents
+
+You can register subagents within an agent. They'll be executed as tools from the parent agent. Read the [using agents as tools](/docs/agents/using-tools#using-agents-as-tools) documentation to learn more.
+
+### Registering subworkflows
+
+You can register subworkflows within an agent. They'll be executed as tools from the parent agent. Read the [using workflows as tools](/docs/agents/using-tools#using-workflows-as-tools) documentation to learn more.
+
 ## Referencing an agent
 
 You can call agents from workflow steps, tools, the Mastra Client, or the command line. Get a reference by calling `.getAgent()` on your `mastra` or `mastraClient` instance, depending on your setup:

--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -90,9 +90,9 @@ tools: { "my-custom-name": weatherTool }
 
 This lets you specify how tools are identified in the stream. If you want the `toolName` to match the tool's `id`, use the tool's `id` as the object key.
 
-### Sub-agents and workflows as tools
+### Subagents and workflows as tools
 
-Sub-agents and workflows follow the same pattern. They are converted to tools with a prefix followed by your object key:
+Subagents and workflows follow the same pattern. They are converted to tools with a prefix followed by your object key:
 
 | Property | Prefix | Example key | `toolName` |
 |----------|--------|-------------|------------|
@@ -101,7 +101,6 @@ Sub-agents and workflows follow the same pattern. They are converted to tools wi
 
 ```typescript
 const orchestrator = new Agent({
-  // ...
   agents: {
     weather: weatherAgent,  // toolName: "agent-weather"
   },
@@ -111,9 +110,9 @@ const orchestrator = new Agent({
 });
 ```
 
-Note that for sub-agents, you'll see two different identifiers in stream responses:
+Note that for subagents, you'll see two different identifiers in stream responses:
 - `toolName: "agent-weather"` in tool call events — the generated tool wrapper name
-- `id: "weather-agent"` in `data-tool-agent` chunks — the sub-agent's actual `id` property
+- `id: "weather-agent"` in `data-tool-agent` chunks — the subagent's actual `id` property
 
 ## Calling an agent
 

--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -64,6 +64,103 @@ export const weatherAgent = new Agent({
 });
 ```
 
+## Using multiple tools
+
+When multiple tools are available, the agent may choose to use one, several, or none, depending on what's needed to answer the query.
+
+```typescript {7} title="src/mastra/agents/weather-agent.ts"
+import { weatherTool } from "../tools/weather-tool";
+import { activitiesTool } from "../tools/activities-tool";
+
+export const weatherAgent = new Agent({
+  id: "weather-agent",
+  name: "Weather Agent",
+  tools: { weatherTool, activitiesTool },
+});
+```
+
+## Using agents as tools
+
+Agents can be added to other agents through the `agents` configuration. When you add a subagent, Mastra automatically converts it to a tool that the parent agent can call. The generated tool is named `agent-<agentName>`.
+
+```typescript title="src/mastra/agents/parent-agent.ts"
+import { Agent } from "@mastra/core/agent";
+
+export const parentAgent = new Agent({
+  id: "parent-agent",
+  name: "Parent Agent",
+  description: "Take care in writing a good description here",
+  instructions: `Instructions`,
+  model: "openai/gpt-5.1",
+  agents: {
+    // highlight-next-line
+    subAgent,
+  },
+});
+
+// highlight-start
+const subAgent = new Agent({
+  id: "sub-agent",
+  name: "Sub Agent",
+  description: "Take care in writing a good description here",
+  instructions: `Instructions`,
+  model: "openai/gpt-5.1",
+})
+// highlight-end
+```
+
+The subagent should include a `description` to help the parent agent understand when to use it. See the [`toolName` docs](#subagents-and-workflows-as-tools) to learn more about the tool naming scheme.
+
+## Using workflows as tools
+
+Workflows can be added to agents through the `workflows` configuration. When you add a workflow, Mastra automatically converts it to a tool that the agent can call. The generated tool is named `workflow-<workflowName>` and uses the workflow's `inputSchema` and `outputSchema`.
+
+```typescript {14-16} title="src/mastra/agents/research-agent.ts"
+import { Agent } from "@mastra/core/agent";
+import { researchWorkflow } from "../workflows/research-workflow";
+
+export const researchAgent = new Agent({
+  id: "research-agent",
+  name: "Research Agent",
+  instructions: `
+      You are a research assistant.
+      Use the research workflow to gather and compile information on topics.`,
+  model: "openai/gpt-5.1",
+  tools: {
+    weatherTool,
+  },
+  workflows: {
+    researchWorkflow,
+  },
+});
+```
+
+The workflow should include a `description` to help the agent understand when to use it:
+
+```typescript title="src/mastra/workflows/research-workflow.ts"
+import { createWorkflow } from "@mastra/core/workflows";
+import { z } from "zod";
+
+export const researchWorkflow = createWorkflow({
+  id: "research-workflow",
+  // highlight-next-line
+  description: "Gathers information on a topic and compiles a summary report.",
+  // Rest of the workflow...
+})
+  .commit();
+```
+
+When the agent calls the workflow tool, it receives a response containing the workflow result and a `runId` that can be used to track the execution:
+
+```typescript
+{
+  result: { summary: "...", sources: ["..."] },
+  runId: "abc-123"
+}
+```
+
+See the [`toolName` docs](#subagents-and-workflows-as-tools) to learn more about the tool naming scheme.
+
 ## Controlling `toolName` in stream responses
 
 The `toolName` in stream responses is determined by the **object key** you use, not the `id` property of the tool, agent, or workflow.
@@ -113,88 +210,6 @@ const orchestrator = new Agent({
 Note that for subagents, you'll see two different identifiers in stream responses:
 - `toolName: "agent-weather"` in tool call events — the generated tool wrapper name
 - `id: "weather-agent"` in `data-tool-agent` chunks — the subagent's actual `id` property
-
-## Calling an agent
-
-The agent uses the tool's `inputSchema` to infer what data the tool expects. In this case, it extracts `London` as the `location` from the message and passes it to the tool's inputData parameter.
-
-```typescript title="src/test-tool.ts"
-import { mastra } from "./mastra";
-
-const agent = mastra.getAgent("weatherAgent");
-
-const result = await agent.generate("What's the weather in London?");
-```
-
-## Using multiple tools
-
-When multiple tools are available, the agent may choose to use one, several, or none, depending on what's needed to answer the query.
-
-```typescript {7} title="src/mastra/agents/weather-agent.ts"
-import { weatherTool } from "../tools/weather-tool";
-import { activitiesTool } from "../tools/activities-tool";
-
-export const weatherAgent = new Agent({
-  id: "weather-agent",
-  name: "Weather Agent",
-  tools: { weatherTool, activitiesTool },
-});
-```
-
-## Using workflows as tools
-
-Workflows can be added to agents through the `workflows` configuration. When you add a workflow, Mastra automatically converts it to a tool that the agent can call. The generated tool is named `workflow-<workflowName>` and uses the workflow's `inputSchema` and `outputSchema`.
-
-```typescript {14-16} title="src/mastra/agents/research-agent.ts"
-import { Agent } from "@mastra/core/agent";
-import { researchWorkflow } from "../workflows/research-workflow";
-
-export const researchAgent = new Agent({
-  id: "research-agent",
-  name: "Research Agent",
-  instructions: `
-      You are a research assistant.
-      Use the research workflow to gather and compile information on topics.`,
-  model: "openai/gpt-5.1",
-  tools: {
-    weatherTool,
-  },
-  workflows: {
-    researchWorkflow,
-  },
-});
-```
-
-The workflow should include a `description` to help the agent understand when to use it:
-
-```typescript title="src/mastra/workflows/research-workflow.ts"
-import { createWorkflow } from "@mastra/core/workflows";
-import { z } from "zod";
-
-export const researchWorkflow = createWorkflow({
-  id: "research-workflow",
-  description: "Gathers information on a topic and compiles a summary report.",
-  inputSchema: z.object({
-    topic: z.string(),
-  }),
-  outputSchema: z.object({
-    summary: z.string(),
-    sources: z.array(z.string()),
-  }),
-})
-  .then(gatherSourcesStep)
-  .then(compileReportStep)
-  .commit();
-```
-
-When the agent calls the workflow tool, it receives a response containing the workflow result and a `runId` that can be used to track the execution:
-
-```typescript
-{
-  result: { summary: "...", sources: ["..."] },
-  runId: "abc-123"
-}
-```
 
 ## Tools with structured output
 

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -8,9 +8,13 @@ packages:
 
 # Observational Memory
 
+**Added in:** `@mastra/memory@1.1.0`
+
 Observational Memory (OM) is Mastra's memory system for long-context agentic memory. Two background agents — an **Observer** and a **Reflector** — watch your agent's conversations and maintain a dense observation log that replaces raw message history as it grows.
 
 ## Quick Start
+
+Enable `observationalMemory` in the memory options when creating your agent:
 
 ```typescript title="src/mastra/agents/agent.ts"
 import { Memory } from "@mastra/memory";
@@ -22,6 +26,7 @@ export const agent = new Agent({
   model: "openai/gpt-5-mini",
   memory: new Memory({
     options: {
+      // highlight-next-line
       observationalMemory: true,
     },
   }),
@@ -78,9 +83,9 @@ When observations exceed their threshold (default: 40,000 tokens), the Reflector
 
 The result is a three-tier system:
 
-1. **Recent messages** — exact conversation history for the current task
-2. **Observations** — a log of what the Observer has seen
-3. **Reflections** — condensed observations when memory becomes too long
+1. **Recent messages**: Exact conversation history for the current task
+2. **Observations**: A log of what the Observer has seen
+3. **Reflections**: Condensed observations when memory becomes too long
 
 ## Models
 
@@ -166,10 +171,9 @@ Mastra Studio shows OM status in real time in the memory tab: token usage, which
 
 ## Comparing OM with other memory features
 
-- **[Message history](/docs/memory/message-history)** — high-fidelity record of the current conversation
-- **[Working memory](/docs/memory/working-memory)** — small, structured state (JSON or markdown) for user preferences, names, goals
-- **[Semantic Recall](/docs/memory/semantic-recall)** — RAG-based retrieval of relevant past messages
-- **Observational Memory** — long-context agentic memory that compresses extended sessions
+- **[Message history](/docs/memory/message-history)**: High-fidelity record of the current conversation
+- **[Working memory](/docs/memory/working-memory)**: Small, structured state (JSON or markdown) for user preferences, names, goals
+- **[Semantic Recall](/docs/memory/semantic-recall)**: RAG-based retrieval of relevant past messages
 
 If you're using working memory to store conversation summaries or ongoing state that grows over time, OM is a better fit. Working memory is for small, structured data; OM is for long-running event logs. OM also manages message history automatically—the `messageTokens` setting controls how much raw history remains before observation runs.
 
@@ -177,7 +181,7 @@ In practical terms, OM replaces both working memory and message history, and has
 
 ## Related
 
-- [Observational Memory Reference](/reference/memory/observational-memory) — configuration options and API
+- [Observational Memory Reference](/reference/memory/observational-memory)
 - [Memory Overview](/docs/memory/overview)
 - [Message History](/docs/memory/message-history)
 - [Memory Processors](/docs/memory/memory-processors)

--- a/docs/src/content/en/docs/server/middleware.mdx
+++ b/docs/src/content/en/docs/server/middleware.mdx
@@ -62,8 +62,6 @@ registerApiRoute("/my-custom-route", {
 });
 ```
 
----
-
 ## Common examples
 
 ### Using `RequestContext`

--- a/docs/src/content/en/docs/streaming/overview.mdx
+++ b/docs/src/content/en/docs/streaming/overview.mdx
@@ -94,7 +94,7 @@ const aiSDKMessages = toAISdkV5Messages(messages);
 
 ### Using `Agent.network()`
 
-The `network()` method enables multi-agent collaboration by executing a network loop where multiple agents can work together to handle complex tasks. The routing agent delegates tasks to appropriate sub-agents, workflows, and tools based on the conversation context.
+The `network()` method enables multi-agent collaboration by executing a network loop where multiple agents can work together to handle complex tasks. The routing agent delegates tasks to appropriate subagents, workflows, and tools based on the conversation context.
 
 > **Note**: This method is experimental and requires memory to be configured on the agent.
 

--- a/docs/src/content/en/docs/workspace/filesystem.mdx
+++ b/docs/src/content/en/docs/workspace/filesystem.mdx
@@ -7,6 +7,8 @@ packages:
 
 # Filesystem
 
+**Added in:** `@mastra/core@1.1.0`
+
 Filesystem providers give agents the ability to read, write, and manage files. When you configure a filesystem on a workspace, agents receive tools for file operations.
 
 A filesystem provider handles all file operations for a workspace:

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -5,7 +5,9 @@ packages:
   - "@mastra/core"
 ---
 
-# Workspace
+# Workspaces
+
+**Added in:** `@mastra/core@1.1.0`
 
 A Mastra workspace gives agents a persistent environment for storing files and executing commands. Agents use workspace tools to read and write files, run shell commands, and search indexed content.
 

--- a/docs/src/content/en/docs/workspace/sandbox.mdx
+++ b/docs/src/content/en/docs/workspace/sandbox.mdx
@@ -7,6 +7,8 @@ packages:
 
 # Sandbox
 
+**Added in:** `@mastra/core@1.1.0`
+
 Sandbox providers give agents the ability to execute shell commands. When you configure a sandbox on a workspace, agents can run commands as part of their tasks.
 
 A sandbox provider executes commands in a controlled environment:

--- a/docs/src/content/en/docs/workspace/search.mdx
+++ b/docs/src/content/en/docs/workspace/search.mdx
@@ -7,6 +7,8 @@ packages:
 
 # Search and Indexing
 
+**Added in:** `@mastra/core@1.1.0`
+
 Search lets agents find relevant content in indexed workspace files. When an agent needs to answer a question or find information, it can search the indexed content instead of reading every file.
 
 ## How it works

--- a/docs/src/content/en/docs/workspace/skills.mdx
+++ b/docs/src/content/en/docs/workspace/skills.mdx
@@ -7,6 +7,8 @@ packages:
 
 # Workspace Skills
 
+**Added in:** `@mastra/core@1.1.0`
+
 Skills are reusable instructions that teach agents how to perform specific tasks. They follow the [Agent Skills specification](https://agentskills.io) - an open standard for packaging agent capabilities.
 
 A skill is a folder containing:

--- a/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
@@ -1555,8 +1555,8 @@ See the [branching-workflow.ts](https://github.com/mastra-ai/ui-dojo/blob/main/s
 
 ### Progress indicators in agent networks
 
-When using agent networks, you can emit custom progress events from tools used by sub-agents to show which agent is currently active.
+When using agent networks, you can emit custom progress events from tools used by subagents to show which agent is currently active.
 
-The UI Dojo example includes a `stage` field in the event data to identify which sub-agent is running (e.g., `"report-generation"`, `"report-review"`). The frontend groups events by this field and displays the latest status for each.
+The UI Dojo example includes a `stage` field in the event data to identify which subagent is running (e.g., `"report-generation"`, `"report-review"`). The frontend groups events by this field and displays the latest status for each.
 
 See the [report-generation-tool.ts](https://github.com/mastra-ai/ui-dojo/blob/main/src/mastra/tools/report-generation-tool.ts) (backend) and [agent-network-custom-events.tsx](https://github.com/mastra-ai/ui-dojo/blob/main/src/pages/ai-sdk/agent-network-custom-events.tsx) (frontend) in UI Dojo.

--- a/docs/src/content/en/reference/agents/listAgents.mdx
+++ b/docs/src/content/en/reference/agents/listAgents.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Reference: Agent.listAgents() | Agents"
-description: "Documentation for the `Agent.listAgents()` method in Mastra agents, which retrieves the sub-agents that the agent can access."
+description: "Documentation for the `Agent.listAgents()` method in Mastra agents, which retrieves the subagents that the agent can access."
 packages:
   - "@mastra/core"
 ---
 
 # Agent.listAgents()
 
-The `.listAgents()` method retrieves the sub-agents configured for an agent, resolving them if they're a function. These sub-agents enable the agent to access other agents and perform complex actions.
+The `.listAgents()` method retrieves the subagents configured for an agent, resolving them if they're a function. These subagents enable the agent to access other agents and perform complex actions.
 
 ## Usage example
 

--- a/docs/src/content/en/reference/agents/network.mdx
+++ b/docs/src/content/en/reference/agents/network.mdx
@@ -9,10 +9,6 @@ import { MODEL_SETTINGS_OBJECT } from "@site/src/components/ModelSettingsPropert
 
 # Agent.network()
 
-:::caution Experimental Feature
-This is an experimental API that may change in future versions. The `network()` method enables multi-agent collaboration and workflow orchestration. Use with caution in production environments.
-:::
-
 The `.network()` method enables multi-agent collaboration and routing. This method accepts messages and optional execution options.
 
 ## Usage example

--- a/docs/src/content/en/reference/client-js/agents.mdx
+++ b/docs/src/content/en/reference/client-js/agents.mdx
@@ -373,7 +373,7 @@ const agent = await mastraClient.createStoredAgent({
   },
   tools: ["calculator", "weather"],
   workflows: ["data-processing"],
-  agents: ["sub-agent-1"],
+  agents: ["subagent-1"],
   memory: "my-memory",
   scorers: {
     "quality-scorer": {

--- a/docs/src/content/en/reference/core/getStoredAgentById.mdx
+++ b/docs/src/content/en/reference/core/getStoredAgentById.mdx
@@ -85,7 +85,7 @@ When creating an `Agent` instance from stored configuration, the method resolves
 
 - **Tools**: Resolved from `tools` registered in Mastra config
 - **Workflows**: Resolved from `workflows` registered in Mastra config
-- **Sub-agents**: Resolved from `agents` registered in Mastra config
+- **Subagents**: Resolved from `agents` registered in Mastra config
 - **Memory**: Resolved from `memory` registered in Mastra config
 - **Scorers**: Resolved from `scorers` registered in Mastra config, including sampling configuration
 
@@ -138,7 +138,7 @@ When using `raw: true`, the returned object has the following structure:
     {
       name: "agents",
       type: "Record<string, unknown>",
-      description: "Sub-agent references to resolve from registry.",
+      description: "Subagent references to resolve from registry.",
       isOptional: true,
     },
     {

--- a/docs/src/content/en/reference/core/listStoredAgents.mdx
+++ b/docs/src/content/en/reference/core/listStoredAgents.mdx
@@ -121,7 +121,7 @@ When creating `Agent` instances (default behavior), each stored agent's configur
 
 - **Tools**: Resolved from `tools` registered in Mastra config
 - **Workflows**: Resolved from `workflows` registered in Mastra config
-- **Sub-agents**: Resolved from `agents` registered in Mastra config
+- **Subagents**: Resolved from `agents` registered in Mastra config
 - **Memory**: Resolved from `memory` registered in Mastra config
 - **Scorers**: Resolved from `scorers` registered in Mastra config
 

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -8,6 +8,8 @@ packages:
 
 # Observational Memory
 
+**Added in:** `@mastra/memory@1.1.0`
+
 Observational Memory (OM) is Mastra's memory system for long-context agentic memory. Two background agents — an **Observer** that watches conversations and creates observations, and a **Reflector** that restructures observations by combining related items, reflecting on overarching patterns, and condensing where possible — maintain an observation log that replaces raw message history as it grows.
 
 ## Usage

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -612,7 +612,7 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Workspace',
+      label: 'Workspaces',
       collapsed: true,
       customProps: {
         tags: ['new'],

--- a/docs/src/content/en/reference/workspace/filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/filesystem.mdx
@@ -7,6 +7,8 @@ packages:
 
 # WorkspaceFilesystem
 
+**Added in:** `@mastra/core@1.1.0`
+
 The `WorkspaceFilesystem` interface defines how workspaces interact with file storage.
 
 ## Methods

--- a/docs/src/content/en/reference/workspace/local-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/local-filesystem.mdx
@@ -7,6 +7,8 @@ packages:
 
 # LocalFilesystem
 
+**Added in:** `@mastra/core@1.1.0`
+
 Stores files in a directory on the local filesystem.
 
 :::info

--- a/docs/src/content/en/reference/workspace/local-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/local-sandbox.mdx
@@ -7,6 +7,8 @@ packages:
 
 # LocalSandbox
 
+**Added in:** `@mastra/core@1.1.0`
+
 Executes commands on the local system.
 
 :::info

--- a/docs/src/content/en/reference/workspace/sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/sandbox.mdx
@@ -7,6 +7,8 @@ packages:
 
 # WorkspaceSandbox
 
+**Added in:** `@mastra/core@1.1.0`
+
 The `WorkspaceSandbox` interface defines how workspaces execute commands.
 
 ## Methods

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -7,6 +7,8 @@ packages:
 
 # Workspace Class
 
+**Added in:** `@mastra/core@1.1.0`
+
 The `Workspace` class combines a filesystem and sandbox to provide agents with file storage and command execution capabilities. It also supports BM25 and vector search for indexed content.
 
 ## Usage Example


### PR DESCRIPTION
## Description

- Add "Added in" notices to docs that are only available in newer versions
- Highlight subagents a bit more by adding them to the agents overview page

## Related Issue(s)

Fixes GRWTH-1399
Fixes GRWTH-1398

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Standardized "subagent" terminology throughout documentation
  * Added version indicators (@mastra/core@1.1.0, @mastra/memory@1.1.0) for new features
  * New documentation sections for registering subagents and subworkflows as agent capabilities
  * Added guide for using agents as tools within agent networks
  * Removed experimental status from Agent.network() API

<!-- end of auto-generated comment: release notes by coderabbit.ai -->