### PR TITLE
fix(ci): don't fail prepack docs generation in E2E tests

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -80,6 +80,7 @@ jobs:
         run: pnpm publish -r --tag ${{ steps.determine-tag.outputs.tag }} --access public --no-git-checks
         env:
           NPM_CONFIG_PROVENANCE: true
+          REQUIRE_PACKAGE_DOCS: 'true'
 
   # ===========================================
   # STABLE RELEASE: Manual trigger only
@@ -169,6 +170,7 @@ jobs:
         run: pnpm publish -r --access public --no-git-checks
         env:
           NPM_CONFIG_PROVENANCE: true
+          REQUIRE_PACKAGE_DOCS: 'true'
 
       - name: Updated alpha versions
         if: ${{ !inputs.dry_run }}
@@ -341,3 +343,4 @@ jobs:
         run: pnpm publish -r --no-git-checks --tag ${{ env.FINAL_TAG }} --access public
         env:
           NPM_CONFIG_PROVENANCE: true
+          REQUIRE_PACKAGE_DOCS: 'true'

--- a/scripts/generate-package-docs.ts
+++ b/scripts/generate-package-docs.ts
@@ -375,7 +375,7 @@ function main(): void {
 try {
   main();
 } catch (error) {
-  if (process.env.CI) {
+  if (process.env.REQUIRE_PACKAGE_DOCS) {
     console.error('Failed to generate package docs:', error);
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

- PR #12836 moved docs generation from build-time to `prepack` hooks. This causes E2E tests to fail because they publish packages to a local Verdaccio registry, which triggers `prepack`, and the script hard-fails in CI when `docs/build/llms-manifest.json` is missing.
- Replace the broad `process.env.CI` check with `process.env.REQUIRE_PACKAGE_DOCS`, which is only set in `npm-publish.yml` publish steps
- E2E tests and local dev now gracefully skip docs generation when the manifest is missing, while real npm publishes still enforce it

## Test plan

- [ ] E2E tests (create-mastra, commonjs, no-bundling, monorepo) should pass in CI now that prepack doesn't hard-fail
- [ ] npm-publish workflow still enforces docs generation via `REQUIRE_PACKAGE_DOCS` env var

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm publish workflow to enforce package documentation generation as a required step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->