### PR TITLE
feat(editor): add observational memory configuration for stored agents

### DIFF
--- a/.changeset/many-stars-enter.md
+++ b/.changeset/many-stars-enter.md
@@ -1,0 +1,73 @@
+---
+'@mastra/core': minor
+'@mastra/server': minor
+'@mastra/editor': minor
+'@mastra/playground-ui': minor
+'@mastra/client-js': minor
+---
+
+Added observational memory configuration support for stored agents. When creating or editing a stored agent in the playground, you can now enable observational memory and configure its settings including model provider/name, scope (thread or resource), share token budget, and detailed observer/reflector parameters like token limits, buffer settings, and blocking thresholds. The configuration is serialized as part of the agent's memory config and round-trips through storage.
+
+**Example usage in the playground:**
+
+Enable the Observational Memory toggle in the Memory section, then configure:
+
+- Top-level model (provider + model) used by both observer and reflector
+- Scope: `thread` (per-conversation) or `resource` (shared across threads)
+- Expand **Observer** or **Reflector** sections to override models and tune token budgets
+
+**Programmatic usage via client SDK:**
+
+```ts
+await client.createStoredAgent({
+  name: 'My Agent',
+  // ...other config
+  memory: {
+    observationalMemory: true, // enable with defaults
+    options: { lastMessages: 40 },
+  },
+});
+
+// Or with custom configuration:
+await client.createStoredAgent({
+  name: 'My Agent',
+  memory: {
+    observationalMemory: {
+      model: 'google/gemini-2.5-flash',
+      scope: 'resource',
+      shareTokenBudget: true,
+      observation: { messageTokens: 50000 },
+      reflection: { observationTokens: 60000 },
+    },
+    options: { lastMessages: 40 },
+  },
+});
+```
+
+**Programmatic usage via editor:**
+
+```ts
+await editor.agent.create({
+  name: 'My Agent',
+  // ...other config
+  memory: {
+    observationalMemory: true, // enable with defaults
+    options: { lastMessages: 40 },
+  },
+});
+
+// Or with custom configuration:
+await editor.agent.create({
+  name: 'My Agent',
+  memory: {
+    observationalMemory: {
+      model: 'google/gemini-2.5-flash',
+      scope: 'resource',
+      shareTokenBudget: true,
+      observation: { messageTokens: 50000 },
+      reflection: { observationTokens: 60000 },
+    },
+    options: { lastMessages: 40 },
+  },
+});
+```

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -644,6 +644,37 @@ export type TitleGenerationConfig =
  *
  * Note: When semanticRecall is enabled, both `vector` (string, not false) and `embedder` must be configured.
  */
+/** Serializable observation step config for observational memory */
+export interface SerializedObservationConfig {
+  model?: string;
+  messageTokens?: number;
+  modelSettings?: Record<string, unknown>;
+  providerOptions?: Record<string, Record<string, unknown> | undefined>;
+  maxTokensPerBatch?: number;
+  bufferTokens?: number | false;
+  bufferActivation?: number;
+  blockAfter?: number;
+}
+
+/** Serializable reflection step config for observational memory */
+export interface SerializedReflectionConfig {
+  model?: string;
+  observationTokens?: number;
+  modelSettings?: Record<string, unknown>;
+  providerOptions?: Record<string, Record<string, unknown> | undefined>;
+  blockAfter?: number;
+  bufferActivation?: number;
+}
+
+/** Serializable observational memory configuration */
+export interface SerializedObservationalMemoryConfig {
+  model?: string;
+  scope?: 'resource' | 'thread';
+  shareTokenBudget?: boolean;
+  observation?: SerializedObservationConfig;
+  reflection?: SerializedReflectionConfig;
+}
+
 export interface SerializedMemoryConfig {
   /**
    * Vector database identifier. Required when semanticRecall is enabled.
@@ -670,6 +701,11 @@ export interface SerializedMemoryConfig {
    * Options to pass to the embedder
    */
   embedderOptions?: Record<string, unknown>;
+  /**
+   * Serialized observational memory configuration.
+   * `true` to enable with defaults, or a config object for customization.
+   */
+  observationalMemory?: boolean | SerializedObservationalMemoryConfig;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,15 @@ export { Mastra, type Config } from './mastra';
 
 // Re-export types needed by editor package
 export { Agent } from './agent';
-export type { SharedMemoryConfig, MemoryConfig, MastraMemory, SerializedMemoryConfig } from './memory';
+export type {
+  SharedMemoryConfig,
+  MemoryConfig,
+  MastraMemory,
+  SerializedMemoryConfig,
+  SerializedObservationalMemoryConfig,
+  SerializedObservationalMemoryObservationConfig,
+  SerializedObservationalMemoryReflectionConfig,
+} from './memory';
 export type { MastraVector as MastraVectorProvider } from './vector';
 export type { IMastraLogger as Logger } from './logger';
 export type { ToolAction } from './tools';

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -37,8 +37,23 @@ import type {
   MessageDeleteInput,
   MemoryRequestContext,
   SerializedMemoryConfig,
+  SerializedObservationalMemoryConfig,
+  ObservationalMemoryOptions,
 } from './types';
 import { isObservationalMemoryEnabled } from './types';
+
+/**
+ * Extract a string model ID from an AgentConfig['model'] value.
+ * Returns undefined for non-serializable values (functions, LanguageModel instances).
+ */
+function extractModelIdString(model: unknown): string | undefined {
+  if (typeof model === 'string') return model;
+  if (typeof model === 'function') return undefined;
+  if (model && typeof model === 'object' && 'id' in model && typeof (model as { id: unknown }).id === 'string') {
+    return (model as { id: string }).id;
+  }
+  return undefined;
+}
 
 export type MemoryProcessorOpts = {
   systemMessage?: string;
@@ -799,7 +814,7 @@ https://mastra.ai/en/docs/memory/overview`,
    * @returns Serializable memory configuration
    */
   getConfig(): SerializedMemoryConfig {
-    const { generateTitle, workingMemory, threads, ...restConfig } = this.threadConfig;
+    const { generateTitle, workingMemory, threads, observationalMemory, ...restConfig } = this.threadConfig;
 
     const config: SerializedMemoryConfig = {
       vector: this.vector?.id,
@@ -847,6 +862,74 @@ https://mastra.ai/en/docs/memory/overview`,
       config.embedderOptions = rest;
     }
 
+    // Serialize observationalMemory configuration
+    if (observationalMemory !== undefined) {
+      config.observationalMemory = this.serializeObservationalMemory(observationalMemory);
+    }
+
     return config;
+  }
+
+  /**
+   * Serialize observational memory config to a JSON-safe representation.
+   * Model references that aren't string IDs are dropped (non-serializable).
+   */
+  private serializeObservationalMemory(
+    om: boolean | ObservationalMemoryOptions,
+  ): SerializedMemoryConfig['observationalMemory'] {
+    if (typeof om === 'boolean') {
+      return om;
+    }
+
+    if (om.enabled === false) {
+      return false;
+    }
+
+    const result: SerializedObservationalMemoryConfig = {
+      scope: om.scope,
+      shareTokenBudget: om.shareTokenBudget,
+    };
+
+    // Extract model ID string from the top-level model
+    const topModelId = extractModelIdString(om.model);
+    if (topModelId) {
+      result.model = topModelId;
+    }
+
+    // Serialize observation config
+    if (om.observation) {
+      const obs = om.observation;
+      result.observation = {
+        messageTokens: obs.messageTokens,
+        modelSettings: obs.modelSettings as Record<string, unknown>,
+        providerOptions: obs.providerOptions,
+        maxTokensPerBatch: obs.maxTokensPerBatch,
+        bufferTokens: obs.bufferTokens,
+        bufferActivation: obs.bufferActivation,
+        blockAfter: obs.blockAfter,
+      };
+      const obsModelId = extractModelIdString(obs.model);
+      if (obsModelId) {
+        result.observation.model = obsModelId;
+      }
+    }
+
+    // Serialize reflection config
+    if (om.reflection) {
+      const ref = om.reflection;
+      result.reflection = {
+        observationTokens: ref.observationTokens,
+        modelSettings: ref.modelSettings as Record<string, unknown>,
+        providerOptions: ref.providerOptions,
+        blockAfter: ref.blockAfter,
+        bufferActivation: ref.bufferActivation,
+      };
+      const refModelId = extractModelIdString(ref.model);
+      if (refModelId) {
+        result.reflection.model = refModelId;
+      }
+    }
+
+    return result;
   }
 }

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -1021,4 +1021,68 @@ export type SerializedMemoryConfig = {
    * Options to pass to the embedder, omitting telemetry
    */
   embedderOptions?: Omit<MastraEmbeddingOptions, 'telemetry'>;
+
+  /**
+   * Serialized observational memory configuration.
+   * `true` to enable with defaults, or a config object for customization.
+   * Only JSON-safe fields are included (model IDs as strings, numeric/boolean settings).
+   */
+  observationalMemory?: boolean | SerializedObservationalMemoryConfig;
+};
+
+/**
+ * JSON-serializable subset of ObservationalMemoryOptions for storage.
+ * Model references are stored as string IDs (e.g., "google/gemini-2.5-flash").
+ */
+export type SerializedObservationalMemoryConfig = {
+  /** Model ID for both Observer and Reflector (e.g., "google/gemini-2.5-flash") */
+  model?: string;
+
+  /** Memory scope: 'resource' or 'thread' */
+  scope?: 'resource' | 'thread';
+
+  /** Share the token budget between messages and observations */
+  shareTokenBudget?: boolean;
+
+  /** Observation step configuration */
+  observation?: SerializedObservationalMemoryObservationConfig;
+
+  /** Reflection step configuration */
+  reflection?: SerializedObservationalMemoryReflectionConfig;
+};
+
+/** Serializable subset of ObservationalMemoryObservationConfig */
+export type SerializedObservationalMemoryObservationConfig = {
+  /** Observer model ID */
+  model?: string;
+  /** Token count threshold that triggers observation */
+  messageTokens?: number;
+  /** Model settings (temperature, maxOutputTokens, etc.) */
+  modelSettings?: Record<string, unknown>;
+  /** Provider-specific options */
+  providerOptions?: Record<string, Record<string, unknown> | undefined>;
+  /** Maximum tokens per batch */
+  maxTokensPerBatch?: number;
+  /** Token interval for async buffering, or false to disable */
+  bufferTokens?: number | false;
+  /** Ratio of buffered observations to activate */
+  bufferActivation?: number;
+  /** Token threshold for synchronous blocking */
+  blockAfter?: number;
+};
+
+/** Serializable subset of ObservationalMemoryReflectionConfig */
+export type SerializedObservationalMemoryReflectionConfig = {
+  /** Reflector model ID */
+  model?: string;
+  /** Token count threshold that triggers reflection */
+  observationTokens?: number;
+  /** Model settings (temperature, maxOutputTokens, etc.) */
+  modelSettings?: Record<string, unknown>;
+  /** Provider-specific options */
+  providerOptions?: Record<string, Record<string, unknown> | undefined>;
+  /** Token threshold for synchronous blocking */
+  blockAfter?: number;
+  /** Ratio for async reflection buffering */
+  bufferActivation?: number;
 };

--- a/packages/playground-ui/src/domains/agents/components/agent-edit-page/agent-edit-sidebar.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-edit-page/agent-edit-sidebar.tsx
@@ -236,7 +236,7 @@ export function AgentEditSidebar({
                 readOnly={readOnly}
               />
               <ScorersSection control={control} readOnly={readOnly} />
-              <MemorySection control={control} readOnly={readOnly} />
+              <MemorySection control={control} setValue={form.setValue} readOnly={readOnly} />
             </div>
           </ScrollArea>
         </TabContent>

--- a/packages/playground-ui/src/domains/agents/components/agent-edit-page/sections/memory-section.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-edit-page/sections/memory-section.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Controller, Control, useWatch } from 'react-hook-form';
+import { Controller, Control, useWatch, type UseFormSetValue } from 'react-hook-form';
 import { ChevronRight } from 'lucide-react';
 
 import { MemoryIcon } from '@/ds/icons';
@@ -16,10 +16,11 @@ import { LLMProviders, LLMModels } from '@/domains/llm';
 
 interface MemorySectionProps {
   control: Control<AgentFormValues>;
+  setValue: UseFormSetValue<AgentFormValues>;
   readOnly?: boolean;
 }
 
-export function MemorySection({ control, readOnly = false }: MemorySectionProps) {
+export function MemorySection({ control, setValue, readOnly = false }: MemorySectionProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isObserverOpen, setIsObserverOpen] = useState(false);
   const [isReflectorOpen, setIsReflectorOpen] = useState(false);
@@ -226,7 +227,14 @@ export function MemorySection({ control, readOnly = false }: MemorySectionProps)
                         control={control}
                         render={({ field }) => (
                           <div className={readOnly ? 'pointer-events-none opacity-60' : ''}>
-                            <LLMProviders value={field.value ?? ''} onValueChange={field.onChange} variant="light" />
+                            <LLMProviders
+                              value={field.value ?? ''}
+                              onValueChange={v => {
+                                field.onChange(v);
+                                setValue('memory.observationalMemory.model.name', '');
+                              }}
+                              variant="light"
+                            />
                           </div>
                         )}
                       />
@@ -320,7 +328,10 @@ export function MemorySection({ control, readOnly = false }: MemorySectionProps)
                                 <div className={readOnly ? 'pointer-events-none opacity-60' : ''}>
                                   <LLMProviders
                                     value={field.value ?? ''}
-                                    onValueChange={field.onChange}
+                                    onValueChange={v => {
+                                      field.onChange(v);
+                                      setValue('memory.observationalMemory.observation.model.name', '');
+                                    }}
                                     variant="light"
                                   />
                                 </div>
@@ -524,7 +535,10 @@ export function MemorySection({ control, readOnly = false }: MemorySectionProps)
                                 <div className={readOnly ? 'pointer-events-none opacity-60' : ''}>
                                   <LLMProviders
                                     value={field.value ?? ''}
-                                    onValueChange={field.onChange}
+                                    onValueChange={v => {
+                                      field.onChange(v);
+                                      setValue('memory.observationalMemory.reflection.model.name', '');
+                                    }}
                                     variant="light"
                                   />
                                 </div>

--- a/packages/playground-ui/src/domains/agents/components/agent-edit-page/sections/memory-section.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-edit-page/sections/memory-section.tsx
@@ -28,10 +28,8 @@ export function MemorySection({ control, readOnly = false }: MemorySectionProps)
   const semanticRecallEnabled = memoryConfig?.semanticRecall ?? false;
   const observationalMemoryEnabled = memoryConfig?.observationalMemory?.enabled ?? false;
   const omProvider = useWatch({ control, name: 'memory.observationalMemory.model.provider' }) ?? '';
-  const observerProvider =
-    useWatch({ control, name: 'memory.observationalMemory.observation.model.provider' }) ?? '';
-  const reflectorProvider =
-    useWatch({ control, name: 'memory.observationalMemory.reflection.model.provider' }) ?? '';
+  const observerProvider = useWatch({ control, name: 'memory.observationalMemory.observation.model.provider' }) ?? '';
+  const reflectorProvider = useWatch({ control, name: 'memory.observationalMemory.reflection.model.provider' }) ?? '';
 
   const { data: vectorsData } = useVectors();
   const { data: embeddersData } = useEmbedders();
@@ -222,19 +220,13 @@ export function MemorySection({ control, readOnly = false }: MemorySectionProps)
                   <div className="ml-2 pl-3 border-l-2 border-border1 flex flex-col gap-4">
                     <div className="flex flex-col gap-1.5">
                       <Label className="text-xs text-icon4">Provider</Label>
-                      <span className="text-xs text-icon3">
-                        Provider for the observer and reflector agents
-                      </span>
+                      <span className="text-xs text-icon3">Provider for the observer and reflector agents</span>
                       <Controller
                         name="memory.observationalMemory.model.provider"
                         control={control}
                         render={({ field }) => (
                           <div className={readOnly ? 'pointer-events-none opacity-60' : ''}>
-                            <LLMProviders
-                              value={field.value ?? ''}
-                              onValueChange={field.onChange}
-                              variant="light"
-                            />
+                            <LLMProviders value={field.value ?? ''} onValueChange={field.onChange} variant="light" />
                           </div>
                         )}
                       />
@@ -242,9 +234,7 @@ export function MemorySection({ control, readOnly = false }: MemorySectionProps)
 
                     <div className="flex flex-col gap-1.5">
                       <Label className="text-xs text-icon4">Model</Label>
-                      <span className="text-xs text-icon3">
-                        Model for the observer and reflector agents
-                      </span>
+                      <span className="text-xs text-icon3">Model for the observer and reflector agents</span>
                       <Controller
                         name="memory.observationalMemory.model.name"
                         control={control}
@@ -272,11 +262,7 @@ export function MemorySection({ control, readOnly = false }: MemorySectionProps)
                           <span className="text-xs text-icon3">
                             Whether observations are scoped per thread or shared across all threads for a resource
                           </span>
-                          <Select
-                            value={field.value ?? 'thread'}
-                            onValueChange={field.onChange}
-                            disabled={readOnly}
-                          >
+                          <Select value={field.value ?? 'thread'} onValueChange={field.onChange} disabled={readOnly}>
                             <SelectTrigger id="memory-om-scope" className="bg-surface3">
                               <SelectValue placeholder="Select scope" />
                             </SelectTrigger>
@@ -344,9 +330,7 @@ export function MemorySection({ control, readOnly = false }: MemorySectionProps)
 
                           <div className="flex flex-col gap-1.5">
                             <Label className="text-xs text-icon4">Model Override</Label>
-                            <span className="text-xs text-icon3">
-                              Override the default model for the observer
-                            </span>
+                            <span className="text-xs text-icon3">Override the default model for the observer</span>
                             <Controller
                               name="memory.observationalMemory.observation.model.name"
                               control={control}
@@ -430,8 +414,8 @@ export function MemorySection({ control, readOnly = false }: MemorySectionProps)
                                   Buffer Tokens
                                 </Label>
                                 <span className="text-xs text-icon3">
-                                  Token interval for async buffering (fraction of messageTokens or absolute count,
-                                  empty to use default 0.2, set 0 to disable)
+                                  Token interval for async buffering (fraction of messageTokens or absolute count, empty
+                                  to use default 0.2, set 0 to disable)
                                 </span>
                                 <Input
                                   id="memory-om-obs-buffer"
@@ -550,9 +534,7 @@ export function MemorySection({ control, readOnly = false }: MemorySectionProps)
 
                           <div className="flex flex-col gap-1.5">
                             <Label className="text-xs text-icon4">Model Override</Label>
-                            <span className="text-xs text-icon3">
-                              Override the default model for the reflector
-                            </span>
+                            <span className="text-xs text-icon3">Override the default model for the reflector</span>
                             <Controller
                               name="memory.observationalMemory.reflection.model.name"
                               control={control}

--- a/packages/playground-ui/src/domains/agents/components/agent-edit-page/sections/memory-section.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-edit-page/sections/memory-section.tsx
@@ -645,7 +645,7 @@ export function MemorySection({ control, setValue, readOnly = false }: MemorySec
                                     const v = e.target.value;
                                     field.onChange(v === '' ? undefined : parseFloat(v));
                                   }}
-                                  placeholder=""
+                                  placeholder="0.8"
                                   className="bg-surface3"
                                   disabled={readOnly}
                                 />

--- a/packages/playground-ui/src/domains/agents/components/agent-edit-page/utils/form-validation.ts
+++ b/packages/playground-ui/src/domains/agents/components/agent-edit-page/utils/form-validation.ts
@@ -80,6 +80,47 @@ const memoryConfigSchema = z
     readOnly: z.boolean().optional(),
     vector: z.string().optional(),
     embedder: z.string().optional(),
+    observationalMemory: z
+      .object({
+        enabled: z.boolean().optional(),
+        model: z
+          .object({
+            provider: z.string().optional(),
+            name: z.string().optional(),
+          })
+          .optional(),
+        scope: z.enum(['resource', 'thread']).optional(),
+        shareTokenBudget: z.boolean().optional(),
+        observation: z
+          .object({
+            model: z
+              .object({
+                provider: z.string().optional(),
+                name: z.string().optional(),
+              })
+              .optional(),
+            messageTokens: z.number().min(1).optional(),
+            maxTokensPerBatch: z.number().min(1).optional(),
+            bufferTokens: z.union([z.number().min(0), z.literal(false)]).optional(),
+            bufferActivation: z.number().min(0).max(1).optional(),
+            blockAfter: z.number().min(0).optional(),
+          })
+          .optional(),
+        reflection: z
+          .object({
+            model: z
+              .object({
+                provider: z.string().optional(),
+                name: z.string().optional(),
+              })
+              .optional(),
+            observationTokens: z.number().min(1).optional(),
+            blockAfter: z.number().min(0).optional(),
+            bufferActivation: z.number().min(0).max(1).optional(),
+          })
+          .optional(),
+      })
+      .optional(),
   })
   .refine(
     data => {

--- a/packages/playground/src/pages/cms/agents/create/index.tsx
+++ b/packages/playground/src/pages/cms/agents/create/index.tsx
@@ -88,8 +88,8 @@ function CmsAgentsCreatePage() {
                       om.observation?.messageTokens ||
                       om.observation?.maxTokensPerBatch ||
                       om.observation?.bufferTokens !== undefined ||
-                      om.observation?.bufferActivation ||
-                      om.observation?.blockAfter
+                      om.observation?.bufferActivation !== undefined ||
+                      om.observation?.blockAfter !== undefined
                         ? {
                             model: obsModelId,
                             messageTokens: om.observation?.messageTokens,
@@ -107,8 +107,8 @@ function CmsAgentsCreatePage() {
                     const reflection =
                       refModelId ||
                       om.reflection?.observationTokens ||
-                      om.reflection?.blockAfter ||
-                      om.reflection?.bufferActivation
+                      om.reflection?.blockAfter !== undefined ||
+                      om.reflection?.bufferActivation !== undefined
                         ? {
                             model: refModelId,
                             observationTokens: om.reflection?.observationTokens,

--- a/packages/playground/src/pages/cms/agents/create/index.tsx
+++ b/packages/playground/src/pages/cms/agents/create/index.tsx
@@ -73,6 +73,61 @@ function CmsAgentsCreatePage() {
                 semanticRecall: values.memory.semanticRecall,
                 readOnly: values.memory.readOnly,
               },
+              observationalMemory: values.memory.observationalMemory?.enabled
+                ? (() => {
+                    const om = values.memory.observationalMemory;
+                    const modelId =
+                      om.model?.provider && om.model?.name ? `${om.model.provider}/${om.model.name}` : undefined;
+
+                    const obsModelId =
+                      om.observation?.model?.provider && om.observation?.model?.name
+                        ? `${om.observation.model.provider}/${om.observation.model.name}`
+                        : undefined;
+                    const observation =
+                      obsModelId ||
+                      om.observation?.messageTokens ||
+                      om.observation?.maxTokensPerBatch ||
+                      om.observation?.bufferTokens !== undefined ||
+                      om.observation?.bufferActivation ||
+                      om.observation?.blockAfter
+                        ? {
+                            model: obsModelId,
+                            messageTokens: om.observation?.messageTokens,
+                            maxTokensPerBatch: om.observation?.maxTokensPerBatch,
+                            bufferTokens: om.observation?.bufferTokens,
+                            bufferActivation: om.observation?.bufferActivation,
+                            blockAfter: om.observation?.blockAfter,
+                          }
+                        : undefined;
+
+                    const refModelId =
+                      om.reflection?.model?.provider && om.reflection?.model?.name
+                        ? `${om.reflection.model.provider}/${om.reflection.model.name}`
+                        : undefined;
+                    const reflection =
+                      refModelId ||
+                      om.reflection?.observationTokens ||
+                      om.reflection?.blockAfter ||
+                      om.reflection?.bufferActivation
+                        ? {
+                            model: refModelId,
+                            observationTokens: om.reflection?.observationTokens,
+                            blockAfter: om.reflection?.blockAfter,
+                            bufferActivation: om.reflection?.bufferActivation,
+                          }
+                        : undefined;
+
+                    return modelId || om.scope || om.shareTokenBudget || observation || reflection
+                      ? {
+                          model: modelId,
+                          scope: om.scope,
+                          shareTokenBudget: om.shareTokenBudget,
+                          observation,
+                          reflection,
+                        }
+                      : true;
+                  })()
+                : undefined,
             }
           : undefined,
         requestContextSchema: values.variables as Record<string, unknown> | undefined,

--- a/packages/playground/src/pages/cms/agents/edit/index.tsx
+++ b/packages/playground/src/pages/cms/agents/edit/index.tsx
@@ -270,8 +270,8 @@ function CmsAgentsEditForm({
                       om.observation?.messageTokens ||
                       om.observation?.maxTokensPerBatch ||
                       om.observation?.bufferTokens !== undefined ||
-                      om.observation?.bufferActivation ||
-                      om.observation?.blockAfter
+                      om.observation?.bufferActivation !== undefined ||
+                      om.observation?.blockAfter !== undefined
                         ? {
                             model: obsModelId,
                             messageTokens: om.observation?.messageTokens,
@@ -286,8 +286,8 @@ function CmsAgentsEditForm({
                     const reflection =
                       refModelId ||
                       om.reflection?.observationTokens ||
-                      om.reflection?.blockAfter ||
-                      om.reflection?.bufferActivation
+                      om.reflection?.blockAfter !== undefined ||
+                      om.reflection?.bufferActivation !== undefined
                         ? {
                             model: refModelId,
                             observationTokens: om.reflection?.observationTokens,

--- a/packages/playground/src/pages/cms/agents/edit/index.tsx
+++ b/packages/playground/src/pages/cms/agents/edit/index.tsx
@@ -95,6 +95,27 @@ function CmsAgentsEditForm({
           vector?: string;
           embedder?: string;
           options?: { lastMessages?: number | false; semanticRecall?: boolean; readOnly?: boolean };
+          observationalMemory?:
+            | boolean
+            | {
+                model?: string;
+                scope?: 'resource' | 'thread';
+                shareTokenBudget?: boolean;
+                observation?: {
+                  model?: string;
+                  messageTokens?: number;
+                  maxTokensPerBatch?: number;
+                  bufferTokens?: number | false;
+                  bufferActivation?: number;
+                  blockAfter?: number;
+                };
+                reflection?: {
+                  model?: string;
+                  observationTokens?: number;
+                  blockAfter?: number;
+                  bufferActivation?: number;
+                };
+              };
         }
       | undefined;
 
@@ -135,6 +156,41 @@ function CmsAgentsEditForm({
             readOnly: memoryData.options.readOnly,
             vector: memoryData.vector,
             embedder: memoryData.embedder,
+            observationalMemory: memoryData.observationalMemory
+              ? (() => {
+                  const om = typeof memoryData.observationalMemory === 'object' ? memoryData.observationalMemory : {};
+                  const splitModel = (id?: string) => {
+                    if (!id) return undefined;
+                    const [p, ...rest] = id.split('/');
+                    const n = rest.join('/');
+                    return p && n ? { provider: p, name: n } : undefined;
+                  };
+                  return {
+                    enabled: true as const,
+                    model: splitModel(om.model),
+                    scope: om.scope,
+                    shareTokenBudget: om.shareTokenBudget,
+                    observation: om.observation
+                      ? {
+                          model: splitModel(om.observation.model),
+                          messageTokens: om.observation.messageTokens,
+                          maxTokensPerBatch: om.observation.maxTokensPerBatch,
+                          bufferTokens: om.observation.bufferTokens,
+                          bufferActivation: om.observation.bufferActivation,
+                          blockAfter: om.observation.blockAfter,
+                        }
+                      : undefined,
+                    reflection: om.reflection
+                      ? {
+                          model: splitModel(om.reflection.model),
+                          observationTokens: om.reflection.observationTokens,
+                          blockAfter: om.reflection.blockAfter,
+                          bufferActivation: om.reflection.bufferActivation,
+                        }
+                      : undefined,
+                  };
+                })()
+              : undefined,
           }
         : undefined,
       instructionBlocks,
@@ -201,6 +257,56 @@ function CmsAgentsEditForm({
                 semanticRecall: values.memory.semanticRecall,
                 readOnly: values.memory.readOnly,
               },
+              observationalMemory: values.memory.observationalMemory?.enabled
+                ? (() => {
+                    const om = values.memory.observationalMemory;
+                    const joinModel = (m?: { provider?: string; name?: string }) =>
+                      m?.provider && m?.name ? `${m.provider}/${m.name}` : undefined;
+                    const modelId = joinModel(om.model);
+
+                    const obsModelId = joinModel(om.observation?.model);
+                    const observation =
+                      obsModelId ||
+                      om.observation?.messageTokens ||
+                      om.observation?.maxTokensPerBatch ||
+                      om.observation?.bufferTokens !== undefined ||
+                      om.observation?.bufferActivation ||
+                      om.observation?.blockAfter
+                        ? {
+                            model: obsModelId,
+                            messageTokens: om.observation?.messageTokens,
+                            maxTokensPerBatch: om.observation?.maxTokensPerBatch,
+                            bufferTokens: om.observation?.bufferTokens,
+                            bufferActivation: om.observation?.bufferActivation,
+                            blockAfter: om.observation?.blockAfter,
+                          }
+                        : undefined;
+
+                    const refModelId = joinModel(om.reflection?.model);
+                    const reflection =
+                      refModelId ||
+                      om.reflection?.observationTokens ||
+                      om.reflection?.blockAfter ||
+                      om.reflection?.bufferActivation
+                        ? {
+                            model: refModelId,
+                            observationTokens: om.reflection?.observationTokens,
+                            blockAfter: om.reflection?.blockAfter,
+                            bufferActivation: om.reflection?.bufferActivation,
+                          }
+                        : undefined;
+
+                    return modelId || om.scope || om.shareTokenBudget || observation || reflection
+                      ? {
+                          model: modelId,
+                          scope: om.scope,
+                          shareTokenBudget: om.shareTokenBudget,
+                          observation,
+                          reflection,
+                        }
+                      : true;
+                  })()
+                : undefined,
             }
           : undefined,
         requestContextSchema: values.variables as Record<string, unknown> | undefined,


### PR DESCRIPTION
Stored agents can now have observational memory configured through the playground UI and client SDK. Previously, observational memory was only available for code-defined agents since it wasn't part of the serialized memory config.

The playground Memory section now has an Observational Memory toggle that expands to show model selection (using the same provider/model pickers as the identity section), scope, share token budget, and collapsible Observer/Reflector sections with all the token/buffer tuning options.

client js
```ts
await client.createStoredAgent({
  name: 'My Agent',
  memory: {
    observationalMemory: true, // defaults
    options: { lastMessages: 40 },
  },
});

// or with custom config
await client.createStoredAgent({
  name: 'My Agent',
  memory: {
    observationalMemory: {
      model: 'google/gemini-2.5-flash',
      scope: 'resource',
      observation: { messageTokens: 50000 },
    },
    options: { lastMessages: 40 },
  },
});
```

editor:
```ts
await editor.agent.create({
  name: 'My Agent',
  // ...other config
  memory: {
    observationalMemory: true, // enable with defaults
    options: { lastMessages: 40 },
  },
});

// Or with custom configuration:
await editor.agent.create({
  name: 'My Agent',
  memory: {
    observationalMemory: {
      model: 'google/gemini-2.5-flash',
      scope: 'resource',
      shareTokenBudget: true,
      observation: { messageTokens: 50000 },
      reflection: { observationTokens: 60000 },
    },
    options: { lastMessages: 40 },
  },
});
```
Changes span core (serialized types + getConfig), server (zod schemas), editor (memory resolution), client-js (types), playground-ui (form schema + UI), and playground (create/edit page transformations).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observational Memory: enable per-agent observational memory with provider/model overrides, scope (thread or resource), and shared token-budget controls.
  * Fine-grained observer & reflector tuning: message/observation token limits, batching, buffers, activation and blocking thresholds.
  * UI & persistence: settings available in the playground and editor UIs, round-trippable in create/edit flows, and supported by the client SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->