### PR TITLE
Fix #12878: Add missing state field to tool approval/suspension chunks

### DIFF
--- a/.changeset/floppy-steaks-help.md
+++ b/.changeset/floppy-steaks-help.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed missing `state` field in `data-tool-call-approval` and `data-tool-call-suspended` stream chunks. Frontend consumers can now use the `state` property on the data payload to identify the part's state consistently with other tool UI parts.

--- a/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
@@ -1,0 +1,135 @@
+import { ReadableStream } from 'node:stream/web';
+import { ChunkFrom } from '@mastra/core/stream';
+import type { MastraModelOutput } from '@mastra/core/stream';
+import { describe, expect, it } from 'vitest';
+import { toAISdkV5Stream } from '../convert-streams';
+import { convertMastraChunkToAISDKv5 } from '../helpers';
+
+describe('tool-call-approval chunk conversion (issue #12878)', () => {
+  describe('convertMastraChunkToAISDKv5', () => {
+    it('should include a state field in the data-tool-call-approval chunk', () => {
+      const chunk = {
+        type: 'tool-call-approval' as const,
+        runId: 'run-123',
+        from: ChunkFrom.AGENT,
+        payload: {
+          toolCallId: 'tooluse_abc123',
+          toolName: 'myTool',
+          args: { param: 'value' },
+          resumeSchema: '{"type":"object","properties":{"approved":{"type":"boolean"}}}',
+        },
+      };
+
+      const result = convertMastraChunkToAISDKv5({ chunk, mode: 'stream' }) as any;
+
+      expect(result).toBeDefined();
+      expect(result.type).toBe('data-tool-call-approval');
+      expect(result.id).toBe('tooluse_abc123');
+
+      // Issue #12878: The data-tool-call-approval chunk should include a state
+      // field so the frontend can identify the part's state consistently
+      // with other tool UI parts (which have states like 'input-available',
+      // 'output-available', etc.)
+      expect(result.data).toHaveProperty('state', 'data-tool-call-approval');
+    });
+
+    it('should include a state field in the data-tool-call-suspended chunk', () => {
+      const chunk = {
+        type: 'tool-call-suspended' as const,
+        runId: 'run-123',
+        from: ChunkFrom.AGENT,
+        payload: {
+          toolCallId: 'tooluse_abc123',
+          toolName: 'myTool',
+          suspendPayload: { reason: 'Needs user input' },
+          resumeSchema: '{"type":"object"}',
+        },
+      };
+
+      const result = convertMastraChunkToAISDKv5({ chunk, mode: 'stream' }) as any;
+
+      expect(result).toBeDefined();
+      expect(result.type).toBe('data-tool-call-suspended');
+      expect(result.id).toBe('tooluse_abc123');
+
+      // Issue #12878: Consistent with tool-call-approval, the suspended chunk
+      // should also include a state field
+      expect(result.data).toHaveProperty('state', 'data-tool-call-suspended');
+    });
+  });
+
+  describe('end-to-end: tool-call-approval through agent stream', () => {
+    it('should emit data-tool-call-approval with state field when tool requires approval', async () => {
+      const mockStream = new ReadableStream({
+        async start(controller) {
+          controller.enqueue({
+            type: 'start',
+            runId: 'run-123',
+            from: ChunkFrom.AGENT,
+            payload: { id: 'msg-1' },
+          });
+
+          controller.enqueue({
+            type: 'step-start',
+            runId: 'run-123',
+            from: ChunkFrom.AGENT,
+            payload: { messageId: 'msg-1' },
+          });
+
+          controller.enqueue({
+            type: 'tool-call',
+            runId: 'run-123',
+            from: ChunkFrom.AGENT,
+            payload: {
+              toolCallId: 'tooluse_abc123',
+              toolName: 'myTool',
+              args: { param: 'value' },
+            },
+          });
+
+          controller.enqueue({
+            type: 'tool-call-approval',
+            runId: 'run-123',
+            from: ChunkFrom.AGENT,
+            payload: {
+              toolCallId: 'tooluse_abc123',
+              toolName: 'myTool',
+              args: { param: 'value' },
+              resumeSchema: '{"type":"object","properties":{"approved":{"type":"boolean"}}}',
+            },
+          });
+
+          controller.close();
+        },
+      });
+
+      const aiSdkStream = toAISdkV5Stream(mockStream as unknown as MastraModelOutput, { from: 'agent' });
+
+      const chunks: any[] = [];
+      for await (const chunk of aiSdkStream) {
+        chunks.push(chunk);
+      }
+
+      // Should have the tool-input-available chunk for the tool call
+      const toolInputChunk = chunks.find(chunk => chunk.type === 'tool-input-available');
+      expect(toolInputChunk).toBeDefined();
+      expect(toolInputChunk.toolCallId).toBe('tooluse_abc123');
+
+      // Should have the data-tool-call-approval chunk
+      const approvalChunk = chunks.find(chunk => chunk.type === 'data-tool-call-approval');
+      expect(approvalChunk).toBeDefined();
+      expect(approvalChunk.type).toBe('data-tool-call-approval');
+      expect(approvalChunk.id).toBe('tooluse_abc123');
+
+      // Issue #12878: The data field should include a state property
+      expect(approvalChunk.data.state).toBe('data-tool-call-approval');
+
+      // The rest of the data should still be present
+      expect(approvalChunk.data.runId).toBe('run-123');
+      expect(approvalChunk.data.toolCallId).toBe('tooluse_abc123');
+      expect(approvalChunk.data.toolName).toBe('myTool');
+      expect(approvalChunk.data.args).toEqual({ param: 'value' });
+      expect(approvalChunk.data.resumeSchema).toBe('{"type":"object","properties":{"approved":{"type":"boolean"}}}');
+    });
+  });
+});

--- a/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transformers.test.ts
@@ -454,6 +454,7 @@ describe('WorkflowStreamToAISDKTransformer', () => {
       expect(toolCallSuspendedChunk.type).toBe('data-tool-call-suspended');
       expect(toolCallSuspendedChunk.id).toBe('tool-call-1');
       expect(toolCallSuspendedChunk.data).toEqual({
+        state: 'data-tool-call-suspended',
         runId: 'agent-run-id',
         toolCallId: 'tool-call-1',
         toolName: 'suspendable-tool',
@@ -461,6 +462,7 @@ describe('WorkflowStreamToAISDKTransformer', () => {
           reason: 'Waiting for user approval',
           data: { value: 42 },
         },
+        resumeSchema: undefined,
       });
     });
 

--- a/client-sdks/ai-sdk/src/helpers.ts
+++ b/client-sdks/ai-sdk/src/helpers.ts
@@ -155,6 +155,7 @@ export function convertMastraChunkToAISDKv5<OUTPUT = undefined>({
         type: 'data-tool-call-approval',
         id: chunk.payload.toolCallId,
         data: {
+          state: 'data-tool-call-approval',
           runId: chunk.runId,
           toolCallId: chunk.payload.toolCallId,
           toolName: chunk.payload.toolName,
@@ -167,6 +168,7 @@ export function convertMastraChunkToAISDKv5<OUTPUT = undefined>({
         type: 'data-tool-call-suspended',
         id: chunk.payload.toolCallId,
         data: {
+          state: 'data-tool-call-suspended',
           runId: chunk.runId,
           toolCallId: chunk.payload.toolCallId,
           toolName: chunk.payload.toolName,


### PR DESCRIPTION
## Description

Fixed missing `state` field in `data-tool-call-approval` and `data-tool-call-suspended` stream chunks. Frontend consumers can now use the `state` property on the data payload to identify the part's state consistently with other tool UI parts.

## Related Issue(s)

Fixes #12878

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added missing state field to tool-call-approval and tool-call-suspended stream chunks, enabling frontend consumers to reliably identify the part's state in the data payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->