### PR TITLE
feat: support worker threads

### DIFF
--- a/.changeset/support-worker-threads-dev-mode.md
+++ b/.changeset/support-worker-threads-dev-mode.md
@@ -1,0 +1,5 @@
+---
+"mastra": minor
+---
+
+Add support for worker threads in development mode by copying public files to output directory. The `mastra dev` command now copies files from `src/mastra/public/` to `.mastra/output/` on startup and watches for changes, bringing dev mode to parity with production builds. This enables Worker thread scripts and other static assets to be available at runtime during development.

--- a/.changeset/support-worker-threads-dev-mode.md
+++ b/.changeset/support-worker-threads-dev-mode.md
@@ -2,4 +2,4 @@
 "mastra": minor
 ---
 
-Add support for worker threads in development mode by copying public files to output directory. The `mastra dev` command now copies files from `src/mastra/public/` to `.mastra/output/` on startup and watches for changes, bringing dev mode to parity with production builds. This enables Worker thread scripts and other static assets to be available at runtime during development.
+Copy `src/mastra/public/` files to `.mastra/output/` during `mastra dev`. The public directory is watched so changes are picked up on rebuild. This lets Worker thread scripts and other static assets work in development, matching the existing `mastra build` behavior.

--- a/packages/cli/src/commands/dev/DevBundler.test.ts
+++ b/packages/cli/src/commands/dev/DevBundler.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { remove } from 'fs-extra/esm';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -82,32 +82,7 @@ describe('DevBundler', () => {
     process.exit = originalExit;
   });
 
-  describe('prepare - public files (issue #5121)', () => {
-    it('should copy public directory files to output during prepare', async () => {
-      // Mimic real layout: project root has src/mastra/ and .mastra/ as siblings
-      const projectRoot = '.test-public-tmp';
-      const mastraDir = join(projectRoot, 'src', 'mastra');
-      const publicDir = join(mastraDir, 'public');
-      const dotMastraPath = join(projectRoot, '.mastra');
-
-      try {
-        // Create a mock mastra project with a worker file in public/
-        mkdirSync(publicDir, { recursive: true });
-        writeFileSync(join(publicDir, 'scanWorker.js'), '// CPU-intensive worker');
-
-        const devBundler = new DevBundler(undefined, mastraDir);
-
-        // prepare() cleans .mastra/ and rebuilds the output directory
-        await devBundler.prepare(dotMastraPath);
-
-        // After prepare(), public files should be available in .mastra/output/
-        // so that Worker threads can reference them via import.meta.url
-        expect(existsSync(join(dotMastraPath, 'output', 'scanWorker.js'))).toBe(true);
-      } finally {
-        await remove(projectRoot);
-      }
-    });
-
+  describe('prepare (issue #5121)', () => {
     it('should handle missing public directory gracefully', async () => {
       // If the user has no public/ dir, prepare() should not fail
       const projectRoot = '.test-no-public-tmp';

--- a/packages/cli/src/commands/dev/DevBundler.test.ts
+++ b/packages/cli/src/commands/dev/DevBundler.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { remove } from 'fs-extra/esm';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -9,12 +9,25 @@ const mockExit = vi.hoisted(() => vi.fn());
 vi.stubGlobal('process', {
   ...process,
   exit: mockExit,
-  argv: ['node', 'test'], // Override command line args
+  argv: ['node', 'test'],
+});
+
+// Hoisted override for stat — null means use the real implementation.
+const statBehavior = vi.hoisted(() => ({ override: null as (() => Promise<any>) | null }));
+
+vi.mock('node:fs/promises', async importOriginal => {
+  const mod = (await importOriginal()) as Record<string, any>;
+  return {
+    ...mod,
+    stat: (...args: any[]) => {
+      if (statBehavior.override) return statBehavior.override();
+      return (mod.stat as any)(...args);
+    },
+  };
 });
 
 // Mock commander to prevent CLI from running
 vi.mock('commander', () => {
-  // Use a class for the Command constructor mock (Vitest v4 requirement)
   class CommandMock {
     name: any;
     version: any;
@@ -43,7 +56,7 @@ vi.mock('commander', () => {
     Command: CommandMock,
   };
 });
-// Don't reference top-level variables in mock definitions
+
 vi.mock('@mastra/deployer/build', () => {
   return {
     createWatcher: vi.fn().mockResolvedValue({
@@ -65,45 +78,23 @@ vi.mock('fs-extra', () => {
   };
 });
 
-// Import DevBundler after mocks
-
 describe('DevBundler', () => {
   const originalEnv = process.env.NODE_ENV;
   const originalExit = process.exit;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Mock process.exit to prevent it from actually exiting during tests
+    statBehavior.override = null;
     process.exit = vi.fn() as any;
   });
 
   afterEach(() => {
     process.env.NODE_ENV = originalEnv;
     process.exit = originalExit;
+    statBehavior.override = null;
   });
 
-  describe('prepare (issue #5121)', () => {
-    it('should handle missing public directory gracefully', async () => {
-      // If the user has no public/ dir, prepare() should not fail
-      const projectRoot = '.test-no-public-tmp';
-      const mastraDir = join(projectRoot, 'src', 'mastra');
-      const dotMastraPath = join(projectRoot, '.mastra');
-
-      try {
-        mkdirSync(mastraDir, { recursive: true });
-
-        const devBundler = new DevBundler(undefined, mastraDir);
-        await devBundler.prepare(dotMastraPath);
-
-        // Should complete without error even with no public/ directory
-        expect(existsSync(join(dotMastraPath, 'output'))).toBe(true);
-      } finally {
-        await remove(projectRoot);
-      }
-    });
-  });
-
-  describe('watch - public files (issue #5121)', () => {
+  describe('watch - public files', () => {
     it('should include public-files-copier plugin in watcher', async () => {
       const devBundler = new DevBundler(undefined, '/fake/src/mastra');
       const { createWatcher } = await import('@mastra/deployer/build');
@@ -112,7 +103,6 @@ describe('DevBundler', () => {
       try {
         await devBundler.watch('test-entry.js', tmpDir, []);
 
-        // Verify createWatcher was called with the public-files-copier plugin
         const call = vi.mocked(createWatcher).mock.calls[0]!;
         const inputOptions = call[0] as { plugins: Array<{ name: string }> };
         const pluginNames = inputOptions.plugins.map((p: { name: string }) => p.name).filter(Boolean);
@@ -122,21 +112,153 @@ describe('DevBundler', () => {
         await remove(tmpDir);
       }
     });
+
+    it('should call copyPublic in the buildEnd hook', async () => {
+      const tmpDir = '.test-buildend-tmp';
+      const mastraDir = join(tmpDir, 'src', 'mastra');
+      const publicDir = join(mastraDir, 'public');
+
+      try {
+        mkdirSync(publicDir, { recursive: true });
+        writeFileSync(join(publicDir, 'worker.js'), 'console.log("worker")');
+
+        const devBundler = new DevBundler(undefined, mastraDir);
+        const { createWatcher } = await import('@mastra/deployer/build');
+
+        await devBundler.watch('test-entry.js', tmpDir, []);
+
+        const call = vi.mocked(createWatcher).mock.calls[0]!;
+        const inputOptions = call[0] as { plugins: Array<{ name: string; buildEnd?: () => Promise<void> }> };
+        const copierPlugin = inputOptions.plugins.find(p => p.name === 'public-files-copier');
+
+        expect(copierPlugin).toBeDefined();
+        expect(copierPlugin!.buildEnd).toBeDefined();
+
+        // Invoke the buildEnd hook — should not throw
+        await copierPlugin!.buildEnd!();
+      } finally {
+        await remove(tmpDir);
+      }
+    });
+
+    it('should call addWatchFile when public directory exists', async () => {
+      const tmpDir = '.test-watchfile-tmp';
+      const mastraDir = join(tmpDir, 'src', 'mastra');
+      const publicDir = join(mastraDir, 'public');
+
+      try {
+        mkdirSync(publicDir, { recursive: true });
+
+        const devBundler = new DevBundler(undefined, mastraDir);
+        const { createWatcher } = await import('@mastra/deployer/build');
+
+        await devBundler.watch('test-entry.js', tmpDir, []);
+
+        const call = vi.mocked(createWatcher).mock.calls[0]!;
+        const inputOptions = call[0] as {
+          plugins: Array<{ name: string; buildStart?: () => void }>;
+        };
+        const copierPlugin = inputOptions.plugins.find(p => p.name === 'public-files-copier');
+
+        const mockAddWatchFile = vi.fn();
+        copierPlugin!.buildStart!.call({ addWatchFile: mockAddWatchFile } as any);
+
+        expect(mockAddWatchFile).toHaveBeenCalledWith(publicDir);
+      } finally {
+        await remove(tmpDir);
+      }
+    });
+
+    it('should skip addWatchFile when public directory does not exist', async () => {
+      const devBundler = new DevBundler(undefined, '/nonexistent/src/mastra');
+      const { createWatcher } = await import('@mastra/deployer/build');
+
+      const tmpDir = '.test-no-watchfile-tmp';
+      try {
+        await devBundler.watch('test-entry.js', tmpDir, []);
+
+        const call = vi.mocked(createWatcher).mock.calls[0]!;
+        const inputOptions = call[0] as {
+          plugins: Array<{ name: string; buildStart?: () => void }>;
+        };
+        const copierPlugin = inputOptions.plugins.find(p => p.name === 'public-files-copier');
+
+        const mockAddWatchFile = vi.fn();
+        copierPlugin!.buildStart!.call({ addWatchFile: mockAddWatchFile } as any);
+
+        expect(mockAddWatchFile).not.toHaveBeenCalled();
+      } finally {
+        await remove(tmpDir);
+      }
+    });
+
+    it('should fall back to dirname(entryFile) when mastraDir is not provided', async () => {
+      const devBundler = new DevBundler();
+      const { createWatcher } = await import('@mastra/deployer/build');
+
+      const tmpDir = '.test-fallback-tmp';
+      try {
+        await devBundler.watch('/some/project/src/mastra/index.ts', tmpDir, []);
+
+        const call = vi.mocked(createWatcher).mock.calls[0]!;
+        const inputOptions = call[0] as {
+          plugins: Array<{ name: string; buildEnd?: () => Promise<void> }>;
+        };
+        const copierPlugin = inputOptions.plugins.find(p => p.name === 'public-files-copier');
+
+        // buildEnd should not throw — copyPublic handles missing directories
+        expect(copierPlugin).toBeDefined();
+        await expect(copierPlugin!.buildEnd!()).resolves.toBeUndefined();
+      } finally {
+        await remove(tmpDir);
+      }
+    });
+  });
+
+  describe('copyPublic', () => {
+    it('should not throw when public directory does not exist', async () => {
+      const devBundler = new DevBundler(undefined, '/nonexistent/mastra');
+
+      await expect((devBundler as any).copyPublic('/nonexistent/mastra', '/tmp/output')).resolves.toBeUndefined();
+    });
+
+    it('should propagate non-ENOENT errors', async () => {
+      statBehavior.override = () => Promise.reject(Object.assign(new Error('Permission denied'), { code: 'EACCES' }));
+
+      const devBundler = new DevBundler(undefined, '/some/mastra');
+
+      await expect((devBundler as any).copyPublic('/some/mastra', '/tmp/output')).rejects.toThrow('Permission denied');
+    });
+
+    it('should call super.copyPublic when public directory exists', async () => {
+      const tmpDir = '.test-copy-tmp';
+      const mastraDir = join(tmpDir, 'src', 'mastra');
+      const publicDir = join(mastraDir, 'public');
+
+      try {
+        mkdirSync(publicDir, { recursive: true });
+        writeFileSync(join(publicDir, 'worker.js'), 'console.log("worker")');
+
+        const devBundler = new DevBundler(undefined, mastraDir);
+
+        // copyPublic should complete without error when the dir exists
+        await expect((devBundler as any).copyPublic(mastraDir, tmpDir)).resolves.toBeUndefined();
+      } finally {
+        await remove(tmpDir);
+      }
+    });
   });
 
   describe('watch', () => {
     it('should use NODE_ENV from environment when available', async () => {
-      // Arrange
       process.env.NODE_ENV = 'test-env';
       const devBundler = new DevBundler();
       const { getWatcherInputOptions } = await import('@mastra/deployer/build');
 
       const tmpDir = '.test-tmp';
       try {
-        // Act
         await devBundler.watch('test-entry.js', tmpDir, []);
 
-        // Assert
         expect(getWatcherInputOptions).toHaveBeenCalledWith(
           'test-entry.js',
           'node',
@@ -151,16 +273,14 @@ describe('DevBundler', () => {
     });
 
     it('should default to development when NODE_ENV is not set', async () => {
-      // Arrange
       delete process.env.NODE_ENV;
       const devBundler = new DevBundler();
       const { getWatcherInputOptions } = await import('@mastra/deployer/build');
 
-      // Act
       const tmpDir = '.test-tmp';
-      await devBundler.watch('test-entry.js', tmpDir, []);
       try {
-        // Assert
+        await devBundler.watch('test-entry.js', tmpDir, []);
+
         expect(getWatcherInputOptions).toHaveBeenCalledWith(
           'test-entry.js',
           'node',

--- a/packages/cli/src/commands/dev/DevBundler.test.ts
+++ b/packages/cli/src/commands/dev/DevBundler.test.ts
@@ -230,7 +230,7 @@ describe('DevBundler', () => {
       await expect((devBundler as any).copyPublic('/some/mastra', '/tmp/output')).rejects.toThrow('Permission denied');
     });
 
-    it('should call super.copyPublic when public directory exists', async () => {
+    it('should resolve when public directory exists', async () => {
       const tmpDir = '.test-copy-tmp';
       const mastraDir = join(tmpDir, 'src', 'mastra');
       const publicDir = join(mastraDir, 'public');
@@ -241,7 +241,6 @@ describe('DevBundler', () => {
 
         const devBundler = new DevBundler(undefined, mastraDir);
 
-        // copyPublic should complete without error when the dir exists
         await expect((devBundler as any).copyPublic(mastraDir, tmpDir)).resolves.toBeUndefined();
       } finally {
         await remove(tmpDir);

--- a/packages/cli/src/commands/dev/DevBundler.ts
+++ b/packages/cli/src/commands/dev/DevBundler.ts
@@ -56,11 +56,6 @@ export class DevBundler extends Bundler {
     await fsExtra.copy(join(dirname(__dirname), join('dist', 'studio')), studioServePath, {
       overwrite: true,
     });
-
-    // Copy public files (e.g., worker thread scripts) to output directory
-    if (this.mastraDir) {
-      await this.copyPublic(this.mastraDir, outputDirectory);
-    }
   }
 
   protected async copyPublic(mastraDir: string, outputDirectory: string) {

--- a/packages/cli/src/commands/dev/DevBundler.ts
+++ b/packages/cli/src/commands/dev/DevBundler.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -131,8 +132,12 @@ export class DevBundler extends Bundler {
           {
             name: 'public-files-copier',
             buildStart() {
-              // Watch the public directory so changes to worker files trigger rebuilds
-              this.addWatchFile(join(mastraDir, 'public'));
+              // Watch the public directory so changes to worker files trigger rebuilds.
+              // Only add the watch if the directory exists to avoid ENOENT warnings from chokidar.
+              const publicDir = join(mastraDir, 'public');
+              if (existsSync(publicDir)) {
+                this.addWatchFile(publicDir);
+              }
             },
             async buildEnd() {
               await bundlerSelf.copyPublic(mastraDir, outputDirectory);

--- a/packages/cli/src/commands/dev/DevBundler.ts
+++ b/packages/cli/src/commands/dev/DevBundler.ts
@@ -62,12 +62,15 @@ export class DevBundler extends Bundler {
     const publicDir = join(mastraDir, 'public');
     try {
       await stat(publicDir);
-    } catch {
-      return;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return;
+      }
+      throw err;
     }
     devLogger.debug(`Copying public files from ${publicDir}`);
     await super.copyPublic(mastraDir, outputDirectory);
-    devLogger.info('Public files copied to output (e.g., worker scripts)');
+    devLogger.info('Public files copied to output');
   }
 
   async watch(
@@ -96,8 +99,7 @@ export class DevBundler extends Bundler {
 
     await this.writePackageJson(outputDir, new Map(), {});
 
-    // Capture instance for use inside Rollup plugin callbacks where `this` is the plugin context
-    const bundlerSelf = this;
+    const bundlerSelf = this; // `this` inside Rollup plugin hooks is the plugin context
     const mastraDir = this.mastraDir ?? dirname(entryFile);
 
     const watcher = await createWatcher(
@@ -127,8 +129,7 @@ export class DevBundler extends Bundler {
           {
             name: 'public-files-copier',
             buildStart() {
-              // Watch the public directory so changes to worker files trigger rebuilds.
-              // Only add the watch if the directory exists to avoid ENOENT warnings from chokidar.
+              // Guard with existsSync to avoid chokidar ENOENT warnings.
               const publicDir = join(mastraDir, 'public');
               if (existsSync(publicDir)) {
                 this.addWatchFile(publicDir);

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -357,7 +357,7 @@ export async function dev({
   const fileService = new FileService();
   const entryFile = fileService.getFirstExistingFile([join(mastraDir, 'index.ts'), join(mastraDir, 'index.js')]);
 
-  const bundler = new DevBundler(env);
+  const bundler = new DevBundler(env, mastraDir);
   bundler.__setLogger(createLogger(debug)); // Keep Pino logger for internal bundler operations
 
   // Use the bundler's getAllToolPaths method to prepare tools paths

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -137,6 +137,13 @@ export abstract class Bundler extends MastraBundler {
     await deps.install({ dir: join(outputDirectory, this.outputDir) });
   }
 
+  /**
+   * Copies files from `{mastraDir}/public/` to the bundled output directory.
+   *
+   * Use `src/mastra/public/` for static files that must be available at runtime
+   * but should not be processed by the bundler — e.g., Worker thread scripts,
+   * WASM binaries, or other assets referenced via `import.meta.url`.
+   */
   protected async copyPublic(mastraDir: string, outputDirectory: string) {
     const publicDir = join(mastraDir, 'public');
 

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -137,13 +137,6 @@ export abstract class Bundler extends MastraBundler {
     await deps.install({ dir: join(outputDirectory, this.outputDir) });
   }
 
-  /**
-   * Copies files from `{mastraDir}/public/` to the bundled output directory.
-   *
-   * Use `src/mastra/public/` for static files that must be available at runtime
-   * but should not be processed by the bundler — e.g., Worker thread scripts,
-   * WASM binaries, or other assets referenced via `import.meta.url`.
-   */
   protected async copyPublic(mastraDir: string, outputDirectory: string) {
     const publicDir = join(mastraDir, 'public');
 


### PR DESCRIPTION
## Description

`mastra dev` never copied files from `src/mastra/public/` to `.mastra/output/`, so Worker thread scripts and other static assets were unavailable at runtime during development. Production builds (`mastra build`) already handled this via `copyPublic()` — this PR brings dev mode to parity.

**What changed:**
- `DevBundler.prepare()` now calls `copyPublic()` on startup
- A new `public-files-copier` Rollup plugin re-copies public files on each rebuild and watches the `public/` directory for changes
- Added a visible log message (`Public files copied to output`) so users discover the convention

## Related Issue(s)

Fixes #5121

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Development mode now automatically copies public asset files to the output directory on startup.
  * Public asset file changes are monitored and detected during development.

* **Tests**
  * Enhanced test coverage for public asset handling and watch mode functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->