### PR TITLE
fix(playground): open Swagger UI link in new tab

### DIFF
--- a/.changeset/odd-camels-hope.md
+++ b/.changeset/odd-camels-hope.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed the Swagger UI (Mastra APIs) link in the sidebar to open in a new browser tab instead of navigating within the studio

--- a/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
+++ b/packages/playground-ui/src/ds/components/MainSidebar/main-sidebar-nav-link.tsx
@@ -21,6 +21,7 @@ export type MainSidebarNavLinkProps = {
   state?: SidebarState;
   children?: React.ReactNode;
   className?: string;
+  target?: '_blank' | '_self' | '_parent' | '_top';
 };
 export function MainSidebarNavLink({
   link,
@@ -28,6 +29,7 @@ export function MainSidebarNavLink({
   children,
   isActive,
   className,
+  target,
 }: MainSidebarNavLinkProps) {
   const { Link } = useLinkComponent();
   const isCollapsed = state === 'collapsed';
@@ -68,7 +70,7 @@ export function MainSidebarNavLink({
           {isCollapsed || link.tooltipMsg ? (
             <Tooltip>
               <TooltipTrigger asChild>
-                <Link href={link.url} {...linkParams}>
+                <Link href={link.url} {...linkParams} target={target}>
                   {link.icon && link.icon}
                   {isCollapsed ? <VisuallyHidden>{link.name}</VisuallyHidden> : link.name} {children}
                 </Link>
@@ -84,7 +86,7 @@ export function MainSidebarNavLink({
               </TooltipContent>
             </Tooltip>
           ) : (
-            <Link href={link.url} {...linkParams}>
+            <Link href={link.url} {...linkParams} target={target}>
               {link.icon && link.icon}
               {isCollapsed ? <VisuallyHidden>{link.name}</VisuallyHidden> : link.name} {children}
             </Link>

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -73,6 +73,7 @@ const mainNavigation: NavSection[] = [
         name: 'Workspaces',
         url: '/workspaces',
         icon: <FolderIcon />,
+        isOnMastraPlatform: true,
       },
       {
         name: 'Request Context',
@@ -125,12 +126,6 @@ const secondNavigation: NavSection = {
   key: 'others',
   title: 'Other links',
   links: [
-    {
-      name: 'Mastra APIs',
-      url: '/swagger-ui',
-      icon: <EarthIcon />,
-      isOnMastraPlatform: false,
-    },
     {
       name: 'Documentation',
       url: 'https://mastra.ai/en/docs',
@@ -215,6 +210,17 @@ export function AppSidebar() {
           <MainSidebar.NavSection>
             <MainSidebar.NavSeparator />
             <MainSidebar.NavList>
+              <MainSidebar.NavLink
+                link={{
+                  name: 'Mastra APIs',
+                  url: '/swagger-ui',
+                  icon: <EarthIcon />,
+                  isOnMastraPlatform: false,
+                }}
+                target="_blank"
+                state={state}
+              />
+
               {secondNavigation.links.filter(filterPlatformLink).map(link => {
                 return <MainSidebar.NavLink key={link.name} link={link} state={state} />;
               })}


### PR DESCRIPTION
The "Mastra APIs" sidebar link was navigating within the studio, which replaced the current page with the Swagger UI. This moves it out of the data-driven nav array and renders it directly with `target="_blank"` so it opens in a new browser tab instead.

Also added a `target` prop to `MainSidebarNavLink` in `playground-ui` to support this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Swagger UI link in sidebar now opens in a new browser tab instead of navigating within the studio.

* **UI Improvements**
  * Mastra APIs link repositioned to the sidebar footer and now opens in a new browser tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->