### PR TITLE
fix(playground-ui): only persist experiment prompt to localStorage when edited

### DIFF
--- a/.changeset/fix-prompt-experiment-localstorage.md
+++ b/.changeset/fix-prompt-experiment-localstorage.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fix prompt experiment localStorage persisting stale prompts: only save to localStorage when the user edits the prompt away from the code-defined value, and clear it when they match. Previously, the code-defined prompt was eagerly saved on first load, causing code changes to agent instructions to be ignored.

--- a/packages/playground-ui/src/domains/agents/context/agent-prompt-experiment-context.tsx
+++ b/packages/playground-ui/src/domains/agents/context/agent-prompt-experiment-context.tsx
@@ -39,20 +39,35 @@ export const AgentPromptExperimentProvider = ({
   useEffect(() => {
     const storedPrompt = localStorage.getItem(`agent-prompt-experiment-${agentId}`);
 
-    setPrompt(storedPrompt ?? initialPromptText);
+    // Only use stored prompt if it differs from code-defined prompt (intentional edit).
+    // If stored prompt equals the old code-defined prompt, the code has changed
+    // underneath us and we should use the new code-defined value instead.
+    if (storedPrompt && storedPrompt !== initialPromptText) {
+      setPrompt(storedPrompt);
+    } else {
+      localStorage.removeItem(`agent-prompt-experiment-${agentId}`);
+      setPrompt(initialPromptText);
+    }
   }, [agentId, initialPromptText]);
 
+  // Only persist to localStorage when the user has actually edited the prompt
+  // away from the code-defined value. If the prompt matches the code, clear
+  // localStorage so the code-defined value always wins on next load.
   useEffect(() => {
     if (!prompt) return;
 
-    localStorage.setItem(`agent-prompt-experiment-${agentId}`, prompt);
-  }, [prompt, agentId]);
+    if (prompt !== initialPromptText) {
+      localStorage.setItem(`agent-prompt-experiment-${agentId}`, prompt);
+    } else {
+      localStorage.removeItem(`agent-prompt-experiment-${agentId}`);
+    }
+  }, [prompt, agentId, initialPromptText]);
 
   const isDirty = prompt !== initialPromptText;
 
   const resetPrompt = () => {
     setPrompt(initialPromptText);
-    localStorage.setItem(`agent-prompt-experiment-${agentId}`, initialPromptText);
+    localStorage.removeItem(`agent-prompt-experiment-${agentId}`);
   };
 
   return (


### PR DESCRIPTION
The prompt experiment context was eagerly saving the code-defined prompt to localStorage on first load. This meant changing agent instructions in code had no effect — localStorage always won, even after deleting the database, rebuilding, and reinstalling node_modules.

Now localStorage is only written when the prompt actually differs from the code-defined value.

Before:
```tsx
// saved to localStorage on every load, even when unchanged
setPrompt(storedPrompt ?? initialPromptText);

useEffect(() => {
  if (!prompt) return;
  localStorage.setItem(`agent-prompt-experiment-${agentId}`, prompt);
}, [prompt, agentId]);
```

After:
```tsx
// only use stored prompt if it was intentionally edited
if (storedPrompt && storedPrompt !== initialPromptText) {
  setPrompt(storedPrompt);
} else {
  localStorage.removeItem(`agent-prompt-experiment-${agentId}`);
  setPrompt(initialPromptText);
}

// only persist if prompt differs from code
if (prompt !== initialPromptText) {
  localStorage.setItem(`agent-prompt-experiment-${agentId}`, prompt);
} else {
  localStorage.removeItem(`agent-prompt-experiment-${agentId}`);
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prompt experiment storage behavior to prevent outdated stored prompts from overriding newly updated code defaults. User customizations are now correctly preserved separate from defaults, ensuring code updates to agent instructions are respected while manual edits persist, and resets properly clear stored data to revert to current defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->