### PR TITLE
fix(ci): add passWithNoTests for vitest sharding

### DIFF
--- a/.github/workflows/vitest-changed.yml
+++ b/.github/workflows/vitest-changed.yml
@@ -74,7 +74,9 @@ jobs:
           pnpm vitest run \
             --changed origin/${{ steps.pr-info.outputs.base_ref }} \
             --reporter=blob \
-            --shard=${{ matrix.shard }}/4
+            --outputFile.blob=.vitest-reports/blob-${{ matrix.shard }}.json \
+            --shard=${{ matrix.shard }}/4 \
+            --passWithNoTests
         env:
           NODE_OPTIONS: '--max_old_space_size=6144'
 

--- a/.github/workflows/vitest-changed.yml
+++ b/.github/workflows/vitest-changed.yml
@@ -32,14 +32,12 @@ jobs:
       contents: read
 
     steps:
-      # Then checkout the PR code for the actual work
       - name: Checkout PR code
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha }}
 
-      # First checkout the base branch to get trusted composite actions
       - name: Checkout trusted actions from base branch
         uses: actions/checkout@v5
         with:
@@ -99,19 +97,17 @@ jobs:
       contents: read
 
     steps:
-      # First checkout the base branch to get trusted composite actions
+      - name: Checkout PR code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
       - name: Checkout trusted actions from base branch
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_branch == '0.x' && '0.x' || 'main' }}
           sparse-checkout: .github/actions
           path: trusted-actions
-
-      # Then checkout the PR code
-      - name: Checkout PR code
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
 
       # Copy trusted actions into the workspace
       - name: Use trusted actions


### PR DESCRIPTION
## Summary

Fixes vitest sharding CI failures when some shards end up with no test files.

## Changes

1. **Added `--passWithNoTests`** - When running vitest with `--changed` and `--shard`, some shards may end up with no test files to run, causing vitest to exit with an error. This flag allows empty shards to pass gracefully.

2. **Added unique blob output files per shard** - Specifies `--outputFile.blob=.vitest-reports/blob-${{ matrix.shard }}.json` to ensure each shard outputs to a unique file, avoiding conflicts when merging test reports.

## Test Plan

The fix will be validated by the CI run on this PR itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing workflow configuration to improve test reporting and handling of scenarios with no tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->