### PR TITLE
feat(playground-ui): create sub-agents on-the-fly via SideDialog

### DIFF
--- a/.changeset/shaggy-badgers-move.md
+++ b/.changeset/shaggy-badgers-move.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added ability to create sub-agents on-the-fly via a SideDialog in the Sub-Agents section of the agent editor

--- a/packages/playground-ui/src/domains/agents/components/agent-create-content.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-create-content.tsx
@@ -1,0 +1,157 @@
+import { useRef } from 'react';
+
+import type { CreateStoredAgentParams } from '@mastra/client-js';
+
+import { toast } from '@/lib/toast';
+
+import { AgentEditLayout } from './agent-edit-page/agent-edit-layout';
+import { AgentEditSidebar } from './agent-edit-page/agent-edit-sidebar';
+import { AgentEditMainContentBlocks } from './agent-edit-page/agent-edit-main-blocks';
+import { useAgentEditForm } from './agent-edit-page/use-agent-edit-form';
+import { useStoredAgentMutations } from '../hooks/use-stored-agents';
+
+interface AgentCreateContentProps {
+  onSuccess?: (agent: { id: string }) => void;
+  hideSubAgentCreate?: boolean;
+}
+
+export function AgentCreateContent({ onSuccess, hideSubAgentCreate }: AgentCreateContentProps) {
+  const { createStoredAgent } = useStoredAgentMutations();
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const { form } = useAgentEditForm();
+
+  const handlePublish = async () => {
+    const isValid = await form.trigger();
+    if (!isValid) {
+      toast.error('Please fill in all required fields');
+      return;
+    }
+
+    const values = form.getValues();
+
+    try {
+      const formScorers = values.scorers ? Object.entries(values.scorers) : undefined;
+      const scorers = formScorers
+        ? Object.fromEntries(
+            formScorers.map(([key, value]) => [
+              key,
+              {
+                description: value.description,
+                sampling: value.sampling
+                  ? {
+                      type: value.sampling.type,
+                      rate: value.sampling.rate || 0,
+                    }
+                  : undefined,
+              },
+            ]),
+          )
+        : undefined;
+
+      const createParams: CreateStoredAgentParams = {
+        name: values.name,
+        description: values.description || undefined,
+        instructions: (values.instructionBlocks ?? []).map(block => ({
+          type: block.type,
+          content: block.content,
+          rules: block.rules,
+        })),
+        model: values.model,
+        tools: values.tools && Object.keys(values.tools).length > 0 ? values.tools : undefined,
+        workflows:
+          values.workflows && Object.keys(values.workflows).length > 0 ? Object.keys(values.workflows) : undefined,
+        agents: values.agents && Object.keys(values.agents).length > 0 ? Object.keys(values.agents) : undefined,
+        scorers,
+        memory: values.memory?.enabled
+          ? {
+              options: {
+                lastMessages: values.memory.lastMessages,
+                semanticRecall: values.memory.semanticRecall,
+                readOnly: values.memory.readOnly,
+              },
+              observationalMemory: values.memory.observationalMemory?.enabled
+                ? (() => {
+                    const om = values.memory.observationalMemory;
+                    const modelId =
+                      om.model?.provider && om.model?.name ? `${om.model.provider}/${om.model.name}` : undefined;
+
+                    const obsModelId =
+                      om.observation?.model?.provider && om.observation?.model?.name
+                        ? `${om.observation.model.provider}/${om.observation.model.name}`
+                        : undefined;
+                    const observation =
+                      obsModelId ||
+                      om.observation?.messageTokens ||
+                      om.observation?.maxTokensPerBatch ||
+                      om.observation?.bufferTokens !== undefined ||
+                      om.observation?.bufferActivation !== undefined ||
+                      om.observation?.blockAfter !== undefined
+                        ? {
+                            model: obsModelId,
+                            messageTokens: om.observation?.messageTokens,
+                            maxTokensPerBatch: om.observation?.maxTokensPerBatch,
+                            bufferTokens: om.observation?.bufferTokens,
+                            bufferActivation: om.observation?.bufferActivation,
+                            blockAfter: om.observation?.blockAfter,
+                          }
+                        : undefined;
+
+                    const refModelId =
+                      om.reflection?.model?.provider && om.reflection?.model?.name
+                        ? `${om.reflection.model.provider}/${om.reflection.model.name}`
+                        : undefined;
+                    const reflection =
+                      refModelId ||
+                      om.reflection?.observationTokens ||
+                      om.reflection?.blockAfter !== undefined ||
+                      om.reflection?.bufferActivation !== undefined
+                        ? {
+                            model: refModelId,
+                            observationTokens: om.reflection?.observationTokens,
+                            blockAfter: om.reflection?.blockAfter,
+                            bufferActivation: om.reflection?.bufferActivation,
+                          }
+                        : undefined;
+
+                    return modelId || om.scope || om.shareTokenBudget || observation || reflection
+                      ? {
+                          model: modelId,
+                          scope: om.scope,
+                          shareTokenBudget: om.shareTokenBudget,
+                          observation,
+                          reflection,
+                        }
+                      : true;
+                  })()
+                : undefined,
+            }
+          : undefined,
+        requestContextSchema: values.variables as Record<string, unknown> | undefined,
+      };
+
+      const created = await createStoredAgent.mutateAsync(createParams);
+      toast.success('Agent created successfully');
+      onSuccess?.(created);
+    } catch (error) {
+      toast.error(`Failed to create agent: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  };
+
+  return (
+    <AgentEditLayout
+      leftSlot={
+        <AgentEditSidebar
+          form={form}
+          onPublish={handlePublish}
+          isSubmitting={createStoredAgent.isPending}
+          formRef={formRef}
+          hideSubAgentCreate={hideSubAgentCreate}
+        />
+      }
+    >
+      <form ref={formRef} className="h-full">
+        <AgentEditMainContentBlocks form={form} />
+      </form>
+    </AgentEditLayout>
+  );
+}

--- a/packages/playground-ui/src/domains/agents/components/agent-create-content.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-create-content.tsx
@@ -11,7 +11,7 @@ import { useAgentEditForm } from './agent-edit-page/use-agent-edit-form';
 import { useStoredAgentMutations } from '../hooks/use-stored-agents';
 
 interface AgentCreateContentProps {
-  onSuccess?: (agent: { id: string }) => void;
+  onSuccess?: (agent: { id: string; description?: string }) => void;
   hideSubAgentCreate?: boolean;
 }
 

--- a/packages/playground-ui/src/domains/agents/components/agent-edit-page/agent-edit-sidebar.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-edit-page/agent-edit-sidebar.tsx
@@ -79,6 +79,7 @@ interface AgentEditSidebarProps {
   formRef?: RefObject<HTMLFormElement | null>;
   mode?: 'create' | 'edit';
   readOnly?: boolean;
+  hideSubAgentCreate?: boolean;
 }
 
 export function AgentEditSidebar({
@@ -89,6 +90,7 @@ export function AgentEditSidebar({
   formRef,
   mode = 'create',
   readOnly = false,
+  hideSubAgentCreate,
 }: AgentEditSidebarProps) {
   const {
     register,
@@ -234,6 +236,7 @@ export function AgentEditSidebar({
                 error={errors.agents?.root?.message}
                 currentAgentId={currentAgentId}
                 readOnly={readOnly}
+                hideCreateButton={hideSubAgentCreate}
               />
               <ScorersSection control={control} readOnly={readOnly} />
               <MemorySection control={control} setValue={form.setValue} readOnly={readOnly} />

--- a/packages/playground-ui/src/domains/agents/components/agent-edit-page/sections/agents-section.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-edit-page/sections/agents-section.tsx
@@ -1,12 +1,15 @@
 import { useMemo, useState } from 'react';
 import { Controller, Control, useWatch } from 'react-hook-form';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, Plus } from 'lucide-react';
 
 import { EntityAccordionItem } from '@/domains/cms';
-import { AgentIcon } from '@/ds/icons';
+import { AgentIcon, Icon } from '@/ds/icons';
 import { MultiCombobox } from '@/ds/components/Combobox';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/ds/components/Collapsible';
+import { Button } from '@/ds/components/Button';
+import { SideDialog } from '@/ds/components/SideDialog';
 import { useAgents } from '../../../hooks/use-agents';
+import { AgentCreateContent } from '../../agent-create-content';
 import type { AgentFormValues } from '../utils/form-validation';
 import { SectionTitle } from '@/domains/cms/components/section/section-title';
 
@@ -19,10 +22,18 @@ interface AgentsSectionProps {
   error?: string;
   currentAgentId?: string;
   readOnly?: boolean;
+  hideCreateButton?: boolean;
 }
 
-export function AgentsSection({ control, error, currentAgentId, readOnly = false }: AgentsSectionProps) {
+export function AgentsSection({
+  control,
+  error,
+  currentAgentId,
+  readOnly = false,
+  hideCreateButton = false,
+}: AgentsSectionProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const { data: agents, isLoading } = useAgents();
   const selectedAgents = useWatch({ control, name: 'agents' });
   const count = Object.keys(selectedAgents || {}).length;
@@ -53,82 +64,133 @@ export function AgentsSection({ control, error, currentAgentId, readOnly = false
 
   return (
     <div className="rounded-md border border-border1 bg-surface2">
-      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <CollapsibleTrigger className="flex items-center gap-1 w-full p-3 bg-surface3">
-          <ChevronRight className="h-4 w-4 text-icon3" />
-          <SectionTitle icon={<AgentIcon className="text-accent1" />}>
-            Sub-Agents{count > 0 && <span className="text-neutral3 font-normal">({count})</span>}
-          </SectionTitle>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <div className="p-3 border-t border-border1">
-            <Controller
-              name="agents"
-              control={control}
-              render={({ field }) => {
-                const selectedIds = Object.keys(field.value || {});
-                const selectedOptions = options.filter(opt => selectedIds.includes(opt.value));
+      <Controller
+        name="agents"
+        control={control}
+        render={({ field }) => {
+          const selectedIds = Object.keys(field.value || {});
+          const selectedOptions = options.filter(opt => selectedIds.includes(opt.value));
 
-                const handleValueChange = (newIds: string[]) => {
-                  const newValue: Record<string, EntityConfig> = {};
-                  for (const id of newIds) {
-                    newValue[id] = field.value?.[id] || {
-                      description: getOriginalDescription(id),
-                    };
-                  }
-                  field.onChange(newValue);
-                };
+          const handleValueChange = (newIds: string[]) => {
+            const newValue: Record<string, EntityConfig> = {};
+            for (const id of newIds) {
+              newValue[id] = field.value?.[id] || {
+                description: getOriginalDescription(id),
+              };
+            }
+            field.onChange(newValue);
+          };
 
-                const handleDescriptionChange = (agentId: string, description: string) => {
+          const handleDescriptionChange = (agentId: string, description: string) => {
+            field.onChange({
+              ...field.value,
+              [agentId]: { ...field.value?.[agentId], description },
+            });
+          };
+
+          const handleRemove = (agentId: string) => {
+            const newValue = { ...field.value };
+            delete newValue[agentId];
+            field.onChange(newValue);
+          };
+
+          return (
+            <>
+              <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+                <div className="flex items-center justify-between p-3 bg-surface3">
+                  <CollapsibleTrigger className="flex items-center gap-1 w-full">
+                    <ChevronRight className="h-4 w-4 text-icon3" />
+                    <SectionTitle icon={<AgentIcon className="text-accent1" />}>
+                      Sub-Agents{count > 0 && <span className="text-neutral3 font-normal">({count})</span>}
+                    </SectionTitle>
+                  </CollapsibleTrigger>
+
+                  {!readOnly && !hideCreateButton && (
+                    <div className="flex justify-end items-center">
+                      <Button variant="outline" size="sm" onClick={() => setIsCreateDialogOpen(true)}>
+                        <Icon size="sm">
+                          <Plus />
+                        </Icon>
+                        Create
+                      </Button>
+                    </div>
+                  )}
+                </div>
+
+                <CollapsibleContent>
+                  <div className="p-3 border-t border-border1">
+                    <div className="flex flex-col gap-2">
+                      <MultiCombobox
+                        options={options}
+                        value={selectedIds}
+                        onValueChange={handleValueChange}
+                        placeholder="Select sub-agents..."
+                        searchPlaceholder="Search agents..."
+                        emptyText="No agents available"
+                        disabled={isLoading || readOnly}
+                        error={error}
+                        variant="light"
+                      />
+                      {selectedOptions.length > 0 && (
+                        <div className="flex flex-col gap-3 mt-2">
+                          {selectedOptions.map(agent => (
+                            <EntityAccordionItem
+                              key={agent.value}
+                              id={agent.value}
+                              name={agent.label}
+                              icon={<AgentIcon className="text-accent1" />}
+                              description={field.value?.[agent.value]?.description || ''}
+                              onDescriptionChange={
+                                readOnly ? undefined : desc => handleDescriptionChange(agent.value, desc)
+                              }
+                              onRemove={readOnly ? undefined : () => handleRemove(agent.value)}
+                            />
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </CollapsibleContent>
+              </Collapsible>
+              <AgentsSideDialog
+                isOpen={isCreateDialogOpen}
+                onClose={() => setIsCreateDialogOpen(false)}
+                onAgentCreated={agent => {
                   field.onChange({
                     ...field.value,
-                    [agentId]: { ...field.value?.[agentId], description },
+                    [agent.id]: { description: '' },
                   });
-                };
-
-                const handleRemove = (agentId: string) => {
-                  const newValue = { ...field.value };
-                  delete newValue[agentId];
-                  field.onChange(newValue);
-                };
-
-                return (
-                  <div className="flex flex-col gap-2">
-                    <MultiCombobox
-                      options={options}
-                      value={selectedIds}
-                      onValueChange={handleValueChange}
-                      placeholder="Select sub-agents..."
-                      searchPlaceholder="Search agents..."
-                      emptyText="No agents available"
-                      disabled={isLoading || readOnly}
-                      error={error}
-                      variant="light"
-                    />
-                    {selectedOptions.length > 0 && (
-                      <div className="flex flex-col gap-3 mt-2">
-                        {selectedOptions.map(agent => (
-                          <EntityAccordionItem
-                            key={agent.value}
-                            id={agent.value}
-                            name={agent.label}
-                            icon={<AgentIcon className="text-accent1" />}
-                            description={field.value?.[agent.value]?.description || ''}
-                            onDescriptionChange={
-                              readOnly ? undefined : desc => handleDescriptionChange(agent.value, desc)
-                            }
-                            onRemove={readOnly ? undefined : () => handleRemove(agent.value)}
-                          />
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                );
-              }}
-            />
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
+                  setIsCreateDialogOpen(false);
+                }}
+              />
+            </>
+          );
+        }}
+      />
     </div>
+  );
+}
+
+interface AgentsSideDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onAgentCreated?: (agent: { id: string }) => void;
+}
+
+function AgentsSideDialog({ isOpen, onClose, onAgentCreated }: AgentsSideDialogProps) {
+  return (
+    <SideDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      dialogTitle="Create a new sub-agent"
+      dialogDescription="Create a new agent to use as a sub-agent."
+    >
+      <SideDialog.Top>
+        <SideDialog.Header>
+          <SideDialog.Heading>Create a new sub-agent</SideDialog.Heading>
+        </SideDialog.Header>
+      </SideDialog.Top>
+      <AgentCreateContent onSuccess={onAgentCreated} hideSubAgentCreate />
+    </SideDialog>
   );
 }

--- a/packages/playground-ui/src/domains/agents/components/agent-edit-page/sections/agents-section.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-edit-page/sections/agents-section.tsx
@@ -158,7 +158,7 @@ export function AgentsSection({
                 onAgentCreated={agent => {
                   field.onChange({
                     ...field.value,
-                    [agent.id]: { description: '' },
+                    [agent.id]: { description: agent.description || '' },
                   });
                   setIsCreateDialogOpen(false);
                 }}
@@ -174,7 +174,7 @@ export function AgentsSection({
 interface AgentsSideDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  onAgentCreated?: (agent: { id: string }) => void;
+  onAgentCreated?: (agent: { id: string; description?: string }) => void;
 }
 
 function AgentsSideDialog({ isOpen, onClose, onAgentCreated }: AgentsSideDialogProps) {

--- a/packages/playground-ui/src/domains/agents/index.tsx
+++ b/packages/playground-ui/src/domains/agents/index.tsx
@@ -24,3 +24,4 @@ export * from './components/agent-layout';
 export * from './components/agent-cms-blocks';
 export * from './components/agent-edit-page/utils/form-validation';
 export * from './components/agent-edit-page';
+export * from './components/agent-create-content';

--- a/packages/playground-ui/src/domains/scores/components/scorer-create-content.tsx
+++ b/packages/playground-ui/src/domains/scores/components/scorer-create-content.tsx
@@ -1,0 +1,69 @@
+import { useRef } from 'react';
+
+import type { CreateStoredScorerParams } from '@mastra/client-js';
+
+import { toast } from '@/lib/toast';
+import { AgentEditLayout } from '@/domains/agents/components/agent-edit-page/agent-edit-layout';
+
+import { ScorerEditSidebar } from './scorer-edit-page/scorer-edit-sidebar';
+import { ScorerEditMain } from './scorer-edit-page/scorer-edit-main';
+import { useScorerEditForm } from './scorer-edit-page/use-scorer-edit-form';
+import { useStoredScorerMutations } from '../hooks/use-stored-scorers';
+
+interface ScorerCreateContentProps {
+  onSuccess?: (scorer: { id: string }) => void;
+}
+
+export function ScorerCreateContent({ onSuccess }: ScorerCreateContentProps) {
+  const { createStoredScorer } = useStoredScorerMutations();
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const { form } = useScorerEditForm();
+
+  const handlePublish = async () => {
+    const isValid = await form.trigger();
+    if (!isValid) {
+      toast.error('Please fill in all required fields');
+      return;
+    }
+
+    const values = form.getValues();
+
+    try {
+      const createParams: CreateStoredScorerParams = {
+        name: values.name,
+        description: values.description || undefined,
+        type: values.type,
+        model: values.model,
+        instructions: values.instructions || undefined,
+        scoreRange: values.scoreRange,
+        ...(values.defaultSampling?.type === 'ratio' &&
+          typeof values.defaultSampling.rate === 'number' && {
+            defaultSampling: values.defaultSampling,
+          }),
+      };
+
+      const created = await createStoredScorer.mutateAsync(createParams);
+      toast.success('Scorer created successfully');
+      onSuccess?.(created);
+    } catch (error) {
+      toast.error(`Failed to create scorer: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  };
+
+  return (
+    <AgentEditLayout
+      leftSlot={
+        <ScorerEditSidebar
+          form={form}
+          onPublish={handlePublish}
+          isSubmitting={createStoredScorer.isPending}
+          formRef={formRef}
+        />
+      }
+    >
+      <form ref={formRef} className="h-full">
+        <ScorerEditMain form={form} />
+      </form>
+    </AgentEditLayout>
+  );
+}

--- a/packages/playground-ui/src/domains/scores/index.ts
+++ b/packages/playground-ui/src/domains/scores/index.ts
@@ -4,6 +4,7 @@ export * from './components/scores-tools';
 export * from './components/scorer-combobox';
 export * from './components/scorers-table/scorers-table';
 export * from './components/scorer-edit-page';
+export * from './components/scorer-create-content';
 export * from './hooks/use-trace-span-scores';
 export { useScorers, useScorer, useScoresByScorerId } from './hooks/use-scorers';
 export { useStoredScorer, useStoredScorerMutations } from './hooks/use-stored-scorers';

--- a/packages/playground/src/pages/cms/agents/create/index.tsx
+++ b/packages/playground/src/pages/cms/agents/create/index.tsx
@@ -1,147 +1,15 @@
-import { useCallback, useRef, useState } from 'react';
-
 import {
-  toast,
   useLinkComponent,
-  useStoredAgentMutations,
-  AgentEditSidebar,
-  AgentEditLayout,
-  useAgentEditForm,
+  AgentCreateContent,
   MainContentLayout,
-  AgentEditMainContentBlocks,
   Header,
   HeaderTitle,
   Icon,
   AgentIcon,
 } from '@mastra/playground-ui';
-import { CreateStoredAgentParams } from '@mastra/client-js';
 
 function CmsAgentsCreatePage() {
   const { navigate, paths } = useLinkComponent();
-  const { createStoredAgent } = useStoredAgentMutations();
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const formRef = useRef<HTMLFormElement | null>(null);
-  const { form } = useAgentEditForm();
-
-  const handlePublish = useCallback(async () => {
-    const isValid = await form.trigger();
-    if (!isValid) {
-      toast.error('Please fill in all required fields');
-      return;
-    }
-
-    const values = form.getValues();
-    setIsSubmitting(true);
-
-    try {
-      const formScorers = values.scorers ? Object.entries(values.scorers) : undefined;
-      const scorers = formScorers
-        ? Object.fromEntries(
-            formScorers.map(([key, value]) => [
-              key,
-              {
-                description: value.description,
-                sampling: value.sampling
-                  ? {
-                      type: value.sampling.type,
-                      rate: value.sampling.rate || 0,
-                    }
-                  : undefined,
-              },
-            ]),
-          )
-        : undefined;
-
-      const createParams: CreateStoredAgentParams = {
-        name: values.name,
-        description: values.description || undefined,
-        instructions: (values.instructionBlocks ?? []).map(block => ({
-          type: block.type,
-          content: block.content,
-          rules: block.rules,
-        })),
-        model: values.model,
-        tools: values.tools && Object.keys(values.tools).length > 0 ? values.tools : undefined,
-        workflows:
-          values.workflows && Object.keys(values.workflows).length > 0 ? Object.keys(values.workflows) : undefined,
-        agents: values.agents && Object.keys(values.agents).length > 0 ? Object.keys(values.agents) : undefined,
-        scorers,
-        memory: values.memory?.enabled
-          ? {
-              options: {
-                lastMessages: values.memory.lastMessages,
-                semanticRecall: values.memory.semanticRecall,
-                readOnly: values.memory.readOnly,
-              },
-              observationalMemory: values.memory.observationalMemory?.enabled
-                ? (() => {
-                    const om = values.memory.observationalMemory;
-                    const modelId =
-                      om.model?.provider && om.model?.name ? `${om.model.provider}/${om.model.name}` : undefined;
-
-                    const obsModelId =
-                      om.observation?.model?.provider && om.observation?.model?.name
-                        ? `${om.observation.model.provider}/${om.observation.model.name}`
-                        : undefined;
-                    const observation =
-                      obsModelId ||
-                      om.observation?.messageTokens ||
-                      om.observation?.maxTokensPerBatch ||
-                      om.observation?.bufferTokens !== undefined ||
-                      om.observation?.bufferActivation !== undefined ||
-                      om.observation?.blockAfter !== undefined
-                        ? {
-                            model: obsModelId,
-                            messageTokens: om.observation?.messageTokens,
-                            maxTokensPerBatch: om.observation?.maxTokensPerBatch,
-                            bufferTokens: om.observation?.bufferTokens,
-                            bufferActivation: om.observation?.bufferActivation,
-                            blockAfter: om.observation?.blockAfter,
-                          }
-                        : undefined;
-
-                    const refModelId =
-                      om.reflection?.model?.provider && om.reflection?.model?.name
-                        ? `${om.reflection.model.provider}/${om.reflection.model.name}`
-                        : undefined;
-                    const reflection =
-                      refModelId ||
-                      om.reflection?.observationTokens ||
-                      om.reflection?.blockAfter !== undefined ||
-                      om.reflection?.bufferActivation !== undefined
-                        ? {
-                            model: refModelId,
-                            observationTokens: om.reflection?.observationTokens,
-                            blockAfter: om.reflection?.blockAfter,
-                            bufferActivation: om.reflection?.bufferActivation,
-                          }
-                        : undefined;
-
-                    return modelId || om.scope || om.shareTokenBudget || observation || reflection
-                      ? {
-                          model: modelId,
-                          scope: om.scope,
-                          shareTokenBudget: om.shareTokenBudget,
-                          observation,
-                          reflection,
-                        }
-                      : true;
-                  })()
-                : undefined,
-            }
-          : undefined,
-        requestContextSchema: values.variables as Record<string, unknown> | undefined,
-      };
-
-      const created = await createStoredAgent.mutateAsync(createParams);
-      toast.success('Agent created successfully');
-      navigate(`${paths.agentLink(created.id)}/chat`);
-    } catch (error) {
-      toast.error(`Failed to create agent: ${error instanceof Error ? error.message : 'Unknown error'}`);
-    } finally {
-      setIsSubmitting(false);
-    }
-  }, [form, createStoredAgent, navigate, paths]);
 
   return (
     <MainContentLayout>
@@ -153,15 +21,7 @@ function CmsAgentsCreatePage() {
           Create an agent
         </HeaderTitle>
       </Header>
-      <AgentEditLayout
-        leftSlot={
-          <AgentEditSidebar form={form} onPublish={handlePublish} isSubmitting={isSubmitting} formRef={formRef} />
-        }
-      >
-        <form ref={formRef} className="h-full">
-          <AgentEditMainContentBlocks form={form} />
-        </form>
-      </AgentEditLayout>
+      <AgentCreateContent onSuccess={agent => navigate(`${paths.agentLink(agent.id)}/chat`)} />
     </MainContentLayout>
   );
 }

--- a/packages/playground/src/pages/cms/scorers/create/index.tsx
+++ b/packages/playground/src/pages/cms/scorers/create/index.tsx
@@ -1,58 +1,16 @@
-import { useRef } from 'react';
 import { GaugeIcon } from 'lucide-react';
 
 import {
-  toast,
   useLinkComponent,
-  useStoredScorerMutations,
-  ScorerEditSidebar,
-  AgentEditLayout,
-  useScorerEditForm,
+  ScorerCreateContent,
   MainContentLayout,
-  ScorerEditMain,
   Header,
   HeaderTitle,
   Icon,
 } from '@mastra/playground-ui';
 
-import type { CreateStoredScorerParams } from '@mastra/client-js';
-
 function CmsScorersCreatePage() {
   const { navigate, paths } = useLinkComponent();
-  const { createStoredScorer } = useStoredScorerMutations();
-  const formRef = useRef<HTMLFormElement | null>(null);
-  const { form } = useScorerEditForm();
-
-  const handlePublish = async () => {
-    const isValid = await form.trigger();
-    if (!isValid) {
-      toast.error('Please fill in all required fields');
-      return;
-    }
-
-    const values = form.getValues();
-
-    try {
-      const createParams: CreateStoredScorerParams = {
-        name: values.name,
-        description: values.description || undefined,
-        type: values.type,
-        model: values.model,
-        instructions: values.instructions || undefined,
-        scoreRange: values.scoreRange,
-        ...(values.defaultSampling?.type === 'ratio' &&
-          typeof values.defaultSampling.rate === 'number' && {
-            defaultSampling: values.defaultSampling,
-          }),
-      };
-
-      const created = await createStoredScorer.mutateAsync(createParams);
-      toast.success('Scorer created successfully');
-      navigate(paths.scorerLink(created.id));
-    } catch (error) {
-      toast.error(`Failed to create scorer: ${error instanceof Error ? error.message : 'Unknown error'}`);
-    }
-  };
 
   return (
     <MainContentLayout>
@@ -64,20 +22,7 @@ function CmsScorersCreatePage() {
           Create a scorer
         </HeaderTitle>
       </Header>
-      <AgentEditLayout
-        leftSlot={
-          <ScorerEditSidebar
-            form={form}
-            onPublish={handlePublish}
-            isSubmitting={createStoredScorer.isPending}
-            formRef={formRef}
-          />
-        }
-      >
-        <form ref={formRef} className="h-full">
-          <ScorerEditMain form={form} />
-        </form>
-      </AgentEditLayout>
+      <ScorerCreateContent onSuccess={scorer => navigate(paths.scorerLink(scorer.id))} />
     </MainContentLayout>
   );
 }


### PR DESCRIPTION
Mirrors the existing scorer on-the-fly creation pattern for sub-agents. When editing or creating an agent, the Sub-Agents section now has a "Create" button that opens a SideDialog with the full agent creation form. The newly created agent is automatically added to the parent's sub-agents list.

Extracted the agent creation logic from the playground create page into a reusable `AgentCreateContent` component in `playground-ui`. The create page is now a thin wrapper, same as the scorer create page.

Recursive nesting (agent form → sub-agents section → create button → agent form → sub-agents section → ...) is prevented with a `hideSubAgentCreate` prop that hides the "Create" button one level deep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create sub-agents on-the-fly from the agent editor using a side dialog in the Sub-Agents section.
  * Create scorers via a side dialog flow from the Scorers section.
  * New unified creation components for agents and scorers used across pages.

* **Improvements**
  * Streamlined agent and scorer creation into consistent dialog-based workflows.
  * Post-creation navigation now redirects directly to the newly created agent or scorer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->