### PR TITLE
fix(core): update workflow loggers in setLogger

### DIFF
--- a/.changeset/workflows-logger-fix.md
+++ b/.changeset/workflows-logger-fix.md
@@ -1,0 +1,7 @@
+---
+"@mastra/core": patch
+---
+
+Fix setLogger to update workflow loggers
+
+When calling `mastra.setLogger()`, workflows were not being updated with the new logger. This caused workflow errors to be logged via the default ConsoleLogger instead of the configured logger (e.g., PinoLogger with HttpTransport), resulting in missing error logs in Cloud deployments.

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -2331,6 +2331,12 @@ export class Mastra<
       });
     }
 
+    if (this.#workflows) {
+      Object.keys(this.#workflows).forEach(key => {
+        this.#workflows?.[key]?.__setLogger(this.#logger);
+      });
+    }
+
     if (this.#serverAdapter) {
       this.#serverAdapter.__setLogger(this.#logger);
     }


### PR DESCRIPTION
## Summary
- When calling `mastra.setLogger()`, workflows were not being updated with the new logger
- This caused workflow errors to be logged via the default ConsoleLogger instead of the configured logger (e.g., PinoLogger with HttpTransport)
- Resulted in missing error logs in Cloud deployments

## Test plan
- [ ] Verify `setLogger()` updates workflow loggers
- [ ] Test workflow errors appear in the new logger output
- [ ] Confirm errors reach Cloud deployments via HttpTransport

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where workflows were not respecting custom logger configurations. Previously, workflows would continue using the default logger, causing error logs to be missed in Cloud deployments. Logger configuration updates now properly propagate to all workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->