### PR TITLE
docs: workspace configuration patterns and filesystem mounts guide

### DIFF
--- a/docs/src/content/en/docs/workspace/filesystem.mdx
+++ b/docs/src/content/en/docs/workspace/filesystem.mdx
@@ -74,6 +74,54 @@ const workspace = new Workspace({
 
 When read-only, write tools (`write_file`, `edit_file`, `delete`, `mkdir`) are not added to the agent's toolset. The agent can still read and list files.
 
+## Mounts and CompositeFilesystem
+
+When you use the `mounts` option on a workspace, Mastra creates a `CompositeFilesystem` that routes file operations to the correct provider based on path prefix.
+
+```typescript
+import { Workspace } from '@mastra/core/workspace';
+import { S3Filesystem } from '@mastra/s3';
+import { GCSFilesystem } from '@mastra/gcs';
+import { E2BSandbox } from '@mastra/e2b';
+
+const workspace = new Workspace({
+  mounts: {
+    '/data': new S3Filesystem({
+      bucket: 'my-bucket',
+      region: 'us-east-1',
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    }),
+    '/models': new GCSFilesystem({
+      bucket: 'ml-models',
+    }),
+  },
+  sandbox: new E2BSandbox({ id: 'dev-sandbox' }),
+});
+```
+
+With this configuration:
+
+- `read_file('/data/input.csv')` reads from the S3 bucket
+- `write_file('/models/output.json', content)` writes to the GCS bucket
+- `list_directory('/')` returns virtual entries for `/data` and `/models`
+- Commands in the sandbox can access files at `/data` and `/models` via FUSE mounts
+
+### Path routing
+
+All file paths must start with a mount prefix. Operations on paths that don't match any mount will fail. Listing the root directory (`/`) returns virtual directory entries for each mount point.
+
+Mount paths cannot be nested — for example, you cannot mount at both `/data` and `/data/sub`.
+
+### `filesystem` vs `mounts`
+
+`filesystem` and `mounts` are mutually exclusive options on a workspace:
+
+- Use **`filesystem`** when you have a single storage provider and don't need to mount it into a sandbox. The agent gets file tools that operate directly against the provider.
+- Use **`mounts`** when you need cloud storage accessible inside a sandbox, or when you want to combine multiple providers. The workspace creates a CompositeFilesystem for file tools and FUSE-mounts the storage into the sandbox.
+
+For local development, you typically don't need `mounts` — a `LocalFilesystem` and `LocalSandbox` pointed at the same directory gives you both file tools and command execution on the same files. See [configuration patterns](/docs/workspace/overview#configuration-patterns) for more detail.
+
 ## Agent tools
 
 When you configure a filesystem on a workspace, agents receive tools for reading, writing, listing, and deleting files. See [workspace class reference](/reference/workspace/workspace-class#filesystem-tools) for details.

--- a/docs/src/content/en/docs/workspace/filesystem.mdx
+++ b/docs/src/content/en/docs/workspace/filesystem.mdx
@@ -92,8 +92,8 @@ const workspace = new Workspace({
       accessKeyId: process.env.AWS_ACCESS_KEY_ID,
       secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
     }),
-    '/models': new GCSFilesystem({
-      bucket: 'ml-models',
+    '/skills': new GCSFilesystem({
+      bucket: 'agent-skills',
     }),
   },
   sandbox: new E2BSandbox({ id: 'dev-sandbox' }),
@@ -103,9 +103,9 @@ const workspace = new Workspace({
 With this configuration:
 
 - `read_file('/data/input.csv')` reads from the S3 bucket
-- `write_file('/models/output.json', content)` writes to the GCS bucket
-- `list_directory('/')` returns virtual entries for `/data` and `/models`
-- Commands in the sandbox can access files at `/data` and `/models` via FUSE mounts
+- `write_file('/skills/guide.md', content)` writes to the GCS bucket
+- `list_directory('/')` returns virtual entries for `/data` and `/skills`
+- Commands in the sandbox can access files at `/data` and `/skills` via FUSE mounts
 
 ### Path routing
 

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -82,31 +82,92 @@ export const myAgent = new Agent({
 });
 ```
 
-## Initialization
+## Configuration patterns
 
-Calling `init()` is optional in most cases—some providers initialize on first operation. Call `init()` manually when using a workspace outside of Mastra (standalone scripts, tests) or when you need to pre-provision resources before the first agent interaction.
+Workspaces support several configuration patterns depending on what capabilities your agent needs. The two main building blocks are `filesystem` (file tools) and `sandbox` (command execution), with `mounts` as the way to bridge cloud storage into sandboxes.
 
-```typescript title="src/mastra/workspaces.ts"
-import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace';
+### Filesystem only
 
+Use a single `filesystem` when agents only need to read and write files. No command execution is available.
+
+```typescript
+const workspace = new Workspace({
+  filesystem: new S3Filesystem({
+    bucket: 'my-bucket',
+    region: 'us-east-1',
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  }),
+});
+```
+
+The agent receives file tools (`read_file`, `write_file`, `list_directory`, etc.) that operate directly against the storage provider.
+
+### Sandbox only
+
+Use a single `sandbox` when agents only need to execute commands. No file tools are added.
+
+```typescript
+const workspace = new Workspace({
+  sandbox: new E2BSandbox({ id: 'dev-sandbox' }),
+});
+```
+
+The agent receives the `execute_command` tool.
+
+### Filesystem + sandbox (local)
+
+For local development, pair a `LocalFilesystem` and `LocalSandbox` pointed at the same directory. Since both operate on the local machine, files written through the filesystem are immediately available to commands in the sandbox:
+
+```typescript
 const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: './workspace' }),
   sandbox: new LocalSandbox({ workingDirectory: './workspace' }),
 });
-
-// Optional: pre-create directories and sandbox before first use
-await workspace.init();
 ```
 
-### What init() does
+The agent receives both file tools and `execute_command`. This is the simplest full-featured setup.
 
-Initialization runs setup logic for each configured provider:
+### Mounts + sandbox (cloud storage)
 
-- `LocalFilesystem`: Creates the base directory if it doesn't exist
-- `LocalSandbox`: Creates the working directory
-- `Search` (if configured): Indexes files from `autoIndexPaths`, see [Search and Indexing](/docs/workspace/search)
+When you need cloud storage accessible inside a sandbox, use `mounts`. This FUSE-mounts the cloud filesystem into the sandbox so commands can read and write files at the mount path:
 
-External providers may perform additional setup like establishing connections or authenticating.
+```typescript
+const workspace = new Workspace({
+  mounts: {
+    '/data': new S3Filesystem({
+      bucket: 'my-bucket',
+      region: 'us-east-1',
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    }),
+    '/models': new GCSFilesystem({
+      bucket: 'ml-models',
+    }),
+  },
+  sandbox: new E2BSandbox({ id: 'dev-sandbox' }),
+});
+```
+
+Under the hood, `mounts` creates a [CompositeFilesystem](/docs/workspace/filesystem#mounts-and-compositefilesystem) that routes file tool operations to the correct provider based on path prefix. Commands in the sandbox access the mounted paths directly (e.g., `ls /data`).
+
+You can mount multiple providers at different paths. Each mount path must be unique and non-overlapping.
+
+:::note
+
+`filesystem` and `mounts` are mutually exclusive — you cannot use both in the same workspace. Use `filesystem` for a single provider without a sandbox, or `mounts` when you need to combine cloud storage with a sandbox.
+
+:::
+
+### Which pattern should I use?
+
+| Scenario | Pattern |
+|---|---|
+| Agent reads/writes files, no command execution needed | `filesystem` only |
+| Agent runs commands, no file tools needed | `sandbox` only |
+| Local development with files and commands | `filesystem` + `sandbox` (both local, same directory) |
+| Cloud storage accessible inside a cloud sandbox | `mounts` + `sandbox` |
+| Multiple cloud providers in one sandbox | `mounts` + `sandbox` (one mount per provider) |
 
 ## Tool configuration
 
@@ -153,6 +214,32 @@ When `requireReadBeforeWrite` is enabled on write tools, agents must read a file
 - **New files**: Can be written without reading (they don't exist yet)
 - **Existing files**: Must be read first
 - **Externally modified files**: If a file changed since the agent read it, the write fails
+
+## Initialization
+
+Calling `init()` is optional in most cases—some providers initialize on first operation. Call `init()` manually when using a workspace outside of Mastra (standalone scripts, tests) or when you need to pre-provision resources before the first agent interaction.
+
+```typescript title="src/mastra/workspaces.ts"
+import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace';
+
+const workspace = new Workspace({
+  filesystem: new LocalFilesystem({ basePath: './workspace' }),
+  sandbox: new LocalSandbox({ workingDirectory: './workspace' }),
+});
+
+// Optional: pre-create directories and sandbox before first use
+await workspace.init();
+```
+
+### What init() does
+
+Initialization runs setup logic for each configured provider:
+
+- `LocalFilesystem`: Creates the base directory if it doesn't exist
+- `LocalSandbox`: Creates the working directory
+- `Search` (if configured): Indexes files from `autoIndexPaths`, see [Search and Indexing](/docs/workspace/search)
+
+External providers may perform additional setup like establishing connections or authenticating.
 
 ## Related
 

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -86,35 +86,6 @@ export const myAgent = new Agent({
 
 Workspaces support several configuration patterns depending on what capabilities your agent needs. The two main building blocks are `filesystem` (file tools) and `sandbox` (command execution), with `mounts` as the way to bridge cloud storage into sandboxes.
 
-### Filesystem only
-
-Use a single `filesystem` when agents only need to read and write files. No command execution is available.
-
-```typescript
-const workspace = new Workspace({
-  filesystem: new S3Filesystem({
-    bucket: 'my-bucket',
-    region: 'us-east-1',
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-  }),
-});
-```
-
-The agent receives file tools (`read_file`, `write_file`, `list_directory`, etc.) that operate directly against the storage provider.
-
-### Sandbox only
-
-Use a single `sandbox` when agents only need to execute commands. No file tools are added.
-
-```typescript
-const workspace = new Workspace({
-  sandbox: new E2BSandbox({ id: 'dev-sandbox' }),
-});
-```
-
-The agent receives the `execute_command` tool.
-
 ### Filesystem + sandbox (local)
 
 For local development, pair a `LocalFilesystem` and `LocalSandbox` pointed at the same directory. Since both operate on the local machine, files written through the filesystem are immediately available to commands in the sandbox:
@@ -159,15 +130,44 @@ You can mount multiple providers at different paths. Each mount path must be uni
 
 :::
 
+### Filesystem only
+
+Use a single `filesystem` when agents only need to read and write files. No command execution is available.
+
+```typescript
+const workspace = new Workspace({
+  filesystem: new S3Filesystem({
+    bucket: 'my-bucket',
+    region: 'us-east-1',
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  }),
+});
+```
+
+The agent receives file tools (`read_file`, `write_file`, `list_directory`, etc.) that operate directly against the storage provider.
+
+### Sandbox only
+
+Use a single `sandbox` when agents only need to execute commands. No file tools are added.
+
+```typescript
+const workspace = new Workspace({
+  sandbox: new E2BSandbox({ id: 'dev-sandbox' }),
+});
+```
+
+The agent receives the `execute_command` tool.
+
 ### Which pattern should I use?
 
 | Scenario | Pattern |
 |---|---|
-| Agent reads/writes files, no command execution needed | `filesystem` only |
-| Agent runs commands, no file tools needed | `sandbox` only |
 | Local development with files and commands | `filesystem` + `sandbox` (both local, same directory) |
 | Cloud storage accessible inside a cloud sandbox | `mounts` + `sandbox` |
 | Multiple cloud providers in one sandbox | `mounts` + `sandbox` (one mount per provider) |
+| Agent reads/writes files, no command execution needed | `filesystem` only |
+| Agent runs commands, no file tools needed | `sandbox` only |
 
 ## Tool configuration
 

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -141,8 +141,8 @@ const workspace = new Workspace({
       accessKeyId: process.env.AWS_ACCESS_KEY_ID,
       secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
     }),
-    '/models': new GCSFilesystem({
-      bucket: 'ml-models',
+    '/skills': new GCSFilesystem({
+      bucket: 'agent-skills',
     }),
   },
   sandbox: new E2BSandbox({ id: 'dev-sandbox' }),


### PR DESCRIPTION
## Summary
- Adds a **"Configuration patterns"** section to the workspace overview explaining when to use `filesystem`, `sandbox`, `mounts`, or combinations — with a decision table
- Adds **"Mounts and CompositeFilesystem"** section to the filesystem guide covering path routing, `filesystem` vs `mounts` tradeoffs, and multi-provider examples

## Test plan
- [ ] Verify docs build successfully
- [ ] Review rendered pages for workspace overview and filesystem guide
- [ ] Confirm internal links work (`#configuration-patterns`, `#mounts-and-compositefilesystem`)

Closes COR-507

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive section on mounts and the composite filesystem, covering path routing, non‑nested mount behavior, examples, and guidance on when to use mounts vs a single filesystem.
  * Reworked workspace docs: replaced "Initialization" with “Configuration patterns” (filesystem-only, sandbox-only, filesystem + sandbox, mounts + sandbox), added a decision table, pattern guidance, and an expanded Initialization section detailing provider setup and pre-use initialization steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->