### PR TITLE
docs: remove unnecessary --force flag from mastra init in Next.js guide

### DIFF
--- a/docs/src/content/en/guides/getting-started/next-js.mdx
+++ b/docs/src/content/en/guides/getting-started/next-js.mdx
@@ -45,7 +45,7 @@ cd my-nextjs-agent
 Run [`mastra init`](/reference/cli/mastra#mastra-init). When prompted, choose a provider (e.g. OpenAI) and enter your key:
 
 ```bash npm2yarn
-npx --force mastra@latest init
+npx mastra@latest init
 ```
 
 This creates a `src/mastra` folder with an example weather agent and the following files:


### PR DESCRIPTION
The npm2yarn remark plugin naively replaces `npx` with `pnpm dlx` without stripping npx-specific flags, so `npx --force mastra@latest init` became `pnpm dlx --force mastra@latest init` — which is invalid.

Since `@latest` already ensures the latest version is fetched, `--force` isn't needed. Removing it lets npm2yarn convert correctly for all package managers.

Closes #13131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the Next.js getting started guide with tabbed installation commands for multiple package managers (npm, pnpm, yarn, bun) for clearer setup.
  * Updated the initialization example to use a standard init command (removed the force flag) so the displayed install step is simpler and safer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->