### PR TITLE
fix(ai-sdk): add sendReasoning and sendSources support to workflow stream handlers

### DIFF
--- a/.changeset/slow-singers-invite.md
+++ b/.changeset/slow-singers-invite.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Added sendReasoning and sendSources support to handleWorkflowStream and workflowRoute. Reasoning and source chunks from agents running inside workflows are now forwarded to the client when these options are enabled, matching the existing behavior of handleChatStream. Closes #12571.

--- a/client-sdks/ai-sdk/src/convert-streams.ts
+++ b/client-sdks/ai-sdk/src/convert-streams.ts
@@ -29,8 +29,8 @@ type ToAISDKFrom = 'agent' | 'network' | 'workflow';
  * @param {string} [options.lastMessageId] - (Agent only) The ID of the last message in the conversation
  * @param {boolean} [options.sendStart=true] - (Agent only) Whether to send start events. Defaults to true
  * @param {boolean} [options.sendFinish=true] - (Agent only) Whether to send finish events. Defaults to true
- * @param {boolean} [options.sendReasoning] - (Agent only) Whether to include reasoning in the output
- * @param {boolean} [options.sendSources] - (Agent only) Whether to include sources in the output
+ * @param {boolean} [options.sendReasoning] - (Agent and Workflow) Whether to include reasoning in the output
+ * @param {boolean} [options.sendSources] - (Agent and Workflow) Whether to include sources in the output
  * @param {Function} [options.messageMetadata] - (Agent only) A function that receives the current stream part and returns metadata to attach to start and finish chunks
  * @param {Function} [options.onError] - (Agent only) A function to handle errors during stream conversion. Receives the error and should return a string representation
  *

--- a/client-sdks/ai-sdk/src/convert-streams.ts
+++ b/client-sdks/ai-sdk/src/convert-streams.ts
@@ -73,7 +73,7 @@ export function toAISdkV5Stream<
   TState extends ZodObject<any>,
 >(
   stream: MastraWorkflowStream<TState, TInput, TOutput, TSteps>,
-  options: { from: 'workflow'; includeTextStreamParts?: boolean },
+  options: { from: 'workflow'; includeTextStreamParts?: boolean; sendReasoning?: boolean; sendSources?: boolean },
 ): ReadableStream<InferUIMessageChunk<UIMessage>>;
 export function toAISdkV5Stream<
   TOutput extends ZodType<any>,
@@ -82,7 +82,7 @@ export function toAISdkV5Stream<
   TState extends ZodObject<any>,
 >(
   stream: WorkflowRunOutput<WorkflowResult<TState, TInput, TOutput, TSteps>>,
-  options: { from: 'workflow'; includeTextStreamParts?: boolean },
+  options: { from: 'workflow'; includeTextStreamParts?: boolean; sendReasoning?: boolean; sendSources?: boolean },
 ): ReadableStream<InferUIMessageChunk<UIMessage>>;
 export function toAISdkV5Stream<OUTPUT = undefined>(
   stream: MastraAgentNetworkStream<OUTPUT>,
@@ -129,7 +129,11 @@ export function toAISdkV5Stream(
     const includeTextStreamParts = options?.includeTextStreamParts ?? true;
 
     return (stream as ReadableStream<ChunkType<any>>).pipeThrough(
-      WorkflowStreamToAISDKTransformer({ includeTextStreamParts }),
+      WorkflowStreamToAISDKTransformer({
+        includeTextStreamParts,
+        sendReasoning: options?.sendReasoning,
+        sendSources: options?.sendSources,
+      }),
     ) as ReadableStream<InferUIMessageChunk<UIMessage>>;
   }
 


### PR DESCRIPTION
`handleWorkflowStream` and `workflowRoute` were missing `sendReasoning` and `sendSources` options that `handleChatStream` already had. This meant reasoning/source chunks from agents running inside workflow steps were silently dropped.

Now you can enable them just like you would with chat streams:

```ts
const stream = await handleWorkflowStream({
  mastra,
  workflowId: 'myWorkflow',
  params,
  sendReasoning: true,
  sendSources: true,
});
```

Or via the route helper:

```ts
workflowRoute({
  path: '/api/workflows/:workflowId/stream',
  sendReasoning: true,
  sendSources: true,
});
```

Closes #12571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow streams can now forward agents' reasoning chains and source information to clients; new options let you enable reasoning and sources alongside workflow results (defaults: disabled). Behavior aligns with existing chat streaming.

* **Tests**
  * Expanded test coverage validating reasoning, source, text-stream parts, and network/tool event handling across workflow streaming scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->