### PR TITLE
fix(server): handle bracket notation in query parameters (#12816)

### DIFF
--- a/.changeset/lazy-foxes-live.md
+++ b/.changeset/lazy-foxes-live.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed sort direction parameters being silently ignored in Thread Messages API when using bracket notation query params (e.g., `orderBy[field]=createdAt&orderBy[direction]=DESC`). The `normalizeQueryParams` function now reconstructs nested objects from bracket-notation keys, so both JSON format and bracket notation work correctly for `orderBy`, `filter`, `metadata`, and other complex query parameters. (Fixes #12816)


### PR DESCRIPTION
## Description

Fixed sort direction parameters being silently ignored in Thread Messages API when using bracket notation query params (e.g., `orderBy[field]=createdAt&orderBy[direction]=DESC`).

The `normalizeQueryParams` function now reconstructs nested objects from bracket-notation keys, so both JSON format and bracket notation work correctly for `orderBy`, `filter`, `metadata`, and other complex query parameters.

## Related Issue(s)

Fixes #12816

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Thread Messages API incorrectly ignoring sort direction parameters when using bracket-notation query parameters
  * API now correctly processes complex query parameters with bracket notation (e.g., `orderBy[field]`, `orderBy[direction]`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->