### PR TITLE
fix: fix server and deployer test failures from isolate:false mock leakage

### DIFF
--- a/packages/deployer/vitest.config.ts
+++ b/packages/deployer/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     name: 'unit:packages/deployer',
-    isolate: false,
     environment: 'node',
     include: ['src/**/*.test.ts'],
   },

--- a/packages/server/src/server/handlers/agents.test.ts
+++ b/packages/server/src/server/handlers/agents.test.ts
@@ -95,6 +95,8 @@ describe('getProvidersHandler', () => {
     // Set some API keys
     process.env.OPENAI_API_KEY = 'test-key';
     process.env.ANTHROPIC_API_KEY = 'test-key';
+    // Ensure Google is not connected
+    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
 
     const result = await GET_PROVIDERS_ROUTE.handler({});
 
@@ -114,7 +116,7 @@ describe('getProvidersHandler', () => {
     // Clear all API keys
     delete process.env.OPENAI_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;
-    delete process.env.GOOGLE_API_KEY;
+    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
 
     const result = await GET_PROVIDERS_ROUTE.handler({});
 
@@ -208,7 +210,7 @@ describe('isProviderConnected', () => {
     // Clear all API keys
     delete process.env.OPENAI_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;
-    delete process.env.GOOGLE_API_KEY;
+    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
   });
 
   afterEach(() => {

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -5,6 +5,5 @@ export default defineConfig({
     name: 'unit:packages/server',
     environment: 'node',
     include: ['src/**/*.test.ts'],
-    isolate: false,
   },
 });


### PR DESCRIPTION
## Summary

- Remove `isolate: false` from server and deployer vitest configs to fix cross-file `vi.mock` leakage (same root cause as core #12919)
- Fix `agents.test.ts` to use `GOOGLE_GENERATIVE_AI_API_KEY` instead of `GOOGLE_API_KEY`

### Server (6 failures fixed)
The `agents.test.ts` Proxy mock for `PROVIDER_REGISTRY` (custom gateway provider tests) was being corrupted by other test files' mocks leaking across the shared module cache.

### Deployer (1 failure fixed)
`swagger-openapi-warning.test.ts` and `option-studio-base.test.ts` mock `healthHandler` to return `{ status: 'ok' }`, which leaked into `server-app-access.test.ts` that expects `{ success: true }`.

### Env var fix
The provider registry defines Google's env var as `GOOGLE_GENERATIVE_AI_API_KEY`, but tests were clearing `GOOGLE_API_KEY`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Google provider connectivity tests with renamed API key environment variable.

* **Chores**
  * Reverted test execution isolation configuration to defaults across test runner setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->