### PR TITLE
fix(editor): register stored scorers on Mastra instance

### DIFF
--- a/.changeset/famous-poems-rule.md
+++ b/.changeset/famous-poems-rule.md
@@ -1,0 +1,6 @@
+---
+'@mastra/editor': patch
+'@mastra/core': patch
+---
+
+Fixed stored scorers not being registered on the Mastra instance. Scorers created via the editor are now automatically discoverable through `mastra.getScorer()` and `mastra.getScorerById()`, matching the existing behavior of stored agents. Previously, stored scorers could only be resolved inline but were invisible to the runtime registry, causing lookups to fail.

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -190,6 +190,12 @@ class MastraScorer<
   #mastra?: Mastra;
   #rawConfig?: Record<string, unknown>;
 
+  /**
+   * Tracks whether this scorer was defined in code or loaded from storage.
+   * Set by `Mastra.addScorer()` when the `source` option is provided.
+   */
+  public source?: 'code' | 'stored';
+
   constructor(
     public config: ScorerConfig<TID, TInput, TRunOutput>,
     private steps: Array<ScorerStepDefinition> = [],

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -339,6 +339,8 @@ export class Mastra<
   #serverCache: MastraServerCache;
   // Cache for stored agents to allow in-memory modifications (like model changes) to persist across requests
   #storedAgentsCache: Map<string, Agent> = new Map();
+  // Cache for stored scorers to allow in-memory modifications to persist across requests
+  #storedScorersCache: Map<string, MastraScorer<any, any, any, any>> = new Map();
   // Registry for prompt blocks (stored or code-defined)
   #promptBlocks: Record<string, StorageResolvedPromptBlockType> = {};
   // Editor instance for handling agent instantiation and configuration
@@ -386,6 +388,14 @@ export class Mastra<
    */
   public getStoredAgentCache() {
     return this.#storedAgentsCache;
+  }
+
+  /**
+   * Gets the stored scorers cache
+   * @internal
+   */
+  public getStoredScorerCache() {
+    return this.#storedScorersCache;
   }
 
   /**
@@ -1485,7 +1495,11 @@ export class Mastra<
    * mastra.addScorer(newScorer, 'customKey'); // Uses custom key
    * ```
    */
-  public addScorer<S extends MastraScorer<any, any, any, any>>(scorer: S, key?: string): void {
+  public addScorer<S extends MastraScorer<any, any, any, any>>(
+    scorer: S,
+    key?: string,
+    options?: { source?: 'code' | 'stored' },
+  ): void {
     if (!scorer) {
       throw createUndefinedPrimitiveError('scorer', scorer, key);
     }
@@ -1499,6 +1513,11 @@ export class Mastra<
 
     // Register Mastra instance with scorer to enable custom gateway access
     scorer.__registerMastra(this);
+
+    // Set the source if provided
+    if (options?.source) {
+      scorer.source = options.source;
+    }
 
     scorers[scorerKey] = scorer;
   }
@@ -1610,14 +1629,24 @@ export class Mastra<
 
     // Try direct key lookup first
     if (scorers[keyOrId]) {
+      const scorerId = scorers[keyOrId]?.id;
       delete scorers[keyOrId];
+      // Clear from stored scorers cache to prevent stale data
+      if (scorerId) {
+        this.#storedScorersCache.delete(scorerId);
+      }
       return true;
     }
 
     // Try finding by ID or name
     const key = Object.keys(scorers).find(k => scorers[k]?.id === keyOrId || scorers[k]?.name === keyOrId);
     if (key) {
+      const scorerId = scorers[key]?.id;
       delete scorers[key];
+      // Clear from stored scorers cache to prevent stale data
+      if (scorerId) {
+        this.#storedScorersCache.delete(scorerId);
+      }
       return true;
     }
 

--- a/packages/editor/src/namespaces/scorer.ts
+++ b/packages/editor/src/namespaces/scorer.ts
@@ -24,6 +24,21 @@ export class EditorScorerNamespace extends CrudEditorNamespace<
     this.mastra?.removeScorer(id);
   }
 
+  /**
+   * Hydrate a stored scorer definition into a runtime MastraScorer instance
+   * and register it on the Mastra instance so it can be discovered via
+   * `mastra.getScorer()` / `mastra.getScorerById()`.
+   */
+  protected override async hydrate(
+    storedScorer: StorageResolvedScorerDefinitionType,
+  ): Promise<StorageResolvedScorerDefinitionType> {
+    const scorer = this.resolve(storedScorer);
+    if (scorer && this.mastra) {
+      this.mastra.addScorer(scorer, storedScorer.id, { source: 'stored' });
+    }
+    return storedScorer;
+  }
+
   protected async getStorageAdapter(): Promise<
     StorageAdapter<
       StorageCreateScorerDefinitionInput,


### PR DESCRIPTION
Stored scorers created via the editor weren't being added to the Mastra instance's runtime registry, so `mastra.getScorer()` and `mastra.getScorerById()` couldn't find them. This worked fine for stored agents but was missing for scorers.

Now when a stored scorer is fetched or created through the editor, it gets resolved into a `MastraScorer` and registered on the Mastra instance automatically. Updates and deletes properly evict and re-register too.

```ts
// This now works for stored scorers (previously only worked for code-defined ones)
const scorer = mastra.getScorerById('my-stored-scorer');
await scorer.score({ input: 'question', output: 'answer' });
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stored scorers to be properly registered on the Mastra instance and discoverable via `getScorer()` and `getScorerById()` methods, aligning functionality with stored agents. Previously, stored scorers created in the editor were only resolvable inline and not visible to the runtime registry.

* **New Features**
  * Added source tracking to indicate whether scorers were defined in code or loaded from storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->