### PR TITLE
chore: add group:monorepos preset to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     ":ignoreModulesAndTests",
     "replacements:all",
     "workarounds:typesNodeVersioning",
+    "group:monorepos",
     "group:recommended",
     ":prConcurrentLimit20"
   ],


### PR DESCRIPTION
Adds the `group:monorepos` preset to automatically group updates from the same monorepo into a single PR. This covers 28+ monorepos used in the project including babel, nextjs, playwright, vitest, tailwindcss, tanstack, radix-ui, opentelemetry, aws-sdk, and others.

https://claude.ai/code/session_01GVqtxaeyULfBMH9yve5stt

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to enable monorepo dependency grouping, improving how dependency updates are organized and grouped across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->