### PR TITLE
fix: route server and workflow errors through Mastra logger

### DIFF
--- a/.changeset/honest-mugs-behave.md
+++ b/.changeset/honest-mugs-behave.md
@@ -1,0 +1,12 @@
+---
+'@mastra/express': patch
+'@mastra/fastify': patch
+'@mastra/hono': patch
+'@mastra/koa': patch
+'@mastra/server': patch
+---
+
+Route server errors through Mastra logger instead of console.error
+
+Server adapter errors (handler errors, parsing errors, auth errors) now use the configured Mastra logger instead of console.error. This ensures errors are properly  
+formatted as structured logs and sent to configured transports like HttpTransport.

--- a/.changeset/workflows-logger-fix.md
+++ b/.changeset/workflows-logger-fix.md
@@ -1,0 +1,7 @@
+---
+"@mastra/core": patch
+---
+
+Fix setLogger to update workflow loggers
+
+When calling `mastra.setLogger()`, workflows were not being updated with the new logger. This caused workflow errors to be logged via the default ConsoleLogger instead of the configured logger (e.g., PinoLogger with HttpTransport), resulting in missing error logs in Cloud deployments.

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -2337,6 +2337,12 @@ export class Mastra<
       });
     }
 
+    if (this.#workflows) {
+      Object.keys(this.#workflows).forEach(key => {
+        this.#workflows?.[key]?.__setLogger(this.#logger);
+      });
+    }
+
     if (this.#serverAdapter) {
       this.#serverAdapter.__setLogger(this.#logger);
     }

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -297,7 +297,9 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
 
       context.requestContext.set('user', user);
     } catch (err) {
-      console.error(err);
+      this.mastra.getLogger()?.error('Authentication error', {
+        error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+      });
       return { status: 401, error: 'Invalid or expired token' };
     }
 
@@ -312,7 +314,9 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
         }
         return null; // Authorization passed
       } catch (err) {
-        console.error(err);
+        this.mastra.getLogger()?.error('Authorization error in authorizeUser', {
+          error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+        });
         return { status: 500, error: 'Authorization error' };
       }
     }
@@ -326,7 +330,11 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
         }
         return null; // Authorization passed
       } catch (err) {
-        console.error(err);
+        this.mastra.getLogger()?.error('Authorization error in authorize', {
+          error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+          path: context.path,
+          method: context.method,
+        });
         return { status: 500, error: 'Authorization error' };
       }
     }

--- a/server-adapters/express/src/auth-middleware.ts
+++ b/server-adapters/express/src/auth-middleware.ts
@@ -71,7 +71,9 @@ export const authenticationMiddleware = async (req: Request, res: Response, next
 
     return next();
   } catch (err) {
-    console.error(err);
+    mastra.getLogger()?.error('Authentication error', {
+      error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+    });
     return res.status(401).json({ error: 'Invalid or expired token' });
   }
 };
@@ -116,7 +118,9 @@ export const authorizationMiddleware = async (req: Request, res: Response, next:
 
       return res.status(403).json({ error: 'Access denied' });
     } catch (err) {
-      console.error(err);
+      mastra.getLogger()?.error('Authorization error in authorizeUser', {
+        error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+      });
       return res.status(500).json({ error: 'Authorization error' });
     }
   }
@@ -146,7 +150,11 @@ export const authorizationMiddleware = async (req: Request, res: Response, next:
 
       return res.status(403).json({ error: 'Access denied' });
     } catch (err) {
-      console.error(err);
+      mastra.getLogger()?.error('Authorization error in authorize', {
+        error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+        path,
+        method,
+      });
       return res.status(500).json({ error: 'Authorization error' });
     }
   }

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -121,7 +121,9 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
         }
       }
     } catch (error) {
-      console.error(error);
+      this.mastra.getLogger()?.error('Error in stream processing', {
+        error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+      });
     } finally {
       res.end();
     }
@@ -142,7 +144,9 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
           const maxFileSize = route.maxBodySize ?? this.bodyLimitOptions?.maxSize;
           body = await this.parseMultipartFormData(request, maxFileSize);
         } catch (error) {
-          console.error('Failed to parse multipart form data:', error);
+          this.mastra.getLogger()?.error('Failed to parse multipart form data', {
+            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          });
           // Re-throw size limit errors, let others fall through to validation
           if (error instanceof Error && error.message.toLowerCase().includes('size')) {
             throw error;
@@ -373,7 +377,9 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
           try {
             params.queryParams = await this.parseQueryParams(route, params.queryParams);
           } catch (error) {
-            console.error('Error parsing query params', error);
+            this.mastra.getLogger()?.error('Error parsing query params', {
+              error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+            });
             // Zod validation errors should return 400 Bad Request with structured issues
             if (error instanceof ZodError) {
               return res.status(400).json(formatZodError(error, 'query parameters'));
@@ -389,7 +395,9 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
           try {
             params.body = await this.parseBody(route, params.body);
           } catch (error) {
-            console.error('Error parsing body:', error instanceof Error ? error.message : String(error));
+            this.mastra.getLogger()?.error('Error parsing body', {
+              error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+            });
             // Zod validation errors should return 400 Bad Request with structured issues
             if (error instanceof ZodError) {
               return res.status(400).json(formatZodError(error, 'request body'));
@@ -417,7 +425,11 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
           const result = await route.handler(handlerParams);
           await this.sendResponse(route, res, result, req, prefix);
         } catch (error) {
-          console.error('Error calling handler', error);
+          this.mastra.getLogger()?.error('Error calling handler', {
+            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+            path: route.path,
+            method: route.method,
+          });
           // Check if it's an HTTPException or MastraError with a status code
           let status = 500;
           if (error && typeof error === 'object') {

--- a/server-adapters/fastify/src/auth-middleware.ts
+++ b/server-adapters/fastify/src/auth-middleware.ts
@@ -71,7 +71,9 @@ export const authenticationMiddleware: preHandlerHookHandler = async (request: F
 
     return;
   } catch (err) {
-    console.error(err);
+    mastra.getLogger()?.error('Authentication error', {
+      error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+    });
     return reply.status(401).send({ error: 'Invalid or expired token' });
   }
 };
@@ -116,7 +118,9 @@ export const authorizationMiddleware: preHandlerHookHandler = async (request: Fa
 
       return reply.status(403).send({ error: 'Access denied' });
     } catch (err) {
-      console.error(err);
+      mastra.getLogger()?.error('Authorization error in authorizeUser', {
+        error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+      });
       return reply.status(500).send({ error: 'Authorization error' });
     }
   }
@@ -146,7 +150,11 @@ export const authorizationMiddleware: preHandlerHookHandler = async (request: Fa
 
       return reply.status(403).send({ error: 'Access denied' });
     } catch (err) {
-      console.error(err);
+      mastra.getLogger()?.error('Authorization error in authorize', {
+        error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+        path,
+        method,
+      });
       return reply.status(500).send({ error: 'Authorization error' });
     }
   }

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -146,7 +146,9 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
         }
       }
     } catch (error) {
-      console.error(error);
+      this.mastra.getLogger()?.error('Error in stream processing', {
+        error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+      });
     } finally {
       reply.raw.end();
     }
@@ -167,7 +169,9 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
           const maxFileSize = route.maxBodySize ?? this.bodyLimitOptions?.maxSize;
           body = await this.parseMultipartFormData(request, maxFileSize);
         } catch (error) {
-          console.error('Failed to parse multipart form data:', error);
+          this.mastra.getLogger()?.error('Failed to parse multipart form data', {
+            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          });
           // Re-throw size limit errors, let others fall through to validation
           if (error instanceof Error && error.message.toLowerCase().includes('size')) {
             throw error;
@@ -402,7 +406,9 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
         try {
           params.queryParams = await this.parseQueryParams(route, params.queryParams);
         } catch (error) {
-          console.error('Error parsing query params', error);
+          this.mastra.getLogger()?.error('Error parsing query params', {
+            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          });
           // Zod validation errors should return 400 Bad Request with structured issues
           if (error instanceof ZodError) {
             return reply.status(400).send(formatZodError(error, 'query parameters'));
@@ -418,7 +424,9 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
         try {
           params.body = await this.parseBody(route, params.body);
         } catch (error) {
-          console.error('Error parsing body:', error instanceof Error ? error.message : String(error));
+          this.mastra.getLogger()?.error('Error parsing body', {
+            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          });
           // Zod validation errors should return 400 Bad Request with structured issues
           if (error instanceof ZodError) {
             return reply.status(400).send(formatZodError(error, 'request body'));
@@ -446,7 +454,11 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
         const result = await route.handler(handlerParams);
         await this.sendResponse(route, reply, result, request, prefix);
       } catch (error) {
-        console.error('Error calling handler', error);
+        this.mastra.getLogger()?.error('Error calling handler', {
+          error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          path: route.path,
+          method: route.method,
+        });
         // Check if it's an HTTPException or MastraError with a status code
         let status = 500;
         if (error && typeof error === 'object') {

--- a/server-adapters/hono/src/auth-middleware.ts
+++ b/server-adapters/hono/src/auth-middleware.ts
@@ -69,7 +69,9 @@ export const authenticationMiddleware = async (c: ContextWithMastra, next: Next)
 
     return next();
   } catch (err) {
-    console.error(err);
+    mastra.getLogger()?.error('Authentication error', {
+      error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+    });
     return c.json({ error: 'Invalid or expired token' }, 401);
   }
 };
@@ -114,7 +116,9 @@ export const authorizationMiddleware = async (c: ContextWithMastra, next: Next) 
 
       return c.json({ error: 'Access denied' }, 403);
     } catch (err) {
-      console.error(err);
+      mastra.getLogger()?.error('Authorization error in authorizeUser', {
+        error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+      });
       return c.json({ error: 'Authorization error' }, 500);
     }
   }
@@ -130,7 +134,11 @@ export const authorizationMiddleware = async (c: ContextWithMastra, next: Next) 
 
       return c.json({ error: 'Access denied' }, 403);
     } catch (err) {
-      console.error(err);
+      mastra.getLogger()?.error('Authorization error in authorize', {
+        error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+        path,
+        method,
+      });
       return c.json({ error: 'Authorization error' }, 500);
     }
   }

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -162,13 +162,17 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
 
           await stream.write('data: [DONE]\n\n');
         } catch (error) {
-          console.error(error);
+          this.mastra.getLogger()?.error('Error in stream processing', {
+            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          });
         } finally {
           await stream.close();
         }
       },
       async err => {
-        console.error(err);
+        this.mastra.getLogger()?.error('Stream error callback', {
+          error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+        });
       },
     );
   }
@@ -188,7 +192,9 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
           const formData = await request.formData();
           body = await this.parseFormData(formData);
         } catch (error) {
-          console.error('Failed to parse multipart form data:', error);
+          this.mastra.getLogger()?.error('Failed to parse multipart form data', {
+            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          });
           // Re-throw size limit errors, let others fall through to validation
           if (error instanceof Error && error.message.toLowerCase().includes('size')) {
             throw error;
@@ -208,7 +214,9 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
           try {
             body = JSON.parse(bodyText);
           } catch (error) {
-            console.error('Failed to parse JSON body:', error);
+            this.mastra.getLogger()?.error('Failed to parse JSON body', {
+              error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+            });
             // Track JSON parse error to return 400 Bad Request
             bodyParseError = {
               message: error instanceof Error ? error.message : 'Invalid JSON in request body',
@@ -366,7 +374,9 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
           try {
             params.queryParams = await this.parseQueryParams(route, params.queryParams);
           } catch (error) {
-            console.error('Error parsing query params', error);
+            this.mastra.getLogger()?.error('Error parsing query params', {
+              error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+            });
             // Zod validation errors should return 400 Bad Request with structured issues
             if (error instanceof ZodError) {
               return c.json(formatZodError(error, 'query parameters'), 400);
@@ -385,7 +395,9 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
           try {
             params.body = await this.parseBody(route, params.body);
           } catch (error) {
-            console.error('Error parsing body:', error instanceof Error ? error.message : String(error));
+            this.mastra.getLogger()?.error('Error parsing body', {
+              error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+            });
             // Zod validation errors should return 400 Bad Request with structured issues
             if (error instanceof ZodError) {
               return c.json(formatZodError(error, 'request body'), 400);
@@ -416,7 +428,11 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
           const result = await route.handler(handlerParams);
           return this.sendResponse(route, c, result, prefix);
         } catch (error) {
-          console.error('Error calling handler', error);
+          this.mastra.getLogger()?.error('Error calling handler', {
+            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+            path: route.path,
+            method: route.method,
+          });
           // Check if it's an HTTPException or MastraError with a status code
           if (error && typeof error === 'object') {
             // Check for direct status property (HTTPException)

--- a/server-adapters/koa/src/auth-middleware.ts
+++ b/server-adapters/koa/src/auth-middleware.ts
@@ -75,7 +75,9 @@ export const authenticationMiddleware: Middleware = async (ctx: Context, next: N
 
     return next();
   } catch (err) {
-    console.error(err);
+    mastra.getLogger()?.error('Authentication error', {
+      error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+    });
     ctx.status = 401;
     ctx.body = { error: 'Invalid or expired token' };
     return;
@@ -124,7 +126,9 @@ export const authorizationMiddleware: Middleware = async (ctx: Context, next: Ne
       ctx.body = { error: 'Access denied' };
       return;
     } catch (err) {
-      console.error(err);
+      mastra.getLogger()?.error('Authorization error in authorizeUser', {
+        error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+      });
       ctx.status = 500;
       ctx.body = { error: 'Authorization error' };
       return;
@@ -158,7 +162,11 @@ export const authorizationMiddleware: Middleware = async (ctx: Context, next: Ne
       ctx.body = { error: 'Access denied' };
       return;
     } catch (err) {
-      console.error(err);
+      mastra.getLogger()?.error('Authorization error in authorize', {
+        error: err instanceof Error ? { message: err.message, stack: err.stack } : err,
+        path,
+        method,
+      });
       ctx.status = 500;
       ctx.body = { error: 'Authorization error' };
       return;

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -135,7 +135,9 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
         }
       }
     } catch (error) {
-      console.error(error);
+      this.mastra.getLogger()?.error('Error in stream processing', {
+        error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+      });
     } finally {
       ctx.res.end();
     }
@@ -156,7 +158,9 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
           const maxFileSize = route.maxBodySize ?? this.bodyLimitOptions?.maxSize;
           body = await this.parseMultipartFormData(ctx, maxFileSize);
         } catch (error) {
-          console.error('Failed to parse multipart form data:', error);
+          this.mastra.getLogger()?.error('Failed to parse multipart form data', {
+            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          });
           // Re-throw size limit errors, let others fall through to validation
           if (error instanceof Error && error.message.toLowerCase().includes('size')) {
             throw error;
@@ -400,7 +404,9 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
         try {
           params.queryParams = await this.parseQueryParams(route, params.queryParams);
         } catch (error) {
-          console.error('Error parsing query params', error);
+          this.mastra.getLogger()?.error('Error parsing query params', {
+            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          });
           // Zod validation errors should return 400 Bad Request with structured issues
           if (error instanceof ZodError) {
             ctx.status = 400;
@@ -420,7 +426,9 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
         try {
           params.body = await this.parseBody(route, params.body);
         } catch (error) {
-          console.error('Error parsing body:', error instanceof Error ? error.message : String(error));
+          this.mastra.getLogger()?.error('Error parsing body', {
+            error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          });
           // Zod validation errors should return 400 Bad Request with structured issues
           if (error instanceof ZodError) {
             ctx.status = 400;
@@ -452,7 +460,11 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
         const result = await route.handler(handlerParams);
         await this.sendResponse(route, ctx, result, prefix);
       } catch (error) {
-        console.error('Error calling handler', error);
+        this.mastra.getLogger()?.error('Error calling handler', {
+          error: error instanceof Error ? { message: error.message, stack: error.stack } : error,
+          path: route.path,
+          method: route.method,
+        });
         // Check if it's an HTTPException or MastraError with a status code
         let status = 500;
         if (error && typeof error === 'object') {


### PR DESCRIPTION
## Summary

- Server adapter errors now use the configured Mastra logger instead of `console.error()`
- `setLogger()` now updates workflow loggers, fixing missing error logs in Cloud deployments

## Problem

Error logs were not being exported to HttpTransport in Cloud because:

1. **Server adapters used `console.error()` directly** - Handler errors, parsing errors, and auth errors bypassed the logging system entirely
2. **`setLogger()` didn't update workflows** - Workflows kept using their default `ConsoleLogger` even after the cloud deployer called `mastra.setLogger()` with a PinoLogger+HttpTransport

## Changes

### Server Adapters
- `server-adapters/hono/src/index.ts` - Replace `console.error` with `this.mastra.getLogger()?.error()`
- `server-adapters/express/src/index.ts` - Same
- `server-adapters/fastify/src/index.ts` - Same  
- `server-adapters/koa/src/index.ts` - Same
- All auth-middleware files updated similarly
- `packages/server/src/server/server-adapter/index.ts` - Auth error logging

### Core
- `packages/core/src/mastra/index.ts` - Add workflow logger updates to `setLogger()`

## Test plan

- [ ] Deploy to Cloud and verify error logs now appear in the logs endpoint
- [ ] Verify structured error logs include path, method, and stack trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflows not receiving updated logger when setLogger() is called, ensuring correct logging in production deployments.
  * Enhanced error logging across server adapters to use configured logger instead of console, ensuring errors are properly captured by logging transports.

* **Chores**
  * Patch version updates for server adapter packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->