### PR TITLE
feat(core): add native @ai-sdk/groq support to model router

### DIFF
--- a/.changeset/groq-provider-support.md
+++ b/.changeset/groq-provider-support.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Add native @ai-sdk/groq support to model router. Groq models now use the official AI SDK package instead of falling back to OpenAI-compatible mode.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -243,6 +243,7 @@
     "@ai-sdk/deepinfra-v5": "npm:@ai-sdk/deepinfra@1.0.32",
     "@ai-sdk/deepseek-v5": "npm:@ai-sdk/deepseek@1.0.31",
     "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.40",
+    "@ai-sdk/groq-v5": "npm:@ai-sdk/groq@2.0.34",
     "@ai-sdk/mistral-v5": "npm:@ai-sdk/mistral@2.0.24",
     "@ai-sdk/openai": "^1.3.24",
     "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.32",

--- a/packages/core/src/llm/model/gateways/constants.ts
+++ b/packages/core/src/llm/model/gateways/constants.ts
@@ -5,6 +5,7 @@ export const PROVIDERS_WITH_INSTALLED_PACKAGES = [
   'deepinfra',
   'deepseek',
   'google',
+  'groq',
   'mistral',
   'openai',
   'openrouter',

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -3,6 +3,7 @@ import { createCerebras } from '@ai-sdk/cerebras-v5';
 import { createDeepInfra } from '@ai-sdk/deepinfra-v5';
 import { createDeepSeek } from '@ai-sdk/deepseek-v5';
 import { createGoogleGenerativeAI } from '@ai-sdk/google-v5';
+import { createGroq } from '@ai-sdk/groq-v5';
 import { createMistral } from '@ai-sdk/mistral-v5';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible-v5';
 import { createOpenAI } from '@ai-sdk/openai-v5';
@@ -212,6 +213,8 @@ export class ModelsDevGateway extends MastraModelGateway {
         return createAnthropic({ apiKey })(modelId);
       case 'mistral':
         return createMistral({ apiKey })(modelId);
+      case 'groq':
+        return createGroq({ apiKey })(modelId);
       case 'openrouter':
         return createOpenRouter({ apiKey, headers })(modelId);
       case 'xai':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2419,6 +2419,9 @@ importers:
       '@ai-sdk/google-v5':
         specifier: npm:@ai-sdk/google@2.0.40
         version: '@ai-sdk/google@2.0.40(zod@3.25.76)'
+      '@ai-sdk/groq-v5':
+        specifier: npm:@ai-sdk/groq@2.0.34
+        version: '@ai-sdk/groq@2.0.34(zod@3.25.76)'
       '@ai-sdk/mistral-v5':
         specifier: npm:@ai-sdk/mistral@2.0.24
         version: '@ai-sdk/mistral@2.0.24(zod@3.25.76)'
@@ -5843,6 +5846,12 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
+
+  '@ai-sdk/groq@2.0.34':
+    resolution: {integrity: sha512-wfCYkVgmVjxNA32T57KbLabVnv9aFUflJ4urJ7eWgTwbnmGQHElCTu+rJ3ydxkXSqxOkXPwMOttDm7XNrvPjmg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/mistral@2.0.24':
     resolution: {integrity: sha512-X9IW0vUCHIq//L1ukirB3j54Hrde5zt40m0uG+ouEE9xz62BPT7Ue94qWL6U02u42vnaoGUE7VxrncwPVMjQjQ==}
@@ -22325,6 +22334,12 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.3(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/groq@2.0.34(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.1
+      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
       zod: 3.25.76
 
   '@ai-sdk/mistral@2.0.24(zod@3.25.76)':


### PR DESCRIPTION
Adds Groq as a first-class provider in the model router instead of falling back to OpenAI-compatible mode.

Changes:
- Added `@ai-sdk/groq-v5` dependency
- Added `groq` to `PROVIDERS_WITH_INSTALLED_PACKAGES`
- Added `createGroq` case in `ModelsDevGateway.resolveLanguageModel`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Groq provider support to the model router, enabling seamless integration with Groq as a language model provider.

* **Chores**
  * Updated dependencies and internal provider configuration to support Groq integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->