### PR TITLE
Remove 'new' tags from Server Adapters documentation

### DIFF
--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -321,17 +321,11 @@ const sidebars = {
           type: 'doc',
           id: 'server/server-adapters',
           label: 'Server Adapters',
-          customProps: {
-            tags: ['new'],
-          },
         },
         {
           type: 'doc',
           id: 'server/custom-adapters',
           label: 'Custom Adapters',
-          customProps: {
-            tags: ['new'],
-          },
         },
         {
           type: 'doc',


### PR DESCRIPTION
## Description

Remove the `customProps` with `tags: ['new']` from the "Server Adapters" and "Custom Adapters" sidebar entries. These tags were likely added when the features were initially released and should now be removed as they are no longer considered new.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, if applicable -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

https://claude.ai/code/session_019D8aXkj8jn6tYzTd4be4Us

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed "new" tag indicators from server adapter documentation entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->