### PR TITLE
feat(core): add video media type detection for prompt support

### DIFF
--- a/.changeset/video-prompt-support.md
+++ b/.changeset/video-prompt-support.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added video input support for prompts. Agents can now accept video content (mp4, webm, quicktime, mpeg, flv, 3gpp) as file parts in messages. Video media types are auto-detected from file bytes when no explicit `mediaType` is provided. Fixes #11743.

--- a/packages/core/src/agent/message-list/prompt/convert-file.test.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-file.test.ts
@@ -1,0 +1,107 @@
+import type { FilePart, ImagePart } from '@ai-sdk/provider-utils-v5';
+import { describe, it, expect } from 'vitest';
+import { convertImageFilePart } from './convert-file';
+
+describe('convertImageFilePart', () => {
+  describe('image parts', () => {
+    it('auto-detects PNG from binary data', () => {
+      const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      const part: ImagePart = { type: 'image', image: png };
+      const result = convertImageFilePart(part);
+      expect(result).toMatchObject({ type: 'file', mediaType: 'image/png' });
+    });
+
+    it('falls back to image/* when detection fails', () => {
+      const unknown = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+      const part: ImagePart = { type: 'image', image: unknown };
+      const result = convertImageFilePart(part);
+      expect(result).toMatchObject({ type: 'file', mediaType: 'image/*' });
+    });
+
+    it('uses provided mediaType when detection fails', () => {
+      const unknown = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+      const part: ImagePart = { type: 'image', image: unknown, mediaType: 'image/svg+xml' };
+      const result = convertImageFilePart(part);
+      expect(result).toMatchObject({ type: 'file', mediaType: 'image/svg+xml' });
+    });
+  });
+
+  describe('file parts with explicit mimeType', () => {
+    it('passes through video/mp4 mimeType', () => {
+      const data = new Uint8Array([0x00, 0x00, 0x00, 0x20]);
+      const part: FilePart = { type: 'file', data, mediaType: 'video/mp4' };
+      const result = convertImageFilePart(part);
+      expect(result).toMatchObject({ type: 'file', mediaType: 'video/mp4' });
+    });
+
+    it('passes through application/pdf mimeType', () => {
+      const data = new Uint8Array([0x25, 0x50, 0x44, 0x46]);
+      const part: FilePart = { type: 'file', data, mediaType: 'application/pdf' };
+      const result = convertImageFilePart(part);
+      expect(result).toMatchObject({ type: 'file', mediaType: 'application/pdf' });
+    });
+  });
+
+  describe('file parts with video auto-detection', () => {
+    it('auto-detects video/webm from binary data', () => {
+      const webm = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 0x01, 0x00, 0x00]);
+      const part: FilePart = { type: 'file', data: webm, mediaType: undefined as unknown as string };
+      const result = convertImageFilePart(part);
+      expect(result).toMatchObject({ type: 'file', mediaType: 'video/webm' });
+    });
+
+    it('auto-detects video/mp4 with isom brand from binary data', () => {
+      const mp4 = new Uint8Array([
+        0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x00, 0x00,
+      ]);
+      const part: FilePart = { type: 'file', data: mp4, mediaType: undefined as unknown as string };
+      const result = convertImageFilePart(part);
+      expect(result).toMatchObject({ type: 'file', mediaType: 'video/mp4' });
+    });
+
+    it('auto-detects video/x-flv from binary data', () => {
+      const flv = new Uint8Array([0x46, 0x4c, 0x56, 0x01, 0x05, 0x00, 0x00, 0x00, 0x09]);
+      const part: FilePart = { type: 'file', data: flv, mediaType: undefined as unknown as string };
+      const result = convertImageFilePart(part);
+      expect(result).toMatchObject({ type: 'file', mediaType: 'video/x-flv' });
+    });
+
+    it('auto-detects video/webm from base64 string', () => {
+      const part: FilePart = {
+        type: 'file',
+        data: 'GkXfowEAAAA',
+        mediaType: undefined as unknown as string,
+      };
+      const result = convertImageFilePart(part);
+      expect(result).toMatchObject({ type: 'file', mediaType: 'video/webm' });
+    });
+
+    it('throws when file part has no mimeType and detection fails', () => {
+      const unknown = new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c]);
+      const part: FilePart = { type: 'file', data: unknown, mediaType: undefined as unknown as string };
+      expect(() => convertImageFilePart(part)).toThrow('Media type is missing for file part');
+    });
+  });
+
+  describe('URL-based parts', () => {
+    it('passes URL data through for image parts', () => {
+      const part: ImagePart = { type: 'image', image: new URL('https://example.com/image.png') };
+      const result = convertImageFilePart(part);
+      expect(result.type).toBe('file');
+      expect((result as any).data).toBeInstanceOf(URL);
+    });
+
+    it('uses downloaded asset for URL-based image', () => {
+      const url = new URL('https://example.com/photo.jpg');
+      const part: ImagePart = { type: 'image', image: url };
+      const downloaded = {
+        [url.toString()]: {
+          data: new Uint8Array([0xff, 0xd8, 0xff, 0xe0]),
+          mediaType: 'image/jpeg' as string | undefined,
+        },
+      };
+      const result = convertImageFilePart(part, downloaded);
+      expect(result).toMatchObject({ type: 'file', mediaType: 'image/jpeg' });
+    });
+  });
+});

--- a/packages/core/src/agent/message-list/prompt/convert-file.test.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-file.test.ts
@@ -76,6 +76,13 @@ describe('convertImageFilePart', () => {
       expect(result).toMatchObject({ type: 'file', mediaType: 'video/webm' });
     });
 
+    it('auto-detects image/png from binary data in file part (fallback chain)', () => {
+      const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      const part: FilePart = { type: 'file', data: png, mediaType: undefined as unknown as string };
+      const result = convertImageFilePart(part);
+      expect(result).toMatchObject({ type: 'file', mediaType: 'image/png' });
+    });
+
     it('throws when file part has no mimeType and detection fails', () => {
       const unknown = new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c]);
       const part: FilePart = { type: 'file', data: unknown, mediaType: undefined as unknown as string };

--- a/packages/core/src/agent/message-list/prompt/convert-file.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-file.ts
@@ -61,7 +61,9 @@ export function convertImageFilePart(
 
     case 'file': {
       if (mediaType == null && (data instanceof Uint8Array || typeof data === 'string')) {
-        mediaType = detectMediaType({ data, signatures: videoMediaTypeSignatures });
+        mediaType =
+          detectMediaType({ data, signatures: imageMediaTypeSignatures }) ??
+          detectMediaType({ data, signatures: videoMediaTypeSignatures });
       }
 
       if (mediaType == null) {

--- a/packages/core/src/agent/message-list/prompt/convert-file.ts
+++ b/packages/core/src/agent/message-list/prompt/convert-file.ts
@@ -1,6 +1,11 @@
 import type { DataContent, ImagePart, FilePart } from '@ai-sdk/provider-utils-v5';
 import type { LanguageModelV2FilePart, LanguageModelV2TextPart } from '@ai-sdk/provider-v5';
-import { convertToDataContent, detectMediaType, imageMediaTypeSignatures } from '../../../stream/aisdk/v5/compat';
+import {
+  convertToDataContent,
+  detectMediaType,
+  imageMediaTypeSignatures,
+  videoMediaTypeSignatures,
+} from '../../../stream/aisdk/v5/compat';
 
 export function convertImageFilePart(
   part: ImagePart | FilePart,
@@ -55,7 +60,10 @@ export function convertImageFilePart(
     }
 
     case 'file': {
-      // We must have a mediaType for files, if not, throw an error.
+      if (mediaType == null && (data instanceof Uint8Array || typeof data === 'string')) {
+        mediaType = detectMediaType({ data, signatures: videoMediaTypeSignatures });
+      }
+
       if (mediaType == null) {
         throw new Error(`Media type is missing for file part`);
       }

--- a/packages/core/src/stream/aisdk/v5/compat/media.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/media.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { detectMediaType, imageMediaTypeSignatures, audioMediaTypeSignatures, videoMediaTypeSignatures } from './media';
+
+describe('detectMediaType', () => {
+  describe('image signatures', () => {
+    it('detects PNG from bytes', () => {
+      const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      expect(detectMediaType({ data: png, signatures: imageMediaTypeSignatures })).toBe('image/png');
+    });
+
+    it('detects JPEG from bytes', () => {
+      const jpeg = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
+      expect(detectMediaType({ data: jpeg, signatures: imageMediaTypeSignatures })).toBe('image/jpeg');
+    });
+
+    it('detects GIF from base64', () => {
+      expect(detectMediaType({ data: 'R0lGODlhAQABAIAAAAAAAP', signatures: imageMediaTypeSignatures })).toBe(
+        'image/gif',
+      );
+    });
+
+    it('returns undefined for non-image data', () => {
+      const random = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+      expect(detectMediaType({ data: random, signatures: imageMediaTypeSignatures })).toBeUndefined();
+    });
+  });
+
+  describe('audio signatures', () => {
+    it('detects WAV from bytes', () => {
+      const wav = new Uint8Array([0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00]);
+      expect(detectMediaType({ data: wav, signatures: audioMediaTypeSignatures })).toBe('audio/wav');
+    });
+
+    it('detects OGG from bytes', () => {
+      const ogg = new Uint8Array([0x4f, 0x67, 0x67, 0x53, 0x00]);
+      expect(detectMediaType({ data: ogg, signatures: audioMediaTypeSignatures })).toBe('audio/ogg');
+    });
+
+    it('detects FLAC from base64', () => {
+      expect(detectMediaType({ data: 'ZkxhQwAAACIA', signatures: audioMediaTypeSignatures })).toBe('audio/flac');
+    });
+  });
+
+  describe('video signatures', () => {
+    it('detects WebM from bytes', () => {
+      const webm = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 0x01, 0x00, 0x00]);
+      expect(detectMediaType({ data: webm, signatures: videoMediaTypeSignatures })).toBe('video/webm');
+    });
+
+    it('detects WebM from base64', () => {
+      expect(detectMediaType({ data: 'GkXfowEAAA', signatures: videoMediaTypeSignatures })).toBe('video/webm');
+    });
+
+    it('detects FLV from bytes', () => {
+      const flv = new Uint8Array([0x46, 0x4c, 0x56, 0x01, 0x05]);
+      expect(detectMediaType({ data: flv, signatures: videoMediaTypeSignatures })).toBe('video/x-flv');
+    });
+
+    it('detects FLV from base64', () => {
+      expect(detectMediaType({ data: 'RkxWAQUAAA', signatures: videoMediaTypeSignatures })).toBe('video/x-flv');
+    });
+
+    it('detects MPEG-PS from bytes', () => {
+      const mpeg = new Uint8Array([0x00, 0x00, 0x01, 0xba, 0x44]);
+      expect(detectMediaType({ data: mpeg, signatures: videoMediaTypeSignatures })).toBe('video/mpeg');
+    });
+
+    it('detects MP4 with isom brand (ftyp box size 24)', () => {
+      // 00 00 00 18 66 74 79 70 69 73 6f 6d
+      const mp4 = new Uint8Array([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0x00]);
+      expect(detectMediaType({ data: mp4, signatures: videoMediaTypeSignatures })).toBe('video/mp4');
+    });
+
+    it('detects MP4 with isom brand (ftyp box size 28)', () => {
+      const mp4 = new Uint8Array([0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0x00]);
+      expect(detectMediaType({ data: mp4, signatures: videoMediaTypeSignatures })).toBe('video/mp4');
+    });
+
+    it('detects MP4 with isom brand (ftyp box size 32)', () => {
+      const mp4 = new Uint8Array([0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0x00]);
+      expect(detectMediaType({ data: mp4, signatures: videoMediaTypeSignatures })).toBe('video/mp4');
+    });
+
+    it('detects MP4 with isom brand from base64', () => {
+      expect(detectMediaType({ data: 'AAAAIGZ0eXBpc29tAAAAAA', signatures: videoMediaTypeSignatures })).toBe(
+        'video/mp4',
+      );
+    });
+
+    it('detects MP4 with mp41 brand', () => {
+      const mp4 = new Uint8Array([0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x31, 0x00]);
+      expect(detectMediaType({ data: mp4, signatures: videoMediaTypeSignatures })).toBe('video/mp4');
+    });
+
+    it('detects MP4 with mp42 brand', () => {
+      const mp4 = new Uint8Array([0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x32, 0x00]);
+      expect(detectMediaType({ data: mp4, signatures: videoMediaTypeSignatures })).toBe('video/mp4');
+    });
+
+    it('detects QuickTime with qt brand', () => {
+      const qt = new Uint8Array([0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x71, 0x74, 0x20, 0x20, 0x00]);
+      expect(detectMediaType({ data: qt, signatures: videoMediaTypeSignatures })).toBe('video/quicktime');
+    });
+
+    it('detects 3GPP with 3gp4 brand', () => {
+      const gpp = new Uint8Array([0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x33, 0x67, 0x70, 0x34, 0x00]);
+      expect(detectMediaType({ data: gpp, signatures: videoMediaTypeSignatures })).toBe('video/3gpp');
+    });
+
+    it('detects 3GPP with 3gp5 brand', () => {
+      const gpp = new Uint8Array([0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x33, 0x67, 0x70, 0x35, 0x00]);
+      expect(detectMediaType({ data: gpp, signatures: videoMediaTypeSignatures })).toBe('video/3gpp');
+    });
+
+    it('returns undefined for non-video data', () => {
+      const random = new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c]);
+      expect(detectMediaType({ data: random, signatures: videoMediaTypeSignatures })).toBeUndefined();
+    });
+
+    it('returns undefined for empty data', () => {
+      const empty = new Uint8Array([]);
+      expect(detectMediaType({ data: empty, signatures: videoMediaTypeSignatures })).toBeUndefined();
+    });
+
+    it('returns undefined for data shorter than signature', () => {
+      const short = new Uint8Array([0x1a, 0x45]);
+      expect(detectMediaType({ data: short, signatures: videoMediaTypeSignatures })).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/stream/aisdk/v5/compat/media.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/media.ts
@@ -111,6 +111,65 @@ export const audioMediaTypeSignatures = [
   },
 ] as const;
 
+export const videoMediaTypeSignatures = [
+  {
+    mediaType: 'video/webm' as const,
+    bytesPrefix: [0x1a, 0x45, 0xdf, 0xa3],
+    base64Prefix: 'GkXf',
+  },
+  {
+    mediaType: 'video/x-flv' as const,
+    bytesPrefix: [0x46, 0x4c, 0x56, 0x01],
+    base64Prefix: 'RkxW',
+  },
+  {
+    mediaType: 'video/mpeg' as const,
+    bytesPrefix: [0x00, 0x00, 0x01, 0xba],
+    base64Prefix: 'AAABug',
+  },
+  // MP4 (ISO BMFF) — ftyp box size varies; entries for common sizes and brands
+  {
+    mediaType: 'video/mp4' as const,
+    bytesPrefix: [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d],
+    base64Prefix: 'AAAAGGZ0eXBpc29t',
+  },
+  {
+    mediaType: 'video/mp4' as const,
+    bytesPrefix: [0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d],
+    base64Prefix: 'AAAAHGZ0eXBpc29t',
+  },
+  {
+    mediaType: 'video/mp4' as const,
+    bytesPrefix: [0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d],
+    base64Prefix: 'AAAAIGZ0eXBpc29t',
+  },
+  {
+    mediaType: 'video/mp4' as const,
+    bytesPrefix: [0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x31],
+    base64Prefix: 'AAAAIGZ0eXBtcDQx',
+  },
+  {
+    mediaType: 'video/mp4' as const,
+    bytesPrefix: [0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x32],
+    base64Prefix: 'AAAAIGZ0eXBtcDQy',
+  },
+  {
+    mediaType: 'video/quicktime' as const,
+    bytesPrefix: [0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x71, 0x74, 0x20, 0x20],
+    base64Prefix: 'AAAAIGZ0eXBxdCAg',
+  },
+  {
+    mediaType: 'video/3gpp' as const,
+    bytesPrefix: [0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x33, 0x67, 0x70, 0x34],
+    base64Prefix: 'AAAAIGZ0eXAzZ3A0',
+  },
+  {
+    mediaType: 'video/3gpp' as const,
+    bytesPrefix: [0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x33, 0x67, 0x70, 0x35],
+    base64Prefix: 'AAAAIGZ0eXAzZ3A1',
+  },
+] as const;
+
 const stripID3 = (data: Uint8Array | string) => {
   const bytes = typeof data === 'string' ? convertBase64ToUint8Array(data) : data;
   const id3Size =
@@ -144,7 +203,7 @@ export function detectMediaType({
   signatures,
 }: {
   data: Uint8Array | string;
-  signatures: typeof audioMediaTypeSignatures | typeof imageMediaTypeSignatures;
+  signatures: typeof audioMediaTypeSignatures | typeof imageMediaTypeSignatures | typeof videoMediaTypeSignatures;
 }): (typeof signatures)[number]['mediaType'] | undefined {
   const processedData = stripID3TagsIfPresent(data);
 

--- a/packages/core/src/stream/aisdk/v5/compat/media.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/media.ts
@@ -111,6 +111,13 @@ export const audioMediaTypeSignatures = [
   },
 ] as const;
 
+// Magic-byte detection for container formats (EBML, ISO BMFF) is inherently limited:
+// - EBML prefix 0x1A45DFA3 is shared by video/webm, audio/webm, and video/x-matroska.
+//   Callers should prefer an explicit mediaType when the container type is known.
+// - ISO BMFF (MP4) entries only cover common ftyp box sizes (0x18, 0x1c, 0x20) and
+//   brands (isom, mp41, mp42, qt, 3gp4, 3gp5). Files with other sizes or brands
+//   (e.g., 0x14, 0x24, 'dash', 'M4V ', 'avc1') won't be auto-detected.
+//   Provide an explicit mediaType for broader coverage.
 export const videoMediaTypeSignatures = [
   {
     mediaType: 'video/webm' as const,
@@ -127,7 +134,6 @@ export const videoMediaTypeSignatures = [
     bytesPrefix: [0x00, 0x00, 0x01, 0xba],
     base64Prefix: 'AAABug',
   },
-  // MP4 (ISO BMFF) — ftyp box size varies; entries for common sizes and brands
   {
     mediaType: 'video/mp4' as const,
     bytesPrefix: [0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d],


### PR DESCRIPTION
## Description

This PR adds support for detecting video media types using magic byte signatures.  
It also enhances file-part conversion by automatically detecting video `mediaType` when not explicitly provided and extends the media detection utilities to handle video formats.

Supported video formats include: mp4, webm, flv, mpeg, quicktime, and 3gpp.

## Related Issue(s)

Closes #11743

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5: This PR teaches the system to recognize video files automatically (like mp4, webm, flv, quicktime, mpeg, 3gpp) so prompts can accept videos just like images. If a file part has no mediaType, the code will try to detect it from the file bytes and handle video inputs end-to-end, with tests added to verify behavior.

* **What changed**
  * Added video media-type detection signatures and exported them: videoMediaTypeSignatures (mp4 variants, webm, flv, mpeg, quicktime, 3gpp).
  * Extended detectMediaType to accept video signatures.
  * convertImageFilePart now falls back to video media-type detection when a 'file' part has no mediaType and data is present (bytes or base64).
  * attachments-to-parts and convert-file tests expanded to include video cases and URL/data/base64 handling for video formats.
  * Changeset added to document the feature and bump package.

* **Files touched (high level)**
  * packages/core/src/stream/aisdk/v5/compat/media.ts — add videoMediaTypeSignatures and update detectMediaType typing/behaviour
  * packages/core/src/stream/aisdk/v5/compat/media.test.ts — new tests covering video signature detection (bytes/base64, MP4 ftyp variants, flv, webm, quicktime, 3gpp)
  * packages/core/src/agent/message-list/prompt/convert-file.ts — try video detection when mediaType missing for file parts
  * packages/core/src/agent/message-list/prompt/convert-file.test.ts — tests for video auto-detection and related file-part behaviors
  * packages/core/src/agent/message-list/prompt/attachments-to-parts.test.ts — tests extended to cover video attachments, data URIs, base64 and gs:// handling
  * .changeset/video-prompt-support.md — changeset describing feature

* **Tests**
  * Comprehensive Vitest coverage added for:
    - detectMediaType over image, audio, and new video signatures
    - convertImageFilePart: image detection, video auto-detection for file parts, URL/downloaded asset handling, and error when detection fails
    - attachmentsToParts: URL, data URI, raw base64, mixed attachments, and preservation of gs:// URLs
  * Includes an end-to-end example/test for video prompt usage (author-provided, gated by an API key) demonstrating intended usage with a video URL.

* **Behavioral notes / limitations**
  * MP4 detection covers common ftyp box sizes and select brands (isom, mp41, mp42, qt, 3gp4/3gp5); not all MP4 variants are detectable—explicit mediaType is still recommended when available.
  * EBML-based containers (e.g., WebM) share signatures with other matroska/EBML formats; callers should prefer explicit mediaType when exact container differentiation is required.

* **Metadata**
  * Type: feat (new feature)
  * Tests: added/updated
  * Closes: #11743
<!-- end of auto-generated comment: release notes by coderabbit.ai -->