### PR TITLE
fix(editor): move agent cloning from Agent class to editor package

### DIFF
--- a/.changeset/witty-rooms-drop.md
+++ b/.changeset/witty-rooms-drop.md
@@ -1,0 +1,22 @@
+---
+'@mastra/core': minor
+'@mastra/editor': minor
+'@mastra/server': patch
+---
+
+**Breaking:** Removed `cloneAgent()` from the `Agent` class. Agent cloning is now handled by the editor package via `editor.agent.clone()`.
+
+If you were calling `agent.cloneAgent()` directly, use the editor's agent namespace instead:
+
+```ts
+// Before
+const result = await agent.cloneAgent({ newId: 'my-clone' });
+
+// After
+const editor = mastra.getEditor();
+const result = await editor.agent.clone(agent, { newId: 'my-clone' });
+```
+
+**Why:** The `Agent` class should not be responsible for storage serialization. The editor package already handles converting between runtime agents and stored configurations, so cloning belongs there.
+
+**Added** `getConfiguredProcessorIds()` to the `Agent` class, which returns raw input/output processor IDs for the agent's configuration.

--- a/packages/core/src/editor/types.ts
+++ b/packages/core/src/editor/types.ts
@@ -2,6 +2,7 @@ import type { Agent } from '../agent';
 import type { MastraScorer } from '../evals';
 import type { IMastraLogger } from '../logger';
 import type { Mastra } from '../mastra';
+import type { RequestContext } from '../request-context';
 import type {
   AgentInstructionBlock,
   StorageCreateAgentInput,
@@ -9,6 +10,7 @@ import type {
   StorageListAgentsInput,
   StorageListAgentsOutput,
   StorageListAgentsResolvedOutput,
+  StorageResolvedAgentType,
   StorageCreatePromptBlockInput,
   StorageUpdatePromptBlockInput,
   StorageListPromptBlocksInput,
@@ -46,6 +48,16 @@ export interface IEditorAgentNamespace {
   list(args?: StorageListAgentsInput): Promise<StorageListAgentsOutput>;
   listResolved(args?: StorageListAgentsInput): Promise<StorageListAgentsResolvedOutput>;
   clearCache(agentId?: string): void;
+  clone(
+    agent: Agent,
+    options: {
+      newId: string;
+      newName?: string;
+      metadata?: Record<string, unknown>;
+      authorId?: string;
+      requestContext?: RequestContext;
+    },
+  ): Promise<StorageResolvedAgentType>;
 }
 
 // ============================================================================

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -835,11 +835,16 @@ export const CLONE_AGENT_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ agentId, mastra, newId, newName, metadata, authorId, requestContext }) => {
     try {
+      const editor = mastra.getEditor();
+      if (!editor) {
+        return handleError(new Error('Editor is not configured on the Mastra instance'), 'Error cloning agent');
+      }
+
       const agent = await getAgentFromSystem({ mastra, agentId });
 
       const cloneId = toSlug(newId || `${agentId}-clone`);
 
-      const result = await agent.cloneAgent({
+      const result = await editor.agent.clone(agent, {
         newId: cloneId,
         newName,
         metadata,


### PR DESCRIPTION
Moves `cloneAgent()` out of the `Agent` class and into `EditorAgentNamespace` as `clone()`. The Agent class shouldn't own storage serialization logic — the editor package already handles converting between runtime agents and stored configs, so cloning belongs there.

```ts
// before
const result = await agent.cloneAgent({ newId: 'my-clone' });

// after
const editor = mastra.getEditor();
const result = await editor.agent.clone(agent, { newId: 'my-clone' });
```

Also adds `getConfiguredProcessorIds()` to the Agent class so the editor can access raw processor IDs without touching private fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `Agent.cloneAgent()` method. Use `editor.agent.clone(agent, { newId: '...' })` instead.

* **New Features**
  * Agent cloning now available through the editor package with improved configuration handling.
  * Added `getConfiguredProcessorIds()` method to retrieve configured processor identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->