### PR TITLE
fix(datasets): cast context type in copy-to-dataset dialog

### DIFF
--- a/packages/playground-ui/src/domains/datasets/components/create-dataset-from-items-dialog.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/create-dataset-from-items-dialog.tsx
@@ -53,6 +53,7 @@ export function CreateDatasetFromItemsDialog({
           datasetId: dataset.id,
           input: item.input,
           expectedOutput: item.expectedOutput,
+          context: item.context as Record<string, unknown> | undefined,
         });
         setProgress(i + 1);
       }


### PR DESCRIPTION
## What
Fixes type mismatch when copying dataset items via the "Create Dataset from Items" dialog.

## Changes
- `create-dataset-from-items-dialog.tsx` — cast `item.context` to `Record<string, unknown> | undefined` to match the `addItem` API, consistent with the other two copy dialogs.

## Test Plan
- `pnpm build` in `playground-ui` passes with no errors.