### PR TITLE
fix: use @ai-sdk/provider-v4 alias in mock-model import

### DIFF
--- a/packages/core/src/agent/__tests__/mock-model.ts
+++ b/packages/core/src/agent/__tests__/mock-model.ts
@@ -1,7 +1,7 @@
 import { openai as openai_v4 } from '@ai-sdk/openai';
 import { openai as openai_v5 } from '@ai-sdk/openai-v5';
 import { openai as openai_v6 } from '@ai-sdk/openai-v6';
-import type { LanguageModelV1 } from '@ai-sdk/provider';
+import type { LanguageModelV1 } from '@ai-sdk/provider-v4';
 import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
 import type { LanguageModelV3 } from '@ai-sdk/provider-v6';
 import { simulateReadableStream } from '@internal/ai-sdk-v4';


### PR DESCRIPTION
## Summary

- Fix import in `packages/core/src/agent/__tests__/mock-model.ts` to use `@ai-sdk/provider-v4` instead of `@ai-sdk/provider`
- The monorepo aliases `@ai-sdk/provider@1.x` as `@ai-sdk/provider-v4` — using the bare package name causes a vitest TypeCheckError

## Test plan

- [x] Tests importing from mock-model pass without TypeCheckError

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal type import source to maintain compatibility with provider dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->