### PR TITLE
fix(workspace): handle absolute paths correctly in `LocalFilesystem.resolvePath`

### DIFF
--- a/.changeset/filesystem-getinfo-completeness.md
+++ b/.changeset/filesystem-getinfo-completeness.md
@@ -1,0 +1,6 @@
+---
+"@mastra/s3": patch
+"@mastra/gcs": patch
+---
+
+Add typed metadata to getInfo() return type and ensure all common FilesystemInfo fields (error, readOnly) are returned.

--- a/.changeset/fix-local-filesystem-absolute-paths.md
+++ b/.changeset/fix-local-filesystem-absolute-paths.md
@@ -1,5 +1,17 @@
 ---
 "@mastra/core": patch
+"@mastra/server": patch
+"@mastra/playground-ui": patch
+"@mastra/s3": patch
+"@mastra/gcs": patch
 ---
 
-Fix LocalFilesystem.resolvePath handling of absolute paths. Previously, absolute paths had their leading slashes stripped and were incorrectly resolved relative to basePath, causing PermissionError for valid paths within the workspace (e.g. skills processor accessing project-local skills directories).
+Fix LocalFilesystem.resolvePath handling of absolute paths and improve workspace filesystem info.
+
+- Fix absolute path resolution: paths were incorrectly stripped of leading slashes and resolved relative to basePath, causing PermissionError for valid paths (e.g. skills processor accessing project-local skills directories).
+- Make `FilesystemInfo` generic (`FilesystemInfo<TMetadata>`) so providers can type their metadata.
+- Move provider-specific fields (`basePath`, `contained`) to metadata in LocalFilesystem.getInfo().
+- Expose filesystem info from getInfo() in the GET /api/workspaces/:id API response.
+- Default Studio file browser to basePath when filesystem containment is disabled.
+- Update getInstructions() for uncontained filesystems to warn agents against listing /.
+- Ensure all filesystem providers return all common fields (error, readOnly) from getInfo().

--- a/.changeset/fix-local-filesystem-absolute-paths.md
+++ b/.changeset/fix-local-filesystem-absolute-paths.md
@@ -7,5 +7,5 @@ Fix LocalFilesystem.resolvePath handling of absolute paths and improve filesyste
 - Fix absolute path resolution: paths were incorrectly stripped of leading slashes and resolved relative to basePath, causing PermissionError for valid paths (e.g. skills processor accessing project-local skills directories).
 - Make `FilesystemInfo` generic (`FilesystemInfo<TMetadata>`) so providers can type their metadata.
 - Move provider-specific fields (`basePath`, `contained`) to metadata in LocalFilesystem.getInfo().
-- Update getInstructions() for uncontained filesystems to warn agents against listing /.
+- Update LocalFilesystem.getInstructions() for uncontained filesystems to warn agents against listing /.
 - Use FilesystemInfo type in WorkspaceInfo instead of duplicated inline shape.

--- a/.changeset/fix-local-filesystem-absolute-paths.md
+++ b/.changeset/fix-local-filesystem-absolute-paths.md
@@ -1,17 +1,11 @@
 ---
 "@mastra/core": patch
-"@mastra/server": patch
-"@mastra/playground-ui": patch
-"@mastra/s3": patch
-"@mastra/gcs": patch
 ---
 
-Fix LocalFilesystem.resolvePath handling of absolute paths and improve workspace filesystem info.
+Fix LocalFilesystem.resolvePath handling of absolute paths and improve filesystem info.
 
 - Fix absolute path resolution: paths were incorrectly stripped of leading slashes and resolved relative to basePath, causing PermissionError for valid paths (e.g. skills processor accessing project-local skills directories).
 - Make `FilesystemInfo` generic (`FilesystemInfo<TMetadata>`) so providers can type their metadata.
 - Move provider-specific fields (`basePath`, `contained`) to metadata in LocalFilesystem.getInfo().
-- Expose filesystem info from getInfo() in the GET /api/workspaces/:id API response.
-- Default Studio file browser to basePath when filesystem containment is disabled.
 - Update getInstructions() for uncontained filesystems to warn agents against listing /.
-- Ensure all filesystem providers return all common fields (error, readOnly) from getInfo().
+- Use FilesystemInfo type in WorkspaceInfo instead of duplicated inline shape.

--- a/.changeset/fix-local-filesystem-absolute-paths.md
+++ b/.changeset/fix-local-filesystem-absolute-paths.md
@@ -1,5 +1,5 @@
 ---
-"@mastra/core": patch
+"@mastra/core": minor
 ---
 
 Fix LocalFilesystem.resolvePath handling of absolute paths and improve filesystem info.

--- a/.changeset/fix-local-filesystem-absolute-paths.md
+++ b/.changeset/fix-local-filesystem-absolute-paths.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fix LocalFilesystem.resolvePath handling of absolute paths. Previously, absolute paths had their leading slashes stripped and were incorrectly resolved relative to basePath, causing PermissionError for valid paths within the workspace (e.g. skills processor accessing project-local skills directories).

--- a/.changeset/studio-default-basepath.md
+++ b/.changeset/studio-default-basepath.md
@@ -1,0 +1,5 @@
+---
+"@mastra/playground-ui": patch
+---
+
+Default Studio file browser to basePath when filesystem containment is disabled, preventing the browser from showing the host root directory.

--- a/.changeset/workspace-api-filesystem-info.md
+++ b/.changeset/workspace-api-filesystem-info.md
@@ -1,0 +1,5 @@
+---
+"@mastra/server": patch
+---
+
+Expose filesystem info from getInfo() in the GET /api/workspaces/:id API response, including provider type, status, readOnly, and provider-specific metadata.

--- a/docs/src/content/en/docs/workspace/filesystem.mdx
+++ b/docs/src/content/en/docs/workspace/filesystem.mdx
@@ -58,6 +58,26 @@ const agent = new Agent({
 const response = await agent.generate('List all files in the workspace');
 ```
 
+## Containment
+
+By default, `LocalFilesystem` runs in **contained mode** — all file operations are restricted to stay within `basePath`. This prevents path traversal attacks and symlink escapes.
+
+In contained mode, absolute paths that fall within `basePath` are used as-is, while other absolute paths are treated as virtual paths relative to `basePath` (e.g. `/file.txt` resolves to `basePath/file.txt`). Any resolved path that escapes `basePath` throws a `PermissionError`.
+
+If your agent needs to access paths outside `basePath` (for example, global skills directories or user home folders), disable containment:
+
+```typescript
+const workspace = new Workspace({
+  filesystem: new LocalFilesystem({
+    basePath: './workspace',
+    // highlight-next-line
+    contained: false,
+  }),
+});
+```
+
+When `contained` is `false`, absolute paths are treated as real filesystem paths with no restriction.
+
 ## Read-only mode
 
 To prevent agents from modifying files, enable read-only mode:

--- a/packages/core/src/workspace/filesystem/filesystem.ts
+++ b/packages/core/src/workspace/filesystem/filesystem.ts
@@ -123,6 +123,8 @@ export interface FilesystemInfo {
   readOnly?: boolean;
   /** Base path (for local filesystems) */
   basePath?: string;
+  /** Whether file operations are restricted to basePath */
+  contained?: boolean;
   /** Icon identifier for UI display */
   icon?: FilesystemIcon;
   /** Storage usage (if available) */

--- a/packages/core/src/workspace/filesystem/filesystem.ts
+++ b/packages/core/src/workspace/filesystem/filesystem.ts
@@ -123,12 +123,6 @@ export interface FilesystemInfo<TMetadata extends Record<string, unknown> = Reco
   readOnly?: boolean;
   /** Icon identifier for UI display */
   icon?: FilesystemIcon;
-  /** Storage usage (if available) */
-  storage?: {
-    totalBytes?: number;
-    usedBytes?: number;
-    availableBytes?: number;
-  };
   /** Provider-specific metadata */
   metadata?: TMetadata;
 }

--- a/packages/core/src/workspace/filesystem/filesystem.ts
+++ b/packages/core/src/workspace/filesystem/filesystem.ts
@@ -123,8 +123,6 @@ export interface FilesystemInfo {
   readOnly?: boolean;
   /** Base path (for local filesystems) */
   basePath?: string;
-  /** Whether file operations are restricted to basePath */
-  contained?: boolean;
   /** Icon identifier for UI display */
   icon?: FilesystemIcon;
   /** Storage usage (if available) */

--- a/packages/core/src/workspace/filesystem/filesystem.ts
+++ b/packages/core/src/workspace/filesystem/filesystem.ts
@@ -108,7 +108,7 @@ export interface CopyOptions {
 /**
  * Information about a filesystem provider's current state.
  */
-export interface FilesystemInfo {
+export interface FilesystemInfo<TMetadata extends Record<string, unknown> = Record<string, unknown>> {
   /** Unique identifier */
   id: string;
   /** Human-readable name */
@@ -121,8 +121,6 @@ export interface FilesystemInfo {
   error?: string;
   /** Whether filesystem is read-only */
   readOnly?: boolean;
-  /** Base path (for local filesystems) */
-  basePath?: string;
   /** Icon identifier for UI display */
   icon?: FilesystemIcon;
   /** Storage usage (if available) */
@@ -132,7 +130,7 @@ export interface FilesystemInfo {
     availableBytes?: number;
   };
   /** Provider-specific metadata */
-  metadata?: Record<string, unknown>;
+  metadata?: TMetadata;
 }
 
 // =============================================================================

--- a/packages/core/src/workspace/filesystem/local-filesystem.test.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.test.ts
@@ -489,9 +489,26 @@ describe('LocalFilesystem', () => {
         });
 
         // This would be blocked in contained mode, but allowed when contained: false
-        // Note: We use a relative path that goes outside the base
-        const content = await uncontainedFs.readFile(`/../${path.basename(outsideFile)}`, { encoding: 'utf-8' });
+        const content = await uncontainedFs.readFile(outsideFile, { encoding: 'utf-8' });
         expect(content).toBe('outside content');
+      } finally {
+        await fs.unlink(outsideFile);
+      }
+    });
+
+    it('should allow absolute paths outside base directory when containment is disabled', async () => {
+      const outsideFile = path.join(os.tmpdir(), 'abs-outside-test.txt');
+      await fs.writeFile(outsideFile, 'absolute outside content');
+
+      try {
+        const uncontainedFs = new LocalFilesystem({
+          basePath: tempDir,
+          contained: false,
+        });
+
+        // Absolute path outside basePath should work with contained: false
+        const content = await uncontainedFs.readFile(outsideFile, { encoding: 'utf-8' });
+        expect(content).toBe('absolute outside content');
       } finally {
         await fs.unlink(outsideFile);
       }

--- a/packages/core/src/workspace/filesystem/local-filesystem.test.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.test.ts
@@ -457,6 +457,26 @@ describe('LocalFilesystem', () => {
       expect(content).toBe('content');
     });
 
+    it('should allow absolute paths inside base directory', async () => {
+      await localFs.writeFile('/abs-test.txt', 'absolute content');
+      const absolutePath = path.join(tempDir, 'abs-test.txt');
+      const content = await localFs.readFile(absolutePath, { encoding: 'utf-8' });
+      expect(content).toBe('absolute content');
+    });
+
+    it('should allow exists() with absolute paths inside base directory', async () => {
+      await localFs.writeFile('/exists-test.txt', 'content');
+      const absolutePath = path.join(tempDir, 'exists-test.txt');
+      const exists = await localFs.exists(absolutePath);
+      expect(exists).toBe(true);
+    });
+
+    it('should not throw on exists() for non-existent absolute path inside base directory', async () => {
+      const absolutePath = path.join(tempDir, 'nonexistent', 'file.txt');
+      const exists = await localFs.exists(absolutePath);
+      expect(exists).toBe(false);
+    });
+
     it('should allow access when containment is disabled', async () => {
       // Create a file in os.tmpdir() (parent of tempDir since tempDir is created via mkdtemp in tmpdir)
       const outsideFile = path.join(os.tmpdir(), 'outside-test.txt');

--- a/packages/core/src/workspace/filesystem/local-filesystem.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.ts
@@ -44,6 +44,18 @@ export interface LocalFilesystemOptions {
   /**
    * When true, all file operations are restricted to stay within basePath.
    * Prevents path traversal attacks and symlink escapes.
+   *
+   * Path resolution depends on this setting:
+   * - `contained: true` (default) — Absolute paths that fall within basePath are
+   *   used as-is; all other absolute paths are treated as virtual (resolved
+   *   relative to basePath, e.g. `/file.txt` → `basePath/file.txt`). Any
+   *   resolved path that escapes basePath throws a PermissionError.
+   * - `contained: false` — Absolute paths are always treated as real filesystem
+   *   paths. No containment check is applied.
+   *
+   * Set to `false` when the filesystem needs to access paths outside basePath,
+   * such as global skills directories or user home directories.
+   *
    * @default true
    */
   contained?: boolean;

--- a/packages/core/src/workspace/filesystem/local-filesystem.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.ts
@@ -621,15 +621,15 @@ export class LocalFilesystem extends MastraFilesystem {
     // LocalFilesystem doesn't clean up files on destroy by default
   }
 
-  getInfo(): FilesystemInfo {
+  getInfo(): FilesystemInfo<{ basePath: string; contained: boolean }> {
     return {
       id: this.id,
       name: this.name,
       provider: this.provider,
       readOnly: this.readOnly,
-      basePath: this.basePath,
       status: this.status,
       metadata: {
+        basePath: this.basePath,
         contained: this._contained,
       },
     };

--- a/packages/core/src/workspace/filesystem/local-filesystem.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.ts
@@ -628,11 +628,15 @@ export class LocalFilesystem extends MastraFilesystem {
       provider: this.provider,
       readOnly: this.readOnly,
       basePath: this.basePath,
+      contained: this._contained,
       status: this.status,
     };
   }
 
   getInstructions(): string {
-    return `Local filesystem at "${this.basePath}". Files at workspace path "/foo" are stored at "${this.basePath}/foo" on disk.`;
+    if (this._contained) {
+      return `Local filesystem at "${this.basePath}". Files at workspace path "/foo" are stored at "${this.basePath}/foo" on disk.`;
+    }
+    return `Local filesystem rooted at "${this.basePath}". Containment is disabled so absolute paths access the real filesystem. Use paths relative to "${this.basePath}" (e.g. "foo/bar.txt") for workspace files. Avoid listing "/" as it would traverse the entire host filesystem.`;
   }
 }

--- a/packages/core/src/workspace/filesystem/local-filesystem.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.ts
@@ -628,6 +628,7 @@ export class LocalFilesystem extends MastraFilesystem {
       provider: this.provider,
       readOnly: this.readOnly,
       status: this.status,
+      error: this.error,
       metadata: {
         basePath: this.basePath,
         contained: this._contained,

--- a/packages/core/src/workspace/filesystem/local-filesystem.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.ts
@@ -640,6 +640,6 @@ export class LocalFilesystem extends MastraFilesystem {
     if (this._contained) {
       return `Local filesystem at "${this.basePath}". Files at workspace path "/foo" are stored at "${this.basePath}/foo" on disk.`;
     }
-    return `Local filesystem rooted at "${this.basePath}". Containment is disabled so absolute paths access the real filesystem. Use paths relative to "${this.basePath}" (e.g. "foo/bar.txt") for workspace files. Avoid listing "/" as it would traverse the entire host filesystem.`;
+    return `Local filesystem rooted at "${this.basePath}". Containment is disabled so absolute paths access the real filesystem. Use paths relative to "${this.basePath}" (e.g. "foo/bar.txt") for workspace files. Avoid unnecessary listing "/" as it would traverse the entire host filesystem.`;
   }
 }

--- a/packages/core/src/workspace/filesystem/local-filesystem.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.ts
@@ -111,9 +111,12 @@ export class LocalFilesystem extends MastraFilesystem {
   }
 
   private resolvePath(inputPath: string): string {
-    const cleanedPath = inputPath.replace(/^\/+/, '');
-    const normalizedInput = nodePath.normalize(cleanedPath);
-    const absolutePath = nodePath.resolve(this._basePath, normalizedInput);
+    // If the input is already an absolute path, use it directly instead of
+    // stripping the leading slash and resolving relative to basePath (which
+    // would produce an incorrect nested path).
+    const absolutePath = nodePath.isAbsolute(inputPath)
+      ? nodePath.normalize(inputPath)
+      : nodePath.resolve(this._basePath, nodePath.normalize(inputPath));
 
     if (this._contained) {
       const relative = nodePath.relative(this._basePath, absolutePath);

--- a/packages/core/src/workspace/filesystem/local-filesystem.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.ts
@@ -628,8 +628,10 @@ export class LocalFilesystem extends MastraFilesystem {
       provider: this.provider,
       readOnly: this.readOnly,
       basePath: this.basePath,
-      contained: this._contained,
       status: this.status,
+      metadata: {
+        contained: this._contained,
+      },
     };
   }
 

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -712,7 +712,7 @@ export class Workspace {
         provider: this._fs.provider,
         name: fsInfo?.name ?? this._fs.name,
         icon: fsInfo?.icon,
-        basePath: fsInfo?.basePath ?? this._fs.basePath,
+        basePath: (fsInfo?.metadata?.basePath as string) ?? this._fs.basePath,
         readOnly: fsInfo?.readOnly ?? this._fs.readOnly,
         status: fsInfo?.status,
         storage: fsInfo?.storage,

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -703,7 +703,6 @@ export class Workspace {
         status: fsInfo?.status,
         error: fsInfo?.error,
         icon: fsInfo?.icon,
-        storage: fsInfo?.storage,
         metadata: fsInfo?.metadata,
       };
 

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -35,7 +35,7 @@ import type { MastraVector } from '../vector';
 
 import { WorkspaceError, SearchNotAvailableError } from './errors';
 import { CompositeFilesystem } from './filesystem';
-import type { WorkspaceFilesystem, FilesystemIcon } from './filesystem';
+import type { WorkspaceFilesystem, FilesystemInfo } from './filesystem';
 import { MastraFilesystem } from './filesystem/mastra-filesystem';
 import { callLifecycle } from './lifecycle';
 import type { WorkspaceSandbox, OnMountHook } from './sandbox';
@@ -294,20 +294,7 @@ export interface WorkspaceInfo {
   lastAccessedAt: Date;
 
   /** Filesystem info (if available) */
-  filesystem?: {
-    provider: string;
-    /** Human-readable name */
-    name?: string;
-    /** Icon identifier for UI display */
-    icon?: FilesystemIcon;
-    basePath?: string;
-    readOnly?: boolean;
-    status?: string;
-    storage?: {
-      totalBytes?: number;
-      usedBytes?: number;
-      availableBytes?: number;
-    };
+  filesystem?: FilesystemInfo & {
     totalFiles?: number;
     totalSize?: number;
   };
@@ -709,13 +696,15 @@ export class Workspace {
     if (this._fs) {
       const fsInfo = await this._fs.getInfo?.();
       info.filesystem = {
-        provider: this._fs.provider,
+        id: fsInfo?.id ?? this._fs.id,
         name: fsInfo?.name ?? this._fs.name,
-        icon: fsInfo?.icon,
-        basePath: (fsInfo?.metadata?.basePath as string) ?? this._fs.basePath,
+        provider: fsInfo?.provider ?? this._fs.provider,
         readOnly: fsInfo?.readOnly ?? this._fs.readOnly,
         status: fsInfo?.status,
+        error: fsInfo?.error,
+        icon: fsInfo?.icon,
         storage: fsInfo?.storage,
+        metadata: fsInfo?.metadata,
       };
 
       if (options?.includeFileCount) {

--- a/packages/playground-ui/src/domains/workspace/types.ts
+++ b/packages/playground-ui/src/domains/workspace/types.ts
@@ -16,9 +16,13 @@ export interface WorkspaceSafety {
 }
 
 export interface WorkspaceFilesystemInfo {
+  id: string;
+  name: string;
   provider: string;
+  status?: string;
+  readOnly?: boolean;
   basePath?: string;
-  contained?: boolean;
+  metadata?: Record<string, unknown>;
 }
 
 export interface WorkspaceInfo {

--- a/packages/playground-ui/src/domains/workspace/types.ts
+++ b/packages/playground-ui/src/domains/workspace/types.ts
@@ -21,7 +21,6 @@ export interface WorkspaceFilesystemInfo {
   provider: string;
   status?: string;
   readOnly?: boolean;
-  basePath?: string;
   metadata?: Record<string, unknown>;
 }
 

--- a/packages/playground-ui/src/domains/workspace/types.ts
+++ b/packages/playground-ui/src/domains/workspace/types.ts
@@ -15,6 +15,12 @@ export interface WorkspaceSafety {
   readOnly: boolean;
 }
 
+export interface WorkspaceFilesystemInfo {
+  provider: string;
+  basePath?: string;
+  contained?: boolean;
+}
+
 export interface WorkspaceInfo {
   isWorkspaceConfigured: boolean;
   id?: string;
@@ -22,6 +28,7 @@ export interface WorkspaceInfo {
   status?: string;
   capabilities?: WorkspaceCapabilities;
   safety?: WorkspaceSafety;
+  filesystem?: WorkspaceFilesystemInfo;
 }
 
 export interface WorkspaceItem {

--- a/packages/playground-ui/src/domains/workspace/types.ts
+++ b/packages/playground-ui/src/domains/workspace/types.ts
@@ -20,7 +20,9 @@ export interface WorkspaceFilesystemInfo {
   name: string;
   provider: string;
   status?: string;
+  error?: string;
   readOnly?: boolean;
+  icon?: string;
   metadata?: Record<string, unknown>;
 }
 

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -51,7 +51,6 @@ export default function Workspace() {
   const [hasUndiscoveredInstall, setHasUndiscoveredInstall] = useState(false);
 
   // Get state from URL query params (path, file, tab are still query params)
-  const pathFromUrl = searchParams.get('path') || '/';
   const fileFromUrl = searchParams.get('file');
   const tabFromUrl = searchParams.get('tab') as TabType | null;
 
@@ -68,6 +67,13 @@ export default function Workspace() {
     isLoading: isLoadingInfo,
     error: workspaceInfoError,
   } = useWorkspaceInfo(effectiveWorkspaceId);
+
+  // For uncontained local filesystems, default to basePath instead of / (which would show the real root)
+  const defaultPath =
+    workspaceInfo?.filesystem?.contained === false && workspaceInfo?.filesystem?.basePath
+      ? workspaceInfo.filesystem.basePath
+      : '/';
+  const pathFromUrl = searchParams.get('path') || defaultPath;
 
   // Check if workspaces are not supported (501 error from server)
   const isWorkspaceNotSupported =

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -71,7 +71,7 @@ export default function Workspace() {
   // For uncontained local filesystems, default to basePath instead of / (which would show the real root)
   const fsMetadata = workspaceInfo?.filesystem?.metadata;
   const defaultPath =
-    fsMetadata?.contained === false && workspaceInfo?.filesystem?.basePath ? workspaceInfo.filesystem.basePath : '/';
+    fsMetadata?.contained === false && typeof fsMetadata?.basePath === 'string' ? fsMetadata.basePath : '/';
   const pathFromUrl = searchParams.get('path') || defaultPath;
 
   // Check if workspaces are not supported (501 error from server)

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -69,10 +69,9 @@ export default function Workspace() {
   } = useWorkspaceInfo(effectiveWorkspaceId);
 
   // For uncontained local filesystems, default to basePath instead of / (which would show the real root)
+  const fsMetadata = workspaceInfo?.filesystem?.metadata;
   const defaultPath =
-    workspaceInfo?.filesystem?.contained === false && workspaceInfo?.filesystem?.basePath
-      ? workspaceInfo.filesystem.basePath
-      : '/';
+    fsMetadata?.contained === false && workspaceInfo?.filesystem?.basePath ? workspaceInfo.filesystem.basePath : '/';
   const pathFromUrl = searchParams.get('path') || defaultPath;
 
   // Check if workspaces are not supported (501 error from server)

--- a/packages/server/src/server/handlers/workspace.ts
+++ b/packages/server/src/server/handlers/workspace.ts
@@ -335,7 +335,9 @@ export const GET_WORKSPACE_ROUTE = createRoute({
               name: fsInfo.name,
               provider: fsInfo.provider,
               status: fsInfo.status,
+              error: fsInfo.error,
               readOnly: fsInfo.readOnly,
+              icon: fsInfo.icon,
               metadata: fsInfo.metadata,
             }
           : undefined,

--- a/packages/server/src/server/handlers/workspace.ts
+++ b/packages/server/src/server/handlers/workspace.ts
@@ -331,9 +331,13 @@ export const GET_WORKSPACE_ROUTE = createRoute({
         },
         filesystem: fsInfo
           ? {
+              id: fsInfo.id,
+              name: fsInfo.name,
               provider: fsInfo.provider,
+              status: fsInfo.status,
+              readOnly: fsInfo.readOnly,
               basePath: fsInfo.basePath,
-              contained: fsInfo.contained,
+              metadata: fsInfo.metadata,
             }
           : undefined,
       };

--- a/packages/server/src/server/handlers/workspace.ts
+++ b/packages/server/src/server/handlers/workspace.ts
@@ -336,7 +336,6 @@ export const GET_WORKSPACE_ROUTE = createRoute({
               provider: fsInfo.provider,
               status: fsInfo.status,
               readOnly: fsInfo.readOnly,
-              basePath: fsInfo.basePath,
               metadata: fsInfo.metadata,
             }
           : undefined,

--- a/packages/server/src/server/handlers/workspace.ts
+++ b/packages/server/src/server/handlers/workspace.ts
@@ -311,6 +311,8 @@ export const GET_WORKSPACE_ROUTE = createRoute({
         };
       }
 
+      const fsInfo = await workspace.filesystem?.getInfo?.();
+
       return {
         isWorkspaceConfigured: true,
         id: workspace.id,
@@ -327,6 +329,13 @@ export const GET_WORKSPACE_ROUTE = createRoute({
         safety: {
           readOnly: workspace.filesystem?.readOnly ?? false,
         },
+        filesystem: fsInfo
+          ? {
+              provider: fsInfo.provider,
+              basePath: fsInfo.basePath,
+              contained: fsInfo.contained,
+            }
+          : undefined,
       };
     } catch (error) {
       return handleWorkspaceError(error, 'Error getting workspace info');

--- a/packages/server/src/server/schemas/workspace.ts
+++ b/packages/server/src/server/schemas/workspace.ts
@@ -208,7 +208,6 @@ export const workspaceInfoResponseSchema = z.object({
       provider: z.string(),
       status: z.string().optional(),
       readOnly: z.boolean().optional(),
-      basePath: z.string().optional(),
       metadata: z.record(z.unknown()).optional(),
     })
     .optional(),

--- a/packages/server/src/server/schemas/workspace.ts
+++ b/packages/server/src/server/schemas/workspace.ts
@@ -201,6 +201,13 @@ export const workspaceInfoResponseSchema = z.object({
       readOnly: z.boolean(),
     })
     .optional(),
+  filesystem: z
+    .object({
+      provider: z.string(),
+      basePath: z.string().optional(),
+      contained: z.boolean().optional(),
+    })
+    .optional(),
 });
 
 const workspaceItemSchema = z.object({

--- a/packages/server/src/server/schemas/workspace.ts
+++ b/packages/server/src/server/schemas/workspace.ts
@@ -203,9 +203,13 @@ export const workspaceInfoResponseSchema = z.object({
     .optional(),
   filesystem: z
     .object({
+      id: z.string(),
+      name: z.string(),
       provider: z.string(),
+      status: z.string().optional(),
+      readOnly: z.boolean().optional(),
       basePath: z.string().optional(),
-      contained: z.boolean().optional(),
+      metadata: z.record(z.unknown()).optional(),
     })
     .optional(),
 });

--- a/packages/server/src/server/schemas/workspace.ts
+++ b/packages/server/src/server/schemas/workspace.ts
@@ -207,7 +207,9 @@ export const workspaceInfoResponseSchema = z.object({
       name: z.string(),
       provider: z.string(),
       status: z.string().optional(),
+      error: z.string().optional(),
       readOnly: z.boolean().optional(),
+      icon: z.string().optional(),
       metadata: z.record(z.unknown()).optional(),
     })
     .optional(),

--- a/workspaces/gcs/package.json
+++ b/workspaces/gcs/package.json
@@ -49,7 +49,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.3.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.4.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/workspaces/gcs/src/filesystem/index.ts
+++ b/workspaces/gcs/src/filesystem/index.ts
@@ -236,12 +236,18 @@ export class GCSFilesystem extends MastraFilesystem {
   /**
    * Get filesystem info for status reporting.
    */
-  getInfo(): FilesystemInfo {
+  getInfo(): FilesystemInfo<{
+    bucket: string;
+    endpoint?: string;
+    prefix?: string;
+  }> {
     return {
       id: this.id,
       name: this.name,
       provider: this.provider,
       status: this.status,
+      error: this.error,
+      readOnly: this.readOnly,
       icon: this.icon,
       metadata: {
         bucket: this.bucketName,

--- a/workspaces/s3/package.json
+++ b/workspaces/s3/package.json
@@ -49,7 +49,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.3.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.4.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/workspaces/s3/src/filesystem/index.ts
+++ b/workspaces/s3/src/filesystem/index.ts
@@ -288,6 +288,7 @@ export class S3Filesystem extends MastraFilesystem {
       provider: this.provider,
       status: this.status,
       error: this.error,
+      readOnly: this.readOnly,
       icon: this.icon,
       metadata: {
         bucket: this.bucket,

--- a/workspaces/s3/src/filesystem/index.ts
+++ b/workspaces/s3/src/filesystem/index.ts
@@ -276,7 +276,12 @@ export class S3Filesystem extends MastraFilesystem {
   /**
    * Get filesystem info for status reporting.
    */
-  getInfo(): FilesystemInfo {
+  getInfo(): FilesystemInfo<{
+    bucket: string;
+    region: string;
+    endpoint?: string;
+    prefix?: string;
+  }> {
     return {
       id: this.id,
       name: this.name,


### PR DESCRIPTION
## Summary

- Fix `LocalFilesystem.resolvePath` stripping leading slashes from absolute paths, which caused them to be incorrectly resolved relative to `basePath`
- Update JSDoc for the `contained` option to document path resolution behavior
- Add docs section for the `contained` option

### Root cause

`resolvePath` unconditionally ran `inputPath.replace(/^\/+/, '')`, turning an absolute path like `/Users/foo/project/.mastracode/skills` into `Users/foo/project/.mastracode/skills`. This was then resolved against `basePath` via `path.resolve(basePath, ...)`, producing a nonsense nested path like `/Users/foo/project/Users/foo/project/.mastracode/skills`. The containment check then rejected it with `PermissionError`.

This manifested as the `SkillsProcessor` failing on every message with "Permission denied: access on /project/.mastracode/skills" because skills paths are passed as absolute paths to `LocalFilesystem.exists()`.

### Fix

Path resolution is now containment-aware:

- **`contained: true`** (default) — Absolute paths that fall within `basePath` are used as-is. Other absolute paths are treated as virtual paths (resolved relative to `basePath`, e.g. `/file.txt` → `basePath/file.txt`). Any resolved path that escapes `basePath` still throws `PermissionError`.
- **`contained: false`** — Absolute paths are always treated as real filesystem paths with no containment check.
- **Relative paths** — Always resolved against `basePath` regardless of containment setting.

## Test plan
- [x] Verify `LocalFilesystem.exists()` works with absolute paths within basePath
- [x] Verify containment still rejects absolute paths outside basePath when `contained: true`
- [x] Verify relative paths still resolve correctly against basePath
- [x] Verify absolute paths outside basePath work when `contained: false`
- [x] Verify skills processor no longer throws PermissionError for project-local skills paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `contained` option to control filesystem path resolution and exposed containment status in workspace info so UIs can adapt default paths.

* **Bug Fixes**
  * Fixed absolute path handling so leading slashes are preserved and valid absolute workspace paths resolve correctly.

* **Documentation**
  * Added containment guidance, examples, and updated read-only usage for the workspace filesystem.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->