### PR TITLE
feat(core): add native cron scheduling for workflows

### DIFF
--- a/.changeset/workflow-cron-schedule.md
+++ b/.changeset/workflow-cron-schedule.md
@@ -1,0 +1,40 @@
+---
+'@mastra/core': minor
+---
+
+Added native cron scheduling support for workflows. Workflows can now be scheduled to run on a recurring basis using standard 5-field cron expressions, without requiring external services like Inngest.
+
+**New API:**
+
+```typescript
+// Define a workflow with a cron schedule
+const billing = createWorkflow({
+  id: 'daily-billing',
+  inputSchema: z.object({}),
+  outputSchema: z.object({ processed: z.boolean() }),
+  steps: [processBilling],
+  schedule: {
+    cron: '0 0 * * *', // Every day at midnight
+    inputData: {},
+    description: 'Daily billing run',
+  },
+});
+
+// Start the scheduler
+const mastra = new Mastra({ workflows: { billing } });
+await mastra.startScheduler();
+
+// List scheduled workflows
+mastra.listScheduledWorkflows();
+// => [{ workflowId: 'daily-billing', cron: '0 0 * * *', description: 'Daily billing run' }]
+
+// Timers are cleaned up on shutdown
+await mastra.shutdown();
+```
+
+- `WorkflowConfig.schedule` — accepts `{ cron, inputData?, description? }`
+- `Workflow.schedule` — getter for introspection
+- `Mastra.startScheduler()` — activates cron timers for all scheduled workflows
+- `Mastra.listScheduledWorkflows()` — returns scheduled workflow metadata
+- `Mastra.shutdown()` — now also stops the cron scheduler
+- Invalid cron expressions are rejected at workflow creation time

--- a/.changeset/workflow-cron-schedule.md
+++ b/.changeset/workflow-cron-schedule.md
@@ -19,10 +19,11 @@ const billing = createWorkflow({
     description: 'Daily billing run',
   },
 });
+billing.then(processBilling).commit();
 
 // Start the scheduler
 const mastra = new Mastra({ workflows: { billing } });
-await mastra.startScheduler();
+mastra.startScheduler();
 
 // List scheduled workflows
 mastra.listScheduledWorkflows();

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -2346,10 +2346,10 @@ export class Mastra<
    * const mastra = new Mastra({
    *   workflows: { billingWorkflow }
    * });
-   * await mastra.startScheduler();
+   * mastra.startScheduler();
    * ```
    */
-  async startScheduler(): Promise<void> {
+  startScheduler(): void {
     if (this.#scheduler) {
       this.#scheduler.stop();
     }

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -32,6 +32,7 @@ import type { MastraTTS } from '../tts';
 import type { MastraIdGenerator, IdGeneratorContext } from '../types';
 import type { MastraVector } from '../vector';
 import type { AnyWorkflow, Workflow } from '../workflows';
+import { CronScheduler } from '../workflows/cron';
 import { WorkflowEventProcessor } from '../workflows/evented/workflow-event-processor';
 import type { AnyWorkspace, RegisteredWorkspace, Workspace } from '../workspace';
 import { createOnScorerHook } from './hooks';
@@ -347,6 +348,8 @@ export class Mastra<
   // Editor instance for handling agent instantiation and configuration
   #editor?: IMastraEditor;
   #datasets?: DatasetsManager;
+  // Cron scheduler for workflows with schedule configs
+  #scheduler?: CronScheduler;
 
   get pubsub() {
     return this.#pubsub;
@@ -2334,6 +2337,51 @@ export class Mastra<
   }
 
   /**
+   * Starts the cron scheduler for all workflows that have a `schedule` config.
+   * Each scheduled workflow will be executed automatically at its cron interval.
+   * Call `shutdown()` to stop the scheduler.
+   *
+   * @example
+   * ```typescript
+   * const mastra = new Mastra({
+   *   workflows: { billingWorkflow }
+   * });
+   * await mastra.startScheduler();
+   * ```
+   */
+  async startScheduler(): Promise<void> {
+    if (this.#scheduler) {
+      this.#scheduler.stop();
+    }
+    this.#scheduler = new CronScheduler();
+    this.#scheduler.start(this.#workflows as Record<string, Workflow>, this.getLogger());
+  }
+
+  /**
+   * Returns a list of all workflows that have a cron schedule configured.
+   *
+   * @example
+   * ```typescript
+   * const scheduled = mastra.listScheduledWorkflows();
+   * // [{ workflowId: 'billing', cron: '0 0 * * *', description: 'Daily billing' }]
+   * ```
+   */
+  listScheduledWorkflows(): Array<{ workflowId: string; cron: string; description?: string }> {
+    const result: Array<{ workflowId: string; cron: string; description?: string }> = [];
+    for (const workflow of Object.values(this.#workflows)) {
+      const schedule = (workflow as Workflow).schedule;
+      if (schedule?.cron) {
+        result.push({
+          workflowId: (workflow as Workflow).id,
+          cron: schedule.cron,
+          ...(schedule.description ? { description: schedule.description } : {}),
+        });
+      }
+    }
+    return result;
+  }
+
+  /**
    * Sets the storage provider for the Mastra instance.
    *
    * @example
@@ -3206,6 +3254,10 @@ export class Mastra<
    * ```
    */
   async shutdown(): Promise<void> {
+    // Stop cron scheduler if running
+    this.#scheduler?.stop();
+    this.#scheduler = undefined;
+
     await this.stopEventEngine();
     // Shutdown observability registry, exporters, etc...
     await this.#observability.shutdown();

--- a/packages/core/src/workflows/cron-schedule.test.ts
+++ b/packages/core/src/workflows/cron-schedule.test.ts
@@ -1,23 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { Mastra } from '../mastra';
+import { parseCron, validateCron, getNextCronDate } from './cron';
 import { createStep, createWorkflow } from './workflow';
 
 /**
- * Failing tests for GitHub Issue #12682: [FEATURE] Workflow CronJob | Schedule
+ * Tests for GitHub Issue #12682: [FEATURE] Workflow CronJob | Schedule
  *
- * These tests define the expected API for native cron scheduling support
- * in Mastra workflows. Currently, cron scheduling is only available through
- * the external Inngest integration — these tests prove that the core
- * `createWorkflow` and `Mastra` class do NOT support cron natively.
- *
- * Expected feature behavior:
- * 1. `WorkflowConfig` accepts a `schedule` option with a cron expression
- * 2. When Mastra is initialized with scheduled workflows, it starts cron timers
- * 3. Scheduled workflows fire automatically at the specified cron intervals
- * 4. `mastra.shutdown()` cleans up all scheduled cron timers
- * 5. Scheduled workflows can provide default inputData
- * 6. Workflows expose their schedule configuration for introspection
+ * Covers:
+ * 1. Cron expression parser — ranges, steps, lists, wildcards, validation
+ * 2. `getNextCronDate` — next fire time computation with DOM/DOW OR semantics
+ * 3. `WorkflowConfig.schedule` — config acceptance and introspection
+ * 4. Mastra lifecycle — scheduler start, execution, shutdown, listing
  */
 
 const billingStep = createStep({
@@ -27,6 +21,170 @@ const billingStep = createStep({
   execute: async () => {
     return { processed: true };
   },
+});
+
+describe('Cron parser (parseCron)', () => {
+  it('should parse a wildcard field into the full range', () => {
+    const fields = parseCron('* * * * *');
+    expect(fields.minutes.size).toBe(60); // 0-59
+    expect(fields.hours.size).toBe(24); // 0-23
+    expect(fields.daysOfMonth.size).toBe(31); // 1-31
+    expect(fields.months.size).toBe(12); // 1-12
+    expect(fields.daysOfWeek.size).toBe(7); // 0-6
+  });
+
+  it('should parse single values', () => {
+    const fields = parseCron('30 12 15 6 3');
+    expect([...fields.minutes]).toEqual([30]);
+    expect([...fields.hours]).toEqual([12]);
+    expect([...fields.daysOfMonth]).toEqual([15]);
+    expect([...fields.months]).toEqual([6]);
+    expect([...fields.daysOfWeek]).toEqual([3]);
+  });
+
+  it('should parse ranges (N-M)', () => {
+    const fields = parseCron('1-5 * * * *');
+    expect([...fields.minutes].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('should parse lists (N,M,O)', () => {
+    const fields = parseCron('0,15,30,45 * * * *');
+    expect([...fields.minutes].sort((a, b) => a - b)).toEqual([0, 15, 30, 45]);
+  });
+
+  it('should parse step values (*/N)', () => {
+    const fields = parseCron('*/15 * * * *');
+    expect([...fields.minutes].sort((a, b) => a - b)).toEqual([0, 15, 30, 45]);
+  });
+
+  it('should parse range with step (N-M/S)', () => {
+    const fields = parseCron('10-30/5 * * * *');
+    expect([...fields.minutes].sort((a, b) => a - b)).toEqual([10, 15, 20, 25, 30]);
+  });
+
+  it('should normalize day-of-week 7 to 0 (both mean Sunday)', () => {
+    const fields = parseCron('* * * * 7');
+    expect(fields.daysOfWeek.has(0)).toBe(true);
+    expect(fields.daysOfWeek.has(7)).toBe(false);
+  });
+
+  it('should track domWildcard and dowWildcard correctly', () => {
+    const both = parseCron('* * * * *');
+    expect(both.domWildcard).toBe(true);
+    expect(both.dowWildcard).toBe(true);
+
+    const domOnly = parseCron('* * 15 * *');
+    expect(domOnly.domWildcard).toBe(false);
+    expect(domOnly.dowWildcard).toBe(true);
+
+    const dowOnly = parseCron('* * * * 1');
+    expect(dowOnly.domWildcard).toBe(true);
+    expect(dowOnly.dowWildcard).toBe(false);
+
+    const neither = parseCron('* * 15 * 1');
+    expect(neither.domWildcard).toBe(false);
+    expect(neither.dowWildcard).toBe(false);
+  });
+
+  it('should throw on wrong number of fields', () => {
+    expect(() => parseCron('* * *')).toThrow('expected 5 fields');
+    expect(() => parseCron('* * * * * *')).toThrow('expected 5 fields');
+  });
+
+  it('should throw on out-of-range values', () => {
+    expect(() => parseCron('60 * * * *')).toThrow('out of range');
+    expect(() => parseCron('* 24 * * *')).toThrow('out of range');
+    expect(() => parseCron('* * 0 * *')).toThrow('out of range');
+    expect(() => parseCron('* * * 13 *')).toThrow('out of range');
+    expect(() => parseCron('* * * * 8')).toThrow('out of range');
+  });
+
+  it('should throw on invalid step values', () => {
+    expect(() => parseCron('*/0 * * * *')).toThrow('Invalid cron step');
+    expect(() => parseCron('*/abc * * * *')).toThrow('Invalid cron step');
+  });
+
+  it('should throw on non-numeric values', () => {
+    expect(() => parseCron('abc * * * *')).toThrow('Invalid cron value');
+  });
+});
+
+describe('validateCron', () => {
+  it('should return true for valid expressions', () => {
+    expect(validateCron('* * * * *')).toBe(true);
+    expect(validateCron('0 0 * * *')).toBe(true);
+    expect(validateCron('*/15 9-17 * * 1-5')).toBe(true);
+  });
+
+  it('should return false for invalid expressions', () => {
+    expect(validateCron('not-valid')).toBe(false);
+    expect(validateCron('60 * * * *')).toBe(false);
+    expect(validateCron('')).toBe(false);
+  });
+});
+
+describe('getNextCronDate', () => {
+  it('should return the next matching minute', () => {
+    // From 2026-01-15 10:30:00, next "0 * * * *" = 2026-01-15 11:00
+    const from = new Date(2026, 0, 15, 10, 30, 0);
+    const next = getNextCronDate('0 * * * *', from);
+    expect(next.getHours()).toBe(11);
+    expect(next.getMinutes()).toBe(0);
+  });
+
+  it('should skip non-matching hours', () => {
+    // From 2026-01-15 18:00:00, next "0 9 * * *" = 2026-01-16 09:00
+    const from = new Date(2026, 0, 15, 18, 0, 0);
+    const next = getNextCronDate('0 9 * * *', from);
+    expect(next.getDate()).toBe(16);
+    expect(next.getHours()).toBe(9);
+    expect(next.getMinutes()).toBe(0);
+  });
+
+  it('should skip non-matching months', () => {
+    // From 2026-03-01 00:00:00, next "0 0 1 6 *" = 2026-06-01 00:00
+    const from = new Date(2026, 2, 1, 0, 0, 0);
+    const next = getNextCronDate('0 0 1 6 *', from);
+    expect(next.getMonth()).toBe(5); // June (0-indexed)
+    expect(next.getDate()).toBe(1);
+  });
+
+  it('should accept pre-parsed CronFields', () => {
+    const fields = parseCron('0 12 * * *');
+    const from = new Date(2026, 0, 1, 0, 0, 0);
+    const next = getNextCronDate(fields, from);
+    expect(next.getHours()).toBe(12);
+    expect(next.getMinutes()).toBe(0);
+  });
+
+  describe('DOM/DOW OR semantics', () => {
+    it('should fire on the 15th OR on Mondays when both are restricted', () => {
+      // "0 0 15 * 1" = midnight on the 15th OR any Monday
+      // From 2026-01-01 (Thursday)
+      const from = new Date(2026, 0, 1, 0, 0, 0);
+      const next = getNextCronDate('0 0 15 * 1', from);
+
+      // 2026-01-05 is Monday, 2026-01-15 is Thursday
+      // Monday (Jan 5) comes first
+      expect(next.getDate()).toBe(5);
+      expect(next.getDay()).toBe(1); // Monday
+    });
+
+    it('should fire on a day-of-month when only DOM is restricted', () => {
+      // "0 0 15 * *" = midnight on the 15th (DOW is wildcard)
+      const from = new Date(2026, 0, 1, 0, 0, 0);
+      const next = getNextCronDate('0 0 15 * *', from);
+      expect(next.getDate()).toBe(15);
+    });
+
+    it('should fire on a day-of-week when only DOW is restricted', () => {
+      // "0 0 * * 5" = midnight on Fridays (DOM is wildcard)
+      const from = new Date(2026, 0, 1, 0, 0, 0); // Thursday
+      const next = getNextCronDate('0 0 * * 5', from);
+      expect(next.getDay()).toBe(5); // Friday
+      expect(next.getDate()).toBe(2); // Jan 2 2026 is Friday
+    });
+  });
 });
 
 describe('Workflow Cron Schedule (Issue #12682)', () => {
@@ -40,8 +198,6 @@ describe('Workflow Cron Schedule (Issue #12682)', () => {
 
   describe('WorkflowConfig.schedule', () => {
     it('should accept a cron expression in the workflow config', () => {
-      // The createWorkflow factory should accept a `schedule` config
-      // with at minimum a `cron` field for cron expression syntax.
       const workflow = createWorkflow({
         id: 'billing-workflow',
         inputSchema: z.object({}),
@@ -54,7 +210,6 @@ describe('Workflow Cron Schedule (Issue #12682)', () => {
 
       workflow.then(billingStep).commit();
 
-      // The workflow should expose its schedule configuration
       expect(workflow.schedule).toBeDefined();
       expect(workflow.schedule?.cron).toBe('0 0 * * *');
     });
@@ -130,9 +285,7 @@ describe('Workflow Cron Schedule (Issue #12682)', () => {
         workflows: { 'auto-scheduled': workflow },
       });
 
-      // Start the scheduler — this should activate cron timers for all
-      // workflows that have a `schedule` config.
-      await mastra.startScheduler();
+      mastra.startScheduler();
 
       // Advance time by 1 minute to trigger the cron
       await vi.advanceTimersByTimeAsync(60_000);
@@ -174,7 +327,7 @@ describe('Workflow Cron Schedule (Issue #12682)', () => {
         workflows: { 'cleanup-test': workflow },
       });
 
-      await mastra.startScheduler();
+      mastra.startScheduler();
 
       // Trigger once
       await vi.advanceTimersByTimeAsync(60_000);
@@ -205,7 +358,6 @@ describe('Workflow Cron Schedule (Issue #12682)', () => {
         workflows: { 'list-test': workflow },
       });
 
-      // Should be able to list scheduled workflows
       const scheduledWorkflows = mastra.listScheduledWorkflows();
 
       expect(scheduledWorkflows).toHaveLength(1);

--- a/packages/core/src/workflows/cron-schedule.test.ts
+++ b/packages/core/src/workflows/cron-schedule.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { Mastra } from '../mastra';
+import { createStep, createWorkflow } from './workflow';
+
+/**
+ * Failing tests for GitHub Issue #12682: [FEATURE] Workflow CronJob | Schedule
+ *
+ * These tests define the expected API for native cron scheduling support
+ * in Mastra workflows. Currently, cron scheduling is only available through
+ * the external Inngest integration — these tests prove that the core
+ * `createWorkflow` and `Mastra` class do NOT support cron natively.
+ *
+ * Expected feature behavior:
+ * 1. `WorkflowConfig` accepts a `schedule` option with a cron expression
+ * 2. When Mastra is initialized with scheduled workflows, it starts cron timers
+ * 3. Scheduled workflows fire automatically at the specified cron intervals
+ * 4. `mastra.shutdown()` cleans up all scheduled cron timers
+ * 5. Scheduled workflows can provide default inputData
+ * 6. Workflows expose their schedule configuration for introspection
+ */
+
+const billingStep = createStep({
+  id: 'process-billing',
+  inputSchema: z.object({}),
+  outputSchema: z.object({ processed: z.boolean() }),
+  execute: async () => {
+    return { processed: true };
+  },
+});
+
+describe('Workflow Cron Schedule (Issue #12682)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('WorkflowConfig.schedule', () => {
+    it('should accept a cron expression in the workflow config', () => {
+      // The createWorkflow factory should accept a `schedule` config
+      // with at minimum a `cron` field for cron expression syntax.
+      const workflow = createWorkflow({
+        id: 'billing-workflow',
+        inputSchema: z.object({}),
+        outputSchema: z.object({ processed: z.boolean() }),
+        steps: [billingStep],
+        schedule: {
+          cron: '0 0 * * *', // Every day at midnight
+        },
+      });
+
+      workflow.then(billingStep).commit();
+
+      // The workflow should expose its schedule configuration
+      expect(workflow.schedule).toBeDefined();
+      expect(workflow.schedule?.cron).toBe('0 0 * * *');
+    });
+
+    it('should accept optional inputData for scheduled runs', () => {
+      const stepWithInput = createStep({
+        id: 'process-with-input',
+        inputSchema: z.object({ region: z.string() }),
+        outputSchema: z.object({ processed: z.boolean() }),
+        execute: async () => {
+          return { processed: true };
+        },
+      });
+
+      const workflow = createWorkflow({
+        id: 'regional-billing',
+        inputSchema: z.object({ region: z.string() }),
+        outputSchema: z.object({ processed: z.boolean() }),
+        steps: [stepWithInput],
+        schedule: {
+          cron: '0 0 * * *',
+          inputData: { region: 'us-east-1' },
+        },
+      });
+
+      workflow.then(stepWithInput).commit();
+
+      expect(workflow.schedule?.inputData).toEqual({ region: 'us-east-1' });
+    });
+
+    it('should accept a human-readable description for the schedule', () => {
+      const workflow = createWorkflow({
+        id: 'described-schedule',
+        inputSchema: z.object({}),
+        outputSchema: z.object({ processed: z.boolean() }),
+        steps: [billingStep],
+        schedule: {
+          cron: '0 0 * * *',
+          description: 'Process billing every day at midnight',
+        },
+      });
+
+      workflow.then(billingStep).commit();
+
+      expect(workflow.schedule?.description).toBe('Process billing every day at midnight');
+    });
+  });
+
+  describe('Mastra scheduled workflow lifecycle', () => {
+    it('should automatically execute scheduled workflows on cron intervals', async () => {
+      const executeSpy = vi.fn().mockResolvedValue({ processed: true });
+
+      const step = createStep({
+        id: 'spy-step',
+        inputSchema: z.object({}),
+        outputSchema: z.object({ processed: z.boolean() }),
+        execute: executeSpy,
+      });
+
+      const workflow = createWorkflow({
+        id: 'auto-scheduled',
+        inputSchema: z.object({}),
+        outputSchema: z.object({ processed: z.boolean() }),
+        steps: [step],
+        schedule: {
+          cron: '* * * * *', // Every minute
+        },
+      });
+
+      workflow.then(step).commit();
+
+      const mastra = new Mastra({
+        workflows: { 'auto-scheduled': workflow },
+      });
+
+      // Start the scheduler — this should activate cron timers for all
+      // workflows that have a `schedule` config.
+      await mastra.startScheduler();
+
+      // Advance time by 1 minute to trigger the cron
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      // The workflow should have been executed once
+      expect(executeSpy).toHaveBeenCalledTimes(1);
+
+      // Advance another minute
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(executeSpy).toHaveBeenCalledTimes(2);
+
+      await mastra.shutdown();
+    });
+
+    it('should clean up cron timers on mastra.shutdown()', async () => {
+      const executeSpy = vi.fn().mockResolvedValue({ processed: true });
+
+      const step = createStep({
+        id: 'cleanup-step',
+        inputSchema: z.object({}),
+        outputSchema: z.object({ processed: z.boolean() }),
+        execute: executeSpy,
+      });
+
+      const workflow = createWorkflow({
+        id: 'cleanup-test',
+        inputSchema: z.object({}),
+        outputSchema: z.object({ processed: z.boolean() }),
+        steps: [step],
+        schedule: {
+          cron: '* * * * *',
+        },
+      });
+
+      workflow.then(step).commit();
+
+      const mastra = new Mastra({
+        workflows: { 'cleanup-test': workflow },
+      });
+
+      await mastra.startScheduler();
+
+      // Trigger once
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(executeSpy).toHaveBeenCalledTimes(1);
+
+      // Shutdown should stop the scheduler
+      await mastra.shutdown();
+
+      // Advancing time after shutdown should NOT trigger another run
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(executeSpy).toHaveBeenCalledTimes(1); // Still 1
+    });
+
+    it('should list scheduled workflows with their cron configs', () => {
+      const workflow = createWorkflow({
+        id: 'list-test',
+        inputSchema: z.object({}),
+        outputSchema: z.object({ processed: z.boolean() }),
+        steps: [billingStep],
+        schedule: {
+          cron: '0 0 * * *',
+        },
+      });
+
+      workflow.then(billingStep).commit();
+
+      const mastra = new Mastra({
+        workflows: { 'list-test': workflow },
+      });
+
+      // Should be able to list scheduled workflows
+      const scheduledWorkflows = mastra.listScheduledWorkflows();
+
+      expect(scheduledWorkflows).toHaveLength(1);
+      expect(scheduledWorkflows[0]).toEqual(
+        expect.objectContaining({
+          workflowId: 'list-test',
+          cron: '0 0 * * *',
+        }),
+      );
+    });
+  });
+
+  describe('Schedule validation', () => {
+    it('should reject invalid cron expressions', () => {
+      expect(() => {
+        const workflow = createWorkflow({
+          id: 'invalid-cron',
+          inputSchema: z.object({}),
+          outputSchema: z.object({ processed: z.boolean() }),
+          steps: [billingStep],
+          schedule: {
+            cron: 'not-a-valid-cron',
+          },
+        });
+
+        workflow.then(billingStep).commit();
+      }).toThrow();
+    });
+  });
+});

--- a/packages/core/src/workflows/cron.ts
+++ b/packages/core/src/workflows/cron.ts
@@ -1,0 +1,240 @@
+/**
+ * Minimal cron expression parser and scheduler for native workflow scheduling.
+ *
+ * Supports standard 5-field cron syntax:
+ *   ┌───────────── minute (0-59)
+ *   │ ┌───────────── hour (0-23)
+ *   │ │ ┌───────────── day of month (1-31)
+ *   │ │ │ ┌───────────── month (1-12)
+ *   │ │ │ │ ┌───────────── day of week (0-7, 0 and 7 = Sunday)
+ *   │ │ │ │ │
+ *   * * * * *
+ *
+ * Each field supports: *, N, N-M, N,M, and /N step values.
+ */
+
+import type { IMastraLogger } from '../logger';
+import type { Workflow } from './workflow';
+
+export interface CronFields {
+  minutes: Set<number>;
+  hours: Set<number>;
+  daysOfMonth: Set<number>;
+  months: Set<number>;
+  daysOfWeek: Set<number>;
+}
+
+/**
+ * Parse a single cron field into the set of matching integer values.
+ */
+function parseCronField(field: string, min: number, max: number): Set<number> {
+  const values = new Set<number>();
+
+  for (const part of field.split(',')) {
+    const trimmed = part.trim();
+
+    if (trimmed.includes('/')) {
+      const [range, stepStr] = trimmed.split('/');
+      const step = parseInt(stepStr!, 10);
+      if (isNaN(step) || step <= 0) {
+        throw new Error(`Invalid cron step value: "${stepStr}"`);
+      }
+
+      let start = min;
+      let end = max;
+
+      if (range !== '*') {
+        if (range!.includes('-')) {
+          const [s, e] = range!.split('-');
+          start = parseInt(s!, 10);
+          end = parseInt(e!, 10);
+        } else {
+          start = parseInt(range!, 10);
+        }
+      }
+
+      for (let i = start; i <= end; i += step) {
+        values.add(i);
+      }
+    } else if (trimmed === '*') {
+      for (let i = min; i <= max; i++) {
+        values.add(i);
+      }
+    } else if (trimmed.includes('-')) {
+      const [s, e] = trimmed.split('-');
+      const start = parseInt(s!, 10);
+      const end = parseInt(e!, 10);
+      if (isNaN(start) || isNaN(end)) {
+        throw new Error(`Invalid cron range: "${trimmed}"`);
+      }
+      for (let i = start; i <= end; i++) {
+        values.add(i);
+      }
+    } else {
+      const val = parseInt(trimmed, 10);
+      if (isNaN(val)) {
+        throw new Error(`Invalid cron value: "${trimmed}"`);
+      }
+      values.add(val);
+    }
+  }
+
+  for (const val of values) {
+    if (val < min || val > max) {
+      throw new Error(`Cron value ${val} out of range [${min}-${max}]`);
+    }
+  }
+
+  return values;
+}
+
+/**
+ * Parse a 5-field cron expression into its component field sets.
+ * Throws if the expression is invalid.
+ */
+export function parseCron(expr: string): CronFields {
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    throw new Error(`Invalid cron expression "${expr}": expected 5 fields, got ${parts.length}`);
+  }
+
+  const minutes = parseCronField(parts[0]!, 0, 59);
+  const hours = parseCronField(parts[1]!, 0, 23);
+  const daysOfMonth = parseCronField(parts[2]!, 1, 31);
+  const months = parseCronField(parts[3]!, 1, 12);
+  const daysOfWeek = parseCronField(parts[4]!, 0, 7);
+
+  // Normalize: 7 (Sunday) → 0
+  if (daysOfWeek.has(7)) {
+    daysOfWeek.add(0);
+    daysOfWeek.delete(7);
+  }
+
+  return { minutes, hours, daysOfMonth, months, daysOfWeek };
+}
+
+/**
+ * Validate a cron expression. Returns true if valid, false otherwise.
+ */
+export function validateCron(expr: string): boolean {
+  try {
+    parseCron(expr);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Compute the next Date matching the given cron expression, strictly after `from`.
+ * Scans forward efficiently by skipping non-matching months, days, and hours.
+ */
+export function getNextCronDate(cronExpr: string, from: Date): Date {
+  const { minutes, hours, daysOfMonth, months, daysOfWeek } = parseCron(cronExpr);
+
+  // Start from the next whole minute after `from`
+  const date = new Date(from.getTime());
+  date.setSeconds(0, 0);
+  date.setMinutes(date.getMinutes() + 1);
+
+  const maxTime = from.getTime() + 4 * 365.25 * 24 * 60 * 60 * 1000;
+
+  while (date.getTime() <= maxTime) {
+    if (!months.has(date.getMonth() + 1)) {
+      date.setMonth(date.getMonth() + 1, 1);
+      date.setHours(0, 0, 0, 0);
+      continue;
+    }
+
+    if (!daysOfMonth.has(date.getDate()) || !daysOfWeek.has(date.getDay())) {
+      date.setDate(date.getDate() + 1);
+      date.setHours(0, 0, 0, 0);
+      continue;
+    }
+
+    if (!hours.has(date.getHours())) {
+      date.setHours(date.getHours() + 1, 0, 0, 0);
+      continue;
+    }
+
+    if (!minutes.has(date.getMinutes())) {
+      date.setMinutes(date.getMinutes() + 1, 0, 0);
+      continue;
+    }
+
+    return date;
+  }
+
+  throw new Error(`No matching cron date found within 4 years for: "${cronExpr}"`);
+}
+
+/**
+ * A lightweight cron scheduler that manages setTimeout-chained execution
+ * of workflows with `schedule` configs.
+ */
+export class CronScheduler {
+  #timers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  #running = false;
+
+  get running() {
+    return this.#running;
+  }
+
+  /**
+   * Start scheduling all workflows that have a `schedule.cron` config.
+   */
+  start(workflows: Record<string, Workflow<any, any, any, any, any, any, any>>, logger?: IMastraLogger): void {
+    this.#running = true;
+    for (const workflow of Object.values(workflows)) {
+      const schedule = workflow.schedule;
+      if (schedule?.cron) {
+        this.#scheduleWorkflow(workflow, logger);
+      }
+    }
+  }
+
+  #scheduleWorkflow(workflow: Workflow<any, any, any, any, any, any, any>, logger?: IMastraLogger): void {
+    const { cron, inputData } = workflow.schedule!;
+
+    const scheduleNext = () => {
+      if (!this.#running) return;
+
+      const now = new Date();
+      let next: Date;
+      try {
+        next = getNextCronDate(cron, now);
+      } catch {
+        logger?.error?.(`Failed to compute next cron date for workflow "${workflow.id}"`);
+        return;
+      }
+
+      const delay = next.getTime() - now.getTime();
+
+      const timer = setTimeout(async () => {
+        if (!this.#running) return;
+        try {
+          const run = await workflow.createRun();
+          await run.start({ inputData: inputData ?? {} });
+        } catch (err) {
+          logger?.error?.(`Cron execution failed for workflow "${workflow.id}":`, err);
+        }
+        scheduleNext();
+      }, delay);
+
+      this.#timers.set(workflow.id, timer);
+    };
+
+    scheduleNext();
+  }
+
+  /**
+   * Stop all scheduled cron timers and prevent further scheduling.
+   */
+  stop(): void {
+    this.#running = false;
+    for (const timer of this.#timers.values()) {
+      clearTimeout(timer);
+    }
+    this.#timers.clear();
+  }
+}

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -728,6 +728,18 @@ export type WorkflowStreamResult<TState, TInput, TOutput, TSteps extends Step<st
       };
     };
 
+/**
+ * Configuration for scheduling a workflow on a cron interval.
+ */
+export type ScheduleConfig<TInput = unknown> = {
+  /** Cron expression in standard 5-field syntax (minute hour day-of-month month day-of-week) */
+  cron: string;
+  /** Default input data for each scheduled run */
+  inputData?: TInput;
+  /** Human-readable description of the schedule */
+  description?: string;
+};
+
 export type WorkflowConfig<
   TWorkflowId extends string,
   TState,
@@ -757,6 +769,8 @@ export type WorkflowConfig<
   options?: WorkflowOptions;
   /** Type of workflow - 'processor' for processor workflows, 'default' otherwise */
   type?: WorkflowType;
+  /** Optional cron schedule for recurring execution */
+  schedule?: ScheduleConfig<TInput>;
 };
 
 /**

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -38,6 +38,7 @@ import type { ToolExecutionContext } from '../tools';
 import type { DynamicArgument } from '../types';
 import { isZodType } from '../utils';
 import { PUBSUB_SYMBOL, STREAM_FORMAT_SYMBOL } from './constants';
+import { validateCron } from './cron';
 import { DefaultExecutionEngine } from './default';
 import type { ExecutionEngine, ExecutionGraph } from './execution-engine';
 import type {
@@ -64,6 +65,7 @@ import type {
   StreamEvent,
   SubsetOf,
   TimeTravelContext,
+  ScheduleConfig,
   WorkflowConfig,
   WorkflowEngineType,
   WorkflowOptions,
@@ -1328,6 +1330,7 @@ export class Workflow<
   };
 
   #mastra?: Mastra;
+  #schedule?: ScheduleConfig<TInput>;
 
   #runs: Map<string, Run<TEngineType, TSteps, TState, TInput, TOutput, TRequestContext>> = new Map();
 
@@ -1344,6 +1347,7 @@ export class Workflow<
     steps,
     options = {},
     type,
+    schedule,
   }: WorkflowConfig<TWorkflowId, TState, TInput, TOutput, TSteps, TRequestContext>) {
     super({ name: id, component: RegisteredLogger.WORKFLOW });
     this.id = id;
@@ -1381,6 +1385,13 @@ export class Workflow<
     this.engineType = 'default';
 
     this.#runs = new Map();
+
+    if (schedule) {
+      if (!validateCron(schedule.cron)) {
+        throw new Error(`Invalid cron expression "${schedule.cron}" for workflow "${id}"`);
+      }
+      this.#schedule = schedule;
+    }
   }
 
   get runs() {
@@ -1393,6 +1404,10 @@ export class Workflow<
 
   get options() {
     return this.#options;
+  }
+
+  get schedule(): ScheduleConfig<TInput> | undefined {
+    return this.#schedule;
   }
 
   __registerMastra(mastra: Mastra) {


### PR DESCRIPTION
## Summary
- Adds native cron-based scheduling for workflows, enabling recurring execution using standard 5-field cron expressions without requiring external services (node-cron, Inngest, Vercel cron)
- Implements a zero-dependency cron parser and setTimeout-chained scheduler in `@mastra/core`
- Integrates scheduler lifecycle into `Mastra` class with explicit start/stop/list APIs

## Changes

### New files
- `packages/core/src/workflows/cron.ts` — Cron expression parser (`parseCron`, `validateCron`, `getNextCronDate`) and `CronScheduler` class
- `packages/core/src/workflows/cron-schedule.test.ts` — 7 tests covering config acceptance, lifecycle, and validation

### Modified files
- `packages/core/src/workflows/types.ts` — Added `ScheduleConfig<TInput>` type, added optional `schedule` field to `WorkflowConfig`
- `packages/core/src/workflows/workflow.ts` — Added `#schedule` private field with getter, cron validation in constructor
- `packages/core/src/mastra/index.ts` — Added `startScheduler()`, `listScheduledWorkflows()`, extended `shutdown()` to clean up cron timers

## API

```typescript
// Define a workflow with a cron schedule
const billing = createWorkflow({
  id: 'daily-billing',
  inputSchema: z.object({}),
  outputSchema: z.object({ processed: z.boolean() }),
  steps: [processBilling],
  schedule: {
    cron: '0 0 * * *',      // Every day at midnight
    inputData: {},            // Default input for each run
    description: 'Daily billing run',
  },
});
billing.then(processBilling).commit();

// Start the scheduler
const mastra = new Mastra({ workflows: { billing } });
await mastra.startScheduler();

// List scheduled workflows
mastra.listScheduledWorkflows();
// => [{ workflowId: 'daily-billing', cron: '0 0 * * *', description: 'Daily billing run' }]

// Clean shutdown stops all cron timers
await mastra.shutdown();
```

## Test plan
- [x] Workflow accepts `schedule` config with cron expression
- [x] Workflow accepts optional `inputData` and `description`
- [x] Scheduled workflows execute automatically at cron intervals (fake timers)
- [x] `mastra.shutdown()` stops all cron timers
- [x] `mastra.listScheduledWorkflows()` returns scheduled workflow metadata
- [x] Invalid cron expressions are rejected at workflow creation time
- [x] TypeScript type checking passes

Fixes #12682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflows can be scheduled using standard 5-field cron expressions with optional input and descriptions.
  * Added global scheduler controls to start/stop recurring workflow execution and to inspect scheduled workflows.
  * Shutdown now also stops any active cron scheduling.
  * Cron expressions are validated at workflow creation time.

* **Tests**
  * Extensive tests added for parsing, validation, next-run computation, scheduler lifecycle, and listing scheduled workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->