### PR TITLE
Fix faithfulness scorer validation error with live agents

### DIFF
--- a/.changeset/metal-rooms-invent.md
+++ b/.changeset/metal-rooms-invent.md
@@ -1,0 +1,5 @@
+---
+'@mastra/evals': patch
+---
+
+Fixed faithfulness scorer failing with 'expected record, received array' error when used with live agents. The preprocess step now returns claims as an object instead of a raw array, matching the expected storage schema.

--- a/packages/evals/src/scorers/llm/faithfulness/index.ts
+++ b/packages/evals/src/scorers/llm/faithfulness/index.ts
@@ -33,7 +33,9 @@ export function createFaithfulnessScorer({
   })
     .preprocess({
       description: 'Extract relevant statements from the LLM output',
-      outputSchema: z.array(z.string()),
+      outputSchema: z.object({
+        claims: z.array(z.string()),
+      }),
       createPrompt: ({ run }) => {
         const prompt = createFaithfulnessExtractPrompt({ output: getAssistantMessageFromRunOutput(run.output) ?? '' });
         return prompt;
@@ -52,7 +54,7 @@ export function createFaithfulnessScorer({
           ) ??
           [];
         const prompt = createFaithfulnessAnalyzePrompt({
-          claims: results.preprocessStepResult || [],
+          claims: results.preprocessStepResult?.claims || [],
           context,
         });
         return prompt;

--- a/packages/evals/src/scorers/llm/faithfulness/schema.test.ts
+++ b/packages/evals/src/scorers/llm/faithfulness/schema.test.ts
@@ -1,0 +1,46 @@
+import { saveScorePayloadSchema } from '@mastra/core/evals';
+import { describe, it, expect } from 'vitest';
+
+describe('Faithfulness scorer preprocessStepResult schema compatibility', () => {
+  it('should produce a preprocessStepResult that conforms to saveScorePayloadSchema (record, not array)', () => {
+    // This test validates the fix for https://github.com/mastra-ai/mastra/issues/12876
+    // The bug was that the preprocess outputSchema was z.array(z.string()), which
+    // produced a raw array as preprocessStepResult. The saveScorePayloadSchema expects
+    // preprocessStepResult to be a record (z.record(z.string(), z.unknown())), not an array.
+
+    // Simulates what the old code would produce: a raw array
+    const rawArrayResult = ['claim 1', 'claim 2'];
+
+    // Simulates what the fixed code produces: an object with a claims property
+    const objectResult = { claims: ['claim 1', 'claim 2'] };
+
+    const basePayload = {
+      scorerId: 'faithfulness-scorer',
+      entityId: 'test-agent',
+      runId: 'test-run-id',
+      input: [{ role: 'user', content: 'test' }],
+      output: [{ role: 'assistant', content: 'test' }],
+      score: 0.5,
+      scorer: { id: 'faithfulness-scorer', name: 'Faithfulness Scorer' },
+      source: 'TEST' as const,
+      entity: { id: 'test-agent', name: 'Test Agent' },
+      entityType: 'AGENT',
+    };
+
+    // The old (buggy) format should fail schema validation
+    expect(() => {
+      saveScorePayloadSchema.parse({
+        ...basePayload,
+        preprocessStepResult: rawArrayResult,
+      });
+    }).toThrow();
+
+    // The new (fixed) format should pass schema validation
+    expect(() => {
+      saveScorePayloadSchema.parse({
+        ...basePayload,
+        preprocessStepResult: objectResult,
+      });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Description

Fixed the faithfulness scorer failing with 'expected record, received array' error when used with live agents. The issue was that the preprocess step's `outputSchema` was `z.array(z.string())`, which produces a raw array. However, `saveScorePayloadSchema` validates `preprocessStepResult` as a record (`z.record(z.string(), z.unknown())`). The fix wraps the claims array in an object to match the expected storage schema and aligns with how other scorers (hallucination, bias, answer-relevancy) handle structured outputs.

## Related Issue(s)

Fixes #12876

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed faithfulness scorer to properly handle data structures when used with live agents, ensuring correct analysis throughout the scoring process.

* **Tests**
  * Added validation tests to verify the faithfulness scorer correctly processes and handles preprocessed data formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->