### PR TITLE
fix: playground ui not picking agent prompt changes

### DIFF
--- a/packages/deployer/src/server/handlers/client.ts
+++ b/packages/deployer/src/server/handlers/client.ts
@@ -41,14 +41,17 @@ const cleanReqId = (id: string) => {
 
 export async function handleTriggerClientsRefresh(c: Context) {
   let requestId = (await c.req.json())['refreshId'];
+
   if (requestId) {
     refreshRequestId = requestId;
     cleanReqId(requestId);
   }
 
+  let data = `data: refresh${requestId ? '-' + requestId : ''}\n\n`;
+
   clients.forEach(controller => {
     try {
-      controller.enqueue('data: refresh\n\n');
+      controller.enqueue(data);
     } catch {
       clients.delete(controller);
     }

--- a/packages/deployer/src/server/handlers/client.ts
+++ b/packages/deployer/src/server/handlers/client.ts
@@ -1,6 +1,9 @@
 import type { Context } from 'hono';
 
 const clients = new Set<ReadableStreamDefaultController>();
+
+//short lived about 2 seconds
+let refreshRequestId: string | undefined;
 let hotReloadDisabled = false;
 
 export function handleClientsRefresh(c: Context): Response {
@@ -8,6 +11,10 @@ export function handleClientsRefresh(c: Context): Response {
     start(controller) {
       clients.add(controller);
       controller.enqueue('data: connected\n\n');
+
+      if (refreshRequestId) {
+        controller.enqueue(`data: refresh-${refreshRequestId}\n\n`);
+      }
 
       c.req.raw.signal.addEventListener('abort', () => {
         clients.delete(controller);
@@ -24,8 +31,21 @@ export function handleClientsRefresh(c: Context): Response {
     },
   });
 }
+const cleanReqId = (id: string) => {
+  setTimeout(() => {
+    if (refreshRequestId === id) {
+      refreshRequestId = undefined;
+    }
+  }, 2000);
+};
 
-export function handleTriggerClientsRefresh(c: Context) {
+export async function handleTriggerClientsRefresh(c: Context) {
+  let requestId = (await c.req.json())['refreshId'];
+  if (requestId) {
+    refreshRequestId = requestId;
+    cleanReqId(requestId);
+  }
+
   clients.forEach(controller => {
     try {
       controller.enqueue('data: refresh\n\n');

--- a/packages/playground-ui/src/domains/agents/context/agent-prompt-experiment-context.tsx
+++ b/packages/playground-ui/src/domains/agents/context/agent-prompt-experiment-context.tsx
@@ -39,10 +39,10 @@ export const AgentPromptExperimentProvider = ({
   useEffect(() => {
     let storedPrompt = localStorage.getItem(`agent-prompt-experiment-${agentId}`);
 
-    const lastPromtOriginal = getPrompt('original');
+    const lastPromptOriginal = getPrompt('original');
 
     //reflect the prompt from code change , overrides browser saved data
-    if (lastPromtOriginal != initialPromptText) {
+    if (lastPromptOriginal !== initialPromptText) {
       storePrompt('original', initialPromptText);
       storePrompt('local', initialPromptText);
       storedPrompt = initialPromptText;

--- a/packages/playground-ui/src/domains/agents/context/agent-prompt-experiment-context.tsx
+++ b/packages/playground-ui/src/domains/agents/context/agent-prompt-experiment-context.tsx
@@ -37,10 +37,26 @@ export const AgentPromptExperimentProvider = ({
   const [prompt, setPrompt] = useState('');
 
   useEffect(() => {
-    const storedPrompt = localStorage.getItem(`agent-prompt-experiment-${agentId}`);
+    let storedPrompt = localStorage.getItem(`agent-prompt-experiment-${agentId}`);
+
+    const lastPromtOriginal = getPrompt('original');
+
+    //reflect the prompt from code change , overrides browser saved data
+    if (lastPromtOriginal != initialPromptText) {
+      storePrompt('original', initialPromptText);
+      storePrompt('local', initialPromptText);
+      storedPrompt = initialPromptText;
+    }
 
     setPrompt(storedPrompt ?? initialPromptText);
   }, [agentId, initialPromptText]);
+
+  const storePrompt = (type: 'original' | 'local', prompt: string) => {
+    return localStorage.setItem(`agent-prompt-${type === 'original' ? 'original-' : ''}experiment-${agentId}`, prompt);
+  };
+  const getPrompt = (type: 'original' | 'local') => {
+    return localStorage.getItem(`agent-prompt-${type === 'original' ? 'original-' : ''}experiment-${agentId}`);
+  };
 
   useEffect(() => {
     if (!prompt) return;

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -25,6 +25,14 @@
           if (event.data === 'refresh') {
             window.location.reload();
           }
+          if (typeof event.data == 'string' && event.data.startsWith('refresh-')) {
+            let refreshId = event.data.substring(8);
+            let lastRefreshId = sessionStorage.getItem('refreshId');
+            if (lastRefreshId !== refreshId) {
+              sessionStorage.setItem('refreshId', refreshId);
+              window.location.reload();
+            }
+          }
         };
 
         events.onerror = () => {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Changed to override browser local prompt with latest prompt 
Resolves an issues where clients are not refreshed due to loss of stream pool during server restart
## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #11763
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Controls to enable/disable hot reload during development.
  * Refresh signaling now carries identifiers to coordinate client reloads and avoid duplicates.

* **Bug Fixes**
  * Added retry for failed refresh requests to improve reliability.
  * Prevented redundant page reloads by tracking refresh identifiers.
  * Improved prompt synchronization so stored and initial prompts stay consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->