### PR TITLE
fix: remove isolate: false from server adapter vitest configs

### DIFF
--- a/server-adapters/express/vitest.config.ts
+++ b/server-adapters/express/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     name: 'unit:server-adapters/express',
-    isolate: false,
     environment: 'node',
     include: ['src/**/*.test.ts'],
     coverage: {

--- a/server-adapters/fastify/vitest.config.ts
+++ b/server-adapters/fastify/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     name: 'unit:server-adapters/fastify',
-    isolate: false,
     environment: 'node',
     include: ['src/**/*.test.ts'],
     coverage: {

--- a/server-adapters/hono/vitest.config.ts
+++ b/server-adapters/hono/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     name: 'unit:server-adapters/hono',
-    isolate: false,
     environment: 'node',
     include: ['src/**/*.test.ts'],
     coverage: {

--- a/server-adapters/koa/vitest.config.ts
+++ b/server-adapters/koa/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     name: 'unit:server-adapters/koa',
-    isolate: false,
     environment: 'node',
     include: ['src/**/*.test.ts'],
     coverage: {


### PR DESCRIPTION
## Summary

- Remove `isolate: false` from vitest configs in all 4 server adapter packages (koa, fastify, hono, express)
- Non-isolated test runs can cause mock/module state leakage between test files, leading to flaky CI failures
- All 4 test suites pass with isolation enabled (~5,370 tests)

## Test plan

- [x] Verified koa tests pass (1,341 tests)
- [x] Verified fastify tests pass (1,343 tests)
- [x] Verified hono tests pass (1,345 tests)
- [x] Verified express tests pass (1,341 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test isolation configuration across server adapters to use default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->