### PR TITLE
fix(core): throw tool execution errors instead of returning them

### DIFF
--- a/.changeset/honest-onions-clap.md
+++ b/.changeset/honest-onions-clap.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed tool execution errors being emitted as `tool-result` instead of `tool-error` in fullStream. Previously, when a tool's execute function threw an error, the error was caught and returned as a value, causing the stream to emit a `tool-result` chunk containing the error object. Now errors are properly propagated, so the stream emits `tool-error` chunks, allowing consumers (including the `@mastra/ai-sdk` conversion pipeline) to correctly distinguish between successful tool results and failed tool executions. Fixes #13123.

--- a/packages/core/src/tools/tool-builder/builder.e2e.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.e2e.test.ts
@@ -752,8 +752,10 @@ describe('Tool Tracing Context Injection', () => {
 
     const builtTool = builder.build();
 
-    // Execute the tool - it should return a MastraError instead of throwing
-    const result = await builtTool.execute!({ message: 'test' }, { toolCallId: 'test-call-id', messages: [] });
+    // Execute the tool - it should throw a MastraError so the stream emits 'tool-error' chunks
+    await expect(builtTool.execute!({ message: 'test' }, { toolCallId: 'test-call-id', messages: [] })).rejects.toThrow(
+      'Tool execution failed',
+    );
 
     // Verify tool span was created
     expect(mockAgentSpan.createChildSpan).toHaveBeenCalled();
@@ -764,10 +766,6 @@ describe('Tool Tracing Context Injection', () => {
       attributes: { success: false },
     });
     expect(mockToolSpan.end).not.toHaveBeenCalled(); // Should not call end() when error() is called
-
-    // Verify the result is a MastraError
-    expect(result).toHaveProperty('id', 'TOOL_EXECUTION_FAILED');
-    expect(result).toHaveProperty('message', 'Tool execution failed');
   });
 
   it('should create child span with correct logType attribute', async () => {

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -509,7 +509,7 @@ export class CoreToolBuilder extends MastraBase {
         );
         logger.trackException(mastraError);
         logger.error(error, { ...rest, model: logModelObject, error: mastraError, args });
-        return mastraError;
+        throw mastraError;
       }
     };
   }


### PR DESCRIPTION
When a tool's `execute` throws, the error was caught in `CoreToolBuilder` and **returned** as a `MastraError` value instead of being re-thrown. This caused the stream to emit `tool-result` chunks containing the error object, instead of `tool-error` chunks — making it impossible for consumers to tell errors apart from successful results by chunk type.

This was introduced in #5601 (Jul 2025) to fix a playground crash, but the server route now has proper `try/catch` error handling, so returning the error at the builder layer is no longer needed.

The fix is a one-liner — `return mastraError` → `throw mastraError` in `builder.ts` — restoring the original behavior. Added a regression test using a `CoreToolBuilder`-built tool to verify the error flows through `tool-call-step` as `{ error }` (not `{ result: MastraError }`).

Fixes #13123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for tool execution: when a tool fails, errors are now properly propagated as tool-error chunks, allowing consumers to distinguish between successful tool results and failed executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->