### PR TITLE
fix(core): update memory loggers in setLogger

### DIFF
--- a/.changeset/memory-logger-fix.md
+++ b/.changeset/memory-logger-fix.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+fix(core): update memory loggers in setLogger
+
+When calling `mastra.setLogger()`, memory instances were not being updated
+with the new logger. This caused memory-related errors to be logged via the
+default ConsoleLogger instead of the configured logger.

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -2374,6 +2374,12 @@ export class Mastra<
       this.#workspace.__setLogger(this.#logger);
     }
 
+    if (this.#memory) {
+      Object.keys(this.#memory).forEach(key => {
+        this.#memory?.[key]?.__setLogger(this.#logger);
+      });
+    }
+
     this.#observability.setLogger({ logger: this.#logger });
   }
 


### PR DESCRIPTION
## Summary
- Adds memory logger updates to `mastra.setLogger()` method
- Memory instances were not being updated with the new logger when `setLogger` was called
- This caused memory-related errors to be logged via the default ConsoleLogger instead of the configured logger

## Test plan
- [x] Build passes (`pnpm build:core`)
- [x] TypeScript type check passes
- [ ] Create a Mastra instance with memory
- [ ] Call `setLogger()` with a custom logger
- [ ] Trigger a memory error
- [ ] Verify error appears in custom logger output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where memory logs were not using the logger configured via `setLogger()`. Memory logs are now properly directed to your configured logger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->