### PR TITLE
fix(playground): deduplicate traces and workflow runs to prevent table instability

### DIFF
--- a/.changeset/fix-logs-table-stability.md
+++ b/.changeset/fix-logs-table-stability.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added client-side deduplication by `runId` in `useWorkflowRuns` to prevent duplicate rows when offset pagination returns overlapping results across refetch cycles. Removed `gcTime: 0` and `staleTime: 0`. Fixed missing `fetchNextPage` in `useEffect` dependency array.

--- a/packages/playground-ui/src/hooks/__tests__/use-workflow-runs.test.ts
+++ b/packages/playground-ui/src/hooks/__tests__/use-workflow-runs.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+
+const PER_PAGE = 20;
+
+// Mirrors getNextPageParam from use-workflow-runs.ts
+function getNextPageParam(
+  lastPage: { runs: Array<{ runId: string }> },
+  _allPages: unknown,
+  lastPageParam: number,
+) {
+  if (lastPage.runs.length < PER_PAGE) {
+    return undefined;
+  }
+  return lastPageParam + 1;
+}
+
+// Mirrors select from use-workflow-runs.ts
+function selectRuns(data: { pages: Array<{ runs: Array<{ runId: string; workflowName: string }> }> }) {
+  const seen = new Set<string>();
+  return data.pages.flatMap(page => page.runs).filter(run => {
+    if (seen.has(run.runId)) return false;
+    seen.add(run.runId);
+    return true;
+  });
+}
+
+describe('useWorkflowRuns logic', () => {
+  it('paginates based on page size threshold', () => {
+    const fullPage = { runs: Array.from({ length: PER_PAGE }, (_, i) => ({ runId: `r${i}`, workflowName: `Run ${i}` })) };
+    expect(getNextPageParam(fullPage, [], 0)).toBe(1);
+    expect(getNextPageParam({ runs: [{ runId: 'r0', workflowName: 'Run 0' }] }, [], 0)).toBeUndefined();
+  });
+
+  it('deduplicates across pages, keeping first occurrence', () => {
+    const data = {
+      pages: [
+        { runs: [{ runId: 'aaa', workflowName: 'First' }, { runId: 'bbb', workflowName: 'Bravo' }] },
+        { runs: [{ runId: 'bbb', workflowName: 'Bravo (stale)' }, { runId: 'ccc', workflowName: 'Charlie' }] },
+      ],
+    };
+    const result = selectRuns(data);
+    expect(result.map(r => r.runId)).toEqual(['aaa', 'bbb', 'ccc']);
+    expect(result[1].workflowName).toBe('Bravo');
+  });
+});

--- a/packages/playground-ui/src/hooks/use-workflow-runs.ts
+++ b/packages/playground-ui/src/hooks/use-workflow-runs.ts
@@ -21,20 +21,25 @@ export const useWorkflowRuns = (workflowId: string, { enabled = true }: { enable
       return lastPageParam + 1;
     },
     select: data => {
-      return data.pages.flatMap(page => page.runs);
+      const seen = new Set<string>();
+      return data.pages.flatMap(page => page.runs).filter(run => {
+        if (seen.has(run.runId)) return false;
+        seen.add(run.runId);
+        return true;
+      });
     },
     retry: false,
     enabled,
     refetchInterval: 5000,
-    gcTime: 0,
-    staleTime: 0,
   });
 
+  const { hasNextPage, isFetchingNextPage, fetchNextPage } = query;
+
   useEffect(() => {
-    if (isEndOfListInView && query.hasNextPage && !query.isFetchingNextPage) {
-      query.fetchNextPage();
+    if (isEndOfListInView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
     }
-  }, [isEndOfListInView, query.hasNextPage, query.isFetchingNextPage]);
+  }, [isEndOfListInView, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return { ...query, setEndOfListElement };
 };

--- a/packages/playground/src/domains/observability/hooks/__tests__/use-traces.test.ts
+++ b/packages/playground/src/domains/observability/hooks/__tests__/use-traces.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+
+// Mirrors getNextPageParam from use-traces.tsx
+function getNextPageParam(
+  lastPage: { pagination?: { hasMore?: boolean } } | undefined,
+  _allPages: unknown,
+  lastPageParam: number,
+) {
+  if (lastPage?.pagination?.hasMore) {
+    return lastPageParam + 1;
+  }
+  return undefined;
+}
+
+// Mirrors select from use-traces.tsx
+function selectTraces(data: { pages: Array<{ spans?: Array<{ traceId: string; name: string }> }> }) {
+  const seen = new Set<string>();
+  return data.pages
+    .flatMap(page => page.spans ?? [])
+    .filter(span => {
+      if (seen.has(span.traceId)) return false;
+      seen.add(span.traceId);
+      return true;
+    });
+}
+
+describe('useTraces logic', () => {
+  it('uses hasMore to determine next page', () => {
+    expect(getNextPageParam({ pagination: { hasMore: true } }, [], 2)).toBe(3);
+    expect(getNextPageParam({ pagination: { hasMore: false } }, [], 2)).toBeUndefined();
+    expect(getNextPageParam(undefined, [], 0)).toBeUndefined();
+  });
+
+  it('deduplicates across pages, keeping first occurrence', () => {
+    // Simulates offset pagination drift: page 1 overlaps with page 0
+    const data = {
+      pages: [
+        {
+          spans: [
+            { traceId: 'aaa', name: 'Alpha' },
+            { traceId: 'bbb', name: 'Bravo' },
+          ],
+        },
+        {
+          spans: [
+            { traceId: 'bbb', name: 'Bravo (stale)' },
+            { traceId: 'ccc', name: 'Charlie' },
+          ],
+        },
+      ],
+    };
+    const result = selectTraces(data);
+    expect(result.map(s => s.traceId)).toEqual(['aaa', 'bbb', 'ccc']);
+    expect(result[1].name).toBe('Bravo');
+  });
+});

--- a/packages/playground/src/domains/observability/hooks/use-traces.tsx
+++ b/packages/playground/src/domains/observability/hooks/use-traces.tsx
@@ -13,15 +13,13 @@ const fetchTracesFn = async ({
   page: number;
   perPage: number;
 }) => {
-  const res = await client.listTraces({
+  return client.listTraces({
     pagination: {
       page,
       perPage,
     },
     filters,
   });
-
-  return res.spans || [];
 };
 
 export interface TracesFilters {
@@ -43,25 +41,32 @@ export const useTraces = ({ filters }: TracesFilters) => {
       }),
     initialPageParam: 0,
     getNextPageParam: (lastPage, _, lastPageParam) => {
-      if (!lastPage?.length) {
-        return undefined;
+      if (lastPage?.pagination?.hasMore) {
+        return lastPageParam + 1;
       }
-      return lastPageParam + 1;
+      return undefined;
     },
-    staleTime: 0,
-    gcTime: 0,
     select: data => {
-      return data.pages.flatMap(page => page);
+      const seen = new Set<string>();
+      return data.pages
+        .flatMap(page => page.spans ?? [])
+        .filter(span => {
+          if (seen.has(span.traceId)) return false;
+          seen.add(span.traceId);
+          return true;
+        });
     },
     retry: false,
     refetchInterval: 3000,
   });
 
+  const { hasNextPage, isFetchingNextPage, fetchNextPage } = query;
+
   useEffect(() => {
-    if (isEndOfListInView && query.hasNextPage && !query.isFetchingNextPage) {
-      query.fetchNextPage();
+    if (isEndOfListInView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
     }
-  }, [isEndOfListInView, query.hasNextPage, query.isFetchingNextPage]);
+  }, [isEndOfListInView, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   return { ...query, setEndOfListElement };
 };


### PR DESCRIPTION
## Summary

Fixes #13057 — duplicate rows in the Logs page table after refetch cycles.

**Root cause:** `useInfiniteQuery` with `refetchInterval: 3000` uses offset-based pagination. When new traces arrive between cycles, page boundaries shift and the same `traceId` appears on multiple pages. The `select` callback did `data.pages.flatMap(page => page)` with no deduplication, producing duplicate React keys. Additionally, `fetchTracesFn` discarded the server's `pagination` metadata (`return res.spans || []`), so `getNextPageParam` used a `!lastPage?.length` heuristic that never terminated for live data.

**What this fixes:**
- Duplicate rows after scrolling/refetch — dedup by `traceId`/`runId` in `select`
- `getNextPageParam` using server's `hasMore` flag instead of length heuristic
- Missing `fetchNextPage` in `useEffect` dependency array
- Removed `gcTime: 0` (added in initial observability commit `eb09742` as part of a bulk refactor with no documented rationale — it destroys the query cache on unmount, losing all loaded pages when navigating away)

**What this does NOT fix:**
- Log detail metadata not showing — may be a separate server-side issue
- The selection mechanism and detail pane already work by `traceId` (not array index): `handleTraceClick` stores `selectedTraceId` as a string, `TraceDialog` receives `traceDetails` via `traces.find(t => t.traceId === selectedTraceId)`, and `EntryListEntry.onClick` passes `entry.id`. Dedup ensures `find()` hits the correct (and only) entry.
- Sort ordering is guaranteed server-side via `listTracesArgsSchema` which defaults to `startedAt DESC`. No client-side sort needed.

### Changes

**`packages/playground/src/domains/observability/hooks/use-traces.tsx`**
- Return full `ListTracesResponse` from `fetchTracesFn` instead of `res.spans || []`
- Use `lastPage?.pagination?.hasMore` in `getNextPageParam`
- Deduplicate by `traceId` in `select` using a `Set`
- Remove `gcTime: 0` and `staleTime: 0`
- Destructure and fix `useEffect` dependency array

**`packages/playground-ui/src/hooks/use-workflow-runs.ts`** (same pattern)
- Deduplicate by `runId` in `select`
- Remove `gcTime: 0` and `staleTime: 0`
- Fix `useEffect` dependency array

### Changeset
- `@mastra/playground-ui: patch`

## Test plan

- [x] Unit tests for dedup and pagination logic (4 tests, both hooks)
- [ ] Manual: navigate to `/observability`, wait 10+ seconds for refetch cycles, verify row count stays stable, click rows to verify correct details pane, navigate away and back to verify cache behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate entries appearing in workflow runs and traces lists during pagination.
  * Improved pagination behavior to properly handle overlapping results across page loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->