### PR TITLE
fix: dynamically discover vitest projects with nested configs

### DIFF
--- a/packages/evals/vitest.config.ts
+++ b/packages/evals/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
           maxConcurrency: 1,
           fileParallelism: false,
           isolate: false,
+          sequence: { groupOrder: 100 },
         },
       },
       {
@@ -23,6 +24,7 @@ export default defineConfig({
           maxConcurrency: 1,
           fileParallelism: false,
           setupFiles: ['dotenv/config'],
+          sequence: { groupOrder: 101 },
         },
       },
     ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,26 +1,105 @@
+import { globSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { TestProjectConfiguration, UserWorkspaceConfig } from 'vitest/config';
 import { defineConfig } from 'vitest/config';
 
-export default defineConfig({
+// Directories to exclude from project discovery
+const EXCLUDED_DIRS = new Set([
+  'packages/_config',
+  'packages/_types-builder',
+  'packages/_vendored',
+  'packages/playground',
+  'packages/playground-ui',
+  'server-adapters/_test-utils',
+  'observability/_examples',
+]);
+
+// Directories to scan for vitest configs
+const PROJECT_GLOBS = [
+  'packages/*/vitest.config.ts',
+  'stores/*/vitest.config.ts',
+  'deployers/*/vitest.config.ts',
+  'voice/*/vitest.config.ts',
+  'server-adapters/*/vitest.config.ts',
+  'client-sdks/*/vitest.config.ts',
+  'auth/*/vitest.config.ts',
+  'observability/*/vitest.config.ts',
+  'pubsub/*/vitest.config.ts',
+  'workflows/*/vitest.config.ts',
+];
+
+/**
+ * Discovers all vitest projects from package configs.
+ * For configs with nested projects, expands them with the correct root path.
+ * For simple configs, returns the directory as a project path.
+ */
+async function discoverProjects(): Promise<TestProjectConfiguration[]> {
+  const projects: TestProjectConfiguration[] = [];
+
+  // Find all vitest.config.ts files
+  const configPaths = PROJECT_GLOBS.flatMap(pattern => globSync(pattern));
+
+  for (const configPath of configPaths) {
+    const projectDir = dirname(configPath);
+
+    // Skip excluded directories
+    if (EXCLUDED_DIRS.has(projectDir)) {
+      continue;
+    }
+
+    // Read the config file to check if it has nested projects
+    const configContent = readFileSync(configPath, 'utf-8');
+    const hasNestedProjects = /test:\s*\{[\s\S]*?projects:\s*\[/.test(configContent);
+
+    if (!hasNestedProjects) {
+      // Simple config - use directory path
+      projects.push(projectDir);
+      continue;
+    }
+
+    // Config has nested projects - import it to extract them
+    try {
+      const absolutePath = resolve(process.cwd(), configPath);
+      const configUrl = pathToFileURL(absolutePath).href;
+      const configModule = await import(/* @vite-ignore */ configUrl);
+      const config = configModule.default as UserWorkspaceConfig;
+
+      if (!config.test?.projects) {
+        // Fallback if config parsing didn't work as expected
+        projects.push(projectDir);
+        continue;
+      }
+
+      // Expand nested projects with root path
+      for (const nestedProject of config.test.projects) {
+        if (typeof nestedProject === 'string') {
+          // String reference - resolve relative to the config's directory
+          projects.push(`${projectDir}/${nestedProject}`);
+        } else {
+          // Inline project config - add root path
+          const projectConfig = nestedProject as UserWorkspaceConfig;
+          projects.push({
+            ...projectConfig,
+            test: {
+              ...projectConfig.test,
+              root: `./${projectDir}`,
+            },
+          });
+        }
+      }
+    } catch (error) {
+      // If we can't import the config, fall back to using the directory path
+      console.warn(`Warning: Could not import ${configPath}, using directory path instead:`, error);
+      projects.push(projectDir);
+    }
+  }
+
+  return projects;
+}
+
+export default defineConfig(async () => ({
   test: {
-    projects: [
-      'packages/*',
-      '!packages/_config',
-      '!packages/_types-builder',
-      '!packages/_vendored',
-      '!packages/playground',
-      '!packages/playground-ui',
-      'stores/*',
-      'deployers/*',
-      'voice/*',
-      'server-adapters/*',
-      '!server-adapters/_test-utils',
-      'client-sdks/*',
-      'auth/*',
-      'observability/*',
-      '!observability/_examples',
-      'pubsub/*',
-      'workflows/*',
-      '!workflows/README.md',
-    ],
+    projects: await discoverProjects(),
   },
-});
+}));


### PR DESCRIPTION
## Summary

Fixes the issue where Vitest doesn't properly discover nested projects in workspace configs (https://github.com/vitest-dev/vitest/issues/8544).

## Changes

- Replace hardcoded project list in `vitest.config.ts` with dynamic discovery using `globSync`
- Automatically detect configs with nested `projects:` arrays by reading file content
- For nested projects (core, evals, schema-compat), import the config and flatten with correct `root` path
- Add `sequence.groupOrder` to evals projects to fix Vitest 4 conflict with different `maxWorkers` settings

## How it works

1. Globs for all `vitest.config.ts` files in the monorepo directories
2. Reads each config to detect if it has a `projects:` array
3. For simple configs, uses the directory path directly
4. For nested projects, imports the config and expands each project with the correct root

## Test Plan

- `pnpm vitest list` now works without the `sequence.groupOrder` error
- `pnpm vitest run --project 'unit:packages/schema-compat:v4'` passes
- `pnpm vitest run --project 'unit:packages/memory'` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted test execution ordering across Vitest projects.
  * Added dynamic project discovery for Vitest so test suites are auto-detected and loaded at runtime, supporting both single-folder and nested project setups.
  * Improved handling for configs that cannot be loaded at runtime by falling back to directory-based discovery with a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->