### PR TITLE
fix(pg): filter pg_constraint queries by schema namespace

### DIFF
--- a/.changeset/few-singers-bet.md
+++ b/.changeset/few-singers-bet.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed pg_constraint queries to filter by schema namespace, preventing false matches across schemas in multi-schema setups. Single-schema (default) setups are unaffected.

--- a/.changeset/few-singers-bet.md
+++ b/.changeset/few-singers-bet.md
@@ -2,4 +2,4 @@
 '@mastra/pg': patch
 ---
 
-Fixed pg_constraint queries to filter by schema namespace, preventing false matches across schemas in multi-schema setups. Single-schema (default) setups are unaffected.
+Fixed cross-schema constraint checks in multi-schema PostgreSQL setups so tables and indexes are created in the intended schema. Single-schema (default) setups are unaffected.


### PR DESCRIPTION
## Summary
- Add `connamespace` filter to `pg_constraint` queries and `schemaname` filter to `pg_indexes` queries in `generateTableSQL()`, `spansPrimaryKeyExists()`, and `addSpansPrimaryKey()`
- Without schema filtering, constraint existence checks matched across ALL schemas instead of just the target one
- Aligns these queries with the existing pattern used by `createIndex()`, `dropIndex()`, `listIndexes()`, and `describeIndex()`

## Test plan
- [ ] Verify single-schema (default `public`) setup still works — constraint checks should behave identically
- [ ] Verify multi-schema setup correctly scopes constraint lookups to the configured schema
- [ ] Run existing `@mastra/pg` test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database validations now respect schema boundaries: constraint, index and primary-key existence checks are limited to the intended schema, preventing false cross-schema matches and ensuring runtime validations and creations occur in the correct schema (single-schema setups unaffected).

* **Chore**
  * Added a release changeset entry describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->