### PR TITLE
fix(core): add missing getDefaultOptions mock in network tests

### DIFF
--- a/packages/core/src/loop/network/index.test.ts
+++ b/packages/core/src/loop/network/index.test.ts
@@ -110,6 +110,7 @@ describe('getRoutingAgent', () => {
         getInputProcessors: vi.fn().mockResolvedValue([]),
         getOutputProcessors: vi.fn().mockResolvedValue([]),
       }),
+      getDefaultOptions: vi.fn().mockResolvedValue({}),
       // New methods for configured-only processors
       listConfiguredInputProcessors: vi.fn().mockResolvedValue(configuredInputProcessors),
       listConfiguredOutputProcessors: vi.fn().mockResolvedValue(configuredOutputProcessors),


### PR DESCRIPTION
## Summary

- PR #12821 added a call to `agent.getDefaultOptions()` in `getRoutingAgent` but didn't update the test mock in `src/loop/network/index.test.ts`
- This caused 8 test failures: `TypeError: agent.getDefaultOptions is not a function`
- Adds the missing `getDefaultOptions` mock to `createMockAgent()`

## Test plan

- [x] `pnpm vitest run src/loop/network/index.test.ts` — all 36 tests pass (18 tests × 2 configs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure to improve coverage for default options handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->