### PR TITLE
fix: Restore parent agent's MastraMemory after sub-agent tool execution

### DIFF
--- a/.changeset/slick-poems-post.md
+++ b/.changeset/slick-poems-post.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Fixed sub-agent memory context pollution that caused 'Exhausted all fallback models' errors when using Observational Memory with sub-agents. The parent agent's memory context is now preserved across sub-agent tool execution.


### PR DESCRIPTION
Fixes #12884

When a parent agent with Observational Memory uses a sub-agent (also with OM via `agents: { researcher: subAgent }`), the sub-agent's `prepare-memory-step` overwrites the shared `RequestContext`'s `MastraMemory` key with its own thread/resource identity. When control returns to the parent, its OM reads the stale sub-agent context, hits a resourceId mismatch, and cascades through all fallback models until it throws "Exhausted all fallback models."

The fix saves and restores the `MastraMemory` key on `RequestContext` around sub-agent tool execution in `listAgentTools()`, so the parent's processors always see the correct memory context on subsequent steps.

Also added a test that sets up a primary agent + sub-agent both with OM, verifies the primary completes successfully, and checks that each agent's OM observations land under the correct thread/resource.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory context pollution issue with sub-agents using Observational Memory that caused "Exhausted all fallback models" errors.
  * Ensured parent agent's memory context is properly preserved during sub-agent tool executions.

* **Tests**
  * Added comprehensive test coverage for multi-agent scenarios with Observational Memory to verify proper memory isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->