### PR TITLE
fix: forward requestContext to tools in createToolCallStep

### DIFF
--- a/.changeset/forward-request-context-tools.md
+++ b/.changeset/forward-request-context-tools.md
@@ -1,0 +1,10 @@
+---
+'@mastra/core': minor
+---
+
+Added support for passing `requestContext` through the tool execution pipeline. The runtime `requestContext` is now correctly forwarded to tool calls and is preferred over the build-time context, following the same pattern as `workspace` and `tracingContext`.
+
+Changes include:
+- Added `requestContext` to the `MastraToolInvocationOptions` type
+- Forwarded `requestContext` from workflow step execute params into `toolOptions` in `createToolCallStep`
+- Updated `CoreToolBuilder` to prefer execution-time `requestContext` over build-time context

--- a/.changeset/forward-request-context-tools.md
+++ b/.changeset/forward-request-context-tools.md
@@ -6,7 +6,7 @@ Added runtime `requestContext` forwarding to tool executions.
 
 Tools invoked within agentic workflow steps now receive the caller's `requestContext` — including authenticated API clients, feature flags, and user metadata set by middleware. Runtime `requestContext` is preferred over build-time context when both are available.
 
-**Why:** Previously, `requestContext` values set during workflow step execution were silently dropped before reaching tools, which meant auth data and configuration never arrived. This aligns the agentic workflow path with the agent network path, where `requestContext` was already forwarded correctly.
+**Why:** Previously, `requestContext` values were silently dropped in two places: (1) the workflow loop stream created a new empty `RequestContext` instead of forwarding the caller's, and (2) `createToolCallStep` didn't pass `requestContext` in tool options. This aligns both the agent generate/stream and agentic workflow paths with the agent network path, where `requestContext` was already forwarded correctly.
 
 **Before:** Tools received an empty `requestContext`, losing all values set by the workflow step.
 ```ts

--- a/.changeset/forward-request-context-tools.md
+++ b/.changeset/forward-request-context-tools.md
@@ -1,10 +1,25 @@
 ---
-'@mastra/core': minor
+'@mastra/core': patch
 ---
 
-Added support for passing `requestContext` through the tool execution pipeline. The runtime `requestContext` is now correctly forwarded to tool calls and is preferred over the build-time context, following the same pattern as `workspace` and `tracingContext`.
+Added runtime `requestContext` forwarding to tool executions.
 
-Changes include:
-- Added `requestContext` to the `MastraToolInvocationOptions` type
-- Forwarded `requestContext` from workflow step execute params into `toolOptions` in `createToolCallStep`
-- Updated `CoreToolBuilder` to prefer execution-time `requestContext` over build-time context
+Tools invoked within agentic workflow steps now receive the caller's `requestContext` — including authenticated API clients, feature flags, and user metadata set by middleware. Runtime `requestContext` is preferred over build-time context when both are available.
+
+**Why:** Previously, `requestContext` values set during workflow step execution were silently dropped before reaching tools, which meant auth data and configuration never arrived. This aligns the agentic workflow path with the agent network path, where `requestContext` was already forwarded correctly.
+
+**Before:** Tools received an empty `requestContext`, losing all values set by the workflow step.
+```ts
+// requestContext with auth data set in workflow step
+requestContext.set('apiClient', authedClient);
+// tool receives empty RequestContext — apiClient is undefined
+```
+
+**After:** Pass `requestContext` via `MastraToolInvocationOptions` and tools receive it.
+```ts
+// requestContext with auth data flows through to the tool
+requestContext.set('apiClient', authedClient);
+// tool receives the same RequestContext — apiClient is available
+```
+
+Fixes #13088

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -374,6 +374,8 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           tracingContext: modelSpanTracker?.getTracingContext(),
           // Pass workspace from _internal (set by llmExecutionStep via prepareStep/processInputStep)
           workspace: _internal?.stepWorkspace,
+          // Forward requestContext so tools receive values set by the workflow step
+          requestContext,
           suspend: async (suspendPayload: any, options?: SuspendOptions) => {
             if (options?.requireToolApproval) {
               controller.enqueue({

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -126,7 +126,7 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
         runId,
       });
 
-      const requestContext = new RequestContext();
+      const requestContext = rest.requestContext ?? new RequestContext();
 
       if (requireToolApproval) {
         requestContext.set('__mastra_requireToolApproval', true);

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -136,6 +136,7 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
         ? await run.resume({
             resumeData: resumeContext.resumeData,
             tracingContext: rest.modelSpanTracker?.getTracingContext(),
+            requestContext,
             label: toolCallId,
           })
         : await run.start({

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -329,7 +329,7 @@ export class CoreToolBuilder extends MastraBase {
             mastra: wrappedMastra,
             memory: options.memory,
             runId: options.runId,
-            requestContext: options.requestContext ?? new RequestContext(),
+            requestContext: execOptions.requestContext ?? options.requestContext ?? new RequestContext(),
             // Workspace for file operations and command execution
             // Execution-time workspace (from prepareStep/processInputStep) takes precedence over build-time workspace
             workspace: execOptions.workspace ?? options.workspace,

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -96,6 +96,12 @@ export type MastraToolInvocationOptions = ToolInvocationOptions & {
    * per-step via prepareStep.
    */
   workspace?: Workspace;
+  /**
+   * Request context for tool execution. When provided at execution time, this overrides
+   * any requestContext configured at tool build time. Allows workflow steps to forward
+   * their requestContext (e.g., authenticated API clients, feature flags) to tools.
+   */
+  requestContext?: RequestContext;
 };
 
 /**


### PR DESCRIPTION
## Description

This PR adds support for passing `requestContext` through the tool execution pipeline.  
It ensures that the runtime `requestContext` is forwarded correctly to tool calls and is preferred over the build-time context, following the same pattern as `workspace` and `tracingContext`.

Specifically:
- Added `requestContext` to the `MastraToolInvocationOptions` type  
- Forwarded `requestContext` from workflow step execute params into `toolOptions` in `createToolCallStep`  
- Updated `CoreToolBuilder` to prefer execution-time `requestContext` over build-time

## Related Issue(s)

Fixes #13088 #12967

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow-invoked tools now receive the step's runtime request context; runtime context overrides build-time and preserves keys like authenticated clients and feature flags.

* **Tests**
  * Added tests verifying request context is forwarded into tool invocation options for both populated and empty contexts.

* **Documentation**
  * Added notes describing before/after behavior of request context propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->