### PR TITLE
fix(opencode): add turbo.json so dist/ is built before npm publish

### DIFF
--- a/.changeset/green-impalas-bake.md
+++ b/.changeset/green-impalas-bake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/opencode': patch
+---
+
+Fixed npm publish for @mastra/opencode — the dist/ folder was missing because turbo couldn't find a build task to run. Added turbo.json so the build:lib script runs correctly during CI.

--- a/integrations/opencode/turbo.json
+++ b/integrations/opencode/turbo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "build": {
+      "dependsOn": ["build:lib"]
+    }
+  }
+}


### PR DESCRIPTION
@mastra/opencode@0.0.2 shipped with no code — just package.json, CHANGELOG.md, and LICENSE.md. The `dist/` folder was completely missing.

The package only had a `build:lib` script but no `turbo.json` to wire it up. Turbo's `build` task had nothing to run, so it silently skipped the package during CI. This adds a `turbo.json` matching the pattern used by stores (e.g. `stores/pg`) that chains `build` → `build:lib`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved npm publish issues related to missing build artifacts.

* **Chores**
  * Added build configuration to standardize the build process during CI/CD.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->