### PR TITLE
fix(datasets): P1 run executor improvements

### DIFF
--- a/packages/core/src/datasets/run/ARCHITECTURE.md
+++ b/packages/core/src/datasets/run/ARCHITECTURE.md
@@ -1,0 +1,227 @@
+# Dataset Run Executor — Architecture
+
+## High-Level Flow
+
+The main `runDataset` function orchestrates the entire run lifecycle: loading the dataset, resolving the target and scorers, then processing each item concurrently via `p-map`. Each item goes through an optional retry loop, scoring, and storage persistence before contributing to the final `RunSummary`. Abort and errors produce a partial summary instead of throwing.
+
+```mermaid
+flowchart TD
+    START([runDataset called]) --> PARSE[Parse RunConfig]
+    PARSE --> STORAGE[Get storage stores<br/>datasetsStore + runsStore]
+    STORAGE --> LOAD_DS[Load dataset + items<br/>by version]
+    LOAD_DS --> RESOLVE_T[Resolve target<br/>agent / workflow / scorer]
+    RESOLVE_T --> RESOLVE_S[Resolve scorers<br/>instances + string IDs]
+    RESOLVE_S --> CREATE_RUN[Create / update run record<br/>status → running]
+    CREATE_RUN --> PMAP
+
+    subgraph PMAP ["p-map  (maxConcurrency items in parallel)"]
+        direction TB
+        CHECK_ABORT{signal<br/>aborted?}
+        CHECK_ABORT -- Yes --> THROW_ABORT[throw AbortError]
+        CHECK_ABORT -- No --> COMPOSE_SIG[Compose per-item signal<br/>itemTimeout + run signal]
+        COMPOSE_SIG --> EXEC_TARGET
+
+        subgraph RETRY_LOOP ["Retry loop (up to maxRetries)"]
+            EXEC_TARGET[executeTarget] --> RESULT_CHECK{error<br/>returned?}
+            RESULT_CHECK -- No error --> EXIT_RETRY[break]
+            RESULT_CHECK -- Error --> TRANSIENT{isTransient<br/>Error?}
+            TRANSIENT -- No --> EXIT_RETRY
+            TRANSIENT -- Yes --> BACKOFF["wait: retryDelay × 2^attempt + jitter"]
+            BACKOFF --> RECHECK_ABORT{signal<br/>aborted?}
+            RECHECK_ABORT -- Yes --> EXIT_RETRY
+            RECHECK_ABORT -- No --> EXEC_TARGET
+        end
+
+        EXIT_RETRY --> COUNT{error?}
+        COUNT -- Yes --> FAIL_INC[failedCount++]
+        COUNT -- No --> SUCC_INC[succeededCount++]
+        FAIL_INC --> BUILD_ITEM[Build ItemResult]
+        SUCC_INC --> BUILD_ITEM
+        BUILD_ITEM --> RUN_SCORERS[runScorersForItem]
+        RUN_SCORERS --> PERSIST_RESULT[Persist to runsStore.addResult<br/>try/catch — non-fatal]
+        PERSIST_RESULT --> RETAIN{retainResults?}
+        RETAIN -- Yes --> STORE_MEM["results[index] = item + scores"]
+        RETAIN -- No --> SKIP_MEM[skip]
+    end
+
+    THROW_ABORT --> CATCH_BLOCK
+    PMAP -- all items done --> FINALIZE
+    PMAP -- fatal error / abort --> CATCH_BLOCK
+
+    subgraph CATCH_BLOCK [Abort / Error Path]
+        UPDATE_FAILED[Update run → failed]
+        UPDATE_FAILED --> CALC_SKIP_F[skippedCount = total − succeeded − failed]
+        CALC_SKIP_F --> RETURN_PARTIAL["Return RunSummary<br/>status: failed<br/>partial results"]
+    end
+
+    subgraph FINALIZE [Normal Completion]
+        CALC_STATUS{"failedCount<br/>== totalItems?"}
+        CALC_STATUS -- Yes --> STATUS_F[status: failed]
+        CALC_STATUS -- No --> STATUS_C[status: completed]
+        STATUS_F --> UPDATE_RUN[Update run in storage]
+        STATUS_C --> UPDATE_RUN
+        UPDATE_RUN --> CALC_SKIP_N[skippedCount = total − succeeded − failed]
+        CALC_SKIP_N --> CALC_CWE["completedWithErrors =<br/>completed && failedCount > 0"]
+        CALC_CWE --> RETURN_SUMMARY["Return RunSummary<br/>results in original order"]
+    end
+```
+
+## executeTarget Dispatch
+
+Routes a single dataset item to the correct executor (agent, workflow, or scorer). Handles the `raceWithSignal` guard that ensures per-item timeouts are enforced even when the target ignores the abort signal. All errors are caught and returned as `{ output: null, error }` — this function never throws.
+
+```mermaid
+flowchart TD
+    ET([executeTarget]) --> SIG_CHECK{signal<br/>aborted?}
+    SIG_CHECK -- Yes --> THROW[throw AbortError]
+    SIG_CHECK -- No --> SWITCH{targetType}
+
+    SWITCH -- agent --> AGENT[executeAgent]
+    SWITCH -- workflow --> WF[executeWorkflow]
+    SWITCH -- scorer --> SC[executeScorer]
+    SWITCH -- processor --> ERR[throw not supported]
+
+    AGENT --> RACE{signal<br/>provided?}
+    WF --> RACE
+    SC --> RACE
+
+    RACE -- Yes --> RACE_SIG["raceWithSignal(promise, signal)<br/>ensures timeout even if<br/>target ignores signal"]
+    RACE -- No --> AWAIT[await promise]
+
+    RACE_SIG --> RESULT[ExecutionResult]
+    AWAIT --> RESULT
+
+    THROW --> CATCH[catch → ExecutionResult<br/>output: null, error: message]
+    RESULT --> OUT([return])
+    CATCH --> OUT
+
+    subgraph AGENT_DETAIL [executeAgent]
+        direction TB
+        GET_MODEL[agent.getModel]
+        GET_MODEL --> MODEL_CHECK{isSupportedLanguageModel?}
+        MODEL_CHECK -- Yes --> GEN["agent.generate(input, {<br/>  scorers: {},<br/>  returnScorerData: true,<br/>  abortSignal: signal<br/>})"]
+        MODEL_CHECK -- No --> LEGACY["agent.generateLegacy?(input, ...)"]
+        LEGACY --> NULL_CHECK{result == null?}
+        NULL_CHECK -- Yes --> THROW_LEGACY[throw: no generateLegacy]
+        NULL_CHECK -- No --> EXTRACT
+        GEN --> EXTRACT[Extract traceId + scoringData]
+    end
+
+    subgraph WF_DETAIL [executeWorkflow]
+        direction TB
+        CREATE_RUN_WF["workflow.createRun({ disableScorers })"]
+        CREATE_RUN_WF --> START["run.start({ inputData })"]
+        START --> WF_STATUS{status}
+        WF_STATUS -- success --> WF_OK[output: result.result]
+        WF_STATUS -- failed --> WF_FAIL[error: message]
+        WF_STATUS -- tripwire --> WF_TRIP[error: tripwire reason]
+        WF_STATUS -- suspended --> WF_SUSP[error: not supported]
+        WF_STATUS -- paused --> WF_PAUSE[error: not supported]
+    end
+
+    subgraph SC_DETAIL [executeScorer]
+        direction TB
+        SC_RUN["scorer.run(item.input)"]
+        SC_RUN --> SC_VALIDATE{score is number<br/>and !NaN?}
+        SC_VALIDATE -- Yes --> SC_OK["output: { score, reason }"]
+        SC_VALIDATE -- No --> SC_WARN["warn + score: null"]
+    end
+```
+
+## Scorer Pipeline
+
+After each item is executed, its output is scored by all configured scorers **in parallel** via `Promise.allSettled`. Each scorer runs in isolation — one scorer failing doesn't affect the others. Score persistence to storage is best-effort (errors are warned, not thrown).
+
+```mermaid
+flowchart TD
+    START([runScorersForItem]) --> EMPTY{scorers<br/>empty?}
+    EMPTY -- Yes --> RETURN_EMPTY["return []"]
+    EMPTY -- No --> PARALLEL
+
+    subgraph PARALLEL ["Promise.allSettled (all scorers in parallel)"]
+        direction TB
+        S1["scorer₁"] --> SAFE1[runScorerSafe]
+        S2["scorer₂"] --> SAFE2[runScorerSafe]
+        SN["scorer_n"] --> SAFEN[runScorerSafe]
+
+        SAFE1 --> PERSIST1["validateAndSaveScore<br/>try/catch — best effort"]
+        SAFE2 --> PERSIST2["validateAndSaveScore<br/>try/catch — best effort"]
+        SAFEN --> PERSISTN["validateAndSaveScore<br/>try/catch — best effort"]
+    end
+
+    PARALLEL --> MAP_SETTLED["Map settled results:<br/>fulfilled → value<br/>rejected → { score: null, error }"]
+    MAP_SETTLED --> RETURN(["ScorerResult[]"])
+
+    subgraph SAFE ["runScorerSafe (per scorer)"]
+        direction TB
+        RUN["scorer.run({<br/>  input: scorerInput ?? item.input,<br/>  output: scorerOutput ?? output,<br/>  groundTruth: item.expectedOutput<br/>})"]
+        RUN --> EXTRACT_SCORE[Extract score + reason]
+        EXTRACT_SCORE --> VALIDATE{score is number?}
+        VALIDATE -- Yes --> OK[ScorerResult with score]
+        VALIDATE -- No --> NULL_SCORE[score: null]
+        RUN -- catch --> ERR_RESULT["ScorerResult<br/>score: null, error: message"]
+    end
+```
+
+## Signal & Timeout Composition
+
+Shows how the run-level `AbortSignal` and per-item `itemTimeout` are composed into a single signal per item. Uses `AbortSignal.timeout()` and `AbortSignal.any()` (Node ≥22.13). The composed signal is passed to `executeTarget` and ultimately to `agent.generate()` via `abortSignal`. Note: `workflow.start()` does not accept a signal — timeout is enforced externally via `raceWithSignal`.
+
+```mermaid
+flowchart LR
+    subgraph CONFIG [RunConfig]
+        RUN_SIGNAL["signal<br/>(run-level AbortSignal)"]
+        TIMEOUT["itemTimeout<br/>(milliseconds)"]
+    end
+
+    TIMEOUT --> TIMEOUT_SIG["AbortSignal.timeout(itemTimeout)"]
+
+    RUN_SIGNAL --> ANY{"both<br/>present?"}
+    TIMEOUT_SIG --> ANY
+
+    ANY -- Yes --> COMBINED["AbortSignal.any([signal, timeoutSignal])"]
+    ANY -- "signal only" --> PASS_SIG[use signal as-is]
+    ANY -- "timeout only" --> PASS_TIMEOUT[use timeoutSignal]
+    ANY -- neither --> NO_SIG[undefined]
+
+    COMBINED --> ITEM_SIG[itemSignal]
+    PASS_SIG --> ITEM_SIG
+    PASS_TIMEOUT --> ITEM_SIG
+    NO_SIG --> ITEM_SIG
+
+    ITEM_SIG --> ET["executeTarget(target, type, item, { signal: itemSignal })"]
+    ET --> RACE["raceWithSignal(promise, itemSignal)<br/>rejects on abort/timeout"]
+```
+
+## Data Flow
+
+End-to-end data shape from dataset input to `RunSummary` output. Each item flows through execution → scoring → dual persistence (storage + in-memory). The `retainResults` flag controls whether results accumulate in memory or are only persisted to storage, allowing large runs to avoid heap pressure.
+
+```mermaid
+flowchart LR
+    subgraph INPUT
+        DS[(Dataset)]
+        ITEMS["DatasetItem[]<br/>{ id, input, expectedOutput, version }"]
+    end
+
+    DS --> ITEMS
+    ITEMS --> PMAP["p-map<br/>(concurrent)"]
+
+    PMAP --> EXEC["executeTarget<br/>→ ExecutionResult<br/>{ output, error, traceId,<br/>scorerInput, scorerOutput }"]
+    EXEC --> SCORERS["runScorersForItem<br/>→ ScorerResult[]<br/>{ scorerId, score, reason, error }"]
+
+    SCORERS --> ITEM_RESULT["ItemWithScores<br/>= ItemResult + scores"]
+
+    ITEM_RESULT --> STORAGE_PATH["runsStore.addResult()<br/>(best-effort persist)"]
+    ITEM_RESULT --> MEM_PATH{"retainResults?"}
+    MEM_PATH -- true --> RESULTS["results[index]<br/>(ordered array)"]
+    MEM_PATH -- false --> DISCARD["discarded<br/>(use storage)"]
+
+    RESULTS --> SUMMARY
+    DISCARD --> SUMMARY
+
+    subgraph SUMMARY [RunSummary]
+        direction TB
+        S_FIELDS["runId, status, totalItems<br/>succeededCount, failedCount<br/>skippedCount, completedWithErrors<br/>startedAt, completedAt<br/>results: ItemWithScores[]"]
+    end
+```

--- a/packages/core/src/datasets/run/AUDIT.md
+++ b/packages/core/src/datasets/run/AUDIT.md
@@ -227,3 +227,15 @@ All tests use mock targets (no LLM calls). Mock agents/workflows/scorers with co
 - 50 items, `maxConcurrency: 10`
 - **Expected:** wall clock ~2500ms (dominated by storage, not execution)
 - Compare against 0ms storage: ~50ms. Ratio ~50x proves storage is in hot path.
+
+---
+
+## FOLLOW-UP WORK
+
+| Item                      | Description                                                                                                                       | Where                          |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| UI: `completedWithErrors` | Display partial failure badge/indicator in Playground run details                                                                 | `packages/playground-ui`       |
+| UI: `skippedCount`        | Show skipped item count in run summary view when abort occurs                                                                     | `packages/playground-ui`       |
+| Workflow abort            | `workflow.start()` does not accept `AbortSignal` — per-item timeout works but in-flight workflow runs to completion in background | `packages/core/src/workflows/` |
+| Memory: streaming results | `retainResults: false` is a workaround; true fix is streaming/paginated result delivery                                           | `index.ts`                     |
+| Dynamic p-map import      | `p-map` is dynamically imported on every `runDataset` call (P2)                                                                   | `index.ts:115`                 |

--- a/packages/core/src/datasets/run/P1-PLAN.md
+++ b/packages/core/src/datasets/run/P1-PLAN.md
@@ -1,0 +1,554 @@
+# P1 Dataset Run Executor: Test-first fixes
+
+## Overview
+
+Fix 5 P1 issues + 1 bonus P2 from both audit files (`AUDIT.md` + `AUDIT-MC.md`) using test-first. Write failing tests in a dedicated regression file, fix the code, verify. All tests use mock agents/workflows — no real LLM calls.
+
+**Prerequisite**: P0 fixes merged via PR #12789 targeting `feat/datasets`.
+
+---
+
+## P1 Bugs (deduplicated from both audits)
+
+| #   | Bug                                                          | File                                   | Line       | Priority |
+| --- | ------------------------------------------------------------ | -------------------------------------- | ---------- | -------- |
+| 6   | Memory accumulation — `results[]` grows unboundedly          | `index.ts:113`, `index.ts:199`         | P1         |
+| 7   | No retry for transient failures — `retryCount` always 0      | `index.ts:160`, `types.ts:51`          | P1         |
+| 8   | Sequential scorers per item — `for` loop blocks p-map slot   | `scorer.ts:53-86`                      | P1         |
+| 9   | Run status logic — no partial failure status                 | `index.ts:234`                         | P1         |
+| 10  | In-flight counter accuracy on abort — counts may be < actual | `index.ts:143-147`, `index.ts:206-218` | P1         |
+| 11  | Results order non-deterministic                              | `index.ts:199`                         | P2 (bonus) |
+
+### Deferred
+
+| #   | Bug                                | Reason                                  |
+| --- | ---------------------------------- | --------------------------------------- |
+| 12  | Dynamic p-map import on every call | Negligible impact, not worth the churn. |
+
+---
+
+## Complexity Estimate
+
+- **Size**: Medium (5 files modified, 1 new test file)
+- **Risk**: Low-Medium — mostly additive changes, `RunStatus` type not changed
+- **Dependencies**: None.
+
+---
+
+## Design Decisions
+
+### Issue 6 — Memory accumulation
+
+**Decision: Opt-in `retainResults: false` in `RunConfig`.**
+
+Adopted from the other agent's plan. Full streaming/pagination is too large a refactor for P1, but we can provide an escape hatch:
+
+- Default `true` — preserves current behavior, no breaking change
+- When `false`, `results[]` stays empty. Counters (`succeededCount`, `failedCount`) still work. Storage persistence still works.
+- Callers using `retainResults: false` must rely on `runsStore` for result retrieval instead of `RunSummary.results`.
+- The `RunSummary.results` type stays `ItemWithScores[]` — it's just an empty array when `false`.
+
+### Issue 7 — Retry logic
+
+**Decision: Implement retry with configurable `maxRetries` in `RunConfig`.**
+
+- Default: `0` (no retry, current behavior preserved)
+- Only retry on transient errors (timeout, rate limit, 5xx, connection errors)
+- `retryCount` in `ItemResult` reflects actual retries attempted
+- Exponential backoff with jitter: `retryDelay * 2^attempt + random(0, retryDelay/2)` — prevents thundering herd when multiple runs hit the same API
+- `retryDelay` configurable, default `1000ms`
+- Re-check `signal?.aborted` after each delay — don't retry if aborted
+
+### Issue 8 — Parallel scorers
+
+**Decision: Replace `for` loop with `Promise.allSettled`.**
+
+- `runScorerSafe` already catches errors, so `allSettled` always has `fulfilled` results
+- Score persistence order becomes non-deterministic (within a single item) — acceptable since scores are keyed by `scorerId`
+- Output `ScorerResult[]` order matches input `scorers[]` order via index mapping
+
+### Issue 9 — Run status logic
+
+**Decision: Keep `RunStatus` type as-is** (`'pending' | 'running' | 'completed' | 'failed'` at `packages/core/src/storage/types.ts:914`). Adding a new status requires storage schema migration + updating every storage adapter + client SDK types + playground UI.
+
+Instead, add `completedWithErrors: boolean` to `RunSummary`:
+
+- `true` when `status === 'completed' && failedCount > 0`
+- Callers can distinguish clean success from partial failure without breaking existing `RunStatus` checks
+- No storage migration. No adapter changes. No UI changes required (but UI can optionally render it).
+
+### Issue 10 — Counter accuracy on abort
+
+**Decision: Add `skippedCount` to `RunSummary`.**
+
+- `skippedCount = totalItems - succeededCount - failedCount`
+- Items mid-execution when abort fired never increment either counter — they are "skipped"
+- Invariant: `succeededCount + failedCount + skippedCount === totalItems`
+- NOT persisted to storage (no schema change needed). Computed from existing counters.
+
+### Issue 11 — Results ordering
+
+**Decision: Use pre-allocated array indexed by original position.**
+
+- p-map passes `index` as second callback arg
+- `results[index] = itemResult` instead of `results.push(itemResult)`
+- On abort, incomplete items are `undefined` → filtered out
+- No sort needed, deterministic order guaranteed
+
+---
+
+## Requirements
+
+| Bug | Requirement                                      | Must Be True                                                                                                                                                                                                                                                                                                    |
+| --- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 6   | `retainResults: false` skips result accumulation | `RunSummary.results === []` when `retainResults: false`. Counters still accurate. Storage still persists. Default `true` preserves current behavior.                                                                                                                                                            |
+| 7   | Retry with configurable `maxRetries`             | Item retried up to `maxRetries` times on transient error. `retryCount` reflects attempts. Success on retry → `succeededCount` incremented. Non-transient errors are NOT retried. Default `maxRetries: 0` preserves current behavior. `AbortError` is never retried. Abort during backoff stops further retries. |
+| 8   | Parallel scorers                                 | `runScorersForItem` runs all scorers concurrently. Wall clock ≈ slowest scorer, not sum. Error isolation preserved per scorer.                                                                                                                                                                                  |
+| 9   | `completedWithErrors` flag                       | `RunSummary.completedWithErrors === true` when `status === 'completed' && failedCount > 0`. `false` when all succeed or when aborted.                                                                                                                                                                           |
+| 10  | Accurate counts on abort                         | `RunSummary.skippedCount >= 0`. `succeededCount + failedCount + skippedCount === totalItems` always holds.                                                                                                                                                                                                      |
+| 11  | Deterministic results order                      | `results[i]` corresponds to `items[i]` from the dataset, regardless of completion order.                                                                                                                                                                                                                        |
+
+---
+
+## Steps
+
+### Step 1 — Create regression test file
+
+**File**: `packages/core/src/datasets/run/__tests__/p1-regression.test.ts` (NEW)
+
+Follows existing patterns from `runDataset.test.ts` and `p0-regression.test.ts`:
+
+- `InMemoryDB`, `DatasetsInMemory`, `RunsInMemory`
+- `createMockAgent` factory with configurable delay/failure
+- `vi.mock` for `isSupportedLanguageModel`
+
+13 test cases (details below).
+
+**Checkpoint — verify tests fail:**
+
+After creating the test file, run:
+
+```bash
+cd packages/core && pnpm vitest run src/datasets/run/__tests__/p1-regression.test.ts
+```
+
+Expected: **all 13 tests fail** (or at most T-7b/T-10b pass as they test default behavior). This confirms the tests are correctly asserting behavior that doesn't exist yet.
+
+| Test  | Expected failure reason                                                       |
+| ----- | ----------------------------------------------------------------------------- |
+| T-6a  | `retainResults` property doesn't exist on `RunConfig`                         |
+| T-6b  | `retainResults` not implemented, results always populated                     |
+| T-7a  | `retryCount` always 0, agent only called once                                 |
+| T-7b  | May pass already (tests default behavior) — baseline test                     |
+| T-7c  | `retryCount` always 0, non-retryable error not distinguished                  |
+| T-7d  | Retry loop doesn't exist yet, can't test abort during backoff                 |
+| T-8a  | Scorers run sequentially (~300ms+), wall clock assertion fails                |
+| T-8b  | Scorer error isolation under parallelism not verified                         |
+| T-9a  | `completedWithErrors` is `undefined` (property doesn't exist on `RunSummary`) |
+| T-9b  | `completedWithErrors` is `undefined` (property doesn't exist on `RunSummary`) |
+| T-10a | `skippedCount` is `undefined` (property doesn't exist on `RunSummary`)        |
+| T-10b | May pass already (tests normal completion baseline)                           |
+| T-11  | Results order matches completion order, not dataset order                     |
+
+Do NOT proceed to Step 2 until you've confirmed the failures.
+
+---
+
+**Test details:**
+
+**T-6a: retainResults false → empty results**
+
+- Mock agent: always succeeds
+- 3 items, `retainResults: false`
+- Assert: `result.results.length === 0`
+- Assert: `result.succeededCount === 3`
+- Assert: `result.status === 'completed'`
+
+**T-6b: retainResults true (default) → results populated**
+
+- Mock agent: always succeeds
+- 3 items, no `retainResults` set
+- Assert: `result.results.length === 3`
+
+**T-7a: Retry on transient failure**
+
+- Mock agent: fails twice with "rate limit" error, succeeds on 3rd call
+- 1 item, `maxRetries: 3`, `retryDelay: 10` (fast for tests)
+- Assert: `result.succeededCount === 1`
+- Assert: `result.results[0].retryCount === 2`
+- Assert: `result.results[0].error === null`
+
+**T-7b: No retry when `maxRetries` is 0 (default)**
+
+- Mock agent: always fails
+- 2 items, no `maxRetries` set
+- Assert: each item's agent.generate called exactly once per item
+- Assert: `result.results[0].retryCount === 0`
+
+**T-7c: Non-retryable error is not retried**
+
+- Mock agent: always fails with "Invalid input format" (non-transient error)
+- 1 item, `maxRetries: 2`, `retryDelay: 10`
+- Assert: `agent.generate` called exactly 1x
+- Assert: `result.results[0].retryCount === 0`
+- Assert: `result.failedCount === 1`
+
+**T-7d: Abort during retry backoff stops retries**
+
+- Mock agent: always fails with "rate limit" error
+- 1 item, `maxRetries: 5`, `retryDelay: 50`
+- `AbortController.abort()` after ~80ms (during first backoff delay)
+- Assert: `agent.generate` called ≤ 2x (initial + at most 1 retry before abort)
+- Assert: run resolves (does not hang)
+
+**T-8a: Parallel scorers faster than sequential**
+
+- Mock agent: instant success
+- 3 mock scorers: each takes 100ms (`setTimeout`)
+- 5 items, `maxConcurrency: 5`
+- Measure wall clock time
+- Assert: total time < 250ms (parallel ≈ 100ms per item) vs 300ms+ (serial = 3×100ms per item)
+- Assert: each item has 3 scores with correct `scorerId`
+
+**T-8b: Scorer error isolation under parallel execution**
+
+- Mock agent: instant success
+- 3 mock scorers: scorer 1 throws, scorers 2 and 3 succeed
+- 1 item
+- Assert: all 3 scorer results present
+- Assert: scorer 1 has `error` non-null, `score === null`
+- Assert: scorers 2 and 3 have valid scores, `error === null`
+
+**T-9a: completedWithErrors true on partial failure**
+
+- Mock agent: 1st item fails, 2nd succeeds
+- `maxConcurrency: 1`
+- Assert: `result.status === 'completed'`
+- Assert: `result.completedWithErrors === true`
+- Assert: `result.failedCount === 1`, `result.succeededCount === 1`
+
+**T-9b: completedWithErrors false when all succeed**
+
+- Mock agent: always succeeds
+- 2 items
+- Assert: `result.status === 'completed'`
+- Assert: `result.completedWithErrors === false`
+
+**T-10a: skippedCount on abort**
+
+- Mock agent: 200ms delay per item
+- 10 items, `maxConcurrency: 2`
+- Abort after ~300ms
+- Assert: `result.skippedCount > 0`
+- Assert: `result.succeededCount + result.failedCount + result.skippedCount === result.totalItems`
+
+**T-10b: skippedCount is 0 on normal completion**
+
+- Mock agent: always succeeds instantly
+- 3 items
+- Assert: `result.skippedCount === 0`
+- Assert: `result.succeededCount === 3`
+- Assert: `result.succeededCount + result.failedCount + result.skippedCount === result.totalItems`
+
+**T-11: Results in dataset order**
+
+- Mock agent: item 0 → 200ms delay, item 1 → 50ms, item 2 → 10ms
+- `maxConcurrency: 3`
+- Assert: `result.results[0]` corresponds to items[0]
+- Assert: `result.results[1]` corresponds to items[1]
+- Assert: `result.results[2]` corresponds to items[2]
+
+---
+
+### Step 2 — Fix Issue 8: Parallel scorers
+
+**File**: `packages/core/src/datasets/run/scorer.ts` (lines 53-86)
+
+Replace the sequential `for` loop with `Promise.allSettled`:
+
+```typescript
+const scorerPromises = scorers.map(async (scorer) => {
+  const result = await runScorerSafe(scorer, item, output, scorerInput, scorerOutput);
+
+  if (storage && result.score !== null) {
+    try {
+      await validateAndSaveScore(storage, { ... });
+    } catch (saveError) {
+      console.warn(`Failed to save score for scorer ${scorer.id}:`, saveError);
+    }
+  }
+
+  return result;
+});
+
+const settled = await Promise.allSettled(scorerPromises);
+return settled.map(s =>
+  s.status === 'fulfilled'
+    ? s.value
+    : { scorerId: 'unknown', scorerName: 'unknown', score: null, reason: null, error: String(s.reason) }
+);
+```
+
+---
+
+### Step 3 — Fix Issue 9: `completedWithErrors` flag
+
+**File**: `packages/core/src/datasets/run/types.ts`
+
+Add to `RunSummary`:
+
+```typescript
+/** True when run completed but some items failed */
+completedWithErrors: boolean;
+```
+
+**File**: `packages/core/src/datasets/run/index.ts`
+
+Set in both return paths:
+
+- Normal completion: `completedWithErrors: status === 'completed' && failedCount > 0`
+- Abort path: `completedWithErrors: false` (status is `'failed'`)
+
+---
+
+### Step 4 — Fix Issue 10: `skippedCount`
+
+**File**: `packages/core/src/datasets/run/types.ts`
+
+Add to `RunSummary`:
+
+```typescript
+/** Number of items not processed (aborted or never started) */
+skippedCount: number;
+```
+
+**File**: `packages/core/src/datasets/run/index.ts`
+
+Compute:
+
+```typescript
+const skippedCount = items.length - succeededCount - failedCount;
+```
+
+Include in both return paths (normal + abort).
+
+---
+
+### Step 5 — Fix Issue 11: Results ordering
+
+**File**: `packages/core/src/datasets/run/index.ts`
+
+Replace `results.push()` with pre-allocated array:
+
+```typescript
+const results: (ItemWithScores | undefined)[] = new Array(items.length);
+
+// In p-map callback (p-map passes index as 2nd arg):
+await pMap(items, async (item, index) => {
+  ...
+  results[index] = { ...itemResult, scores: itemScores };
+}, { concurrency: maxConcurrency });
+
+// After p-map:
+const orderedResults = results.filter((r): r is ItemWithScores => r !== undefined);
+```
+
+On abort, incomplete items remain `undefined` and are filtered out.
+
+---
+
+### Step 6 — Fix Issue 6: Memory accumulation opt-out
+
+**File**: `packages/core/src/datasets/run/types.ts`
+
+Add to `RunConfig`:
+
+```typescript
+/** When false, results are not accumulated in memory. Use storage to retrieve results. Default: true. */
+retainResults?: boolean;
+```
+
+**File**: `packages/core/src/datasets/run/index.ts`
+
+Gate result accumulation:
+
+```typescript
+const { retainResults = true } = config;
+
+// In p-map callback:
+if (retainResults) {
+  results[index] = { ...itemResult, scores: itemScores };
+}
+
+// Return path:
+const orderedResults = retainResults ? results.filter((r): r is ItemWithScores => r !== undefined) : [];
+```
+
+---
+
+### Step 7 — Fix Issue 7: Retry logic
+
+**File**: `packages/core/src/datasets/run/types.ts`
+
+Add to `RunConfig`:
+
+```typescript
+/** Maximum retry attempts per item on transient failure. Default: 0 (no retry). */
+maxRetries?: number;
+/** Base delay between retries in ms. Actual delay: retryDelay * 2^attempt + jitter. Default: 1000. */
+retryDelay?: number;
+```
+
+**File**: `packages/core/src/datasets/run/index.ts`
+
+Add transient error detector:
+
+```typescript
+function isTransientError(error: string): boolean {
+  const patterns = [
+    /timeout/i,
+    /rate.?limit/i,
+    /429/,
+    /503/,
+    /5\d\d/,
+    /ECONNRESET/i,
+    /ECONNREFUSED/i,
+    /ETIMEDOUT/i,
+    /socket hang up/i,
+    /fetch failed/i,
+  ];
+  // Never retry abort errors
+  if (/abort/i.test(error)) return false;
+  return patterns.some(p => p.test(error));
+}
+```
+
+Wrap `executeTarget` in retry loop inside p-map callback:
+
+```typescript
+const { maxRetries = 0, retryDelay = 1000 } = config;
+
+// Inside p-map callback:
+let execResult: ExecutionResult;
+let retryCount = 0;
+
+for (let attempt = 0; attempt <= maxRetries; attempt++) {
+  execResult = await executeTarget(target, targetType, item, { signal: itemSignal });
+
+  if (!execResult.error || attempt === maxRetries) break;
+  if (!isTransientError(execResult.error)) break;
+  if (itemSignal?.aborted) break;
+
+  retryCount = attempt + 1;
+  const jitter = Math.random() * (retryDelay / 2);
+  await new Promise(r => setTimeout(r, retryDelay * Math.pow(2, attempt) + jitter));
+
+  // Re-check abort after delay
+  if (itemSignal?.aborted) break;
+}
+```
+
+Update `retryCount` in `itemResult` and `addResult` to use the computed value.
+
+---
+
+### Step 8 — Run tests and verify all pass
+
+```bash
+cd packages/core && pnpm vitest run src/datasets/run/__tests__/p1-regression.test.ts
+cd packages/core && pnpm vitest run src/datasets/run/__tests__/
+```
+
+**Checkpoint — verify tests pass:**
+
+Expected: **all 13 P1 tests pass**, plus all existing tests (P0 regression + original) pass unchanged.
+
+| Test  | Expected result                                                 |
+| ----- | --------------------------------------------------------------- |
+| T-6a  | ✅ `results === []`, counters correct                           |
+| T-6b  | ✅ `results.length === 3`, backward compat                      |
+| T-7a  | ✅ Agent retried, `retryCount === 2`, succeeded                 |
+| T-7b  | ✅ No retry, agent called once per item                         |
+| T-7c  | ✅ Non-retryable error, called 1x, `retryCount === 0`           |
+| T-7d  | ✅ Abort during backoff, ≤2 calls, run resolves                 |
+| T-8a  | ✅ Wall clock < 250ms for 3×100ms scorers                       |
+| T-8b  | ✅ Scorer error isolated, other scorers still have valid scores |
+| T-9a  | ✅ `completedWithErrors === true`                               |
+| T-9b  | ✅ `completedWithErrors === false`                              |
+| T-10a | ✅ `skippedCount > 0`, invariant holds                          |
+| T-10b | ✅ `skippedCount === 0` on normal completion                    |
+| T-11  | ✅ Results in dataset item order                                |
+
+If any existing tests break, check whether they need `completedWithErrors` / `skippedCount` added to their assertions.
+
+---
+
+## Files Modified
+
+| File                              | Change                                                                                                                           |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `__tests__/p1-regression.test.ts` | **NEW** — 13 regression tests                                                                                                    |
+| `types.ts`                        | Add `maxRetries`, `retryDelay`, `retainResults` to `RunConfig`. Add `completedWithErrors`, `skippedCount` to `RunSummary`.       |
+| `index.ts`                        | Retry loop, `isTransientError` helper, pre-allocated results array, `retainResults` gate, `skippedCount`, `completedWithErrors`. |
+| `scorer.ts`                       | Parallel scorers via `Promise.allSettled` replacing sequential `for` loop.                                                       |
+
+All paths relative to `packages/core/src/datasets/run/`.
+
+---
+
+## Verification
+
+### Tests
+
+```bash
+cd packages/core && pnpm vitest run src/datasets/run/__tests__/
+```
+
+All 13 new P1 tests pass. All existing tests (including 5 P0 regression + 31 original) pass unchanged.
+
+### Manual checks
+
+- T-6a: `retainResults: false` → empty results, counters accurate
+- T-6b: default → results populated (backward compat)
+- T-7a: transient error retried, `retryCount` reflects attempts
+- T-7b: no retry by default, agent called once per item
+- T-7c: non-retryable error not retried, called exactly once
+- T-7d: abort during retry backoff stops further attempts
+- T-8a: parallel scorers ≈ 100ms wall clock, not 300ms
+- T-8b: scorer error isolated, other scorers unaffected under parallelism
+- T-9a: `completedWithErrors === true` when partial failure
+- T-9b: `completedWithErrors === false` when all succeed
+- T-10a: `skippedCount + succeededCount + failedCount === totalItems` on abort
+- T-10b: `skippedCount === 0` on normal completion
+- T-11: results in dataset item order regardless of completion order
+
+### Risks
+
+- **Retry exponential backoff with jitter**: `retryDelay * 2^attempt + random(0, retryDelay/2)`. With `maxRetries: 3` and default `retryDelay: 1000`, worst case is ~8.5s extra per item. Acceptable — opt-in only. Jitter prevents thundering herd.
+- **`isTransientError` heuristic**: Pattern matching on error strings is fragile. Could miss or misclassify. No structured error types exist in executor output. Explicitly excludes `AbortError`.
+- **New `RunSummary` fields**: `completedWithErrors` and `skippedCount` are additive. No breaking change. Server handler (`datasets.ts:585`) runs `runDataset` fire-and-forget, doesn't serialize `RunSummary` — no immediate consumer impact.
+- **Parallel scorer persistence order**: Score writes within a single item become non-deterministic. Acceptable — scores are keyed by `scorerId`.
+- **Pre-allocated results array**: Same memory footprint as `push`. `retainResults: false` is the actual memory fix.
+- **`retainResults: false`**: Callers must rely on storage for results. No `RunSummary.results` data. Type is still `ItemWithScores[]` (empty array), so no type break.
+
+---
+
+## What changed from the previous plan
+
+| Aspect                    | Previous plan                                  | Updated plan                                                                                                                                              |
+| ------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Issue 6 (Memory)          | Deferred entirely                              | **Opt-in `retainResults: false`** — escape hatch without breaking API                                                                                     |
+| Retry backoff             | Linear: `1000ms * attempt`                     | **Exponential with jitter: `retryDelay * 2^attempt + random(0, retryDelay/2)`** — prevents thundering herd                                                |
+| Retry config              | Only `maxRetries`                              | **`maxRetries` + `retryDelay`** — configurable base delay                                                                                                 |
+| `isTransientError`        | Excluded `AbortError` implicitly               | **Explicitly checks for `/abort/i` and returns false**                                                                                                    |
+| Issue 9 (Status)          | `completedWithErrors: boolean` on `RunSummary` | Same — kept conservative approach (no `RunStatus` enum change)                                                                                            |
+| Issue 10 (`skippedCount`) | Computed, not persisted                        | Same — kept lightweight approach (no schema change)                                                                                                       |
+| Test count                | 7 tests                                        | **13 tests** — added T-6a/T-6b for `retainResults`, T-7c/T-7d for retry edge cases, T-8b for scorer error isolation, T-10b for normal completion baseline |
+
+---
+
+## Existing test updates expected
+
+- Some existing tests may need `completedWithErrors` and `skippedCount` added to their assertions
+- Verify `retryCount` default of `0` matches existing `ItemResult` shape
+- Results ordering change (pre-allocated array) should not break existing tests as they don't assert order

--- a/packages/core/src/datasets/run/STREAMING-PLAN.md
+++ b/packages/core/src/datasets/run/STREAMING-PLAN.md
@@ -1,0 +1,270 @@
+# Streaming Dataset Run Executor — Plan
+
+## Overview
+
+Add `onItemComplete` callback to `runDataset` so callers can consume results as they complete without accumulating them in memory. Smart default: when `onItemComplete` is provided, `retainResults` defaults to `false`.
+
+**Prerequisite**: P0 + P1 fixes merged via PRs #12789, #12797 targeting `feat/datasets`.
+
+**No breaking changes** — this feature has not shipped to customer-facing users yet.
+
+---
+
+## Memory Model
+
+```
+WITHOUT onItemComplete (current default):
+  item completes → persist to storage → hold in results[] → GC after runDataset returns
+  Memory: O(N × result_size) for entire run duration
+
+WITH onItemComplete (new behavior):
+  item completes → persist to storage → callback(result) → drop reference → GC immediately
+  Memory: O(1) per completed item — only live items in p-map slots
+```
+
+When `onItemComplete` is provided: `retainResults` auto-defaults to `false`.
+Caller can override with `retainResults: true` if they need both.
+
+---
+
+## Design Decisions
+
+1. **Callback over AsyncGenerator/ReadableStream** — `runDataset` returns `Promise<RunSummary>`. A callback is additive. Callers can build their own stream/EventEmitter on top.
+
+2. **Smart default for `retainResults`** — When `onItemComplete` is provided, `retainResults` defaults to `false`. Explicit `retainResults: true` overrides.
+
+3. **No `onProgress` callback** — Callers compute progress trivially in `onItemComplete` (`count++`). Can be added later.
+
+4. **Callback is awaited** — Enables backpressure: a slow callback holds its p-map concurrency slot.
+
+5. **Callback errors are non-fatal** — Same pattern as `addResult`: catch + `console.warn`.
+
+---
+
+## Interaction Matrix
+
+| `retainResults`  | `onItemComplete` | Behavior                                                          |
+| ---------------- | ---------------- | ----------------------------------------------------------------- |
+| `true` (default) | not set          | Current behavior — all results in `RunSummary.results`            |
+| `true`           | set              | Results in memory + callback fired per item                       |
+| auto `false`     | set              | **Zero-memory streaming** — callback gets each item, nothing held |
+| `false`          | not set          | Empty `results[]` — must use storage to fetch results             |
+
+---
+
+## Complexity Estimate
+
+- **Size**: Small (3 files modified, 1 new test file)
+- **Risk**: Low — purely additive, no changes to return types or existing behavior
+- **Dependencies**: None
+
+---
+
+## Requirements
+
+| Feature             | Requirement                                                   | Must Be True                                                                                                                      |
+| ------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `onItemComplete`    | Callback fires once per completed item                        | Called exactly `items.length` times on normal completion. Both succeeded and failed items. Receives `ItemWithScores` and `index`. |
+| Smart default       | `retainResults` defaults to `false` when `onItemComplete` set | Without explicit `retainResults: true`, `RunSummary.results` is empty when callback is provided.                                  |
+| Explicit override   | `retainResults: true` + `onItemComplete` gives both           | Results in memory AND callback fires per item.                                                                                    |
+| Callback ordering   | Callbacks fire in completion order (not dataset order)        | With concurrent execution, fastest items call back first. `index` reflects original dataset position.                             |
+| Callback error      | Callback throw is non-fatal                                   | A throwing callback does not abort the run. Error is caught + warned.                                                             |
+| Async callback      | Callback can be async (awaited)                               | `onItemComplete` return value is awaited if it's a Promise.                                                                       |
+| Callback on abort   | Callback fires for items completed before abort               | Items that finished before abort trigger the callback. Skipped items do not.                                                      |
+| Zero-memory pattern | `onItemComplete` without explicit retain holds no results     | `RunSummary.results === []`. Outputs are GC-eligible after callback returns.                                                      |
+
+---
+
+## Steps
+
+### Step 1 — Add `onItemComplete` to RunConfig
+
+**File**: `packages/core/src/datasets/run/types.ts`
+
+Add after `retryDelay` (line 29):
+
+```typescript
+/** Called after each item completes execution, scoring, and persistence.
+ *  Callback errors are logged but do not stop the run.
+ *  If the callback returns a Promise, it is awaited before proceeding.
+ *  When provided, retainResults defaults to false (zero memory accumulation). */
+onItemComplete?: (result: ItemWithScores, index: number) => void | Promise<void>;
+```
+
+---
+
+### Step 2 — Create regression tests
+
+**File**: `packages/core/src/datasets/run/__tests__/streaming-regression.test.ts` (NEW)
+
+7 test cases:
+
+**T-1: onItemComplete fires for each item**
+
+- 5 items, mock agent
+- `onItemComplete` spy
+- Assert: spy called 5 times
+- Assert: each call receives `ItemWithScores` and correct `index`
+
+**T-2: onItemComplete auto-defaults retainResults to false**
+
+- 5 items, `onItemComplete` collects items (no explicit `retainResults`)
+- Assert: `RunSummary.results` is empty (`[]`)
+- Assert: callback collected 5 items
+
+**T-3: onItemComplete + explicit retainResults true gives both**
+
+- 3 items, `retainResults: true`, `onItemComplete` spy
+- Assert: `RunSummary.results.length === 3`
+- Assert: spy called 3 times
+
+**T-4: onItemComplete receives both success and failure items**
+
+- 3 items: 2 succeed, 1 fails
+- `onItemComplete` tracks errors
+- Assert: callback called 3 times
+- Assert: exactly 1 call has `item.error !== null`
+
+**T-5: onItemComplete throw is non-fatal**
+
+- 3 items, `onItemComplete` throws on every call
+- Assert: run completes successfully
+- Assert: `succeededCount === 3`
+
+**T-6: async onItemComplete is awaited**
+
+- 3 items, `maxConcurrency: 1`
+- `onItemComplete` has 50ms delay
+- Track call end times
+- Assert: callbacks don't overlap (each starts after previous finishes)
+
+**T-7: onItemComplete on abort — only completed items**
+
+- 10 items, `maxConcurrency: 2`
+- Mock agent: 200ms per item
+- Abort after ~300ms
+- `onItemComplete` collects items
+- Assert: callback called for completed items only (< 10)
+
+**Checkpoint — verify tests fail:**
+
+```bash
+cd packages/core && pnpm vitest run src/datasets/run/__tests__/streaming-regression.test.ts
+```
+
+Expected: all 7 tests fail (property doesn't exist on `RunConfig` / callback never invoked).
+
+Do NOT proceed to Step 3 until failures are confirmed.
+
+---
+
+### Step 3 — Implement in runDataset
+
+**File**: `packages/core/src/datasets/run/index.ts`
+
+**3a** — Destructure `onItemComplete` and apply smart default for `retainResults`:
+
+```typescript
+const {
+  // ... existing fields ...
+  onItemComplete,
+  retainResults = onItemComplete ? false : true,
+  runId: providedRunId,
+} = config;
+```
+
+Note: `onItemComplete` must be destructured **before** `retainResults` so the default expression can reference it.
+
+**3b** — After the `if (retainResults)` block (line ~223), invoke callback:
+
+```typescript
+if (onItemComplete) {
+  try {
+    await onItemComplete({ ...itemResult, scores: itemScores }, index);
+  } catch (callbackError) {
+    console.warn(`onItemComplete callback error for item ${item.id}:`, callbackError);
+  }
+}
+```
+
+---
+
+### Step 4 — Server handler optimization
+
+**File**: `packages/server/src/server/handlers/datasets.ts`
+
+The server handler calls `runDataset` fire-and-forget and never reads `RunSummary.results`. Add `retainResults: false`:
+
+```typescript
+await runDataset(mastra, {
+  // ... existing fields ...
+  retainResults: false, // Results fetched via listResults API
+});
+```
+
+One-line change, no behavioral difference — results are already available via `GET /datasets/:id/runs/:runId/results`.
+
+---
+
+### Step 5 — Run tests and verify
+
+```bash
+cd packages/core && pnpm vitest run src/datasets/run/__tests__/streaming-regression.test.ts
+cd packages/core && pnpm vitest run src/datasets/run/__tests__/
+```
+
+**Checkpoint**: All 7 new tests pass. All existing tests unchanged.
+
+---
+
+## Edge Cases
+
+- **Slow callback** — Holds its p-map concurrency slot. This is correct: enables backpressure. Heavy work should be offloaded to a queue.
+- **Callback throws** — Caught + warned. Run continues. Item is already persisted to storage before callback fires.
+- **Abort during callback** — Current callback completes (it's already awaited). Next p-map iteration sees abort and skips.
+- **Object identity** — Callback receives a fresh copy (`{ ...itemResult, scores }`), not a reference to the internal results array slot. Safe to mutate.
+
+---
+
+## Files Modified
+
+| File                                     | Change                                             |
+| ---------------------------------------- | -------------------------------------------------- |
+| `types.ts`                               | Add `onItemComplete` to `RunConfig`                |
+| `index.ts`                               | Smart default + invoke callback                    |
+| `__tests__/streaming-regression.test.ts` | **NEW** — 7 regression tests                       |
+| `packages/server/.../datasets.ts`        | Add `retainResults: false` to fire-and-forget call |
+
+All paths relative to `packages/core/src/datasets/run/` unless specified.
+
+---
+
+## Verification
+
+### Tests
+
+```bash
+cd packages/core && pnpm vitest run src/datasets/run/__tests__/
+```
+
+All new + existing tests pass.
+
+---
+
+## Risks
+
+| Risk                                    | Mitigation                                                                                                   |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Slow `onItemComplete` blocks p-map slot | By design — enables backpressure. Document that heavy work should be offloaded to a queue.                   |
+| Callback ordering confusion             | Document: callbacks fire in completion order, `index` gives dataset position.                                |
+| Smart default surprise                  | If caller expects `results` but passes `onItemComplete`, they get `[]`. Override with `retainResults: true`. |
+| Server handler change                   | One-line, no behavioral difference. Results already in storage.                                              |
+
+---
+
+## What This Does NOT Do
+
+- **No `onProgress` callback** — callers compute progress in `onItemComplete` trivially
+- **No AsyncGenerator/ReadableStream** — callback is simpler and sufficient
+- **No batched storage writes** — separate concern
+- **No SSE/WebSocket for server** — follow-up task; callback API makes it possible

--- a/packages/core/src/datasets/run/__tests__/p1-regression.test.ts
+++ b/packages/core/src/datasets/run/__tests__/p1-regression.test.ts
@@ -1,0 +1,447 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Agent } from '../../../agent';
+import type { MastraScorer } from '../../../evals/base';
+import type { Mastra } from '../../../mastra';
+import type { MastraCompositeStore, StorageDomains } from '../../../storage/base';
+import { DatasetsInMemory } from '../../../storage/domains/datasets/inmemory';
+import { InMemoryDB } from '../../../storage/domains/inmemory-db';
+import { RunsInMemory } from '../../../storage/domains/runs/inmemory';
+import { runDataset } from '../index';
+
+// Mock isSupportedLanguageModel at module level
+vi.mock('../../../agent', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    isSupportedLanguageModel: vi.fn().mockReturnValue(true),
+  };
+});
+
+// Helper: mock agent with configurable behavior
+const createMockAgent = (
+  opts: { delayMs?: number; shouldFail?: boolean; response?: string; failMessage?: string } = {},
+): Agent => {
+  const { delayMs = 0, shouldFail = false, response = 'ok', failMessage = 'Agent error' } = opts;
+  return {
+    id: 'test-agent',
+    name: 'Test Agent',
+    getModel: vi.fn().mockResolvedValue({ specificationVersion: 'v2' }),
+    generate: vi.fn().mockImplementation(async () => {
+      if (delayMs > 0) await new Promise(r => setTimeout(r, delayMs));
+      if (shouldFail) throw new Error(failMessage);
+      return { text: response };
+    }),
+  } as unknown as Agent;
+};
+
+// Helper: create a mock scorer with configurable delay
+const createDelayedScorer = (id: string, name: string, delayMs: number): MastraScorer<any, any, any, any> =>
+  ({
+    id,
+    name,
+    description: `Mock scorer ${id}`,
+    run: vi.fn().mockImplementation(async () => {
+      await new Promise(r => setTimeout(r, delayMs));
+      return { score: 1.0, reason: 'ok' };
+    }),
+  }) as unknown as MastraScorer<any, any, any, any>;
+
+// Shared test infrastructure
+let db: InMemoryDB;
+let datasetsStorage: DatasetsInMemory;
+let runsStorage: RunsInMemory;
+let mockStorage: MastraCompositeStore;
+let mastra: Mastra;
+let datasetId: string;
+
+async function setupDataset(itemCount: number) {
+  db = new InMemoryDB();
+  datasetsStorage = new DatasetsInMemory({ db });
+  runsStorage = new RunsInMemory({ db });
+
+  const dataset = await datasetsStorage.createDataset({
+    name: 'P1 Test Dataset',
+    description: 'Regression',
+  });
+  datasetId = dataset.id;
+
+  for (let i = 0; i < itemCount; i++) {
+    await datasetsStorage.addItem({
+      datasetId: dataset.id,
+      input: { prompt: `item-${i}` },
+      expectedOutput: null,
+    });
+  }
+
+  mockStorage = {
+    id: 'test-storage',
+    stores: {
+      datasets: datasetsStorage,
+      runs: runsStorage,
+    } as unknown as StorageDomains,
+    getStore: vi.fn().mockImplementation(async (name: keyof StorageDomains) => {
+      if (name === 'datasets') return datasetsStorage;
+      if (name === 'runs') return runsStorage;
+      return undefined;
+    }),
+  } as unknown as MastraCompositeStore;
+}
+
+function setupMastra(agent: Agent) {
+  mastra = {
+    getStorage: vi.fn().mockReturnValue(mockStorage),
+    getAgent: vi.fn().mockReturnValue(agent),
+    getAgentById: vi.fn().mockReturnValue(agent),
+    getScorerById: vi.fn(),
+    getWorkflowById: vi.fn(),
+    getWorkflow: vi.fn(),
+  } as unknown as Mastra;
+}
+
+describe('P1 Regression', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- Issue 6: Memory accumulation ---
+
+  describe('Issue 6: retainResults', () => {
+    it('T-6a: retainResults false → empty results, counters accurate', async () => {
+      await setupDataset(3);
+      const agent = createMockAgent();
+      setupMastra(agent);
+
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        retainResults: false,
+      });
+
+      expect(result.results).toHaveLength(0);
+      expect(result.succeededCount).toBe(3);
+      expect(result.status).toBe('completed');
+    });
+
+    it('T-6b: retainResults true (default) → results populated', async () => {
+      await setupDataset(3);
+      const agent = createMockAgent();
+      setupMastra(agent);
+
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+      });
+
+      expect(result.results).toHaveLength(3);
+    });
+  });
+
+  // --- Issue 7: Retry logic ---
+
+  describe('Issue 7: Retry', () => {
+    it('T-7a: retries transient failure and succeeds', async () => {
+      await setupDataset(1);
+
+      let callCount = 0;
+      const agent = {
+        id: 'retry-agent',
+        name: 'Retry Agent',
+        getModel: vi.fn().mockResolvedValue({ specificationVersion: 'v2' }),
+        generate: vi.fn().mockImplementation(async () => {
+          callCount++;
+          if (callCount <= 2) throw new Error('429 rate limit exceeded');
+          return { text: 'ok' };
+        }),
+      } as unknown as Agent;
+
+      setupMastra(agent);
+
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'retry-agent',
+        maxRetries: 3,
+        retryDelay: 10,
+      });
+
+      expect(result.succeededCount).toBe(1);
+      expect(result.results[0].retryCount).toBe(2);
+      expect(result.results[0].error).toBeNull();
+      expect(callCount).toBe(3);
+    });
+
+    it('T-7b: no retry when maxRetries is 0 (default)', async () => {
+      await setupDataset(2);
+      const agent = createMockAgent({ shouldFail: true });
+      setupMastra(agent);
+
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        maxConcurrency: 1,
+      });
+
+      // Agent called exactly once per item (no retry)
+      expect(agent.generate).toHaveBeenCalledTimes(2);
+      expect(result.results[0].retryCount).toBe(0);
+      expect(result.failedCount).toBe(2);
+    });
+
+    it('T-7c: non-retryable error is not retried', async () => {
+      await setupDataset(1);
+      const agent = createMockAgent({ shouldFail: true, failMessage: 'Invalid input format' });
+      setupMastra(agent);
+
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        maxRetries: 2,
+        retryDelay: 10,
+      });
+
+      // Non-transient error: should only be called once
+      expect(agent.generate).toHaveBeenCalledTimes(1);
+      expect(result.results[0].retryCount).toBe(0);
+      expect(result.failedCount).toBe(1);
+    });
+
+    it('T-7d: abort during retry backoff stops retries', { timeout: 5000 }, async () => {
+      await setupDataset(1);
+
+      // Agent always fails with transient error
+      const agent = createMockAgent({ shouldFail: true, failMessage: '429 rate limit exceeded' });
+      setupMastra(agent);
+
+      const controller = new AbortController();
+      // Abort after 80ms — during first retry backoff (retryDelay=50)
+      setTimeout(() => controller.abort(), 80);
+
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        maxRetries: 5,
+        retryDelay: 50,
+        signal: controller.signal,
+      });
+
+      // Should have called at most 2 times (initial + maybe 1 retry before abort)
+      expect((agent.generate as ReturnType<typeof vi.fn>).mock.calls.length).toBeLessThanOrEqual(2);
+      // Run should resolve (not hang)
+      expect(result).toBeDefined();
+    });
+  });
+
+  // --- Issue 8: Parallel scorers ---
+
+  describe('Issue 8: Parallel scorers', () => {
+    it('T-8a: parallel scorers faster than sequential', { timeout: 5000 }, async () => {
+      await setupDataset(5);
+      const agent = createMockAgent();
+      setupMastra(agent);
+
+      const scorer1 = createDelayedScorer('s1', 'Scorer 1', 100);
+      const scorer2 = createDelayedScorer('s2', 'Scorer 2', 100);
+      const scorer3 = createDelayedScorer('s3', 'Scorer 3', 100);
+
+      const start = performance.now();
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        scorers: [scorer1, scorer2, scorer3],
+        maxConcurrency: 5,
+      });
+      const elapsed = performance.now() - start;
+
+      // Parallel: ~100ms per item (all 3 scorers run concurrently)
+      // Sequential would be: ~300ms per item × 5 items = 1500ms
+      // Parallel should be: ~100ms per item × (5 items / 5 concurrency) = ~100ms
+      // Be generous: < 750ms means they're running in parallel
+      expect(elapsed).toBeLessThan(750);
+
+      // All items should have 3 scores
+      for (const item of result.results) {
+        expect(item.scores).toHaveLength(3);
+        const scorerIds = item.scores.map(s => s.scorerId);
+        expect(scorerIds).toContain('s1');
+        expect(scorerIds).toContain('s2');
+        expect(scorerIds).toContain('s3');
+      }
+    });
+
+    it('T-8b: scorer error isolation under parallel execution', async () => {
+      await setupDataset(1);
+      const agent = createMockAgent();
+      setupMastra(agent);
+
+      const failingScorer: MastraScorer<any, any, any, any> = {
+        id: 'failing',
+        name: 'Failing Scorer',
+        description: 'Always fails',
+        run: vi.fn().mockRejectedValue(new Error('Scorer crash')),
+      };
+      const workingScorer1 = createDelayedScorer('ok1', 'OK 1', 10);
+      const workingScorer2 = createDelayedScorer('ok2', 'OK 2', 10);
+
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        scorers: [failingScorer, workingScorer1, workingScorer2],
+      });
+
+      expect(result.status).toBe('completed');
+      const scores = result.results[0].scores;
+      expect(scores).toHaveLength(3);
+
+      const failedScore = scores.find(s => s.scorerId === 'failing');
+      expect(failedScore?.error).toBe('Scorer crash');
+      expect(failedScore?.score).toBeNull();
+
+      const ok1 = scores.find(s => s.scorerId === 'ok1');
+      expect(ok1?.score).toBe(1.0);
+      expect(ok1?.error).toBeNull();
+
+      const ok2 = scores.find(s => s.scorerId === 'ok2');
+      expect(ok2?.score).toBe(1.0);
+      expect(ok2?.error).toBeNull();
+    });
+  });
+
+  // --- Issue 9: completedWithErrors ---
+
+  describe('Issue 9: completedWithErrors', () => {
+    it('T-9a: completedWithErrors true on partial failure', async () => {
+      await setupDataset(2);
+
+      let callCount = 0;
+      const agent = {
+        id: 'partial-agent',
+        name: 'Partial Agent',
+        getModel: vi.fn().mockResolvedValue({ specificationVersion: 'v2' }),
+        generate: vi.fn().mockImplementation(async () => {
+          callCount++;
+          if (callCount === 1) throw new Error('Fail first');
+          return { text: 'ok' };
+        }),
+      } as unknown as Agent;
+
+      setupMastra(agent);
+
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'partial-agent',
+        maxConcurrency: 1,
+      });
+
+      expect(result.status).toBe('completed');
+      expect(result.completedWithErrors).toBe(true);
+      expect(result.failedCount).toBe(1);
+      expect(result.succeededCount).toBe(1);
+    });
+
+    it('T-9b: completedWithErrors false when all succeed', async () => {
+      await setupDataset(2);
+      const agent = createMockAgent();
+      setupMastra(agent);
+
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+      });
+
+      expect(result.status).toBe('completed');
+      expect(result.completedWithErrors).toBe(false);
+    });
+  });
+
+  // --- Issue 10: skippedCount ---
+
+  describe('Issue 10: skippedCount', () => {
+    it('T-10a: skippedCount on abort', { timeout: 5000 }, async () => {
+      await setupDataset(10);
+      const agent = createMockAgent({ delayMs: 200 });
+      setupMastra(agent);
+
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), 300);
+
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        maxConcurrency: 2,
+        signal: controller.signal,
+      });
+
+      expect(result.skippedCount).toBeGreaterThan(0);
+      expect(result.succeededCount + result.failedCount + result.skippedCount).toBe(result.totalItems);
+    });
+
+    it('T-10b: skippedCount is 0 on normal completion', async () => {
+      await setupDataset(3);
+      const agent = createMockAgent();
+      setupMastra(agent);
+
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+      });
+
+      expect(result.skippedCount).toBe(0);
+      expect(result.succeededCount).toBe(3);
+      expect(result.succeededCount + result.failedCount + result.skippedCount).toBe(result.totalItems);
+    });
+  });
+
+  // --- Issue 11: Results ordering ---
+
+  describe('Issue 11: Results ordering', () => {
+    it('T-11: results in dataset order regardless of completion order', async () => {
+      await setupDataset(3);
+
+      // Items complete in reverse order due to varying delays
+      const items = await datasetsStorage.getItemsByVersion({
+        datasetId,
+        version: (await datasetsStorage.getDatasetById({ id: datasetId }))!.version,
+      });
+
+      let callIndex = 0;
+      const agent = {
+        id: 'varied-agent',
+        name: 'Varied Agent',
+        getModel: vi.fn().mockResolvedValue({ specificationVersion: 'v2' }),
+        generate: vi.fn().mockImplementation(async (input: any) => {
+          // item-0: 200ms, item-1: 50ms, item-2: 10ms
+          const delays: Record<string, number> = { 'item-0': 200, 'item-1': 50, 'item-2': 10 };
+          const prompt = input?.prompt ?? `item-${callIndex++}`;
+          const delay = delays[prompt] ?? 10;
+          await new Promise(r => setTimeout(r, delay));
+          return { text: `response-${prompt}` };
+        }),
+      } as unknown as Agent;
+
+      setupMastra(agent);
+
+      const result = await runDataset(mastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'varied-agent',
+        maxConcurrency: 3,
+      });
+
+      // Results should be in dataset order, not completion order
+      expect(result.results[0].itemId).toBe(items[0].id);
+      expect(result.results[1].itemId).toBe(items[1].id);
+      expect(result.results[2].itemId).toBe(items[2].id);
+    });
+  });
+});

--- a/packages/core/src/datasets/run/__tests__/streaming-regression.test.ts
+++ b/packages/core/src/datasets/run/__tests__/streaming-regression.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Agent } from '../../../agent';
+import type { Mastra } from '../../../mastra';
+import type { MastraCompositeStore, StorageDomains } from '../../../storage/base';
+import { DatasetsInMemory } from '../../../storage/domains/datasets/inmemory';
+import { InMemoryDB } from '../../../storage/domains/inmemory-db';
+import { RunsInMemory } from '../../../storage/domains/runs/inmemory';
+import { runDataset } from '../index';
+
+// Mock isSupportedLanguageModel at module level
+vi.mock('../../../agent', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    isSupportedLanguageModel: vi.fn().mockReturnValue(true),
+  };
+});
+
+// Helper: mock agent with configurable behavior
+const createMockAgent = (
+  opts: { delayMs?: number; shouldFail?: boolean; response?: string; failMessage?: string } = {},
+): Agent => {
+  const { delayMs = 0, shouldFail = false, response = 'ok', failMessage = 'Agent error' } = opts;
+  return {
+    id: 'test-agent',
+    name: 'Test Agent',
+    getModel: vi.fn().mockResolvedValue({ specificationVersion: 'v2' }),
+    generate: vi.fn().mockImplementation(async () => {
+      if (delayMs > 0) await new Promise(r => setTimeout(r, delayMs));
+      if (shouldFail) throw new Error(failMessage);
+      return { text: response };
+    }),
+  } as unknown as Agent;
+};
+
+// Shared test infrastructure
+let db: InMemoryDB;
+let datasetsStorage: DatasetsInMemory;
+let runsStorage: RunsInMemory;
+let mockStorage: MastraCompositeStore;
+let mastra: Mastra;
+let datasetId: string;
+
+async function setupDataset(itemCount: number) {
+  db = new InMemoryDB();
+  datasetsStorage = new DatasetsInMemory({ db });
+  runsStorage = new RunsInMemory({ db });
+
+  const dataset = await datasetsStorage.createDataset({
+    name: 'Streaming Test Dataset',
+    description: 'Regression',
+  });
+  datasetId = dataset.id;
+
+  for (let i = 0; i < itemCount; i++) {
+    await datasetsStorage.addItem({
+      datasetId: dataset.id,
+      input: { prompt: `item-${i}` },
+      expectedOutput: null,
+    });
+  }
+
+  mockStorage = {
+    id: 'test-storage',
+    stores: {
+      datasets: datasetsStorage,
+      runs: runsStorage,
+    } as unknown as StorageDomains,
+    getStore: vi.fn().mockImplementation(async (name: keyof StorageDomains) => {
+      if (name === 'datasets') return datasetsStorage;
+      if (name === 'runs') return runsStorage;
+      return undefined;
+    }),
+  } as unknown as MastraCompositeStore;
+}
+
+function setupMastra(agent: Agent) {
+  mastra = {
+    getStorage: vi.fn().mockReturnValue(mockStorage),
+    getAgent: vi.fn().mockReturnValue(agent),
+    getAgentById: vi.fn().mockReturnValue(agent),
+    getScorerById: vi.fn(),
+    getWorkflowById: vi.fn(),
+    getWorkflow: vi.fn(),
+  } as unknown as Mastra;
+}
+
+describe('Streaming: onItemComplete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // T-1: onItemComplete fires for each item
+  it('T-1: onItemComplete fires for each item', async () => {
+    await setupDataset(5);
+    const agent = createMockAgent();
+    setupMastra(agent);
+
+    const collected: Array<{ index: number }> = [];
+    const onItemComplete = vi.fn().mockImplementation((_result, index) => {
+      collected.push({ index });
+    });
+
+    await runDataset(mastra, {
+      datasetId,
+      targetType: 'agent',
+      targetId: 'test-agent',
+      onItemComplete,
+    });
+
+    expect(onItemComplete).toHaveBeenCalledTimes(5);
+    // Each call should have (ItemWithScores, index)
+    for (let i = 0; i < 5; i++) {
+      const call = onItemComplete.mock.calls[i];
+      expect(call[0]).toHaveProperty('scores');
+      expect(typeof call[1]).toBe('number');
+    }
+  });
+
+  // T-2: onItemComplete auto-defaults retainResults to false
+  it('T-2: onItemComplete auto-defaults retainResults to false', async () => {
+    await setupDataset(5);
+    const agent = createMockAgent();
+    setupMastra(agent);
+
+    const collected: unknown[] = [];
+    const onItemComplete = vi.fn().mockImplementation(result => {
+      collected.push(result);
+    });
+
+    const result = await runDataset(mastra, {
+      datasetId,
+      targetType: 'agent',
+      targetId: 'test-agent',
+      onItemComplete,
+    });
+
+    // Smart default: results not retained
+    expect(result.results).toHaveLength(0);
+    // But callback collected all items
+    expect(collected).toHaveLength(5);
+    expect(result.succeededCount).toBe(5);
+  });
+
+  // T-3: onItemComplete + explicit retainResults true gives both
+  it('T-3: onItemComplete + retainResults true gives both', async () => {
+    await setupDataset(3);
+    const agent = createMockAgent();
+    setupMastra(agent);
+
+    const onItemComplete = vi.fn();
+
+    const result = await runDataset(mastra, {
+      datasetId,
+      targetType: 'agent',
+      targetId: 'test-agent',
+      onItemComplete,
+      retainResults: true,
+    });
+
+    expect(result.results).toHaveLength(3);
+    expect(onItemComplete).toHaveBeenCalledTimes(3);
+  });
+
+  // T-4: onItemComplete receives both success and failure items
+  it('T-4: onItemComplete receives both success and failure items', async () => {
+    await setupDataset(3);
+
+    let callIdx = 0;
+    const agent = {
+      id: 'test-agent',
+      name: 'Test Agent',
+      getModel: vi.fn().mockResolvedValue({ specificationVersion: 'v2' }),
+      generate: vi.fn().mockImplementation(async () => {
+        callIdx++;
+        // Fail on 2nd call
+        if (callIdx === 2) throw new Error('deliberate failure');
+        return { text: 'ok' };
+      }),
+    } as unknown as Agent;
+    setupMastra(agent);
+
+    const errors: (string | null)[] = [];
+    const onItemComplete = vi.fn().mockImplementation(result => {
+      errors.push(result.error);
+    });
+
+    const result = await runDataset(mastra, {
+      datasetId,
+      targetType: 'agent',
+      targetId: 'test-agent',
+      maxConcurrency: 1,
+      onItemComplete,
+    });
+
+    expect(onItemComplete).toHaveBeenCalledTimes(3);
+    expect(errors.filter(e => e !== null)).toHaveLength(1);
+    expect(result.succeededCount).toBe(2);
+    expect(result.failedCount).toBe(1);
+  });
+
+  // T-5: onItemComplete throw is non-fatal
+  it('T-5: onItemComplete throw is non-fatal', async () => {
+    await setupDataset(3);
+    const agent = createMockAgent();
+    setupMastra(agent);
+
+    const onItemComplete = vi.fn().mockImplementation(() => {
+      throw new Error('callback boom');
+    });
+
+    const result = await runDataset(mastra, {
+      datasetId,
+      targetType: 'agent',
+      targetId: 'test-agent',
+      onItemComplete,
+    });
+
+    expect(result.succeededCount).toBe(3);
+    expect(result.status).toBe('completed');
+  });
+
+  // T-6: async onItemComplete is awaited
+  it('T-6: async onItemComplete is awaited', async () => {
+    await setupDataset(3);
+    const agent = createMockAgent();
+    setupMastra(agent);
+
+    const timestamps: number[] = [];
+    const onItemComplete = vi.fn().mockImplementation(async () => {
+      timestamps.push(performance.now());
+      await new Promise(r => setTimeout(r, 50));
+      timestamps.push(performance.now());
+    });
+
+    await runDataset(mastra, {
+      datasetId,
+      targetType: 'agent',
+      targetId: 'test-agent',
+      maxConcurrency: 1,
+      onItemComplete,
+    });
+
+    expect(onItemComplete).toHaveBeenCalledTimes(3);
+    // Each callback's end (even index) should be before next callback's start (odd index)
+    // timestamps: [start0, end0, start1, end1, start2, end2]
+    for (let i = 1; i < timestamps.length - 1; i += 2) {
+      // end of callback i should be <= start of callback i+1
+      expect(timestamps[i]).toBeLessThanOrEqual(timestamps[i + 1]);
+    }
+  });
+
+  // T-7: onItemComplete on abort — only completed items
+  it('T-7: onItemComplete on abort — only completed items', { timeout: 5000 }, async () => {
+    await setupDataset(10);
+    const agent = createMockAgent({ delayMs: 200 });
+    setupMastra(agent);
+
+    const collected: unknown[] = [];
+    const onItemComplete = vi.fn().mockImplementation(result => {
+      collected.push(result);
+    });
+
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 300);
+
+    const result = await runDataset(mastra, {
+      datasetId,
+      targetType: 'agent',
+      targetId: 'test-agent',
+      maxConcurrency: 2,
+      signal: controller.signal,
+      onItemComplete,
+    });
+
+    // Some items completed, but not all
+    expect(collected.length).toBeGreaterThan(0);
+    expect(collected.length).toBeLessThan(10);
+    // Callback count should match collected
+    expect(onItemComplete).toHaveBeenCalledTimes(collected.length);
+    // Run should have partial results
+    expect(result.status).toBe('failed');
+  });
+});

--- a/packages/core/src/datasets/run/types.ts
+++ b/packages/core/src/datasets/run/types.ts
@@ -21,6 +21,12 @@ export interface RunConfig {
   signal?: AbortSignal;
   /** Per-item execution timeout in milliseconds. Default: no timeout. */
   itemTimeout?: number;
+  /** When false, results are not accumulated in memory. Use storage to retrieve results. Default: true. */
+  retainResults?: boolean;
+  /** Maximum retry attempts per item on transient failure. Default: 0 (no retry). */
+  maxRetries?: number;
+  /** Base delay between retries in ms. Actual delay: retryDelay * 2^attempt + jitter. Default: 1000. */
+  retryDelay?: number;
   /** Pre-created run ID (for async trigger - skips run creation) */
   runId?: string;
 }
@@ -93,6 +99,10 @@ export interface RunSummary {
   startedAt: Date;
   /** When the run completed */
   completedAt: Date;
+  /** True when run completed but some items failed */
+  completedWithErrors: boolean;
+  /** Number of items not processed (aborted or never started) */
+  skippedCount: number;
   /** All item results with their scores */
   results: ItemWithScores[];
 }

--- a/packages/core/src/datasets/run/types.ts
+++ b/packages/core/src/datasets/run/types.ts
@@ -27,6 +27,11 @@ export interface RunConfig {
   maxRetries?: number;
   /** Base delay between retries in ms. Actual delay: retryDelay * 2^attempt + jitter. Default: 1000. */
   retryDelay?: number;
+  /** Called after each item completes execution, scoring, and persistence.
+   *  Callback errors are logged but do not stop the run.
+   *  If the callback returns a Promise, it is awaited before proceeding.
+   *  When provided, retainResults defaults to false (zero memory accumulation). */
+  onItemComplete?: (result: ItemWithScores, index: number) => void | Promise<void>;
   /** Pre-created run ID (for async trigger - skips run creation) */
   runId?: string;
 }

--- a/packages/server/src/server/handlers/datasets.ts
+++ b/packages/server/src/server/handlers/datasets.ts
@@ -591,6 +591,7 @@ export const TRIGGER_RUN_ROUTE = createRoute({
             version: version instanceof Date ? version : undefined,
             maxConcurrency,
             runId, // Pass pre-created runId to avoid duplicate creation
+            retainResults: false, // Results fetched via listResults API
           });
         } catch (err) {
           // Log error and update run status to failed


### PR DESCRIPTION
## Summary

P1 fixes for dataset run executor, following up on P0 fixes in PR #12789.

### Changes

| Issue | Fix |
|-------|-----|
| #8 Sequential scorers | Replace `for` loop with `Promise.allSettled` in `runScorersForItem` |
| #9 No partial failure status | Add `completedWithErrors: boolean` to `RunSummary` |
| #10 Abort skippedCount | Add `skippedCount` to `RunSummary` for unprocessed items |
| #11 Non-deterministic results | Pre-allocated array indexed by position, filtered at end |
| #6 Memory accumulation | `retainResults: false` opt-in to skip in-memory result collection |
| #7 No retry | `maxRetries` + `retryDelay` with exponential backoff and jitter |

### Files Modified
- `scorer.ts` — parallel scorers via `Promise.allSettled`
- `types.ts` — `completedWithErrors`, `skippedCount`, `retainResults`, `maxRetries`, `retryDelay`
- `index.ts` — retry loop, results ordering, abort skippedCount, retainResults gate
- `__tests__/p1-regression.test.ts` — 13 new regression tests
- `P1-PLAN.md` — planning doc

### Test Plan
```bash
cd packages/core && pnpm vitest run src/datasets/run/__tests__/
```
All 49 tests pass (4 files).

### Breaking Changes
None. All new fields (`completedWithErrors`, `skippedCount`) are additive. New config options (`retainResults`, `maxRetries`, `retryDelay`) default to existing behavior.