### PR TITLE
fix(playground): fix chat flashing when loading thread messages

### DIFF
--- a/.changeset/salty-ties-rhyme.md
+++ b/.changeset/salty-ties-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/react': patch
+---
+
+Fixed chat messages flashing when loading a thread. Messages now update reactively via useEffect instead of lazy state initialization, preventing the brief flash of empty state.

--- a/packages/playground-ui/src/domains/agents/components/agent-chat.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-chat.tsx
@@ -5,7 +5,7 @@ import { ChatProps } from '@/types';
 import { useAgentSettings } from '../context/agent-context';
 import { useAgentMessages } from '@/hooks/use-agent-messages';
 import { MastraUIMessage } from '@mastra/react';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { toAISdkV4Messages, toAISdkV5Messages } from '@mastra/ai-sdk/ui';
 import { useMergedRequestContext } from '@/domains/request-context/context/schema-request-context';
 
@@ -46,12 +46,9 @@ export const AgentChat = ({
     }
   }, [messageId, data, isMessagesLoading]);
 
-  if (isMessagesLoading) {
-    return null;
-  }
-
-  const v5Messages = data?.messages ? (toAISdkV5Messages(data.messages) as MastraUIMessage[]) : [];
-  const v4Messages = data?.messages ? toAISdkV4Messages(data.messages) : [];
+  const messages = data?.messages ?? [];
+  const v5Messages = useMemo(() => toAISdkV5Messages(messages) as MastraUIMessage[], [messages]);
+  const v4Messages = useMemo(() => toAISdkV4Messages(messages), [messages]);
 
   return (
     <MastraRuntimeProvider

--- a/packages/playground-ui/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground-ui/src/services/mastra-runtime-provider.tsx
@@ -4,9 +4,9 @@ import {
   AppendMessage,
   AssistantRuntimeProvider,
 } from '@assistant-ui/react';
-import { useState, ReactNode, useRef } from 'react';
+import { useState, ReactNode, useRef, useEffect } from 'react';
 import { RequestContext } from '@mastra/core/di';
-import { ChatProps, Message } from '@/types';
+import { ChatProps } from '@/types';
 import { CoreUserMessage } from '@mastra/core/llm';
 import { fileToBase64 } from '@/lib/file/toBase64';
 import { toAssistantUIMessage, useMastraClient } from '@mastra/react';
@@ -324,9 +324,11 @@ export function MastraRuntimeProvider({
   const { prompt: instructions } = useAgentPromptExperiment();
   const { settings: tracingSettings } = useTracingSettings();
   const [isLegacyRunning, setIsLegacyRunning] = useState(false);
-  const [legacyMessages, setLegacyMessages] = useState<ThreadMessageLike[]>(() => {
-    return memory ? initializeMessageState(initialLegacyMessages || []) : [];
-  });
+  const [legacyMessages, setLegacyMessages] = useState<ThreadMessageLike[]>([]);
+
+  useEffect(() => {
+    setLegacyMessages(initializeMessageState(initialLegacyMessages || []));
+  }, [initialLegacyMessages]);
 
   const {
     messages,
@@ -344,7 +346,7 @@ export function MastraRuntimeProvider({
     networkToolCallApprovals,
   } = useChat({
     agentId,
-    initializeMessages: () => initialMessages || [],
+    initialMessages,
   });
 
   const { refetch: refreshWorkingMemory } = useWorkingMemory();

--- a/packages/playground-ui/src/types.ts
+++ b/packages/playground-ui/src/types.ts
@@ -57,7 +57,7 @@ export interface ChatProps {
   agentId: string;
   agentName?: string;
   modelVersion?: string;
-  threadId?: string;
+  threadId: string;
   initialMessages?: MastraUIMessage[];
   initialLegacyMessages?: UIMessageWithMetadata[];
   memory?: boolean;

--- a/packages/playground/e2e/tests/agents/$agentId/stream.spec.ts
+++ b/packages/playground/e2e/tests/agents/$agentId/stream.spec.ts
@@ -1,15 +1,18 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect, Page, BrowserContext } from '@playwright/test';
 import { selectFixture } from '../../__utils__/select-fixture';
 import { resetStorage } from '../../__utils__/reset-storage';
 
 let page: Page;
+let context: BrowserContext;
 
 test.beforeEach(async ({ browser }) => {
-  const context = await browser.newContext();
+  await resetStorage();
+  context = await browser.newContext();
   page = await context.newPage();
 });
 
 test.afterEach(async () => {
+  await context.close();
   await resetStorage();
 });
 

--- a/packages/playground/e2e/tests/agents/$agentId/stream.spec.ts
+++ b/packages/playground/e2e/tests/agents/$agentId/stream.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
 import { selectFixture } from '../../__utils__/select-fixture';
-import { nanoid } from 'nanoid';
 import { resetStorage } from '../../__utils__/reset-storage';
 
 let page: Page;
@@ -18,7 +17,7 @@ test('text stream', async () => {
   const expectedResult = `I can help you get accurate weather forecasts by providing real-time data for your location. Just tell me your city or location, and I'll give you current conditions and detailed forecasts with temperature, humidity, and wind speed. Whether you're planning a trip or just checking today, I'm here to help! What is your current location?`;
 
   await selectFixture(page, 'text-stream');
-  await page.goto(`/agents/weatherAgent/chat/${nanoid()}`);
+  await page.goto(`/agents/weatherAgent/chat/new`);
   await page.click('text=Model settings');
   await page.click('text=Stream');
 
@@ -50,7 +49,7 @@ test('text stream', async () => {
 
 test('tool stream', async () => {
   await selectFixture(page, 'tool-stream');
-  await page.goto(`/agents/weatherAgent/chat/${nanoid()}`);
+  await page.goto(`/agents/weatherAgent/chat/new`);
   await page.click('text=Model settings');
   await page.click('text=Stream');
 
@@ -87,7 +86,7 @@ async function assertToolStream(page: Page) {
 
 test('workflow stream', async () => {
   await selectFixture(page, 'workflow-stream');
-  await page.goto(`/agents/weatherAgent/chat/${nanoid()}`);
+  await page.goto(`/agents/weatherAgent/chat/new`);
   await page.click('text=Model settings');
   await page.click('text=Stream');
 

--- a/packages/playground/e2e/tests/agents/observational-memory.spec.ts
+++ b/packages/playground/e2e/tests/agents/observational-memory.spec.ts
@@ -39,7 +39,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
 
       // ASSERT: OM sidebar section should be visible with progress bars
       // The sidebar should show "Observational Memory" section
-      const omSection = page.locator('text=Observational Memory').first();
+      const omSection = page.getByRole('heading', { name: 'Observational Memory' });
       await expect(omSection).toBeVisible({ timeout: 10000 });
 
       // Progress bars should be present (Messages and Observations labels)
@@ -63,7 +63,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
       await page.getByRole('tab', { name: 'Memory' }).click();
 
       // Wait for OM section
-      await expect(page.getByText('Observational Memory')).toBeVisible({ timeout: 10000 });
+      await expect(page.getByRole('heading', { name: 'Observational Memory' })).toBeVisible({ timeout: 10000 });
 
       // ACT: Hover over the info icon next to Messages
       const messagesLabel = page.getByText('Messages', { exact: true });
@@ -76,10 +76,10 @@ test.describe('Observational Memory - Behavior Tests', () => {
         const tooltip = page.getByRole('tooltip');
         await expect(tooltip).toBeVisible({ timeout: 5000 });
         await expect(tooltip).toContainText(/Observer Settings/i);
-        // Verify the model name is shown (from omMemory config: openai/gpt-4o-mini)
-        await expect(tooltip).toContainText(/gpt-4o-mini/i);
-        // Verify the threshold value is shown (from omMemory config: 10000)
-        await expect(tooltip).toContainText(/10.*k|10,?000/i);
+        // Verify the model name is shown (from fixture config: mock/mock-observer)
+        await expect(tooltip).toContainText(/mock-observer/i);
+        // Verify the threshold value is shown (from fixture config: 20 tokens)
+        await expect(tooltip).toContainText(/20 tokens/i);
       }
     });
   });
@@ -278,7 +278,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
       await page.getByRole('tab', { name: 'Memory' }).click();
 
       // ASSERT: OM sidebar should show adaptive threshold behavior
-      const omSection = page.getByText('Observational Memory');
+      const omSection = page.getByRole('heading', { name: 'Observational Memory' });
       await expect(omSection).toBeVisible({ timeout: 10000 });
 
       // Progress bars should be visible (use .first() since "Observations" may appear in both progress bar and section header)
@@ -362,8 +362,11 @@ test.describe('Observational Memory - Edge Cases', () => {
     // ASSERT: Page should load without stuck loading states
     await expect(page.locator('h2')).toContainText('OM Agent', { timeout: 10000 });
 
+    // Click on the Memory tab to see OM sidebar
+    await page.getByRole('tab', { name: 'Memory' }).click();
+
     // OM section should not show stuck "observing" state
-    const omSection = page.getByText('Observational Memory');
+    const omSection = page.getByRole('heading', { name: 'Observational Memory' });
     await expect(omSection).toBeVisible({ timeout: 10000 });
   });
 
@@ -391,9 +394,12 @@ test.describe('Observational Memory - Edge Cases', () => {
     await page.goto('/agents/om-agent/chat/new');
     await expect(page.locator('h2')).toContainText('OM Agent');
 
+    // Click on the Memory tab to see OM sidebar
+    await page.getByRole('tab', { name: 'Memory' }).click();
+
     // ASSERT: Second thread should start fresh
     // Progress bars should be at 0 or initial state
-    const omSection = page.getByText('Observational Memory');
+    const omSection = page.getByRole('heading', { name: 'Observational Memory' });
     await expect(omSection).toBeVisible({ timeout: 10000 });
 
     // Navigate back to first thread

--- a/packages/playground/e2e/tests/agents/observational-memory.spec.ts
+++ b/packages/playground/e2e/tests/agents/observational-memory.spec.ts
@@ -29,7 +29,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
     test('should display progress bars when OM is enabled', async ({ page }) => {
       // ARRANGE
       await selectFixture(page, 'om-observation-success');
-      await page.goto('/agents/om-agent/chat?new=true');
+      await page.goto('/agents/om-agent/chat/new');
 
       // Wait for the page to load and OM to initialize
       await expect(page.locator('h2')).toContainText('OM Agent');
@@ -54,7 +54,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
     test('should show threshold info tooltip on hover', async ({ page }) => {
       // ARRANGE
       await selectFixture(page, 'om-observation-success');
-      await page.goto('/agents/om-agent/chat?new=true');
+      await page.goto('/agents/om-agent/chat/new');
 
       // Wait for page to load
       await expect(page.locator('h2')).toContainText('OM Agent');
@@ -92,7 +92,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
     test('should show observing indicator when observation starts', async ({ page }) => {
       // ARRANGE
       await selectFixture(page, 'om-observation-success');
-      await page.goto('/agents/om-agent/chat?new=true');
+      await page.goto('/agents/om-agent/chat/new');
 
       // Wait for page to load
       await expect(page.locator('h2')).toContainText('OM Agent');
@@ -139,7 +139,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
     test('should show completion stats when observation finishes', async ({ page }) => {
       // ARRANGE
       await selectFixture(page, 'om-observation-success');
-      await page.goto('/agents/om-agent/chat?new=true');
+      await page.goto('/agents/om-agent/chat/new');
 
       const chatInput = page.locator('textarea[placeholder*="message"]').first();
       const threadWrapper = page.locator('[data-testid="thread-wrapper"]');
@@ -170,7 +170,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
     test('should persist observations after page reload', async ({ page }) => {
       // ARRANGE
       await selectFixture(page, 'om-observation-success');
-      await page.goto('/agents/om-agent/chat?new=true');
+      await page.goto('/agents/om-agent/chat/new');
 
       // Wait for page to load
       await expect(page.locator('h2')).toContainText('OM Agent');
@@ -231,7 +231,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
     test('should show reflection indicator when reflection occurs', async ({ page }) => {
       // ARRANGE
       await selectFixture(page, 'om-reflection');
-      await page.goto('/agents/om-agent/chat?new=true');
+      await page.goto('/agents/om-agent/chat/new');
 
       // Wait for page to load
       await expect(page.locator('h2')).toContainText('OM Agent');
@@ -269,7 +269,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
     test('should show adaptive threshold indicator', async ({ page }) => {
       // ARRANGE
       await selectFixture(page, 'om-shared-budget');
-      await page.goto('/agents/om-adaptive-agent/chat?new=true');
+      await page.goto('/agents/om-adaptive-agent/chat/new');
 
       // Wait for page to load
       await expect(page.locator('h2')).toContainText('OM Adaptive Agent');
@@ -310,7 +310,7 @@ test.describe('Observational Memory - Behavior Tests', () => {
     test('should show previous observations when history exists', async ({ page }) => {
       // ARRANGE
       await selectFixture(page, 'om-reflection');
-      await page.goto('/agents/om-agent/chat?new=true');
+      await page.goto('/agents/om-agent/chat/new');
 
       // Click on the Memory tab to see OM sidebar
       await page.getByRole('tab', { name: 'Memory' }).click();
@@ -345,7 +345,7 @@ test.describe('Observational Memory - Edge Cases', () => {
   test('should handle interrupted observation gracefully', async ({ page }) => {
     // ARRANGE
     await selectFixture(page, 'om-observation-success');
-    await page.goto('/agents/om-agent/chat?new=true');
+    await page.goto('/agents/om-agent/chat/new');
 
     // ACT: Start a message then navigate away
     const chatInput = page.locator('textarea[placeholder*="message"]').first();
@@ -357,7 +357,7 @@ test.describe('Observational Memory - Edge Cases', () => {
     await page.goto('/agents');
 
     // Navigate back
-    await page.goto('/agents/om-agent/chat?new=true');
+    await page.goto('/agents/om-agent/chat/new');
 
     // ASSERT: Page should load without stuck loading states
     await expect(page.locator('h2')).toContainText('OM Agent', { timeout: 10000 });
@@ -376,7 +376,7 @@ test.describe('Observational Memory - Edge Cases', () => {
     await selectFixture(page, 'om-observation-success');
 
     // Create first thread
-    await page.goto('/agents/om-agent/chat?new=true');
+    await page.goto('/agents/om-agent/chat/new');
     await expect(page.locator('h2')).toContainText('OM Agent');
 
     const chatInput = page.locator('textarea[placeholder*="message"]').first();
@@ -388,7 +388,7 @@ test.describe('Observational Memory - Edge Cases', () => {
     const thread1Url = page.url();
 
     // ACT: Create second thread
-    await page.goto('/agents/om-agent/chat?new=true');
+    await page.goto('/agents/om-agent/chat/new');
     await expect(page.locator('h2')).toContainText('OM Agent');
 
     // ASSERT: Second thread should start fresh

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -66,7 +66,7 @@ const paths: LinkComponentProviderProps['paths'] = {
       ? `/workspaces/${workspaceId}/skills/${skillName}?agentId=${encodeURIComponent(agentId)}`
       : `/workspaces`,
   agentsLink: () => `/agents`,
-  agentNewThreadLink: (agentId: string) => `/agents/${agentId}/chat/${uuid()}?new=true`,
+  agentNewThreadLink: (agentId: string) => `/agents/${agentId}/chat/new`,
   agentThreadLink: (agentId: string, threadId: string, messageId?: string) =>
     messageId ? `/agents/${agentId}/chat/${threadId}?messageId=${messageId}` : `/agents/${agentId}/chat/${threadId}`,
   workflowsLink: () => `/workflows`,

--- a/packages/playground/src/pages/agents/agent/index.tsx
+++ b/packages/playground/src/pages/agents/agent/index.tsx
@@ -120,7 +120,7 @@ function Agent() {
                           />
                         )
                       }
-                      rightSlot={<AgentInformation agentId={agentId!} threadId={threadId!} />}
+                      rightSlot={<AgentInformation agentId={agentId!} threadId={actualThreadId!} />}
                     >
                       <AgentChat
                         agentId={agentId!}

--- a/packages/playground/src/pages/agents/agent/index.tsx
+++ b/packages/playground/src/pages/agents/agent/index.tsx
@@ -15,32 +15,36 @@ import {
   SchemaRequestContextProvider,
   type AgentSettingsType,
 } from '@mastra/playground-ui';
-import { useEffect, useMemo } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router';
+import { useEffect, useMemo, useState } from 'react';
 import { v4 as uuid } from '@lukeed/uuid';
+import { useNavigate, useParams, useSearchParams } from 'react-router';
 
 import { AgentSidebar } from '@/domains/agents/agent-sidebar';
 
 function Agent() {
   const { agentId, threadId } = useParams();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const { data: agent, isLoading: isAgentLoading } = useAgent(agentId!);
   const { data: memory } = useMemory(agentId!);
   const navigate = useNavigate();
-  const isNewThread = searchParams.get('new') === 'true';
+  const isNewThread = threadId === 'new';
+  const [newThreadId, setNewThreadId] = useState<string>(() => uuid());
+
+  const hasMemory = Boolean(memory?.result);
+
   const {
     data: threads,
     isLoading: isThreadsLoading,
     refetch: refreshThreads,
-  } = useThreads({ resourceId: agentId!, agentId: agentId!, isMemoryEnabled: !!memory?.result });
+  } = useThreads({ resourceId: agentId!, agentId: agentId!, isMemoryEnabled: hasMemory });
 
   useEffect(() => {
-    if (memory?.result && !threadId) {
-      // use @lukeed/uuid because we don't need a cryptographically secure uuid (this is a debugging local uuid)
-      // using crypto.randomUUID() on a domain without https (ex a local domain like local.lan:4111) will cause a TypeError
-      navigate(`/agents/${agentId}/chat/${uuid()}?new=true`);
-    }
-  }, [memory?.result, threadId, agentId, navigate]);
+    if (!hasMemory) return;
+    if (threadId) return;
+
+    // After redirects on /agents/:agentId
+    navigate(`/agents/${agentId}/chat/new`);
+  }, [hasMemory, threadId, agentId, navigate]);
 
   const messageId = searchParams.get('messageId') ?? undefined;
 
@@ -84,12 +88,15 @@ function Agent() {
     return <div className="text-center py-4">Agent not found</div>;
   }
 
-  const handleRefreshThreadList = () => {
-    // Create a new URLSearchParams to avoid mutation issues
-    const newParams = new URLSearchParams(searchParams);
-    newParams.delete('new');
-    setSearchParams(newParams, { replace: true });
-    refreshThreads();
+  const actualThreadId = isNewThread ? newThreadId : threadId;
+
+  const handleRefreshThreadList = async () => {
+    await refreshThreads();
+
+    if (isNewThread) {
+      setNewThreadId(() => uuid());
+      navigate(`/agents/${agentId}/chat/${newThreadId}`);
+    }
   };
 
   return (
@@ -97,17 +104,17 @@ function Agent() {
       <AgentPromptExperimentProvider initialPrompt={agent!.instructions} agentId={agentId!}>
         <AgentSettingsProvider agentId={agentId!} defaultSettings={defaultSettings}>
           <SchemaRequestContextProvider>
-            <WorkingMemoryProvider agentId={agentId!} threadId={threadId!} resourceId={agentId!}>
+            <WorkingMemoryProvider agentId={agentId!} threadId={actualThreadId!} resourceId={agentId!}>
               <ThreadInputProvider>
                 <ObservationalMemoryProvider>
                   <ActivatedSkillsProvider>
                     <AgentLayout
                       agentId={agentId!}
                       leftSlot={
-                        Boolean(memory?.result) && (
+                        hasMemory && (
                           <AgentSidebar
                             agentId={agentId!}
-                            threadId={threadId!}
+                            threadId={actualThreadId!}
                             threads={threads || []}
                             isLoading={isThreadsLoading}
                           />
@@ -116,12 +123,11 @@ function Agent() {
                       rightSlot={<AgentInformation agentId={agentId!} threadId={threadId!} />}
                     >
                       <AgentChat
-                        key={threadId}
                         agentId={agentId!}
                         agentName={agent?.name}
                         modelVersion={agent?.modelVersion}
-                        threadId={threadId}
-                        memory={memory?.result}
+                        threadId={actualThreadId!}
+                        memory={hasMemory}
                         refreshThreadList={handleRefreshThreadList}
                         modelList={agent?.modelList}
                         messageId={messageId}


### PR DESCRIPTION
Chat messages were flashing briefly when loading a thread because `useState` lazy initialization only runs once — navigating between threads wouldn't re-initialize the state with new messages.

Switched to `useEffect` to reactively update messages when `initialMessages` changes, so the chat content updates properly without the empty-state flash.

Also cleaned up the new-thread URL pattern from `/chat/{uuid}?new=true` to `/chat/new`, deferring the actual UUID generation until the thread is used.

**`@mastra/react`**
- `useChat` now takes `initialMessages` (data) instead of `initializeMessages` (function)
- Moved `extractRunIdFromMessages` outside the hook

**`@mastra/playground-ui`**
- Removed early `return null` during message loading in `AgentChat` — was causing unmount/remount flicker
- Wrapped message format conversions in `useMemo`
- Made `threadId` required in `ChatProps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat messages no longer flash while loading; messages now update reactively for a smoother, non-flickering experience.
  * UI no longer returns blank during load—chat content renders more consistently.

* **Improvements**
  * Creating a new thread now uses a stable /chat/new URL path for simpler navigation.
  * Initial messages load more reliably on open, improving message and thread consistency.
  * Chat input/send interaction made more reliable for consistent message submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->