### PR TITLE
fix(deployer): resolve cross-package tsconfig path alias deps in dev

### DIFF
--- a/.changeset/fix-monorepo-tsconfig-aliases.md
+++ b/.changeset/fix-monorepo-tsconfig-aliases.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed monorepo tsconfig path alias resolution in dev mode. When path aliases (e.g., `@lib/*`) point to files in a different workspace package, their transitive dependencies are now correctly resolved at runtime. Previously, `mastra dev` would fail with `Cannot find package` errors for dependencies only installed in the aliased package's `node_modules`. Fixes #12550.

--- a/packages/deployer/src/build/plugins/tsconfig-paths.test.ts
+++ b/packages/deployer/src/build/plugins/tsconfig-paths.test.ts
@@ -147,7 +147,7 @@ describe('tsconfig-paths plugin', () => {
       expect(result.output[0].code).toContain('hello');
     });
 
-    it('should not mark transitive dependencies of tsconfig-resolved cross-package imports as external (issue #12550)', async () => {
+    it('should resolve cross-package npm dependencies via tsconfig path aliases in dev mode', async () => {
       const mastraDir = join(tempDir, 'apps', 'mastra');
       const mastraSrcDir = join(mastraDir, 'src', 'mastra');
       const libDir = join(tempDir, 'packages', 'lib');
@@ -156,7 +156,6 @@ describe('tsconfig-paths plugin', () => {
       fs.mkdirSync(mastraSrcDir, { recursive: true });
       fs.mkdirSync(betterAuthDir, { recursive: true });
 
-      // Create tsconfig.json in the mastra app with path alias to lib package
       const tsConfigPath = join(mastraDir, 'tsconfig.json');
       fs.writeFileSync(
         tsConfigPath,
@@ -170,7 +169,6 @@ describe('tsconfig-paths plugin', () => {
         }),
       );
 
-      // Create the lib package's auth module that imports an external dependency
       fs.writeFileSync(
         join(libDir, 'package.json'),
         JSON.stringify({
@@ -186,7 +184,6 @@ describe('tsconfig-paths plugin', () => {
         `import { betterAuth } from 'better-auth';\nexport const auth = betterAuth({ database: 'test' });`,
       );
 
-      // Create the fake better-auth package (only in packages/lib/node_modules)
       fs.writeFileSync(
         join(betterAuthDir, 'package.json'),
         JSON.stringify({
@@ -198,14 +195,11 @@ describe('tsconfig-paths plugin', () => {
       );
       fs.writeFileSync(join(betterAuthDir, 'index.js'), `export function betterAuth(config) { return { config }; }`);
 
-      // Create the mastra entry file
       const indexFile = join(mastraSrcDir, 'index.ts');
       fs.writeFileSync(indexFile, `import { auth } from '@lib/auth';\nexport const mastra = { auth };`);
 
-      // Use tsConfigPaths with localResolve: true (same as dev mode)
       const plugin = tsConfigPaths({ tsConfigPath, localResolve: true });
 
-      // Build using rollup - this simulates the dev mode bundling
       const bundle = await rollup({
         logLevel: 'silent',
         input: indexFile,

--- a/packages/deployer/src/build/plugins/tsconfig-paths.ts
+++ b/packages/deployer/src/build/plugins/tsconfig-paths.ts
@@ -135,12 +135,6 @@ export function tsConfigPaths({ tsConfigPath, respectCoreModule, localResolve }:
         if (!moduleName) {
           const resolved = await this.resolve(request, importer, { skipSelf: true, ...options });
           if (!resolved) {
-            // When localResolve is enabled and the importer was resolved via tsconfig-paths
-            // (e.g., @lib/auth -> ../../packages/lib/auth.ts), bare imports from the resolved
-            // module may not be resolvable from the output directory (.mastra/output/).
-            // Resolve them from the importer's location using absolute paths so Node.js can
-            // find them at runtime regardless of CWD.
-            // See: https://github.com/mastra-ai/mastra/issues/12550
             if (localResolve && !request.startsWith('./') && !request.startsWith('../')) {
               const importerInfo = this.getModuleInfo(importer);
               if (importerInfo?.meta?.[PLUGIN_NAME]?.resolved) {

--- a/packages/deployer/src/build/plugins/tsconfig-paths.ts
+++ b/packages/deployer/src/build/plugins/tsconfig-paths.ts
@@ -143,7 +143,7 @@ export function tsConfigPaths({ tsConfigPath, respectCoreModule, localResolve }:
                   const resolvedPath = importerRequire.resolve(request);
                   return {
                     id: resolvedPath,
-                    external: true,
+                    external: !request.startsWith('hono/') && request !== 'hono',
                   };
                 } catch {
                   // Can't resolve from importer's location, fall through


### PR DESCRIPTION
## Description
- When tsconfig path aliases point to files in a different monorepo package, their transitive dependencies (e.g., `better-auth`) were unresolvable at runtime from `.mastra/output/`
- Use `createRequire` to resolve bare imports from the importer's location and emit absolute paths

## Before
<img width="1611" height="503" alt="image" src="https://github.com/user-attachments/assets/35258f16-9803-4eeb-92d2-651299fb7ca8" />

## After
<img width="1239" height="405" alt="Screenshot 2026-02-26 173636" src="https://github.com/user-attachments/assets/84243337-67ce-4e48-9089-40b661b0e5a0" />

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)
#12550 
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

## Test plan
- [x] Added regression test for cross-package tsconfig alias resolution
- [x] All 304 deployer tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path alias resolution in development — resolves "Cannot find package" errors when running mastra dev. Transitive dependencies of aliased workspace packages (e.g., @lib/*) are now properly discovered at runtime and no longer treated as external during bundling.

* **Tests**
  * Added integration tests to verify transitive dependency resolution for aliased packages during builds.

* **Chores**
  * Added a changeset entry and bumped the package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->