### PR TITLE
fix(memory): skip data-* parts in token counting and deduplicate markers

### DIFF
--- a/.changeset/fix-om-token-jump-after-activation.md
+++ b/.changeset/fix-om-token-jump-after-activation.md
@@ -1,0 +1,9 @@
+---
+"@mastra/memory": patch
+---
+
+Fixed a bug where the OM context window would jump to extremely high token counts (e.g. 16k → 114k) after observation activation. Two issues were causing this:
+
+- **Token counter included OM metadata parts**: `data-om-activation` marker parts (which contain the full observation text, up to 150k+ characters) were being counted as message tokens when loaded from the database. These parts are never sent to the LLM and are now skipped during token counting.
+
+- **Marker duplication on messages**: Activation markers were being added to assistant messages twice — once by the AI SDK stream and once by the persistence layer — doubling every marker and compounding the token inflation. Both `persistMarkerToMessage` and `persistMarkerToStorage` now deduplicate by `type + cycleId` before adding a marker.

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -2374,11 +2374,11 @@ Ask about preferred brewing method
       createTestMessage('What kind do you prefer?', 'assistant', 'msg-2'),
     ];
 
-    await (om as any).doSynchronousObservation(
-      await storage.getObservationalMemory(null, 'resource-1'),
-      'thread-1',
-      messages,
-    );
+    await (om as any).doSynchronousObservation({
+      record: await storage.getObservationalMemory(null, 'resource-1'),
+      threadId: 'thread-1',
+      unobservedMessages: messages,
+    });
 
     // Check stored observations have thread tag
     const record = await storage.getObservationalMemory(null, 'resource-1');
@@ -2442,11 +2442,11 @@ Ask about preferred brewing method
 
     const messages = [createTestMessage('I love tea!', 'user', 'msg-1')];
 
-    await (om as any).doSynchronousObservation(
-      await storage.getObservationalMemory('thread-1', 'resource-1'),
-      'thread-1',
-      messages,
-    );
+    await (om as any).doSynchronousObservation({
+      record: await storage.getObservationalMemory('thread-1', 'resource-1'),
+      threadId: 'thread-1',
+      unobservedMessages: messages,
+    });
 
     const record = await storage.getObservationalMemory('thread-1', 'resource-1');
     // Should NOT have thread tags in thread scope
@@ -2538,10 +2538,10 @@ describe('Locking Behavior', () => {
 
     // Try to reflect — stale isReflecting should be detected and cleared,
     // because no operation is registered in this process's activeOps registry
-    await (om as any).maybeReflect(
-      { ...record, isReflecting: true },
-      500, // Token count exceeds threshold
-    );
+    await (om as any).maybeReflect({
+      record: { ...record, isReflecting: true },
+      observationTokens: 500, // Token count exceeds threshold
+    });
 
     // Reflector SHOULD be called because the stale flag was cleared
     expect(reflectorCalled).toBe(true);
@@ -2698,7 +2698,7 @@ describe('Reflection with Thread Attribution', () => {
     // Trigger reflection via maybeReflect (called internally)
     const record = await storage.getObservationalMemory(null, 'resource-1');
     // @ts-expect-error - accessing private method for testing
-    await om.maybeReflect(record!, 500);
+    await om.maybeReflect({ record: record!, observationTokens: 500 });
 
     // Get all records for this resource
     const allRecords = await storage.getObservationalMemoryHistory(null, 'resource-1');
@@ -2787,7 +2787,7 @@ describe('Reflection with Thread Attribution', () => {
     // Trigger reflection
     const record = await storage.getObservationalMemory(null, 'resource-1');
     // @ts-expect-error - accessing private method for testing
-    await om.maybeReflect(record!, 500);
+    await om.maybeReflect({ record: record!, observationTokens: 500 });
 
     // Get the new reflection record
     const allRecords = await storage.getObservationalMemoryHistory(null, 'resource-1');
@@ -2858,7 +2858,7 @@ describe('Reflection with Thread Attribution', () => {
 
     // Trigger reflection
     // @ts-expect-error - accessing private method for testing
-    await om.maybeReflect(recordBeforeReflection!, 500);
+    await om.maybeReflect({ record: recordBeforeReflection!, observationTokens: 500 });
 
     // Get the new reflection record
     const allRecords = await storage.getObservationalMemoryHistory(null, 'resource-1');

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -2564,8 +2564,8 @@ ${suggestedResponse}
    * Calculate all threshold-related values for observation decision making.
    */
   private calculateObservationThresholds(
-    allMessages: MastraDBMessage[],
-    _unobservedMessages: MastraDBMessage[],
+    _allMessages: MastraDBMessage[],
+    unobservedMessages: MastraDBMessage[],
     _pendingTokens: number,
     otherThreadTokens: number,
     currentObservationTokens: number,
@@ -2576,16 +2576,13 @@ ${suggestedResponse}
     effectiveObservationTokensThreshold: number;
     isSharedBudget: boolean;
   } {
-    // For threshold checking, count ALL messages currently in the context window.
-    // With async buffering, observed messages may remain in context until the next
-    // turn (they're only removed at step 0). Using unobserved-only would undercount
-    // the actual context size, preventing threshold triggers and causing overflow.
-    const contextWindowTokens = this.tokenCounter.countMessages(allMessages);
+    // Count only unobserved messages for threshold checking.
+    // Already-observed messages may still be in the messageList (the AI SDK
+    // repopulates it each step), but they shouldn't count toward the threshold
+    // since they've already been captured in observations.
+    const contextWindowTokens = this.tokenCounter.countMessages(unobservedMessages);
 
-    // Total pending = all in-context tokens + other threads
-    // Note: we don't add record.pendingMessageTokens here because that's a DB artifact
-    // for cross-request state tracking. The allMessages already includes everything
-    // currently in the context window.
+    // Total pending = unobserved in-context tokens + other threads
     const totalPendingTokens = Math.max(0, contextWindowTokens + otherThreadTokens);
 
     const threshold = this.calculateDynamicThreshold(this.observationConfig.messageTokens, currentObservationTokens);
@@ -2747,10 +2744,10 @@ ${suggestedResponse}
       const freshAllMessages = messageList.get.all.db();
       let freshUnobservedMessages = this.getUnobservedMessages(freshAllMessages, freshRecord);
 
-      // Re-check threshold inside the lock using all context window tokens.
-      // After activation, observed messages may still be in context (removed at next step 0),
-      // so we count everything to get the true context size.
-      const freshContextTokens = this.tokenCounter.countMessages(freshAllMessages);
+      // Re-check threshold inside the lock using only unobserved messages.
+      // Already-observed messages may still be in the messageList but shouldn't
+      // count toward the threshold since they've been captured in observations.
+      const freshContextTokens = this.tokenCounter.countMessages(freshUnobservedMessages);
       let freshOtherThreadTokens = 0;
       if (this.scope === 'resource' && resourceId) {
         const freshOtherContext = await this.loadOtherThreadsContext(resourceId, threadId);
@@ -3246,6 +3243,7 @@ ${suggestedResponse}
       if (bufferedChunks.length > 0) {
         // Compute threshold to check if activation is warranted
         const allMsgsForCheck = messageList.get.all.db();
+        const unobservedMsgsForCheck = this.getUnobservedMessages(allMsgsForCheck, record);
         const otherThreadTokensForCheck = unobservedContextBlocks
           ? this.tokenCounter.countString(unobservedContextBlocks)
           : 0;
@@ -3253,7 +3251,7 @@ ${suggestedResponse}
         const { totalPendingTokens: step0PendingTokens, threshold: step0Threshold } =
           this.calculateObservationThresholds(
             allMsgsForCheck,
-            [], // unobserved not needed for threshold calculation
+            unobservedMsgsForCheck,
             0, // pendingTokens not needed — allMessages covers context
             otherThreadTokensForCheck,
             currentObsTokensForCheck,
@@ -3371,6 +3369,13 @@ ${suggestedResponse}
       );
       const { totalPendingTokens, threshold } = thresholds;
 
+      // Subtract already-buffered message tokens from the pending count for buffering decisions.
+      // Buffered messages are "unobserved" (not yet in activeObservations) but have already been
+      // sent to the observer — counting them would cause redundant buffering ops, especially
+      // after activation resets lastBufferedBoundary to 0.
+      const bufferedChunkTokens = this.getBufferedChunks(record).reduce((sum, c) => sum + (c.tokenCount ?? 0), 0);
+      const unbufferedPendingTokens = Math.max(0, totalPendingTokens - bufferedChunkTokens);
+
       // Merge per-state sealedIds with static sealedMessageIds (survives across OM instances)
       const stateSealedIds: Set<string> = (state.sealedIds as Set<string>) ?? new Set<string>();
       const staticSealedIds = ObservationalMemory.sealedMessageIds.get(threadId) ?? new Set<string>();
@@ -3383,23 +3388,37 @@ ${suggestedResponse}
       // ════════════════════════════════════════════════════════════════════════
 
       if (this.isAsyncObservationEnabled() && totalPendingTokens < threshold) {
-        const shouldTrigger = this.shouldTriggerAsyncObservation(totalPendingTokens, lockKey, record);
+        const shouldTrigger = this.shouldTriggerAsyncObservation(unbufferedPendingTokens, lockKey, record);
         omDebug(
-          `[OM:async-obs] belowThreshold: pending=${totalPendingTokens}, threshold=${threshold}, shouldTrigger=${shouldTrigger}, isBufferingObs=${record.isBufferingObservation}, lastBufferedAt=${record.lastBufferedAtTokens}`,
+          `[OM:async-obs] belowThreshold: pending=${totalPendingTokens}, unbuffered=${unbufferedPendingTokens}, threshold=${threshold}, shouldTrigger=${shouldTrigger}, isBufferingObs=${record.isBufferingObservation}, lastBufferedAt=${record.lastBufferedAtTokens}`,
         );
         if (shouldTrigger) {
-          this.startAsyncBufferedObservation(record, threadId, unobservedMessages, lockKey, writer, totalPendingTokens);
+          this.startAsyncBufferedObservation(
+            record,
+            threadId,
+            unobservedMessages,
+            lockKey,
+            writer,
+            unbufferedPendingTokens,
+          );
         }
       } else if (this.isAsyncObservationEnabled()) {
         // Above threshold but we still need to check async buffering:
         // - At step 0, sync observation won't run, so we need chunks ready
         // - Below blockAfter, sync observation won't run, so we need chunks ready
-        const shouldTrigger = this.shouldTriggerAsyncObservation(totalPendingTokens, lockKey, record);
+        const shouldTrigger = this.shouldTriggerAsyncObservation(unbufferedPendingTokens, lockKey, record);
         omDebug(
-          `[OM:async-obs] atOrAboveThreshold: pending=${totalPendingTokens}, threshold=${threshold}, step=${stepNumber}, shouldTrigger=${shouldTrigger}`,
+          `[OM:async-obs] atOrAboveThreshold: pending=${totalPendingTokens}, unbuffered=${unbufferedPendingTokens}, threshold=${threshold}, step=${stepNumber}, shouldTrigger=${shouldTrigger}`,
         );
         if (shouldTrigger) {
-          this.startAsyncBufferedObservation(record, threadId, unobservedMessages, lockKey, writer, totalPendingTokens);
+          this.startAsyncBufferedObservation(
+            record,
+            threadId,
+            unobservedMessages,
+            lockKey,
+            writer,
+            unbufferedPendingTokens,
+          );
         }
       }
 

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -611,8 +611,8 @@ export function formatMessagesForObserver(messages: MastraDBMessage[], options?:
               const argsStr = JSON.stringify(inv.args, null, 2);
               return `[Tool Call: ${inv.toolName}]\n${maybeTruncate(argsStr, maxLen)}`;
             }
-            // Skip observation marker parts
-            if (part.type?.startsWith('data-om-observation-')) return '';
+            // Skip all data-* parts (observation markers, activation markers, buffering markers, etc.)
+            if (part.type?.startsWith('data-')) return '';
             return '';
           })
           .filter(Boolean)

--- a/packages/memory/src/processors/observational-memory/token-counter.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.ts
@@ -79,6 +79,9 @@ export class TokenCounter {
                 `Unhandled tool-invocation state '${(part as any).toolInvocation?.state}' in token counting for part type '${part.type}'`,
               );
             }
+          } else if (typeof part.type === 'string' && part.type.startsWith('data-')) {
+            // Skip data-* parts (e.g. data-om-activation, data-om-buffering-start, etc.)
+            // These are OM metadata parts that are never sent to the LLM.
           } else {
             tokenString += JSON.stringify(part);
           }


### PR DESCRIPTION
Token counter was counting `data-om-activation` marker parts (which contain full observation/reflection text) as message tokens. These parts are metadata for the UI and never sent to the LLM so they shouldn't have been counted.

Also, activation markers were getting duplicated on messages — once via the agent stream writer and once via persistence. Both `persistMarkerToMessage` and `persistMarkerToStorage` now check for existing markers by `type + cycleId` before adding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected inflated token counts by excluding internal metadata from token calculations.
  * Prevented duplicate activation markers and added safeguards to avoid redundant activations when context changes.

* **Tests**
  * Added unit tests to verify internal metadata is ignored during token counting and markers are not duplicated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->