### PR TITLE
Add safeExecuteTool utility with tests

### DIFF
--- a/.changeset/safe-execute-tool.md
+++ b/.changeset/safe-execute-tool.md
@@ -1,0 +1,23 @@
+---
+'@mastra/core': minor
+---
+
+Added `safeExecuteTool` utility for safely calling one tool from within another tool's `execute` function.
+
+```typescript
+import { createTool, safeExecuteTool } from '@mastra/core/tools';
+
+const compositeTool = createTool({
+  id: 'composite-tool',
+  execute: async (input, context) => {
+    const result = await safeExecuteTool(otherTool, { query: 'test' }, context);
+    if (!result) return { error: 'inner tool failed' };
+    return { data: result };
+  },
+});
+```
+
+- Returns `null` on failure instead of throwing, so one tool's error won't crash the parent
+- Detects circular/deeply nested calls and aborts at a configurable max depth (default: 10)
+- Propagates `requestContext`, `tracingContext`, `abortSignal`, and `writer` to nested tools
+- Automatically creates child tracing spans for observability of nested tool calls

--- a/packages/core/src/tools/__tests__/safe-execute.test.ts
+++ b/packages/core/src/tools/__tests__/safe-execute.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi } from 'vitest';
+import { safeExecuteTool } from '../safe-execute';
+
+describe('safeExecuteTool', () => {
+  // Basic execution
+  it('should execute a tool and return its result', async () => {
+    const tool = {
+      id: 'test-tool',
+      execute: vi.fn().mockResolvedValue({ data: 'hello' }),
+    };
+    const result = await safeExecuteTool(tool, { input: 'test' });
+    expect(result).toEqual({ data: 'hello' });
+    expect(tool.execute).toHaveBeenCalledOnce();
+  });
+
+  // Null/missing tool handling
+  it('should return null if tool is null', async () => {
+    const result = await safeExecuteTool(null as any, {});
+    expect(result).toBeNull();
+  });
+
+  it('should return null if tool has no execute function', async () => {
+    const result = await safeExecuteTool({ id: 'no-exec' } as any, {});
+    expect(result).toBeNull();
+  });
+
+  // Error handling
+  it('should return null if tool.execute throws', async () => {
+    const tool = {
+      id: 'throwing-tool',
+      execute: vi.fn().mockRejectedValue(new Error('boom')),
+    };
+    const result = await safeExecuteTool(tool, {});
+    expect(result).toBeNull();
+  });
+
+  // Context propagation
+  it('should forward context to the inner tool', async () => {
+    const mockContext = {
+      requestContext: { userId: '123' },
+      tracingContext: { spanId: 'abc' },
+    };
+    const tool = {
+      id: 'ctx-tool',
+      execute: vi.fn().mockResolvedValue('ok'),
+    };
+    await safeExecuteTool(tool, { input: 'test' }, mockContext as any);
+    const passedContext = tool.execute.mock.calls[0][1];
+    expect(passedContext.requestContext).toEqual({ userId: '123' });
+  });
+
+  // Max depth protection
+  it('should return null when max depth is exceeded', async () => {
+    const tool = {
+      id: 'deep-tool',
+      execute: vi.fn().mockResolvedValue('ok'),
+    };
+    // Test with maxDepth: 0 to ensure immediate rejection
+    const result = await safeExecuteTool(tool, {}, undefined, { maxDepth: 0 });
+    expect(result).toBeNull();
+    expect(tool.execute).not.toHaveBeenCalled();
+  });
+
+  // AbortSignal respect
+  it('should return null if abortSignal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const tool = {
+      id: 'abort-tool',
+      execute: vi.fn().mockResolvedValue('ok'),
+    };
+    const result = await safeExecuteTool(tool, {}, { abortSignal: controller.signal } as any);
+    expect(result).toBeNull();
+    expect(tool.execute).not.toHaveBeenCalled();
+  });
+
+  // Custom max depth
+  it('should respect custom maxDepth option', async () => {
+    const tool = {
+      id: 'depth-tool',
+      execute: vi.fn().mockResolvedValue('ok'),
+    };
+    const result = await safeExecuteTool(tool, {}, undefined, { maxDepth: 5 });
+    expect(result).toEqual('ok');
+  });
+
+  // Depth tracking
+  it('should track call depth across nested calls', async () => {
+    const innerTool = {
+      id: 'inner-tool',
+      execute: vi.fn().mockResolvedValue('inner-result'),
+    };
+
+    const outerTool = {
+      id: 'outer-tool',
+      execute: async (input: any, context: any) => {
+        const innerResult = await safeExecuteTool(innerTool, {}, context);
+        return { outer: true, inner: innerResult };
+      },
+    };
+
+    const result = await safeExecuteTool(outerTool, {});
+    expect(result).toEqual({ outer: true, inner: 'inner-result' });
+  });
+
+  // Test with tool missing id
+  it('should handle tool without id gracefully', async () => {
+    const tool = {
+      execute: vi.fn().mockResolvedValue('no-id-result'),
+    };
+    const result = await safeExecuteTool(tool, {});
+    expect(result).toEqual('no-id-result');
+  });
+
+  // Test custom span name
+  it('should use custom span name when provided', async () => {
+    const tool = {
+      id: 'custom-span-tool',
+      execute: vi.fn().mockResolvedValue('ok'),
+    };
+    const result = await safeExecuteTool(tool, {}, undefined, { spanName: 'my-custom-span' });
+    expect(result).toEqual('ok');
+  });
+
+  // Tracing integration tests
+  describe('tracing integration', () => {
+    it('should create a child span when a currentSpan exists in tracingContext', async () => {
+      const childSpan = {
+        id: 'child-span',
+        end: vi.fn(),
+        error: vi.fn(),
+      };
+
+      const createChildSpan = vi.fn().mockReturnValue(childSpan);
+
+      const parentSpan = {
+        id: 'parent-span',
+        createChildSpan,
+      };
+
+      const tracingContext = {
+        currentSpan: parentSpan,
+      };
+
+      const tool = {
+        id: 'traced-tool',
+        execute: vi.fn().mockResolvedValue('trace-result'),
+      };
+
+      const result = await safeExecuteTool(tool, { foo: 'bar' }, { tracingContext } as any);
+
+      expect(result).toEqual('trace-result');
+      expect(createChildSpan).toHaveBeenCalledTimes(1);
+      expect(createChildSpan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'tool_call',
+          name: 'safeExecuteTool:traced-tool',
+          input: { foo: 'bar' },
+          entityType: 'tool',
+          entityId: 'traced-tool',
+          entityName: 'traced-tool',
+        }),
+      );
+    });
+
+    it('should pass the child span to nested tool calls via tracingContext', async () => {
+      const innerChildSpan = {
+        id: 'inner-child-span',
+        end: vi.fn(),
+        error: vi.fn(),
+      };
+
+      const outerChildSpan = {
+        id: 'outer-child-span',
+        end: vi.fn(),
+        error: vi.fn(),
+        createChildSpan: vi.fn().mockReturnValue(innerChildSpan),
+      };
+
+      const parentSpan = {
+        id: 'parent-span',
+        createChildSpan: vi.fn().mockReturnValue(outerChildSpan),
+      };
+
+      const tracingContext = {
+        currentSpan: parentSpan,
+      };
+
+      const innerToolSpans: any[] = [];
+
+      const innerTool = {
+        id: 'inner-traced-tool',
+        execute: vi.fn(async (_input: any, context: any) => {
+          innerToolSpans.push(context?.tracingContext?.currentSpan);
+          return 'inner-trace-result';
+        }),
+      };
+
+      const outerTool = {
+        id: 'outer-traced-tool',
+        execute: async (_input: any, context: any) => {
+          const innerResult = await safeExecuteTool(innerTool, {}, context);
+          return { outer: true, inner: innerResult };
+        },
+      };
+
+      const result = await safeExecuteTool(outerTool, {}, { tracingContext } as any);
+
+      expect(result).toEqual({ outer: true, inner: 'inner-trace-result' });
+      // The outer call should create a child span from the parent
+      expect(parentSpan.createChildSpan).toHaveBeenCalledTimes(1);
+      // The outer child span should have created a child span for the inner tool call
+      expect(outerChildSpan.createChildSpan).toHaveBeenCalledTimes(1);
+      // The inner tool should see the inner child span (created from outerChildSpan) as its currentSpan
+      expect(innerToolSpans[0]).toBe(innerChildSpan);
+    });
+
+    it('should call childSpan.end with result and success attributes on success', async () => {
+      const childSpan = {
+        id: 'child-span',
+        end: vi.fn(),
+        error: vi.fn(),
+      };
+
+      const createChildSpan = vi.fn().mockReturnValue(childSpan);
+
+      const parentSpan = {
+        id: 'parent-span',
+        createChildSpan,
+      };
+
+      const tracingContext = {
+        currentSpan: parentSpan,
+      };
+
+      const tool = {
+        id: 'end-span-tool',
+        execute: vi.fn().mockResolvedValue({ ok: true }),
+      };
+
+      const result = await safeExecuteTool(tool, { input: 'x' }, { tracingContext } as any);
+
+      expect(result).toEqual({ ok: true });
+      expect(childSpan.end).toHaveBeenCalledTimes(1);
+      expect(childSpan.end).toHaveBeenCalledWith({
+        output: { ok: true },
+        attributes: { success: true },
+      });
+    });
+
+    it('should call childSpan.error when the tool throws an error', async () => {
+      const childSpan = {
+        id: 'child-span',
+        end: vi.fn(),
+        error: vi.fn(),
+      };
+
+      const createChildSpan = vi.fn().mockReturnValue(childSpan);
+
+      const parentSpan = {
+        id: 'parent-span',
+        createChildSpan,
+      };
+
+      const tracingContext = {
+        currentSpan: parentSpan,
+      };
+
+      const toolError = new Error('tool failed');
+      const tool = {
+        id: 'error-span-tool',
+        execute: vi.fn().mockRejectedValue(toolError),
+      };
+
+      const result = await safeExecuteTool(tool, { input: 'y' }, { tracingContext } as any);
+
+      expect(result).toBeNull();
+      expect(childSpan.error).toHaveBeenCalledTimes(1);
+      expect(childSpan.error).toHaveBeenCalledWith({
+        error: toolError,
+        attributes: { success: false },
+      });
+    });
+
+    it('should create a proper span hierarchy for deeply nested tool calls', async () => {
+      const deepestSpan = {
+        id: 'deepest-span',
+        end: vi.fn(),
+        error: vi.fn(),
+      };
+
+      const middleSpan = {
+        id: 'middle-span',
+        end: vi.fn(),
+        error: vi.fn(),
+        createChildSpan: vi.fn().mockReturnValue(deepestSpan),
+      };
+
+      const outerSpan = {
+        id: 'outer-span',
+        end: vi.fn(),
+        error: vi.fn(),
+        createChildSpan: vi.fn().mockReturnValue(middleSpan),
+      };
+
+      const rootSpan = {
+        id: 'root-span',
+        createChildSpan: vi.fn().mockReturnValue(outerSpan),
+      };
+
+      const tracingContext = {
+        currentSpan: rootSpan,
+      };
+
+      const spansSeen: any[] = [];
+
+      const deepestTool = {
+        id: 'deepest-tool',
+        execute: vi.fn(async (_input: any, context: any) => {
+          spansSeen.push(context?.tracingContext?.currentSpan);
+          return 'deepest';
+        }),
+      };
+
+      const middleTool = {
+        id: 'middle-tool',
+        execute: async (_input: any, context: any) => {
+          spansSeen.push(context?.tracingContext?.currentSpan);
+          return safeExecuteTool(deepestTool, {}, context);
+        },
+      };
+
+      const outerTool = {
+        id: 'outer-tool',
+        execute: async (_input: any, context: any) => {
+          spansSeen.push(context?.tracingContext?.currentSpan);
+          return safeExecuteTool(middleTool, {}, context);
+        },
+      };
+
+      const result = await safeExecuteTool(outerTool, {}, { tracingContext } as any);
+      expect(result).toEqual('deepest');
+
+      // Three child spans should be created: outer, middle, deepest
+      expect(rootSpan.createChildSpan).toHaveBeenCalledTimes(1);
+      expect(outerSpan.createChildSpan).toHaveBeenCalledTimes(1);
+      expect(middleSpan.createChildSpan).toHaveBeenCalledTimes(1);
+
+      // Verify the span hierarchy
+      expect(spansSeen[0]).toBe(outerSpan);
+      expect(spansSeen[1]).toBe(middleSpan);
+      expect(spansSeen[2]).toBe(deepestSpan);
+    });
+  });
+});

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -4,3 +4,4 @@ export * from './ui-types';
 export { isVercelTool } from './toolchecks';
 export { ToolStream } from './stream';
 export { type ValidationError } from './validation';
+export { safeExecuteTool, type SafeExecuteToolOptions } from './safe-execute';

--- a/packages/core/src/tools/safe-execute.ts
+++ b/packages/core/src/tools/safe-execute.ts
@@ -1,0 +1,142 @@
+import { EntityType, SpanType } from '../observability';
+import type { ToolExecutionContext } from './types';
+
+/**
+ * Symbol used to track tool execution depth for circular call protection.
+ */
+const TOOL_CALL_DEPTH = Symbol('toolCallDepth');
+const TOOL_CALL_CHAIN = Symbol('toolCallChain');
+
+export interface SafeExecuteToolOptions {
+  /** Maximum nested tool call depth before aborting (default: 10) */
+  maxDepth?: number;
+  /** Custom span name for tracing (defaults to tool.id or 'unknown-tool') */
+  spanName?: string;
+}
+
+/**
+ * Safely execute a Mastra tool from within another tool's execute function.
+ *
+ * Features:
+ * - Graceful error handling (returns null on failure instead of throwing)
+ * - Tracing span creation for nested tool calls (child spans under parent)
+ * - Full context propagation (requestContext, tracingContext, abortSignal, writer)
+ * - Circular dependency detection via max depth tracking
+ * - AbortSignal respect (checks before execution)
+ *
+ * @example
+ * ```typescript
+ * import { createTool, safeExecuteTool } from '@mastra/core/tools';
+ *
+ * const compositeTool = createTool({
+ *   id: 'composite-tool',
+ *   execute: async (input, context) => {
+ *     const result = await safeExecuteTool(otherTool, { query: 'test' }, context);
+ *     if (!result) return { error: 'inner tool failed' };
+ *     return { data: result };
+ *   }
+ * });
+ * ```
+ */
+export async function safeExecuteTool<TOutput, TInput = any>(
+  tool: { id?: string; execute?: (input: TInput, context?: any) => Promise<TOutput> },
+  input: TInput,
+  context?: ToolExecutionContext<any, any, any>,
+  options?: SafeExecuteToolOptions,
+): Promise<TOutput | null> {
+  // Guard: tool must have an execute function
+  if (!tool || typeof tool.execute !== 'function') {
+    return null;
+  }
+
+  // Store execute function to avoid non-null assertions later
+  const executeFunction = tool.execute;
+  const maxDepth = options?.maxDepth ?? 10;
+  const toolId = tool.id || 'unknown-tool';
+  const spanName = options?.spanName || `safeExecuteTool:${toolId}`;
+
+  // Check abort signal before starting
+  if (context?.abortSignal?.aborted) {
+    return null;
+  }
+
+  // Circular call / max depth protection
+  // Using symbols to avoid collisions with user properties
+  const contextWithSymbols = context as any;
+  const currentDepth = (contextWithSymbols?.[TOOL_CALL_DEPTH] as number) ?? 0;
+  const callChain: string[] = (contextWithSymbols?.[TOOL_CALL_CHAIN] as string[]) ?? [];
+
+  if (currentDepth >= maxDepth) {
+    const chain = [...callChain, toolId].join(' → ');
+    const logger = context?.mastra?.getLogger?.();
+    logger?.warn?.(
+      `[safeExecuteTool] Max depth (${maxDepth}) reached. Call chain: ${chain}. Aborting to prevent infinite recursion.`,
+    );
+    return null;
+  }
+
+  // Build child context with incremented depth and updated call chain
+  const childContext = {
+    ...context,
+    [TOOL_CALL_DEPTH]: currentDepth + 1,
+    [TOOL_CALL_CHAIN]: [...callChain, toolId],
+  };
+
+  // Get logger once at the start
+  const logger = context?.mastra?.getLogger?.();
+
+  // Execute with tracing if available
+  try {
+    // Log the nested tool call for observability
+    logger?.debug?.(`[safeExecuteTool] Executing nested tool: ${toolId} (depth: ${currentDepth + 1}/${maxDepth})`, {
+      toolId,
+      depth: currentDepth + 1,
+      maxDepth,
+      callChain: [...callChain, toolId],
+    });
+
+    // If we have tracing context, create a child span
+    const currentSpan = context?.tracingContext?.currentSpan;
+    if (currentSpan) {
+      const childSpan = currentSpan.createChildSpan?.({
+        type: SpanType.TOOL_CALL,
+        name: spanName,
+        input,
+        entityType: EntityType.TOOL,
+        entityId: toolId,
+        entityName: toolId,
+      });
+
+      // Update child context to include the child span in tracingContext
+      // This ensures nested tool calls see the child span as the current span
+      const childContextWithTracing = childSpan
+        ? {
+            ...childContext,
+            tracingContext: {
+              ...context?.tracingContext,
+              currentSpan: childSpan,
+            },
+          }
+        : childContext;
+
+      try {
+        const result = await executeFunction(input, childContextWithTracing);
+        childSpan?.end?.({ output: result, attributes: { success: true } });
+        return result;
+      } catch (error) {
+        // Use the span's error method to record the error properly
+        childSpan?.error?.({ error: error as Error, attributes: { success: false } });
+
+        logger?.error?.(`[safeExecuteTool] Tool ${toolId} threw an error`, { error, toolId });
+        return null;
+      }
+    }
+
+    // Fallback: execute without tracing span
+    const result = await executeFunction(input, childContext);
+    return result;
+  } catch (error) {
+    logger?.error?.(`[safeExecuteTool] Tool ${toolId} threw an error`, { error, toolId });
+    return null;
+  }
+}


### PR DESCRIPTION
## Description

Adds a `safeExecuteTool` utility function to `@mastra/core/tools` that enables safe nested tool execution from within another tool's `execute` function.

Key features:
- **Graceful error handling** — returns `null` on failure instead of throwing, preventing one tool's failure from crashing the parent
- **Circular dependency protection** — tracks call depth via symbols and aborts when max depth (default: 10) is reached
- **Full context propagation** — forwards `requestContext`, `tracingContext`, `abortSignal`, and `writer` to nested tools
- **Tracing integration** — automatically creates child spans under the parent span for observability of nested tool calls
- **AbortSignal respect** — checks for abort before execution begins

### Usage

```typescript
import { createTool, safeExecuteTool } from '@mastra/core/tools';

const compositeTool = createTool({
  id: 'composite-tool',
  execute: async (input, context) => {
    const result = await safeExecuteTool(otherTool, { query: 'test' }, context);
    if (!result) return { error: 'inner tool failed' };
    return { data: result };
  },
});
```

## Related Issue(s)

Fixes mastra-ai/mastra#13068

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safeExecuteTool: safely invoke one tool from another with context propagation, abort-signal awareness, configurable recursion-depth protection, and automatic child-span tracing. Returns null on failure instead of throwing.

* **Tests**
  * Added comprehensive tests covering nested execution, depth limits, abort behavior, context and tracing propagation, success/error span signaling, handling of missing/malformed tools, and multi-level tracing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->