### PR TITLE
Gate datasets behind EXPERIMENTAL_FEATURES flag

### DIFF
--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -353,6 +353,14 @@ export class Mastra<
   }
 
   get datasets(): DatasetsManager {
+    if (process.env.EXPERIMENTAL_FEATURES !== 'true') {
+      throw new MastraError({
+        id: 'DATASETS_FEATURE_NOT_ENABLED',
+        text: 'Datasets require the EXPERIMENTAL_FEATURES=true environment variable.',
+        domain: 'STORAGE',
+        category: 'USER',
+      });
+    }
     if (!this.#datasets) {
       this.#datasets = new DatasetsManager(this);
     }

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -121,6 +121,7 @@ const RootLayout = () => {
 
 // Determine platform status at module level for route configuration
 const isMastraPlatform = Boolean(window.MASTRA_CLOUD_API_ENDPOINT);
+const isExperimentalFeatures = window.MASTRA_EXPERIMENTAL_FEATURES === 'true';
 
 const routes = [
   {
@@ -194,14 +195,18 @@ const routes = [
         ],
       },
 
-      { path: '/datasets', element: <Datasets /> },
-      { path: '/datasets/:datasetId', element: <DatasetPage /> },
-      { path: '/datasets/:datasetId/items/:itemId', element: <DatasetItemPage /> },
-      { path: '/datasets/:datasetId/items/:itemId/versions', element: <DatasetCompareVersions /> },
-      { path: '/datasets/:datasetId/experiments/:experimentId', element: <DatasetExperiment /> },
-      { path: '/datasets/:datasetId/compare', element: <DatasetCompare /> },
-      { path: '/datasets/:datasetId/items', element: <DatasetCompareItems /> },
-      { path: '/datasets/:datasetId/versions', element: <DatasetCompareDatasetVersions /> },
+      ...(isExperimentalFeatures
+        ? [
+            { path: '/datasets', element: <Datasets /> },
+            { path: '/datasets/:datasetId', element: <DatasetPage /> },
+            { path: '/datasets/:datasetId/items/:itemId', element: <DatasetItemPage /> },
+            { path: '/datasets/:datasetId/items/:itemId/versions', element: <DatasetCompareVersions /> },
+            { path: '/datasets/:datasetId/experiments/:experimentId', element: <DatasetExperiment /> },
+            { path: '/datasets/:datasetId/compare', element: <DatasetCompare /> },
+            { path: '/datasets/:datasetId/items', element: <DatasetCompareItems /> },
+            { path: '/datasets/:datasetId/versions', element: <DatasetCompareDatasetVersions /> },
+          ]
+        : []),
 
       { index: true, loader: () => redirect('/agents') },
       { path: '/request-context', element: <RequestContext /> },

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -27,6 +27,7 @@ import {
   MastraVersionFooter,
   useMastraPlatform,
   NavLink,
+  useExperimentalFeatures,
 } from '@mastra/playground-ui';
 
 const mainNavigation: NavSection[] = [
@@ -173,8 +174,12 @@ export function AppSidebar() {
 
   const hideCloudCta = window?.MASTRA_HIDE_CLOUD_CTA === 'true';
   const { isMastraPlatform } = useMastraPlatform();
+  const { experimentalFeaturesEnabled } = useExperimentalFeatures();
 
   const filterPlatformLink = (link: NavLink) => {
+    if (link.name === 'Datasets' && !experimentalFeaturesEnabled) {
+      return false;
+    }
     if (isMastraPlatform) {
       return link.isOnMastraPlatform;
     }

--- a/packages/server/src/server/server-adapter/routes/index.ts
+++ b/packages/server/src/server/server-adapter/routes/index.ts
@@ -110,7 +110,7 @@ export const SERVER_ROUTES: ServerRoute<any, any, any>[] = [
   ...STORED_AGENTS_ROUTES,
   ...STORED_SCORERS_ROUTES,
   ...SYSTEM_ROUTES,
-  ...DATASETS_ROUTES,
+  ...(process.env.EXPERIMENTAL_FEATURES === 'true' ? DATASETS_ROUTES : []),
 ];
 
 // Export route builder and OpenAPI utilities

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -145,8 +145,9 @@ export class LibSQLStore extends MastraCompositeStore {
     const memory = new MemoryLibSQL(domainConfig);
     const observability = new ObservabilityLibSQL(domainConfig);
     const agents = new AgentsLibSQL(domainConfig);
-    const datasets = new DatasetsLibSQL(domainConfig);
-    const experiments = new ExperimentsLibSQL(domainConfig);
+    const isExperimental = process.env.EXPERIMENTAL_FEATURES === 'true';
+    const datasets = isExperimental ? new DatasetsLibSQL(domainConfig) : undefined;
+    const experiments = isExperimental ? new ExperimentsLibSQL(domainConfig) : undefined;
     const promptBlocks = new PromptBlocksLibSQL(domainConfig);
     const scorerDefinitions = new ScorerDefinitionsLibSQL(domainConfig);
 


### PR DESCRIPTION
## Summary
- Gates the entire datasets feature behind `EXPERIMENTAL_FEATURES=true` env var
- When flag is off (default): no dataset UI routes, no sidebar link, no API endpoints, no DB table creation
- When flag is on: everything works exactly as before

## Changes
- **Server routes** — conditionally spread `DATASETS_ROUTES` into `SERVER_ROUTES`
- **LibSQL store** — conditionally instantiate `DatasetsLibSQL` + `ExperimentsLibSQL`
- **Playground routes** — conditionally register 8 dataset routes
- **Sidebar** — filter Datasets nav link via `useExperimentalFeatures()` hook
- **Core getter** — `mastra.datasets` throws `DATASETS_FEATURE_NOT_ENABLED` when flag is off

## Test plan
- [ ] `pnpm dev:playground` (no flag) — no Datasets in sidebar, `/datasets` doesn't render, API returns 404
- [ ] `EXPERIMENTAL_FEATURES=true pnpm dev:playground` — Datasets visible, all routes + API work
- [ ] `pnpm build` passes (97/97 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)