### PR TITLE
fix: pass abort signal in chatRoute to enable request cancellation

### DIFF
--- a/.changeset/pink-pillows-say.md
+++ b/.changeset/pink-pillows-say.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed chatRoute to pass the request's abort signal to the agent, so client-side cancellation (e.g., user clicking stop) now properly stops LLM generation on the server instead of running to completion. Closes #13038.

--- a/client-sdks/ai-sdk/src/__tests__/abort-signal.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/abort-signal.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for issue #13038: chatRoute should pass abort signal to enable request cancellation.
+ */
+import { Agent } from '@mastra/core/agent';
+import { Mastra } from '@mastra/core/mastra';
+import type { UIMessage } from 'ai';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from 'ai/test';
+import { describe, expect, it, vi } from 'vitest';
+
+import { chatRoute, handleChatStream } from '../chat-route';
+
+function createMockModel() {
+  return new MockLanguageModelV2({
+    doStream: async () => ({
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'msg-1', modelId: 'mock-model', timestamp: new Date() },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Hello world' },
+        { type: 'text-end', id: 'text-1' },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+        },
+      ] as any),
+      rawCall: { rawPrompt: [], rawSettings: {} },
+      warnings: [],
+    }),
+  });
+}
+
+function createTestAgent() {
+  return new Agent({
+    id: 'test-agent',
+    name: 'Test Agent',
+    instructions: 'You are a helpful assistant.',
+    model: createMockModel(),
+  });
+}
+
+function createTestMastra(agent: Agent) {
+  return new Mastra({
+    agents: { [agent.id]: agent },
+  });
+}
+
+describe('abort signal propagation (issue #13038)', () => {
+  describe('handleChatStream', () => {
+    it('should pass abortSignal through to agent.stream() via params', async () => {
+      const agent = createTestAgent();
+      const mastra = createTestMastra(agent);
+      const streamSpy = vi.spyOn(agent, 'stream');
+      const abortController = new AbortController();
+
+      const messages: UIMessage[] = [{ id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] }];
+
+      const stream = await handleChatStream({
+        mastra,
+        agentId: 'test-agent',
+        params: {
+          messages,
+          abortSignal: abortController.signal,
+        },
+      });
+
+      const reader = stream.getReader();
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+
+      expect(streamSpy).toHaveBeenCalledTimes(1);
+      const options = streamSpy.mock.calls[0]![1];
+      expect(options).toBeDefined();
+      expect(options!.abortSignal).toBe(abortController.signal);
+
+      streamSpy.mockRestore();
+    });
+  });
+
+  describe('chatRoute', () => {
+    it('should pass request abort signal to handleChatStream params', async () => {
+      const agent = createTestAgent();
+      const mastra = createTestMastra(agent);
+      const streamSpy = vi.spyOn(agent, 'stream');
+
+      const route = chatRoute({
+        path: '/chat/:agentId',
+      });
+
+      const abortController = new AbortController();
+      const mockBody = JSON.stringify({
+        messages: [{ id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      });
+
+      const mockRequest = new Request('http://localhost/chat/test-agent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: mockBody,
+        signal: abortController.signal,
+      });
+
+      const contextStore = new Map<string, any>();
+      contextStore.set('mastra', mastra);
+
+      const mockContext = {
+        req: {
+          raw: mockRequest,
+          json: () => Promise.resolve(JSON.parse(mockBody)),
+          param: (name: string) => {
+            if (name === 'agentId') return 'test-agent';
+            return undefined;
+          },
+        },
+        get: (key: string) => contextStore.get(key),
+      };
+
+      const response = await (route as any).handler(mockContext);
+
+      if (response?.body) {
+        const reader = response.body.getReader();
+        try {
+          while (true) {
+            const { done } = await reader.read();
+            if (done) break;
+          }
+        } catch {
+          // Stream may error on abort
+        }
+      }
+
+      expect(streamSpy).toHaveBeenCalledTimes(1);
+      const options = streamSpy.mock.calls[0]![1];
+      expect(options).toBeDefined();
+      // new Request() creates its own linked AbortSignal, so compare against the request's signal
+      expect(options!.abortSignal).toBe(mockRequest.signal);
+
+      streamSpy.mockRestore();
+    });
+  });
+});

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -337,6 +337,7 @@ export function chatRoute<OUTPUT = undefined>({
         params: {
           ...params,
           requestContext: effectiveRequestContext,
+          abortSignal: c.req.raw.signal,
         } as any,
         defaultOptions,
         sendStart,


### PR DESCRIPTION
## Description

Pass the HTTP request's abort signal from the Hono context through to `handleChatStream` so client-side cancellation (e.g., user clicking "stop" in the UI) properly stops LLM generation on the server instead of running to completion.

## Related Issue(s)

Fixes #13038

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the server would continue processing LLM requests even after the client disconnected or cancelled a request, ensuring resources are properly freed when streaming is interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->