### PR TITLE
chore(ci): use --frozen-lockfile in CI installs

### DIFF
--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -29,4 +29,4 @@ runs:
     - name: Install dependencies
       if: ${{ inputs.install-dependencies == 'true' }}
       shell: bash
-      run: pnpm install
+      run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Adds `--frozen-lockfile` to the shared `setup-pnpm-node` GitHub Action so CI test/build workflows always install exactly what's in the committed lockfile
- Without this flag, `pnpm install` is free to re-resolve transitive dependencies on each run, meaning two runs of the same commit can produce different `node_modules` layouts if any transitive dep published a new patch between runs
- This is a one-line change in `.github/actions/setup-pnpm-node/action.yaml`

## Workflows using the shared action (affected by this change)

- `vitest-changed.yml` (7 jobs)
- `lint.yml` (4 jobs)
- `secrets.test-core.yml`
- `secrets.test-memory.yml`
- `secrets.test-mcp.yml`
- `secrets.test-agent-builder.yml`
- `secrets.test-rag.yml`
- `secrets.test-combined-stores.yml`
- `secrets.test-observability.yml`
- `secrets.test-workspaces.yml`
- `secrets.tool-builder-test.yml`
- `test-auth.yml`
- `test-cli.yml`
- `test-server.yml`
- `test-server-adapters.yml`
- `test-client-ai-sdk.yml`
- `test-client-js.yml`
- `test-client-react.yml`
- `test-deployer.yml`
- `test-editor.yml`
- `test-evals.yml`
- `test-docs-mcp.yml`
- `test-schema-compat.yml`
- `test-workspaces.yml`
- `bird-checker-eval.yml`
- `prebuild.yml`
- `validate-docs-frontmatter.yml`
- `check-redirects.yml`
- `regenerate-provider-registry.yml`
- `sync-templates.yml`
- `sync_renovate-changesets.yml`
- `version-packages.yml`
- `backport-auto.yml`

## Workflows NOT using the shared action (not affected)

These have their own `pnpm install` calls and are intentionally left as-is because they run installs after version bumps or publish steps where the lockfile is expected to be out of date:

- `npm-publish.yml` — 6 bare `pnpm install` calls (pre/post publish steps)
- `create-release.yml` — 4 bare `pnpm install` calls (release flow)
- `secrets.e2e.yml` — 8 bare `pnpm install` calls (local Verdaccio publish)

Additionally, several workflows have `pnpm install --ignore-workspace` calls for integration test subdirectories that use their own lockfiles — these are unrelated to the monorepo lockfile.

## Why this matters

- Ensures CI test/build runs are deterministic and reproducible
- If someone changes `package.json` but forgets to run `pnpm install` locally, CI will fail fast instead of silently resolving a different lockfile
- Eliminates a class of flaky test failures caused by non-deterministic dependency resolution (see #12916 for context on `@ai-sdk/provider-utils` version sprawl)

## Test plan

- [ ] CI workflows pass with `--frozen-lockfile` (confirms the committed lockfile is up to date)
- [ ] If a future PR modifies `package.json` without updating the lockfile, CI should fail with a clear error