### PR TITLE
feat(core): add allowedPaths to LocalFilesystem

### DIFF
--- a/.changeset/allowed-paths-filesystem.md
+++ b/.changeset/allowed-paths-filesystem.md
@@ -1,0 +1,22 @@
+---
+'@mastra/core': minor
+---
+
+Added `allowedPaths` option to `LocalFilesystem` for granting agents access to specific directories outside `basePath` without disabling containment.
+
+```typescript
+const workspace = new Workspace({
+  filesystem: new LocalFilesystem({
+    basePath: './workspace',
+    allowedPaths: ['/home/user/.config', '/home/user/documents'],
+  }),
+});
+```
+
+Allowed paths can be updated at runtime using `setAllowedPaths()`:
+
+```typescript
+workspace.filesystem.setAllowedPaths(prev => [...prev, '/home/user/new-dir']);
+```
+
+This is the recommended approach for least-privilege access — agents can only reach the specific directories you allow, while containment stays enabled for everything else.

--- a/packages/core/src/workspace/filesystem/local-filesystem.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.ts
@@ -66,6 +66,23 @@ export interface LocalFilesystemOptions extends MastraFilesystemOptions {
    * @default false
    */
   readOnly?: boolean;
+  /**
+   * Additional paths (absolute) that are allowed beyond basePath.
+   * Useful with `contained: true` to grant access to specific directories
+   * outside the basePath without disabling containment entirely.
+   *
+   * Paths are resolved to absolute paths using `path.resolve()`.
+   *
+   * @example
+   * ```typescript
+   * new LocalFilesystem({
+   *   basePath: '/project',
+   *   contained: true,
+   *   allowedPaths: ['/home/user/.config'],
+   * })
+   * ```
+   */
+  allowedPaths?: string[];
 }
 
 /**
@@ -96,6 +113,7 @@ export class LocalFilesystem extends MastraFilesystem {
 
   private readonly _basePath: string;
   private readonly _contained: boolean;
+  private _allowedPaths: string[];
 
   /**
    * The absolute base path on disk where files are stored.
@@ -105,16 +123,54 @@ export class LocalFilesystem extends MastraFilesystem {
     return this._basePath;
   }
 
+  /**
+   * Current set of additional allowed paths (absolute, resolved).
+   * These paths are permitted beyond basePath when containment is enabled.
+   */
+  get allowedPaths(): readonly string[] {
+    return this._allowedPaths;
+  }
+
+  /**
+   * Update allowed paths. Accepts a direct array or an updater callback
+   * receiving the current paths (React setState pattern).
+   *
+   * @example
+   * ```typescript
+   * // Set directly
+   * fs.setAllowedPaths(['/home/user/.config']);
+   *
+   * // Update with callback
+   * fs.setAllowedPaths(prev => [...prev, '/home/user/.ssh']);
+   * ```
+   */
+  setAllowedPaths(pathsOrUpdater: string[] | ((current: readonly string[]) => string[])): void {
+    const newPaths = typeof pathsOrUpdater === 'function' ? pathsOrUpdater(this._allowedPaths) : pathsOrUpdater;
+    this._allowedPaths = newPaths.map(p => nodePath.resolve(p));
+  }
+
   constructor(options: LocalFilesystemOptions) {
     super({ ...options, name: 'LocalFilesystem' });
     this.id = options.id ?? this.generateId();
     this._basePath = nodePath.resolve(options.basePath);
     this._contained = options.contained ?? true;
     this.readOnly = options.readOnly;
+    this._allowedPaths = (options.allowedPaths ?? []).map(p => nodePath.resolve(p));
   }
 
   private generateId(): string {
     return `local-fs-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  /**
+   * Check if an absolute path falls within basePath or any allowed path.
+   */
+  private _isWithinAnyRoot(absolutePath: string): boolean {
+    const roots = [this._basePath, ...this._allowedPaths];
+    return roots.some(root => {
+      const relative = nodePath.relative(root, absolutePath);
+      return !relative.startsWith('..') && !nodePath.isAbsolute(relative);
+    });
   }
 
   private toBuffer(content: FileContent): Buffer {
@@ -131,11 +187,10 @@ export class LocalFilesystem extends MastraFilesystem {
       absolutePath = nodePath.normalize(inputPath);
     } else if (this._contained && nodePath.isAbsolute(inputPath)) {
       // Containment enabled — check if this is a real path within basePath
-      // (e.g. "/Users/foo/project/.mastracode/skills") vs the virtual-root
+      // or an allowed path (e.g. "/Users/foo/project/src") vs the virtual-root
       // convention (e.g. "/file.txt" meaning "basePath/file.txt")
       const normalized = nodePath.normalize(inputPath);
-      const relative = nodePath.relative(this._basePath, normalized);
-      if (!relative.startsWith('..') && !nodePath.isAbsolute(relative)) {
+      if (this._isWithinAnyRoot(normalized)) {
         absolutePath = normalized;
       } else {
         const cleanedPath = inputPath.replace(/^\/+/, '');
@@ -148,8 +203,7 @@ export class LocalFilesystem extends MastraFilesystem {
     }
 
     if (this._contained) {
-      const relative = nodePath.relative(this._basePath, absolutePath);
-      if (relative.startsWith('..') || nodePath.isAbsolute(relative)) {
+      if (!this._isWithinAnyRoot(absolutePath)) {
         throw new PermissionError(inputPath, 'access');
       }
     }
@@ -174,14 +228,22 @@ export class LocalFilesystem extends MastraFilesystem {
   private async assertPathContained(absolutePath: string): Promise<void> {
     if (!this._contained) return;
 
-    let baseReal: string;
-    try {
-      baseReal = await fs.realpath(this._basePath);
-    } catch (error: unknown) {
-      if (isEnoentError(error)) {
-        throw new DirectoryNotFoundError(this._basePath);
+    // Resolve real paths for all roots (basePath + allowedPaths)
+    const rootReals: string[] = [];
+    for (const root of [this._basePath, ...this._allowedPaths]) {
+      try {
+        rootReals.push(await fs.realpath(root));
+      } catch (error: unknown) {
+        if (isEnoentError(error)) {
+          // Root doesn't exist yet — skip (operations will fail naturally)
+          continue;
+        }
+        throw error;
       }
-      throw error;
+    }
+
+    if (rootReals.length === 0) {
+      throw new DirectoryNotFoundError(this._basePath);
     }
 
     let targetReal: string;
@@ -213,7 +275,11 @@ export class LocalFilesystem extends MastraFilesystem {
       }
     }
 
-    if (targetReal !== baseReal && !targetReal.startsWith(baseReal + nodePath.sep)) {
+    const isWithinRoot = rootReals.some(
+      rootReal => targetReal === rootReal || targetReal.startsWith(rootReal + nodePath.sep),
+    );
+
+    if (!isWithinRoot) {
       throw new PermissionError(absolutePath, 'access');
     }
   }
@@ -622,7 +688,7 @@ export class LocalFilesystem extends MastraFilesystem {
     // LocalFilesystem doesn't clean up files on destroy by default
   }
 
-  getInfo(): FilesystemInfo<{ basePath: string; contained: boolean }> {
+  getInfo(): FilesystemInfo<{ basePath: string; contained: boolean; allowedPaths?: string[] }> {
     return {
       id: this.id,
       name: this.name,
@@ -633,14 +699,19 @@ export class LocalFilesystem extends MastraFilesystem {
       metadata: {
         basePath: this.basePath,
         contained: this._contained,
+        ...(this._allowedPaths.length > 0 && { allowedPaths: [...this._allowedPaths] }),
       },
     };
   }
 
   getInstructions(): string {
+    const allowedNote =
+      this._allowedPaths.length > 0
+        ? ` Additionally, the following paths outside basePath are accessible: ${this._allowedPaths.join(', ')}.`
+        : '';
     if (this._contained) {
-      return `Local filesystem at "${this.basePath}". Files at workspace path "/foo" are stored at "${this.basePath}/foo" on disk.`;
+      return `Local filesystem at "${this.basePath}". Files at workspace path "/foo" are stored at "${this.basePath}/foo" on disk.${allowedNote}`;
     }
-    return `Local filesystem rooted at "${this.basePath}". Containment is disabled so absolute paths access the real filesystem. Use paths relative to "${this.basePath}" (e.g. "foo/bar.txt") for workspace files. Avoid unnecessary listing "/" as it would traverse the entire host filesystem.`;
+    return `Local filesystem rooted at "${this.basePath}". Containment is disabled so absolute paths access the real filesystem. Use paths relative to "${this.basePath}" (e.g. "foo/bar.txt") for workspace files. Avoid unnecessary listing "/" as it would traverse the entire host filesystem.${allowedNote}`;
   }
 }


### PR DESCRIPTION
## Summary

Adds `allowedPaths` option to `LocalFilesystem` for granting agents access to specific directories outside `basePath` without disabling containment entirely.

- **`allowedPaths`** constructor option — additional absolute paths permitted beyond basePath
- **`allowedPaths`** readonly getter — current set of allowed paths
- **`setAllowedPaths()`** — update allowed paths at runtime (supports updater callback pattern)
- Updated `resolvePath()` to recognize absolute paths within allowed roots as real paths (not virtualized)
- Updated `assertPathContained()` to check symlink escapes against all roots
- Updated `getInfo()` and `getInstructions()` to reflect allowed paths

```typescript
const workspace = new Workspace({
  filesystem: new LocalFilesystem({
    basePath: './workspace',
    allowedPaths: ['/home/user/.config', '/home/user/documents'],
  }),
});

// Update at runtime
workspace.filesystem.setAllowedPaths(prev => [...prev, '/home/user/new-dir']);
```

This is the recommended approach for least-privilege access — agents can only reach the specific directories you allow, while containment stays enabled for everything else.

Related: docs PR #13062

## Test plan

- [x] 20 new tests covering constructor, setAllowedPaths (array, callback, clear), file operations with allowedPaths (read, write, exists, stat, readdir), dynamic add/remove of paths, getInfo, getInstructions
- [x] All 87 LocalFilesystem tests pass
- [x] Existing containment behavior unchanged when no allowedPaths set