### PR TITLE
fix(cli): write mastra-packages.json during build for CMS detection

### DIFF
--- a/.changeset/legal-apes-stay.md
+++ b/.changeset/legal-apes-stay.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed CMS features (Create an agent button, clone, edit, create scorer) not appearing in built output. The build command now writes package metadata so the studio can detect installed Mastra packages at runtime.

--- a/.changeset/legal-apes-stay.md
+++ b/.changeset/legal-apes-stay.md
@@ -3,6 +3,10 @@
 '@mastra/server': patch
 '@mastra/client-js': patch
 '@mastra/playground-ui': patch
+'@mastra/deployer-netlify': patch
+'@mastra/deployer-vercel': patch
+'@mastra/deployer-cloudflare': patch
+'@mastra/deployer-cloud': patch
 ---
 
 Fixed CMS features (Create an agent button, clone, edit, create scorer) not appearing in built output. The build command now writes package metadata so the studio can detect installed Mastra packages at runtime.

--- a/.changeset/legal-apes-stay.md
+++ b/.changeset/legal-apes-stay.md
@@ -1,5 +1,10 @@
 ---
 'mastra': patch
+'@mastra/server': patch
+'@mastra/client-js': patch
+'@mastra/playground-ui': patch
 ---
 
 Fixed CMS features (Create an agent button, clone, edit, create scorer) not appearing in built output. The build command now writes package metadata so the studio can detect installed Mastra packages at runtime.
+
+The version footer in the sidebar now only displays in dev mode, keeping built studio output clean.

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -1250,6 +1250,7 @@ export interface MastraPackage {
 
 export interface GetSystemPackagesResponse {
   packages: MastraPackage[];
+  isDev: boolean;
 }
 
 // ============================================================================

--- a/deployers/cloud/src/index.ts
+++ b/deployers/cloud/src/index.ts
@@ -98,6 +98,8 @@ export class CloudDeployer extends Deployer {
 
   private getEntry(): string {
     return `
+import { fileURLToPath as __pkgFileURLToPath } from 'node:url';
+import { dirname as __pkgDirname, join as __pkgJoin } from 'node:path';
 import { createNodeServer, getToolExports } from '#server';
 import { tools } from '#tools';
 import { mastra } from '#mastra';
@@ -106,6 +108,12 @@ import { PinoLogger } from '@mastra/loggers';
 import { HttpTransport } from '@mastra/loggers/http';
 import { LibSQLStore, LibSQLVector } from '@mastra/libsql';
 import { scoreTracesWorkflow } from '@mastra/core/evals/scoreTraces';
+// Set packages file path for CMS availability detection in built output
+if (!process.env.MASTRA_PACKAGES_FILE) {
+  const __bundleDir = __pkgDirname(__pkgFileURLToPath(import.meta.url));
+  process.env.MASTRA_PACKAGES_FILE = __pkgJoin(__bundleDir, 'mastra-packages.json');
+}
+
 const startTime = process.env.RUNNER_START_TIME ? new Date(process.env.RUNNER_START_TIME).getTime() : Date.now();
 const createNodeServerStartTime = Date.now();
 

--- a/deployers/cloudflare/src/index.ts
+++ b/deployers/cloudflare/src/index.ts
@@ -140,8 +140,16 @@ export const sys = {
 
   private getEntry(): string {
     return `
+    import { fileURLToPath as __pkgFileURLToPath } from 'node:url';
+    import { dirname as __pkgDirname, join as __pkgJoin } from 'node:path';
     import '#polyfills';
     import { scoreTracesWorkflow } from '@mastra/core/evals/scoreTraces';
+
+    // Set packages file path for CMS availability detection in built output
+    if (!process.env.MASTRA_PACKAGES_FILE) {
+      const __bundleDir = __pkgDirname(__pkgFileURLToPath(import.meta.url));
+      process.env.MASTRA_PACKAGES_FILE = __pkgJoin(__bundleDir, 'mastra-packages.json');
+    }
 
     export default {
       fetch: async (request, env, context) => {

--- a/deployers/netlify/src/index.ts
+++ b/deployers/netlify/src/index.ts
@@ -72,11 +72,19 @@ export class NetlifyDeployer extends Deployer {
 
   private getEntry(): string {
     return `
+    import { fileURLToPath as __pkgFileURLToPath } from 'node:url';
+    import { dirname as __pkgDirname, join as __pkgJoin } from 'node:path';
     import { handle } from 'hono/netlify'
     import { mastra } from '#mastra';
     import { createHonoServer, getToolExports } from '#server';
     import { tools } from '#tools';
     import { scoreTracesWorkflow } from '@mastra/core/evals/scoreTraces';
+
+    // Set packages file path for CMS availability detection in built output
+    if (!process.env.MASTRA_PACKAGES_FILE) {
+      const __bundleDir = __pkgDirname(__pkgFileURLToPath(import.meta.url));
+      process.env.MASTRA_PACKAGES_FILE = __pkgJoin(__bundleDir, 'mastra-packages.json');
+    }
 
     if (mastra.getStorage()) {
       mastra.__registerInternalWorkflow(scoreTracesWorkflow);

--- a/deployers/vercel/src/index.ts
+++ b/deployers/vercel/src/index.ts
@@ -24,11 +24,19 @@ export class VercelDeployer extends Deployer {
 
   private getEntry(): string {
     return `
+import { fileURLToPath as __pkgFileURLToPath } from 'node:url';
+import { dirname as __pkgDirname, join as __pkgJoin } from 'node:path';
 import { handle } from 'hono/vercel'
 import { mastra } from '#mastra';
 import { createHonoServer, getToolExports } from '#server';
 import { tools } from '#tools';
 import { scoreTracesWorkflow } from '@mastra/core/evals/scoreTraces';
+
+// Set packages file path for CMS availability detection in built output
+if (!process.env.MASTRA_PACKAGES_FILE) {
+  const __bundleDir = __pkgDirname(__pkgFileURLToPath(import.meta.url));
+  process.env.MASTRA_PACKAGES_FILE = __pkgJoin(__bundleDir, 'mastra-packages.json');
+}
 
 if (mastra.getStorage()) {
   mastra.__registerInternalWorkflow(scoreTracesWorkflow);

--- a/packages/cli/src/commands/build/BuildBundler.ts
+++ b/packages/cli/src/commands/build/BuildBundler.ts
@@ -76,11 +76,20 @@ export class BuildBundler extends Bundler {
 
   protected getEntry(): string {
     return `
+    import { fileURLToPath as __pkgFileURLToPath } from 'node:url';
+    import { dirname as __pkgDirname, join as __pkgJoin } from 'node:path';
     // @ts-expect-error
     import { scoreTracesWorkflow } from '@mastra/core/evals/scoreTraces';
     import { mastra } from '#mastra';
     import { createNodeServer, getToolExports } from '#server';
     import { tools } from '#tools';
+
+    // Set packages file path for CMS availability detection in built output
+    if (!process.env.MASTRA_PACKAGES_FILE) {
+      const __bundleDir = __pkgDirname(__pkgFileURLToPath(import.meta.url));
+      process.env.MASTRA_PACKAGES_FILE = __pkgJoin(__bundleDir, 'mastra-packages.json');
+    }
+
     // @ts-expect-error
     await createNodeServer(mastra, { tools: getToolExports(tools), studio: ${this.studio} });
 

--- a/packages/cli/src/commands/build/build.ts
+++ b/packages/cli/src/commands/build/build.ts
@@ -1,3 +1,4 @@
+import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { getDeployer } from '@mastra/deployer';
 import { FileService } from '../../services/service.file';
@@ -47,6 +48,10 @@ export async function build({
         toolsPaths: discoveredTools,
         projectRoot: rootDir,
       });
+
+      // Write mastra packages info to the output directory for CMS availability detection
+      await writeFile(join(outputDirectory, 'output', 'mastra-packages.json'), JSON.stringify(mastraPackages), 'utf-8');
+
       logger.info(`Build successful, you can now deploy the .mastra/output directory to your target platform.`);
       if (studio) {
         logger.info(
@@ -69,6 +74,10 @@ export async function build({
       toolsPaths: discoveredTools,
       projectRoot: rootDir,
     });
+
+    // Write mastra packages info to the output directory for CMS availability detection
+    await writeFile(join(outputDirectory, 'output', 'mastra-packages.json'), JSON.stringify(mastraPackages), 'utf-8');
+
     logger.info('You can now deploy the .mastra/output directory to your target platform.');
   } catch (error) {
     try {

--- a/packages/cli/src/commands/build/build.ts
+++ b/packages/cli/src/commands/build/build.ts
@@ -1,4 +1,3 @@
-import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { getDeployer } from '@mastra/deployer';
 import { FileService } from '../../services/service.file';
@@ -49,9 +48,6 @@ export async function build({
         projectRoot: rootDir,
       });
 
-      // Write mastra packages info to the output directory for CMS availability detection
-      await writeFile(join(outputDirectory, 'output', 'mastra-packages.json'), JSON.stringify(mastraPackages), 'utf-8');
-
       logger.info(`Build successful, you can now deploy the .mastra/output directory to your target platform.`);
       if (studio) {
         logger.info(
@@ -74,9 +70,6 @@ export async function build({
       toolsPaths: discoveredTools,
       projectRoot: rootDir,
     });
-
-    // Write mastra packages info to the output directory for CMS availability detection
-    await writeFile(join(outputDirectory, 'output', 'mastra-packages.json'), JSON.stringify(mastraPackages), 'utf-8');
 
     logger.info('You can now deploy the .mastra/output directory to your target platform.');
   } catch (error) {

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -266,6 +266,39 @@ export abstract class Bundler extends MastraBundler {
     return inputs;
   }
 
+  private async writeMastraPackagesJson(projectRoot: string, bundleLocation: string): Promise<void> {
+    try {
+      const pkgJsonPath = join(projectRoot, 'package.json');
+      const pkgJson = await readJSON(pkgJsonPath);
+      const allDeps: Record<string, string> = {
+        ...(pkgJson.dependencies ?? {}),
+        ...(pkgJson.devDependencies ?? {}),
+      };
+
+      const mastraDeps = Object.entries(allDeps).filter(([name]) => name.startsWith('@mastra/') || name === 'mastra');
+
+      const packages = await Promise.all(
+        mastraDeps.map(async ([name, specifiedVersion]) => {
+          try {
+            const rootPath = await getPackageRootPath(name, projectRoot);
+            if (rootPath) {
+              const depPkg = await readJSON(join(rootPath, 'package.json'));
+              return { name, version: depPkg.version ?? specifiedVersion };
+            }
+          } catch {
+            // fall through
+          }
+          return { name, version: specifiedVersion };
+        }),
+      );
+
+      await writeFile(join(bundleLocation, 'mastra-packages.json'), JSON.stringify(packages), 'utf-8');
+      this.logger.debug('Wrote mastra-packages.json');
+    } catch (error) {
+      this.logger.debug('Failed to write mastra-packages.json', { error });
+    }
+  }
+
   protected async _bundle(
     serverFile: string,
     mastraEntryFile: string,
@@ -425,6 +458,8 @@ export abstract class Bundler extends MastraBundler {
 export const tools = [${toolsExports.join(', ')}]`,
       );
       this.logger.info('Bundling Mastra done');
+
+      await this.writeMastraPackagesJson(projectRoot, bundleLocation);
 
       this.logger.info('Copying public files');
       await this.copyPublic(dirname(mastraEntryFile), outputDirectory);

--- a/packages/playground-ui/src/domains/configuration/components/mastra-version-footer.tsx
+++ b/packages/playground-ui/src/domains/configuration/components/mastra-version-footer.tsx
@@ -51,6 +51,11 @@ export const MastraVersionFooter = ({ collapsed }: MastraVersionFooterProps) => 
     return null;
   }
 
+  // Only show version footer in dev mode
+  if (!data?.isDev) {
+    return null;
+  }
+
   if (isLoadingPackages) {
     return (
       <div className="px-3 py-2">

--- a/packages/server/src/server/handlers/system.test.ts
+++ b/packages/server/src/server/handlers/system.test.ts
@@ -36,7 +36,7 @@ describe('System Handlers', () => {
 
       const result = await GET_SYSTEM_PACKAGES_ROUTE.handler();
 
-      expect(result).toEqual({ packages });
+      expect(result).toEqual({ packages, isDev: false });
     });
 
     it('should return empty array when MASTRA_PACKAGES_FILE is not set', async () => {
@@ -44,7 +44,7 @@ describe('System Handlers', () => {
 
       const result = await GET_SYSTEM_PACKAGES_ROUTE.handler();
 
-      expect(result).toEqual({ packages: [] });
+      expect(result).toEqual({ packages: [], isDev: false });
     });
 
     it('should return empty array when MASTRA_PACKAGES_FILE points to invalid JSON', async () => {
@@ -53,7 +53,7 @@ describe('System Handlers', () => {
 
       const result = await GET_SYSTEM_PACKAGES_ROUTE.handler();
 
-      expect(result).toEqual({ packages: [] });
+      expect(result).toEqual({ packages: [], isDev: false });
     });
 
     it('should return empty array when MASTRA_PACKAGES_FILE points to non-existent file', async () => {
@@ -61,7 +61,16 @@ describe('System Handlers', () => {
 
       const result = await GET_SYSTEM_PACKAGES_ROUTE.handler();
 
-      expect(result).toEqual({ packages: [] });
+      expect(result).toEqual({ packages: [], isDev: false });
+    });
+
+    it('should return isDev true when MASTRA_DEV is set', async () => {
+      process.env.MASTRA_DEV = 'true';
+      delete process.env.MASTRA_PACKAGES_FILE;
+
+      const result = await GET_SYSTEM_PACKAGES_ROUTE.handler();
+
+      expect(result).toEqual({ packages: [], isDev: true });
     });
   });
 });

--- a/packages/server/src/server/handlers/system.ts
+++ b/packages/server/src/server/handlers/system.ts
@@ -29,7 +29,7 @@ export const GET_SYSTEM_PACKAGES_ROUTE = createRoute({
         }
       }
 
-      return { packages };
+      return { packages, isDev: process.env.MASTRA_DEV === 'true' };
     } catch (error) {
       return handleError(error, 'Error getting system packages');
     }

--- a/packages/server/src/server/schemas/system.ts
+++ b/packages/server/src/server/schemas/system.ts
@@ -7,6 +7,7 @@ export const mastraPackageSchema = z.object({
 
 export const systemPackagesResponseSchema = z.object({
   packages: z.array(mastraPackageSchema),
+  isDev: z.boolean(),
 });
 
 export type MastraPackage = z.infer<typeof mastraPackageSchema>;


### PR DESCRIPTION
## Summary
- The "Create an agent" button and other CMS features (clone, edit, create scorer) were missing when running built output (`node .mastra/output/index.mjs`) but appeared correctly in dev mode (`mastra dev`)
- Root cause: the build command never wrote `mastra-packages.json` to the output directory or set the `MASTRA_PACKAGES_FILE` env var, so the `/system/packages` endpoint returned an empty array and `isCmsAvailable` was always `false`
- Fix: write `mastra-packages.json` alongside the bundle output during build, and set the env var in the generated entry point so the server handler can discover it at runtime

## Test plan
- [x] Existing `BuildBundler` tests pass (9/9)
- [ ] Run `pnpm mastra:build -s` in `examples/agent`, then `MASTRA_STUDIO_PATH=.mastra/output/studio node .mastra/output/index.mjs` and verify "Create an agent" button appears
- [ ] Verify `mastra-packages.json` exists in `.mastra/output/` after build
- [ ] Verify dev mode (`pnpm mastra:dev`) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restores missing CMS UI actions (create, clone, edit, scorer) in built output so studio features appear correctly.

* **New Features**
  * System packages API now includes an isDev flag so clients can detect dev vs. prod.
  * Version footer in the sidebar is shown only in dev mode.

* **Chores**
  * Build now emits package metadata beside bundles and sets up runtime env so the built studio can detect installed packages.
  * Build command now emits a success/info log after bundling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->