### PR TITLE
Fix tool input validation for stringified JSON arrays/objects 

### DIFF
--- a/.changeset/silver-baboons-matter.md
+++ b/.changeset/silver-baboons-matter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed tool input validation failing when LLMs return stringified JSON for array or object parameters. Some models (e.g., GLM4.7) send `"[\"file.py\"]"` instead of `["file.py"]` for array fields, which caused Zod validation to reject the input. The validation pipeline now automatically detects and parses stringified JSON values when the schema expects an array or object. (GitHub #12757)

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -3,7 +3,7 @@ import type { AgentExecutionOptionsBase } from '../agent/agent.types';
 import type { SerializedError } from '../error';
 import type { ScoringSamplingConfig } from '../evals/types';
 import type { MastraDBMessage, StorageThreadType, SerializedMemoryConfig } from '../memory/types';
-import { getZodTypeName } from '../utils/zod-utils';
+import { getZodInnerType, getZodTypeName } from '../utils/zod-utils';
 import type { StepResult, WorkflowRunState, WorkflowRunStatus } from '../workflows';
 
 export type StoragePagination = {
@@ -663,83 +663,21 @@ export interface UpdateWorkflowStateOptions {
   resumeLabels?: Record<string, { stepId: string; foreachIndex?: number }>;
 }
 
-/**
- * Get the inner type from a wrapper schema (nullable, optional, default, effects, branded).
- * Compatible with both Zod 3 and Zod 4.
- */
-function getInnerType(schema: z.ZodTypeAny, typeName: string): z.ZodTypeAny | undefined {
-  const schemaAny = schema as any;
-
-  // For nullable, optional, default - the inner type is at _def.innerType
-  if (typeName === 'ZodNullable' || typeName === 'ZodOptional' || typeName === 'ZodDefault') {
-    return schemaAny._zod?.def?.innerType ?? schemaAny._def?.innerType;
-  }
-
-  // For effects - the inner type is at _def.schema
-  if (typeName === 'ZodEffects') {
-    return schemaAny._zod?.def?.schema ?? schemaAny._def?.schema;
-  }
-
-  // For branded - the inner type is at _def.type
-  if (typeName === 'ZodBranded') {
-    return schemaAny._zod?.def?.type ?? schemaAny._def?.type;
-  }
-
-  return undefined;
-}
-
 function unwrapSchema(schema: z.ZodTypeAny): { base: z.ZodTypeAny; nullable: boolean } {
   let current = schema;
   let nullable = false;
 
   while (true) {
     const typeName = getZodTypeName(current);
+    if (!typeName) break;
 
-    if (typeName === 'ZodNullable') {
+    if (typeName === 'ZodNullable' || typeName === 'ZodOptional') {
       nullable = true;
-      const inner = getInnerType(current, typeName);
-      if (inner) {
-        current = inner;
-        continue;
-      }
     }
 
-    if (typeName === 'ZodOptional') {
-      // For DB purposes, we usually treat "optional" as "nullable"
-      nullable = true;
-      const inner = getInnerType(current, typeName);
-      if (inner) {
-        current = inner;
-        continue;
-      }
-    }
-
-    if (typeName === 'ZodDefault') {
-      const inner = getInnerType(current, typeName);
-      if (inner) {
-        current = inner;
-        continue;
-      }
-    }
-
-    if (typeName === 'ZodEffects') {
-      const inner = getInnerType(current, typeName);
-      if (inner) {
-        current = inner;
-        continue;
-      }
-    }
-
-    if (typeName === 'ZodBranded') {
-      const inner = getInnerType(current, typeName);
-      if (inner) {
-        current = inner;
-        continue;
-      }
-    }
-
-    // If you ever use ZodCatch/ZodPipeline, you can unwrap them here too.
-    break;
+    const inner = getZodInnerType(current, typeName);
+    if (!inner) break;
+    current = inner;
   }
 
   return { base: current, nullable };


### PR DESCRIPTION
## Description

Fixed tool input validation failing when LLMs return stringified JSON for array or object parameters. Some models (e.g., GLM4.7) send `"[\"parse_excel.py\"]"` instead of `["parse_excel.py"]` for array fields, causing Zod validation to reject the input. The validation pipeline now automatically detects and parses stringified JSON values when the schema expects an array or object.

## Related Issue(s)

Fixes #12757

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Implementation Details

**New Utilities** (`packages/core/src/utils/zod-utils.ts`):
- `getZodInnerType()` - Extracts inner type from Zod wrapper schemas (optional, nullable, default, effects, branded)
- `unwrapZodType()` - Peels all wrappers to find the base schema type

**Validation Enhancement** (`packages/core/src/tools/validation.ts`):
- Added `coerceStringifiedJsonValues()` function that walks object properties and attempts to JSON.parse string values when the schema expects arrays or objects
- Inserted as Step 4 in the validation pipeline (after first validation fails, before null-stripping retry)
- Conservative: Only triggers for strings starting with `[` or `{`, and verifies parsed result matches expected type

**Tests** (`packages/core/src/tools/validation.test.ts`):
- 11 tests covering stringified arrays, objects, exact GLM4.7 reproduction, end-to-end usage, and edge cases
- All tests pass; 67 existing validation tests pass with no regression

**Code Consolidation** (`packages/core/src/storage/types.ts`):
- Removed duplicate `getInnerType()` function (28 lines)
- Simplified `unwrapSchema()` to use shared `getZodInnerType()` (from 55 to 16 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Tool input validation now automatically parses stringified JSON values for array and object parameters. Values like `"[\"file.py\"]"` are correctly interpreted during validation instead of causing failures, improving compatibility with different model output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->