### PR TITLE
fix: remove GITHUB_REF_NAME from turbo cache scoping

### DIFF
--- a/.github/workflows/secrets.e2e.yml
+++ b/.github/workflows/secrets.e2e.yml
@@ -84,7 +84,6 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
-      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo
@@ -135,7 +134,6 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
-      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo
@@ -182,7 +180,6 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
-      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo
@@ -227,7 +224,6 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
-      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo
@@ -272,7 +268,6 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
-      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo
@@ -317,7 +312,6 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
-      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo
@@ -362,7 +356,6 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
-      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo
@@ -408,7 +401,6 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
-      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/secrets.test-agent-builder.yml
+++ b/.github/workflows/secrets.test-agent-builder.yml
@@ -88,13 +88,11 @@ jobs:
         run: pnpm turbo build --filter "@mastra/agent-builder^..." --filter "./stores/*"
         env:
           NODE_OPTIONS: '--max_old_space_size=6144'
-          GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
       - name: Run Agent Builder unit tests
         run: pnpm --filter "@mastra/agent-builder" test
         env:
           NODE_OPTIONS: '--max_old_space_size=6144'
-          GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
       - name: Install integration test dependencies
         run: pnpm install --ignore-workspace
@@ -105,7 +103,6 @@ jobs:
         working-directory: packages/agent-builder/integration-tests
         env:
           NODE_OPTIONS: '--max_old_space_size=6144'
-          GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
   test-success:

--- a/.github/workflows/secrets.test-combined-stores.yml
+++ b/.github/workflows/secrets.test-combined-stores.yml
@@ -112,7 +112,6 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
-      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/secrets.test-core.yml
+++ b/.github/workflows/secrets.test-core.yml
@@ -76,7 +76,6 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
-      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/secrets.test-mcp.yml
+++ b/.github/workflows/secrets.test-mcp.yml
@@ -76,7 +76,6 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
-      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/secrets.test-memory.yml
+++ b/.github/workflows/secrets.test-memory.yml
@@ -109,7 +109,6 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
-      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/secrets.test-observability.yml
+++ b/.github/workflows/secrets.test-observability.yml
@@ -21,7 +21,6 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
-      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/secrets.test-rag.yml
+++ b/.github/workflows/secrets.test-rag.yml
@@ -76,7 +76,6 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_CACHE: remote:r
-      GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/secrets.tool-builder-test.yml
+++ b/.github/workflows/secrets.tool-builder-test.yml
@@ -88,13 +88,11 @@ jobs:
         run: pnpm build:core && pnpm build:deployer
         env:
           NODE_OPTIONS: '--max_old_space_size=6144'
-          GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
 
       - name: Run tool-builder test
         run: pnpm test:tool-builder
         env:
           NODE_OPTIONS: '--max_old_space_size=6144'
-          GITHUB_REF_NAME: ${{ github.event.workflow_run.head_branch }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["GITHUB_REF_NAME"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Remove GITHUB_REF_NAME from turbo.json globalEnv and workflow env blocks where it was used solely for Turbo cache scoping. Vercel Remote Cache is content-addressed, so this manual scoping is unnecessary and was causing cache misses between Prebuild and downstream workflow_run jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configurations to streamline environment variable handling across multiple test and build pipelines.
  * Updated build tool configuration to remove unused environment variable declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->