### PR TITLE
fix(memory): semantic recall search with non-default embedding dimensions

### DIFF
--- a/.changeset/eight-dancers-poke.md
+++ b/.changeset/eight-dancers-poke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed semantic recall search in Mastra Studio returning no results when using non-default embedding dimensions (e.g., fastembed with 384-dim). The SemanticRecall processor now probes the embedder for its actual output dimension, ensuring the vector index name matches between write and read paths. Previously, the processor defaulted to a 1536-dim index name regardless of the actual embedder, causing a mismatch with the dimension-aware index name used by Studio's search. Fixes #13039

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -74,7 +74,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/core": ">=1.4.1-0 <2.0.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "homepage": "https://mastra.ai",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -74,7 +74,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.4.1-0 <2.0.0-0",
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "homepage": "https://mastra.ai",

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -11,10 +11,6 @@ class TestableMemory extends Memory {
   public testUpdateMessageToHideWorkingMemoryV2(message: MastraDBMessage): MastraDBMessage | null {
     return this.updateMessageToHideWorkingMemoryV2(message);
   }
-
-  public testGetEmbeddingIndexName(dimensions?: number): string {
-    return this.getEmbeddingIndexName(dimensions);
-  }
 }
 
 describe('Memory', () => {
@@ -716,113 +712,6 @@ describe('Memory', () => {
       });
     });
 
-    describe('semantic recall index naming', () => {
-      it('should use the same vector index for processor writes and recall reads with non-default embedding dimensions', async () => {
-        // 384-dim embeddings (like fastembed) — NOT the default 1536
-        const embeddingDim = 384;
-        const fakeEmbedding = new Array(embeddingDim).fill(0.1);
-
-        const mockVector: MastraVector = {
-          createIndex: vi.fn().mockResolvedValue(undefined),
-          upsert: vi.fn().mockResolvedValue(undefined),
-          query: vi.fn().mockResolvedValue([]),
-          listIndexes: vi.fn().mockResolvedValue([]),
-          deleteVectors: vi.fn().mockResolvedValue(undefined),
-          describeIndex: vi.fn().mockResolvedValue({ dimension: embeddingDim }),
-          id: 'mock-vector',
-        } as any;
-
-        const mockEmbedder = {
-          doEmbed: vi.fn().mockResolvedValue({
-            embeddings: [fakeEmbedding],
-          }),
-          modelId: 'mock-384-embedder',
-          specificationVersion: 'v1',
-          provider: 'mock',
-        } as any;
-
-        const memory = new Memory({
-          storage: new InMemoryStore(),
-          vector: mockVector,
-          embedder: mockEmbedder,
-          options: {
-            semanticRecall: { scope: 'thread' },
-            lastMessages: 10,
-            generateTitle: false,
-          },
-        });
-
-        // Create a thread
-        await memory.saveThread({
-          thread: {
-            id: 'sr-thread-1',
-            resourceId: 'sr-resource-1',
-            title: 'Test Thread',
-            createdAt: new Date(),
-            updatedAt: new Date(),
-          },
-        });
-
-        // --- WRITE PATH: SemanticRecall output processor (used by agent) ---
-        const outputProcessors = await memory.getOutputProcessors();
-        const semanticProcessor = outputProcessors.find(p => p.id === 'semantic-recall');
-        expect(semanticProcessor).toBeDefined();
-
-        const testMessage: MastraDBMessage = {
-          id: 'sr-msg-1',
-          role: 'user',
-          content: {
-            format: 2,
-            parts: [{ type: 'text', text: 'What is machine learning?' }],
-            content: 'What is machine learning?',
-          },
-          createdAt: new Date(),
-          threadId: 'sr-thread-1',
-          resourceId: 'sr-resource-1',
-        };
-
-        const messageList = new MessageList();
-        messageList.add([testMessage], 'input');
-
-        const requestContext = new RequestContext();
-        requestContext.set('MastraMemory', {
-          thread: { id: 'sr-thread-1', resourceId: 'sr-resource-1' },
-          resourceId: 'sr-resource-1',
-        });
-
-        await semanticProcessor!.processOutputResult!({
-          messages: [testMessage],
-          messageList,
-          abort: vi.fn() as any,
-          requestContext,
-        });
-
-        // Capture the index name used for the write (upsert)
-        expect(mockVector.upsert).toHaveBeenCalled();
-        const writeIndexName = vi.mocked(mockVector.upsert).mock.calls[0]![0].indexName;
-
-        // Clear mocks for the read path
-        vi.mocked(mockVector.createIndex).mockClear();
-        vi.mocked(mockVector.query).mockClear();
-
-        // --- READ PATH: memory.recall() (used by Studio's Semantic Recall search) ---
-        await memory.recall({
-          threadId: 'sr-thread-1',
-          resourceId: 'sr-resource-1',
-          vectorSearchString: 'machine learning',
-        });
-
-        // Capture the index name used for the read (query)
-        expect(mockVector.query).toHaveBeenCalled();
-        const readIndexName = vi.mocked(mockVector.query).mock.calls[0]![0].indexName;
-
-        // The write and read paths MUST use the same index name.
-        // With a 384-dim embedder, the processor writes to one index
-        // while recall() searches a different one — causing search to return nothing.
-        expect(writeIndexName).toBe(readIndexName);
-      });
-    });
-
     describe('getCloneHistory', () => {
       it('should return the full clone chain', async () => {
         // Create a chain: original -> clone1 -> clone2
@@ -1104,6 +993,114 @@ describe('Memory', () => {
         const page2Ids = page2.threads.map(t => t.id);
         expect(page1Ids).not.toEqual(page2Ids);
       });
+    });
+  });
+
+  describe('semantic recall index naming', () => {
+    it('should use the same vector index for processor writes and recall reads with non-default embedding dimensions', async () => {
+      // 384-dim embeddings (like fastembed) — NOT the default 1536
+      const embeddingDim = 384;
+      const fakeEmbedding = new Array(embeddingDim).fill(0.1);
+
+      const mockVector: MastraVector = {
+        createIndex: vi.fn().mockResolvedValue(undefined),
+        upsert: vi.fn().mockResolvedValue(undefined),
+        query: vi.fn().mockResolvedValue([]),
+        listIndexes: vi.fn().mockResolvedValue([]),
+        deleteVectors: vi.fn().mockResolvedValue(undefined),
+        describeIndex: vi.fn().mockResolvedValue({ dimension: embeddingDim }),
+        id: 'mock-vector',
+      } as any;
+
+      const mockEmbedder = {
+        doEmbed: vi.fn().mockResolvedValue({
+          embeddings: [fakeEmbedding],
+        }),
+        modelId: 'mock-384-embedder',
+        specificationVersion: 'v1',
+        provider: 'mock',
+      } as any;
+
+      const memory = new Memory({
+        storage: new InMemoryStore(),
+        vector: mockVector,
+        embedder: mockEmbedder,
+        options: {
+          semanticRecall: { scope: 'thread' },
+          lastMessages: 10,
+          generateTitle: false,
+        },
+      });
+
+      // Create a thread
+      await memory.saveThread({
+        thread: {
+          id: 'sr-thread-1',
+          resourceId: 'sr-resource-1',
+          title: 'Test Thread',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+
+      // --- WRITE PATH: SemanticRecall output processor (used by agent) ---
+      const outputProcessors = await memory.getOutputProcessors();
+      const semanticProcessor = outputProcessors.find(p => p.id === 'semantic-recall');
+      expect(semanticProcessor).toBeDefined();
+
+      const testMessage: MastraDBMessage = {
+        id: 'sr-msg-1',
+        role: 'user',
+        content: {
+          format: 2,
+          parts: [{ type: 'text', text: 'What is machine learning?' }],
+          content: 'What is machine learning?',
+        },
+        createdAt: new Date(),
+        threadId: 'sr-thread-1',
+        resourceId: 'sr-resource-1',
+      };
+
+      const messageList = new MessageList();
+      messageList.add([testMessage], 'input');
+
+      const requestContext = new RequestContext();
+      requestContext.set('MastraMemory', {
+        thread: { id: 'sr-thread-1', resourceId: 'sr-resource-1' },
+        resourceId: 'sr-resource-1',
+      });
+
+      await semanticProcessor!.processOutputResult!({
+        messages: [testMessage],
+        messageList,
+        abort: vi.fn() as any,
+        requestContext,
+      });
+
+      // Capture the index name used for the write (upsert)
+      expect(mockVector.upsert).toHaveBeenCalled();
+      const writeIndexName = vi.mocked(mockVector.upsert).mock.calls[0]![0].indexName;
+
+      // Clear mocks for the read path
+      vi.mocked(mockVector.createIndex).mockClear();
+      vi.mocked(mockVector.query).mockClear();
+
+      // --- READ PATH: memory.recall() (used by Studio's Semantic Recall search) ---
+      await memory.recall({
+        threadId: 'sr-thread-1',
+        resourceId: 'sr-resource-1',
+        vectorSearchString: 'machine learning',
+      });
+
+      // Capture the index name used for the read (query)
+      expect(mockVector.query).toHaveBeenCalled();
+      const readIndexName = vi.mocked(mockVector.query).mock.calls[0]![0].indexName;
+
+      // The write and read paths MUST use the same index name.
+      // With a 384-dim embedder, the processor writes to one index
+      // while recall() searches a different one — causing search to return nothing.
+      expect(writeIndexName).toBe(readIndexName);
+      expect(writeIndexName).toContain('384');
     });
   });
 });

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -1,12 +1,19 @@
+import { MessageList } from '@mastra/core/agent';
 import type { MastraDBMessage } from '@mastra/core/agent';
+import { RequestContext } from '@mastra/core/request-context';
 import { InMemoryStore } from '@mastra/core/storage';
-import { describe, it, expect, beforeEach } from 'vitest';
+import type { MastraVector } from '@mastra/core/vector';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Memory } from './index';
 
-// Expose protected method for testing
+// Expose protected methods for testing
 class TestableMemory extends Memory {
   public testUpdateMessageToHideWorkingMemoryV2(message: MastraDBMessage): MastraDBMessage | null {
     return this.updateMessageToHideWorkingMemoryV2(message);
+  }
+
+  public testGetEmbeddingIndexName(dimensions?: number): string {
+    return this.getEmbeddingIndexName(dimensions);
   }
 }
 
@@ -706,6 +713,113 @@ describe('Memory', () => {
       it('should return empty array when source thread does not exist', async () => {
         const clones = await memory.listClones('non-existent');
         expect(clones).toHaveLength(0);
+      });
+    });
+
+    describe('semantic recall index naming', () => {
+      it('should use the same vector index for processor writes and recall reads with non-default embedding dimensions', async () => {
+        // 384-dim embeddings (like fastembed) — NOT the default 1536
+        const embeddingDim = 384;
+        const fakeEmbedding = new Array(embeddingDim).fill(0.1);
+
+        const mockVector: MastraVector = {
+          createIndex: vi.fn().mockResolvedValue(undefined),
+          upsert: vi.fn().mockResolvedValue(undefined),
+          query: vi.fn().mockResolvedValue([]),
+          listIndexes: vi.fn().mockResolvedValue([]),
+          deleteVectors: vi.fn().mockResolvedValue(undefined),
+          describeIndex: vi.fn().mockResolvedValue({ dimension: embeddingDim }),
+          id: 'mock-vector',
+        } as any;
+
+        const mockEmbedder = {
+          doEmbed: vi.fn().mockResolvedValue({
+            embeddings: [fakeEmbedding],
+          }),
+          modelId: 'mock-384-embedder',
+          specificationVersion: 'v1',
+          provider: 'mock',
+        } as any;
+
+        const memory = new Memory({
+          storage: new InMemoryStore(),
+          vector: mockVector,
+          embedder: mockEmbedder,
+          options: {
+            semanticRecall: { scope: 'thread' },
+            lastMessages: 10,
+            generateTitle: false,
+          },
+        });
+
+        // Create a thread
+        await memory.saveThread({
+          thread: {
+            id: 'sr-thread-1',
+            resourceId: 'sr-resource-1',
+            title: 'Test Thread',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        });
+
+        // --- WRITE PATH: SemanticRecall output processor (used by agent) ---
+        const outputProcessors = await memory.getOutputProcessors();
+        const semanticProcessor = outputProcessors.find(p => p.id === 'semantic-recall');
+        expect(semanticProcessor).toBeDefined();
+
+        const testMessage: MastraDBMessage = {
+          id: 'sr-msg-1',
+          role: 'user',
+          content: {
+            format: 2,
+            parts: [{ type: 'text', text: 'What is machine learning?' }],
+            content: 'What is machine learning?',
+          },
+          createdAt: new Date(),
+          threadId: 'sr-thread-1',
+          resourceId: 'sr-resource-1',
+        };
+
+        const messageList = new MessageList();
+        messageList.add([testMessage], 'input');
+
+        const requestContext = new RequestContext();
+        requestContext.set('MastraMemory', {
+          thread: { id: 'sr-thread-1', resourceId: 'sr-resource-1' },
+          resourceId: 'sr-resource-1',
+        });
+
+        await semanticProcessor!.processOutputResult!({
+          messages: [testMessage],
+          messageList,
+          abort: vi.fn() as any,
+          requestContext,
+        });
+
+        // Capture the index name used for the write (upsert)
+        expect(mockVector.upsert).toHaveBeenCalled();
+        const writeIndexName = vi.mocked(mockVector.upsert).mock.calls[0]![0].indexName;
+
+        // Clear mocks for the read path
+        vi.mocked(mockVector.createIndex).mockClear();
+        vi.mocked(mockVector.query).mockClear();
+
+        // --- READ PATH: memory.recall() (used by Studio's Semantic Recall search) ---
+        await memory.recall({
+          threadId: 'sr-thread-1',
+          resourceId: 'sr-resource-1',
+          vectorSearchString: 'machine learning',
+        });
+
+        // Capture the index name used for the read (query)
+        expect(mockVector.query).toHaveBeenCalled();
+        const readIndexName = vi.mocked(mockVector.query).mock.calls[0]![0].indexName;
+
+        // The write and read paths MUST use the same index name.
+        // With a 384-dim embedder, the processor writes to one index
+        // while recall() searches a different one — causing search to return nothing.
+        expect(writeIndexName).toBe(readIndexName);
       });
     });
 


### PR DESCRIPTION
## Description

Fixed semantic recall search in Mastra Studio returning no results when using non-default embedding dimensions (e.g., fastembed with 384-dim instead of the default 1536-dim).

The root cause was an index naming mismatch between the write and read paths:
- **Write path** (SemanticRecall output processor): Called `getEmbeddingIndexName()` without a dimension argument, defaulting to 1536 and producing index name `memory_messages`
- **Read path** (`memory.recall()`, used by Studio): Correctly determined the actual dimension (384) and produced index name `memory_messages_384`

The fix probes the embedder for its actual output dimension when initializing the SemanticRecall processor, ensuring both paths use the same dimension-aware index name. The probe result is cached so subsequent calls are free.

## Related Issue(s)

Fixes #13039

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed semantic recall/search failures when using non-default embedding dimensions (e.g., 384-dim). The system now detects an embedder’s actual output dimension and uses a matching index name for both write and read paths, preventing dimension mismatches and ensuring consistent, reliable memory recall and search behavior across different embedding configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->