### PR TITLE
fix(editor):persisting req ctx

### DIFF
--- a/.changeset/clever-moles-flash.md
+++ b/.changeset/clever-moles-flash.md
@@ -1,6 +1,7 @@
 ---
 '@mastra/core': patch
 '@mastra/libsql': patch
+'@mastra/mongodb': patch
 '@mastra/pg': patch
 ---
 

--- a/.changeset/clever-moles-flash.md
+++ b/.changeset/clever-moles-flash.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/pg': patch
+---
+
+Fixed agent version storage to persist the requestContextSchema field. Previously, requestContextSchema was defined on the agent snapshot type but was not included in the database schema, INSERT statements, or row parsing logic, causing it to be silently dropped when saving and loading agent versions.

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -125,6 +125,7 @@ export const AGENT_VERSIONS_SCHEMA: Record<string, StorageColumn> = {
   outputProcessors: { type: 'jsonb', nullable: true },
   memory: { type: 'jsonb', nullable: true },
   scorers: { type: 'jsonb', nullable: true },
+  requestContextSchema: { type: 'jsonb', nullable: true },
   // Version metadata
   changedFields: { type: 'jsonb', nullable: true }, // Array of field names
   changeMessage: { type: 'text', nullable: true },

--- a/packages/core/src/storage/domains/agents/inmemory.ts
+++ b/packages/core/src/storage/domains/agents/inmemory.ts
@@ -109,6 +109,7 @@ export class InMemoryAgentsStorage extends AgentsStorage {
       'outputProcessors',
       'memory',
       'scorers',
+      'requestContextSchema',
     ];
 
     // Check if any config fields are present in the update

--- a/stores/_test-utils/src/domains/agents/data.ts
+++ b/stores/_test-utils/src/domains/agents/data.ts
@@ -21,6 +21,7 @@ export const createSampleAgent = ({
   outputProcessors,
   memory,
   scorers,
+  requestContextSchema,
 }: Partial<StorageCreateAgentInput> = {}): StorageCreateAgentInput => ({
   id,
   name,
@@ -37,6 +38,7 @@ export const createSampleAgent = ({
   ...(outputProcessors && { outputProcessors }),
   ...(memory && { memory }),
   ...(scorers && { scorers }),
+  ...(requestContextSchema && { requestContextSchema }),
 });
 
 /**
@@ -68,6 +70,14 @@ export const createFullSampleAgent = ({
   memory: { vector: 'default-vector' },
   scorers: {
     relevance: { sampling: { type: 'ratio', rate: 0.8 } },
+  },
+  requestContextSchema: {
+    type: 'object',
+    properties: {
+      tenantId: { type: 'string' },
+      role: { type: 'string', enum: ['admin', 'user'] },
+    },
+    required: ['tenantId'],
   },
   metadata: {
     category: 'test',

--- a/stores/_test-utils/src/domains/agents/index.ts
+++ b/stores/_test-utils/src/domains/agents/index.ts
@@ -72,6 +72,7 @@ export function createAgentsTests({ storage }: { storage: MastraStorage }) {
         expect(resolved?.outputProcessors).toEqual(agent.outputProcessors);
         expect(resolved?.memory).toEqual(agent.memory);
         expect(resolved?.scorers).toEqual(agent.scorers);
+        expect(resolved?.requestContextSchema).toEqual(agent.requestContextSchema);
         expect(resolved?.metadata).toEqual(agent.metadata);
       });
 

--- a/stores/libsql/src/storage/domains/agents/index.ts
+++ b/stores/libsql/src/storage/domains/agents/index.ts
@@ -43,6 +43,7 @@ const SNAPSHOT_FIELDS = [
   'outputProcessors',
   'memory',
   'scorers',
+  'requestContextSchema',
 ] as const;
 
 export class AgentsLibSQL extends AgentsStorage {
@@ -643,6 +644,7 @@ export class AgentsLibSQL extends AgentsStorage {
           outputProcessors: input.outputProcessors ?? null,
           memory: input.memory ?? null,
           scorers: input.scorers ?? null,
+          requestContextSchema: input.requestContextSchema ?? null,
           changedFields: input.changedFields ?? null,
           changeMessage: input.changeMessage ?? null,
           createdAt: now,
@@ -943,6 +945,7 @@ export class AgentsLibSQL extends AgentsStorage {
       outputProcessors: this.parseJson(row.outputProcessors, 'outputProcessors'),
       memory: this.parseJson(row.memory, 'memory'),
       scorers: this.parseJson(row.scorers, 'scorers'),
+      requestContextSchema: this.parseJson(row.requestContextSchema, 'requestContextSchema'),
       changedFields: this.parseJson(row.changedFields, 'changedFields'),
       changeMessage: row.changeMessage as string | undefined,
       createdAt: new Date(row.createdAt as string),

--- a/stores/mongodb/src/storage/domains/agents/index.ts
+++ b/stores/mongodb/src/storage/domains/agents/index.ts
@@ -44,6 +44,7 @@ const SNAPSHOT_FIELDS = [
   'outputProcessors',
   'memory',
   'scorers',
+  'requestContextSchema',
 ] as const;
 
 export class MongoDBAgentsStorage extends AgentsStorage {

--- a/stores/pg/src/storage/domains/agents/index.ts
+++ b/stores/pg/src/storage/domains/agents/index.ts
@@ -470,6 +470,7 @@ export class AgentsPG extends AgentsStorage {
         'outputProcessors',
         'memory',
         'scorers',
+        'requestContextSchema',
       ];
 
       // Check if any config fields are present in the update
@@ -707,9 +708,10 @@ export class AgentsPG extends AgentsStorage {
           name, description, instructions, model, tools,
           "defaultOptions", workflows, agents, "integrationTools",
           "inputProcessors", "outputProcessors", memory, scorers,
+          "requestContextSchema",
           "changedFields", "changeMessage",
           "createdAt", "createdAtZ"
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)`,
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)`,
         [
           input.id,
           input.agentId,
@@ -727,6 +729,7 @@ export class AgentsPG extends AgentsStorage {
           input.outputProcessors ? JSON.stringify(input.outputProcessors) : null,
           input.memory ? JSON.stringify(input.memory) : null,
           input.scorers ? JSON.stringify(input.scorers) : null,
+          input.requestContextSchema ? JSON.stringify(input.requestContextSchema) : null,
           input.changedFields ? JSON.stringify(input.changedFields) : null,
           input.changeMessage ?? null,
           nowIso,
@@ -993,6 +996,7 @@ export class AgentsPG extends AgentsStorage {
       outputProcessors: this.parseJson(row.outputProcessors, 'outputProcessors'),
       memory: this.parseJson(row.memory, 'memory'),
       scorers: this.parseJson(row.scorers, 'scorers'),
+      requestContextSchema: this.parseJson(row.requestContextSchema, 'requestContextSchema'),
       changedFields: this.parseJson(row.changedFields, 'changedFields'),
       changeMessage: row.changeMessage as string | undefined,
       createdAt: row.createdAtZ || row.createdAt,


### PR DESCRIPTION
Fixed agent version storage to persist the requestContextSchema field. Previously, requestContextSchema was defined on the agent snapshot type but was not included in the database schema, INSERT statements, or row parsing logic, causing it to be silently dropped when saving and loading agent versions.