### PR TITLE
fix(core): guard ReadableStream controller against enqueue-after-close crash

### DIFF
--- a/packages/core/src/stream/base/input.ts
+++ b/packages/core/src/stream/base/input.ts
@@ -15,6 +15,7 @@ export abstract class MastraModelInput extends MastraBase {
 
   initialize({ runId, createStream, onResult }: { createStream: CreateStream; runId: string; onResult: OnResult }) {
     const self = this;
+    let controllerClosed = false;
 
     const stream = new ReadableStream<ChunkType>({
       async start(controller) {
@@ -33,10 +34,19 @@ export abstract class MastraModelInput extends MastraBase {
             controller,
           });
 
-          controller.close();
+          if (!controllerClosed) {
+            controllerClosed = true;
+            controller.close();
+          }
         } catch (error) {
-          controller.error(error);
+          if (!controllerClosed) {
+            controllerClosed = true;
+            controller.error(error);
+          }
         }
+      },
+      cancel() {
+        controllerClosed = true;
       },
     });
 


### PR DESCRIPTION
## Summary

Fixes #13107

When the stream consumer disconnects or the controller is closed between agent loop iterations (e.g., after a tool call completes but before the next LLM call starts), calling `controller.enqueue()` on the already-closed `ReadableStreamDefaultController` throws an unhandled `TypeError [ERR_INVALID_STATE]` that crashes the entire Node.js process:

```
TypeError [ERR_INVALID_STATE]: Invalid state: Controller is already closed
    at ReadableStreamDefaultController.enqueue (node:internal/webstreams/readablestream:1077:13)
    at Object.start (@mastra/core/dist/chunk-FVVQY6UU.js:271:28)
```

### Root Cause

`MastraAgentNetworkStream`'s constructor creates a `ReadableStream` with an `async start()` callback that has two concurrent producers (a `WritableStream` writer and a `for await` loop) sharing one controller with no lifecycle guards. When the stream closes (either from consumer cancellation or between agent loop iterations during multi-step tool execution), late-arriving chunks crash the process.

`MastraModelInput.initialize()` has the same vulnerable pattern — a `ReadableStream` with `async start()` that calls `controller.close()` and `controller.error()` without checking if the controller is already closed.

### Fix

Adds a `controllerClosed` flag and `cancel()` handler to both classes:

- **`MastraAgentNetworkStream`**: All `controller.enqueue()`, `controller.close()`, and `controller.error()` calls are guarded. The `for await` loop breaks early when the controller is closed. A `cancel()` callback marks the controller as closed when the consumer cancels.

- **`MastraModelInput.initialize()`**: Same guard pattern — `close()` and `error()` are guarded, and a `cancel()` callback is added.

Note: `MastraModelOutput.#createEventedStream()` and `RunOutput.fullStream` already have `cancel()` handlers that call `removeAllListeners()`, so they are not affected.

### Reproduction

1. Use `agent.stream()` or `agent.network()` with tools enabled
2. Trigger a tool call that completes successfully (the tool result arrives)
3. The LLM streaming step finishes → controller closes
4. Agent loop starts next LLM call → new chunks try to enqueue → **crash**

Also reproducible when the HTTP client disconnects mid-stream during a tool call.

## Test plan

- [ ] Verify existing stream tests pass
- [ ] Test agent streaming with tool calls (multi-step agent loop)
- [ ] Test client disconnection during streaming
- [ ] Test `agent.network()` with structured output and tool calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved stream errors that occurred when connections disconnected unexpectedly, improving application stability.
* Enhanced stream lifecycle management to prevent errors during connection closure and ensure proper graceful shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->