### PR TITLE
Rename logger parameter to mastraLogger for consistency

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -431,7 +431,7 @@ export class Agent<
     return new ProcessorRunner({
       inputProcessors,
       outputProcessors,
-      logger: this.logger,
+      mastraLogger: this.logger,
       agentName: this.name,
       processorStates,
     });

--- a/packages/core/src/loop/loop.ts
+++ b/packages/core/src/loop/loop.ts
@@ -10,7 +10,7 @@ import { workflowLoopStream } from './workflows/stream';
 export function loop<Tools extends ToolSet = ToolSet, OUTPUT = undefined>({
   resumeContext,
   models,
-  logger,
+  mastraLogger,
   runId,
   idGenerator,
   messageList,
@@ -26,7 +26,7 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT = undefined>({
   ...rest
 }: LoopOptions<Tools, OUTPUT>) {
   let loggerToUse =
-    logger ||
+    mastraLogger ||
     new ConsoleLogger({
       level: 'debug',
     });
@@ -89,7 +89,7 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT = undefined>({
     resumeContext,
     models,
     runId: runIdToUse,
-    logger: loggerToUse,
+    mastraLogger: loggerToUse,
     startTimestamp: startTimestamp!,
     messageList,
     includeRawChunks: !!includeRawChunks,

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -482,7 +482,7 @@ export async function createNetworkLoop({
       ? new ProcessorRunner({
           outputProcessors: configuredOutputProcessors,
           inputProcessors: [],
-          logger: agent.getMastraInstance()?.getLogger() || noopLogger,
+          mastraLogger: agent.getMastraInstance()?.getLogger() || noopLogger,
           agentName: agent.name,
         })
       : null;

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -93,7 +93,7 @@ export type LoopOptions<TOOLS extends ToolSet = ToolSet, OUTPUT = undefined> = {
   };
   toolCallId?: string;
   models: ModelManagerModelConfig[];
-  logger?: IMastraLogger;
+  mastraLogger?: IMastraLogger;
   mode?: 'generate' | 'stream';
   runId?: string;
   idGenerator?: MastraIdGenerator;

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -513,7 +513,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
   structuredOutput,
   outputProcessors,
   inputProcessors,
-  logger,
+  mastraLogger,
   agentId,
   downloadRetries,
   downloadConcurrency,
@@ -549,7 +549,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
         stepWorkspace?: Workspace;
       }>(
         models,
-        logger,
+        mastraLogger,
       )(async (modelConfig, isLastModel) => {
         const model = modelConfig.model;
         const modelHeaders = modelConfig.headers;
@@ -594,7 +594,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           const processorRunner = new ProcessorRunner({
             inputProcessors: inputStepProcessors,
             outputProcessors: [],
-            logger: logger || new ConsoleLogger({ level: 'error' }),
+            logger: mastraLogger || new ConsoleLogger({ level: 'error' }),
             agentName: agentId || 'unknown',
             processorStates,
           });
@@ -672,7 +672,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                 stepTools: tools,
               };
             }
-            logger?.error('Error in processInputStep processors:', error);
+            mastraLogger?.error('Error in processInputStep processors:', error);
             throw error;
           }
         }
@@ -859,7 +859,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               request,
               rawResponse,
             },
-            logger,
+            logger: mastraLogger,
           });
         } catch (error) {
           const provider = model?.provider;
@@ -869,14 +869,14 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           if (isUpstreamError) {
             const providerInfo = provider ? ` from ${provider}` : '';
             const modelInfo = modelIdStr ? ` (model: ${modelIdStr})` : '';
-            logger?.error(`Upstream LLM API error${providerInfo}${modelInfo}`, {
+            mastraLogger?.error(`Upstream LLM API error${providerInfo}${modelInfo}`, {
               error,
               runId,
               ...(provider && { provider }),
               ...(modelIdStr && { modelId: modelIdStr }),
             });
           } else {
-            logger?.error('Error in LLM execution', {
+            mastraLogger?.error('Error in LLM execution', {
               error,
               runId,
               ...(provider && { provider }),
@@ -1016,7 +1016,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
         const processorRunner = new ProcessorRunner({
           inputProcessors: [],
           outputProcessors,
-          logger: logger || new ConsoleLogger({ level: 'error' }),
+          logger: mastraLogger || new ConsoleLogger({ level: 'error' }),
           agentName: agentId || 'unknown',
           processorStates,
         });
@@ -1063,7 +1063,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             // If retry is requested, we'll handle it below
             // For now, we just capture the tripwire
           } else {
-            logger?.error('Error in processOutputStep processors:', error);
+            mastraLogger?.error('Error in processOutputStep processors:', error);
             throw error;
           }
         }
@@ -1090,9 +1090,9 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
       // Log if retry was requested but not allowed
       if (retryRequested && !canRetry) {
         if (maxProcessorRetries === undefined) {
-          logger?.warn?.(`Processor requested retry but maxProcessorRetries is not set. Treating as abort.`);
+          mastraLogger?.warn?.(`Processor requested retry but maxProcessorRetries is not set. Treating as abort.`);
         } else {
-          logger?.warn?.(
+          mastraLogger?.warn?.(
             `Processor requested retry but maxProcessorRetries (${maxProcessorRetries}) exceeded. ` +
               `Current count: ${currentProcessorRetryCount}. Treating as abort.`,
           );

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -46,7 +46,7 @@ type ProcessOutputStreamOptions<OUTPUT = undefined> = {
     request: any;
     rawResponse: any;
   };
-  logger?: IMastraLogger;
+  mastraLogger?: IMastraLogger;
 };
 
 async function processOutputStream<OUTPUT = undefined>({
@@ -59,7 +59,7 @@ async function processOutputStream<OUTPUT = undefined>({
   controller,
   responseFromModel,
   includeRawChunks,
-  logger,
+  mastraLogger,
 }: ProcessOutputStreamOptions<OUTPUT>) {
   for await (const chunk of outputStream._getBaseStream()) {
     if (!chunk) {
@@ -200,7 +200,7 @@ async function processOutputStream<OUTPUT = undefined>({
               abortSignal: options?.abortSignal,
             });
           } catch (error) {
-            logger?.error('Error calling onInputStart', error);
+            mastraLogger?.error('Error calling onInputStart', error);
           }
         }
 
@@ -225,7 +225,7 @@ async function processOutputStream<OUTPUT = undefined>({
               abortSignal: options?.abortSignal,
             });
           } catch (error) {
-            logger?.error('Error calling onInputDelta', error);
+            mastraLogger?.error('Error calling onInputDelta', error);
           }
         }
         if (isControllerOpen(controller)) {
@@ -441,7 +441,7 @@ async function processOutputStream<OUTPUT = undefined>({
 
 function executeStreamWithFallbackModels<T>(
   models: ModelManagerModelConfig[],
-  logger?: IMastraLogger,
+  mastraLogger?: IMastraLogger,
 ): ExecuteStreamModelManager<T> {
   return async callback => {
     let index = 0;
@@ -473,7 +473,7 @@ function executeStreamWithFallbackModels<T>(
 
           attempt++;
 
-          logger?.error(`Error executing model ${modelConfig.model.modelId}, attempt ${attempt}====`, err);
+          mastraLogger?.error(`Error executing model ${modelConfig.model.modelId}, attempt ${attempt}====`, err);
 
           // If we've exhausted all retries for this model, break and try the next model
           if (attempt > maxRetries) {
@@ -488,7 +488,7 @@ function executeStreamWithFallbackModels<T>(
       }
     }
     if (typeof finalResult === 'undefined') {
-      logger?.error('Exhausted all fallback models and reached the maximum number of retries.');
+      mastraLogger?.error('Exhausted all fallback models and reached the maximum number of retries.');
       throw new Error('Exhausted all fallback models and reached the maximum number of retries.');
     }
     return finalResult;
@@ -594,7 +594,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           const processorRunner = new ProcessorRunner({
             inputProcessors: inputStepProcessors,
             outputProcessors: [],
-            logger: mastraLogger || new ConsoleLogger({ level: 'error' }),
+            mastraLogger: mastraLogger || new ConsoleLogger({ level: 'error' }),
             agentName: agentId || 'unknown',
             processorStates,
           });
@@ -859,7 +859,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               request,
               rawResponse,
             },
-            logger: mastraLogger,
+            mastraLogger,
           });
         } catch (error) {
           const provider = model?.provider;
@@ -1016,7 +1016,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
         const processorRunner = new ProcessorRunner({
           inputProcessors: [],
           outputProcessors,
-          logger: mastraLogger || new ConsoleLogger({ level: 'error' }),
+          mastraLogger: mastraLogger || new ConsoleLogger({ level: 'error' }),
           agentName: agentId || 'unknown',
           processorStates,
         });

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -35,7 +35,7 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
       ? new ProcessorRunner({
           inputProcessors: [],
           outputProcessors: rest.outputProcessors,
-          logger: rest.mastraLogger,
+          mastraLogger: rest.mastraLogger,
           agentName: 'LLMMappingStep',
           processorStates: rest.processorStates,
         })

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -31,11 +31,11 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
    * 3. Blocking/tripwire works correctly for tool results
    */
   const processorRunner =
-    rest.outputProcessors?.length && rest.logger
+    rest.outputProcessors?.length && rest.mastraLogger
       ? new ProcessorRunner({
           inputProcessors: [],
           outputProcessors: rest.outputProcessors,
-          logger: rest.logger,
+          logger: rest.mastraLogger,
           agentName: 'LLMMappingStep',
           processorStates: rest.processorStates,
         })

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -36,7 +36,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
   streamState,
   modelSpanTracker,
   _internal,
-  logger,
+  mastraLogger,
 }: OuterLLMRun<Tools, OUTPUT>) {
   return createStep({
     id: 'toolCallStep',
@@ -176,7 +176,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
             try {
               await saveQueueManager.flushMessages(messageList, threadId, memoryConfig);
             } catch (error) {
-              logger?.error('Error removing tool suspension metadata:', error);
+              mastraLogger?.error('Error removing tool suspension metadata:', error);
             }
           }
         }
@@ -208,7 +208,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           // Flush all pending messages immediately
           await saveQueueManager.flushMessages(messageList, threadId, memoryConfig);
         } catch (error) {
-          logger?.error('Error flushing messages before suspension:', error);
+          mastraLogger?.error('Error flushing messages before suspension:', error);
         }
       };
 
@@ -233,7 +233,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
             abortSignal: options?.abortSignal,
           });
         } catch (error) {
-          logger?.error('Error calling onInputAvailable', error);
+          mastraLogger?.error('Error calling onInputAvailable', error);
         }
       }
 
@@ -270,7 +270,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
             toolRequiresApproval = needsApprovalResult;
           } catch (error) {
             // Log error to help developers debug faulty needsApprovalFn implementations
-            logger?.error(`Error evaluating needsApprovalFn for tool ${inputData.toolName}:`, error);
+            mastraLogger?.error(`Error evaluating needsApprovalFn for tool ${inputData.toolName}:`, error);
             // On error, default to requiring approval to be safe
             toolRequiresApproval = true;
           }
@@ -514,7 +514,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
               abortSignal: options?.abortSignal,
             });
           } catch (error) {
-            logger?.error('Error calling onOutput', error);
+            mastraLogger?.error('Error calling onOutput', error);
           }
         }
 

--- a/packages/core/src/processors/process-input-step.test.ts
+++ b/packages/core/src/processors/process-input-step.test.ts
@@ -69,7 +69,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [countingProcessor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -99,7 +99,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [stepProcessor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -132,7 +132,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [stepProcessor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -157,7 +157,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [stepProcessor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -252,7 +252,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [typeTransformProcessor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -331,7 +331,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor1, processor2],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -407,7 +407,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor1, processor2, processor3],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -470,7 +470,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor1, processor2],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -527,7 +527,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -573,7 +573,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor1, processor2],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -604,7 +604,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -650,7 +650,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor1, processor2],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -686,7 +686,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -729,7 +729,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -801,7 +801,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor1, processor2, processor3],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -848,7 +848,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -882,7 +882,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -915,7 +915,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -951,7 +951,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1009,7 +1009,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor1, processor2],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1048,7 +1048,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1107,7 +1107,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor1, processor2],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1147,7 +1147,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1188,7 +1188,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1219,7 +1219,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1249,7 +1249,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1279,7 +1279,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1309,7 +1309,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1345,7 +1345,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1388,7 +1388,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [dualProcessor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1471,7 +1471,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [inputOnlyProcessor, stepOnlyProcessor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1514,7 +1514,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1573,7 +1573,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor1, processor2],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1610,7 +1610,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1665,7 +1665,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor1, processor2],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1708,7 +1708,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1748,7 +1748,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor1, processor2],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1784,7 +1784,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1814,7 +1814,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1842,7 +1842,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1878,7 +1878,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1919,7 +1919,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor1, processor2],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1969,7 +1969,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -2014,7 +2014,7 @@ describe('processInputStep', () => {
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 

--- a/packages/core/src/processors/processors/token-limiter.test.ts
+++ b/packages/core/src/processors/processors/token-limiter.test.ts
@@ -831,7 +831,7 @@ describe('TokenLimiterProcessor', () => {
 
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -952,7 +952,7 @@ describe('TokenLimiterProcessor', () => {
 
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1032,7 +1032,7 @@ describe('TokenLimiterProcessor', () => {
 
       const runner = new ProcessorRunner({
         inputProcessors: [processor],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 

--- a/packages/core/src/processors/runner.test.ts
+++ b/packages/core/src/processors/runner.test.ts
@@ -41,7 +41,7 @@ describe('ProcessorRunner', () => {
     runner = new ProcessorRunner({
       inputProcessors: [],
       outputProcessors: [],
-      logger: mockLogger,
+      mastraLogger: mockLogger,
       agentName: 'test-agent',
     });
   });
@@ -73,7 +73,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors,
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -116,7 +116,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors,
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -150,7 +150,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors,
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -175,7 +175,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors,
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -211,7 +211,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors,
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -252,7 +252,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors,
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -307,7 +307,7 @@ describe('ProcessorRunner', () => {
         runner = new ProcessorRunner({
           inputProcessors,
           outputProcessors: [],
-          logger: mockLogger,
+          mastraLogger: mockLogger,
           agentName: 'test-agent',
         });
 
@@ -363,7 +363,7 @@ describe('ProcessorRunner', () => {
         runner = new ProcessorRunner({
           inputProcessors,
           outputProcessors: [],
-          logger: mockLogger,
+          mastraLogger: mockLogger,
           agentName: 'test-agent',
         });
 
@@ -411,7 +411,7 @@ describe('ProcessorRunner', () => {
         runner = new ProcessorRunner({
           inputProcessors,
           outputProcessors: [],
-          logger: mockLogger,
+          mastraLogger: mockLogger,
           agentName: 'test-agent',
         });
 
@@ -455,7 +455,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -491,7 +491,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -529,7 +529,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -574,7 +574,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -603,7 +603,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -631,7 +631,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -688,7 +688,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -705,7 +705,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -745,7 +745,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -786,7 +786,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -846,7 +846,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -894,7 +894,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -939,7 +939,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -991,7 +991,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1051,7 +1051,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1130,7 +1130,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1220,7 +1220,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1259,7 +1259,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors,
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1301,7 +1301,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors,
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1347,7 +1347,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors,
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1385,7 +1385,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors,
         outputProcessors: [],
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1426,7 +1426,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1468,7 +1468,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1529,7 +1529,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1571,7 +1571,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1625,7 +1625,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1671,7 +1671,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1714,7 +1714,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1760,7 +1760,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 
@@ -1792,7 +1792,7 @@ describe('ProcessorRunner', () => {
       runner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors,
-        logger: mockLogger,
+        mastraLogger: mockLogger,
         agentName: 'test-agent',
       });
 

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -112,7 +112,7 @@ type ProcessorOrWorkflow = Processor | ProcessorWorkflow;
 export class ProcessorRunner {
   public readonly inputProcessors: ProcessorOrWorkflow[];
   public readonly outputProcessors: ProcessorOrWorkflow[];
-  private readonly logger: IMastraLogger;
+  private readonly mastraLogger: IMastraLogger;
   private readonly agentName: string;
   /**
    * Shared processor state that persists across loop iterations.
@@ -124,19 +124,19 @@ export class ProcessorRunner {
   constructor({
     inputProcessors,
     outputProcessors,
-    logger,
+    mastraLogger,
     agentName,
     processorStates,
   }: {
     inputProcessors?: ProcessorOrWorkflow[];
     outputProcessors?: ProcessorOrWorkflow[];
-    logger: IMastraLogger;
+    mastraLogger: IMastraLogger;
     agentName: string;
     processorStates?: Map<string, ProcessorState>;
   }) {
     this.inputProcessors = inputProcessors ?? [];
     this.outputProcessors = outputProcessors ?? [];
-    this.logger = logger;
+    this.mastraLogger = mastraLogger;
     this.agentName = agentName;
     this.processorStates = processorStates ?? new Map();
   }
@@ -420,7 +420,10 @@ export class ProcessorRunner {
                 processorId: error.processorId || workflowId,
               };
             }
-            this.logger.error(`[Agent:${this.agentName}] - Output processor workflow ${workflowId} failed:`, error);
+            this.mastraLogger.error(
+              `[Agent:${this.agentName}] - Output processor workflow ${workflowId} failed:`,
+              error,
+            );
           }
           continue;
         }
@@ -479,7 +482,7 @@ export class ProcessorRunner {
           const state = processorStates.get(processor.id);
           state?.span?.error({ error: error as Error, endSpan: true });
           // Log error but continue with original part
-          this.logger.error(`[Agent:${this.agentName}] - Output processor ${processor.id} failed:`, error);
+          this.mastraLogger.error(`[Agent:${this.agentName}] - Output processor ${processor.id} failed:`, error);
         }
       }
 
@@ -495,7 +498,7 @@ export class ProcessorRunner {
 
       return { part: processedPart, blocked: false };
     } catch (error) {
-      this.logger.error(`[Agent:${this.agentName}] - Stream part processing failed:`, error);
+      this.mastraLogger.error(`[Agent:${this.agentName}] - Stream part processing failed:`, error);
       // End all spans on fatal error
       for (const state of processorStates.values()) {
         state.span?.error({ error: error as Error, endSpan: true });
@@ -533,7 +536,7 @@ export class ProcessorRunner {
 
             if (blocked) {
               // Log that part was blocked
-              void this.logger.debug(`[Agent:${this.agentName}] - Stream part blocked by output processor`, {
+              void this.mastraLogger.debug(`[Agent:${this.agentName}] - Stream part blocked by output processor`, {
                 reason,
                 originalPart: value,
               });
@@ -929,7 +932,7 @@ export class ProcessorRunner {
           throw error;
         }
         processorSpan?.error({ error: error as Error, endSpan: true });
-        this.logger.error(`[Agent:${this.agentName}] - Input step processor ${processor.id} failed:`, error);
+        this.mastraLogger.error(`[Agent:${this.agentName}] - Input step processor ${processor.id} failed:`, error);
         throw error;
       }
     }
@@ -1141,7 +1144,7 @@ export class ProcessorRunner {
           throw error;
         }
         processorSpan?.error({ error: error as Error, endSpan: true });
-        this.logger.error(`[Agent:${this.agentName}] - Output step processor ${processor.id} failed:`, error);
+        this.mastraLogger.error(`[Agent:${this.agentName}] - Output step processor ${processor.id} failed:`, error);
         throw error;
       }
     }

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -281,7 +281,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
       this.processorRunner = new ProcessorRunner({
         inputProcessors: [],
         outputProcessors: options.outputProcessors,
-        logger: this.logger,
+        mastraLogger: this.logger,
         agentName: 'MastraModelOutput',
         processorStates: options.processorStates,
       });


### PR DESCRIPTION
## Description

This PR renames the `logger` parameter to `mastraLogger` throughout the loop execution system for improved naming consistency and clarity. The change affects:

- Loop options type definition and implementation
- LLM execution step creation and processing
- LLM mapping step
- Tool call step execution

This is a straightforward parameter rename that improves code consistency by using a more descriptive name that clearly indicates this is the Mastra-specific logger instance.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

https://claude.ai/code/session_01Ug6E4xRaK8j1Nw3R1G8UqL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the public logging option from `logger` to `mastraLogger` across loops, workflows, processors, network, agent, stream output, and related APIs for a consistent logging key.
* **Tests**
  * Updated tests and constructor/options usages to pass `mastraLogger` instead of `logger`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->