### PR TITLE
fix(core): resolve model version catch-22 for unknown providers

### DIFF
--- a/.changeset/fix-ollama-provider-streaming.md
+++ b/.changeset/fix-ollama-provider-streaming.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a catch-22 where third-party AI SDK providers (like `ollama-ai-provider-v2`) were rejected by both `stream()` and `streamLegacy()` due to unrecognized `specificationVersion` values.
+
+When a model has a `specificationVersion` that isn't `'v1'`, `'v2'`, or `'v3'` (e.g., from a third-party provider), two fixes now apply:
+
+1. **Auto-wrapping in `resolveModelConfig()`**: Models with unknown spec versions that have `doStream`/`doGenerate` methods are automatically wrapped as AI SDK v5 models, preventing the catch-22 entirely.
+
+2. **Improved error messages**: If a model still reaches the version check, error messages now show the actual unrecognized `specificationVersion` instead of creating circular suggestions between `stream()` and `streamLegacy()`.

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -865,9 +865,14 @@ export class AgentLegacyHandler {
     const { llm, before, after } = await this.prepareLLMOptions(messages, mergedGenerateOptions as any, 'generate');
 
     if (llm.getModel().specificationVersion !== 'v1') {
-      this.capabilities.logger.error('V2 models are not supported for generateLegacy. Please use generate instead.', {
-        modelId: llm.getModel().modelId,
-      });
+      const specVersion = llm.getModel().specificationVersion;
+      this.capabilities.logger.error(
+        `Models with specificationVersion "${specVersion}" are not supported for generateLegacy. Please use generate() instead.`,
+        {
+          modelId: llm.getModel().modelId,
+          specificationVersion: specVersion,
+        },
+      );
 
       throw new MastraError({
         id: 'AGENT_GENERATE_V2_MODEL_NOT_SUPPORTED',
@@ -875,8 +880,9 @@ export class AgentLegacyHandler {
         category: ErrorCategory.USER,
         details: {
           modelId: llm.getModel().modelId,
+          specificationVersion: specVersion,
         },
-        text: 'V2 models are not supported for generateLegacy. Please use generate instead.',
+        text: `Models with specificationVersion "${specVersion}" are not supported for generateLegacy(). Please use generate() instead.`,
       });
     }
 
@@ -1155,9 +1161,14 @@ export class AgentLegacyHandler {
     const { llm, before, after } = await this.prepareLLMOptions(messages, mergedStreamOptions as any, 'stream');
 
     if (llm.getModel().specificationVersion !== 'v1') {
-      this.capabilities.logger.error('V2 models are not supported for streamLegacy. Please use stream instead.', {
-        modelId: llm.getModel().modelId,
-      });
+      const specVersion = llm.getModel().specificationVersion;
+      this.capabilities.logger.error(
+        `Models with specificationVersion "${specVersion}" are not supported for streamLegacy. Please use stream() instead.`,
+        {
+          modelId: llm.getModel().modelId,
+          specificationVersion: specVersion,
+        },
+      );
 
       throw new MastraError({
         id: 'AGENT_STREAM_V2_MODEL_NOT_SUPPORTED',
@@ -1165,8 +1176,9 @@ export class AgentLegacyHandler {
         category: ErrorCategory.USER,
         details: {
           modelId: llm.getModel().modelId,
+          specificationVersion: specVersion,
         },
-        text: 'V2 models are not supported for streamLegacy. Please use stream instead.',
+        text: `Models with specificationVersion "${specVersion}" are not supported for streamLegacy(). Please use stream() instead.`,
       });
     }
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3965,17 +3965,21 @@ export class Agent<
     if (!isSupportedLanguageModel(modelInfo)) {
       const modelId = modelInfo.modelId || 'unknown';
       const provider = modelInfo.provider || 'unknown';
+      const specVersion = modelInfo.specificationVersion;
 
       throw new MastraError({
         id: 'AGENT_GENERATE_V1_MODEL_NOT_SUPPORTED',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
-        text: `Agent \"${this.name}\" is using AI SDK v4 model (${provider}:${modelId}) which is not compatible with generate(). Please use AI SDK v5+ models or call the generateLegacy() method instead. See https://mastra.ai/en/docs/streaming/overview for more information.`,
+        text:
+          specVersion === 'v1'
+            ? `Agent "${this.name}" is using AI SDK v4 model (${provider}:${modelId}) which is not compatible with generate(). Please use AI SDK v5+ models or call the generateLegacy() method instead. See https://mastra.ai/en/docs/streaming/overview for more information.`
+            : `Agent "${this.name}" has a model (${provider}:${modelId}) with unrecognized specificationVersion "${specVersion}". Supported versions: v1 (legacy), v2 (AI SDK v5), v3 (AI SDK v6). Please ensure your AI SDK provider is compatible with this version of Mastra.`,
         details: {
           agentName: this.name,
           modelId,
           provider,
-          specificationVersion: modelInfo.specificationVersion,
+          specificationVersion: specVersion,
         },
       });
     }
@@ -4058,17 +4062,21 @@ export class Agent<
     if (!isSupportedLanguageModel(modelInfo)) {
       const modelId = modelInfo.modelId || 'unknown';
       const provider = modelInfo.provider || 'unknown';
+      const specVersion = modelInfo.specificationVersion;
 
       throw new MastraError({
         id: 'AGENT_STREAM_V1_MODEL_NOT_SUPPORTED',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
-        text: `Agent \"${this.name}\" is using AI SDK v4 model (${provider}:${modelId}) which is not compatible with stream(). Please use AI SDK v5+ models or call the streamLegacy() method instead. See https://mastra.ai/en/docs/streaming/overview for more information.`,
+        text:
+          specVersion === 'v1'
+            ? `Agent "${this.name}" is using AI SDK v4 model (${provider}:${modelId}) which is not compatible with stream(). Please use AI SDK v5+ models or call the streamLegacy() method instead. See https://mastra.ai/en/docs/streaming/overview for more information.`
+            : `Agent "${this.name}" has a model (${provider}:${modelId}) with unrecognized specificationVersion "${specVersion}". Supported versions: v1 (legacy), v2 (AI SDK v5), v3 (AI SDK v6). Please ensure your AI SDK provider is compatible with this version of Mastra.`,
         details: {
           agentName: this.name,
           modelId,
           provider,
-          specificationVersion: modelInfo.specificationVersion,
+          specificationVersion: specVersion,
         },
       });
     }
@@ -4155,11 +4163,21 @@ export class Agent<
     });
 
     if (!isSupportedLanguageModel(llm.getModel())) {
+      const modelInfo = llm.getModel();
+      const specVersion = modelInfo.specificationVersion;
       throw new MastraError({
         id: 'AGENT_STREAM_V1_MODEL_NOT_SUPPORTED',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
-        text: 'V1 models are not supported for stream. Please use streamLegacy instead.',
+        text:
+          specVersion === 'v1'
+            ? 'V1 models are not supported for resumeStream. Please use streamLegacy instead.'
+            : `Model has unrecognized specificationVersion "${specVersion}". Supported versions: v1 (legacy), v2 (AI SDK v5), v3 (AI SDK v6). Please ensure your AI SDK provider is compatible with this version of Mastra.`,
+        details: {
+          modelId: modelInfo.modelId,
+          provider: modelInfo.provider,
+          specificationVersion: specVersion,
+        },
       });
     }
 
@@ -4237,16 +4255,20 @@ export class Agent<
     if (!isSupportedLanguageModel(modelInfo)) {
       const modelId = modelInfo.modelId || 'unknown';
       const provider = modelInfo.provider || 'unknown';
+      const specVersion = modelInfo.specificationVersion;
       throw new MastraError({
         id: 'AGENT_GENERATE_V1_MODEL_NOT_SUPPORTED',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
-        text: `Agent \"${this.name}\" is using AI SDK v4 model (${provider}:${modelId}) which is not compatible with generate(). Please use AI SDK v5+ models or call the generateLegacy() method instead. See https://mastra.ai/en/docs/streaming/overview for more information.`,
+        text:
+          specVersion === 'v1'
+            ? `Agent "${this.name}" is using AI SDK v4 model (${provider}:${modelId}) which is not compatible with generate(). Please use AI SDK v5+ models or call the generateLegacy() method instead. See https://mastra.ai/en/docs/streaming/overview for more information.`
+            : `Agent "${this.name}" has a model (${provider}:${modelId}) with unrecognized specificationVersion "${specVersion}". Supported versions: v1 (legacy), v2 (AI SDK v5), v3 (AI SDK v6). Please ensure your AI SDK provider is compatible with this version of Mastra.`,
         details: {
           agentName: this.name,
           modelId,
           provider,
-          specificationVersion: modelInfo.specificationVersion,
+          specificationVersion: specVersion,
         },
       });
     }

--- a/packages/core/src/llm/model/resolve-model.ts
+++ b/packages/core/src/llm/model/resolve-model.ts
@@ -104,7 +104,15 @@ export async function resolveModelConfig(
     if (modelConfig.specificationVersion === 'v3') {
       return new AISDKV6LanguageModel(modelConfig as LanguageModelV3);
     }
-    // V1 (legacy) models pass through without wrapping
+    if (modelConfig.specificationVersion === 'v1') {
+      return modelConfig;
+    }
+    // Unknown specificationVersion from a third-party provider (e.g. ollama-ai-provider-v2).
+    // If the model has doStream/doGenerate methods, wrap it as a modern model
+    // to prevent the stream()/streamLegacy() catch-22 where neither method accepts the model.
+    if (typeof (modelConfig as any).doStream === 'function' && typeof (modelConfig as any).doGenerate === 'function') {
+      return new AISDKV5LanguageModel(modelConfig as LanguageModelV2);
+    }
     return modelConfig;
   }
 


### PR DESCRIPTION
## Description

This PR resolves a version detection issue (the "Catch-22") with third-party AI SDK providers like `ollama-ai-provider-v2`. Previously, these providers were rejected by `stream()` as "legacy v4 models" but also rejected by `streamLegacy()` as "modern V2 models", leaving users with no working streaming method.

**Changes:**
- Implemented **Duck-Typing fallback** in `resolveModelConfig`: If a model has an unknown `specificationVersion` but provides valid `doStream` and `doGenerate` methods, it is now automatically wrapped as a modern `AISDKV5LanguageModel`.
- Improved error messages in `Agent` and `AgentLegacy` to display the actual `specificationVersion` received, preventing confusing circular suggestions.
- Added unit tests to verify behavior for unknown specification versions.

## Related Issue(s)

Fixes #12052

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages to include the model specification version and clearer guidance when a model isn't supported.
  * Added fallback handling so models with unknown specification versions are accepted when they expose streaming/generation capabilities.

* **Tests**
  * Added tests covering unknown specification-version scenarios to ensure correct wrapping/passthrough behavior.

* **Chores**
  * Added a changelog entry describing the fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->