### PR TITLE
tsc OOM: createStep() with Zod schemas causes exponential type instan…

### DIFF
--- a/.changeset/1770374014-tsc-oom-zod-docs.md
+++ b/.changeset/1770374014-tsc-oom-zod-docs.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Added compatibility notes to README documenting minimum Zod version requirement (>=4.3.6) to prevent tsc OOM issues when using createStep() with Zod schemas

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,22 @@
 # @mastra/core
 
+## Compatibility notes
+
+- Minimum Zod version for `zod` 4.x: **>= 4.3.6**.
+
+Reason: a TypeScript compiler edge case with chained `export *` re-exports in `zod@4.3.5` can cause `tsc` or DTS generation to OOM when consumers instantiate deep Zod generics (for example, calling `createStep()` with Zod schemas). Zod `4.3.6` fixed the export chaining issue; upgrading prevents the OOM during type-checking.
+
+## What to do if you see errors
+
+- If your project is pinned to `zod@4.3.5`, update it to `^4.3.6` in your `package.json` and re-install (or update your lockfile):
+
+```bash
+pnpm add -w zod@^4.3.6
+# or with npm/yarn as appropriate
+```
+
+- If your CI or install fails on peer dependency mismatches, allow or bump the dependency in your monorepo/lockfile to `>=4.3.6`.
+
 Mastra is a framework for building AI-powered applications and agents with a modern TypeScript stack.
 
 It includes everything you need to go from early prototypes to production-ready applications. Mastra integrates with frontend and backend frameworks like React, Next.js, and Node, or you can deploy it anywhere as a standalone server. It's the easiest way to build, tune, and scale reliable AI products.


### PR DESCRIPTION
## Description
tsc --noEmit and DTS generation both OOM at 4GB when you use createStep() with Zod schemas. Been debugging this for a while and narrowed it down pretty well.
Only I added a note in Readme.

## Related Issue(s)
#12753 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a compatibility notes section outlining a minimum required Zod version (4.3.6+) to avoid TypeScript compiler issues, with guidance on upgrading, troubleshooting error messages, and recommended peer-dependency adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->