### PR TITLE
Filter pnpm-specific env vars when running npm commands

### DIFF
--- a/packages/_types-builder/src/index.js
+++ b/packages/_types-builder/src/index.js
@@ -22,9 +22,7 @@ const pnpmSpecificEnvVars = new Set([
  * @returns {NodeJS.ProcessEnv}
  */
 function getFilteredEnv() {
-  return Object.fromEntries(
-    Object.entries(process.env).filter(([key]) => !pnpmSpecificEnvVars.has(key)),
-  );
+  return Object.fromEntries(Object.entries(process.env).filter(([key]) => !pnpmSpecificEnvVars.has(key)));
 }
 
 // @see https://blog.devgenius.io/compiling-from-typescript-with-js-extension-e2b6de3e6baf


### PR DESCRIPTION
## Description

This change filters out pnpm-specific npm config environment variables before passing the environment to npm/npx commands. When pnpm runs npm commands via `execSync`, it sets various `npm_config_*` variables that npm doesn't recognize, causing "Unknown env config" warnings.

Fixes logs like these during build:
```
@mastra/braintrust:build: npm warn Unknown env config "catalog". This will stop working in the next major version of npm.
@mastra/braintrust:build: npm warn Unknown env config "verify-deps-before-run". This will stop working in the next major version of npm.
@mastra/braintrust:build: npm warn Unknown env config "npm-globalconfig". This will stop working in the next major version of npm.
@mastra/braintrust:build: npm warn Unknown env config "_jsr-registry". This will stop working in the next major version of npm.
@mastra/braintrust:build: npm warn Unknown env config "patched-dependencies". This will stop working in the next major version of npm.
```

The fix introduces a `getFilteredEnv()` function that removes known pnpm-specific environment variables from `process.env` before passing it to the `tsc` command execution in the `generateTypes()` function.

no changeset required.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

https://claude.ai/code/session_0117DXfM2uyfuau2VbxaDBQ8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents spurious "unknown environment" warnings during TypeScript compilation when using pnpm, improving build clarity.
  * Makes local build and compile runs more reliable by filtering unrelated environment noise, reducing confusing messages for developers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->