### PR TITLE
Fix custom API routes 404 on non-Hono server adapters

### DIFF
--- a/.changeset/free-bananas-burn.md
+++ b/.changeset/free-bananas-burn.md
@@ -1,0 +1,34 @@
+---
+'@mastra/express': patch
+'@mastra/fastify': patch
+'@mastra/hono': patch
+'@mastra/koa': patch
+'@mastra/server': patch
+---
+
+Fixed custom API routes registered via `registerApiRoute()` being silently ignored by Koa, Express, Fastify, and Hono server adapters. Routes previously appeared in the OpenAPI spec but returned 404 at runtime. Custom routes now work correctly across all server adapters.
+
+**Example:**
+
+```ts
+import Koa from 'koa';
+import { Mastra } from '@mastra/core';
+import { registerApiRoute } from '@mastra/core/server';
+import { MastraServer } from '@mastra/koa';
+
+const mastra = new Mastra({
+  server: {
+    apiRoutes: [
+      registerApiRoute('/hello', {
+        method: 'GET',
+        handler: async c => c.json({ message: 'Hello!' }),
+      }),
+    ],
+  },
+});
+
+const app = new Koa();
+const server = new MastraServer({ app, mastra });
+await server.init();
+// GET /hello now returns 200 instead of 404
+```

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -3,6 +3,7 @@ import type { Mastra } from '@mastra/core/mastra';
 import { RequestContext } from '@mastra/core/request-context';
 import { MastraServerBase } from '@mastra/core/server';
 import type { ApiRoute } from '@mastra/core/server';
+import { Hono } from 'hono';
 
 import type { InMemoryTaskStore } from '../a2a/store';
 import { defaultAuthConfig } from '../auth/defaults';
@@ -158,6 +159,9 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
   protected streamOptions: StreamOptions;
   protected customApiRoutes?: ApiRoute[];
   protected mcpOptions?: MCPOptions;
+  private customRouteHandler:
+    | ((request: Request, env?: { requestContext?: RequestContext }) => Promise<Response>)
+    | null = null;
 
   constructor({
     app,
@@ -369,7 +373,140 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
   async init() {
     this.registerContextMiddleware();
     this.registerAuthMiddleware();
+    await this.registerCustomApiRoutes();
     await this.registerRoutes();
+  }
+
+  /**
+   * Override in adapters to register custom API routes defined via registerApiRoute().
+   * Called by init() between registerAuthMiddleware() and registerRoutes().
+   */
+  async registerCustomApiRoutes(): Promise<void> {
+    // Default no-op. Adapters override this to register custom routes
+    // using their framework-specific middleware.
+  }
+
+  /**
+   * Creates an internal Hono sub-app with all custom API routes registered.
+   * Stores the handler on this instance for use by handleCustomRouteRequest().
+   * Returns true if custom routes were found and registered.
+   */
+  protected async buildCustomRouteHandler(): Promise<boolean> {
+    const routes = this.customApiRoutes ?? this.mastra.getServer()?.apiRoutes;
+    if (!routes || routes.length === 0) return false;
+
+    const NOT_FOUND_HEADER = 'x-mastra-custom-route-not-found';
+    const mastra = this.mastra;
+
+    const app = new Hono<{
+      Bindings: { requestContext?: RequestContext };
+      Variables: { mastra: Mastra; requestContext: RequestContext };
+    }>();
+
+    // Internal context middleware — sets variables that custom route handlers expect
+    app.use('*', async (c, next) => {
+      c.set('mastra', mastra);
+      c.set('requestContext', c.env?.requestContext ?? new RequestContext());
+      await next();
+    });
+
+    // Register each custom route
+    for (const route of routes) {
+      const handler =
+        'handler' in route && route.handler
+          ? route.handler
+          : 'createHandler' in route
+            ? await route.createHandler({ mastra })
+            : undefined;
+      if (!handler) continue;
+
+      const middlewares: any[] = [];
+      if (route.middleware) {
+        middlewares.push(...(Array.isArray(route.middleware) ? route.middleware : [route.middleware]));
+      }
+
+      const allHandlers = [...middlewares, handler];
+      if (route.method === 'ALL') {
+        app.all(route.path, allHandlers[0]!, ...allHandlers.slice(1));
+      } else {
+        app.on(route.method, route.path, allHandlers[0]!, ...allHandlers.slice(1));
+      }
+    }
+
+    // Mark unmatched requests so the adapter bridge can fall through to next()
+    app.notFound(() => new Response(null, { status: 404, headers: { [NOT_FOUND_HEADER]: 'true' } }));
+
+    this.customRouteHandler = async (request, env) => app.fetch(request, env);
+    return true;
+  }
+
+  /**
+   * Forwards a request to the internal custom route handler.
+   * Returns the Response if a custom route matched, or null to fall through.
+   * Used by non-Hono adapter bridges.
+   */
+  protected async handleCustomRouteRequest(
+    url: string,
+    method: string,
+    headers: Record<string, string | string[] | undefined>,
+    body: unknown,
+    requestContext?: RequestContext,
+  ): Promise<Response | null> {
+    if (!this.customRouteHandler) return null;
+
+    const fetchHeaders = new Headers();
+    for (const [key, value] of Object.entries(headers)) {
+      if (typeof value === 'string') fetchHeaders.set(key, value);
+      else if (Array.isArray(value)) value.forEach(v => fetchHeaders.append(key, v));
+    }
+
+    const init: RequestInit = { method, headers: fetchHeaders };
+    if (['POST', 'PUT', 'PATCH'].includes(method) && body !== undefined) {
+      const contentType = (typeof headers['content-type'] === 'string' ? headers['content-type'] : '') || '';
+      if (contentType.includes('application/json')) {
+        init.body = JSON.stringify(body);
+      }
+    }
+
+    const request = new globalThis.Request(url, init);
+    const response = await this.customRouteHandler(request, { requestContext });
+
+    if (response.headers.get('x-mastra-custom-route-not-found') === 'true') return null;
+    return response;
+  }
+
+  /**
+   * Pipes a custom route Response to a Node.js ServerResponse (http.ServerResponse).
+   * Works with Koa (ctx.res), Express (res), and Fastify (reply.raw).
+   */
+  protected async writeCustomRouteResponse(
+    response: Response,
+    nodeRes: {
+      writeHead(status: number, headers: Record<string, string>): void;
+      write(chunk: unknown): void;
+      end(data?: string): void;
+    },
+  ): Promise<void> {
+    const headers: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+    nodeRes.writeHead(response.status, headers);
+
+    if (response.body) {
+      const reader = response.body.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          nodeRes.write(value);
+        }
+      } finally {
+        nodeRes.end();
+      }
+    } else {
+      nodeRes.end(await response.text());
+    }
   }
 
   async registerOpenAPIRoute(app: TApp, config: OpenAPIConfig = {}, { prefix }: { prefix?: string }): Promise<void> {

--- a/server-adapters/express/src/__tests__/express-adapter.test.ts
+++ b/server-adapters/express/src/__tests__/express-adapter.test.ts
@@ -12,6 +12,8 @@ import {
   consumeSSEStream,
   createMultipartTestSuite,
 } from '@internal/server-adapter-test-utils';
+import { Mastra } from '@mastra/core';
+import { registerApiRoute } from '@mastra/core/server';
 import type { ServerRoute } from '@mastra/server/server-adapter';
 import express from 'express';
 import type { Application } from 'express';
@@ -558,5 +560,96 @@ describe('Express Server Adapter', () => {
     applyMiddleware: (app, middleware) => {
       app.use(middleware);
     },
+  });
+
+  describe('Custom API Routes (registerApiRoute)', () => {
+    let server: Server | null = null;
+
+    afterEach(async () => {
+      if (server) {
+        await new Promise<void>((resolve, reject) => {
+          server!.close(err => {
+            if (err) reject(err);
+            else resolve();
+          });
+        });
+        server = null;
+      }
+    });
+
+    it('should register and respond to custom API routes added via registerApiRoute', async () => {
+      const customRoutes = [
+        registerApiRoute('/hello', {
+          method: 'GET',
+          handler: async c => {
+            return c.json({ message: 'Hello from custom route!' });
+          },
+        }),
+      ];
+
+      const mastra = new Mastra({});
+      const app = express();
+      app.use(express.json());
+
+      const adapter = new MastraServer({
+        app,
+        mastra,
+        customApiRoutes: customRoutes,
+      });
+
+      await adapter.init();
+
+      server = await new Promise(resolve => {
+        const s = app.listen(0, () => resolve(s));
+      });
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+
+      const response = await fetch(`http://localhost:${port}/hello`);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({ message: 'Hello from custom route!' });
+    });
+
+    it('should register custom API routes with POST method', async () => {
+      const customRoutes = [
+        registerApiRoute('/echo', {
+          method: 'POST',
+          handler: async c => {
+            const body = await c.req.json();
+            return c.json({ echo: body });
+          },
+        }),
+      ];
+
+      const mastra = new Mastra({});
+      const app = express();
+      app.use(express.json());
+
+      const adapter = new MastraServer({
+        app,
+        mastra,
+        customApiRoutes: customRoutes,
+      });
+
+      await adapter.init();
+
+      server = await new Promise(resolve => {
+        const s = app.listen(0, () => resolve(s));
+      });
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+
+      const response = await fetch(`http://localhost:${port}/echo`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ test: 'data' }),
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({ echo: { test: 'data' } });
+    });
   });
 });

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -453,6 +453,22 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
     );
   }
 
+  async registerCustomApiRoutes(): Promise<void> {
+    if (!(await this.buildCustomRouteHandler())) return;
+
+    this.app.use(async (req: Request, res: Response, next: NextFunction) => {
+      const response = await this.handleCustomRouteRequest(
+        `${req.protocol}://${req.get('host') || 'localhost'}${req.originalUrl}`,
+        req.method,
+        req.headers as Record<string, string | string[] | undefined>,
+        req.body,
+        res.locals.requestContext,
+      );
+      if (!response) return next();
+      await this.writeCustomRouteResponse(response, res);
+    });
+  }
+
   registerContextMiddleware(): void {
     this.app.use(this.createContextMiddleware());
   }

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -521,8 +521,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
   async registerCustomApiRoutes(): Promise<void> {
     if (!(await this.buildCustomRouteHandler())) return;
 
-    const routes = this.customApiRoutes ?? this.mastra.getServer()?.apiRoutes;
-    if (!routes || routes.length === 0) return;
+    const routes = this.customApiRoutes ?? this.mastra.getServer()?.apiRoutes ?? [];
 
     for (const route of routes) {
       const fastifyHandler: RouteHandlerMethod = async (request: FastifyRequest, reply: FastifyReply) => {

--- a/server-adapters/hono/src/__tests__/hono-adapter.test.ts
+++ b/server-adapters/hono/src/__tests__/hono-adapter.test.ts
@@ -13,9 +13,11 @@ import {
   consumeSSEStream,
   createMultipartTestSuite,
 } from '@internal/server-adapter-test-utils';
+import { Mastra } from '@mastra/core';
+import { registerApiRoute } from '@mastra/core/server';
 import type { ServerRoute } from '@mastra/server/server-adapter';
 import { Hono } from 'hono';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { MastraServer } from '../index';
 
 // Wrapper describe block so the factory can call describe() inside
@@ -460,5 +462,94 @@ describe('Hono Server Adapter', () => {
     applyMiddleware: (app, middleware) => {
       app.use('*', middleware);
     },
+  });
+
+  describe('Custom API Routes (registerApiRoute)', () => {
+    let server: Server | null = null;
+
+    afterEach(async () => {
+      if (server) {
+        await new Promise<void>((resolve, reject) => {
+          server!.close(err => {
+            if (err) reject(err);
+            else resolve();
+          });
+        });
+        server = null;
+      }
+    });
+
+    it('should register and respond to custom API routes added via registerApiRoute', async () => {
+      const customRoutes = [
+        registerApiRoute('/hello', {
+          method: 'GET',
+          handler: async c => {
+            return c.json({ message: 'Hello from custom route!' });
+          },
+        }),
+      ];
+
+      const mastra = new Mastra({});
+      const app = new Hono();
+
+      const adapter = new MastraServer({
+        app,
+        mastra,
+        customApiRoutes: customRoutes,
+      });
+
+      await adapter.init();
+
+      server = await new Promise(resolve => {
+        const s = serve({ fetch: app.fetch, port: 0 }, () => resolve(s));
+      });
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+
+      const response = await fetch(`http://localhost:${port}/hello`);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({ message: 'Hello from custom route!' });
+    });
+
+    it('should register custom API routes with POST method', async () => {
+      const customRoutes = [
+        registerApiRoute('/echo', {
+          method: 'POST',
+          handler: async c => {
+            const body = await c.req.json();
+            return c.json({ echo: body });
+          },
+        }),
+      ];
+
+      const mastra = new Mastra({});
+      const app = new Hono();
+
+      const adapter = new MastraServer({
+        app,
+        mastra,
+        customApiRoutes: customRoutes,
+      });
+
+      await adapter.init();
+
+      server = await new Promise(resolve => {
+        const s = serve({ fetch: app.fetch, port: 0 }, () => resolve(s));
+      });
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+
+      const response = await fetch(`http://localhost:${port}/echo`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ test: 'data' }),
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({ echo: { test: 'data' } });
+    });
   });
 });

--- a/server-adapters/koa/src/__tests__/koa-adapter.test.ts
+++ b/server-adapters/koa/src/__tests__/koa-adapter.test.ts
@@ -599,7 +599,6 @@ describe('Koa Server Adapter', () => {
       // Request the custom route
       const response = await fetch(`http://localhost:${port}/hello`);
 
-      // BUG: This currently returns 404 because init() never registers customApiRoutes
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data).toEqual({ message: 'Hello from custom route!' });

--- a/server-adapters/koa/src/__tests__/koa-adapter.test.ts
+++ b/server-adapters/koa/src/__tests__/koa-adapter.test.ts
@@ -12,6 +12,8 @@ import {
   consumeSSEStream,
   createMultipartTestSuite,
 } from '@internal/server-adapter-test-utils';
+import { Mastra } from '@mastra/core';
+import { registerApiRoute } from '@mastra/core/server';
 import type { ServerRoute } from '@mastra/server/server-adapter';
 import Koa from 'koa';
 import bodyParser from 'koa-bodyparser';
@@ -544,5 +546,104 @@ describe('Koa Server Adapter', () => {
     applyMiddleware: (app, middleware) => {
       app.use(middleware);
     },
+  });
+
+  describe('Custom API Routes (registerApiRoute)', () => {
+    let server: Server | null = null;
+
+    afterEach(async () => {
+      if (server) {
+        await new Promise<void>((resolve, reject) => {
+          server!.close(err => {
+            if (err) reject(err);
+            else resolve();
+          });
+        });
+        server = null;
+      }
+    });
+
+    it('should register and respond to custom API routes added via registerApiRoute', async () => {
+      // This reproduces the bug reported by users: custom API routes registered via
+      // registerApiRoute() are silently ignored by non-Hono server adapters.
+      // They show up in the OpenAPI spec but return 404.
+      const customRoutes = [
+        registerApiRoute('/hello', {
+          method: 'GET',
+          handler: async c => {
+            return c.json({ message: 'Hello from custom route!' });
+          },
+        }),
+      ];
+
+      const mastra = new Mastra({});
+
+      const app = new Koa();
+      app.use(bodyParser());
+
+      const adapter = new MastraServer({
+        app,
+        mastra,
+        customApiRoutes: customRoutes,
+      });
+
+      await adapter.init();
+
+      // Start server
+      server = await new Promise(resolve => {
+        const s = app.listen(0, () => resolve(s));
+      });
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+
+      // Request the custom route
+      const response = await fetch(`http://localhost:${port}/hello`);
+
+      // BUG: This currently returns 404 because init() never registers customApiRoutes
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({ message: 'Hello from custom route!' });
+    });
+
+    it('should register custom API routes with POST method', async () => {
+      const customRoutes = [
+        registerApiRoute('/echo', {
+          method: 'POST',
+          handler: async c => {
+            const body = await c.req.json();
+            return c.json({ echo: body });
+          },
+        }),
+      ];
+
+      const mastra = new Mastra({});
+
+      const app = new Koa();
+      app.use(bodyParser());
+
+      const adapter = new MastraServer({
+        app,
+        mastra,
+        customApiRoutes: customRoutes,
+      });
+
+      await adapter.init();
+
+      server = await new Promise(resolve => {
+        const s = app.listen(0, () => resolve(s));
+      });
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+
+      const response = await fetch(`http://localhost:${port}/echo`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ test: 'data' }),
+      });
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({ echo: { test: 'data' } });
+    });
   });
 });


### PR DESCRIPTION
## Description

Custom API routes registered via `registerApiRoute()` were silently ignored by all non-Hono server adapters (Koa, Express, Fastify). Routes appeared in the OpenAPI spec but returned 404 at runtime.

**Root cause:** The base `MastraServer.init()` only called `registerRoutes()`, which iterates over built-in `SERVER_ROUTES`. The stored `customApiRoutes` was only used for OpenAPI spec generation in `registerOpenAPIRoute()`. Actual custom route registration only happened in the deployer's `createHonoServer()` path — which uses Hono-specific APIs and is never called by server adapters.

**Why a Hono sub-app bridge?** Custom routes use Hono-typed handlers (`Handler` from 'hono') that expect a Hono `Context` and return a Hono `Response`. These are fundamentally different from the framework-agnostic `ServerRoute` handlers used by `registerRoute()`, which receive a destructured params object `{ urlParams, queryParams, body, mastra, ... }` and return raw values. Since `hono` is already a production dependency of `@mastra/server`, the fix creates a lightweight internal Hono app to execute custom route handlers natively, then bridges the response back to each framework.

**Changes:**

**`@mastra/server` — base class** (`packages/server/src/server/server-adapter/index.ts`)
- Updated `init()` to call `registerCustomApiRoutes()` between auth middleware and built-in route registration
- Added `registerCustomApiRoutes()` — empty default for adapters to override
- Added `buildCustomRouteHandler()` — creates an internal Hono sub-app with all custom routes registered, including per-route middleware and a `notFound` handler that sets an `x-mastra-custom-route-not-found` header to distinguish unmatched routes from intentional 404s
- Added `handleCustomRouteRequest()` — reusable helper that builds a `Request` from framework-specific inputs, calls the Hono sub-app, and returns `Response | null` (null = no match, fall through)
- Added `writeCustomRouteResponse()` — reusable helper that pipes a `Response` (status, headers, streaming body) to a Node.js `ServerResponse`

**`@mastra/koa`** (`server-adapters/koa/src/index.ts`)
- Overrides `registerCustomApiRoutes()` with catch-all middleware that forwards to the Hono bridge via the base class helpers; sets `ctx.respond = false` and writes directly to `ctx.res`

**`@mastra/express`** (`server-adapters/express/src/index.ts`)
- Overrides `registerCustomApiRoutes()` with catch-all middleware using the base class helpers; falls through to `next()` on no match

**`@mastra/hono`** (`server-adapters/hono/src/index.ts`)
- Overrides `registerCustomApiRoutes()` with **native** Hono registration (no bridge needed) — resolves handlers from the `ApiRoute` union type and registers them directly on the app

**`@mastra/fastify`** (`server-adapters/fastify/src/index.ts`)
- Overrides `registerCustomApiRoutes()` with explicit per-route registration (Fastify requires declared routes, not catch-all middleware); uses `reply.hijack()` to write raw responses via the base class helpers

**Tests** — Added 2 tests each to Koa, Express, and Hono adapter test suites (GET and POST custom routes)

## Related Issue(s)

Community bug report from Slack (no GitHub issue).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works