### PR TITLE
fix(core): use correct base URL for Moonshot AI models

### DIFF
--- a/.changeset/heavy-worlds-peel.md
+++ b/.changeset/heavy-worlds-peel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Moonshot AI (moonshotai and moonshotai-cn) models using the wrong base URL. The Anthropic-compatible endpoint was not being applied, causing API calls to fail with an upstream LLM error.

--- a/packages/core/src/llm/model/gateways/models-dev.test.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.test.ts
@@ -99,7 +99,7 @@ describe('ModelsDevGateway', () => {
       expect(providers.cerebras.url).toBeUndefined(); // No URL needed - uses native @ai-sdk/cerebras
     });
 
-    it('should apply OPENAI_COMPATIBLE_OVERRIDES', async () => {
+    it('should apply PROVIDER_OVERRIDES', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => mockApiResponse,

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -31,13 +31,12 @@ interface ModelsDevResponse {
   [providerId: string]: ModelsDevProviderInfo;
 }
 
-// Special cases: providers that are OpenAI-compatible but have their own SDKs
-// These providers work with OpenAI-compatible endpoints even though models.dev
-// might list them with their own SDK packages
+// Provider-specific overrides for URL, npm package, and other config.
+// These take priority over what models.dev returns (e.g. correct base URLs, SDK packages).
 // This constant is ONLY used during generation in fetchProviders() to determine
 // which providers from models.dev should be included in the registry.
 // At runtime, buildUrl() and buildHeaders() use the pre-generated PROVIDER_REGISTRY instead.
-const OPENAI_COMPATIBLE_OVERRIDES: Record<string, Partial<ProviderConfig>> = {
+const PROVIDER_OVERRIDES: Record<string, Partial<ProviderConfig>> = {
   mistral: {
     url: 'https://api.mistral.ai/v1',
   },
@@ -94,7 +93,7 @@ export class ModelsDevGateway extends MastraModelGateway {
       const isOpenAICompatible =
         providerInfo.npm === '@ai-sdk/openai-compatible' ||
         providerInfo.npm === '@ai-sdk/gateway' || // Vercel AI Gateway is OpenAI-compatible
-        normalizedId in OPENAI_COMPATIBLE_OVERRIDES;
+        normalizedId in PROVIDER_OVERRIDES;
 
       // these have their ai sdk provider package installed and don't use openai-compat
       const hasInstalledPackage = PROVIDERS_WITH_INSTALLED_PACKAGES.includes(providerId);
@@ -111,7 +110,7 @@ export class ModelsDevGateway extends MastraModelGateway {
           .sort();
 
         // Get the API URL - overrides take priority over models.dev data
-        const url = OPENAI_COMPATIBLE_OVERRIDES[normalizedId]?.url || providerInfo.api;
+        const url = PROVIDER_OVERRIDES[normalizedId]?.url || providerInfo.api;
 
         // Skip if we don't have a URL
         if (!hasInstalledPackage && !url) {
@@ -124,7 +123,7 @@ export class ModelsDevGateway extends MastraModelGateway {
 
         // Determine the API key header (special case for Anthropic)
         const apiKeyHeader = !hasInstalledPackage
-          ? OPENAI_COMPATIBLE_OVERRIDES[normalizedId]?.apiKeyHeader || 'Authorization'
+          ? PROVIDER_OVERRIDES[normalizedId]?.apiKeyHeader || 'Authorization'
           : undefined;
 
         providerConfigs[normalizedId] = {
@@ -138,7 +137,7 @@ export class ModelsDevGateway extends MastraModelGateway {
           // Only store npm when it's a non-default SDK (not openai-compatible/gateway) to keep the registry small
           // Overrides take priority (e.g., moonshotai uses @ai-sdk/anthropic, not the openai-compatible listed in models.dev)
           npm:
-            OPENAI_COMPATIBLE_OVERRIDES[normalizedId]?.npm ||
+            PROVIDER_OVERRIDES[normalizedId]?.npm ||
             (providerInfo.npm &&
             providerInfo.npm !== '@ai-sdk/openai-compatible' &&
             providerInfo.npm !== '@ai-sdk/gateway'

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -110,8 +110,8 @@ export class ModelsDevGateway extends MastraModelGateway {
           .map(([modelId]) => modelId)
           .sort();
 
-        // Get the API URL from the provider info or overrides
-        const url = providerInfo.api || OPENAI_COMPATIBLE_OVERRIDES[normalizedId]?.url;
+        // Get the API URL - overrides take priority over models.dev data
+        const url = OPENAI_COMPATIBLE_OVERRIDES[normalizedId]?.url || providerInfo.api;
 
         // Skip if we don't have a URL
         if (!hasInstalledPackage && !url) {
@@ -136,12 +136,14 @@ export class ModelsDevGateway extends MastraModelGateway {
           docUrl: providerInfo.doc, // Include documentation URL if available
           gateway: `models.dev`,
           // Only store npm when it's a non-default SDK (not openai-compatible/gateway) to keep the registry small
+          // Overrides take priority (e.g., moonshotai uses @ai-sdk/anthropic, not the openai-compatible listed in models.dev)
           npm:
-            providerInfo.npm &&
+            OPENAI_COMPATIBLE_OVERRIDES[normalizedId]?.npm ||
+            (providerInfo.npm &&
             providerInfo.npm !== '@ai-sdk/openai-compatible' &&
             providerInfo.npm !== '@ai-sdk/gateway'
               ? providerInfo.npm
-              : undefined,
+              : undefined),
         };
       }
     }

--- a/packages/core/src/llm/model/provider-registry.json
+++ b/packages/core/src/llm/model/provider-registry.json
@@ -10,7 +10,7 @@
       "gateway": "models.dev"
     },
     "moonshotai-cn": {
-      "url": "https://api.moonshot.cn/v1",
+      "url": "https://api.moonshot.cn/anthropic/v1",
       "apiKeyEnvVar": "MOONSHOT_API_KEY",
       "apiKeyHeader": "Authorization",
       "name": "Moonshot AI (China)",
@@ -23,7 +23,8 @@
         "kimi-k2.5"
       ],
       "docUrl": "https://platform.moonshot.cn/docs/api/chat",
-      "gateway": "models.dev"
+      "gateway": "models.dev",
+      "npm": "@ai-sdk/anthropic"
     },
     "firmware": {
       "url": "https://app.firmware.ai/api/v1",
@@ -77,7 +78,7 @@
       "gateway": "models.dev"
     },
     "moonshotai": {
-      "url": "https://api.moonshot.ai/v1",
+      "url": "https://api.moonshot.ai/anthropic/v1",
       "apiKeyEnvVar": "MOONSHOT_API_KEY",
       "apiKeyHeader": "Authorization",
       "name": "Moonshot AI",
@@ -90,7 +91,8 @@
         "kimi-k2.5"
       ],
       "docUrl": "https://platform.moonshot.ai/docs/api/chat",
-      "gateway": "models.dev"
+      "gateway": "models.dev",
+      "npm": "@ai-sdk/anthropic"
     },
     "302ai": {
       "url": "https://api.302.ai/v1",


### PR DESCRIPTION
Moonshot AI models (`moonshotai` and `moonshotai-cn`) were hitting the wrong API endpoint because `OPENAI_COMPATIBLE_OVERRIDES` URLs were never applied — `providerInfo.api` from `models.dev` always won the `||` since it was truthy.

This meant requests went to `https://api.moonshot.ai/v1/messages` instead of the correct Anthropic-compatible endpoint `https://api.moonshot.ai/anthropic/v1/messages`, causing upstream LLM API errors.

```ts
// before — models.dev URL always wins since it's truthy
const url = providerInfo.api || OPENAI_COMPATIBLE_OVERRIDES[normalizedId]?.url;

// after — overrides take priority
const url = OPENAI_COMPATIBLE_OVERRIDES[normalizedId]?.url || providerInfo.api;
```

Also applies the `npm` field from overrides so the registry correctly stores `@ai-sdk/anthropic` for moonshotai instead of filtering it out. Regenerated `provider-registry.json` with the correct URLs and npm fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Moonshot AI model connectivity by correcting the Anthropic-compatible endpoint URL.

* **Chores**
  * Updated Moonshot provider entries to reference the Anthropic path and associated SDK package.

* **Tests**
  * Updated test descriptions to reflect provider configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->