### PR TITLE
fix(datasets): P0 run executor bugs — abort, timeout, signal, storage

### DIFF
--- a/packages/core/src/datasets/run/AUDIT-MC.md
+++ b/packages/core/src/datasets/run/AUDIT-MC.md
@@ -1,0 +1,191 @@
+# Dataset Run Executor — Audit
+
+## OVERVIEW
+
+The executor runs dataset items against a target (agent, workflow, or scorer) concurrently via `p-map`, scores results, and persists them to storage. This audit covers load handling, failure modes, and scale concerns.
+
+---
+
+## FILES
+
+| File                 | Role                                                            |
+| -------------------- | --------------------------------------------------------------- |
+| `index.ts`           | Orchestrator — `runDataset()` drives the run loop               |
+| `executor.ts`        | Target dispatch — `executeTarget()` → agent / workflow / scorer |
+| `scorer.ts`          | Score computation + persistence — `runScorersForItem()`         |
+| `types.ts`           | Shared types                                                    |
+| `analytics/index.ts` | Post-run analytics computation                                  |
+
+---
+
+## BUGS
+
+### 1. Abort loses partial results
+
+**Location:** `index.ts:194`
+
+If `p-map` throws (e.g., on abort), the catch block updates the run to `failed` and re-throws. No `RunSummary` is returned, so all partial results collected up to that point are lost.
+
+**Fix:** Return a `RunSummary` with partial data instead of re-throwing.
+
+---
+
+### 2. Abort leaves counts incomplete
+
+**Location:** `index.ts:199`
+
+When aborted mid-run, `succeededCount` and `failedCount` only reflect items processed so far. The final status update uses these incomplete counts.
+
+**Fix:** Track `processedCount` separately and include `skippedCount = items.length - processedCount` in the summary.
+
+---
+
+### 3. `generateLegacy?.()` silent undefined
+
+**Location:** `executor.ts:101-129`
+
+In `executeAgent`, if `generateLegacy` is `null`/`undefined`, the optional call returns `undefined` silently. The result is treated as a success with no output.
+
+**Fix:** Guard with an explicit check and throw if the generate method is unavailable.
+
+---
+
+## ISSUES
+
+### 4. AbortSignal not forwarded to targets
+
+**Location:** `index.ts:121`, `executor.ts`
+
+`AbortSignal` is checked at the top of each `p-map` iteration but is never passed to `agent.generate()` or `workflow.createRun()`. An in-flight LLM call will run to completion even after abort.
+
+**Fix:** Forward the signal to `agent.generate({ abortSignal })` and `workflow.createRun({ signal })`.
+
+---
+
+### 5. No per-item timeout
+
+A hanging agent/workflow call blocks a `p-map` slot indefinitely. With `maxConcurrency: 5`, one stuck call reduces throughput by 20%.
+
+**Fix:** Wrap `executeTarget` in `AbortSignal.timeout(ms)` or equivalent.
+
+---
+
+### 6. Scorers run sequentially per item
+
+**Location:** `scorer.ts:53`
+
+`for (const scorer of scorers)` runs each scorer one after another within a single item callback. If a scorer is slow (e.g., LLM-as-judge), it blocks the `p-map` slot.
+
+**Fix:** Run scorers in parallel with `Promise.all` or `Promise.allSettled`.
+
+---
+
+### 7. Score persistence is inline and unbatched
+
+**Location:** `scorer.ts:59-85`, `index.ts:170`
+
+`validateAndSaveScore` is called inline per scorer per item, and `runsStore.addResult()` is called per item. With 1,000 items × 3 scorers, that's 4,000 sequential-per-item storage writes with no batching.
+
+**Fix:** Batch writes or use a write queue with configurable flush interval.
+
+---
+
+### 8. No backpressure on storage failures
+
+**Location:** `scorer.ts:81-84`
+
+Score save errors are caught and logged with `console.warn`. There is no signal to the orchestrator that persistence is failing. A bad storage connection silently drops all scores.
+
+**Fix:** Track save failure count. If it exceeds a threshold, surface it in the `RunSummary` or abort.
+
+---
+
+### 9. Workflow `suspended`/`paused` treated as errors
+
+**Location:** `executor.ts:157-162`
+
+Workflows returning `suspended` or `paused` status are treated as execution errors. These may be valid intermediate states depending on workflow design.
+
+**Fix:** Decide on semantics — either document that only `completed` is valid, or add a wait/resume mechanism.
+
+---
+
+### 10. `retryCount` is hardcoded to 0
+
+**Location:** `index.ts:152`
+
+`retryCount` is set to `0` and never incremented. It's stored in results but serves no purpose.
+
+**Fix:** Implement retry logic or remove the field.
+
+---
+
+## MINOR CONCERNS
+
+### 11. Unbounded `results` array in memory
+
+**Location:** `index.ts:112`
+
+`results: ItemWithScores[]` grows without bound. For large datasets (10k+ items with scores), this could cause memory pressure.
+
+---
+
+### 12. Non-deterministic result order
+
+`results.push()` order depends on `p-map` completion order, not item order. This is safe in Node's event loop but may confuse consumers expecting ordered results.
+
+---
+
+### 13. Partial failure marked as `completed`
+
+**Location:** `index.ts:217`
+
+`status = failedCount === items.length ? 'failed' : 'completed'`. A run where 999/1000 items failed is still `completed`. Consider adding a `partial` status or `completedWithErrors`.
+
+---
+
+### 14. Dynamic import on every call
+
+**Location:** `index.ts:115`
+
+`p-map` is dynamically imported on every `runDataset()` invocation. Minor overhead, easily cached.
+
+---
+
+## SCALE CONCERNS
+
+| Items        | Risk     | Detail                                                                                                                         |
+| ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| < 100        | Low      | Works fine with defaults                                                                                                       |
+| 100–1,000    | Medium   | Memory OK; long wall-clock time; storage write volume notable                                                                  |
+| 1,000–10,000 | High     | Memory pressure from `results[]`; 4× storage writes per item (result + scorers); no timeout means one stuck item blocks a slot |
+| 10,000+      | Critical | Unbounded memory; no streaming/pagination of results; storage becomes bottleneck                                               |
+
+---
+
+## TEST COVERAGE GAPS
+
+- Large dataset (1,000+ items)
+- Abort mid-execution (partial results)
+- Storage write failure during run
+- Per-item timeout / hanging target
+- Scorer parallel execution
+- `generateLegacy` returning `undefined`
+
+---
+
+## RECOMMENDED PRIORITY
+
+| Priority | Item                                 | Effort |
+| -------- | ------------------------------------ | ------ |
+| P0       | #1 Abort loses partial results       | Small  |
+| P0       | #3 `generateLegacy` silent undefined | Small  |
+| P1       | #4 Forward AbortSignal to targets    | Medium |
+| P1       | #5 Per-item timeout                  | Medium |
+| P1       | #8 Backpressure on storage failures  | Medium |
+| P2       | #6 Parallel scorers                  | Small  |
+| P2       | #7 Batch storage writes              | Medium |
+| P2       | #9 Workflow suspended semantics      | Small  |
+| P3       | #10 Remove or implement retryCount   | Small  |
+| P3       | #11 Streaming results for large sets | Large  |
+| P3       | #13 Partial failure status           | Small  |

--- a/packages/core/src/datasets/run/AUDIT.md
+++ b/packages/core/src/datasets/run/AUDIT.md
@@ -1,0 +1,229 @@
+# Dataset Run Executor — Audit
+
+Combined analysis from two independent audits of the run executor (`packages/core/src/datasets/run/`).
+
+---
+
+## FILES ANALYZED
+
+- `index.ts` — orchestrator (`runDataset`, `resolveTarget`)
+- `executor.ts` — target execution (`executeTarget`, `executeAgent`, `executeWorkflow`, `executeScorer`)
+- `scorer.ts` — scorer resolution and execution (`resolveScorers`, `runScorersForItem`, `runScorerSafe`)
+- `types.ts` — type definitions (`RunConfig`, `ItemResult`, `ScorerResult`, `ItemWithScores`, `RunSummary`)
+
+---
+
+## WHAT WORKS WELL
+
+| Area                     | Details                                                                                               |
+| ------------------------ | ----------------------------------------------------------------------------------------------------- |
+| Concurrency control      | `p-map` with `maxConcurrency` (default 5). No unbounded `Promise.all`.                                |
+| Item failure isolation   | `executeTarget` catches errors at both inner and outer level. One item failing doesn't crash the run. |
+| Scorer failure isolation | `runScorerSafe` wraps each scorer independently. One scorer crashing doesn't affect others.           |
+| Score persistence        | `validateAndSaveScore` is wrapped in try/catch with `console.warn`. Best-effort, non-blocking.        |
+
+---
+
+## ISSUES FOUND
+
+### P0 — HIGH SEVERITY
+
+#### 1. No per-item timeout
+
+A hanging `agent.generate()` or `workflow.start()` blocks a concurrency slot indefinitely. The only escape is the caller-provided `AbortSignal`, which requires external setup.
+
+- **Location:** `index.ts:129` (`executeTarget` call)
+- **Impact:** A single hung target can stall the entire run
+
+#### 2. AbortSignal not forwarded to targets
+
+The signal check at `index.ts:121` only prevents _starting_ new items. It cannot interrupt in-flight LLM calls. Signal is not passed to `agent.generate()` or `workflow.createRun()`.
+
+- **Location:** `index.ts:121-123`, `executor.ts:107`, `executor.ts:136`
+- **Impact:** Abort is cooperative-only — long-running targets ignore it
+
+#### 3. `addResult` failure kills entire run
+
+`runsStore.addResult()` at `index.ts:170` is inside the p-map callback but has no try/catch. If storage throws, the error propagates to p-map, which aborts the entire run. A storage hiccup kills all remaining items.
+
+- **Location:** `index.ts:170-184`
+- **Impact:** Storage transient failure = total run failure, even though target execution succeeded
+
+#### 4. `generateLegacy` silent false success
+
+When `isSupportedLanguageModel()` returns `false` and `generateLegacy` is `undefined`, the optional chain `agent.generateLegacy?.()` returns `undefined`. This flows back as `{ output: undefined, error: null }` — a false success with no output.
+
+- **Location:** `executor.ts:111-114`
+- **Impact:** Items silently marked as succeeded with `undefined` output
+
+---
+
+### P1 — MEDIUM SEVERITY
+
+#### 5. Abort loses partial results
+
+When abort fires mid-run, the catch block (`index.ts:194-213`) updates the run status to `failed` in storage, then re-throws the `AbortError`. The caller receives an exception — not a `RunSummary`. Items that completed successfully before the abort are persisted individually via `addResult`, but the function returns nothing useful to the caller.
+
+- **Location:** `index.ts:194-213`
+- **Impact:** Caller gets no partial summary. Must reconstruct from storage.
+
+#### 6. Memory accumulation at scale
+
+`results: ItemWithScores[]` at `index.ts:112` grows unboundedly. All outputs are held in RAM until the function returns. Agent/workflow outputs can be large (full LLM responses with metadata).
+
+- **Location:** `index.ts:112`, `index.ts:187-190`
+- **Impact:** At 1000+ items with large outputs, significant heap pressure. At 10k+, risk of OOM.
+
+#### 7. No retry for transient failures
+
+`retryCount` is hardcoded to `0` at `index.ts:152`. The field exists in `ItemResult` but is never used. A transient LLM API error (rate limit, timeout, 503) permanently fails the item.
+
+- **Location:** `index.ts:152`, `types.ts:49`
+- **Impact:** Transient errors are treated as permanent. No recovery.
+
+#### 8. Sequential scorers per item
+
+Scorers run serially in a `for` loop at `scorer.ts:53`. Each scorer (often an LLM call) must complete before the next starts. With N scorers, each p-map slot is occupied N× longer than necessary.
+
+- **Location:** `scorer.ts:53-86`
+- **Impact:** 5 scorers × 100ms each = 500ms holding a concurrency slot. Effective throughput reduced by scorer count.
+
+#### 9. Run status logic — no partial failure
+
+`status = failedCount === items.length ? 'failed' : 'completed'` at `index.ts:217`. A run where 999/1000 items fail is marked `completed`.
+
+- **Location:** `index.ts:217`
+- **Impact:** Callers cannot distinguish clean success from nearly-total failure without inspecting individual results.
+
+#### 10. In-flight counter accuracy on abort
+
+When abort fires, items currently in-flight within p-map won't have incremented `succeededCount`/`failedCount`. The counts stored in the run record may be less than the actual completed items.
+
+- **Location:** `index.ts:136-139`, `index.ts:198-206`
+- **Impact:** Run record has inaccurate counts after abort.
+
+---
+
+### P2 — LOW SEVERITY
+
+#### 11. Results order is non-deterministic
+
+`results.push()` at `index.ts:187` appends in completion order, not input order. With concurrent execution, faster items appear first.
+
+- **Location:** `index.ts:187`
+- **Impact:** Consumers expecting input-order results will get wrong ordering.
+
+#### 12. Dynamic import of p-map on every call
+
+`await import('p-map')` at `index.ts:115` runs on every `runDataset` invocation. Minor overhead per call.
+
+- **Location:** `index.ts:115`
+- **Impact:** Negligible for most use cases. Could be hoisted.
+
+---
+
+## NOT AUDITED
+
+- Behavior when `getItemsByVersion` returns items with missing/malformed `input` fields
+- Side effects or performance of the `resolveTarget` fallback chain (`getAgentById` → `getAgent`)
+- Thread safety of `validateAndSaveScore` under concurrent writes
+- Behavior when `datasetsStore` and `runsStore` point to different storage backends
+
+---
+
+## TEST PLAN
+
+All tests use mock targets (no LLM calls). Mock agents/workflows/scorers with configurable delay, output size, and failure rate.
+
+### Mock Infrastructure
+
+| Component       | Mock                                                                   |
+| --------------- | ---------------------------------------------------------------------- |
+| `Mastra`        | `getStorage()`, `getAgentById()`, `getScorerById()`                    |
+| `Agent`         | `generate()` — configurable delay/response/failure                     |
+| `Workflow`      | `createRun()` returning mock run with `start()`                        |
+| `MastraScorer`  | `run()` — configurable delay/score/failure                             |
+| `runsStore`     | `createRun`, `updateRun`, `addResult` — spy-able, configurable failure |
+| `datasetsStore` | `getDatasetById`, `getItemsByVersion` — returns canned items           |
+
+### Tests by Issue
+
+#### T1 — Per-item timeout (Issue #1)
+
+- Mock target: hangs forever (never resolves)
+- 5 items, `maxConcurrency: 5`
+- No `AbortSignal` provided
+- **Expected:** run never completes (proves no timeout exists)
+- Use `Promise.race` with a test-level timeout to avoid hanging the test suite
+
+#### T2 — AbortSignal not forwarded (Issue #2)
+
+- Mock target: takes 5 seconds, checks no signal internally
+- 1 item
+- Abort after 100ms
+- **Expected:** item is NOT interrupted. Abort only checked before next item starts.
+- Verify `executeTarget` completes its full 5s despite abort
+
+#### T3 — `addResult` failure kills run (Issue #3)
+
+- Mock target: always succeeds
+- Mock `runsStore.addResult`: throws on 3rd call
+- 10 items, `maxConcurrency: 1` (sequential for determinism)
+- **Expected:** run fails after item 3. Items 4-10 never execute.
+- Verify `updateRun` called with `status: 'failed'`
+
+#### T4 — `generateLegacy` silent undefined (Issue #4)
+
+- Mock agent: `isSupportedLanguageModel()` returns false, no `generateLegacy` method
+- Call `executeTarget(agent, 'agent', item)`
+- **Expected:** `{ output: undefined, error: null }` — false success
+
+#### T5 — Abort loses partial results (Issue #5)
+
+- Mock target: 100ms per item
+- 20 items, `maxConcurrency: 5`
+- Abort after 250ms
+- **Expected:** function throws `AbortError`. No `RunSummary` returned.
+- Verify `addResult` was called for completed items (data exists in storage)
+- Verify caller gets zero usable data from the thrown error
+
+#### T6 — Memory accumulation (Issue #6)
+
+- Mock target: returns 1MB string per item
+- 500 items, `maxConcurrency: 50`
+- Snapshot `process.memoryUsage().heapUsed` before and after
+- **Expected:** heap delta > 500MB (all outputs held simultaneously)
+
+#### T7 — No retry (Issue #7)
+
+- Mock target: fails on first call per item, succeeds on retry
+- Track call count per item via `Map`
+- 10 items
+- **Expected:** all 10 fail. Each item called exactly once. `retryCount` is 0.
+
+#### T8 — Sequential scorers bottleneck (Issue #8)
+
+- Mock target: 0ms
+- 3 mock scorers: 100ms each
+- 20 items, `maxConcurrency: 20`
+- Measure wall clock with scorers vs without
+- **Expected:** ~300ms with scorers (serial), ~0ms without. Ratio proves bottleneck.
+
+#### T9 — Status logic (Issue #9)
+
+- Mock target: fails 99 out of 100 items
+- **Expected:** `status === 'completed'` despite 99% failure rate
+
+#### T10 — Results ordering (Issue #11)
+
+- Mock target: item 0 = 200ms, item 1 = 50ms, item 2 = 10ms
+- `maxConcurrency: 3`
+- **Expected:** `results[0].itemId` is item 2 (fastest), not item 0
+
+#### T11 — Backpressure from slow storage (Issue #3 related)
+
+- Mock target: 10ms
+- Mock `addResult`: 500ms
+- 50 items, `maxConcurrency: 10`
+- **Expected:** wall clock ~2500ms (dominated by storage, not execution)
+- Compare against 0ms storage: ~50ms. Ratio ~50x proves storage is in hot path.

--- a/packages/core/src/datasets/run/__tests__/p0-regression.test.ts
+++ b/packages/core/src/datasets/run/__tests__/p0-regression.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Agent } from '../../../agent';
+import type { Mastra } from '../../../mastra';
+import type { MastraCompositeStore, StorageDomains } from '../../../storage/base';
+import { DatasetsInMemory } from '../../../storage/domains/datasets/inmemory';
+import { InMemoryDB } from '../../../storage/domains/inmemory-db';
+import { RunsInMemory } from '../../../storage/domains/runs/inmemory';
+import { executeTarget } from '../executor';
+import { runDataset } from '../index';
+
+// Mock isSupportedLanguageModel at module level
+vi.mock('../../../agent', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    isSupportedLanguageModel: vi.fn().mockReturnValue(true),
+  };
+});
+
+// Import after mock setup
+// eslint-disable-next-line import/order
+import { isSupportedLanguageModel } from '../../../agent';
+
+// Helper: mock agent with configurable delay
+const createMockAgent = (opts: { delayMs?: number; shouldFail?: boolean; response?: string } = {}): Agent => {
+  const { delayMs = 0, shouldFail = false, response = 'ok' } = opts;
+  return {
+    id: 'test-agent',
+    name: 'Test Agent',
+    getModel: vi.fn().mockResolvedValue({ specificationVersion: 'v2' }),
+    generate: vi.fn().mockImplementation(async () => {
+      if (delayMs > 0) await new Promise(r => setTimeout(r, delayMs));
+      if (shouldFail) throw new Error('Agent error');
+      return { text: response };
+    }),
+  } as unknown as Agent;
+};
+
+// Shared test infrastructure
+let db: InMemoryDB;
+let datasetsStorage: DatasetsInMemory;
+let runsStorage: RunsInMemory;
+let mockStorage: MastraCompositeStore;
+let mastra: Mastra;
+let datasetId: string;
+
+async function setupDataset(itemCount: number) {
+  db = new InMemoryDB();
+  datasetsStorage = new DatasetsInMemory({ db });
+  runsStorage = new RunsInMemory({ db });
+
+  const dataset = await datasetsStorage.createDataset({
+    name: 'P0 Test Dataset',
+    description: 'Regression',
+  });
+  datasetId = dataset.id;
+
+  for (let i = 0; i < itemCount; i++) {
+    await datasetsStorage.addItem({
+      datasetId: dataset.id,
+      input: { prompt: `item-${i}` },
+      expectedOutput: null,
+    });
+  }
+
+  mockStorage = {
+    id: 'test-storage',
+    stores: {
+      datasets: datasetsStorage,
+      runs: runsStorage,
+    } as unknown as StorageDomains,
+    getStore: vi.fn().mockImplementation(async (name: keyof StorageDomains) => {
+      if (name === 'datasets') return datasetsStorage;
+      if (name === 'runs') return runsStorage;
+      return undefined;
+    }),
+  } as unknown as MastraCompositeStore;
+}
+
+function setupMastra(agent: Agent) {
+  mastra = {
+    getStorage: vi.fn().mockReturnValue(mockStorage),
+    getAgent: vi.fn().mockReturnValue(agent),
+    getAgentById: vi.fn().mockReturnValue(agent),
+    getScorerById: vi.fn(),
+    getWorkflowById: vi.fn(),
+    getWorkflow: vi.fn(),
+  } as unknown as Mastra;
+}
+
+describe('P0 Regression', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isSupportedLanguageModel).mockReturnValue(true);
+  });
+
+  // T-A: Abort returns partial summary (not throw)
+  describe('Bug A: Abort returns partial summary', () => {
+    it('resolves with partial RunSummary when aborted mid-run', async () => {
+      await setupDataset(10);
+      const agent = createMockAgent({ delayMs: 200 });
+      setupMastra(agent);
+
+      const controller = new AbortController();
+
+      // Abort after ~300ms — some items should have completed
+      setTimeout(() => controller.abort(), 300);
+
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        maxConcurrency: 2,
+        signal: controller.signal,
+      });
+
+      // Must resolve, not reject
+      expect(result).toBeDefined();
+      expect(result.status).toBe('failed');
+      expect(result.results.length).toBeGreaterThan(0);
+      expect(result.results.length).toBeLessThan(10);
+      expect(result.succeededCount + result.failedCount).toBe(result.results.length);
+    });
+  });
+
+  // T-B: generateLegacy missing → explicit error
+  describe('Bug B: generateLegacy silent false success', () => {
+    it('returns error when generateLegacy is not available', async () => {
+      vi.mocked(isSupportedLanguageModel).mockReturnValue(false);
+
+      // Agent WITHOUT generateLegacy
+      const agent = {
+        id: 'no-legacy-agent',
+        name: 'No Legacy Agent',
+        getModel: vi.fn().mockResolvedValue({ specificationVersion: 'v1' }),
+        generate: vi.fn(),
+      } as unknown as Agent;
+
+      const item = {
+        id: 'item-1',
+        datasetId: 'ds-1',
+        input: 'test input',
+        expectedOutput: null,
+        version: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const result = await executeTarget(agent, 'agent', item);
+
+      expect(result.output).toBeNull();
+      expect(result.error).toBeTruthy();
+      expect(result.error).toContain('generateLegacy');
+    });
+  });
+
+  // T-C: Per-item timeout
+  describe('Bug C: Per-item timeout', () => {
+    it('times out hanging items without blocking the run', { timeout: 5000 }, async () => {
+      await setupDataset(2);
+
+      // Agent that never resolves
+      const hangingAgent = {
+        id: 'hanging-agent',
+        name: 'Hanging Agent',
+        getModel: vi.fn().mockResolvedValue({ specificationVersion: 'v2' }),
+        generate: vi.fn().mockImplementation(() => new Promise(() => {})),
+      } as unknown as Agent;
+
+      setupMastra(hangingAgent);
+
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'hanging-agent',
+        maxConcurrency: 2,
+        itemTimeout: 100,
+      });
+
+      expect(result).toBeDefined();
+      expect(result.failedCount).toBe(2);
+      expect(result.succeededCount).toBe(0);
+      // Each item should have a timeout-related error
+      for (const item of result.results) {
+        expect(item.error).toBeTruthy();
+        expect(item.error!.toLowerCase()).toContain('timeout');
+      }
+    });
+  });
+
+  // T-D: AbortSignal forwarded to agent.generate()
+  describe('Bug D: AbortSignal forwarded to agent', () => {
+    it('passes abortSignal to agent.generate() options', async () => {
+      await setupDataset(1);
+
+      const generateSpy = vi.fn().mockResolvedValue({ text: 'ok' });
+      const agent = {
+        id: 'spy-agent',
+        name: 'Spy Agent',
+        getModel: vi.fn().mockResolvedValue({ specificationVersion: 'v2' }),
+        generate: generateSpy,
+      } as unknown as Agent;
+
+      setupMastra(agent);
+
+      const controller = new AbortController();
+
+      await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'spy-agent',
+        signal: controller.signal,
+      });
+
+      expect(generateSpy).toHaveBeenCalledTimes(1);
+      const callArgs = generateSpy.mock.calls[0];
+      // Second arg should contain abortSignal
+      expect(callArgs[1]).toHaveProperty('abortSignal');
+      expect(callArgs[1].abortSignal).toBeInstanceOf(AbortSignal);
+    });
+  });
+
+  // T-E: addResult failure doesn't kill run
+  describe('Bug E: addResult failure is non-fatal', () => {
+    it('completes run even when storage addResult throws', async () => {
+      await setupDataset(3);
+      const agent = createMockAgent({ response: 'success' });
+      setupMastra(agent);
+
+      // Override runsStorage.addResult to throw
+      runsStorage.addResult = vi.fn().mockRejectedValue(new Error('DB down'));
+
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        maxConcurrency: 1,
+      });
+
+      expect(result).toBeDefined();
+      expect(result.status).toBe('completed');
+      expect(result.succeededCount).toBe(3);
+      expect(result.results.length).toBe(3);
+
+      // Verify addResult was attempted
+      expect(runsStorage.addResult).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/packages/core/src/datasets/run/__tests__/runDataset.test.ts
+++ b/packages/core/src/datasets/run/__tests__/runDataset.test.ts
@@ -298,20 +298,23 @@ describe('runDataset', () => {
   });
 
   describe('cancellation', () => {
-    it('respects AbortSignal', async () => {
+    it('respects AbortSignal and returns partial summary', async () => {
       const controller = new AbortController();
 
       // Abort immediately
       controller.abort();
 
-      await expect(
-        runDataset(mastra, {
-          datasetId,
-          targetType: 'agent',
-          targetId: 'test-agent',
-          signal: controller.signal,
-        }),
-      ).rejects.toThrow('Aborted');
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        signal: controller.signal,
+      });
+
+      // Should resolve with failed status, not reject
+      expect(result.status).toBe('failed');
+      expect(result.results).toHaveLength(0);
+      expect(result.totalItems).toBe(2);
     });
   });
 

--- a/packages/core/src/datasets/run/types.ts
+++ b/packages/core/src/datasets/run/types.ts
@@ -19,6 +19,8 @@ export interface RunConfig {
   maxConcurrency?: number;
   /** AbortSignal for cancellation */
   signal?: AbortSignal;
+  /** Per-item execution timeout in milliseconds. Default: no timeout. */
+  itemTimeout?: number;
   /** Pre-created run ID (for async trigger - skips run creation) */
   runId?: string;
 }

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -71,12 +71,6 @@ const mainNavigation: NavSection[] = [
         isOnMastraPlatform: true,
       },
       {
-        name: 'Datasets',
-        url: '/datasets',
-        icon: <DatabaseIcon />,
-        isOnMastraPlatform: false,
-      },
-      {
         name: 'Workspaces',
         url: '/workspaces',
         icon: <FolderIcon />,
@@ -98,6 +92,12 @@ const mainNavigation: NavSection[] = [
         url: '/observability',
         icon: <EyeIcon />,
         isOnMastraPlatform: true,
+      },
+      {
+        name: 'Datasets',
+        url: '/datasets',
+        icon: <DatabaseIcon />,
+        isOnMastraPlatform: false,
       },
     ],
   },


### PR DESCRIPTION
## Summary

Fixes 5 P0 bugs in the dataset run executor identified during audit.

| Bug | Fix |
|-----|-----|
| **A** Abort loses partial results | `runDataset` returns partial `RunSummary` with `status: 'failed'` instead of throwing |
| **B** `generateLegacy` silent false success | Explicit error when method is missing |
| **C** No per-item timeout | `RunConfig.itemTimeout` — uses `AbortSignal.timeout()` + `AbortSignal.any()` |
| **D** AbortSignal not forwarded to agent | `abortSignal` passed to `agent.generate()` options |
| **E** `addResult` failure kills entire run | Storage errors caught + warned, run continues |

## Files Changed

| File | Change |
|------|--------|
| `executor.ts` | Signal param, `abortSignal` forwarding, `generateLegacy` null check, `raceWithSignal` helper |
| `index.ts` | Abort returns partial summary, `addResult` try/catch, per-item timeout signal composition |
| `types.ts` | Added `itemTimeout?: number` to `RunConfig` |
| `runDataset.test.ts` | Updated abort test to expect partial summary |
| `p0-regression.test.ts` | **NEW** — 5 regression tests (mock agents, no LLM calls) |
| `AUDIT.md`, `AUDIT-MC.md` | Audit documents |

## Breaking Change

**Abort semantics**: `runDataset` no longer throws on abort — it resolves with `{ status: 'failed', results: [...partial] }`. Callers catching `AbortError` should check `result.status` instead.

## Known Limitation

`workflow.start()` does not accept an `AbortSignal`. Per-item timeout still works (the item fails), but the in-flight workflow execution runs to completion in the background.

## Test Plan

```bash
cd packages/core && pnpm vitest run src/datasets/run/__tests__/
```

All 36 tests pass (31 existing + 5 new regression tests).