### PR TITLE
feat(playground): unify tools and integration tools into single CMS page

### DIFF
--- a/.changeset/great-facts-look.md
+++ b/.changeset/great-facts-look.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Merged Tools and Integration Tools into a single unified page in the agent CMS. Both tool types now appear in one combobox with visual differentiation: regular tools show a diamond icon while integration tools show a plug icon with a provider badge.

--- a/examples/agent/src/mastra/index.ts
+++ b/examples/agent/src/mastra/index.ts
@@ -4,6 +4,7 @@ import { MastraEditor } from '@mastra/editor';
 import { LibSQLStore } from '@mastra/libsql';
 import { Observability, DefaultExporter, CloudExporter, SensitiveDataFilter } from '@mastra/observability';
 import { z } from 'zod';
+import { ComposioToolProvider } from '@mastra/editor/composio';
 
 import {
   agentThatHarassesYou,
@@ -221,5 +222,9 @@ const config = {
 
 export const mastra = new Mastra({
   ...config,
-  editor: new MastraEditor(),
+  editor: new MastraEditor({
+    toolProviders: {
+      composio: new ComposioToolProvider({ apiKey: '' }),
+    },
+  }),
 });

--- a/packages/playground-ui/src/domains/agents/components/agent-edit-page/use-agent-edit-form.ts
+++ b/packages/playground-ui/src/domains/agents/components/agent-edit-page/use-agent-edit-form.ts
@@ -54,6 +54,7 @@ export function useAgentEditForm(options: UseAgentEditFormOptions = {}) {
       instructions: initialValues?.instructions ?? '',
       model: initialValues?.model ?? { provider: '', name: '' },
       tools: initialValues?.tools ?? {},
+      integrationTools: initialValues?.integrationTools ?? {},
       workflows: initialValues?.workflows ?? {},
       agents: initialValues?.agents ?? {},
       scorers: initialValues?.scorers ?? {},

--- a/packages/playground-ui/src/domains/agents/components/agent-edit-page/utils/form-validation.ts
+++ b/packages/playground-ui/src/domains/agents/components/agent-edit-page/utils/form-validation.ts
@@ -145,6 +145,7 @@ export const agentFormSchema = z.object({
     name: z.string().min(1, 'Model is required'),
   }),
   tools: z.record(z.string(), entityConfigSchema).optional(),
+  integrationTools: z.record(z.string(), entityConfigSchema).optional(),
   workflows: z.record(z.string(), entityConfigSchema).optional(),
   agents: z.record(z.string(), entityConfigSchema).optional(),
   scorers: z.record(z.string(), scorerConfigSchema).optional(),

--- a/packages/playground-ui/src/domains/tool-providers/hooks/index.ts
+++ b/packages/playground-ui/src/domains/tool-providers/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-tool-providers';

--- a/packages/playground-ui/src/domains/tool-providers/hooks/use-tool-providers.ts
+++ b/packages/playground-ui/src/domains/tool-providers/hooks/use-tool-providers.ts
@@ -1,0 +1,52 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMastraClient } from '@mastra/react';
+
+export const useToolProviders = () => {
+  const client = useMastraClient();
+
+  return useQuery({
+    queryKey: ['tool-providers'],
+    queryFn: () => client.listToolProviders(),
+  });
+};
+
+export interface IntegrationTool {
+  slug: string;
+  name: string;
+  description?: string;
+  toolkit?: string;
+  providerId: string;
+  providerName: string;
+}
+
+export const useAllIntegrationTools = () => {
+  const client = useMastraClient();
+  const { data: providersData, isLoading: isLoadingProviders } = useToolProviders();
+  const providers = providersData?.providers ?? [];
+
+  const toolsQuery = useQuery({
+    queryKey: ['integration-tools-all', providers.map(p => p.id)],
+    queryFn: async () => {
+      const results: IntegrationTool[] = [];
+
+      for (const provider of providers) {
+        const response = await client.getToolProvider(provider.id).listTools();
+        for (const tool of response.data) {
+          results.push({
+            ...tool,
+            providerId: provider.id,
+            providerName: provider.name,
+          });
+        }
+      }
+
+      return results;
+    },
+    enabled: providers.length > 0,
+  });
+
+  return {
+    data: toolsQuery.data ?? [],
+    isLoading: isLoadingProviders || toolsQuery.isLoading,
+  };
+};

--- a/packages/playground-ui/src/domains/tool-providers/index.ts
+++ b/packages/playground-ui/src/domains/tool-providers/index.ts
@@ -1,0 +1,1 @@
+export * from './hooks';

--- a/packages/playground-ui/src/ds/components/Combobox/combobox-styles.ts
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox-styles.ts
@@ -19,7 +19,7 @@ export const comboboxStyles = {
 
   /** Popup container */
   popup: cn(
-    'min-w-[var(--anchor-width)] w-max rounded-md bg-surface3 text-neutral5',
+    'min-w-[var(--anchor-width)] w-max max-w-[500px] rounded-md bg-surface3 text-neutral5',
     'shadow-elevated',
     'origin-[var(--transform-origin)]',
     'transition-[transform,scale,opacity] duration-150 ease-out',
@@ -79,13 +79,16 @@ export const comboboxStyles = {
   checkboxIcon: 'h-3 w-3 text-white',
 
   /** Option content wrapper */
-  optionContent: 'whitespace-nowrap flex items-center gap-2 w-full',
+  optionContent: 'flex items-center gap-2 w-full min-w-0',
 
   /** Option label/description wrapper */
-  optionText: 'flex flex-col gap-0.5',
+  optionText: 'flex flex-col gap-0.5 min-w-0',
+
+  /** Option label */
+  optionLabel: 'truncate',
 
   /** Option description */
-  optionDescription: 'text-xs text-neutral3',
+  optionDescription: 'text-xs text-neutral3 truncate',
 
   /** Option end slot */
   optionEnd: 'ml-auto',

--- a/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/combobox.tsx
@@ -103,7 +103,7 @@ export function Combobox({
                     <span className={comboboxStyles.optionContent}>
                       {option.start}
                       <span className={comboboxStyles.optionText}>
-                        <span>{option.label}</span>
+                        <span className={comboboxStyles.optionLabel}>{option.label}</span>
                         {option.description && (
                           <span className={comboboxStyles.optionDescription}>{option.description}</span>
                         )}

--- a/packages/playground-ui/src/ds/components/Combobox/multi-combobox.tsx
+++ b/packages/playground-ui/src/ds/components/Combobox/multi-combobox.tsx
@@ -101,7 +101,7 @@ export function MultiCombobox({
                       <span className={comboboxStyles.optionContent}>
                         {option.start}
                         <span className={comboboxStyles.optionText}>
-                          <span>{option.label}</span>
+                          <span className={comboboxStyles.optionLabel}>{option.label}</span>
                           {option.description && (
                             <span className={comboboxStyles.optionDescription}>{option.description}</span>
                           )}

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -105,6 +105,7 @@ export { cn } from './lib/utils';
 export * from './lib/ai-ui/tools/tool-fallback';
 export * from './domains/workflows/runs/workflow-run-list';
 export * from './domains/mcps/index';
+export * from './domains/tool-providers/index';
 export * from './lib/toast';
 export * from './domains/configuration/index';
 export * from './domains/workspace/index';


### PR DESCRIPTION
The agent CMS had two separate pages for tools — "Tools" for regular tools and "Integration Tools" for provider-based tools. This merges them into a single "Tools" page with one combobox.

Regular tools show a diamond icon, integration tools show a plug icon with a provider badge so you can tell them apart at a glance. Under the hood, both `tools` and `integrationTools` form fields are managed from the single combobox — selections get routed to the correct field automatically.

Also added `integrationTools` to the form schema/defaults and fixed the layout transforms to serialize integration tools in the nested `providerId -> tools` format the API expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merged Tools and Integration Tools into a single unified page in the agent CMS.
  * Added support for integration tools with visual differentiation: regular tools display with a diamond icon; integration tools display with a plug icon and provider badge.

* **UI/UX Improvements**
  * Enhanced combobox styling for improved label and text overflow handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->