### PR TITLE
fix:  Prisma + mastra dev SyntaxError

### DIFF
--- a/.changeset/fix-prisma-dev-cjs-interop.md
+++ b/.changeset/fix-prisma-dev-cjs-interop.md
@@ -1,0 +1,16 @@
+---
+'@mastra/deployer': patch
+'@mastra/cli': patch
+---
+
+Fix `mastra dev` failing with Prisma due to CJS/ESM interop issues.
+
+**What was fixed:**
+
+- DevBundler now forwards user `bundler.externals` config to the dev watcher, so users can control which packages are externalized in dev mode
+- The `commonjs` Rollup plugin is no longer disabled when `externalsPreset` is true — it now emits safe namespace imports instead of broken default imports for ESM packages
+- Added `@prisma/client` to `GLOBAL_EXTERNALS` alongside `pg`, `pino`, and other commonly externalized packages
+
+**Why this happened:**
+
+The dev bundler read the user's bundler config but only forwarded `sourcemap`, silently ignoring `externals`. The watcher defaulted to externalizing all deps while also disabling the `commonjs` plugin, which meant any CJS `require()` calls in bundled workspace code got transformed to `import x from '...'` (default import). At runtime this fails for ESM packages like `@prisma/client-runtime-utils` that have no default export.

--- a/packages/cli/src/commands/dev/DevBundler.test.ts
+++ b/packages/cli/src/commands/dev/DevBundler.test.ts
@@ -99,7 +99,14 @@ describe('DevBundler', () => {
           {
             'process.env.NODE_ENV': JSON.stringify('test-env'),
           },
-          expect.objectContaining({ sourcemap: false }),
+          expect.objectContaining({
+            sourcemap: false,
+            bundlerOptions: expect.objectContaining({
+              enableSourcemap: false,
+              enableEsmShim: true,
+              externals: true,
+            }),
+          }),
         );
       } finally {
         await remove(tmpDir);
@@ -123,7 +130,14 @@ describe('DevBundler', () => {
           {
             'process.env.NODE_ENV': JSON.stringify('development'),
           },
-          expect.objectContaining({ sourcemap: false }),
+          expect.objectContaining({
+            sourcemap: false,
+            bundlerOptions: expect.objectContaining({
+              enableSourcemap: false,
+              enableEsmShim: true,
+              externals: true,
+            }),
+          }),
         );
       } finally {
         await remove(tmpDir);

--- a/packages/deployer/src/build/analyze/bundleExternals.test.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.test.ts
@@ -6,6 +6,7 @@ import type { WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
 import type { DependencyMetadata } from '../types';
 import type * as UtilsModule from '../utils';
 import { createVirtualDependencies, bundleExternals } from './bundleExternals';
+import { GLOBAL_EXTERNALS } from './constants';
 
 // Mock the utilities that bundleExternals depends on
 vi.mock('../utils', async importOriginal => {
@@ -34,6 +35,18 @@ vi.mock('../plugins/esbuild', () => ({
 vi.mock('../plugins/hono-alias', () => ({
   aliasHono: vi.fn(() => ({ name: 'hono-alias-mock' })),
 }));
+
+describe('GLOBAL_EXTERNALS', () => {
+  it('should include @prisma/client to prevent CJS/ESM interop issues', () => {
+    expect(GLOBAL_EXTERNALS).toContain('@prisma/client');
+  });
+
+  it('should include commonly problematic native/CJS packages', () => {
+    expect(GLOBAL_EXTERNALS).toContain('pg');
+    expect(GLOBAL_EXTERNALS).toContain('pino');
+    expect(GLOBAL_EXTERNALS).toContain('@libsql/client');
+  });
+});
 
 describe('createVirtualDependencies', () => {
   it('should handle named exports only', () => {

--- a/packages/deployer/src/build/analyze/constants.ts
+++ b/packages/deployer/src/build/analyze/constants.ts
@@ -10,5 +10,6 @@ export const GLOBAL_EXTERNALS = [
   'typescript',
   'undici',
   'readable-stream',
+  '@prisma/client',
 ];
 export const DEPRECATED_EXTERNALS = ['fastembed', 'nodemailer', 'jsdom', 'sqlite3'];

--- a/packages/deployer/src/build/watcher.test.ts
+++ b/packages/deployer/src/build/watcher.test.ts
@@ -91,6 +91,68 @@ describe('watcher', () => {
       );
     });
 
+    describe('bundlerOptions forwarding', () => {
+      it('should default externalsPreset to true when bundlerOptions not provided', async () => {
+        const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
+
+        await getInputOptions('test-entry.js', 'node');
+
+        expect(bundlerGetInputOptions).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.any(Object),
+          'node',
+          undefined,
+          expect.objectContaining({
+            externalsPreset: true,
+          }),
+        );
+      });
+
+      it('should set externalsPreset to true when externals is true', async () => {
+        const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
+
+        await getInputOptions('test-entry.js', 'node', undefined, {
+          bundlerOptions: {
+            enableSourcemap: false,
+            enableEsmShim: true,
+            externals: true,
+          },
+        });
+
+        expect(bundlerGetInputOptions).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.any(Object),
+          'node',
+          undefined,
+          expect.objectContaining({
+            externalsPreset: true,
+          }),
+        );
+      });
+
+      it('should set externalsPreset to false when externals is an array', async () => {
+        const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
+
+        await getInputOptions('test-entry.js', 'node', undefined, {
+          bundlerOptions: {
+            enableSourcemap: false,
+            enableEsmShim: true,
+            externals: ['@prisma/client'],
+          },
+        });
+
+        expect(bundlerGetInputOptions).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.any(Object),
+          'node',
+          undefined,
+          expect.objectContaining({
+            externalsPreset: false,
+          }),
+        );
+      });
+    });
+
     describe('platform parameter handling', () => {
       it('forwards "node" platform to bundler', async () => {
         const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;


### PR DESCRIPTION
## Description
Fixes `mastra dev` crashing when Prisma is installed due to an invalid ESM default import generated from a CJS dependency.

This PR:
- Properly forwards user `bundler.externals` config to the dev watcher.
- Keeps the CommonJS Rollup plugin enabled when `externalsPreset` is true so CJS → ESM transforms stay safe.
- Adds `@prisma/client` to `GLOBAL_EXTERNALS` to prevent Prisma internals from being bundled.

## Before
<img width="1407" height="381" alt="image" src="https://github.com/user-attachments/assets/29dbf2bc-eb92-4df1-ac29-3f6aed31308e" />

## After
<img width="937" height="260" alt="Screenshot 2026-02-11 001534" src="https://github.com/user-attachments/assets/e5413c7f-d0e7-4e0a-ae1d-86b648c2fe62" />

## Related Issue(s)
Fixes #11295

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Prisma CJS/ESM interoperability issues in dev mode by properly forwarding bundler configuration to the dev watcher.
  * Corrected broken import handling for ESM packages by using namespace imports instead of default imports.
  * Enhanced externals configuration handling to customize behavior during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->