### PR TITLE
fix(playground): prevent chat flash when sending first message on new thread

### DIFF
--- a/.changeset/fix-studio-first-prompt-flash.md
+++ b/.changeset/fix-studio-first-prompt-flash.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Fixed chat flashing empty state when sending the first message on a new thread. Stabilized the empty messages array fallback so useChat doesn't reset streamed messages during the /chat/new to /chat/<uuid> URL transition.
+Fixed chat briefly showing an empty conversation after sending the first message on a new thread.

--- a/.changeset/fix-studio-first-prompt-flash.md
+++ b/.changeset/fix-studio-first-prompt-flash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed chat flashing empty state when sending the first message on a new thread. Stabilized the empty messages array fallback so useChat doesn't reset streamed messages during the /chat/new to /chat/<uuid> URL transition.

--- a/packages/playground-ui/src/domains/agents/components/agent-chat.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-chat.tsx
@@ -46,7 +46,12 @@ export const AgentChat = ({
     }
   }, [messageId, data, isMessagesLoading]);
 
-  const messages = data?.messages ?? [];
+  // Stable empty array per thread: stays the same reference across re-renders
+  // (preventing useChat from wiping streamed messages), but changes when threadId
+  // changes (allowing useChat to reset when switching threads).
+  const emptyMessages = useMemo(() => [] as never[], [threadId]);
+
+  const messages = data?.messages ?? emptyMessages;
   const v5Messages = useMemo(() => toAISdkV5Messages(messages) as MastraUIMessage[], [messages]);
   const v4Messages = useMemo(() => toAISdkV4Messages(messages), [messages]);
 

--- a/packages/playground/src/pages/agents/agent/index.tsx
+++ b/packages/playground/src/pages/agents/agent/index.tsx
@@ -15,7 +15,7 @@ import {
   SchemaRequestContextProvider,
   type AgentSettingsType,
 } from '@mastra/playground-ui';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { v4 as uuid } from '@lukeed/uuid';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 
@@ -28,7 +28,11 @@ function Agent() {
   const { data: memory } = useMemory(agentId!);
   const navigate = useNavigate();
   const isNewThread = threadId === 'new';
-  const [newThreadId, setNewThreadId] = useState<string>(() => uuid());
+
+  // Generate a stable thread ID for new threads. Regenerate when threadId
+  // changes (e.g., clicking "New Chat" navigates back to /chat/new).
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- threadId is intentional: we need a new UUID per thread
+  const newThreadId = useMemo(() => uuid(), [threadId]);
 
   const hasMemory = Boolean(memory?.result);
 
@@ -94,7 +98,6 @@ function Agent() {
     await refreshThreads();
 
     if (isNewThread) {
-      setNewThreadId(() => uuid());
       navigate(`/agents/${agentId}/chat/${newThreadId}`);
     }
   };


### PR DESCRIPTION
## Summary

- Stabilize the empty messages array fallback using `useMemo` keyed on `threadId`, preventing `useChat` from resetting streamed messages during the `/chat/new` → `/chat/<uuid>` transition
- Replace `useState` with `useMemo` for `newThreadId` generation to avoid an intermediate state change that created a new array reference mid-render

## Problem

When sending the first message on a new chat in Studio, the browser redirects from `/agents/:agentId/chat/new` to `/agents/:agentId/chat/<uuid>`. This URL change re-enables `useAgentMessages`, and during loading `data?.messages` becomes `undefined`. The `[] ` fallback (`data?.messages ?? []`) created a **new array reference on every render**, causing `useChat`'s effect to fire `setMessages([])` — producing a visible flash where the chat goes empty then reloads.

## Root cause

1. `handleRefreshThreadList` navigates from `/chat/new` to `/chat/<uuid>`
2. `isNewThread` flips `false` → `useAgentMessages` enables with the new threadId
3. Query starts loading → `data = undefined` → `messages = []` (new ref each render)
4. `useMemo(() => toAISdkV5Messages(messages), [messages])` recomputes (new input ref)
5. `useChat` effect fires: `setMessages([])` → **flash**

## Fix

- **`agent-chat.tsx`**: `useMemo(() => [] as never[], [threadId])` — stable empty array per thread. Same reference across re-renders within a thread, new reference when switching threads.
- **`agent/index.tsx`**: `useMemo(() => uuid(), [threadId])` replaces `useState` — eliminates the `setNewThreadId()` call that caused an intermediate re-render with a changed `actualThreadId`, which defeated the stable reference.

## Test plan

- [ ] Send first message on a new chat — no flash/refresh occurs
- [ ] Thread appears in sidebar after sending
- [ ] Click "New Chat" — get a fresh empty chat
- [ ] Navigate to existing thread — messages load correctly
- [ ] Refresh page on a thread with messages — messages load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stops the chat briefly flashing an empty conversation and preserves streamed messages when starting or switching threads, maintaining message continuity.

* **Refactor**
  * Streamlines thread creation so new threads receive fresh identifiers and navigation behaves consistently without transient state issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->