### PR TITLE
chore: Update @clack/prompts

### DIFF
--- a/.changeset/fancy-places-trade.md
+++ b/.changeset/fancy-places-trade.md
@@ -1,0 +1,6 @@
+---
+'@mastra/codemod': patch
+'mastra': patch
+---
+
+Update internal dependency `@clack/prompts` to v1

--- a/packages/_changeset-cli/package.json
+++ b/packages/_changeset-cli/package.json
@@ -21,7 +21,7 @@
     "@changesets/read": "^0.6.6",
     "@changesets/types": "^6.1.0",
     "@changesets/write": "^0.4.0",
-    "@clack/prompts": "1.0.0-alpha.9",
+    "@clack/prompts": "^1.0.1",
     "@inquirer/editor": "^4.2.23",
     "@manypkg/get-packages": "^3.1.0",
     "@manypkg/tools": "^2.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,7 @@
     "devtools"
   ],
   "dependencies": {
-    "@clack/prompts": "^0.11.0",
+    "@clack/prompts": "^1.0.1",
     "@expo/devcert": "^1.2.1",
     "@mastra/deployer": "workspace:^",
     "@mastra/loggers": "workspace:^",

--- a/packages/cli/src/commands/create/utils.ts
+++ b/packages/cli/src/commands/create/utils.ts
@@ -181,7 +181,7 @@ export const createMastraProject = async ({
       placeholder: 'my-mastra-app',
       defaultValue: 'my-mastra-app',
       validate: value => {
-        if (value.length === 0) return 'Project name cannot be empty';
+        if (!value || value.length === 0) return 'Project name cannot be empty';
         if (fsSync.existsSync(value)) {
           return `A directory named "${value}" already exists. Please choose a different name.`;
         }

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -713,7 +713,7 @@ export const interactivePrompt = async (args: InteractivePromptArgs = {}) => {
             message: 'Enter your API key:',
             placeholder: 'sk-...',
             validate: value => {
-              if (value.length === 0) return 'API key cannot be empty';
+              if (!value || value.length === 0) return 'API key cannot be empty';
             },
           });
         }

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -27,7 +27,7 @@
     "codemod"
   ],
   "dependencies": {
-    "@clack/prompts": "1.0.0-alpha.9",
+    "@clack/prompts": "^1.0.1",
     "commander": "^14.0.3",
     "debug": "^4.4.3",
     "jscodeshift": "^17.3.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1712,8 +1712,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
       '@clack/prompts':
-        specifier: 1.0.0-alpha.9
-        version: 1.0.0-alpha.9
+        specifier: ^1.0.1
+        version: 1.0.1
       '@inquirer/editor':
         specifier: ^4.2.23
         version: 4.2.23(@types/node@22.19.7)
@@ -2201,8 +2201,8 @@ importers:
   packages/cli:
     dependencies:
       '@clack/prompts':
-        specifier: ^0.11.0
-        version: 0.11.0
+        specifier: ^1.0.1
+        version: 1.0.1
       '@expo/devcert':
         specifier: ^1.2.1
         version: 1.2.1
@@ -2322,8 +2322,8 @@ importers:
   packages/codemod:
     dependencies:
       '@clack/prompts':
-        specifier: 1.0.0-alpha.9
-        version: 1.0.0-alpha.9
+        specifier: ^1.0.1
+        version: 1.0.1
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -7558,17 +7558,11 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@clack/core@0.5.0':
-    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
+  '@clack/core@1.0.1':
+    resolution: {integrity: sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==}
 
-  '@clack/core@1.0.0-alpha.7':
-    resolution: {integrity: sha512-3vdh6Ar09D14rVxJZIm3VQJkU+ZOKKT5I5cC0cOVazy70CNyYYjiwRj9unwalhESndgxx6bGc/m6Hhs4EKF5XQ==}
-
-  '@clack/prompts@0.11.0':
-    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
-
-  '@clack/prompts@1.0.0-alpha.9':
-    resolution: {integrity: sha512-sKs0UjiHFWvry4SiRfBi5Qnj0C/6AYx8aKkFPZQSuUZXgAram25ZDmhQmP7vj1aFyLpfHWtLQjWvOvcat0TOLg==}
+  '@clack/prompts@1.0.1':
+    resolution: {integrity: sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==}
 
   '@clerk/backend@1.34.0':
     resolution: {integrity: sha512-9rZ8hQJVpX5KX2bEpiuVXfpjhojQCiqCWADJDdCI0PCeKxn58Ep0JPYiIcczg4VKUc3a7jve9vXylykG2XajLQ==}
@@ -25271,25 +25265,14 @@ snapshots:
       human-id: 4.1.2
       prettier: 2.8.8
 
-  '@clack/core@0.5.0':
+  '@clack/core@1.0.1':
     dependencies:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
-  '@clack/core@1.0.0-alpha.7':
+  '@clack/prompts@1.0.1':
     dependencies:
-      picocolors: 1.1.1
-      sisteransi: 1.0.5
-
-  '@clack/prompts@0.11.0':
-    dependencies:
-      '@clack/core': 0.5.0
-      picocolors: 1.1.1
-      sisteransi: 1.0.5
-
-  '@clack/prompts@1.0.0-alpha.9':
-    dependencies:
-      '@clack/core': 1.0.0-alpha.7
+      '@clack/core': 1.0.1
       picocolors: 1.1.1
       sisteransi: 1.0.5
 


### PR DESCRIPTION
## Description

Updates `@clack/prompts` to v1: https://github.com/bombshell-dev/clack/releases/tag/%40clack%2Fprompts%401.0.0
Only has ESM-only as a breaking change compared to v1-alpha or 0.x versions.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [X] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project name validation to reject undefined, null, and empty values.
  * Enhanced API key input validation to handle undefined, null, and empty values.

* **Chores**
  * Updated prompt library dependency to stable version (^1.0.1) across packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->