### PR TITLE
docs: mark observational memory resource scope as experimental

### DIFF
--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -123,7 +123,7 @@ See [model configuration](/reference/memory/observational-memory#custom-model) f
 
 ### Thread scope (default)
 
-Each thread has its own observations.
+Each thread has its own observations. This scope is well tested and works well as a general purpose memory system, especially for long horizon agentic use-cases.
 
 ```typescript
 const memory = new Memory({
@@ -136,7 +136,7 @@ const memory = new Memory({
 });
 ```
 
-### Resource scope
+### Resource scope (experimental)
 
 Observations are shared across all threads for a resource (typically a user). Enables cross-conversation memory.
 
@@ -151,9 +151,17 @@ const memory = new Memory({
 });
 ```
 
+Resource scope works, however it's marked as experimental for now until we prove task adherence/continuity across multiple ongoing simultaneous threads.
+As of today, you may need to tweak your system prompt to prevent one thread from continuing the work that another had already started (but hadn't finished).
+
+This is because in resource scope, each thread is a perspective on _all_ threads for the resource.
+
+For your use-case this may not be a problem, so your mileage may vary.
+
 :::warning
 
 In resource scope, unobserved messages across *all* threads are processed together. For users with many existing threads, this can be slow. Use thread scope for existing apps.
+
 
 :::
 

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -56,7 +56,7 @@ The `observationalMemory` option accepts `true`, a configuration object, or `fal
       name: "scope",
       type: "'resource' | 'thread'",
       description:
-        "Memory scope for observations. `'thread'` keeps observations per-thread. `'resource'` shares observations across all threads for a resource, enabling cross-conversation memory.",
+        "Memory scope for observations. `'thread'` keeps observations per-thread. `'resource'` (experimental) shares observations across all threads for a resource, enabling cross-conversation memory.",
       isOptional: true,
       defaultValue: "'thread'",
     },
@@ -218,7 +218,7 @@ The `observationalMemory` option accepts `true`, a configuration object, or `fal
 
 ## Examples
 
-### Resource scope with custom thresholds
+### Resource scope with custom thresholds (experimental)
 
 ```typescript title="src/mastra/agents/agent.ts"
 import { Memory } from "@mastra/memory";


### PR DESCRIPTION
Marks the observational memory `scope: "resource"` option as experimental in both the guide and reference docs. Thread scope is well tested and works great, but resource scope needs more validation around task adherence/continuity across simultaneous threads before we drop this experimental label.
I noticed in some cases a model in a second thread will strongly desire to continue the unfinished work of another thread. This is likely due to model differences, and definitely due to how cross thread memory is represented to the agent. We will need to tune the formatting more to ensure it works well across models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Resource scope in observational memory configuration marked as experimental.
  * Enhanced documentation with cautions about cross-thread continuity and performance considerations, along with updated usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->