### PR TITLE
feat: add clone agent feature

### DIFF
--- a/.changeset/clone-agent-feature.md
+++ b/.changeset/clone-agent-feature.md
@@ -5,6 +5,14 @@
 '@mastra/playground-ui': minor
 ---
 
-Add clone agent feature. Code-defined or stored agents can be cloned into new stored agents via `POST /agents/:agentId/clone`. The clone serializes the agent's resolved config (model, instructions, tools, workflows, memory, etc.) using the provided `requestContext` and saves it as a new stored agent.
+Add clone agent feature. Code-defined or stored agents can be cloned into new stored agents via a "Clone" button in the playground or the client SDK:
 
-Also replaces `@sindresorhus/slugify` in `@mastra/server` with a lightweight inline `toSlug` helper to avoid ESM-only transitive dependency issues in dev mode.
+```ts
+const client = new MastraClient();
+const cloned = await client.getAgent('my-agent').clone({
+  newName: 'My Agent Copy',
+  requestContext: { workspace: 'dev' },
+});
+```
+
+The clone serializes the agent's full resolved configuration — model, instructions, tools, workflows, sub-agents, memory, input/output processors, and scorers — using the caller's `requestContext` and persists it as a new stored agent.

--- a/.changeset/clone-agent-feature.md
+++ b/.changeset/clone-agent-feature.md
@@ -1,0 +1,10 @@
+---
+'@mastra/core': minor
+'@mastra/server': minor
+'@mastra/client-js': minor
+'@mastra/playground-ui': minor
+---
+
+Add clone agent feature. Code-defined or stored agents can be cloned into new stored agents via `POST /agents/:agentId/clone`. The clone serializes the agent's resolved config (model, instructions, tools, workflows, memory, etc.) using the provided `requestContext` and saves it as a new stored agent.
+
+Also replaces `@sindresorhus/slugify` in `@mastra/server` with a lightweight inline `toSlug` helper to avoid ESM-only transitive dependency issues in dev mode.

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -30,6 +30,8 @@ import type {
   ReorderModelListParams,
   NetworkStreamParams,
   StreamParamsBaseWithoutMessages,
+  CloneAgentParams,
+  StoredAgentResponse,
 } from '../types';
 
 import { parseClientRequestContext, requestContextQueryString } from '../utils';
@@ -200,6 +202,22 @@ export class Agent extends BaseResource {
     return this.request(`/agents/${this.agentId}/instructions/enhance`, {
       method: 'POST',
       body: { instructions, comment },
+    });
+  }
+
+  /**
+   * Clones this agent to a new stored agent in the database
+   * @param params - Clone parameters including optional newId, newName, metadata, authorId, and requestContext
+   * @returns Promise containing the created stored agent
+   */
+  clone(params?: CloneAgentParams): Promise<StoredAgentResponse> {
+    const { requestContext, ...rest } = params || {};
+    return this.request(`/agents/${this.agentId}/clone`, {
+      method: 'POST',
+      body: {
+        ...rest,
+        requestContext: parseClientRequestContext(requestContext),
+      },
     });
   }
 

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -767,6 +767,22 @@ export interface ListStoredAgentsResponse {
 }
 
 /**
+ * Parameters for cloning an agent to a stored agent
+ */
+export interface CloneAgentParams {
+  /** ID for the cloned agent. If not provided, derived from agent ID. */
+  newId?: string;
+  /** Name for the cloned agent. Defaults to "{name} (Clone)". */
+  newName?: string;
+  /** Additional metadata for the cloned agent. */
+  metadata?: Record<string, unknown>;
+  /** Author identifier for the cloned agent. */
+  authorId?: string;
+  /** Request context for resolving dynamic agent configuration (instructions, model, tools, etc.) */
+  requestContext?: RequestContext | Record<string, any>;
+}
+
+/**
  * Parameters for creating a stored agent.
  * Flat union of agent-record fields and config fields.
  */

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -45,6 +45,12 @@ import { SkillsProcessor } from '../processors/processors/skills';
 import type { ProcessorState } from '../processors/runner';
 import { ProcessorRunner } from '../processors/runner';
 import { RequestContext, MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../request-context';
+import type {
+  StorageCreateAgentInput,
+  StorageDefaultOptions,
+  StorageModelConfig,
+  StorageResolvedAgentType,
+} from '../storage/types';
 import type { MastraAgentNetworkStream } from '../stream';
 import type { FullOutput, MastraModelOutput } from '../stream/base/output';
 import { createTool } from '../tools';
@@ -1459,6 +1465,197 @@ export class Agent<
   __resetToOriginalModel() {
     this.model = Array.isArray(this.#originalModel) ? [...this.#originalModel] : this.#originalModel;
     this.logger.debug(`[Agents:${this.name}] Model reset to original.`, { model: this.model, name: this.name });
+  }
+
+  /**
+   * Clones this agent's configuration to storage, creating a stored agent that behaves identically.
+   * The cloned agent will have source='stored' when loaded from storage.
+   *
+   * @param options - Options for the clone operation
+   * @param options.newId - The ID for the cloned stored agent. Required.
+   * @param options.newName - Optional new name. Defaults to "{originalName} (Clone)".
+   * @param options.metadata - Optional metadata for the stored agent.
+   * @param options.authorId - Optional author ID for the stored agent.
+   * @returns The StorageResolvedAgentType of the created stored agent.
+   *
+   * @example
+   * ```typescript
+   * const cloned = await agent.cloneAgent({
+   *   newId: 'my-agent-clone',
+   *   newName: 'My Agent Clone',
+   * });
+   * console.log(cloned.id); // 'my-agent-clone'
+   * ```
+   */
+  public async cloneAgent(options: {
+    newId: string;
+    newName?: string;
+    metadata?: Record<string, unknown>;
+    authorId?: string;
+    requestContext?: RequestContext;
+  }): Promise<StorageResolvedAgentType> {
+    const requestContext = options.requestContext ?? new RequestContext();
+
+    // 1. Get the mastra instance
+    const mastra = this.getMastraInstance();
+    if (!mastra) {
+      const mastraError = new MastraError({
+        id: 'AGENT_CLONE_MISSING_MASTRA',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        details: {
+          agentName: this.name,
+        },
+        text: `[Agent:${this.name}] - Cannot clone agent without a registered Mastra instance.`,
+      });
+      this.logger.trackException(mastraError);
+      this.logger.error(mastraError.toString());
+      throw mastraError;
+    }
+
+    // 2. Get storage and agents store
+    const storage = mastra.getStorage();
+    if (!storage) {
+      const mastraError = new MastraError({
+        id: 'AGENT_CLONE_MISSING_STORAGE',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        details: {
+          agentName: this.name,
+        },
+        text: `[Agent:${this.name}] - Cannot clone agent without storage configured on the Mastra instance.`,
+      });
+      this.logger.trackException(mastraError);
+      this.logger.error(mastraError.toString());
+      throw mastraError;
+    }
+
+    const agentsStore = await storage.getStore('agents');
+    if (!agentsStore) {
+      const mastraError = new MastraError({
+        id: 'AGENT_CLONE_MISSING_AGENTS_STORE',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        details: {
+          agentName: this.name,
+        },
+        text: `[Agent:${this.name}] - Cannot clone agent: agents storage domain is not available.`,
+      });
+      this.logger.trackException(mastraError);
+      this.logger.error(mastraError.toString());
+      throw mastraError;
+    }
+
+    // 3. Extract model config via getLLM (resolve dynamic model with requestContext)
+    const llm = await this.getLLM({ requestContext });
+    const provider = llm.getProvider();
+    const modelId = llm.getModelId();
+
+    // Extract model settings from default options (resolve dynamic defaultOptions with requestContext)
+    const defaultOptions = await this.getDefaultOptions({ requestContext });
+    const modelSettings = (defaultOptions as Record<string, any>)?.modelSettings;
+
+    const model: StorageModelConfig = {
+      provider,
+      name: modelId,
+      ...(modelSettings?.temperature !== undefined && { temperature: modelSettings.temperature }),
+      ...(modelSettings?.topP !== undefined && { topP: modelSettings.topP }),
+      ...(modelSettings?.frequencyPenalty !== undefined && { frequencyPenalty: modelSettings.frequencyPenalty }),
+      ...(modelSettings?.presencePenalty !== undefined && { presencePenalty: modelSettings.presencePenalty }),
+      ...(modelSettings?.maxOutputTokens !== undefined && { maxCompletionTokens: modelSettings.maxOutputTokens }),
+    };
+
+    // 4. Extract instructions as string (resolve dynamic instructions with requestContext)
+    const instructions = await this.getInstructions({ requestContext });
+    let instructionsStr: string;
+    if (typeof instructions === 'string') {
+      instructionsStr = instructions;
+    } else if (Array.isArray(instructions)) {
+      instructionsStr = instructions
+        .map(msg => {
+          if (typeof msg === 'string') {
+            return msg;
+          }
+          return typeof msg.content === 'string' ? msg.content : '';
+        })
+        .filter(Boolean)
+        .join('\n\n');
+    } else if (instructions && typeof instructions === 'object' && 'content' in instructions) {
+      instructionsStr = typeof instructions.content === 'string' ? instructions.content : '';
+    } else {
+      instructionsStr = '';
+    }
+
+    // 5. Extract tool keys (resolve dynamic tools with requestContext)
+    const tools = await this.listTools({ requestContext });
+    const toolKeys = Object.keys(tools || {});
+
+    // 6. Extract workflow keys (resolve dynamic workflows with requestContext)
+    const workflows = await this.listWorkflows({ requestContext });
+    const workflowKeys = Object.keys(workflows || {});
+
+    // 7. Extract sub-agent keys (resolve dynamic agents with requestContext)
+    const agents = await this.listAgents({ requestContext });
+    const agentKeys = Object.keys(agents || {});
+
+    // 8. Extract memory config (resolve dynamic memory with requestContext)
+    const memory = await this.getMemory({ requestContext });
+    const memoryConfig = memory?.getConfig();
+
+    // 9. Extract default options (serializable parts only)
+    const storageDefaultOptions: StorageDefaultOptions | undefined = defaultOptions
+      ? {
+          maxSteps: (defaultOptions as Record<string, any>)?.maxSteps,
+          runId: (defaultOptions as Record<string, any>)?.runId,
+          savePerStep: (defaultOptions as Record<string, any>)?.savePerStep,
+          activeTools: (defaultOptions as Record<string, any>)?.activeTools,
+          toolChoice: (defaultOptions as Record<string, any>)?.toolChoice,
+          modelSettings: (defaultOptions as Record<string, any>)?.modelSettings,
+          returnScorerData: (defaultOptions as Record<string, any>)?.returnScorerData,
+          requireToolApproval: (defaultOptions as Record<string, any>)?.requireToolApproval,
+          autoResumeSuspendedTools: (defaultOptions as Record<string, any>)?.autoResumeSuspendedTools,
+          toolCallConcurrency: (defaultOptions as Record<string, any>)?.toolCallConcurrency,
+          maxProcessorRetries: (defaultOptions as Record<string, any>)?.maxProcessorRetries,
+          includeRawChunks: (defaultOptions as Record<string, any>)?.includeRawChunks,
+        }
+      : undefined;
+
+    // 10. Create the stored agent
+    const createInput: StorageCreateAgentInput = {
+      id: options.newId,
+      name: options.newName || `${this.name} (Clone)`,
+      description: this.getDescription() || undefined,
+      instructions: instructionsStr,
+      model,
+      tools: toolKeys.length > 0 ? toolKeys : undefined,
+      workflows: workflowKeys.length > 0 ? workflowKeys : undefined,
+      agents: agentKeys.length > 0 ? agentKeys : undefined,
+      memory: memoryConfig,
+      defaultOptions: storageDefaultOptions,
+      metadata: options.metadata,
+      authorId: options.authorId,
+    };
+
+    await agentsStore.createAgent({ agent: createInput });
+
+    const resolved = await agentsStore.getAgentByIdResolved({ id: options.newId });
+    if (!resolved) {
+      const mastraError = new MastraError({
+        id: 'AGENT_CLONE_FAILED_TO_RESOLVE',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        details: {
+          agentName: this.name,
+          cloneId: options.newId,
+        },
+        text: `[Agent:${this.name}] - Failed to resolve cloned agent '${options.newId}' after creation.`,
+      });
+      this.logger.trackException(mastraError);
+      this.logger.error(mastraError.toString());
+      throw mastraError;
+    }
+
+    return resolved;
   }
 
   reorderModels(modelIds: string[]) {

--- a/packages/playground-ui/src/domains/agents/components/agent-entity-header.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-entity-header.tsx
@@ -1,6 +1,6 @@
 import { EntityHeader } from '@/ds/components/EntityHeader';
 import { Badge } from '@/ds/components/Badge';
-import { CopyIcon, Pencil } from 'lucide-react';
+import { CopyIcon, Pencil, CopyPlus } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/ds/components/Tooltip';
 import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 import { AgentIcon } from '@/ds/icons/AgentIcon';
@@ -9,6 +9,7 @@ import { useLinkComponent } from '@/lib/framework';
 import { Truncate } from '@/ds/components/Truncate';
 import { AgentSourceIcon } from './agent-source-icon';
 import { useIsCmsAvailable } from '@/domains/cms';
+import { useCloneAgent } from '../hooks/use-clone-agent';
 
 export interface AgentEntityHeaderProps {
   agentId: string;
@@ -19,10 +20,18 @@ export const AgentEntityHeader = ({ agentId }: AgentEntityHeaderProps) => {
   const { handleCopy } = useCopyToClipboard({ text: agentId });
   const { isCmsAvailable } = useIsCmsAvailable();
   const { navigate } = useLinkComponent();
+  const { cloneAgent, isCloning } = useCloneAgent();
   const agentName = agent?.name || '';
   const isStoredAgent = agent?.source === 'stored';
 
   const showStoredAgentBadge = isCmsAvailable && isStoredAgent;
+
+  const handleClone = async () => {
+    const clonedAgent = await cloneAgent(agentId);
+    if (clonedAgent?.id) {
+      navigate(`/agents/${clonedAgent.id}/chat`);
+    }
+  };
 
   return (
     <TooltipProvider>
@@ -57,6 +66,18 @@ export const AgentEntityHeader = ({ agentId }: AgentEntityHeaderProps) => {
               </button>
             </TooltipTrigger>
             <TooltipContent>Edit agent configuration</TooltipContent>
+          </Tooltip>
+        )}
+        {isCmsAvailable && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button onClick={handleClone} disabled={isCloning} className="h-badge-default shrink-0 ml-2">
+                <Badge icon={<CopyPlus />} variant="default">
+                  {isCloning ? 'Cloning...' : 'Clone'}
+                </Badge>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Clone agent to a new stored agent</TooltipContent>
           </Tooltip>
         )}
       </EntityHeader>

--- a/packages/playground-ui/src/domains/agents/hooks/use-clone-agent.ts
+++ b/packages/playground-ui/src/domains/agents/hooks/use-clone-agent.ts
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { useMastraClient } from '@mastra/react';
+import { useQueryClient } from '@tanstack/react-query';
+import { usePlaygroundStore } from '@/store/playground-store';
+import { toast } from '@/lib/toast';
+
+export const useCloneAgent = () => {
+  const client = useMastraClient();
+  const queryClient = useQueryClient();
+  const { requestContext } = usePlaygroundStore();
+  const [isCloning, setIsCloning] = useState(false);
+
+  const cloneAgent = async (agentId: string) => {
+    setIsCloning(true);
+    try {
+      const result = await client.getAgent(agentId).clone({ requestContext });
+      // Invalidate agent lists so the cloned agent appears
+      queryClient.invalidateQueries({ queryKey: ['agents'] });
+      queryClient.invalidateQueries({ queryKey: ['stored-agents'] });
+      toast.success(`Agent cloned successfully`);
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to clone agent';
+      toast.error(message);
+      return null;
+    } finally {
+      setIsCloning(false);
+    }
+  };
+
+  return { cloneAgent, isCloning };
+};

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -120,7 +120,6 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@sindresorhus/slugify": "^2.2.1",
     "hono": "^4.11.3"
   }
 }

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -47,6 +47,8 @@ import type { ServerRoute } from '../server-adapter/routes';
 import { createRoute } from '../server-adapter/routes/route-builder';
 import type { Context } from '../types';
 
+import { toSlug } from '../utils';
+
 import { handleError } from './error';
 import {
   sanitizeBody,
@@ -832,7 +834,7 @@ export const CLONE_AGENT_ROUTE = createRoute({
     try {
       const agent = await getAgentFromSystem({ mastra, agentId });
 
-      const cloneId = newId || `${agentId}-clone`;
+      const cloneId = toSlug(newId || `${agentId}-clone`);
 
       const result = await agent.cloneAgent({
         newId: cloneId,

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -41,6 +41,7 @@ import {
   approveNetworkToolCallBodySchema,
   declineNetworkToolCallBodySchema,
 } from '../schemas/agents';
+import { createStoredAgentResponseSchema } from '../schemas/stored-agents';
 import { getAgentSkillResponseSchema } from '../schemas/workspace';
 import type { ServerRoute } from '../server-adapter/routes';
 import { createRoute } from '../server-adapter/routes/route-builder';
@@ -804,6 +805,46 @@ export const GET_AGENT_BY_ID_ROUTE = createRoute({
       return result;
     } catch (error) {
       return handleError(error, 'Error getting agent');
+    }
+  },
+});
+
+/**
+ * POST /agents/:agentId/clone - Clone an agent to a stored agent
+ */
+export const CLONE_AGENT_ROUTE = createRoute({
+  method: 'POST',
+  path: '/agents/:agentId/clone',
+  responseType: 'json',
+  pathParamSchema: agentIdPathParams,
+  bodySchema: z.object({
+    newId: z.string().optional().describe('ID for the cloned agent. If not provided, derived from agent ID.'),
+    newName: z.string().optional().describe('Name for the cloned agent. Defaults to "{name} (Clone)".'),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+    authorId: z.string().optional(),
+  }),
+  responseSchema: createStoredAgentResponseSchema,
+  summary: 'Clone agent',
+  description: 'Clones a code-defined or stored agent to a new stored agent in the database',
+  tags: ['Agents'],
+  requiresAuth: true,
+  handler: async ({ agentId, mastra, newId, newName, metadata, authorId, requestContext }) => {
+    try {
+      const agent = await getAgentFromSystem({ mastra, agentId });
+
+      const cloneId = newId || `${agentId}-clone`;
+
+      const result = await agent.cloneAgent({
+        newId: cloneId,
+        newName,
+        metadata,
+        authorId,
+        requestContext,
+      });
+
+      return result;
+    } catch (error) {
+      return handleError(error, 'Error cloning agent');
     }
   },
 });

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -1,5 +1,3 @@
-import slugify from '@sindresorhus/slugify';
-
 import { HTTPException } from '../http-exception';
 import {
   storedAgentIdPathParams,
@@ -15,6 +13,7 @@ import {
   previewInstructionsResponseSchema,
 } from '../schemas/stored-agents';
 import { createRoute } from '../server-adapter/routes/route-builder';
+import { toSlug } from '../utils';
 
 import { handleAutoVersioning } from './agent-versions';
 import { handleError } from './error';
@@ -150,7 +149,7 @@ export const CREATE_STORED_AGENT_ROUTE = createRoute({
       }
 
       // Derive ID from name if not explicitly provided
-      const id = providedId || slugify(name);
+      const id = providedId || toSlug(name);
 
       if (!id) {
         throw new HTTPException(400, {

--- a/packages/server/src/server/server-adapter/routes/agents.ts
+++ b/packages/server/src/server/server-adapter/routes/agents.ts
@@ -2,6 +2,7 @@ import {
   // Agent route objects
   LIST_AGENTS_ROUTE,
   GET_AGENT_BY_ID_ROUTE,
+  CLONE_AGENT_ROUTE,
   GENERATE_AGENT_ROUTE,
   GENERATE_AGENT_VNEXT_ROUTE,
   STREAM_GENERATE_ROUTE,
@@ -43,6 +44,7 @@ export const AGENTS_ROUTES: ServerRoute<any, any, any>[] = [
   LIST_AGENTS_ROUTE,
   GET_PROVIDERS_ROUTE,
   GET_AGENT_BY_ID_ROUTE,
+  CLONE_AGENT_ROUTE,
 
   // ============================================================================
   // Voice Routes

--- a/packages/server/src/server/utils.ts
+++ b/packages/server/src/server/utils.ts
@@ -228,6 +228,18 @@ export class WorkflowRegistry {
   }
 }
 
+/**
+ * Converts a string to a URL-friendly slug.
+ * Lowercases, replaces non-alphanumeric characters with hyphens,
+ * collapses consecutive hyphens, and trims leading/trailing hyphens.
+ */
+export function toSlug(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
 export function convertInstructionsToString(message: SystemMessage): string {
   if (!message) {
     return '';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3705,9 +3705,6 @@ importers:
 
   packages/server:
     dependencies:
-      '@sindresorhus/slugify':
-        specifier: ^2.2.1
-        version: 2.2.1
       hono:
         specifier: ^4.11.3
         version: 4.11.7


### PR DESCRIPTION
Adds the ability to clone any agent (code-defined or stored) into a new stored agent.

**Server**: `POST /agents/:agentId/clone` — serializes the agent's resolved config using the caller's `requestContext` and saves it as a new stored agent via the storage layer.

**Core**: `Agent.cloneAgent()` extracts model, instructions, tools, workflows, agents, memory, scorers, processors, and default options into a `StorageCreateAgentInput`.

**Client SDK**: `client.getAgent(id).clone({ requestContext })`

**Playground UI**: Clone button in the agent header (visible when CMS/editor is available). Navigates to the cloned agent on success.

Also replaces `@sindresorhus/slugify` in `@mastra/server` with a lightweight inline `toSlug()` helper — the ESM-only package wasn't resolvable at runtime in dev mode due to pnpm's strict dependency hoisting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent cloning: create a full copy of an existing agent with optional new name, ID, author, and metadata; cloned agents are ready-to-use.
  * One-click Clone button in the UI with loading state, success/error notifications, and automatic navigation to the cloned agent.
  * Clone available via client API/SDK for programmatic cloning.

* **Bug Fixes**
  * Improved agent ID generation when no explicit ID is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->