### PR TITLE
fix(core): fix updateWorkingMemory failing in Vite SSR due to instanceof

### DIFF
--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -6,6 +6,15 @@ import type { MCPToolProperties, ToolAction, ToolExecutionContext } from './type
 import { validateToolInput, validateToolOutput, validateToolSuspendData, validateRequestContext } from './validation';
 
 /**
+ * Marker to identify Mastra tools even when `instanceof` fails.
+ * This can happen in environments like Vite SSR where the same module
+ * may be loaded multiple times, creating different class instances.
+ * Uses Symbol.for() so the same symbol is shared across module copies.
+ * Follows the naming convention: <org>.<product>.<category>.<className>
+ */
+export const MASTRA_TOOL_MARKER = Symbol.for('mastra.core.tool.Tool');
+
+/**
  * A type-safe tool that agents and workflows can call to perform specific actions.
  *
  * @template TSchemaIn - Input schema type
@@ -163,6 +172,7 @@ export class Tool<
    * ```
    */
   constructor(opts: ToolAction<TSchemaIn, TSchemaOut, TSuspendSchema, TResumeSchema, TContext, TId, TRequestContext>) {
+    (this as any)[MASTRA_TOOL_MARKER] = true;
     this.id = opts.id;
     this.description = opts.description;
     this.inputSchema = opts.inputSchema;

--- a/packages/core/src/tools/toolchecks.ts
+++ b/packages/core/src/tools/toolchecks.ts
@@ -1,6 +1,15 @@
-import { Tool } from './tool';
+import { Tool, MASTRA_TOOL_MARKER } from './tool';
 import type { ToolToConvert } from './tool-builder/builder';
 import type { VercelTool } from './types';
+
+/**
+ * Checks if a tool is a Mastra Tool, using both instanceof and marker.
+ * The marker fallback handles environments like Vite SSR where the same
+ * module may be loaded multiple times, causing instanceof to fail.
+ */
+function isMastraTool(tool: unknown): boolean {
+  return tool instanceof Tool || (typeof tool === 'object' && tool !== null && MASTRA_TOOL_MARKER in tool);
+}
 
 /**
  * Checks if a tool is a Vercel Tool (AI SDK tool)
@@ -14,7 +23,7 @@ export function isVercelTool(tool?: ToolToConvert): tool is VercelTool {
   // This prevents plain objects with inputSchema (like client tools) from being treated as VercelTools
   return !!(
     tool &&
-    !(tool instanceof Tool) &&
+    !isMastraTool(tool) &&
     ('parameters' in tool || ('execute' in tool && typeof tool.execute === 'function' && 'inputSchema' in tool))
   );
 }


### PR DESCRIPTION
## Summary
- In environments like Vite SSR, the `Tool` class can be loaded from multiple module instances, causing `instanceof Tool` to return `false` for legitimate Mastra tools
- This makes `isVercelTool()` incorrectly identify them as AI SDK tools, so the tool is called with raw AI SDK options (no `memory` in context) instead of the enriched Mastra tool context
- The `updateWorkingMemory` tool then throws `"Memory instance is required for working memory updates"`
- Added a `Symbol.for('mastra.core.tool.Tool')` marker to the `Tool` class and a fallback check in `isVercelTool()` so Mastra tools are correctly identified even when `instanceof` fails
- Follows the same pattern used by the AI SDK (`Symbol.for('vercel.ai.error.<className>')` in `invalid-content-error.ts`)

## Test plan
- [x] Added test that simulates `instanceof` failure (overriding `Symbol.hasInstance`) — reproduces the exact error without the fix, passes with it
- [x] Added tests for agent with working memory inside workflow steps and foreach steps
- [x] All 6 working-memory-context tests pass
- [x] All 23 existing utils/isVercelTool tests pass
- [x] All 67 memory-related tests pass
- [x] All 149 tool unit tests pass (9 e2e failures are pre-existing, require API keys)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded tests to validate memory propagation across workflow steps and foreach iterations, including edge-case tool invocation scenarios.

* **Bug Fixes**
  * Improved tool detection so tools are reliably recognized even when module instances are duplicated.

* **New Features**
  * Added a public tool identifier to ensure consistent tool recognition across different runtime/module instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->