### PR TITLE
fix: Handle undefined assignees in gh-issue-triage workflow

### DIFF
--- a/scripts/gh-issue-triage/index.ts
+++ b/scripts/gh-issue-triage/index.ts
@@ -88,21 +88,27 @@ async function main() {
 
   if (result.status === 'success') {
     const workflowOutput = result.result;
-    const assignees = workflowOutput.result.assignees
-      .map((assignee: string) => mappings[assignee])
-      .filter(Boolean)
-      .map(assignee => `<@${assignee}>`);
+    const assigneesList = workflowOutput?.assignees ?? workflowOutput?.result?.assignees;
 
-    await tools['slack_slack_post_message'].execute({
-      context: {
-        channel_id: CHANNEL_ID,
-        text: `
+    if (Array.isArray(assigneesList) && assigneesList.length > 0) {
+      const assignees = assigneesList
+        .map((assignee: string) => mappings[assignee])
+        .filter(Boolean)
+        .map(assignee => `<@${assignee}>`);
+
+      if (assignees.length > 0) {
+        await tools['slack_slack_post_message'].execute({
+          context: {
+            channel_id: CHANNEL_ID,
+            text: `
                 New issue assigned to ${assignees.join(', ')}
                 * Title: ${issue.data.title}
                 * Link: https://github.com/${OWNER}/${REPO}/issues/${ISSUE_NUMBER}
             `,
-      },
-    });
+          },
+        });
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Description:

- fixes a TypeError in the GitHub issue triage workflow when assignees is undefined. The code attempted to call .map() on result.assignees without checking if it exists.

- The fix adds safety checks to handle cases where assignees may be missing or structured differently, preventing the workflow from crashing and only sending Slack notifications when valid assignees are present.

### Related Issue(s):

fixes #12996

### Type of Change:
[x] Bug fix (non-breaking change that fixes an issue)