### PR TITLE
fix(docs): remove stale scope and siteId from NetlifyDeployer example

### DIFF
--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -56,10 +56,7 @@ import { Mastra } from "@mastra/core";
 import { NetlifyDeployer } from "@mastra/deployer-netlify";
 
 export const mastra = new Mastra({
-  deployer: new NetlifyDeployer({
-    scope: "your-team",
-    siteId: "your-site-id",
-  }),
+  deployer: new NetlifyDeployer(),
 });
 ```
 


### PR DESCRIPTION
## Description

Removes the deprecated `scope` and `siteId` options from the `NetlifyDeployer` example in `configuration.mdx`.  
These options were removed in a previous refactor, and the constructor now accepts no arguments.

## Related Issue(s)

Fixes #13104

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified Netlify deployment configuration documentation to demonstrate using default settings instead of explicit parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->