### PR TITLE
fix(memory, pg): round token counts to integers before PG writes

### DIFF
--- a/.changeset/fix-om-non-integer-token-counts.md
+++ b/.changeset/fix-om-non-integer-token-counts.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/pg': patch
+---
+
+Fixed observational memory computing non-integer token counts, which caused `invalid input syntax for type integer` errors when writing to PostgreSQL. The root cause was `TOKENS_PER_MESSAGE = 3.8` producing fractional values. Token counts are now rounded at the source and defensively before all integer column writes.

--- a/.changeset/fix-om-non-integer-token-counts.md
+++ b/.changeset/fix-om-non-integer-token-counts.md
@@ -3,4 +3,4 @@
 '@mastra/pg': patch
 ---
 
-Fixed observational memory computing non-integer token counts, which caused `invalid input syntax for type integer` errors when writing to PostgreSQL. The root cause was `TOKENS_PER_MESSAGE = 3.8` producing fractional values. Token counts are now rounded at the source and defensively before all integer column writes.
+Fixed observational memory writing non-integer token counts to PostgreSQL, which caused `invalid input syntax for type integer` errors. Token counts are now correctly rounded to integers before all database writes.

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -1071,6 +1071,12 @@ describe('Token Counter', () => {
       // Message should have overhead beyond just the content
       expect(msgCount).toBeGreaterThan(stringCount);
     });
+
+    it('should always return an integer', () => {
+      const msg = createTestMessage('Hello, world!');
+      const count = counter.countMessage(msg);
+      expect(Number.isInteger(count)).toBe(true);
+    });
   });
 
   describe('countMessages', () => {
@@ -1090,6 +1096,12 @@ describe('Token Counter', () => {
 
     it('should return 0 for empty array', () => {
       expect(counter.countMessages([])).toBe(0);
+    });
+
+    it('should always return an integer', () => {
+      const messages = createTestMessages(3);
+      const count = counter.countMessages(messages);
+      expect(Number.isInteger(count)).toBe(true);
     });
   });
 

--- a/packages/memory/src/processors/observational-memory/token-counter.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.ts
@@ -92,7 +92,7 @@ export class TokenCounter {
     }
 
     // Allow all special tokens to avoid errors with content containing tokens like <|endoftext|>
-    return this.encoder.encode(tokenString, 'all').length + overhead;
+    return Math.round(this.encoder.encode(tokenString, 'all').length + overhead);
   }
 
   /**

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -2002,7 +2002,7 @@ export class MemoryPG extends MemoryStorage {
 
       if (lastBufferedAtTokens !== undefined) {
         query = `UPDATE ${tableName} SET "isBufferingObservation" = $1, "lastBufferedAtTokens" = $2, "updatedAt" = $3, "updatedAtZ" = $4 WHERE id = $5`;
-        values = [isBuffering, lastBufferedAtTokens, nowStr, nowStr, id];
+        values = [isBuffering, Math.round(lastBufferedAtTokens), nowStr, nowStr, id];
       } else {
         query = `UPDATE ${tableName} SET "isBufferingObservation" = $1, "updatedAt" = $2, "updatedAtZ" = $3 WHERE id = $4`;
         values = [isBuffering, nowStr, nowStr, id];

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -1789,8 +1789,8 @@ export class MemoryPG extends MemoryStorage {
           input.observations,
           lastObservedAtStr,
           lastObservedAtStr,
-          input.tokenCount,
-          input.tokenCount,
+          Math.round(input.tokenCount),
+          Math.round(input.tokenCount),
           observedMessageIdsJson,
           nowStr,
           nowStr,
@@ -1885,8 +1885,8 @@ export class MemoryPG extends MemoryStorage {
           nowStr, // lastReflectionAt
           nowStr, // lastReflectionAtZ
           record.pendingMessageTokens,
-          record.totalTokensObserved,
-          record.observationTokenCount,
+          Math.round(record.totalTokensObserved),
+          Math.round(record.observationTokenCount),
           false, // isObserving
           false, // isReflecting
           false, // isBufferingObservation
@@ -2106,7 +2106,7 @@ export class MemoryPG extends MemoryStorage {
           "updatedAt" = $2,
           "updatedAtZ" = $3
         WHERE id = $4`,
-        [tokenCount, nowStr, nowStr, id],
+        [Math.round(tokenCount), nowStr, nowStr, id],
       );
 
       if (result.rowCount === 0) {
@@ -2151,9 +2151,9 @@ export class MemoryPG extends MemoryStorage {
         id: `ombuf-${randomUUID()}`,
         cycleId: input.chunk.cycleId,
         observations: input.chunk.observations,
-        tokenCount: input.chunk.tokenCount,
+        tokenCount: Math.round(input.chunk.tokenCount),
         messageIds: input.chunk.messageIds,
-        messageTokens: input.chunk.messageTokens,
+        messageTokens: Math.round(input.chunk.messageTokens ?? 0),
         lastObservedAt: input.chunk.lastObservedAt,
         createdAt: new Date(),
         suggestedContinuation: input.chunk.suggestedContinuation,
@@ -2297,8 +2297,8 @@ export class MemoryPG extends MemoryStorage {
 
       // Combine activated observations
       const activatedContent = activatedChunks.map(c => c.observations).join('\n\n');
-      const activatedTokens = activatedChunks.reduce((sum, c) => sum + c.tokenCount, 0);
-      const activatedMessageTokens = activatedChunks.reduce((sum, c) => sum + (c.messageTokens ?? 0), 0);
+      const activatedTokens = Math.round(activatedChunks.reduce((sum, c) => sum + c.tokenCount, 0));
+      const activatedMessageTokens = Math.round(activatedChunks.reduce((sum, c) => sum + (c.messageTokens ?? 0), 0));
       const activatedMessageCount = activatedChunks.reduce((sum, c) => sum + c.messageIds.length, 0);
       const activatedCycleIds = activatedChunks.map(c => c.cycleId).filter((id): id is string => !!id);
       const activatedMessageIds = activatedChunks.flatMap(c => c.messageIds ?? []);
@@ -2399,8 +2399,8 @@ export class MemoryPG extends MemoryStorage {
         WHERE id = $7`,
         [
           input.reflection,
-          input.tokenCount,
-          input.inputTokenCount,
+          Math.round(input.tokenCount),
+          Math.round(input.inputTokenCount),
           input.reflectedObservationLineCount,
           nowStr,
           nowStr,


### PR DESCRIPTION
`TOKENS_PER_MESSAGE = 3.8` in the token counter caused fractional token counts like `37448.6` to be written to PostgreSQL integer columns, resulting in `invalid input syntax for type integer` errors in `swapBufferedToActive` and other write paths.

Fixed by rounding at the source in `TokenCounter.countMessage()`:

```ts
// before
return this.encoder.encode(tokenString, "all").length + overhead;

// after
return Math.round(this.encoder.encode(tokenString, "all").length + overhead);
```

Also added defensive `Math.round()` calls in all 6 PG write paths that touch integer token columns, in case existing buffered data already contains floats.

Two new tests verify `countMessage()` and `countMessages()` always return integers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where fractional token counts could cause storage errors; token counts are now rounded consistently at source and before persisting.

* **Tests**
  * Added assertions to ensure token counts are returned and stored as integer values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->