### PR TITLE
feat: allow users to enrich Mastra database tables with their own columns

### DIFF
--- a/.changeset/custom-database-columns.md
+++ b/.changeset/custom-database-columns.md
@@ -5,3 +5,52 @@
 ---
 
 Add support for custom user-defined columns in Mastra database tables. Developers can now enrich the default storage schema with their own fields without spinning up a separate database or writing a custom storage adapter. This makes Mastra's Memory layer more flexible for real-world multi-tenant and domain-specific use cases.
+
+## What's new:
+
+- `schemaExtensions` configuration option for storage adapters (PostgreSQL, LibSQL) to declare custom columns
+- `customColumns` property on threads carrying user-defined column values
+- Filtering support in `listThreads()` to query by custom column values
+- Automatic schema creation and migration handling for custom columns
+
+## Example usage:
+
+**Before:** Custom data forced into metadata (unindexed, harder to query)
+```typescript
+const memory = new Memory({ storage });
+const thread = await memory.createThread({
+  resourceId: 'user-123',
+  metadata: { organizationId: 'org-456' }, // Not indexed
+});
+```
+
+**After:** Custom columns as first-class fields (indexed, queryable)
+```typescript
+const memory = new Memory({
+  storage: new PostgresStore({
+    schemaExtensions: {
+      'mastra_threads': {
+        organizationId: { type: 'text', nullable: false },
+        tenantId: { type: 'text', nullable: true },
+      },
+    },
+  }),
+});
+
+const thread = await memory.createThread({
+  resourceId: 'user-123',
+  customColumns: {
+    organizationId: 'org-456',
+    tenantId: 'tenant-789',
+  },
+});
+
+// Filter threads efficiently by custom column
+const result = await memory.listThreads({
+  filter: {
+    customColumns: { organizationId: 'org-456' },
+  },
+});
+```
+
+Fixes #11076

--- a/.changeset/custom-database-columns.md
+++ b/.changeset/custom-database-columns.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': minor
+'@mastra/pg': minor
+'@mastra/libsql': minor
+---
+
+Add support for custom user-defined columns in Mastra database tables. Developers can now enrich the default storage schema with their own fields without spinning up a separate database or writing a custom storage adapter. This makes Mastra's Memory layer more flexible for real-world multi-tenant and domain-specific use cases.

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -457,6 +457,7 @@ https://mastra.ai/en/docs/memory/overview`,
     resourceId,
     title,
     metadata,
+    customColumns,
     memoryConfig,
     saveThread = true,
   }: {
@@ -464,6 +465,8 @@ https://mastra.ai/en/docs/memory/overview`,
     threadId?: string;
     title?: string;
     metadata?: Record<string, unknown>;
+    /** Values for user-defined custom columns declared via schemaExtensions */
+    customColumns?: Record<string, unknown>;
     memoryConfig?: MemoryConfig;
     saveThread?: boolean;
   }): Promise<StorageThreadType> {
@@ -480,6 +483,7 @@ https://mastra.ai/en/docs/memory/overview`,
       createdAt: new Date(),
       updatedAt: new Date(),
       metadata,
+      customColumns,
     };
 
     return saveThread ? this.saveThread({ thread, memoryConfig }) : thread;

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -43,6 +43,8 @@ export type StorageThreadType = {
   createdAt: Date;
   updatedAt: Date;
   metadata?: Record<string, unknown>;
+  /** Values for user-defined custom columns declared via schemaExtensions */
+  customColumns?: Record<string, unknown>;
 };
 
 /**

--- a/packages/core/src/storage/custom-columns.test.ts
+++ b/packages/core/src/storage/custom-columns.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { StorageThreadType } from '../memory/types';
+import { TABLE_SCHEMAS, TABLE_THREADS } from './constants';
+import { InMemoryDB } from './domains/inmemory-db';
+import { InMemoryMemory } from './domains/memory/inmemory';
+import type { StorageColumn } from './types';
+import { mergeSchemaExtensions, extractCustomColumns } from './utils';
+
+describe('Issue #11076 — Custom columns on Mastra tables', () => {
+  describe('mergeSchemaExtensions()', () => {
+    it('should return base schema unchanged when no extensions provided', () => {
+      const base = TABLE_SCHEMAS[TABLE_THREADS];
+      const result = mergeSchemaExtensions(base, undefined);
+      expect(result).toBe(base); // same reference
+    });
+
+    it('should return base schema unchanged for empty extensions', () => {
+      const base = TABLE_SCHEMAS[TABLE_THREADS];
+      const result = mergeSchemaExtensions(base, {});
+      expect(result).toBe(base);
+    });
+
+    it('should merge custom columns into base schema', () => {
+      const base = TABLE_SCHEMAS[TABLE_THREADS];
+      const extensions: Record<string, StorageColumn> = {
+        organizationId: { type: 'text', nullable: false },
+        tenantId: { type: 'text', nullable: true },
+      };
+      const result = mergeSchemaExtensions(base, extensions);
+
+      // Has all base columns
+      for (const key of Object.keys(base)) {
+        expect(result).toHaveProperty(key);
+      }
+      // Has custom columns
+      expect(result).toHaveProperty('organizationId');
+      expect(result.organizationId).toEqual({ type: 'text', nullable: false });
+      expect(result).toHaveProperty('tenantId');
+      expect(result.tenantId).toEqual({ type: 'text', nullable: true });
+    });
+
+    it('should throw when custom column name conflicts with built-in column', () => {
+      const base = TABLE_SCHEMAS[TABLE_THREADS];
+      const extensions: Record<string, StorageColumn> = {
+        id: { type: 'text', nullable: false }, // 'id' is a built-in column
+      };
+      expect(() => mergeSchemaExtensions(base, extensions)).toThrow(/conflicts with a built-in column/);
+    });
+
+    it('should throw when custom column has primaryKey', () => {
+      const base = TABLE_SCHEMAS[TABLE_THREADS];
+      const extensions: Record<string, StorageColumn> = {
+        myKey: { type: 'text', nullable: false, primaryKey: true },
+      };
+      expect(() => mergeSchemaExtensions(base, extensions)).toThrow(/cannot be a primary key/);
+    });
+
+    it('should throw for invalid column names', () => {
+      const base = TABLE_SCHEMAS[TABLE_THREADS];
+      const extensions: Record<string, StorageColumn> = {
+        'bad-name': { type: 'text', nullable: true },
+      };
+      expect(() => mergeSchemaExtensions(base, extensions)).toThrow(/Invalid schema extension column name/);
+    });
+
+    it('should allow column names with underscores and numbers', () => {
+      const base = TABLE_SCHEMAS[TABLE_THREADS];
+      const extensions: Record<string, StorageColumn> = {
+        org_id_2: { type: 'text', nullable: true },
+        _private: { type: 'integer', nullable: true },
+      };
+      const result = mergeSchemaExtensions(base, extensions);
+      expect(result).toHaveProperty('org_id_2');
+      expect(result).toHaveProperty('_private');
+    });
+  });
+
+  describe('extractCustomColumns()', () => {
+    it('should return undefined when no extension column names', () => {
+      const row = { id: '1', organizationId: 'org-1' };
+      expect(extractCustomColumns(row, [])).toBeUndefined();
+    });
+
+    it('should extract custom column values from a row', () => {
+      const row = { id: '1', resourceId: 'user-1', organizationId: 'org-1', tenantId: 'tenant-1' };
+      const result = extractCustomColumns(row, ['organizationId', 'tenantId']);
+      expect(result).toEqual({ organizationId: 'org-1', tenantId: 'tenant-1' });
+    });
+
+    it('should skip columns not present in the row', () => {
+      const row = { id: '1', organizationId: 'org-1' };
+      const result = extractCustomColumns(row, ['organizationId', 'tenantId']);
+      expect(result).toEqual({ organizationId: 'org-1' });
+    });
+
+    it('should return undefined when no extension columns exist in row', () => {
+      const row = { id: '1', resourceId: 'user-1' };
+      expect(extractCustomColumns(row, ['organizationId'])).toBeUndefined();
+    });
+  });
+
+  describe('InMemory adapter with customColumns', () => {
+    let db: InMemoryDB;
+    let memory: InMemoryMemory;
+
+    beforeEach(() => {
+      db = new InMemoryDB();
+      memory = new InMemoryMemory({ db });
+    });
+
+    it('should save and retrieve a thread with customColumns', async () => {
+      const thread: StorageThreadType = {
+        id: 'thread-1',
+        resourceId: 'user-1',
+        title: 'Test Thread',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        metadata: { foo: 'bar' },
+        customColumns: { organizationId: 'org-123' },
+      };
+
+      await memory.saveThread({ thread });
+      const retrieved = await memory.getThreadById({ threadId: 'thread-1' });
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved!.customColumns).toEqual({ organizationId: 'org-123' });
+      expect(retrieved!.metadata).toEqual({ foo: 'bar' });
+    });
+
+    it('should update thread customColumns', async () => {
+      const thread: StorageThreadType = {
+        id: 'thread-2',
+        resourceId: 'user-1',
+        title: 'Original',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        customColumns: { organizationId: 'org-1', tenantId: 'tenant-1' },
+      };
+
+      await memory.saveThread({ thread });
+      const updated = await memory.updateThread({
+        id: 'thread-2',
+        title: 'Updated',
+        metadata: {},
+        customColumns: { tenantId: 'tenant-2' },
+      });
+
+      expect(updated.customColumns).toEqual({ organizationId: 'org-1', tenantId: 'tenant-2' });
+      expect(updated.title).toBe('Updated');
+    });
+
+    it('should filter threads by customColumns in listThreads', async () => {
+      const threads: StorageThreadType[] = [
+        {
+          id: 't-1',
+          resourceId: 'user-1',
+          title: 'Org A Thread 1',
+          createdAt: new Date('2024-01-01'),
+          updatedAt: new Date('2024-01-01'),
+          customColumns: { organizationId: 'org-a' },
+        },
+        {
+          id: 't-2',
+          resourceId: 'user-1',
+          title: 'Org B Thread',
+          createdAt: new Date('2024-01-02'),
+          updatedAt: new Date('2024-01-02'),
+          customColumns: { organizationId: 'org-b' },
+        },
+        {
+          id: 't-3',
+          resourceId: 'user-2',
+          title: 'Org A Thread 2',
+          createdAt: new Date('2024-01-03'),
+          updatedAt: new Date('2024-01-03'),
+          customColumns: { organizationId: 'org-a' },
+        },
+      ];
+
+      for (const t of threads) {
+        await memory.saveThread({ thread: t });
+      }
+
+      const result = await memory.listThreads({
+        filter: { customColumns: { organizationId: 'org-a' } },
+      });
+
+      expect(result.threads).toHaveLength(2);
+      expect(result.threads.map(t => t.id).sort()).toEqual(['t-1', 't-3']);
+    });
+
+    it('should filter threads by customColumns AND resourceId', async () => {
+      const threads: StorageThreadType[] = [
+        {
+          id: 't-1',
+          resourceId: 'user-1',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          customColumns: { organizationId: 'org-a' },
+        },
+        {
+          id: 't-2',
+          resourceId: 'user-2',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          customColumns: { organizationId: 'org-a' },
+        },
+      ];
+
+      for (const t of threads) {
+        await memory.saveThread({ thread: t });
+      }
+
+      const result = await memory.listThreads({
+        filter: { resourceId: 'user-1', customColumns: { organizationId: 'org-a' } },
+      });
+
+      expect(result.threads).toHaveLength(1);
+      expect(result.threads[0]!.id).toBe('t-1');
+    });
+
+    it('should clone thread with customColumns', async () => {
+      const thread: StorageThreadType = {
+        id: 'source-thread',
+        resourceId: 'user-1',
+        title: 'Source Thread',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        customColumns: { organizationId: 'org-123' },
+      };
+
+      await memory.saveThread({ thread });
+      const result = await memory.cloneThread({
+        sourceThreadId: 'source-thread',
+        newThreadId: 'cloned-thread',
+      });
+
+      expect(result.thread.customColumns).toEqual({ organizationId: 'org-123' });
+      expect(result.thread.id).toBe('cloned-thread');
+    });
+
+    it('should return threads without customColumns when none set', async () => {
+      const thread: StorageThreadType = {
+        id: 'plain-thread',
+        resourceId: 'user-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      await memory.saveThread({ thread });
+      const retrieved = await memory.getThreadById({ threadId: 'plain-thread' });
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved!.customColumns).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/storage/domains/memory/base.ts
+++ b/packages/core/src/storage/domains/memory/base.ts
@@ -52,10 +52,13 @@ export abstract class MemoryStorage extends StorageDomain {
     id,
     title,
     metadata,
+    customColumns,
   }: {
     id: string;
     title: string;
     metadata: Record<string, unknown>;
+    /** Values for user-defined custom columns to update (merged with existing) */
+    customColumns?: Record<string, unknown>;
   }): Promise<StorageThreadType>;
 
   abstract deleteThread({ threadId }: { threadId: string }): Promise<void>;

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -48,7 +48,13 @@ export class InMemoryMemory extends MemoryStorage {
   async getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null> {
     this.logger.debug(`InMemoryMemory: getThreadById called for ${threadId}`);
     const thread = this.db.threads.get(threadId);
-    return thread ? { ...thread, metadata: thread.metadata ? { ...thread.metadata } : thread.metadata } : null;
+    return thread
+      ? {
+          ...thread,
+          metadata: thread.metadata ? { ...thread.metadata } : thread.metadata,
+          customColumns: thread.customColumns ? { ...thread.customColumns } : thread.customColumns,
+        }
+      : null;
   }
 
   async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -62,10 +62,12 @@ export class InMemoryMemory extends MemoryStorage {
     id,
     title,
     metadata,
+    customColumns,
   }: {
     id: string;
     title: string;
     metadata: Record<string, unknown>;
+    customColumns?: Record<string, unknown>;
   }): Promise<StorageThreadType> {
     this.logger.debug(`InMemoryMemory: updateThread called for ${id}`);
     const thread = this.db.threads.get(id);
@@ -77,6 +79,9 @@ export class InMemoryMemory extends MemoryStorage {
     if (thread) {
       thread.title = title;
       thread.metadata = { ...thread.metadata, ...metadata };
+      if (customColumns) {
+        thread.customColumns = { ...thread.customColumns, ...customColumns };
+      }
       thread.updatedAt = new Date();
     }
     return thread;
@@ -574,6 +579,16 @@ export class InMemoryMemory extends MemoryStorage {
       });
     }
 
+    // Apply customColumns filter if provided (AND logic - all key-value pairs must match)
+    if (filter?.customColumns && Object.keys(filter.customColumns).length > 0) {
+      threads = threads.filter(thread => {
+        if (!thread.customColumns) return false;
+        return Object.entries(filter.customColumns!).every(([key, value]) =>
+          jsonValueEquals(thread.customColumns![key], value),
+        );
+      });
+    }
+
     const sortedThreads = this.sortThreads(threads, field, direction);
     const clonedThreads = sortedThreads.map(thread => ({
       ...thread,
@@ -712,6 +727,7 @@ export class InMemoryMemory extends MemoryStorage {
       },
       createdAt: now,
       updatedAt: now,
+      customColumns: sourceThread.customColumns ? { ...sourceThread.customColumns } : undefined,
     };
 
     // Save the new thread

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -593,6 +593,7 @@ export class InMemoryMemory extends MemoryStorage {
     const clonedThreads = sortedThreads.map(thread => ({
       ...thread,
       metadata: thread.metadata ? { ...thread.metadata } : thread.metadata,
+      customColumns: thread.customColumns ? { ...thread.customColumns } : thread.customColumns,
     })) as StorageThreadType[];
 
     const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -28,6 +28,25 @@ export interface StorageTableConfig {
   columns: Record<string, StorageColumn>;
   compositePrimaryKey?: string[];
 }
+
+/**
+ * Schema extensions allow users to add custom columns to Mastra's built-in tables.
+ * Custom columns are real database columns (not JSONB metadata), enabling proper
+ * indexing, type checking, and efficient queries.
+ *
+ * Maps table name to a record of column name → column definition.
+ *
+ * @example
+ * ```typescript
+ * const extensions: SchemaExtensions = {
+ *   mastra_threads: {
+ *     organizationId: { type: 'text', nullable: false },
+ *     priority: { type: 'integer', nullable: true },
+ *   },
+ * };
+ * ```
+ */
+export type SchemaExtensions = Partial<Record<string, Record<string, StorageColumn>>>;
 export interface WorkflowRuns {
   runs: WorkflowRun[];
   total: number;
@@ -179,6 +198,12 @@ export type StorageListThreadsInput = {
      * All specified key-value pairs must match (AND logic).
      */
     metadata?: Record<string, unknown>;
+    /**
+     * Filter threads by custom column values declared via schemaExtensions.
+     * All specified key-value pairs must match (AND logic).
+     * Keys must correspond to columns declared in the store's schemaExtensions config.
+     */
+    customColumns?: Record<string, unknown>;
   };
 };
 

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -6,6 +6,7 @@ import type { MastraDBMessage, StorageThreadType, SerializedMemoryConfig } from 
 import type { ProcessorPhase } from '../processor-provider';
 import { getZodInnerType, getZodTypeName } from '../utils/zod-utils';
 import type { StepResult, WorkflowRunState, WorkflowRunStatus } from '../workflows';
+import type { TABLE_NAMES } from './constants';
 
 export type StoragePagination = {
   page: number;
@@ -46,7 +47,7 @@ export interface StorageTableConfig {
  * };
  * ```
  */
-export type SchemaExtensions = Partial<Record<string, Record<string, StorageColumn>>>;
+export type SchemaExtensions = Partial<Record<TABLE_NAMES, Record<string, StorageColumn>>>;
 export interface WorkflowRuns {
   runs: WorkflowRun[];
   total: number;

--- a/stores/libsql/src/storage/db/index.ts
+++ b/stores/libsql/src/storage/db/index.ts
@@ -9,7 +9,7 @@ import {
   TABLE_SPANS,
   TABLE_SCHEMAS,
 } from '@mastra/core/storage';
-import type { TABLE_NAMES, StorageColumn } from '@mastra/core/storage';
+import type { TABLE_NAMES, StorageColumn, SchemaExtensions } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
 import {
   buildSelectColumns,
@@ -34,6 +34,11 @@ export type LibSQLDomainBaseConfig = {
    * @default 100
    */
   initialBackoffMs?: number;
+  /**
+   * Optional schema extensions to add custom columns to built-in tables.
+   * Keys are table names, values are column definitions.
+   */
+  schemaExtensions?: SchemaExtensions;
 };
 
 /**

--- a/stores/libsql/src/storage/db/utils.ts
+++ b/stores/libsql/src/storage/db/utils.ts
@@ -18,8 +18,8 @@ import { parseSqlIdentifier } from '@mastra/core/utils';
  * @param tableName - The table name to get the schema for
  * @returns A comma-separated column list with json() wrappers for JSONB columns
  */
-export function buildSelectColumns(tableName: TABLE_NAMES): string {
-  const schema = TABLE_SCHEMAS[tableName];
+export function buildSelectColumns(tableName: TABLE_NAMES, schemaOverride?: Record<string, StorageColumn>): string {
+  const schema = schemaOverride || TABLE_SCHEMAS[tableName];
   return Object.keys(schema)
     .map(col => {
       const colDef = schema[col];

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -921,14 +921,21 @@ export class MemoryLibSQL extends MemoryStorage {
       }
 
       const row = queryResult.rows[0]!;
-      // Parse JSON columns
+      // Parse JSON columns - only for known JSONB columns (handled by buildSelectColumns)
+      // Metadata is the primary JSONB column in threads; custom columns are stored as-is
+      const KNOWN_JSON_COLUMNS = new Set(['metadata']);
       const result = Object.fromEntries(
         Object.entries(row).map(([k, v]) => {
-          try {
-            return [k, typeof v === 'string' ? (v.startsWith('{') || v.startsWith('[') ? JSON.parse(v) : v) : v];
-          } catch {
-            return [k, v];
+          // Only attempt to parse known JSON columns (metadata, etc.)
+          if (KNOWN_JSON_COLUMNS.has(k) && typeof v === 'string') {
+            try {
+              return [k, JSON.parse(v)];
+            } catch {
+              return [k, v];
+            }
           }
+          // Leave all other values unchanged (preserves user strings)
+          return [k, v];
         }),
       );
 
@@ -1037,9 +1044,23 @@ export class MemoryLibSQL extends MemoryStorage {
       }
 
       // Add customColumns filters if provided (must be before baseQuery is built)
+      // Validate all custom column keys first (USER error, not caught by try)
+      if (filter?.customColumns && Object.keys(filter.customColumns).length > 0) {
+        for (const [key] of Object.entries(filter.customColumns)) {
+          if (!this.#threadExtensionCols.includes(key)) {
+            throw new MastraError({
+              id: createStorageErrorId('LIBSQL', 'LIST_THREADS', 'INVALID_CUSTOM_COLUMN'),
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.USER,
+              text: `Custom column '${key}' is not declared in schemaExtensions for ${TABLE_THREADS}`,
+            });
+          }
+        }
+      }
+
+      // Build WHERE clauses for custom columns (after validation)
       if (filter?.customColumns && Object.keys(filter.customColumns).length > 0) {
         for (const [key, value] of Object.entries(filter.customColumns)) {
-          if (!this.#threadExtensionCols.includes(key)) continue;
           const parsedKey = parseSqlIdentifier(key, 'column name');
           if (value === null) {
             whereClauses.push(`${parsedKey} IS NULL`);
@@ -1193,12 +1214,13 @@ export class MemoryLibSQL extends MemoryStorage {
         ...metadata,
       },
       customColumns: mergedCustomColumns,
+      updatedAt: new Date(),
     };
 
     try {
       // Build SET clauses dynamically
-      let sql = `UPDATE ${TABLE_THREADS} SET title = ?, metadata = jsonb(?)`;
-      const args: InValue[] = [title, JSON.stringify(updatedThread.metadata)];
+      let sql = `UPDATE ${TABLE_THREADS} SET title = ?, metadata = jsonb(?), "updatedAt" = ?`;
+      const args: InValue[] = [title, JSON.stringify(updatedThread.metadata), updatedThread.updatedAt.toISOString()];
 
       for (const col of this.#threadExtensionCols) {
         const parsedCol = parseSqlIdentifier(col, 'column name');

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -1036,10 +1036,7 @@ export class MemoryLibSQL extends MemoryStorage {
         }
       }
 
-      const whereClause = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
-      const baseQuery = `FROM ${TABLE_THREADS} ${whereClause}`;
-
-      // Add customColumns filters if provided
+      // Add customColumns filters if provided (must be before baseQuery is built)
       if (filter?.customColumns && Object.keys(filter.customColumns).length > 0) {
         for (const [key, value] of Object.entries(filter.customColumns)) {
           if (!this.#threadExtensionCols.includes(key)) continue;
@@ -1052,6 +1049,9 @@ export class MemoryLibSQL extends MemoryStorage {
           }
         }
       }
+
+      const whereClause = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
+      const baseQuery = `FROM ${TABLE_THREADS} ${whereClause}`;
 
       const mapRowToStorageThreadType = (row: any): StorageThreadType => ({
         id: row.id as string,

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -24,6 +24,7 @@ import type {
   UpdateBufferedReflectionInput,
   SwapBufferedReflectionToActiveInput,
   CreateReflectionGenerationInput,
+  StorageColumn,
 } from '@mastra/core/storage';
 import {
   createStorageErrorId,
@@ -34,6 +35,8 @@ import {
   TABLE_RESOURCES,
   TABLE_THREADS,
   TABLE_SCHEMAS,
+  mergeSchemaExtensions,
+  extractCustomColumns,
 } from '@mastra/core/storage';
 
 /**
@@ -52,16 +55,20 @@ export class MemoryLibSQL extends MemoryStorage {
 
   #client: Client;
   #db: LibSQLDB;
+  #threadSchema: Record<string, StorageColumn>;
+  #threadExtensionCols: string[];
 
   constructor(config: LibSQLDomainConfig) {
     super();
     const client = resolveClient(config);
     this.#client = client;
     this.#db = new LibSQLDB({ client, maxRetries: config.maxRetries, initialBackoffMs: config.initialBackoffMs });
+    this.#threadSchema = mergeSchemaExtensions(TABLE_SCHEMAS[TABLE_THREADS], config.schemaExtensions?.[TABLE_THREADS]);
+    this.#threadExtensionCols = Object.keys(config.schemaExtensions?.[TABLE_THREADS] || {});
   }
 
   async init(): Promise<void> {
-    await this.#db.createTable({ tableName: TABLE_THREADS, schema: TABLE_SCHEMAS[TABLE_THREADS] });
+    await this.#db.createTable({ tableName: TABLE_THREADS, schema: this.#threadSchema });
     await this.#db.createTable({ tableName: TABLE_MESSAGES, schema: TABLE_SCHEMAS[TABLE_MESSAGES] });
     await this.#db.createTable({ tableName: TABLE_RESOURCES, schema: TABLE_SCHEMAS[TABLE_RESOURCES] });
 
@@ -902,22 +909,37 @@ export class MemoryLibSQL extends MemoryStorage {
 
   async getThreadById({ threadId }: { threadId: string }): Promise<StorageThreadType | null> {
     try {
-      const result = await this.#db.select<
-        Omit<StorageThreadType, 'createdAt' | 'updatedAt'> & { createdAt: string; updatedAt: string }
-      >({
-        tableName: TABLE_THREADS,
-        keys: { id: threadId },
+      const columns = buildSelectColumns(TABLE_THREADS, this.#threadSchema);
+      const parsedTableName = parseSqlIdentifier(TABLE_THREADS, 'table name');
+      const queryResult = await this.#client.execute({
+        sql: `SELECT ${columns} FROM ${parsedTableName} WHERE id = ? ORDER BY createdAt DESC LIMIT 1`,
+        args: [threadId],
       });
 
-      if (!result) {
+      if (!queryResult.rows || queryResult.rows.length === 0) {
         return null;
       }
 
+      const row = queryResult.rows[0]!;
+      // Parse JSON columns
+      const result = Object.fromEntries(
+        Object.entries(row).map(([k, v]) => {
+          try {
+            return [k, typeof v === 'string' ? (v.startsWith('{') || v.startsWith('[') ? JSON.parse(v) : v) : v];
+          } catch {
+            return [k, v];
+          }
+        }),
+      );
+
       return {
-        ...result,
+        id: result.id as string,
+        resourceId: result.resourceId as string,
+        title: result.title as string,
         metadata: typeof result.metadata === 'string' ? JSON.parse(result.metadata) : result.metadata,
-        createdAt: new Date(result.createdAt),
-        updatedAt: new Date(result.updatedAt),
+        createdAt: new Date(result.createdAt as string),
+        updatedAt: new Date(result.updatedAt as string),
+        customColumns: extractCustomColumns(result as Record<string, unknown>, this.#threadExtensionCols),
       };
     } catch (error) {
       throw new MastraError(
@@ -1017,6 +1039,20 @@ export class MemoryLibSQL extends MemoryStorage {
       const whereClause = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
       const baseQuery = `FROM ${TABLE_THREADS} ${whereClause}`;
 
+      // Add customColumns filters if provided
+      if (filter?.customColumns && Object.keys(filter.customColumns).length > 0) {
+        for (const [key, value] of Object.entries(filter.customColumns)) {
+          if (!this.#threadExtensionCols.includes(key)) continue;
+          const parsedKey = parseSqlIdentifier(key, 'column name');
+          if (value === null) {
+            whereClauses.push(`${parsedKey} IS NULL`);
+          } else {
+            whereClauses.push(`${parsedKey} = ?`);
+            queryParams.push(value as InValue);
+          }
+        }
+      }
+
       const mapRowToStorageThreadType = (row: any): StorageThreadType => ({
         id: row.id as string,
         resourceId: row.resourceId as string,
@@ -1024,6 +1060,7 @@ export class MemoryLibSQL extends MemoryStorage {
         createdAt: new Date(row.createdAt as string),
         updatedAt: new Date(row.updatedAt as string),
         metadata: typeof row.metadata === 'string' ? JSON.parse(row.metadata) : row.metadata,
+        customColumns: extractCustomColumns(row as Record<string, unknown>, this.#threadExtensionCols),
       });
 
       const countResult = await this.#client.execute({
@@ -1044,7 +1081,7 @@ export class MemoryLibSQL extends MemoryStorage {
 
       const limitValue = perPageInput === false ? total : perPage;
       const dataResult = await this.#client.execute({
-        sql: `SELECT ${buildSelectColumns(TABLE_THREADS)} ${baseQuery} ORDER BY "${field}" ${direction} LIMIT ? OFFSET ?`,
+        sql: `SELECT ${buildSelectColumns(TABLE_THREADS, this.#threadSchema)} ${baseQuery} ORDER BY "${field}" ${direction} LIMIT ? OFFSET ?`,
         args: [...queryParams, limitValue, offset],
       });
 
@@ -1088,12 +1125,20 @@ export class MemoryLibSQL extends MemoryStorage {
 
   async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {
     try {
+      // Spread custom columns as top-level record fields for DB insertion
+      const { customColumns, ...threadFields } = thread;
+      const record: Record<string, unknown> = { ...threadFields };
+      if (customColumns) {
+        for (const col of this.#threadExtensionCols) {
+          if (col in customColumns) {
+            record[col] = customColumns[col];
+          }
+        }
+      }
+
       await this.#db.insert({
         tableName: TABLE_THREADS,
-        record: {
-          ...thread,
-          // metadata is handled by prepareStatement which stringifies jsonb columns
-        },
+        record,
       });
 
       return thread;
@@ -1117,10 +1162,12 @@ export class MemoryLibSQL extends MemoryStorage {
     id,
     title,
     metadata,
+    customColumns,
   }: {
     id: string;
     title: string;
     metadata: Record<string, unknown>;
+    customColumns?: Record<string, unknown>;
   }): Promise<StorageThreadType> {
     const thread = await this.getThreadById({ threadId: id });
     if (!thread) {
@@ -1136,20 +1183,33 @@ export class MemoryLibSQL extends MemoryStorage {
       });
     }
 
-    const updatedThread = {
+    const mergedCustomColumns = customColumns ? { ...thread.customColumns, ...customColumns } : thread.customColumns;
+
+    const updatedThread: StorageThreadType = {
       ...thread,
       title,
       metadata: {
         ...thread.metadata,
         ...metadata,
       },
+      customColumns: mergedCustomColumns,
     };
 
     try {
-      await this.#client.execute({
-        sql: `UPDATE ${TABLE_THREADS} SET title = ?, metadata = jsonb(?) WHERE id = ?`,
-        args: [title, JSON.stringify(updatedThread.metadata), id],
-      });
+      // Build SET clauses dynamically
+      let sql = `UPDATE ${TABLE_THREADS} SET title = ?, metadata = jsonb(?)`;
+      const args: InValue[] = [title, JSON.stringify(updatedThread.metadata)];
+
+      for (const col of this.#threadExtensionCols) {
+        const parsedCol = parseSqlIdentifier(col, 'column name');
+        sql += `, ${parsedCol} = ?`;
+        args.push((mergedCustomColumns?.[col] ?? null) as InValue);
+      }
+
+      sql += ` WHERE id = ?`;
+      args.push(id);
+
+      await this.#client.execute({ sql, args });
 
       return updatedThread;
     } catch (error) {
@@ -1290,24 +1350,34 @@ export class MemoryLibSQL extends MemoryStorage {
         },
         createdAt: now,
         updatedAt: now,
+        customColumns: sourceThread.customColumns,
       };
 
       // Use transaction for consistency
       const tx = await this.#client.transaction('write');
 
       try {
-        // Insert the new thread
+        // Insert the new thread with dynamic columns
+        const columns = ['id', '"resourceId"', 'title', 'metadata', '"createdAt"', '"updatedAt"'];
+        const placeholders = ['?', '?', '?', 'jsonb(?)', '?', '?'];
+        const insertArgs: InValue[] = [
+          newThread.id,
+          newThread.resourceId,
+          newThread.title ?? '',
+          JSON.stringify(newThread.metadata),
+          nowStr,
+          nowStr,
+        ];
+
+        for (const col of this.#threadExtensionCols) {
+          columns.push(`"${col}"`);
+          placeholders.push('?');
+          insertArgs.push((newThread.customColumns?.[col] ?? null) as InValue);
+        }
+
         await tx.execute({
-          sql: `INSERT INTO "${TABLE_THREADS}" (id, "resourceId", title, metadata, "createdAt", "updatedAt")
-                VALUES (?, ?, ?, jsonb(?), ?, ?)`,
-          args: [
-            newThread.id,
-            newThread.resourceId,
-            newThread.title ?? '',
-            JSON.stringify(newThread.metadata),
-            nowStr,
-            nowStr,
-          ],
+          sql: `INSERT INTO "${TABLE_THREADS}" (${columns.join(', ')}) VALUES (${placeholders.join(', ')})`,
+          args: insertArgs,
         });
 
         // Clone messages with new IDs

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -1370,7 +1370,7 @@ export class MemoryLibSQL extends MemoryStorage {
         ];
 
         for (const col of this.#threadExtensionCols) {
-          columns.push(`"${col}"`);
+          columns.push(parseSqlIdentifier(col, 'column name'));
           placeholders.push('?');
           insertArgs.push((newThread.customColumns?.[col] ?? null) as InValue);
         }

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@libsql/client';
 import type { Client } from '@libsql/client';
-import type { StorageDomains } from '@mastra/core/storage';
+import type { StorageDomains, SchemaExtensions } from '@mastra/core/storage';
 import { MastraCompositeStore } from '@mastra/core/storage';
 
 import { AgentsLibSQL } from './domains/agents';
@@ -73,6 +73,11 @@ export type LibSQLBaseConfig = {
    * // No auto-init, tables must already exist
    */
   disableInit?: boolean;
+  /**
+   * Optional schema extensions to add custom columns to built-in tables.
+   * Keys are table names, values are column definitions.
+   */
+  schemaExtensions?: SchemaExtensions;
 };
 
 export type LibSQLConfig =
@@ -148,6 +153,7 @@ export class LibSQLStore extends MastraCompositeStore {
       client: this.client,
       maxRetries: this.maxRetries,
       initialBackoffMs: this.initialBackoffMs,
+      schemaExtensions: config.schemaExtensions,
     };
 
     const scores = new ScoresLibSQL(domainConfig);

--- a/stores/pg/src/shared/config.ts
+++ b/stores/pg/src/shared/config.ts
@@ -1,5 +1,5 @@
 import type { ConnectionOptions } from 'node:tls';
-import type { CreateIndexOptions } from '@mastra/core/storage';
+import type { CreateIndexOptions, SchemaExtensions } from '@mastra/core/storage';
 import type { ClientConfig, Pool, PoolConfig } from 'pg';
 
 /**
@@ -57,6 +57,24 @@ export interface PostgresBaseConfig {
    * ```
    */
   indexes?: CreateIndexOptions[];
+  /**
+   * Custom columns to add to Mastra's built-in database tables.
+   * These columns are created as real database columns during initialization,
+   * enabling proper indexing, type checking, and efficient queries.
+   *
+   * @example
+   * ```typescript
+   * const store = new PostgresStore({
+   *   connectionString: '...',
+   *   schemaExtensions: {
+   *     mastra_threads: {
+   *       organizationId: { type: 'text', nullable: false },
+   *     },
+   *   },
+   * });
+   * ```
+   */
+  schemaExtensions?: SchemaExtensions;
 }
 
 /**

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -15,6 +15,7 @@ import type {
   CreateIndexOptions,
   IndexInfo,
   StorageIndexStats,
+  SchemaExtensions,
 } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
 import { Pool } from 'pg';
@@ -45,6 +46,8 @@ export interface PgDomainClientConfig {
   skipDefaultIndexes?: boolean;
   /** Custom indexes to create for this domain's tables */
   indexes?: CreateIndexOptions[];
+  /** Custom columns to add to Mastra's built-in database tables */
+  schemaExtensions?: SchemaExtensions;
 }
 
 /**
@@ -59,6 +62,8 @@ export interface PgDomainPoolConfig {
   skipDefaultIndexes?: boolean;
   /** Custom indexes to create for this domain's tables */
   indexes?: CreateIndexOptions[];
+  /** Custom columns to add to Mastra's built-in database tables */
+  schemaExtensions?: SchemaExtensions;
 }
 
 /**
@@ -71,6 +76,8 @@ export type PgDomainRestConfig = {
   skipDefaultIndexes?: boolean;
   /** Custom indexes to create for this domain's tables */
   indexes?: CreateIndexOptions[];
+  /** Custom columns to add to Mastra's built-in database tables */
+  schemaExtensions?: SchemaExtensions;
 } & (
   | {
       host: string;
@@ -95,6 +102,7 @@ export function resolvePgConfig(config: PgDomainConfig): {
   schemaName?: string;
   skipDefaultIndexes?: boolean;
   indexes?: CreateIndexOptions[];
+  schemaExtensions?: SchemaExtensions;
 } {
   // Existing client
   if ('client' in config) {
@@ -103,6 +111,7 @@ export function resolvePgConfig(config: PgDomainConfig): {
       schemaName: config.schemaName,
       skipDefaultIndexes: config.skipDefaultIndexes,
       indexes: config.indexes,
+      schemaExtensions: config.schemaExtensions,
     };
   }
 
@@ -113,6 +122,7 @@ export function resolvePgConfig(config: PgDomainConfig): {
       schemaName: config.schemaName,
       skipDefaultIndexes: config.skipDefaultIndexes,
       indexes: config.indexes,
+      schemaExtensions: config.schemaExtensions,
     };
   }
 
@@ -139,6 +149,7 @@ export function resolvePgConfig(config: PgDomainConfig): {
     schemaName: config.schemaName,
     skipDefaultIndexes: config.skipDefaultIndexes,
     indexes: config.indexes,
+    schemaExtensions: config.schemaExtensions,
   };
 }
 

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -12,6 +12,8 @@ import {
   TABLE_THREADS,
   TABLE_SCHEMAS,
   createStorageErrorId,
+  mergeSchemaExtensions,
+  extractCustomColumns,
 } from '@mastra/core/storage';
 
 /**
@@ -34,6 +36,7 @@ try {
   // OM not available in this version of core
 }
 import type {
+  StorageColumn,
   StorageResourceType,
   StorageListMessagesInput,
   StorageListMessagesByResourceIdInput,
@@ -104,22 +107,27 @@ export class MemoryPG extends MemoryStorage {
   #schema: string;
   #skipDefaultIndexes?: boolean;
   #indexes?: CreateIndexOptions[];
+  #threadSchema: Record<string, StorageColumn>;
+  #threadExtensionCols: string[];
 
   /** Tables managed by this domain */
   static readonly MANAGED_TABLES = [TABLE_THREADS, TABLE_MESSAGES, TABLE_RESOURCES, OM_TABLE] as const;
 
   constructor(config: PgDomainConfig) {
     super();
-    const { client, schemaName, skipDefaultIndexes, indexes } = resolvePgConfig(config);
+    const { client, schemaName, skipDefaultIndexes, indexes, schemaExtensions } = resolvePgConfig(config);
     this.#db = new PgDB({ client, schemaName, skipDefaultIndexes });
     this.#schema = schemaName || 'public';
     this.#skipDefaultIndexes = skipDefaultIndexes;
     // Filter indexes to only those for tables managed by this domain
     this.#indexes = indexes?.filter(idx => (MemoryPG.MANAGED_TABLES as readonly string[]).includes(idx.table));
+    // Merge custom columns for threads
+    this.#threadSchema = mergeSchemaExtensions(TABLE_SCHEMAS[TABLE_THREADS], schemaExtensions?.[TABLE_THREADS]);
+    this.#threadExtensionCols = Object.keys(schemaExtensions?.[TABLE_THREADS] || {});
   }
 
   async init(): Promise<void> {
-    await this.#db.createTable({ tableName: TABLE_THREADS, schema: TABLE_SCHEMAS[TABLE_THREADS] });
+    await this.#db.createTable({ tableName: TABLE_THREADS, schema: this.#threadSchema });
     await this.#db.createTable({ tableName: TABLE_MESSAGES, schema: TABLE_SCHEMAS[TABLE_MESSAGES] });
     await this.#db.createTable({ tableName: TABLE_RESOURCES, schema: TABLE_SCHEMAS[TABLE_RESOURCES] });
 
@@ -321,7 +329,7 @@ export class MemoryPG extends MemoryStorage {
         return null;
       }
 
-      return {
+      const result: StorageThreadType = {
         id: thread.id,
         resourceId: thread.resourceId,
         title: thread.title,
@@ -329,6 +337,13 @@ export class MemoryPG extends MemoryStorage {
         createdAt: thread.createdAtZ || thread.createdAt,
         updatedAt: thread.updatedAtZ || thread.updatedAt,
       };
+
+      const customColumns = extractCustomColumns(thread as Record<string, unknown>, this.#threadExtensionCols);
+      if (customColumns) {
+        result.customColumns = customColumns;
+      }
+
+      return result;
     } catch (error) {
       throw new MastraError(
         {
@@ -405,6 +420,23 @@ export class MemoryPG extends MemoryStorage {
         }
       }
 
+      // Add custom column filters if provided (AND logic)
+      if (filter?.customColumns && Object.keys(filter.customColumns).length > 0) {
+        for (const [key, value] of Object.entries(filter.customColumns)) {
+          if (!this.#threadExtensionCols.includes(key)) {
+            throw new MastraError({
+              id: createStorageErrorId('PG', 'LIST_THREADS', 'INVALID_CUSTOM_COLUMN'),
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.USER,
+              text: `Custom column '${key}' is not declared in schemaExtensions for ${TABLE_THREADS}`,
+            });
+          }
+          whereClauses.push(`"${key}" = $${paramIndex}`);
+          queryParams.push(value);
+          paramIndex++;
+        }
+      }
+
       const whereClause = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
       const baseQuery = `FROM ${tableName} ${whereClause}`;
 
@@ -423,22 +455,27 @@ export class MemoryPG extends MemoryStorage {
       }
 
       const limitValue = perPageInput === false ? total : perPage;
-      // Select both standard and timezone-aware columns (*Z) for proper UTC timestamp handling
-      const dataQuery = `SELECT id, "resourceId", title, metadata, "createdAt", "createdAtZ", "updatedAt", "updatedAtZ" ${baseQuery} ORDER BY "${field}" ${direction} LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`;
+      // Use SELECT * to include custom columns alongside standard columns
+      const dataQuery = `SELECT * ${baseQuery} ORDER BY "${field}" ${direction} LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`;
       const rows = await this.#db.client.manyOrNone<StorageThreadType & { createdAtZ: Date; updatedAtZ: Date }>(
         dataQuery,
         [...queryParams, limitValue, offset],
       );
 
-      const threads = (rows || []).map(thread => ({
-        id: thread.id,
-        resourceId: thread.resourceId,
-        title: thread.title,
-        metadata: typeof thread.metadata === 'string' ? JSON.parse(thread.metadata) : thread.metadata,
-        // Use timezone-aware columns (*Z) for correct UTC timestamps, with fallback for legacy data
-        createdAt: thread.createdAtZ || thread.createdAt,
-        updatedAt: thread.updatedAtZ || thread.updatedAt,
-      }));
+      const threads: StorageThreadType[] = (rows || []).map(thread => {
+        const result: StorageThreadType = {
+          id: thread.id,
+          resourceId: thread.resourceId,
+          title: thread.title,
+          metadata: typeof thread.metadata === 'string' ? JSON.parse(thread.metadata) : thread.metadata,
+          // Use timezone-aware columns (*Z) for correct UTC timestamps, with fallback for legacy data
+          createdAt: thread.createdAtZ || thread.createdAt,
+          updatedAt: thread.updatedAtZ || thread.updatedAt,
+        };
+        const cc = extractCustomColumns(thread as unknown as Record<string, unknown>, this.#threadExtensionCols);
+        if (cc) result.customColumns = cc;
+        return result;
+      });
 
       return {
         threads,
@@ -476,35 +513,45 @@ export class MemoryPG extends MemoryStorage {
   async saveThread({ thread }: { thread: StorageThreadType }): Promise<StorageThreadType> {
     try {
       const tableName = getTableName({ indexName: TABLE_THREADS, schemaName: getSchemaName(this.#schema) });
+
+      // Build base columns and values
+      const columns: string[] = [
+        'id',
+        '"resourceId"',
+        'title',
+        'metadata',
+        '"createdAt"',
+        '"createdAtZ"',
+        '"updatedAt"',
+        '"updatedAtZ"',
+      ];
+      const values: unknown[] = [
+        thread.id,
+        thread.resourceId,
+        thread.title,
+        thread.metadata ? JSON.stringify(thread.metadata) : null,
+        thread.createdAt,
+        thread.createdAt,
+        thread.updatedAt,
+        thread.updatedAt,
+      ];
+
+      // Add custom column values
+      for (const col of this.#threadExtensionCols) {
+        columns.push(`"${col}"`);
+        values.push(thread.customColumns?.[col] ?? null);
+      }
+
+      const placeholders = values.map((_, i) => `$${i + 1}`).join(', ');
+      const updateClauses = columns
+        .filter(c => c !== 'id')
+        .map(c => `${c} = EXCLUDED.${c}`)
+        .join(', ');
+
       await this.#db.client.none(
-        `INSERT INTO ${tableName} (
-          id,
-          "resourceId",
-          title,
-          metadata,
-          "createdAt",
-          "createdAtZ",
-          "updatedAt",
-          "updatedAtZ"
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-        ON CONFLICT (id) DO UPDATE SET
-          "resourceId" = EXCLUDED."resourceId",
-          title = EXCLUDED.title,
-          metadata = EXCLUDED.metadata,
-          "createdAt" = EXCLUDED."createdAt",
-          "createdAtZ" = EXCLUDED."createdAtZ",
-          "updatedAt" = EXCLUDED."updatedAt",
-          "updatedAtZ" = EXCLUDED."updatedAtZ"`,
-        [
-          thread.id,
-          thread.resourceId,
-          thread.title,
-          thread.metadata ? JSON.stringify(thread.metadata) : null,
-          thread.createdAt,
-          thread.createdAt,
-          thread.updatedAt,
-          thread.updatedAt,
-        ],
+        `INSERT INTO ${tableName} (${columns.join(', ')}) VALUES (${placeholders})
+        ON CONFLICT (id) DO UPDATE SET ${updateClauses}`,
+        values,
       );
 
       return thread;
@@ -527,10 +574,12 @@ export class MemoryPG extends MemoryStorage {
     id,
     title,
     metadata,
+    customColumns,
   }: {
     id: string;
     title: string;
     metadata: Record<string, unknown>;
+    customColumns?: Record<string, unknown>;
   }): Promise<StorageThreadType> {
     const threadTableName = getTableName({ indexName: TABLE_THREADS, schemaName: getSchemaName(this.#schema) });
     const existingThread = await this.getThreadById({ threadId: id });
@@ -552,19 +601,31 @@ export class MemoryPG extends MemoryStorage {
       ...metadata,
     };
 
+    const mergedCustomColumns = customColumns
+      ? { ...existingThread.customColumns, ...customColumns }
+      : existingThread.customColumns;
+
     try {
       const now = new Date().toISOString();
+
+      // Build SET clauses dynamically
+      const setClauses: string[] = ['title = $1', 'metadata = $2', '"updatedAt" = $3', '"updatedAtZ" = $4'];
+      const values: unknown[] = [title, mergedMetadata, now, now];
+      let paramIdx = 5;
+
+      // Add custom column SET clauses
+      for (const col of this.#threadExtensionCols) {
+        setClauses.push(`"${col}" = $${paramIdx++}`);
+        values.push(mergedCustomColumns?.[col] ?? null);
+      }
+
+      values.push(id);
       const thread = await this.#db.client.one<StorageThreadType & { createdAtZ: Date; updatedAtZ: Date }>(
         `UPDATE ${threadTableName}
-                    SET
-                        title = $1,
-                        metadata = $2,
-                        "updatedAt" = $3,
-                        "updatedAtZ" = $4
-                    WHERE id = $5
-                    RETURNING *
-                `,
-        [title, mergedMetadata, now, now, id],
+                    SET ${setClauses.join(', ')}
+                    WHERE id = $${paramIdx}
+                    RETURNING *`,
+        values,
       );
 
       return {
@@ -574,6 +635,7 @@ export class MemoryPG extends MemoryStorage {
         metadata: typeof thread.metadata === 'string' ? JSON.parse(thread.metadata) : thread.metadata,
         createdAt: thread.createdAtZ || thread.createdAt,
         updatedAt: thread.updatedAtZ || thread.updatedAt,
+        customColumns: extractCustomColumns(thread as unknown as Record<string, unknown>, this.#threadExtensionCols),
       };
     } catch (error) {
       throw new MastraError(
@@ -1545,31 +1607,38 @@ export class MemoryPG extends MemoryStorage {
           },
           createdAt: now,
           updatedAt: now,
+          customColumns: sourceThread.customColumns,
         };
 
-        // Insert the new thread
-        await t.none(
-          `INSERT INTO ${threadTableName} (
-            id,
-            "resourceId",
-            title,
-            metadata,
-            "createdAt",
-            "createdAtZ",
-            "updatedAt",
-            "updatedAtZ"
-          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-          [
-            newThread.id,
-            newThread.resourceId,
-            newThread.title,
-            newThread.metadata ? JSON.stringify(newThread.metadata) : null,
-            now,
-            now,
-            now,
-            now,
-          ],
-        );
+        // Insert the new thread with dynamic columns
+        const columns: string[] = [
+          'id',
+          '"resourceId"',
+          'title',
+          'metadata',
+          '"createdAt"',
+          '"createdAtZ"',
+          '"updatedAt"',
+          '"updatedAtZ"',
+        ];
+        const values: unknown[] = [
+          newThread.id,
+          newThread.resourceId,
+          newThread.title,
+          newThread.metadata ? JSON.stringify(newThread.metadata) : null,
+          now,
+          now,
+          now,
+          now,
+        ];
+
+        for (const col of this.#threadExtensionCols) {
+          columns.push(`"${col}"`);
+          values.push(newThread.customColumns?.[col] ?? null);
+        }
+
+        const placeholders = values.map((_, i) => `$${i + 1}`).join(', ');
+        await t.none(`INSERT INTO ${threadTableName} (${columns.join(', ')}) VALUES (${placeholders})`, values);
 
         // Clone messages with new IDs
         const clonedMessages: MastraDBMessage[] = [];

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -438,9 +438,14 @@ export class MemoryPG extends MemoryStorage {
       // Validation already done above, so just build the WHERE clauses
       if (filter?.customColumns && Object.keys(filter.customColumns).length > 0) {
         for (const [key, value] of Object.entries(filter.customColumns)) {
-          whereClauses.push(`"${key}" = $${paramIndex}`);
-          queryParams.push(value);
-          paramIndex++;
+          if (value === null) {
+            // NULL-aware comparison: use IS NULL instead of = NULL
+            whereClauses.push(`"${key}" IS NULL`);
+          } else {
+            whereClauses.push(`"${key}" = $${paramIndex}`);
+            queryParams.push(value);
+            paramIndex++;
+          }
         }
       }
 

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -184,6 +184,26 @@ export class MemoryPG extends MemoryStorage {
   }
 
   /**
+   * Maps a database row to a StorageThreadType object, handling metadata parsing,
+   * timezone-aware date conversion, and custom column extraction.
+   * @internal
+   */
+  private mapThreadRow(row: any): StorageThreadType {
+    return {
+      id: row.id,
+      resourceId: row.resourceId,
+      title: row.title,
+      metadata: typeof row.metadata === 'string' ? JSON.parse(row.metadata) : row.metadata,
+      createdAt: row.createdAtZ || row.createdAt,
+      updatedAt: row.updatedAtZ || row.updatedAt,
+      ...(() => {
+        const cc = extractCustomColumns(row as Record<string, unknown>, this.#threadExtensionCols);
+        return cc ? { customColumns: cc } : {};
+      })(),
+    };
+  }
+
+  /**
    * Returns default index definitions for the memory domain tables.
    * @param schemaPrefix - Prefix for index names (e.g. "my_schema_" or "")
    */
@@ -329,21 +349,7 @@ export class MemoryPG extends MemoryStorage {
         return null;
       }
 
-      const result: StorageThreadType = {
-        id: thread.id,
-        resourceId: thread.resourceId,
-        title: thread.title,
-        metadata: typeof thread.metadata === 'string' ? JSON.parse(thread.metadata) : thread.metadata,
-        createdAt: thread.createdAtZ || thread.createdAt,
-        updatedAt: thread.updatedAtZ || thread.updatedAt,
-      };
-
-      const customColumns = extractCustomColumns(thread as Record<string, unknown>, this.#threadExtensionCols);
-      if (customColumns) {
-        result.customColumns = customColumns;
-      }
-
-      return result;
+      return this.mapThreadRow(thread);
     } catch (error) {
       throw new MastraError(
         {
@@ -474,20 +480,7 @@ export class MemoryPG extends MemoryStorage {
         [...queryParams, limitValue, offset],
       );
 
-      const threads: StorageThreadType[] = (rows || []).map(thread => {
-        const result: StorageThreadType = {
-          id: thread.id,
-          resourceId: thread.resourceId,
-          title: thread.title,
-          metadata: typeof thread.metadata === 'string' ? JSON.parse(thread.metadata) : thread.metadata,
-          // Use timezone-aware columns (*Z) for correct UTC timestamps, with fallback for legacy data
-          createdAt: thread.createdAtZ || thread.createdAt,
-          updatedAt: thread.updatedAtZ || thread.updatedAt,
-        };
-        const cc = extractCustomColumns(thread as unknown as Record<string, unknown>, this.#threadExtensionCols);
-        if (cc) result.customColumns = cc;
-        return result;
-      });
+      const threads: StorageThreadType[] = (rows || []).map(thread => this.mapThreadRow(thread));
 
       return {
         threads,

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -189,6 +189,7 @@ export class MemoryPG extends MemoryStorage {
    * @internal
    */
   private mapThreadRow(row: any): StorageThreadType {
+    const cc = extractCustomColumns(row as Record<string, unknown>, this.#threadExtensionCols);
     return {
       id: row.id,
       resourceId: row.resourceId,
@@ -196,10 +197,7 @@ export class MemoryPG extends MemoryStorage {
       metadata: typeof row.metadata === 'string' ? JSON.parse(row.metadata) : row.metadata,
       createdAt: row.createdAtZ || row.createdAt,
       updatedAt: row.updatedAtZ || row.updatedAt,
-      ...(() => {
-        const cc = extractCustomColumns(row as Record<string, unknown>, this.#threadExtensionCols);
-        return cc ? { customColumns: cc } : {};
-      })(),
+      ...(cc ? { customColumns: cc } : {}),
     };
   }
 
@@ -549,7 +547,7 @@ export class MemoryPG extends MemoryStorage {
 
       const placeholders = values.map((_, i) => `$${i + 1}`).join(', ');
       const updateClauses = columns
-        .filter(c => c !== 'id')
+        .filter(c => c !== 'id' && c !== '"createdAt"' && c !== '"createdAtZ"')
         .map(c => `${c} = EXCLUDED.${c}`)
         .join(', ');
 
@@ -633,15 +631,7 @@ export class MemoryPG extends MemoryStorage {
         values,
       );
 
-      return {
-        id: thread.id,
-        resourceId: thread.resourceId,
-        title: thread.title,
-        metadata: typeof thread.metadata === 'string' ? JSON.parse(thread.metadata) : thread.metadata,
-        createdAt: thread.createdAtZ || thread.createdAt,
-        updatedAt: thread.updatedAtZ || thread.updatedAt,
-        customColumns: extractCustomColumns(thread as unknown as Record<string, unknown>, this.#threadExtensionCols),
-      };
+      return this.mapThreadRow(thread);
     } catch (error) {
       throw new MastraError(
         {

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -394,6 +394,20 @@ export class MemoryPG extends MemoryStorage {
     const { field, direction } = this.parseOrderBy(orderBy);
     const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
 
+    // Validate custom columns to prevent undeclared column filtering (USER error, not caught by try)
+    if (filter?.customColumns && Object.keys(filter.customColumns).length > 0) {
+      for (const [key] of Object.entries(filter.customColumns)) {
+        if (!this.#threadExtensionCols.includes(key)) {
+          throw new MastraError({
+            id: createStorageErrorId('PG', 'LIST_THREADS', 'INVALID_CUSTOM_COLUMN'),
+            domain: ErrorDomain.STORAGE,
+            category: ErrorCategory.USER,
+            text: `Custom column '${key}' is not declared in schemaExtensions for ${TABLE_THREADS}`,
+          });
+        }
+      }
+    }
+
     try {
       const tableName = getTableName({ indexName: TABLE_THREADS, schemaName: getSchemaName(this.#schema) });
       const whereClauses: string[] = [];
@@ -421,16 +435,9 @@ export class MemoryPG extends MemoryStorage {
       }
 
       // Add custom column filters if provided (AND logic)
+      // Validation already done above, so just build the WHERE clauses
       if (filter?.customColumns && Object.keys(filter.customColumns).length > 0) {
         for (const [key, value] of Object.entries(filter.customColumns)) {
-          if (!this.#threadExtensionCols.includes(key)) {
-            throw new MastraError({
-              id: createStorageErrorId('PG', 'LIST_THREADS', 'INVALID_CUSTOM_COLUMN'),
-              domain: ErrorDomain.STORAGE,
-              category: ErrorCategory.USER,
-              text: `Custom column '${key}' is not declared in schemaExtensions for ${TABLE_THREADS}`,
-            });
-          }
           whereClauses.push(`"${key}" = $${paramIndex}`);
           queryParams.push(value);
           paramIndex++;

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -146,6 +146,7 @@ export class PostgresStore extends MastraCompositeStore {
         schemaName: this.schema,
         skipDefaultIndexes: config.skipDefaultIndexes,
         indexes: config.indexes,
+        schemaExtensions: config.schemaExtensions,
       };
 
       this.stores = {


### PR DESCRIPTION
## Description

This PR adds support for **custom user-defined columns** in Mastra’s database tables.  
Developers can now enrich the default storage schema with their own fields without:

- Spinning up a separate database
- Writing a custom storage adapter
- Forking or modifying core tables

This makes Mastra’s Memory layer more flexible for real-world multi-tenant and domain-specific use cases.

---

## Related Issue(s)

Fixes #11076

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

---

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support user-defined schema extensions via schemaExtensions config; threads now carry a customColumns property and can be created, saved, cloned, updated, and returned with custom column values.
  * listThreads filter supports filtering by filter.customColumns.

* **Tests**
  * Added comprehensive tests covering schema-extension merging, custom-column extraction, adapter end-to-end behavior, filtering, cloning, and edge cases.

* **Chores**
  * Changeset and versioning updates documenting the custom-columns feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->