### PR TITLE
fix(ai-sdk): Add initialState support to handleWorkflowStream

### DIFF
--- a/.changeset/late-adults-vanish.md
+++ b/.changeset/late-adults-vanish.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Added initialState support to handleWorkflowStream in @mastra/ai-sdk. Previously, the WorkflowStreamHandlerParams type was missing the initialState property, preventing users from initializing global workflow state when using handleWorkflowStream.

--- a/client-sdks/ai-sdk/src/__tests__/workflow-route.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/workflow-route.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { WorkflowStreamHandlerParams } from '../workflow-route';
+import { handleWorkflowStream } from '../workflow-route';
+
+describe('handleWorkflowStream', () => {
+  const mockStreamOutput = {
+    fullStream: new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }),
+  };
+
+  const mockRun = {
+    stream: vi.fn().mockReturnValue(mockStreamOutput),
+    resumeStream: vi.fn().mockReturnValue(mockStreamOutput),
+  };
+
+  const mockWorkflow = {
+    createRun: vi.fn().mockResolvedValue(mockRun),
+  };
+
+  const mockMastra = {
+    getWorkflowById: vi.fn().mockReturnValue(mockWorkflow),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMastra.getWorkflowById.mockReturnValue(mockWorkflow);
+    mockWorkflow.createRun.mockResolvedValue(mockRun);
+    mockRun.stream.mockReturnValue(mockStreamOutput);
+    mockRun.resumeStream.mockReturnValue(mockStreamOutput);
+  });
+
+  it('WorkflowStreamHandlerParams should accept initialState', () => {
+    // This test verifies the type accepts initialState.
+    // If the type is missing initialState, this will fail TypeScript compilation.
+    const params: WorkflowStreamHandlerParams = {
+      inputData: { test: true },
+      initialState: { counter: 0 },
+    };
+    expect(params.initialState).toEqual({ counter: 0 });
+  });
+
+  it('should pass initialState through to run.stream()', async () => {
+    const initialState = { counter: 0, items: ['a', 'b'] };
+
+    await handleWorkflowStream({
+      mastra: mockMastra as any,
+      workflowId: 'test-workflow',
+      params: {
+        runId: 'test-run',
+        inputData: { foo: 'bar' },
+        initialState,
+      } as WorkflowStreamHandlerParams,
+    });
+
+    expect(mockRun.stream).toHaveBeenCalledTimes(1);
+    const streamCallArgs = mockRun.stream.mock.calls[0]![0];
+    expect(streamCallArgs).toHaveProperty('initialState');
+    expect(streamCallArgs.initialState).toEqual(initialState);
+  });
+
+  it('should pass inputData to run.stream() when no resumeData', async () => {
+    const params: WorkflowStreamHandlerParams = {
+      runId: 'test-run',
+      inputData: { foo: 'bar' },
+    };
+
+    await handleWorkflowStream({
+      mastra: mockMastra as any,
+      workflowId: 'test-workflow',
+      params,
+    });
+
+    expect(mockRun.stream).toHaveBeenCalledTimes(1);
+    const streamCallArgs = mockRun.stream.mock.calls[0]![0];
+    expect(streamCallArgs.inputData).toEqual({ foo: 'bar' });
+  });
+
+  it('should call resumeStream when resumeData is provided', async () => {
+    const params: WorkflowStreamHandlerParams = {
+      runId: 'test-run',
+      resumeData: { answer: 42 },
+      step: 'step1',
+    };
+
+    await handleWorkflowStream({
+      mastra: mockMastra as any,
+      workflowId: 'test-workflow',
+      params,
+    });
+
+    expect(mockRun.resumeStream).toHaveBeenCalledTimes(1);
+    expect(mockRun.stream).not.toHaveBeenCalled();
+  });
+});

--- a/client-sdks/ai-sdk/src/workflow-route.ts
+++ b/client-sdks/ai-sdk/src/workflow-route.ts
@@ -10,6 +10,7 @@ export type WorkflowStreamHandlerParams = {
   runId?: string;
   resourceId?: string;
   inputData?: Record<string, any>;
+  initialState?: Record<string, any>;
   resumeData?: Record<string, any>;
   requestContext?: RequestContext;
   tracingOptions?: TracingOptions;
@@ -55,7 +56,7 @@ export async function handleWorkflowStream<UI_MESSAGE extends UIMessage>({
   sendReasoning = false,
   sendSources = false,
 }: WorkflowStreamHandlerOptions): Promise<ReadableStream<InferUIMessageChunk<UI_MESSAGE>>> {
-  const { runId, resourceId, inputData, resumeData, requestContext, ...rest } = params;
+  const { runId, resourceId, inputData, initialState, resumeData, requestContext, ...rest } = params;
 
   const workflowObj = mastra.getWorkflowById(workflowId);
   if (!workflowObj) {
@@ -66,7 +67,7 @@ export async function handleWorkflowStream<UI_MESSAGE extends UIMessage>({
 
   const stream = resumeData
     ? run.resumeStream({ resumeData, ...rest, requestContext })
-    : run.stream({ inputData, ...rest, requestContext });
+    : run.stream({ inputData, initialState, ...rest, requestContext });
 
   return createUIMessageStream<UI_MESSAGE>({
     execute: async ({ writer }) => {


### PR DESCRIPTION
## Description

Added support for passing `initialState` when using `handleWorkflowStream`. The `WorkflowStreamHandlerParams` type now includes the `initialState` property, allowing users to initialize global workflow state when streaming workflow execution through the AI SDK handler.

## Related Issue(s)

Fixes #12875

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for initializing global workflow state in workflow streaming operations, enabling better control over execution context.

* **Tests**
  * Added comprehensive test coverage for workflow stream state initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->