### PR TITLE
fix(playground): fix scorer creation form validation and e2e tests

### DIFF
--- a/.changeset/six-sheep-relax.md
+++ b/.changeset/six-sheep-relax.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed missing validation for the instructions field in the scorer creation form and replaced manual submission state tracking with the mutation hook's built-in pending state

--- a/packages/playground-ui/src/domains/scores/components/scorer-edit-page/use-scorer-edit-form.ts
+++ b/packages/playground-ui/src/domains/scores/components/scorer-edit-page/use-scorer-edit-form.ts
@@ -23,6 +23,10 @@ const scorerFormResolver: Resolver<ScorerFormValues> = async values => {
     errors['model.name'] = { type: 'required', message: 'Model is required' };
   }
 
+  if (!values.instructions || values.instructions.trim() === '') {
+    errors.instructions = { type: 'required', message: 'Instructions are required' };
+  }
+
   return {
     values: Object.keys(errors).length === 0 ? values : {},
     errors: Object.keys(errors).length > 0 ? errors : {},

--- a/packages/playground/src/pages/cms/scorers/create/index.tsx
+++ b/packages/playground/src/pages/cms/scorers/create/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useRef } from 'react';
 import { GaugeIcon } from 'lucide-react';
 
 import {
@@ -20,11 +20,10 @@ import type { CreateStoredScorerParams } from '@mastra/client-js';
 function CmsScorersCreatePage() {
   const { navigate, paths } = useLinkComponent();
   const { createStoredScorer } = useStoredScorerMutations();
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const formRef = useRef<HTMLFormElement | null>(null);
   const { form } = useScorerEditForm();
 
-  const handlePublish = useCallback(async () => {
+  const handlePublish = async () => {
     const isValid = await form.trigger();
     if (!isValid) {
       toast.error('Please fill in all required fields');
@@ -32,7 +31,6 @@ function CmsScorersCreatePage() {
     }
 
     const values = form.getValues();
-    setIsSubmitting(true);
 
     try {
       const createParams: CreateStoredScorerParams = {
@@ -53,10 +51,8 @@ function CmsScorersCreatePage() {
       navigate(paths.scorerLink(created.id));
     } catch (error) {
       toast.error(`Failed to create scorer: ${error instanceof Error ? error.message : 'Unknown error'}`);
-    } finally {
-      setIsSubmitting(false);
     }
-  }, [form, createStoredScorer, navigate, paths]);
+  };
 
   return (
     <MainContentLayout>
@@ -70,7 +66,12 @@ function CmsScorersCreatePage() {
       </Header>
       <AgentEditLayout
         leftSlot={
-          <ScorerEditSidebar form={form} onPublish={handlePublish} isSubmitting={isSubmitting} formRef={formRef} />
+          <ScorerEditSidebar
+            form={form}
+            onPublish={handlePublish}
+            isSubmitting={createStoredScorer.isPending}
+            formRef={formRef}
+          />
         }
       >
         <form ref={formRef} className="h-full">


### PR DESCRIPTION
The scorer creation form was missing validation on the instructions field, and the e2e tests weren't filling in all required fields — causing flaky failures.

This adds the missing `instructions` validation in the form resolver, updates the e2e tests to always provide `description` and `instructions`, fixes URL regex patterns to match uppercase characters in scorer IDs, and swaps the manual `isSubmitting` state for `createStoredScorer.isPending`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing validation for the instructions field in scorer creation, now preventing form submission when instructions are empty or contain only whitespace.
  * Improved form submission state handling during scorer creation for more reliable user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->