### PR TITLE
fix: forward requestContext to tools in createToolCallStep

### DIFF
--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -370,6 +370,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           toolCallId: inputData.toolCallId,
           messages: messageList.get.input.aiV5.model(),
           outputWriter,
+          requestContext,
           // Pass current step span as parent for tool call spans
           tracingContext: modelSpanTracker?.getTracingContext(),
           // Pass workspace from _internal (set by llmExecutionStep via prepareStep/processInputStep)

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -329,7 +329,7 @@ export class CoreToolBuilder extends MastraBase {
             mastra: wrappedMastra,
             memory: options.memory,
             runId: options.runId,
-            requestContext: options.requestContext ?? new RequestContext(),
+            requestContext: execOptions.requestContext ?? options.requestContext ?? new RequestContext(),
             // Workspace for file operations and command execution
             // Execution-time workspace (from prepareStep/processInputStep) takes precedence over build-time workspace
             workspace: execOptions.workspace ?? options.workspace,

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -86,6 +86,12 @@ export type MastraToolInvocationOptions = ToolInvocationOptions & {
   outputWriter?: OutputWriter;
   tracingContext?: TracingContext;
   /**
+   * Request context for tool execution. When provided at execution time, this overrides
+   * any request context configured at tool build time. Allows dynamic context propagation
+   * per-step via workflow execution.
+   */
+  requestContext?: RequestContext;
+  /**
    * Optional MCP-specific context passed when tool is executed in MCP server.
    * This is populated by the MCP server and passed through to the tool's execution context.
    */


### PR DESCRIPTION
fix: #13088

### description

- fixes a bug where requestContext from workflow steps wasn't forwarded to tools in createToolCallStep(). Tools received an empty RequestContext instead of the one set by the workflow step.

### Changes:

- Added requestContext to MastraToolInvocationOptions type
- Pass requestContext through toolOptions in createToolCallStep()
- Updated builder to prefer execution-time requestContext over build-time context

### Related Issue(s)
- Type of Change
[x] Bug fix (non-breaking change that fixes an issue)

### Checklist
[ ] I have made corresponding changes to the documentation (if applicable)
[ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced request context propagation during tool execution, allowing execution-time context configuration to take precedence over build-time settings, improving flexibility in request-scoped data handling within tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->