### PR TITLE
[codex] Fix network tracingContext propagation across delegated primitives

### DIFF
--- a/packages/core/src/agent/agent-network.test.ts
+++ b/packages/core/src/agent/agent-network.test.ts
@@ -6099,6 +6099,132 @@ describe('Agent - network - requestContext propagation (issue #12330)', () => {
   });
 });
 
+describe('Agent - network - tracingContext propagation', () => {
+  const createMockSpan = () => {
+    const span: any = {
+      id: 'test-span-id',
+      traceId: 'test-trace-id',
+      isValid: true,
+      externalTraceId: 'test-trace-id',
+      createChildSpan: vi.fn(),
+      createChildEvent: vi.fn(),
+      end: vi.fn(),
+      update: vi.fn(),
+      error: vi.fn(),
+      executeInContext: async (fn: () => Promise<any>) => await fn(),
+      executeInContextSync: (fn: () => any) => fn(),
+    };
+
+    span.createChildSpan.mockImplementation(() => createMockSpan());
+    span.createChildEvent.mockImplementation(() => createMockSpan());
+
+    return span;
+  };
+
+  it('should propagate tracingContext to sub-agents executed within the network', async () => {
+    const memory = new MockMemory();
+
+    const subAgentModel = new MockLanguageModelV2({
+      doGenerate: async () => {
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          content: [{ type: 'text', text: 'Sub-agent handled task' }],
+          warnings: [],
+        };
+      },
+      doStream: async () => {
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-delta', id: 'id-0', delta: 'Sub-agent handled task' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 } },
+          ]),
+        };
+      },
+    });
+
+    const subAgent = new Agent({
+      id: 'tracing-sub-agent',
+      name: 'Tracing Sub-Agent',
+      instructions: 'Handle delegated tasks.',
+      model: subAgentModel,
+    });
+
+    const subAgentStreamSpy = vi.spyOn(subAgent, 'stream');
+
+    const routingSelectSubAgent = JSON.stringify({
+      primitiveId: 'tracing-sub-agent',
+      primitiveType: 'agent',
+      prompt: 'Handle this delegated task',
+      selectionReason: 'Delegating to tracing sub-agent',
+    });
+
+    const completionResponse = JSON.stringify({
+      isComplete: true,
+      finalResult: 'Done',
+      completionReason: 'Sub-agent completed the task',
+    });
+
+    let callCount = 0;
+    const routingModel = new MockLanguageModelV2({
+      doGenerate: async () => {
+        callCount++;
+        const text = callCount === 1 ? routingSelectSubAgent : completionResponse;
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          content: [{ type: 'text', text }],
+          warnings: [],
+        };
+      },
+      doStream: async () => {
+        callCount++;
+        const text = callCount === 1 ? routingSelectSubAgent : completionResponse;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-delta', id: 'id-0', delta: text },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+          ]),
+        };
+      },
+    });
+
+    const networkAgent = new Agent({
+      id: 'network-agent-tracing',
+      name: 'Network Tracing Agent',
+      instructions: 'Delegate tasks to tracing-sub-agent.',
+      model: routingModel,
+      agents: { 'tracing-sub-agent': subAgent },
+      memory,
+    });
+
+    const rootSpan = createMockSpan();
+    const tracingContext = { currentSpan: rootSpan };
+
+    const anStream = await networkAgent.network('Run delegated task', {
+      tracingContext: tracingContext as any,
+      memory: {
+        thread: 'test-thread-network-tracing-propagation',
+        resource: 'test-resource-network-tracing-propagation',
+      },
+    });
+
+    for await (const _chunk of anStream) {
+      // consume
+    }
+
+    expect(subAgentStreamSpy).toHaveBeenCalled();
+    const subAgentStreamOptions = subAgentStreamSpy.mock.calls[0]?.[1] as any;
+    expect(subAgentStreamOptions?.tracingContext?.currentSpan).toBe(rootSpan);
+  });
+});
+
 describe('Agent - network - abort functionality', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3600,6 +3600,7 @@ export class Agent<
       routingAgentOptions: {
         modelSettings: mergedOptions?.modelSettings,
         memory: mergedOptions?.memory,
+        tracingContext: mergedOptions?.tracingContext,
       } as unknown as AgentExecutionOptions<OUTPUT>,
       generateId: context => this.#mastra?.generateId(context) || randomUUID(),
       maxIterations: mergedOptions?.maxSteps || 1,
@@ -3674,6 +3675,7 @@ export class Agent<
       routingAgentOptions: {
         modelSettings: mergedOptions?.modelSettings,
         memory: mergedOptions?.memory,
+        tracingContext: mergedOptions?.tracingContext,
       },
       generateId: context => this.#mastra?.generateId(context) || randomUUID(),
       maxIterations: mergedOptions?.maxSteps || 1,

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -464,7 +464,7 @@ export async function createNetworkLoop({
   requestContext: RequestContext;
   runId: string;
   agent: Agent;
-  routingAgentOptions?: Pick<MultiPrimitiveExecutionOptions, 'modelSettings'>;
+  routingAgentOptions?: Pick<MultiPrimitiveExecutionOptions, 'modelSettings' | 'tracingContext'>;
   generateId: NetworkIdGenerator;
   routing?: {
     additionalInstructions?: string;
@@ -703,7 +703,7 @@ export async function createNetworkLoop({
       isComplete: z.boolean().optional(),
       iteration: z.number(),
     }),
-    execute: async ({ inputData, writer, getInitData, suspend, resumeData }) => {
+    execute: async ({ inputData, writer, getInitData, suspend, resumeData, tracingContext }) => {
       // Check if aborted before executing
       if (abortSignal?.aborted) {
         await onAbort?.({
@@ -789,6 +789,7 @@ export async function createNetworkLoop({
         ? agentForStep.resumeStream(resumeData, {
             requestContext: requestContext,
             runId,
+            tracingContext,
             memory: {
               thread: threadId,
               resource: resourceId,
@@ -802,6 +803,7 @@ export async function createNetworkLoop({
         : agentForStep.stream(messagesForSubAgent, {
             requestContext: requestContext,
             runId,
+            tracingContext,
             memory: {
               thread: threadId,
               resource: resourceId,
@@ -1043,7 +1045,7 @@ export async function createNetworkLoop({
       isComplete: z.boolean().optional(),
       iteration: z.number(),
     }),
-    execute: async ({ inputData, writer, getInitData, suspend, resumeData, mastra }) => {
+    execute: async ({ inputData, writer, getInitData, suspend, resumeData, mastra, tracingContext }) => {
       // Check if aborted before executing
       if (abortSignal?.aborted) {
         await onAbort?.({
@@ -1148,10 +1150,12 @@ export async function createNetworkLoop({
         ? run.resumeStream({
             resumeData,
             requestContext: requestContext,
+            tracingContext,
           })
         : run.stream({
             inputData: input,
             requestContext: requestContext,
+            tracingContext,
           });
 
       // const wflowAbortCb = () => {
@@ -1375,7 +1379,7 @@ export async function createNetworkLoop({
         .boolean()
         .describe('Controls if the tool call is approved or not, should be true when approved and false when declined'),
     }),
-    execute: async ({ inputData, getInitData, writer, resumeData, mastra, suspend }) => {
+    execute: async ({ inputData, getInitData, writer, resumeData, mastra, suspend, tracingContext }) => {
       const initData = await getInitData<{ threadId: string; threadResourceId: string }>();
       const logger = mastra?.getLogger();
 
@@ -1721,8 +1725,7 @@ export async function createNetworkLoop({
           runId,
           memory,
           context: inputDataToUse,
-          // TODO: Pass proper tracing context when network supports tracing
-          tracingContext: { currentSpan: undefined },
+          tracingContext,
           writer,
         },
         { toolCallId, messages: [] },
@@ -2587,6 +2590,7 @@ export async function networkLoop<OUTPUT = undefined>({
         return run.resumeStream({
           resumeData: resumeDataToUse,
           requestContext,
+          tracingContext: routingAgentOptions?.tracingContext,
         }).fullStream;
       }
       return run.stream({
@@ -2602,6 +2606,7 @@ export async function networkLoop<OUTPUT = undefined>({
           verboseIntrospection: true,
         },
         requestContext,
+        tracingContext: routingAgentOptions?.tracingContext,
       }).fullStream;
     },
   });


### PR DESCRIPTION
## Summary
Fixes network tracing context propagation so delegated primitives stay in the same trace tree.

This addresses the regression where a single `agent.network()` execution produced disconnected traces in Langfuse instead of one nested hierarchy.

## Linked issue
- Closes #12979

## Root cause
`network()` accepted `tracingContext`, but network internals did not pass it through consistently:
- `agent.network()`/`resumeNetwork()` dropped `tracingContext` when building `routingAgentOptions`
- network step executors (`agentStep`, `workflowStep`, `toolStep`) invoked delegated primitives without forwarding step tracing context
- top-level `run.stream()`/`run.resumeStream()` in `networkLoop` started without forwarded tracing context

## What changed
- `packages/core/src/agent/agent.ts`
  - Include `tracingContext` in `routingAgentOptions` for both `network()` and `resumeNetwork()`.

- `packages/core/src/loop/network/index.ts`
  - Extend `createNetworkLoop` routing options typing to include `tracingContext`.
  - Forward step `tracingContext` to:
    - `agentForStep.stream(...)`
    - `agentForStep.resumeStream(...)`
    - `run.stream(...)` (workflow primitive)
    - `run.resumeStream(...)` (workflow primitive)
    - tool execution context (`tool.execute(..., { tracingContext, ... })`)
  - Forward network-level tracing context to main workflow run:
    - `run.stream(...)`
    - `run.resumeStream(...)`

- `packages/core/src/agent/agent-network.test.ts`
  - Keep and update regression test:
    - `should propagate tracingContext to sub-agents executed within the network`
  - Assert delegated sub-agent receives propagated tracing span context (same trace, non-undefined).

## Verification
```bash
pnpm --filter @mastra/core exec vitest run src/agent/agent-network.test.ts
```

Result: passing (71 passed, 16 skipped).

## Minimal repro (before fix)
```ts
const stream = await networkAgent.network("Run delegated task", {
  tracingContext,
  memory: { thread: "t1", resource: "r1" },
});
for await (const _ of stream) {}
```

Expected trace shape:
- one root trace for network execution
- workflow + delegated agent/model spans nested under that root

Before this fix, delegated execution could start separate traces, causing disconnected spans in Langfuse.
