### PR TITLE
fix(core): fix tree-formatter sort order and save-and-errors test assertion

### DIFF
--- a/packages/core/src/agent/__tests__/save-and-errors.test.ts
+++ b/packages/core/src/agent/__tests__/save-and-errors.test.ts
@@ -625,16 +625,12 @@ function saveAndErrorTests(version: 'v1' | 'v2') {
     });
 
     it('should save thread but not messages if error occurs during LLM generation', async () => {
-      // v2: Threads are now created upfront to prevent race conditions with storage backends
-      // like PostgresStore that validate thread existence before saving messages.
-      // When an error occurs during LLM generation, the thread will exist but no messages
-      // will be saved since the response never completed.
-      //
-      // v1 (legacy): Does not use memory processors, so the old behavior applies where
-      // threads are not saved until the request completes successfully.
+      // Both v1 and v2: Threads are now created upfront to prevent race conditions with
+      // storage backends like PostgresStore that validate thread existence before saving
+      // messages. When an error occurs during LLM generation, the thread will exist but
+      // no messages will be saved since the response never completed.
       const mockMemory = new MockMemory();
       const saveMessagesSpy = vi.spyOn(mockMemory, 'saveMessages');
-      const saveThreadSpy = vi.spyOn(mockMemory, 'saveThread');
 
       let errorModel: MockLanguageModelV1 | MockLanguageModelV2;
       if (version === 'v1') {
@@ -691,17 +687,12 @@ function saveAndErrorTests(version: 'v1' | 'v2') {
 
       const thread = await mockMemory.getThreadById({ threadId: 'thread-err' });
 
-      if (version === 'v1') {
-        // v1 (legacy): Thread should NOT exist - old behavior preserved
-        expect(saveThreadSpy).not.toHaveBeenCalled();
-        expect(thread).toBeNull();
-      } else {
-        // v2: Thread should exist (created upfront to prevent race condition)
-        expect(thread).not.toBeNull();
-        expect(thread?.id).toBe('thread-err');
-        // But no messages should be saved since the LLM call failed
-        expect(saveMessagesSpy).not.toHaveBeenCalled();
-      }
+      // Both v1 and v2: Thread should exist (created upfront to prevent race conditions
+      // with storage backends like PostgresStore that validate thread existence before saving messages)
+      expect(thread).not.toBeNull();
+      expect(thread?.id).toBe('thread-err');
+      // But no messages should be saved since the LLM call failed
+      expect(saveMessagesSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/workspace/tools/tree-formatter.test.ts
+++ b/packages/core/src/workspace/tools/tree-formatter.test.ts
@@ -66,13 +66,13 @@ describe('tree-formatter', () => {
 
       const result = await formatAsTree(filesystem, '/');
 
-      // Directories first, then files, all case-insensitive alphabetical (to match native tree)
+      // Directories first, then files, all ASCII alphabetical (to match native tree's strcmp)
       expect(result.tree).toBe(
         `.
 ├── src
 │   └── index.ts
-├── package.json
-└── README.md`,
+├── README.md
+└── package.json`,
       );
       expect(result.dirCount).toBe(1);
       expect(result.fileCount).toBe(3);

--- a/packages/core/src/workspace/tools/tree-formatter.ts
+++ b/packages/core/src/workspace/tools/tree-formatter.ts
@@ -141,11 +141,11 @@ export async function formatAsTree(fs: WorkspaceFilesystem, path: string, option
       });
     }
 
-    // Sort: directories first, then case-insensitive alphabetically (to match native tree)
+    // Sort: directories first, then alphabetically (ASCII order to match native tree's strcmp)
     filtered.sort((a, b) => {
       if (a.type === 'directory' && b.type !== 'directory') return -1;
       if (a.type !== 'directory' && b.type === 'directory') return 1;
-      return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+      return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
     });
 
     for (let i = 0; i < filtered.length; i++) {
@@ -234,11 +234,11 @@ export function formatEntriesAsTree(entries: Array<{ name: string; type: 'file' 
 
   function renderNode(node: TreeNode, prefix: string): void {
     const children = Array.from(node.children.values());
-    // Sort: directories first, then case-insensitive alphabetically (to match native tree)
+    // Sort: directories first, then alphabetically (ASCII order to match native tree's strcmp)
     children.sort((a, b) => {
       if (a.type === 'directory' && b.type !== 'directory') return -1;
       if (a.type !== 'directory' && b.type === 'directory') return 1;
-      return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+      return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
     });
 
     for (let i = 0; i < children.length; i++) {


### PR DESCRIPTION
Tree-formatter was using `localeCompare` with `sensitivity: 'base'` which gives different ordering than native `tree`'s strcmp on Linux. For example, `package.json` sorted before `README.md` because lowercase `p` < lowercase `r`, but ASCII order puts `R` (82) before `p` (112). Reverted both `formatAsTree` and `formatEntriesAsTree` to use ASCII comparison:

```ts
// before
return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });

// after
return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
```

Also fixed the `save-and-errors` test — the v1 branch expected `saveThread` not to be called when LLM errors, but `agent-legacy.ts` now creates threads upfront with `saveThread: true` (matching v2 behavior). Unified the assertion for both versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Unified error handling test expectations across versioned models
  * Updated file tree ordering test expectations

* **Refactor**
  * Changed file tree sorting from locale-sensitive to ASCII-based ordering with directories listed first

<!-- end of auto-generated comment: release notes by coderabbit.ai -->