### PR TITLE
fix(core): type inputData in dowhile/dountil loop conditions

### DIFF
--- a/.changeset/icy-swans-mix.md
+++ b/.changeset/icy-swans-mix.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `inputData` in `dowhile` and `dountil` loop condition functions to be properly typed as the step's output schema instead of `any`. This means you no longer need to manually cast `inputData` in your loop conditions — TypeScript will now correctly infer the type from your step's `outputSchema`.

--- a/packages/core/src/workflows/workflow-schema-types.test-d.ts
+++ b/packages/core/src/workflows/workflow-schema-types.test-d.ts
@@ -149,6 +149,156 @@ describe('Workflow schema type inference', () => {
       expectTypeOf(chained).not.toBeNever();
     });
 
+    it('should type inputData in dowhile condition as the step output schema', () => {
+      const inputSchema = z.object({
+        taskId: z.string(),
+      });
+      const outputSchema = z.object({
+        taskId: z.string(),
+        status: z.string(),
+      });
+
+      const step = createStep({
+        id: 'fetch-task',
+        inputSchema,
+        outputSchema,
+        execute: async ({ inputData }) => {
+          return { taskId: inputData.taskId, status: 'pending' };
+        },
+      });
+
+      const workflow = createWorkflow({
+        id: 'poll-workflow',
+        inputSchema,
+        outputSchema,
+      });
+
+      workflow.dowhile(step, async ({ inputData }) => {
+        // inputData should be typed as the step's OUTPUT schema, not input schema.
+        // After the fix, `status` should be a known property typed as string.
+        expectTypeOf(inputData).not.toBeAny();
+        expectTypeOf(inputData.status).toBeString();
+        expectTypeOf(inputData.taskId).toBeString();
+        return inputData.status === 'pending';
+      });
+    });
+
+    it('should type inputData in dountil condition as the step output schema', () => {
+      const inputSchema = z.object({
+        taskId: z.string(),
+      });
+      const outputSchema = z.object({
+        taskId: z.string(),
+        status: z.string(),
+      });
+
+      const step = createStep({
+        id: 'fetch-task',
+        inputSchema,
+        outputSchema,
+        execute: async ({ inputData }) => {
+          return { taskId: inputData.taskId, status: 'pending' };
+        },
+      });
+
+      const workflow = createWorkflow({
+        id: 'poll-workflow',
+        inputSchema,
+        outputSchema,
+      });
+
+      workflow.dountil(step, async ({ inputData }) => {
+        // inputData should be typed as the step's OUTPUT schema, not input schema.
+        // After the fix, `status` should be a known property typed as string.
+        expectTypeOf(inputData).not.toBeAny();
+        expectTypeOf(inputData.status).toBeString();
+        expectTypeOf(inputData.taskId).toBeString();
+        return inputData.status === 'completed';
+      });
+    });
+
+    it('should type inputData in dowhile condition with output-only fields', () => {
+      // Scenario: output has fields that input does NOT have.
+      // The condition should see the output fields, not the input fields.
+      const step = createStep({
+        id: 'process-step',
+        inputSchema: z.object({ seed: z.number() }),
+        outputSchema: z.object({ seed: z.number(), result: z.number(), done: z.boolean() }),
+        execute: async ({ inputData }) => {
+          return { seed: inputData.seed, result: inputData.seed * 2, done: false };
+        },
+      });
+
+      const workflow = createWorkflow({
+        id: 'process-workflow',
+        inputSchema: z.object({ seed: z.number() }),
+        outputSchema: z.object({ seed: z.number(), result: z.number(), done: z.boolean() }),
+      });
+
+      workflow.dowhile(step, async ({ inputData }) => {
+        expectTypeOf(inputData).not.toBeAny();
+        // `result` and `done` only exist on output, not input
+        expectTypeOf(inputData.result).toBeNumber();
+        expectTypeOf(inputData.done).toBeBoolean();
+        expectTypeOf(inputData.seed).toBeNumber();
+        return !inputData.done;
+      });
+    });
+
+    it('should type inputData in dountil condition with output-only fields', () => {
+      const step = createStep({
+        id: 'process-step',
+        inputSchema: z.object({ seed: z.number() }),
+        outputSchema: z.object({ seed: z.number(), result: z.number(), done: z.boolean() }),
+        execute: async ({ inputData }) => {
+          return { seed: inputData.seed, result: inputData.seed * 2, done: false };
+        },
+      });
+
+      const workflow = createWorkflow({
+        id: 'process-workflow',
+        inputSchema: z.object({ seed: z.number() }),
+        outputSchema: z.object({ seed: z.number(), result: z.number(), done: z.boolean() }),
+      });
+
+      workflow.dountil(step, async ({ inputData }) => {
+        expectTypeOf(inputData).not.toBeAny();
+        expectTypeOf(inputData.result).toBeNumber();
+        expectTypeOf(inputData.done).toBeBoolean();
+        expectTypeOf(inputData.seed).toBeNumber();
+        return inputData.done;
+      });
+    });
+
+    it('should type iterationCount as number in loop condition', () => {
+      const schema = z.object({ value: z.number() });
+
+      const step = createStep({
+        id: 'loop-step',
+        inputSchema: schema,
+        outputSchema: schema,
+        execute: async ({ inputData }) => ({ value: inputData.value + 1 }),
+      });
+
+      const workflow = createWorkflow({
+        id: 'iter-workflow',
+        inputSchema: schema,
+        outputSchema: schema,
+      });
+
+      workflow.dowhile(step, async ({ inputData, iterationCount }) => {
+        expectTypeOf(iterationCount).toBeNumber();
+        expectTypeOf(inputData).not.toBeAny();
+        return inputData.value < 10;
+      });
+
+      workflow.dountil(step, async ({ inputData, iterationCount }) => {
+        expectTypeOf(iterationCount).toBeNumber();
+        expectTypeOf(inputData).not.toBeAny();
+        return inputData.value >= 10;
+      });
+    });
+
     it('should still reject steps with incompatible input schemas', () => {
       const workflowSchema = z.object({
         name: z.string(),

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1820,7 +1820,7 @@ export class Workflow<
 
   dowhile<TStepState, TStepInputSchema extends TPrevSchema, TStepId extends string, TSchemaOut>(
     step: Step<TStepId, SubsetOf<TStepState, TState>, TStepInputSchema, TSchemaOut, any, any, TEngineType>,
-    condition: LoopConditionFunction<TState, any, any, any, any, TEngineType>,
+    condition: LoopConditionFunction<TState, TSchemaOut, any, any, any, TEngineType>,
   ) {
     this.stepFlow.push({
       type: 'loop',
@@ -1857,7 +1857,7 @@ export class Workflow<
 
   dountil<TStepState, TStepInputSchema extends TPrevSchema, TStepId extends string, TSchemaOut>(
     step: Step<TStepId, SubsetOf<TStepState, TState>, TStepInputSchema, TSchemaOut, any, any, TEngineType>,
-    condition: LoopConditionFunction<TState, any, any, any, any, TEngineType>,
+    condition: LoopConditionFunction<TState, TSchemaOut, any, any, any, TEngineType>,
   ) {
     this.stepFlow.push({
       type: 'loop',


### PR DESCRIPTION
## Description

`inputData` in `dowhile` and `dountil` loop condition functions was typed as `any`, requiring users to manually cast it. This fix changes the `LoopConditionFunction` type parameter from `any` to `TSchemaOut` so that `inputData` is properly inferred from the step's `outputSchema` — matching the actual runtime behavior where the condition receives the step's output.

## Related Issue(s)

Fixes #12739

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type inference for loop conditions to correctly reference step output schemas, eliminating the need for manual type casting in dowhile and dountil loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->