### PR TITLE
fix(core): prevent typecheck project from running all test files

### DIFF
--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
         test: {
           name: 'typecheck:packages/core',
           environment: 'node',
+          include: [],
           typecheck: {
             enabled: true,
             include: ['src/**/*.test-d.ts'],


### PR DESCRIPTION
The typecheck vitest project had no `test.include` at the project level, so it defaulted to running every `.test.ts` file (190 files, ~91s) on top of the intended `.test-d.ts` type-check files. This duplicated the entire unit test suite under a 5s default timeout, causing 9 extra test file failures in CI.

Before:
```
Test Files  8 failed | 182 passed (190)
Duration    91.27s (tests 694.07s)
```

After (adding `include: []`):
```
Test Files  7 passed (7)
Duration    8.03s (tests 0.26s)
```

Introduced in #12662 alongside the `isolate: false` change — the `include` omission was an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration settings to adjust test file discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->