### PR TITLE
feat(editor): dynamic instructions for stored agents

### DIFF
--- a/.changeset/four-eels-enjoy.md
+++ b/.changeset/four-eels-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Added POST /stored/agents/preview-instructions endpoint for resolving instruction blocks against a request context. This enables UI previews of how agent instructions will render with specific variables and rule conditions. Updated Zod schemas to support the new AgentInstructionBlock union type (text, prompt_block_ref, inline prompt_block) in agent version and stored agent responses.

--- a/.changeset/funny-parrots-hear.md
+++ b/.changeset/funny-parrots-hear.md
@@ -1,0 +1,56 @@
+---
+'@mastra/core': minor
+'@mastra/editor': minor
+---
+
+Added dynamic instructions for stored agents. Agent instructions can now be composed from reusable prompt blocks with conditional rules and variable interpolation, enabling a prompt-CMS-like editing experience.
+
+**Instruction blocks** can be mixed in an agent's instructions array:
+
+- `text` — static text with `{{variable}}` interpolation
+- `prompt_block_ref` — reference to a versioned prompt block stored in the database
+- `prompt_block` — inline prompt block with optional conditional rules
+
+**Creating a prompt block and using it in a stored agent:**
+
+```ts
+// Create a reusable prompt block
+const block = await editor.createPromptBlock({
+  id: 'security-rules',
+  name: 'Security Rules',
+  content: "You must verify the user's identity. The user's role is {{user.role}}.",
+  rules: {
+    operator: 'AND',
+    conditions: [{ field: 'user.isAuthenticated', operator: 'equals', value: true }],
+  },
+});
+
+// Create a stored agent that references the prompt block
+await editor.createStoredAgent({
+  id: 'support-agent',
+  name: 'Support Agent',
+  instructions: [
+    { type: 'text', content: 'You are a helpful support agent for {{company}}.' },
+    { type: 'prompt_block_ref', id: 'security-rules' },
+    {
+      type: 'prompt_block',
+      content: 'Always be polite.',
+      rules: { operator: 'AND', conditions: [{ field: 'tone', operator: 'equals', value: 'formal' }] },
+    },
+  ],
+  model: { provider: 'openai', name: 'gpt-4o' },
+});
+
+// At runtime, instructions resolve dynamically based on request context
+const agent = await editor.getStoredAgentById('support-agent');
+const result = await agent.generate('Help me reset my password', {
+  requestContext: new RequestContext([
+    ['company', 'Acme Corp'],
+    ['user.isAuthenticated', true],
+    ['user.role', 'admin'],
+    ['tone', 'formal'],
+  ]),
+});
+```
+
+Prompt blocks are versioned — updating a block's content takes effect immediately for all agents referencing it, with no cache clearing required.

--- a/.changeset/open-spiders-cheer.md
+++ b/.changeset/open-spiders-cheer.md
@@ -1,0 +1,9 @@
+---
+'@mastra/pg': patch
+'@mastra/libsql': patch
+'@mastra/mongodb': patch
+'@mastra/clickhouse': patch
+'@mastra/cloudflare': patch
+---
+
+Added prompt block storage implementations for PostgreSQL, LibSQL, and MongoDB. Each store supports full CRUD for prompt blocks and their versions, including JSON serialization for rules and metadata. Also updated agent instructions serialization in PG and LibSQL to support the new AgentInstructionBlock array format alongside plain strings.

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -495,6 +495,7 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
         toolCall = response.toolResults.find((result: any) => result.toolName === 'noSchemaTool');
       } else {
         response = await agent.generate('Use the noSchemaTool to get test data');
+        console.log('response', JSON.stringify(response, null, 2));
         toolCall = response.toolResults.find((result: any) => result.payload.toolName === 'noSchemaTool')?.payload;
       }
 

--- a/packages/core/src/editor/types.ts
+++ b/packages/core/src/editor/types.ts
@@ -1,7 +1,7 @@
 import type { Agent } from '../agent';
 import type { IMastraLogger } from '../logger';
 import type { Mastra } from '../mastra';
-import type { StorageResolvedAgentType } from '../storage/types';
+import type { AgentInstructionBlock, StorageResolvedAgentType } from '../storage/types';
 
 export interface MastraEditorConfig {
   logger?: IMastraLogger;
@@ -65,4 +65,10 @@ export interface IMastraEditor {
    * Clear the stored agent cache for a specific agent ID, or all cached agents.
    */
   clearStoredAgentCache(agentId?: string): void;
+
+  /**
+   * Preview the resolved instructions for a given set of instruction blocks and context.
+   * Resolves prompt_block_ref references, evaluates rules, and renders template variables.
+   */
+  previewInstructions(blocks: AgentInstructionBlock[], context: Record<string, unknown>): Promise<string>;
 }

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -1,6 +1,13 @@
 import { MastraBase } from '../base';
 
-import type { AgentsStorage, ScoresStorage, WorkflowsStorage, MemoryStorage, ObservabilityStorage } from './domains';
+import type {
+  AgentsStorage,
+  PromptBlocksStorage,
+  ScoresStorage,
+  WorkflowsStorage,
+  MemoryStorage,
+  ObservabilityStorage,
+} from './domains';
 
 export type StorageDomains = {
   workflows: WorkflowsStorage;
@@ -8,6 +15,7 @@ export type StorageDomains = {
   memory: MemoryStorage;
   observability?: ObservabilityStorage;
   agents?: AgentsStorage;
+  promptBlocks?: PromptBlocksStorage;
 };
 
 /**
@@ -198,6 +206,7 @@ export class MastraCompositeStore extends MastraBase {
         scores: domainOverrides.scores ?? defaultStores?.scores,
         observability: domainOverrides.observability ?? defaultStores?.observability,
         agents: domainOverrides.agents ?? defaultStores?.agents,
+        promptBlocks: domainOverrides.promptBlocks ?? defaultStores?.promptBlocks,
       } as StorageDomains;
     }
     // Otherwise, subclasses set stores themselves
@@ -252,6 +261,10 @@ export class MastraCompositeStore extends MastraBase {
 
     if (this.stores?.agents) {
       initTasks.push(this.stores.agents.init());
+    }
+
+    if (this.stores?.promptBlocks) {
+      initTasks.push(this.stores.promptBlocks.init());
     }
 
     this.hasInitialized = Promise.all(initTasks).then(() => true);

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -12,6 +12,8 @@ export const TABLE_SPANS = 'mastra_ai_spans';
 export const TABLE_AGENTS = 'mastra_agents';
 export const TABLE_AGENT_VERSIONS = 'mastra_agent_versions';
 export const TABLE_OBSERVATIONAL_MEMORY = 'mastra_observational_memory';
+export const TABLE_PROMPT_BLOCKS = 'mastra_prompt_blocks';
+export const TABLE_PROMPT_BLOCK_VERSIONS = 'mastra_prompt_block_versions';
 
 export type TABLE_NAMES =
   | typeof TABLE_WORKFLOW_SNAPSHOT
@@ -22,7 +24,9 @@ export type TABLE_NAMES =
   | typeof TABLE_SCORERS
   | typeof TABLE_SPANS
   | typeof TABLE_AGENTS
-  | typeof TABLE_AGENT_VERSIONS;
+  | typeof TABLE_AGENT_VERSIONS
+  | typeof TABLE_PROMPT_BLOCKS
+  | typeof TABLE_PROMPT_BLOCK_VERSIONS;
 
 export const SCORERS_SCHEMA: Record<string, StorageColumn> = {
   id: { type: 'text', nullable: false, primaryKey: true },
@@ -123,6 +127,29 @@ export const AGENT_VERSIONS_SCHEMA: Record<string, StorageColumn> = {
   createdAt: { type: 'timestamp', nullable: false },
 };
 
+export const PROMPT_BLOCKS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  status: { type: 'text', nullable: false }, // 'draft', 'published', or 'archived'
+  activeVersionId: { type: 'text', nullable: true }, // FK to prompt_block_versions.id
+  authorId: { type: 'text', nullable: true },
+  metadata: { type: 'jsonb', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+  updatedAt: { type: 'timestamp', nullable: false },
+};
+
+export const PROMPT_BLOCK_VERSIONS_SCHEMA: Record<string, StorageColumn> = {
+  id: { type: 'text', nullable: false, primaryKey: true },
+  blockId: { type: 'text', nullable: false },
+  versionNumber: { type: 'integer', nullable: false },
+  name: { type: 'text', nullable: false },
+  description: { type: 'text', nullable: true },
+  content: { type: 'text', nullable: false },
+  rules: { type: 'jsonb', nullable: true },
+  changedFields: { type: 'jsonb', nullable: true },
+  changeMessage: { type: 'text', nullable: true },
+  createdAt: { type: 'timestamp', nullable: false },
+};
+
 export const OBSERVATIONAL_MEMORY_SCHEMA: Record<string, StorageColumn> = {
   id: { type: 'text', nullable: false, primaryKey: true },
   lookupKey: { type: 'text', nullable: false }, // 'resource:{resourceId}' or 'thread:{threadId}'
@@ -213,6 +240,8 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
   },
   [TABLE_AGENTS]: AGENTS_SCHEMA,
   [TABLE_AGENT_VERSIONS]: AGENT_VERSIONS_SCHEMA,
+  [TABLE_PROMPT_BLOCKS]: PROMPT_BLOCKS_SCHEMA,
+  [TABLE_PROMPT_BLOCK_VERSIONS]: PROMPT_BLOCK_VERSIONS_SCHEMA,
 };
 
 /**

--- a/packages/core/src/storage/domains/index.ts
+++ b/packages/core/src/storage/domains/index.ts
@@ -1,5 +1,6 @@
 export * from './base';
 export * from './agents';
+export * from './prompt-blocks';
 export * from './scores';
 export * from './observability';
 export * from './operations';

--- a/packages/core/src/storage/domains/inmemory-db.ts
+++ b/packages/core/src/storage/domains/inmemory-db.ts
@@ -3,12 +3,14 @@ import type { StorageThreadType } from '../../memory/types';
 import type {
   StorageAgentType,
   StorageMessageType,
+  StoragePromptBlockType,
   StorageResourceType,
   StorageWorkflowRun,
   ObservationalMemoryRecord,
 } from '../types';
 import type { AgentVersion } from './agents';
 import type { TraceEntry } from './observability';
+import type { PromptBlockVersion } from './prompt-blocks';
 
 /**
  * InMemoryDB is a thin database layer for in-memory storage.
@@ -26,6 +28,8 @@ export class InMemoryDB {
   readonly traces = new Map<string, TraceEntry>();
   readonly agents = new Map<string, StorageAgentType>();
   readonly agentVersions = new Map<string, AgentVersion>();
+  readonly promptBlocks = new Map<string, StoragePromptBlockType>();
+  readonly promptBlockVersions = new Map<string, PromptBlockVersion>();
   /** Observational memory records, keyed by resourceId, each holding array of records (generations) */
   readonly observationalMemory = new Map<string, ObservationalMemoryRecord[]>();
 
@@ -42,6 +46,8 @@ export class InMemoryDB {
     this.traces.clear();
     this.agents.clear();
     this.agentVersions.clear();
+    this.promptBlocks.clear();
+    this.promptBlockVersions.clear();
     this.observationalMemory.clear();
   }
 }

--- a/packages/core/src/storage/domains/operations/inmemory.ts
+++ b/packages/core/src/storage/domains/operations/inmemory.ts
@@ -22,6 +22,8 @@ export class StoreOperationsInMemory extends StoreOperations {
       mastra_agents: new Map(),
       mastra_agent_versions: new Map(),
       mastra_observational_memory: new Map(),
+      mastra_prompt_blocks: new Map(),
+      mastra_prompt_block_versions: new Map(),
     };
   }
 

--- a/packages/core/src/storage/domains/prompt-blocks/base.ts
+++ b/packages/core/src/storage/domains/prompt-blocks/base.ts
@@ -1,0 +1,384 @@
+import type {
+  StoragePromptBlockType,
+  StoragePromptBlockSnapshotType,
+  StorageResolvedPromptBlockType,
+  StorageCreatePromptBlockInput,
+  StorageUpdatePromptBlockInput,
+  StorageListPromptBlocksInput,
+  StorageListPromptBlocksOutput,
+  StorageListPromptBlocksResolvedOutput,
+  StorageOrderBy,
+  ThreadOrderBy,
+  ThreadSortDirection,
+} from '../../types';
+import { StorageDomain } from '../base';
+
+// ============================================================================
+// Prompt Block Version Types
+// ============================================================================
+
+/**
+ * Represents a stored version of a prompt block's content.
+ * Config fields are top-level on the version row (no nested snapshot object).
+ */
+export interface PromptBlockVersion extends StoragePromptBlockSnapshotType {
+  /** UUID identifier for this version */
+  id: string;
+  /** ID of the prompt block this version belongs to */
+  blockId: string;
+  /** Sequential version number (1, 2, 3, ...) */
+  versionNumber: number;
+  /** Array of field names that changed from the previous version */
+  changedFields?: string[];
+  /** Optional message describing the changes */
+  changeMessage?: string;
+  /** When this version was created */
+  createdAt: Date;
+}
+
+/**
+ * Input for creating a new prompt block version.
+ * Config fields are top-level (no nested snapshot object).
+ */
+export interface CreatePromptBlockVersionInput extends StoragePromptBlockSnapshotType {
+  /** UUID identifier for this version */
+  id: string;
+  /** ID of the prompt block this version belongs to */
+  blockId: string;
+  /** Sequential version number */
+  versionNumber: number;
+  /** Array of field names that changed from the previous version */
+  changedFields?: string[];
+  /** Optional message describing the changes */
+  changeMessage?: string;
+}
+
+/**
+ * Sort direction for version listings.
+ */
+export type PromptBlockVersionSortDirection = ThreadSortDirection;
+
+/**
+ * Fields that can be used for ordering version listings.
+ */
+export type PromptBlockVersionOrderBy = 'versionNumber' | 'createdAt';
+
+/**
+ * Input for listing prompt block versions with pagination and sorting.
+ */
+export interface ListPromptBlockVersionsInput {
+  /** ID of the prompt block to list versions for */
+  blockId: string;
+  /** Page number (0-indexed) */
+  page?: number;
+  /**
+   * Number of items per page, or `false` to fetch all records without pagination limit.
+   * Defaults to 20 if not specified.
+   */
+  perPage?: number | false;
+  /** Sorting options */
+  orderBy?: {
+    field?: PromptBlockVersionOrderBy;
+    direction?: PromptBlockVersionSortDirection;
+  };
+}
+
+/**
+ * Output for listing prompt block versions with pagination info.
+ */
+export interface ListPromptBlockVersionsOutput {
+  /** Array of versions for the current page */
+  versions: PromptBlockVersion[];
+  /** Total number of versions */
+  total: number;
+  /** Current page number */
+  page: number;
+  /** Items per page */
+  perPage: number | false;
+  /** Whether there are more pages */
+  hasMore: boolean;
+}
+
+// ============================================================================
+// Constants for validation
+// ============================================================================
+
+const PROMPT_BLOCK_ORDER_BY_SET: Record<ThreadOrderBy, true> = {
+  createdAt: true,
+  updatedAt: true,
+};
+
+const PROMPT_BLOCK_SORT_DIRECTION_SET: Record<ThreadSortDirection, true> = {
+  ASC: true,
+  DESC: true,
+};
+
+const VERSION_ORDER_BY_SET: Record<PromptBlockVersionOrderBy, true> = {
+  versionNumber: true,
+  createdAt: true,
+};
+
+// ============================================================================
+// PromptBlocksStorage Base Class
+// ============================================================================
+
+export abstract class PromptBlocksStorage extends StorageDomain {
+  constructor() {
+    super({
+      component: 'STORAGE',
+      name: 'PROMPT_BLOCKS',
+    });
+  }
+
+  // ==========================================================================
+  // Prompt Block CRUD Methods
+  // ==========================================================================
+
+  /**
+   * Retrieves a prompt block by its unique identifier (raw thin record, without version resolution).
+   * @param id - The unique identifier of the prompt block
+   * @returns The thin prompt block record if found, null otherwise
+   */
+  abstract getPromptBlockById({ id }: { id: string }): Promise<StoragePromptBlockType | null>;
+
+  /**
+   * Retrieves a prompt block by its unique identifier, resolving config from the active version.
+   * This is the preferred method for fetching prompt blocks as it ensures the returned
+   * configuration matches the active version.
+   *
+   * @param id - The unique identifier of the prompt block
+   * @returns The resolved prompt block (metadata + version config), or null if not found
+   */
+  async getPromptBlockByIdResolved({ id }: { id: string }): Promise<StorageResolvedPromptBlockType | null> {
+    const block = await this.getPromptBlockById({ id });
+
+    if (!block) {
+      return null;
+    }
+
+    // Try to get the version to merge with
+    let version: PromptBlockVersion | null = null;
+
+    // If an active version is set, use that
+    if (block.activeVersionId) {
+      version = await this.getVersion(block.activeVersionId);
+
+      // Warn if activeVersionId points to a non-existent version
+      if (!version) {
+        console.warn(
+          `[PromptBlocksStorage] Prompt block ${block.id} has activeVersionId ${block.activeVersionId} but version not found. Falling back to latest version.`,
+        );
+      }
+    }
+
+    // If no active version or it wasn't found, fall back to latest version
+    if (!version) {
+      version = await this.getLatestVersion(block.id);
+    }
+
+    // If we have a version, merge its config with block metadata
+    if (version) {
+      // Extract snapshot config fields from the version
+      const {
+        id: _versionId,
+        blockId: _blockId,
+        versionNumber: _versionNumber,
+        changedFields: _changedFields,
+        changeMessage: _changeMessage,
+        createdAt: _createdAt,
+        ...snapshotConfig
+      } = version;
+
+      // Return merged block metadata + version config
+      return {
+        ...block,
+        ...snapshotConfig,
+      };
+    }
+
+    // No versions exist - return thin record cast as resolved (config fields will be undefined)
+    return block as StorageResolvedPromptBlockType;
+  }
+
+  /**
+   * Lists all prompt blocks with version resolution.
+   * For each block that has an activeVersionId, the config is resolved from the version.
+   *
+   * @param args - Pagination and ordering options
+   * @returns Paginated list of resolved prompt blocks
+   */
+  async listPromptBlocksResolved(args?: StorageListPromptBlocksInput): Promise<StorageListPromptBlocksResolvedOutput> {
+    const result = await this.listPromptBlocks(args);
+
+    // Resolve each block's active version or latest version
+    const resolvedBlocks = await Promise.all(
+      result.promptBlocks.map(async block => {
+        // Try to get the version to merge with
+        let version: PromptBlockVersion | null = null;
+
+        // If an active version is set, use that
+        if (block.activeVersionId) {
+          version = await this.getVersion(block.activeVersionId);
+        }
+
+        // If no active version or it wasn't found, fall back to latest version
+        if (!version) {
+          version = await this.getLatestVersion(block.id);
+        }
+
+        // If we have a version, merge its config with block metadata
+        if (version) {
+          const {
+            id: _versionId,
+            blockId: _blockId,
+            versionNumber: _versionNumber,
+            changedFields: _changedFields,
+            changeMessage: _changeMessage,
+            createdAt: _createdAt,
+            ...snapshotConfig
+          } = version;
+
+          return {
+            ...block,
+            ...snapshotConfig,
+          } as StorageResolvedPromptBlockType;
+        }
+
+        // No versions exist - return thin record cast as resolved
+        return block as StorageResolvedPromptBlockType;
+      }),
+    );
+
+    return {
+      ...result,
+      promptBlocks: resolvedBlocks,
+    };
+  }
+
+  /**
+   * Creates a new prompt block in storage.
+   * @param promptBlock - The prompt block data to create (thin record fields + initial snapshot)
+   * @returns The created thin prompt block record with timestamps
+   */
+  abstract createPromptBlock({
+    promptBlock,
+  }: {
+    promptBlock: StorageCreatePromptBlockInput;
+  }): Promise<StoragePromptBlockType>;
+
+  /**
+   * Updates an existing prompt block in storage.
+   * @param id - The unique identifier of the prompt block to update
+   * @param updates - The fields to update
+   * @returns The updated thin prompt block record
+   */
+  abstract updatePromptBlock({ id, ...updates }: StorageUpdatePromptBlockInput): Promise<StoragePromptBlockType>;
+
+  /**
+   * Deletes a prompt block from storage.
+   * @param id - The unique identifier of the prompt block to delete
+   */
+  abstract deletePromptBlock({ id }: { id: string }): Promise<void>;
+
+  /**
+   * Lists all prompt blocks with optional pagination.
+   * @param args - Pagination and ordering options
+   * @returns Paginated list of thin prompt block records
+   */
+  abstract listPromptBlocks(args?: StorageListPromptBlocksInput): Promise<StorageListPromptBlocksOutput>;
+
+  // ==========================================================================
+  // Prompt Block Version Methods
+  // ==========================================================================
+
+  /**
+   * Creates a new version record for a prompt block.
+   * @param input - The version data to create (config fields are top-level)
+   * @returns The created version with timestamp
+   */
+  abstract createVersion(input: CreatePromptBlockVersionInput): Promise<PromptBlockVersion>;
+
+  /**
+   * Retrieves a version by its unique ID.
+   * @param id - The UUID of the version
+   * @returns The version if found, null otherwise
+   */
+  abstract getVersion(id: string): Promise<PromptBlockVersion | null>;
+
+  /**
+   * Retrieves a version by block ID and version number.
+   * @param blockId - The ID of the prompt block
+   * @param versionNumber - The version number to look up
+   * @returns The version if found, null otherwise
+   */
+  abstract getVersionByNumber(blockId: string, versionNumber: number): Promise<PromptBlockVersion | null>;
+
+  /**
+   * Retrieves the latest (highest versionNumber) version for a prompt block.
+   * @param blockId - The ID of the prompt block
+   * @returns The latest version if found, null otherwise
+   */
+  abstract getLatestVersion(blockId: string): Promise<PromptBlockVersion | null>;
+
+  /**
+   * Lists versions for a prompt block with pagination and sorting.
+   * @param input - Pagination and filter options
+   * @returns Paginated list of versions
+   */
+  abstract listVersions(input: ListPromptBlockVersionsInput): Promise<ListPromptBlockVersionsOutput>;
+
+  /**
+   * Deletes a specific version by ID.
+   * @param id - The UUID of the version to delete
+   */
+  abstract deleteVersion(id: string): Promise<void>;
+
+  /**
+   * Deletes all versions for a prompt block.
+   * @param blockId - The ID of the prompt block
+   */
+  abstract deleteVersionsByBlockId(blockId: string): Promise<void>;
+
+  /**
+   * Counts the total number of versions for a prompt block.
+   * @param blockId - The ID of the prompt block
+   * @returns The count of versions
+   */
+  abstract countVersions(blockId: string): Promise<number>;
+
+  // ==========================================================================
+  // Protected Helper Methods
+  // ==========================================================================
+
+  /**
+   * Parses orderBy input for consistent prompt block sorting behavior.
+   */
+  protected parseOrderBy(
+    orderBy?: StorageOrderBy,
+    defaultDirection: ThreadSortDirection = 'DESC',
+  ): { field: ThreadOrderBy; direction: ThreadSortDirection } {
+    return {
+      field: orderBy?.field && orderBy.field in PROMPT_BLOCK_ORDER_BY_SET ? orderBy.field : 'createdAt',
+      direction:
+        orderBy?.direction && orderBy.direction in PROMPT_BLOCK_SORT_DIRECTION_SET
+          ? orderBy.direction
+          : defaultDirection,
+    };
+  }
+
+  /**
+   * Parses orderBy input for consistent version sorting behavior.
+   */
+  protected parseVersionOrderBy(
+    orderBy?: ListPromptBlockVersionsInput['orderBy'],
+    defaultDirection: PromptBlockVersionSortDirection = 'DESC',
+  ): { field: PromptBlockVersionOrderBy; direction: PromptBlockVersionSortDirection } {
+    return {
+      field: orderBy?.field && orderBy.field in VERSION_ORDER_BY_SET ? orderBy.field : 'versionNumber',
+      direction:
+        orderBy?.direction && orderBy.direction in PROMPT_BLOCK_SORT_DIRECTION_SET
+          ? orderBy.direction
+          : defaultDirection,
+    };
+  }
+}

--- a/packages/core/src/storage/domains/prompt-blocks/base.ts
+++ b/packages/core/src/storage/domains/prompt-blocks/base.ts
@@ -165,8 +165,8 @@ export abstract class PromptBlocksStorage extends StorageDomain {
 
       // Warn if activeVersionId points to a non-existent version
       if (!version) {
-        console.warn(
-          `[PromptBlocksStorage] Prompt block ${block.id} has activeVersionId ${block.activeVersionId} but version not found. Falling back to latest version.`,
+        this.logger?.warn?.(
+          `Prompt block ${block.id} has activeVersionId ${block.activeVersionId} but version not found. Falling back to latest version.`,
         );
       }
     }

--- a/packages/core/src/storage/domains/prompt-blocks/index.ts
+++ b/packages/core/src/storage/domains/prompt-blocks/index.ts
@@ -1,0 +1,2 @@
+export * from './base';
+export * from './inmemory';

--- a/packages/core/src/storage/domains/prompt-blocks/inmemory.test.ts
+++ b/packages/core/src/storage/domains/prompt-blocks/inmemory.test.ts
@@ -1,0 +1,667 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { InMemoryDB } from '../inmemory-db';
+import { InMemoryPromptBlocksStorage } from './inmemory';
+
+describe('InMemoryPromptBlocksStorage', () => {
+  let db: InMemoryDB;
+  let storage: InMemoryPromptBlocksStorage;
+
+  beforeEach(() => {
+    db = new InMemoryDB();
+    storage = new InMemoryPromptBlocksStorage({ db });
+  });
+
+  // ==========================================================================
+  // createPromptBlock
+  // ==========================================================================
+
+  describe('createPromptBlock', () => {
+    it('should create a block with status=draft and no activeVersionId', async () => {
+      const result = await storage.createPromptBlock({
+        promptBlock: {
+          id: 'block-1',
+          name: 'Test Block',
+          content: 'Hello world',
+        },
+      });
+
+      expect(result.id).toBe('block-1');
+      expect(result.status).toBe('draft');
+      expect(result.activeVersionId).toBeUndefined();
+      expect(result.createdAt).toBeInstanceOf(Date);
+      expect(result.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it('should auto-create version 1 with initial config', async () => {
+      await storage.createPromptBlock({
+        promptBlock: {
+          id: 'block-1',
+          name: 'Test Block',
+          content: 'Hello world',
+          description: 'A test block',
+        },
+      });
+
+      const versionCount = await storage.countVersions('block-1');
+      expect(versionCount).toBe(1);
+
+      const latestVersion = await storage.getLatestVersion('block-1');
+      expect(latestVersion).not.toBeNull();
+      expect(latestVersion!.versionNumber).toBe(1);
+      expect(latestVersion!.name).toBe('Test Block');
+      expect(latestVersion!.content).toBe('Hello world');
+      expect(latestVersion!.description).toBe('A test block');
+      expect(latestVersion!.changeMessage).toBe('Initial version');
+    });
+
+    it('should store optional fields (authorId, metadata, rules)', async () => {
+      const rules = {
+        operator: 'AND' as const,
+        conditions: [{ field: 'user.role', operator: 'equals' as const, value: 'admin' }],
+      };
+
+      const result = await storage.createPromptBlock({
+        promptBlock: {
+          id: 'block-2',
+          name: 'Admin Block',
+          content: 'Admin content',
+          authorId: 'user-123',
+          metadata: { category: 'admin' },
+          rules,
+        },
+      });
+
+      expect(result.authorId).toBe('user-123');
+      expect(result.metadata).toEqual({ category: 'admin' });
+
+      // Rules should be on the version, not the thin record
+      const latestVersion = await storage.getLatestVersion('block-2');
+      expect(latestVersion!.rules).toEqual(rules);
+    });
+
+    it('should throw if block with same ID already exists', async () => {
+      await storage.createPromptBlock({
+        promptBlock: { id: 'dup', name: 'First', content: 'First' },
+      });
+
+      await expect(
+        storage.createPromptBlock({
+          promptBlock: { id: 'dup', name: 'Second', content: 'Second' },
+        }),
+      ).rejects.toThrow('Prompt block with id dup already exists');
+    });
+  });
+
+  // ==========================================================================
+  // getPromptBlockById
+  // ==========================================================================
+
+  describe('getPromptBlockById', () => {
+    it('should return thin record for existing block', async () => {
+      await storage.createPromptBlock({
+        promptBlock: { id: 'block-1', name: 'Test', content: 'Content' },
+      });
+
+      const block = await storage.getPromptBlockById({ id: 'block-1' });
+      expect(block).not.toBeNull();
+      expect(block!.id).toBe('block-1');
+      expect(block!.status).toBe('draft');
+    });
+
+    it('should return null for non-existent block', async () => {
+      const block = await storage.getPromptBlockById({ id: 'nonexistent' });
+      expect(block).toBeNull();
+    });
+
+    it('should return a deep copy (mutation safety)', async () => {
+      await storage.createPromptBlock({
+        promptBlock: { id: 'block-1', name: 'Test', content: 'Content', metadata: { key: 'value' } },
+      });
+
+      const block1 = await storage.getPromptBlockById({ id: 'block-1' });
+      const block2 = await storage.getPromptBlockById({ id: 'block-1' });
+
+      block1!.metadata!['key'] = 'mutated';
+      expect(block2!.metadata!['key']).toBe('value');
+    });
+  });
+
+  // ==========================================================================
+  // getPromptBlockByIdResolved
+  // ==========================================================================
+
+  describe('getPromptBlockByIdResolved', () => {
+    it('should resolve latest version for block without activeVersionId', async () => {
+      await storage.createPromptBlock({
+        promptBlock: { id: 'block-1', name: 'Test', content: 'Content v1' },
+      });
+
+      const resolved = await storage.getPromptBlockByIdResolved({ id: 'block-1' });
+      expect(resolved).not.toBeNull();
+      expect(resolved!.id).toBe('block-1');
+      expect(resolved!.name).toBe('Test');
+      expect(resolved!.content).toBe('Content v1');
+      expect(resolved!.status).toBe('draft');
+    });
+
+    it('should resolve the active version when activeVersionId is set', async () => {
+      await storage.createPromptBlock({
+        promptBlock: { id: 'block-1', name: 'V1 Name', content: 'V1 Content' },
+      });
+
+      // Create version 2 with different content
+      const v2Id = 'version-2';
+      await storage.createVersion({
+        id: v2Id,
+        blockId: 'block-1',
+        versionNumber: 2,
+        name: 'V2 Name',
+        content: 'V2 Content',
+        changedFields: ['name', 'content'],
+        changeMessage: 'Updated to v2',
+      });
+
+      // Set active to version 2 (but latest is also v2)
+      await storage.updatePromptBlock({
+        id: 'block-1',
+        activeVersionId: v2Id,
+      });
+
+      const resolved = await storage.getPromptBlockByIdResolved({ id: 'block-1' });
+      expect(resolved!.name).toBe('V2 Name');
+      expect(resolved!.content).toBe('V2 Content');
+      expect(resolved!.status).toBe('published');
+    });
+
+    it('should fall back to latest version when activeVersionId points to missing version', async () => {
+      await storage.createPromptBlock({
+        promptBlock: { id: 'block-1', name: 'Test', content: 'Content' },
+      });
+
+      // Manually set an invalid activeVersionId
+      db.promptBlocks.get('block-1')!.activeVersionId = 'nonexistent-version';
+
+      const resolved = await storage.getPromptBlockByIdResolved({ id: 'block-1' });
+      expect(resolved).not.toBeNull();
+      expect(resolved!.name).toBe('Test');
+      expect(resolved!.content).toBe('Content');
+    });
+
+    it('should return null for non-existent block', async () => {
+      const resolved = await storage.getPromptBlockByIdResolved({ id: 'nonexistent' });
+      expect(resolved).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // updatePromptBlock
+  // ==========================================================================
+
+  describe('updatePromptBlock', () => {
+    let blockId: string;
+
+    beforeEach(async () => {
+      blockId = 'update-block';
+      await storage.createPromptBlock({
+        promptBlock: {
+          id: blockId,
+          name: 'Original Name',
+          content: 'Original content',
+          authorId: 'user-1',
+          metadata: { key1: 'val1', key2: 'val2' },
+        },
+      });
+    });
+
+    it('should update metadata without creating a new version', async () => {
+      const versionCountBefore = await storage.countVersions(blockId);
+      expect(versionCountBefore).toBe(1);
+
+      const result = await storage.updatePromptBlock({
+        id: blockId,
+        metadata: { key2: 'updated', key3: 'val3' },
+      });
+
+      // Metadata merged
+      expect(result.metadata).toEqual({
+        key1: 'val1',
+        key2: 'updated',
+        key3: 'val3',
+      });
+
+      // No new version
+      const versionCountAfter = await storage.countVersions(blockId);
+      expect(versionCountAfter).toBe(1);
+    });
+
+    it('should create a new version when updating config fields', async () => {
+      const versionCountBefore = await storage.countVersions(blockId);
+      expect(versionCountBefore).toBe(1);
+
+      await storage.updatePromptBlock({
+        id: blockId,
+        name: 'Updated Name',
+        content: 'Updated content',
+      });
+
+      // New version created
+      const versionCountAfter = await storage.countVersions(blockId);
+      expect(versionCountAfter).toBe(2);
+
+      // Resolved should reflect new values
+      const resolved = await storage.getPromptBlockByIdResolved({ id: blockId });
+      expect(resolved!.name).toBe('Updated Name');
+      expect(resolved!.content).toBe('Updated content');
+    });
+
+    it('should set status=published when activeVersionId is updated', async () => {
+      // Create a second version
+      const versionId = 'v2-id';
+      await storage.createVersion({
+        id: versionId,
+        blockId,
+        versionNumber: 2,
+        name: 'Version 2',
+        content: 'Version 2 content',
+        changedFields: ['name', 'content'],
+      });
+
+      const result = await storage.updatePromptBlock({
+        id: blockId,
+        activeVersionId: versionId,
+      });
+
+      expect(result.status).toBe('published');
+      expect(result.activeVersionId).toBe(versionId);
+    });
+
+    it('should handle mixed metadata and config updates', async () => {
+      await storage.updatePromptBlock({
+        id: blockId,
+        metadata: { key3: 'val3' },
+        name: 'Mixed Update Name',
+      });
+
+      // Should create a new version for config change
+      const versionCount = await storage.countVersions(blockId);
+      expect(versionCount).toBe(2);
+
+      const block = await storage.getPromptBlockById({ id: blockId });
+      expect(block!.metadata).toEqual({
+        key1: 'val1',
+        key2: 'val2',
+        key3: 'val3',
+      });
+
+      const resolved = await storage.getPromptBlockByIdResolved({ id: blockId });
+      expect(resolved!.name).toBe('Mixed Update Name');
+    });
+
+    it('should throw for non-existent block', async () => {
+      await expect(storage.updatePromptBlock({ id: 'nonexistent', name: 'Nope' })).rejects.toThrow(
+        'Prompt block with id nonexistent not found',
+      );
+    });
+  });
+
+  // ==========================================================================
+  // deletePromptBlock
+  // ==========================================================================
+
+  describe('deletePromptBlock', () => {
+    it('should delete block and all its versions', async () => {
+      await storage.createPromptBlock({
+        promptBlock: { id: 'del-block', name: 'To Delete', content: 'Content' },
+      });
+
+      // Create extra version
+      await storage.createVersion({
+        id: 'v2',
+        blockId: 'del-block',
+        versionNumber: 2,
+        name: 'V2',
+        content: 'V2 Content',
+      });
+
+      expect(await storage.countVersions('del-block')).toBe(2);
+
+      await storage.deletePromptBlock({ id: 'del-block' });
+
+      expect(await storage.getPromptBlockById({ id: 'del-block' })).toBeNull();
+      expect(await storage.countVersions('del-block')).toBe(0);
+    });
+
+    it('should be idempotent (no error for non-existent block)', async () => {
+      await expect(storage.deletePromptBlock({ id: 'nonexistent' })).resolves.toBeUndefined();
+    });
+  });
+
+  // ==========================================================================
+  // listPromptBlocks
+  // ==========================================================================
+
+  describe('listPromptBlocks', () => {
+    beforeEach(async () => {
+      for (let i = 1; i <= 5; i++) {
+        await storage.createPromptBlock({
+          promptBlock: {
+            id: `block-${i}`,
+            name: `Block ${i}`,
+            content: `Content ${i}`,
+            authorId: i <= 3 ? 'author-a' : 'author-b',
+            metadata: { index: i },
+          },
+        });
+        // Stagger creation times slightly
+        await new Promise(r => setTimeout(r, 5));
+      }
+    });
+
+    it('should return all blocks with default pagination', async () => {
+      const result = await storage.listPromptBlocks();
+      expect(result.promptBlocks).toHaveLength(5);
+      expect(result.total).toBe(5);
+      expect(result.page).toBe(0);
+    });
+
+    it('should support pagination', async () => {
+      const page0 = await storage.listPromptBlocks({ page: 0, perPage: 2 });
+      expect(page0.promptBlocks).toHaveLength(2);
+      expect(page0.hasMore).toBe(true);
+      expect(page0.total).toBe(5);
+
+      const page1 = await storage.listPromptBlocks({ page: 1, perPage: 2 });
+      expect(page1.promptBlocks).toHaveLength(2);
+      expect(page1.hasMore).toBe(true);
+
+      const page2 = await storage.listPromptBlocks({ page: 2, perPage: 2 });
+      expect(page2.promptBlocks).toHaveLength(1);
+      expect(page2.hasMore).toBe(false);
+    });
+
+    it('should filter by authorId', async () => {
+      const result = await storage.listPromptBlocks({ authorId: 'author-a' });
+      expect(result.promptBlocks).toHaveLength(3);
+      result.promptBlocks.forEach(b => expect(b.authorId).toBe('author-a'));
+    });
+
+    it('should filter by metadata', async () => {
+      const result = await storage.listPromptBlocks({ metadata: { index: 3 } });
+      expect(result.promptBlocks).toHaveLength(1);
+      expect(result.promptBlocks[0]!.id).toBe('block-3');
+    });
+
+    it('should sort by createdAt DESC by default', async () => {
+      const result = await storage.listPromptBlocks();
+      const ids = result.promptBlocks.map(b => b.id);
+      // DESC means newest first
+      expect(ids[0]).toBe('block-5');
+      expect(ids[4]).toBe('block-1');
+    });
+
+    it('should sort by createdAt ASC when specified', async () => {
+      const result = await storage.listPromptBlocks({
+        orderBy: { field: 'createdAt', direction: 'ASC' },
+      });
+      const ids = result.promptBlocks.map(b => b.id);
+      expect(ids[0]).toBe('block-1');
+      expect(ids[4]).toBe('block-5');
+    });
+
+    it('should return empty list when no blocks exist', async () => {
+      db.promptBlocks.clear();
+      const result = await storage.listPromptBlocks();
+      expect(result.promptBlocks).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  // ==========================================================================
+  // listPromptBlocksResolved
+  // ==========================================================================
+
+  describe('listPromptBlocksResolved', () => {
+    it('should return blocks with version config resolved', async () => {
+      await storage.createPromptBlock({
+        promptBlock: { id: 'block-1', name: 'Block One', content: 'Content One' },
+      });
+      await storage.createPromptBlock({
+        promptBlock: { id: 'block-2', name: 'Block Two', content: 'Content Two' },
+      });
+
+      const result = await storage.listPromptBlocksResolved();
+      expect(result.promptBlocks).toHaveLength(2);
+
+      // Each resolved block should have both thin record fields and snapshot fields
+      for (const block of result.promptBlocks) {
+        expect(block.name).toBeDefined();
+        expect(block.content).toBeDefined();
+        expect(block.status).toBeDefined();
+        expect(block.id).toBeDefined();
+      }
+    });
+  });
+
+  // ==========================================================================
+  // Version CRUD
+  // ==========================================================================
+
+  describe('version methods', () => {
+    const blockId = 'versioned-block';
+
+    beforeEach(async () => {
+      await storage.createPromptBlock({
+        promptBlock: { id: blockId, name: 'V1', content: 'Content V1' },
+      });
+    });
+
+    it('should create and retrieve version by ID', async () => {
+      const v2 = await storage.createVersion({
+        id: 'v2-uuid',
+        blockId,
+        versionNumber: 2,
+        name: 'V2',
+        content: 'Content V2',
+        changedFields: ['name', 'content'],
+        changeMessage: 'Updated to v2',
+      });
+
+      expect(v2.id).toBe('v2-uuid');
+      expect(v2.blockId).toBe(blockId);
+      expect(v2.versionNumber).toBe(2);
+      expect(v2.createdAt).toBeInstanceOf(Date);
+
+      const fetched = await storage.getVersion('v2-uuid');
+      expect(fetched).not.toBeNull();
+      expect(fetched!.name).toBe('V2');
+      expect(fetched!.content).toBe('Content V2');
+      expect(fetched!.changedFields).toEqual(['name', 'content']);
+      expect(fetched!.changeMessage).toBe('Updated to v2');
+    });
+
+    it('should return null for non-existent version', async () => {
+      expect(await storage.getVersion('nonexistent')).toBeNull();
+    });
+
+    it('should throw when creating version with duplicate ID', async () => {
+      const existingVersion = await storage.getLatestVersion(blockId);
+      await expect(
+        storage.createVersion({
+          id: existingVersion!.id,
+          blockId,
+          versionNumber: 2,
+          name: 'Dup',
+          content: 'Dup',
+        }),
+      ).rejects.toThrow('already exists');
+    });
+
+    it('should throw when creating version with duplicate versionNumber', async () => {
+      await expect(
+        storage.createVersion({
+          id: 'new-id',
+          blockId,
+          versionNumber: 1, // already exists
+          name: 'Dup',
+          content: 'Dup',
+        }),
+      ).rejects.toThrow('Version number 1 already exists');
+    });
+
+    it('should get version by block ID and version number', async () => {
+      const version = await storage.getVersionByNumber(blockId, 1);
+      expect(version).not.toBeNull();
+      expect(version!.name).toBe('V1');
+      expect(version!.versionNumber).toBe(1);
+    });
+
+    it('should return null for non-existent version number', async () => {
+      const version = await storage.getVersionByNumber(blockId, 999);
+      expect(version).toBeNull();
+    });
+
+    it('should get latest version', async () => {
+      await storage.createVersion({
+        id: 'v2-id',
+        blockId,
+        versionNumber: 2,
+        name: 'V2',
+        content: 'V2 Content',
+      });
+      await storage.createVersion({
+        id: 'v3-id',
+        blockId,
+        versionNumber: 3,
+        name: 'V3',
+        content: 'V3 Content',
+      });
+
+      const latest = await storage.getLatestVersion(blockId);
+      expect(latest).not.toBeNull();
+      expect(latest!.versionNumber).toBe(3);
+      expect(latest!.name).toBe('V3');
+    });
+
+    it('should return null for latest version of non-existent block', async () => {
+      const latest = await storage.getLatestVersion('nonexistent');
+      expect(latest).toBeNull();
+    });
+
+    it('should list versions with pagination', async () => {
+      await storage.createVersion({
+        id: 'v2-id',
+        blockId,
+        versionNumber: 2,
+        name: 'V2',
+        content: 'V2',
+      });
+      await storage.createVersion({
+        id: 'v3-id',
+        blockId,
+        versionNumber: 3,
+        name: 'V3',
+        content: 'V3',
+      });
+
+      const all = await storage.listVersions({ blockId, perPage: false });
+      expect(all.versions).toHaveLength(3);
+      expect(all.total).toBe(3);
+
+      // Default sort is versionNumber DESC
+      expect(all.versions[0]!.versionNumber).toBe(3);
+      expect(all.versions[2]!.versionNumber).toBe(1);
+
+      const page0 = await storage.listVersions({ blockId, page: 0, perPage: 2 });
+      expect(page0.versions).toHaveLength(2);
+      expect(page0.hasMore).toBe(true);
+
+      const page1 = await storage.listVersions({ blockId, page: 1, perPage: 2 });
+      expect(page1.versions).toHaveLength(1);
+      expect(page1.hasMore).toBe(false);
+    });
+
+    it('should list versions sorted by versionNumber ASC', async () => {
+      await storage.createVersion({
+        id: 'v2-id',
+        blockId,
+        versionNumber: 2,
+        name: 'V2',
+        content: 'V2',
+      });
+
+      const result = await storage.listVersions({
+        blockId,
+        orderBy: { field: 'versionNumber', direction: 'ASC' },
+      });
+      expect(result.versions[0]!.versionNumber).toBe(1);
+      expect(result.versions[1]!.versionNumber).toBe(2);
+    });
+
+    it('should delete a single version', async () => {
+      const v2 = await storage.createVersion({
+        id: 'v2-del',
+        blockId,
+        versionNumber: 2,
+        name: 'V2',
+        content: 'V2',
+      });
+
+      expect(await storage.countVersions(blockId)).toBe(2);
+      await storage.deleteVersion(v2.id);
+      expect(await storage.countVersions(blockId)).toBe(1);
+      expect(await storage.getVersion('v2-del')).toBeNull();
+    });
+
+    it('should delete all versions by block ID', async () => {
+      await storage.createVersion({
+        id: 'v2-id',
+        blockId,
+        versionNumber: 2,
+        name: 'V2',
+        content: 'V2',
+      });
+
+      expect(await storage.countVersions(blockId)).toBe(2);
+      await storage.deleteVersionsByBlockId(blockId);
+      expect(await storage.countVersions(blockId)).toBe(0);
+    });
+
+    it('should count versions correctly', async () => {
+      expect(await storage.countVersions(blockId)).toBe(1);
+
+      await storage.createVersion({
+        id: 'v2-id',
+        blockId,
+        versionNumber: 2,
+        name: 'V2',
+        content: 'V2',
+      });
+
+      expect(await storage.countVersions(blockId)).toBe(2);
+      expect(await storage.countVersions('nonexistent')).toBe(0);
+    });
+  });
+
+  // ==========================================================================
+  // dangerouslyClearAll
+  // ==========================================================================
+
+  describe('dangerouslyClearAll', () => {
+    it('should clear all prompt blocks and versions', async () => {
+      await storage.createPromptBlock({
+        promptBlock: { id: 'block-1', name: 'B1', content: 'C1' },
+      });
+      await storage.createPromptBlock({
+        promptBlock: { id: 'block-2', name: 'B2', content: 'C2' },
+      });
+
+      expect(db.promptBlocks.size).toBe(2);
+      expect(db.promptBlockVersions.size).toBe(2); // one version per block
+
+      await storage.dangerouslyClearAll();
+
+      expect(db.promptBlocks.size).toBe(0);
+      expect(db.promptBlockVersions.size).toBe(0);
+    });
+  });
+});

--- a/packages/core/src/storage/domains/prompt-blocks/inmemory.test.ts
+++ b/packages/core/src/storage/domains/prompt-blocks/inmemory.test.ts
@@ -382,7 +382,9 @@ describe('InMemoryPromptBlocksStorage', () => {
     it('should filter by authorId', async () => {
       const result = await storage.listPromptBlocks({ authorId: 'author-a' });
       expect(result.promptBlocks).toHaveLength(3);
-      result.promptBlocks.forEach(b => expect(b.authorId).toBe('author-a'));
+      result.promptBlocks.forEach(b => {
+        expect(b.authorId).toBe('author-a');
+      });
     });
 
     it('should filter by metadata', async () => {

--- a/packages/core/src/storage/domains/prompt-blocks/inmemory.ts
+++ b/packages/core/src/storage/domains/prompt-blocks/inmemory.ts
@@ -1,0 +1,418 @@
+import { deepEqual } from '../../../utils';
+import { normalizePerPage, calculatePagination } from '../../base';
+import type {
+  StoragePromptBlockType,
+  StorageCreatePromptBlockInput,
+  StorageUpdatePromptBlockInput,
+  StorageListPromptBlocksInput,
+  StorageListPromptBlocksOutput,
+  ThreadOrderBy,
+  ThreadSortDirection,
+} from '../../types';
+import type { InMemoryDB } from '../inmemory-db';
+import type {
+  PromptBlockVersion,
+  CreatePromptBlockVersionInput,
+  ListPromptBlockVersionsInput,
+  ListPromptBlockVersionsOutput,
+  PromptBlockVersionOrderBy,
+  PromptBlockVersionSortDirection,
+} from './base';
+import { PromptBlocksStorage } from './base';
+
+export class InMemoryPromptBlocksStorage extends PromptBlocksStorage {
+  private db: InMemoryDB;
+
+  constructor({ db }: { db: InMemoryDB }) {
+    super();
+    this.db = db;
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    this.db.promptBlocks.clear();
+    this.db.promptBlockVersions.clear();
+  }
+
+  // ==========================================================================
+  // Prompt Block CRUD Methods
+  // ==========================================================================
+
+  async getPromptBlockById({ id }: { id: string }): Promise<StoragePromptBlockType | null> {
+    this.logger.debug(`InMemoryPromptBlocksStorage: getPromptBlockById called for ${id}`);
+    const block = this.db.promptBlocks.get(id);
+    return block ? this.deepCopyBlock(block) : null;
+  }
+
+  async createPromptBlock({
+    promptBlock,
+  }: {
+    promptBlock: StorageCreatePromptBlockInput;
+  }): Promise<StoragePromptBlockType> {
+    this.logger.debug(`InMemoryPromptBlocksStorage: createPromptBlock called for ${promptBlock.id}`);
+
+    if (this.db.promptBlocks.has(promptBlock.id)) {
+      throw new Error(`Prompt block with id ${promptBlock.id} already exists`);
+    }
+
+    const now = new Date();
+    const newBlock: StoragePromptBlockType = {
+      id: promptBlock.id,
+      status: 'draft',
+      activeVersionId: undefined,
+      authorId: promptBlock.authorId,
+      metadata: promptBlock.metadata,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.db.promptBlocks.set(promptBlock.id, newBlock);
+
+    // Extract config fields from the flat input (everything except block-record fields)
+    const { id: _id, authorId: _authorId, metadata: _metadata, ...snapshotConfig } = promptBlock;
+
+    // Create version 1 from the config
+    const versionId = crypto.randomUUID();
+    await this.createVersion({
+      id: versionId,
+      blockId: promptBlock.id,
+      versionNumber: 1,
+      ...snapshotConfig,
+      changedFields: Object.keys(snapshotConfig),
+      changeMessage: 'Initial version',
+    });
+
+    // Return the thin block record
+    return this.deepCopyBlock(newBlock);
+  }
+
+  async updatePromptBlock({ id, ...updates }: StorageUpdatePromptBlockInput): Promise<StoragePromptBlockType> {
+    this.logger.debug(`InMemoryPromptBlocksStorage: updatePromptBlock called for ${id}`);
+
+    const existingBlock = this.db.promptBlocks.get(id);
+    if (!existingBlock) {
+      throw new Error(`Prompt block with id ${id} not found`);
+    }
+
+    // Separate metadata fields from config fields
+    const { authorId, activeVersionId, metadata, status, ...configFields } = updates;
+
+    // Config field names from StoragePromptBlockSnapshotType
+    const configFieldNames = ['name', 'description', 'content', 'rules'];
+
+    // Check if any config fields are present in the update
+    const hasConfigUpdate = configFieldNames.some(field => field in configFields);
+
+    // Update metadata fields on the block record
+    const updatedBlock: StoragePromptBlockType = {
+      ...existingBlock,
+      ...(authorId !== undefined && { authorId }),
+      ...(activeVersionId !== undefined && { activeVersionId }),
+      ...(status !== undefined && { status: status as StoragePromptBlockType['status'] }),
+      ...(metadata !== undefined && {
+        metadata: { ...existingBlock.metadata, ...metadata },
+      }),
+      updatedAt: new Date(),
+    };
+
+    // If activeVersionId is set, mark as published
+    if (activeVersionId !== undefined) {
+      updatedBlock.status = 'published';
+    }
+
+    // If config fields are being updated, create a new version
+    if (hasConfigUpdate) {
+      // Get the latest version to use as base
+      const latestVersion = await this.getLatestVersion(id);
+      if (!latestVersion) {
+        throw new Error(`No versions found for prompt block ${id}`);
+      }
+
+      // Extract config from latest version
+      const {
+        id: _versionId,
+        blockId: _blockId,
+        versionNumber: _versionNumber,
+        changedFields: _changedFields,
+        changeMessage: _changeMessage,
+        createdAt: _createdAt,
+        ...latestConfig
+      } = latestVersion;
+
+      // Merge updates into latest config
+      const newConfig = {
+        ...latestConfig,
+        ...configFields,
+      };
+
+      // Identify which fields changed
+      const changedFields = configFieldNames.filter(
+        field =>
+          field in configFields &&
+          configFields[field as keyof typeof configFields] !== latestConfig[field as keyof typeof latestConfig],
+      );
+
+      // Create new version
+      const newVersionId = crypto.randomUUID();
+      const newVersionNumber = latestVersion.versionNumber + 1;
+
+      await this.createVersion({
+        id: newVersionId,
+        blockId: id,
+        versionNumber: newVersionNumber,
+        ...newConfig,
+        changedFields,
+        changeMessage: `Updated ${changedFields.join(', ')}`,
+      });
+    }
+
+    // Save the updated block record
+    this.db.promptBlocks.set(id, updatedBlock);
+    return this.deepCopyBlock(updatedBlock);
+  }
+
+  async deletePromptBlock({ id }: { id: string }): Promise<void> {
+    this.logger.debug(`InMemoryPromptBlocksStorage: deletePromptBlock called for ${id}`);
+    // Idempotent delete
+    this.db.promptBlocks.delete(id);
+    // Also delete all versions for this block
+    await this.deleteVersionsByBlockId(id);
+  }
+
+  async listPromptBlocks(args?: StorageListPromptBlocksInput): Promise<StorageListPromptBlocksOutput> {
+    const { page = 0, perPage: perPageInput, orderBy, authorId, metadata } = args || {};
+    const { field, direction } = this.parseOrderBy(orderBy);
+
+    this.logger.debug(`InMemoryPromptBlocksStorage: listPromptBlocks called`);
+
+    // Normalize perPage for query (false → MAX_SAFE_INTEGER, 0 → 0, undefined → 100)
+    const perPage = normalizePerPage(perPageInput, 100);
+
+    if (page < 0) {
+      throw new Error('page must be >= 0');
+    }
+
+    // Prevent unreasonably large page values
+    const maxOffset = Number.MAX_SAFE_INTEGER / 2;
+    if (page * perPage > maxOffset) {
+      throw new Error('page value too large');
+    }
+
+    // Get all blocks and apply filters
+    let blocks = Array.from(this.db.promptBlocks.values());
+
+    // Filter by authorId if provided
+    if (authorId !== undefined) {
+      blocks = blocks.filter(block => block.authorId === authorId);
+    }
+
+    // Filter by metadata if provided (AND logic)
+    if (metadata && Object.keys(metadata).length > 0) {
+      blocks = blocks.filter(block => {
+        if (!block.metadata) return false;
+        return Object.entries(metadata).every(([key, value]) => deepEqual(block.metadata![key], value));
+      });
+    }
+
+    // Sort filtered blocks
+    const sortedBlocks = this.sortBlocks(blocks, field, direction);
+
+    // Deep clone blocks to avoid mutation
+    const clonedBlocks = sortedBlocks.map(block => this.deepCopyBlock(block));
+
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    return {
+      promptBlocks: clonedBlocks.slice(offset, offset + perPage),
+      total: clonedBlocks.length,
+      page,
+      perPage: perPageForResponse,
+      hasMore: offset + perPage < clonedBlocks.length,
+    };
+  }
+
+  // ==========================================================================
+  // Prompt Block Version Methods
+  // ==========================================================================
+
+  async createVersion(input: CreatePromptBlockVersionInput): Promise<PromptBlockVersion> {
+    this.logger.debug(`InMemoryPromptBlocksStorage: createVersion called for block ${input.blockId}`);
+
+    // Check if version with this ID already exists
+    if (this.db.promptBlockVersions.has(input.id)) {
+      throw new Error(`Version with id ${input.id} already exists`);
+    }
+
+    // Check for duplicate (blockId, versionNumber) pair
+    for (const version of this.db.promptBlockVersions.values()) {
+      if (version.blockId === input.blockId && version.versionNumber === input.versionNumber) {
+        throw new Error(`Version number ${input.versionNumber} already exists for prompt block ${input.blockId}`);
+      }
+    }
+
+    const version: PromptBlockVersion = {
+      ...input,
+      createdAt: new Date(),
+    };
+
+    // Deep clone before storing
+    this.db.promptBlockVersions.set(input.id, this.deepCopyVersion(version));
+    return this.deepCopyVersion(version);
+  }
+
+  async getVersion(id: string): Promise<PromptBlockVersion | null> {
+    this.logger.debug(`InMemoryPromptBlocksStorage: getVersion called for ${id}`);
+    const version = this.db.promptBlockVersions.get(id);
+    return version ? this.deepCopyVersion(version) : null;
+  }
+
+  async getVersionByNumber(blockId: string, versionNumber: number): Promise<PromptBlockVersion | null> {
+    this.logger.debug(`InMemoryPromptBlocksStorage: getVersionByNumber called for block ${blockId}, v${versionNumber}`);
+
+    for (const version of this.db.promptBlockVersions.values()) {
+      if (version.blockId === blockId && version.versionNumber === versionNumber) {
+        return this.deepCopyVersion(version);
+      }
+    }
+    return null;
+  }
+
+  async getLatestVersion(blockId: string): Promise<PromptBlockVersion | null> {
+    this.logger.debug(`InMemoryPromptBlocksStorage: getLatestVersion called for block ${blockId}`);
+
+    let latest: PromptBlockVersion | null = null;
+    for (const version of this.db.promptBlockVersions.values()) {
+      if (version.blockId === blockId) {
+        if (!latest || version.versionNumber > latest.versionNumber) {
+          latest = version;
+        }
+      }
+    }
+    return latest ? this.deepCopyVersion(latest) : null;
+  }
+
+  async listVersions(input: ListPromptBlockVersionsInput): Promise<ListPromptBlockVersionsOutput> {
+    const { blockId, page = 0, perPage: perPageInput, orderBy } = input;
+    const { field, direction } = this.parseVersionOrderBy(orderBy);
+
+    this.logger.debug(`InMemoryPromptBlocksStorage: listVersions called for block ${blockId}`);
+
+    // Normalize perPage (false -> MAX_SAFE_INTEGER, 0 -> 0, undefined -> 20)
+    const perPage = normalizePerPage(perPageInput, 20);
+
+    if (page < 0) {
+      throw new Error('page must be >= 0');
+    }
+
+    const maxOffset = Number.MAX_SAFE_INTEGER / 2;
+    if (page * perPage > maxOffset) {
+      throw new Error('page value too large');
+    }
+
+    // Filter versions by blockId
+    let versions = Array.from(this.db.promptBlockVersions.values()).filter(v => v.blockId === blockId);
+
+    // Sort versions
+    versions = this.sortVersions(versions, field, direction);
+
+    // Deep clone
+    const clonedVersions = versions.map(v => this.deepCopyVersion(v));
+
+    const total = clonedVersions.length;
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+    const paginatedVersions = clonedVersions.slice(offset, offset + perPage);
+
+    return {
+      versions: paginatedVersions,
+      total,
+      page,
+      perPage: perPageForResponse,
+      hasMore: offset + perPage < total,
+    };
+  }
+
+  async deleteVersion(id: string): Promise<void> {
+    this.logger.debug(`InMemoryPromptBlocksStorage: deleteVersion called for ${id}`);
+    this.db.promptBlockVersions.delete(id);
+  }
+
+  async deleteVersionsByBlockId(blockId: string): Promise<void> {
+    this.logger.debug(`InMemoryPromptBlocksStorage: deleteVersionsByBlockId called for block ${blockId}`);
+
+    const idsToDelete: string[] = [];
+    for (const [id, version] of this.db.promptBlockVersions.entries()) {
+      if (version.blockId === blockId) {
+        idsToDelete.push(id);
+      }
+    }
+
+    for (const id of idsToDelete) {
+      this.db.promptBlockVersions.delete(id);
+    }
+  }
+
+  async countVersions(blockId: string): Promise<number> {
+    this.logger.debug(`InMemoryPromptBlocksStorage: countVersions called for block ${blockId}`);
+
+    let count = 0;
+    for (const version of this.db.promptBlockVersions.values()) {
+      if (version.blockId === blockId) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  // ==========================================================================
+  // Private Helper Methods
+  // ==========================================================================
+
+  private deepCopyBlock(block: StoragePromptBlockType): StoragePromptBlockType {
+    return {
+      ...block,
+      metadata: block.metadata ? { ...block.metadata } : block.metadata,
+    };
+  }
+
+  private deepCopyVersion(version: PromptBlockVersion): PromptBlockVersion {
+    return {
+      ...version,
+      rules: version.rules ? JSON.parse(JSON.stringify(version.rules)) : version.rules,
+      changedFields: version.changedFields ? [...version.changedFields] : version.changedFields,
+    };
+  }
+
+  private sortBlocks(
+    blocks: StoragePromptBlockType[],
+    field: ThreadOrderBy,
+    direction: ThreadSortDirection,
+  ): StoragePromptBlockType[] {
+    return blocks.sort((a, b) => {
+      const aValue = new Date(a[field]).getTime();
+      const bValue = new Date(b[field]).getTime();
+
+      return direction === 'ASC' ? aValue - bValue : bValue - aValue;
+    });
+  }
+
+  private sortVersions(
+    versions: PromptBlockVersion[],
+    field: PromptBlockVersionOrderBy,
+    direction: PromptBlockVersionSortDirection,
+  ): PromptBlockVersion[] {
+    return versions.sort((a, b) => {
+      let aVal: number;
+      let bVal: number;
+
+      if (field === 'createdAt') {
+        aVal = a.createdAt.getTime();
+        bVal = b.createdAt.getTime();
+      } else {
+        // versionNumber
+        aVal = a.versionNumber;
+        bVal = b.versionNumber;
+      }
+
+      return direction === 'ASC' ? aVal - bVal : bVal - aVal;
+    });
+  }
+}

--- a/packages/core/src/storage/domains/prompt-blocks/inmemory.ts
+++ b/packages/core/src/storage/domains/prompt-blocks/inmemory.ts
@@ -387,8 +387,8 @@ export class InMemoryPromptBlocksStorage extends PromptBlocksStorage {
     direction: ThreadSortDirection,
   ): StoragePromptBlockType[] {
     return blocks.sort((a, b) => {
-      const aValue = new Date(a[field]).getTime();
-      const bValue = new Date(b[field]).getTime();
+      const aValue = a[field].getTime();
+      const bValue = b[field].getTime();
 
       return direction === 'ASC' ? aValue - bValue : bValue - aValue;
     });

--- a/packages/core/src/storage/mock.ts
+++ b/packages/core/src/storage/mock.ts
@@ -4,6 +4,7 @@ import { InMemoryAgentsStorage } from './domains/agents/inmemory';
 import { InMemoryDB } from './domains/inmemory-db';
 import { InMemoryMemory } from './domains/memory/inmemory';
 import { ObservabilityInMemory } from './domains/observability/inmemory';
+import { InMemoryPromptBlocksStorage } from './domains/prompt-blocks/inmemory';
 import { ScoresInMemory } from './domains/scores/inmemory';
 import { WorkflowsInMemory } from './domains/workflows/inmemory';
 /**
@@ -50,6 +51,7 @@ export class InMemoryStore extends MastraCompositeStore {
       scores: new ScoresInMemory({ db: this.#db }),
       observability: new ObservabilityInMemory({ db: this.#db }),
       agents: new InMemoryAgentsStorage({ db: this.#db }),
+      promptBlocks: new InMemoryPromptBlocksStorage({ db: this.#db }),
     };
   }
 

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -14,9 +14,28 @@ import type {
   SharedMemoryConfig,
 } from '@mastra/core';
 
+import type { RequestContext } from '@mastra/core/request-context';
+
+import type {
+  AgentInstructionBlock,
+  StorageCreatePromptBlockInput,
+  StorageUpdatePromptBlockInput,
+  StorageListPromptBlocksInput,
+  StorageListPromptBlocksOutput,
+  StorageResolvedPromptBlockType,
+  StorageListPromptBlocksResolvedOutput,
+} from '@mastra/core/storage';
+import type { PromptBlocksStorage } from '@mastra/core/storage';
+
 import type { Processor, InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '@mastra/core/processors';
 
+import { resolveInstructionBlocks } from './instruction-builder';
+
 export type { MastraEditorConfig };
+
+export { renderTemplate } from './template-engine';
+export { evaluateRuleGroup } from './rule-evaluator';
+export { resolveInstructionBlocks } from './instruction-builder';
 
 export class MastraEditor implements IMastraEditor {
   private logger?: Logger;
@@ -47,6 +66,17 @@ export class MastraEditor implements IMastraEditor {
     const agentsStore = await storage.getStore('agents');
     if (!agentsStore) throw new Error('Agents storage domain is not available');
     return agentsStore;
+  }
+
+  /**
+   * Get the prompt blocks storage domain from the Mastra storage.
+   */
+  private async getPromptBlocksStore(): Promise<PromptBlocksStorage> {
+    const storage = this.mastra!.getStorage();
+    if (!storage) throw new Error('Storage is not configured');
+    const promptBlocksStore = await storage.getStore('promptBlocks');
+    if (!promptBlocksStore) throw new Error('Prompt blocks storage domain is not available');
+    return promptBlocksStore;
   }
 
   /**
@@ -234,6 +264,80 @@ export class MastraEditor implements IMastraEditor {
     };
   }
 
+  // ==========================================================================
+  // Prompt Block CRUD Methods
+  // ==========================================================================
+
+  /**
+   * Create a new prompt block with an initial version.
+   */
+  public async createPromptBlock(input: StorageCreatePromptBlockInput): Promise<StorageResolvedPromptBlockType> {
+    if (!this.mastra) throw new Error('MastraEditor is not registered with a Mastra instance');
+    const store = await this.getPromptBlocksStore();
+    await store.createPromptBlock({ promptBlock: input });
+    const resolved = await store.getPromptBlockByIdResolved({ id: input.id });
+    return resolved!;
+  }
+
+  /**
+   * Get a prompt block by ID, resolved with its active version.
+   */
+  public async getPromptBlock(id: string): Promise<StorageResolvedPromptBlockType | null> {
+    if (!this.mastra) throw new Error('MastraEditor is not registered with a Mastra instance');
+    const store = await this.getPromptBlocksStore();
+    return store.getPromptBlockByIdResolved({ id });
+  }
+
+  /**
+   * Update a prompt block, creating a new version with the changes.
+   */
+  public async updatePromptBlock(input: StorageUpdatePromptBlockInput): Promise<StorageResolvedPromptBlockType> {
+    if (!this.mastra) throw new Error('MastraEditor is not registered with a Mastra instance');
+    const store = await this.getPromptBlocksStore();
+    await store.updatePromptBlock(input);
+    const resolved = await store.getPromptBlockByIdResolved({ id: input.id });
+    return resolved!;
+  }
+
+  /**
+   * Delete a prompt block and all its versions.
+   */
+  public async deletePromptBlock(id: string): Promise<void> {
+    if (!this.mastra) throw new Error('MastraEditor is not registered with a Mastra instance');
+    const store = await this.getPromptBlocksStore();
+    await store.deletePromptBlock({ id });
+  }
+
+  /**
+   * List prompt blocks with optional pagination and filtering.
+   */
+  public async listPromptBlocks(args?: StorageListPromptBlocksInput): Promise<StorageListPromptBlocksOutput> {
+    if (!this.mastra) throw new Error('MastraEditor is not registered with a Mastra instance');
+    const store = await this.getPromptBlocksStore();
+    return store.listPromptBlocks(args);
+  }
+
+  /**
+   * List prompt blocks resolved with their active version config.
+   */
+  public async listPromptBlocksResolved(
+    args?: StorageListPromptBlocksInput,
+  ): Promise<StorageListPromptBlocksResolvedOutput> {
+    if (!this.mastra) throw new Error('MastraEditor is not registered with a Mastra instance');
+    const store = await this.getPromptBlocksStore();
+    return store.listPromptBlocksResolved(args);
+  }
+
+  /**
+   * Preview the resolved instructions for a given set of instruction blocks and context.
+   * Useful for UI preview endpoints.
+   */
+  public async previewInstructions(blocks: AgentInstructionBlock[], context: Record<string, unknown>): Promise<string> {
+    if (!this.mastra) throw new Error('MastraEditor is not registered with a Mastra instance');
+    const store = await this.getPromptBlocksStore();
+    return resolveInstructionBlocks(blocks, context, { promptBlocksStorage: store });
+  }
+
   /**
    * Clear the stored agent cache for a specific agent ID, or all cached agents.
    */
@@ -286,12 +390,15 @@ export class MastraEditor implements IMastraEditor {
     // Extract additional options from defaultOptions
     const defaultOptions = storedAgent.defaultOptions;
 
+    // Resolve instructions: string is backward compatible, AgentInstructionBlock[] needs dynamic resolution
+    const instructions = this.resolveStoredInstructions(storedAgent.instructions);
+
     // Create agent instance with resolved dependencies
     const agent = new Agent({
       id: storedAgent.id,
       name: storedAgent.name,
       description: storedAgent.description,
-      instructions: storedAgent.instructions,
+      instructions: instructions ?? '',
       model,
       memory,
       tools,
@@ -318,6 +425,37 @@ export class MastraEditor implements IMastraEditor {
     this.logger?.debug(`[createAgentFromStoredConfig] Successfully created agent \"${storedAgent.id}\"`);
 
     return agent;
+  }
+
+  /**
+   * Resolve stored instructions to a value compatible with the Agent constructor.
+   * - `string` → pass through as-is (backward compatible)
+   * - `AgentInstructionBlock[]` → wrap in a DynamicArgument function that resolves at runtime
+   * - `undefined` → return undefined
+   */
+  private resolveStoredInstructions(
+    instructions: string | AgentInstructionBlock[] | undefined,
+  ):
+    | string
+    | (({ requestContext, mastra }: { requestContext: RequestContext; mastra?: Mastra }) => Promise<string>)
+    | undefined {
+    if (instructions === undefined || instructions === null) {
+      return undefined;
+    }
+
+    // Backward compatible: plain string instructions
+    if (typeof instructions === 'string') {
+      return instructions;
+    }
+
+    // AgentInstructionBlock[] → wrap in a DynamicArgument function
+    const blocks = instructions;
+    return async ({ requestContext }: { requestContext: RequestContext; mastra?: Mastra }) => {
+      const store = await this.getPromptBlocksStore();
+      // Convert RequestContext to a plain record for template interpolation and rule evaluation
+      const context = requestContext.toJSON();
+      return resolveInstructionBlocks(blocks, context, { promptBlocksStorage: store });
+    };
   }
 
   /**

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -276,7 +276,10 @@ export class MastraEditor implements IMastraEditor {
     const store = await this.getPromptBlocksStore();
     await store.createPromptBlock({ promptBlock: input });
     const resolved = await store.getPromptBlockByIdResolved({ id: input.id });
-    return resolved!;
+    if (!resolved) {
+      throw new Error(`Failed to resolve prompt block ${input.id} after creation`);
+    }
+    return resolved;
   }
 
   /**
@@ -296,7 +299,10 @@ export class MastraEditor implements IMastraEditor {
     const store = await this.getPromptBlocksStore();
     await store.updatePromptBlock(input);
     const resolved = await store.getPromptBlockByIdResolved({ id: input.id });
-    return resolved!;
+    if (!resolved) {
+      throw new Error(`Failed to resolve prompt block ${input.id} after update`);
+    }
+    return resolved;
   }
 
   /**

--- a/packages/editor/src/instruction-builder.test.ts
+++ b/packages/editor/src/instruction-builder.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resolveInstructionBlocks } from './instruction-builder';
+import { InMemoryDB } from '@mastra/core/storage';
+import { InMemoryPromptBlocksStorage } from '@mastra/core/storage';
+import type { AgentInstructionBlock } from '@mastra/core/storage';
+
+describe('resolveInstructionBlocks', () => {
+  let db: InMemoryDB;
+  let storage: InMemoryPromptBlocksStorage;
+
+  beforeEach(() => {
+    db = new InMemoryDB();
+    storage = new InMemoryPromptBlocksStorage({ db });
+  });
+
+  it('should resolve a static text block', async () => {
+    const blocks: AgentInstructionBlock[] = [{ type: 'text', content: 'You are a helpful assistant.' }];
+    const result = await resolveInstructionBlocks(blocks, {}, { promptBlocksStorage: storage });
+    expect(result).toBe('You are a helpful assistant.');
+  });
+
+  it('should resolve a text block with template variables', async () => {
+    const blocks: AgentInstructionBlock[] = [{ type: 'text', content: 'Hello {{name}}, your role is {{role}}.' }];
+    const result = await resolveInstructionBlocks(
+      blocks,
+      { name: 'Alice', role: 'admin' },
+      { promptBlocksStorage: storage },
+    );
+    expect(result).toBe('Hello Alice, your role is admin.');
+  });
+
+  it('should join multiple text blocks with double newlines', async () => {
+    const blocks: AgentInstructionBlock[] = [
+      { type: 'text', content: 'First block.' },
+      { type: 'text', content: 'Second block.' },
+    ];
+    const result = await resolveInstructionBlocks(blocks, {}, { promptBlocksStorage: storage });
+    expect(result).toBe('First block.\n\nSecond block.');
+  });
+
+  it('should skip empty text blocks', async () => {
+    const blocks: AgentInstructionBlock[] = [
+      { type: 'text', content: 'First.' },
+      { type: 'text', content: '   ' },
+      { type: 'text', content: 'Third.' },
+    ];
+    const result = await resolveInstructionBlocks(blocks, {}, { promptBlocksStorage: storage });
+    expect(result).toBe('First.\n\nThird.');
+  });
+
+  it('should resolve a prompt_block_ref from storage', async () => {
+    await storage.createPromptBlock({
+      promptBlock: {
+        id: 'block-1',
+        name: 'Greeting',
+        content: 'Welcome to our service.',
+        status: 'published',
+      },
+    });
+
+    const blocks: AgentInstructionBlock[] = [{ type: 'prompt_block_ref', id: 'block-1' }];
+    const result = await resolveInstructionBlocks(blocks, {}, { promptBlocksStorage: storage });
+    expect(result).toBe('Welcome to our service.');
+  });
+
+  it('should apply template rendering to prompt_block_ref content', async () => {
+    await storage.createPromptBlock({
+      promptBlock: {
+        id: 'block-tmpl',
+        name: 'Personalized greeting',
+        content: 'Hello {{user.name}}, you have {{user.credits}} credits.',
+        status: 'published',
+      },
+    });
+
+    const blocks: AgentInstructionBlock[] = [{ type: 'prompt_block_ref', id: 'block-tmpl' }];
+    const context = { user: { name: 'Bob', credits: 100 } };
+    const result = await resolveInstructionBlocks(blocks, context, { promptBlocksStorage: storage });
+    expect(result).toBe('Hello Bob, you have 100 credits.');
+  });
+
+  it('should skip a prompt_block_ref that is not found in storage', async () => {
+    const blocks: AgentInstructionBlock[] = [
+      { type: 'text', content: 'Start.' },
+      { type: 'prompt_block_ref', id: 'nonexistent' },
+      { type: 'text', content: 'End.' },
+    ];
+    const result = await resolveInstructionBlocks(blocks, {}, { promptBlocksStorage: storage });
+    expect(result).toBe('Start.\n\nEnd.');
+  });
+
+  it('should skip a prompt_block_ref with status other than published', async () => {
+    await storage.createPromptBlock({
+      promptBlock: {
+        id: 'draft-block',
+        name: 'Draft',
+        content: 'Draft content.',
+        status: 'draft',
+      },
+    });
+
+    const blocks: AgentInstructionBlock[] = [{ type: 'prompt_block_ref', id: 'draft-block' }];
+    const result = await resolveInstructionBlocks(blocks, {}, { promptBlocksStorage: storage });
+    expect(result).toBe('');
+  });
+
+  it('should include a prompt_block_ref when rules pass', async () => {
+    await storage.createPromptBlock({
+      promptBlock: {
+        id: 'admin-block',
+        name: 'Admin instructions',
+        content: 'You have admin privileges.',
+        status: 'published',
+        rules: {
+          operator: 'AND',
+          conditions: [{ field: 'user.role', operator: 'equals', value: 'admin' }],
+        },
+      },
+    });
+
+    const blocks: AgentInstructionBlock[] = [{ type: 'prompt_block_ref', id: 'admin-block' }];
+    const result = await resolveInstructionBlocks(
+      blocks,
+      { user: { role: 'admin' } },
+      { promptBlocksStorage: storage },
+    );
+    expect(result).toBe('You have admin privileges.');
+  });
+
+  it('should exclude a prompt_block_ref when rules fail', async () => {
+    await storage.createPromptBlock({
+      promptBlock: {
+        id: 'admin-block',
+        name: 'Admin instructions',
+        content: 'You have admin privileges.',
+        status: 'published',
+        rules: {
+          operator: 'AND',
+          conditions: [{ field: 'user.role', operator: 'equals', value: 'admin' }],
+        },
+      },
+    });
+
+    const blocks: AgentInstructionBlock[] = [{ type: 'prompt_block_ref', id: 'admin-block' }];
+    const result = await resolveInstructionBlocks(
+      blocks,
+      { user: { role: 'viewer' } },
+      { promptBlocksStorage: storage },
+    );
+    expect(result).toBe('');
+  });
+
+  it('should mix text and prompt_block_ref references', async () => {
+    await storage.createPromptBlock({
+      promptBlock: {
+        id: 'personality',
+        name: 'Personality',
+        content: 'Be friendly and concise.',
+        status: 'published',
+      },
+    });
+
+    const blocks: AgentInstructionBlock[] = [
+      { type: 'text', content: 'You are an AI assistant.' },
+      { type: 'prompt_block_ref', id: 'personality' },
+      { type: 'text', content: 'Always respond in {{language}}.' },
+    ];
+    const result = await resolveInstructionBlocks(blocks, { language: 'English' }, { promptBlocksStorage: storage });
+    expect(result).toBe('You are an AI assistant.\n\nBe friendly and concise.\n\nAlways respond in English.');
+  });
+
+  // --- Inline prompt_block tests ---
+
+  it('should resolve an inline prompt_block', async () => {
+    const blocks: AgentInstructionBlock[] = [
+      { type: 'prompt_block', content: 'You are a security-focused assistant.' },
+    ];
+    const result = await resolveInstructionBlocks(blocks, {}, { promptBlocksStorage: storage });
+    expect(result).toBe('You are a security-focused assistant.');
+  });
+
+  it('should resolve an inline prompt_block with template variables', async () => {
+    const blocks: AgentInstructionBlock[] = [
+      { type: 'prompt_block', content: 'Welcome {{user.name}}, your tier is {{user.tier}}.' },
+    ];
+    const result = await resolveInstructionBlocks(
+      blocks,
+      { user: { name: 'Eve', tier: 'gold' } },
+      { promptBlocksStorage: storage },
+    );
+    expect(result).toBe('Welcome Eve, your tier is gold.');
+  });
+
+  it('should include an inline prompt_block when rules pass', async () => {
+    const blocks: AgentInstructionBlock[] = [
+      {
+        type: 'prompt_block',
+        content: 'You have premium access.',
+        rules: {
+          operator: 'AND',
+          conditions: [{ field: 'user.isPremium', operator: 'equals', value: true }],
+        },
+      },
+    ];
+    const result = await resolveInstructionBlocks(
+      blocks,
+      { user: { isPremium: true } },
+      { promptBlocksStorage: storage },
+    );
+    expect(result).toBe('You have premium access.');
+  });
+
+  it('should exclude an inline prompt_block when rules fail', async () => {
+    const blocks: AgentInstructionBlock[] = [
+      {
+        type: 'prompt_block',
+        content: 'You have premium access.',
+        rules: {
+          operator: 'AND',
+          conditions: [{ field: 'user.isPremium', operator: 'equals', value: true }],
+        },
+      },
+    ];
+    const result = await resolveInstructionBlocks(
+      blocks,
+      { user: { isPremium: false } },
+      { promptBlocksStorage: storage },
+    );
+    expect(result).toBe('');
+  });
+
+  it('should mix text, prompt_block_ref, and inline prompt_block', async () => {
+    await storage.createPromptBlock({
+      promptBlock: {
+        id: 'stored-block',
+        name: 'Stored personality',
+        content: 'Be concise and helpful.',
+        status: 'published',
+      },
+    });
+
+    const blocks: AgentInstructionBlock[] = [
+      { type: 'text', content: 'You are an AI assistant.' },
+      { type: 'prompt_block_ref', id: 'stored-block' },
+      {
+        type: 'prompt_block',
+        content: 'User language: {{language}}.',
+        rules: {
+          operator: 'AND',
+          conditions: [{ field: 'language', operator: 'exists', value: null }],
+        },
+      },
+    ];
+    const result = await resolveInstructionBlocks(blocks, { language: 'Spanish' }, { promptBlocksStorage: storage });
+    expect(result).toBe('You are an AI assistant.\n\nBe concise and helpful.\n\nUser language: Spanish.');
+  });
+
+  it('should handle empty blocks array', async () => {
+    const result = await resolveInstructionBlocks([], {}, { promptBlocksStorage: storage });
+    expect(result).toBe('');
+  });
+});

--- a/packages/editor/src/instruction-builder.ts
+++ b/packages/editor/src/instruction-builder.ts
@@ -37,9 +37,11 @@ export async function resolveInstructionBlocks(
   const segments: string[] = [];
 
   // Batch-fetch all prompt block ref IDs to avoid N+1 queries
-  const blockIds = blocks
-    .filter((b): b is { type: 'prompt_block_ref'; id: string } => b.type === 'prompt_block_ref')
-    .map(b => b.id);
+  const blockIds = [
+    ...new Set(
+      blocks.filter((b): b is { type: 'prompt_block_ref'; id: string } => b.type === 'prompt_block_ref').map(b => b.id),
+    ),
+  ];
 
   const resolvedBlocksMap = new Map<string, StorageResolvedPromptBlockType>();
   if (blockIds.length > 0) {

--- a/packages/editor/src/instruction-builder.ts
+++ b/packages/editor/src/instruction-builder.ts
@@ -1,0 +1,112 @@
+/**
+ * InstructionBuilder: Resolves an array of AgentInstructionBlock items
+ * into a final instruction string.
+ *
+ * For each block:
+ *  - `{ type: 'text', content }` → render template with context
+ *  - `{ type: 'prompt_block_ref', id }` → fetch from storage, evaluate rules, render template
+ *  - `{ type: 'prompt_block', content, rules? }` → inline block, evaluate rules, render template
+ *
+ * Blocks that fail rule evaluation are excluded.
+ * Resolved text segments are joined with double newlines.
+ */
+
+import type { AgentInstructionBlock, StorageResolvedPromptBlockType } from '@mastra/core/storage';
+import type { PromptBlocksStorage } from '@mastra/core/storage';
+
+import { renderTemplate } from './template-engine';
+import { evaluateRuleGroup } from './rule-evaluator';
+
+export interface InstructionBuilderDeps {
+  promptBlocksStorage: PromptBlocksStorage;
+}
+
+/**
+ * Resolves an array of instruction blocks into a final instruction string.
+ *
+ * @param blocks - Array of instruction block references (text, prompt_block_ref, or inline prompt_block)
+ * @param context - Runtime context for template interpolation and rule evaluation
+ * @param deps - Dependencies (storage)
+ * @returns The resolved instruction string
+ */
+export async function resolveInstructionBlocks(
+  blocks: AgentInstructionBlock[],
+  context: Record<string, unknown>,
+  deps: InstructionBuilderDeps,
+): Promise<string> {
+  const segments: string[] = [];
+
+  // Batch-fetch all prompt block ref IDs to avoid N+1 queries
+  const blockIds = blocks
+    .filter((b): b is { type: 'prompt_block_ref'; id: string } => b.type === 'prompt_block_ref')
+    .map(b => b.id);
+
+  const resolvedBlocksMap = new Map<string, StorageResolvedPromptBlockType>();
+  if (blockIds.length > 0) {
+    // Fetch all blocks in parallel
+    const fetchResults = await Promise.all(
+      blockIds.map(id => deps.promptBlocksStorage.getPromptBlockByIdResolved({ id })),
+    );
+    for (let i = 0; i < blockIds.length; i++) {
+      const result = fetchResults[i];
+      if (result) {
+        resolvedBlocksMap.set(blockIds[i]!, result);
+      }
+    }
+  }
+
+  for (const block of blocks) {
+    if (block.type === 'text') {
+      // Static text blocks: render template, always included
+      const rendered = renderTemplate(block.content, context);
+      if (rendered.trim()) {
+        segments.push(rendered);
+      }
+      continue;
+    }
+
+    if (block.type === 'prompt_block') {
+      // Inline prompt block: evaluate rules and render template directly
+      if (block.rules) {
+        const passes = evaluateRuleGroup(block.rules, context);
+        if (!passes) {
+          continue;
+        }
+      }
+
+      const rendered = renderTemplate(block.content, context);
+      if (rendered.trim()) {
+        segments.push(rendered);
+      }
+      continue;
+    }
+
+    // Prompt block reference (prompt_block_ref)
+    const resolved = resolvedBlocksMap.get(block.id);
+    if (!resolved) {
+      // Block not found in storage — skip silently
+      continue;
+    }
+
+    // Only include published blocks
+    if (resolved.status !== 'published') {
+      continue;
+    }
+
+    // Evaluate rules if present
+    if (resolved.rules) {
+      const passes = evaluateRuleGroup(resolved.rules, context);
+      if (!passes) {
+        continue;
+      }
+    }
+
+    // Render template content
+    const rendered = renderTemplate(resolved.content, context);
+    if (rendered.trim()) {
+      segments.push(rendered);
+    }
+  }
+
+  return segments.join('\n\n');
+}

--- a/packages/editor/src/rule-evaluator.test.ts
+++ b/packages/editor/src/rule-evaluator.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateRuleGroup } from './rule-evaluator';
+import type { Rule, RuleGroup } from '@mastra/core/storage';
+
+describe('evaluateRuleGroup', () => {
+  describe('empty conditions', () => {
+    it('should return true for empty AND group', () => {
+      expect(evaluateRuleGroup({ operator: 'AND', conditions: [] }, {})).toBe(true);
+    });
+
+    it('should return true for empty OR group', () => {
+      expect(evaluateRuleGroup({ operator: 'OR', conditions: [] }, {})).toBe(true);
+    });
+  });
+
+  describe('equals / not_equals', () => {
+    it('should pass for equals match', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'role', operator: 'equals', value: 'admin' }],
+      };
+      expect(evaluateRuleGroup(group, { role: 'admin' })).toBe(true);
+    });
+
+    it('should fail for equals mismatch', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'role', operator: 'equals', value: 'admin' }],
+      };
+      expect(evaluateRuleGroup(group, { role: 'user' })).toBe(false);
+    });
+
+    it('should pass for not_equals mismatch', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'role', operator: 'not_equals', value: 'admin' }],
+      };
+      expect(evaluateRuleGroup(group, { role: 'user' })).toBe(true);
+    });
+
+    it('should fail for not_equals match', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'role', operator: 'not_equals', value: 'admin' }],
+      };
+      expect(evaluateRuleGroup(group, { role: 'admin' })).toBe(false);
+    });
+  });
+
+  describe('contains / not_contains', () => {
+    it('should pass for string contains', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'name', operator: 'contains', value: 'lic' }],
+      };
+      expect(evaluateRuleGroup(group, { name: 'Alice' })).toBe(true);
+    });
+
+    it('should pass for array contains', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'tags', operator: 'contains', value: 'vip' }],
+      };
+      expect(evaluateRuleGroup(group, { tags: ['vip', 'active'] })).toBe(true);
+    });
+
+    it('should fail for string not containing', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'name', operator: 'contains', value: 'xyz' }],
+      };
+      expect(evaluateRuleGroup(group, { name: 'Alice' })).toBe(false);
+    });
+
+    it('should pass for not_contains when absent from string', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'name', operator: 'not_contains', value: 'xyz' }],
+      };
+      expect(evaluateRuleGroup(group, { name: 'Alice' })).toBe(true);
+    });
+
+    it('should fail for not_contains when present', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'name', operator: 'not_contains', value: 'lic' }],
+      };
+      expect(evaluateRuleGroup(group, { name: 'Alice' })).toBe(false);
+    });
+
+    it('should return false for contains on non-string/non-array', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'count', operator: 'contains', value: 1 }],
+      };
+      expect(evaluateRuleGroup(group, { count: 42 })).toBe(false);
+    });
+
+    it('should return true for not_contains on non-string/non-array', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'count', operator: 'not_contains', value: 1 }],
+      };
+      expect(evaluateRuleGroup(group, { count: 42 })).toBe(true);
+    });
+  });
+
+  describe('comparison operators', () => {
+    it('should pass greater_than', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'age', operator: 'greater_than', value: 18 }],
+      };
+      expect(evaluateRuleGroup(group, { age: 25 })).toBe(true);
+    });
+
+    it('should fail greater_than when equal', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'age', operator: 'greater_than', value: 25 }],
+      };
+      expect(evaluateRuleGroup(group, { age: 25 })).toBe(false);
+    });
+
+    it('should pass less_than', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'age', operator: 'less_than', value: 30 }],
+      };
+      expect(evaluateRuleGroup(group, { age: 25 })).toBe(true);
+    });
+
+    it('should pass greater_than_or_equal when equal', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'age', operator: 'greater_than_or_equal', value: 25 }],
+      };
+      expect(evaluateRuleGroup(group, { age: 25 })).toBe(true);
+    });
+
+    it('should pass less_than_or_equal when equal', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'age', operator: 'less_than_or_equal', value: 25 }],
+      };
+      expect(evaluateRuleGroup(group, { age: 25 })).toBe(true);
+    });
+
+    it('should fail comparison on non-numeric', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'age', operator: 'greater_than', value: 18 }],
+      };
+      expect(evaluateRuleGroup(group, { age: 'twenty' })).toBe(false);
+    });
+  });
+
+  describe('in / not_in', () => {
+    it('should pass when value is in array', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'role', operator: 'in', value: ['admin', 'editor'] }],
+      };
+      expect(evaluateRuleGroup(group, { role: 'admin' })).toBe(true);
+    });
+
+    it('should fail when value is not in array', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'role', operator: 'in', value: ['admin', 'editor'] }],
+      };
+      expect(evaluateRuleGroup(group, { role: 'viewer' })).toBe(false);
+    });
+
+    it('should pass not_in when value absent', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'role', operator: 'not_in', value: ['admin', 'editor'] }],
+      };
+      expect(evaluateRuleGroup(group, { role: 'viewer' })).toBe(true);
+    });
+
+    it('should fail not_in when value present', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'role', operator: 'not_in', value: ['admin', 'editor'] }],
+      };
+      expect(evaluateRuleGroup(group, { role: 'admin' })).toBe(false);
+    });
+  });
+
+  describe('exists / not_exists', () => {
+    it('should pass exists when field has a value', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'name', operator: 'exists', value: null }],
+      };
+      expect(evaluateRuleGroup(group, { name: 'Alice' })).toBe(true);
+    });
+
+    it('should fail exists when field is undefined', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'name', operator: 'exists', value: null }],
+      };
+      expect(evaluateRuleGroup(group, {})).toBe(false);
+    });
+
+    it('should fail exists when field is null', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'name', operator: 'exists', value: null }],
+      };
+      expect(evaluateRuleGroup(group, { name: null })).toBe(false);
+    });
+
+    it('should pass not_exists when field is undefined', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'name', operator: 'not_exists', value: null }],
+      };
+      expect(evaluateRuleGroup(group, {})).toBe(true);
+    });
+  });
+
+  describe('nested path resolution', () => {
+    it('should evaluate rules using dot-notation paths', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'user.role', operator: 'equals', value: 'admin' }],
+      };
+      expect(evaluateRuleGroup(group, { user: { role: 'admin' } })).toBe(true);
+    });
+
+    it('should handle missing intermediate path segments', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'user.profile.role', operator: 'exists', value: null }],
+      };
+      expect(evaluateRuleGroup(group, { user: {} })).toBe(false);
+    });
+  });
+
+  describe('AND grouping', () => {
+    it('should pass when all conditions pass', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [
+          { field: 'role', operator: 'equals', value: 'admin' },
+          { field: 'active', operator: 'equals', value: true },
+        ],
+      };
+      expect(evaluateRuleGroup(group, { role: 'admin', active: true })).toBe(true);
+    });
+
+    it('should fail when one condition fails', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [
+          { field: 'role', operator: 'equals', value: 'admin' },
+          { field: 'active', operator: 'equals', value: true },
+        ],
+      };
+      expect(evaluateRuleGroup(group, { role: 'admin', active: false })).toBe(false);
+    });
+  });
+
+  describe('OR grouping', () => {
+    it('should pass when at least one condition passes', () => {
+      const group: RuleGroup = {
+        operator: 'OR',
+        conditions: [
+          { field: 'role', operator: 'equals', value: 'admin' },
+          { field: 'role', operator: 'equals', value: 'editor' },
+        ],
+      };
+      expect(evaluateRuleGroup(group, { role: 'editor' })).toBe(true);
+    });
+
+    it('should fail when no conditions pass', () => {
+      const group: RuleGroup = {
+        operator: 'OR',
+        conditions: [
+          { field: 'role', operator: 'equals', value: 'admin' },
+          { field: 'role', operator: 'equals', value: 'editor' },
+        ],
+      };
+      expect(evaluateRuleGroup(group, { role: 'viewer' })).toBe(false);
+    });
+  });
+
+  describe('nested RuleGroups', () => {
+    it('should evaluate nested groups recursively', () => {
+      // (role == admin) AND (tier == gold OR tier == platinum)
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [
+          { field: 'role', operator: 'equals', value: 'admin' },
+          {
+            operator: 'OR',
+            conditions: [
+              { field: 'tier', operator: 'equals', value: 'gold' },
+              { field: 'tier', operator: 'equals', value: 'platinum' },
+            ],
+          },
+        ],
+      };
+      expect(evaluateRuleGroup(group, { role: 'admin', tier: 'platinum' })).toBe(true);
+      expect(evaluateRuleGroup(group, { role: 'admin', tier: 'silver' })).toBe(false);
+      expect(evaluateRuleGroup(group, { role: 'user', tier: 'gold' })).toBe(false);
+    });
+
+    it('should handle deeply nested groups', () => {
+      const group: RuleGroup = {
+        operator: 'OR',
+        conditions: [
+          {
+            operator: 'AND',
+            conditions: [
+              { field: 'a', operator: 'equals', value: 1 },
+              { field: 'b', operator: 'equals', value: 2 },
+            ],
+          },
+          {
+            operator: 'AND',
+            conditions: [
+              { field: 'c', operator: 'equals', value: 3 },
+              { field: 'd', operator: 'equals', value: 4 },
+            ],
+          },
+        ],
+      };
+      expect(evaluateRuleGroup(group, { a: 1, b: 2, c: 0, d: 0 })).toBe(true);
+      expect(evaluateRuleGroup(group, { a: 0, b: 0, c: 3, d: 4 })).toBe(true);
+      expect(evaluateRuleGroup(group, { a: 1, b: 0, c: 3, d: 0 })).toBe(false);
+    });
+  });
+
+  describe('unknown operator', () => {
+    it('should return false for an unknown operator', () => {
+      const group: RuleGroup = {
+        operator: 'AND',
+        conditions: [{ field: 'x', operator: 'banana' as any, value: 1 }],
+      };
+      expect(evaluateRuleGroup(group, { x: 1 })).toBe(false);
+    });
+  });
+});

--- a/packages/editor/src/rule-evaluator.ts
+++ b/packages/editor/src/rule-evaluator.ts
@@ -1,0 +1,120 @@
+/**
+ * RuleEvaluator: Evaluates recursive RuleGroup conditions against a context object.
+ *
+ * Supports:
+ *   - Leaf rules with operators: equals, not_equals, contains, not_contains,
+ *     greater_than, less_than, greater_than_or_equal, less_than_or_equal,
+ *     in, not_in, exists, not_exists
+ *   - Recursive AND / OR grouping via RuleGroup
+ */
+
+import type { Rule, RuleGroup } from '@mastra/core/storage';
+
+/**
+ * Resolves a dot-notation path against a context object.
+ */
+function resolvePath(context: Record<string, unknown>, path: string): unknown {
+  const segments = path.split('.');
+  let current: unknown = context;
+
+  for (const segment of segments) {
+    if (current === null || current === undefined || typeof current !== 'object') {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return current;
+}
+
+/**
+ * Evaluates a single leaf rule against a context object.
+ */
+function evaluateRule(rule: Rule, context: Record<string, unknown>): boolean {
+  const fieldValue = resolvePath(context, rule.field);
+
+  switch (rule.operator) {
+    case 'equals':
+      return fieldValue === rule.value;
+
+    case 'not_equals':
+      return fieldValue !== rule.value;
+
+    case 'contains': {
+      if (typeof fieldValue === 'string' && typeof rule.value === 'string') {
+        return fieldValue.includes(rule.value);
+      }
+      if (Array.isArray(fieldValue)) {
+        return fieldValue.includes(rule.value);
+      }
+      return false;
+    }
+
+    case 'not_contains': {
+      if (typeof fieldValue === 'string' && typeof rule.value === 'string') {
+        return !fieldValue.includes(rule.value);
+      }
+      if (Array.isArray(fieldValue)) {
+        return !fieldValue.includes(rule.value);
+      }
+      return true;
+    }
+
+    case 'greater_than':
+      return typeof fieldValue === 'number' && typeof rule.value === 'number' && fieldValue > rule.value;
+
+    case 'less_than':
+      return typeof fieldValue === 'number' && typeof rule.value === 'number' && fieldValue < rule.value;
+
+    case 'greater_than_or_equal':
+      return typeof fieldValue === 'number' && typeof rule.value === 'number' && fieldValue >= rule.value;
+
+    case 'less_than_or_equal':
+      return typeof fieldValue === 'number' && typeof rule.value === 'number' && fieldValue <= rule.value;
+
+    case 'in':
+      return Array.isArray(rule.value) && rule.value.includes(fieldValue);
+
+    case 'not_in':
+      return Array.isArray(rule.value) && !rule.value.includes(fieldValue);
+
+    case 'exists':
+      return fieldValue !== undefined && fieldValue !== null;
+
+    case 'not_exists':
+      return fieldValue === undefined || fieldValue === null;
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Evaluates a RuleGroup (which may contain nested RuleGroups) against a context object.
+ *
+ * @param ruleGroup - The rule group to evaluate (AND/OR with nested conditions)
+ * @param context - The context object to evaluate against
+ * @returns true if the rule group passes, false otherwise
+ */
+export function evaluateRuleGroup(ruleGroup: RuleGroup, context: Record<string, unknown>): boolean {
+  if (ruleGroup.conditions.length === 0) {
+    // Empty conditions = always true (no constraints)
+    return true;
+  }
+
+  const results = ruleGroup.conditions.map(condition => {
+    if ('conditions' in condition) {
+      // Nested RuleGroup
+      return evaluateRuleGroup(condition, context);
+    }
+    // Leaf Rule
+    return evaluateRule(condition, context);
+  });
+
+  if (ruleGroup.operator === 'AND') {
+    return results.every(Boolean);
+  }
+
+  // OR
+  return results.some(Boolean);
+}

--- a/packages/editor/src/template-engine.test.ts
+++ b/packages/editor/src/template-engine.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { renderTemplate } from './template-engine';
+
+describe('renderTemplate', () => {
+  describe('simple variable substitution', () => {
+    it('should replace a simple variable', () => {
+      expect(renderTemplate('Hello {{name}}!', { name: 'World' })).toBe('Hello World!');
+    });
+
+    it('should replace multiple variables', () => {
+      const result = renderTemplate('{{greeting}} {{name}}!', { greeting: 'Hello', name: 'World' });
+      expect(result).toBe('Hello World!');
+    });
+
+    it('should handle numeric values', () => {
+      expect(renderTemplate('Count: {{count}}', { count: 42 })).toBe('Count: 42');
+    });
+
+    it('should handle boolean values', () => {
+      expect(renderTemplate('Active: {{active}}', { active: true })).toBe('Active: true');
+    });
+
+    it('should leave unresolved variables as-is', () => {
+      expect(renderTemplate('Hello {{name}}!', {})).toBe('Hello {{name}}!');
+    });
+
+    it('should handle variables with underscores', () => {
+      expect(renderTemplate('{{user_name}}', { user_name: 'Alice' })).toBe('Alice');
+    });
+
+    it('should handle whitespace inside braces', () => {
+      expect(renderTemplate('{{ name }}', { name: 'Alice' })).toBe('Alice');
+    });
+
+    it('should handle null values as unresolved', () => {
+      expect(renderTemplate('Hello {{name}}!', { name: null })).toBe('Hello {{name}}!');
+    });
+
+    it('should handle undefined values as unresolved', () => {
+      expect(renderTemplate('Hello {{name}}!', { name: undefined })).toBe('Hello {{name}}!');
+    });
+  });
+
+  describe('nested path resolution', () => {
+    it('should resolve a nested path', () => {
+      const context = { user: { name: 'Alice' } };
+      expect(renderTemplate('Hello {{user.name}}!', context)).toBe('Hello Alice!');
+    });
+
+    it('should resolve deeply nested paths', () => {
+      const context = { a: { b: { c: { d: 'deep' } } } };
+      expect(renderTemplate('{{a.b.c.d}}', context)).toBe('deep');
+    });
+
+    it('should leave unresolved nested paths as-is', () => {
+      expect(renderTemplate('{{user.name}}', { user: {} })).toBe('{{user.name}}');
+    });
+
+    it('should handle missing intermediate segments', () => {
+      expect(renderTemplate('{{user.profile.name}}', { user: {} })).toBe('{{user.profile.name}}');
+    });
+
+    it('should handle null intermediate segments', () => {
+      expect(renderTemplate('{{user.name}}', { user: null })).toBe('{{user.name}}');
+    });
+  });
+
+  describe('fallback values', () => {
+    it('should use single-quoted fallback when variable is missing', () => {
+      expect(renderTemplate("Hello {{name || 'Guest'}}!", {})).toBe('Hello Guest!');
+    });
+
+    it('should use double-quoted fallback when variable is missing', () => {
+      expect(renderTemplate('Hello {{name || "Guest"}}!', {})).toBe('Hello Guest!');
+    });
+
+    it('should prefer resolved value over fallback', () => {
+      expect(renderTemplate("Hello {{name || 'Guest'}}!", { name: 'Alice' })).toBe('Hello Alice!');
+    });
+
+    it('should use fallback for null values', () => {
+      expect(renderTemplate("{{val || 'default'}}", { val: null })).toBe('default');
+    });
+
+    it('should handle empty string fallback', () => {
+      expect(renderTemplate("{{val || ''}}", {})).toBe('');
+    });
+
+    it('should handle fallback with spaces', () => {
+      expect(renderTemplate("{{val || 'hello world'}}", {})).toBe('hello world');
+    });
+
+    it('should handle nested path with fallback', () => {
+      expect(renderTemplate("{{user.role || 'viewer'}}", {})).toBe('viewer');
+    });
+  });
+
+  describe('no-op cases', () => {
+    it('should return plain text unchanged', () => {
+      expect(renderTemplate('Hello World!', {})).toBe('Hello World!');
+    });
+
+    it('should handle empty template', () => {
+      expect(renderTemplate('', {})).toBe('');
+    });
+
+    it('should not match single braces', () => {
+      expect(renderTemplate('{name}', { name: 'Alice' })).toBe('{name}');
+    });
+
+    it('should not match triple braces', () => {
+      expect(renderTemplate('{{{name}}}', { name: 'Alice' })).toBe('{Alice}');
+    });
+  });
+});

--- a/packages/editor/src/template-engine.ts
+++ b/packages/editor/src/template-engine.ts
@@ -1,0 +1,70 @@
+/**
+ * TemplateEngine: Simple variable interpolation for prompt block content.
+ *
+ * Supports:
+ *   {{variableName}}         - Direct variable substitution
+ *   {{nested.path.value}}    - Dot-notation path resolution
+ *   {{variable || 'default'}} - Fallback values (single or double quotes)
+ *
+ * Variables that cannot be resolved (and have no fallback) are left as-is.
+ */
+
+/**
+ * Resolves a dot-notation path against a context object.
+ * Returns undefined if any segment is missing.
+ */
+function resolvePath(context: Record<string, unknown>, path: string): unknown {
+  const segments = path.split('.');
+  let current: unknown = context;
+
+  for (const segment of segments) {
+    if (current === null || current === undefined || typeof current !== 'object') {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return current;
+}
+
+/**
+ * Pattern that matches:
+ *   {{variableName}}
+ *   {{nested.path}}
+ *   {{variable || 'fallback'}}
+ *   {{variable || "fallback"}}
+ *
+ * Captures:
+ *   Group 1: the variable path (trimmed)
+ *   Group 2 (optional): the fallback value (without quotes)
+ */
+const TEMPLATE_PATTERN = /\{\{\s*([a-zA-Z_][\w.]*)\s*(?:\|\|\s*(?:'([^']*)'|"([^"]*)")\s*)?\}\}/g;
+
+/**
+ * Renders a template string by interpolating variables from the given context.
+ *
+ * @param template - The template string with {{variable}} placeholders
+ * @param context - A key-value context object for variable resolution
+ * @returns The rendered string with variables replaced
+ */
+export function renderTemplate(template: string, context: Record<string, unknown>): string {
+  return template.replace(
+    TEMPLATE_PATTERN,
+    (match, variablePath: string, singleFallback?: string, doubleFallback?: string) => {
+      const resolved = resolvePath(context, variablePath);
+
+      if (resolved !== undefined && resolved !== null) {
+        return String(resolved);
+      }
+
+      // Use fallback if provided
+      const fallback = singleFallback ?? doubleFallback;
+      if (fallback !== undefined) {
+        return fallback;
+      }
+
+      // Leave unresolved variables as-is
+      return match;
+    },
+  );
+}

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -9,6 +9,8 @@ import {
   createStoredAgentResponseSchema,
   updateStoredAgentResponseSchema,
   deleteStoredAgentResponseSchema,
+  previewInstructionsBodySchema,
+  previewInstructionsResponseSchema,
 } from '../schemas/stored-agents';
 import { createRoute } from '../server-adapter/routes/route-builder';
 
@@ -365,6 +367,36 @@ export const DELETE_STORED_AGENT_ROUTE = createRoute({
       return { success: true, message: `Agent ${storedAgentId} deleted successfully` };
     } catch (error) {
       return handleError(error, 'Error deleting stored agent');
+    }
+  },
+});
+
+/**
+ * POST /stored/agents/preview-instructions - Preview resolved instructions
+ */
+export const PREVIEW_INSTRUCTIONS_ROUTE = createRoute({
+  method: 'POST',
+  path: '/stored/agents/preview-instructions',
+  responseType: 'json',
+  bodySchema: previewInstructionsBodySchema,
+  responseSchema: previewInstructionsResponseSchema,
+  summary: 'Preview resolved instructions',
+  description:
+    'Resolves an array of instruction blocks against a request context, evaluating rules, fetching prompt block references, and rendering template variables. Returns the final concatenated instruction string.',
+  tags: ['Stored Agents'],
+  requiresAuth: true,
+  handler: async ({ mastra, blocks, context }) => {
+    try {
+      const editor = mastra.getEditor();
+      if (!editor) {
+        throw new HTTPException(500, { message: 'Editor is not configured' });
+      }
+
+      const result = await editor.previewInstructions(blocks, context ?? {});
+
+      return { result };
+    } catch (error) {
+      return handleError(error, 'Error previewing instructions');
     }
   },
 });

--- a/packages/server/src/server/schemas/agent-versions.ts
+++ b/packages/server/src/server/schemas/agent-versions.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 import { paginationInfoSchema, createPagePaginationSchema } from './common';
 import { defaultOptionsSchema } from './default-options';
 import { serializedMemoryConfigSchema } from './memory-config';
-import { scorerConfigSchema } from './stored-agents';
+import { scorerConfigSchema, instructionsSchema } from './stored-agents';
 
 // ============================================================================
 // Path Parameter Schemas
@@ -78,7 +78,7 @@ export const agentVersionSchema = z.object({
   // Top-level config fields (from StorageAgentSnapshotType)
   name: z.string().describe('Name of the agent'),
   description: z.string().optional().describe('Description of the agent'),
-  instructions: z.string().describe('System instructions for the agent'),
+  instructions: instructionsSchema,
   model: z.record(z.string(), z.unknown()).describe('Model configuration (provider, name, etc.)'),
   tools: z.array(z.string()).optional().describe('Array of tool keys to resolve from Mastra registry'),
   defaultOptions: defaultOptionsSchema.optional().describe('Default options for generate/stream calls'),

--- a/packages/server/src/server/schemas/stored-agents.ts
+++ b/packages/server/src/server/schemas/stored-agents.ts
@@ -52,10 +52,6 @@ const scorerConfigSchema = z.object({
 });
 
 /**
- * Agent snapshot config fields (name, description, instructions, model, tools, etc.)
- * These live in version snapshots, not on the thin agent record.
- */
-/**
  * Rule and RuleGroup schemas for conditional prompt block evaluation.
  */
 const ruleSchema = z.object({
@@ -103,6 +99,10 @@ export const instructionsSchema = z
   .union([z.string(), z.array(agentInstructionBlockSchema)])
   .describe('System instructions for the agent (string or array of instruction blocks)');
 
+/**
+ * Agent snapshot config fields (name, description, instructions, model, tools, etc.)
+ * These live in version snapshots, not on the thin agent record.
+ */
 const snapshotConfigSchema = z.object({
   name: z.string().describe('Name of the agent'),
   description: z.string().optional().describe('Description of the agent'),

--- a/packages/server/src/server/schemas/stored-agents.ts
+++ b/packages/server/src/server/schemas/stored-agents.ts
@@ -55,10 +55,58 @@ const scorerConfigSchema = z.object({
  * Agent snapshot config fields (name, description, instructions, model, tools, etc.)
  * These live in version snapshots, not on the thin agent record.
  */
+/**
+ * Rule and RuleGroup schemas for conditional prompt block evaluation.
+ */
+const ruleSchema = z.object({
+  field: z.string(),
+  operator: z.enum([
+    'equals',
+    'not_equals',
+    'contains',
+    'not_contains',
+    'greater_than',
+    'less_than',
+    'greater_than_or_equal',
+    'less_than_or_equal',
+    'in',
+    'not_in',
+    'exists',
+    'not_exists',
+  ]),
+  value: z.unknown(),
+});
+
+type RuleGroupZod = z.ZodType<{ operator: 'AND' | 'OR'; conditions: (z.infer<typeof ruleSchema> | RuleGroupInput)[] }>;
+type RuleGroupInput = z.infer<RuleGroupZod>;
+
+const ruleGroupSchema: RuleGroupZod = z.lazy(() =>
+  z.object({
+    operator: z.enum(['AND', 'OR']),
+    conditions: z.array(z.union([ruleSchema, ruleGroupSchema])),
+  }),
+);
+
+/**
+ * Agent instruction block schema for prompt-block-based instructions.
+ */
+const agentInstructionBlockSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('text'), content: z.string() }),
+  z.object({ type: z.literal('prompt_block_ref'), id: z.string() }),
+  z.object({ type: z.literal('prompt_block'), content: z.string(), rules: ruleGroupSchema.optional() }),
+]);
+
+/**
+ * Instructions can be a plain string or an array of instruction blocks (text + prompt_block references).
+ */
+export const instructionsSchema = z
+  .union([z.string(), z.array(agentInstructionBlockSchema)])
+  .describe('System instructions for the agent (string or array of instruction blocks)');
+
 const snapshotConfigSchema = z.object({
   name: z.string().describe('Name of the agent'),
   description: z.string().optional().describe('Description of the agent'),
-  instructions: z.string().describe('System instructions for the agent'),
+  instructions: instructionsSchema,
   model: z
     .object({
       provider: z.string().describe('Model provider (e.g., openai, anthropic)'),
@@ -126,7 +174,7 @@ export const storedAgentSchema = z.object({
   // Version snapshot config fields (resolved from active version)
   name: z.string().describe('Name of the agent'),
   description: z.string().optional().describe('Description of the agent'),
-  instructions: z.string().describe('System instructions for the agent'),
+  instructions: instructionsSchema,
   model: z
     .object({
       provider: z.string().describe('Model provider (e.g., openai, anthropic)'),
@@ -195,6 +243,29 @@ export const updateStoredAgentResponseSchema = z.union([
 export const deleteStoredAgentResponseSchema = z.object({
   success: z.boolean(),
   message: z.string(),
+});
+
+// ============================================================================
+// Preview Instructions Schemas
+// ============================================================================
+
+/**
+ * POST /stored/agents/preview-instructions - Preview resolved instructions
+ */
+export const previewInstructionsBodySchema = z.object({
+  blocks: z.array(agentInstructionBlockSchema).describe('Array of instruction blocks to resolve'),
+  context: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .default({})
+    .describe('Request context for variable interpolation and rule evaluation'),
+});
+
+/**
+ * Response for POST /stored/agents/preview-instructions
+ */
+export const previewInstructionsResponseSchema = z.object({
+  result: z.string().describe('The resolved instructions string'),
 });
 
 /**

--- a/packages/server/src/server/server-adapter/routes/stored-agents.ts
+++ b/packages/server/src/server/server-adapter/routes/stored-agents.ts
@@ -13,6 +13,7 @@ import {
   CREATE_STORED_AGENT_ROUTE,
   UPDATE_STORED_AGENT_ROUTE,
   DELETE_STORED_AGENT_ROUTE,
+  PREVIEW_INSTRUCTIONS_ROUTE,
 } from '../../handlers/stored-agents';
 import type { ServerRoute } from '.';
 
@@ -24,8 +25,11 @@ import type { ServerRoute } from '.';
 export const STORED_AGENTS_ROUTES: ServerRoute<any, any, any>[] = [
   // ============================================================================
   // Stored Agents CRUD Routes
+  // IMPORTANT: Routes with literal paths (e.g., /preview-instructions) must come
+  // BEFORE routes with path parameters (e.g., /:storedAgentId) to ensure correct matching.
   // ============================================================================
   LIST_STORED_AGENTS_ROUTE,
+  PREVIEW_INSTRUCTIONS_ROUTE, // Must be before GET_STORED_AGENT_ROUTE
   GET_STORED_AGENT_ROUTE,
   CREATE_STORED_AGENT_ROUTE,
   UPDATE_STORED_AGENT_ROUTE,

--- a/server-adapters/_test-utils/src/test-helpers.ts
+++ b/server-adapters/_test-utils/src/test-helpers.ts
@@ -454,6 +454,12 @@ export async function createDefaultTestContext(): Promise<AdapterTestContext> {
     },
   });
 
+  // Mock getEditor to return an object with previewInstructions for stored agents routes
+  vi.spyOn(mastra, 'getEditor').mockReturnValue({
+    previewInstructions: vi.fn().mockResolvedValue('resolved instructions preview'),
+    clearStoredAgentCache: vi.fn(),
+  } as any);
+
   await mockWorkflowRun(workflow);
   await setupWorkflowRegistryMocks(
     {

--- a/stores/clickhouse/src/storage/db/utils.ts
+++ b/stores/clickhouse/src/storage/db/utils.ts
@@ -9,6 +9,8 @@ import {
   safelyParseJSON,
   TABLE_SPANS,
   TABLE_AGENT_VERSIONS,
+  TABLE_PROMPT_BLOCKS,
+  TABLE_PROMPT_BLOCK_VERSIONS,
 } from '@mastra/core/storage';
 
 export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
@@ -24,6 +26,8 @@ export const TABLE_ENGINES: Record<TABLE_NAMES, string> = {
   [TABLE_SPANS]: `ReplacingMergeTree(updatedAt)`,
   mastra_agents: `ReplacingMergeTree()`,
   [TABLE_AGENT_VERSIONS]: `MergeTree()`,
+  [TABLE_PROMPT_BLOCKS]: `ReplacingMergeTree()`,
+  [TABLE_PROMPT_BLOCK_VERSIONS]: `MergeTree()`,
 };
 
 export const COLUMN_TYPES: Record<StorageColumn['type'], string> = {

--- a/stores/cloudflare/src/storage/types.ts
+++ b/stores/cloudflare/src/storage/types.ts
@@ -13,10 +13,14 @@ import type {
   TABLE_SPANS,
   TABLE_AGENTS,
   TABLE_AGENT_VERSIONS,
+  TABLE_PROMPT_BLOCKS,
+  TABLE_PROMPT_BLOCK_VERSIONS,
   SpanRecord,
   StorageAgentType,
+  StoragePromptBlockType,
 } from '@mastra/core/storage';
 import type { AgentVersion } from '@mastra/core/storage/domains/agents';
+import type { PromptBlockVersion } from '@mastra/core/storage/domains/prompt-blocks';
 import type { WorkflowRunState } from '@mastra/core/workflows';
 import type Cloudflare from 'cloudflare';
 
@@ -112,6 +116,8 @@ export type RecordTypes = {
   [TABLE_SPANS]: SpanRecord;
   [TABLE_AGENTS]: StorageAgentType;
   [TABLE_AGENT_VERSIONS]: AgentVersion;
+  [TABLE_PROMPT_BLOCKS]: StoragePromptBlockType;
+  [TABLE_PROMPT_BLOCK_VERSIONS]: PromptBlockVersion;
 };
 
 export type ListOptions = {

--- a/stores/libsql/src/storage/domains/agents/index.ts
+++ b/stores/libsql/src/storage/domains/agents/index.ts
@@ -22,6 +22,7 @@ import type {
   CreateVersionInput,
   ListVersionsInput,
   ListVersionsOutput,
+  AgentInstructionBlock,
 } from '@mastra/core/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
@@ -137,7 +138,7 @@ export class AgentsLibSQL extends AgentsStorage {
           versionNumber: 1,
           name: (row.name as string) ?? agentId,
           description: row.description ?? null,
-          instructions: (row.instructions as string) ?? '',
+          instructions: this.serializeInstructions((row.instructions as string) ?? ''),
           model: row.model ?? '{}',
           tools: row.tools ?? null,
           defaultOptions: row.defaultOptions ?? null,
@@ -661,7 +662,7 @@ export class AgentsLibSQL extends AgentsStorage {
           versionNumber: input.versionNumber,
           name: input.name ?? null,
           description: input.description ?? null,
-          instructions: input.instructions,
+          instructions: this.serializeInstructions(input.instructions),
           model: input.model,
           tools: input.tools ?? null,
           defaultOptions: input.defaultOptions ?? null,
@@ -931,6 +932,21 @@ export class AgentsLibSQL extends AgentsStorage {
   // Private Helper Methods
   // ==========================================================================
 
+  private serializeInstructions(instructions: string | AgentInstructionBlock[]): string {
+    return Array.isArray(instructions) ? JSON.stringify(instructions) : instructions;
+  }
+
+  private deserializeInstructions(raw: string): string | AgentInstructionBlock[] {
+    if (!raw) return raw;
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) return parsed as AgentInstructionBlock[];
+    } catch {
+      // Not JSON — plain string
+    }
+    return raw;
+  }
+
   private parseVersionRow(row: any): AgentVersion {
     return {
       id: row.id as string,
@@ -938,7 +954,7 @@ export class AgentsLibSQL extends AgentsStorage {
       versionNumber: row.versionNumber as number,
       name: row.name as string,
       description: row.description as string | undefined,
-      instructions: row.instructions as string,
+      instructions: this.deserializeInstructions(row.instructions as string),
       model: this.parseJson(row.model, 'model'),
       tools: this.parseJson(row.tools, 'tools'),
       defaultOptions: this.parseJson(row.defaultOptions, 'defaultOptions'),

--- a/stores/libsql/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/libsql/src/storage/domains/prompt-blocks/index.ts
@@ -1,0 +1,567 @@
+import type { Client, InValue } from '@libsql/client';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  PromptBlocksStorage,
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_PROMPT_BLOCKS,
+  TABLE_PROMPT_BLOCK_VERSIONS,
+  PROMPT_BLOCKS_SCHEMA,
+  PROMPT_BLOCK_VERSIONS_SCHEMA,
+} from '@mastra/core/storage';
+import type {
+  StoragePromptBlockType,
+  StorageCreatePromptBlockInput,
+  StorageUpdatePromptBlockInput,
+  StorageListPromptBlocksInput,
+  StorageListPromptBlocksOutput,
+  PromptBlockVersion,
+  CreatePromptBlockVersionInput,
+  ListPromptBlockVersionsInput,
+  ListPromptBlockVersionsOutput,
+} from '@mastra/core/storage';
+import { LibSQLDB, resolveClient } from '../../db';
+import type { LibSQLDomainConfig } from '../../db';
+import { buildSelectColumns } from '../../db/utils';
+
+/**
+ * Config fields that live on version rows (from StoragePromptBlockSnapshotType).
+ */
+const SNAPSHOT_FIELDS = ['name', 'description', 'content', 'rules'] as const;
+
+export class PromptBlocksLibSQL extends PromptBlocksStorage {
+  #db: LibSQLDB;
+  #client: Client;
+
+  constructor(config: LibSQLDomainConfig) {
+    super();
+    const client = resolveClient(config);
+    this.#client = client;
+    this.#db = new LibSQLDB({ client, maxRetries: config.maxRetries, initialBackoffMs: config.initialBackoffMs });
+  }
+
+  async init(): Promise<void> {
+    await this.#db.createTable({ tableName: TABLE_PROMPT_BLOCKS, schema: PROMPT_BLOCKS_SCHEMA });
+    await this.#db.createTable({ tableName: TABLE_PROMPT_BLOCK_VERSIONS, schema: PROMPT_BLOCK_VERSIONS_SCHEMA });
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    await this.#db.deleteData({ tableName: TABLE_PROMPT_BLOCKS });
+    await this.#db.deleteData({ tableName: TABLE_PROMPT_BLOCK_VERSIONS });
+  }
+
+  // ==========================================================================
+  // Prompt Block CRUD
+  // ==========================================================================
+
+  async getPromptBlockById({ id }: { id: string }): Promise<StoragePromptBlockType | null> {
+    try {
+      const result = await this.#client.execute({
+        sql: `SELECT ${buildSelectColumns(TABLE_PROMPT_BLOCKS)} FROM "${TABLE_PROMPT_BLOCKS}" WHERE id = ?`,
+        args: [id],
+      });
+      const row = result.rows?.[0];
+      return row ? this.#parseBlockRow(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'GET_PROMPT_BLOCK', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async createPromptBlock({
+    promptBlock,
+  }: {
+    promptBlock: StorageCreatePromptBlockInput;
+  }): Promise<StoragePromptBlockType> {
+    try {
+      const now = new Date();
+
+      // Insert thin block record
+      await this.#db.insert({
+        tableName: TABLE_PROMPT_BLOCKS,
+        record: {
+          id: promptBlock.id,
+          status: 'draft',
+          activeVersionId: null,
+          authorId: promptBlock.authorId ?? null,
+          metadata: promptBlock.metadata ?? null,
+          createdAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+        },
+      });
+
+      // Extract config fields for version 1
+      const { id: _id, authorId: _authorId, metadata: _metadata, ...snapshotConfig } = promptBlock;
+      const versionId = crypto.randomUUID();
+      await this.createVersion({
+        id: versionId,
+        blockId: promptBlock.id,
+        versionNumber: 1,
+        ...snapshotConfig,
+        changedFields: Object.keys(snapshotConfig),
+        changeMessage: 'Initial version',
+      });
+
+      return {
+        id: promptBlock.id,
+        status: 'draft',
+        activeVersionId: undefined,
+        authorId: promptBlock.authorId,
+        metadata: promptBlock.metadata,
+        createdAt: now,
+        updatedAt: now,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'CREATE_PROMPT_BLOCK', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async updatePromptBlock({ id, ...updates }: StorageUpdatePromptBlockInput): Promise<StoragePromptBlockType> {
+    try {
+      const existing = await this.getPromptBlockById({ id });
+      if (!existing) {
+        throw new Error(`Prompt block with id ${id} not found`);
+      }
+
+      const { authorId, activeVersionId, metadata, status, ...configFields } = updates;
+
+      const configFieldNames = SNAPSHOT_FIELDS as readonly string[];
+      const hasConfigUpdate = configFieldNames.some(field => field in configFields);
+
+      // Build update data for the block record
+      const updateData: Record<string, unknown> = {
+        updatedAt: new Date().toISOString(),
+      };
+
+      if (authorId !== undefined) updateData.authorId = authorId;
+      if (activeVersionId !== undefined) {
+        updateData.activeVersionId = activeVersionId;
+        updateData.status = 'published';
+      }
+      if (status !== undefined && activeVersionId === undefined) updateData.status = status;
+      if (metadata !== undefined) {
+        updateData.metadata = { ...existing.metadata, ...metadata };
+      }
+
+      await this.#db.update({
+        tableName: TABLE_PROMPT_BLOCKS,
+        keys: { id },
+        data: updateData,
+      });
+
+      // If config fields changed, create a new version
+      if (hasConfigUpdate) {
+        const latestVersion = await this.getLatestVersion(id);
+        if (!latestVersion) {
+          throw new Error(`No versions found for prompt block ${id}`);
+        }
+
+        const {
+          id: _versionId,
+          blockId: _blockId,
+          versionNumber: _versionNumber,
+          changedFields: _changedFields,
+          changeMessage: _changeMessage,
+          createdAt: _createdAt,
+          ...latestConfig
+        } = latestVersion;
+
+        const newConfig = { ...latestConfig, ...configFields };
+        const changedFields = configFieldNames.filter(
+          field =>
+            field in configFields &&
+            configFields[field as keyof typeof configFields] !== latestConfig[field as keyof typeof latestConfig],
+        );
+
+        const newVersionId = crypto.randomUUID();
+        await this.createVersion({
+          id: newVersionId,
+          blockId: id,
+          versionNumber: latestVersion.versionNumber + 1,
+          ...newConfig,
+          changedFields,
+          changeMessage: `Updated ${changedFields.join(', ')}`,
+        });
+      }
+
+      // Fetch and return updated block
+      const updated = await this.getPromptBlockById({ id });
+      return updated!;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'UPDATE_PROMPT_BLOCK', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async deletePromptBlock({ id }: { id: string }): Promise<void> {
+    try {
+      await this.deleteVersionsByBlockId(id);
+      await this.#client.execute({
+        sql: `DELETE FROM "${TABLE_PROMPT_BLOCKS}" WHERE "id" = ?`,
+        args: [id],
+      });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'DELETE_PROMPT_BLOCK', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async listPromptBlocks(args?: StorageListPromptBlocksInput): Promise<StorageListPromptBlocksOutput> {
+    try {
+      const { page = 0, perPage: perPageInput, orderBy, authorId, metadata } = args || {};
+      const { field, direction } = this.parseOrderBy(orderBy);
+
+      const conditions: string[] = [];
+      const queryParams: InValue[] = [];
+
+      if (authorId !== undefined) {
+        conditions.push('authorId = ?');
+        queryParams.push(authorId);
+      }
+
+      if (metadata && Object.keys(metadata).length > 0) {
+        for (const [key, value] of Object.entries(metadata)) {
+          conditions.push(`json_extract(metadata, '$.${key}') = ?`);
+          queryParams.push(typeof value === 'string' ? value : JSON.stringify(value));
+        }
+      }
+
+      const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+      // Get total count
+      const countResult = await this.#client.execute({
+        sql: `SELECT COUNT(*) as count FROM "${TABLE_PROMPT_BLOCKS}" ${whereClause}`,
+        args: queryParams,
+      });
+      const total = Number(countResult.rows?.[0]?.count ?? 0);
+
+      if (total === 0) {
+        return {
+          promptBlocks: [],
+          total: 0,
+          page,
+          perPage: perPageInput ?? 100,
+          hasMore: false,
+        };
+      }
+
+      const perPage = normalizePerPage(perPageInput, 100);
+      const { offset: start, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+      const limitValue = perPageInput === false ? total : perPage;
+      const end = perPageInput === false ? total : start + perPage;
+
+      const result = await this.#client.execute({
+        sql: `SELECT ${buildSelectColumns(TABLE_PROMPT_BLOCKS)} FROM "${TABLE_PROMPT_BLOCKS}" ${whereClause} ORDER BY ${field} ${direction} LIMIT ? OFFSET ?`,
+        args: [...queryParams, limitValue, start],
+      });
+
+      const promptBlocks = result.rows?.map(row => this.#parseBlockRow(row)) ?? [];
+
+      return {
+        promptBlocks,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore: end < total,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'LIST_PROMPT_BLOCKS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  // ==========================================================================
+  // Prompt Block Version Methods
+  // ==========================================================================
+
+  async createVersion(input: CreatePromptBlockVersionInput): Promise<PromptBlockVersion> {
+    try {
+      const now = new Date();
+      await this.#db.insert({
+        tableName: TABLE_PROMPT_BLOCK_VERSIONS,
+        record: {
+          id: input.id,
+          blockId: input.blockId,
+          versionNumber: input.versionNumber,
+          name: input.name,
+          description: input.description ?? null,
+          content: input.content,
+          rules: input.rules ?? null,
+          changedFields: input.changedFields ?? null,
+          changeMessage: input.changeMessage ?? null,
+          createdAt: now.toISOString(),
+        },
+      });
+
+      return {
+        ...input,
+        createdAt: now,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'CREATE_PROMPT_BLOCK_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async getVersion(id: string): Promise<PromptBlockVersion | null> {
+    try {
+      const result = await this.#client.execute({
+        sql: `SELECT ${buildSelectColumns(TABLE_PROMPT_BLOCK_VERSIONS)} FROM "${TABLE_PROMPT_BLOCK_VERSIONS}" WHERE id = ?`,
+        args: [id],
+      });
+      const row = result.rows?.[0];
+      return row ? this.#parseVersionRow(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'GET_PROMPT_BLOCK_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async getVersionByNumber(blockId: string, versionNumber: number): Promise<PromptBlockVersion | null> {
+    try {
+      const result = await this.#client.execute({
+        sql: `SELECT ${buildSelectColumns(TABLE_PROMPT_BLOCK_VERSIONS)} FROM "${TABLE_PROMPT_BLOCK_VERSIONS}" WHERE blockId = ? AND versionNumber = ?`,
+        args: [blockId, versionNumber],
+      });
+      const row = result.rows?.[0];
+      return row ? this.#parseVersionRow(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'GET_PROMPT_BLOCK_VERSION_BY_NUMBER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async getLatestVersion(blockId: string): Promise<PromptBlockVersion | null> {
+    try {
+      const result = await this.#client.execute({
+        sql: `SELECT ${buildSelectColumns(TABLE_PROMPT_BLOCK_VERSIONS)} FROM "${TABLE_PROMPT_BLOCK_VERSIONS}" WHERE blockId = ? ORDER BY versionNumber DESC LIMIT 1`,
+        args: [blockId],
+      });
+      const row = result.rows?.[0];
+      return row ? this.#parseVersionRow(row) : null;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'GET_LATEST_PROMPT_BLOCK_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async listVersions(input: ListPromptBlockVersionsInput): Promise<ListPromptBlockVersionsOutput> {
+    try {
+      const { blockId, page = 0, perPage: perPageInput, orderBy } = input;
+      const { field, direction } = this.parseVersionOrderBy(orderBy);
+
+      // Get total count
+      const countResult = await this.#client.execute({
+        sql: `SELECT COUNT(*) as count FROM "${TABLE_PROMPT_BLOCK_VERSIONS}" WHERE blockId = ?`,
+        args: [blockId],
+      });
+      const total = Number(countResult.rows?.[0]?.count ?? 0);
+
+      if (total === 0) {
+        return {
+          versions: [],
+          total: 0,
+          page,
+          perPage: perPageInput ?? 20,
+          hasMore: false,
+        };
+      }
+
+      const perPage = normalizePerPage(perPageInput, 20);
+      const { offset: start, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+      const limitValue = perPageInput === false ? total : perPage;
+      const end = perPageInput === false ? total : start + perPage;
+
+      const result = await this.#client.execute({
+        sql: `SELECT ${buildSelectColumns(TABLE_PROMPT_BLOCK_VERSIONS)} FROM "${TABLE_PROMPT_BLOCK_VERSIONS}" WHERE blockId = ? ORDER BY ${field} ${direction} LIMIT ? OFFSET ?`,
+        args: [blockId, limitValue, start],
+      });
+
+      const versions = result.rows?.map(row => this.#parseVersionRow(row)) ?? [];
+
+      return {
+        versions,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore: end < total,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'LIST_PROMPT_BLOCK_VERSIONS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteVersion(id: string): Promise<void> {
+    try {
+      await this.#client.execute({
+        sql: `DELETE FROM "${TABLE_PROMPT_BLOCK_VERSIONS}" WHERE "id" = ?`,
+        args: [id],
+      });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'DELETE_PROMPT_BLOCK_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteVersionsByBlockId(blockId: string): Promise<void> {
+    try {
+      await this.#client.execute({
+        sql: `DELETE FROM "${TABLE_PROMPT_BLOCK_VERSIONS}" WHERE "blockId" = ?`,
+        args: [blockId],
+      });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'DELETE_PROMPT_BLOCK_VERSIONS_BY_BLOCK', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  async countVersions(blockId: string): Promise<number> {
+    try {
+      const result = await this.#client.execute({
+        sql: `SELECT COUNT(*) as count FROM "${TABLE_PROMPT_BLOCK_VERSIONS}" WHERE blockId = ?`,
+        args: [blockId],
+      });
+      return Number(result.rows?.[0]?.count ?? 0);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('LIBSQL', 'COUNT_PROMPT_BLOCK_VERSIONS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  // ==========================================================================
+  // Private Helpers
+  // ==========================================================================
+
+  #parseBlockRow(row: Record<string, unknown>): StoragePromptBlockType {
+    const safeParseJSON = (val: unknown): unknown => {
+      if (val === null || val === undefined) return undefined;
+      if (typeof val === 'string') {
+        try {
+          return JSON.parse(val);
+        } catch {
+          return val;
+        }
+      }
+      return val;
+    };
+
+    return {
+      id: row.id as string,
+      status: (row.status as StoragePromptBlockType['status']) ?? 'draft',
+      activeVersionId: (row.activeVersionId as string) ?? undefined,
+      authorId: (row.authorId as string) ?? undefined,
+      metadata: safeParseJSON(row.metadata) as Record<string, unknown> | undefined,
+      createdAt: new Date(row.createdAt as string),
+      updatedAt: new Date(row.updatedAt as string),
+    };
+  }
+
+  #parseVersionRow(row: Record<string, unknown>): PromptBlockVersion {
+    const safeParseJSON = (val: unknown): unknown => {
+      if (val === null || val === undefined) return undefined;
+      if (typeof val === 'string') {
+        try {
+          return JSON.parse(val);
+        } catch {
+          return val;
+        }
+      }
+      return val;
+    };
+
+    return {
+      id: row.id as string,
+      blockId: row.blockId as string,
+      versionNumber: Number(row.versionNumber),
+      name: row.name as string,
+      description: (row.description as string) ?? undefined,
+      content: row.content as string,
+      rules: safeParseJSON(row.rules) as PromptBlockVersion['rules'],
+      changedFields: safeParseJSON(row.changedFields) as string[] | undefined,
+      changeMessage: (row.changeMessage as string) ?? undefined,
+      createdAt: new Date(row.createdAt as string),
+    };
+  }
+}

--- a/stores/libsql/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/libsql/src/storage/domains/prompt-blocks/index.ts
@@ -44,6 +44,11 @@ export class PromptBlocksLibSQL extends PromptBlocksStorage {
   async init(): Promise<void> {
     await this.#db.createTable({ tableName: TABLE_PROMPT_BLOCKS, schema: PROMPT_BLOCKS_SCHEMA });
     await this.#db.createTable({ tableName: TABLE_PROMPT_BLOCK_VERSIONS, schema: PROMPT_BLOCK_VERSIONS_SCHEMA });
+
+    // Unique constraint on (blockId, versionNumber) to prevent duplicate versions from concurrent updates
+    await this.#client.execute(
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_prompt_block_versions_block_version ON "${TABLE_PROMPT_BLOCK_VERSIONS}" ("blockId", "versionNumber")`,
+    );
   }
 
   async dangerouslyClearAll(): Promise<void> {

--- a/stores/libsql/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/libsql/src/storage/domains/prompt-blocks/index.ts
@@ -248,6 +248,16 @@ export class PromptBlocksLibSQL extends PromptBlocksStorage {
 
       if (metadata && Object.keys(metadata).length > 0) {
         for (const [key, value] of Object.entries(metadata)) {
+          // Sanitize key to prevent SQL injection via json_extract path
+          if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(key)) {
+            throw new MastraError({
+              id: createStorageErrorId('LIBSQL', 'LIST_PROMPT_BLOCKS', 'INVALID_METADATA_KEY'),
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.USER,
+              text: `Invalid metadata key: ${key}. Keys must be alphanumeric with underscores.`,
+              details: { key },
+            });
+          }
           conditions.push(`json_extract(metadata, '$.${key}') = ?`);
           queryParams.push(typeof value === 'string' ? value : JSON.stringify(value));
         }

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -6,11 +6,12 @@ import { MastraCompositeStore } from '@mastra/core/storage';
 import { AgentsLibSQL } from './domains/agents';
 import { MemoryLibSQL } from './domains/memory';
 import { ObservabilityLibSQL } from './domains/observability';
+import { PromptBlocksLibSQL } from './domains/prompt-blocks';
 import { ScoresLibSQL } from './domains/scores';
 import { WorkflowsLibSQL } from './domains/workflows';
 
 // Export domain classes for direct use with MastraStorage composition
-export { AgentsLibSQL, MemoryLibSQL, ObservabilityLibSQL, ScoresLibSQL, WorkflowsLibSQL };
+export { AgentsLibSQL, MemoryLibSQL, ObservabilityLibSQL, PromptBlocksLibSQL, ScoresLibSQL, WorkflowsLibSQL };
 export type { LibSQLDomainConfig } from './db';
 
 /**
@@ -131,6 +132,7 @@ export class LibSQLStore extends MastraCompositeStore {
     const memory = new MemoryLibSQL(domainConfig);
     const observability = new ObservabilityLibSQL(domainConfig);
     const agents = new AgentsLibSQL(domainConfig);
+    const promptBlocks = new PromptBlocksLibSQL(domainConfig);
 
     this.stores = {
       scores,
@@ -138,6 +140,7 @@ export class LibSQLStore extends MastraCompositeStore {
       memory,
       observability,
       agents,
+      promptBlocks,
     };
   }
 }

--- a/stores/mongodb/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/mongodb/src/storage/domains/prompt-blocks/index.ts
@@ -1,0 +1,712 @@
+import { randomUUID } from 'node:crypto';
+
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  PromptBlocksStorage,
+  createStorageErrorId,
+  TABLE_PROMPT_BLOCKS,
+  TABLE_PROMPT_BLOCK_VERSIONS,
+  normalizePerPage,
+  calculatePagination,
+} from '@mastra/core/storage';
+import type {
+  StoragePromptBlockType,
+  StorageCreatePromptBlockInput,
+  StorageUpdatePromptBlockInput,
+  StorageListPromptBlocksInput,
+  StorageListPromptBlocksOutput,
+} from '@mastra/core/storage';
+import type {
+  PromptBlockVersion,
+  CreatePromptBlockVersionInput,
+  ListPromptBlockVersionsInput,
+  ListPromptBlockVersionsOutput,
+} from '@mastra/core/storage/domains/prompt-blocks';
+import type { MongoDBConnector } from '../../connectors/MongoDBConnector';
+import { resolveMongoDBConfig } from '../../db';
+import type { MongoDBDomainConfig, MongoDBIndexConfig } from '../../types';
+
+/**
+ * Snapshot config fields that live on prompt block version documents.
+ */
+const SNAPSHOT_FIELDS = ['name', 'description', 'content', 'rules'] as const;
+
+export class MongoDBPromptBlocksStorage extends PromptBlocksStorage {
+  #connector: MongoDBConnector;
+  #skipDefaultIndexes?: boolean;
+  #indexes?: MongoDBIndexConfig[];
+
+  static readonly MANAGED_COLLECTIONS = [TABLE_PROMPT_BLOCKS, TABLE_PROMPT_BLOCK_VERSIONS] as const;
+
+  constructor(config: MongoDBDomainConfig) {
+    super();
+    this.#connector = resolveMongoDBConfig(config);
+    this.#skipDefaultIndexes = config.skipDefaultIndexes;
+    this.#indexes = config.indexes?.filter(idx =>
+      (MongoDBPromptBlocksStorage.MANAGED_COLLECTIONS as readonly string[]).includes(idx.collection),
+    );
+  }
+
+  private async getCollection(name: string) {
+    return this.#connector.getCollection(name);
+  }
+
+  getDefaultIndexDefinitions(): MongoDBIndexConfig[] {
+    return [
+      { collection: TABLE_PROMPT_BLOCKS, keys: { id: 1 }, options: { unique: true } },
+      { collection: TABLE_PROMPT_BLOCKS, keys: { createdAt: -1 } },
+      { collection: TABLE_PROMPT_BLOCKS, keys: { updatedAt: -1 } },
+      { collection: TABLE_PROMPT_BLOCKS, keys: { authorId: 1 } },
+      { collection: TABLE_PROMPT_BLOCK_VERSIONS, keys: { id: 1 }, options: { unique: true } },
+      {
+        collection: TABLE_PROMPT_BLOCK_VERSIONS,
+        keys: { blockId: 1, versionNumber: -1 },
+        options: { unique: true },
+      },
+      { collection: TABLE_PROMPT_BLOCK_VERSIONS, keys: { blockId: 1, createdAt: -1 } },
+    ];
+  }
+
+  async createDefaultIndexes(): Promise<void> {
+    if (this.#skipDefaultIndexes) {
+      return;
+    }
+
+    for (const indexDef of this.getDefaultIndexDefinitions()) {
+      try {
+        const collection = await this.getCollection(indexDef.collection);
+        await collection.createIndex(indexDef.keys, indexDef.options);
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create index on ${indexDef.collection}:`, error);
+      }
+    }
+  }
+
+  async createCustomIndexes(): Promise<void> {
+    if (!this.#indexes || this.#indexes.length === 0) {
+      return;
+    }
+
+    for (const indexDef of this.#indexes) {
+      try {
+        const collection = await this.getCollection(indexDef.collection);
+        await collection.createIndex(indexDef.keys, indexDef.options);
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create custom index on ${indexDef.collection}:`, error);
+      }
+    }
+  }
+
+  async init(): Promise<void> {
+    await this.createDefaultIndexes();
+    await this.createCustomIndexes();
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    const versionsCollection = await this.getCollection(TABLE_PROMPT_BLOCK_VERSIONS);
+    await versionsCollection.deleteMany({});
+    const blocksCollection = await this.getCollection(TABLE_PROMPT_BLOCKS);
+    await blocksCollection.deleteMany({});
+  }
+
+  // ==========================================================================
+  // Prompt Block CRUD
+  // ==========================================================================
+
+  async getPromptBlockById({ id }: { id: string }): Promise<StoragePromptBlockType | null> {
+    try {
+      const collection = await this.getCollection(TABLE_PROMPT_BLOCKS);
+      const result = await collection.findOne<any>({ id });
+
+      if (!result) {
+        return null;
+      }
+
+      return this.transformBlock(result);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'GET_PROMPT_BLOCK_BY_ID', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id },
+        },
+        error,
+      );
+    }
+  }
+
+  async createPromptBlock({
+    promptBlock,
+  }: {
+    promptBlock: StorageCreatePromptBlockInput;
+  }): Promise<StoragePromptBlockType> {
+    try {
+      const collection = await this.getCollection(TABLE_PROMPT_BLOCKS);
+
+      // Check if block already exists
+      const existing = await collection.findOne({ id: promptBlock.id });
+      if (existing) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'CREATE_PROMPT_BLOCK', 'ALREADY_EXISTS'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { id: promptBlock.id },
+          text: `Prompt block with id ${promptBlock.id} already exists`,
+        });
+      }
+
+      const now = new Date();
+
+      // Create thin block record
+      const newBlock: StoragePromptBlockType = {
+        id: promptBlock.id,
+        status: 'draft',
+        activeVersionId: undefined,
+        authorId: promptBlock.authorId,
+        metadata: promptBlock.metadata,
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      await collection.insertOne(this.serializeBlock(newBlock));
+
+      // Extract snapshot config from flat input
+      const snapshotConfig: Record<string, any> = {};
+      for (const field of SNAPSHOT_FIELDS) {
+        if ((promptBlock as any)[field] !== undefined) {
+          snapshotConfig[field] = (promptBlock as any)[field];
+        }
+      }
+
+      // Create version 1
+      const versionId = randomUUID();
+      await this.createVersion({
+        id: versionId,
+        blockId: promptBlock.id,
+        versionNumber: 1,
+        ...snapshotConfig,
+        changedFields: Object.keys(snapshotConfig),
+        changeMessage: 'Initial version',
+      } as CreatePromptBlockVersionInput);
+
+      return newBlock;
+    } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'CREATE_PROMPT_BLOCK', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id: promptBlock.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async updatePromptBlock({ id, ...updates }: StorageUpdatePromptBlockInput): Promise<StoragePromptBlockType> {
+    try {
+      const collection = await this.getCollection(TABLE_PROMPT_BLOCKS);
+
+      const existingBlock = await collection.findOne<any>({ id });
+      if (!existingBlock) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'UPDATE_PROMPT_BLOCK', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { id },
+          text: `Prompt block with id ${id} not found`,
+        });
+      }
+
+      const updateDoc: Record<string, any> = {
+        updatedAt: new Date(),
+      };
+
+      // Metadata-level fields
+      const metadataFields = {
+        authorId: updates.authorId,
+        activeVersionId: updates.activeVersionId,
+        metadata: updates.metadata,
+        status: updates.status,
+      };
+
+      // Extract config fields
+      const configFields: Record<string, any> = {};
+      for (const field of SNAPSHOT_FIELDS) {
+        if ((updates as any)[field] !== undefined) {
+          configFields[field] = (updates as any)[field];
+        }
+      }
+
+      // If we have config updates, create a new version
+      if (Object.keys(configFields).length > 0) {
+        const latestVersion = await this.getLatestVersion(id);
+        const nextVersionNumber = latestVersion ? latestVersion.versionNumber + 1 : 1;
+
+        if (!latestVersion) {
+          throw new MastraError({
+            id: createStorageErrorId('MONGODB', 'UPDATE_PROMPT_BLOCK', 'NO_VERSION'),
+            domain: ErrorDomain.STORAGE,
+            category: ErrorCategory.USER,
+            text: `Cannot update config fields for prompt block ${id} - no versions exist`,
+            details: { id },
+          });
+        }
+
+        // Extract existing snapshot and merge with updates
+        const existingSnapshot = this.extractSnapshotFields(latestVersion);
+
+        await this.createVersion({
+          id: randomUUID(),
+          blockId: id,
+          versionNumber: nextVersionNumber,
+          ...existingSnapshot,
+          ...configFields,
+          changedFields: Object.keys(configFields),
+          changeMessage: `Updated: ${Object.keys(configFields).join(', ')}`,
+        } as CreatePromptBlockVersionInput);
+      }
+
+      // Handle metadata-level updates
+      if (metadataFields.authorId !== undefined) updateDoc.authorId = metadataFields.authorId;
+      if (metadataFields.activeVersionId !== undefined) {
+        updateDoc.activeVersionId = metadataFields.activeVersionId;
+      }
+      if (metadataFields.status !== undefined) {
+        updateDoc.status = metadataFields.status;
+      }
+
+      // Merge metadata
+      if (metadataFields.metadata !== undefined) {
+        const existingMetadata = existingBlock.metadata || {};
+        updateDoc.metadata = { ...existingMetadata, ...metadataFields.metadata };
+      }
+
+      await collection.updateOne({ id }, { $set: updateDoc });
+
+      const updatedBlock = await collection.findOne<any>({ id });
+      if (!updatedBlock) {
+        throw new MastraError({
+          id: createStorageErrorId('MONGODB', 'UPDATE_PROMPT_BLOCK', 'NOT_FOUND_AFTER_UPDATE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.SYSTEM,
+          text: `Prompt block with id ${id} was deleted during update`,
+          details: { id },
+        });
+      }
+      return this.transformBlock(updatedBlock);
+    } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'UPDATE_PROMPT_BLOCK', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id },
+        },
+        error,
+      );
+    }
+  }
+
+  async deletePromptBlock({ id }: { id: string }): Promise<void> {
+    try {
+      // Delete all versions first
+      await this.deleteVersionsByBlockId(id);
+
+      // Then delete the block
+      const collection = await this.getCollection(TABLE_PROMPT_BLOCKS);
+      await collection.deleteOne({ id });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'DELETE_PROMPT_BLOCK', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { id },
+        },
+        error,
+      );
+    }
+  }
+
+  async listPromptBlocks(args?: StorageListPromptBlocksInput): Promise<StorageListPromptBlocksOutput> {
+    try {
+      const { page = 0, perPage: perPageInput, orderBy, authorId, metadata } = args || {};
+      const { field, direction } = this.parseOrderBy(orderBy);
+
+      if (page < 0) {
+        throw new MastraError(
+          {
+            id: createStorageErrorId('MONGODB', 'LIST_PROMPT_BLOCKS', 'INVALID_PAGE'),
+            domain: ErrorDomain.STORAGE,
+            category: ErrorCategory.USER,
+            details: { page },
+          },
+          new Error('page must be >= 0'),
+        );
+      }
+
+      const perPage = normalizePerPage(perPageInput, 100);
+      const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+      const collection = await this.getCollection(TABLE_PROMPT_BLOCKS);
+
+      // Build filter
+      const filter: Record<string, any> = {};
+      if (authorId) {
+        filter.authorId = authorId;
+      }
+      if (metadata) {
+        for (const [key, value] of Object.entries(metadata)) {
+          filter[`metadata.${key}`] = value;
+        }
+      }
+
+      const total = await collection.countDocuments(filter);
+
+      if (total === 0 || perPage === 0) {
+        return {
+          promptBlocks: [],
+          total,
+          page,
+          perPage: perPageForResponse,
+          hasMore: false,
+        };
+      }
+
+      const sortOrder = direction === 'ASC' ? 1 : -1;
+
+      let cursor = collection
+        .find(filter)
+        .sort({ [field]: sortOrder })
+        .skip(offset);
+
+      if (perPageInput !== false) {
+        cursor = cursor.limit(perPage);
+      }
+
+      const results = await cursor.toArray();
+      const promptBlocks = results.map((doc: any) => this.transformBlock(doc));
+
+      return {
+        promptBlocks,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore: perPageInput !== false && offset + perPage < total,
+      };
+    } catch (error) {
+      if (error instanceof MastraError) {
+        throw error;
+      }
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'LIST_PROMPT_BLOCKS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  // ==========================================================================
+  // Prompt Block Version Methods
+  // ==========================================================================
+
+  async createVersion(input: CreatePromptBlockVersionInput): Promise<PromptBlockVersion> {
+    try {
+      const collection = await this.getCollection(TABLE_PROMPT_BLOCK_VERSIONS);
+      const now = new Date();
+
+      const versionDoc: Record<string, any> = {
+        id: input.id,
+        blockId: input.blockId,
+        versionNumber: input.versionNumber,
+        changedFields: input.changedFields ?? undefined,
+        changeMessage: input.changeMessage ?? undefined,
+        createdAt: now,
+      };
+
+      // Copy snapshot fields
+      for (const field of SNAPSHOT_FIELDS) {
+        if ((input as any)[field] !== undefined) {
+          versionDoc[field] = (input as any)[field];
+        }
+      }
+
+      await collection.insertOne(versionDoc);
+
+      return {
+        ...input,
+        createdAt: now,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'CREATE_PROMPT_BLOCK_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { versionId: input.id, blockId: input.blockId },
+        },
+        error,
+      );
+    }
+  }
+
+  async getVersion(id: string): Promise<PromptBlockVersion | null> {
+    try {
+      const collection = await this.getCollection(TABLE_PROMPT_BLOCK_VERSIONS);
+      const result = await collection.findOne<any>({ id });
+
+      if (!result) {
+        return null;
+      }
+
+      return this.transformVersion(result);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'GET_PROMPT_BLOCK_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { versionId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async getVersionByNumber(blockId: string, versionNumber: number): Promise<PromptBlockVersion | null> {
+    try {
+      const collection = await this.getCollection(TABLE_PROMPT_BLOCK_VERSIONS);
+      const result = await collection.findOne<any>({ blockId, versionNumber });
+
+      if (!result) {
+        return null;
+      }
+
+      return this.transformVersion(result);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'GET_PROMPT_BLOCK_VERSION_BY_NUMBER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { blockId, versionNumber },
+        },
+        error,
+      );
+    }
+  }
+
+  async getLatestVersion(blockId: string): Promise<PromptBlockVersion | null> {
+    try {
+      const collection = await this.getCollection(TABLE_PROMPT_BLOCK_VERSIONS);
+      const result = await collection.find<any>({ blockId }).sort({ versionNumber: -1 }).limit(1).toArray();
+
+      if (!result || result.length === 0) {
+        return null;
+      }
+
+      return this.transformVersion(result[0]);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'GET_LATEST_PROMPT_BLOCK_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { blockId },
+        },
+        error,
+      );
+    }
+  }
+
+  async listVersions(input: ListPromptBlockVersionsInput): Promise<ListPromptBlockVersionsOutput> {
+    const { blockId, page = 0, perPage: perPageInput, orderBy } = input;
+
+    if (page < 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'LIST_PROMPT_BLOCK_VERSIONS', 'INVALID_PAGE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { page },
+        },
+        new Error('page must be >= 0'),
+      );
+    }
+
+    const perPage = normalizePerPage(perPageInput, 20);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    try {
+      const { field, direction } = this.parseVersionOrderBy(orderBy);
+      const collection = await this.getCollection(TABLE_PROMPT_BLOCK_VERSIONS);
+
+      const total = await collection.countDocuments({ blockId });
+
+      if (total === 0 || perPage === 0) {
+        return {
+          versions: [],
+          total,
+          page,
+          perPage: perPageForResponse,
+          hasMore: false,
+        };
+      }
+
+      const sortOrder = direction === 'ASC' ? 1 : -1;
+
+      let cursor = collection
+        .find({ blockId })
+        .sort({ [field]: sortOrder })
+        .skip(offset);
+
+      if (perPageInput !== false) {
+        cursor = cursor.limit(perPage);
+      }
+
+      const results = await cursor.toArray();
+      const versions = results.map((doc: any) => this.transformVersion(doc));
+
+      return {
+        versions,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore: perPageInput !== false && offset + perPage < total,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'LIST_PROMPT_BLOCK_VERSIONS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { blockId },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteVersion(id: string): Promise<void> {
+    try {
+      const collection = await this.getCollection(TABLE_PROMPT_BLOCK_VERSIONS);
+      await collection.deleteOne({ id });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'DELETE_PROMPT_BLOCK_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { versionId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteVersionsByBlockId(blockId: string): Promise<void> {
+    try {
+      const collection = await this.getCollection(TABLE_PROMPT_BLOCK_VERSIONS);
+      await collection.deleteMany({ blockId });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'DELETE_VERSIONS_BY_BLOCK_ID', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { blockId },
+        },
+        error,
+      );
+    }
+  }
+
+  async countVersions(blockId: string): Promise<number> {
+    try {
+      const collection = await this.getCollection(TABLE_PROMPT_BLOCK_VERSIONS);
+      return await collection.countDocuments({ blockId });
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MONGODB', 'COUNT_PROMPT_BLOCK_VERSIONS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { blockId },
+        },
+        error,
+      );
+    }
+  }
+
+  // ==========================================================================
+  // Private Helper Methods
+  // ==========================================================================
+
+  private transformBlock(doc: any): StoragePromptBlockType {
+    const { _id, ...rest } = doc;
+    return {
+      id: rest.id,
+      status: rest.status,
+      activeVersionId: rest.activeVersionId,
+      authorId: rest.authorId,
+      metadata: rest.metadata,
+      createdAt: rest.createdAt instanceof Date ? rest.createdAt : new Date(rest.createdAt),
+      updatedAt: rest.updatedAt instanceof Date ? rest.updatedAt : new Date(rest.updatedAt),
+    };
+  }
+
+  private serializeBlock(block: StoragePromptBlockType): Record<string, any> {
+    return {
+      id: block.id,
+      status: block.status,
+      activeVersionId: block.activeVersionId,
+      authorId: block.authorId,
+      metadata: block.metadata,
+      createdAt: block.createdAt,
+      updatedAt: block.updatedAt,
+    };
+  }
+
+  private transformVersion(doc: any): PromptBlockVersion {
+    const { _id, ...version } = doc;
+
+    const result: any = {
+      id: version.id,
+      blockId: version.blockId,
+      versionNumber: version.versionNumber,
+      changedFields: version.changedFields,
+      changeMessage: version.changeMessage,
+      createdAt: version.createdAt instanceof Date ? version.createdAt : new Date(version.createdAt),
+    };
+
+    // Copy snapshot fields
+    for (const field of SNAPSHOT_FIELDS) {
+      if (version[field] !== undefined) {
+        result[field] = version[field];
+      }
+    }
+
+    return result as PromptBlockVersion;
+  }
+
+  private extractSnapshotFields(version: PromptBlockVersion): Record<string, any> {
+    const result: Record<string, any> = {};
+    for (const field of SNAPSHOT_FIELDS) {
+      if ((version as any)[field] !== undefined) {
+        result[field] = (version as any)[field];
+      }
+    }
+    return result;
+  }
+}

--- a/stores/mongodb/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/mongodb/src/storage/domains/prompt-blocks/index.ts
@@ -275,6 +275,10 @@ export class MongoDBPromptBlocksStorage extends PromptBlocksStorage {
       if (metadataFields.authorId !== undefined) updateDoc.authorId = metadataFields.authorId;
       if (metadataFields.activeVersionId !== undefined) {
         updateDoc.activeVersionId = metadataFields.activeVersionId;
+        // Auto-set status to 'published' when activeVersionId is set, consistent with InMemory and LibSQL
+        if (metadataFields.status === undefined) {
+          updateDoc.status = 'published';
+        }
       }
       if (metadataFields.status !== undefined) {
         updateDoc.status = metadataFields.status;

--- a/stores/mongodb/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/mongodb/src/storage/domains/prompt-blocks/index.ts
@@ -245,7 +245,6 @@ export class MongoDBPromptBlocksStorage extends PromptBlocksStorage {
       // If we have config updates, create a new version
       if (Object.keys(configFields).length > 0) {
         const latestVersion = await this.getLatestVersion(id);
-        const nextVersionNumber = latestVersion ? latestVersion.versionNumber + 1 : 1;
 
         if (!latestVersion) {
           throw new MastraError({
@@ -263,7 +262,7 @@ export class MongoDBPromptBlocksStorage extends PromptBlocksStorage {
         await this.createVersion({
           id: randomUUID(),
           blockId: id,
-          versionNumber: nextVersionNumber,
+          versionNumber: latestVersion.versionNumber + 1,
           ...existingSnapshot,
           ...configFields,
           changedFields: Object.keys(configFields),

--- a/stores/mongodb/src/storage/index.ts
+++ b/stores/mongodb/src/storage/index.ts
@@ -6,6 +6,7 @@ import { resolveMongoDBConfig } from './db';
 import { MongoDBAgentsStorage } from './domains/agents';
 import { MemoryStorageMongoDB } from './domains/memory';
 import { ObservabilityMongoDB } from './domains/observability';
+import { MongoDBPromptBlocksStorage } from './domains/prompt-blocks';
 import { ScoresStorageMongoDB } from './domains/scores';
 import { WorkflowsStorageMongoDB } from './domains/workflows';
 import type { MongoDBConfig } from './types';
@@ -14,6 +15,7 @@ import type { MongoDBConfig } from './types';
 export {
   MongoDBAgentsStorage,
   MemoryStorageMongoDB,
+  MongoDBPromptBlocksStorage,
   ObservabilityMongoDB,
   ScoresStorageMongoDB,
   WorkflowsStorageMongoDB,
@@ -64,12 +66,15 @@ export class MongoDBStore extends MastraCompositeStore {
 
     const agents = new MongoDBAgentsStorage(domainConfig);
 
+    const promptBlocks = new MongoDBPromptBlocksStorage(domainConfig);
+
     this.stores = {
       memory,
       scores,
       workflows,
       observability,
       agents,
+      promptBlocks,
     };
   }
 

--- a/stores/pg/src/storage/domains/agents/index.ts
+++ b/stores/pg/src/storage/domains/agents/index.ts
@@ -1021,12 +1021,13 @@ export class AgentsPG extends AgentsStorage {
   // Private Helper Methods
   // ==========================================================================
 
-  private serializeInstructions(instructions: string | AgentInstructionBlock[]): string {
+  private serializeInstructions(instructions: string | AgentInstructionBlock[] | undefined | null): string | undefined {
+    if (instructions == null) return undefined;
     return Array.isArray(instructions) ? JSON.stringify(instructions) : instructions;
   }
 
-  private deserializeInstructions(raw: string): string | AgentInstructionBlock[] {
-    if (!raw) return raw;
+  private deserializeInstructions(raw: string | null | undefined): string | AgentInstructionBlock[] {
+    if (!raw) return '';
     try {
       const parsed = JSON.parse(raw);
       if (Array.isArray(parsed)) return parsed as AgentInstructionBlock[];

--- a/stores/pg/src/storage/domains/agents/index.ts
+++ b/stores/pg/src/storage/domains/agents/index.ts
@@ -17,6 +17,7 @@ import type {
   StorageListAgentsResolvedOutput,
   StorageResolvedAgentType,
   CreateIndexOptions,
+  AgentInstructionBlock,
 } from '@mastra/core/storage';
 import type {
   AgentVersion,
@@ -156,7 +157,7 @@ export class AgentsPG extends AgentsStorage {
           1,
           row.name ?? agentId,
           row.description ?? null,
-          row.instructions ?? '',
+          this.serializeInstructions(row.instructions ?? ''),
           row.model ? JSON.stringify(row.model) : '{}',
           row.tools ? JSON.stringify(row.tools) : null,
           row.defaultOptions ? JSON.stringify(row.defaultOptions) : null,
@@ -723,7 +724,7 @@ export class AgentsPG extends AgentsStorage {
             ...agent,
             name: row.version_name,
             description: row.version_description,
-            instructions: row.version_instructions,
+            instructions: this.deserializeInstructions(row.version_instructions as string),
             model: this.parseJson(row.version_model, 'model'),
             tools: this.parseJson(row.version_tools, 'tools'),
             defaultOptions: this.parseJson(row.version_defaultOptions, 'defaultOptions'),
@@ -785,7 +786,7 @@ export class AgentsPG extends AgentsStorage {
           input.versionNumber,
           input.name,
           input.description ?? null,
-          input.instructions,
+          this.serializeInstructions(input.instructions),
           JSON.stringify(input.model),
           input.tools ? JSON.stringify(input.tools) : null,
           input.defaultOptions ? JSON.stringify(input.defaultOptions) : null,
@@ -1020,6 +1021,21 @@ export class AgentsPG extends AgentsStorage {
   // Private Helper Methods
   // ==========================================================================
 
+  private serializeInstructions(instructions: string | AgentInstructionBlock[]): string {
+    return Array.isArray(instructions) ? JSON.stringify(instructions) : instructions;
+  }
+
+  private deserializeInstructions(raw: string): string | AgentInstructionBlock[] {
+    if (!raw) return raw;
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) return parsed as AgentInstructionBlock[];
+    } catch {
+      // Not JSON — plain string
+    }
+    return raw;
+  }
+
   private parseVersionRow(row: any): AgentVersion {
     return {
       id: row.id as string,
@@ -1027,7 +1043,7 @@ export class AgentsPG extends AgentsStorage {
       versionNumber: row.versionNumber as number,
       name: row.name as string,
       description: row.description as string | undefined,
-      instructions: row.instructions as string,
+      instructions: this.deserializeInstructions(row.instructions as string),
       model: this.parseJson(row.model, 'model'),
       tools: this.parseJson(row.tools, 'tools'),
       defaultOptions: this.parseJson(row.defaultOptions, 'defaultOptions'),

--- a/stores/pg/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/pg/src/storage/domains/prompt-blocks/index.ts
@@ -214,6 +214,7 @@ export class PromptBlocksPG extends PromptBlocksStorage {
       }
 
       const { authorId, activeVersionId, metadata, status, ...configFields } = updates;
+      let versionCreated = false;
 
       // Check if any snapshot config fields are present
       const hasConfigUpdate = SNAPSHOT_FIELDS.some(field => field in configFields);
@@ -248,6 +249,7 @@ export class PromptBlocksPG extends PromptBlocksStorage {
         );
 
         if (changedFields.length > 0) {
+          versionCreated = true;
           const newVersionId = crypto.randomUUID();
           await this.createVersion({
             id: newVersionId,
@@ -299,8 +301,8 @@ export class PromptBlocksPG extends PromptBlocksStorage {
 
       values.push(id);
 
-      if (setClauses.length > 2) {
-        // More than just updatedAt and updatedAtZ
+      if (setClauses.length > 2 || versionCreated) {
+        // More than just updatedAt and updatedAtZ, or a new version was created
         await this.#db.client.none(
           `UPDATE ${tableName} SET ${setClauses.join(', ')} WHERE id = $${paramIndex}`,
           values,

--- a/stores/pg/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/pg/src/storage/domains/prompt-blocks/index.ts
@@ -273,6 +273,11 @@ export class PromptBlocksPG extends PromptBlocksStorage {
       if (activeVersionId !== undefined) {
         setClauses.push(`"activeVersionId" = $${paramIndex++}`);
         values.push(activeVersionId);
+        // Auto-set status to 'published' when activeVersionId is set, consistent with InMemory and LibSQL
+        if (status === undefined) {
+          setClauses.push(`status = $${paramIndex++}`);
+          values.push('published');
+        }
       }
 
       if (status !== undefined) {

--- a/stores/pg/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/pg/src/storage/domains/prompt-blocks/index.ts
@@ -288,8 +288,9 @@ export class PromptBlocksPG extends PromptBlocksStorage {
       }
 
       if (metadata !== undefined) {
+        const mergedMetadata = { ...(existingBlock.metadata || {}), ...metadata };
         setClauses.push(`metadata = $${paramIndex++}`);
-        values.push(JSON.stringify(metadata));
+        values.push(JSON.stringify(mergedMetadata));
       }
 
       // Always update timestamps

--- a/stores/pg/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/pg/src/storage/domains/prompt-blocks/index.ts
@@ -1,0 +1,748 @@
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  PromptBlocksStorage,
+  createStorageErrorId,
+  normalizePerPage,
+  calculatePagination,
+  TABLE_PROMPT_BLOCKS,
+  TABLE_PROMPT_BLOCK_VERSIONS,
+  TABLE_SCHEMAS,
+} from '@mastra/core/storage';
+import type {
+  StoragePromptBlockType,
+  StorageCreatePromptBlockInput,
+  StorageUpdatePromptBlockInput,
+  StorageListPromptBlocksInput,
+  StorageListPromptBlocksOutput,
+  CreateIndexOptions,
+} from '@mastra/core/storage';
+import type {
+  PromptBlockVersion,
+  CreatePromptBlockVersionInput,
+  ListPromptBlockVersionsInput,
+  ListPromptBlockVersionsOutput,
+} from '@mastra/core/storage/domains/prompt-blocks';
+import { PgDB, resolvePgConfig } from '../../db';
+import type { PgDomainConfig } from '../../db';
+import { getTableName, getSchemaName } from '../utils';
+
+const SNAPSHOT_FIELDS = ['name', 'description', 'content', 'rules'] as const;
+
+export class PromptBlocksPG extends PromptBlocksStorage {
+  #db: PgDB;
+  #schema: string;
+  #skipDefaultIndexes?: boolean;
+  #indexes?: CreateIndexOptions[];
+
+  static readonly MANAGED_TABLES = [TABLE_PROMPT_BLOCKS, TABLE_PROMPT_BLOCK_VERSIONS] as const;
+
+  constructor(config: PgDomainConfig) {
+    super();
+    const { client, schemaName, skipDefaultIndexes, indexes } = resolvePgConfig(config);
+    this.#db = new PgDB({ client, schemaName, skipDefaultIndexes });
+    this.#schema = schemaName || 'public';
+    this.#skipDefaultIndexes = skipDefaultIndexes;
+    this.#indexes = indexes?.filter(idx => (PromptBlocksPG.MANAGED_TABLES as readonly string[]).includes(idx.table));
+  }
+
+  getDefaultIndexDefinitions(): CreateIndexOptions[] {
+    return [
+      {
+        name: 'idx_prompt_block_versions_block_version',
+        table: TABLE_PROMPT_BLOCK_VERSIONS,
+        columns: ['blockId', 'versionNumber'],
+        unique: true,
+      },
+    ];
+  }
+
+  async createDefaultIndexes(): Promise<void> {
+    if (this.#skipDefaultIndexes) {
+      return;
+    }
+    for (const indexDef of this.getDefaultIndexDefinitions()) {
+      try {
+        await this.#db.createIndex(indexDef);
+      } catch {
+        // Indexes are performance optimizations, continue on failure
+      }
+    }
+  }
+
+  async init(): Promise<void> {
+    await this.#db.createTable({ tableName: TABLE_PROMPT_BLOCKS, schema: TABLE_SCHEMAS[TABLE_PROMPT_BLOCKS] });
+    await this.#db.createTable({
+      tableName: TABLE_PROMPT_BLOCK_VERSIONS,
+      schema: TABLE_SCHEMAS[TABLE_PROMPT_BLOCK_VERSIONS],
+    });
+    await this.createDefaultIndexes();
+    await this.createCustomIndexes();
+  }
+
+  async createCustomIndexes(): Promise<void> {
+    if (!this.#indexes || this.#indexes.length === 0) {
+      return;
+    }
+    for (const indexDef of this.#indexes) {
+      try {
+        await this.#db.createIndex(indexDef);
+      } catch (error) {
+        this.logger?.warn?.(`Failed to create custom index ${indexDef.name}:`, error);
+      }
+    }
+  }
+
+  async dangerouslyClearAll(): Promise<void> {
+    await this.#db.clearTable({ tableName: TABLE_PROMPT_BLOCK_VERSIONS });
+    await this.#db.clearTable({ tableName: TABLE_PROMPT_BLOCKS });
+  }
+
+  // ==========================================================================
+  // Prompt Block CRUD Methods
+  // ==========================================================================
+
+  async getPromptBlockById({ id }: { id: string }): Promise<StoragePromptBlockType | null> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_PROMPT_BLOCKS, schemaName: getSchemaName(this.#schema) });
+      const result = await this.#db.client.oneOrNone(`SELECT * FROM ${tableName} WHERE id = $1`, [id]);
+
+      if (!result) {
+        return null;
+      }
+
+      return this.parseBlockRow(result);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_PROMPT_BLOCK_BY_ID', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { blockId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async createPromptBlock({
+    promptBlock,
+  }: {
+    promptBlock: StorageCreatePromptBlockInput;
+  }): Promise<StoragePromptBlockType> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_PROMPT_BLOCKS, schemaName: getSchemaName(this.#schema) });
+      const now = new Date();
+      const nowIso = now.toISOString();
+
+      // 1. Create the thin block record
+      await this.#db.client.none(
+        `INSERT INTO ${tableName} (
+          id, status, "activeVersionId", "authorId", metadata,
+          "createdAt", "createdAtZ", "updatedAt", "updatedAtZ"
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+        [
+          promptBlock.id,
+          'draft',
+          null,
+          promptBlock.authorId ?? null,
+          promptBlock.metadata ? JSON.stringify(promptBlock.metadata) : null,
+          nowIso,
+          nowIso,
+          nowIso,
+          nowIso,
+        ],
+      );
+
+      // 2. Extract snapshot fields and create version 1
+      const { id: _id, authorId: _authorId, metadata: _metadata, ...snapshotConfig } = promptBlock;
+      const versionId = crypto.randomUUID();
+      await this.createVersion({
+        id: versionId,
+        blockId: promptBlock.id,
+        versionNumber: 1,
+        ...snapshotConfig,
+        changedFields: [...SNAPSHOT_FIELDS],
+        changeMessage: 'Initial version',
+      });
+
+      return {
+        id: promptBlock.id,
+        status: 'draft',
+        activeVersionId: undefined,
+        authorId: promptBlock.authorId,
+        metadata: promptBlock.metadata,
+        createdAt: now,
+        updatedAt: now,
+      };
+    } catch (error) {
+      // Best-effort cleanup
+      try {
+        const tableName = getTableName({ indexName: TABLE_PROMPT_BLOCKS, schemaName: getSchemaName(this.#schema) });
+        await this.#db.client.none(
+          `DELETE FROM ${tableName} WHERE id = $1 AND status = 'draft' AND "activeVersionId" IS NULL`,
+          [promptBlock.id],
+        );
+      } catch {
+        // Ignore cleanup errors
+      }
+
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'CREATE_PROMPT_BLOCK', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { blockId: promptBlock.id },
+        },
+        error,
+      );
+    }
+  }
+
+  async updatePromptBlock({ id, ...updates }: StorageUpdatePromptBlockInput): Promise<StoragePromptBlockType> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_PROMPT_BLOCKS, schemaName: getSchemaName(this.#schema) });
+
+      const existingBlock = await this.getPromptBlockById({ id });
+      if (!existingBlock) {
+        throw new MastraError({
+          id: createStorageErrorId('PG', 'UPDATE_PROMPT_BLOCK', 'NOT_FOUND'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          text: `Prompt block ${id} not found`,
+          details: { blockId: id },
+        });
+      }
+
+      const { authorId, activeVersionId, metadata, status, ...configFields } = updates;
+
+      // Check if any snapshot config fields are present
+      const hasConfigUpdate = SNAPSHOT_FIELDS.some(field => field in configFields);
+
+      if (hasConfigUpdate) {
+        const latestVersion = await this.getLatestVersion(id);
+        if (!latestVersion) {
+          throw new MastraError({
+            id: createStorageErrorId('PG', 'UPDATE_PROMPT_BLOCK', 'NO_VERSIONS'),
+            domain: ErrorDomain.STORAGE,
+            category: ErrorCategory.SYSTEM,
+            text: `No versions found for prompt block ${id}`,
+            details: { blockId: id },
+          });
+        }
+
+        const {
+          id: _versionId,
+          blockId: _blockId,
+          versionNumber: _versionNumber,
+          changedFields: _changedFields,
+          changeMessage: _changeMessage,
+          createdAt: _createdAt,
+          ...latestConfig
+        } = latestVersion;
+
+        const newConfig = { ...latestConfig, ...configFields };
+        const changedFields = SNAPSHOT_FIELDS.filter(
+          field =>
+            field in configFields &&
+            configFields[field as keyof typeof configFields] !== latestConfig[field as keyof typeof latestConfig],
+        );
+
+        if (changedFields.length > 0) {
+          const newVersionId = crypto.randomUUID();
+          await this.createVersion({
+            id: newVersionId,
+            blockId: id,
+            versionNumber: latestVersion.versionNumber + 1,
+            ...newConfig,
+            changedFields: [...changedFields],
+            changeMessage: `Updated ${changedFields.join(', ')}`,
+          });
+        }
+      }
+
+      // Update metadata fields on the block record
+      const setClauses: string[] = [];
+      const values: any[] = [];
+      let paramIndex = 1;
+
+      if (authorId !== undefined) {
+        setClauses.push(`"authorId" = $${paramIndex++}`);
+        values.push(authorId);
+      }
+
+      if (activeVersionId !== undefined) {
+        setClauses.push(`"activeVersionId" = $${paramIndex++}`);
+        values.push(activeVersionId);
+      }
+
+      if (status !== undefined) {
+        setClauses.push(`status = $${paramIndex++}`);
+        values.push(status);
+      }
+
+      if (metadata !== undefined) {
+        setClauses.push(`metadata = $${paramIndex++}`);
+        values.push(JSON.stringify(metadata));
+      }
+
+      // Always update timestamps
+      const now = new Date().toISOString();
+      setClauses.push(`"updatedAt" = $${paramIndex++}`);
+      values.push(now);
+      setClauses.push(`"updatedAtZ" = $${paramIndex++}`);
+      values.push(now);
+
+      values.push(id);
+
+      if (setClauses.length > 2) {
+        // More than just updatedAt and updatedAtZ
+        await this.#db.client.none(
+          `UPDATE ${tableName} SET ${setClauses.join(', ')} WHERE id = $${paramIndex}`,
+          values,
+        );
+      }
+
+      const updatedBlock = await this.getPromptBlockById({ id });
+      return updatedBlock!;
+    } catch (error) {
+      if (error instanceof MastraError) throw error;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'UPDATE_PROMPT_BLOCK', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { blockId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async deletePromptBlock({ id }: { id: string }): Promise<void> {
+    try {
+      const tableName = getTableName({ indexName: TABLE_PROMPT_BLOCKS, schemaName: getSchemaName(this.#schema) });
+      await this.deleteVersionsByBlockId(id);
+      await this.#db.client.none(`DELETE FROM ${tableName} WHERE id = $1`, [id]);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'DELETE_PROMPT_BLOCK', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { blockId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async listPromptBlocks(args?: StorageListPromptBlocksInput): Promise<StorageListPromptBlocksOutput> {
+    const { page = 0, perPage: perPageInput, orderBy, authorId, metadata } = args || {};
+    const { field, direction } = this.parseOrderBy(orderBy);
+
+    if (page < 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'LIST_PROMPT_BLOCKS', 'INVALID_PAGE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { page },
+        },
+        new Error('page must be >= 0'),
+      );
+    }
+
+    const perPage = normalizePerPage(perPageInput, 100);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    try {
+      const tableName = getTableName({ indexName: TABLE_PROMPT_BLOCKS, schemaName: getSchemaName(this.#schema) });
+
+      // Build WHERE conditions
+      const conditions: string[] = [];
+      const queryParams: any[] = [];
+      let paramIdx = 1;
+
+      if (authorId !== undefined) {
+        conditions.push(`"authorId" = $${paramIdx++}`);
+        queryParams.push(authorId);
+      }
+
+      if (metadata && Object.keys(metadata).length > 0) {
+        for (const [key, value] of Object.entries(metadata)) {
+          conditions.push(`metadata->>'${key}' = $${paramIdx++}`);
+          queryParams.push(typeof value === 'string' ? value : JSON.stringify(value));
+        }
+      }
+
+      const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+      // Get total count
+      const countResult = await this.#db.client.one(
+        `SELECT COUNT(*) as count FROM ${tableName} ${whereClause}`,
+        queryParams,
+      );
+      const total = parseInt(countResult.count, 10);
+
+      if (total === 0) {
+        return {
+          promptBlocks: [],
+          total: 0,
+          page,
+          perPage: perPageForResponse,
+          hasMore: false,
+        };
+      }
+
+      const limitValue = perPageInput === false ? total : perPage;
+      const dataResult = await this.#db.client.manyOrNone(
+        `SELECT * FROM ${tableName} ${whereClause} ORDER BY "${field}" ${direction} LIMIT $${paramIdx++} OFFSET $${paramIdx++}`,
+        [...queryParams, limitValue, offset],
+      );
+
+      const promptBlocks = (dataResult || []).map(row => this.parseBlockRow(row));
+
+      return {
+        promptBlocks,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore: perPageInput === false ? false : offset + perPage < total,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'LIST_PROMPT_BLOCKS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
+  // ==========================================================================
+  // Prompt Block Version Methods
+  // ==========================================================================
+
+  async createVersion(input: CreatePromptBlockVersionInput): Promise<PromptBlockVersion> {
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_PROMPT_BLOCK_VERSIONS,
+        schemaName: getSchemaName(this.#schema),
+      });
+      const now = new Date();
+      const nowIso = now.toISOString();
+
+      await this.#db.client.none(
+        `INSERT INTO ${tableName} (
+          id, "blockId", "versionNumber",
+          name, description, content, rules,
+          "changedFields", "changeMessage",
+          "createdAt", "createdAtZ"
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+        [
+          input.id,
+          input.blockId,
+          input.versionNumber,
+          input.name,
+          input.description ?? null,
+          input.content,
+          input.rules ? JSON.stringify(input.rules) : null,
+          input.changedFields ? JSON.stringify(input.changedFields) : null,
+          input.changeMessage ?? null,
+          nowIso,
+          nowIso,
+        ],
+      );
+
+      return {
+        ...input,
+        createdAt: now,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'CREATE_PROMPT_BLOCK_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { versionId: input.id, blockId: input.blockId },
+        },
+        error,
+      );
+    }
+  }
+
+  async getVersion(id: string): Promise<PromptBlockVersion | null> {
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_PROMPT_BLOCK_VERSIONS,
+        schemaName: getSchemaName(this.#schema),
+      });
+      const result = await this.#db.client.oneOrNone(`SELECT * FROM ${tableName} WHERE id = $1`, [id]);
+
+      if (!result) {
+        return null;
+      }
+
+      return this.parseVersionRow(result);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_PROMPT_BLOCK_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { versionId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async getVersionByNumber(blockId: string, versionNumber: number): Promise<PromptBlockVersion | null> {
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_PROMPT_BLOCK_VERSIONS,
+        schemaName: getSchemaName(this.#schema),
+      });
+      const result = await this.#db.client.oneOrNone(
+        `SELECT * FROM ${tableName} WHERE "blockId" = $1 AND "versionNumber" = $2`,
+        [blockId, versionNumber],
+      );
+
+      if (!result) {
+        return null;
+      }
+
+      return this.parseVersionRow(result);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_PROMPT_BLOCK_VERSION_BY_NUMBER', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { blockId, versionNumber },
+        },
+        error,
+      );
+    }
+  }
+
+  async getLatestVersion(blockId: string): Promise<PromptBlockVersion | null> {
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_PROMPT_BLOCK_VERSIONS,
+        schemaName: getSchemaName(this.#schema),
+      });
+      const result = await this.#db.client.oneOrNone(
+        `SELECT * FROM ${tableName} WHERE "blockId" = $1 ORDER BY "versionNumber" DESC LIMIT 1`,
+        [blockId],
+      );
+
+      if (!result) {
+        return null;
+      }
+
+      return this.parseVersionRow(result);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'GET_LATEST_PROMPT_BLOCK_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { blockId },
+        },
+        error,
+      );
+    }
+  }
+
+  async listVersions(input: ListPromptBlockVersionsInput): Promise<ListPromptBlockVersionsOutput> {
+    const { blockId, page = 0, perPage: perPageInput, orderBy } = input;
+
+    if (page < 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'LIST_PROMPT_BLOCK_VERSIONS', 'INVALID_PAGE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { page },
+        },
+        new Error('page must be >= 0'),
+      );
+    }
+
+    const perPage = normalizePerPage(perPageInput, 20);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    try {
+      const { field, direction } = this.parseVersionOrderBy(orderBy);
+      const tableName = getTableName({
+        indexName: TABLE_PROMPT_BLOCK_VERSIONS,
+        schemaName: getSchemaName(this.#schema),
+      });
+
+      const countResult = await this.#db.client.one(`SELECT COUNT(*) as count FROM ${tableName} WHERE "blockId" = $1`, [
+        blockId,
+      ]);
+      const total = parseInt(countResult.count, 10);
+
+      if (total === 0) {
+        return {
+          versions: [],
+          total: 0,
+          page,
+          perPage: perPageForResponse,
+          hasMore: false,
+        };
+      }
+
+      const limitValue = perPageInput === false ? total : perPage;
+      const dataResult = await this.#db.client.manyOrNone(
+        `SELECT * FROM ${tableName} WHERE "blockId" = $1 ORDER BY "${field}" ${direction} LIMIT $2 OFFSET $3`,
+        [blockId, limitValue, offset],
+      );
+
+      const versions = (dataResult || []).map(row => this.parseVersionRow(row));
+
+      return {
+        versions,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore: perPageInput === false ? false : offset + perPage < total,
+      };
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'LIST_PROMPT_BLOCK_VERSIONS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { blockId },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteVersion(id: string): Promise<void> {
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_PROMPT_BLOCK_VERSIONS,
+        schemaName: getSchemaName(this.#schema),
+      });
+      await this.#db.client.none(`DELETE FROM ${tableName} WHERE id = $1`, [id]);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'DELETE_PROMPT_BLOCK_VERSION', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { versionId: id },
+        },
+        error,
+      );
+    }
+  }
+
+  async deleteVersionsByBlockId(blockId: string): Promise<void> {
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_PROMPT_BLOCK_VERSIONS,
+        schemaName: getSchemaName(this.#schema),
+      });
+      await this.#db.client.none(`DELETE FROM ${tableName} WHERE "blockId" = $1`, [blockId]);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'DELETE_PROMPT_BLOCK_VERSIONS_BY_BLOCK_ID', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { blockId },
+        },
+        error,
+      );
+    }
+  }
+
+  async countVersions(blockId: string): Promise<number> {
+    try {
+      const tableName = getTableName({
+        indexName: TABLE_PROMPT_BLOCK_VERSIONS,
+        schemaName: getSchemaName(this.#schema),
+      });
+      const result = await this.#db.client.one(`SELECT COUNT(*) as count FROM ${tableName} WHERE "blockId" = $1`, [
+        blockId,
+      ]);
+      return parseInt(result.count, 10);
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'COUNT_PROMPT_BLOCK_VERSIONS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { blockId },
+        },
+        error,
+      );
+    }
+  }
+
+  // ==========================================================================
+  // Private Helper Methods
+  // ==========================================================================
+
+  private parseJson(value: any, fieldName?: string): any {
+    if (!value) return undefined;
+    if (typeof value !== 'string') return value;
+
+    try {
+      return JSON.parse(value);
+    } catch (error) {
+      const details: Record<string, string> = {
+        value: value.length > 100 ? value.substring(0, 100) + '...' : value,
+      };
+      if (fieldName) {
+        details.field = fieldName;
+      }
+
+      throw new MastraError(
+        {
+          id: createStorageErrorId('PG', 'PARSE_JSON', 'INVALID_JSON'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.SYSTEM,
+          text: `Failed to parse JSON${fieldName ? ` for field "${fieldName}"` : ''}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          details,
+        },
+        error,
+      );
+    }
+  }
+
+  private parseBlockRow(row: any): StoragePromptBlockType {
+    return {
+      id: row.id as string,
+      status: row.status as StoragePromptBlockType['status'],
+      activeVersionId: row.activeVersionId as string | undefined,
+      authorId: row.authorId as string | undefined,
+      metadata: this.parseJson(row.metadata, 'metadata'),
+      createdAt: row.createdAtZ || row.createdAt,
+      updatedAt: row.updatedAtZ || row.updatedAt,
+    };
+  }
+
+  private parseVersionRow(row: any): PromptBlockVersion {
+    return {
+      id: row.id as string,
+      blockId: row.blockId as string,
+      versionNumber: row.versionNumber as number,
+      name: row.name as string,
+      description: row.description as string | undefined,
+      content: row.content as string,
+      rules: this.parseJson(row.rules, 'rules'),
+      changedFields: this.parseJson(row.changedFields, 'changedFields'),
+      changeMessage: row.changeMessage as string | undefined,
+      createdAt: row.createdAtZ || row.createdAt,
+    };
+  }
+}

--- a/stores/pg/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/pg/src/storage/domains/prompt-blocks/index.ts
@@ -369,10 +369,8 @@ export class PromptBlocksPG extends PromptBlocksStorage {
       }
 
       if (metadata && Object.keys(metadata).length > 0) {
-        for (const [key, value] of Object.entries(metadata)) {
-          conditions.push(`metadata->>'${key}' = $${paramIdx++}`);
-          queryParams.push(typeof value === 'string' ? value : JSON.stringify(value));
-        }
+        conditions.push(`metadata @> $${paramIdx++}::jsonb`);
+        queryParams.push(JSON.stringify(metadata));
       }
 
       const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';

--- a/stores/pg/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/pg/src/storage/domains/prompt-blocks/index.ts
@@ -310,7 +310,16 @@ export class PromptBlocksPG extends PromptBlocksStorage {
       }
 
       const updatedBlock = await this.getPromptBlockById({ id });
-      return updatedBlock!;
+      if (!updatedBlock) {
+        throw new MastraError({
+          id: createStorageErrorId('PG', 'UPDATE_PROMPT_BLOCK', 'NOT_FOUND_AFTER_UPDATE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.SYSTEM,
+          text: `Prompt block ${id} not found after update`,
+          details: { blockId: id },
+        });
+      }
+      return updatedBlock;
     } catch (error) {
       if (error instanceof MastraError) throw error;
       throw new MastraError(

--- a/stores/pg/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/pg/src/storage/domains/prompt-blocks/index.ts
@@ -740,8 +740,8 @@ export class PromptBlocksPG extends PromptBlocksStorage {
       activeVersionId: row.activeVersionId as string | undefined,
       authorId: row.authorId as string | undefined,
       metadata: this.parseJson(row.metadata, 'metadata'),
-      createdAt: row.createdAtZ || row.createdAt,
-      updatedAt: row.updatedAtZ || row.updatedAt,
+      createdAt: new Date(row.createdAtZ || row.createdAt),
+      updatedAt: new Date(row.updatedAtZ || row.updatedAt),
     };
   }
 
@@ -756,7 +756,7 @@ export class PromptBlocksPG extends PromptBlocksStorage {
       rules: this.parseJson(row.rules, 'rules'),
       changedFields: this.parseJson(row.changedFields, 'changedFields'),
       changeMessage: row.changeMessage as string | undefined,
-      createdAt: row.createdAtZ || row.createdAt,
+      createdAt: new Date(row.createdAtZ || row.createdAt),
     };
   }
 }

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -17,6 +17,7 @@ import type { PgDomainClientConfig } from './db';
 import { AgentsPG } from './domains/agents';
 import { MemoryPG } from './domains/memory';
 import { ObservabilityPG } from './domains/observability';
+import { PromptBlocksPG } from './domains/prompt-blocks';
 import { ScoresPG } from './domains/scores';
 import { WorkflowsPG } from './domains/workflows';
 
@@ -27,7 +28,7 @@ const DEFAULT_IDLE_TIMEOUT_MS = 30000;
 
 export { exportSchemas } from './db';
 // Export domain classes for direct use with MastraStorage composition
-export { AgentsPG, MemoryPG, ObservabilityPG, ScoresPG, WorkflowsPG };
+export { AgentsPG, MemoryPG, ObservabilityPG, PromptBlocksPG, ScoresPG, WorkflowsPG };
 export { PoolAdapter } from './client';
 export type { DbClient, TxClient, QueryValues, Pool, PoolClient, QueryResult } from './client';
 export type { PgDomainConfig, PgDomainClientConfig, PgDomainPoolConfig, PgDomainRestConfig } from './db';
@@ -94,6 +95,7 @@ export class PostgresStore extends MastraCompositeStore {
         memory: new MemoryPG(domainConfig),
         observability: new ObservabilityPG(domainConfig),
         agents: new AgentsPG(domainConfig),
+        promptBlocks: new PromptBlocksPG(domainConfig),
       };
     } catch (e) {
       throw new MastraError(


### PR DESCRIPTION
Adds dynamic instructions support to stored agents. Instead of just plain string instructions, agents can now use an array of instruction blocks that resolve at runtime based on request context.

Three block types are supported:

```ts
instructions: [
  { type: "text", content: "You are a {{company}} support agent." },
  { type: "prompt_block_ref", id: "security-rules" },
  { type: "prompt_block", content: "Be formal.", rules: { operator: "AND", conditions: [{ field: "tone", operator: "equals", value: "formal" }] } },
]
```

Prompt blocks are reusable, versioned chunks of instructions stored in the database. They support conditional rules (AND/OR) and `{{variable}}` interpolation. Updating a block takes effect immediately for all agents that reference it.

Also adds a `POST /stored/agents/preview-instructions` server endpoint so the UI can preview how instructions resolve with a given context.

Storage implementations added for PG, LibSQL, and MongoDB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic agent instructions using reusable, versioned prompt blocks (text, references, inline) with conditional rules and immediate propagation.
  * New POST /stored/agents/preview-instructions endpoint to render instruction previews with a request context.
  * Editor: prompt block CRUD, instruction preview, and runtime resolution for stored agents.
  * Storage: prompt-blocks domain added across providers (in-memory, LibSQL, Postgres, MongoDB, ClickHouse, Cloudflare).

* **Tests**
  * Extensive E2E and unit tests for templating, rule evaluation, instruction resolution, versioning, and storage behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->