### PR TITLE
docs: add reference docs for E2BSandbox, S3Filesystem, GCSFilesystem

### DIFF
--- a/docs/src/content/en/docs/workspace/filesystem.mdx
+++ b/docs/src/content/en/docs/workspace/filesystem.mdx
@@ -24,10 +24,12 @@ A filesystem provider handles all file operations for a workspace:
 Available providers:
 
 - [`LocalFilesystem`](/reference/workspace/local-filesystem) - Stores files in a directory on disk
+- [`S3Filesystem`](/reference/workspace/s3-filesystem) - Stores files in Amazon S3 or S3-compatible storage (R2, MinIO)
+- [`GCSFilesystem`](/reference/workspace/gcs-filesystem) - Stores files in Google Cloud Storage
 
 :::tip
 
-`LocalFilesystem` is the simplest way to get started as it requires no external services.
+`LocalFilesystem` is the simplest way to get started as it requires no external services. For cloud storage, use `S3Filesystem` or `GCSFilesystem`.
 
 :::
 
@@ -79,5 +81,7 @@ When you configure a filesystem on a workspace, agents receive tools for reading
 ## Related
 
 - [LocalFilesystem reference](/reference/workspace/local-filesystem)
+- [S3Filesystem reference](/reference/workspace/s3-filesystem)
+- [GCSFilesystem reference](/reference/workspace/gcs-filesystem)
 - [Workspace overview](/docs/workspace/overview)
 - [Sandbox](/docs/workspace/sandbox)

--- a/docs/src/content/en/docs/workspace/sandbox.mdx
+++ b/docs/src/content/en/docs/workspace/sandbox.mdx
@@ -26,6 +26,7 @@ When you assign a workspace with a sandbox to an agent, Mastra automatically inc
 Available providers:
 
 - [`LocalSandbox`](/reference/workspace/local-sandbox) - Executes commands on the local machine
+- [`E2BSandbox`](/reference/workspace/e2b-sandbox) - Executes commands in isolated E2B cloud sandboxes
 
 ## Basic usage
 
@@ -64,5 +65,6 @@ When you configure a sandbox on a workspace, agents receive the `execute_command
 ## Related
 
 - [`LocalSandbox` reference](/reference/workspace/local-sandbox)
+- [`E2BSandbox` reference](/reference/workspace/e2b-sandbox)
 - [Workspace overview](/docs/workspace/overview)
 - [Filesystem](/docs/workspace/filesystem)

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -633,7 +633,18 @@ const sidebars = {
           id: 'workspace/local-filesystem',
           label: 'LocalFilesystem',
         },
+        {
+          type: 'doc',
+          id: 'workspace/s3-filesystem',
+          label: 'S3Filesystem',
+        },
+        {
+          type: 'doc',
+          id: 'workspace/gcs-filesystem',
+          label: 'GCSFilesystem',
+        },
         { type: 'doc', id: 'workspace/local-sandbox', label: 'LocalSandbox' },
+        { type: 'doc', id: 'workspace/e2b-sandbox', label: 'E2BSandbox' },
         {
           type: 'doc',
           id: 'workspace/filesystem',

--- a/docs/src/content/en/reference/workspace/e2b-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/e2b-sandbox.mdx
@@ -1,0 +1,406 @@
+---
+title: "Reference: E2BSandbox | Workspace"
+description: "Documentation for the E2BSandbox provider for isolated cloud code execution."
+packages:
+  - "@mastra/e2b"
+---
+
+# E2BSandbox
+
+Executes commands in isolated [E2B](https://e2b.dev) cloud sandboxes. Provides secure, ephemeral environments with support for mounting cloud storage.
+
+:::info
+
+For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
+
+:::
+
+## Installation
+
+```bash
+npm install @mastra/e2b
+```
+
+## Usage
+
+Add an `E2BSandbox` to a workspace and assign it to an agent:
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { Workspace } from '@mastra/core/workspace';
+import { E2BSandbox } from '@mastra/e2b';
+
+const workspace = new Workspace({
+  sandbox: new E2BSandbox({
+    id: 'dev-sandbox',
+    timeout: 60_000, // 60 second timeout (default: 5 minutes)
+  }),
+});
+
+const agent = new Agent({
+  name: 'dev-agent',
+  model: 'anthropic/claude-opus-4-5',
+  workspace,
+});
+```
+
+## Constructor parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "apiKey",
+      type: "string",
+      description: "E2B API key. Falls back to E2B_API_KEY environment variable.",
+      isOptional: true,
+    },
+    {
+      name: "timeout",
+      type: "number",
+      description: "Execution timeout in milliseconds",
+      isOptional: true,
+      defaultValue: "300000 (5 minutes)",
+    },
+    {
+      name: "template",
+      type: "string | TemplateBuilder | function",
+      description: "Sandbox template specification. Can be a template ID string, a TemplateBuilder, or a function that customizes the default template.",
+      isOptional: true,
+    },
+    {
+      name: "env",
+      type: "Record<string, string>",
+      description: "Environment variables to set in the sandbox",
+      isOptional: true,
+    },
+    {
+      name: "runtimes",
+      type: "SandboxRuntime[]",
+      description: "Supported runtimes",
+      isOptional: true,
+      defaultValue: "['node', 'python', 'bash']",
+    },
+    {
+      name: "id",
+      type: "string",
+      description: "Unique identifier for this sandbox instance",
+      isOptional: true,
+      defaultValue: "Auto-generated",
+    },
+    {
+      name: "domain",
+      type: "string",
+      description: "Domain for self-hosted E2B. Falls back to E2B_DOMAIN env var.",
+      isOptional: true,
+    },
+    {
+      name: "apiUrl",
+      type: "string",
+      description: "API URL for self-hosted E2B. Falls back to E2B_API_URL env var.",
+      isOptional: true,
+    },
+    {
+      name: "accessToken",
+      type: "string",
+      description: "Access token for authentication. Falls back to E2B_ACCESS_TOKEN env var.",
+      isOptional: true,
+    },
+  ]}
+/>
+
+## Properties
+
+<PropertiesTable
+  content={[
+    {
+      name: "id",
+      type: "string",
+      description: "Sandbox instance identifier",
+    },
+    {
+      name: "name",
+      type: "string",
+      description: "Provider name ('E2BSandbox')",
+    },
+    {
+      name: "provider",
+      type: "string",
+      description: "Provider identifier ('e2b')",
+    },
+    {
+      name: "status",
+      type: "ProviderStatus",
+      description: "'pending' | 'initializing' | 'ready' | 'error'",
+    },
+    {
+      name: "supportsMounting",
+      type: "boolean",
+      description: "Always true - E2B sandboxes support mounting cloud filesystems",
+    },
+  ]}
+/>
+
+## Methods
+
+### `start()`
+
+Initialize and start the sandbox. Creates the E2B sandbox instance and mounts any configured filesystems.
+
+```typescript
+await sandbox.start();
+```
+
+Called automatically on first command execution or by `workspace.init()`.
+
+### `stop()`
+
+Stop the sandbox and release resources.
+
+```typescript
+await sandbox.stop();
+```
+
+### `destroy()`
+
+Clean up sandbox resources completely.
+
+```typescript
+await sandbox.destroy();
+```
+
+### `executeCommand(command, args?, options?)`
+
+Execute a shell command in the sandbox.
+
+```typescript
+const result = await sandbox.executeCommand('ls', ['-la']);
+const npmResult = await sandbox.executeCommand('npm', ['install', 'lodash'], {
+  timeout: 60000,
+  cwd: '/app',
+});
+```
+
+**Parameters:**
+
+<PropertiesTable
+  content={[
+    {
+      name: "command",
+      type: "string",
+      description: "Command to execute",
+    },
+    {
+      name: "args",
+      type: "string[]",
+      description: "Command arguments",
+      isOptional: true,
+    },
+    {
+      name: "options.timeout",
+      type: "number",
+      description: "Execution timeout in milliseconds",
+      isOptional: true,
+    },
+    {
+      name: "options.cwd",
+      type: "string",
+      description: "Working directory for the command",
+      isOptional: true,
+    },
+    {
+      name: "options.env",
+      type: "Record<string, string>",
+      description: "Additional environment variables",
+      isOptional: true,
+    },
+    {
+      name: "options.onStdout",
+      type: "(data: string) => void",
+      description: "Callback for stdout streaming",
+      isOptional: true,
+    },
+    {
+      name: "options.onStderr",
+      type: "(data: string) => void",
+      description: "Callback for stderr streaming",
+      isOptional: true,
+    },
+  ]}
+/>
+
+### `canMount(filesystem)`
+
+Check if a filesystem can be mounted into this sandbox.
+
+```typescript
+const canMount = sandbox.canMount(s3Filesystem);
+// true for S3Filesystem and GCSFilesystem
+```
+
+### `mount(filesystem, mountPath)`
+
+Mount a filesystem into the sandbox at the specified path.
+
+```typescript
+await sandbox.mount(s3Filesystem, '/mnt/data');
+```
+
+### `unmount(mountPath)`
+
+Unmount a previously mounted filesystem.
+
+```typescript
+await sandbox.unmount('/mnt/data');
+```
+
+### `getMounts()`
+
+Get a list of currently mounted filesystems.
+
+```typescript
+const mounts = await sandbox.getMounts();
+// [{ path: '/mnt/data', filesystem: 's3' }]
+```
+
+### `getInfo()`
+
+Get sandbox status and resource information.
+
+```typescript
+const info = await sandbox.getInfo();
+// { id: '...', name: 'E2BSandbox', provider: 'e2b', status: 'ready', supportsMounting: true }
+```
+
+## Mounting Cloud Storage
+
+E2B sandboxes can mount S3 or GCS filesystems, making cloud storage accessible as local directories inside the sandbox. This is useful for:
+
+- Processing large datasets stored in cloud buckets
+- Writing output files directly to cloud storage
+- Sharing data between sandbox sessions
+
+### Using the mounts config
+
+The simplest way to mount filesystems is through the workspace `mounts` config:
+
+```typescript
+import { Workspace } from '@mastra/core/workspace';
+import { S3Filesystem } from '@mastra/s3';
+import { GCSFilesystem } from '@mastra/gcs';
+import { E2BSandbox } from '@mastra/e2b';
+
+const workspace = new Workspace({
+  mounts: {
+    '/s3-data': new S3Filesystem({
+      bucket: 'my-s3-bucket',
+      region: 'us-east-1',
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    }),
+    '/gcs-data': new GCSFilesystem({
+      bucket: 'my-gcs-bucket',
+      projectId: 'my-project',
+      credentials: JSON.parse(process.env.GCS_SERVICE_ACCOUNT_KEY),
+    }),
+  },
+  sandbox: new E2BSandbox({ id: 'dev-sandbox' }),
+});
+```
+
+When the sandbox starts, the filesystems are automatically mounted at the specified paths. Code running in the sandbox can then access files at `/s3-data` and `/gcs-data` as if they were local directories.
+
+### How mounting works
+
+E2B sandboxes use FUSE (Filesystem in Userspace) to mount cloud storage:
+
+- **S3/R2**: Mounted via [s3fs-fuse](https://github.com/s3fs-fuse/s3fs-fuse)
+- **GCS**: Mounted via [gcsfuse](https://github.com/GoogleCloudPlatform/gcsfuse)
+
+The E2B sandbox automatically installs the required FUSE tools when mounting is used. For best performance, pre-build a custom template with the tools installed.
+
+## Custom Templates
+
+By default, when no template is specified, E2BSandbox automatically builds a template with `s3fs` installed for S3 mounting support. This template is cached and reused across sandbox instances.
+
+For GCS mounting, `gcsfuse` is automatically installed at mount time if not already present. For additional tools or faster cold starts, use custom templates.
+
+### Using an existing template
+
+If you have a pre-built template, pass its ID:
+
+```typescript
+const workspace = new Workspace({
+  sandbox: new E2BSandbox({
+    id: 'dev-sandbox',
+    template: 'my-custom-template',
+  }),
+});
+```
+
+### Customizing the default template
+
+Pass a function to customize the default mountable template. The function receives a `TemplateBuilder` and should return the modified template:
+
+```typescript
+const workspace = new Workspace({
+  sandbox: new E2BSandbox({
+    template: (base) => base
+      .aptInstall(['ffmpeg', 'imagemagick', 'poppler-utils'])
+      .pipInstall(['pandas', 'numpy'])
+      .npmInstall(['sharp']),
+  }),
+});
+```
+
+The template builder supports method chaining with operations like:
+
+- `aptInstall(packages)` - Install system packages
+- `pipInstall(packages)` - Install Python packages
+- `npmInstall(packages)` - Install Node.js packages
+- `runCmd(command)` - Run shell commands
+- `setEnvs(vars)` - Set environment variables
+- `copy(src, dest)` - Copy files into the template
+
+See [E2B's template documentation](https://e2b.dev/docs/template/defining-template) for the full list of available methods.
+
+### Pre-building templates
+
+The default template is built on first use and cached. For faster cold starts or to include GCS support, you can pre-build a template:
+
+```typescript
+import { createDefaultMountableTemplate } from '@mastra/e2b';
+import { Template } from 'e2b';
+
+// Get the default mountable template (includes s3fs)
+const { template, id } = createDefaultMountableTemplate();
+
+// Build and save to E2B
+const result = await Template.build(template, id);
+console.log('Template ID:', result.templateId);
+
+// Use this ID in your E2BSandbox config for instant startup
+const sandbox = new E2BSandbox({
+  template: result.templateId,
+});
+```
+
+For faster GCS cold starts, pre-install `gcsfuse` in a custom template:
+
+```typescript
+const workspace = new Workspace({
+  sandbox: new E2BSandbox({
+    id: 'dev-sandbox',
+    template: (base) => base.aptInstall(['gcsfuse']),
+  }),
+});
+```
+
+This is optional—`gcsfuse` is installed automatically at mount time if not present.
+
+## Related
+
+- [WorkspaceSandbox interface](/reference/workspace/sandbox)
+- [LocalSandbox reference](/reference/workspace/local-sandbox)
+- [S3Filesystem reference](/reference/workspace/s3-filesystem)
+- [GCSFilesystem reference](/reference/workspace/gcs-filesystem)
+- [Workspace overview](/docs/workspace/overview)

--- a/docs/src/content/en/reference/workspace/gcs-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/gcs-filesystem.mdx
@@ -1,0 +1,238 @@
+---
+title: "Reference: GCSFilesystem | Workspace"
+description: "Documentation for the GCSFilesystem provider for Google Cloud Storage."
+packages:
+  - "@mastra/gcs"
+---
+
+# GCSFilesystem
+
+Stores files in Google Cloud Storage.
+
+:::info
+
+For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
+
+:::
+
+## Installation
+
+```bash
+npm install @mastra/gcs
+```
+
+## Usage
+
+Add a `GCSFilesystem` to a workspace and assign it to an agent:
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { Workspace } from '@mastra/core/workspace';
+import { GCSFilesystem } from '@mastra/gcs';
+
+const workspace = new Workspace({
+  filesystem: new GCSFilesystem({
+    bucket: 'my-gcs-bucket',
+    projectId: 'my-project-id',
+    credentials: JSON.parse(process.env.GCS_SERVICE_ACCOUNT_KEY),
+  }),
+});
+
+const agent = new Agent({
+  name: 'file-agent',
+  model: 'anthropic/claude-opus-4-5',
+  workspace,
+});
+```
+
+### Using Application Default Credentials
+
+If running on Google Cloud or with `gcloud` CLI configured, you can omit credentials:
+
+```typescript
+import { GCSFilesystem } from '@mastra/gcs';
+
+const filesystem = new GCSFilesystem({
+  bucket: 'my-gcs-bucket',
+  // Uses Application Default Credentials automatically
+});
+```
+
+[Application Default Credentials (ADC)](https://cloud.google.com/docs/authentication/application-default-credentials) automatically discovers credentials in this order:
+1. `GOOGLE_APPLICATION_CREDENTIALS` environment variable (path to a service account key file)
+2. Default service account when running on GCP (Compute Engine, Cloud Run, GKE, etc.)
+3. User credentials from `gcloud auth application-default login` (for local development)
+
+### Using a Key File Path
+
+You can also pass a path to a service account key file:
+
+```typescript
+import { GCSFilesystem } from '@mastra/gcs';
+
+const filesystem = new GCSFilesystem({
+  bucket: 'my-gcs-bucket',
+  projectId: 'my-project-id',
+  credentials: '/path/to/service-account-key.json',
+});
+```
+
+## Constructor parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "bucket",
+      type: "string",
+      description: "GCS bucket name",
+    },
+    {
+      name: "projectId",
+      type: "string",
+      description: "GCS project ID. Required when using service account credentials.",
+      isOptional: true,
+    },
+    {
+      name: "credentials",
+      type: "object | string",
+      description: "Service account key JSON object or path to key file. If not provided, uses Application Default Credentials.",
+      isOptional: true,
+    },
+    {
+      name: "prefix",
+      type: "string",
+      description: "Optional prefix for all keys (acts like a subdirectory)",
+      isOptional: true,
+    },
+    {
+      name: "id",
+      type: "string",
+      description: "Unique identifier for this filesystem instance",
+      isOptional: true,
+      defaultValue: "Auto-generated",
+    },
+    {
+      name: "displayName",
+      type: "string",
+      description: "Human-friendly display name for the UI",
+      isOptional: true,
+    },
+    {
+      name: "readOnly",
+      type: "boolean",
+      description: "When true, all write operations are blocked",
+      isOptional: true,
+      defaultValue: "false",
+    },
+    {
+      name: "endpoint",
+      type: "string",
+      description: "Custom API endpoint URL. Used for local development with emulators.",
+      isOptional: true,
+    },
+  ]}
+/>
+
+## Properties
+
+<PropertiesTable
+  content={[
+    {
+      name: "id",
+      type: "string",
+      description: "Filesystem instance identifier",
+    },
+    {
+      name: "name",
+      type: "string",
+      description: "Provider name ('GCSFilesystem')",
+    },
+    {
+      name: "provider",
+      type: "string",
+      description: "Provider identifier ('gcs')",
+    },
+    {
+      name: "bucket",
+      type: "string",
+      description: "The GCS bucket name",
+    },
+    {
+      name: "readOnly",
+      type: "boolean | undefined",
+      description: "Whether the filesystem is in read-only mode",
+    },
+  ]}
+/>
+
+## Methods
+
+GCSFilesystem implements the [WorkspaceFilesystem interface](/reference/workspace/filesystem), providing all standard filesystem methods:
+
+- `readFile(path, options?)` - Read file contents
+- `writeFile(path, content, options?)` - Write content to a file
+- `appendFile(path, content)` - Append content to a file
+- `deleteFile(path, options?)` - Delete a file
+- `copyFile(src, dest, options?)` - Copy a file
+- `moveFile(src, dest, options?)` - Move or rename a file
+- `mkdir(path, options?)` - Create a directory
+- `rmdir(path, options?)` - Remove a directory
+- `readdir(path, options?)` - List directory contents
+- `exists(path)` - Check if a path exists
+- `stat(path)` - Get file or directory metadata
+
+### `init()`
+
+Initialize the filesystem. Verifies bucket access and credentials.
+
+```typescript
+await filesystem.init();
+```
+
+### `getInfo()`
+
+Returns metadata about this filesystem instance.
+
+```typescript
+const info = filesystem.getInfo();
+// { id: '...', name: 'GCSFilesystem', provider: 'gcs', status: 'ready' }
+```
+
+### `getMountConfig()`
+
+Returns the mount configuration for sandboxes that support mounting this filesystem type.
+
+```typescript
+const config = filesystem.getMountConfig();
+// { type: 'gcs', bucket: 'my-bucket', ... }
+```
+
+## Mounting in E2B Sandboxes
+
+GCSFilesystem can be mounted into E2B sandboxes, making the bucket accessible as a local directory:
+
+```typescript
+import { Workspace } from '@mastra/core/workspace';
+import { GCSFilesystem } from '@mastra/gcs';
+import { E2BSandbox } from '@mastra/e2b';
+
+const workspace = new Workspace({
+  mounts: {
+    '/data': new GCSFilesystem({
+      bucket: 'my-gcs-bucket',
+      projectId: 'my-project-id',
+      credentials: JSON.parse(process.env.GCS_SERVICE_ACCOUNT_KEY),
+    }),
+  },
+  sandbox: new E2BSandbox({ id: 'dev-sandbox' }),
+});
+```
+
+See [E2BSandbox reference](/reference/workspace/e2b-sandbox) for more details on mounting.
+
+## Related
+
+- [WorkspaceFilesystem interface](/reference/workspace/filesystem)
+- [S3Filesystem reference](/reference/workspace/s3-filesystem)
+- [E2BSandbox reference](/reference/workspace/e2b-sandbox)
+- [Workspace overview](/docs/workspace/overview)

--- a/docs/src/content/en/reference/workspace/s3-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/s3-filesystem.mdx
@@ -1,0 +1,241 @@
+---
+title: "Reference: S3Filesystem | Workspace"
+description: "Documentation for the S3Filesystem provider for Amazon S3 and S3-compatible storage."
+packages:
+  - "@mastra/s3"
+---
+
+# S3Filesystem
+
+Stores files in Amazon S3 or S3-compatible storage services like Cloudflare R2, MinIO, and DigitalOcean Spaces.
+
+:::info
+
+For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
+
+:::
+
+## Installation
+
+```bash
+npm install @mastra/s3
+```
+
+## Usage
+
+Add an `S3Filesystem` to a workspace and assign it to an agent:
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { Workspace } from '@mastra/core/workspace';
+import { S3Filesystem } from '@mastra/s3';
+
+const workspace = new Workspace({
+  filesystem: new S3Filesystem({
+    bucket: 'my-bucket',
+    region: 'us-east-1',
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  }),
+});
+
+const agent = new Agent({
+  name: 'file-agent',
+  model: 'anthropic/claude-opus-4-5',
+  workspace,
+});
+```
+
+### Cloudflare R2
+
+```typescript
+import { S3Filesystem } from '@mastra/s3';
+
+const filesystem = new S3Filesystem({
+  bucket: 'my-r2-bucket',
+  region: 'auto',
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  accessKeyId: process.env.R2_ACCESS_KEY_ID,
+  secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+});
+```
+
+### MinIO
+
+```typescript
+import { S3Filesystem } from '@mastra/s3';
+
+const filesystem = new S3Filesystem({
+  bucket: 'my-bucket',
+  region: 'us-east-1',
+  endpoint: 'http://localhost:9000',
+  accessKeyId: 'minioadmin',
+  secretAccessKey: 'minioadmin',
+});
+```
+
+## Constructor parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "bucket",
+      type: "string",
+      description: "S3 bucket name",
+    },
+    {
+      name: "region",
+      type: "string",
+      description: "AWS region (use 'auto' for R2)",
+    },
+    {
+      name: "accessKeyId",
+      type: "string",
+      description: "AWS access key ID. Optional for public buckets (read-only access).",
+      isOptional: true,
+    },
+    {
+      name: "secretAccessKey",
+      type: "string",
+      description: "AWS secret access key. Optional for public buckets (read-only access).",
+      isOptional: true,
+    },
+    {
+      name: "endpoint",
+      type: "string",
+      description: "Custom endpoint URL for S3-compatible storage (R2, MinIO, etc.)",
+      isOptional: true,
+    },
+    {
+      name: "prefix",
+      type: "string",
+      description: "Optional prefix for all keys (acts like a subdirectory)",
+      isOptional: true,
+    },
+    {
+      name: "id",
+      type: "string",
+      description: "Unique identifier for this filesystem instance",
+      isOptional: true,
+      defaultValue: "Auto-generated",
+    },
+    {
+      name: "displayName",
+      type: "string",
+      description: "Human-friendly display name for the UI",
+      isOptional: true,
+    },
+    {
+      name: "readOnly",
+      type: "boolean",
+      description: "When true, all write operations are blocked",
+      isOptional: true,
+      defaultValue: "false",
+    },
+  ]}
+/>
+
+## Properties
+
+<PropertiesTable
+  content={[
+    {
+      name: "id",
+      type: "string",
+      description: "Filesystem instance identifier",
+    },
+    {
+      name: "name",
+      type: "string",
+      description: "Provider name ('S3Filesystem')",
+    },
+    {
+      name: "provider",
+      type: "string",
+      description: "Provider identifier ('s3')",
+    },
+    {
+      name: "bucket",
+      type: "string",
+      description: "The S3 bucket name",
+    },
+    {
+      name: "readOnly",
+      type: "boolean | undefined",
+      description: "Whether the filesystem is in read-only mode",
+    },
+  ]}
+/>
+
+## Methods
+
+S3Filesystem implements the [WorkspaceFilesystem interface](/reference/workspace/filesystem), providing all standard filesystem methods:
+
+- `readFile(path, options?)` - Read file contents
+- `writeFile(path, content, options?)` - Write content to a file
+- `appendFile(path, content)` - Append content to a file
+- `deleteFile(path, options?)` - Delete a file
+- `copyFile(src, dest, options?)` - Copy a file
+- `moveFile(src, dest, options?)` - Move or rename a file
+- `mkdir(path, options?)` - Create a directory
+- `rmdir(path, options?)` - Remove a directory
+- `readdir(path, options?)` - List directory contents
+- `exists(path)` - Check if a path exists
+- `stat(path)` - Get file or directory metadata
+
+### `init()`
+
+Initialize the filesystem. Verifies bucket access and credentials.
+
+```typescript
+await filesystem.init();
+```
+
+### `getInfo()`
+
+Returns metadata about this filesystem instance.
+
+```typescript
+const info = filesystem.getInfo();
+// { id: '...', name: 'S3Filesystem', provider: 's3', status: 'ready' }
+```
+
+### `getMountConfig()`
+
+Returns the mount configuration for sandboxes that support mounting this filesystem type.
+
+```typescript
+const config = filesystem.getMountConfig();
+// { type: 's3', bucket: 'my-bucket', region: 'us-east-1', ... }
+```
+
+## Mounting in E2B Sandboxes
+
+S3Filesystem can be mounted into E2B sandboxes, making the bucket accessible as a local directory:
+
+```typescript
+import { Workspace } from '@mastra/core/workspace';
+import { S3Filesystem } from '@mastra/s3';
+import { E2BSandbox } from '@mastra/e2b';
+
+const workspace = new Workspace({
+  mounts: {
+    '/data': new S3Filesystem({
+      bucket: 'my-bucket',
+      region: 'us-east-1',
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    }),
+  },
+  sandbox: new E2BSandbox({ id: 'dev-sandbox' }),
+});
+```
+
+See [E2BSandbox reference](/reference/workspace/e2b-sandbox) for more details on mounting.
+
+## Related
+
+- [WorkspaceFilesystem interface](/reference/workspace/filesystem)
+- [GCSFilesystem reference](/reference/workspace/gcs-filesystem)
+- [E2BSandbox reference](/reference/workspace/e2b-sandbox)
+- [Workspace overview](/docs/workspace/overview)


### PR DESCRIPTION
## Summary

Adds reference documentation for the new workspace provider packages:

- **E2BSandbox** - Cloud sandbox provider with custom templates and FUSE mounting support
- **S3Filesystem** - Amazon S3 and S3-compatible storage (R2, MinIO)
- **GCSFilesystem** - Google Cloud Storage with ADC support

Also updates the existing workspace docs to mention the new providers and adds the pages to the sidebar navigation.

## Test plan

- [ ] Verify docs build locally
- [ ] Check new pages render correctly
- [ ] Verify sidebar links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive reference documentation for three new workspace providers: E2BSandbox, S3Filesystem, and GCSFilesystem.
  * Updated filesystem provider guides to include cloud storage integration options.
  * Enhanced navigation with new provider references in documentation sidebars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->