### PR TITLE
feat(core): support structured output and initial state in runEvals

### DIFF
--- a/.changeset/evals-structured-output-initial-state.md
+++ b/.changeset/evals-structured-output-initial-state.md
@@ -1,0 +1,9 @@
+---
+"@mastra/core": minor
+---
+
+Support structured output and workflow initial state in `runEvals`.
+
+- Add `structuredOutput` option for agents using AI SDK v5/v6 models, forwarded to `agent.generate()`.
+- Add `output` option for agents using legacy AI SDK v4 models, forwarded to `agent.generateLegacy()`.
+- Add `initialState` field to eval data items, forwarded to `run.start()` for workflow targets.

--- a/.changeset/evals-structured-output-initial-state.md
+++ b/.changeset/evals-structured-output-initial-state.md
@@ -2,8 +2,44 @@
 "@mastra/core": minor
 ---
 
-Support structured output and workflow initial state in `runEvals`.
+Support structured output and workflow initial state in `runEvals`. Closes #12680.
 
 - Add `structuredOutput` option for agents using AI SDK v5/v6 models, forwarded to `agent.generate()`.
 - Add `output` option for agents using legacy AI SDK v4 models, forwarded to `agent.generateLegacy()`.
-- Add `initialState` field to eval data items, forwarded to `run.start()` for workflow targets.
+- Workflow initial state: Data items now accept an `initialState` field, forwarded to `run.start()` for workflow targets.
+
+```ts
+import { runEvals } from '@mastra/core/evals';
+import { z } from 'zod';
+
+// Structured output with v5+ models
+await runEvals({
+  target: myAgent,
+  data: [{ input: 'Analyze this text', groundTruth: 'expected' }],
+  scorers: [myScorer],
+  structuredOutput: {
+    schema: z.object({ answer: z.string(), confidence: z.number() }),
+  },
+});
+
+// Legacy output schema with v4 models
+await runEvals({
+  target: legacyAgent,
+  data: [{ input: 'Analyze this text', groundTruth: 'expected' }],
+  scorers: [myScorer],
+  output: z.object({ answer: z.string(), confidence: z.number() }),
+});
+
+// Workflow with initial state
+await runEvals({
+  target: myWorkflow,
+  data: [
+    {
+      input: { query: 'test' },
+      initialState: { counter: 0, label: 'init' },
+      groundTruth: 'expected',
+    },
+  ],
+  scorers: [myScorer],
+});
+```


### PR DESCRIPTION
## Description

Add `structuredOutput` and `output` options to agent evals, and support `initialState` on data items for workflow evals.

## Related Issue(s)

Fixes #12680

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured output support added for modern AI models (JSON/Zod schema options) to enforce/validate response shape during evals.
  * Legacy model output schema support added for older AI models.
  * Workflow evaluations can now receive an initial state so runs start with provided state values.

* **Tests**
  * Added tests verifying structured output propagation and workflow initial-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->