### PR TITLE
fix(server): add servers field to OpenAPI spec for Swagger UI

### DIFF
--- a/.changeset/kind-jokes-rescue.md
+++ b/.changeset/kind-jokes-rescue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed Swagger UI not including the API prefix (e.g., /api) in request URLs. The OpenAPI spec now includes a servers field with the configured prefix, so Swagger UI correctly generates URLs like http://localhost:4111/api/agents instead of http://localhost:4111/agents.

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -378,6 +378,11 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
       description,
     });
 
+    // Set the servers field so Swagger UI knows routes are served under the prefix
+    if (prefix) {
+      openApiSpec.servers = [{ url: prefix }];
+    }
+
     // Merge custom API routes into the OpenAPI spec
     if (this.customApiRoutes && this.customApiRoutes.length > 0) {
       const customPaths = convertCustomRoutesToOpenAPIPaths(this.customApiRoutes);


### PR DESCRIPTION
## Description

Swagger UI was not including the API prefix (e.g., /api) in request URLs. The OpenAPI spec now includes a servers field with the configured prefix, ensuring Swagger UI generates correct request URLs like `http://localhost:4111/api/agents` instead of `http://localhost:4111/agents`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Swagger UI to generate request URLs with the configured API prefix. Previously generated URLs would omit the server prefix and route directly to endpoints; this fix ensures they now include the configured prefix (e.g., /api) for proper routing alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->