### PR TITLE
ci: remove typecheck step from prebuild workflow

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   prebuild:
-    name: Build & Type Check
+    name: Build
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'mastra-ai/mastra' && !contains(github.event.pull_request.files.*.path, 'examples/') && !contains(github.event.pull_request.files.*.path, 'docs/') && !contains(github.event.pull_request.files.*.path, '.changeset/') && !contains(github.event.pull_request.files.*.path, 'generated-changesets/') }}
     env:
@@ -31,6 +31,3 @@ jobs:
 
       - name: Build
         run: pnpm turbo --filter "!./examples/**/*" --filter "!./docs/" --filter "!./explorations/**/*" build
-
-      - name: Type Check
-        run: pnpm typecheck


### PR DESCRIPTION
## Summary

Removes the typecheck step from the prebuild workflow since the build step already performs type checking as part of the TypeScript compilation process.

## Changes

- Removed `pnpm typecheck` step from prebuild.yml
- Updated job name from "Build & Type Check" to "Build"

## Test Plan

The prebuild workflow will run on this PR to verify it works correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the prebuild workflow by removing the type checking step. The workflow now focuses solely on building the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->