### PR TITLE
fix(docs): use getStore('memory') for withMastra storage examples

### DIFF
--- a/docs/src/content/en/guides/agent-frameworks/ai-sdk.mdx
+++ b/docs/src/content/en/guides/agent-frameworks/ai-sdk.mdx
@@ -76,9 +76,11 @@ const storage = new LibSQLStore({
 });
 await storage.init();
 
+const memoryStorage = await storage.getStore('memory');
+
 const model = withMastra(openai('gpt-4o'), {
   memory: {
-    storage,
+    storage: memoryStorage!,
     threadId: 'user-thread-123',
     resourceId: 'user-123',
     lastMessages: 10,
@@ -104,11 +106,13 @@ import { LibSQLStore } from '@mastra/libsql';
 const storage = new LibSQLStore({ id: 'my-app', url: 'file:./data.db' });
 await storage.init();
 
+const memoryStorage = await storage.getStore('memory');
+
 const model = withMastra(openai('gpt-4o'), {
   inputProcessors: [myGuardProcessor],
   outputProcessors: [myLoggingProcessor],
   memory: {
-    storage,
+    storage: memoryStorage!,
     threadId: 'thread-123',
     resourceId: 'user-123',
     lastMessages: 10,

--- a/docs/src/content/en/reference/ai-sdk/with-mastra.mdx
+++ b/docs/src/content/en/reference/ai-sdk/with-mastra.mdx
@@ -75,7 +75,7 @@ const { text } = await generateText({
     {
       name: "options.memory.storage",
       type: "MemoryStorage",
-      description: "Storage adapter for message persistence (e.g., LibSQLStore, PostgresStore).",
+      description: "Memory storage domain for message persistence. Get it from a composite store using `await storage.getStore('memory')`.",
       isOptional: false,
     },
     {


### PR DESCRIPTION
## Description

Fixed type errors in `withMastra` docs by showing the correct way to pass storage to the memory option. The docs incorrectly passed a composite store (LibSQLStore/PostgresStore) directly, but the memory option expects a MemoryStorage instance obtained via `storage.getStore('memory')`.

## Related Issue(s)

Fixes #12938

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI SDK guides and reference documentation to clarify memory storage configuration, including clearer instructions for retrieving and configuring dedicated memory stores within the framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->