### PR TITLE
feat(observability): update JsonExporter to support all signals (T/M/…

### DIFF
--- a/.changeset/thin-knives-accept.md
+++ b/.changeset/thin-knives-accept.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': minor
+---
+
+Added a unified observability type system with interfaces for structured logging, metrics (counters, gauges, histograms), scores, and feedback alongside the existing tracing infrastructure.
+
+**Why?** Previously, only tracing flowed through execution contexts. Logging was ad-hoc and metrics did not exist. This change establishes the type system and context plumbing so that when concrete implementations land, logging and metrics will flow through execute callbacks automatically — no migration needed.
+
+**What changed:**
+
+- New `ObservabilityContext` interface combining tracing, logging, and metrics contexts
+- New type definitions for `LoggerContext`, `MetricsContext`, `ScoreInput`, `FeedbackInput`, and `ObservabilityEventBus`
+- `createObservabilityContext()` factory and `resolveObservabilityContext()` resolver with no-op defaults for graceful degradation
+- Migrated 60+ internal forwarding sites from `TracingContext` to `ObservabilityContext` so future signals propagate without additional changes
+- Added `loggerVNext` and `metrics` getters to the `Mastra` class

--- a/.changeset/thin-knives-accept.md
+++ b/.changeset/thin-knives-accept.md
@@ -11,5 +11,5 @@ Added a unified observability type system with interfaces for structured logging
 - New `ObservabilityContext` interface combining tracing, logging, and metrics contexts
 - New type definitions for `LoggerContext`, `MetricsContext`, `ScoreInput`, `FeedbackInput`, and `ObservabilityEventBus`
 - `createObservabilityContext()` factory and `resolveObservabilityContext()` resolver with no-op defaults for graceful degradation
-- Migrated 60+ internal forwarding sites from `TracingContext` to `ObservabilityContext` so future signals propagate without additional changes
+- Future logging and metrics signals will propagate automatically through execution contexts — no migration needed
 - Added `loggerVNext` and `metrics` getters to the `Mastra` class

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ test-output.log
 .playwright-mcp
 om-debug.log
 om-reflector-fixture.json
+.notion
+.dev/lima

--- a/packages/core/src/agent/__tests__/scorers.test.ts
+++ b/packages/core/src/agent/__tests__/scorers.test.ts
@@ -243,26 +243,28 @@ function scorersTests(version: 'v1' | 'v2') {
       }
 
       // Verify the exact call parameters
-      expect(runScorer).toHaveBeenCalledWith({
-        scorerId: 'scorer-1',
-        scorerObject: expect.objectContaining({
-          scorer: scorer1,
+      expect(runScorer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scorerId: 'scorer-1',
+          scorerObject: expect.objectContaining({
+            scorer: scorer1,
+          }),
+          runId: expect.any(String),
+          input: expect.any(Object),
+          output: expect.any(Object),
+          requestContext: expect.any(Object),
+          entity: expect.objectContaining({
+            id: 'test-agent',
+            name: 'Test Agent',
+          }),
+          source: 'LIVE',
+          entityType: 'AGENT',
+          structuredOutput: false,
+          threadId: undefined,
+          resourceId: undefined,
+          tracingContext: expect.any(Object),
         }),
-        runId: expect.any(String),
-        input: expect.any(Object),
-        output: expect.any(Object),
-        requestContext: expect.any(Object),
-        entity: expect.objectContaining({
-          id: 'test-agent',
-          name: 'Test Agent',
-        }),
-        source: 'LIVE',
-        entityType: 'AGENT',
-        structuredOutput: false,
-        threadId: undefined,
-        resourceId: undefined,
-        tracingContext: expect.any(Object),
-      });
+      );
     });
   });
 }

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -32,8 +32,15 @@ import { networkLoop } from '../loop/network';
 import type { Mastra } from '../mastra';
 import type { MastraMemory } from '../memory/memory';
 import type { MemoryConfig } from '../memory/types';
-import type { TracingContext, TracingProperties } from '../observability';
-import { EntityType, InternalSpans, SpanType, getOrCreateSpan } from '../observability';
+import type { ObservabilityContext, TracingProperties } from '../observability';
+import {
+  EntityType,
+  InternalSpans,
+  SpanType,
+  getOrCreateSpan,
+  createObservabilityContext,
+  resolveObservabilityContext,
+} from '../observability';
 import type {
   InputProcessorOrWorkflow,
   OutputProcessorOrWorkflow,
@@ -1633,16 +1640,15 @@ export class Agent<
   async generateTitleFromUserMessage({
     message,
     requestContext = new RequestContext(),
-    tracingContext,
     model,
     instructions,
+    ...observabilityContext
   }: {
     message: string | MessageInput;
     requestContext?: RequestContext;
-    tracingContext: TracingContext;
     model?: DynamicArgument<MastraModelConfig>;
     instructions?: DynamicArgument<string>;
-  }) {
+  } & ObservabilityContext) {
     // need to use text, not object output or it will error for models that don't support structured output (eg Deepseek R1)
     const llm = await this.getLLM({ requestContext, model });
 
@@ -1696,7 +1702,7 @@ export class Agent<
       const result = (llm as MastraLLMVNext).stream({
         methodType: 'generate',
         requestContext,
-        tracingContext,
+        ...observabilityContext,
         messageList,
         agentId: this.id,
         agentName: this.name,
@@ -1706,7 +1712,7 @@ export class Agent<
     } else {
       const result = await (llm as MastraLLMV1).__text({
         requestContext,
-        tracingContext,
+        ...observabilityContext,
         messages: [
           {
             role: 'system',
@@ -1735,7 +1741,7 @@ export class Agent<
   async genTitle(
     userMessage: string | MessageInput | undefined,
     requestContext: RequestContext,
-    tracingContext: TracingContext,
+    observabilityContext: ObservabilityContext,
     model?: DynamicArgument<MastraModelConfig>,
     instructions?: DynamicArgument<string>,
   ) {
@@ -1746,7 +1752,7 @@ export class Agent<
           return await this.generateTitleFromUserMessage({
             message: normMessage,
             requestContext,
-            tracingContext,
+            ...observabilityContext,
             model,
             instructions,
           });
@@ -1774,20 +1780,20 @@ export class Agent<
     resourceId,
     threadId,
     requestContext,
-    tracingContext,
     mastraProxy,
     memoryConfig,
     autoResumeSuspendedTools,
+    ...rest
   }: {
     runId?: string;
     resourceId?: string;
     threadId?: string;
     requestContext: RequestContext;
-    tracingContext?: TracingContext;
     mastraProxy?: MastraUnion;
     memoryConfig?: MemoryConfig;
     autoResumeSuspendedTools?: boolean;
-  }) {
+  } & Partial<ObservabilityContext>) {
+    const observabilityContext = resolveObservabilityContext(rest);
     let convertedMemoryTools: Record<string, CoreTool> = {};
 
     if (this._agentNetworkAppend) {
@@ -1825,7 +1831,7 @@ export class Agent<
           memory,
           agentName: this.name,
           requestContext,
-          tracingContext,
+          ...observabilityContext,
           model: await this.getModel({ requestContext }),
           tracingPolicy: this.#options?.tracingPolicy,
           requireApproval: (toolObj as any).requireApproval,
@@ -1847,18 +1853,18 @@ export class Agent<
     resourceId,
     threadId,
     requestContext,
-    tracingContext,
     mastraProxy,
     autoResumeSuspendedTools,
+    ...rest
   }: {
     runId?: string;
     resourceId?: string;
     threadId?: string;
     requestContext: RequestContext;
-    tracingContext?: TracingContext;
     mastraProxy?: MastraUnion;
     autoResumeSuspendedTools?: boolean;
-  }) {
+  } & Partial<ObservabilityContext>) {
+    const observabilityContext = resolveObservabilityContext(rest);
     let convertedWorkspaceTools: Record<string, CoreTool> = {};
 
     if (this._agentNetworkAppend) {
@@ -1891,7 +1897,7 @@ export class Agent<
           mastra: mastraProxy as MastraUnion | undefined,
           agentName: this.name,
           requestContext,
-          tracingContext,
+          ...observabilityContext,
           model: await this.getModel({ requestContext }),
           tracingPolicy: this.#options?.tracingPolicy,
           requireApproval: (toolObj as any).requireApproval,
@@ -1910,17 +1916,16 @@ export class Agent<
    */
   private async __runInputProcessors({
     requestContext,
-    tracingContext,
     messageList,
     inputProcessorOverrides,
     processorStates,
+    ...observabilityContext
   }: {
     requestContext: RequestContext;
-    tracingContext: TracingContext;
     messageList: MessageList;
     inputProcessorOverrides?: InputProcessorOrWorkflow[];
     processorStates?: Map<string, ProcessorState>;
-  }): Promise<{
+  } & ObservabilityContext): Promise<{
     messageList: MessageList;
     tripwire?: {
       reason: string;
@@ -1938,7 +1943,7 @@ export class Agent<
         processorStates,
       });
       try {
-        messageList = await runner.runInputProcessors(messageList, tracingContext, requestContext);
+        messageList = await runner.runInputProcessors(messageList, observabilityContext, requestContext);
       } catch (error) {
         if (error instanceof TripWire) {
           tripwire = {
@@ -1973,15 +1978,14 @@ export class Agent<
    */
   private async __runOutputProcessors({
     requestContext,
-    tracingContext,
     messageList,
     outputProcessorOverrides,
+    ...observabilityContext
   }: {
     requestContext: RequestContext;
-    tracingContext: TracingContext;
     messageList: MessageList;
     outputProcessorOverrides?: OutputProcessorOrWorkflow[];
-  }): Promise<{
+  } & ObservabilityContext): Promise<{
     messageList: MessageList;
     tripwire?: {
       reason: string;
@@ -1999,7 +2003,7 @@ export class Agent<
       });
 
       try {
-        messageList = await runner.runOutputProcessors(messageList, tracingContext, requestContext);
+        messageList = await runner.runOutputProcessors(messageList, observabilityContext, requestContext);
       } catch (e) {
         if (e instanceof TripWire) {
           tripwire = {
@@ -2067,20 +2071,20 @@ export class Agent<
     resourceId,
     threadId,
     requestContext,
-    tracingContext,
     mastraProxy,
     outputWriter,
     autoResumeSuspendedTools,
+    ...rest
   }: {
     runId?: string;
     resourceId?: string;
     threadId?: string;
     requestContext: RequestContext;
-    tracingContext?: TracingContext;
     mastraProxy?: MastraUnion;
     outputWriter?: OutputWriter;
     autoResumeSuspendedTools?: boolean;
-  }) {
+  } & Partial<ObservabilityContext>) {
+    const observabilityContext = resolveObservabilityContext(rest);
     let toolsForRequest: Record<string, CoreTool> = {};
 
     this.logger.debug(`[Agents:${this.name}] - Assembling assigned tools`, { runId, threadId, resourceId });
@@ -2108,7 +2112,7 @@ export class Agent<
           memory,
           agentName: this.name,
           requestContext,
-          tracingContext,
+          ...observabilityContext,
           model: await this.getModel({ requestContext }),
           outputWriter,
           tracingPolicy: this.#options?.tracingPolicy,
@@ -2139,19 +2143,19 @@ export class Agent<
     resourceId,
     toolsets,
     requestContext,
-    tracingContext,
     mastraProxy,
     autoResumeSuspendedTools,
+    ...rest
   }: {
     runId?: string;
     threadId?: string;
     resourceId?: string;
     toolsets: ToolsetsInput;
     requestContext: RequestContext;
-    tracingContext?: TracingContext;
     mastraProxy?: MastraUnion;
     autoResumeSuspendedTools?: boolean;
-  }) {
+  } & Partial<ObservabilityContext>) {
+    const observabilityContext = resolveObservabilityContext(rest);
     let toolsForRequest: Record<string, CoreTool> = {};
 
     const memory = await this.getMemory({ requestContext });
@@ -2174,7 +2178,7 @@ export class Agent<
             memory,
             agentName: this.name,
             requestContext,
-            tracingContext,
+            ...observabilityContext,
             model: await this.getModel({ requestContext }),
             tracingPolicy: this.#options?.tracingPolicy,
             requireApproval: (toolObj as any).requireApproval,
@@ -2197,20 +2201,20 @@ export class Agent<
     threadId,
     resourceId,
     requestContext,
-    tracingContext,
     mastraProxy,
     clientTools,
     autoResumeSuspendedTools,
+    ...rest
   }: {
     runId?: string;
     threadId?: string;
     resourceId?: string;
     requestContext: RequestContext;
-    tracingContext?: TracingContext;
     mastraProxy?: MastraUnion;
     clientTools?: ToolsInput;
     autoResumeSuspendedTools?: boolean;
-  }) {
+  } & Partial<ObservabilityContext>) {
+    const observabilityContext = resolveObservabilityContext(rest);
     let toolsForRequest: Record<string, CoreTool> = {};
     const memory = await this.getMemory({ requestContext });
     // Convert client tools
@@ -2231,7 +2235,7 @@ export class Agent<
           memory,
           agentName: this.name,
           requestContext,
-          tracingContext,
+          ...observabilityContext,
           model: await this.getModel({ requestContext }),
           tracingPolicy: this.#options?.tracingPolicy,
           requireApproval: (tool as any).requireApproval,
@@ -2253,18 +2257,18 @@ export class Agent<
     threadId,
     resourceId,
     requestContext,
-    tracingContext,
     methodType,
     autoResumeSuspendedTools,
+    ...rest
   }: {
     runId?: string;
     threadId?: string;
     resourceId?: string;
     requestContext: RequestContext;
-    tracingContext?: TracingContext;
     methodType: AgentMethodType;
     autoResumeSuspendedTools?: boolean;
-  }) {
+  } & Partial<ObservabilityContext>) {
+    const observabilityContext = resolveObservabilityContext(rest);
     const convertedAgentTools: Record<string, CoreTool> = {};
     const agents = await this.listAgents({ requestContext });
 
@@ -2351,7 +2355,7 @@ export class Agent<
                   ? await agent.resumeGenerate(resumeData, {
                       runId: suspendedToolRunId,
                       requestContext,
-                      tracingContext: context?.tracingContext,
+                      ...resolveObservabilityContext(context ?? {}),
                       ...(inputData.instructions && { instructions: inputData.instructions }),
                       ...(inputData.maxSteps && { maxSteps: inputData.maxSteps }),
                       ...(resourceId && threadId
@@ -2360,7 +2364,7 @@ export class Agent<
                     })
                   : await agent.generate(inputData.prompt, {
                       requestContext,
-                      tracingContext: context?.tracingContext,
+                      ...resolveObservabilityContext(context ?? {}),
                       ...(inputData.instructions && { instructions: inputData.instructions }),
                       ...(inputData.maxSteps && { maxSteps: inputData.maxSteps }),
                       ...(resourceId && threadId
@@ -2385,7 +2389,7 @@ export class Agent<
               } else if (methodType === 'generate' && modelVersion === 'v1') {
                 const generateResult = await agent.generateLegacy(inputData.prompt, {
                   requestContext,
-                  tracingContext: context?.tracingContext,
+                  ...resolveObservabilityContext(context ?? {}),
                 });
                 result = { text: generateResult.text };
               } else if (
@@ -2400,7 +2404,7 @@ export class Agent<
                   ? await agent.resumeStream(resumeData, {
                       runId: suspendedToolRunId,
                       requestContext,
-                      tracingContext: context?.tracingContext,
+                      ...resolveObservabilityContext(context ?? {}),
                       ...(inputData.instructions && { instructions: inputData.instructions }),
                       ...(inputData.maxSteps && { maxSteps: inputData.maxSteps }),
                       ...(resourceId && threadId
@@ -2414,7 +2418,7 @@ export class Agent<
                     })
                   : await agent.stream(inputData.prompt, {
                       requestContext,
-                      tracingContext: context?.tracingContext,
+                      ...resolveObservabilityContext(context ?? {}),
                       ...(inputData.instructions && { instructions: inputData.instructions }),
                       ...(inputData.maxSteps && { maxSteps: inputData.maxSteps }),
                       ...(resourceId && threadId
@@ -2476,7 +2480,7 @@ export class Agent<
               } else {
                 const streamResult = await agent.streamLegacy(inputData.prompt, {
                   requestContext,
-                  tracingContext: context?.tracingContext,
+                  ...resolveObservabilityContext(context ?? {}),
                 });
 
                 let fullText = '';
@@ -2535,7 +2539,7 @@ export class Agent<
           agentName: this.name,
           requestContext,
           model: await this.getModel({ requestContext }),
-          tracingContext,
+          ...observabilityContext,
           tracingPolicy: this.#options?.tracingPolicy,
         };
 
@@ -2561,18 +2565,18 @@ export class Agent<
     threadId,
     resourceId,
     requestContext,
-    tracingContext,
     methodType,
     autoResumeSuspendedTools,
+    ...rest
   }: {
     runId?: string;
     threadId?: string;
     resourceId?: string;
     requestContext: RequestContext;
-    tracingContext?: TracingContext;
     methodType: AgentMethodType;
     autoResumeSuspendedTools?: boolean;
-  }) {
+  } & Partial<ObservabilityContext>) {
+    const observabilityContext = resolveObservabilityContext(rest);
     const convertedWorkflowTools: Record<string, CoreTool> = {};
     const workflows = await this.listWorkflows({ requestContext });
     if (Object.keys(workflows).length > 0) {
@@ -2625,13 +2629,13 @@ export class Agent<
                   result = await run.resume({
                     resumeData,
                     requestContext,
-                    tracingContext: context?.tracingContext,
+                    ...resolveObservabilityContext(context ?? {}),
                   });
                 } else {
                   result = await run.start({
                     inputData: workflowInputData,
                     requestContext,
-                    tracingContext: context?.tracingContext,
+                    ...resolveObservabilityContext(context ?? {}),
                     ...(initialState && { initialState }),
                   });
                 }
@@ -2639,7 +2643,7 @@ export class Agent<
                 const streamResult = run.streamLegacy({
                   inputData: workflowInputData,
                   requestContext,
-                  tracingContext: context?.tracingContext,
+                  ...resolveObservabilityContext(context ?? {}),
                 });
 
                 if (context?.writer) {
@@ -2656,12 +2660,12 @@ export class Agent<
                   ? run.resumeStream({
                       resumeData,
                       requestContext,
-                      tracingContext: context?.tracingContext,
+                      ...resolveObservabilityContext(context ?? {}),
                     })
                   : run.stream({
                       inputData: workflowInputData,
                       requestContext,
-                      tracingContext: context?.tracingContext,
+                      ...resolveObservabilityContext(context ?? {}),
                       ...(initialState && { initialState }),
                     });
 
@@ -2746,7 +2750,7 @@ export class Agent<
           agentName: this.name,
           requestContext,
           model: await this.getModel({ requestContext }),
-          tracingContext,
+          ...observabilityContext,
           tracingPolicy: this.#options?.tracingPolicy,
         };
 
@@ -2773,11 +2777,11 @@ export class Agent<
     resourceId,
     runId,
     requestContext,
-    tracingContext,
     outputWriter,
     methodType,
     memoryConfig,
     autoResumeSuspendedTools,
+    ...rest
   }: {
     toolsets?: ToolsetsInput;
     clientTools?: ToolsInput;
@@ -2785,12 +2789,12 @@ export class Agent<
     resourceId?: string;
     runId?: string;
     requestContext: RequestContext;
-    tracingContext?: TracingContext;
     outputWriter?: OutputWriter;
     methodType: AgentMethodType;
     memoryConfig?: MemoryConfig;
     autoResumeSuspendedTools?: boolean;
-  }): Promise<Record<string, CoreTool>> {
+  } & Partial<ObservabilityContext>): Promise<Record<string, CoreTool>> {
+    const observabilityContext = resolveObservabilityContext(rest);
     let mastraProxy = undefined;
     const logger = this.logger;
 
@@ -2803,7 +2807,7 @@ export class Agent<
       resourceId,
       threadId,
       requestContext,
-      tracingContext,
+      ...observabilityContext,
       mastraProxy,
       outputWriter,
       autoResumeSuspendedTools,
@@ -2814,7 +2818,7 @@ export class Agent<
       resourceId,
       threadId,
       requestContext,
-      tracingContext,
+      ...observabilityContext,
       mastraProxy,
       memoryConfig,
       autoResumeSuspendedTools,
@@ -2825,7 +2829,7 @@ export class Agent<
       resourceId,
       threadId,
       requestContext,
-      tracingContext,
+      ...observabilityContext,
       mastraProxy,
       toolsets: toolsets!,
       autoResumeSuspendedTools,
@@ -2836,7 +2840,7 @@ export class Agent<
       resourceId,
       threadId,
       requestContext,
-      tracingContext,
+      ...observabilityContext,
       mastraProxy,
       clientTools: clientTools!,
       autoResumeSuspendedTools,
@@ -2848,7 +2852,7 @@ export class Agent<
       threadId,
       requestContext,
       methodType,
-      tracingContext,
+      ...observabilityContext,
       autoResumeSuspendedTools,
     });
 
@@ -2858,7 +2862,7 @@ export class Agent<
       threadId,
       requestContext,
       methodType,
-      tracingContext,
+      ...observabilityContext,
       autoResumeSuspendedTools,
     });
 
@@ -2867,7 +2871,7 @@ export class Agent<
       resourceId,
       threadId,
       requestContext,
-      tracingContext,
+      ...observabilityContext,
       mastraProxy,
       autoResumeSuspendedTools,
     });
@@ -2964,7 +2968,7 @@ export class Agent<
     overrideScorers,
     threadId,
     resourceId,
-    tracingContext,
+    ...observabilityContext
   }: {
     messageList: MessageList;
     runId: string;
@@ -2975,8 +2979,7 @@ export class Agent<
       | Record<string, { scorer: MastraScorer['name']; sampling?: ScoringSamplingConfig }>;
     threadId?: string;
     resourceId?: string;
-    tracingContext: TracingContext;
-  }) {
+  } & ObservabilityContext) {
     let scorers: Record<string, { scorer: MastraScorer; sampling?: ScoringSamplingConfig }> = {};
     try {
       scorers = overrideScorers
@@ -3014,7 +3017,7 @@ export class Agent<
           structuredOutput: !!structuredOutput,
           threadId,
           resourceId,
-          tracingContext,
+          ...observabilityContext,
         });
       }
     }
@@ -3352,7 +3355,8 @@ export class Agent<
     });
 
     const run = await executionWorkflow.createRun();
-    const result = await run.start({ tracingContext: { currentSpan: agentSpan } });
+    const observabilityContext = createObservabilityContext({ currentSpan: agentSpan });
+    const result = await run.start({ ...observabilityContext });
 
     return result;
   }
@@ -3456,10 +3460,11 @@ export class Agent<
         if (shouldGenerate && !threadExists) {
           const userMessage = this.getMostRecentUserMessage(messageList.get.all.ui());
           if (userMessage) {
+            const observabilityContext = createObservabilityContext({ currentSpan: agentSpan });
             const title = await this.genTitle(
               userMessage,
               requestContext,
-              { currentSpan: agentSpan },
+              observabilityContext,
               titleModel,
               titleInstructions,
             );
@@ -3523,7 +3528,7 @@ export class Agent<
       requestContext,
       structuredOutput,
       overrideScorers,
-      tracingContext: { currentSpan: agentSpan },
+      ...createObservabilityContext({ currentSpan: agentSpan }),
     });
 
     agentSpan?.end({

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -5,7 +5,7 @@ import type { ProviderOptions } from '../llm/model/provider-options';
 import type { MastraLanguageModel } from '../llm/model/shared.types';
 import type { CompletionConfig } from '../loop/network/validation';
 import type { LoopConfig, LoopOptions, PrepareStepFunction } from '../loop/types';
-import type { TracingContext, TracingOptions } from '../observability';
+import type { ObservabilityContext, TracingOptions } from '../observability';
 import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '../processors';
 import type { RequestContext } from '../request-context';
 import type { OutputWriter } from '../workflows/types';
@@ -59,9 +59,6 @@ export type NetworkOptions<OUTPUT = undefined> = {
 
   /** Maximum number of iterations to run */
   maxSteps?: number;
-
-  /** Tracing context for span hierarchy and metadata */
-  tracingContext?: TracingContext;
 
   /** Model-specific settings like temperature, maxTokens, topP, etc. */
   modelSettings?: LoopOptions['modelSettings'];
@@ -141,7 +138,7 @@ export type NetworkOptions<OUTPUT = undefined> = {
    * Signal to abort the streaming operation
    */
   abortSignal?: LoopConfig<OUTPUT>['abortSignal'];
-};
+} & Partial<ObservabilityContext>;
 
 /**
  * @deprecated Use NetworkOptions instead
@@ -222,8 +219,6 @@ export type AgentExecutionOptionsBase<OUTPUT> = {
   scorers?: MastraScorers | Record<string, { scorer: MastraScorer['name']; sampling?: ScoringSamplingConfig }>;
   /** Whether to return detailed scoring data in the response */
   returnScorerData?: boolean;
-  /** tracing context for span hierarchy and metadata */
-  tracingContext?: TracingContext;
   /** tracing options for starting new traces */
   tracingOptions?: TracingOptions;
 
@@ -241,7 +236,7 @@ export type AgentExecutionOptionsBase<OUTPUT> = {
 
   /** Whether to include raw chunks in the stream output (not available on all model providers) */
   includeRawChunks?: boolean;
-};
+} & Partial<ObservabilityContext>;
 
 export type AgentExecutionOptions<OUTPUT = unknown> = AgentExecutionOptionsBase<OUTPUT> &
   (OUTPUT extends {} ? { structuredOutput: StructuredOutputOptions<OUTPUT> } : { structuredOutput?: never });

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -25,7 +25,7 @@ import type { IMastraLogger } from '../logger';
 import type { Mastra } from '../mastra';
 import type { MastraMemory } from '../memory/memory';
 import type { MemoryConfig, StorageThreadType } from '../memory/types';
-import type { Span, SpanType, TracingContext, TracingOptions, TracingPolicy } from '../observability';
+import type { ObservabilityContext, Span, SpanType, TracingOptions, TracingPolicy } from '../observability';
 import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '../processors/index';
 import type { RequestContext } from '../request-context';
 import type { OutputSchema } from '../stream';
@@ -331,34 +331,33 @@ export type AgentGenerateOptions<
    * If not set, no retries are performed.
    */
   maxProcessorRetries?: number;
-  /** tracing context for span hierarchy and metadata */
-  tracingContext?: TracingContext;
   /** tracing options for starting new traces */
   tracingOptions?: TracingOptions;
   /** Provider-specific options for supported AI SDK packages (Anthropic, Google, OpenAI, xAI) */
   providerOptions?: ProviderOptions;
-} & (
-  | {
-      /**
-       * @deprecated Use the `memory` property instead for all memory-related options.
-       */
-      resourceId?: undefined;
-      /**
-       * @deprecated Use the `memory` property instead for all memory-related options.
-       */
-      threadId?: undefined;
-    }
-  | {
-      /**
-       * @deprecated Use the `memory` property instead for all memory-related options.
-       */
-      resourceId: string;
-      /**
-       * @deprecated Use the `memory` property instead for all memory-related options.
-       */
-      threadId: string;
-    }
-) &
+} & Partial<ObservabilityContext> &
+  (
+    | {
+        /**
+         * @deprecated Use the `memory` property instead for all memory-related options.
+         */
+        resourceId?: undefined;
+        /**
+         * @deprecated Use the `memory` property instead for all memory-related options.
+         */
+        threadId?: undefined;
+      }
+    | {
+        /**
+         * @deprecated Use the `memory` property instead for all memory-related options.
+         */
+        resourceId: string;
+        /**
+         * @deprecated Use the `memory` property instead for all memory-related options.
+         */
+        threadId: string;
+      }
+  ) &
   (OUTPUT extends undefined ? DefaultLLMTextOptions : DefaultLLMTextObjectOptions);
 
 /**
@@ -408,36 +407,35 @@ export type AgentStreamOptions<
   savePerStep?: boolean;
   /** Input processors to use for this generation call (overrides agent's default) */
   inputProcessors?: InputProcessorOrWorkflow[];
-  /** tracing context for span hierarchy and metadata */
-  tracingContext?: TracingContext;
   /** tracing options for starting new traces */
   tracingOptions?: TracingOptions;
   /** Scorers to use for this generation */
   scorers?: MastraScorers | Record<string, { scorer: MastraScorer['name']; sampling?: ScoringSamplingConfig }>;
   /** Provider-specific options for supported AI SDK packages (Anthropic, Google, OpenAI, xAI) */
   providerOptions?: ProviderOptions;
-} & (
-  | {
-      /**
-       * @deprecated Use the `memory` property instead for all memory-related options.
-       */
-      resourceId?: undefined;
-      /**
-       * @deprecated Use the `memory` property instead for all memory-related options.
-       */
-      threadId?: undefined;
-    }
-  | {
-      /**
-       * @deprecated Use the `memory` property instead for all memory-related options.
-       */
-      resourceId: string;
-      /**
-       * @deprecated Use the `memory` property instead for all memory-related options.
-       */
-      threadId: string;
-    }
-) &
+} & Partial<ObservabilityContext> &
+  (
+    | {
+        /**
+         * @deprecated Use the `memory` property instead for all memory-related options.
+         */
+        resourceId?: undefined;
+        /**
+         * @deprecated Use the `memory` property instead for all memory-related options.
+         */
+        threadId?: undefined;
+      }
+    | {
+        /**
+         * @deprecated Use the `memory` property instead for all memory-related options.
+         */
+        resourceId: string;
+        /**
+         * @deprecated Use the `memory` property instead for all memory-related options.
+         */
+        threadId: string;
+      }
+  ) &
   (OUTPUT extends undefined ? DefaultLLMStreamOptions : DefaultLLMStreamObjectOptions);
 
 export type AgentModelManagerConfig = ModelManagerModelConfig & { enabled: boolean };

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -4,6 +4,7 @@ import { getModelMethodFromAgentMethod } from '../../../llm/model/model-method-f
 import type { ModelLoopStreamArgs, ModelMethodType } from '../../../llm/model/model.loop.types';
 import type { MastraMemory } from '../../../memory/memory';
 import type { MemoryConfig } from '../../../memory/types';
+import { resolveObservabilityContext, createObservabilityContext } from '../../../observability';
 import type { Span, SpanType } from '../../../observability';
 import { StructuredOutputProcessor } from '../../../processors';
 import type { RequestContext } from '../../../request-context';
@@ -51,7 +52,7 @@ export function createMapResultsStep<OUTPUT = undefined>({
   },
   ModelLoopStreamArgs<any, OUTPUT>
 >['execute'] {
-  return async ({ inputData, bail, tracingContext }) => {
+  return async ({ inputData, bail, ...observabilityContext }) => {
     const toolsData = inputData['prepare-tools-step'];
     const memoryData = inputData['prepare-memory-step'];
 
@@ -113,7 +114,7 @@ export function createMapResultsStep<OUTPUT = undefined>({
       const modelOutput = await getModelOutputForTripwire<OUTPUT>({
         tripwire: memoryData.tripwire!,
         runId,
-        tracingContext,
+        ...resolveObservabilityContext(observabilityContext),
         options: options,
         model: agentModel,
         messageList: memoryData.messageList,
@@ -162,7 +163,7 @@ export function createMapResultsStep<OUTPUT = undefined>({
       methodType: modelMethodType,
       agentId,
       requestContext: result.requestContext!,
-      tracingContext: { currentSpan: agentSpan },
+      ...createObservabilityContext({ currentSpan: agentSpan }),
       runId,
       toolChoice: result.toolChoice,
       tools: result.tools,
@@ -203,7 +204,7 @@ export function createMapResultsStep<OUTPUT = undefined>({
           try {
             const outputText = messageList.get.all
               .core()
-              .map(m => m.content)
+              .map((m: { content: unknown }) => m.content)
               .join('\n');
 
             await capabilities.executeOnFinish({

--- a/packages/core/src/agent/workflows/prepare-stream/prepare-tools-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/prepare-tools-step.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { MastraMemory } from '../../../memory/memory';
 import type { StorageThreadType } from '../../../memory/types';
 import type { Span, SpanType } from '../../../observability';
+import { createObservabilityContext } from '../../../observability';
 import type { RequestContext } from '../../../request-context';
 import { createStep } from '../../../workflows';
 import type { InnerAgentExecutionOptions } from '../../agent.types';
@@ -63,7 +64,7 @@ export function createPrepareToolsStep<OUTPUT = undefined>({
         resourceId,
         runId,
         requestContext,
-        tracingContext: { currentSpan: agentSpan },
+        ...createObservabilityContext({ currentSpan: agentSpan }),
         outputWriter: options.outputWriter,
         methodType,
         memoryConfig: options.memory?.options,

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -6,8 +6,8 @@ import { ErrorCategory, ErrorDomain, MastraError } from '../error';
 import { resolveModelConfig } from '../llm/model/resolve-model';
 import type { MastraModelConfig } from '../llm/model/shared.types';
 import type { Mastra } from '../mastra';
-import type { TracingContext } from '../observability';
-import { InternalSpans } from '../observability';
+import { InternalSpans, resolveObservabilityContext } from '../observability';
+import type { ObservabilityContext } from '../observability';
 import { createWorkflow, createStep } from '../workflows';
 import type { ScoringSamplingConfig, ScorerRunInputForAgent, ScorerRunOutputForAgent } from './types';
 
@@ -46,13 +46,12 @@ interface ScorerConfig<TID extends string, TInput = any, TRunOutput = any> {
 }
 
 // Standardized input type for all pipelines
-interface ScorerRun<TInput = any, TOutput = any> {
+interface ScorerRun<TInput = any, TOutput = any> extends Partial<ObservabilityContext> {
   runId?: string;
   input?: TInput;
   output: TOutput;
   groundTruth?: any;
   requestContext?: Record<string, any>;
-  tracingContext?: TracingContext;
 }
 
 // Prompt object definition with conditional typing
@@ -408,7 +407,7 @@ class MastraScorer<
       });
     }
 
-    const { tracingContext } = input;
+    const observabilityContext = resolveObservabilityContext(input);
 
     let runId = input.runId;
     if (!runId) {
@@ -423,7 +422,7 @@ class MastraScorer<
       inputData: {
         run,
       },
-      tracingContext,
+      ...observabilityContext,
     });
 
     if (workflowResult.status === 'failed') {
@@ -476,7 +475,8 @@ class MastraScorer<
         description: `Scorer step: ${scorerStep.name}`,
         inputSchema: z.any(),
         outputSchema: z.any(),
-        execute: async ({ inputData, getInitData, tracingContext }) => {
+        execute: async ({ inputData, getInitData, ...rest }) => {
+          const observabilityContext = resolveObservabilityContext(rest);
           const { accumulatedResults = {}, generatedPrompts = {} } = inputData;
           const { run } = getInitData<{ run: ScorerRun<TInput, TRunOutput> }>();
 
@@ -485,7 +485,7 @@ class MastraScorer<
           let stepResult;
           let newGeneratedPrompts = generatedPrompts;
           if (scorerStep.isPromptObject) {
-            const { result, prompt } = await this.executePromptStep(scorerStep, tracingContext, context);
+            const { result, prompt } = await this.executePromptStep(scorerStep, observabilityContext, context);
             stepResult = result;
             newGeneratedPrompts = {
               ...generatedPrompts,
@@ -560,7 +560,11 @@ class MastraScorer<
     return await scorerStep.definition(context);
   }
 
-  private async executePromptStep(scorerStep: ScorerStepDefinition, tracingContext: TracingContext, context: any) {
+  private async executePromptStep(
+    scorerStep: ScorerStepDefinition,
+    observabilityContext: ObservabilityContext,
+    context: any,
+  ) {
     const originalStep = this.originalPromptObjects.get(scorerStep.name);
     if (!originalStep) {
       throw new Error(`Step "${scorerStep.name}" is not a prompt object`);
@@ -604,12 +608,12 @@ class MastraScorer<
           structuredOutput: {
             schema,
           },
-          tracingContext,
+          ...observabilityContext,
         });
       } else {
         result = await judge.generateLegacy(prompt, {
           output: schema,
-          tracingContext,
+          ...observabilityContext,
         });
       }
       return { result: result.object.score, prompt };
@@ -618,9 +622,9 @@ class MastraScorer<
     } else if (scorerStep.name === 'generateReason') {
       let result;
       if (isSupportedLanguageModel(resolvedModel)) {
-        result = await judge.generate(prompt, { tracingContext });
+        result = await judge.generate(prompt, { ...observabilityContext });
       } else {
-        result = await judge.generateLegacy(prompt, { tracingContext });
+        result = await judge.generateLegacy(prompt, { ...observabilityContext });
       }
       return { result: result.text, prompt };
     } else {
@@ -631,12 +635,12 @@ class MastraScorer<
           structuredOutput: {
             schema: promptStep.outputSchema,
           },
-          tracingContext,
+          ...observabilityContext,
         });
       } else {
         result = await judge.generateLegacy(prompt, {
           output: promptStep.outputSchema,
-          tracingContext,
+          ...observabilityContext,
         });
       }
       return { result: result.object, prompt };

--- a/packages/core/src/evals/hooks.ts
+++ b/packages/core/src/evals/hooks.ts
@@ -1,5 +1,5 @@
 import { AvailableHooks, executeHook } from '../hooks';
-import type { TracingContext } from '../observability';
+import type { ObservabilityContext } from '../observability';
 import type { MastraScorerEntry } from './base';
 import type { ScoringEntityType, ScoringHookInput, ScoringSource } from './types';
 
@@ -16,7 +16,7 @@ export function runScorer({
   entityType,
   threadId,
   resourceId,
-  tracingContext,
+  ...observabilityContext
 }: {
   scorerId: string;
   scorerObject: MastraScorerEntry;
@@ -30,8 +30,7 @@ export function runScorer({
   entityType: ScoringEntityType;
   threadId?: string;
   resourceId?: string;
-  tracingContext?: TracingContext;
-}) {
+} & ObservabilityContext) {
   let shouldExecute = false;
 
   if (!scorerObject?.sampling || scorerObject?.sampling?.type === 'none') {
@@ -68,7 +67,7 @@ export function runScorer({
     entityType,
     threadId,
     resourceId,
-    tracingContext,
+    ...observabilityContext,
   };
 
   executeHook(AvailableHooks.ON_SCORER_RUN, payload);

--- a/packages/core/src/evals/run/index.test.ts
+++ b/packages/core/src/evals/run/index.test.ts
@@ -177,11 +177,14 @@ describe('runEvals', () => {
       });
 
       expect(mockAgent.generateLegacy).toHaveBeenCalledTimes(1);
-      expect(mockAgent.generateLegacy).toHaveBeenCalledWith('test input', {
-        scorers: {},
-        returnScorerData: true,
-        requestContext: undefined,
-      });
+      expect(mockAgent.generateLegacy).toHaveBeenCalledWith(
+        'test input',
+        expect.objectContaining({
+          scorers: {},
+          returnScorerData: true,
+          requestContext: undefined,
+        }),
+      );
     });
 
     it('should pass requestContext when provided', async () => {
@@ -200,11 +203,14 @@ describe('runEvals', () => {
       });
 
       expect(mockAgent.generateLegacy).toHaveBeenCalledTimes(1);
-      expect(mockAgent.generateLegacy).toHaveBeenCalledWith('test input', {
-        scorers: {},
-        returnScorerData: true,
-        requestContext,
-      });
+      expect(mockAgent.generateLegacy).toHaveBeenCalledWith(
+        'test input',
+        expect.objectContaining({
+          scorers: {},
+          returnScorerData: true,
+          requestContext,
+        }),
+      );
     });
   });
 
@@ -226,11 +232,13 @@ describe('runEvals', () => {
         target: mockAgent,
       });
 
-      expect(mockScorers[0].run).toHaveBeenCalledWith({
-        input: mockResponse.scoringData.input,
-        output: mockResponse.scoringData.output,
-        groundTruth: 'truth',
-      });
+      expect(mockScorers[0].run).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: mockResponse.scoringData.input,
+          output: mockResponse.scoringData.output,
+          groundTruth: 'truth',
+        }),
+      );
     });
 
     it('should handle missing scoringData gracefully', async () => {
@@ -242,11 +250,13 @@ describe('runEvals', () => {
         target: mockAgent,
       });
 
-      expect(mockScorers[0].run).toHaveBeenCalledWith({
-        input: undefined,
-        output: undefined,
-        groundTruth: 'truth',
-      });
+      expect(mockScorers[0].run).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: undefined,
+          output: undefined,
+          groundTruth: 'truth',
+        }),
+      );
     });
   });
 
@@ -422,12 +432,14 @@ describe('runEvals', () => {
       });
 
       // Verify the scorer was called with step-specific data
-      expect(scorerSpy).toHaveBeenCalledWith({
-        input: { input: 'Test input' }, // step payload
-        output: { output: 'Processed: Test input' }, // step output
-        groundTruth: 'Expected',
-        requestContext: undefined,
-      });
+      expect(scorerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: { input: 'Test input' }, // step payload
+          output: { output: 'Processed: Test input' }, // step output
+          groundTruth: 'Expected',
+          requestContext: undefined,
+        }),
+      );
     });
 
     it('should capture step scorer results in experiment output', async () => {

--- a/packages/core/src/evals/scoreTraces/scoreTracesWorkflow.ts
+++ b/packages/core/src/evals/scoreTraces/scoreTracesWorkflow.ts
@@ -1,8 +1,8 @@
 import pMap from 'p-map';
 import z from 'zod';
 import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
-import { InternalSpans } from '../../observability';
-import type { TracingContext } from '../../observability';
+import { InternalSpans, resolveObservabilityContext } from '../../observability';
+import type { ObservabilityContext } from '../../observability';
 import type { SpanRecord, TraceRecord, MastraStorage } from '../../storage';
 import { createStep, createWorkflow } from '../../workflows/evented';
 import type { MastraScorer, ScorerRun } from '../base';
@@ -22,7 +22,8 @@ const getTraceStep = createStep({
     scorerId: z.string(),
   }),
   outputSchema: z.any(),
-  execute: async ({ inputData, tracingContext, mastra }) => {
+  execute: async ({ inputData, mastra, ...rest }) => {
+    const observabilityContext = resolveObservabilityContext(rest);
     const logger = mastra.getLogger();
     if (!logger) {
       console.warn(
@@ -71,7 +72,7 @@ const getTraceStep = createStep({
       inputData.targets,
       async target => {
         try {
-          await runScorerOnTarget({ storage, scorer, target, tracingContext });
+          await runScorerOnTarget({ storage, scorer, target, ...observabilityContext });
         } catch (error) {
           const mastraError = new MastraError(
             {
@@ -99,13 +100,12 @@ export async function runScorerOnTarget({
   storage,
   scorer,
   target,
-  tracingContext,
+  ...observabilityContext
 }: {
   storage: MastraStorage;
   scorer: MastraScorer;
   target: { traceId: string; spanId?: string };
-  tracingContext: TracingContext;
-}) {
+} & Partial<ObservabilityContext>) {
   // TODO: add storage api to get a single span
   const observabilityStore = await storage.getStore('observability');
   if (!observabilityStore) {
@@ -136,7 +136,7 @@ export async function runScorerOnTarget({
 
   const scorerRun = buildScorerRun({
     scorerType: scorer.type === 'agent' ? 'agent' : undefined,
-    tracingContext,
+    ...observabilityContext,
     trace,
     targetSpan: span,
   });
@@ -179,28 +179,19 @@ async function validateAndSaveScore({ storage, scorerResult }: { storage: Mastra
 
 function buildScorerRun({
   scorerType,
-  tracingContext,
   trace,
   targetSpan,
+  ...observabilityContext
 }: {
   scorerType?: string;
-  tracingContext: TracingContext;
   trace: TraceRecord;
   targetSpan: SpanRecord;
-}) {
-  let runPayload: ScorerRun;
+} & Partial<ObservabilityContext>): ScorerRun {
   if (scorerType === 'agent') {
     const { input, output } = transformTraceToScorerInputAndOutput(trace);
-    runPayload = {
-      input,
-      output,
-    };
-  } else {
-    runPayload = { input: targetSpan.input, output: targetSpan.output };
+    return { input, output, ...observabilityContext };
   }
-
-  runPayload.tracingContext = tracingContext;
-  return runPayload;
+  return { input: targetSpan.input, output: targetSpan.output, ...observabilityContext };
 }
 
 async function attachScoreToSpan({

--- a/packages/core/src/evals/types.ts
+++ b/packages/core/src/evals/types.ts
@@ -2,7 +2,7 @@ import type { CoreMessage, CoreSystemMessage } from '@internal/ai-sdk-v4';
 import { z } from 'zod';
 import type { MastraDBMessage } from '../agent';
 import { SpanType } from '../observability';
-import type { TracingContext } from '../observability';
+import type { ObservabilityContext } from '../observability';
 import { dbTimestamps, paginationInfoSchema } from '../storage/domains/shared';
 
 // ============================================================================
@@ -58,13 +58,11 @@ export const scoringInputSchema = z.object({
   output: z.unknown(),
   additionalContext: optionalRecordSchema,
   requestContext: optionalRecordSchema,
-  // Note: tracingContext is not serializable, so we don't include it in the schema
+  // Note: observabilityContext is not serializable, so we don't include it in the schema
   // It's added at runtime when needed
 });
 
-export type ScoringInput = z.infer<typeof scoringInputSchema> & {
-  tracingContext?: TracingContext;
-};
+export type ScoringInput = z.infer<typeof scoringInputSchema> & Partial<ObservabilityContext>;
 
 // ============================================================================
 // Scoring Hook Input
@@ -86,12 +84,10 @@ export const scoringHookInputSchema = z.object({
   spanId: z.string().optional(),
   resourceId: z.string().optional(),
   threadId: z.string().optional(),
-  // Note: tracingContext is not serializable, so we don't include it in the schema
+  // Note: observabilityContext is not serializable, so we don't include it in the schema
 });
 
-export type ScoringHookInput = z.infer<typeof scoringHookInputSchema> & {
-  tracingContext?: TracingContext;
-};
+export type ScoringHookInput = z.infer<typeof scoringHookInputSchema> & Partial<ObservabilityContext>;
 
 // ============================================================================
 // Extract Step Result
@@ -130,8 +126,7 @@ export type ScoringInputWithExtractStepResult<TExtract = any> = Omit<
   'extractStepResult'
 > & {
   extractStepResult?: TExtract;
-  tracingContext?: TracingContext;
-};
+} & Partial<ObservabilityContext>;
 
 export const scoringInputWithExtractStepResultAndAnalyzeStepResultSchema =
   scoringInputWithExtractStepResultSchema.extend({
@@ -146,8 +141,7 @@ export type ScoringInputWithExtractStepResultAndAnalyzeStepResult<TExtract = any
 > & {
   extractStepResult?: TExtract;
   analyzeStepResult?: TScore;
-  tracingContext?: TracingContext;
-};
+} & Partial<ObservabilityContext>;
 
 export const scoringInputWithExtractStepResultAndScoreAndReasonSchema =
   scoringInputWithExtractStepResultAndAnalyzeStepResultSchema.extend({
@@ -157,9 +151,8 @@ export const scoringInputWithExtractStepResultAndScoreAndReasonSchema =
 
 export type ScoringInputWithExtractStepResultAndScoreAndReason = z.infer<
   typeof scoringInputWithExtractStepResultAndScoreAndReasonSchema
-> & {
-  tracingContext?: TracingContext;
-};
+> &
+  Partial<ObservabilityContext>;
 
 // ============================================================================
 // Score Row Data (stored in DB)

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -18,7 +18,7 @@ import type { SystemModelMessage } from '@internal/ai-sdk-v5';
 import type { JSONSchema7 } from 'json-schema';
 import type { z, ZodSchema } from 'zod';
 
-import type { TracingContext } from '../observability';
+import type { ObservabilityContext } from '../observability';
 import type { RequestContext } from '../request-context';
 import type { Run } from '../run/types';
 import type { CoreTool } from '../tools/types';
@@ -111,14 +111,13 @@ export type DefaultLLMTextObjectOptions = Omit<GenerateObjectOptions, MastraCust
 export type DefaultLLMStreamOptions = Omit<StreamTextOptions, MastraCustomLLMOptionsKeys>;
 export type DefaultLLMStreamObjectOptions = Omit<StreamObjectOptions, MastraCustomLLMOptionsKeys>;
 
-type MastraCustomLLMOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = {
+type MastraCustomLLMOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = ObservabilityContext & {
   tools?: Record<string, CoreTool>;
   onStepFinish?: (step: unknown) => Promise<void> | void;
   experimental_output?: Z;
   threadId?: string;
   resourceId?: string;
   requestContext: RequestContext;
-  tracingContext: TracingContext;
 } & Run;
 
 export type LLMTextOptions<Z extends ZodSchema | JSONSchema7 | undefined = undefined> = {

--- a/packages/core/src/llm/model/base.types.ts
+++ b/packages/core/src/llm/model/base.types.ts
@@ -21,19 +21,18 @@ import type { JSONSchema7 } from 'json-schema';
 import type { ZodSchema } from 'zod';
 import type { MessageList } from '../../agent/types';
 import type { ScorerRunInputForAgent, ScorerRunOutputForAgent } from '../../evals';
-import type { TracingContext, TracingProperties } from '../../observability';
+import type { ObservabilityContext, TracingProperties } from '../../observability';
 import type { OutputProcessorOrWorkflow } from '../../processors';
 import type { RequestContext } from '../../request-context';
 import type { inferOutput, ScoringProperties, TripwireProperties } from './shared.types';
 
 export type { ToolSet } from '@internal/ai-sdk-v4';
 
-type MastraCustomLLMOptions = {
+type MastraCustomLLMOptions = ObservabilityContext & {
   tools?: Record<string, Tool>;
   threadId?: string;
   resourceId?: string;
   requestContext: RequestContext;
-  tracingContext: TracingContext;
   runId?: string;
   outputProcessors?: OutputProcessorOrWorkflow[];
 };

--- a/packages/core/src/llm/model/model.loop.ts
+++ b/packages/core/src/llm/model/model.loop.ts
@@ -17,7 +17,7 @@ import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
 import { loop } from '../../loop';
 import type { LoopOptions } from '../../loop/types';
 import type { Mastra } from '../../mastra';
-import { SpanType } from '../../observability';
+import { SpanType, resolveObservabilityContext } from '../../observability';
 import type { MastraModelOutput } from '../../stream/base/output';
 import type { OutputSchema } from '../../stream/base/schema';
 import type { ModelManagerModelConfig } from '../../stream/types';
@@ -154,7 +154,6 @@ export class MastraLLMVNext extends MastraBase {
     outputProcessors,
     returnScorerData,
     providerOptions,
-    tracingContext,
     messageList,
     requireToolApproval,
     toolCallConcurrency,
@@ -170,7 +169,9 @@ export class MastraLLMVNext extends MastraBase {
     processorStates,
     activeTools,
     workspace,
+    ...rest
   }: ModelLoopStreamArgs<Tools, OUTPUT>): MastraModelOutput<OUTPUT> {
+    const observabilityContext = resolveObservabilityContext(rest);
     let stopWhenToUse;
 
     if (maxSteps && typeof maxSteps === 'number') {
@@ -190,7 +191,7 @@ export class MastraLLMVNext extends MastraBase {
       tools: Object.keys(tools || {}),
     });
 
-    const modelSpan = tracingContext?.currentSpan?.createChildSpan({
+    const modelSpan = observabilityContext.tracingContext.currentSpan?.createChildSpan({
       name: `llm: '${firstModel.modelId}'`,
       type: SpanType.MODEL_GENERATION,
       input: {
@@ -244,6 +245,7 @@ export class MastraLLMVNext extends MastraBase {
         processorStates,
         activeTools,
         workspace,
+        ...observabilityContext,
         options: {
           ...options,
           onStepFinish: async props => {

--- a/packages/core/src/llm/model/model.loop.types.ts
+++ b/packages/core/src/llm/model/model.loop.types.ts
@@ -11,7 +11,7 @@ import type { JSONSchema7 } from 'json-schema';
 import type { ZodSchema } from 'zod';
 import type { MessageList } from '../../agent';
 import type { LoopOptions } from '../../loop/types';
-import type { TracingContext } from '../../observability';
+import type { ObservabilityContext } from '../../observability';
 import type { OutputProcessorOrWorkflow } from '../../processors';
 import type { RequestContext } from '../../request-context';
 import type { inferOutput } from './shared.types';
@@ -38,11 +38,11 @@ export type ModelLoopStreamArgs<TOOLS extends ToolSet, OUTPUT = undefined> = {
   messages?: UIMessage[] | ModelMessage[];
   outputProcessors?: OutputProcessorOrWorkflow[];
   requestContext: RequestContext;
-  tracingContext: TracingContext;
   resourceId?: string;
   threadId?: string;
   returnScorerData?: boolean;
   messageList: MessageList;
-} & Omit<LoopOptions<TOOLS, OUTPUT>, 'models' | 'messageList'>;
+} & ObservabilityContext &
+  Omit<LoopOptions<TOOLS, OUTPUT>, 'models' | 'messageList'>;
 
 export type ModelMethodType = 'generate' | 'stream';

--- a/packages/core/src/llm/model/model.ts
+++ b/packages/core/src/llm/model/model.ts
@@ -22,7 +22,7 @@ import type { MastraPrimitives } from '../../action';
 import { MastraBase } from '../../base';
 import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
 import type { Mastra } from '../../mastra';
-import { SpanType } from '../../observability';
+import { SpanType, resolveObservabilityContext } from '../../observability';
 import { executeWithContext, executeWithContextSync } from '../../observability/utils';
 import { convertV4Usage } from '../../stream/aisdk/v4/usage';
 import { delay, isZodType } from '../../utils';
@@ -128,10 +128,10 @@ export class MastraLLMV1 extends MastraBase {
     threadId,
     resourceId,
     requestContext,
-    tracingContext,
     ...rest
   }: GenerateTextWithMessagesArgs<Tools, Z>): Promise<GenerateTextResult<Tools, Z>> {
     const model = this.#model;
+    const observabilityContext = resolveObservabilityContext(rest);
 
     this.logger.debug(`[LLM] - Generating text`, {
       runId,
@@ -163,7 +163,7 @@ export class MastraLLMV1 extends MastraBase {
       }
     }
 
-    const llmSpan = tracingContext.currentSpan?.createChildSpan({
+    const llmSpan = observabilityContext.tracingContext.currentSpan?.createChildSpan({
       name: `llm: '${model.modelId}'`,
       type: SpanType.MODEL_GENERATION,
       input: {
@@ -304,14 +304,14 @@ export class MastraLLMV1 extends MastraBase {
     threadId,
     resourceId,
     requestContext,
-    tracingContext,
     ...rest
   }: GenerateObjectWithMessagesArgs<Z>): Promise<GenerateObjectResult<Z>> {
     const model = this.#model;
+    const observabilityContext = resolveObservabilityContext(rest);
 
     this.logger.debug(`[LLM] - Generating a text object`, { runId });
 
-    const llmSpan = tracingContext.currentSpan?.createChildSpan({
+    const llmSpan = observabilityContext.tracingContext.currentSpan?.createChildSpan({
       name: `llm: '${model.modelId}'`,
       type: SpanType.MODEL_GENERATION,
       input: {
@@ -437,10 +437,11 @@ export class MastraLLMV1 extends MastraBase {
     threadId,
     resourceId,
     requestContext,
-    tracingContext,
     ...rest
   }: StreamTextWithMessagesArgs<Tools, Z>): StreamTextResult<Tools, Z> {
     const model = this.#model;
+    const observabilityContext = resolveObservabilityContext(rest);
+
     this.logger.debug(`[LLM] - Streaming text`, {
       runId,
       threadId,
@@ -465,7 +466,7 @@ export class MastraLLMV1 extends MastraBase {
       }
     }
 
-    const llmSpan = tracingContext.currentSpan?.createChildSpan({
+    const llmSpan = observabilityContext.tracingContext.currentSpan?.createChildSpan({
       name: `llm: '${model.modelId}'`,
       type: SpanType.MODEL_GENERATION,
       input: {
@@ -638,16 +639,17 @@ export class MastraLLMV1 extends MastraBase {
     resourceId,
     onFinish,
     structuredOutput,
-    tracingContext,
     ...rest
   }: StreamObjectWithMessagesArgs<T>): StreamObjectResult<T> {
     const model = this.#model;
+    const observabilityContext = resolveObservabilityContext(rest);
+
     this.logger.debug(`[LLM] - Streaming structured output`, {
       runId,
       messages,
     });
 
-    const llmSpan = tracingContext.currentSpan?.createChildSpan({
+    const llmSpan = observabilityContext.tracingContext.currentSpan?.createChildSpan({
       name: `llm: '${model.modelId}'`,
       type: SpanType.MODEL_GENERATION,
       input: {

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -10,7 +10,8 @@ import type { StructuredOutputOptions } from '../../agent/types';
 import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
 import type { MastraLLMVNext } from '../../llm/model/model.loop';
 import { noopLogger } from '../../logger';
-import type { TracingContext } from '../../observability';
+import type { ObservabilityContext } from '../../observability';
+import { createObservabilityContext, resolveObservabilityContext } from '../../observability';
 import { ProcessorRunner } from '../../processors/runner';
 import type { RequestContext } from '../../request-context';
 import { ChunkFrom } from '../../stream';
@@ -239,8 +240,8 @@ export async function prepareMemoryStep({
   routingAgent,
   requestContext,
   generateId,
-  tracingContext,
   memoryConfig,
+  ...rest
 }: {
   threadId: string;
   resourceId: string;
@@ -248,9 +249,9 @@ export async function prepareMemoryStep({
   routingAgent: Agent;
   requestContext: RequestContext;
   generateId: NetworkIdGenerator;
-  tracingContext?: TracingContext;
   memoryConfig?: any;
-}) {
+} & Partial<ObservabilityContext>) {
+  const observabilityContext = resolveObservabilityContext(rest);
   const memory = await routingAgent.getMemory({ requestContext });
   let thread = await memory?.getThreadById({ threadId });
   if (!thread) {
@@ -337,13 +338,7 @@ export async function prepareMemoryStep({
       if (isFirstUserMessage) {
         promises.push(
           routingAgent
-            .genTitle(
-              userMessage,
-              requestContext,
-              tracingContext || { currentSpan: undefined },
-              titleModel,
-              titleInstructions,
-            )
+            .genTitle(userMessage, requestContext, observabilityContext, titleModel, titleInstructions)
             .then(title => {
               if (title) {
                 return memory.createThread({
@@ -384,9 +379,8 @@ async function saveMessagesWithProcessors(
   messages: MastraDBMessage[],
   processorRunner: ProcessorRunner | null,
   context?: {
-    tracingContext?: TracingContext;
     requestContext?: RequestContext;
-  },
+  } & Partial<ObservabilityContext>,
 ): Promise<void> {
   if (!memory) return;
 
@@ -402,7 +396,12 @@ async function saveMessagesWithProcessors(
   }
 
   // Run output processors on the messages
-  await processorRunner.runOutputProcessors(messageList, context?.tracingContext, context?.requestContext);
+  const { requestContext, ...observabilityContext } = context ?? {};
+  await processorRunner.runOutputProcessors(
+    messageList,
+    resolveObservabilityContext(observabilityContext),
+    requestContext,
+  );
 
   // Get the processed messages and save them
   const processedMessages = messageList.get.response.db();
@@ -1722,7 +1721,7 @@ export async function createNetworkLoop({
           memory,
           context: inputDataToUse,
           // TODO: Pass proper tracing context when network supports tracing
-          tracingContext: { currentSpan: undefined },
+          ...createObservabilityContext({ currentSpan: undefined }),
           writer,
         },
         { toolCallId, messages: [] },
@@ -2130,7 +2129,7 @@ export async function networkLoop<OUTPUT = undefined>({
                 requestContext,
                 messageList,
                 agentId: routingAgent.id,
-                tracingContext: routingAgentOptions?.tracingContext!,
+                ...resolveObservabilityContext(routingAgentOptions ?? {}),
                 structuredOutput: {
                   schema: z.object({
                     resumeData: z.string(),
@@ -2576,7 +2575,7 @@ export async function networkLoop<OUTPUT = undefined>({
     messages,
     routingAgent,
     generateId,
-    tracingContext: routingAgentOptions?.tracingContext,
+    ...resolveObservabilityContext(routingAgentOptions ?? {}),
     memoryConfig: routingAgentMemoryOptions?.options,
   });
 

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -17,7 +17,7 @@ import type { MastraLanguageModelV2, OpenAICompatibleConfig, SharedProviderOptio
 import type { IMastraLogger } from '../logger';
 import type { Mastra } from '../mastra';
 import type { MastraMemory, MemoryConfig } from '../memory';
-import type { IModelSpanTracker } from '../observability';
+import type { IModelSpanTracker, ObservabilityContext } from '../observability';
 import type {
   InputProcessorOrWorkflow,
   OutputProcessorOrWorkflow,
@@ -141,7 +141,7 @@ export type LoopOptions<TOOLS extends ToolSet = ToolSet, OUTPUT = undefined> = {
    * Keyed by processor ID.
    */
   processorStates?: Map<string, ProcessorState>;
-};
+} & Partial<ObservabilityContext>;
 
 export type LoopRun<Tools extends ToolSet = ToolSet, OUTPUT = undefined> = LoopOptions<Tools, OUTPUT> & {
   messageId: string;

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -17,8 +17,8 @@ import { LogLevel, noopLogger, ConsoleLogger } from '../logger';
 import type { IMastraLogger } from '../logger';
 import type { MCPServerBase } from '../mcp';
 import type { MastraMemory } from '../memory';
-import type { ObservabilityEntrypoint } from '../observability';
-import { NoOpObservability } from '../observability';
+import type { ObservabilityEntrypoint, LoggerContext, MetricsContext } from '../observability';
+import { NoOpObservability, noOpLoggerContext, noOpMetricsContext } from '../observability';
 import type { Processor } from '../processors';
 import type { MastraServerBase } from '../server/base';
 import type { Middleware, ServerConfig } from '../server/types';
@@ -2463,6 +2463,26 @@ export class Mastra<
 
   get observability(): ObservabilityEntrypoint {
     return this.#observability;
+  }
+
+  /**
+   * Structured logging API for observability.
+   * Logs emitted via this API will not have trace correlation when used outside a span.
+   * Use for startup logs, background jobs, or other non-traced scenarios.
+   *
+   * Note: For the infrastructure logger (IMastraLogger), use getLogger() instead.
+   */
+  get loggerVNext(): LoggerContext {
+    return this.#observability.getDefaultInstance()?.getLoggerContext?.() ?? noOpLoggerContext;
+  }
+
+  /**
+   * Direct metrics API for use outside trace context.
+   * Metrics emitted via this API will not have auto-labels from spans.
+   * Use for background jobs, startup metrics, or other non-traced scenarios.
+   */
+  get metrics(): MetricsContext {
+    return this.#observability.getDefaultInstance()?.getMetricsContext?.() ?? noOpMetricsContext;
   }
 
   public getServerMiddleware() {

--- a/packages/core/src/observability/context-factory.test.ts
+++ b/packages/core/src/observability/context-factory.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { createObservabilityContext, resolveObservabilityContext } from './context-factory';
+import { noOpLoggerContext, noOpMetricsContext } from './no-op';
+import type { LoggerContext, MetricsContext, ObservabilityInstance, TracingContext } from './types';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function mockLoggerContext(): LoggerContext {
+  return { debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, fatal: () => {} };
+}
+
+function mockMetricsContext(): MetricsContext {
+  return {
+    counter: () => ({ add: () => {} }),
+    gauge: () => ({ set: () => {} }),
+    histogram: () => ({ record: () => {} }),
+  };
+}
+
+/**
+ * Creates a mock span with an observabilityInstance that returns the
+ * provided logger/metrics contexts (or undefined if not provided).
+ */
+function mockSpanWithInstance(opts?: { logger?: LoggerContext; metrics?: MetricsContext }) {
+  const instance: Partial<ObservabilityInstance> = {
+    getLoggerContext: opts?.logger ? vi.fn().mockReturnValue(opts.logger) : undefined,
+    getMetricsContext: opts?.metrics ? vi.fn().mockReturnValue(opts.metrics) : undefined,
+  };
+
+  return {
+    spanId: 'test-span',
+    observabilityInstance: instance as ObservabilityInstance,
+  } as any;
+}
+
+// ============================================================================
+// createObservabilityContext
+// ============================================================================
+
+describe('createObservabilityContext', () => {
+  it('returns no-op contexts when called without arguments', () => {
+    const ctx = createObservabilityContext();
+
+    expect(ctx.tracing.currentSpan).toBeUndefined();
+    expect(ctx.loggerVNext).toBe(noOpLoggerContext);
+    expect(ctx.metrics).toBe(noOpMetricsContext);
+  });
+
+  it('returns tracingContext alias pointing to tracing', () => {
+    const ctx = createObservabilityContext();
+
+    expect(ctx.tracingContext).toBe(ctx.tracing);
+  });
+
+  it('uses provided tracing context when passed', () => {
+    const mockSpan = { spanId: 'test-span' } as any;
+    const mockTracing: TracingContext = { currentSpan: mockSpan };
+
+    const ctx = createObservabilityContext(mockTracing);
+
+    expect(ctx.tracing).toBe(mockTracing);
+    expect(ctx.tracing.currentSpan).toBe(mockSpan);
+    expect(ctx.tracingContext).toBe(mockTracing);
+  });
+
+  it('derives logger context from span observability instance', () => {
+    const logger = mockLoggerContext();
+    const span = mockSpanWithInstance({ logger });
+    const tracing: TracingContext = { currentSpan: span };
+
+    const ctx = createObservabilityContext(tracing);
+
+    expect(ctx.loggerVNext).toBe(logger);
+    expect(span.observabilityInstance.getLoggerContext).toHaveBeenCalledWith(span);
+  });
+
+  it('derives metrics context from span observability instance', () => {
+    const metrics = mockMetricsContext();
+    const span = mockSpanWithInstance({ metrics });
+    const tracing: TracingContext = { currentSpan: span };
+
+    const ctx = createObservabilityContext(tracing);
+
+    expect(ctx.metrics).toBe(metrics);
+    expect(span.observabilityInstance.getMetricsContext).toHaveBeenCalledWith(span);
+  });
+
+  it('derives both logger and metrics from span observability instance', () => {
+    const logger = mockLoggerContext();
+    const metrics = mockMetricsContext();
+    const span = mockSpanWithInstance({ logger, metrics });
+    const tracing: TracingContext = { currentSpan: span };
+
+    const ctx = createObservabilityContext(tracing);
+
+    expect(ctx.loggerVNext).toBe(logger);
+    expect(ctx.metrics).toBe(metrics);
+  });
+
+  it('falls back to no-op when instance does not implement getLoggerContext', () => {
+    const span = mockSpanWithInstance({ metrics: mockMetricsContext() });
+    const tracing: TracingContext = { currentSpan: span };
+
+    const ctx = createObservabilityContext(tracing);
+
+    expect(ctx.loggerVNext).toBe(noOpLoggerContext);
+  });
+
+  it('falls back to no-op when instance does not implement getMetricsContext', () => {
+    const span = mockSpanWithInstance({ logger: mockLoggerContext() });
+    const tracing: TracingContext = { currentSpan: span };
+
+    const ctx = createObservabilityContext(tracing);
+
+    expect(ctx.metrics).toBe(noOpMetricsContext);
+  });
+
+  it('falls back to no-op when span has no observability instance', () => {
+    const span = { spanId: 'bare-span' } as any;
+    const tracing: TracingContext = { currentSpan: span };
+
+    const ctx = createObservabilityContext(tracing);
+
+    expect(ctx.loggerVNext).toBe(noOpLoggerContext);
+    expect(ctx.metrics).toBe(noOpMetricsContext);
+  });
+});
+
+// ============================================================================
+// resolveObservabilityContext
+// ============================================================================
+
+describe('resolveObservabilityContext', () => {
+  it('returns no-op contexts when called with empty partial', () => {
+    const ctx = resolveObservabilityContext({});
+
+    expect(ctx.tracing.currentSpan).toBeUndefined();
+    expect(ctx.loggerVNext).toBe(noOpLoggerContext);
+    expect(ctx.metrics).toBe(noOpMetricsContext);
+  });
+
+  it('uses provided logger context when passed', () => {
+    const logger = mockLoggerContext();
+
+    const ctx = resolveObservabilityContext({ loggerVNext: logger });
+
+    expect(ctx.loggerVNext).toBe(logger);
+  });
+
+  it('uses provided metrics context when passed', () => {
+    const metrics = mockMetricsContext();
+
+    const ctx = resolveObservabilityContext({ metrics });
+
+    expect(ctx.metrics).toBe(metrics);
+  });
+
+  it('uses all provided contexts when passed', () => {
+    const mockSpan = { spanId: 'test-span' } as any;
+    const mockTracing: TracingContext = { currentSpan: mockSpan };
+    const logger = mockLoggerContext();
+    const metrics = mockMetricsContext();
+
+    const ctx = resolveObservabilityContext({ tracing: mockTracing, loggerVNext: logger, metrics });
+
+    expect(ctx.tracing).toBe(mockTracing);
+    expect(ctx.loggerVNext).toBe(logger);
+    expect(ctx.metrics).toBe(metrics);
+  });
+
+  it('prefers tracing over tracingContext alias', () => {
+    const mockSpan1 = { spanId: 'span-1' } as any;
+    const mockSpan2 = { spanId: 'span-2' } as any;
+
+    const ctx = resolveObservabilityContext({
+      tracing: { currentSpan: mockSpan1 },
+      tracingContext: { currentSpan: mockSpan2 },
+    });
+
+    expect(ctx.tracing.currentSpan).toBe(mockSpan1);
+  });
+
+  it('falls back to tracingContext alias when tracing is missing', () => {
+    const mockSpan = { spanId: 'test-span' } as any;
+
+    const ctx = resolveObservabilityContext({ tracingContext: { currentSpan: mockSpan } });
+
+    expect(ctx.tracing.currentSpan).toBe(mockSpan);
+  });
+
+  it('derives logger from span when not explicitly provided', () => {
+    const logger = mockLoggerContext();
+    const span = mockSpanWithInstance({ logger });
+    const tracing: TracingContext = { currentSpan: span };
+
+    const ctx = resolveObservabilityContext({ tracing });
+
+    expect(ctx.loggerVNext).toBe(logger);
+    expect(span.observabilityInstance.getLoggerContext).toHaveBeenCalledWith(span);
+  });
+
+  it('derives metrics from span when not explicitly provided', () => {
+    const metrics = mockMetricsContext();
+    const span = mockSpanWithInstance({ metrics });
+    const tracing: TracingContext = { currentSpan: span };
+
+    const ctx = resolveObservabilityContext({ tracing });
+
+    expect(ctx.metrics).toBe(metrics);
+    expect(span.observabilityInstance.getMetricsContext).toHaveBeenCalledWith(span);
+  });
+
+  it('prefers explicit logger over derived logger', () => {
+    const explicitLogger = mockLoggerContext();
+    const derivedLogger = mockLoggerContext();
+    const span = mockSpanWithInstance({ logger: derivedLogger });
+    const tracing: TracingContext = { currentSpan: span };
+
+    const ctx = resolveObservabilityContext({ tracing, loggerVNext: explicitLogger });
+
+    expect(ctx.loggerVNext).toBe(explicitLogger);
+  });
+
+  it('prefers explicit metrics over derived metrics', () => {
+    const explicitMetrics = mockMetricsContext();
+    const derivedMetrics = mockMetricsContext();
+    const span = mockSpanWithInstance({ metrics: derivedMetrics });
+    const tracing: TracingContext = { currentSpan: span };
+
+    const ctx = resolveObservabilityContext({ tracing, metrics: explicitMetrics });
+
+    expect(ctx.metrics).toBe(explicitMetrics);
+  });
+});
+
+// ============================================================================
+// noOpLoggerContext
+// ============================================================================
+
+describe('noOpLoggerContext', () => {
+  it('has all required methods', () => {
+    expect(typeof noOpLoggerContext.debug).toBe('function');
+    expect(typeof noOpLoggerContext.info).toBe('function');
+    expect(typeof noOpLoggerContext.warn).toBe('function');
+    expect(typeof noOpLoggerContext.error).toBe('function');
+    expect(typeof noOpLoggerContext.fatal).toBe('function');
+  });
+
+  it('debug does not throw', () => {
+    expect(() => noOpLoggerContext.debug('test message')).not.toThrow();
+    expect(() => noOpLoggerContext.debug('test message', { key: 'value' })).not.toThrow();
+  });
+
+  it('info does not throw', () => {
+    expect(() => noOpLoggerContext.info('test message')).not.toThrow();
+    expect(() => noOpLoggerContext.info('test message', { key: 'value' })).not.toThrow();
+  });
+
+  it('warn does not throw', () => {
+    expect(() => noOpLoggerContext.warn('test message')).not.toThrow();
+    expect(() => noOpLoggerContext.warn('test message', { key: 'value' })).not.toThrow();
+  });
+
+  it('error does not throw', () => {
+    expect(() => noOpLoggerContext.error('test message')).not.toThrow();
+    expect(() => noOpLoggerContext.error('test message', { key: 'value' })).not.toThrow();
+  });
+
+  it('fatal does not throw', () => {
+    expect(() => noOpLoggerContext.fatal('test message')).not.toThrow();
+    expect(() => noOpLoggerContext.fatal('test message', { key: 'value' })).not.toThrow();
+  });
+});
+
+// ============================================================================
+// noOpMetricsContext
+// ============================================================================
+
+describe('noOpMetricsContext', () => {
+  it('has all required methods', () => {
+    expect(typeof noOpMetricsContext.counter).toBe('function');
+    expect(typeof noOpMetricsContext.gauge).toBe('function');
+    expect(typeof noOpMetricsContext.histogram).toBe('function');
+  });
+
+  describe('counter', () => {
+    it('returns an object with add method', () => {
+      const counter = noOpMetricsContext.counter('test_counter');
+      expect(typeof counter.add).toBe('function');
+    });
+
+    it('add does not throw', () => {
+      const counter = noOpMetricsContext.counter('test_counter');
+      expect(() => counter.add(1)).not.toThrow();
+      expect(() => counter.add(5, { label: 'value' })).not.toThrow();
+    });
+  });
+
+  describe('gauge', () => {
+    it('returns an object with set method', () => {
+      const gauge = noOpMetricsContext.gauge('test_gauge');
+      expect(typeof gauge.set).toBe('function');
+    });
+
+    it('set does not throw', () => {
+      const gauge = noOpMetricsContext.gauge('test_gauge');
+      expect(() => gauge.set(42)).not.toThrow();
+      expect(() => gauge.set(100, { label: 'value' })).not.toThrow();
+    });
+  });
+
+  describe('histogram', () => {
+    it('returns an object with record method', () => {
+      const histogram = noOpMetricsContext.histogram('test_histogram');
+      expect(typeof histogram.record).toBe('function');
+    });
+
+    it('record does not throw', () => {
+      const histogram = noOpMetricsContext.histogram('test_histogram');
+      expect(() => histogram.record(0.5)).not.toThrow();
+      expect(() => histogram.record(123.45, { label: 'value' })).not.toThrow();
+    });
+  });
+});

--- a/packages/core/src/observability/context-factory.ts
+++ b/packages/core/src/observability/context-factory.ts
@@ -1,0 +1,74 @@
+// packages/core/src/observability/context-factory.ts
+
+import { noOpLoggerContext, noOpMetricsContext, noOpTracingContext } from './no-op';
+import type { LoggerContext, MetricsContext, ObservabilityContext, TracingContext } from './types';
+
+// ============================================================================
+// Context Derivation
+// ============================================================================
+
+/**
+ * Derives a LoggerContext from the current span's ObservabilityInstance.
+ * Falls back to no-op when there is no span or the instance doesn't support logging.
+ */
+function deriveLoggerContext(tracing: TracingContext): LoggerContext {
+  const span = tracing.currentSpan;
+  return span?.observabilityInstance?.getLoggerContext?.(span) ?? noOpLoggerContext;
+}
+
+/**
+ * Derives a MetricsContext from the current span's ObservabilityInstance.
+ * Falls back to no-op when there is no span or the instance doesn't support metrics.
+ */
+function deriveMetricsContext(tracing: TracingContext): MetricsContext {
+  const span = tracing.currentSpan;
+  return span?.observabilityInstance?.getMetricsContext?.(span) ?? noOpMetricsContext;
+}
+
+// ============================================================================
+// Context Factory
+// ============================================================================
+
+/**
+ * Creates an observability context with real or no-op implementations for
+ * tracing, logging, and metrics.
+ *
+ * When a TracingContext with a current span is provided, the logger and metrics
+ * contexts are derived from the span's ObservabilityInstance so that log entries
+ * and metric data points are automatically correlated to the active trace.
+ *
+ * @param tracingContext - TracingContext with current span, or undefined for no-op
+ * @returns ObservabilityContext with all three signals (tracing, logger, metrics)
+ */
+export function createObservabilityContext(tracingContext?: TracingContext): ObservabilityContext {
+  const tracing = tracingContext ?? noOpTracingContext;
+
+  return {
+    tracing,
+    loggerVNext: deriveLoggerContext(tracing),
+    metrics: deriveMetricsContext(tracing),
+    tracingContext: tracing, // alias — preferred at forwarding sites
+  };
+}
+
+/**
+ * Resolves a partial observability context (from execute params) into a
+ * complete ObservabilityContext with no-op defaults for any missing fields.
+ *
+ * Explicitly provided logger/metrics contexts are preserved (e.g. when set
+ * upstream). When missing, they are derived from the tracing context's span,
+ * following the same derivation logic as createObservabilityContext().
+ *
+ * @param partial - Partial context from ExecuteFunctionParams
+ * @returns Complete ObservabilityContext
+ */
+export function resolveObservabilityContext(partial: Partial<ObservabilityContext>): ObservabilityContext {
+  const tracing = partial.tracing ?? partial.tracingContext ?? noOpTracingContext;
+
+  return {
+    tracing,
+    loggerVNext: partial.loggerVNext ?? deriveLoggerContext(tracing),
+    metrics: partial.metrics ?? deriveMetricsContext(tracing),
+    tracingContext: tracing, // alias — preferred at forwarding sites
+  };
+}

--- a/packages/core/src/observability/context.ts
+++ b/packages/core/src/observability/context.ts
@@ -10,6 +10,7 @@ import type { MastraPrimitives } from '../action';
 import type { Agent } from '../agent';
 import type { Mastra } from '../mastra';
 import type { Workflow } from '../workflows';
+import { createObservabilityContext } from './context-factory';
 import type { TracingContext, AnySpan } from './types';
 
 const AGENT_GETTERS = ['getAgent', 'getAgentById'];
@@ -108,7 +109,7 @@ function wrapAgent<T extends Agent>(agent: T, tracingContext: TracingContext): T
             return (input: any, options: any = {}) => {
               return (target as any)[prop](input, {
                 ...options,
-                tracingContext,
+                ...createObservabilityContext(tracingContext),
               });
             };
           }
@@ -157,7 +158,7 @@ function wrapWorkflow<T extends Workflow>(workflow: T, tracingContext: TracingCo
             return (input: any, options: any = {}) => {
               return (target as any)[prop](input, {
                 ...options,
-                tracingContext,
+                ...createObservabilityContext(tracingContext),
               });
             };
           }
@@ -196,7 +197,7 @@ function wrapRun<T extends object>(run: T, tracingContext: TracingContext): T {
             return (startOptions: any = {}) => {
               return (target as any).start({
                 ...startOptions,
-                tracingContext: startOptions.tracingContext ?? tracingContext,
+                ...createObservabilityContext(startOptions.tracingContext ?? tracingContext),
               });
             };
           }

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -10,3 +10,4 @@ export * from './types';
 export * from './no-op';
 export * from './utils';
 export { wrapMastra } from './context';
+export { createObservabilityContext, resolveObservabilityContext } from './context-factory';

--- a/packages/core/src/observability/no-op.ts
+++ b/packages/core/src/observability/no-op.ts
@@ -1,6 +1,84 @@
 import type { Mastra } from '..';
 import type { IMastraLogger } from '../logger';
-import type { ObservabilityInstance, ConfigSelectorOptions, ObservabilityEntrypoint, ConfigSelector } from './types';
+import type {
+  ConfigSelector,
+  ConfigSelectorOptions,
+  Counter,
+  Gauge,
+  Histogram,
+  LoggerContext,
+  MetricsContext,
+  ObservabilityEntrypoint,
+  ObservabilityInstance,
+  TracingContext,
+} from './types';
+
+// ============================================================================
+// No-Op Metric Instruments
+// ============================================================================
+
+const noOpCounter: Counter = {
+  add() {},
+};
+
+const noOpGauge: Gauge = {
+  set() {},
+};
+
+const noOpHistogram: Histogram = {
+  record() {},
+};
+
+// ============================================================================
+// No-Op TracingContext
+// ============================================================================
+
+/**
+ * No-op tracing context used when observability is not configured.
+ */
+export const noOpTracingContext: TracingContext = {
+  currentSpan: undefined,
+};
+
+// ============================================================================
+// No-Op LoggerContext
+// ============================================================================
+
+/**
+ * No-op logger context that silently discards all log calls.
+ * Used when observability is not configured.
+ */
+export const noOpLoggerContext: LoggerContext = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+  fatal() {},
+};
+
+// ============================================================================
+// No-Op MetricsContext
+// ============================================================================
+
+/**
+ * No-op metrics context that silently discards all metric operations.
+ * Used when observability is not configured.
+ */
+export const noOpMetricsContext: MetricsContext = {
+  counter() {
+    return noOpCounter;
+  },
+  gauge() {
+    return noOpGauge;
+  },
+  histogram() {
+    return noOpHistogram;
+  },
+};
+
+// ============================================================================
+// No-Op Observability
+// ============================================================================
 
 export class NoOpObservability implements ObservabilityEntrypoint {
   setMastraContext(_options: { mastra: Mastra }): void {

--- a/packages/core/src/observability/types/core.ts
+++ b/packages/core/src/observability/types/core.ts
@@ -1,0 +1,492 @@
+/**
+ * Top-level observability infrastructure types.
+ *
+ * This file contains the core observability interfaces for managing instances,
+ * exporters, bridges, configuration, event bus, and the context mixin.
+ *
+ * For tracing-specific types (spans, span types, attributes, etc.), see tracing.ts.
+ */
+import type { IMastraLogger } from '../../logger';
+import type { Mastra } from '../../mastra';
+import type { RequestContext } from '../../request-context';
+import type { FeedbackEvent } from './feedback';
+import type { LoggerContext, LogEvent } from './logging';
+import type { MetricsContext, MetricEvent } from './metrics';
+import type { ScoreEvent } from './scores';
+import type {
+  AnySpan,
+  CreateSpanOptions,
+  ExportedSpan,
+  Span,
+  SpanIds,
+  SpanOutputProcessor,
+  SpanType,
+  StartSpanOptions,
+  TracingContext,
+  TracingEvent,
+} from './tracing';
+
+// ============================================================================
+// ObservabilityContext
+// ============================================================================
+
+/**
+ * Mixin interface that provides unified observability access.
+ * All execution contexts (tools, workflow steps, processors) extend this
+ * to gain access to tracing, logging, and metrics.
+ *
+ * ## Naming conventions
+ *
+ * `tracingContext` is the **source** — it represents your position in the span tree.
+ * Creating a child span produces a new `tracingContext` with that child as `currentSpan`.
+ *
+ * `loggerVNext` and `metrics` are **derived** — they are rebuilt from the current span so that
+ * log entries and metric data points are automatically correlated to the active trace:
+ *
+ * ```
+ * tracingContext → create child span → new tracingContext
+ *                                    → new loggerVNext (correlated to child span)
+ *                                    → new metrics     (tagged with child span metadata)
+ * ```
+ *
+ * The short names (`tracing`, `loggerVNext`, `metrics`) read naturally at **usage sites**:
+ * `tracing.createSpan()`, `loggerVNext.info()`, `metrics.record()`.
+ *
+ * `loggerVNext` uses the VNext suffix to distinguish from the existing `logger: IMastraLogger`
+ * infrastructure logger used throughout the codebase (e.g. `MastraPrimitives.logger`).
+ *
+ * The `tracingContext` alias is preferred at **forwarding sites** where the "Context"
+ * suffix clarifies that a structural context object is being passed, not a subsystem.
+ */
+export interface ObservabilityContext {
+  /** Tracing context for span creation and tree navigation. */
+  tracing: TracingContext;
+
+  /** Logger derived from the current span — log entries are trace-correlated. Uses VNext suffix to avoid conflict with IMastraLogger. */
+  loggerVNext: LoggerContext;
+
+  /** Metrics derived from the current span — data points are span-tagged. */
+  metrics: MetricsContext;
+
+  /**
+   * Alias for `tracing`. Preferred at forwarding sites where the "Context" suffix
+   * clarifies that a structural context object is being passed between functions.
+   */
+  tracingContext: TracingContext;
+}
+
+// ============================================================================
+// ObservabilityEventBus
+// ============================================================================
+
+/**
+ * Generic event bus interface for observability events.
+ * Implementations handle buffering, batching, and delivery to exporters.
+ */
+export interface ObservabilityEventBus<TEvent> {
+  /** Emit an event to the bus */
+  emit(event: TEvent): void;
+
+  /** Subscribe to events. Returns unsubscribe function. */
+  subscribe(handler: (event: TEvent) => void): () => void;
+
+  /** Flush any buffered events */
+  flush(): Promise<void>;
+
+  /** Shutdown the bus and release resources */
+  shutdown(): Promise<void>;
+}
+
+/**
+ * Union of all observability event types.
+ * Used by the unified ObservabilityBus that handles all signals.
+ */
+export type ObservabilityEvent = TracingEvent | LogEvent | MetricEvent | ScoreEvent | FeedbackEvent;
+
+// ============================================================================
+// ObservabilityInstance
+// ============================================================================
+
+/**
+ * Primary interface for Observability
+ */
+export interface ObservabilityInstance {
+  /**
+   * Get current configuration
+   */
+  getConfig(): Readonly<ObservabilityInstanceConfig>;
+
+  /**
+   * Get all exporters
+   */
+  getExporters(): readonly ObservabilityExporter[];
+
+  /**
+   * Get all span output processors
+   */
+  getSpanOutputProcessors(): readonly SpanOutputProcessor[];
+
+  /**
+   * Get the logger instance (for exporters and other components)
+   */
+  getLogger(): IMastraLogger;
+
+  /**
+   * Get the bridge instance if configured
+   */
+  getBridge(): ObservabilityBridge | undefined;
+
+  /**
+   * Start a new span of a specific SpanType
+   */
+  startSpan<TType extends SpanType>(options: StartSpanOptions<TType>): Span<TType>;
+
+  /**
+   * Rebuild a span from exported data for lifecycle operations.
+   * Used by durable execution engines (e.g., Inngest) to end/update spans
+   * that were created in a previous durable operation.
+   *
+   * @param cached - The exported span data to rebuild from
+   * @returns A span that can have end()/update()/error() called on it
+   */
+  rebuildSpan<TType extends SpanType>(cached: ExportedSpan<TType>): Span<TType>;
+
+  /**
+   * Force flush any buffered/queued spans from all exporters and the bridge
+   * without shutting down the observability instance.
+   *
+   * This is useful in serverless environments (like Vercel's fluid compute) where
+   * you need to ensure all spans are exported before the runtime instance is
+   * terminated, while keeping the observability system active for future requests.
+   *
+   * Unlike shutdown(), flush() does not release resources or prevent future tracing.
+   */
+  flush(): Promise<void>;
+
+  /**
+   * Shutdown tracing and clean up resources
+   */
+  shutdown(): Promise<void>;
+
+  /**
+   * Override setLogger to add tracing specific initialization log
+   */
+  __setLogger(logger: IMastraLogger): void;
+
+  /**
+   * Get a LoggerContext for this instance, optionally correlated to a span.
+   * When a span is provided, the returned logger automatically includes
+   * the span's traceId, spanId, and other metadata in every log entry.
+   * Returns no-op context when logging is not configured on this instance.
+   *
+   * @param span - Optional span to correlate logs with
+   */
+  getLoggerContext?(span?: AnySpan): LoggerContext;
+
+  /**
+   * Get a MetricsContext for this instance, optionally tagged from a span.
+   * When a span is provided, the returned metrics context automatically
+   * includes the span's metadata as labels/tags on emitted data points.
+   * Returns no-op context when metrics are not configured on this instance.
+   *
+   * @param span - Optional span to derive metric tags from
+   */
+  getMetricsContext?(span?: AnySpan): MetricsContext;
+}
+
+// ============================================================================
+// ObservabilityEntrypoint
+// ============================================================================
+
+export interface ObservabilityEntrypoint {
+  shutdown(): Promise<void>;
+
+  setMastraContext(options: { mastra: Mastra }): void;
+
+  setLogger(options: { logger: IMastraLogger }): void;
+
+  getSelectedInstance(options: ConfigSelectorOptions): ObservabilityInstance | undefined;
+
+  // Registry management methods
+  registerInstance(name: string, instance: ObservabilityInstance, isDefault?: boolean): void;
+  getInstance(name: string): ObservabilityInstance | undefined;
+  getDefaultInstance(): ObservabilityInstance | undefined;
+  listInstances(): ReadonlyMap<string, ObservabilityInstance>;
+  unregisterInstance(name: string): boolean;
+  hasInstance(name: string): boolean;
+  setConfigSelector(selector: ConfigSelector): void;
+  clear(): void;
+}
+
+// ============================================================================
+// Sampling Strategy
+// ============================================================================
+
+/**
+ * Sampling strategy types
+ */
+export enum SamplingStrategyType {
+  ALWAYS = 'always',
+  NEVER = 'never',
+  RATIO = 'ratio',
+  CUSTOM = 'custom',
+}
+
+/**
+ * Sampling strategy configuration
+ */
+export type SamplingStrategy =
+  | { type: SamplingStrategyType.ALWAYS }
+  | { type: SamplingStrategyType.NEVER }
+  | { type: SamplingStrategyType.RATIO; probability: number }
+  | { type: SamplingStrategyType.CUSTOM; sampler: (options?: CustomSamplerOptions) => boolean };
+
+/**
+ * Options passed when using a custom sampler strategy
+ */
+export interface CustomSamplerOptions {
+  requestContext?: RequestContext;
+  metadata?: Record<string, any>;
+}
+
+// ============================================================================
+// Serialization Options
+// ============================================================================
+
+/**
+ * Options for controlling serialization of span data.
+ * These options control how input, output, and attributes are cleaned before export.
+ */
+export interface SerializationOptions {
+  /**
+   * Maximum length for string values
+   * @default 1024
+   */
+  maxStringLength?: number;
+  /**
+   * Maximum depth for nested objects
+   * @default 6
+   */
+  maxDepth?: number;
+  /**
+   * Maximum number of items in arrays
+   * @default 50
+   */
+  maxArrayLength?: number;
+  /**
+   * Maximum number of keys in objects
+   * @default 50
+   */
+  maxObjectKeys?: number;
+}
+
+// ============================================================================
+// Registry Config
+// ============================================================================
+
+/**
+ * Configuration for a single observability instance
+ */
+export interface ObservabilityInstanceConfig {
+  /** Unique identifier for this config in the observability registry */
+  name: string;
+  /** Service name for observability */
+  serviceName: string;
+  /** Sampling strategy - controls whether tracing is collected (defaults to ALWAYS) */
+  sampling?: SamplingStrategy;
+  /** Custom exporters */
+  exporters?: ObservabilityExporter[];
+  /** Custom processors */
+  spanOutputProcessors?: SpanOutputProcessor[];
+  /** OpenTelemetry bridge for integration with existing OTEL infrastructure */
+  bridge?: ObservabilityBridge;
+  /** Set to `true` if you want to see spans internal to the operation of mastra */
+  includeInternalSpans?: boolean;
+  /**
+   * RequestContext keys to automatically extract as metadata for all spans
+   * created with this observability configuration.
+   * Supports dot notation for nested values.
+   */
+  requestContextKeys?: string[];
+  /**
+   * Options for controlling serialization of span data (input/output/attributes).
+   * Use these to customize truncation limits for large payloads.
+   */
+  serializationOptions?: SerializationOptions;
+}
+
+/**
+ * Complete Observability registry configuration
+ */
+export interface ObservabilityRegistryConfig {
+  /** Enables default exporters, with sampling: always, and sensitive data filtering */
+  default?: {
+    enabled?: boolean;
+  };
+  /** Map of tracing instance names to their configurations or pre-instantiated instances */
+  configs?: Record<string, Omit<ObservabilityInstanceConfig, 'name'> | ObservabilityInstance>;
+  /** Optional selector function to choose which tracing instance to use */
+  configSelector?: ConfigSelector;
+}
+
+// ============================================================================
+// Config Selector
+// ============================================================================
+
+/**
+ *  Options passed when using a custom tracing config selector
+ */
+export interface ConfigSelectorOptions {
+  /** Request Context */
+  requestContext?: RequestContext;
+}
+
+/**
+ * Function to select which tracing instance to use for a given span
+ * Returns the name of the tracing instance, or undefined to use default
+ */
+export type ConfigSelector = (
+  options: ConfigSelectorOptions,
+  availableConfigs: ReadonlyMap<string, ObservabilityInstance>,
+) => string | undefined;
+
+// ============================================================================
+// Exporter and Bridge Interfaces
+// ============================================================================
+
+export interface InitExporterOptions {
+  mastra?: Mastra;
+  config?: ObservabilityInstanceConfig;
+}
+
+export interface InitBridgeOptions {
+  mastra?: Mastra;
+  config?: ObservabilityInstanceConfig;
+}
+
+/**
+ * Interface for tracing exporters
+ */
+export interface ObservabilityExporter {
+  /** Exporter name */
+  name: string;
+
+  /** Initialize exporter with tracing configuration and/or access to Mastra */
+  init?(options: InitExporterOptions): void;
+
+  /** Sets logger instance on the exporter.  */
+  __setLogger?(logger: IMastraLogger): void;
+
+  /** Handle tracing events */
+  onTracingEvent?(event: TracingEvent): void | Promise<void>;
+
+  /** Handle log events */
+  onLogEvent?(event: LogEvent): void | Promise<void>;
+
+  /** Handle metric events */
+  onMetricEvent?(event: MetricEvent): void | Promise<void>;
+
+  /** Handle score events */
+  onScoreEvent?(event: ScoreEvent): void | Promise<void>;
+
+  /** Handle feedback events */
+  onFeedbackEvent?(event: FeedbackEvent): void | Promise<void>;
+
+  /** Export tracing events */
+  exportTracingEvent(event: TracingEvent): Promise<void>;
+
+  addScoreToTrace?({
+    traceId,
+    spanId,
+    score,
+    reason,
+    scorerName,
+    metadata,
+  }: {
+    traceId: string;
+    spanId?: string;
+    score: number;
+    reason?: string;
+    scorerName: string;
+    metadata?: Record<string, any>;
+  }): Promise<void>;
+
+  /**
+   * Force flush any buffered/queued spans without shutting down the exporter.
+   * This is useful in serverless environments where you need to ensure spans
+   * are exported before the runtime instance is terminated, while keeping
+   * the exporter active for future requests.
+   *
+   * Unlike shutdown(), flush() does not release resources or prevent future exports.
+   */
+  flush(): Promise<void>;
+
+  /** Shutdown exporter */
+  shutdown(): Promise<void>;
+}
+
+/**
+ * Interface for observability bridges
+ */
+export interface ObservabilityBridge {
+  /** Bridge name */
+  name: string;
+
+  /** Initialize bridge with observability configuration and/or access to Mastra */
+  init?(options: InitBridgeOptions): void;
+
+  /** Sets logger instance on the bridge  */
+  __setLogger?(logger: IMastraLogger): void;
+
+  /**
+   * Export Mastra tracing events to OTEL infrastructure
+   * Called for SPAN_STARTED, SPAN_UPDATED, SPAN_ENDED events
+   *
+   * @param event - Tracing event with exported span
+   */
+  exportTracingEvent(event: TracingEvent): Promise<void>;
+
+  /**
+   * Execute an async function within the tracing context of a Mastra span.
+   * This enables auto-instrumented operations (HTTP, DB) to have correct parent spans
+   * in the external tracing system (e.g., OpenTelemetry, DataDog, etc.).
+   *
+   * @param spanId - The ID of the Mastra span to use as context
+   * @param fn - The async function to execute within the span context
+   * @returns The result of the function execution
+   */
+  executeInContext?<T>(spanId: string, fn: () => Promise<T>): Promise<T>;
+
+  /**
+   * Execute a synchronous function within the tracing context of a Mastra span.
+   * This enables auto-instrumented operations (HTTP, DB) to have correct parent spans
+   * in the external tracing system (e.g., OpenTelemetry, DataDog, etc.).
+   *
+   * @param spanId - The ID of the Mastra span to use as context
+   * @param fn - The synchronous function to execute within the span context
+   * @returns The result of the function execution
+   */
+  executeInContextSync?<T>(spanId: string, fn: () => T): T;
+
+  /**
+   * Create a span in the bridge's tracing system.
+   * Called during Mastra span construction to get bridge-generated identifiers.
+   *
+   * @param options - Span creation options from Mastra
+   * @returns Span identifiers (spanId, traceId, parentSpanId) from bridge, or undefined if creation fails
+   */
+  createSpan(options: CreateSpanOptions<SpanType>): SpanIds | undefined;
+
+  /**
+   * Force flush any buffered/queued spans without shutting down the bridge.
+   * This is useful in serverless environments where you need to ensure spans
+   * are exported before the runtime instance is terminated, while keeping
+   * the bridge active for future requests.
+   *
+   * Unlike shutdown(), flush() does not release resources or prevent future exports.
+   */
+  flush(): Promise<void>;
+
+  /** Shutdown bridge and cleanup resources */
+  shutdown(): Promise<void>;
+}

--- a/packages/core/src/observability/types/feedback.ts
+++ b/packages/core/src/observability/types/feedback.ts
@@ -1,0 +1,88 @@
+// packages/core/src/observability/types/feedback.ts
+
+// ============================================================================
+// FeedbackInput (User Input)
+// ============================================================================
+
+/**
+ * User-provided feedback data for human evaluation of span/trace quality.
+ * Used with span.addFeedback() and trace.addFeedback().
+ */
+export interface FeedbackInput {
+  /** Source of the feedback (e.g., "user", "admin", "qa") */
+  source: string;
+
+  /** Type of feedback (e.g., "thumbs", "rating", "correction") */
+  feedbackType: string;
+
+  /** Feedback value (e.g., "up"/"down", 1-5, correction text) */
+  value: number | string;
+
+  /** Optional comment explaining the feedback */
+  comment?: string;
+
+  /** User who provided the feedback */
+  userId?: string;
+
+  /** Experiment identifier for A/B testing or evaluation runs */
+  experimentId?: string;
+
+  /** Additional metadata specific to this feedback */
+  metadata?: Record<string, unknown>;
+}
+
+// ============================================================================
+// ExportedFeedback (Event Bus Transport)
+// ============================================================================
+
+/**
+ * Feedback data transported via the event bus.
+ * Must be JSON-serializable (Date serializes via toJSON()).
+ *
+ * Context fields (organizationId, environment, etc.) are stored
+ * in metadata, following the same pattern as tracing spans. The metadata
+ * is inherited from the span/trace receiving feedback.
+ */
+export interface ExportedFeedback {
+  /** When the feedback was recorded */
+  timestamp: Date;
+
+  /** Trace receiving feedback */
+  traceId: string;
+
+  /** Specific span receiving feedback (undefined = trace-level feedback) */
+  spanId?: string;
+
+  /** Source of the feedback */
+  source: string;
+
+  /** Type of feedback */
+  feedbackType: string;
+
+  /** Feedback value */
+  value: number | string;
+
+  /** Optional comment */
+  comment?: string;
+
+  /** Experiment identifier for A/B testing */
+  experimentId?: string;
+
+  /**
+   * User-defined metadata.
+   * Inherited from the span/trace receiving feedback, merged with feedback-specific metadata.
+   * Contains context fields: organizationId, environment, serviceName,
+   * entityType, entityName, etc. The userId from FeedbackInput is also stored here.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+// ============================================================================
+// FeedbackEvent (Event Bus Event)
+// ============================================================================
+
+/** Feedback event emitted to the ObservabilityBus */
+export interface FeedbackEvent {
+  type: 'feedback';
+  feedback: ExportedFeedback;
+}

--- a/packages/core/src/observability/types/index.ts
+++ b/packages/core/src/observability/types/index.ts
@@ -1,1 +1,6 @@
+export * from './core';
 export * from './tracing';
+export * from './logging';
+export * from './metrics';
+export * from './scores';
+export * from './feedback';

--- a/packages/core/src/observability/types/logging.ts
+++ b/packages/core/src/observability/types/logging.ts
@@ -1,0 +1,74 @@
+// ============================================================================
+// Log Level
+// ============================================================================
+
+/** Log severity levels */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+
+// ============================================================================
+// LoggerContext (API Interface)
+// ============================================================================
+
+/**
+ * LoggerContext - API for emitting structured logs.
+ * Logs are automatically correlated with the current span's trace/span IDs.
+ */
+export interface LoggerContext {
+  debug(message: string, data?: Record<string, unknown>): void;
+  info(message: string, data?: Record<string, unknown>): void;
+  warn(message: string, data?: Record<string, unknown>): void;
+  error(message: string, data?: Record<string, unknown>): void;
+  fatal(message: string, data?: Record<string, unknown>): void;
+}
+
+// ============================================================================
+// ExportedLog (Event Bus Transport)
+// ============================================================================
+
+/**
+ * Log data transported via the event bus.
+ * Must be JSON-serializable (Date serializes via toJSON()).
+ *
+ * Context fields (runId, sessionId, userId, environment, etc.) are stored
+ * in metadata, following the same pattern as tracing spans.
+ */
+export interface ExportedLog {
+  /** When the log was emitted */
+  timestamp: Date;
+
+  /** Log severity level */
+  level: LogLevel;
+
+  /** Human-readable log message */
+  message: string;
+
+  /** Structured data associated with this log */
+  data?: Record<string, unknown>;
+
+  /** Trace ID for correlation (from current span) */
+  traceId?: string;
+
+  /** Span ID for correlation (from current span) */
+  spanId?: string;
+
+  /** Optional tags for filtering/categorization */
+  tags?: string[];
+
+  /**
+   * User-defined metadata.
+   * Context fields are stored here: runId, sessionId, userId, environment,
+   * serviceName, organizationId, entityType, entityName, etc.
+   * This follows the same pattern as BaseSpan.metadata in tracing.ts.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+// ============================================================================
+// LogEvent (Event Bus Event)
+// ============================================================================
+
+/** Log event emitted to the ObservabilityBus */
+export interface LogEvent {
+  type: 'log';
+  log: ExportedLog;
+}

--- a/packages/core/src/observability/types/metrics.ts
+++ b/packages/core/src/observability/types/metrics.ts
@@ -1,0 +1,125 @@
+// ============================================================================
+// Metric Type
+// ============================================================================
+
+/** Types of metrics */
+export type MetricType = 'counter' | 'gauge' | 'histogram';
+
+// ============================================================================
+// MetricsContext (API Interface)
+// ============================================================================
+
+/**
+ * MetricsContext - API for emitting metrics.
+ * Provides counter, gauge, and histogram metric types.
+ */
+export interface MetricsContext {
+  counter(name: string): Counter;
+  gauge(name: string): Gauge;
+  histogram(name: string): Histogram;
+}
+
+export interface Counter {
+  add(value: number, additionalLabels?: Record<string, string>): void;
+}
+
+export interface Gauge {
+  set(value: number, additionalLabels?: Record<string, string>): void;
+}
+
+export interface Histogram {
+  record(value: number, additionalLabels?: Record<string, string>): void;
+}
+
+// ============================================================================
+// ExportedMetric (Event Bus Transport)
+// ============================================================================
+
+/**
+ * Metric data transported via the event bus.
+ * Represents a single metric observation.
+ * Must be JSON-serializable (Date serializes via toJSON()).
+ *
+ * Environment fields (organizationId, environment, serviceName) are stored
+ * in metadata, following the same pattern as tracing spans.
+ *
+ * Note: Histogram aggregation (bucket counts, sum, count) is computed at
+ * the storage layer, not in the individual metric event.
+ */
+export interface ExportedMetric {
+  /** When the metric was recorded */
+  timestamp: Date;
+
+  /** Metric name (e.g., mastra_agent_duration_ms) */
+  name: string;
+
+  /** Type of metric */
+  metricType: MetricType;
+
+  /** Metric value (single observation) */
+  value: number;
+
+  /** Metric labels for dimensional filtering */
+  labels: Record<string, string>;
+
+  /**
+   * User-defined metadata.
+   * Environment fields are stored here: organizationId, environment,
+   * serviceName, etc. These are kept separate from labels to avoid
+   * cardinality issues.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+// ============================================================================
+// MetricEvent (Event Bus Event)
+// ============================================================================
+
+/** Metric event emitted to the ObservabilityBus */
+export interface MetricEvent {
+  type: 'metric';
+  metric: ExportedMetric;
+}
+
+// ============================================================================
+// Cardinality Protection
+// ============================================================================
+
+/**
+ * Default labels to block from metrics to prevent cardinality explosion.
+ * These are high-cardinality fields that should not be used as metric labels.
+ */
+export const DEFAULT_BLOCKED_LABELS = [
+  'trace_id',
+  'span_id',
+  'run_id',
+  'request_id',
+  'user_id',
+  'resource_id',
+  'session_id',
+  'thread_id',
+] as const;
+
+/** Cardinality protection configuration */
+export interface CardinalityConfig {
+  /**
+   * Labels to block from metrics.
+   * Set to undefined to use DEFAULT_BLOCKED_LABELS.
+   * Set to empty array to allow all labels.
+   */
+  blockedLabels?: string[];
+
+  /**
+   * Whether to block UUID-like values in labels.
+   * @default true
+   */
+  blockUUIDs?: boolean;
+}
+
+/** Metrics-specific configuration */
+export interface MetricsConfig {
+  /** Whether metrics are enabled */
+  enabled?: boolean;
+  /** Cardinality protection settings */
+  cardinality?: CardinalityConfig;
+}

--- a/packages/core/src/observability/types/scores.ts
+++ b/packages/core/src/observability/types/scores.ts
@@ -1,0 +1,79 @@
+// packages/core/src/observability/types/scores.ts
+
+// ============================================================================
+// ScoreInput (User Input)
+// ============================================================================
+
+/**
+ * User-provided score data for evaluating span/trace quality.
+ * Used with span.addScore() and trace.addScore().
+ */
+export interface ScoreInput {
+  /** Name of the scorer (e.g., "relevance", "accuracy", "toxicity") */
+  scorerName: string;
+
+  /** Numeric score value (typically 0-1 or 0-100) */
+  score: number;
+
+  /** Human-readable explanation of the score */
+  reason?: string;
+
+  /** Experiment identifier for A/B testing or evaluation runs */
+  experimentId?: string;
+
+  /** Additional metadata specific to this score */
+  metadata?: Record<string, unknown>;
+}
+
+// ============================================================================
+// ExportedScore (Event Bus Transport)
+// ============================================================================
+
+/**
+ * Score data transported via the event bus.
+ * Must be JSON-serializable (Date serializes via toJSON()).
+ *
+ * Context fields (organizationId, userId, environment, etc.) are stored
+ * in metadata, following the same pattern as tracing spans. The metadata
+ * is inherited from the span/trace being scored.
+ */
+export interface ExportedScore {
+  /** When the score was recorded */
+  timestamp: Date;
+
+  /** Trace being scored */
+  traceId: string;
+
+  /** Specific span being scored (undefined = trace-level score) */
+  spanId?: string;
+
+  /** Name of the scorer */
+  scorerName: string;
+
+  /** Numeric score value */
+  score: number;
+
+  /** Human-readable explanation */
+  reason?: string;
+
+  /** Experiment identifier for A/B testing */
+  experimentId?: string;
+
+  /**
+   * User-defined metadata.
+   * Inherited from the span/trace being scored, merged with score-specific metadata.
+   * Contains context fields: organizationId, userId, environment, serviceName,
+   * entityType, entityName, etc.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+// ============================================================================
+// ScoreEvent (Event Bus Event)
+// ============================================================================
+
+/** Score event emitted to the ObservabilityBus */
+export interface ScoreEvent {
+  type: 'score';
+  score: ExportedScore;
+}

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -6,7 +6,7 @@ import type { TripWireOptions } from '../agent/trip-wire';
 import type { ModelRouterModelId } from '../llm/model';
 import type { MastraLanguageModel, OpenAICompatibleConfig, SharedProviderOptions } from '../llm/model/shared.types';
 import type { Mastra } from '../mastra';
-import type { TracingContext } from '../observability';
+import type { ObservabilityContext } from '../observability';
 import type { RequestContext } from '../request-context';
 import type { ChunkType, InferSchemaOutput, OutputSchema } from '../stream';
 import type { DataChunkType } from '../stream/types';
@@ -30,15 +30,13 @@ export interface ProcessorStreamWriter {
 /**
  * Base context shared by all processor methods
  */
-export interface ProcessorContext<TTripwireMetadata = unknown> {
+export interface ProcessorContext<TTripwireMetadata = unknown> extends Partial<ObservabilityContext> {
   /**
    * Function to abort processing with an optional reason and options.
    * @param reason - The reason for aborting
    * @param options - Options including retry flag and metadata
    */
   abort: (reason?: string, options?: TripWireOptions<TTripwireMetadata>) => never;
-  /** Optional tracing context for observability */
-  tracingContext?: TracingContext;
   /** Optional runtime context with execution metadata */
   requestContext?: RequestContext;
   /**

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -2,7 +2,7 @@ import type { Processor } from '..';
 import type { MastraDBMessage, MessageList } from '../../agent';
 import { parseMemoryRequestContext } from '../../memory';
 import { removeWorkingMemoryTags } from '../../memory/working-memory-utils';
-import type { TracingContext } from '../../observability';
+import type { ObservabilityContext } from '../../observability';
 import type { RequestContext } from '../../request-context';
 import type { MemoryStorage } from '../../storage';
 
@@ -61,13 +61,14 @@ export class MessageHistory implements Processor {
     return null;
   }
 
-  async processInput(args: {
-    messages: MastraDBMessage[];
-    messageList: MessageList;
-    abort: (reason?: string) => never;
-    tracingContext?: TracingContext;
-    requestContext?: RequestContext;
-  }): Promise<MessageList | MastraDBMessage[]> {
+  async processInput(
+    args: {
+      messages: MastraDBMessage[];
+      messageList: MessageList;
+      abort: (reason?: string) => never;
+      requestContext?: RequestContext;
+    } & Partial<ObservabilityContext>,
+  ): Promise<MessageList | MastraDBMessage[]> {
     const { messageList, requestContext } = args;
 
     // Get memory context from RequestContext or MessageList
@@ -176,13 +177,14 @@ export class MessageHistory implements Processor {
       .filter((m): m is NonNullable<typeof m> => Boolean(m));
   }
 
-  async processOutputResult(args: {
-    messages: MastraDBMessage[];
-    messageList: MessageList;
-    abort: (reason?: string) => never;
-    tracingContext?: TracingContext;
-    requestContext?: RequestContext;
-  }): Promise<MessageList> {
+  async processOutputResult(
+    args: {
+      messages: MastraDBMessage[];
+      messageList: MessageList;
+      abort: (reason?: string) => never;
+      requestContext?: RequestContext;
+    } & Partial<ObservabilityContext>,
+  ): Promise<MessageList> {
     const { messageList, requestContext } = args;
 
     // Get memory context from RequestContext or MessageList

--- a/packages/core/src/processors/memory/semantic-recall.ts
+++ b/packages/core/src/processors/memory/semantic-recall.ts
@@ -5,7 +5,7 @@ import { MessageList } from '../../agent';
 import type { IMastraLogger } from '../../logger';
 import { parseMemoryRequestContext } from '../../memory';
 import type { MastraDBMessage } from '../../memory';
-import type { TracingContext } from '../../observability';
+import type { ObservabilityContext } from '../../observability';
 import type { RequestContext } from '../../request-context';
 import type { MemoryStorage } from '../../storage';
 import type { MastraEmbeddingModel, MastraEmbeddingOptions, MastraVector } from '../../vector';
@@ -162,13 +162,14 @@ export class SemanticRecall implements Processor {
     }
   }
 
-  async processInput(args: {
-    messages: MastraDBMessage[];
-    messageList: MessageList;
-    abort: (reason?: string) => never;
-    tracingContext?: TracingContext;
-    requestContext?: RequestContext;
-  }): Promise<MessageList | MastraDBMessage[]> {
+  async processInput(
+    args: {
+      messages: MastraDBMessage[];
+      messageList: MessageList;
+      abort: (reason?: string) => never;
+      requestContext?: RequestContext;
+    } & Partial<ObservabilityContext>,
+  ): Promise<MessageList | MastraDBMessage[]> {
     const { messages, messageList, requestContext } = args;
 
     // Get memory context from RequestContext
@@ -483,13 +484,14 @@ export class SemanticRecall implements Processor {
    * Process output messages to create embeddings for messages being saved
    * This allows semantic recall to index new messages for future retrieval
    */
-  async processOutputResult(args: {
-    messages: MastraDBMessage[];
-    messageList?: MessageList;
-    abort: (reason?: string) => never;
-    tracingContext?: TracingContext;
-    requestContext?: RequestContext;
-  }): Promise<MessageList | MastraDBMessage[]> {
+  async processOutputResult(
+    args: {
+      messages: MastraDBMessage[];
+      messageList?: MessageList;
+      abort: (reason?: string) => never;
+      requestContext?: RequestContext;
+    } & Partial<ObservabilityContext>,
+  ): Promise<MessageList | MastraDBMessage[]> {
     const { messages, messageList, requestContext } = args;
 
     if (!this.vector || !this.embedder || !this.storage) {

--- a/packages/core/src/processors/processors/moderation.ts
+++ b/packages/core/src/processors/processors/moderation.ts
@@ -5,7 +5,8 @@ import type { MastraDBMessage } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
 import type { ProviderOptions } from '../../llm/model/provider-options';
 import type { MastraModelConfig } from '../../llm/model/shared.types';
-import type { TracingContext } from '../../observability';
+import type { ObservabilityContext } from '../../observability';
+import { resolveObservabilityContext } from '../../observability';
 import type { ChunkType } from '../../stream';
 import type { Processor } from '../index';
 
@@ -153,13 +154,15 @@ export class ModerationProcessor implements Processor<'moderation'> {
     });
   }
 
-  async processInput(args: {
-    messages: MastraDBMessage[];
-    abort: (reason?: string) => never;
-    tracingContext?: TracingContext;
-  }): Promise<MastraDBMessage[]> {
+  async processInput(
+    args: {
+      messages: MastraDBMessage[];
+      abort: (reason?: string) => never;
+    } & Partial<ObservabilityContext>,
+  ): Promise<MastraDBMessage[]> {
     try {
-      const { messages, abort, tracingContext } = args;
+      const { messages, abort, ...rest } = args;
+      const observabilityContext = resolveObservabilityContext(rest);
 
       if (messages.length === 0) {
         return messages;
@@ -177,7 +180,7 @@ export class ModerationProcessor implements Processor<'moderation'> {
           continue;
         }
 
-        const moderationResult = await this.moderateContent(textContent, false, tracingContext);
+        const moderationResult = await this.moderateContent(textContent, false, observabilityContext);
         results.push(moderationResult);
 
         if (this.isModerationFlagged(moderationResult)) {
@@ -201,23 +204,26 @@ export class ModerationProcessor implements Processor<'moderation'> {
     }
   }
 
-  async processOutputResult(args: {
-    messages: MastraDBMessage[];
-    abort: (reason?: string) => never;
-    tracingContext?: TracingContext;
-  }): Promise<MastraDBMessage[]> {
+  async processOutputResult(
+    args: {
+      messages: MastraDBMessage[];
+      abort: (reason?: string) => never;
+    } & Partial<ObservabilityContext>,
+  ): Promise<MastraDBMessage[]> {
     return this.processInput(args);
   }
 
-  async processOutputStream(args: {
-    part: ChunkType;
-    streamParts: ChunkType[];
-    state: Record<string, any>;
-    abort: (reason?: string) => never;
-    tracingContext?: TracingContext;
-  }): Promise<ChunkType | null | undefined> {
+  async processOutputStream(
+    args: {
+      part: ChunkType;
+      streamParts: ChunkType[];
+      state: Record<string, any>;
+      abort: (reason?: string) => never;
+    } & Partial<ObservabilityContext>,
+  ): Promise<ChunkType | null | undefined> {
     try {
-      const { part, streamParts, abort, tracingContext } = args;
+      const { part, streamParts, abort, ...rest } = args;
+      const observabilityContext = resolveObservabilityContext(rest);
 
       // Only process text-delta chunks for moderation
       if (part.type !== 'text-delta') {
@@ -227,7 +233,7 @@ export class ModerationProcessor implements Processor<'moderation'> {
       // Build context from chunks based on chunkWindow (streamParts includes the current part)
       const contentToModerate = this.buildContextFromChunks(streamParts);
 
-      const moderationResult = await this.moderateContent(contentToModerate, true, tracingContext);
+      const moderationResult = await this.moderateContent(contentToModerate, true, observabilityContext);
 
       if (this.isModerationFlagged(moderationResult)) {
         this.handleFlaggedContent(moderationResult, this.strategy, abort);
@@ -255,7 +261,7 @@ export class ModerationProcessor implements Processor<'moderation'> {
   private async moderateContent(
     content: string,
     isStream = false,
-    tracingContext?: TracingContext,
+    observabilityContext?: ObservabilityContext,
   ): Promise<ModerationResult> {
     const prompt = this.createModerationPrompt(content, isStream);
 
@@ -290,14 +296,14 @@ export class ModerationProcessor implements Processor<'moderation'> {
             temperature: 0,
           },
           providerOptions: this.providerOptions,
-          tracingContext,
+          ...observabilityContext,
         });
       } else {
         response = await this.moderationAgent.generateLegacy(prompt, {
           output: schema,
           temperature: 0,
           providerOptions: this.providerOptions as SharedV2ProviderOptions,
-          tracingContext,
+          ...observabilityContext,
         });
       }
 

--- a/packages/core/src/processors/processors/pii-detector.ts
+++ b/packages/core/src/processors/processors/pii-detector.ts
@@ -6,7 +6,8 @@ import type { MastraDBMessage } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
 import type { ProviderOptions } from '../../llm/model/provider-options';
 import type { MastraModelConfig } from '../../llm/model/shared.types';
-import type { TracingContext } from '../../observability';
+import type { ObservabilityContext } from '../../observability';
+import { resolveObservabilityContext } from '../../observability';
 import type { ChunkType } from '../../stream';
 import type { Processor } from '../index';
 
@@ -200,13 +201,15 @@ export class PIIDetector implements Processor<'pii-detector'> {
     });
   }
 
-  async processInput(args: {
-    messages: MastraDBMessage[];
-    abort: (reason?: string) => never;
-    tracingContext?: TracingContext;
-  }): Promise<MastraDBMessage[]> {
+  async processInput(
+    args: {
+      messages: MastraDBMessage[];
+      abort: (reason?: string) => never;
+    } & Partial<ObservabilityContext>,
+  ): Promise<MastraDBMessage[]> {
     try {
-      const { messages, abort, tracingContext } = args;
+      const { messages, abort, ...rest } = args;
+      const observabilityContext = resolveObservabilityContext(rest);
 
       if (messages.length === 0) {
         return messages;
@@ -223,7 +226,7 @@ export class PIIDetector implements Processor<'pii-detector'> {
           continue;
         }
 
-        const detectionResult = await this.detectPII(textContent, tracingContext);
+        const detectionResult = await this.detectPII(textContent, observabilityContext);
 
         if (this.isPIIFlagged(detectionResult)) {
           const processedMessage = this.handleDetectedPII(message, detectionResult, this.strategy, abort);
@@ -256,7 +259,7 @@ export class PIIDetector implements Processor<'pii-detector'> {
   /**
    * Detect PII using the internal agent
    */
-  private async detectPII(content: string, tracingContext?: TracingContext): Promise<PIIDetectionResult> {
+  private async detectPII(content: string, observabilityContext?: ObservabilityContext): Promise<PIIDetectionResult> {
     const prompt = this.createDetectionPrompt(content);
 
     try {
@@ -317,14 +320,14 @@ export class PIIDetector implements Processor<'pii-detector'> {
             temperature: 0,
           },
           providerOptions: this.providerOptions,
-          tracingContext,
+          ...observabilityContext,
         });
       } else {
         response = await this.detectionAgent.generateLegacy(prompt, {
           output: schema,
           temperature: 0,
           providerOptions: this.providerOptions as SharedV2ProviderOptions,
-          tracingContext,
+          ...observabilityContext,
         });
       }
 
@@ -575,14 +578,16 @@ IMPORTANT: Only include PII types that are actually detected. If no PII is found
   /**
    * Process streaming output chunks for PII detection and redaction
    */
-  async processOutputStream(args: {
-    part: ChunkType;
-    streamParts: ChunkType[];
-    state: Record<string, any>;
-    abort: (reason?: string) => never;
-    tracingContext?: TracingContext;
-  }): Promise<ChunkType | null> {
-    const { part, abort, tracingContext } = args;
+  async processOutputStream(
+    args: {
+      part: ChunkType;
+      streamParts: ChunkType[];
+      state: Record<string, any>;
+      abort: (reason?: string) => never;
+    } & Partial<ObservabilityContext>,
+  ): Promise<ChunkType | null> {
+    const { part, abort, ...rest } = args;
+    const observabilityContext = resolveObservabilityContext(rest);
     try {
       // Only process text-delta chunks
       if (part.type !== 'text-delta') {
@@ -594,7 +599,7 @@ IMPORTANT: Only include PII types that are actually detected. If no PII is found
         return part;
       }
 
-      const detectionResult = await this.detectPII(textContent, tracingContext);
+      const detectionResult = await this.detectPII(textContent, observabilityContext);
 
       if (this.isPIIFlagged(detectionResult)) {
         switch (this.strategy) {
@@ -651,12 +656,12 @@ IMPORTANT: Only include PII types that are actually detected. If no PII is found
   async processOutputResult({
     messages,
     abort,
-    tracingContext,
+    ...rest
   }: {
     messages: MastraDBMessage[];
     abort: (reason?: string) => never;
-    tracingContext?: TracingContext;
-  }): Promise<MastraDBMessage[]> {
+  } & Partial<ObservabilityContext>): Promise<MastraDBMessage[]> {
+    const observabilityContext = resolveObservabilityContext(rest);
     try {
       if (messages.length === 0) {
         return messages;
@@ -673,7 +678,7 @@ IMPORTANT: Only include PII types that are actually detected. If no PII is found
           continue;
         }
 
-        const detectionResult = await this.detectPII(textContent, tracingContext);
+        const detectionResult = await this.detectPII(textContent, observabilityContext);
 
         if (this.isPIIFlagged(detectionResult)) {
           const processedMessage = this.handleDetectedPII(message, detectionResult, this.strategy, abort);

--- a/packages/core/src/processors/processors/prompt-injection-detector.ts
+++ b/packages/core/src/processors/processors/prompt-injection-detector.ts
@@ -5,7 +5,8 @@ import type { MastraDBMessage } from '../../agent/message-list';
 import { TripWire } from '../../agent/trip-wire';
 import type { ProviderOptions } from '../../llm/model/provider-options';
 import type { MastraModelConfig } from '../../llm/model/shared.types';
-import type { TracingContext } from '../../observability';
+import type { ObservabilityContext } from '../../observability';
+import { resolveObservabilityContext } from '../../observability';
 import type { Processor } from '../index';
 
 /**
@@ -135,13 +136,15 @@ export class PromptInjectionDetector implements Processor<'prompt-injection-dete
     });
   }
 
-  async processInput(args: {
-    messages: MastraDBMessage[];
-    abort: (reason?: string) => never;
-    tracingContext?: TracingContext;
-  }): Promise<MastraDBMessage[]> {
+  async processInput(
+    args: {
+      messages: MastraDBMessage[];
+      abort: (reason?: string) => never;
+    } & Partial<ObservabilityContext>,
+  ): Promise<MastraDBMessage[]> {
     try {
-      const { messages, abort, tracingContext } = args;
+      const { messages, abort, ...rest } = args;
+      const observabilityContext = resolveObservabilityContext(rest);
 
       if (messages.length === 0) {
         return messages;
@@ -159,7 +162,7 @@ export class PromptInjectionDetector implements Processor<'prompt-injection-dete
           continue;
         }
 
-        const detectionResult = await this.detectPromptInjection(textContent, tracingContext);
+        const detectionResult = await this.detectPromptInjection(textContent, observabilityContext);
         results.push(detectionResult);
 
         if (this.isInjectionFlagged(detectionResult)) {
@@ -194,7 +197,7 @@ export class PromptInjectionDetector implements Processor<'prompt-injection-dete
    */
   private async detectPromptInjection(
     content: string,
-    tracingContext?: TracingContext,
+    observabilityContext?: ObservabilityContext,
   ): Promise<PromptInjectionResult> {
     const prompt = this.createDetectionPrompt(content);
     try {
@@ -239,14 +242,14 @@ export class PromptInjectionDetector implements Processor<'prompt-injection-dete
             temperature: 0,
           },
           providerOptions: this.providerOptions,
-          tracingContext,
+          ...observabilityContext,
         });
       } else {
         response = await this.detectionAgent.generateLegacy(prompt, {
           output: schema,
           temperature: 0,
           providerOptions: this.providerOptions as SharedV2ProviderOptions,
-          tracingContext,
+          ...observabilityContext,
         });
       }
 

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -4,7 +4,8 @@ import type { StructuredOutputOptions } from '../../agent/types';
 import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
 import type { ProviderOptions } from '../../llm/model/provider-options';
 import type { IMastraLogger } from '../../logger';
-import type { TracingContext } from '../../observability';
+import type { ObservabilityContext } from '../../observability';
+import { resolveObservabilityContext } from '../../observability';
 import { ChunkFrom } from '../../stream';
 import type { ChunkType, OutputSchema } from '../../stream';
 import type { ToolCallChunk, ToolResultChunk } from '../../stream/types';
@@ -72,17 +73,19 @@ export class StructuredOutputProcessor<OUTPUT extends {}> implements Processor<'
     });
   }
 
-  async processOutputStream(args: {
-    part: ChunkType;
-    streamParts: ChunkType[];
-    state: Record<string, unknown> & {
-      controller?: TransformStreamDefaultController<ChunkType<OUTPUT>>;
-    };
-    abort: (reason?: string, options?: unknown) => never;
-    tracingContext?: TracingContext;
-    retryCount: number;
-  }): Promise<ChunkType | null | undefined> {
-    const { part, state, streamParts, abort, tracingContext } = args;
+  async processOutputStream(
+    args: {
+      part: ChunkType;
+      streamParts: ChunkType[];
+      state: Record<string, unknown> & {
+        controller?: TransformStreamDefaultController<ChunkType<OUTPUT>>;
+      };
+      abort: (reason?: string, options?: unknown) => never;
+      retryCount: number;
+    } & Partial<ObservabilityContext>,
+  ): Promise<ChunkType | null | undefined> {
+    const { part, state, streamParts, abort, ...rest } = args;
+    const observabilityContext = resolveObservabilityContext(rest);
     const controller = state.controller as TransformStreamDefaultController<ChunkType<OUTPUT>>;
 
     switch (part.type) {
@@ -91,7 +94,7 @@ export class StructuredOutputProcessor<OUTPUT extends {}> implements Processor<'
         // - enqueue the structuring agent stream chunks into the main stream
         // - when the structuring agent stream is finished, enqueue the final chunk into the main stream
 
-        await this.processAndEmitStructuredOutput(streamParts, controller, abort, tracingContext);
+        await this.processAndEmitStructuredOutput(streamParts, controller, abort, observabilityContext);
         return part;
 
       default:
@@ -103,7 +106,7 @@ export class StructuredOutputProcessor<OUTPUT extends {}> implements Processor<'
     streamParts: ChunkType[],
     controller: TransformStreamDefaultController<ChunkType<OUTPUT>>,
     abort: (reason?: string) => never,
-    tracingContext?: TracingContext,
+    observabilityContext?: ObservabilityContext,
   ): Promise<void> {
     if (this.isStructuringAgentStreamStarted) return;
     this.isStructuringAgentStreamStarted = true;
@@ -118,7 +121,7 @@ export class StructuredOutputProcessor<OUTPUT extends {}> implements Processor<'
           jsonPromptInjection: this.jsonPromptInjection,
         },
         providerOptions: this.providerOptions,
-        tracingContext,
+        ...observabilityContext,
       });
 
       const excludedChunkTypes = [

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -7,8 +7,8 @@ import { isSupportedLanguageModel, supportedLanguageModelSpecifications } from '
 import { MastraError } from '../error';
 import { resolveModelConfig } from '../llm';
 import type { IMastraLogger } from '../logger';
-import { EntityType, SpanType } from '../observability';
-import type { Span, TracingContext } from '../observability';
+import { EntityType, SpanType, createObservabilityContext, resolveObservabilityContext } from '../observability';
+import type { ObservabilityContext, Span } from '../observability';
 import type { RequestContext } from '../request-context';
 import type { ChunkType } from '../stream';
 import type { MastraModelOutput } from '../stream/base/output';
@@ -41,12 +41,13 @@ export class ProcessorState<OUTPUT = undefined> {
   public streamParts: ChunkType<OUTPUT>[] = [];
   public span?: Span<SpanType.PROCESSOR_RUN>;
 
-  constructor(options?: {
-    processorName?: string;
-    tracingContext?: TracingContext;
-    processorIndex?: number;
-    createSpan?: boolean;
-  }) {
+  constructor(
+    options?: {
+      processorName?: string;
+      processorIndex?: number;
+      createSpan?: boolean;
+    } & Partial<ObservabilityContext>,
+  ) {
     // Only create span if explicitly requested (legacy processors)
     // Workflow processors handle span creation in workflow.ts
     if (!options?.createSpan || !options.processorName) {
@@ -163,7 +164,7 @@ export class ProcessorRunner {
   private async executeWorkflowAsProcessor(
     workflow: ProcessorWorkflow,
     input: ProcessorStepOutput,
-    tracingContext?: TracingContext,
+    observabilityContext?: ObservabilityContext,
     requestContext?: RequestContext,
     writer?: ProcessorStreamWriter,
     abortSignal?: AbortSignal,
@@ -180,7 +181,7 @@ export class ProcessorRunner {
         // Pass abortSignal so processors can cancel in-flight work
         abortSignal,
       } as ProcessorStepOutput,
-      tracingContext,
+      ...observabilityContext,
       requestContext,
       outputWriter: writer ? chunk => writer.custom(chunk) : undefined,
     });
@@ -247,7 +248,7 @@ export class ProcessorRunner {
 
   async runOutputProcessors(
     messageList: MessageList,
-    tracingContext?: TracingContext,
+    observabilityContext?: ObservabilityContext,
     requestContext?: RequestContext,
     retryCount: number = 0,
     writer?: ProcessorStreamWriter,
@@ -268,7 +269,7 @@ export class ProcessorRunner {
             messageList,
             retryCount,
           },
-          tracingContext,
+          observabilityContext,
           requestContext,
           writer,
         );
@@ -289,7 +290,7 @@ export class ProcessorRunner {
         continue;
       }
 
-      const currentSpan = tracingContext?.currentSpan;
+      const currentSpan = observabilityContext?.tracingContext?.currentSpan;
       const parentSpan = currentSpan?.findParent(SpanType.AGENT_RUN) || currentSpan?.parent || currentSpan;
       const processorSpan = parentSpan?.createChildSpan({
         type: SpanType.PROCESSOR_RUN,
@@ -315,7 +316,7 @@ export class ProcessorRunner {
         messageList,
         state: processorState.customState,
         abort,
-        tracingContext: { currentSpan: processorSpan },
+        ...createObservabilityContext({ currentSpan: processorSpan }),
         requestContext,
         retryCount,
         writer,
@@ -368,7 +369,7 @@ export class ProcessorRunner {
   async processPart<OUTPUT>(
     part: ChunkType<OUTPUT>,
     processorStates: Map<string, ProcessorState<OUTPUT>>,
-    tracingContext?: TracingContext,
+    observabilityContext?: ObservabilityContext,
     requestContext?: RequestContext,
     messageList?: MessageList,
     retryCount: number = 0,
@@ -414,7 +415,7 @@ export class ProcessorRunner {
                 messageList,
                 retryCount,
               },
-              tracingContext,
+              observabilityContext,
               requestContext,
             );
 
@@ -447,7 +448,7 @@ export class ProcessorRunner {
             if (!state) {
               state = new ProcessorState<OUTPUT>({
                 processorName: processor.name ?? processor.id,
-                tracingContext,
+                ...observabilityContext,
                 processorIndex: index,
                 createSpan: true,
               });
@@ -464,7 +465,7 @@ export class ProcessorRunner {
               abort: <TMetadata = unknown>(reason?: string, options?: TripWireOptions<TMetadata>): never => {
                 throw new TripWire(reason || `Stream part blocked by ${processor.id}`, options, processor.id);
               },
-              tracingContext: { currentSpan: state.span },
+              ...createObservabilityContext({ currentSpan: state.span }),
               requestContext,
               messageList,
               retryCount,
@@ -520,7 +521,7 @@ export class ProcessorRunner {
 
   async runOutputProcessorsForStream<OUTPUT = undefined>(
     streamResult: MastraModelOutput<OUTPUT>,
-    tracingContext?: TracingContext,
+    observabilityContext?: ObservabilityContext,
   ): Promise<ReadableStream<any>> {
     return new ReadableStream({
       start: async controller => {
@@ -543,7 +544,7 @@ export class ProcessorRunner {
               reason,
               tripwireOptions,
               processorId,
-            } = await this.processPart(value, processorStates, tracingContext);
+            } = await this.processPart(value, processorStates, observabilityContext);
 
             if (blocked) {
               // Log that part was blocked
@@ -579,7 +580,7 @@ export class ProcessorRunner {
 
   async runInputProcessors(
     messageList: MessageList,
-    tracingContext?: TracingContext,
+    observabilityContext?: ObservabilityContext,
     requestContext?: RequestContext,
     retryCount: number = 0,
   ): Promise<MessageList> {
@@ -600,7 +601,7 @@ export class ProcessorRunner {
             systemMessages: currentSystemMessages,
             retryCount,
           },
-          tracingContext,
+          observabilityContext,
           requestContext,
         );
         continue;
@@ -620,7 +621,7 @@ export class ProcessorRunner {
         continue;
       }
 
-      const currentSpan = tracingContext?.currentSpan;
+      const currentSpan = observabilityContext?.tracingContext?.currentSpan;
       const parentSpan = currentSpan?.findParent(SpanType.AGENT_RUN) || currentSpan?.parent || currentSpan;
       const processorSpan = parentSpan?.createChildSpan({
         type: SpanType.PROCESSOR_RUN,
@@ -649,7 +650,7 @@ export class ProcessorRunner {
         systemMessages: currentSystemMessages,
         state: processorState.customState,
         abort,
-        tracingContext: { currentSpan: processorSpan },
+        ...createObservabilityContext({ currentSpan: processorSpan }),
         messageList,
         requestContext,
         retryCount,
@@ -785,7 +786,8 @@ export class ProcessorRunner {
    * @returns The processed MessageList
    */
   async runProcessInputStep(args: RunProcessInputStepArgs): Promise<RunProcessInputStepResult> {
-    const { messageList, stepNumber, steps, tracingContext, requestContext, writer } = args;
+    const { messageList, stepNumber, steps, requestContext, writer } = args;
+    const observabilityContext = resolveObservabilityContext(args);
 
     // Initialize with all provided values - processors will modify this object in order
     const stepInput: RunProcessInputStepResult = {
@@ -824,7 +826,7 @@ export class ProcessorRunner {
             systemMessages: currentSystemMessages,
             ...stepInput,
           },
-          tracingContext,
+          observabilityContext,
           requestContext,
           writer,
           args.abortSignal,
@@ -864,7 +866,7 @@ export class ProcessorRunner {
       };
 
       // Use the current span (the step span) as the parent for processor spans
-      const currentSpan = tracingContext?.currentSpan;
+      const currentSpan = observabilityContext.tracingContext?.currentSpan;
       const processorSpan = currentSpan?.createChildSpan({
         type: SpanType.PROCESSOR_RUN,
         name: `input step processor: ${processor.id}`,
@@ -897,7 +899,7 @@ export class ProcessorRunner {
           ...inputData,
           state: processorState.customState,
           abort,
-          tracingContext: { currentSpan: processorSpan },
+          ...createObservabilityContext({ currentSpan: processorSpan }),
           retryCount: args.retryCount ?? 0,
           writer,
           abortSignal: args.abortSignal,
@@ -992,19 +994,20 @@ export class ProcessorRunner {
    *
    * @returns The processed MessageList
    */
-  async runProcessOutputStep(args: {
-    steps: Array<StepResult<any>>;
-    messages: MastraDBMessage[];
-    messageList: MessageList;
-    stepNumber: number;
-    finishReason?: string;
-    toolCalls?: ToolCallInfo[];
-    text?: string;
-    tracingContext?: TracingContext;
-    requestContext?: RequestContext;
-    retryCount?: number;
-    writer?: ProcessorStreamWriter;
-  }): Promise<MessageList> {
+  async runProcessOutputStep(
+    args: {
+      steps: Array<StepResult<any>>;
+      messages: MastraDBMessage[];
+      messageList: MessageList;
+      stepNumber: number;
+      finishReason?: string;
+      toolCalls?: ToolCallInfo[];
+      text?: string;
+      requestContext?: RequestContext;
+      retryCount?: number;
+      writer?: ProcessorStreamWriter;
+    } & Partial<ObservabilityContext>,
+  ): Promise<MessageList> {
     const {
       steps,
       messageList,
@@ -1012,11 +1015,11 @@ export class ProcessorRunner {
       finishReason,
       toolCalls,
       text,
-      tracingContext,
       requestContext,
       retryCount = 0,
       writer,
     } = args;
+    const observabilityContext = resolveObservabilityContext(args);
 
     // Run through all output processors that have processOutputStep
     for (const [index, processorOrWorkflow] of this.outputProcessors.entries()) {
@@ -1041,7 +1044,7 @@ export class ProcessorRunner {
             steps,
             retryCount,
           },
-          tracingContext,
+          observabilityContext,
           requestContext,
           writer,
         );
@@ -1061,7 +1064,7 @@ export class ProcessorRunner {
         throw new TripWire(reason || `Tripwire triggered by ${processor.id}`, options, processor.id);
       };
 
-      const currentSpan = tracingContext?.currentSpan;
+      const currentSpan = observabilityContext.tracingContext?.currentSpan;
       const parentSpan = currentSpan?.findParent(SpanType.AGENT_RUN) || currentSpan?.parent || currentSpan;
       const processorSpan = parentSpan?.createChildSpan({
         type: SpanType.PROCESSOR_RUN,
@@ -1097,7 +1100,7 @@ export class ProcessorRunner {
           steps,
           state: processorState.customState,
           abort,
-          tracingContext: { currentSpan: processorSpan },
+          ...createObservabilityContext({ currentSpan: processorSpan }),
           requestContext,
           retryCount,
           writer,

--- a/packages/core/src/stream/aisdk/v4/usage.ts
+++ b/packages/core/src/stream/aisdk/v4/usage.ts
@@ -1,4 +1,4 @@
-import type { UsageStats } from '../../../observability/types/tracing';
+import type { UsageStats } from '../../../observability';
 
 /**
  * AI SDK v4 LanguageModelUsage type definition

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -7,6 +7,7 @@ import { MastraBase } from '../../base';
 import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
 import { getErrorFromUnknown } from '../../error/utils.js';
 import type { ScorerRunInputForAgent, ScorerRunOutputForAgent } from '../../evals';
+import { resolveObservabilityContext } from '../../observability';
 import { STRUCTURED_OUTPUT_PROCESSOR_NAME } from '../../processors/processors/structured-output';
 import { ProcessorState, ProcessorRunner } from '../../processors/runner';
 import type { WorkflowRunStatus } from '../../workflows';
@@ -348,7 +349,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               } = await processorRunner.processPart(
                 chunk,
                 processorStates,
-                options.tracingContext,
+                resolveObservabilityContext(options),
                 options.requestContext,
                 self.messageList,
               );
@@ -715,7 +716,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
 
                   self.messageList = await self.processorRunner.runOutputProcessors(
                     self.messageList,
-                    options.tracingContext,
+                    resolveObservabilityContext(options),
                     self.#options.requestContext,
                   );
 

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -17,7 +17,7 @@ import type { AIV5Type } from '../agent/message-list/types';
 import type { StructuredOutputOptions } from '../agent/types';
 import type { MastraLanguageModel } from '../llm/model/shared.types';
 import type { ScorerResult } from '../loop';
-import type { TracingContext } from '../observability';
+import type { ObservabilityContext } from '../observability';
 import type { OutputProcessorOrWorkflow } from '../processors';
 import type { RequestContext } from '../request-context';
 import type { WorkflowRunStatus, WorkflowStepStatus } from '../workflows/types';
@@ -836,10 +836,9 @@ export type MastraModelOutputOptions<OUTPUT = undefined> = {
   outputProcessors?: OutputProcessorOrWorkflow[];
   isLLMExecutionStep?: boolean;
   returnScorerData?: boolean;
-  tracingContext?: TracingContext;
   processorStates?: Map<string, any>;
   requestContext?: RequestContext;
-};
+} & Partial<ObservabilityContext>;
 
 /**
  * Tripwire data attached to a step when a processor triggers a tripwire.

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -13,7 +13,7 @@ import { zodToJsonSchema } from '@mastra/schema-compat/zod-to-json';
 import { z } from 'zod';
 import { MastraBase } from '../../base';
 import { ErrorCategory, MastraError, ErrorDomain } from '../../error';
-import { SpanType, wrapMastra, executeWithContext, EntityType } from '../../observability';
+import { SpanType, wrapMastra, executeWithContext, EntityType, createObservabilityContext } from '../../observability';
 import { RequestContext } from '../../request-context';
 import { isVercelTool } from '../../tools/toolchecks';
 import type { ToolOptions } from '../../utils';
@@ -342,7 +342,7 @@ export class CoreToolBuilder extends MastraBase {
               },
               options.outputWriter || execOptions.outputWriter,
             ),
-            tracingContext: { currentSpan: toolSpan },
+            ...createObservabilityContext({ currentSpan: toolSpan }),
             abortSignal: execOptions.abortSignal,
             suspend: (args: any, suspendOptions?: SuspendOptions) => {
               suspendData = args;

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -12,7 +12,7 @@ import type { ElicitRequest, ElicitResult } from '@modelcontextprotocol/sdk/type
 
 import type { MastraUnion } from '../action';
 import type { Mastra } from '../mastra';
-import type { TracingContext } from '../observability';
+import type { ObservabilityContext } from '../observability';
 import type { RequestContext } from '../request-context';
 import type { SchemaWithValidation } from '../stream/base/schema';
 import type { SuspendOptions, OutputWriter } from '../workflows';
@@ -80,23 +80,23 @@ export interface MCPToolExecutionContext {
  * - Converts to: ToolExecutionContext for Mastra tool execution
  * - Returns: Results back to AI SDK
  */
-export type MastraToolInvocationOptions = ToolInvocationOptions & {
-  suspend?: (suspendPayload: any, suspendOptions?: SuspendOptions) => Promise<any>;
-  resumeData?: any;
-  outputWriter?: OutputWriter;
-  tracingContext?: TracingContext;
-  /**
-   * Optional MCP-specific context passed when tool is executed in MCP server.
-   * This is populated by the MCP server and passed through to the tool's execution context.
-   */
-  mcp?: MCPToolExecutionContext;
-  /**
-   * Workspace for tool execution. When provided at execution time, this overrides
-   * any workspace configured at tool build time. Allows dynamic workspace selection
-   * per-step via prepareStep.
-   */
-  workspace?: Workspace;
-};
+export type MastraToolInvocationOptions = ToolInvocationOptions &
+  Partial<ObservabilityContext> & {
+    suspend?: (suspendPayload: any, suspendOptions?: SuspendOptions) => Promise<any>;
+    resumeData?: any;
+    outputWriter?: OutputWriter;
+    /**
+     * Optional MCP-specific context passed when tool is executed in MCP server.
+     * This is populated by the MCP server and passed through to the tool's execution context.
+     */
+    mcp?: MCPToolExecutionContext;
+    /**
+     * Workspace for tool execution. When provided at execution time, this overrides
+     * any workspace configured at tool build time. Allows dynamic workspace selection
+     * per-step via prepareStep.
+     */
+    workspace?: Workspace;
+  };
 
 /**
  * The type of tool registered with the MCP server.
@@ -244,11 +244,10 @@ export interface ToolExecutionContext<
   TSuspend = unknown,
   TResume = unknown,
   TRequestContext extends Record<string, any> | unknown = unknown,
-> {
+> extends Partial<ObservabilityContext> {
   // ============ Common properties (available in all contexts) ============
   mastra?: MastraUnion;
   requestContext?: RequestContext<TRequestContext>;
-  tracingContext?: TracingContext;
   abortSignal?: AbortSignal;
 
   /**

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -9,7 +9,7 @@ import type { MastraLanguageModel, MastraLegacyLanguageModel } from './llm/model
 import type { IMastraLogger } from './logger';
 import type { Mastra } from './mastra';
 import type { AiMessageType, MastraMemory } from './memory';
-import type { TracingContext, TracingPolicy } from './observability';
+import type { ObservabilityContext, TracingPolicy } from './observability';
 import type { RequestContext } from './request-context';
 import type { CoreTool, VercelTool, VercelToolV5 } from './tools';
 import { Tool } from './tools/tool';
@@ -267,7 +267,7 @@ export function resolveSerializedZodOutput(schema: string): z.ZodType {
   return Function('z', `"use strict";return (${schema});`)(z);
 }
 
-export interface ToolOptions {
+export interface ToolOptions extends Partial<ObservabilityContext> {
   name: string;
   runId?: string;
   threadId?: string;
@@ -276,8 +276,6 @@ export interface ToolOptions {
   description?: string;
   mastra?: (Mastra & MastraPrimitives) | MastraPrimitives;
   requestContext: RequestContext;
-  /** Build-time tracing context (fallback for Legacy methods that can't pass request context) */
-  tracingContext?: TracingContext;
   tracingPolicy?: TracingPolicy;
   memory?: MastraMemory;
   agentName?: string;

--- a/packages/core/src/workflows/evented/step-executor.ts
+++ b/packages/core/src/workflows/evented/step-executor.ts
@@ -6,6 +6,7 @@ import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
 import { getErrorFromUnknown } from '../../error/utils.js';
 import { RegisteredLogger } from '../../logger';
 import type { Mastra } from '../../mastra';
+import { createObservabilityContext } from '../../observability';
 import { ToolStream } from '../../tools/stream';
 import { PUBSUB_SYMBOL, STREAM_FORMAT_SYMBOL } from '../constants';
 import { getStepResult } from '../step';
@@ -198,7 +199,7 @@ export class StepExecutor extends MastraBase {
             engine: {},
             abortSignal: abortController?.signal,
             // TODO
-            tracingContext: {},
+            ...createObservabilityContext(),
           },
           {
             paramName: 'runCount',
@@ -407,7 +408,7 @@ export class StepExecutor extends MastraBase {
           engine: {},
           abortSignal: abortController?.signal,
           // TODO
-          tracingContext: {},
+          ...createObservabilityContext(),
           iterationCount,
         },
         {
@@ -487,7 +488,7 @@ export class StepExecutor extends MastraBase {
             engine: {},
             abortSignal: abortController?.signal,
             // TODO
-            tracingContext: {},
+            ...createObservabilityContext(),
           },
           {
             paramName: 'runCount',
@@ -570,7 +571,7 @@ export class StepExecutor extends MastraBase {
             engine: {},
             abortSignal: abortController?.signal,
             // TODO
-            tracingContext: {},
+            ...createObservabilityContext(),
           },
           {
             paramName: 'runCount',

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -12,8 +12,8 @@ import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
 import type { MastraScorers } from '../../evals';
 import type { Event } from '../../events';
 import type { Mastra } from '../../mastra';
-import type { TracingContext } from '../../observability';
-import { EntityType, SpanType } from '../../observability';
+import { EntityType, SpanType, createObservabilityContext, resolveObservabilityContext } from '../../observability';
+import type { ObservabilityContext } from '../../observability';
 import type { Processor } from '../../processors';
 import { ProcessorRunner, ProcessorStepOutputSchema, ProcessorStepSchema } from '../../processors';
 import type { ProcessorStepOutput } from '../../processors/step-schema';
@@ -430,10 +430,11 @@ function createStepFromAgent<TStepId extends string, TStepOutput>(
       mastra,
       [PUBSUB_SYMBOL]: pubsub,
       requestContext,
-      tracingContext,
       abortSignal,
       abort,
+      ...obsFields
     }) => {
+      const observabilityContext = resolveObservabilityContext(obsFields);
       const logger = mastra?.getLogger();
       const toolData = {
         name: params.name,
@@ -464,7 +465,7 @@ function createStepFromAgent<TStepId extends string, TStepOutput>(
         // V2+ model path: use .stream() which returns MastraModelOutput
         const modelOutput = await params.stream((inputData as { prompt: string }).prompt, {
           ...(agentOptions ?? {}),
-          tracingContext,
+          ...observabilityContext,
           requestContext,
           onFinish: result => {
             handleFinish(result);
@@ -483,7 +484,7 @@ function createStepFromAgent<TStepId extends string, TStepOutput>(
 
         const legacyResult = await params.streamLegacy((inputData as { prompt: string }).prompt, {
           ...(agentOptions ?? {}),
-          tracingContext,
+          ...observabilityContext,
           requestContext,
           onFinish: result => {
             handleFinish(result);
@@ -548,7 +549,19 @@ function createStepFromTool<TStepInput, TSuspend, TResume, TStepOutput>(
     retries: toolOpts?.retries,
     scorers: toolOpts?.scorers,
     metadata: toolOpts?.metadata,
-    execute: async ({ inputData, mastra, requestContext, suspend, resumeData, runId, workflowId, state, setState }) => {
+    execute: async ({
+      inputData,
+      mastra,
+      requestContext,
+      suspend,
+      resumeData,
+      runId,
+      workflowId,
+      state,
+      setState,
+      ...obsFields
+    }) => {
+      const observabilityContext = resolveObservabilityContext(obsFields);
       // Tools receive (input, context) - just call the tool's execute
       if (!params.execute) {
         throw new Error(`Tool ${params.id} does not have an execute function`);
@@ -558,7 +571,7 @@ function createStepFromTool<TStepInput, TSuspend, TResume, TStepOutput>(
       const context = {
         mastra,
         requestContext,
-        tracingContext: { currentSpan: undefined }, // TODO: Pass proper tracing context when evented workflows support tracing
+        ...observabilityContext,
         workflow: {
           runId,
           workflowId,
@@ -645,7 +658,8 @@ function createStepFromProcessor<TProcessorId extends string>(
     description: processor.name ?? `Processor ${processor.id}`,
     inputSchema: ProcessorStepSchema,
     outputSchema: ProcessorStepOutputSchema,
-    execute: async ({ inputData, requestContext, tracingContext }) => {
+    execute: async ({ inputData, requestContext, ...obsFields }) => {
+      const observabilityContext = resolveObservabilityContext(obsFields);
       // Cast to output type for easier property access - the discriminated union
       // ensures type safety at the schema level, but inside the execute function
       // we need access to all possible properties
@@ -689,7 +703,7 @@ function createStepFromProcessor<TProcessorId extends string>(
 
       // Create processor span for non-stream phases
       // outputStream phase doesn't need its own span (stream chunks are already tracked)
-      const currentSpan = tracingContext?.currentSpan;
+      const currentSpan = observabilityContext.tracingContext?.currentSpan;
 
       // Find appropriate parent span:
       // - For input/outputResult: find AGENT_RUN (processor runs once at start/end)
@@ -717,18 +731,18 @@ function createStepFromProcessor<TProcessorId extends string>(
             })
           : undefined;
 
-      // Create tracing context with processor span so internal agent calls nest correctly
-      const processorTracingContext: TracingContext | undefined = processorSpan
-        ? { currentSpan: processorSpan }
-        : tracingContext;
+      // Create observability context with processor span so internal agent calls nest correctly
+      const processorObservabilityContext: ObservabilityContext | undefined = createObservabilityContext(
+        processorSpan ? { currentSpan: processorSpan } : observabilityContext.tracingContext,
+      );
 
       // Base context for all processor methods - includes requestContext for memory processors
-      // and tracingContext for proper span nesting when processors call internal agents
+      // and observabilityContext for proper span nesting when processors call internal agents
       const baseContext = {
         abort,
         retryCount: retryCount ?? 0,
         requestContext,
-        tracingContext: processorTracingContext,
+        ...processorObservabilityContext,
         state: state ?? {},
         abortSignal,
       };
@@ -948,10 +962,10 @@ function createStepFromProcessor<TProcessorId extends string>(
                 };
               }
 
-              // Create tracing context with processor span for internal agent calls
-              const processorTracingContext = processorSpan
-                ? { currentSpan: processorSpan }
-                : baseContext.tracingContext;
+              // Create observability context with processor span for internal agent calls
+              const processorObservabilityContext = createObservabilityContext(
+                processorSpan ? { currentSpan: processorSpan } : baseContext.tracingContext,
+              );
 
               // Handle outputStream span lifecycle explicitly (not via executePhaseWithSpan)
               // because outputStream uses a per-processor span stored in mutableState
@@ -959,7 +973,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               try {
                 result = await processor.processOutputStream({
                   ...baseContext,
-                  tracingContext: processorTracingContext,
+                  ...processorObservabilityContext,
                   part: part as ChunkType,
                   streamParts: (streamParts ?? []) as ChunkType[],
                   state: mutableState,

--- a/packages/core/src/workflows/handlers/entry.ts
+++ b/packages/core/src/workflows/handlers/entry.ts
@@ -1,7 +1,8 @@
 import type { RequestContext } from '../../di';
 import type { SerializedError } from '../../error';
 import type { PubSub } from '../../events/pubsub';
-import type { TracingContext } from '../../observability';
+import { resolveObservabilityContext } from '../../observability';
+import type { ObservabilityContext } from '../../observability';
 import type { DefaultExecutionEngine } from '../default';
 import type {
   EntryExecutionResult,
@@ -84,7 +85,7 @@ export async function persistStepUpdate(
   });
 }
 
-export interface ExecuteEntryParams {
+export interface ExecuteEntryParams extends ObservabilityContext {
   workflowId: string;
   runId: string;
   resourceId?: string;
@@ -101,7 +102,6 @@ export interface ExecuteEntryParams {
     resumePath: number[];
   };
   executionContext: ExecutionContext;
-  tracingContext: TracingContext;
   pubsub: PubSub;
   abortController: AbortController;
   requestContext: RequestContext;
@@ -126,14 +126,15 @@ export async function executeEntry(
     timeTravel,
     resume,
     executionContext,
-    tracingContext,
     pubsub,
     abortController,
     requestContext,
     outputWriter,
     disableScorers,
     perStep,
+    ...rest
   } = params;
+  const observabilityContext = resolveObservabilityContext(rest);
 
   const prevOutput = engine.getStepOutput(stepResults, prevStep);
   let execResults: any;
@@ -152,7 +153,7 @@ export async function executeEntry(
       restart,
       resume,
       prevOutput,
-      tracingContext,
+      ...observabilityContext,
       pubsub,
       abortController,
       requestContext,
@@ -188,7 +189,7 @@ export async function executeEntry(
         activeStepsPath: executionContext.activeStepsPath,
         state: executionContext.state,
       },
-      tracingContext,
+      ...observabilityContext,
       pubsub,
       abortController,
       requestContext,
@@ -272,7 +273,7 @@ export async function executeEntry(
       restart,
       resume,
       executionContext,
-      tracingContext,
+      ...observabilityContext,
       pubsub,
       abortController,
       requestContext,
@@ -292,7 +293,7 @@ export async function executeEntry(
       restart,
       resume,
       executionContext,
-      tracingContext,
+      ...observabilityContext,
       pubsub,
       abortController,
       requestContext,
@@ -312,7 +313,7 @@ export async function executeEntry(
       restart,
       resume,
       executionContext,
-      tracingContext,
+      ...observabilityContext,
       pubsub,
       abortController,
       requestContext,
@@ -333,7 +334,7 @@ export async function executeEntry(
       restart,
       resume,
       executionContext,
-      tracingContext,
+      ...observabilityContext,
       pubsub,
       abortController,
       requestContext,
@@ -387,7 +388,7 @@ export async function executeEntry(
       serializedStepGraph,
       resume,
       executionContext,
-      tracingContext,
+      ...observabilityContext,
       pubsub,
       abortController,
       requestContext,
@@ -491,7 +492,7 @@ export async function executeEntry(
       serializedStepGraph,
       resume,
       executionContext,
-      tracingContext,
+      ...observabilityContext,
       pubsub,
       abortController,
       requestContext,

--- a/packages/core/src/workflows/step.ts
+++ b/packages/core/src/workflows/step.ts
@@ -1,7 +1,7 @@
 import type { MastraScorers } from '../evals';
 import type { PubSub } from '../events';
 import type { Mastra } from '../mastra';
-import type { TracingContext } from '../observability';
+import type { ObservabilityContext } from '../observability';
 import type { RequestContext } from '../request-context';
 import type { InferZodLikeSchema, SchemaWithValidation } from '../stream/base/schema';
 import type { ToolStream } from '../tools/stream';
@@ -28,7 +28,7 @@ export type ExecuteFunctionParams<
   TSuspend,
   EngineType,
   TRequestContext extends Record<string, any> | unknown = unknown,
-> = {
+> = Partial<ObservabilityContext> & {
   runId: string;
   resourceId?: string;
   workflowId: string;
@@ -40,7 +40,6 @@ export type ExecuteFunctionParams<
   resumeData?: TResume;
   suspendData?: TSuspend;
   retryCount: number;
-  tracingContext: TracingContext;
   getInitData<T>(): T extends AnyWorkflow ? InferZodLikeSchema<T['inputSchema']> : T;
   getStepResult<TOutput>(step: string): TOutput;
   getStepResult<TStep extends Step<string, any, any, any, any, any, EngineType>>(

--- a/packages/core/src/workflows/types.ts
+++ b/packages/core/src/workflows/types.ts
@@ -6,7 +6,7 @@ import type { MastraScorers } from '../evals';
 import type { PubSub } from '../events/pubsub';
 import type { IMastraLogger } from '../logger';
 import type { Mastra } from '../mastra';
-import type { AnySpan, TracingContext, TracingPolicy, TracingProperties } from '../observability';
+import type { AnySpan, ObservabilityContext, TracingPolicy, TracingProperties } from '../observability';
 import type { RequestContext } from '../request-context';
 import type { OutputSchema } from '../stream';
 import type { InferZodLikeSchema, SchemaWithValidation } from '../stream/base/schema';
@@ -888,7 +888,6 @@ export type RegularStepExecutionParams = {
   pubsub: PubSub;
   abortController: AbortController;
   requestContext: RequestContext;
-  tracingContext?: TracingContext;
   writableStream?: WritableStream<ChunkType>;
   startedAt: number;
   resumeDataToUse?: any;
@@ -898,7 +897,7 @@ export type RegularStepExecutionParams = {
   serializedStepGraph: SerializedStepFlowEntry[];
   resourceId?: string;
   disableScorers?: boolean;
-};
+} & Partial<ObservabilityContext>;
 
 /**
  * Result from step execution core logic

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -16,8 +16,14 @@ import type { PubSub } from '../events/pubsub';
 import type { Event } from '../events/types';
 import { RegisteredLogger } from '../logger';
 import type { Mastra } from '../mastra';
-import type { TracingContext, TracingOptions, TracingPolicy } from '../observability';
-import { EntityType, SpanType, getOrCreateSpan } from '../observability';
+import type { ObservabilityContext, TracingOptions, TracingPolicy } from '../observability';
+import {
+  EntityType,
+  SpanType,
+  createObservabilityContext,
+  getOrCreateSpan,
+  resolveObservabilityContext,
+} from '../observability';
 import { ProcessorRunner, ProcessorState } from '../processors';
 import type { Processor, ProcessorStreamWriter } from '../processors';
 import { ProcessorStepOutputSchema, ProcessorStepInputSchema } from '../processors/step-schema';
@@ -388,11 +394,12 @@ function createStepFromAgent<TStepId extends string, TStepOutput>(
       [PUBSUB_SYMBOL]: pubsub,
       [STREAM_FORMAT_SYMBOL]: streamFormat,
       requestContext,
-      tracingContext,
       abortSignal,
       abort,
       writer,
+      ...rest
     }) => {
+      const observabilityContext = resolveObservabilityContext(rest);
       let streamPromise = {} as {
         promise: Promise<string>;
         resolve: (value: string) => void;
@@ -418,7 +425,7 @@ function createStepFromAgent<TStepId extends string, TStepOutput>(
         const { fullStream } = await params.streamLegacy((inputData as { prompt: string }).prompt, {
           ...agentOptions,
           requestContext,
-          tracingContext,
+          ...observabilityContext,
           onFinish: result => {
             // Capture structured output if available
             const resultWithObject = result as typeof result & { object?: unknown };
@@ -435,7 +442,7 @@ function createStepFromAgent<TStepId extends string, TStepOutput>(
         const modelOutput = await params.stream((inputData as { prompt: string }).prompt, {
           ...agentOptions,
           requestContext,
-          tracingContext,
+          ...observabilityContext,
           onFinish: result => {
             // Capture structured output if available
             const resultWithObject = result as typeof result & { object?: unknown };
@@ -539,19 +546,20 @@ function createStepFromTool<TStepInput, TSuspend, TResume, TStepOutput>(
       inputData,
       mastra,
       requestContext,
-      tracingContext,
       suspend,
       resumeData,
       runId,
       workflowId,
       state,
       setState,
+      ...rest
     }) => {
       // BREAKING CHANGE v1.0: Pass raw input as first arg, context as second
+      const observabilityContext = resolveObservabilityContext(rest);
       const toolContext = {
         mastra,
         requestContext,
-        tracingContext,
+        ...observabilityContext,
         resumeData,
         workflow: {
           runId,
@@ -715,10 +723,10 @@ function createStepFromProcessor<TProcessorId extends string>(
             })
           : undefined;
 
-      // Create tracing context with processor span so internal agent calls nest correctly
-      const processorTracingContext: TracingContext | undefined = processorSpan
-        ? { currentSpan: processorSpan }
-        : tracingContext;
+      // Create observability context with processor span so internal agent calls nest correctly
+      const processorObservabilityContext: ObservabilityContext | undefined = createObservabilityContext(
+        processorSpan ? { currentSpan: processorSpan } : tracingContext,
+      );
 
       // Create ProcessorStreamWriter from outputWriter if available
       // This enables processors to stream data-* parts to the UI in real-time
@@ -754,7 +762,7 @@ function createStepFromProcessor<TProcessorId extends string>(
         abort,
         retryCount: retryCount ?? 0,
         requestContext,
-        tracingContext: processorTracingContext,
+        ...processorObservabilityContext,
         state: processorState,
         writer: processorWriter,
         abortSignal,
@@ -980,10 +988,10 @@ function createStepFromProcessor<TProcessorId extends string>(
                 };
               }
 
-              // Create tracing context with processor span for internal agent calls
-              const processorTracingContext = processorSpan
-                ? { currentSpan: processorSpan }
-                : baseContext.tracingContext;
+              // Create observability context with processor span for internal agent calls
+              const processorObservabilityContext = createObservabilityContext(
+                processorSpan ? { currentSpan: processorSpan } : baseContext.tracingContext,
+              );
 
               // Handle outputStream span lifecycle explicitly (not via executePhaseWithSpan)
               // because outputStream uses a per-processor span stored in mutableState
@@ -991,7 +999,7 @@ function createStepFromProcessor<TProcessorId extends string>(
               try {
                 result = await processor.processOutputStream({
                   ...baseContext,
-                  tracingContext: processorTracingContext,
+                  ...processorObservabilityContext,
                   part: part as ChunkType,
                   streamParts: (streamParts ?? []) as ChunkType[],
                   state: mutableState,
@@ -2120,10 +2128,12 @@ export class Workflow<
     abort,
     abortSignal,
     retryCount,
-    tracingContext,
     outputWriter,
     validateInputs,
     perStep,
+    engine: _engine,
+    bail: _bail,
+    ...rest
   }: {
     runId?: string;
     inputData: TInput;
@@ -2153,11 +2163,11 @@ export class Workflow<
     bail: (result: any) => any;
     abort: () => any;
     retryCount?: number;
-    tracingContext?: TracingContext;
     outputWriter?: OutputWriter;
     validateInputs?: boolean;
     perStep?: boolean;
-  }): Promise<TOutput | undefined> {
+  } & Partial<ObservabilityContext>): Promise<TOutput | undefined> {
+    const observabilityContext = resolveObservabilityContext(rest);
     this.__registerMastra(mastra);
 
     const effectiveValidateInputs = validateInputs ?? this.#options.validateInputs ?? true;
@@ -2218,19 +2228,19 @@ export class Workflow<
         context: (timeTravel?.nestedStepResults?.[this.id] ?? {}) as any,
         nestedStepsContext: timeTravel?.nestedStepResults as any,
         requestContext,
-        tracingContext,
+        ...observabilityContext,
         outputWriter,
         outputOptions: { includeState: true, includeResumeLabels: true },
         perStep,
       });
     } else if (restart) {
-      res = await run.restart({ requestContext, tracingContext, outputWriter });
+      res = await run.restart({ requestContext, ...observabilityContext, outputWriter });
     } else if (isResume) {
       res = await run.resume({
         resumeData,
         step: resume.steps?.length > 0 ? (resume.steps as any) : undefined,
         requestContext,
-        tracingContext,
+        ...observabilityContext,
         outputWriter,
         outputOptions: { includeState: true, includeResumeLabels: true },
         label: resume.label,
@@ -2240,7 +2250,7 @@ export class Workflow<
       res = await run.start({
         inputData,
         requestContext,
-        tracingContext,
+        ...observabilityContext,
         outputWriter,
         initialState: state,
         outputOptions: { includeState: true, includeResumeLabels: true },
@@ -2834,11 +2844,11 @@ export class Run<
     initialState,
     requestContext,
     outputWriter,
-    tracingContext,
     tracingOptions,
     format,
     outputOptions,
     perStep,
+    ...rest
   }: (TInput extends unknown
     ? {
         inputData?: TInput;
@@ -2855,7 +2865,6 @@ export class Run<
         }) & {
       requestContext?: RequestContext<TRequestContext>;
       outputWriter?: OutputWriter;
-      tracingContext?: TracingContext;
       tracingOptions?: TracingOptions;
       format?: 'legacy' | 'vnext' | undefined;
       outputOptions?: {
@@ -2863,7 +2872,8 @@ export class Run<
         includeResumeLabels?: boolean;
       };
       perStep?: boolean;
-    }): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+    } & Partial<ObservabilityContext>): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+    const observabilityContext = resolveObservabilityContext(rest);
     // note: this span is ended inside this.executionEngine.execute()
     const workflowSpan = getOrCreateSpan({
       type: SpanType.WORKFLOW_RUN,
@@ -2877,7 +2887,7 @@ export class Run<
       },
       tracingPolicy: this.tracingPolicy,
       tracingOptions,
-      tracingContext,
+      tracingContext: observabilityContext.tracingContext,
       requestContext: requestContext as RequestContext,
       mastra: this.#mastra,
     });
@@ -2937,14 +2947,13 @@ export class Run<
           }) & {
         requestContext?: RequestContext<TRequestContext>;
         outputWriter?: OutputWriter;
-        tracingContext?: TracingContext;
         tracingOptions?: TracingOptions;
         outputOptions?: {
           includeState?: boolean;
           includeResumeLabels?: boolean;
         };
         perStep?: boolean;
-      },
+      } & Partial<ObservabilityContext>,
   ): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
     return this._start(args);
   }
@@ -2978,7 +2987,7 @@ export class Run<
           includeResumeLabels?: boolean;
         };
         perStep?: boolean;
-      },
+      } & Partial<ObservabilityContext>,
   ): Promise<{ runId: string }> {
     // Fire execution in background, don't await completion
     this._start(args).catch(err => {
@@ -2997,8 +3006,8 @@ export class Run<
       inputData,
       requestContext,
       onChunk,
-      tracingContext,
       tracingOptions,
+      ...rest
     }: (TInput extends unknown
       ? {
           inputData?: TInput;
@@ -3007,10 +3016,9 @@ export class Run<
           inputData: TInput;
         }) & {
       requestContext?: RequestContext<TRequestContext>;
-      tracingContext?: TracingContext;
       onChunk?: (chunk: StreamEvent) => Promise<unknown>;
       tracingOptions?: TracingOptions;
-    } = {} as (TInput extends unknown
+    } & Partial<ObservabilityContext> = {} as (TInput extends unknown
       ? {
           inputData?: TInput;
         }
@@ -3018,14 +3026,14 @@ export class Run<
           inputData: TInput;
         }) & {
       requestContext?: RequestContext<TRequestContext>;
-      tracingContext?: TracingContext;
       onChunk?: (chunk: StreamEvent) => Promise<unknown>;
       tracingOptions?: TracingOptions;
-    },
+    } & Partial<ObservabilityContext>,
   ): {
     stream: ReadableStream<StreamEvent>;
     getWorkflowState: () => Promise<WorkflowResult<TState, TInput, TOutput, TSteps>>;
   } {
+    const observabilityContext = resolveObservabilityContext(rest);
     if (this.closeStreamAction) {
       return {
         stream: this.observeStreamLegacy().stream,
@@ -3079,7 +3087,7 @@ export class Run<
       inputData,
       requestContext,
       format: 'legacy',
-      tracingContext,
+      ...observabilityContext,
       tracingOptions,
     } as any).then(result => {
       if (result.status !== 'suspended') {
@@ -3159,12 +3167,12 @@ export class Run<
   stream({
     inputData,
     requestContext,
-    tracingContext,
     tracingOptions,
     closeOnSuspend = true,
     initialState,
     outputOptions,
     perStep,
+    ...rest
   }: (TInput extends unknown
     ? {
         inputData?: TInput;
@@ -3180,7 +3188,6 @@ export class Run<
           initialState: TState;
         }) & {
       requestContext?: RequestContext<TRequestContext>;
-      tracingContext?: TracingContext;
       tracingOptions?: TracingOptions;
       closeOnSuspend?: boolean;
       outputOptions?: {
@@ -3188,7 +3195,8 @@ export class Run<
         includeResumeLabels?: boolean;
       };
       perStep?: boolean;
-    }): WorkflowRunOutput<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+    } & Partial<ObservabilityContext>): WorkflowRunOutput<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+    const observabilityContext = resolveObservabilityContext(rest);
     if (this.closeStreamAction && this.streamOutput) {
       return this.streamOutput;
     }
@@ -3240,7 +3248,7 @@ export class Run<
         const executionResultsPromise = self._start({
           inputData,
           requestContext,
-          tracingContext,
+          ...observabilityContext,
           tracingOptions,
           initialState,
           outputOptions,
@@ -3294,11 +3302,11 @@ export class Run<
     step,
     resumeData,
     requestContext,
-    tracingContext,
     tracingOptions,
     forEachIndex,
     outputOptions,
     perStep,
+    ...rest
   }: {
     resumeData?: TResume;
     step?:
@@ -3310,7 +3318,6 @@ export class Run<
       | string
       | string[];
     requestContext?: RequestContext<TRequestContext>;
-    tracingContext?: TracingContext;
     tracingOptions?: TracingOptions;
     forEachIndex?: number;
     outputOptions?: {
@@ -3318,7 +3325,8 @@ export class Run<
       includeResumeLabels?: boolean;
     };
     perStep?: boolean;
-  } = {}) {
+  } & Partial<ObservabilityContext> = {}) {
+    const observabilityContext = resolveObservabilityContext(rest);
     this.closeStreamAction = async () => {};
 
     const self = this;
@@ -3366,7 +3374,7 @@ export class Run<
           resumeData,
           step,
           requestContext,
-          tracingContext,
+          ...observabilityContext,
           tracingOptions,
           outputWriter: async chunk => {
             void controller.enqueue(chunk);
@@ -3461,29 +3469,30 @@ export class Run<
     return this.watch(cb);
   }
 
-  async resume<TResume>(params: {
-    resumeData?: TResume;
-    step?:
-      | Step<string, any, any, any, TResume, any, TEngineType, any>
-      | [
-          ...Step<string, any, any, any, any, any, TEngineType, any>[],
-          Step<string, any, any, any, TResume, any, TEngineType, any>,
-        ]
-      | string
-      | string[];
-    label?: string;
-    requestContext?: RequestContext<TRequestContext>;
-    retryCount?: number;
-    tracingContext?: TracingContext;
-    tracingOptions?: TracingOptions;
-    outputWriter?: OutputWriter;
-    outputOptions?: {
-      includeState?: boolean;
-      includeResumeLabels?: boolean;
-    };
-    forEachIndex?: number;
-    perStep?: boolean;
-  }): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+  async resume<TResume>(
+    params: {
+      resumeData?: TResume;
+      step?:
+        | Step<string, any, any, any, TResume, any, TEngineType, any>
+        | [
+            ...Step<string, any, any, any, any, any, TEngineType, any>[],
+            Step<string, any, any, any, TResume, any, TEngineType, any>,
+          ]
+        | string
+        | string[];
+      label?: string;
+      requestContext?: RequestContext<TRequestContext>;
+      retryCount?: number;
+      tracingOptions?: TracingOptions;
+      outputWriter?: OutputWriter;
+      outputOptions?: {
+        includeState?: boolean;
+        includeResumeLabels?: boolean;
+      };
+      forEachIndex?: number;
+      perStep?: boolean;
+    } & Partial<ObservabilityContext>,
+  ): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
     return this._resume(params);
   }
 
@@ -3495,38 +3504,39 @@ export class Run<
     args: {
       requestContext?: RequestContext<TRequestContext>;
       outputWriter?: OutputWriter;
-      tracingContext?: TracingContext;
       tracingOptions?: TracingOptions;
-    } = {},
+    } & Partial<ObservabilityContext> = {},
   ): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
     return this._restart(args);
   }
 
-  protected async _resume<TResume>(params: {
-    resumeData?: TResume;
-    step?:
-      | Step<string, any, any, TResume, any, any, TEngineType, any>
-      | [
-          ...Step<string, any, any, any, any, any, TEngineType, any>[],
-          Step<string, any, any, TResume, any, any, TEngineType, any>,
-        ]
-      | string
-      | string[];
-    label?: string;
-    requestContext?: RequestContext<TRequestContext>;
-    retryCount?: number;
-    tracingContext?: TracingContext;
-    tracingOptions?: TracingOptions;
-    outputWriter?: OutputWriter;
-    format?: 'legacy' | 'vnext' | undefined;
-    isVNext?: boolean;
-    outputOptions?: {
-      includeState?: boolean;
-      includeResumeLabels?: boolean;
-    };
-    forEachIndex?: number;
-    perStep?: boolean;
-  }): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+  protected async _resume<TResume>(
+    params: {
+      resumeData?: TResume;
+      step?:
+        | Step<string, any, any, TResume, any, any, TEngineType, any>
+        | [
+            ...Step<string, any, any, any, any, any, TEngineType, any>[],
+            Step<string, any, any, TResume, any, any, TEngineType, any>,
+          ]
+        | string
+        | string[];
+      label?: string;
+      requestContext?: RequestContext<TRequestContext>;
+      retryCount?: number;
+      tracingOptions?: TracingOptions;
+      outputWriter?: OutputWriter;
+      format?: 'legacy' | 'vnext' | undefined;
+      isVNext?: boolean;
+      outputOptions?: {
+        includeState?: boolean;
+        includeResumeLabels?: boolean;
+      };
+      forEachIndex?: number;
+      perStep?: boolean;
+    } & Partial<ObservabilityContext>,
+  ): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+    const observabilityContext = resolveObservabilityContext(params);
     const workflowsStore = await this.#mastra?.getStorage()?.getStore('workflows');
     const snapshot = await workflowsStore?.loadWorkflowSnapshot({
       workflowName: this.workflowId,
@@ -3637,7 +3647,7 @@ export class Run<
       },
       tracingPolicy: this.tracingPolicy,
       tracingOptions: params.tracingOptions,
-      tracingContext: params.tracingContext,
+      tracingContext: observabilityContext.tracingContext,
       requestContext: requestContextToUse as RequestContext,
       mastra: this.#mastra,
     });
@@ -3691,14 +3701,14 @@ export class Run<
   protected async _restart({
     requestContext,
     outputWriter,
-    tracingContext,
     tracingOptions,
+    ...rest
   }: {
     requestContext?: RequestContext<TRequestContext>;
     outputWriter?: OutputWriter;
-    tracingContext?: TracingContext;
     tracingOptions?: TracingOptions;
-  }): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+  } & Partial<ObservabilityContext>): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+    const observabilityContext = resolveObservabilityContext(rest);
     if (this.workflowEngineType !== 'default') {
       throw new Error(`restart() is not supported on ${this.workflowEngineType} workflows`);
     }
@@ -3769,7 +3779,7 @@ export class Run<
       },
       tracingPolicy: this.tracingPolicy,
       tracingOptions,
-      tracingContext,
+      tracingContext: observabilityContext.tracingContext,
       requestContext: requestContextToUse as RequestContext,
       mastra: this.#mastra,
     });
@@ -3809,10 +3819,10 @@ export class Run<
     nestedStepsContext,
     requestContext,
     outputWriter,
-    tracingContext,
     tracingOptions,
     outputOptions,
     perStep,
+    ...rest
   }: {
     inputData?: TInput;
     resumeData?: any;
@@ -3829,14 +3839,14 @@ export class Run<
     nestedStepsContext?: Record<string, TimeTravelContext<any, any, any, any>>;
     requestContext?: RequestContext<TRequestContext>;
     outputWriter?: OutputWriter;
-    tracingContext?: TracingContext;
     tracingOptions?: TracingOptions;
     outputOptions?: {
       includeState?: boolean;
       includeResumeLabels?: boolean;
     };
     perStep?: boolean;
-  }): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+  } & Partial<ObservabilityContext>): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+    const observabilityContext = resolveObservabilityContext(rest);
     if (!stepParam || (Array.isArray(stepParam) && stepParam.length === 0)) {
       throw new Error('Step is required and must be a valid step or array of steps');
     }
@@ -3901,7 +3911,7 @@ export class Run<
       },
       tracingPolicy: this.tracingPolicy,
       tracingOptions,
-      tracingContext,
+      tracingContext: observabilityContext.tracingContext,
       requestContext: requestContextToUse as RequestContext,
       mastra: this.#mastra,
     });
@@ -3934,30 +3944,31 @@ export class Run<
     return result;
   }
 
-  async timeTravel<TInput>(args: {
-    inputData?: TInput;
-    resumeData?: any;
-    initialState?: TState;
-    step:
-      | Step<string, any, TInput, any, any, any, TEngineType, any>
-      | [
-          ...Step<string, any, any, any, any, any, TEngineType, any>[],
-          Step<string, any, TInput, any, any, any, TEngineType, any>,
-        ]
-      | string
-      | string[];
-    context?: TimeTravelContext<any, any, any, any>;
-    nestedStepsContext?: Record<string, TimeTravelContext<any, any, any, any>>;
-    requestContext?: RequestContext<TRequestContext>;
-    outputWriter?: OutputWriter;
-    tracingContext?: TracingContext;
-    tracingOptions?: TracingOptions;
-    outputOptions?: {
-      includeState?: boolean;
-      includeResumeLabels?: boolean;
-    };
-    perStep?: boolean;
-  }): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
+  async timeTravel<TInput>(
+    args: {
+      inputData?: TInput;
+      resumeData?: any;
+      initialState?: TState;
+      step:
+        | Step<string, any, TInput, any, any, any, TEngineType, any>
+        | [
+            ...Step<string, any, any, any, any, any, TEngineType, any>[],
+            Step<string, any, TInput, any, any, any, TEngineType, any>,
+          ]
+        | string
+        | string[];
+      context?: TimeTravelContext<any, any, any, any>;
+      nestedStepsContext?: Record<string, TimeTravelContext<any, any, any, any>>;
+      requestContext?: RequestContext<TRequestContext>;
+      outputWriter?: OutputWriter;
+      tracingOptions?: TracingOptions;
+      outputOptions?: {
+        includeState?: boolean;
+        includeResumeLabels?: boolean;
+      };
+      perStep?: boolean;
+    } & Partial<ObservabilityContext>,
+  ): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
     return this._timeTravel(args);
   }
 
@@ -3969,10 +3980,10 @@ export class Run<
     context,
     nestedStepsContext,
     requestContext,
-    tracingContext,
     tracingOptions,
     outputOptions,
     perStep,
+    ...rest
   }: {
     inputData?: TTravelInput;
     initialState?: TState;
@@ -3988,14 +3999,14 @@ export class Run<
     context?: TimeTravelContext<any, any, any, any>;
     nestedStepsContext?: Record<string, TimeTravelContext<any, any, any, any>>;
     requestContext?: RequestContext<TRequestContext>;
-    tracingContext?: TracingContext;
     tracingOptions?: TracingOptions;
     outputOptions?: {
       includeState?: boolean;
       includeResumeLabels?: boolean;
     };
     perStep?: boolean;
-  }) {
+  } & Partial<ObservabilityContext>) {
+    const observabilityContext = resolveObservabilityContext(rest);
     this.closeStreamAction = async () => {};
 
     const self = this;
@@ -4034,7 +4045,7 @@ export class Run<
           resumeData,
           initialState,
           requestContext,
-          tracingContext,
+          ...observabilityContext,
           tracingOptions,
           outputWriter: async chunk => {
             void controller.enqueue(chunk);


### PR DESCRIPTION
…L/S/F)

Implements Phase 2.2 of the observability implementation plan:
- Add onLogEvent(), onMetricEvent(), onScoreEvent(), onFeedbackEvent() handlers
- Add query methods for all signal types (getLogsByLevel, getMetricsByName, etc.)
- Add cross-signal getByTraceId returning logs/scores/feedback alongside spans
- Update getStatistics() with breakdowns for all signals
- Update toJSON() to include logs, metrics, scores, feedback data
- Add internal metrics collection (event counts, signal breakdown, flush count)
- Add getInternalMetrics() and summary logging on flush()
- Add 32 new tests covering all signal handlers, queries, and internal metrics

https://claude.ai/code/session_015MGMfwaCiYpWVvhUyQSunb

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
