### PR TITLE
fix(evals): use refine() instead of min/max for Anthropic API compatibility

### DIFF
--- a/.changeset/thirty-sheep-battle.md
+++ b/.changeset/thirty-sheep-battle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/evals': patch
+---
+
+Fixed LLM scorer schema compatibility with Anthropic API by replacing z.number().min(0).max(1) with z.number().refine() for score validation. The min/max constraints were being converted to JSON Schema minimum/maximum properties which some providers don't support.

--- a/packages/evals/src/scorers/llm/noise-sensitivity/index.ts
+++ b/packages/evals/src/scorers/llm/noise-sensitivity/index.ts
@@ -24,6 +24,9 @@ export interface NoiseSensitivityOptions {
   };
 }
 
+// Helper for score validation - uses refine() instead of min/max for Anthropic API compatibility
+const scoreSchema = z.number().refine(n => n >= 0 && n <= 1, { message: 'Score must be between 0 and 1' });
+
 const analyzeOutputSchema = z.object({
   dimensions: z.array(
     z.object({
@@ -35,7 +38,7 @@ const analyzeOutputSchema = z.object({
   ),
   overallAssessment: z.string(),
   majorIssues: z.array(z.string()).optional().default([]),
-  robustnessScore: z.number().min(0).max(1),
+  robustnessScore: scoreSchema,
 });
 
 // Default scoring constants for maintainability and clarity

--- a/packages/evals/src/scorers/llm/prompt-alignment/index.ts
+++ b/packages/evals/src/scorers/llm/prompt-alignment/index.ts
@@ -15,9 +15,12 @@ export interface PromptAlignmentOptions {
   evaluationMode?: 'user' | 'system' | 'both';
 }
 
+// Helper for score validation - uses refine() instead of min/max for Anthropic API compatibility
+const scoreSchema = z.number().refine(n => n >= 0 && n <= 1, { message: 'Score must be between 0 and 1' });
+
 const analyzeOutputSchema = z.object({
   intentAlignment: z.object({
-    score: z.number().min(0).max(1),
+    score: scoreSchema,
     primaryIntent: z.string(),
     isAddressed: z.boolean(),
     reasoning: z.string(),
@@ -30,15 +33,15 @@ const analyzeOutputSchema = z.object({
         reasoning: z.string(),
       }),
     ),
-    overallScore: z.number().min(0).max(1),
+    overallScore: scoreSchema,
   }),
   completeness: z.object({
-    score: z.number().min(0).max(1),
+    score: scoreSchema,
     missingElements: z.array(z.string()),
     reasoning: z.string(),
   }),
   responseAppropriateness: z.object({
-    score: z.number().min(0).max(1),
+    score: scoreSchema,
     formatAlignment: z.boolean(),
     toneAlignment: z.boolean(),
     reasoning: z.string(),


### PR DESCRIPTION
The `prompt-alignment` and `noise-sensitivity` scorers used `z.number().min(0).max(1)` for score validation. When converted to JSON Schema, this adds `minimum`/`maximum` properties which some providers (like Anthropic) don't support.

Switched to `z.number().refine(n => n >= 0 && n <= 1)` which provides runtime validation without adding unsupported JSON Schema properties.

Tested with both OpenAI and Anthropic - both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LLM scorer validation schema compatibility with external providers by updating how score range validation is implemented, ensuring scores remain between 0 and 1 while avoiding unsupported JSON Schema properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->