### PR TITLE
fix(server): include requestContextSchema in agent list API response

### DIFF
--- a/.changeset/new-lemons-smash.md
+++ b/.changeset/new-lemons-smash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed requestContextSchema missing from the agent list API response. Agents with a requestContextSchema now correctly include it when listed via GET /agents.

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -474,6 +474,16 @@ async function formatAgentList({
     },
   }));
 
+  // Serialize requestContextSchema if present
+  let serializedRequestContextSchema: string | undefined;
+  if (agent.requestContextSchema) {
+    try {
+      serializedRequestContextSchema = stringify(zodToJsonSchema(agent.requestContextSchema));
+    } catch (error) {
+      logger.error('Error serializing requestContextSchema for agent', { agentName: agent.name, error });
+    }
+  }
+
   return {
     id: agent.id || id,
     name: agent.name,
@@ -494,6 +504,7 @@ async function formatAgentList({
     modelList,
     defaultGenerateOptionsLegacy,
     defaultStreamOptionsLegacy,
+    requestContextSchema: serializedRequestContextSchema,
     source: (agent as any).source ?? 'code',
   };
 }


### PR DESCRIPTION
The `formatAgentList` function (used by `GET /agents`) was missing `requestContextSchema` from its return object, even though the single-agent `formatAgent` function (used by `GET /agents/:agentId`) already had it.

Before this fix, listing agents would always return `requestContextSchema: undefined` even when the agent had one configured. Now it serializes it the same way the detail endpoint does:

```ts
// GET /agents response now includes:
{
  id: 'my-agent',
  name: 'My Agent',
  requestContextSchema: '{"type":"object","properties":{"userId":{"type":"string"}}}',
  // ...
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The agent list endpoint now returns complete agent configuration information that was previously omitted, ensuring all agent details are included when retrieving agents via the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->