### PR TITLE
fix(server): list tools API endpoint returns empty collection

### DIFF
--- a/.changeset/few-trams-go.md
+++ b/.changeset/few-trams-go.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed the /api/tools endpoint returning an empty list even when tools are registered on the Mastra instance. Closes #12983

--- a/packages/server/src/server/handlers/tools.test.ts
+++ b/packages/server/src/server/handlers/tools.test.ts
@@ -59,6 +59,22 @@ describe('Tools Handlers', () => {
       expect(result[mockTool.id]).toHaveProperty('id', mockTool.id);
       // expect(result[mockVercelTool.id]).toHaveProperty('id', mockVercelTool.id);
     });
+
+    it('should fall back to mastra.listTools() when registeredTools is empty object', async () => {
+      const mastra = new Mastra({
+        logger: false,
+        tools: mockTools,
+      });
+      // This mirrors what happens in the real server adapters (hono/express):
+      // they set registeredTools to `this.tools || {}`, so when no tools are
+      // passed to the server constructor, registeredTools becomes {}
+      const result = await LIST_TOOLS_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        registeredTools: {},
+      });
+      expect(result).toHaveProperty(mockTool.id);
+      expect(result[mockTool.id]).toHaveProperty('id', mockTool.id);
+    });
   });
 
   describe('getToolByIdHandler', () => {

--- a/packages/server/src/server/handlers/tools.ts
+++ b/packages/server/src/server/handlers/tools.ts
@@ -33,7 +33,8 @@ export const LIST_TOOLS_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, registeredTools }) => {
     try {
-      const allTools = registeredTools || mastra.listTools() || {};
+      const allTools =
+        registeredTools && Object.keys(registeredTools).length > 0 ? registeredTools : mastra.listTools() || {};
 
       const serializedTools = Object.entries(allTools).reduce(
         (acc, [id, _tool]) => {


### PR DESCRIPTION
The `GET /api/tools` endpoint was always returning `{}` even when tools were registered on the Mastra instance. Meanwhile `GET /api/tools/:toolId` worked fine for individual lookups.

The handler used `registeredTools || mastra.listTools()`, but server adapters (Hono/Express) always set `registeredTools` to `this.tools || {}`. Since `{}` is truthy in JS, the fallback to `mastra.listTools()` was never reached. The single-tool endpoint already had the correct check (`Object.keys(registeredTools).length > 0`), so this just applies the same pattern.

Added a test that reproduces the exact scenario.

Closes #12983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the /api/tools endpoint to correctly return the list of registered tools, ensuring proper fallback behavior (issue #12983)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->