### PR TITLE
fix(core): resolve Workflow #private type error with requestContextSchema

### DIFF
--- a/.changeset/upset-cows-brush.md
+++ b/.changeset/upset-cows-brush.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed Workflow type incompatibility with Mastra constructor when using requestContextSchema. Workflows with a requestContextSchema can now be passed to `new Mastra({ workflows: { ... } })` without a `#private` type error. Also introduced an `AnyWorkflow` type alias to prevent this class of issue in the future.
+Fixed: You can now pass workflows with a `requestContextSchema` to the Mastra constructor without a type error. Related: #12773.

--- a/.changeset/upset-cows-brush.md
+++ b/.changeset/upset-cows-brush.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Workflow type incompatibility with Mastra constructor when using requestContextSchema. Workflows with a requestContextSchema can now be passed to `new Mastra({ workflows: { ... } })` without a `#private` type error. Also introduced an `AnyWorkflow` type alias to prevent this class of issue in the future.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -62,7 +62,7 @@ import type { ToolOptions } from '../utils';
 import type { MastraVoice } from '../voice';
 import { DefaultVoice } from '../voice';
 import { createWorkflow, createStep, isProcessor } from '../workflows';
-import type { OutputWriter, Step, Workflow, WorkflowResult } from '../workflows';
+import type { AnyWorkflow, OutputWriter, Step, WorkflowResult } from '../workflows';
 import type { Workspace } from '../workspace';
 import { createWorkspaceTools } from '../workspace';
 import type { SkillFormat } from '../workspace/skills';
@@ -150,7 +150,7 @@ export class Agent<
   #mastra?: Mastra;
   #memory?: DynamicArgument<MastraMemory>;
   #skillsFormat?: SkillFormat;
-  #workflows?: DynamicArgument<Record<string, Workflow<any, any, any, any, any, any, any>>>;
+  #workflows?: DynamicArgument<Record<string, AnyWorkflow>>;
   #defaultGenerateOptionsLegacy: DynamicArgument<AgentGenerateOptions>;
   #defaultStreamOptionsLegacy: DynamicArgument<AgentStreamOptions>;
   #defaultOptions: DynamicArgument<AgentExecutionOptions<TOutput>>;
@@ -902,7 +902,7 @@ export class Agent<
    */
   public async listWorkflows({
     requestContext = new RequestContext(),
-  }: { requestContext?: RequestContext } = {}): Promise<Record<string, Workflow<any, any, any, any, any, any, any>>> {
+  }: { requestContext?: RequestContext } = {}): Promise<Record<string, AnyWorkflow>> {
     let workflowRecord;
     if (typeof this.#workflows === 'function') {
       workflowRecord = await Promise.resolve(this.#workflows({ requestContext, mastra: this.#mastra }));

--- a/packages/core/src/evals/run/index.ts
+++ b/packages/core/src/evals/run/index.ts
@@ -6,7 +6,7 @@ import { validateAndSaveScore } from '../../mastra/hooks';
 import type { TracingContext } from '../../observability';
 import type { RequestContext } from '../../request-context';
 import { Workflow } from '../../workflows';
-import type { WorkflowResult, StepResult } from '../../workflows';
+import type { AnyWorkflow, WorkflowResult, StepResult } from '../../workflows';
 import type { MastraScorer } from '../base';
 import { ScoreAccumulator } from './scorerAccumulator';
 
@@ -47,7 +47,7 @@ export function runEvals<TAgent extends Agent>(config: {
 }): Promise<RunEvalsResult>;
 
 // Workflow with scorers array
-export function runEvals<TWorkflow extends Workflow<any, any, any, any, any, any, any>>(config: {
+export function runEvals<TWorkflow extends AnyWorkflow>(config: {
   data: RunEvalsDataItem<TWorkflow>[];
   scorers: MastraScorer<any, any, any, any>[];
   target: TWorkflow;
@@ -60,7 +60,7 @@ export function runEvals<TWorkflow extends Workflow<any, any, any, any, any, any
 }): Promise<RunEvalsResult>;
 
 // Workflow with workflow configuration
-export function runEvals<TWorkflow extends Workflow<any, any, any, any, any, any, any>>(config: {
+export function runEvals<TWorkflow extends AnyWorkflow>(config: {
   data: RunEvalsDataItem<TWorkflow>[];
   scorers: WorkflowScorerConfig;
   target: TWorkflow;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,7 @@ export type { SharedMemoryConfig, MemoryConfig, MastraMemory, SerializedMemoryCo
 export type { MastraVector as MastraVectorProvider } from './vector';
 export type { IMastraLogger as Logger } from './logger';
 export type { ToolAction } from './tools';
-export type { Workflow } from './workflows';
+export type { AnyWorkflow, Workflow } from './workflows';
 export type { MastraScorers, ScoringSamplingConfig } from './evals';
 export type { StorageResolvedAgentType, StorageScorerConfig } from './storage';
 export type { IMastraEditor, MastraEditorConfig } from './editor';

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -29,7 +29,7 @@ import type { ToolAction } from '../tools';
 import type { MastraTTS } from '../tts';
 import type { MastraIdGenerator, IdGeneratorContext } from '../types';
 import type { MastraVector } from '../vector';
-import type { Workflow } from '../workflows';
+import type { AnyWorkflow, Workflow } from '../workflows';
 import { WorkflowEventProcessor } from '../workflows/evented/workflow-event-processor';
 import type { Workspace } from '../workspace';
 import { createOnScorerHook } from './hooks';
@@ -98,10 +98,7 @@ function createUndefinedPrimitiveError(
  */
 export interface Config<
   TAgents extends Record<string, Agent<any>> = Record<string, Agent<any>>,
-  TWorkflows extends Record<string, Workflow<any, any, any, any, any, any, any>> = Record<
-    string,
-    Workflow<any, any, any, any, any, any, any>
-  >,
+  TWorkflows extends Record<string, AnyWorkflow> = Record<string, AnyWorkflow>,
   TVectors extends Record<string, MastraVector<any>> = Record<string, MastraVector<any>>,
   TTTS extends Record<string, MastraTTS> = Record<string, MastraTTS>,
   TLogger extends IMastraLogger = IMastraLogger,
@@ -292,10 +289,7 @@ export interface Config<
  */
 export class Mastra<
   TAgents extends Record<string, Agent<any>> = Record<string, Agent<any>>,
-  TWorkflows extends Record<string, Workflow<any, any, any, any, any, any, any>> = Record<
-    string,
-    Workflow<any, any, any, any, any, any, any>
-  >,
+  TWorkflows extends Record<string, AnyWorkflow> = Record<string, AnyWorkflow>,
   TVectors extends Record<string, MastraVector<any>> = Record<string, MastraVector<any>>,
   TTTS extends Record<string, MastraTTS> = Record<string, MastraTTS>,
   TLogger extends IMastraLogger = IMastraLogger,
@@ -2189,12 +2183,12 @@ export class Mastra<
    * mastra.addWorkflow(newWorkflow, 'customKey'); // Uses custom key
    * ```
    */
-  public addWorkflow(workflow: Workflow<any, any, any, any, any, any, any>, key?: string): void {
+  public addWorkflow(workflow: AnyWorkflow, key?: string): void {
     if (!workflow) {
       throw createUndefinedPrimitiveError('workflow', workflow, key);
     }
     const workflowKey = key || workflow.id;
-    const workflows = this.#workflows as Record<string, Workflow<any, any, any, any, any, any, any>>;
+    const workflows = this.#workflows as Record<string, AnyWorkflow>;
     if (workflows[workflowKey]) {
       const logger = this.getLogger();
       logger.debug(`Workflow with key ${workflowKey} already exists. Skipping addition.`);

--- a/packages/core/src/mastra/mastra-workflow-types.test-d.ts
+++ b/packages/core/src/mastra/mastra-workflow-types.test-d.ts
@@ -1,0 +1,127 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import { z } from 'zod';
+import { createWorkflow, createStep } from '../workflows/workflow';
+import { Mastra } from './index';
+
+/**
+ * Type tests for Workflow compatibility with Mastra constructor.
+ *
+ * Ensures that workflows created via createWorkflow can be passed
+ * to the Mastra constructor without type errors.
+ */
+describe('Mastra workflow type compatibility', () => {
+  it('should accept a basic workflow in the workflows config', () => {
+    const step = createStep({
+      id: 'my-step',
+      inputSchema: z.object({ id: z.string() }),
+      outputSchema: z.object({ result: z.string() }),
+      execute: async ({ inputData }) => {
+        return { result: inputData.id };
+      },
+    });
+
+    const myWorkflow = createWorkflow({
+      id: 'my-workflow',
+      inputSchema: z.object({ id: z.string() }),
+      outputSchema: z.object({ result: z.string() }),
+    }).then(step);
+
+    // This should compile without error — a workflow created via createWorkflow
+    // should be assignable to Mastra's workflows config.
+    const mastra = new Mastra({
+      workflows: {
+        myWorkflow,
+      },
+    });
+
+    expectTypeOf(mastra).not.toBeNever();
+  });
+
+  it('should accept a workflow with request context schema', () => {
+    const step = createStep({
+      id: 'context-step',
+      inputSchema: z.object({ name: z.string() }),
+      outputSchema: z.object({ greeting: z.string() }),
+      execute: async ({ inputData }) => {
+        return { greeting: `Hello, ${inputData.name}` };
+      },
+    });
+
+    const myWorkflow = createWorkflow({
+      id: 'context-workflow',
+      inputSchema: z.object({ name: z.string() }),
+      outputSchema: z.object({ greeting: z.string() }),
+      requestContextSchema: z.object({ userId: z.string() }),
+    }).then(step);
+
+    const mastra = new Mastra({
+      workflows: {
+        myWorkflow,
+      },
+    });
+
+    expectTypeOf(mastra).not.toBeNever();
+  });
+
+  it('should accept multiple workflows with different type signatures', () => {
+    const stepA = createStep({
+      id: 'step-a',
+      inputSchema: z.object({ id: z.string() }),
+      outputSchema: z.object({ result: z.string() }),
+      execute: async ({ inputData }) => ({ result: inputData.id }),
+    });
+
+    const stepB = createStep({
+      id: 'step-b',
+      inputSchema: z.object({ count: z.number() }),
+      outputSchema: z.object({ doubled: z.number() }),
+      execute: async ({ inputData }) => ({ doubled: inputData.count * 2 }),
+    });
+
+    const workflowA = createWorkflow({
+      id: 'workflow-a',
+      inputSchema: z.object({ id: z.string() }),
+      outputSchema: z.object({ result: z.string() }),
+    }).then(stepA);
+
+    const workflowB = createWorkflow({
+      id: 'workflow-b',
+      inputSchema: z.object({ count: z.number() }),
+      outputSchema: z.object({ doubled: z.number() }),
+    }).then(stepB);
+
+    const mastra = new Mastra({
+      workflows: {
+        workflowA,
+        workflowB,
+      },
+    });
+
+    expectTypeOf(mastra).not.toBeNever();
+  });
+
+  it('should accept a committed workflow', () => {
+    const step = createStep({
+      id: 'my-step',
+      inputSchema: z.object({ value: z.number() }),
+      outputSchema: z.object({ result: z.number() }),
+      execute: async ({ inputData }) => ({ result: inputData.value + 1 }),
+    });
+
+    const myWorkflow = createWorkflow({
+      id: 'committed-workflow',
+      inputSchema: z.object({ value: z.number() }),
+      outputSchema: z.object({ result: z.number() }),
+    })
+      .then(step)
+      .commit();
+
+    const mastra = new Mastra({
+      workflows: {
+        myWorkflow,
+      },
+    });
+
+    expectTypeOf(mastra).not.toBeNever();
+  });
+});

--- a/packages/core/src/workflows/step.ts
+++ b/packages/core/src/workflows/step.ts
@@ -8,7 +8,7 @@ import type { ToolStream } from '../tools/stream';
 import type { DynamicArgument } from '../types';
 import type { PUBSUB_SYMBOL, STREAM_FORMAT_SYMBOL } from './constants';
 import type { OutputWriter, StepResult, StepMetadata } from './types';
-import type { Workflow } from './workflow';
+import type { AnyWorkflow } from './workflow';
 
 export type SuspendOptions = {
   resumeLabel?: string | string[];
@@ -41,7 +41,7 @@ export type ExecuteFunctionParams<
   suspendData?: TSuspend;
   retryCount: number;
   tracingContext: TracingContext;
-  getInitData<T>(): T extends Workflow<any, any, any, any, any, any, any> ? InferZodLikeSchema<T['inputSchema']> : T;
+  getInitData<T>(): T extends AnyWorkflow ? InferZodLikeSchema<T['inputSchema']> : T;
   getStepResult<TOutput>(step: string): TOutput;
   getStepResult<TStep extends Step<string, any, any, any, any, any, EngineType>>(
     step: TStep,

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -102,7 +102,7 @@ export function mapVariable<TStep extends Step<string, any, any, any, any, any>>
   step: TStep;
   path: PathsToStringProps<ExtractSchemaType<ExtractSchemaFromStep<TStep, 'outputSchema'>>> | '.';
 };
-export function mapVariable<TWorkflow extends Workflow<any, any, any, any, any, any, any>>({
+export function mapVariable<TWorkflow extends AnyWorkflow>({
   initData: TWorkflow,
   path,
 }: {
@@ -1221,6 +1221,13 @@ export function isProcessor(obj: unknown): obj is Processor {
       typeof (obj as any).processOutputStep === 'function')
   );
 }
+
+/**
+ * A Workflow with all type parameters erased.
+ * Use this instead of manually specifying `Workflow<any, any, ...>` so that
+ * adding or removing type parameters only requires updating one place.
+ */
+export type AnyWorkflow = Workflow<any, any, any, any, any, any, any, any>;
 
 export function createWorkflow<
   TWorkflowId extends string = string,


### PR DESCRIPTION
## Description

Workflows with a `requestContextSchema` could not be passed to the `Mastra` constructor due to a TypeScript `#private` type incompatibility error:

```
Property '#private' in type 'Workflow' refers to a different member that cannot be accessed from within type 'Workflow'.
```

**Root cause:** The `Workflow` class has 8 type parameters (the 8th being `TRequestContext`), but all internal type references only specified 7 `any`s — leaving the 8th to default to `unknown`. When a user provided a concrete `requestContextSchema`, TypeScript couldn't reconcile the private field types.

**Fix:** 
- Introduced an `AnyWorkflow` type alias (`Workflow<any, any, any, any, any, any, any, any>`) so all 8 params are covered
- Replaced all `Workflow<any, any, any, any, any, any, any>` references in `packages/core` with `AnyWorkflow`
- Future type parameter additions only require updating the alias in one place

## Related Issue(s)

Fixes #12773

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Broader workflow support: the system now accepts a wider range of workflow shapes in configs and APIs.

* **Bug Fixes**
  * Resolved a type incompatibility that blocked workflows with request context schemas from being used in the Mastra constructor.
  * Removed type errors when passing certain workflow configurations to the framework.

* **Tests**
  * Added type-level tests to verify workflow compatibility across common scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->