### PR TITLE
fix: include actual error details in processor and model exhaustion failures

### DIFF
--- a/.changeset/improve-processor-error-messages.md
+++ b/.changeset/improve-processor-error-messages.md
@@ -1,0 +1,8 @@
+---
+"@mastra/core": patch
+---
+
+Improve error messages when processor workflows or model fallback retries fail.
+
+- Include the last error message and cause when all fallback models are exhausted, instead of the generic "Exhausted all fallback models" message.
+- Extract error details from failed workflow results and individual step failures when a processor workflow fails, instead of just reporting "failed with status: failed".

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -202,11 +202,24 @@ export class ProcessorRunner {
 
     // Check for execution failure
     if (result.status !== 'success') {
+      // Collect error details from the workflow result and failed steps
+      const details: string[] = [];
+      if (result.status === 'failed') {
+        if (result.error) {
+          details.push(result.error.message || JSON.stringify(result.error));
+        }
+        for (const [stepId, step] of Object.entries(result.steps)) {
+          if (step.status === 'failed' && step.error?.message) {
+            details.push(`step ${stepId}: ${step.error.message}`);
+          }
+        }
+      }
+      const detailStr = details.length > 0 ? ` — ${details.join('; ')}` : '';
       throw new MastraError({
         category: 'USER',
         domain: 'AGENT',
         id: 'PROCESSOR_WORKFLOW_FAILED',
-        text: `Processor workflow ${workflow.id} failed with status: ${result.status}`,
+        text: `Processor workflow ${workflow.id} failed with status: ${result.status}${detailStr}`,
       });
     }
 


### PR DESCRIPTION
## Summary

- **Processor workflow failures** now include the actual error message and per-step failure details instead of just "failed with status: failed"
- **Model exhaustion errors** ("Exhausted all fallback models") now include the last caught error message and preserve the original error as `cause`

Previously, when a processor (e.g. skills processor) failed with a permission error, the error would cascade through the model retry loop and surface as the unhelpful "Exhausted all fallback models and reached the maximum number of retries" with no indication of the root cause. Now the error chain is preserved end-to-end.

### Before
```
Error: Exhausted all fallback models and reached the maximum number of retries.
```

### After
```
Error: Exhausted all fallback models and reached the maximum number of retries.
Last error: Processor workflow code-agent-input-processor failed with status: failed
— Permission denied: access on /project/.mastracode/skills;
step processor:skills-processor: Permission denied: access on /project/.mastracode/skills
```

## Test plan
- [ ] Trigger a processor failure (e.g. skills processor with invalid path) and verify the error message includes the root cause
- [ ] Verify normal agent streaming still works without regressions
- [ ] Verify TripWire errors are still re-thrown immediately and not affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when model retries are exhausted: failures now include the most recent error details and preserve the original cause for clearer diagnostics.
  * Enhanced workflow failure reporting: when a workflow fails, messages now aggregate per-step and workflow-level failure details into a single, more informative error to simplify troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->