### PR TITLE
fix(deployer): watch workspace package source files during mastra dev

### DIFF
--- a/.changeset/fix-mastra-dev-workspace-watch.md
+++ b/.changeset/fix-mastra-dev-workspace-watch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed `mastra dev` not detecting changes to workspace packages in monorepo setups. Workspace package source and dist files are now watched via Rollup's `addWatchFile` API, so editing a shared package triggers an automatic rebuild without changing how workspace dependencies are bundled.

--- a/packages/deployer/src/build/watcher.test.ts
+++ b/packages/deployer/src/build/watcher.test.ts
@@ -3,6 +3,7 @@ import type { Plugin } from 'rollup';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getInputOptions } from './watcher';
 
+// Mock bundler module at the top level
 vi.mock('./bundler', () => ({
   getInputOptions: vi.fn().mockResolvedValue({ plugins: [] }),
 }));
@@ -45,12 +46,16 @@ describe('watcher', () => {
 
   describe('getInputOptions', () => {
     it('should pass NODE_ENV to bundler when provided', async () => {
+      // Arrange
       const env = { 'process.env.NODE_ENV': JSON.stringify('test') };
       const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
 
+      // Act
       await getInputOptions('test-entry.js', 'node', env);
 
+      // Assert
       expect(bundlerGetInputOptions).toHaveBeenCalledWith(
+        // expect.stringMatching(/\.mastra\/\.build\/entry-0\.mjs$/),
         expect.stringMatching('test-entry.js'),
         expect.objectContaining({
           dependencies: expect.any(Map),
@@ -69,10 +74,13 @@ describe('watcher', () => {
     });
 
     it('should not pass NODE_ENV to bundler when not provided', async () => {
+      // Act
       await getInputOptions('test-entry.js', 'node');
       const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
 
+      // Assert
       expect(bundlerGetInputOptions).toHaveBeenCalledWith(
+        // expect.stringMatching(/\.mastra\/\.build\/entry-0\.mjs$/),
         expect.stringMatching('test-entry.js'),
         expect.objectContaining({
           dependencies: expect.any(Map),
@@ -112,6 +120,9 @@ describe('watcher', () => {
       });
 
       it('forwards "neutral" platform to bundler for Bun runtime support', async () => {
+        // When running under Bun, callers should pass 'neutral' to preserve
+        // Bun-specific globals (like Bun.s3). The watcher correctly forwards
+        // whatever platform value is passed to it.
         const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
 
         await getInputOptions('test-entry.js', 'neutral');

--- a/packages/deployer/src/build/watcher.test.ts
+++ b/packages/deployer/src/build/watcher.test.ts
@@ -1,7 +1,8 @@
+import { join } from 'node:path';
+import type { Plugin } from 'rollup';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getInputOptions } from './watcher';
 
-// Mock bundler module at the top level
 vi.mock('./bundler', () => ({
   getInputOptions: vi.fn().mockResolvedValue({ plugins: [] }),
 }));
@@ -31,6 +32,11 @@ vi.mock('find-workspaces', () => ({
 vi.mock('empathic/package', () => ({
   up: vi.fn().mockReturnValue('/test/project/package.json'),
 }));
+vi.mock('node:fs', () => ({
+  readdirSync: vi.fn().mockImplementation(() => {
+    throw new Error('ENOENT');
+  }),
+}));
 
 describe('watcher', () => {
   beforeEach(() => {
@@ -39,16 +45,12 @@ describe('watcher', () => {
 
   describe('getInputOptions', () => {
     it('should pass NODE_ENV to bundler when provided', async () => {
-      // Arrange
       const env = { 'process.env.NODE_ENV': JSON.stringify('test') };
       const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
 
-      // Act
       await getInputOptions('test-entry.js', 'node', env);
 
-      // Assert
       expect(bundlerGetInputOptions).toHaveBeenCalledWith(
-        // expect.stringMatching(/\.mastra\/\.build\/entry-0\.mjs$/),
         expect.stringMatching('test-entry.js'),
         expect.objectContaining({
           dependencies: expect.any(Map),
@@ -67,13 +69,10 @@ describe('watcher', () => {
     });
 
     it('should not pass NODE_ENV to bundler when not provided', async () => {
-      // Act
       await getInputOptions('test-entry.js', 'node');
       const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
 
-      // Assert
       expect(bundlerGetInputOptions).toHaveBeenCalledWith(
-        // expect.stringMatching(/\.mastra\/\.build\/entry-0\.mjs$/),
         expect.stringMatching('test-entry.js'),
         expect.objectContaining({
           dependencies: expect.any(Map),
@@ -113,9 +112,6 @@ describe('watcher', () => {
       });
 
       it('forwards "neutral" platform to bundler for Bun runtime support', async () => {
-        // When running under Bun, callers should pass 'neutral' to preserve
-        // Bun-specific globals (like Bun.s3). The watcher correctly forwards
-        // whatever platform value is passed to it.
         const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
 
         await getInputOptions('test-entry.js', 'neutral');
@@ -133,6 +129,197 @@ describe('watcher', () => {
             isDev: true,
           }),
         );
+      });
+    });
+
+    describe('workspace-file-watcher plugin', () => {
+      it('adds workspace-file-watcher plugin to the plugin chain', async () => {
+        const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
+        bundlerGetInputOptions.mockResolvedValueOnce({
+          plugins: [{ name: 'esbuild' } satisfies Plugin],
+        });
+
+        const result = await getInputOptions('test-entry.js', 'node');
+
+        const pluginNames = (result.plugins as Plugin[]).map(p => p.name);
+        expect(pluginNames).toContain('workspace-file-watcher');
+      });
+
+      it('preserves alias-optimized-deps in the plugin chain', async () => {
+        const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
+        bundlerGetInputOptions.mockResolvedValueOnce({
+          plugins: [
+            { name: 'alias-optimized-deps', resolveId: () => null } satisfies Plugin,
+            { name: 'esbuild' } satisfies Plugin,
+          ],
+        });
+
+        const result = await getInputOptions('test-entry.js', 'node');
+
+        const pluginNames = (result.plugins as Plugin[]).map(p => p.name);
+        expect(pluginNames).toContain('alias-optimized-deps');
+        expect(pluginNames).toContain('workspace-file-watcher');
+      });
+
+      it('calls addWatchFile for source and dist files in buildStart', async () => {
+        const { readdirSync } = await import('node:fs');
+        vi.mocked(readdirSync).mockImplementation(((dir: string) => {
+          if (dir === '/workspace/packages/core/src') {
+            return [
+              { name: 'index.ts', isDirectory: () => false },
+              { name: 'utils.ts', isDirectory: () => false },
+            ];
+          }
+          if (dir === '/workspace/packages/core/dist') {
+            return [{ name: 'index.js', isDirectory: () => false }];
+          }
+          throw new Error('ENOENT');
+        }) as typeof readdirSync);
+
+        const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
+        bundlerGetInputOptions.mockResolvedValueOnce({
+          plugins: [{ name: 'esbuild' } satisfies Plugin],
+        });
+
+        const result = await getInputOptions('test-entry.js', 'node');
+
+        const watcher = (result.plugins as Plugin[]).find(p => p.name === 'workspace-file-watcher');
+        expect(watcher).toBeDefined();
+
+        const addWatchFile = vi.fn();
+        (watcher!.buildStart as Function).call({ addWatchFile });
+
+        expect(addWatchFile).toHaveBeenCalledWith(expect.stringContaining('/workspace/packages/core/src/index.ts'));
+        expect(addWatchFile).toHaveBeenCalledWith(expect.stringContaining('/workspace/packages/core/src/utils.ts'));
+        expect(addWatchFile).toHaveBeenCalledWith(expect.stringContaining('/workspace/packages/core/dist/index.js'));
+        expect(addWatchFile).toHaveBeenCalledTimes(3);
+      });
+
+      it('recursively watches files in subdirectories', async () => {
+        const { readdirSync } = await import('node:fs');
+        vi.mocked(readdirSync).mockImplementation(((dir: string) => {
+          if (dir === '/workspace/packages/core/src') {
+            return [
+              { name: 'index.ts', isDirectory: () => false },
+              { name: 'utils', isDirectory: () => true },
+            ];
+          }
+          if (dir === '/workspace/packages/core/src/utils') {
+            return [{ name: 'helper.ts', isDirectory: () => false }];
+          }
+          throw new Error('ENOENT');
+        }) as typeof readdirSync);
+
+        const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
+        bundlerGetInputOptions.mockResolvedValueOnce({
+          plugins: [{ name: 'esbuild' } satisfies Plugin],
+        });
+
+        const result = await getInputOptions('test-entry.js', 'node');
+
+        const watcher = (result.plugins as Plugin[]).find(p => p.name === 'workspace-file-watcher');
+        const addWatchFile = vi.fn();
+        (watcher!.buildStart as Function).call({ addWatchFile });
+
+        expect(addWatchFile).toHaveBeenCalledWith(expect.stringContaining('/workspace/packages/core/src/index.ts'));
+        expect(addWatchFile).toHaveBeenCalledWith(
+          expect.stringContaining(join('/workspace/packages/core/src/utils', 'helper.ts')),
+        );
+      });
+
+      it('skips node_modules directories', async () => {
+        const { readdirSync } = await import('node:fs');
+        vi.mocked(readdirSync).mockImplementation(((dir: string) => {
+          if (dir === '/workspace/packages/core/src') {
+            return [
+              { name: 'index.ts', isDirectory: () => false },
+              { name: 'node_modules', isDirectory: () => true },
+            ];
+          }
+          throw new Error('ENOENT');
+        }) as typeof readdirSync);
+
+        const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
+        bundlerGetInputOptions.mockResolvedValueOnce({
+          plugins: [{ name: 'esbuild' } satisfies Plugin],
+        });
+
+        const result = await getInputOptions('test-entry.js', 'node');
+
+        const watcher = (result.plugins as Plugin[]).find(p => p.name === 'workspace-file-watcher');
+        const addWatchFile = vi.fn();
+        (watcher!.buildStart as Function).call({ addWatchFile });
+
+        expect(addWatchFile).toHaveBeenCalledTimes(1);
+        expect(addWatchFile).toHaveBeenCalledWith(expect.stringContaining('index.ts'));
+      });
+
+      it('handles missing src and dist directories gracefully', async () => {
+        const { readdirSync } = await import('node:fs');
+        vi.mocked(readdirSync).mockImplementation(() => {
+          throw new Error('ENOENT');
+        });
+
+        const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
+        bundlerGetInputOptions.mockResolvedValueOnce({
+          plugins: [{ name: 'esbuild' } satisfies Plugin],
+        });
+
+        const result = await getInputOptions('test-entry.js', 'node');
+
+        const watcher = (result.plugins as Plugin[]).find(p => p.name === 'workspace-file-watcher');
+        const addWatchFile = vi.fn();
+        (watcher!.buildStart as Function).call({ addWatchFile });
+
+        expect(addWatchFile).not.toHaveBeenCalled();
+      });
+
+      it('ignores non-source files like .json and .md', async () => {
+        const { readdirSync } = await import('node:fs');
+        vi.mocked(readdirSync).mockImplementation(((dir: string) => {
+          if (dir === '/workspace/packages/core/src') {
+            return [
+              { name: 'index.ts', isDirectory: () => false },
+              { name: 'README.md', isDirectory: () => false },
+              { name: 'config.json', isDirectory: () => false },
+              { name: 'styles.css', isDirectory: () => false },
+            ];
+          }
+          throw new Error('ENOENT');
+        }) as typeof readdirSync);
+
+        const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
+        bundlerGetInputOptions.mockResolvedValueOnce({
+          plugins: [{ name: 'esbuild' } satisfies Plugin],
+        });
+
+        const result = await getInputOptions('test-entry.js', 'node');
+
+        const watcher = (result.plugins as Plugin[]).find(p => p.name === 'workspace-file-watcher');
+        const addWatchFile = vi.fn();
+        (watcher!.buildStart as Function).call({ addWatchFile });
+
+        expect(addWatchFile).toHaveBeenCalledTimes(1);
+        expect(addWatchFile).toHaveBeenCalledWith(expect.stringContaining('index.ts'));
+      });
+
+      it('preserves other plugins in the chain', async () => {
+        const bundlerGetInputOptions = vi.mocked(await import('./bundler')).getInputOptions;
+        bundlerGetInputOptions.mockResolvedValueOnce({
+          plugins: [
+            { name: 'some-other-plugin' } satisfies Plugin,
+            { name: 'alias-optimized-deps', resolveId: () => null } satisfies Plugin,
+            { name: 'esbuild' } satisfies Plugin,
+          ],
+        });
+
+        const result = await getInputOptions('test-entry.js', 'node');
+
+        const pluginNames = (result.plugins as Plugin[]).map(p => p.name);
+        expect(pluginNames).toContain('some-other-plugin');
+        expect(pluginNames).toContain('alias-optimized-deps');
+        expect(pluginNames).toContain('esbuild');
+        expect(pluginNames).toContain('workspace-file-watcher');
       });
     });
   });

--- a/packages/deployer/src/build/watcher.ts
+++ b/packages/deployer/src/build/watcher.ts
@@ -1,4 +1,5 @@
-import { dirname, posix } from 'node:path';
+import { readdirSync } from 'node:fs';
+import { dirname, join, posix } from 'node:path';
 import { noopLogger } from '@mastra/core/logger';
 import * as pkg from 'empathic/package';
 import type { InputOptions, OutputOptions, Plugin } from 'rollup';
@@ -12,6 +13,25 @@ import { tsConfigPaths } from './plugins/tsconfig-paths';
 import type { BundlerOptions } from './types';
 import { getPackageName, slash } from './utils';
 import type { BundlerPlatform } from './utils';
+
+function collectSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === 'node_modules') continue;
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...collectSourceFiles(fullPath));
+      } else if (/\.[mc]?[jt]sx?$/.test(entry.name)) {
+        files.push(fullPath);
+      }
+    }
+  } catch {
+    // directory doesn't exist or isn't readable
+  }
+  return files;
+}
 
 export async function getInputOptions(
   entryFile: string,
@@ -88,6 +108,20 @@ export async function getInputOptions(
     inputOptions.plugins.push(aliasHono());
     // fixes imports like lodash/fp/get
     inputOptions.plugins.push(nodeModulesExtensionResolver());
+
+    inputOptions.plugins.push({
+      name: 'workspace-file-watcher',
+      buildStart() {
+        for (const [, info] of workspaceMap.entries()) {
+          for (const file of collectSourceFiles(join(info.location, 'src'))) {
+            this.addWatchFile(slash(file));
+          }
+          for (const file of collectSourceFiles(join(info.location, 'dist'))) {
+            this.addWatchFile(slash(file));
+          }
+        }
+      },
+    } satisfies Plugin);
   }
 
   return inputOptions;


### PR DESCRIPTION
## Description

During `mastra dev`, workspace packages are marked as `external: true` by the `alias-optimized-deps` plugin, which means Rollup excludes them from its module graph and never watches them for changes. This PR adds a `workspace-file-watcher` Rollup plugin that uses `this.addWatchFile()` in `buildStart` to register workspace package source and dist files with Rollup's watcher — without changing how workspace dependencies are bundled.

When a watched file changes, Rollup triggers a rebuild → the dev server restarts → picks up the updated workspace package code.

### What it watches
- `src/` — recursively watches all source files (`.ts`, `.js`, `.tsx`, `.jsx`, `.mts`, `.mjs`, `.cts`, `.cjs`) for immediate change detection
- `dist/` — watches compiled output so rebuilds also trigger when a build pipeline (e.g. turborepo) finishes compiling the workspace package
- Skips `node_modules` directories
- Handles missing `src/` or `dist/` directories gracefully

### What it does NOT change
- `alias-optimized-deps` is preserved as-is — workspace packages remain `external: true`
- No changes to bundling, tree-shaking, or module resolution behavior
- Production builds are unaffected

## Related Issue(s)

Fixes #13033
Fixes #10063

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When you're developing with multiple related packages in a monorepo and using `mastra dev`, your changes in shared packages weren't being detected. This fix adds a file watcher that tells Rollup to pay attention to changes in workspace package source files, so the dev server automatically rebuilds when you edit code—no manual restart needed.

## Summary

This PR fixes `mastra dev` to detect and respond to changes in workspace packages within monorepo setups by adding a Rollup plugin that registers workspace package files with Rollup's watch system.

### Changes Made

**New Plugin: `workspace-file-watcher`**  
A Rollup plugin added to `packages/deployer/src/build/watcher.ts` that:
- Registers source files (TypeScript/JavaScript) from each workspace package's `src/` directory for watching
- Also watches compiled output in `dist/` directories to detect when external build pipelines complete
- Recursively collects files with extensions: `.ts`, `.js`, `.tsx`, `.jsx`, `.mts`, `.mjs`, `.cts`, `.cjs`
- Skips `node_modules` directories automatically
- Gracefully handles missing `src/` or `dist/` directories without errors
- Calls Rollup's `this.addWatchFile()` API during the `buildStart` hook to register files

**Integration**  
The plugin is injected into the Rollup input options during `mastra dev` by the `getInputOptions` function, alongside existing plugins while preserving the `alias-optimized-deps` plugin and overall dependency bundling behavior.

**Behavior**  
When a developer edits a file in a workspace package:
1. Rollup detects the file change via the registered watch files
2. Rollup triggers a rebuild
3. The dev server restarts automatically
4. The updated workspace package code is picked up without manual intervention

**No Bundling Changes**  
The fix preserves all existing behavior:
- Workspace packages remain marked as `external: true` (not bundled)
- No changes to tree-shaking, module resolution, or production builds
- The `alias-optimized-deps` plugin continues to work as intended

### Testing

Comprehensive test coverage in `packages/deployer/src/build/watcher.test.ts` validates:
- Plugin is added to the Rollup plugin chain
- Source and dist files are correctly registered via `addWatchFile`
- Recursive directory traversal works for nested file structures
- `node_modules` directories are properly skipped
- Missing directories are handled gracefully
- Non-source files (.json, .md, .css) are ignored
- Other plugins in the chain are preserved

### Issues Addressed

- **#13033**: Turborepo watch on monorepo mastra setup — enables hot-reload detection without needing Turborepo workarounds
- **#10063**: File watching support in monorepos — ensures the dev server automatically picks up workspace package changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->