### PR TITLE
feat: Harness primitive + MastraCode CLI

### DIFF
--- a/mastracode/package.json
+++ b/mastracode/package.json
@@ -15,6 +15,7 @@
     "@ai-sdk/openai": "^3.0.21",
     "@mariozechner/pi-tui": "^0.52.12",
     "@mastra/core": "workspace:*",
+    "@mastra/libsql": "^1.4.0",
     "ai": "^6.0.50",
     "chalk": "^5.6.2",
     "cli-highlight": "^2.1.11",

--- a/mastracode/package.json
+++ b/mastracode/package.json
@@ -6,21 +6,29 @@
   "scripts": {
     "dev": "tsx watch src/main.ts",
     "start": "tsx src/main.ts",
-    "typecheck": "tsc --noEmit",
+    "build": "tsup",
+    "typecheck": "NODE_OPTIONS='--max-old-space-size=8192' tsc --noEmit",
     "test": "vitest"
   },
   "dependencies": {
-    "ai": "^6.0.50",
     "@ai-sdk/anthropic": "^3.0.23",
     "@ai-sdk/openai": "^3.0.21",
     "@mariozechner/pi-tui": "^0.52.12",
     "@mastra/core": "workspace:*",
+    "ai": "^6.0.50",
     "chalk": "^5.6.2",
     "cli-highlight": "^2.1.11",
+    "execa": "^9.6.1",
+    "fastest-levenshtein": "^1.0.16",
+    "js-tiktoken": "^1.0.21",
+    "strip-ansi": "^7.1.2",
+    "tree-kill": "^1.2.2",
     "zod": "catalog:"
   },
   "devDependencies": {
     "@types/node": "22.19.3",
+    "@types/strip-ansi": "^5.2.1",
+    "tsup": "^8.5.1",
     "tsx": "^4.19.2",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/mastracode/package.json
+++ b/mastracode/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@mastra/mastracode",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/main.ts",
+    "start": "tsx src/main.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "ai": "^6.0.50",
+    "@ai-sdk/anthropic": "^3.0.23",
+    "@ai-sdk/openai": "^3.0.21",
+    "@mariozechner/pi-tui": "^0.52.12",
+    "@mastra/core": "workspace:*",
+    "chalk": "^5.6.2",
+    "cli-highlight": "^2.1.11",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "22.19.3",
+    "tsx": "^4.19.2",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/mastracode/package.json
+++ b/mastracode/package.json
@@ -15,6 +15,7 @@
     "@ai-sdk/openai": "^3.0.21",
     "@mariozechner/pi-tui": "^0.52.12",
     "@mastra/core": "workspace:*",
+    "@mastra/memory": "workspace:*",
     "@mastra/libsql": "^1.4.0",
     "ai": "^6.0.50",
     "chalk": "^5.6.2",

--- a/mastracode/src/agents/coding.ts
+++ b/mastracode/src/agents/coding.ts
@@ -1,0 +1,23 @@
+import { Mastra } from "@mastra/core/mastra"
+import { noopLogger } from "@mastra/core/logger"
+import type { MastraCompositeStore } from "@mastra/core/storage"
+import { Agent } from "@mastra/core/agent";
+import { getDynamicModel } from "../model";
+
+export function createCodingAgent(storage: MastraCompositeStore) {
+    const codeAgent = new Agent({
+        id: "code-agent",
+        name: "Code Agent",
+        instructions: '',
+        model: getDynamicModel,
+    });
+
+    const mastraInstance = new Mastra({
+        agents: { codeAgent },
+        storage,
+        logger: noopLogger,
+    })
+
+    return mastraInstance.getAgent("codeAgent");
+}
+

--- a/mastracode/src/agents/execute.ts
+++ b/mastracode/src/agents/execute.ts
@@ -1,0 +1,58 @@
+/**
+ * Execute subagent — focused task execution with write capabilities.
+ *
+ * This subagent is given a specific implementation task and uses both
+ * read and write tools to complete it. It can modify files, run commands,
+ * and perform actual development work within a constrained scope.
+ */
+import type { SubagentDefinition } from "./types"
+
+export const executeSubagent: SubagentDefinition = {
+    id: "execute",
+    name: "Execute",
+    instructions: `You are a focused execution agent. Your job is to complete a specific, well-defined task by making the necessary changes to the codebase.
+
+## Rules
+- You have FULL ACCESS to read, write, and execute within your task scope.
+- Stay focused on the specific task given. Do not make unrelated changes.
+- Read files before modifying them — use read_file first, then edit_file or write_file.
+- Verify your changes work by running relevant tests or checking for errors.
+
+## Tool Strategy
+- **Read first**: Always read_file before editing
+- **Edit precisely**: Use edit_file with enough context to match uniquely
+- **Use specialized tools**: Prefer read_file/grep/list_files over shell commands for reading
+- **Parallelize**: Make independent tool calls together (e.g., read multiple files at once)
+
+## Workflow
+. Understand the task and explore relevant code
+. For complex tasks (3+ steps): use todo_write to track progress
+. Make changes incrementally — verify each change before moving on
+. Run tests or type-check to verify
+
+## Efficiency
+Your output returns to the parent agent. Be concise:
+- Don't repeat file contents in your response
+- Summarize what changed, don't narrate each step
+- Keep your final summary under 300 words
+
+## Output Format
+End with a structured summary:
+. **Completed**: What you implemented (1-2 sentences)
+. **Changes**: Files modified/created
+. **Verification**: How you verified it works
+. **Notes**: Follow-up needed (if any)`,
+    allowedTools: [
+        // Read tools
+        "mastra_workspace_read_file",
+        "mastra_workspace_list_files",
+        "grep",
+        // Write tools
+        "mastra_workspace_edit_file",
+        "mastra_workspace_write_file",
+        // Execution tool
+        "mastra_workspace_execute_command",
+        // Task tracking
+        "todo_write",
+    ],
+}

--- a/mastracode/src/agents/explore.ts
+++ b/mastracode/src/agents/explore.ts
@@ -1,0 +1,44 @@
+/**
+ * Explore subagent — read-only codebase exploration.
+ *
+ * This subagent is given a focused task (e.g., "find all usages of X",
+ * "understand how module Y works") and uses read-only tools to explore
+ * the codebase, then returns a concise summary of its findings.
+ */
+import type { SubagentDefinition } from "./types"
+
+export const exploreSubagent: SubagentDefinition = {
+    id: "explore",
+    name: "Explore",
+    instructions: `You are an expert code explorer. Your job is to investigate a codebase and answer a specific question or gather specific information.
+
+## Rules
+- You have READ-ONLY access. You cannot modify files or run commands.
+- Be thorough — search broadly first, then drill into relevant files.
+- After gathering enough information, produce a clear, concise summary of your findings.
+
+## Tool Strategy
+- **Start broad**: Use list_files (glob) to understand project structure
+- **Search smart**: Use grep with specific patterns — avoid overly broad searches
+- **Read efficiently**: Use read_file for targeted sections — don't read entire files if you only need a section
+- **Parallelize**: Make multiple independent tool calls in one round when exploring different areas
+
+## Efficiency
+Your output returns to the parent agent. Be concise:
+- Don't include raw file contents in your response — summarize what you found
+- Reference files by path and line number, not by copying code
+- If a search returns many results, report the count and key examples, not every match
+
+## Output Format
+End with a structured summary:
+. **Answer**: Direct answer to the question (1-2 sentences)
+. **Key Files**: Most relevant files with line numbers
+. **Details**: Additional context if needed
+
+Keep your summary under 300 words.`,
+    allowedTools: [
+        "mastra_workspace_read_file",
+        "mastra_workspace_list_files",
+        "grep",
+    ],
+}

--- a/mastracode/src/agents/index.ts
+++ b/mastracode/src/agents/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Subagent registry — maps subagent IDs to their definitions.
+ */
+
+export type { SubagentDefinition } from "./types"
+export { exploreSubagent } from "./explore"
+export { planSubagent } from "./plan"
+export { executeSubagent } from "./execute"
+
+import type { SubagentDefinition } from "./types"
+import { exploreSubagent } from "./explore"
+import { planSubagent } from "./plan"
+import { executeSubagent } from "./execute"
+
+/** All registered subagent definitions, keyed by ID. */
+const subagentRegistry: Record<string, SubagentDefinition> = {
+    explore: exploreSubagent,
+    plan: planSubagent,
+    execute: executeSubagent,
+}
+
+/**
+ * Look up a subagent definition by ID.
+ * Returns undefined if not found.
+ */
+export function getSubagentDefinition(
+    id: string,
+): SubagentDefinition | undefined {
+    return subagentRegistry[id]
+}
+
+/**
+ * Get all registered subagent IDs (for tool description / validation).
+ */
+export function getSubagentIds(): string[] {
+    return Object.keys(subagentRegistry)
+}

--- a/mastracode/src/agents/plan.ts
+++ b/mastracode/src/agents/plan.ts
@@ -1,0 +1,46 @@
+/**
+ * Plan subagent — read-only analysis and planning.
+ *
+ * This subagent is given a task to analyze and produces a structured
+ * implementation plan. It can read the codebase to understand existing
+ * patterns and architecture, but cannot modify anything.
+ */
+import type { SubagentDefinition } from "./types"
+
+export const planSubagent: SubagentDefinition = {
+    id: "plan",
+    name: "Plan",
+    instructions: `You are an expert software architect and planner. Your job is to analyze a codebase and produce a detailed implementation plan for a given task.
+
+## Rules
+- You have READ-ONLY access. You cannot modify files or run commands.
+- First, explore the codebase to understand existing patterns, architecture, and conventions.
+- Produce a concrete, actionable plan — not vague suggestions.
+
+## Tool Strategy
+- **Discover structure**: Use list_files (glob) to understand project layout and find relevant files
+- **Find patterns**: Use grep to locate existing implementations, imports, and conventions
+- **Understand deeply**: Use read_file to read specific sections of key files
+- **Parallelize**: Make multiple independent tool calls when exploring different areas
+
+## Efficiency
+Your output returns to the parent agent. Be concise:
+- Don't include raw file contents — reference by path and line number
+- Focus on actionable details, not general observations
+- If you find many similar patterns, describe the pattern once with examples
+
+## Output Format
+Structure your plan as:
+
+. **Summary**: One-paragraph overview (2-3 sentences)
+. **Files to Change**: List each file with specific changes needed
+. **Implementation Order**: Numbered steps in dependency order
+. **Risks**: Potential issues or edge cases (if any)
+
+Be specific about code locations (file paths, function names, line numbers). Keep the plan actionable and under 500 words.`,
+    allowedTools: [
+        "mastra_workspace_read_file",
+        "mastra_workspace_list_files",
+        "grep",
+    ],
+}

--- a/mastracode/src/agents/types.ts
+++ b/mastracode/src/agents/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Subagent type definitions.
+ *
+ * A subagent is a lightweight Agent instance with a constrained tool set,
+ * spawned by the parent agent via the `subagent` meta-tool. Each subagent
+ * runs in its own conversation thread and returns a single text result.
+ */
+
+export interface SubagentDefinition {
+    /** Unique identifier for this subagent type (e.g., "explore", "plan") */
+    id: string
+
+    /** Human-readable name shown in tool output */
+    name: string
+
+    /** System prompt for this subagent */
+    instructions: string
+
+    /**
+     * Which tool IDs this subagent may use.
+     * These are keys from the parent agent's tool registry
+     * (e.g., "mastra_workspace_read_file", "grep").
+     */
+    allowedTools: string[]
+}

--- a/mastracode/src/auth/claude/middleware.ts
+++ b/mastracode/src/auth/claude/middleware.ts
@@ -1,0 +1,101 @@
+import { LanguageModelMiddleware } from "ai"
+
+/**
+ * Prompt caching middleware for Anthropic
+ *
+ * Adds cache breakpoints at strategic locations:
+ * 1. Last system message (end of static instructions + dynamic memory)
+ * 2. Most recent user/assistant message (conversation context)
+ *
+ * This allows Anthropic to cache:
+ * - System prompts and instructions (rarely change)
+ * - Conversation history up to the last message
+ */
+export const promptCacheMiddleware: LanguageModelMiddleware = {
+    specificationVersion: "v3",
+    transformParams: async ({ params }) => {
+        const prompt = [...params.prompt]
+
+        const cacheControl = { type: "ephemeral" as const, ttl: "5m" as const }
+
+        // Helper to add cache control to a message's last content part
+        const addCacheToMessage = (msg: any) => {
+            // For system messages with string content
+            if (typeof msg.content === "string") {
+                return {
+                    ...msg,
+                    providerOptions: {
+                        ...msg.providerOptions,
+                        anthropic: { ...msg.providerOptions?.anthropic, cacheControl },
+                    },
+                }
+            }
+
+            // For messages with array content, add to last part
+            if (Array.isArray(msg.content) && msg.content.length > 0) {
+                const content = [...msg.content]
+                const lastPart = content[content.length - 1]
+                content[content.length - 1] = {
+                    ...lastPart,
+                    providerOptions: {
+                        ...lastPart.providerOptions,
+                        anthropic: { ...lastPart.providerOptions?.anthropic, cacheControl },
+                    },
+                }
+                return { ...msg, content }
+            }
+
+            return msg
+        }
+
+        // Find the last system message index
+        let lastSystemIdx = -1
+        for (let i = prompt.length - 1; i >= 0; i--) {
+            if ((prompt[i] as any).role === "system") {
+                lastSystemIdx = i
+                break
+            }
+        }
+
+        // Add cache breakpoint to last system message
+        if (lastSystemIdx >= 0) {
+            prompt[lastSystemIdx] = addCacheToMessage(prompt[lastSystemIdx])
+        }
+
+        // Add cache breakpoint to the most recent message (last in array)
+        const lastIdx = prompt.length - 1
+        if (lastIdx >= 0 && lastIdx !== lastSystemIdx) {
+            prompt[lastIdx] = addCacheToMessage(prompt[lastIdx])
+        }
+
+        return { ...params, prompt }
+    },
+}
+
+// Required for Claude Max plan OAuth - the endpoint checks for this system message
+const claudeCodeIdentity =
+    "You are Claude Code, Anthropic's official CLI for Claude."
+
+/**
+ * Middleware that injects the Claude Code identity system message
+ * Required for Claude Max OAuth authentication
+ */
+export const claudeCodeMiddleware: LanguageModelMiddleware = {
+    specificationVersion: "v3",
+    transformParams: async ({ params }) => {
+        // Prepend the Claude Code identity as the first system message
+        const systemMessage = {
+            role: "system" as const,
+            content: claudeCodeIdentity,
+        }
+
+        if (params.temperature) {
+            delete params.topP
+        }
+
+        return {
+            ...params,
+            prompt: [systemMessage, ...params.prompt],
+        }
+    },
+}

--- a/mastracode/src/auth/claude/middleware.ts
+++ b/mastracode/src/auth/claude/middleware.ts
@@ -1,4 +1,4 @@
-import { LanguageModelMiddleware } from "ai"
+import type { LanguageModelMiddleware } from "ai"
 
 /**
  * Prompt caching middleware for Anthropic

--- a/mastracode/src/auth/claude/oauth.ts
+++ b/mastracode/src/auth/claude/oauth.ts
@@ -1,0 +1,143 @@
+/**
+ * Anthropic OAuth flow (Claude Pro/Max)
+ *
+ * Inspired by pi-mono's OAuth implementation:
+ * https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/utils/oauth/anthropic.ts
+ */
+
+import { generatePKCE } from "../storage/pkce.js"
+import type {
+    OAuthCredentials,
+    OAuthLoginCallbacks,
+    OAuthProviderInterface,
+} from "../storage/types.js"
+
+const decode = (s: string) => atob(s)
+const CLIENT_ID = decode("OWQxYzI1MGEtZTYxYi00NGQ5LTg4ZWQtNTk0NGQxOTYyZjVl")
+const AUTHORIZE_URL = "https://claude.ai/oauth/authorize"
+const TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+const REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
+const SCOPES = "org:create_api_key user:profile user:inference"
+
+/**
+ * Login with Anthropic OAuth (device code flow)
+ */
+export async function loginClaude(
+    onAuthUrl: (url: string) => void,
+    onPromptCode: () => Promise<string>,
+): Promise<OAuthCredentials> {
+    const { verifier, challenge } = await generatePKCE()
+
+    // Build authorization URL
+    const authParams = new URLSearchParams({
+        code: "true",
+        client_id: CLIENT_ID,
+        response_type: "code",
+        redirect_uri: REDIRECT_URI,
+        scope: SCOPES,
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        state: verifier,
+    })
+
+    const authUrl = `${AUTHORIZE_URL}?${authParams.toString()}`
+
+    // Notify caller with URL to open
+    onAuthUrl(authUrl)
+
+    // Wait for user to paste authorization code (format: code#state)
+    const authCode = await onPromptCode()
+    const splits = authCode.split("#")
+    const code = splits[0]
+    const state = splits[1]
+
+    // Exchange code for tokens
+    const tokenResponse = await fetch(TOKEN_URL, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            grant_type: "authorization_code",
+            client_id: CLIENT_ID,
+            code: code,
+            state: state,
+            redirect_uri: REDIRECT_URI,
+            code_verifier: verifier,
+        }),
+    })
+
+    if (!tokenResponse.ok) {
+        const error = await tokenResponse.text()
+        throw new Error(`Token exchange failed: ${error}`)
+    }
+
+    const tokenData = (await tokenResponse.json()) as {
+        access_token: string
+        refresh_token: string
+        expires_in: number
+    }
+
+    // Calculate expiry time (current time + expires_in seconds - 5 min buffer)
+    const expiresAt = Date.now() + tokenData.expires_in * 1000 - 5 * 60 * 1000
+
+    return {
+        refresh: tokenData.refresh_token,
+        access: tokenData.access_token,
+        expires: expiresAt,
+    }
+}
+
+/**
+ * Refresh Anthropic OAuth token
+ */
+export async function refreshClaudeToken(
+    refreshToken: string,
+): Promise<OAuthCredentials> {
+    const response = await fetch(TOKEN_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            grant_type: "refresh_token",
+            client_id: CLIENT_ID,
+            refresh_token: refreshToken,
+        }),
+    })
+
+    if (!response.ok) {
+        const error = await response.text()
+        throw new Error(`Anthropic token refresh failed: ${error}`)
+    }
+
+    const data = (await response.json()) as {
+        access_token: string
+        refresh_token: string
+        expires_in: number
+    }
+
+    return {
+        refresh: data.refresh_token,
+        access: data.access_token,
+        expires: Date.now() + data.expires_in * 1000 - 5 * 60 * 1000,
+    }
+}
+
+export const claudeOAuthProvider: OAuthProviderInterface = {
+    id: "anthropic",
+    name: "Claude (Pro/Max)",
+
+    async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+        return loginClaude(
+            (url) => callbacks.onAuth({ url }),
+            () => callbacks.onPrompt({ message: "Paste the authorization code:" }),
+        )
+    },
+
+    async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+        return refreshClaudeToken(credentials.refresh)
+    },
+
+    getApiKey(credentials: OAuthCredentials): string {
+        return credentials.access
+    },
+}

--- a/mastracode/src/auth/claude/provider.ts
+++ b/mastracode/src/auth/claude/provider.ts
@@ -1,0 +1,66 @@
+import { createAnthropic } from "@ai-sdk/anthropic"
+import { MastraModelConfig } from "@mastra/core/llm"
+import { wrapLanguageModel } from "ai"
+import { claudeCodeMiddleware, promptCacheMiddleware } from "./middleware"
+import { getAuthStorage } from "../storage-singleton"
+
+/**
+ * Creates an Anthropic model using Claude Max OAuth authentication
+ * Uses OAuth tokens from AuthStorage (auto-refreshes when needed)
+ */
+export function opencodeClaudeMaxProvider(
+    modelId: string = "claude-sonnet-4-20250514",
+): MastraModelConfig {
+    // Test environment: use API key
+    if (process.env.NODE_ENV === "test" || process.env.VITEST) {
+        const anthropic = createAnthropic({
+            apiKey: process.env.ANTHROPIC_API_KEY || "test-api-key",
+        })
+        return wrapLanguageModel({
+            model: anthropic(modelId),
+            middleware: [claudeCodeMiddleware, promptCacheMiddleware],
+        })
+    }
+
+    // Custom fetch that handles OAuth
+    const oauthFetch = async (
+        url: string | URL | Request,
+        init?: Parameters<typeof fetch>[1],
+    ) => {
+        const authStorage = getAuthStorage()
+
+        // Reload from disk to handle multi-instance refresh
+        authStorage.reload()
+
+        // Get access token (auto-refreshes if expired)
+        const accessToken = await authStorage.getApiKey("anthropic")
+
+        if (!accessToken) {
+            throw new Error("Not logged in to Anthropic. Run /login first.")
+        }
+
+        // Make request with OAuth headers
+        return fetch(url, {
+            ...init,
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+                "anthropic-beta":
+                    "oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
+                "anthropic-version": "2023-06-01",
+            },
+        })
+    }
+
+    const anthropic = createAnthropic({
+        // Provide a dummy API key - the actual auth is handled via OAuth in oauthFetch
+        // This prevents the SDK from throwing "API key is missing" at model creation time
+        apiKey: "oauth-placeholder",
+        fetch: oauthFetch as any,
+    })
+
+    // Wrap with middleware to inject Claude Code identity and enable prompt caching
+    return wrapLanguageModel({
+        model: anthropic(modelId),
+        middleware: [claudeCodeMiddleware, promptCacheMiddleware],
+    })
+}

--- a/mastracode/src/auth/claude/provider.ts
+++ b/mastracode/src/auth/claude/provider.ts
@@ -1,5 +1,5 @@
 import { createAnthropic } from "@ai-sdk/anthropic"
-import { MastraModelConfig } from "@mastra/core/llm"
+import type { MastraModelConfig } from "@mastra/core/llm"
 import { wrapLanguageModel } from "ai"
 import { claudeCodeMiddleware, promptCacheMiddleware } from "./middleware"
 import { getAuthStorage } from "../storage-singleton"

--- a/mastracode/src/auth/codex/constants.ts
+++ b/mastracode/src/auth/codex/constants.ts
@@ -1,0 +1,9 @@
+// Codex API endpoint (not standard OpenAI API)
+export const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
+
+// Default instructions for Codex API (required)
+export const CODEX_INSTRUCTIONS = `
+You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
+
+IMPORTANT: You should be concise, direct, and helpful. Focus on solving the user's problem efficiently.
+`

--- a/mastracode/src/auth/codex/middleware.ts
+++ b/mastracode/src/auth/codex/middleware.ts
@@ -1,0 +1,30 @@
+import { LanguageModelMiddleware } from "ai"
+import { CODEX_INSTRUCTIONS } from "./constants"
+
+/**
+ * Middleware for OpenAI Codex - handles any special transformations needed
+ */
+export const codexMiddleware: LanguageModelMiddleware = {
+    specificationVersion: "v3",
+    transformParams: async ({ params }) => {
+        // Remove topP if temperature is set (OpenAI doesn't like both)
+        if (params.temperature) {
+            delete params.topP
+        }
+
+        // Codex API requires specific settings via providerOptions
+        // Use type assertion to satisfy JSONValue constraints
+        params.providerOptions = {
+            ...params.providerOptions,
+            openai: {
+                ...(params.providerOptions?.openai ?? {}),
+                // Codex API requires instructions
+                instructions: CODEX_INSTRUCTIONS,
+                // Codex API requires store to be false
+                store: false,
+            },
+        } as typeof params.providerOptions
+
+        return params
+    },
+}

--- a/mastracode/src/auth/codex/middleware.ts
+++ b/mastracode/src/auth/codex/middleware.ts
@@ -1,4 +1,4 @@
-import { LanguageModelMiddleware } from "ai"
+import type { LanguageModelMiddleware } from "ai"
 import { CODEX_INSTRUCTIONS } from "./constants"
 
 /**

--- a/mastracode/src/auth/codex/oauth.ts
+++ b/mastracode/src/auth/codex/oauth.ts
@@ -1,0 +1,502 @@
+/**
+ * OpenAI Codex (ChatGPT OAuth) flow
+ *
+ * Inspired by pi-mono's OAuth implementation:
+ * https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/utils/oauth/openai-codex.ts
+ *
+ * NOTE: This module uses Node.js crypto and http for the OAuth callback.
+ * It is only intended for CLI use, not browser environments.
+ */
+
+// NEVER convert to top-level imports - breaks browser/Vite builds (web-ui)
+let _randomBytes: typeof import("node:crypto").randomBytes | null = null
+let _http: typeof import("node:http") | null = null
+if (
+    typeof process !== "undefined" &&
+    (process.versions?.node || process.versions?.bun)
+) {
+    import("node:crypto").then((m) => {
+        _randomBytes = m.randomBytes
+    })
+    import("node:http").then((m) => {
+        _http = m
+    })
+}
+
+import { generatePKCE } from "../storage/pkce.js"
+import type {
+    OAuthCredentials,
+    OAuthLoginCallbacks,
+    OAuthPrompt,
+    OAuthProviderInterface,
+} from "../storage/types.js"
+
+const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize"
+const TOKEN_URL = "https://auth.openai.com/oauth/token"
+const REDIRECT_URI = "http://localhost:1455/auth/callback"
+const SCOPE = "openid profile email offline_access"
+const JWT_CLAIM_PATH = "https://api.openai.com/auth"
+
+const SUCCESS_HTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Authentication successful</title>
+</head>
+<body>
+  <p>Authentication successful. Return to your terminal to continue.</p>
+</body>
+</html>`
+
+type TokenSuccess = {
+    type: "success"
+    access: string
+    refresh: string
+    expires: number
+}
+type TokenFailure = { type: "failed" }
+type TokenResult = TokenSuccess | TokenFailure
+
+type JwtPayload = {
+    [JWT_CLAIM_PATH]?: {
+        chatgpt_account_id?: string
+    }
+    [key: string]: unknown
+}
+
+function createState(): string {
+    if (!_randomBytes) {
+        throw new Error(
+            "OpenAI Codex OAuth is only available in Node.js environments",
+        )
+    }
+    return _randomBytes(16).toString("hex")
+}
+
+function parseAuthorizationInput(input: string): {
+    code?: string
+    state?: string
+} {
+    const value = input.trim()
+    if (!value) return {}
+
+    try {
+        const url = new URL(value)
+        return {
+            code: url.searchParams.get("code") ?? undefined,
+            state: url.searchParams.get("state") ?? undefined,
+        }
+    } catch {
+        // not a URL
+    }
+
+    if (value.includes("#")) {
+        const [code, state] = value.split("#", 2)
+        return { code, state }
+    }
+
+    if (value.includes("code=")) {
+        const params = new URLSearchParams(value)
+        return {
+            code: params.get("code") ?? undefined,
+            state: params.get("state") ?? undefined,
+        }
+    }
+
+    return { code: value }
+}
+
+function decodeJwt(token: string): JwtPayload | null {
+    try {
+        const parts = token.split(".")
+        if (parts.length !== 3) return null
+        const payload = parts[1] ?? ""
+        const decoded = atob(payload)
+        return JSON.parse(decoded) as JwtPayload
+    } catch {
+        return null
+    }
+}
+
+async function exchangeAuthorizationCode(
+    code: string,
+    verifier: string,
+    redirectUri: string = REDIRECT_URI,
+): Promise<TokenResult> {
+    const response = await fetch(TOKEN_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+            grant_type: "authorization_code",
+            client_id: CLIENT_ID,
+            code,
+            code_verifier: verifier,
+            redirect_uri: redirectUri,
+        }),
+    })
+
+    if (!response.ok) {
+        const text = await response.text().catch(() => "")
+        console.error("[openai-codex] code->token failed:", response.status, text)
+        return { type: "failed" }
+    }
+
+    const json = (await response.json()) as {
+        access_token?: string
+        refresh_token?: string
+        expires_in?: number
+    }
+
+    if (
+        !json.access_token ||
+        !json.refresh_token ||
+        typeof json.expires_in !== "number"
+    ) {
+        console.error("[openai-codex] token response missing fields:", json)
+        return { type: "failed" }
+    }
+
+    return {
+        type: "success",
+        access: json.access_token,
+        refresh: json.refresh_token,
+        expires: Date.now() + json.expires_in * 1000,
+    }
+}
+
+async function refreshAccessToken(refreshToken: string): Promise<TokenResult> {
+    try {
+        const response = await fetch(TOKEN_URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: new URLSearchParams({
+                grant_type: "refresh_token",
+                refresh_token: refreshToken,
+                client_id: CLIENT_ID,
+            }),
+        })
+
+        if (!response.ok) {
+            const text = await response.text().catch(() => "")
+            console.error(
+                "[openai-codex] Token refresh failed:",
+                response.status,
+                text,
+            )
+            return { type: "failed" }
+        }
+
+        const json = (await response.json()) as {
+            access_token?: string
+            refresh_token?: string
+            expires_in?: number
+        }
+
+        if (
+            !json.access_token ||
+            !json.refresh_token ||
+            typeof json.expires_in !== "number"
+        ) {
+            console.error(
+                "[openai-codex] Token refresh response missing fields:",
+                json,
+            )
+            return { type: "failed" }
+        }
+
+        return {
+            type: "success",
+            access: json.access_token,
+            refresh: json.refresh_token,
+            expires: Date.now() + json.expires_in * 1000,
+        }
+    } catch (error) {
+        console.error("[openai-codex] Token refresh error:", error)
+        return { type: "failed" }
+    }
+}
+
+async function createAuthorizationFlow(
+    originator: string = "pi",
+): Promise<{ verifier: string; state: string; url: string }> {
+    const { verifier, challenge } = await generatePKCE()
+    const state = createState()
+
+    const url = new URL(AUTHORIZE_URL)
+    url.searchParams.set("response_type", "code")
+    url.searchParams.set("client_id", CLIENT_ID)
+    url.searchParams.set("redirect_uri", REDIRECT_URI)
+    url.searchParams.set("scope", SCOPE)
+    url.searchParams.set("code_challenge", challenge)
+    url.searchParams.set("code_challenge_method", "S256")
+    url.searchParams.set("state", state)
+    url.searchParams.set("id_token_add_organizations", "true")
+    url.searchParams.set("codex_cli_simplified_flow", "true")
+    url.searchParams.set("originator", originator)
+
+    return { verifier, state, url: url.toString() }
+}
+
+type OAuthServerInfo = {
+    close: () => void
+    cancelWait: () => void
+    waitForCode: () => Promise<{ code: string } | null>
+}
+
+function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
+    if (!_http) {
+        throw new Error(
+            "OpenAI Codex OAuth is only available in Node.js environments",
+        )
+    }
+    let lastCode: string | null = null
+    let cancelled = false
+    const server = _http.createServer((req, res) => {
+        try {
+            const url = new URL(req.url || "", "http://localhost")
+            if (url.pathname !== "/auth/callback") {
+                res.statusCode = 404
+                res.end("Not found")
+                return
+            }
+            if (url.searchParams.get("state") !== state) {
+                res.statusCode = 400
+                res.end("State mismatch")
+                return
+            }
+            const code = url.searchParams.get("code")
+            if (!code) {
+                res.statusCode = 400
+                res.end("Missing authorization code")
+                return
+            }
+            res.statusCode = 200
+            res.setHeader("Content-Type", "text/html; charset=utf-8")
+            res.end(SUCCESS_HTML)
+            lastCode = code
+        } catch {
+            res.statusCode = 500
+            res.end("Internal error")
+        }
+    })
+
+    return new Promise((resolve) => {
+        server
+            .listen(1455, "127.0.0.1", () => {
+                resolve({
+                    close: () => server.close(),
+                    cancelWait: () => {
+                        cancelled = true
+                    },
+                    waitForCode: async () => {
+                        const sleep = () => new Promise((r) => setTimeout(r, 100))
+                        for (let i = 0; i < 600; i += 1) {
+                            if (lastCode) return { code: lastCode }
+                            if (cancelled) return null
+                            await sleep()
+                        }
+                        return null
+                    },
+                })
+            })
+            .on("error", (err: NodeJS.ErrnoException) => {
+                console.error(
+                    "[openai-codex] Failed to bind http://127.0.0.1:1455 (",
+                    err.code,
+                    ") Falling back to manual paste.",
+                )
+                resolve({
+                    close: () => {
+                        try {
+                            server.close()
+                        } catch {
+                            // ignore
+                        }
+                    },
+                    cancelWait: () => { },
+                    waitForCode: async () => null,
+                })
+            })
+    })
+}
+
+function getAccountId(accessToken: string): string | null {
+    const payload = decodeJwt(accessToken)
+    const auth = payload?.[JWT_CLAIM_PATH]
+    const accountId = auth?.chatgpt_account_id
+    return typeof accountId === "string" && accountId.length > 0
+        ? accountId
+        : null
+}
+
+/**
+ * Login with OpenAI Codex OAuth
+ *
+ * @param options.onAuth - Called with URL and instructions when auth starts
+ * @param options.onPrompt - Called to prompt user for manual code paste (fallback if no onManualCodeInput)
+ * @param options.onProgress - Optional progress messages
+ * @param options.onManualCodeInput - Optional promise that resolves with user-pasted code.
+ *                                    Races with browser callback - whichever completes first wins.
+ *                                    Useful for showing paste input immediately alongside browser flow.
+ * @param options.originator - OAuth originator parameter (defaults to "pi")
+ */
+export async function loginOpenAICodex(options: {
+    onAuth: (info: { url: string; instructions?: string }) => void
+    onPrompt: (prompt: OAuthPrompt) => Promise<string>
+    onProgress?: (message: string) => void
+    onManualCodeInput?: () => Promise<string>
+    originator?: string
+}): Promise<OAuthCredentials> {
+    const { verifier, state, url } = await createAuthorizationFlow(
+        options.originator,
+    )
+    const server = await startLocalOAuthServer(state)
+
+    options.onAuth({
+        url,
+        instructions: "A browser window should open. Complete login to finish.",
+    })
+
+    let code: string | undefined
+    try {
+        if (options.onManualCodeInput) {
+            // Race between browser callback and manual input
+            let manualCode: string | undefined
+            let manualError: Error | undefined
+            const manualPromise = options
+                .onManualCodeInput()
+                .then((input) => {
+                    manualCode = input
+                    server.cancelWait()
+                })
+                .catch((err) => {
+                    manualError = err instanceof Error ? err : new Error(String(err))
+                    server.cancelWait()
+                })
+
+            const result = await server.waitForCode()
+
+            // If manual input was cancelled, throw that error
+            if (manualError) {
+                throw manualError
+            }
+
+            if (result?.code) {
+                // Browser callback won
+                code = result.code
+            } else if (manualCode) {
+                // Manual input won (or callback timed out and user had entered code)
+                const parsed = parseAuthorizationInput(manualCode)
+                if (parsed.state && parsed.state !== state) {
+                    throw new Error("State mismatch")
+                }
+                code = parsed.code
+            }
+
+            // If still no code, wait for manual promise to complete and try that
+            if (!code) {
+                await manualPromise
+                if (manualError) {
+                    throw manualError
+                }
+                if (manualCode) {
+                    const parsed = parseAuthorizationInput(manualCode)
+                    if (parsed.state && parsed.state !== state) {
+                        throw new Error("State mismatch")
+                    }
+                    code = parsed.code
+                }
+            }
+        } else {
+            // Original flow: wait for callback, then prompt if needed
+            const result = await server.waitForCode()
+            if (result?.code) {
+                code = result.code
+            }
+        }
+
+        // Fallback to onPrompt if still no code
+        if (!code) {
+            const input = await options.onPrompt({
+                message: "Paste the authorization code (or full redirect URL):",
+            })
+            const parsed = parseAuthorizationInput(input)
+            if (parsed.state && parsed.state !== state) {
+                throw new Error("State mismatch")
+            }
+            code = parsed.code
+        }
+
+        if (!code) {
+            throw new Error("Missing authorization code")
+        }
+
+        const tokenResult = await exchangeAuthorizationCode(code, verifier)
+        if (tokenResult.type !== "success") {
+            throw new Error("Token exchange failed")
+        }
+
+        const accountId = getAccountId(tokenResult.access)
+        if (!accountId) {
+            throw new Error("Failed to extract accountId from token")
+        }
+
+        return {
+            access: tokenResult.access,
+            refresh: tokenResult.refresh,
+            expires: tokenResult.expires,
+            accountId,
+        }
+    } finally {
+        server.close()
+    }
+}
+
+/**
+ * Refresh OpenAI Codex OAuth token
+ */
+export async function refreshOpenAICodexToken(
+    refreshToken: string,
+): Promise<OAuthCredentials> {
+    const result = await refreshAccessToken(refreshToken)
+    if (result.type !== "success") {
+        throw new Error("Failed to refresh OpenAI Codex token")
+    }
+
+    const accountId = getAccountId(result.access)
+    if (!accountId) {
+        throw new Error("Failed to extract accountId from token")
+    }
+
+    return {
+        access: result.access,
+        refresh: result.refresh,
+        expires: result.expires,
+        accountId,
+    }
+}
+
+export const codexOAuthProvider: OAuthProviderInterface = {
+    id: "openai-codex",
+    name: "ChatGPT Plus/Pro (Codex Subscription)",
+    usesCallbackServer: true,
+
+    async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+        return loginOpenAICodex({
+            onAuth: callbacks.onAuth,
+            onPrompt: callbacks.onPrompt,
+            onProgress: callbacks.onProgress,
+            onManualCodeInput: callbacks.onManualCodeInput,
+        })
+    },
+
+    async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+        return refreshOpenAICodexToken(credentials.refresh)
+    },
+
+    getApiKey(credentials: OAuthCredentials): string {
+        return credentials.access
+    },
+}

--- a/mastracode/src/auth/codex/provider.ts
+++ b/mastracode/src/auth/codex/provider.ts
@@ -1,0 +1,125 @@
+import { createOpenAI } from "@ai-sdk/openai"
+import { MastraModelConfig } from "@mastra/core/llm"
+import { wrapLanguageModel } from "ai"
+import { CODEX_API_ENDPOINT } from "./constants"
+import { codexMiddleware } from "./middleware"
+import { getAuthStorage } from "../storage-singleton"
+
+/**
+ * Creates an OpenAI model using ChatGPT OAuth authentication
+ * Uses OAuth tokens from AuthStorage (auto-refreshes when needed)
+ *
+ * IMPORTANT: This uses the Codex API endpoint, not the standard OpenAI API.
+ * URLs are rewritten from /v1/responses or /chat/completions to the Codex endpoint.
+ */
+export function codexProvider(
+    modelId: string = "codex-mini-latest",
+): MastraModelConfig {
+    // Test environment: use API key
+    if (process.env.NODE_ENV === "test" || process.env.VITEST) {
+        const openai = createOpenAI({
+            apiKey: process.env.OPENAI_API_KEY || "test-api-key",
+        })
+        return wrapLanguageModel({
+            model: openai.responses(modelId),
+            middleware: [codexMiddleware],
+        })
+    }
+
+    // Custom fetch that handles OAuth and URL rewriting
+    const oauthFetch = async (
+        url: string | URL | Request,
+        init?: Parameters<typeof fetch>[1],
+    ) => {
+        const authStorage = getAuthStorage()
+
+        // Reload from disk to handle multi-instance refresh
+        authStorage.reload()
+
+        // Get credentials (includes accountId)
+        const cred = authStorage.get("openai-codex")
+
+        if (!cred || cred.type !== "oauth") {
+            throw new Error("Not logged in to OpenAI Codex. Run /login first.")
+        }
+
+        // Check if token needs refresh
+        let accessToken = cred.access
+        if (Date.now() >= cred.expires) {
+            // Token expired, need to refresh via getApiKey which handles refresh
+            const refreshedToken = await authStorage.getApiKey("openai-codex")
+            if (!refreshedToken) {
+                throw new Error(
+                    "Failed to refresh OpenAI Codex token. Please /login again.",
+                )
+            }
+            accessToken = refreshedToken
+            // Reload to get updated accountId
+            authStorage.reload()
+        }
+
+        // Get accountId from credentials
+        const accountId = (cred as any).accountId as string | undefined
+
+        // Build headers - remove any existing authorization header first
+        const headers = new Headers()
+        if (init?.headers) {
+            if (init.headers instanceof Headers) {
+                init.headers.forEach((value, key) => {
+                    if (key.toLowerCase() !== "authorization") {
+                        headers.set(key, value)
+                    }
+                })
+            } else if (Array.isArray(init.headers)) {
+                for (const [key, value] of init.headers) {
+                    if (key.toLowerCase() !== "authorization" && value !== undefined) {
+                        headers.set(key, String(value))
+                    }
+                }
+            } else {
+                for (const [key, value] of Object.entries(init.headers)) {
+                    if (key.toLowerCase() !== "authorization" && value !== undefined) {
+                        headers.set(key, String(value))
+                    }
+                }
+            }
+        }
+
+        // Set authorization header with access token
+        headers.set("Authorization", `Bearer ${accessToken}`)
+
+        // Set ChatGPT-Account-Id header for organization subscriptions
+        if (accountId) {
+            headers.set("ChatGPT-Account-Id", accountId)
+        }
+
+        // Rewrite URL to Codex endpoint if it's a chat/responses request
+        const parsed =
+            url instanceof URL
+                ? url
+                : new URL(typeof url === "string" ? url : (url as Request).url)
+
+        const shouldRewrite =
+            parsed.pathname.includes("/v1/responses") ||
+            parsed.pathname.includes("/chat/completions")
+        const finalUrl = shouldRewrite ? new URL(CODEX_API_ENDPOINT) : parsed
+
+        return fetch(finalUrl, {
+            ...init,
+            headers,
+        })
+    }
+
+    const openai = createOpenAI({
+        // Use a dummy API key since we're using OAuth
+        apiKey: "oauth-dummy-key",
+        fetch: oauthFetch as any,
+    })
+
+    // Use the responses API for Codex models
+    // Wrap with middleware
+    return wrapLanguageModel({
+        model: openai.responses(modelId),
+        middleware: [codexMiddleware],
+    })
+}

--- a/mastracode/src/auth/codex/provider.ts
+++ b/mastracode/src/auth/codex/provider.ts
@@ -1,5 +1,5 @@
 import { createOpenAI } from "@ai-sdk/openai"
-import { MastraModelConfig } from "@mastra/core/llm"
+import type { MastraModelConfig } from "@mastra/core/llm"
 import { wrapLanguageModel } from "ai"
 import { CODEX_API_ENDPOINT } from "./constants"
 import { codexMiddleware } from "./middleware"

--- a/mastracode/src/auth/registry/index.ts
+++ b/mastracode/src/auth/registry/index.ts
@@ -1,0 +1,24 @@
+import { claudeOAuthProvider } from "../claude/oauth"
+import { codexOAuthProvider } from "../codex/oauth"
+import { OAuthProviderId, OAuthProviderInterface } from "../storage/types"
+
+const oauthProviderRegistry = new Map<string, OAuthProviderInterface>([
+    [claudeOAuthProvider.id, claudeOAuthProvider],
+    [codexOAuthProvider.id, codexOAuthProvider],
+])
+
+/**
+ * Get an OAuth provider by ID
+ */
+export function getOAuthProvider(
+    id: OAuthProviderId,
+): OAuthProviderInterface | undefined {
+    return oauthProviderRegistry.get(id)
+}
+
+/**
+ * Get all registered OAuth providers
+ */
+export function getOAuthProviders(): OAuthProviderInterface[] {
+    return Array.from(oauthProviderRegistry.values())
+}

--- a/mastracode/src/auth/registry/index.ts
+++ b/mastracode/src/auth/registry/index.ts
@@ -1,6 +1,6 @@
 import { claudeOAuthProvider } from "../claude/oauth"
 import { codexOAuthProvider } from "../codex/oauth"
-import { OAuthProviderId, OAuthProviderInterface } from "../storage/types"
+import type { OAuthProviderId, OAuthProviderInterface } from "../storage/types"
 
 const oauthProviderRegistry = new Map<string, OAuthProviderInterface>([
     [claudeOAuthProvider.id, claudeOAuthProvider],

--- a/mastracode/src/auth/storage-singleton.ts
+++ b/mastracode/src/auth/storage-singleton.ts
@@ -1,0 +1,21 @@
+import { AuthStorage } from "./storage"
+
+// Singleton auth storage instance (shared with claude-max.ts)
+let authStorageInstance: AuthStorage | null = null
+
+/**
+ * Get or create the shared AuthStorage instance
+ */
+export function getAuthStorage(): AuthStorage {
+    if (!authStorageInstance) {
+        authStorageInstance = new AuthStorage()
+    }
+    return authStorageInstance
+}
+
+/**
+ * Set a custom AuthStorage instance (useful for TUI integration)
+ */
+export function setAuthStorage(storage: AuthStorage): void {
+    authStorageInstance = storage
+}

--- a/mastracode/src/auth/storage/index.ts
+++ b/mastracode/src/auth/storage/index.ts
@@ -1,0 +1,268 @@
+/**
+ * Credential storage for API keys and OAuth tokens.
+ * Handles loading, saving, and refreshing credentials from auth.json.
+ * Also stores global preferences like last used model.
+ */
+
+import {
+    existsSync,
+    mkdirSync,
+    readFileSync,
+    writeFileSync,
+    chmodSync,
+} from "fs"
+import { dirname, join } from "path"
+import { getAppDataDir } from "../../utils/project"
+import type {
+    AuthCredential,
+    AuthStorageData,
+    OAuthLoginCallbacks,
+    OAuthProviderId,
+} from "./types.js"
+import { getOAuthProvider } from "../registry/index.js"
+
+/**
+ * Best/default models for each OAuth provider.
+ * Used when auto-selecting a model after login.
+ */
+export const PROVIDER_DEFAULT_MODELS: Record<OAuthProviderId, string> = {
+    anthropic: "anthropic/claude-opus-4-6",
+    "openai-codex": "openai/gpt-5.3-codex",
+}
+
+/**
+ * Credential storage backed by a JSON file.
+ */
+export class AuthStorage {
+    private data: AuthStorageData = {}
+
+    constructor(private authPath: string = join(getAppDataDir(), "auth.json")) {
+        this.reload()
+    }
+
+    /**
+     * Reload credentials from disk.
+     */
+    reload(): void {
+        if (!existsSync(this.authPath)) {
+            this.data = {}
+            return
+        }
+        try {
+            this.data = JSON.parse(readFileSync(this.authPath, "utf-8"))
+        } catch {
+            this.data = {}
+        }
+    }
+
+    /**
+     * Save credentials to disk.
+     */
+    private save(): void {
+        const dir = dirname(this.authPath)
+        if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true, mode: 0o700 })
+        }
+        writeFileSync(this.authPath, JSON.stringify(this.data, null, 2), "utf-8")
+        chmodSync(this.authPath, 0o600)
+    }
+
+    /**
+     * Get credential for a provider.
+     */
+    get(provider: string): AuthCredential | undefined {
+        return this.data[provider] ?? undefined
+    }
+
+    /**
+     * Set credential for a provider.
+     */
+    set(provider: string, credential: AuthCredential): void {
+        this.data[provider] = credential
+        this.save()
+    }
+
+    /**
+     * Remove credential for a provider.
+     */
+    remove(provider: string): void {
+        delete this.data[provider]
+        this.save()
+    }
+
+    /**
+     * List all providers with credentials.
+     */
+    list(): string[] {
+        return Object.keys(this.data)
+    }
+
+    /**
+     * Check if credentials exist for a provider.
+     */
+    has(provider: string): boolean {
+        return provider in this.data
+    }
+
+    /**
+     * Check if logged in via OAuth for a provider.
+     */
+    isLoggedIn(provider: string): boolean {
+        const cred = this.data[provider]
+        return cred?.type === "oauth"
+    }
+
+    /**
+     * Login to an OAuth provider.
+     */
+    async login(
+        providerId: OAuthProviderId,
+        callbacks: OAuthLoginCallbacks,
+    ): Promise<void> {
+        const provider = getOAuthProvider(providerId)
+        if (!provider) {
+            throw new Error(`Unknown OAuth provider: ${providerId}`)
+        }
+
+        const credentials = await provider.login(callbacks)
+        this.set(providerId, { type: "oauth", ...credentials })
+    }
+
+    /**
+     * Logout from a provider.
+     */
+    logout(provider: string): void {
+        this.remove(provider)
+    }
+
+    /**
+     * Get API key for a provider, auto-refreshing OAuth tokens if needed.
+     */
+    async getApiKey(providerId: string): Promise<string | undefined> {
+        const cred = this.data[providerId]
+
+        if (cred?.type === "api_key") {
+            return cred.key
+        }
+
+        if (cred?.type === "oauth") {
+            const provider = getOAuthProvider(providerId)
+            if (!provider) {
+                return undefined
+            }
+
+            // Check if token needs refresh
+            if (Date.now() >= cred.expires) {
+                try {
+                    const newCreds = await provider.refreshToken(cred)
+                    this.set(providerId, { type: "oauth", ...newCreds })
+                    return provider.getApiKey(newCreds)
+                } catch {
+                    // Refresh failed - user needs to re-login
+                    return undefined
+                }
+            }
+
+            return provider.getApiKey(cred)
+        }
+
+        return undefined
+    }
+
+    /**
+     * Get the last used model ID (global preference).
+     */
+    getLastModelId(): string | undefined {
+        return (this.data as any)._lastModelId
+    }
+
+    /**
+     * Set the last used model ID (global preference).
+     */
+    setLastModelId(modelId: string): void {
+        ; (this.data as any)._lastModelId = modelId
+        this.save()
+    }
+
+    /**
+     * Get the global model ID for a specific mode.
+     * @param modeId Mode ID (e.g., "build", "plan", "explore")
+     */
+    getModeModelId(modeId: string): string | undefined {
+        return (this.data as any)[`_modeModelId_${modeId}`]
+    }
+
+    /**
+     * Set the global model ID for a specific mode.
+     * @param modeId Mode ID (e.g., "build", "plan", "explore")
+     * @param modelId Full model ID
+     */
+    setModeModelId(modeId: string, modelId: string): void {
+        ; (this.data as any)[`_modeModelId_${modeId}`] = modelId
+        this.save()
+    }
+
+    /**
+     * Get the global subagent model ID for an agent type.
+     * @param agentType Optional agent type (explore, plan, execute)
+     */
+    getSubagentModelId(agentType?: string): string | undefined {
+        if (agentType) {
+            return (this.data as any)[`_subagentModelId_${agentType}`]
+        }
+        return (this.data as any)._subagentModelId
+    }
+
+    /**
+     * Set the global subagent model ID for an agent type.
+     * @param modelId Full model ID
+     * @param agentType Optional agent type (explore, plan, execute)
+     */
+    setSubagentModelId(modelId: string, agentType?: string): void {
+        if (agentType) {
+            ; (this.data as any)[`_subagentModelId_${agentType}`] = modelId
+        } else {
+            ; (this.data as any)._subagentModelId = modelId
+        }
+        this.save()
+    }
+
+    /**
+     * Get the default model for a provider after login.
+     */
+    getDefaultModelForProvider(providerId: OAuthProviderId): string | undefined {
+        return PROVIDER_DEFAULT_MODELS[providerId]
+    }
+
+    // ===========================================================================
+    // Model Usage Ranking
+    // ===========================================================================
+
+    private getModelRanks(): Record<string, number> {
+        return (this.data as any)._modelRanks ?? {}
+    }
+
+    /**
+     * Get the use count for a model (0 if never used).
+     */
+    getModelUseCount(modelId: string): number {
+        return this.getModelRanks()[modelId] ?? 0
+    }
+
+    /**
+     * Get all model use counts.
+     */
+    getAllModelUseCounts(): Record<string, number> {
+        return { ...this.getModelRanks() }
+    }
+
+    /**
+     * Increment the use count for a model and persist.
+     */
+    incrementModelUseCount(modelId: string): void {
+        const ranks = this.getModelRanks()
+        ranks[modelId] = (ranks[modelId] ?? 0) + 1
+            ; (this.data as any)._modelRanks = ranks
+        this.save()
+    }
+}

--- a/mastracode/src/auth/storage/pkce.ts
+++ b/mastracode/src/auth/storage/pkce.ts
@@ -1,0 +1,37 @@
+/**
+ * PKCE utilities using Web Crypto API.
+ * Works in both Node.js 20+ and browsers.
+ */
+
+/**
+ * Encode bytes as base64url string.
+ */
+function base64urlEncode(bytes: Uint8Array): string {
+    let binary = ""
+    for (const byte of bytes) {
+        binary += String.fromCharCode(byte)
+    }
+    return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "")
+}
+
+/**
+ * Generate PKCE code verifier and challenge.
+ * Uses Web Crypto API for cross-platform compatibility.
+ */
+export async function generatePKCE(): Promise<{
+    verifier: string
+    challenge: string
+}> {
+    // Generate random verifier
+    const verifierBytes = new Uint8Array(32)
+    crypto.getRandomValues(verifierBytes)
+    const verifier = base64urlEncode(verifierBytes)
+
+    // Compute SHA-256 challenge
+    const encoder = new TextEncoder()
+    const data = encoder.encode(verifier)
+    const hashBuffer = await crypto.subtle.digest("SHA-256", data)
+    const challenge = base64urlEncode(new Uint8Array(hashBuffer))
+
+    return { verifier, challenge }
+}

--- a/mastracode/src/auth/storage/types.ts
+++ b/mastracode/src/auth/storage/types.ts
@@ -1,0 +1,61 @@
+/**
+ * OAuth types for authentication providers
+ */
+
+export interface OAuthCredentials {
+    refresh: string
+    access: string
+    expires: number
+    [key: string]: unknown
+}
+
+export type OAuthProviderId = string
+
+export interface OAuthAuthInfo {
+    url: string
+    instructions?: string
+}
+
+export interface OAuthPrompt {
+    message: string
+    placeholder?: string
+    allowEmpty?: boolean
+}
+
+export interface OAuthLoginCallbacks {
+    onAuth: (info: OAuthAuthInfo) => void
+    onPrompt: (prompt: OAuthPrompt) => Promise<string>
+    onProgress?: (message: string) => void
+    onManualCodeInput?: () => Promise<string>
+    signal?: AbortSignal
+}
+
+export interface OAuthProviderInterface {
+    readonly id: OAuthProviderId
+    readonly name: string
+
+    /** Whether this provider uses a local callback server (vs manual code paste) */
+    readonly usesCallbackServer?: boolean
+
+    /** Run the login flow, return credentials to persist */
+    login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials>
+
+    /** Refresh expired credentials, return updated credentials to persist */
+    refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials>
+
+    /** Convert credentials to API key string for the provider */
+    getApiKey(credentials: OAuthCredentials): string
+}
+
+export type ApiKeyCredential = {
+    type: "api_key"
+    key: string
+}
+
+export type OAuthCredential = {
+    type: "oauth"
+} & OAuthCredentials
+
+export type AuthCredential = ApiKeyCredential | OAuthCredential
+
+export type AuthStorageData = Record<string, AuthCredential>

--- a/mastracode/src/harness.ts
+++ b/mastracode/src/harness.ts
@@ -1,0 +1,81 @@
+import { z } from "zod"
+
+import type { Agent } from "@mastra/core/agent"
+import { Harness } from "@mastra/core/harness"
+import type {
+    HarnessMode,
+} from "@mastra/core/harness"
+import type { MastraCompositeStore } from "@mastra/core/storage"
+
+export const mastraCodeStateSchema = z.object({
+    currentModelId: z.string().default("anthropic/claude-sonnet-4-20250514"),
+    cwd: z.string().optional(),
+})
+
+export type MastraCodeState = z.infer<typeof mastraCodeStateSchema>
+
+export interface CreateMastraCodeHarnessOptions {
+    id?: string
+    resourceId: string
+    storage: MastraCompositeStore
+    stateSchema?: z.ZodObject<z.ZodRawShape>
+    modes?: HarnessMode[]
+    defaultAgent?: Agent
+    initialState?: Record<string, unknown>
+    userId?: string
+    isRemoteStorage?: boolean
+    configOverrides?: Record<string, unknown>
+}
+
+/**
+ * First application-layer consumer of the core Harness primitive.
+ * This keeps core generic while giving MastraCode a concrete entrypoint.
+ */
+export function createMastraCodeHarness(
+    options: CreateMastraCodeHarnessOptions,
+): Harness {
+    const {
+        id = "mastracode",
+        resourceId,
+        storage,
+        stateSchema,
+        modes,
+        defaultAgent,
+        initialState,
+        userId,
+        isRemoteStorage,
+        configOverrides,
+    } = options
+
+    const resolvedModes: HarnessMode[] =
+        modes ??
+        (defaultAgent
+            ? [
+                {
+                    id: "code",
+                    name: "Code",
+                    default: true,
+                    agent: defaultAgent,
+                },
+            ]
+            : [])
+
+    if (resolvedModes.length === 0) {
+        throw new Error(
+            "createMastraCodeHarness requires either `modes` or `defaultAgent`.",
+        )
+    }
+
+    return new Harness({
+        id,
+        resourceId,
+        storage,
+        stateSchema: (stateSchema ?? mastraCodeStateSchema) as any,
+        initialState,
+        modes: resolvedModes,
+        userId,
+        isRemoteStorage,
+        ...(configOverrides as any),
+    })
+}
+

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -1,0 +1,11 @@
+// MastraCode — application-layer consumer of the Harness primitive.
+export {
+    createMastraCodeHarness,
+    mastraCodeStateSchema,
+} from "./harness"
+export { MastraTUI, mastra } from "./tui"
+export type {
+    CreateMastraCodeHarnessOptions,
+    MastraCodeState,
+} from "./harness"
+export type { MastraTUIOptions, ThemeColor } from "./tui"

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -1,11 +1,9 @@
 // MastraCode — application-layer consumer of the Harness primitive.
-export {
-    createMastraCodeHarness,
-    mastraCodeStateSchema,
-} from "./harness"
 export { MastraTUI, mastra } from "./tui"
 export type {
-    CreateMastraCodeHarnessOptions,
-    MastraCodeState,
+    MastraCodeCustomEvent,
+    MastraCodeEvent,
+    SubagentEvent,
+    UIEvent,
 } from "./harness"
 export type { MastraTUIOptions, ThemeColor } from "./tui"

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -5,19 +5,11 @@
  * separate mastracode repo, but keeps missing subsystems as placeholders
  * for now (TUI/hooks/MCP/providers).
  */
-import * as path from "node:path"
-
 import { z } from "zod"
 
 import { createMastraCodeHarness } from "./harness"
 import { MastraTUI, mastra } from "./tui"
-
-type ProjectInfo = {
-    rootPath: string
-    name: string
-    resourceId: string
-    gitBranch?: string
-}
+import { detectProject } from "./utils"
 
 type ThreadRecord = {
     id: string
@@ -37,20 +29,6 @@ type MessageRecord = {
     content: {
         format: 2
         parts: Array<Record<string, unknown>>
-    }
-}
-
-/**
- * Placeholder project detection. Mirrors old structure for now.
- * TODO: Replace with robust git/project detection from mastracode utilities.
- */
-function detectProject(cwd: string): ProjectInfo {
-    const rootPath = path.resolve(cwd)
-    return {
-        rootPath,
-        name: path.basename(rootPath),
-        resourceId: rootPath,
-        gitBranch: undefined,
     }
 }
 
@@ -185,13 +163,6 @@ async function main() {
     const project = detectProject(process.cwd())
     const storage = createPlaceholderStore()
     const agent = createPlaceholderAgent()
-
-    console.log(`Project: ${project.name}`)
-    console.log(`Resource ID: ${project.resourceId}`)
-    if (project.gitBranch) {
-        console.log(`Branch: ${project.gitBranch}`)
-    }
-    console.log()
 
     const harness = createMastraCodeHarness({
         id: "mastra-code",

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -8,6 +8,7 @@
 import { z } from "zod"
 
 import { createMastraCodeHarness } from "./harness"
+import { createStorage } from "./storage"
 import { MastraTUI, mastra } from "./tui"
 import { detectProject } from "./utils"
 
@@ -161,7 +162,7 @@ const stateSchema = z.object({
 
 async function main() {
     const project = detectProject(process.cwd())
-    const storage = createPlaceholderStore()
+    const storage = createStorage(project)
     const agent = createPlaceholderAgent()
 
     const harness = createMastraCodeHarness({

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -1,0 +1,250 @@
+/**
+ * MastraCode CLI entrypoint.
+ *
+ * This intentionally mirrors the structure of the old `main.ts` from the
+ * separate mastracode repo, but keeps missing subsystems as placeholders
+ * for now (TUI/hooks/MCP/providers).
+ */
+import * as path from "node:path"
+
+import { z } from "zod"
+
+import { createMastraCodeHarness } from "./harness"
+import { MastraTUI, mastra } from "./tui"
+
+type ProjectInfo = {
+    rootPath: string
+    name: string
+    resourceId: string
+    gitBranch?: string
+}
+
+type ThreadRecord = {
+    id: string
+    resourceId: string
+    title: string
+    createdAt: Date
+    updatedAt: Date
+    metadata?: Record<string, unknown>
+}
+
+type MessageRecord = {
+    id: string
+    role: "user" | "assistant" | "system"
+    threadId: string
+    resourceId: string
+    createdAt: Date
+    content: {
+        format: 2
+        parts: Array<Record<string, unknown>>
+    }
+}
+
+/**
+ * Placeholder project detection. Mirrors old structure for now.
+ * TODO: Replace with robust git/project detection from mastracode utilities.
+ */
+function detectProject(cwd: string): ProjectInfo {
+    const rootPath = path.resolve(cwd)
+    return {
+        rootPath,
+        name: path.basename(rootPath),
+        resourceId: rootPath,
+        gitBranch: undefined,
+    }
+}
+
+/**
+ * Minimal in-memory store that satisfies the harness' required memory methods.
+ * TODO: Replace with LibSQLStore (or other persistent storage) wiring.
+ */
+function createPlaceholderStore() {
+    const threads = new Map<string, ThreadRecord>()
+    const messages = new Map<string, MessageRecord[]>()
+
+    const memory = {
+        async saveThread({ thread }: { thread: ThreadRecord }) {
+            threads.set(thread.id, { ...thread })
+            return thread
+        },
+        async getThreadById({ threadId }: { threadId: string }) {
+            return threads.get(threadId) ?? null
+        },
+        async listThreads({
+            filter,
+            perPage,
+        }: {
+            filter?: { resourceId?: string }
+            perPage?: number | false
+        }) {
+            let list = Array.from(threads.values())
+            if (filter?.resourceId) {
+                list = list.filter((t) => t.resourceId === filter.resourceId)
+            }
+            list.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+            return {
+                threads:
+                    perPage === false
+                        ? list
+                        : list.slice(0, typeof perPage === "number" ? perPage : 40),
+                total: list.length,
+                page: 0,
+                perPage: perPage ?? 40,
+                hasMore: false,
+            }
+        },
+        async saveMessages({ messages: incoming }: { messages: MessageRecord[] }) {
+            for (const message of incoming) {
+                const threadMessages = messages.get(message.threadId) ?? []
+                threadMessages.push(message)
+                messages.set(message.threadId, threadMessages)
+            }
+        },
+        async listMessages({
+            threadId,
+        }: {
+            threadId: string | string[]
+            perPage?: number | false
+        }) {
+            const ids = Array.isArray(threadId) ? threadId : [threadId]
+            const list = ids.flatMap((id) => messages.get(id) ?? [])
+            list.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+            return {
+                messages: list,
+                total: list.length,
+                page: 0,
+                perPage: false,
+                hasMore: false,
+            }
+        },
+    }
+
+    return {
+        async init() { },
+        async getStore(name: string) {
+            return name === "memory" ? memory : undefined
+        },
+    }
+}
+
+/**
+ * Placeholder coding agent stream.
+ * TODO: Replace with real Agent + providers/tools/prompts.
+ */
+function createPlaceholderAgent() {
+    return {
+        id: "mastracode-agent",
+        name: "MastraCode Agent",
+        async stream(prompt: string) {
+            const text = `Placeholder response for: ${prompt}`
+            const fullStream = new ReadableStream({
+                start(controller) {
+                    controller.enqueue({
+                        type: "text-start",
+                        payload: { id: "placeholder-msg" },
+                    })
+                    controller.enqueue({
+                        type: "text-delta",
+                        payload: { id: "placeholder-msg", text },
+                    })
+                    controller.enqueue({
+                        type: "finish",
+                        payload: {
+                            stepResult: { reason: "stop" },
+                            output: {
+                                usage: {
+                                    inputTokens: 5,
+                                    outputTokens: 6,
+                                    totalTokens: 11,
+                                },
+                            },
+                        },
+                    })
+                    controller.close()
+                },
+            })
+            return { fullStream }
+        },
+    } as any
+}
+
+const stateSchema = z.object({
+    projectPath: z.string().optional(),
+    projectName: z.string().optional(),
+    gitBranch: z.string().optional(),
+    currentModelId: z
+        .string()
+        .default("anthropic/claude-sonnet-4-20250514"),
+    // Keep placeholders for parity with old main.ts shape.
+    yolo: z.boolean().default(false),
+    observationThreshold: z.number().default(30_000),
+    reflectionThreshold: z.number().default(40_000),
+})
+
+async function main() {
+    const project = detectProject(process.cwd())
+    const storage = createPlaceholderStore()
+    const agent = createPlaceholderAgent()
+
+    console.log(`Project: ${project.name}`)
+    console.log(`Resource ID: ${project.resourceId}`)
+    if (project.gitBranch) {
+        console.log(`Branch: ${project.gitBranch}`)
+    }
+    console.log()
+
+    const harness = createMastraCodeHarness({
+        id: "mastra-code",
+        resourceId: project.resourceId,
+        storage: storage as any,
+        stateSchema: stateSchema as any,
+        initialState: {
+            projectPath: project.rootPath,
+            projectName: project.name,
+            gitBranch: project.gitBranch,
+        },
+        modes: [
+            {
+                id: "build",
+                name: "Build",
+                default: true,
+                color: mastra.purple,
+                agent,
+            },
+            {
+                id: "plan",
+                name: "Plan",
+                color: mastra.blue,
+                agent,
+            },
+            {
+                id: "fast",
+                name: "Fast",
+                color: mastra.green,
+                agent,
+            },
+        ],
+    })
+
+    // Placeholders for parity with old main.ts architecture.
+    // TODO: Replace with real modules:
+    // - Hook manager lifecycle
+    // - MCP manager init/disconnect
+    // - Notification and rich rendering components
+    // - Auth/provider wiring
+
+    const tui = new MastraTUI({
+        harness,
+        appName: "Mastra Code",
+        version: "0.1.0",
+        inlineQuestions: true,
+    })
+
+    await tui.run()
+}
+
+void main().catch((error) => {
+    console.error("Fatal error:", error)
+    process.exit(1)
+})
+

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -1,179 +1,36 @@
 /**
  * MastraCode CLI entrypoint.
- *
- * This intentionally mirrors the structure of the old `main.ts` from the
- * separate mastracode repo, but keeps missing subsystems as placeholders
- * for now (TUI/hooks/MCP/providers).
  */
-import { z } from "zod"
-
-import { createMastraCodeHarness } from "./harness"
+import { Harness } from "@mastra/core/harness"
 import { createStorage } from "./storage"
 import { MastraTUI, mastra } from "./tui"
 import { detectProject } from "./utils"
+import { stateSchema } from "./state/schema"
+import type { MastraCodeCustomEvent } from "./harness"
+import { createCodingAgent } from "./agents/coding"
+import { getAuthStorage } from "./auth/storage-singleton"
 
-type ThreadRecord = {
-    id: string
-    resourceId: string
-    title: string
-    createdAt: Date
-    updatedAt: Date
-    metadata?: Record<string, unknown>
-}
-
-type MessageRecord = {
-    id: string
-    role: "user" | "assistant" | "system"
-    threadId: string
-    resourceId: string
-    createdAt: Date
-    content: {
-        format: 2
-        parts: Array<Record<string, unknown>>
-    }
-}
-
-/**
- * Minimal in-memory store that satisfies the harness' required memory methods.
- * TODO: Replace with LibSQLStore (or other persistent storage) wiring.
- */
-function createPlaceholderStore() {
-    const threads = new Map<string, ThreadRecord>()
-    const messages = new Map<string, MessageRecord[]>()
-
-    const memory = {
-        async saveThread({ thread }: { thread: ThreadRecord }) {
-            threads.set(thread.id, { ...thread })
-            return thread
-        },
-        async getThreadById({ threadId }: { threadId: string }) {
-            return threads.get(threadId) ?? null
-        },
-        async listThreads({
-            filter,
-            perPage,
-        }: {
-            filter?: { resourceId?: string }
-            perPage?: number | false
-        }) {
-            let list = Array.from(threads.values())
-            if (filter?.resourceId) {
-                list = list.filter((t) => t.resourceId === filter.resourceId)
-            }
-            list.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
-            return {
-                threads:
-                    perPage === false
-                        ? list
-                        : list.slice(0, typeof perPage === "number" ? perPage : 40),
-                total: list.length,
-                page: 0,
-                perPage: perPage ?? 40,
-                hasMore: false,
-            }
-        },
-        async saveMessages({ messages: incoming }: { messages: MessageRecord[] }) {
-            for (const message of incoming) {
-                const threadMessages = messages.get(message.threadId) ?? []
-                threadMessages.push(message)
-                messages.set(message.threadId, threadMessages)
-            }
-        },
-        async listMessages({
-            threadId,
-        }: {
-            threadId: string | string[]
-            perPage?: number | false
-        }) {
-            const ids = Array.isArray(threadId) ? threadId : [threadId]
-            const list = ids.flatMap((id) => messages.get(id) ?? [])
-            list.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
-            return {
-                messages: list,
-                total: list.length,
-                page: 0,
-                perPage: false,
-                hasMore: false,
-            }
-        },
-    }
-
-    return {
-        async init() { },
-        async getStore(name: string) {
-            return name === "memory" ? memory : undefined
-        },
-    }
-}
-
-/**
- * Placeholder coding agent stream.
- * TODO: Replace with real Agent + providers/tools/prompts.
- */
-function createPlaceholderAgent() {
-    return {
-        id: "mastracode-agent",
-        name: "MastraCode Agent",
-        async stream(prompt: string) {
-            const text = `Placeholder response for: ${prompt}`
-            const fullStream = new ReadableStream({
-                start(controller) {
-                    controller.enqueue({
-                        type: "text-start",
-                        payload: { id: "placeholder-msg" },
-                    })
-                    controller.enqueue({
-                        type: "text-delta",
-                        payload: { id: "placeholder-msg", text },
-                    })
-                    controller.enqueue({
-                        type: "finish",
-                        payload: {
-                            stepResult: { reason: "stop" },
-                            output: {
-                                usage: {
-                                    inputTokens: 5,
-                                    outputTokens: 6,
-                                    totalTokens: 11,
-                                },
-                            },
-                        },
-                    })
-                    controller.close()
-                },
-            })
-            return { fullStream }
-        },
-    } as any
-}
-
-const stateSchema = z.object({
-    projectPath: z.string().optional(),
-    projectName: z.string().optional(),
-    gitBranch: z.string().optional(),
-    currentModelId: z
-        .string()
-        .default("anthropic/claude-sonnet-4-20250514"),
-    // Keep placeholders for parity with old main.ts shape.
-    yolo: z.boolean().default(false),
-    observationThreshold: z.number().default(30_000),
-    reflectionThreshold: z.number().default(40_000),
-})
+const DEFAULT_MODEL_ID = "anthropic/claude-sonnet-4-20250514"
 
 async function main() {
     const project = detectProject(process.cwd())
     const storage = createStorage(project)
-    const agent = createPlaceholderAgent()
+    const agent = createCodingAgent(storage)
 
-    const harness = createMastraCodeHarness({
+    // Resolve initial model: last used > hardcoded default
+    const authStorage = getAuthStorage()
+    const initialModelId = authStorage.getLastModelId() || DEFAULT_MODEL_ID
+
+    const harness = new Harness<typeof stateSchema, MastraCodeCustomEvent>({
         id: "mastra-code",
         resourceId: project.resourceId,
-        storage: storage as any,
-        stateSchema: stateSchema as any,
+        storage,
+        stateSchema: stateSchema,
         initialState: {
             projectPath: project.rootPath,
             projectName: project.name,
             gitBranch: project.gitBranch,
+            currentModelId: initialModelId,
         },
         modes: [
             {
@@ -188,6 +45,18 @@ async function main() {
                 name: "Plan",
                 color: mastra.blue,
                 agent,
+                toolPolicy: {
+                    readOnly: true,
+                    allowedTools: [
+                        "mastra_workspace_read_file",
+                        "mastra_workspace_list_files",
+                        "grep",
+                        "todo_write",
+                        "ask_user",
+                        "submit_plan",
+                        "subagent",
+                    ],
+                },
             },
             {
                 id: "fast",
@@ -197,13 +66,6 @@ async function main() {
             },
         ],
     })
-
-    // Placeholders for parity with old main.ts architecture.
-    // TODO: Replace with real modules:
-    // - Hook manager lifecycle
-    // - MCP manager init/disconnect
-    // - Notification and rich rendering components
-    // - Auth/provider wiring
 
     const tui = new MastraTUI({
         harness,
@@ -219,4 +81,3 @@ void main().catch((error) => {
     console.error("Fatal error:", error)
     process.exit(1)
 })
-

--- a/mastracode/src/memory/constants.ts
+++ b/mastracode/src/memory/constants.ts
@@ -1,0 +1,2 @@
+// Default OM model - using gemini-2.5-flash for efficiency
+export const DEFAULT_OM_MODEL_ID = process.env.DEFAULT_OM_MODEL_ID || "google/gemini-2.5-flash"

--- a/mastracode/src/memory/index.ts
+++ b/mastracode/src/memory/index.ts
@@ -1,0 +1,101 @@
+// =============================================================================
+// Create Memory with Observational Memory support
+// =============================================================================
+
+import type { RequestContext } from "@mastra/core/request-context"
+import { getOmScope } from "../utils"
+import { DEFAULT_OM_MODEL_ID } from "./constants"
+import { Memory } from "@mastra/memory"
+import type { MastraCodeState } from "../state/schema"
+import type { MastraCompositeStore } from "@mastra/core/storage"
+import { resolveModel } from "../model"
+
+// Default OM thresholds — per-thread overrides are loaded from thread metadata
+const DEFAULT_OBS_THRESHOLD = 40_000
+const DEFAULT_REF_THRESHOLD = 50_000
+
+// Mutable OM state — updated by harness event listeners, read by OM config
+// functions. We use this instead of requestContext because Mastra's OM system
+// does NOT propagate requestContext to observer/reflector agent.generate() calls.
+export const omState = {
+    observerModelId: DEFAULT_OM_MODEL_ID,
+    reflectorModelId: DEFAULT_OM_MODEL_ID,
+    obsThreshold: DEFAULT_OBS_THRESHOLD,
+    refThreshold: DEFAULT_REF_THRESHOLD,
+}
+
+// OM model resolvers — called by Memory's OM system which does NOT
+// propagate requestContext. Read from mutable omState instead.
+// Cast needed: resolveModel returns a union including ai SDK LanguageModel
+// which is structurally compatible but not assignable to MastraModelConfig.
+function getObserverModel() {
+    return resolveModel(omState.observerModelId) as any
+}
+
+function getReflectorModel() {
+    return resolveModel(omState.reflectorModelId) as any
+}
+
+// Cache for Memory instances by threshold config
+let cachedMemory: Memory | null = null
+let cachedMemoryKey: string | null = null
+
+/**
+ * Dynamic memory factory function.
+ * Creates Memory with current threshold values from harness state.
+ * Caches instance and reuses if config unchanged.
+ */
+export function getDynamicMemory({
+    requestContext,
+    storage,
+}: {
+    requestContext: RequestContext
+    storage: MastraCompositeStore
+}) {
+    const state = requestContext.get("state") as MastraCodeState | undefined
+
+    // Resolved OM scope (read once at startup, can be changed via config)
+    const omScope = getOmScope(state?.projectPath ?? "")
+
+    const obsThreshold = state?.observationThreshold ?? omState.obsThreshold
+    const refThreshold = state?.reflectionThreshold ?? omState.refThreshold
+
+    const cacheKey = `${obsThreshold}:${refThreshold}:${omScope}`;
+
+    if (cachedMemory && cachedMemoryKey === cacheKey) {
+        return cachedMemory
+    }
+
+    cachedMemory = new Memory({
+        storage,
+        options: {
+            observationalMemory: {
+                enabled: true,
+                scope: omScope,
+                observation: {
+                    bufferTokens: 1 / 10,
+                    bufferActivation: 4 / 5,
+                    model: getObserverModel,
+                    messageTokens: obsThreshold,
+                    blockAfter: 1,
+                    modelSettings: {
+                        maxOutputTokens: 60000,
+                    },
+                },
+                reflection: {
+                    bufferActivation: 1 / 2,
+                    blockAfter: 1.1,
+                    model: getReflectorModel,
+                    observationTokens: refThreshold,
+                    modelSettings: {
+                        maxOutputTokens: 60000,
+                    },
+                },
+            },
+        },
+    })
+
+    cachedMemoryKey = cacheKey
+
+    return cachedMemory
+}

--- a/mastracode/src/model/index.ts
+++ b/mastracode/src/model/index.ts
@@ -1,0 +1,64 @@
+import type { LanguageModel } from "ai"
+import { createAnthropic } from "@ai-sdk/anthropic"
+import { opencodeClaudeMaxProvider } from "../auth/claude/provider"
+import { codexProvider } from "../auth/codex/provider"
+import { ModelRouterLanguageModel, type MastraModelConfig } from "@mastra/core/llm"
+import type { RequestContext } from "@mastra/core/request-context"
+import type { MastraLanguageModel } from "@mastra/core/agent"
+import { getAuthStorage } from "../auth/storage-singleton"
+import type { MastraCodeState } from "../state/schema"
+
+type ModelType = LanguageModel | MastraLanguageModel | MastraModelConfig
+
+/**
+ * Resolve a model ID to the correct provider instance.
+ * Shared by the main agent, observer, and reflector.
+ *
+ * - For anthropic/* models: Uses Claude Max OAuth provider (opencode auth)
+ * - For openai/* models with OAuth: Uses OpenAI Codex OAuth provider
+ * - For moonshotai/* models: Uses Moonshot AI Anthropic-compatible endpoint
+ * - For all other providers: Uses Mastra's model router (models.dev gateway)
+ */
+export function resolveModel(modelId: string): ModelType {
+    const authStorage = getAuthStorage()
+
+    const isAnthropicModel = modelId.startsWith("anthropic/")
+    const isOpenAIModel = modelId.startsWith("openai/")
+    const isMoonshotModel = modelId.startsWith("moonshotai/")
+
+    if (isMoonshotModel) {
+        if (!process.env.MOONSHOT_AI_API_KEY) {
+            throw new Error(`Need MOONSHOT_AI_API_KEY`)
+        }
+        return createAnthropic({
+            apiKey: process.env.MOONSHOT_AI_API_KEY!,
+            baseURL: "https://api.moonshot.ai/anthropic/v1",
+            name: "moonshotai.anthropicv1",
+        })(modelId.substring("moonshotai/".length))
+    } else if (isAnthropicModel) {
+        return opencodeClaudeMaxProvider(modelId.substring(`anthropic/`.length))
+    } else if (isOpenAIModel && authStorage.isLoggedIn("openai-codex")) {
+        return codexProvider(modelId.substring(`openai/`.length))
+    } else {
+        return new ModelRouterLanguageModel(modelId)
+    }
+}
+
+/**
+ * Dynamic model function that reads the current model from harness state.
+ * This allows runtime model switching via the /models picker.
+ */
+export function getDynamicModel({
+    requestContext,
+}: {
+    requestContext: RequestContext
+}): ModelType {
+    const state = requestContext.get("state") as MastraCodeState | undefined
+
+    const modelId = state?.currentModelId
+    if (!modelId) {
+        throw new Error("No model selected. Use /models to select a model first.")
+    }
+
+    return resolveModel(modelId)
+}

--- a/mastracode/src/permissions.ts
+++ b/mastracode/src/permissions.ts
@@ -1,0 +1,179 @@
+/**
+ * Granular tool permission system.
+ *
+ * Tools are classified into categories by risk level.
+ * Each category has a configurable policy: "allow", "ask", or "deny".
+ * Session-scoped grants let the user approve a category once per session.
+ */
+
+// ---------------------------------------------------------------------------
+// Categories
+// ---------------------------------------------------------------------------
+
+export type ToolCategory = "read" | "edit" | "execute" | "mcp"
+
+export const TOOL_CATEGORIES: Record<
+    ToolCategory,
+    { label: string; description: string }
+> = {
+    read: {
+        label: "Read",
+        description: "Read files, search, list directories",
+    },
+    edit: {
+        label: "Edit",
+        description: "Create, modify, or delete files",
+    },
+    execute: {
+        label: "Execute",
+        description: "Run shell commands",
+    },
+    mcp: {
+        label: "MCP",
+        description: "External MCP server tools",
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Tool -> Category mapping
+// ---------------------------------------------------------------------------
+
+const TOOL_CATEGORY_MAP: Record<string, ToolCategory> = {
+    // Read-only tools
+    view: "read",
+    search_content: "read",
+    find_files: "read",
+    web_search: "read",
+    "web-search": "read",
+    web_extract: "read",
+    "web-extract": "read",
+
+    // Edit tools
+    string_replace_lsp: "edit",
+    ast_smart_edit: "edit",
+    write_file: "edit",
+    subagent: "edit",
+
+    // Execute tools
+    execute_command: "execute",
+}
+
+const ALWAYS_ALLOW_TOOLS = new Set([
+    "ask_user",
+    "todo_write",
+    "todo_check",
+    "submit_plan",
+    "request_sandbox_access",
+])
+
+export function getToolCategory(toolName: string): ToolCategory | null {
+    if (ALWAYS_ALLOW_TOOLS.has(toolName)) return null
+    return TOOL_CATEGORY_MAP[toolName] ?? "mcp"
+}
+
+export function getToolsForCategory(category: ToolCategory): string[] {
+    return Object.entries(TOOL_CATEGORY_MAP)
+        .filter(([, cat]) => cat === category)
+        .map(([tool]) => tool)
+}
+
+// ---------------------------------------------------------------------------
+// Policies
+// ---------------------------------------------------------------------------
+
+export type PermissionPolicy = "allow" | "ask" | "deny"
+
+export interface PermissionRules {
+    categories: Partial<Record<ToolCategory, PermissionPolicy>>
+    tools: Record<string, PermissionPolicy>
+}
+
+export const DEFAULT_POLICIES: Record<ToolCategory, PermissionPolicy> = {
+    read: "allow",
+    edit: "ask",
+    execute: "ask",
+    mcp: "ask",
+}
+
+export const YOLO_POLICIES: Record<ToolCategory, PermissionPolicy> = {
+    read: "allow",
+    edit: "allow",
+    execute: "allow",
+    mcp: "allow",
+}
+
+export function createDefaultRules(): PermissionRules {
+    return {
+        categories: { ...DEFAULT_POLICIES },
+        tools: {},
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Session grants
+// ---------------------------------------------------------------------------
+
+export class SessionGrants {
+    private grantedCategories = new Set<ToolCategory>()
+    private grantedTools = new Set<string>()
+
+    allowCategory(category: ToolCategory): void {
+        this.grantedCategories.add(category)
+    }
+
+    allowTool(toolName: string): void {
+        this.grantedTools.add(toolName)
+    }
+
+    isGranted(toolName: string, category: ToolCategory): boolean {
+        return this.grantedTools.has(toolName) || this.grantedCategories.has(category)
+    }
+
+    reset(): void {
+        this.grantedCategories.clear()
+        this.grantedTools.clear()
+    }
+
+    getGrantedCategories(): ToolCategory[] {
+        return [...this.grantedCategories]
+    }
+
+    getGrantedTools(): string[] {
+        return [...this.grantedTools]
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decision engine
+// ---------------------------------------------------------------------------
+
+export type ApprovalDecision = "allow" | "ask" | "deny"
+
+/**
+ * Determine whether a tool call should be allowed, prompted, or denied.
+ *
+ * Priority:
+ *  1. Always-allowed tools (ask_user, todo_write, etc.) -> allow
+ *  2. Per-tool policy override -> use that policy
+ *  3. Session grants (user said "always allow" this session) -> allow
+ *  4. Category policy -> use that policy
+ *  5. Fallback -> "ask"
+ */
+export function resolveApproval(
+    toolName: string,
+    rules: PermissionRules,
+    sessionGrants: SessionGrants,
+): ApprovalDecision {
+    const category = getToolCategory(toolName)
+    if (category === null) return "allow"
+
+    const toolPolicy = rules.tools[toolName]
+    if (toolPolicy) return toolPolicy
+
+    if (sessionGrants.isGranted(toolName, category)) return "allow"
+
+    const categoryPolicy = rules.categories[category]
+    if (categoryPolicy) return categoryPolicy
+
+    return DEFAULT_POLICIES[category] ?? "ask"
+}

--- a/mastracode/src/prompts/base.ts
+++ b/mastracode/src/prompts/base.ts
@@ -1,0 +1,158 @@
+/**
+ * Base system prompt — shared behavioral instructions for all modes.
+ * This is the "brain" that makes the agent a good coding assistant.
+ */
+
+export interface PromptContext {
+    projectPath: string
+    projectName: string
+    gitBranch?: string
+    platform: string
+    date: string
+    mode: string
+    activePlan?: { title: string; plan: string; approvedAt: string } | null
+}
+
+export function buildBasePrompt(ctx: PromptContext): string {
+    return `You are Mastra Code, an interactive CLI coding agent that helps users with software engineering tasks.
+
+# Environment
+Working directory: ${ctx.projectPath}
+Project: ${ctx.projectName}
+${ctx.gitBranch ? `Git branch: ${ctx.gitBranch}` : "Not a git repository"}
+Platform: ${ctx.platform}
+Date: ${ctx.date}
+Current mode: ${ctx.mode}
+
+# Tone and Style
+- Your output is displayed on a command line interface. Keep responses concise.
+- Use Github-flavored markdown for formatting.
+- Only use emojis if the user explicitly requests it.
+- Do NOT use tools to communicate with the user. All text you output is displayed directly.
+- Prioritize technical accuracy over validating the user's beliefs. Be direct and objective. Respectful correction is more valuable than false agreement.
+
+# Tool Usage Rules
+
+IMPORTANT: You can ONLY call tools by their exact registered names listed below. Shell commands like \`git\`, \`npm\`, \`ls\`, etc. are NOT tools — they must be run via the \`execute_command\` tool.
+
+You have access to the following tools. Use the RIGHT tool for the job:
+
+**view** — Read file contents or list directories
+- Use this to read files before editing them. NEVER propose changes to code you haven't read.
+- Use \`view_range\` for large files to read specific sections.
+- For directory listings, this shows 2 levels deep.
+- Example: To check lines 50-100 of a large file: \`view("src/big-file.ts", { view_range: [50, 100] })\`
+
+**grep** — Search file contents using regex
+- Use this for ALL content search (finding functions, variables, error messages, imports, etc.)
+- NEVER use \`execute_command\` with grep, rg, or ag. Always use the grep tool.
+- Supports regex patterns, file type filtering, and context lines.
+- Example: Find where a function is defined: \`grep("function handleSubmit", { glob: "**/*.ts" })\`
+- Example: Find all imports of a module: \`grep("from ['\"]express['\"]", { glob: "**/*.ts" })\`
+
+**glob** — Find files by name pattern
+- Use this to find files matching a pattern (e.g., "**/*.ts", "src/**/test*").
+- NEVER use \`execute_command\` with find or ls for file search. Always use glob.
+- Respects .gitignore automatically.
+- Example: Find all test files: \`glob("**/*.test.ts")\`
+- Example: Find config files: \`glob("**/config.{js,ts,json}")\`
+
+**string_replace_lsp** — Edit files by replacing exact text
+- You MUST read a file with \`view\` before editing it.
+- \`old_str\` must be an exact match of existing text in the file.
+- Provide enough surrounding context in \`old_str\` to make it unique.
+- For creating new files, use \`write_file\` instead.
+- Good: Include 2-3 lines of surrounding context to ensure uniqueness.
+- Bad: Using just \`return true;\` — too common, will match multiple places.
+
+**write_file** — Create new files or overwrite existing ones
+- Use this to create new files.
+- If overwriting an existing file, you MUST have read it first with \`view\`.
+- NEVER create files unless necessary. Prefer editing existing files.
+
+**execute_command** — Run shell commands
+- Use for: git, npm/pnpm, docker, build tools, test runners, and other terminal operations.
+- Do NOT use for: file reading (use view), file search (use grep/glob), file editing (use string_replace_lsp/write_file).
+- Commands have a 30-second default timeout. Use the \`timeout\` parameter for longer-running commands.
+- Pipe to \`| tail -N\` for commands with long output — the full output streams to the user, only the last N lines are returned to you. If you're building any kind of package you should be tailing.
+- Good: Run independent commands in parallel when possible.
+- Bad: Running \`cat file.txt\` — use the view tool instead.
+
+**web_search** / **web_extract** — Search the web / extract page content
+- Use for looking up documentation, error messages, package APIs.
+- Available depending on the model and API keys configured.
+
+**todo_write** — Track tasks for complex multi-step work
+- Use when a task requires 3 or more distinct steps or actions.
+- Pass the FULL todo list each time (replaces previous list).
+- Mark tasks \`in_progress\` BEFORE starting work. Only ONE task should be \`in_progress\` at a time.
+- Mark tasks \`completed\` IMMEDIATELY after finishing each task. Do not batch completions.
+- Each todo has: content (imperative form), status (pending|in_progress|completed), activeForm (present continuous form shown during execution).
+
+**todo_check** — Check completion status of todos
+- Use this BEFORE deciding you're done with a task to verify all todos are completed.
+- Returns the number of completed, in progress, and pending tasks.
+- If any tasks remain incomplete, continue working on them.
+- IMPORTANT: Always check todo completion before ending work on a complex task.
+
+**ask_user** — Ask the user a structured question
+- Use when you need clarification, want to validate assumptions, or need the user to make a decision.
+- Provide clear, specific questions. End with a question mark.
+- Include options (2-4 choices) for structured decisions. Omit options for open-ended questions.
+- Don't use this for simple yes/no — just ask in your text response.
+
+# How to Work on Tasks
+
+## Start by Understanding
+- Read relevant code before making changes. Use grep/glob to find related files.
+- For unfamiliar codebases, check git log to understand recent changes and patterns.
+- Identify existing conventions (naming, structure, error handling) and follow them.
+
+## Work Incrementally
+- Focus on ONE thing at a time. Complete it fully before moving to the next.
+- Leave the codebase in a clean state after each change — no half-implemented features.
+- For multi-step tasks, use todos to track progress and ensure nothing is missed.
+
+## Verify Before Moving On
+- After each change, verify it works. Don't assume — actually test it.
+- Run the relevant tests, check for type errors, or manually verify the behavior.
+- If something breaks, fix it immediately. Don't pile more changes on top of broken code.
+
+# Coding Philosophy
+
+- **Avoid over-engineering.** Only make changes that are directly requested or clearly necessary.
+- **Don't add extras.** No unrequested features, refactoring, docstrings, comments, or type annotations to code you didn't change. Only add comments where the logic isn't self-evident.
+- **Don't add unnecessary error handling.** Trust internal code and framework guarantees. Only validate at system boundaries (user input, external APIs).
+- **Don't create premature abstractions.** Three similar lines of code is better than a helper function used once. Don't design for hypothetical future requirements.
+- **Clean up dead code.** If something is unused, delete it completely. No backwards-compatibility shims, no renaming to \`_unused\`, no \`// removed\` comments.
+- **Be careful with security.** Don't introduce command injection, XSS, SQL injection, or other vulnerabilities. If you notice insecure code you wrote, fix it immediately.
+
+# Git Safety
+
+## Hard Rules
+- NEVER run destructive commands (\`push --force\`, \`reset --hard\`, \`clean -fd\`) unless explicitly requested.
+- NEVER use interactive flags (\`git rebase -i\`, \`git add -i\`) — TTY input isn't supported.
+- NEVER commit or push unless the user explicitly asks.
+- NEVER force push to \`main\` or \`master\` without warning the user first.
+- Avoid \`git commit --amend\` unless the commit was just created and hasn't been pushed.
+
+## Secrets
+Don't commit files likely to contain secrets (\`.env\`, \`*.key\`, \`credentials.json\`). Warn if asked.
+
+## Commits
+Write commit messages that explain WHY, not just WHAT. Match the repo's existing style. Include \`Co-Authored-By: Mastra Code <noreply@mastra.ai>\` in the message body.
+
+## Pull Requests
+Use \`gh pr create\`. Include a summary of what changed and a test plan.
+
+# Important Reminders
+- NEVER guess file paths or function signatures. Use grep/glob to find them.
+- NEVER make up URLs. Only use URLs the user provides or that you find in the codebase.
+- When referencing code locations, include the file path and line number.
+- If you're unsure about something, ask the user rather than guessing.
+
+# File Access & Sandbox
+
+By default, you can only access files within the current project directory. If you get a "Permission denied" or "Access denied" error when trying to read, write, or access files outside the project root, do NOT keep retrying. Instead, tell the user to run the \`/sandbox\` command to add the external directory to the allowed paths for this thread. Once they do, you will be able to access it.
+`
+}

--- a/mastracode/src/prompts/build.ts
+++ b/mastracode/src/prompts/build.ts
@@ -1,0 +1,81 @@
+/**
+ * Build mode prompt — full tool access, make changes and verify.
+ */
+
+import type { PromptContext } from "./base"
+
+/**
+ * Dynamic build mode prompt function.
+ * When an approved plan exists in state, prepends it so the agent
+ * knows exactly what to implement.
+ */
+export function buildModePromptFn(ctx: PromptContext): string {
+    if (ctx.activePlan) {
+        return (
+            `# Approved Plan
+
+**${ctx.activePlan.title}**
+
+${ctx.activePlan.plan}
+
+---
+
+Implement the approved plan above. Follow the steps in order and verify each step works before moving on.
+
+` + buildModePrompt
+        )
+    }
+    return buildModePrompt
+}
+
+export const buildModePrompt = `
+# Build Mode
+
+You are in BUILD mode. You have full access to all tools and can read, write, edit, and execute commands.
+
+## Working Style
+
+**For simple tasks** (typo fixes, small edits, single-file changes):
+- Just do it. No need to explain your plan first.
+
+**For non-trivial tasks** (3+ files, architectural decisions, unclear requirements):
+- Use todo_write to track your steps
+- Work on ONE step at a time — complete it and verify it works before moving on
+- If the approach is risky or ambiguous, ask the user before proceeding
+
+## The Implementation Loop
+
+For each change you make:
+
+1. **Understand** — Read the relevant code. Check how similar things are done elsewhere.
+2. **Implement** — Make the change. Follow existing patterns and conventions.
+3. **Verify** — Test that it works. Don't assume — actually run it.
+4. **Clean up** — Ensure no broken code, no debug statements, no half-done features.
+
+Only move to the next change after the current one is verified working.
+
+## Verification is Required
+
+Before considering any task complete:
+- Run relevant tests (check package.json for test scripts)
+- For TypeScript, run \`tsc --noEmit\` to catch type errors
+- If there are no automated tests, manually verify the behavior works as expected
+- Use todo_check to ensure all tracked tasks are done
+
+**Don't mark something as done until you've verified it actually works.**
+
+## Error Recovery
+
+When something breaks:
+1. Read the full error output carefully — don't guess
+2. Find the root cause, not just the symptom
+3. Fix it properly — no casts or suppressions to hide errors
+4. Re-run to confirm the fix
+5. If stuck after 2 attempts, tell the user what you've tried
+
+## Git in Build Mode
+
+- Don't commit unless asked — just report what you changed
+- Before committing, verify the code compiles and passes lint
+- Use descriptive branch names: \`feat/...\`, \`fix/...\`, \`refactor/...\`
+`

--- a/mastracode/src/prompts/fast.ts
+++ b/mastracode/src/prompts/fast.ts
@@ -1,0 +1,22 @@
+/**
+ * Fast mode prompt — quick answers and small edits, minimal overhead.
+ */
+
+export const fastModePrompt = `
+# Fast Mode
+
+You are in FAST mode. Optimize for speed and brevity.
+
+## Rules
+- Keep responses short. Under 200 words unless the task genuinely requires more.
+- Skip planning. Just do the task directly.
+- For questions: give the direct answer, not a tutorial.
+- For edits: make the change, show what you did, move on.
+- Don't explore the codebase more than necessary for the immediate task.
+
+## When to Use Tools vs. Just Answer
+- If the user asks a general programming question, answer directly from knowledge. Don't search the codebase.
+- If the user asks about THIS project's code, use tools to look it up — don't guess.
+- If the user asks for a quick edit and you know the file, read it and edit it. Don't ask for confirmation.
+- One tool call to read + one to edit is ideal. Minimize round trips.
+`

--- a/mastracode/src/prompts/index.ts
+++ b/mastracode/src/prompts/index.ts
@@ -1,0 +1,89 @@
+/**
+ * Prompt system — exports the prompt builder and mode-specific prompts.
+ */
+
+export { buildBasePrompt } from "./base"
+export { buildModePrompt, buildModePromptFn } from "./build"
+export { planModePrompt } from "./plan"
+export { fastModePrompt } from "./fast"
+
+import {
+    buildBasePrompt,
+    type PromptContext as BasePromptContext,
+} from "./base"
+import { buildModePromptFn } from "./build"
+import { planModePrompt } from "./plan"
+import { fastModePrompt } from "./fast"
+import {
+    loadAgentInstructions,
+    formatAgentInstructions,
+} from "../utils/instructions"
+
+/**
+ * Extended prompt context that includes runtime information.
+ */
+export interface PromptContext extends BasePromptContext {
+    modeId: string
+    state?: any
+    currentDate: string
+    workingDir: string
+    /** Mode-specific available tools description */
+    availableTools?: string
+}
+
+const modePrompts: Record<string, string | ((ctx: PromptContext) => string)> = {
+    build: buildModePromptFn,
+    plan: planModePrompt,
+    fast: fastModePrompt,
+}
+
+/**
+ * Build the full system prompt for a given mode and context.
+ * Combines the base prompt with mode-specific instructions,
+ * available tools, current todo state, and agent instructions.
+ */
+export function buildFullPrompt(ctx: PromptContext): string {
+    const baseCtx: BasePromptContext = {
+        projectPath: ctx.workingDir,
+        projectName: ctx.projectName || "unknown",
+        gitBranch: ctx.gitBranch,
+        platform: process.platform,
+        date: ctx.currentDate,
+        mode: ctx.modeId,
+        activePlan: ctx.state?.activePlan,
+    }
+
+    const base = buildBasePrompt(baseCtx)
+    const entry = modePrompts[ctx.modeId] || modePrompts.build
+    const modeSpecific = typeof entry === "function" ? entry(ctx) : entry
+
+    let toolsSection = ""
+    if (ctx.availableTools) {
+        toolsSection = `\n# Available Tools for ${ctx.modeId} mode:\n${ctx.availableTools}\n`
+    }
+
+    let todoSection = ""
+    const todos = ctx.state?.todos as
+        | { content: string; status: string; activeForm: string }[]
+        | undefined
+    if (todos && todos.length > 0) {
+        const lines = todos.map((t) => {
+            const icon =
+                t.status === "completed" ? "✓" : t.status === "in_progress" ? "▸" : "○"
+            return `  ${icon} [${t.status}] ${t.content}`
+        })
+        todoSection = `\n<current-task-list>\n${lines.join("\n")}\n</current-task-list>\n`
+    }
+
+    const instructionSources = loadAgentInstructions(ctx.workingDir)
+    const instructionsSection = formatAgentInstructions(instructionSources)
+
+    return (
+        base +
+        toolsSection +
+        todoSection +
+        instructionsSection +
+        "\n" +
+        modeSpecific
+    )
+}

--- a/mastracode/src/prompts/plan.ts
+++ b/mastracode/src/prompts/plan.ts
@@ -1,0 +1,73 @@
+/**
+ * Plan mode prompt — read-only exploration and planning.
+ */
+
+export const planModePrompt = `
+# Plan Mode — READ-ONLY
+
+You are in PLAN mode. Your job is to explore the codebase and design an implementation plan — NOT to make changes.
+
+## CRITICAL: Read-Only Mode
+
+This mode is **strictly read-only**. You must NOT modify anything.
+
+**Allowed tools:**
+- \`view\` — read files and directories
+- \`grep\` — search file contents
+- \`glob\` — find files by pattern
+- \`execute_command\` — ONLY for read-only commands (git status, git log, git diff, etc.)
+- \`submit_plan\` — submit your completed plan
+
+**Prohibited actions:**
+- Do NOT use \`string_replace_lsp\` or \`write_file\` — no file modifications
+- Do NOT use \`execute_command\` for anything that changes state (no git commit, no npm install, no file creation)
+- Do NOT create, delete, or modify any files
+- Do NOT run build commands, tests, or scripts that have side effects
+
+If the user asks you to make changes while in Plan mode, explain that you're in read-only mode and they should switch to Build mode (\`/mode build\`) first.
+
+## Exploration Strategy
+
+Before writing any plan, build a mental model of the codebase:
+1. Start with the directory structure (\`view\` on the project root or relevant subdirectory).
+2. Find the relevant entry points and core files using \`grep\` and \`glob\`.
+3. Read the actual code — don't assume based on file names alone.
+4. Trace data flow: where does input come from, how is it transformed, where does it go?
+5. Identify existing patterns the codebase uses (naming, structure, error handling, testing).
+
+## Your Plan Output
+
+Produce a clear, step-by-step plan with this structure:
+
+### Overview
+One paragraph: what the change does and why.
+
+### Complexity Estimate
+- **Size**: Small (1-2 files) / Medium (3-5 files) / Large (6+ files)
+- **Risk**: Low (additive, no breaking changes) / Medium (modifies existing behavior) / High (architectural, affects many consumers)
+- **Dependencies**: List any new packages, external services, or migration steps needed.
+
+### Steps
+For each step:
+1. **File**: path to create or modify
+2. **Change**: what to add/modify/remove, with enough specificity to implement directly
+3. **Why**: brief rationale connecting this step to the overall goal
+
+### Verification
+- What tests to run
+- What to check manually
+- What could go wrong
+
+## When Done
+
+When your plan is complete, call the \`submit_plan\` tool with:
+- **title**: A short descriptive title (e.g., "Add dark mode toggle")
+- **plan**: The full plan in markdown, using the structure above (Overview, Complexity, Steps, Verification)
+
+The user will see the plan rendered inline and can:
+- **Approve** — automatically switches to Build mode for implementation
+- **Reject** — stays in Plan mode
+- **Request changes** — provides feedback for you to revise and resubmit
+
+Do NOT start implementing until the plan is approved. If rejected with feedback, revise the plan and call \`submit_plan\` again.
+`

--- a/mastracode/src/state/schema.ts
+++ b/mastracode/src/state/schema.ts
@@ -1,0 +1,56 @@
+import z from "zod";
+import { DEFAULT_OM_MODEL_ID } from "../memory/constants";
+
+export const stateSchema = z.object({
+    projectPath: z.string().optional(),
+    projectName: z.string().optional(),
+    gitBranch: z.string().optional(),
+    lastCommand: z.string().optional(),
+    currentModelId: z.string().default(""),
+    // Subagent model settings (per-thread/per-mode)
+    subagentModelId: z.string().optional(), // Thread-level default for subagents
+    // Observational Memory model settings
+    observerModelId: z.string().default(DEFAULT_OM_MODEL_ID),
+    reflectorModelId: z.string().default(DEFAULT_OM_MODEL_ID),
+    // Observational Memory threshold settings
+    observationThreshold: z.number().default(30_000),
+    reflectionThreshold: z.number().default(40_000),
+    // Thinking level for extended thinking (Anthropic models)
+    thinkingLevel: z.string().default("off"),
+    // YOLO mode — auto-approve all tool calls
+    yolo: z.boolean().default(false),
+    // Permission rules — per-category and per-tool approval policies
+    permissionRules: z
+        .object({
+            categories: z.record(z.enum(["allow", "ask", "deny"])).default({}),
+            tools: z.record(z.enum(["allow", "ask", "deny"])).default({}),
+        })
+        .default({}),
+    // Smart editing mode — use AST-based analysis for code edits
+    smartEditing: z.boolean().default(true),
+    // Notification mode — alert when TUI needs user attention
+    notifications: z.enum(["bell", "system", "both", "off"]).default("off"),
+    // Todo list (persisted per-thread)
+    todos: z
+        .array(
+            z.object({
+                content: z.string(),
+                status: z.enum(["pending", "in_progress", "completed"]),
+                activeForm: z.string(),
+            }),
+        )
+        .default([]),
+    // Sandbox allowed paths (per-thread, absolute paths allowed in addition to project root)
+    sandboxAllowedPaths: z.array(z.string()).default([]),
+    // Active plan (set when a plan is approved in Plan mode)
+    activePlan: z
+        .object({
+            title: z.string(),
+            plan: z.string(),
+            approvedAt: z.string(),
+        })
+        .nullable()
+        .default(null),
+})
+
+export type MastraCodeState = z.infer<typeof stateSchema>

--- a/mastracode/src/storage/index.ts
+++ b/mastracode/src/storage/index.ts
@@ -1,0 +1,17 @@
+import { getStorageConfig } from "../utils/project"
+import type { ProjectInfo } from "../utils/project"
+import { LibSQLStore } from "@mastra/libsql"
+
+// =============================================================================
+// Create Storage (shared across all projects)
+// =============================================================================
+
+export function createStorage(project: ProjectInfo): LibSQLStore {
+    const storageConfig = getStorageConfig(project.rootPath)
+    return new LibSQLStore({
+        id: "mastra-code-storage",
+        url: storageConfig.url,
+        ...(storageConfig.authToken ? { authToken: storageConfig.authToken } : {}),
+    })
+}
+

--- a/mastracode/src/storage/index.ts
+++ b/mastracode/src/storage/index.ts
@@ -6,7 +6,7 @@ import { LibSQLStore } from "@mastra/libsql"
 // Create Storage (shared across all projects)
 // =============================================================================
 
-export function createStorage(project: ProjectInfo): LibSQLStore {
+export function createStorage(project: ProjectInfo) {
     const storageConfig = getStorageConfig(project.rootPath)
     return new LibSQLStore({
         id: "mastra-code-storage",

--- a/mastracode/src/tools/ask-user.ts
+++ b/mastracode/src/tools/ask-user.ts
@@ -1,0 +1,64 @@
+/**
+ * ask_user tool — presents structured questions to the user via TUI dialogs.
+ * Supports single-select options and free-text input.
+ */
+import { createTool } from "@mastra/core/tools"
+import { z } from "zod"
+
+let questionCounter = 0
+
+export const askUserTool = createTool({
+    id: "ask_user",
+    description: `Ask the user a question and wait for their response. Use this when you need clarification, want to validate assumptions, or need the user to make a decision between options. Provide options for structured choices (2-4 options), or omit them for open-ended questions.`,
+    inputSchema: z.object({
+        question: z
+            .string()
+            .min(1)
+            .describe("The question to ask the user. Should be clear and specific."),
+        options: z
+            .array(
+                z.object({
+                    label: z
+                        .string()
+                        .describe("Short display text for this option (1-5 words)"),
+                    description: z
+                        .string()
+                        .optional()
+                        .describe("Explanation of what this option means"),
+                }),
+            )
+            .optional()
+            .describe(
+                "Optional choices. If provided, shows a selection list. If omitted, shows a free-text input.",
+            ),
+    }),
+    execute: async ({ question, options }, context) => {
+        try {
+            const harnessCtx = (context as any)?.requestContext?.get("harness")
+
+            if (!harnessCtx?.emitEvent || !harnessCtx?.registerQuestion) {
+                return {
+                    content: `[Question for user]: ${question}${options ? "\nOptions: " + options.map((o: any) => o.label).join(", ") : ""}`,
+                    isError: false,
+                }
+            }
+
+            const questionId = `q_${++questionCounter}_${Date.now()}`
+
+            const answer = await new Promise<string>((resolve) => {
+                harnessCtx.registerQuestion!(questionId, resolve)
+                harnessCtx.emitEvent!({
+                    type: "ask_question",
+                    questionId,
+                    question,
+                    options,
+                } as any)
+            })
+
+            return { content: `User answered: ${answer}`, isError: false }
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : "Unknown error"
+            return { content: `Failed to ask user: ${msg}`, isError: true }
+        }
+    },
+})

--- a/mastracode/src/tools/file-editor.ts
+++ b/mastracode/src/tools/file-editor.ts
@@ -1,0 +1,673 @@
+/**
+ * FileEditor — fuzzy string replacement engine.
+ *
+ * This provides the "smart" string replacement that agents use for editing
+ * files. It handles exact matches, whitespace-normalized matches, and
+ * Levenshtein-based fuzzy matching — making agent edits robust even when
+ * the LLM doesn't perfectly reproduce the target text.
+ *
+ * Ported from mastra-code with file I/O helpers inlined (the original
+ * imported from ./utils.ts which was removed in favor of workspace tools).
+ */
+
+import { promises as fs } from "node:fs"
+import { exec } from "node:child_process"
+import { promisify } from "node:util"
+import * as path from "node:path"
+import { distance } from "fastest-levenshtein"
+import { truncateStringForTokenEstimate } from "../utils/tokens"
+
+const execAsync = promisify(exec)
+
+// ---------------------------------------------------------------------------
+// Inline file I/O helpers (previously in tools/utils.ts)
+// ---------------------------------------------------------------------------
+
+const SNIPPET_LINES = 4
+
+async function readFile(filePath: string): Promise<string> {
+    try {
+        return await fs.readFile(filePath, "utf8")
+    } catch (e) {
+        const error = e instanceof Error ? e : new Error("Unknown error")
+        throw new Error(`Failed to read ${filePath}: ${error.message}`)
+    }
+}
+
+async function writeFile(filePath: string, content: string): Promise<void> {
+    try {
+        await fs.mkdir(path.dirname(filePath), { recursive: true })
+        await fs.writeFile(filePath, content, "utf8")
+    } catch (e) {
+        const error = e instanceof Error ? e : new Error("Unknown error")
+        throw new Error(`Failed to write to ${filePath}: ${error.message}`)
+    }
+}
+
+/** Per-file write queue to serialize concurrent writes to the same path. */
+const fileWriteQueues = new Map<string, Promise<unknown>>()
+
+async function withFileLock<T>(
+    filePath: string,
+    fn: () => Promise<T>,
+): Promise<T> {
+    const normalizedPath = path.resolve(filePath)
+    const currentQueue =
+        fileWriteQueues.get(normalizedPath) ?? Promise.resolve()
+
+    let resolve!: (value: T) => void
+    let reject!: (error: unknown) => void
+    const ourPromise = new Promise<T>((res, rej) => {
+        resolve = res
+        reject = rej
+    })
+
+    const queuePromise = currentQueue
+        .catch(() => { })
+        .then(async () => {
+            try {
+                resolve(await fn())
+            } catch (error) {
+                reject(error)
+            }
+        })
+
+    fileWriteQueues.set(normalizedPath, queuePromise)
+    queuePromise.finally(() => {
+        if (fileWriteQueues.get(normalizedPath) === queuePromise) {
+            fileWriteQueues.delete(normalizedPath)
+        }
+    })
+
+    return ourPromise
+}
+
+function makeOutput(
+    fileContent: string,
+    fileDescriptor: string,
+    initLine = 1,
+    expandTabs = true,
+): string {
+    if (expandTabs) {
+        fileContent = fileContent.replace(/\t/g, "    ")
+    }
+    const displayPath = path.isAbsolute(fileDescriptor)
+        ? path.relative(process.cwd(), fileDescriptor)
+        : fileDescriptor
+    const lines = fileContent.split("\n")
+    const numberedLines = lines
+        .map((line, i) => `${(i + initLine).toString().padStart(6)}\t${line}`)
+        .join("\n")
+    return `Here's the result of running \`cat -n\` on ${displayPath}:\n${truncateStringForTokenEstimate(numberedLines, 500, false)}\n`
+}
+
+async function validatePath(
+    command: string,
+    filePath: string,
+): Promise<void> {
+    const absolutePath = path.isAbsolute(filePath)
+        ? filePath
+        : path.join(process.cwd(), filePath)
+    if (!path.isAbsolute(filePath)) {
+        filePath = absolutePath
+    }
+    try {
+        const stats = await fs.stat(filePath)
+        if (stats.isDirectory() && command !== "view") {
+            throw new Error(
+                `The path ${filePath} is a directory and only the \`view\` command can be used on directories`,
+            )
+        }
+        if (command === "create" && stats.isFile()) {
+            throw new Error(
+                `File already exists at: ${filePath}. Cannot overwrite files using command \`create\``,
+            )
+        }
+    } catch (e: any) {
+        if (e?.code === "ENOENT" && command !== "create") {
+            throw new Error(
+                `The path ${filePath} does not exist. Please provide a valid path.`,
+            )
+        }
+        if (command !== "create") {
+            throw e
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// String normalization helpers
+// ---------------------------------------------------------------------------
+
+function removeWhitespace(str: string): string {
+    return str
+        .replace(/\t/g, "")
+        .replace(/ +/g, "")
+        .replace(/^ +| +$/gm, "")
+        .replace(/\r?\n/g, "\n")
+        .replace(/\s/g, "")
+}
+
+function removeVaryingChars(str: string): string {
+    return removeWhitespace(str)
+        .replaceAll("\n", "")
+        .replaceAll("'", "")
+        .replaceAll('"', "")
+        .replaceAll("`", "")
+        .replaceAll("\\r", "")
+}
+
+// ---------------------------------------------------------------------------
+// Argument interfaces
+// ---------------------------------------------------------------------------
+
+interface ViewArgs {
+    path: string
+    view_range?: [number, number]
+}
+
+interface CreateArgs {
+    path: string
+    file_text: string
+}
+
+interface StrReplaceArgs {
+    path: string
+    old_str: string
+    new_str: string
+    start_line?: number
+}
+
+interface InsertArgs {
+    path: string
+    insert_line: number
+    new_str: string
+}
+
+// ---------------------------------------------------------------------------
+// FileEditor class
+// ---------------------------------------------------------------------------
+
+export class FileEditor {
+    async view(args: ViewArgs) {
+        await validatePath("view", args.path)
+        if (await this.isDirectory(args.path)) {
+            if (args.view_range) {
+                return "The `view_range` parameter is not allowed when `path` points to a directory."
+            }
+            const { stdout, stderr } = await execAsync(
+                `find "${args.path}" -maxdepth 2 -not -path '*/\\.*'`,
+            )
+            if (stderr) return stderr
+            return `Here's the files and directories up to 2 levels deep in ${args.path}, excluding hidden items:\n${stdout}\n`
+        }
+        const fileContent = await readFile(args.path)
+        if (args.view_range) {
+            const fileLines = fileContent.split("\n")
+            const nLinesFile = fileLines.length
+            const [start] = args.view_range
+            let [, end] = args.view_range
+            if (start < 1 || start > nLinesFile) {
+                return `Invalid \`view_range\`: ${args.view_range}. Its first element \`${start}\` should be within the range of lines of the file: [1, ${nLinesFile}]`
+            }
+            if (end !== -1) {
+                if (end > nLinesFile) {
+                    end = nLinesFile
+                }
+                if (end < start) {
+                    return `Invalid \`view_range\`: ${args.view_range}. Its second element \`${end}\` should be larger or equal than its first \`${start}\``
+                }
+            }
+            const selectedLines =
+                end === -1
+                    ? fileLines.slice(start - 1)
+                    : fileLines.slice(start - 1, end)
+            return makeOutput(
+                selectedLines.join("\n"),
+                String(args.path),
+                start,
+            )
+        }
+        return makeOutput(fileContent, String(args.path))
+    }
+
+    async create(args: CreateArgs) {
+        await validatePath("create", args.path)
+        await writeFile(args.path, args.file_text)
+        return `File created successfully at: ${args.path}`
+    }
+
+    async strReplace(args: StrReplaceArgs) {
+        await validatePath("string_replace", args.path)
+        if (args.old_str === args.new_str) {
+            return `Received the same string for old_str and new_str`
+        }
+
+        return withFileLock(args.path, async () => {
+            const fileContent = await readFile(args.path)
+
+            // ---- Pass 1: exact match ----
+            if (fileContent.includes(args.old_str)) {
+                const processedNewStr = args.new_str || ""
+                const newFileContent = fileContent
+                    .split(args.old_str)
+                    .join(processedNewStr)
+                await writeFile(args.path, newFileContent)
+                return `The file ${args.path} has been edited. `
+            }
+
+            // ---- Pass 2: whitespace-normalized exact match ----
+            const normalizeWhitespace = (str: string) =>
+                str.replace(/\s+/g, " ").trim()
+            const normalizedOldStr = normalizeWhitespace(args.old_str)
+            const normalizedContent = normalizeWhitespace(fileContent)
+
+            if (normalizedContent.includes(normalizedOldStr)) {
+                const lines = fileContent.split("\n")
+                let bestMatch = { start: -1, end: -1, content: "" }
+                const originalOldLineCount = args.old_str.split("\n").length
+                const maxWindow = originalOldLineCount + 5
+
+                for (let i = 0; i < lines.length; i++) {
+                    for (
+                        let j = i;
+                        j <= Math.min(i + maxWindow, lines.length - 1);
+                        j++
+                    ) {
+                        const candidate = lines.slice(i, j + 1).join("\n")
+                        if (
+                            normalizeWhitespace(candidate) === normalizedOldStr
+                        ) {
+                            bestMatch = {
+                                start: i,
+                                end: j,
+                                content: candidate,
+                            }
+                            break
+                        }
+                    }
+                    if (bestMatch.start !== -1) break
+                }
+
+                if (bestMatch.start !== -1) {
+                    const beforeLines = lines.slice(0, bestMatch.start)
+                    const afterLines = lines.slice(bestMatch.end + 1)
+                    const newFileContent = [
+                        ...beforeLines,
+                        args.new_str || "",
+                        ...afterLines,
+                    ].join("\n")
+                    await writeFile(args.path, newFileContent)
+
+                    const fileLines = newFileContent.split("\n")
+                    const startLine = Math.max(
+                        0,
+                        bestMatch.start - SNIPPET_LINES,
+                    )
+                    const endLine = Math.min(
+                        fileLines.length,
+                        bestMatch.start +
+                        SNIPPET_LINES +
+                        (args.new_str || "").split("\n").length,
+                    )
+                    const snippet = fileLines
+                        .slice(startLine, endLine)
+                        .join("\n")
+                    let successMsg = `The file ${args.path} has been edited. `
+                    successMsg += makeOutput(
+                        snippet,
+                        `a snippet of ${args.path}`,
+                        startLine + 1,
+                    )
+                    successMsg +=
+                        "Review the changes and make sure they are as expected. Edit the file again if necessary."
+                    return successMsg
+                }
+            }
+
+            // ---- Pass 3: fuzzy whitespace-agnostic matching ----
+            const processedNewStr = args.new_str || ""
+            const removeLeadingLineNumbers = (str: string): string => {
+                return str
+                    .split("\n")
+                    .map((line) => line.replace(/^\s*\d+\s*/, ""))
+                    .join("\n")
+            }
+            let oldStr = removeLeadingLineNumbers(args.old_str)
+            let newStr = removeLeadingLineNumbers(processedNewStr)
+            if (oldStr.startsWith("\\\n")) {
+                oldStr = oldStr.substring("\\\n".length)
+            }
+            if (newStr.startsWith("\\\n")) {
+                newStr = newStr.substring("\\\n".length)
+            }
+
+            const startLineArg =
+                typeof args.start_line === "number"
+                    ? Math.max(args.start_line - 5, 0)
+                    : undefined
+
+            const oldLinesSplit = oldStr.split("\n")
+            const oldLinesOriginal = oldLinesSplit.filter((l, i) => {
+                if (i === 0) return removeWhitespace(l) !== ""
+                if (i + 1 !== oldLinesSplit.length) return true
+                return removeWhitespace(l) !== ""
+            })
+            const oldLines = oldLinesOriginal.map(removeWhitespace)
+
+            const split = (str: string): string[] => {
+                return str
+                    .split("\n")
+                    .map((l: string) => l.replaceAll("\n", "\\n"))
+            }
+            const fileLines = split(fileContent)
+            const normFileLines = fileLines.map(removeWhitespace)
+
+            const bestMatch: {
+                start: number
+                avgDist: number
+                type: string
+                end?: number
+            } = {
+                start: -1,
+                avgDist: Infinity,
+                type: "replace-lines",
+            }
+
+            const isSingleLineReplacement = oldLines.length === 1
+            const matchLineNumbers = normFileLines
+                .map((l: string, index: number) =>
+                    l === oldLines[0] ? index + 1 : null,
+                )
+                .filter(Boolean)
+
+            if (
+                isSingleLineReplacement &&
+                matchLineNumbers.length > 1 &&
+                !startLineArg
+            ) {
+                return `Single line search string "${oldLines[0]}" has too many matches. This will result in innacurate replacements. Found ${matchLineNumbers.length} matches. Pass start_line to choose one. Found on lines ${matchLineNumbers.join(", ")}`
+            }
+
+            let divergedMessage: string | undefined
+            let divergenceAfterX = 0
+            const fileNoSpace = removeVaryingChars(fileContent)
+            const oldStringNoSpace = removeVaryingChars(oldStr)
+
+            if (fileNoSpace.includes(oldStringNoSpace.substring(0, -1))) {
+                let oldStringNoSpaceBuffer = oldStringNoSpace
+                let startIndex: number | null = null
+                let endIndex: number | null = null
+
+                for (const [index, line] of split(fileContent).entries()) {
+                    if (
+                        startIndex === null &&
+                        typeof startLineArg !== "undefined" &&
+                        index + 1 > startLineArg + 50
+                    ) {
+                        continue
+                    }
+                    if (
+                        typeof startLineArg !== "undefined" &&
+                        index < startLineArg
+                    ) {
+                        continue
+                    }
+                    const lineNoSpace = removeVaryingChars(line)
+                    if (lineNoSpace === "" && !startIndex) continue
+
+                    const startsWith =
+                        oldStringNoSpaceBuffer.startsWith(lineNoSpace)
+                    const startsWithNoDanglingCommaTho =
+                        !startsWith &&
+                        lineNoSpace.endsWith(",") &&
+                        oldStringNoSpaceBuffer
+                            .substring(lineNoSpace.length - 1)
+                            .startsWith(")") &&
+                        oldStringNoSpaceBuffer.startsWith(
+                            lineNoSpace.substring(0, lineNoSpace.length - 1),
+                        )
+
+                    if (startsWith || startsWithNoDanglingCommaTho) {
+                        if (startIndex === null) {
+                            startIndex = index
+                        }
+                        oldStringNoSpaceBuffer =
+                            oldStringNoSpaceBuffer.substring(
+                                startsWithNoDanglingCommaTho
+                                    ? lineNoSpace.length - 1
+                                    : lineNoSpace.length,
+                            )
+                        if (
+                            oldStringNoSpaceBuffer.length === 0 &&
+                            startIndex !== null
+                        ) {
+                            endIndex = index
+                            break
+                        }
+                    } else if (startIndex !== null) {
+                        startIndex = null
+                        oldStringNoSpaceBuffer = oldStringNoSpace
+                    }
+                }
+
+                if (startIndex !== null && endIndex !== null) {
+                    bestMatch.start = startIndex
+                    bestMatch.end = endIndex
+                }
+            }
+
+            for (const [index, normLine] of normFileLines.entries()) {
+                if (!normLine) continue
+                if (bestMatch.end) break
+                if (
+                    typeof startLineArg !== "undefined" &&
+                    index + 1 < startLineArg
+                )
+                    continue
+                if (
+                    typeof startLineArg !== "undefined" &&
+                    index + 1 > startLineArg + 50
+                )
+                    continue
+                if (
+                    typeof startLineArg !== "undefined" &&
+                    index + 1 > startLineArg + 5 &&
+                    isSingleLineReplacement
+                ) {
+                    break
+                }
+
+                const firstDistance = distance(oldLines[0] || "", normLine || "")
+                const firstPercentDiff =
+                    (firstDistance / (normLine?.length || 1)) * 100
+
+                if (
+                    isSingleLineReplacement &&
+                    (normLine === oldLines[0] ||
+                        normLine.includes(oldLines[0]!))
+                ) {
+                    bestMatch.start = index
+                    bestMatch.type = "replace-in-line"
+                    continue
+                }
+
+                if (oldLines[0] === normLine || firstPercentDiff < 5) {
+                    let isMatching = true
+                    let matchingLineCount = 0
+
+                    for (const [matchIndex, oldLine] of oldLines.entries()) {
+                        const innerNormLine =
+                            normFileLines[index + matchIndex] ?? ""
+                        const innerDistance = distance(
+                            oldLine,
+                            innerNormLine,
+                        )
+                        const innerPercentDiff =
+                            (innerDistance / (innerNormLine.length || 1)) * 100
+                        const remainingLines =
+                            oldLines.length - matchingLineCount
+                        const percentLinesRemaining =
+                            (remainingLines / oldLines.length) * 100
+                        const isMatch =
+                            oldLine === innerNormLine || innerPercentDiff < 5
+                        const fewLinesAreLeft =
+                            oldLines.length >= 30 && percentLinesRemaining < 1
+
+                        if (isMatch || fewLinesAreLeft) {
+                            matchingLineCount++
+                        } else {
+                            const message = `old_str matching diverged after ${matchingLineCount} matching lines.\nExpected line from old_str: \`${oldLinesOriginal[matchIndex]}\` (line ${matchIndex + 1} in old_str), found line: \`${fileLines[index + matchIndex]}\` (line ${index + 1 + matchIndex} in file). ${remainingLines - 1} lines remained to compare but they were not checked due to this line not matching.\n\nHere are the lines that did match up until the old_str diverged:\n\n${oldLinesOriginal.slice(0, matchIndex).join("\n")}\n\nHere are the remaining lines you would've had to provide for the old_str to match:\n\n${fileLines
+                                .slice(
+                                    index + matchIndex,
+                                    index + matchIndex + remainingLines,
+                                )
+                                .join("\n")}`
+
+                            if (matchingLineCount > divergenceAfterX) {
+                                divergenceAfterX = matchingLineCount
+                                divergedMessage = message
+                            }
+                            isMatching = false
+                            break
+                        }
+                    }
+                    if (isMatching) {
+                        bestMatch.start = index
+                        break
+                    }
+                }
+            }
+
+            if (
+                bestMatch.start === -1 &&
+                (isSingleLineReplacement || oldStr === "\n") &&
+                newStr === "" &&
+                typeof startLineArg === "number"
+            ) {
+                bestMatch.start = startLineArg
+                bestMatch.type = "delete-line"
+            }
+
+            let newFileContent = ""
+
+            if (bestMatch.start === -1) {
+                return `No replacement was performed. No sufficiently close match for old_str found in ${args.path}.\n${divergedMessage ? divergedMessage : ""}Try adjusting your input or the file content.`
+            }
+
+            if (bestMatch.type === "replace-lines") {
+                const newFileLines = [
+                    ...fileLines.slice(0, bestMatch.start),
+                    ...(newStr ? newStr.split("\n") : []),
+                    ...fileLines.slice(
+                        bestMatch.end
+                            ? bestMatch.end + 1
+                            : bestMatch.start + oldLines.length,
+                    ),
+                ]
+                newFileContent = newFileLines.join("\n")
+                await writeFile(args.path, newFileContent)
+            } else if (bestMatch.type === "replace-in-line") {
+                const [firstNew, ...restNew] = newStr
+                    ? newStr.split("\n")
+                    : []
+                const newFileLines = [
+                    ...fileLines.slice(0, bestMatch.start),
+                    ...(restNew?.length
+                        ? [firstNew, ...restNew]
+                        : [
+                            fileLines
+                                .at(bestMatch.start)
+                                ?.replace(
+                                    oldLinesOriginal[0]!,
+                                    firstNew || "",
+                                ) ?? "",
+                        ]),
+                    ...fileLines.slice(bestMatch.start + 1),
+                ]
+                newFileContent = newFileLines.join("\n")
+                await writeFile(args.path, newFileContent)
+            } else if (bestMatch.type === "delete-line") {
+                const newFileLines = [
+                    ...fileLines.slice(0, bestMatch.start),
+                    ...fileLines.slice(bestMatch.start + 1),
+                ]
+                newFileContent = newFileLines.join("\n")
+                await writeFile(args.path, newFileContent)
+            }
+
+            const replacementLine = bestMatch.start + 1
+            const startLine = Math.max(0, replacementLine - SNIPPET_LINES)
+            const endLine =
+                replacementLine + SNIPPET_LINES + newStr.split("\n").length
+            const snippet = newFileContent
+                .split("\n")
+                .slice(startLine, endLine + 1)
+                .join("\n")
+            let successMsg = `The file ${args.path} has been edited. `
+            successMsg += makeOutput(
+                snippet,
+                `a snippet of ${args.path}`,
+                startLine + 1,
+            )
+            successMsg +=
+                "Review the changes and make sure they are as expected. Edit the file again if necessary."
+            return successMsg
+        })
+    }
+
+    async insert(args: InsertArgs) {
+        await validatePath("insert", args.path)
+        const fileContent = await readFile(args.path)
+        const newStr = args.new_str
+        const fileLines = fileContent.split("\n")
+        const nLinesFile = fileLines.length
+
+        if (args.insert_line < 0 || args.insert_line > nLinesFile) {
+            return `Invalid \`insert_line\` parameter: ${args.insert_line}. It should be within the range of lines of the file: [0, ${nLinesFile}]`
+        }
+
+        const newStrLines = newStr.split("\n")
+        const newFileLines = [
+            ...fileLines.slice(0, args.insert_line + 1),
+            ...newStrLines,
+            ...fileLines.slice(args.insert_line + 1),
+        ]
+        const snippetLines = [
+            ...fileLines.slice(
+                Math.max(0, args.insert_line - SNIPPET_LINES),
+                args.insert_line + 1,
+            ),
+            ...newStrLines,
+            ...fileLines.slice(
+                args.insert_line + 1,
+                args.insert_line + SNIPPET_LINES,
+            ),
+        ]
+        const newFileContent = newFileLines.join("\n")
+        const snippet = snippetLines.join("\n")
+        await writeFile(args.path, newFileContent)
+
+        let successMsg = `The file ${args.path} has been edited. `
+        successMsg += makeOutput(
+            snippet,
+            "a snippet of the edited file",
+            Math.max(1, args.insert_line - SNIPPET_LINES + 1),
+        )
+        successMsg +=
+            "Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary."
+        return successMsg
+    }
+
+    private async isDirectory(filePath: string) {
+        try {
+            const stats = await fs.stat(filePath)
+            return stats.isDirectory()
+        } catch {
+            return false
+        }
+    }
+}
+
+/** Singleton instance of FileEditor */
+export const sharedFileEditor = new FileEditor()

--- a/mastracode/src/tools/grep.ts
+++ b/mastracode/src/tools/grep.ts
@@ -1,0 +1,216 @@
+/**
+ * Grep tool — fast content search using ripgrep (rg) with Node.js fallback.
+ */
+import { createTool } from "@mastra/core/tools"
+import { z } from "zod"
+import { execa } from "execa"
+import * as path from "path"
+import { truncateStringForTokenEstimate } from "../utils/tokens"
+import { assertPathAllowed, getAllowedPathsFromContext } from "./security"
+
+const MAX_GREP_TOKENS = 3_000
+
+/**
+ * Check if ripgrep is available on the system.
+ */
+let rgAvailable: boolean | null = null
+async function hasRipgrep(): Promise<boolean> {
+	if (rgAvailable !== null) return rgAvailable
+	try {
+		await execa("rg", ["--version"])
+		rgAvailable = true
+	} catch {
+		rgAvailable = false
+	}
+	return rgAvailable
+}
+
+/**
+ * Create the grep tool for searching file contents.
+ */
+export function createGrepTool(projectRoot?: string) {
+	return createTool({
+		id: "search_content",
+		// requireApproval: true,
+		description: `Search file contents using regex patterns. Returns matching lines with file paths and line numbers.
+
+Usage notes:
+- Use this for ALL content search (finding functions, variables, error messages, imports, etc.)
+- NEVER use execute_command with grep, rg, or ag. Always use this tool instead.
+- Supports full regex syntax (e.g., "function\\s+\\w+", "import.*from")
+- Use the \`glob\` parameter to filter by file type (e.g., "*.ts", "*.py")
+- Use \`contextLines\` to see surrounding code for each match
+- Results are sorted by file path for readability
+- Output is truncated if too large — narrow your search with a more specific pattern or glob filter`,
+		inputSchema: z.object({
+			pattern: z
+				.string()
+				.describe("Regex pattern to search for in file contents"),
+			path: z
+				.string()
+				.optional()
+				.describe(
+					"Directory or file to search in (relative to project root). Defaults to project root.",
+				),
+			glob: z
+				.string()
+				.optional()
+				.describe(
+					'Glob pattern to filter files (e.g., "*.ts", "*.{js,jsx}", "test/**")',
+				),
+			contextLines: z
+				.number()
+				.optional()
+				.describe(
+					"Number of lines to show before and after each match (default: 0)",
+				),
+			maxResults: z
+				.number()
+				.optional()
+				.describe("Maximum number of matching lines to return (default: 100)"),
+			caseSensitive: z
+				.boolean()
+				.optional()
+				.describe("Whether the search is case-sensitive (default: true)"),
+		}),
+		execute: async (context, toolContext) => {
+			try {
+				const root = projectRoot || process.cwd()
+				const searchPath = context.path
+					? path.resolve(root, context.path)
+					: root
+
+				// Security: ensure the search path is within the project root or allowed paths
+				const allowedPaths = getAllowedPathsFromContext(toolContext)
+				assertPathAllowed(searchPath, root, allowedPaths)
+				const maxResults = context.maxResults ?? 100
+				const contextLines = context.contextLines ?? 0
+				const caseSensitive = context.caseSensitive ?? true
+
+				const useRg = await hasRipgrep()
+
+				let output: string
+
+				if (useRg) {
+					// Build ripgrep command
+					const args: string[] = [
+						"--line-number",
+						"--no-heading",
+						"--color=never",
+						"--max-count",
+						String(maxResults),
+					]
+
+					if (!caseSensitive) args.push("--ignore-case")
+					if (contextLines > 0) {
+						args.push("--context", String(contextLines))
+					}
+					if (context.glob) {
+						args.push("--glob", context.glob)
+					}
+
+					args.push("--", context.pattern, searchPath)
+
+					const result = await execa("rg", args, {
+						reject: false,
+						timeout: 15_000,
+						cwd: root,
+					})
+
+					if (result.exitCode === 1) {
+						// No matches found
+						return {
+							content: `No matches found for pattern: ${context.pattern}`,
+							isError: false,
+						}
+					}
+					if (result.exitCode !== 0 && result.exitCode !== 1) {
+						return {
+							content: `grep error: ${result.stderr || "Unknown error"}`,
+							isError: true,
+						}
+					}
+
+					output = result.stdout || ""
+				} else {
+					// Fallback to grep
+					const args: string[] = ["-r", "-n", "--color=never"]
+
+					if (!caseSensitive) args.push("-i")
+					if (contextLines > 0) {
+						args.push(`-C${contextLines}`)
+					}
+					if (context.glob) {
+						args.push(`--include=${context.glob}`)
+					}
+
+					args.push("--", context.pattern, searchPath)
+
+					const result = await execa("grep", args, {
+						reject: false,
+						timeout: 15_000,
+						cwd: root,
+					})
+
+					if (result.exitCode === 1) {
+						return {
+							content: `No matches found for pattern: ${context.pattern}`,
+							isError: false,
+						}
+					}
+					if (result.exitCode !== 0 && result.exitCode !== 1) {
+						return {
+							content: `grep error: ${result.stderr || "Unknown error"}`,
+							isError: true,
+						}
+					}
+
+					output = result.stdout || ""
+
+					// Truncate to maxResults lines (grep doesn't have --max-count for recursive)
+					const lines = output.split("\n")
+					if (lines.length > maxResults) {
+						output =
+							lines.slice(0, maxResults).join("\n") +
+							`\n... (${lines.length - maxResults} more matches, narrow your search)`
+					}
+				}
+
+				// Make paths relative to project root for readability
+				const relativized = output
+					.split("\n")
+					.map((line) => {
+						if (line.startsWith(root + "/")) {
+							return line.slice(root.length + 1)
+						}
+						if (line.startsWith(root)) {
+							return line.slice(root.length)
+						}
+						return line
+					})
+					.join("\n")
+
+				const matchCount = relativized
+					.split("\n")
+					.filter((l) => l.trim() && !l.startsWith("--")).length
+
+				const header = `Found ${matchCount} match${matchCount !== 1 ? "es" : ""} for "${context.pattern}":\n\n`
+
+				return {
+					content: truncateStringForTokenEstimate(
+						header + relativized,
+						MAX_GREP_TOKENS,
+						false,
+					),
+					isError: false,
+				}
+			} catch (error) {
+				const msg = error instanceof Error ? error.message : "Unknown error"
+				return {
+					content: `grep failed: ${msg}`,
+					isError: true,
+				}
+			}
+		},
+	})
+}

--- a/mastracode/src/tools/index.ts
+++ b/mastracode/src/tools/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Tool exports for mastracode.
+ *
+ * File operations (read, write, edit, list, delete, stat, mkdir) are provided
+ * by @mastra/core workspace tools via createWorkspaceTools(). This module only
+ * exports tools that go beyond what workspace provides.
+ */
+
+// Regex content search (ripgrep) — workspace has BM25/vector, not regex grep
+export { createGrepTool } from "./grep"
+
+// Enhanced command execution with tail extraction, abort, tree-kill
+export { createExecuteCommandTool, executeCommandTool } from "./shell"
+
+// Fuzzy string replacement engine (handles whitespace drift, line numbers, etc.)
+export { FileEditor, sharedFileEditor } from "./file-editor"
+
+// Web search + content extraction (Tavily-powered)
+export { createWebSearchTool, createWebExtractTool, hasTavilyKey } from "./web-search"
+
+// Agent interaction tools
+export { askUserTool } from "./ask-user"
+export { todoWriteTool } from "./todo"
+export type { TodoItem } from "./todo"
+export { submitPlanTool } from "./submit-plan"
+export type { PlanApprovalResult } from "./submit-plan"
+
+// Todo completion checker
+export { createTodoCheckTool } from "./todo-check"
+export type { TodoCheckDeps } from "./todo-check"
+
+// Subagent spawning — delegates focused tasks to constrained agents
+export { createSubagentTool, parseSubagentMeta } from "./subagent"
+export type { SubagentToolDeps } from "./subagent"
+
+// Sandbox access request (for paths outside project root)
+export { createRequestSandboxAccessTool } from "./request-sandbox-access"
+export type { SandboxAccessDeps } from "./request-sandbox-access"
+
+// Global confirmation tracking
+export { setGlobalConfirmationId, getGlobalConfirmationId } from "./wrap-with-confirmation"
+
+// Path security helpers (used by tools that touch local FS directly)
+export { isPathAllowed, assertPathAllowed, getAllowedPathsFromContext } from "./security"

--- a/mastracode/src/tools/index.ts
+++ b/mastracode/src/tools/index.ts
@@ -34,8 +34,7 @@ export { createSubagentTool, parseSubagentMeta } from "./subagent"
 export type { SubagentToolDeps } from "./subagent"
 
 // Sandbox access request (for paths outside project root)
-export { createRequestSandboxAccessTool } from "./request-sandbox-access"
-export type { SandboxAccessDeps } from "./request-sandbox-access"
+export { requestSandboxAccessTool } from "./request-sandbox-access"
 
 // Global confirmation tracking
 export { setGlobalConfirmationId, getGlobalConfirmationId } from "./wrap-with-confirmation"

--- a/mastracode/src/tools/request-sandbox-access.ts
+++ b/mastracode/src/tools/request-sandbox-access.ts
@@ -1,0 +1,112 @@
+/**
+ * request_sandbox_access tool — requests permission to access a directory
+ * outside the project root. The user can approve or deny the request via
+ * TUI dialog.
+ *
+ * Adapted for the monorepo: uses deps-based pattern for emitEvent,
+ * registerQuestion, getState, and setState instead of reading from
+ * HarnessRuntimeContext.
+ */
+import { createTool } from "@mastra/core/tools"
+import { z } from "zod"
+import * as path from "node:path"
+import { isPathAllowed, getAllowedPathsFromContext } from "./security"
+import type { HarnessEvent } from "@mastra/core/harness"
+
+export interface SandboxAccessDeps {
+    emitEvent: (event: HarnessEvent) => void
+    registerQuestion: (questionId: string, resolve: (answer: string) => void) => void
+    getState: () => Record<string, unknown>
+    setState: (updates: Record<string, unknown>) => void
+}
+
+let requestCounter = 0
+
+export function createRequestSandboxAccessTool(deps: SandboxAccessDeps) {
+    return createTool({
+        id: "request_sandbox_access",
+        description: `Request permission to access a directory outside the current project. Use this when you need to read or write files in a directory that is not within the project root. The user will be prompted to approve or deny the request.`,
+        inputSchema: z.object({
+            path: z
+                .string()
+                .min(1)
+                .describe(
+                    "The absolute path to the directory you need access to.",
+                ),
+            reason: z
+                .string()
+                .min(1)
+                .describe(
+                    "Brief explanation of why you need access to this directory.",
+                ),
+        }),
+        execute: async ({
+            path: requestedPath,
+            reason,
+        }) => {
+            try {
+                const absolutePath = path.isAbsolute(requestedPath)
+                    ? requestedPath
+                    : path.resolve(process.cwd(), requestedPath)
+
+                const projectRoot = process.cwd()
+                const state = deps.getState()
+                const allowedPaths =
+                    (state.sandboxAllowedPaths as string[]) ?? []
+
+                if (isPathAllowed(absolutePath, projectRoot, allowedPaths)) {
+                    return {
+                        content: `Access already granted: "${absolutePath}" is within the project root or allowed paths.`,
+                        isError: false,
+                    }
+                }
+
+                const questionId = `sandbox_${++requestCounter}_${Date.now()}`
+
+                const answer = await new Promise<string>((resolve) => {
+                    deps.registerQuestion(questionId, resolve)
+
+                    deps.emitEvent({
+                        type: "sandbox_access_request",
+                        questionId,
+                        path: absolutePath,
+                        reason,
+                    })
+                })
+
+                const approved =
+                    answer.toLowerCase().startsWith("y") ||
+                    answer.toLowerCase() === "approve"
+
+                if (approved) {
+                    const currentAllowed =
+                        (deps.getState().sandboxAllowedPaths as string[]) ?? []
+                    if (!currentAllowed.includes(absolutePath)) {
+                        deps.setState({
+                            sandboxAllowedPaths: [
+                                ...currentAllowed,
+                                absolutePath,
+                            ],
+                        })
+                    }
+                    return {
+                        content: `Access granted: "${absolutePath}" has been added to allowed paths. You can now access files in this directory.`,
+                        isError: false,
+                    }
+                } else {
+                    return {
+                        content: `Access denied: The user declined access to "${absolutePath}".`,
+                        isError: false,
+                    }
+                }
+            } catch (error) {
+                const msg =
+                    error instanceof Error ? error.message : "Unknown error"
+                return {
+                    content: `Failed to request sandbox access: ${msg}`,
+                    isError: true,
+                }
+            }
+        },
+    })
+}

--- a/mastracode/src/tools/request-sandbox-access.ts
+++ b/mastracode/src/tools/request-sandbox-access.ts
@@ -3,110 +3,111 @@
  * outside the project root. The user can approve or deny the request via
  * TUI dialog.
  *
- * Adapted for the monorepo: uses deps-based pattern for emitEvent,
- * registerQuestion, getState, and setState instead of reading from
- * HarnessRuntimeContext.
+ * Accesses the harness via requestContext.get("harness"), which the core
+ * Harness populates with emitEvent, requestInteraction, getState, setState.
  */
 import { createTool } from "@mastra/core/tools"
 import { z } from "zod"
 import * as path from "node:path"
-import { isPathAllowed, getAllowedPathsFromContext } from "./security"
-import type { HarnessEvent } from "@mastra/core/harness"
-
-export interface SandboxAccessDeps {
-    emitEvent: (event: HarnessEvent) => void
-    registerQuestion: (questionId: string, resolve: (answer: string) => void) => void
-    getState: () => Record<string, unknown>
-    setState: (updates: Record<string, unknown>) => void
-}
+import { isPathAllowed } from "./security"
 
 let requestCounter = 0
 
-export function createRequestSandboxAccessTool(deps: SandboxAccessDeps) {
-    return createTool({
-        id: "request_sandbox_access",
-        description: `Request permission to access a directory outside the current project. Use this when you need to read or write files in a directory that is not within the project root. The user will be prompted to approve or deny the request.`,
-        inputSchema: z.object({
-            path: z
-                .string()
-                .min(1)
-                .describe(
-                    "The absolute path to the directory you need access to.",
-                ),
-            reason: z
-                .string()
-                .min(1)
-                .describe(
-                    "Brief explanation of why you need access to this directory.",
-                ),
-        }),
-        execute: async ({
-            path: requestedPath,
-            reason,
-        }) => {
-            try {
-                const absolutePath = path.isAbsolute(requestedPath)
-                    ? requestedPath
-                    : path.resolve(process.cwd(), requestedPath)
+export const requestSandboxAccessTool = createTool({
+    id: "request_sandbox_access",
+    description: `Request permission to access a directory outside the current project. Use this when you need to read or write files in a directory that is not within the project root. The user will be prompted to approve or deny the request.`,
+    inputSchema: z.object({
+        path: z
+            .string()
+            .min(1)
+            .describe(
+                "The absolute path to the directory you need access to.",
+            ),
+        reason: z
+            .string()
+            .min(1)
+            .describe(
+                "Brief explanation of why you need access to this directory.",
+            ),
+    }),
+    execute: async ({
+        path: requestedPath,
+        reason,
+    }, context) => {
+        try {
+            const harnessCtx = (context as any)?.requestContext?.get("harness")
 
-                const projectRoot = process.cwd()
-                const state = deps.getState()
-                const allowedPaths =
-                    (state.sandboxAllowedPaths as string[]) ?? []
-
-                if (isPathAllowed(absolutePath, projectRoot, allowedPaths)) {
-                    return {
-                        content: `Access already granted: "${absolutePath}" is within the project root or allowed paths.`,
-                        isError: false,
-                    }
-                }
-
-                const questionId = `sandbox_${++requestCounter}_${Date.now()}`
-
-                const answer = await new Promise<string>((resolve) => {
-                    deps.registerQuestion(questionId, resolve)
-
-                    deps.emitEvent({
-                        type: "sandbox_access_request",
-                        questionId,
-                        path: absolutePath,
-                        reason,
-                    })
-                })
-
-                const approved =
-                    answer.toLowerCase().startsWith("y") ||
-                    answer.toLowerCase() === "approve"
-
-                if (approved) {
-                    const currentAllowed =
-                        (deps.getState().sandboxAllowedPaths as string[]) ?? []
-                    if (!currentAllowed.includes(absolutePath)) {
-                        deps.setState({
-                            sandboxAllowedPaths: [
-                                ...currentAllowed,
-                                absolutePath,
-                            ],
-                        })
-                    }
-                    return {
-                        content: `Access granted: "${absolutePath}" has been added to allowed paths. You can now access files in this directory.`,
-                        isError: false,
-                    }
-                } else {
-                    return {
-                        content: `Access denied: The user declined access to "${absolutePath}".`,
-                        isError: false,
-                    }
-                }
-            } catch (error) {
-                const msg =
-                    error instanceof Error ? error.message : "Unknown error"
+            if (!harnessCtx?.emitEvent || !harnessCtx?.requestInteraction) {
                 return {
-                    content: `Failed to request sandbox access: ${msg}`,
-                    isError: true,
+                    content: `[Sandbox access request] Path: ${requestedPath}, Reason: ${reason}`,
+                    isError: false,
                 }
             }
-        },
-    })
-}
+
+            const absolutePath = path.isAbsolute(requestedPath)
+                ? requestedPath
+                : path.resolve(process.cwd(), requestedPath)
+
+            const projectRoot = process.cwd()
+            const state = harnessCtx.getState()
+            const allowedPaths =
+                (state.sandboxAllowedPaths as string[]) ?? []
+
+            if (isPathAllowed(absolutePath, projectRoot, allowedPaths)) {
+                return {
+                    content: `Access already granted: "${absolutePath}" is within the project root or allowed paths.`,
+                    isError: false,
+                }
+            }
+
+            const questionId = `sandbox_${++requestCounter}_${Date.now()}`
+
+            // Emit the event so the TUI renders the approval dialog
+            harnessCtx.emitEvent({
+                type: "sandbox_access_request",
+                questionId,
+                path: absolutePath,
+                reason,
+            })
+
+            // Await the user's response via the unified interaction system
+            const answer = await harnessCtx.requestInteraction<string>(
+                "question",
+                questionId,
+            )
+
+            const approved =
+                answer.toLowerCase().startsWith("y") ||
+                answer.toLowerCase() === "approve"
+
+            if (approved) {
+                const currentAllowed =
+                    (harnessCtx.getState().sandboxAllowedPaths as string[]) ?? []
+                if (!currentAllowed.includes(absolutePath)) {
+                    harnessCtx.setState({
+                        sandboxAllowedPaths: [
+                            ...currentAllowed,
+                            absolutePath,
+                        ],
+                    })
+                }
+                return {
+                    content: `Access granted: "${absolutePath}" has been added to allowed paths. You can now access files in this directory.`,
+                    isError: false,
+                }
+            } else {
+                return {
+                    content: `Access denied: The user declined access to "${absolutePath}".`,
+                    isError: false,
+                }
+            }
+        } catch (error) {
+            const msg =
+                error instanceof Error ? error.message : "Unknown error"
+            return {
+                content: `Failed to request sandbox access: ${msg}`,
+                isError: true,
+            }
+        }
+    },
+})

--- a/mastracode/src/tools/security.ts
+++ b/mastracode/src/tools/security.ts
@@ -1,0 +1,58 @@
+/**
+ * Path security helpers for tools that operate on the local filesystem.
+ * These guard against path traversal outside the project root.
+ */
+import * as path from "node:path"
+
+export function isPathAllowed(
+    targetPath: string,
+    projectRoot: string,
+    allowedPaths: string[] = [],
+): boolean {
+    const resolved = path.resolve(targetPath)
+    const roots = [projectRoot, ...allowedPaths].map((p) => path.resolve(p))
+    return roots.some(
+        (root) => resolved === root || resolved.startsWith(root + path.sep),
+    )
+}
+
+export function assertPathAllowed(
+    targetPath: string,
+    projectRoot: string,
+    allowedPaths: string[] = [],
+): void {
+    if (!isPathAllowed(targetPath, projectRoot, allowedPaths)) {
+        const resolvedTarget = path.resolve(targetPath)
+        const resolvedRoot = path.resolve(projectRoot)
+        throw new Error(
+            `Access denied: "${resolvedTarget}" is outside the project root "${resolvedRoot}"` +
+            (allowedPaths.length
+                ? ` and allowed paths [${allowedPaths.join(", ")}]`
+                : "") +
+            `. Use /sandbox to add additional allowed paths.`,
+        )
+    }
+}
+
+/**
+ * Read sandboxAllowedPaths from the harness request context.
+ * Returns an empty array when unavailable (e.g. in tests).
+ */
+export function getAllowedPathsFromContext(
+    toolContext:
+        | { requestContext?: { get: (key: string) => unknown } }
+        | undefined,
+): string[] {
+    if (!toolContext?.requestContext) return []
+    const harnessCtx = toolContext.requestContext.get("harness") as
+        | {
+            state?: { sandboxAllowedPaths?: string[] }
+            getState?: () => { sandboxAllowedPaths?: string[] }
+        }
+        | undefined
+    return (
+        harnessCtx?.getState?.()?.sandboxAllowedPaths ??
+        harnessCtx?.state?.sandboxAllowedPaths ??
+        []
+    )
+}

--- a/mastracode/src/tools/shell.ts
+++ b/mastracode/src/tools/shell.ts
@@ -1,0 +1,397 @@
+/**
+ * Shell tool — execute commands with streaming, timeout, and cleanup.
+ *
+ * Simplified from the original: ACP/IPC dependencies removed,
+ * core subprocess management and harness event streaming preserved.
+ */
+import { z } from "zod"
+import { execa, ExecaError } from "execa"
+import stripAnsi from "strip-ansi"
+import { truncateStringForTokenEstimate } from "../utils/tokens"
+import treeKill from "tree-kill"
+import { createTool } from "@mastra/core/tools"
+import * as path from "node:path"
+import { isPathAllowed, getAllowedPathsFromContext } from "./security"
+
+// Track active subprocesses to clean up on exit
+const activeSubprocesses = new Set<number>()
+let cleanupHandlersRegistered = false
+
+function registerCleanupHandlers() {
+    if (cleanupHandlersRegistered) return
+    cleanupHandlersRegistered = true
+
+    const killAllSubprocesses = () => {
+        for (const pid of activeSubprocesses) {
+            try {
+                process.kill(-pid, "SIGKILL")
+            } catch {
+                // Process may already be dead
+            }
+            treeKill(pid, "SIGKILL", () => { })
+        }
+        activeSubprocesses.clear()
+    }
+
+    process.on("exit", () => killAllSubprocesses())
+    process.on("SIGINT", () => {
+        killAllSubprocesses()
+        process.exit(0)
+    })
+    process.on("SIGTERM", () => {
+        killAllSubprocesses()
+        process.exit(0)
+    })
+}
+
+function applyTail(output: string, tailLines?: number): string {
+    if (!tailLines || tailLines <= 0) return output
+    const lines = output.split("\n")
+    if (lines.length <= tailLines) return output
+    return lines.slice(-tailLines).join("\n")
+}
+
+const ExecuteCommandSchema = z.object({
+    command: z.string().describe("Full shell command to execute"),
+    cwd: z
+        .string()
+        .optional()
+        .describe("Working directory for command execution"),
+    timeout: z
+        .number()
+        .optional()
+        .describe(
+            "The number of seconds until the shell command should be killed if it hasn't exited yet. Defaults to 30 seconds",
+        ),
+})
+
+export function createExecuteCommandTool(projectRoot?: string) {
+    return createTool({
+        id: "execute_command",
+        description: `Execute a shell command in the local system.
+
+Usage notes:
+- Use for: git commands, npm/pnpm, docker, build tools, test runners, linters, and other terminal operations.
+- Do NOT use for: reading files (use view tool), searching file contents (use grep tool), finding files (use glob tool), editing files (use string_replace_lsp tool).
+- Commands run with a 30-second default timeout. Use the timeout parameter for longer commands.
+- Output is stripped of ANSI codes and truncated if too long. Pipe to "| tail -N" for long outputs.
+- Be careful with destructive commands. Never run git push --force, git reset --hard, or rm -rf without explicit user request.
+- For interactive commands that need user input, they will fail. CI=true is already forced.`,
+        inputSchema: ExecuteCommandSchema,
+        execute: async (context, toolContext) => {
+            let { command } = context
+            let extractedTail: number | undefined
+
+            // Extract `| tail -N` or `| tail -n N` from command
+            const tailPipeMatch = command.match(
+                /\|\s*tail\s+(?:-n\s+)?(-?\d+)\s*$/,
+            )
+            if (tailPipeMatch) {
+                const tailLines = Math.abs(parseInt(tailPipeMatch[1], 10))
+                if (tailLines > 0) {
+                    extractedTail = tailLines
+                    command = command
+                        .replace(/\|\s*tail\s+(?:-n\s+)?-?\d+\s*$/, "")
+                        .trim()
+                }
+            }
+
+            const cwd = context.cwd || projectRoot || process.cwd()
+            const root = projectRoot || process.cwd()
+
+            // Security: if a custom cwd was provided, ensure it's within the project root
+            if (context.cwd) {
+                const allowedPaths = getAllowedPathsFromContext(toolContext)
+                const resolvedCwd = path.resolve(context.cwd)
+                if (!isPathAllowed(resolvedCwd, root, allowedPaths)) {
+                    return {
+                        content: [
+                            {
+                                type: "text" as const,
+                                text: `Error: cwd "${resolvedCwd}" is outside the project root "${root}". Use /sandbox to add additional allowed paths.`,
+                            },
+                        ],
+                        isError: true,
+                    }
+                }
+            }
+
+            const timeoutMS = context.timeout ? context.timeout * 1000 : 30_000
+
+            let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+            let manuallyKilled = false
+            let abortedBySignal = false
+            let subprocess: ReturnType<typeof execa> | undefined
+            let capturedOutput = ""
+
+            // Get abort signal and emit function from harness context
+            const harnessCtx = (toolContext as any)?.requestContext?.get(
+                "harness",
+            )
+            const abortSignal = harnessCtx?.abortSignal as
+                | AbortSignal
+                | undefined
+            const emitEvent = harnessCtx?.emitEvent as
+                | ((event: {
+                    type: "shell_output"
+                    toolCallId: string
+                    output: string
+                    stream: "stdout" | "stderr"
+                }) => void)
+                | undefined
+            const toolCallId = (toolContext as any)?.agent?.toolCallId as
+                | string
+                | undefined
+
+            const abortHandler = () => {
+                if (subprocess?.pid) {
+                    abortedBySignal = true
+                    try {
+                        process.kill(-subprocess.pid, "SIGKILL")
+                    } catch {
+                        treeKill(subprocess.pid, "SIGKILL", () => { })
+                    }
+                }
+            }
+
+            try {
+                subprocess = execa(command, {
+                    cwd,
+                    shell: true,
+                    stdio: ["pipe", "pipe", "pipe"],
+                    buffer: true,
+                    all: true,
+                    env: {
+                        ...process.env,
+                        FORCE_COLOR: "1",
+                        CLICOLOR_FORCE: "1",
+                        TERM: process.env.TERM || "xterm-256color",
+                        CI: "true",
+                        NONINTERACTIVE: "1",
+                        DEBIAN_FRONTEND: "noninteractive",
+                    },
+                    stripFinalNewline: false,
+                    timeout: timeoutMS,
+                    forceKillAfterDelay: 100,
+                    killSignal: "SIGKILL",
+                    cleanup: true,
+                    detached: true,
+                })
+
+                registerCleanupHandlers()
+                if (subprocess.pid) {
+                    activeSubprocesses.add(subprocess.pid)
+                }
+
+                if (timeoutMS && subprocess.pid) {
+                    timeoutHandle = setTimeout(() => {
+                        if (subprocess?.pid) {
+                            manuallyKilled = true
+                            try {
+                                process.kill(-subprocess.pid, "SIGKILL")
+                            } catch {
+                                treeKill(subprocess.pid, "SIGKILL")
+                            }
+                        }
+                    }, timeoutMS - 100)
+                }
+
+                if (abortSignal) {
+                    abortSignal.addEventListener("abort", abortHandler)
+                }
+
+                // Capture and stream output
+                if (subprocess.stdout) {
+                    subprocess.stdout.on("data", (chunk: Buffer) => {
+                        const text = chunk.toString()
+                        capturedOutput += text
+                        if (emitEvent && toolCallId) {
+                            emitEvent({
+                                type: "shell_output",
+                                toolCallId,
+                                output: text,
+                                stream: "stdout",
+                            })
+                        }
+                    })
+                }
+
+                if (subprocess.stderr) {
+                    subprocess.stderr.on("data", (chunk: Buffer) => {
+                        const text = chunk.toString()
+                        capturedOutput += text
+                        if (emitEvent && toolCallId) {
+                            emitEvent({
+                                type: "shell_output",
+                                toolCallId,
+                                output: text,
+                                stream: "stderr",
+                            })
+                        }
+                    })
+                }
+
+                const result = await subprocess
+
+                if (abortSignal) {
+                    abortSignal.removeEventListener("abort", abortHandler)
+                }
+
+                if (abortedBySignal) {
+                    if (timeoutHandle) clearTimeout(timeoutHandle)
+                    let cleanOutput = stripAnsi(capturedOutput)
+                    if (extractedTail) {
+                        cleanOutput = applyTail(cleanOutput, extractedTail)
+                    }
+                    return {
+                        content: [
+                            {
+                                type: "text" as const,
+                                text: cleanOutput.trim()
+                                    ? `[User aborted command]\n\nPartial output:\n${truncateStringForTokenEstimate(cleanOutput, 1_000)}`
+                                    : "[User aborted command]",
+                            },
+                        ],
+                        isError: true,
+                    }
+                }
+
+                if (timeoutHandle) clearTimeout(timeoutHandle)
+
+                const rawOutput =
+                    result.all ||
+                    result.stdout ||
+                    result.stderr ||
+                    "Command executed successfully with no output"
+                let cleanOutput = stripAnsi(
+                    typeof rawOutput === "string"
+                        ? rawOutput
+                        : rawOutput.toString(),
+                )
+
+                if (extractedTail) {
+                    cleanOutput = applyTail(cleanOutput, extractedTail)
+                }
+
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: truncateStringForTokenEstimate(
+                                cleanOutput,
+                                2_000,
+                            ),
+                        },
+                    ],
+                    isError: false,
+                }
+            } catch (error: any) {
+                if (abortSignal) {
+                    abortSignal.removeEventListener("abort", abortHandler)
+                }
+                if (timeoutHandle) clearTimeout(timeoutHandle)
+
+                if (abortedBySignal) {
+                    let cleanOutput = stripAnsi(capturedOutput)
+                    if (extractedTail) {
+                        cleanOutput = applyTail(cleanOutput, extractedTail)
+                    }
+                    return {
+                        content: [
+                            {
+                                type: "text" as const,
+                                text: cleanOutput.trim()
+                                    ? `[User aborted command]\n\nPartial output:\n${truncateStringForTokenEstimate(cleanOutput, 1_000)}`
+                                    : "[User aborted command]",
+                            },
+                        ],
+                        isError: true,
+                    }
+                }
+
+                let cleanError = ""
+                if (error instanceof ExecaError) {
+                    const causeMessage =
+                        (error.cause as Error)?.message || ""
+                    const stderr = error.stderr
+                        ? stripAnsi(error.stderr)
+                        : ""
+                    const stdout = error.stdout
+                        ? stripAnsi(error.stdout)
+                        : ""
+                    const all = error.all ? stripAnsi(error.all) : ""
+                    const isTimeout =
+                        error.timedOut || error.isCanceled || manuallyKilled
+
+                    const parts = []
+                    if (isTimeout) {
+                        parts.push(
+                            `Error: command timed out after ${timeoutMS}ms`,
+                        )
+                    } else if (causeMessage) {
+                        parts.push(`Error: ${stripAnsi(causeMessage)}`)
+                    }
+
+                    if (all) {
+                        parts.push(`Output: ${all}`)
+                    } else {
+                        if (stderr) parts.push(`STDERR: ${stderr}`)
+                        if (stdout) parts.push(`STDOUT: ${stdout}`)
+                    }
+
+                    cleanError = parts.join("\n\n")
+                } else {
+                    try {
+                        if (
+                            error &&
+                            typeof error === "object" &&
+                            "message" in error &&
+                            typeof error.message === "string"
+                        ) {
+                            cleanError = error.message
+                        } else {
+                            cleanError = String(error)
+                        }
+                    } catch {
+                        cleanError = String(error)
+                    }
+                }
+
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: truncateStringForTokenEstimate(
+                                cleanError,
+                                2_000,
+                            ),
+                        },
+                    ],
+                    isError: true,
+                }
+            } finally {
+                if (subprocess?.pid) {
+                    activeSubprocesses.delete(subprocess.pid)
+                }
+                if (subprocess?.pid) {
+                    try {
+                        process.kill(-subprocess.pid, "SIGKILL")
+                    } catch {
+                        // Process group may already be dead
+                    }
+                    const pid = subprocess.pid
+                    try {
+                        await new Promise<void>((resolve) => {
+                            treeKill(pid, "SIGKILL", () => resolve())
+                        })
+                    } catch {
+                        // Ignore
+                    }
+                }
+            }
+        },
+    })
+}
+
+export const executeCommandTool = createExecuteCommandTool()
+export default executeCommandTool

--- a/mastracode/src/tools/subagent.ts
+++ b/mastracode/src/tools/subagent.ts
@@ -1,0 +1,385 @@
+/**
+ * Subagent tool — spawns a subagent to perform a focused task.
+ *
+ * The parent agent calls this tool with a task description and agent type.
+ * A fresh Agent instance is created with the subagent's constrained tool set,
+ * runs via agent.stream(), and returns the text result.
+ *
+ * Stream events are forwarded to the parent harness so the TUI can show
+ * real-time subagent activity (tool calls, text deltas, etc.).
+ *
+ * Note: emitEvent and abortSignal are passed through deps (closed over the
+ * harness at construction time) rather than through HarnessRequestContext,
+ * which is serializable-only.
+ */
+import { createTool } from "@mastra/core/tools"
+import { Agent } from "@mastra/core/agent"
+import { z } from "zod"
+import { getSubagentDefinition, getSubagentIds } from "../agents"
+import type { HarnessEvent } from "@mastra/core/harness"
+
+export interface SubagentToolDeps {
+    /**
+     * The full tool registry from the parent agent.
+     * The subagent will receive a subset based on its allowedTools.
+     */
+    tools: Record<string, any>
+
+    /**
+     * Function to resolve a model ID to a language model instance.
+     * Shared with the parent agent so subagents use the same providers.
+     */
+    resolveModel: (modelId: string) => any
+
+    /**
+     * Emit a HarnessEvent to the TUI for live updates.
+     * Closed over the harness instance at tool-construction time.
+     */
+    emitEvent: (event: HarnessEvent) => void
+
+    /**
+     * Get the current abort signal (changes per-stream invocation).
+     * Returns undefined if no stream is active.
+     */
+    getAbortSignal?: () => AbortSignal | undefined
+
+    /**
+     * Resolve a configured model ID for a specific subagent type.
+     * Used for per-type model overrides (e.g., "use fast model for explore").
+     */
+    getSubagentModelId?: (agentType: string) => Promise<string | undefined>
+
+    /**
+     * Model ID to use for subagent tasks.
+     * Defaults to a fast model to keep costs down.
+     */
+    defaultModelId?: string
+
+    /**
+     * Restrict which agent types can be spawned.
+     * If not provided, all registered agent types are available.
+     */
+    allowedAgentTypes?: string[]
+}
+
+const DEFAULT_SUBAGENT_MODEL = "anthropic/claude-sonnet-4-20250514"
+
+export function createSubagentTool(deps: SubagentToolDeps) {
+    const allAgentTypes = getSubagentIds()
+    const validAgentTypes = deps.allowedAgentTypes
+        ? allAgentTypes.filter((t) => deps.allowedAgentTypes!.includes(t))
+        : allAgentTypes
+
+    const typeDescriptions: Record<string, string> = {
+        explore: `- **explore**: Read-only codebase exploration. Has access to read_file, list_files, and grep. Use for questions like "find all usages of X", "how does module Y work", "what files are related to Z".`,
+        plan: `- **plan**: Read-only analysis and planning. Same tools as explore. Use for "create an implementation plan for X", "analyze the architecture of Y".`,
+        execute: `- **execute**: Task execution with write capabilities. Has access to all tools including edit_file, write_file, and execute_command. Use for "implement feature X", "fix bug Y", "refactor module Z".`,
+    }
+
+    const availableTypesDocs = validAgentTypes
+        .map((t) => typeDescriptions[t] ?? `- **${t}**`)
+        .join("\n")
+
+    const hasExecute = validAgentTypes.includes("execute")
+
+    return createTool({
+        id: "subagent",
+        description: `Delegate a focused task to a specialized subagent. The subagent runs independently with a constrained toolset, then returns its findings as text.
+
+Available agent types:
+${availableTypesDocs}
+
+The subagent runs in its own context — it does NOT see the parent conversation history. Write a clear, self-contained task description.
+
+Use this tool when:
+- You want to run multiple investigations in parallel
+- The task is self-contained and can be delegated${hasExecute ? "\n- You want to perform a focused implementation task (execute type)" : ""}`,
+        inputSchema: z.object({
+            agentType: z
+                .enum(validAgentTypes as [string, ...string[]])
+                .describe("Type of subagent to spawn"),
+            task: z
+                .string()
+                .describe(
+                    "Clear, self-contained description of what the subagent should do. Include all relevant context — the subagent cannot see the parent conversation.",
+                ),
+            modelId: z
+                .string()
+                .optional()
+                .describe(
+                    `Model ID to use for this task. Defaults to ${DEFAULT_SUBAGENT_MODEL}.`,
+                ),
+        }),
+        execute: async ({ agentType, task, modelId }) => {
+            const definition = getSubagentDefinition(agentType)
+            if (!definition) {
+                return {
+                    content: `Unknown agent type: ${agentType}. Valid types: ${validAgentTypes.join(", ")}`,
+                    isError: true,
+                }
+            }
+
+            const emitEvent = deps.emitEvent
+            const abortSignal = deps.getAbortSignal?.()
+            const toolCallId = "subagent-" + Date.now()
+
+            // Build the constrained tool set
+            const subagentTools: Record<string, any> = {}
+            for (const toolId of definition.allowedTools) {
+                if (deps.tools[toolId]) {
+                    subagentTools[toolId] = deps.tools[toolId]
+                }
+            }
+
+            // Resolve model with precedence:
+            // 1. Explicit modelId from tool call
+            // 2. Configured per-type model from harness
+            // 3. Deps default model
+            // 4. Hardcoded default
+            const configuredSubagentModel =
+                await deps.getSubagentModelId?.(agentType)
+
+            const resolvedModelId =
+                modelId ??
+                configuredSubagentModel ??
+                deps.defaultModelId ??
+                DEFAULT_SUBAGENT_MODEL
+
+            let model: any
+            try {
+                model = deps.resolveModel(resolvedModelId)
+            } catch (err) {
+                return {
+                    content: `Failed to resolve model "${resolvedModelId}": ${err instanceof Error ? err.message : String(err)}`,
+                    isError: true,
+                }
+            }
+
+            // Create a fresh agent with constrained tools
+            const subagent = new Agent({
+                id: `subagent-${definition.id}`,
+                name: `${definition.name} Subagent`,
+                instructions: definition.instructions,
+                model,
+                tools: subagentTools,
+            })
+
+            const startTime = Date.now()
+
+            emitEvent({
+                type: "subagent_start",
+                toolCallId,
+                agentType,
+                task,
+                modelId: resolvedModelId,
+            })
+
+            let partialText = ""
+            const toolCallLog: Array<{ name: string; isError?: boolean }> = []
+
+            try {
+                const response = await subagent.stream(task, {
+                    maxSteps: 50,
+                    abortSignal,
+                })
+
+                const reader = response.fullStream.getReader()
+
+                while (true) {
+                    const { done, value: chunk } = await reader.read()
+                    if (done) break
+
+                    switch (chunk.type) {
+                        case "text-delta":
+                            partialText += chunk.payload.text
+                            emitEvent({
+                                type: "subagent_text_delta",
+                                toolCallId,
+                                agentType,
+                                textDelta: chunk.payload.text,
+                            })
+                            break
+
+                        case "tool-call":
+                            toolCallLog.push({
+                                name: chunk.payload.toolName,
+                            })
+                            emitEvent({
+                                type: "subagent_tool_start",
+                                toolCallId,
+                                agentType,
+                                subToolName: chunk.payload.toolName,
+                                subToolArgs: chunk.payload.args,
+                            })
+                            break
+
+                        case "tool-result": {
+                            const isErr = chunk.payload.isError ?? false
+                            for (
+                                let i = toolCallLog.length - 1;
+                                i >= 0;
+                                i--
+                            ) {
+                                if (
+                                    toolCallLog[i]!.name ===
+                                    chunk.payload.toolName &&
+                                    toolCallLog[i]!.isError === undefined
+                                ) {
+                                    toolCallLog[i]!.isError = isErr
+                                    break
+                                }
+                            }
+                            emitEvent({
+                                type: "subagent_tool_end",
+                                toolCallId,
+                                agentType,
+                                subToolName: chunk.payload.toolName,
+                                subToolResult: chunk.payload.result,
+                                isError: isErr,
+                            })
+                            break
+                        }
+                    }
+                }
+
+                if (abortSignal?.aborted) {
+                    const durationMs = Date.now() - startTime
+                    const abortResult = partialText
+                        ? `[Aborted by user]\n\nPartial output:\n${partialText}`
+                        : "[Aborted by user]"
+
+                    emitEvent({
+                        type: "subagent_end",
+                        toolCallId,
+                        agentType,
+                        result: abortResult,
+                        isError: false,
+                        durationMs,
+                    })
+
+                    return { content: abortResult, isError: false }
+                }
+
+                const fullOutput = await response.getFullOutput()
+                const resultText = fullOutput.text || partialText
+
+                const durationMs = Date.now() - startTime
+                emitEvent({
+                    type: "subagent_end",
+                    toolCallId,
+                    agentType,
+                    result: resultText,
+                    isError: false,
+                    durationMs,
+                })
+
+                const meta = buildSubagentMeta(
+                    resolvedModelId,
+                    durationMs,
+                    toolCallLog,
+                )
+                return { content: resultText + meta, isError: false }
+            } catch (err) {
+                const isAbort =
+                    err instanceof Error &&
+                    (err.name === "AbortError" ||
+                        err.message?.includes("abort") ||
+                        err.message?.includes("cancel"))
+                const durationMs = Date.now() - startTime
+
+                if (isAbort) {
+                    const abortResult = partialText
+                        ? `[Aborted by user]\n\nPartial output:\n${partialText}`
+                        : "[Aborted by user]"
+
+                    emitEvent({
+                        type: "subagent_end",
+                        toolCallId,
+                        agentType,
+                        result: abortResult,
+                        isError: false,
+                        durationMs,
+                    })
+
+                    const meta = buildSubagentMeta(
+                        resolvedModelId,
+                        durationMs,
+                        toolCallLog,
+                    )
+                    return { content: abortResult + meta, isError: false }
+                }
+
+                const message =
+                    err instanceof Error ? err.message : String(err)
+
+                emitEvent({
+                    type: "subagent_end",
+                    toolCallId,
+                    agentType,
+                    result: message,
+                    isError: true,
+                    durationMs,
+                })
+
+                const meta = buildSubagentMeta(
+                    resolvedModelId,
+                    durationMs,
+                    toolCallLog,
+                )
+                return {
+                    content:
+                        `Subagent "${definition.name}" failed: ${message}` +
+                        meta,
+                    isError: true,
+                }
+            }
+        },
+    })
+}
+
+/**
+ * Build a metadata tag appended to subagent results.
+ * The TUI parses this to display model ID, duration, and tool calls
+ * when loading from history (where live events aren't available).
+ */
+function buildSubagentMeta(
+    modelId: string,
+    durationMs: number,
+    toolCalls: Array<{ name: string; isError?: boolean }>,
+): string {
+    const tools = toolCalls
+        .map((tc) => `${tc.name}:${tc.isError ? "err" : "ok"}`)
+        .join(",")
+    return `\n<subagent-meta modelId="${modelId}" durationMs="${durationMs}" tools="${tools}" />`
+}
+
+/**
+ * Parse subagent metadata from a tool result string.
+ * Returns the metadata and the cleaned result text (without the tag).
+ */
+export function parseSubagentMeta(content: string): {
+    text: string
+    modelId?: string
+    durationMs?: number
+    toolCalls?: Array<{ name: string; isError: boolean }>
+} {
+    const match = content.match(
+        /\n<subagent-meta modelId="([^"]*)" durationMs="(\d+)" tools="([^"]*)" \/>$/,
+    )
+    if (!match) return { text: content }
+
+    const text = content.slice(0, match.index!)
+    const modelId = match[1]
+    const durationMs = parseInt(match[2]!, 10)
+    const toolCalls = match[3]
+        ? match[3]
+            .split(",")
+            .filter(Boolean)
+            .map((entry) => {
+                const [name, status] = entry.split(":")
+                return { name: name!, isError: status === "err" }
+            })
+        : []
+
+    return { text, modelId, durationMs, toolCalls }
+}

--- a/mastracode/src/tools/subagent.ts
+++ b/mastracode/src/tools/subagent.ts
@@ -16,7 +16,7 @@ import { createTool } from "@mastra/core/tools"
 import { Agent } from "@mastra/core/agent"
 import { z } from "zod"
 import { getSubagentDefinition, getSubagentIds } from "../agents"
-import type { HarnessEvent } from "@mastra/core/harness"
+import type { MastraCodeEvent } from "../harness"
 
 export interface SubagentToolDeps {
     /**
@@ -32,16 +32,17 @@ export interface SubagentToolDeps {
     resolveModel: (modelId: string) => any
 
     /**
-     * Emit a HarnessEvent to the TUI for live updates.
-     * Closed over the harness instance at tool-construction time.
+     * Emit a MastraCodeEvent to the TUI for live updates.
+     * Wire to harness.emitEvent() or use requestContext.get("harness").emitEvent.
      */
-    emitEvent: (event: HarnessEvent) => void
+    emitEvent: (event: MastraCodeEvent) => void
 
     /**
      * Get the current abort signal (changes per-stream invocation).
      * Returns undefined if no stream is active.
+     * Wire to harness.getAbortSignal().
      */
-    getAbortSignal?: () => AbortSignal | undefined
+    getAbortSignal: () => AbortSignal | undefined
 
     /**
      * Resolve a configured model ID for a specific subagent type.

--- a/mastracode/src/tools/submit-plan.ts
+++ b/mastracode/src/tools/submit-plan.ts
@@ -1,0 +1,74 @@
+/**
+ * submit_plan tool — presents a completed plan for user review.
+ * Renders inline as markdown with Approve/Reject/Edit options.
+ * On approval, auto-switches to Build mode.
+ */
+import { createTool } from "@mastra/core/tools"
+import { z } from "zod"
+
+let planCounter = 0
+
+export interface PlanApprovalResult {
+    action: "approved" | "rejected"
+    feedback?: string
+}
+
+export const submitPlanTool = createTool({
+    id: "submit_plan",
+    description: `Submit a completed implementation plan for user review. The plan will be rendered as markdown and the user can approve, reject, or request changes. Use this when your exploration is complete and you have a concrete plan ready for review. On approval, the system automatically switches to Build mode so you can implement.`,
+    inputSchema: z.object({
+        title: z
+            .string()
+            .optional()
+            .describe("Short title for the plan (e.g., 'Add dark mode toggle')"),
+        plan: z
+            .string()
+            .min(1)
+            .describe(
+                "The full plan content in markdown format. Should include Overview, Steps, and Verification sections.",
+            ),
+    }),
+    execute: async ({ title, plan }, context) => {
+        try {
+            const harnessCtx = (context as any)?.requestContext?.get("harness")
+
+            if (!harnessCtx?.emitEvent || !harnessCtx?.registerPlanApproval) {
+                return {
+                    content: `[Plan submitted for review]\n\nTitle: ${title || "Implementation Plan"}\n\n${plan}`,
+                    isError: false,
+                }
+            }
+
+            const planId = `plan_${++planCounter}_${Date.now()}`
+
+            const result = await new Promise<PlanApprovalResult>((resolve) => {
+                harnessCtx.registerPlanApproval!(planId, resolve)
+                harnessCtx.emitEvent!({
+                    type: "plan_approval_required",
+                    planId,
+                    title: title || "Implementation Plan",
+                    plan,
+                } as any)
+            })
+
+            if (result.action === "approved") {
+                return {
+                    content:
+                        "Plan approved. The system has switched to Build mode. Proceed with implementation following the approved plan.",
+                    isError: false,
+                }
+            }
+
+            const feedback = result.feedback
+                ? `\n\nUser feedback: ${result.feedback}`
+                : ""
+            return {
+                content: `Plan was not approved. The user wants revisions.${feedback}\n\nPlease revise the plan based on the feedback and submit again with submit_plan.`,
+                isError: false,
+            }
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : "Unknown error"
+            return { content: `Failed to submit plan: ${msg}`, isError: true }
+        }
+    },
+})

--- a/mastracode/src/tools/todo-check.ts
+++ b/mastracode/src/tools/todo-check.ts
@@ -1,0 +1,93 @@
+/**
+ * TodoCheck tool — checks the completion status of the current todo list.
+ * Helps the agent determine if all tasks are completed before ending work.
+ *
+ * Adapted for the monorepo: uses deps-based pattern instead of reading
+ * from HarnessRuntimeContext, since HarnessRequestContext is serializable-only.
+ */
+import { createTool } from "@mastra/core/tools"
+import { z } from "zod"
+
+export interface TodoCheckDeps {
+    /** Get the current harness state (including todos). */
+    getState: () => Record<string, unknown>
+}
+
+export function createTodoCheckTool(deps: TodoCheckDeps) {
+    return createTool({
+        id: "todo_check",
+        description: `Check the completion status of your current todo list. Use this before deciding to end work on a task to ensure all todos are completed.
+
+Returns:
+- Total number of todos
+- Number of completed, in progress, and pending tasks
+- List of incomplete tasks (if any)
+- Boolean indicating if all tasks are done`,
+        inputSchema: z.object({}),
+        execute: async () => {
+            try {
+                const state = deps.getState()
+                const typedState = state as {
+                    todos?: Array<{
+                        content: string
+                        status: "pending" | "in_progress" | "completed"
+                        activeForm: string
+                    }>
+                }
+
+                const todos = typedState.todos || []
+
+                if (todos.length === 0) {
+                    return {
+                        content:
+                            "No todos found. Consider using todo_write to create a task list for complex work.",
+                        isError: false,
+                    }
+                }
+
+                const completed = todos.filter(
+                    (t) => t.status === "completed",
+                )
+                const inProgress = todos.filter(
+                    (t) => t.status === "in_progress",
+                )
+                const pending = todos.filter((t) => t.status === "pending")
+                const incomplete = [...inProgress, ...pending]
+                const allDone = incomplete.length === 0
+
+                let response = `Todo Status: [${completed.length}/${todos.length} completed]\n`
+                response += `- Completed: ${completed.length}\n`
+                response += `- In Progress: ${inProgress.length}\n`
+                response += `- Pending: ${pending.length}\n`
+                response += `\nAll tasks completed: ${allDone ? "✓ YES" : "✗ NO"}`
+
+                if (!allDone) {
+                    response += "\n\nIncomplete tasks:"
+                    if (inProgress.length > 0) {
+                        response += "\n\nIn Progress:"
+                        inProgress.forEach((t) => {
+                            response += `\n- ${t.content}`
+                        })
+                    }
+                    if (pending.length > 0) {
+                        response += "\n\nPending:"
+                        pending.forEach((t) => {
+                            response += `\n- ${t.content}`
+                        })
+                    }
+                    response +=
+                        "\n\nContinue working on these tasks before ending."
+                }
+
+                return { content: response, isError: false }
+            } catch (error) {
+                const msg =
+                    error instanceof Error ? error.message : "Unknown error"
+                return {
+                    content: `Failed to check todos: ${msg}`,
+                    isError: true,
+                }
+            }
+        },
+    })
+}

--- a/mastracode/src/tools/todo.ts
+++ b/mastracode/src/tools/todo.ts
@@ -1,0 +1,73 @@
+/**
+ * TodoWrite tool — manages a structured task list for the coding session.
+ * Full-replacement semantics: each call replaces the entire todo list.
+ */
+import { createTool } from "@mastra/core/tools"
+import { z } from "zod"
+
+const todoItemSchema = z.object({
+    content: z
+        .string()
+        .min(1)
+        .describe(
+            "Task description in imperative form (e.g., 'Fix authentication bug')",
+        ),
+    status: z
+        .enum(["pending", "in_progress", "completed"])
+        .describe("Current task status"),
+    activeForm: z
+        .string()
+        .min(1)
+        .describe(
+            "Present continuous form shown during execution (e.g., 'Fixing authentication bug')",
+        ),
+})
+
+export type TodoItem = z.infer<typeof todoItemSchema>
+
+export const todoWriteTool = createTool({
+    id: "todo_write",
+    description: `Create and manage a structured task list for your current coding session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.
+
+Usage:
+- Pass the FULL todo list each time (replaces previous list)
+- Each todo has: content (imperative), status (pending|in_progress|completed), activeForm (present continuous)
+- Mark tasks in_progress BEFORE starting work (only ONE at a time)
+- Mark tasks completed IMMEDIATELY after finishing
+- Use this for multi-step tasks requiring 3+ distinct actions
+
+States:
+- pending: Not yet started
+- in_progress: Currently working on (limit to ONE)
+- completed: Finished successfully`,
+    inputSchema: z.object({
+        todos: z.array(todoItemSchema).describe("The complete updated todo list"),
+    }),
+    execute: async ({ todos }, context) => {
+        try {
+            const harnessCtx = (context as any)?.requestContext?.get("harness")
+
+            if (harnessCtx) {
+                await harnessCtx.setState({ todos })
+                harnessCtx.emitEvent?.({
+                    type: "todo_updated",
+                    todos,
+                } as any)
+            }
+
+            const completed = todos.filter((t) => t.status === "completed").length
+            const inProgress = todos.find((t) => t.status === "in_progress")
+            const total = todos.length
+
+            let summary = `Todos updated: [${completed}/${total} completed]`
+            if (inProgress) {
+                summary += `\nCurrently: ${inProgress.activeForm}`
+            }
+
+            return { content: summary, isError: false }
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : "Unknown error"
+            return { content: `Failed to update todos: ${msg}`, isError: true }
+        }
+    },
+})

--- a/mastracode/src/tools/web-search.ts
+++ b/mastracode/src/tools/web-search.ts
@@ -1,0 +1,195 @@
+/**
+ * Web search + extract tools powered by Tavily.
+ *
+ * Only available when TAVILY_API_KEY is set in the environment.
+ * When not available, falls back gracefully (returns empty results).
+ */
+import { createTool } from "@mastra/core/tools"
+import { z } from "zod"
+
+const MIN_RELEVANCE_SCORE = 0.25
+
+// Lazily cached Tavily client — created on first use when the API key is available.
+let cachedTavilyClient: any | null = null
+
+function getTavilyClient() {
+    if (cachedTavilyClient) return cachedTavilyClient
+    const apiKey = process.env.TAVILY_API_KEY
+    if (!apiKey) return null
+    try {
+        // Dynamic import to avoid hard dependency on @tavily/core
+        const { tavily } = require("@tavily/core")
+        cachedTavilyClient = tavily({ apiKey })
+        return cachedTavilyClient
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Check whether a Tavily API key is available in the environment.
+ * Used by main.ts to decide whether to include Tavily tools or fall back
+ * to provider-native web search.
+ */
+export function hasTavilyKey(): boolean {
+    return !!process.env.TAVILY_API_KEY
+}
+
+export function createWebSearchTool() {
+    return createTool({
+        id: "web_search",
+        description:
+            "Search the web for information. Use this to find documentation, look up error messages, check package APIs, or research any topic. Returns relevant web results with content snippets and optionally images.",
+        inputSchema: z.object({
+            query: z.string().describe("The search query"),
+            searchDepth: z
+                .enum(["basic", "advanced"])
+                .optional()
+                .default("basic")
+                .describe(
+                    "Search depth - 'basic' for quick searches, 'advanced' for more thorough results",
+                ),
+            maxResults: z
+                .number()
+                .optional()
+                .default(10)
+                .describe("Maximum number of results to return"),
+            includeImages: z
+                .boolean()
+                .optional()
+                .default(false)
+                .describe(
+                    "Whether to include related images in results",
+                ),
+        }),
+        outputSchema: z.object({
+            results: z.array(
+                z.object({
+                    title: z.string(),
+                    url: z.string(),
+                    content: z.string(),
+                }),
+            ),
+            images: z.array(z.string()).optional(),
+            answer: z.string().optional(),
+        }),
+        execute: async (context) => {
+            const tavilyClient = getTavilyClient()
+            if (!tavilyClient) {
+                return { results: [], images: [], answer: undefined }
+            }
+            try {
+                const response = await tavilyClient.search(context.query, {
+                    searchDepth: context.searchDepth || "basic",
+                    maxResults: context.maxResults || 10,
+                    includeAnswer: true,
+                    includeImages: context.includeImages || false,
+                })
+
+                const filteredResults = response.results.filter(
+                    (r: any) => (r.score ?? 1) >= MIN_RELEVANCE_SCORE,
+                )
+
+                return {
+                    results: filteredResults.map((r: any) => ({
+                        title: r.title,
+                        url: r.url,
+                        content: r.content,
+                    })),
+                    images: (response.images || [])
+                        .map((img: { url?: string } | string) =>
+                            typeof img === "string" ? img : img.url || "",
+                        )
+                        .filter(Boolean),
+                    answer: response.answer,
+                }
+            } catch {
+                return { results: [], images: [], answer: undefined }
+            }
+        },
+    })
+}
+
+export function createWebExtractTool() {
+    return createTool({
+        id: "web_extract",
+        description:
+            "Extract content from one or more URLs. Use this to read web pages, documentation, articles, or any URL. Returns the raw content in markdown format. You can provide up to 20 URLs at once.",
+        inputSchema: z.object({
+            urls: z
+                .array(z.string())
+                .min(1)
+                .max(20)
+                .describe("URLs to extract content from (max 20)"),
+            extractDepth: z
+                .enum(["basic", "advanced"])
+                .optional()
+                .default("basic")
+                .describe(
+                    "Extraction depth - 'basic' for simple text, 'advanced' for JS-rendered pages",
+                ),
+            includeImages: z
+                .boolean()
+                .optional()
+                .default(false)
+                .describe(
+                    "Whether to include extracted image URLs",
+                ),
+        }),
+        outputSchema: z.object({
+            results: z.array(
+                z.object({
+                    url: z.string(),
+                    rawContent: z.string(),
+                }),
+            ),
+            failedResults: z.array(
+                z.object({
+                    url: z.string(),
+                    error: z.string(),
+                }),
+            ),
+        }),
+        execute: async (context) => {
+            const tavilyClient = getTavilyClient()
+            if (!tavilyClient) {
+                return {
+                    results: [],
+                    failedResults: context.urls.map((url) => ({
+                        url,
+                        error: "TAVILY_API_KEY not configured",
+                    })),
+                }
+            }
+            try {
+                const response = await tavilyClient.extract(context.urls, {
+                    extractDepth: context.extractDepth || "basic",
+                    includeImages: context.includeImages || false,
+                })
+
+                return {
+                    results: (response.results || []).map(
+                        (r: { url: string; rawContent: string }) => ({
+                            url: r.url,
+                            rawContent: r.rawContent,
+                        }),
+                    ),
+                    failedResults: (response.failedResults || []).map(
+                        (r: { url: string; error: string }) => ({
+                            url: r.url,
+                            error: r.error,
+                        }),
+                    ),
+                }
+            } catch (error) {
+                return {
+                    results: [],
+                    failedResults: context.urls.map((url) => ({
+                        url,
+                        error: String(error),
+                    })),
+                }
+            }
+        },
+    })
+}

--- a/mastracode/src/tools/wrap-with-confirmation.ts
+++ b/mastracode/src/tools/wrap-with-confirmation.ts
@@ -1,0 +1,18 @@
+/**
+ * Global confirmation tracking — used to manage a pending confirmation
+ * ID when the TUI needs to coordinate confirmation dialogs with tool
+ * execution.
+ *
+ * This is a minimal stub (the original was also a stub). In TUI mode,
+ * confirmation is handled via the tool approval flow in the harness.
+ */
+
+let globalConfirmationId: string | null = null
+
+export function setGlobalConfirmationId(id: string | null) {
+    globalConfirmationId = id
+}
+
+export function getGlobalConfirmationId(): string | null {
+    return globalConfirmationId
+}

--- a/mastracode/src/tui/clipboard.ts
+++ b/mastracode/src/tui/clipboard.ts
@@ -1,0 +1,167 @@
+/**
+ * Platform-specific clipboard image extraction.
+ *
+ * Checks the system clipboard for image data and returns it as base64.
+ * Uses synchronous execution (execSync) since this only runs on paste events.
+ */
+
+import { execSync } from "node:child_process"
+import { readFileSync, unlinkSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+export interface ClipboardImage {
+    data: string // base64-encoded image data
+    mimeType: string
+}
+
+/**
+ * Check the system clipboard for image data and return it as base64.
+ * Returns null if no image data is found or extraction fails.
+ */
+export function getClipboardImage(): ClipboardImage | null {
+    try {
+        if (process.platform === "darwin") {
+            return getMacClipboardImage()
+        }
+        if (process.platform === "linux") {
+            return getLinuxClipboardImage()
+        }
+        return null
+    } catch {
+        return null
+    }
+}
+
+// =============================================================================
+// macOS
+// =============================================================================
+
+function getMacClipboardImage(): ClipboardImage | null {
+    let clipInfo: string
+    try {
+        clipInfo = execSync("osascript -e 'clipboard info'", {
+            encoding: "utf-8",
+            timeout: 3000,
+            stdio: ["pipe", "pipe", "pipe"],
+        })
+    } catch {
+        return null
+    }
+
+    const hasPng =
+        clipInfo.includes("PNGf") || clipInfo.includes("public.png")
+    const hasTiff = clipInfo.includes("TIFF")
+
+    if (!hasPng && !hasTiff) {
+        return null
+    }
+
+    const tmpFile = join(tmpdir(), `mastra-clipboard-${Date.now()}.png`)
+
+    try {
+        const clipboardClass = hasPng ? "PNGf" : "TIFF"
+        const script = `
+            set theImage to the clipboard as «class ${clipboardClass}»
+            set theFile to open for access POSIX file "${tmpFile}" with write permission
+            write theImage to theFile
+            close access theFile
+        `
+        execSync(`osascript -e '${script.replace(/'/g, "'\\''")}'`, {
+            timeout: 5000,
+            stdio: ["pipe", "pipe", "pipe"],
+        })
+
+        const buffer = readFileSync(tmpFile)
+        const base64 = buffer.toString("base64")
+
+        return {
+            data: base64,
+            mimeType: hasPng ? "image/png" : "image/tiff",
+        }
+    } catch {
+        return null
+    } finally {
+        try {
+            unlinkSync(tmpFile)
+        } catch {
+            // ignore cleanup errors
+        }
+    }
+}
+
+// =============================================================================
+// Linux
+// =============================================================================
+
+function getLinuxClipboardImage(): ClipboardImage | null {
+    return getLinuxClipboardImageXclip() ?? getLinuxClipboardImageWlPaste()
+}
+
+function getLinuxClipboardImageXclip(): ClipboardImage | null {
+    try {
+        const targets = execSync(
+            "xclip -selection clipboard -target TARGETS -o",
+            {
+                encoding: "utf-8",
+                timeout: 3000,
+                stdio: ["pipe", "pipe", "pipe"],
+            },
+        )
+
+        if (!targets.includes("image/png")) {
+            return null
+        }
+
+        const buffer = execSync(
+            "xclip -selection clipboard -target image/png -o",
+            {
+                timeout: 5000,
+                stdio: ["pipe", "pipe", "pipe"],
+                maxBuffer: 50 * 1024 * 1024,
+            },
+        )
+
+        if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+            return null
+        }
+
+        return {
+            data: buffer.toString("base64"),
+            mimeType: "image/png",
+        }
+    } catch {
+        return null
+    }
+}
+
+function getLinuxClipboardImageWlPaste(): ClipboardImage | null {
+    try {
+        const types = execSync("wl-paste --list-types", {
+            encoding: "utf-8",
+            timeout: 3000,
+            stdio: ["pipe", "pipe", "pipe"],
+        })
+
+        if (!types.includes("image/png")) {
+            return null
+        }
+
+        const buffer = execSync("wl-paste --type image/png", {
+            timeout: 5000,
+            stdio: ["pipe", "pipe", "pipe"],
+            maxBuffer: 50 * 1024 * 1024,
+        })
+
+        if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+            return null
+        }
+
+        return {
+            data: buffer.toString("base64"),
+            mimeType: "image/png",
+        }
+    } catch {
+        return null
+    }
+}

--- a/mastracode/src/tui/components/dialogs/ask-question-dialog.ts
+++ b/mastracode/src/tui/components/dialogs/ask-question-dialog.ts
@@ -1,0 +1,33 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export interface AskQuestionDialogOption {
+    id: string
+    label: string
+}
+
+export interface AskQuestionDialogQuestion {
+    id: string
+    prompt: string
+    options: AskQuestionDialogOption[]
+    allowMultiple?: boolean
+}
+
+export class AskQuestionDialogComponent extends Container {
+    constructor(
+        title: string,
+        question: AskQuestionDialogQuestion,
+        onSubmit: (answers: string[]) => void,
+    ) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(new Text(`[question] ${title}`, 0, 0))
+        this.addChild(new Text(question.prompt, 0, 0))
+        for (const option of question.options) {
+            this.addChild(new Text(` - ${option.id}: ${option.label}`, 0, 0))
+        }
+        this.onSubmit = onSubmit
+    }
+
+    readonly onSubmit: (answers: string[]) => void
+}
+

--- a/mastracode/src/tui/components/dialogs/login-dialog.ts
+++ b/mastracode/src/tui/components/dialogs/login-dialog.ts
@@ -1,0 +1,13 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export class LoginDialogComponent extends Container {
+    constructor(onLogin: () => void) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(new Text("[login] Sign in required.", 0, 0))
+        this.onLogin = onLogin
+    }
+
+    readonly onLogin: () => void
+}
+

--- a/mastracode/src/tui/components/dialogs/login-selector.ts
+++ b/mastracode/src/tui/components/dialogs/login-selector.ts
@@ -1,0 +1,24 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export interface LoginProvider {
+    id: string
+    label: string
+}
+
+export class LoginSelectorComponent extends Container {
+    constructor(
+        providers: LoginProvider[],
+        onSelect: (providerId: string) => void,
+    ) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(new Text("Select login provider:", 0, 0))
+        for (const provider of providers) {
+            this.addChild(new Text(` - ${provider.id}: ${provider.label}`, 0, 0))
+        }
+        this.onSelect = onSelect
+    }
+
+    readonly onSelect: (providerId: string) => void
+}
+

--- a/mastracode/src/tui/components/dialogs/settings.ts
+++ b/mastracode/src/tui/components/dialogs/settings.ts
@@ -1,0 +1,19 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export interface SettingsItem {
+    key: string
+    label: string
+    value: string | number | boolean
+}
+
+export class SettingsComponent extends Container {
+    constructor(items: SettingsItem[]) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(new Text("Settings", 0, 0))
+        for (const item of items) {
+            this.addChild(new Text(` - ${item.label}: ${String(item.value)}`, 0, 0))
+        }
+    }
+}
+

--- a/mastracode/src/tui/components/dialogs/thinking-settings.ts
+++ b/mastracode/src/tui/components/dialogs/thinking-settings.ts
@@ -1,0 +1,22 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export class ThinkingSettingsComponent extends Container {
+    constructor(
+        enabled: boolean,
+        onToggle: (enabled: boolean) => void,
+    ) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(
+            new Text(
+                `Thinking visibility: ${enabled ? "enabled" : "hidden"}`,
+                0,
+                0,
+            ),
+        )
+        this.onToggle = onToggle
+    }
+
+    readonly onToggle: (enabled: boolean) => void
+}
+

--- a/mastracode/src/tui/components/index.ts
+++ b/mastracode/src/tui/components/index.ts
@@ -1,0 +1,54 @@
+export { AssistantMessageComponent } from "./message/assistant"
+export { UserMessageComponent } from "./message/user"
+
+export {
+    ToolExecutionComponentEnhanced,
+    type ToolResult,
+} from "./tool/execution-enhanced"
+export type { IToolExecutionComponent } from "./tool/execution-interface"
+export { ToolApprovalDialogComponent, type ApprovalAction } from "./tool/approval-dialog"
+export { ToolValidationErrorComponent } from "./tool/validation-error"
+
+export {
+    ThreadSelectorComponent,
+} from "./shared/thread-selector"
+export { ModelSelectorComponent, type ModelItem } from "./shared/model-selector"
+export { CustomEditor } from "./shared/custom-editor"
+export { Collapsible } from "./shared/collapsible"
+export { GradientAnimator, applyGradientSweep } from "./shared/obi-loader"
+
+export {
+    AskQuestionDialogComponent,
+    type AskQuestionDialogQuestion,
+    type AskQuestionDialogOption,
+} from "./dialogs/ask-question-dialog"
+export { LoginDialogComponent } from "./dialogs/login-dialog"
+export { LoginSelectorComponent, type LoginProvider } from "./dialogs/login-selector"
+export { SettingsComponent, type SettingsItem } from "./dialogs/settings"
+export { ThinkingSettingsComponent } from "./dialogs/thinking-settings"
+
+export { AskQuestionInlineComponent } from "./inline/ask-question-inline"
+export { PlanApprovalInlineComponent, PlanResultComponent } from "./inline/plan-approval-inline"
+
+export { SimpleProgressComponent } from "./progress/simple-progress"
+export { MultiStepProgressComponent, type MultiStepProgressItem } from "./progress/multi-step-progress"
+export { TodoProgressComponent, type TodoItem } from "./progress/todo-progress"
+
+export { DiffOutputComponent } from "./output/diff-output"
+export { ShellOutputComponent } from "./output/shell-output"
+export { SystemReminderComponent } from "./output/system-reminder"
+export { SlashCommandComponent } from "./output/slash-command"
+export { ErrorDisplayComponent } from "./output/error-display"
+export { SubagentExecutionComponent } from "./output/subagent-execution"
+
+export { OMMarkerComponent, type OMMarkerData } from "./om/marker"
+export { OMOutputComponent } from "./om/output"
+export {
+    OMProgressComponent,
+    defaultOMProgressState,
+    formatObservationStatus,
+    formatReflectionStatus,
+    type OMProgressState,
+} from "./om/progress"
+export { OMSettingsComponent, type OMSettings } from "./om/settings"
+

--- a/mastracode/src/tui/components/inline/ask-question-inline.ts
+++ b/mastracode/src/tui/components/inline/ask-question-inline.ts
@@ -1,0 +1,20 @@
+import { Container, Text } from "@mariozechner/pi-tui"
+import type { AskQuestionDialogQuestion } from "../dialogs/ask-question-dialog"
+
+export class AskQuestionInlineComponent extends Container {
+    constructor(
+        question: AskQuestionDialogQuestion,
+        onSubmit: (answers: string[]) => void,
+    ) {
+        super()
+        this.addChild(new Text(`[ask] ${question.prompt}`, 0, 0))
+        this.onSubmit = onSubmit
+    }
+
+    readonly onSubmit: (answers: string[]) => void
+
+    handleInput(_data: string): void {
+        // Input routing hook retained for runner integration.
+    }
+}
+

--- a/mastracode/src/tui/components/inline/plan-approval-inline.ts
+++ b/mastracode/src/tui/components/inline/plan-approval-inline.ts
@@ -1,0 +1,26 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export class PlanApprovalInlineComponent extends Container {
+    constructor(onDecision: (approved: boolean) => void) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(
+            new Text("[plan] Approve proposed plan? (y/n)", 0, 0),
+        )
+        this.onDecision = onDecision
+    }
+
+    readonly onDecision: (approved: boolean) => void
+
+    handleInput(_data: string): void {
+        // Input routing hook retained for runner integration.
+    }
+}
+
+export class PlanResultComponent extends Container {
+    constructor(message: string) {
+        super()
+        this.addChild(new Text(`[plan] ${message}`, 0, 0))
+    }
+}
+

--- a/mastracode/src/tui/components/message/assistant.ts
+++ b/mastracode/src/tui/components/message/assistant.ts
@@ -1,0 +1,152 @@
+
+/**
+ * Component that renders an assistant message with streaming support.
+ */
+
+import fs from "node:fs"
+import path from "node:path"
+import {
+    Container,
+    Markdown,
+    type MarkdownTheme,
+    Spacer,
+    Text,
+} from "@mariozechner/pi-tui"
+import type { HarnessMessage } from "@mastra/core/harness"
+import { getMarkdownTheme, theme } from "../../theme.js"
+
+let _compId = 0
+function asmDebugLog(...args: unknown[]) {
+    if (process.env.DEBUG_MASTRA_CODE !== `true`) {
+        return
+    }
+    const line = `[ASM ${new Date().toISOString()}] ${args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ")}\n`
+    try {
+        fs.appendFileSync(path.join(process.cwd(), "tui-debug.log"), line)
+    } catch { }
+}
+
+export class AssistantMessageComponent extends Container {
+    private contentContainer: Container
+    private hideThinkingBlock: boolean
+    private markdownTheme: MarkdownTheme
+    private lastMessage?: HarnessMessage
+    private _id: number
+
+    constructor(
+        message?: HarnessMessage,
+        hideThinkingBlock = false,
+        markdownTheme: MarkdownTheme = getMarkdownTheme(),
+    ) {
+        super()
+        this._id = ++_compId
+
+        this.hideThinkingBlock = hideThinkingBlock
+        this.markdownTheme = markdownTheme
+
+        // Container for text/thinking content
+        this.contentContainer = new Container()
+        this.addChild(this.contentContainer)
+
+        asmDebugLog(`COMP#${this._id} CREATED`)
+
+        if (message) {
+            this.updateContent(message)
+        }
+    }
+
+    override invalidate(): void {
+        super.invalidate()
+        if (this.lastMessage) {
+            const summary = this.lastMessage.content
+                .map((c) => (c.type === "text" ? `text(${c.text.length}ch)` : c.type))
+                .join(", ")
+            asmDebugLog(`COMP#${this._id} INVALIDATE lastMessage=[${summary}]`)
+            this.updateContent(this.lastMessage)
+        }
+    }
+
+    setHideThinkingBlock(hide: boolean): void {
+        this.hideThinkingBlock = hide
+        if (this.lastMessage) {
+            this.updateContent(this.lastMessage)
+        }
+    }
+
+    updateContent(message: HarnessMessage): void {
+        // Deep copy the message to prevent mutation from the harness's shared content array
+        this.lastMessage = {
+            ...message,
+            content: message.content.map((c) => ({ ...c })),
+        }
+
+        // Clear content container
+        this.contentContainer.clear()
+
+        const hasVisibleContent = message.content.some(
+            (c) =>
+                (c.type === "text" && c.text.trim()) ||
+                (c.type === "thinking" && c.thinking.trim()),
+        )
+
+        if (hasVisibleContent) {
+            this.contentContainer.addChild(new Spacer(1))
+        }
+
+        // Render content in order
+        for (let i = 0; i < message.content.length; i++) {
+            const content = message.content[i]
+
+            if (content.type === "text" && content.text.trim()) {
+                // Assistant text messages - trim the text
+                this.contentContainer.addChild(
+                    new Markdown(content.text.trim(), 1, 0, this.markdownTheme),
+                )
+            } else if (content.type === "thinking" && content.thinking.trim()) {
+                // Check if there's text content after this thinking block
+                const hasTextAfter = message.content
+                    .slice(i + 1)
+                    .some((c) => c.type === "text" && c.text.trim())
+
+                if (this.hideThinkingBlock) {
+                    // Show static "Thinking..." label when hidden
+                    this.contentContainer.addChild(
+                        new Text(
+                            theme.italic(theme.fg("thinkingText", "Thinking...")),
+                            1,
+                            0,
+                        ),
+                    )
+                    if (hasTextAfter) {
+                        this.contentContainer.addChild(new Spacer(1))
+                    }
+                } else {
+                    // Thinking traces in thinkingText color, italic
+                    this.contentContainer.addChild(
+                        new Markdown(content.thinking.trim(), 1, 0, this.markdownTheme, {
+                            color: (text: string) => theme.fg("thinkingText", text),
+                            italic: true,
+                        }),
+                    )
+                    this.contentContainer.addChild(new Spacer(1))
+                }
+            }
+            // Skip tool_call and tool_result - those are rendered by ToolExecutionComponent
+        }
+
+        // Check if aborted or error - show after partial content
+        if (message.stopReason === "aborted") {
+            const abortMessage = message.errorMessage || "Interrupted"
+            this.contentContainer.addChild(new Spacer(1))
+            this.contentContainer.addChild(
+                new Text(theme.fg("error", abortMessage), 1, 0),
+            )
+        } else if (message.stopReason === "error") {
+            const errorMsg = message.errorMessage || "Unknown error"
+            this.contentContainer.addChild(new Spacer(1))
+            this.contentContainer.addChild(
+                new Text(theme.fg("error", `Error: ${errorMsg}`), 1, 0),
+            )
+        }
+    }
+}

--- a/mastracode/src/tui/components/message/user.ts
+++ b/mastracode/src/tui/components/message/user.ts
@@ -1,0 +1,24 @@
+/**
+ * Component that renders a user message.
+ */
+
+import {
+    Container,
+    Markdown,
+    type MarkdownTheme,
+    Spacer,
+} from "@mariozechner/pi-tui"
+import { getMarkdownTheme, theme } from "../../theme.js"
+
+export class UserMessageComponent extends Container {
+    constructor(text: string, markdownTheme: MarkdownTheme = getMarkdownTheme()) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(
+            new Markdown(text, 1, 1, markdownTheme, {
+                bgColor: (text: string) => theme.bg("userMessageBg", text),
+                color: (text: string) => theme.fg("userMessageText", text),
+            }),
+        )
+    }
+}

--- a/mastracode/src/tui/components/om/marker.ts
+++ b/mastracode/src/tui/components/om/marker.ts
@@ -1,29 +1,132 @@
-import { Container, Text } from "@mariozechner/pi-tui"
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+import { fg } from "../../theme"
 
-export interface OMMarkerData {
-    label: string
-    active: boolean
+function formatTokens(tokens: number): string {
+    if (tokens === 0) return "0"
+    const k = tokens / 1000
+    return k % 1 === 0 ? `${k}k` : `${k.toFixed(1)}k`
 }
 
+export type OMMarkerData =
+    | {
+        type: "om_observation_start"
+        tokensToObserve: number
+        operationType?: "observation" | "reflection"
+    }
+    | {
+        type: "om_observation_end"
+        tokensObserved: number
+        observationTokens: number
+        durationMs: number
+        operationType?: "observation" | "reflection"
+    }
+    | {
+        type: "om_observation_failed"
+        error: string
+        tokensAttempted?: number
+        operationType?: "observation" | "reflection"
+    }
+    | {
+        type: "om_buffering_start"
+        operationType: "observation" | "reflection"
+        tokensToBuffer: number
+    }
+    | {
+        type: "om_buffering_end"
+        operationType: "observation" | "reflection"
+        tokensBuffered: number
+        bufferedTokens: number
+        observations?: string
+    }
+    | {
+        type: "om_buffering_failed"
+        operationType: "observation" | "reflection"
+        error: string
+    }
+    | {
+        type: "om_activation"
+        operationType: "observation" | "reflection"
+        tokensActivated: number
+        observationTokens: number
+    }
+
 export class OMMarkerComponent extends Container {
-    private textNode: Text
+    private textChild: Text
 
     constructor(data: OMMarkerData) {
         super()
-        this.textNode = new Text("", 0, 0)
-        this.addChild(this.textNode)
-        this.update(data)
+        this.addChild(new Spacer(1))
+        this.textChild = new Text(formatMarker(data), 0, 0)
+        this.addChild(this.textChild)
     }
 
     update(data: OMMarkerData): void {
-        this.clear()
-        this.textNode = new Text(
-            `[om:${data.active ? "active" : "idle"}] ${data.label}`,
-            0,
-            0,
-        )
-        this.addChild(this.textNode)
-        this.invalidate()
+        this.textChild.setText(formatMarker(data))
+    }
+}
+
+function formatMarker(data: OMMarkerData): string {
+    const isReflection = data.operationType === "reflection"
+    const label = isReflection ? "Reflection" : "Observation"
+
+    switch (data.type) {
+        case "om_observation_start": {
+            const tokens =
+                data.tokensToObserve > 0 ? ` ~${formatTokens(data.tokensToObserve)} tokens` : ""
+            return fg("muted", `  🧠 ${label} in progress${tokens}...`)
+        }
+        case "om_observation_end": {
+            const observed = formatTokens(data.tokensObserved)
+            const compressed = formatTokens(data.observationTokens)
+            const ratio =
+                data.tokensObserved > 0 && data.observationTokens > 0
+                    ? `${Math.round(data.tokensObserved / data.observationTokens)}x`
+                    : ""
+            const duration = (data.durationMs / 1000).toFixed(1)
+            const ratioStr = ratio ? ` (${ratio} compression)` : ""
+            return fg(
+                "success",
+                `  🧠 Observed: ${observed} -> ${compressed} tokens${ratioStr} in ${duration}s`,
+            )
+        }
+        case "om_observation_failed": {
+            const tokens = data.tokensAttempted
+                ? ` (${formatTokens(data.tokensAttempted)} tokens)`
+                : ""
+            return fg("error", `  x ${label} failed${tokens}: ${data.error}`)
+        }
+        case "om_buffering_start": {
+            const tokens =
+                data.tokensToBuffer > 0 ? ` ~${formatTokens(data.tokensToBuffer)} tokens` : ""
+            return fg("muted", `  o Buffering ${label.toLowerCase()}${tokens}...`)
+        }
+        case "om_buffering_end": {
+            const input = formatTokens(data.tokensBuffered)
+            const outputTokens =
+                data.operationType === "observation" && data.observations
+                    ? Math.round(data.observations.length / 4)
+                    : data.bufferedTokens
+            const output = formatTokens(outputTokens)
+            const ratio =
+                data.tokensBuffered > 0 && outputTokens > 0
+                    ? ` (${Math.round(data.tokensBuffered / outputTokens)}x)`
+                    : ""
+            return fg(
+                "success",
+                `  ok Buffered ${label.toLowerCase()}: ${input} -> ${output} tokens${ratio}`,
+            )
+        }
+        case "om_buffering_failed":
+            return fg("error", `  x Buffering ${label.toLowerCase()} failed: ${data.error}`)
+        case "om_activation": {
+            const kind = data.operationType === "reflection" ? "reflection" : "observations"
+            const msgTokens = formatTokens(data.tokensActivated)
+            const obsTokens = formatTokens(data.observationTokens)
+            return fg(
+                "success",
+                `  ok Activated ${kind}: -${msgTokens} msg tokens, +${obsTokens} obs tokens`,
+            )
+        }
     }
 }
 

--- a/mastracode/src/tui/components/om/marker.ts
+++ b/mastracode/src/tui/components/om/marker.ts
@@ -1,0 +1,29 @@
+import { Container, Text } from "@mariozechner/pi-tui"
+
+export interface OMMarkerData {
+    label: string
+    active: boolean
+}
+
+export class OMMarkerComponent extends Container {
+    private textNode: Text
+
+    constructor(data: OMMarkerData) {
+        super()
+        this.textNode = new Text("", 0, 0)
+        this.addChild(this.textNode)
+        this.update(data)
+    }
+
+    update(data: OMMarkerData): void {
+        this.clear()
+        this.textNode = new Text(
+            `[om:${data.active ? "active" : "idle"}] ${data.label}`,
+            0,
+            0,
+        )
+        this.addChild(this.textNode)
+        this.invalidate()
+    }
+}
+

--- a/mastracode/src/tui/components/om/output.ts
+++ b/mastracode/src/tui/components/om/output.ts
@@ -1,13 +1,134 @@
 import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+import chalk from "chalk"
+import { mastra } from "../../theme"
+
+const OBSERVER_COLOR = "#f59e0b"
+const REFLECTOR_COLOR = "#ef4444"
+const COLLAPSED_LINES = 10
+
+function formatTokens(tokens: number): string {
+    if (tokens === 0) return "0"
+    const k = tokens / 1000
+    return k % 1 === 0 ? `${k}k` : `${k.toFixed(1)}k`
+}
+
+export type OMOutputType = "observation" | "reflection"
+
+export interface OMOutputData {
+    type: OMOutputType
+    observations: string
+    currentTask?: string
+    suggestedResponse?: string
+    durationMs?: number
+    tokensObserved?: number
+    observationTokens?: number
+    compressedTokens?: number
+}
 
 export class OMOutputComponent extends Container {
-    constructor(entries: string[] = []) {
+    private data: OMOutputData
+    private expanded = false
+
+    constructor(data: OMOutputData) {
         super()
+        this.data = data
+        this.rebuild()
+    }
+
+    setExpanded(expanded: boolean): void {
+        this.expanded = expanded
+        this.rebuild()
+    }
+
+    toggleExpanded(): void {
+        this.setExpanded(!this.expanded)
+    }
+
+    private rebuild(): void {
+        this.clear()
         this.addChild(new Spacer(1))
-        this.addChild(new Text("[om] output", 0, 0))
-        for (const entry of entries) {
-            this.addChild(new Text(` - ${entry}`, 0, 0))
+
+        const isReflection = this.data.type === "reflection"
+        const color = isReflection ? REFLECTOR_COLOR : OBSERVER_COLOR
+        const border = (char: string) => chalk.bold.hex(color)(char)
+
+        const termWidth = process.stdout.columns || 80
+        const maxLineWidth = termWidth - 6
+        const allLines = this.data.observations.split("\n")
+        const lines =
+            !this.expanded && allLines.length > COLLAPSED_LINES
+                ? [
+                    ...allLines.slice(0, 5),
+                    `... ${allLines.length} lines total (ctrl+e to expand)`,
+                    ...allLines.slice(-4),
+                ]
+                : allLines
+
+        this.addChild(new Text(border("┌──"), 0, 0))
+        for (const line of lines) {
+            const clipped = line.length > maxLineWidth ? `${line.slice(0, maxLineWidth - 1)}…` : line
+            this.addChild(
+                new Text(border("│") + " " + chalk.hex(mastra.specialGray)(clipped), 0, 0),
+            )
         }
+
+        if (this.data.currentTask && this.expanded) {
+            this.addChild(
+                new Text(
+                    border("│") +
+                    " " +
+                    chalk.hex(color).bold("Current task: ") +
+                    chalk.hex(mastra.specialGray)(this.data.currentTask),
+                    0,
+                    0,
+                ),
+            )
+        }
+        if (this.data.suggestedResponse && this.expanded) {
+            this.addChild(
+                new Text(
+                    border("│") +
+                    " " +
+                    chalk.hex(color).bold("Suggested response: ") +
+                    chalk.hex(mastra.specialGray)(this.data.suggestedResponse),
+                    0,
+                    0,
+                ),
+            )
+        }
+
+        this.addChild(new Text(`${border("└──")} ${this.buildFooterText(color)}`, 0, 0))
+    }
+
+    private buildFooterText(color: string): string {
+        const isReflection = this.data.type === "reflection"
+        if (isReflection) {
+            const observed = formatTokens(this.data.tokensObserved ?? 0)
+            const compressed = formatTokens(
+                this.data.compressedTokens ?? this.data.observationTokens ?? 0,
+            )
+            const ratio =
+                (this.data.tokensObserved ?? 0) > 0 &&
+                    (this.data.compressedTokens ?? this.data.observationTokens ?? 0) > 0
+                    ? `${Math.round((this.data.tokensObserved ?? 0) / (this.data.compressedTokens ?? this.data.observationTokens ?? 1))}x`
+                    : ""
+            const durationStr = this.data.durationMs
+                ? ` in ${(this.data.durationMs / 1000).toFixed(1)}s`
+                : ""
+            const ratioStr = ratio ? ` (${ratio} compression)` : ""
+            return chalk
+                .hex(color)(`Reflected: ${observed} -> ${compressed} tokens${ratioStr}${durationStr}`)
+        }
+
+        const observed = formatTokens(this.data.tokensObserved ?? 0)
+        const compressed = formatTokens(this.data.observationTokens ?? 0)
+        const ratio =
+            (this.data.tokensObserved ?? 0) > 0 && (this.data.observationTokens ?? 0) > 0
+                ? `${Math.round((this.data.tokensObserved ?? 0) / (this.data.observationTokens ?? 1))}x`
+                : ""
+        const durationStr = this.data.durationMs ? ` in ${(this.data.durationMs / 1000).toFixed(1)}s` : ""
+        const ratioStr = ratio ? ` (${ratio} compression)` : ""
+        return chalk.hex(color)(`Observed: ${observed} -> ${compressed} tokens${ratioStr}${durationStr}`)
     }
 }
 

--- a/mastracode/src/tui/components/om/output.ts
+++ b/mastracode/src/tui/components/om/output.ts
@@ -1,0 +1,13 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export class OMOutputComponent extends Container {
+    constructor(entries: string[] = []) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(new Text("[om] output", 0, 0))
+        for (const entry of entries) {
+            this.addChild(new Text(` - ${entry}`, 0, 0))
+        }
+    }
+}
+

--- a/mastracode/src/tui/components/om/progress.ts
+++ b/mastracode/src/tui/components/om/progress.ts
@@ -1,0 +1,241 @@
+import { Container, Text } from "@mariozechner/pi-tui"
+import chalk from "chalk"
+import { fg, mastra } from "../../theme"
+
+export type OMStatus = "idle" | "observing" | "reflecting"
+export type OMBufferedStatus = "idle" | "running" | "complete"
+
+export interface OMProgressState {
+    status: OMStatus
+    pendingTokens: number
+    threshold: number
+    thresholdPercent: number
+    observationTokens: number
+    reflectionThreshold: number
+    reflectionThresholdPercent: number
+    buffered: {
+        observations: {
+            status: OMBufferedStatus
+            chunks: number
+            messageTokens: number
+            projectedMessageRemoval: number
+            observationTokens: number
+        }
+        reflection: {
+            status: OMBufferedStatus
+            inputObservationTokens: number
+            observationTokens: number
+        }
+    }
+    generationCount: number
+    stepNumber: number
+    cycleId?: string
+    startTime?: number
+    // Compatibility shape used by current local TUI event code.
+    observing?: boolean
+    reflecting?: boolean
+    bufferingMessages?: boolean
+    bufferingObservations?: boolean
+}
+
+export function defaultOMProgressState(): OMProgressState {
+    return {
+        status: "idle",
+        pendingTokens: 0,
+        threshold: 30000,
+        thresholdPercent: 0,
+        observationTokens: 0,
+        reflectionThreshold: 40000,
+        reflectionThresholdPercent: 0,
+        buffered: {
+            observations: {
+                status: "idle",
+                chunks: 0,
+                messageTokens: 0,
+                projectedMessageRemoval: 0,
+                observationTokens: 0,
+            },
+            reflection: {
+                status: "idle",
+                inputObservationTokens: 0,
+                observationTokens: 0,
+            },
+        },
+        generationCount: 0,
+        stepNumber: 0,
+        observing: false,
+        reflecting: false,
+        bufferingMessages: false,
+        bufferingObservations: false,
+    }
+}
+
+export class OMProgressComponent extends Container {
+    private state: OMProgressState = defaultOMProgressState()
+    private statusText: Text
+    private spinnerFrame = 0
+
+    constructor(state: OMProgressState = defaultOMProgressState()) {
+        super()
+        this.statusText = new Text("")
+        this.children.push(this.statusText)
+        this.update(state)
+    }
+
+    update(state: OMProgressState): void {
+        this.state = normalizeState(state, this.state)
+        this.updateDisplay()
+        this.invalidate()
+    }
+
+    private updateDisplay(): void {
+        if (this.state.status === "idle") {
+            if (this.state.thresholdPercent > 0) {
+                const percent = Math.round(this.state.thresholdPercent)
+                const bar = this.renderProgressBar(percent, 10)
+                this.statusText.setText(fg("muted", `OM ${bar} ${percent}%`))
+            } else {
+                this.statusText.setText("")
+            }
+            return
+        }
+        if (this.state.status === "observing") {
+            const elapsed = this.state.startTime
+                ? Math.round((Date.now() - this.state.startTime) / 1000)
+                : 0
+            this.statusText.setText(
+                chalk.hex(mastra.orange)(`${this.getSpinner()} Observing... ${elapsed}s`),
+            )
+            return
+        }
+        const elapsed = this.state.startTime
+            ? Math.round((Date.now() - this.state.startTime) / 1000)
+            : 0
+        this.statusText.setText(
+            chalk.hex(mastra.pink)(`${this.getSpinner()} Reflecting... ${elapsed}s`),
+        )
+    }
+
+    private renderProgressBar(percent: number, width: number): string {
+        const filled = Math.min(width, Math.round((percent / 100) * width))
+        const empty = width - filled
+        const bar = "━".repeat(filled) + "─".repeat(empty)
+        if (percent >= 90) return chalk.hex(mastra.red)(bar)
+        if (percent >= 70) return chalk.hex(mastra.orange)(bar)
+        return chalk.hex(mastra.darkGray)(bar)
+    }
+
+    private getSpinner(): string {
+        const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+        this.spinnerFrame = (this.spinnerFrame + 1) % frames.length
+        return frames[this.spinnerFrame]!
+    }
+
+    render(maxWidth: number): string[] {
+        this.updateDisplay()
+        return this.statusText.render(maxWidth)
+    }
+}
+
+function formatTokensValue(n: number): string {
+    if (n === 0) return "0"
+    const k = n / 1000
+    const s = k.toFixed(1)
+    return s.endsWith(".0") ? s.slice(0, -2) : s
+}
+
+function formatTokensThreshold(n: number): string {
+    const k = n / 1000
+    const s = k.toFixed(1)
+    return `${s.endsWith(".0") ? s.slice(0, -2) : s}k`
+}
+
+function colorByPercent(text: string, percent: number): string {
+    if (percent >= 90) return chalk.hex(mastra.red)(text)
+    if (percent >= 70) return chalk.hex(mastra.orange)(text)
+    return chalk.hex(mastra.darkGray)(text)
+}
+
+export function formatObservationStatus(
+    state: OMProgressState,
+    compact?: "percentOnly" | "noBuffer" | "full",
+    labelStyler?: (label: string) => string,
+): string {
+    const percent = Math.round(state.thresholdPercent)
+    const pct = colorByPercent(`${percent}%`, percent)
+    const style = labelStyler ?? ((s: string) => chalk.hex(mastra.specialGray)(s))
+    if (compact === "percentOnly") return style("msg ") + pct
+    const label = compact === "full" ? "messages" : "msg"
+    const fraction = `${formatTokensValue(state.pendingTokens)}/${formatTokensThreshold(state.threshold)}`
+    const buffered =
+        compact !== "noBuffer" && state.buffered.observations.projectedMessageRemoval > 0
+            ? chalk.hex("#555")(
+                ` ↓${formatTokensThreshold(state.buffered.observations.projectedMessageRemoval)}`,
+            )
+            : ""
+    return style(`${label} `) + colorByPercent(fraction, percent) + buffered
+}
+
+export function formatReflectionStatus(
+    state: OMProgressState,
+    compact?: "percentOnly" | "noBuffer" | "full",
+    labelStyler?: (label: string) => string,
+): string {
+    const percent = Math.round(state.reflectionThresholdPercent)
+    const pct = colorByPercent(`${percent}%`, percent)
+    const style = labelStyler ?? ((s: string) => chalk.hex(mastra.specialGray)(s))
+    const label = style(compact === "full" ? "memory" : "mem") + " "
+    if (compact === "percentOnly") return label + pct
+    const fraction = `${formatTokensValue(state.observationTokens)}/${formatTokensThreshold(state.reflectionThreshold)}`
+    const savings =
+        state.buffered.reflection.inputObservationTokens -
+        state.buffered.reflection.observationTokens
+    const buffered =
+        compact !== "noBuffer" && state.buffered.reflection.status === "complete"
+            ? chalk.hex("#555")(` ↓${formatTokensThreshold(savings)}`)
+            : ""
+    return label + colorByPercent(fraction, percent) + buffered
+}
+
+export function formatOMStatus(state: OMProgressState): string {
+    return formatObservationStatus(state)
+}
+
+function normalizeState(
+    next: OMProgressState,
+    prev: OMProgressState,
+): OMProgressState {
+    const statusFromBooleans =
+        next.observing === true
+            ? "observing"
+            : next.reflecting === true
+                ? "reflecting"
+                : "idle"
+
+    const merged: OMProgressState = {
+        ...prev,
+        ...next,
+        status: next.status ?? statusFromBooleans,
+    }
+
+    merged.buffered = {
+        observations: {
+            ...prev.buffered.observations,
+            ...next.buffered?.observations,
+            status:
+                next.buffered?.observations?.status ??
+                (next.bufferingMessages ? "running" : prev.buffered.observations.status),
+        },
+        reflection: {
+            ...prev.buffered.reflection,
+            ...next.buffered?.reflection,
+            status:
+                next.buffered?.reflection?.status ??
+                (next.bufferingObservations
+                    ? "running"
+                    : prev.buffered.reflection.status),
+        },
+    }
+    return merged
+}
+

--- a/mastracode/src/tui/components/om/settings.ts
+++ b/mastracode/src/tui/components/om/settings.ts
@@ -1,0 +1,22 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export interface OMSettings {
+    enabled: boolean
+    minImportance?: number
+    minNovelty?: number
+}
+
+export class OMSettingsComponent extends Container {
+    constructor(settings: OMSettings) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(
+            new Text(
+                `[om:settings] enabled=${settings.enabled} importance=${settings.minImportance ?? "n/a"} novelty=${settings.minNovelty ?? "n/a"}`,
+                0,
+                0,
+            ),
+        )
+    }
+}
+

--- a/mastracode/src/tui/components/output/diff-output.ts
+++ b/mastracode/src/tui/components/output/diff-output.ts
@@ -1,0 +1,11 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export class DiffOutputComponent extends Container {
+    constructor(diffText: string) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(new Text("[diff]", 0, 0))
+        this.addChild(new Text(diffText, 0, 0))
+    }
+}
+

--- a/mastracode/src/tui/components/output/error-display.ts
+++ b/mastracode/src/tui/components/output/error-display.ts
@@ -1,0 +1,59 @@
+import { Container, Spacer, Text, type TUI } from "@mariozechner/pi-tui"
+import { bg, bold, fg } from "../../theme"
+import { CollapsibleComponent } from "../shared/collapsible"
+
+interface ErrorInfo {
+    message: string
+    name?: string
+    stack?: string
+}
+
+function parseErrorInfo(error: Error | string): ErrorInfo {
+    if (typeof error === "string") {
+        const lines = error.split("\n").filter((line) => line.trim())
+        const firstLine = lines[0] || ""
+        const m = firstLine.match(/^([A-Z][a-zA-Z]*Error):\s*(.+)$/)
+        if (m) {
+            return { name: m[1], message: m[2], stack: lines.slice(1).join("\n") }
+        }
+        return {
+            message: firstLine,
+            stack: lines.length > 1 ? lines.slice(1).join("\n") : undefined,
+        }
+    }
+    return { name: error.name, message: error.message, stack: error.stack }
+}
+
+export class ErrorDisplayComponent extends Container {
+    constructor(
+        error: Error | string,
+        options: { showStack?: boolean; expanded?: boolean } = {},
+        ui?: TUI,
+    ) {
+        super()
+        const info = parseErrorInfo(error)
+        this.addChild(new Spacer(1))
+        this.addChild(new Text(fg("error", `┌─ Error ${"─".repeat(40)}┐`), 0, 0))
+        const name = info.name && info.name !== "Error" ? `${info.name}: ` : ""
+        this.addChild(new Text(`│ ${bg("errorBg", ` ${bold(fg("error", `${name}${info.message}`))} `)}`, 0, 0))
+        if (options.showStack && info.stack && ui) {
+            this.addChild(new Spacer(1))
+            const stackSection = new CollapsibleComponent(
+                {
+                    header: "Stack Trace",
+                    expanded: options.expanded ?? false,
+                    collapsedLines: 5,
+                    expandedLines: 100,
+                    showLineCount: true,
+                },
+                ui,
+            )
+            stackSection.setContent(info.stack)
+            this.addChild(
+                stackSection,
+            )
+        }
+        this.addChild(new Text(fg("error", `└${"─".repeat(50)}┘`), 0, 0))
+    }
+}
+

--- a/mastracode/src/tui/components/output/shell-output.ts
+++ b/mastracode/src/tui/components/output/shell-output.ts
@@ -1,0 +1,11 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export class ShellOutputComponent extends Container {
+    constructor(command: string, output: string) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(new Text(`[shell] ${command}`, 0, 0))
+        this.addChild(new Text(output, 0, 0))
+    }
+}
+

--- a/mastracode/src/tui/components/output/slash-command.ts
+++ b/mastracode/src/tui/components/output/slash-command.ts
@@ -1,0 +1,32 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export class SlashCommandComponent extends Container {
+    private expanded = false
+    private content: Container
+    private command: string
+    private result: string
+
+    constructor(command: string, result: string) {
+        super()
+        this.command = command
+        this.result = result
+        this.content = new Container()
+        this.addChild(this.content)
+        this.renderContent()
+    }
+
+    setExpanded(expanded: boolean): void {
+        this.expanded = expanded
+        this.renderContent()
+    }
+
+    private renderContent(): void {
+        this.content.clear()
+        this.content.addChild(new Spacer(1))
+        this.content.addChild(new Text(`[slash] ${this.command}`, 0, 0))
+        if (this.expanded) {
+            this.content.addChild(new Text(this.result, 0, 0))
+        }
+    }
+}
+

--- a/mastracode/src/tui/components/output/subagent-execution.ts
+++ b/mastracode/src/tui/components/output/subagent-execution.ts
@@ -1,0 +1,10 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export class SubagentExecutionComponent extends Container {
+    constructor(agentName: string, status: string) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(new Text(`[subagent] ${agentName}: ${status}`, 0, 0))
+    }
+}
+

--- a/mastracode/src/tui/components/output/system-reminder.ts
+++ b/mastracode/src/tui/components/output/system-reminder.ts
@@ -1,0 +1,10 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export class SystemReminderComponent extends Container {
+    constructor(message: string) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(new Text(`[system] ${message}`, 0, 0))
+    }
+}
+

--- a/mastracode/src/tui/components/progress/multi-step-progress.ts
+++ b/mastracode/src/tui/components/progress/multi-step-progress.ts
@@ -1,0 +1,36 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export interface MultiStepProgressItem {
+    id: string
+    label: string
+    status: "pending" | "in_progress" | "completed" | "cancelled"
+}
+
+export class MultiStepProgressComponent extends Container {
+    private content: Container
+
+    constructor(items: MultiStepProgressItem[] = []) {
+        super()
+        this.content = new Container()
+        this.addChild(this.content)
+        this.setItems(items)
+    }
+
+    setItems(items: MultiStepProgressItem[]): void {
+        this.content.clear()
+        this.content.addChild(new Spacer(1))
+        this.content.addChild(new Text("Progress", 0, 0))
+        for (const item of items) {
+            const marker =
+                item.status === "completed"
+                    ? "ok"
+                    : item.status === "in_progress"
+                        ? ">"
+                        : item.status === "cancelled"
+                            ? "x"
+                            : "-"
+            this.content.addChild(new Text(` ${marker} ${item.label}`, 0, 0))
+        }
+    }
+}
+

--- a/mastracode/src/tui/components/progress/multi-step-progress.ts
+++ b/mastracode/src/tui/components/progress/multi-step-progress.ts
@@ -18,6 +18,9 @@ export class MultiStepProgressComponent extends Container {
 
     setItems(items: MultiStepProgressItem[]): void {
         this.content.clear()
+        if (items.length === 0) {
+            return
+        }
         this.content.addChild(new Spacer(1))
         this.content.addChild(new Text("Progress", 0, 0))
         for (const item of items) {

--- a/mastracode/src/tui/components/progress/simple-progress.ts
+++ b/mastracode/src/tui/components/progress/simple-progress.ts
@@ -1,0 +1,19 @@
+import { Container, Text } from "@mariozechner/pi-tui"
+
+export class SimpleProgressComponent extends Container {
+    private textNode: Text
+
+    constructor(label = "Working...") {
+        super()
+        this.textNode = new Text(label, 0, 0)
+        this.addChild(this.textNode)
+    }
+
+    setLabel(label: string): void {
+        this.clear()
+        this.textNode = new Text(label, 0, 0)
+        this.addChild(this.textNode)
+        this.invalidate()
+    }
+}
+

--- a/mastracode/src/tui/components/progress/todo-progress.ts
+++ b/mastracode/src/tui/components/progress/todo-progress.ts
@@ -1,0 +1,23 @@
+import { MultiStepProgressComponent, type MultiStepProgressItem } from "./multi-step-progress"
+
+export interface TodoItem {
+    id: string
+    content: string
+    status: "pending" | "in_progress" | "completed" | "cancelled"
+}
+
+export class TodoProgressComponent extends MultiStepProgressComponent {
+    constructor() {
+        super([])
+    }
+
+    updateTodos(todos: TodoItem[]): void {
+        const items: MultiStepProgressItem[] = todos.map((todo) => ({
+            id: todo.id,
+            label: todo.content,
+            status: todo.status,
+        }))
+        this.setItems(items)
+    }
+}
+

--- a/mastracode/src/tui/components/shared/collapsible.ts
+++ b/mastracode/src/tui/components/shared/collapsible.ts
@@ -1,0 +1,170 @@
+import { Container, Text, type TUI } from "@mariozechner/pi-tui"
+import { highlight } from "cli-highlight"
+import { theme } from "../../theme"
+
+export interface CollapsibleOptions {
+    expanded?: boolean
+    header: string | Container
+    summary?: string
+    collapsedLines?: number
+    expandedLines?: number
+    showLineCount?: boolean
+}
+
+export class CollapsibleComponent extends Container {
+    private expanded: boolean
+    private header: string | Container
+    protected summary?: string
+    private content: string[] = []
+    private options: CollapsibleOptions
+    private ui: TUI
+
+    constructor(options: CollapsibleOptions, ui: TUI) {
+        super()
+        this.options = {
+            expanded: false,
+            collapsedLines: 10,
+            expandedLines: 100,
+            showLineCount: true,
+            ...options,
+        }
+        this.expanded = this.options.expanded ?? false
+        this.header = options.header
+        this.summary = options.summary
+        this.ui = ui
+        this.updateDisplay()
+    }
+
+    setContent(content: string | string[]): void {
+        this.content = Array.isArray(content) ? content : content.split("\n")
+        this.updateDisplay()
+    }
+
+    isExpanded(): boolean {
+        return this.expanded
+    }
+
+    setExpanded(expanded: boolean): void {
+        this.expanded = expanded
+        this.updateDisplay()
+    }
+
+    toggle(): void {
+        this.expanded = !this.expanded
+        this.updateDisplay()
+    }
+
+    private updateDisplay(): void {
+        this.clear()
+        const lineCount =
+            this.options.showLineCount && this.content.length > 0
+                ? theme.fg("muted", ` (${this.content.length} lines)`)
+                : ""
+
+        const headerText =
+            typeof this.header === "string"
+                ? `${this.header}${lineCount}`
+                : this.header
+
+        if (typeof headerText === "string") {
+            this.addChild(new Text(headerText, 0, 0))
+        } else {
+            this.addChild(headerText)
+        }
+
+        if (!this.expanded && this.summary) {
+            this.addChild(new Text(theme.fg("muted", this.summary), 0, 0))
+            return
+        }
+        if (this.content.length === 0) return
+
+        const maxLines = this.expanded
+            ? this.options.expandedLines!
+            : this.options.collapsedLines!
+        if (maxLines === 0 && !this.expanded) return
+
+        const linesToShow = Math.min(this.content.length, maxLines)
+        const hasMore = this.content.length > maxLines
+        for (let i = 0; i < linesToShow; i++) {
+            this.addChild(new Text(this.content[i]!, 0, 0))
+        }
+        if (hasMore) {
+            const remaining = this.content.length - linesToShow
+            const action = this.expanded ? "collapse" : "expand"
+            this.addChild(
+                new Text(
+                    theme.fg("muted", `... ${remaining} more lines (Ctrl+E to ${action} all)`),
+                    0,
+                    0,
+                ),
+            )
+        }
+    }
+}
+
+export class CollapsibleFileViewer extends CollapsibleComponent {
+    constructor(
+        path: string,
+        content: string,
+        options: Partial<CollapsibleOptions>,
+        ui: TUI,
+    ) {
+        const lines = content.split("\n").map((line) => line.trimEnd())
+        let codeLines = lines
+        if (lines.length > 0 && lines[0]!.includes("Here's the result of running")) {
+            codeLines = lines.slice(1)
+        }
+        codeLines = codeLines.map((line) => line.replace(/^\s*\d+\t/, ""))
+        while (codeLines.length > 0 && codeLines[codeLines.length - 1] === "") {
+            codeLines.pop()
+        }
+
+        let highlightedLines = codeLines
+        try {
+            const highlighted = highlight(codeLines.join("\n"), {
+                language: getLanguageFromPath(path),
+                ignoreIllegals: true,
+            })
+            highlightedLines = highlighted.split("\n")
+        } catch { }
+
+        const header = `${theme.bold(theme.fg("toolTitle", "view"))} ${theme.fg("accent", path)}`
+        super(
+            {
+                header,
+                collapsedLines: 20,
+                expandedLines: 200,
+                showLineCount: true,
+                ...options,
+            },
+            ui,
+        )
+        this.setContent(highlightedLines)
+    }
+}
+
+function getLanguageFromPath(path: string): string | undefined {
+    const ext = path.split(".").pop()?.toLowerCase()
+    const langMap: Record<string, string> = {
+        ts: "typescript",
+        tsx: "typescript",
+        js: "javascript",
+        jsx: "javascript",
+        json: "json",
+        md: "markdown",
+        py: "python",
+        rb: "ruby",
+        rs: "rust",
+        go: "go",
+        java: "java",
+        css: "css",
+        scss: "scss",
+        sql: "sql",
+        yml: "yaml",
+        yaml: "yaml",
+    }
+    return ext ? langMap[ext] : undefined
+}
+
+export const Collapsible = CollapsibleComponent
+

--- a/mastracode/src/tui/components/shared/custom-editor.ts
+++ b/mastracode/src/tui/components/shared/custom-editor.ts
@@ -1,0 +1,79 @@
+import {
+    Editor,
+    matchesKey,
+    type EditorTheme,
+    type TUI,
+} from "@mariozechner/pi-tui"
+
+type EditorAction =
+    | "clear"
+    | "undo"
+    | "toggleThinking"
+    | "expandTools"
+    | "followUp"
+    | "cycleMode"
+    | "toggleYolo"
+
+export class CustomEditor extends Editor {
+    private handlers = new Map<EditorAction, () => void>()
+
+    onImagePaste?: (image: { data: string; mimeType: string }) => void
+    onCtrlD?: () => void
+    escapeEnabled = true
+
+    constructor(tui: TUI, theme: EditorTheme) {
+        super(tui, theme)
+    }
+
+    onAction(action: EditorAction, callback: () => void): void {
+        this.handlers.set(action, callback)
+    }
+
+    private triggerAction(action: EditorAction): void {
+        this.handlers.get(action)?.()
+    }
+
+    override handleInput(data: string): void {
+        if (matchesKey(data, "ctrl+c")) {
+            this.triggerAction("clear")
+            return
+        }
+        if (matchesKey(data, "escape") && this.escapeEnabled) {
+            this.triggerAction("clear")
+            return
+        }
+        if (matchesKey(data, "ctrl+d")) {
+            if (this.getText().length === 0) {
+                this.onCtrlD?.()
+            }
+            return
+        }
+        if (matchesKey(data, "ctrl+z")) {
+            this.triggerAction("undo")
+            return
+        }
+        if (matchesKey(data, "ctrl+t")) {
+            this.triggerAction("toggleThinking")
+            return
+        }
+        if (matchesKey(data, "ctrl+e")) {
+            this.triggerAction("expandTools")
+            return
+        }
+        if (matchesKey(data, "ctrl+f")) {
+            this.triggerAction("followUp")
+            return
+        }
+        if (matchesKey(data, "shift+tab")) {
+            this.triggerAction("cycleMode")
+            return
+        }
+        if (matchesKey(data, "ctrl+y")) {
+            this.triggerAction("toggleYolo")
+            return
+        }
+
+        super.handleInput(data)
+    }
+}
+

--- a/mastracode/src/tui/components/shared/model-selector.ts
+++ b/mastracode/src/tui/components/shared/model-selector.ts
@@ -1,0 +1,33 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export interface ModelItem {
+    id: string
+    label: string
+    description?: string
+}
+
+export class ModelSelectorComponent extends Container {
+    constructor(
+        models: ModelItem[],
+        currentId: string,
+        onSelect: (id: string) => void,
+    ) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(new Text("Available models:", 0, 0))
+        for (const model of models) {
+            const marker = model.id === currentId ? "*" : " "
+            this.addChild(
+                new Text(
+                    ` ${marker} ${model.id} - ${model.label}${model.description ? ` (${model.description})` : ""}`,
+                    0,
+                    0,
+                ),
+            )
+        }
+        this.onSelect = onSelect
+    }
+
+    readonly onSelect: (id: string) => void
+}
+

--- a/mastracode/src/tui/components/shared/obi-loader.ts
+++ b/mastracode/src/tui/components/shared/obi-loader.ts
@@ -1,0 +1,121 @@
+import chalk from "chalk"
+
+const GRADIENT_WIDTH = 30
+const BASE_COLOR: [number, number, number] = [124, 58, 237]
+const MIN_BRIGHTNESS = 0.45
+const IDLE_BRIGHTNESS = 0.8
+
+function hexToRgb(hex: string): [number, number, number] {
+    const h = hex.replace("#", "")
+    return [
+        parseInt(h.slice(0, 2), 16),
+        parseInt(h.slice(2, 4), 16),
+        parseInt(h.slice(4, 6), 16),
+    ]
+}
+
+export function applyGradientSweep(
+    text: string,
+    offset: number,
+    color?: string,
+    fadeProgress = 0,
+): string {
+    const chars = [...text]
+    const totalChars = chars.length
+    if (totalChars === 0) return text
+    const baseColor = color ? hexToRgb(color) : BASE_COLOR
+    const gradientCenter = (offset % 1) * 100
+
+    return chars
+        .map((char, i) => {
+            if (char === " ") return " "
+            const charPosition = (i / totalChars) * 100
+            let distance = Math.abs(charPosition - gradientCenter)
+            if (distance > 50) distance = 100 - distance
+            const normalizedDistance = Math.min(distance / (GRADIENT_WIDTH / 2), 1)
+            const animBrightness =
+                MIN_BRIGHTNESS + (1 - MIN_BRIGHTNESS) * (1 - normalizedDistance)
+            const brightness =
+                animBrightness + (IDLE_BRIGHTNESS - animBrightness) * fadeProgress
+
+            const r = Math.floor(baseColor[0] * brightness)
+            const g = Math.floor(baseColor[1] * brightness)
+            const b = Math.floor(baseColor[2] * brightness)
+            return chalk.rgb(r, g, b)(char)
+        })
+        .join("")
+}
+
+export class GradientAnimator {
+    private offset = 0
+    private intervalId: ReturnType<typeof setInterval> | null = null
+    private onTick: () => void
+    private isFadingOutState = false
+    private isFadingInState = false
+    private fadeProgress = 0
+
+    constructor(onTick: () => void) {
+        this.onTick = onTick
+    }
+
+    start(): void {
+        if (this.intervalId && !this.isFadingOutState) return
+        if (this.intervalId) {
+            clearInterval(this.intervalId)
+            this.intervalId = null
+        }
+        this.isFadingOutState = false
+        this.isFadingInState = true
+        this.fadeProgress = 1
+        this.offset = 0
+        this.intervalId = setInterval(() => {
+            this.offset += 0.03
+            if (this.isFadingInState) {
+                this.fadeProgress -= 0.06
+                if (this.fadeProgress <= 0) {
+                    this.fadeProgress = 0
+                    this.isFadingInState = false
+                }
+            }
+            this.onTick()
+        }, 80)
+    }
+
+    fadeOut(): void {
+        if (!this.intervalId || this.isFadingOutState) return
+        this.isFadingOutState = true
+        this.fadeProgress = 0
+        clearInterval(this.intervalId)
+        this.intervalId = setInterval(() => {
+            this.fadeProgress += 0.08
+            if (this.fadeProgress >= 1) {
+                this.fadeProgress = 1
+                this.stop()
+            }
+            this.onTick()
+        }, 40)
+    }
+
+    stop(): void {
+        if (this.intervalId) {
+            clearInterval(this.intervalId)
+            this.intervalId = null
+        }
+        this.isFadingOutState = false
+        this.fadeProgress = 0
+        this.offset = 0
+    }
+
+    getOffset(): number {
+        return this.offset
+    }
+
+    getFadeProgress(): number {
+        return this.fadeProgress
+    }
+
+    isRunning(): boolean {
+        return this.intervalId !== null
+    }
+}
+

--- a/mastracode/src/tui/components/shared/thread-selector.ts
+++ b/mastracode/src/tui/components/shared/thread-selector.ts
@@ -1,0 +1,24 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+import type { HarnessThread } from "@mastra/core/harness"
+
+export class ThreadSelectorComponent extends Container {
+    constructor(
+        threads: HarnessThread[],
+        currentThreadId: string | null,
+        onSelect: (threadId: string) => void,
+    ) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(new Text("Threads:", 0, 0))
+        for (const thread of threads) {
+            const marker = thread.id === currentThreadId ? "*" : " "
+            this.addChild(
+                new Text(` ${marker} ${thread.title ?? "Untitled"} (${thread.id})`, 0, 0),
+            )
+        }
+        this.onSelect = onSelect
+    }
+
+    readonly onSelect: (threadId: string) => void
+}
+

--- a/mastracode/src/tui/components/tool/approval-dialog.ts
+++ b/mastracode/src/tui/components/tool/approval-dialog.ts
@@ -1,0 +1,25 @@
+import { Container, Spacer, Text } from "@mariozechner/pi-tui"
+
+export type ApprovalAction = "approve" | "decline"
+
+export class ToolApprovalDialogComponent extends Container {
+    constructor(
+        toolName: string,
+        onDecision: (decision: ApprovalAction) => void,
+    ) {
+        super()
+        this.addChild(new Spacer(1))
+        this.addChild(
+            new Text(
+                `[approval] ${toolName} requested. Type 'y' to approve or 'n' to deny.`,
+                0,
+                0,
+            ),
+        )
+        // Keep callback for parity with upstream dialog shape.
+        this.onDecision = onDecision
+    }
+
+    readonly onDecision: (decision: ApprovalAction) => void
+}
+

--- a/mastracode/src/tui/components/tool/execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool/execution-enhanced.ts
@@ -1,0 +1,241 @@
+import * as os from "node:os"
+import { Box, Container, Spacer, Text } from "@mariozechner/pi-tui"
+import { theme } from "../../theme"
+import { ErrorDisplayComponent } from "../output/error-display"
+import type {
+    IToolExecutionComponent,
+    ToolResult,
+    ToolResultPart,
+} from "./execution-interface"
+import {
+    parseValidationErrors,
+    ToolValidationErrorComponent,
+} from "./validation-error"
+
+export type { ToolResult }
+
+export class ToolExecutionComponentEnhanced
+    extends Container
+    implements IToolExecutionComponent {
+    private contentBox: Box
+    private args: unknown
+    private result?: ToolResult
+    private expanded = false
+    private isPartial = true
+    private startTime = Date.now()
+    private streamingOutput = ""
+
+    constructor(
+        private toolName: string,
+        args: unknown,
+    ) {
+        super()
+        this.args = args
+        this.addChild(new Spacer(1))
+        this.contentBox = new Box(1, 1, (text: string) =>
+            theme.bg("toolPendingBg", text),
+        )
+        this.addChild(this.contentBox)
+        this.rebuild()
+    }
+
+    updateArgs(args: unknown): void {
+        this.args = args
+        this.rebuild()
+    }
+
+    updateResult(result: ToolResult, isPartial = false): void {
+        this.result = result
+        this.isPartial = isPartial
+        this.rebuild()
+    }
+
+    appendStreamingOutput(output: string): void {
+        this.streamingOutput += output
+        this.rebuild()
+    }
+
+    setExpanded(expanded: boolean): void {
+        this.expanded = expanded
+        this.rebuild()
+    }
+
+    private rebuild(): void {
+        this.contentBox.clear()
+        this.updateBgColor()
+        const status = this.statusIndicator()
+        const header = `${theme.bold(theme.fg("toolTitle", this.toolLabel()))}${status}`
+
+        const output = this.formattedOutput()
+        const visibleOutput = this.expanded ? output : truncateLines(output, 18)
+
+        if (this.isPartial && !output.trim()) {
+            this.contentBox.addChild(new Text(`${header} ${this.argsSummary()}`, 0, 0))
+            return
+        }
+
+        if (!this.isPartial && this.result?.isError) {
+            this.contentBox.addChild(new Text(`${header} ${this.argsSummary()}`, 0, 0))
+            if (looksLikeValidationError(output)) {
+                this.contentBox.addChild(
+                    new ToolValidationErrorComponent({
+                        toolName: this.toolName,
+                        errors: parseValidationErrors(output),
+                        args: this.args,
+                    }),
+                )
+            } else if (output.trim()) {
+                this.contentBox.addChild(
+                    new ErrorDisplayComponent(output, {
+                        showStack: true,
+                        expanded: this.expanded,
+                    }),
+                )
+            }
+            return
+        }
+
+        if (this.isFramedTool()) {
+            const border = (c: string) => theme.bold(theme.fg("accent", c))
+            this.contentBox.addChild(new Text(border("┌──"), 0, 0))
+            if (visibleOutput.trim()) {
+                const maxLineWidth = (process.stdout.columns || 80) - 6
+                const lines = visibleOutput.split("\n").map((line) => {
+                    return `${border("│")} ${truncateAnsi(line, maxLineWidth)}`
+                })
+                this.contentBox.addChild(new Text(lines.join("\n"), 0, 0))
+            }
+            const footer = `${header} ${this.argsSummary()}${this.durationSuffix()}`
+            this.contentBox.addChild(new Text(`${border("└──")} ${footer}`, 0, 0))
+            return
+        }
+
+        this.contentBox.addChild(new Text(`${header} ${this.argsSummary()}`, 0, 0))
+        if (visibleOutput.trim()) {
+            this.contentBox.addChild(new Text(visibleOutput, 0, 0))
+        }
+    }
+
+    private isFramedTool(): boolean {
+        return (
+            this.toolName.includes("execute_command") ||
+            this.toolName.includes("read_file") ||
+            this.toolName === "view" ||
+            this.toolName.includes("edit_file") ||
+            this.toolName === "string_replace_lsp"
+        )
+    }
+
+    private toolLabel(): string {
+        if (this.toolName.includes("execute_command")) return "$"
+        if (this.toolName.includes("read_file") || this.toolName === "view") return "view"
+        if (this.toolName.includes("edit_file") || this.toolName === "string_replace_lsp")
+            return "edit"
+        return this.toolName
+    }
+
+    private argsSummary(): string {
+        const argsObj = this.args as Record<string, unknown> | undefined
+        if (!argsObj || typeof argsObj !== "object") return ""
+        if (argsObj.path) {
+            return theme.fg("accent", shortenPath(String(argsObj.path)))
+        }
+        if (argsObj.command) {
+            return theme.fg("accent", String(argsObj.command))
+        }
+        const keys = Object.keys(argsObj)
+        return theme.fg("muted", keys.length > 0 ? `(${keys.length} args)` : "")
+    }
+
+    private formattedOutput(): string {
+        const text = this.getResultText()
+        if (!text.trim()) return this.streamingOutput
+        return text.trim().replace(/\n\s*\n\s*\n/g, "\n\n")
+    }
+
+    private getResultText(): string {
+        if (!this.result) return ""
+        const content = this.result.content
+        if (typeof content === "string") return content
+        const parts = content as ToolResultPart[]
+        return parts
+            .filter((p) => p.type === "text" && p.text)
+            .map((p) => p.text || "")
+            .join("\n")
+    }
+
+    private statusIndicator(): string {
+        if (this.isPartial) return theme.fg("muted", " ⋯")
+        return this.result?.isError ? theme.fg("error", " ✗") : theme.fg("success", " ✓")
+    }
+
+    private durationSuffix(): string {
+        if (this.isPartial) return ""
+        const ms = Date.now() - this.startTime
+        return ms < 1000 ? theme.fg("muted", ` ${ms}ms`) : theme.fg("muted", ` ${(ms / 1000).toFixed(1)}s`)
+    }
+
+    private updateBgColor(): void {
+        const color = this.isPartial
+            ? "toolPendingBg"
+            : this.result?.isError
+                ? "toolErrorBg"
+                : "toolSuccessBg"
+        this.contentBox.setBgFn((text: string) => theme.bg(color, text))
+    }
+}
+
+function shortenPath(path: string): string {
+    const home = os.homedir()
+    return path.startsWith(home) ? `~${path.slice(home.length)}` : path
+}
+
+function truncateLines(text: string, maxLines: number): string {
+    const lines = text.split("\n")
+    if (lines.length <= maxLines) return text
+    const remaining = lines.length - maxLines
+    return `${lines.slice(0, maxLines).join("\n")}\n${theme.fg("muted", `... ${remaining} more lines (ctrl+e to expand)`)}`
+}
+
+function truncateAnsi(str: string, maxWidth: number): string {
+    // eslint-disable-next-line no-control-regex
+    const ansiRegex = /\x1b\[[0-9;]*m|\x1b\]8;[^\x07]*\x07/g
+    let visibleLength = 0
+    let result = ""
+    let lastIndex = 0
+    let match: RegExpExecArray | null
+
+    while ((match = ansiRegex.exec(str)) !== null) {
+        const textBefore = str.slice(lastIndex, match.index)
+        const remaining = maxWidth - visibleLength
+        if (textBefore.length <= remaining) {
+            result += textBefore
+            visibleLength += textBefore.length
+        } else {
+            result += `${textBefore.slice(0, Math.max(0, remaining - 1))}…`
+            return result
+        }
+        result += match[0]
+        lastIndex = match.index + match[0].length
+    }
+    const remaining = str.slice(lastIndex)
+    const spaceLeft = maxWidth - visibleLength
+    if (remaining.length <= spaceLeft) {
+        result += remaining
+    } else {
+        result += `${remaining.slice(0, Math.max(0, spaceLeft - 1))}…`
+    }
+    return result
+}
+
+function looksLikeValidationError(text: string): boolean {
+    const lower = text.toLowerCase()
+    return (
+        lower.includes("validation") ||
+        lower.includes("required parameter") ||
+        lower.includes("missing required") ||
+        /at "\w+"/i.test(text) ||
+        (text.includes("Expected") && text.includes("Received"))
+    )
+}
+

--- a/mastracode/src/tui/components/tool/execution-interface.ts
+++ b/mastracode/src/tui/components/tool/execution-interface.ts
@@ -1,0 +1,19 @@
+export interface ToolResultPart {
+    type: string
+    text?: string
+    data?: string
+    mimeType?: string
+}
+
+export interface ToolResult {
+    content: string | ToolResultPart[]
+    isError: boolean
+}
+
+export interface IToolExecutionComponent {
+    updateArgs(args: unknown): void
+    updateResult(result: ToolResult, isPartial?: boolean): void
+    setExpanded(expanded: boolean): void
+    appendStreamingOutput?(output: string): void
+}
+

--- a/mastracode/src/tui/components/tool/validation-error.ts
+++ b/mastracode/src/tui/components/tool/validation-error.ts
@@ -1,0 +1,75 @@
+import { Container, Text, type TUI } from "@mariozechner/pi-tui"
+import { theme } from "../../theme"
+
+export interface ValidationError {
+    field: string
+    message: string
+    expected?: string
+    received?: string
+}
+
+export interface ToolValidationErrorOptions {
+    toolName: string
+    errors: ValidationError[]
+    args?: unknown
+}
+
+export function parseValidationErrors(error: unknown): ValidationError[] {
+    const errors: ValidationError[] = []
+    if (typeof error === "string") {
+        const zodMatch = error.match(/at "([^"]+)".*?: (.+?)(?:\n|$)/g)
+        if (zodMatch) {
+            zodMatch.forEach((match) => {
+                const parts = match.match(/at "([^"]+)".*?: (.+?)(?:\n|$)/)
+                if (parts?.[1] && parts[2]) {
+                    errors.push({ field: parts[1], message: parts[2] })
+                }
+            })
+        }
+        if (errors.length === 0) {
+            errors.push({ field: "unknown", message: error })
+        }
+    } else if (typeof error === "object" && error) {
+        const obj = error as { issues?: Array<{ path?: unknown[]; message?: string }> }
+        if (Array.isArray(obj.issues)) {
+            for (const issue of obj.issues) {
+                errors.push({
+                    field: Array.isArray(issue.path) ? issue.path.join(".") : "unknown",
+                    message: issue.message || "Validation issue",
+                })
+            }
+        }
+    }
+    return errors.length > 0 ? errors : [{ field: "unknown", message: String(error) }]
+}
+
+export class ToolValidationErrorComponent extends Container {
+    constructor(options: ToolValidationErrorOptions, _ui?: TUI) {
+        super()
+        this.addChild(
+            new Text(
+                `${theme.fg("error", "✗ Tool validation failed: ")}${theme.bold(theme.fg("toolTitle", options.toolName))}`,
+                0,
+                0,
+            ),
+        )
+        this.addChild(new Text("", 0, 0))
+        for (const error of options.errors) {
+            this.addChild(
+                new Text(
+                    `${theme.fg("muted", "  Parameter: ")}${theme.fg("accent", error.field)}`,
+                    0,
+                    0,
+                ),
+            )
+            this.addChild(
+                new Text(
+                    `${theme.fg("muted", "  Issue: ")}${theme.fg("error", error.message)}`,
+                    0,
+                    0,
+                ),
+            )
+        }
+    }
+}
+

--- a/mastracode/src/tui/index.ts
+++ b/mastracode/src/tui/index.ts
@@ -7,4 +7,9 @@ export {
     ThreadSelectorComponent,
     type ToolResult,
 } from "./components"
-
+export { getClipboardImage, type ClipboardImage } from "./clipboard"
+export {
+    sendNotification,
+    type NotificationMode,
+    type NotificationReason,
+} from "./notify"

--- a/mastracode/src/tui/index.ts
+++ b/mastracode/src/tui/index.ts
@@ -1,0 +1,10 @@
+export { MastraTUI, type MastraTUIOptions } from "./tui"
+export { mastra, type ThemeColor } from "./theme"
+export {
+    AssistantMessageComponent,
+    UserMessageComponent,
+    ToolExecutionComponentEnhanced,
+    ThreadSelectorComponent,
+    type ToolResult,
+} from "./components"
+

--- a/mastracode/src/tui/notify.ts
+++ b/mastracode/src/tui/notify.ts
@@ -1,0 +1,71 @@
+/**
+ * Notification utility for alerting the user when the TUI needs attention.
+ * Sends a terminal bell and optionally a native OS notification.
+ */
+
+import { exec } from "node:child_process"
+
+export type NotificationMode = "bell" | "system" | "both" | "off"
+
+export type NotificationReason =
+    | "agent_done"
+    | "ask_question"
+    | "tool_approval"
+    | "plan_approval"
+    | "sandbox_access"
+
+/**
+ * Send a notification to the user.
+ * - "bell": writes \x07 to stdout (terminal bell)
+ * - "system": sends a native OS notification (macOS only for now)
+ * - "both": bell + system
+ * - "off": no-op
+ */
+export function sendNotification(
+    reason: NotificationReason,
+    opts: {
+        mode: NotificationMode
+        message?: string
+    },
+): void {
+    const { mode, message } = opts
+
+    if (mode === "off") return
+
+    if (mode === "bell" || mode === "both") {
+        process.stdout.write("\x07")
+    }
+
+    if (mode === "system" || mode === "both") {
+        sendSystemNotification(reason, message)
+    }
+}
+
+function sendSystemNotification(
+    reason: NotificationReason,
+    message?: string,
+): void {
+    if (process.platform === "darwin") {
+        const title = "Mastra Code"
+        const body = message || reasonToMessage(reason)
+        const escaped = body.replace(/"/g, '\\"')
+        exec(
+            `osascript -e 'display notification "${escaped}" with title "${title}"'`,
+        )
+    }
+}
+
+function reasonToMessage(reason: NotificationReason): string {
+    switch (reason) {
+        case "agent_done":
+            return "Agent finished — waiting for your input"
+        case "ask_question":
+            return "Agent has a question for you"
+        case "tool_approval":
+            return "Tool requires your approval"
+        case "plan_approval":
+            return "Plan requires your approval"
+        case "sandbox_access":
+            return "Sandbox access requested"
+    }
+}

--- a/mastracode/src/tui/theme.ts
+++ b/mastracode/src/tui/theme.ts
@@ -1,0 +1,326 @@
+/**
+ * Theme system for the Mastra Code TUI.
+ * Simplified from pi-mono's theme system.
+ */
+
+import type { SettingsListTheme, SelectListTheme } from "@mariozechner/pi-tui"
+import chalk from "chalk"
+
+// =============================================================================
+// Mastra Brand Palette
+// =============================================================================
+
+/** Mastra brand colors — single source of truth for all hex values. */
+export const mastra = {
+    purple: "#7f45e0", // #b588fe brand is too washed out for terminal
+    green: "#059669", // #7aff78 too vibrant
+    orange: "#fdac53",
+    pink: "#ff69cc",
+    blue: "#2563eb", // #6ccdfb brand is to washed out
+    red: "#DC5663", // #ff4758 too intense
+    yellow: "#e7e67b",
+    // Surface colors
+    bg: "#020202",
+    antiGrid: "#0d0d0d",
+    elevationSm: "#1a1a1a",
+    elevationLg: "#141414",
+    hover: "#262626",
+    // Text colors
+    white: "#f0f0f0",
+    specialGray: "#cccccc",
+    mainGray: "#939393",
+    darkGray: "#424242",
+    // Border colors
+    borderAntiGrid: "#141414",
+    borderElevation: "#1a1a1a",
+} as const
+
+/** Tint a hex color by a brightness factor (0–1). e.g. tintHex("#ff8800", 0.15) → near-black orange */
+export function tintHex(hex: string, factor: number): string {
+    const r = Math.floor(parseInt(hex.slice(1, 3), 16) * factor)
+    const g = Math.floor(parseInt(hex.slice(3, 5), 16) * factor)
+    const b = Math.floor(parseInt(hex.slice(5, 7), 16) * factor)
+    return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`
+}
+
+// =============================================================================
+// Theme Colors
+// =============================================================================
+
+export type ThemeColor =
+    | "accent"
+    | "border"
+    | "borderAccent"
+    | "borderMuted"
+    | "success"
+    | "error"
+    | "warning"
+    | "muted"
+    | "dim"
+    | "text"
+    | "thinkingText"
+    | "userMessageText"
+    | "toolTitle"
+    | "toolOutput"
+    | "toolBorderPending"
+    | "toolBorderSuccess"
+    | "toolBorderError"
+    | "function"
+    | "path"
+    | "number"
+
+export type ThemeBg =
+    | "selectedBg"
+    | "userMessageBg"
+    | "systemReminderBg"
+    | "toolPendingBg"
+    | "toolSuccessBg"
+    | "toolErrorBg"
+    | "overlayBg"
+    | "errorBg"
+
+export interface ThemeColors {
+    // Core UI
+    accent: string
+    border: string
+    borderAccent: string
+    borderMuted: string
+    success: string
+    error: string
+    warning: string
+    muted: string
+    dim: string
+    text: string
+    thinkingText: string
+    // User messages
+    userMessageBg: string
+    userMessageText: string
+    // System reminders
+    systemReminderBg: string
+    // Tool execution
+    toolPendingBg: string
+    toolSuccessBg: string
+    toolErrorBg: string
+    toolBorderPending: string
+    toolBorderSuccess: string
+    toolBorderError: string
+    toolTitle: string
+    toolOutput: string
+    // Selection
+    selectedBg: string
+    // Overlays
+    overlayBg: string
+    // Error display
+    errorBg: string
+    path: string
+    number: string
+    function: string
+}
+
+// =============================================================================
+// Default Dark Theme
+// =============================================================================
+
+const darkTheme: ThemeColors = {
+    // Core UI
+    accent: "#7c3aed", // Purple
+    border: "#3f3f46",
+    borderAccent: "#7c3aed",
+    borderMuted: "#27272a",
+    success: "#22c55e",
+    error: "#ef4444",
+    warning: "#f59e0b",
+    muted: "#71717a",
+    dim: "#52525b",
+    text: "#fafafa",
+    thinkingText: "#a1a1aa",
+    // User messages
+    userMessageBg: "#0f172a", // Slate blue
+    userMessageText: "#fafafa",
+    // System reminders
+    systemReminderBg: "#1a1400", // Dark orange tint
+    // Tool execution
+    toolPendingBg: "#18152a", // Dark purple (matches tool title accent)
+    toolSuccessBg: "#18152a", // Dark purple (same as pending)
+    toolErrorBg: "#1f0a0a", // Dark red tint
+    toolBorderPending: "#6366f1", // Indigo for pending
+    toolBorderSuccess: "#22c55e", // Green for success
+    toolBorderError: "#ef4444", // Red for error
+    toolTitle: "#a78bfa",
+    toolOutput: "#d4d4d8",
+    // Error display
+    errorBg: "#291415", // Slightly lighter than toolErrorBg for contrast
+    path: "#9ca3af", // Gray for file paths
+    number: "#fbbf24", // Yellow for line numbers
+    function: "#60a5fa", // Light blue for function names
+    // Selection
+    selectedBg: mastra.hover,
+    // Overlays
+    overlayBg: mastra.antiGrid,
+}
+
+// =============================================================================
+// Theme Instance
+// =============================================================================
+
+let currentTheme: ThemeColors = darkTheme
+
+/**
+ * Get the current theme colors.
+ */
+export function getTheme(): ThemeColors {
+    return currentTheme
+}
+
+/**
+ * Set the current theme.
+ */
+export function setTheme(colors: ThemeColors): void {
+    currentTheme = colors
+}
+
+// =============================================================================
+// Theme Helper Functions
+// =============================================================================
+
+/**
+ * Apply foreground color from theme.
+ */
+export function fg(color: ThemeColor, text: string): string {
+    const hex = currentTheme[color]
+    if (!hex) return text
+    return chalk.hex(hex)(text)
+}
+
+/**
+ * Apply background color from theme.
+ */
+export function bg(color: ThemeBg, text: string): string {
+    const hex = currentTheme[color]
+    if (!hex) return text
+    return chalk.bgHex(hex)(text)
+}
+
+/**
+ * Apply bold styling.
+ */
+export function bold(text: string): string {
+    return chalk.bold(text)
+}
+
+/**
+ * Apply italic styling.
+ */
+export function italic(text: string): string {
+    return chalk.italic(text)
+}
+
+/**
+ * Apply dim styling.
+ */
+export function dim(text: string): string {
+    return chalk.dim(text)
+}
+
+/**
+ * Returns "#ffffff" or "#000000" depending on which has better contrast
+ * against the given hex background color (WCAG relative luminance).
+ */
+export function getContrastText(hexBg: string): string {
+    const hex = hexBg.replace("#", "")
+    const r = parseInt(hex.slice(0, 2), 16) / 255
+    const g = parseInt(hex.slice(2, 4), 16) / 255
+    const b = parseInt(hex.slice(4, 6), 16) / 255
+    const toLinear = (c: number) =>
+        c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+    const luminance =
+        0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b)
+    return luminance > 0.179 ? "#000000" : "#ffffff"
+}
+
+// =============================================================================
+// Theme Object (for compatibility with pi-tui components)
+// =============================================================================
+
+export const theme = {
+    fg,
+    bg,
+    bold,
+    italic,
+    dim,
+    getTheme,
+    setTheme,
+}
+
+// =============================================================================
+// Markdown Theme (for pi-tui Markdown component)
+// =============================================================================
+
+import type { MarkdownTheme, EditorTheme } from "@mariozechner/pi-tui"
+
+export function getMarkdownTheme(): MarkdownTheme {
+    const t = getTheme()
+    return {
+        heading: (text: string) => chalk.hex(t.accent).bold(text),
+        link: (text: string) => chalk.hex(t.accent)(text),
+        linkUrl: (text: string) => chalk.hex(t.muted)(text),
+        code: (text: string) => chalk.hex(t.accent)(text),
+        codeBlock: (text: string) => text,
+        codeBlockBorder: (text: string) => chalk.hex(t.borderMuted)(text),
+        quote: (text: string) => chalk.hex(t.muted).italic(text),
+        quoteBorder: (text: string) => chalk.hex(t.borderMuted)(text),
+        hr: (text: string) => chalk.hex(t.borderMuted)(text),
+        listBullet: (text: string) => chalk.hex(t.accent)(text),
+        // Required by MarkdownTheme interface
+        bold: (text: string) => chalk.bold(text),
+        italic: (text: string) => chalk.italic(text),
+        strikethrough: (text: string) => chalk.strikethrough(text),
+        underline: (text: string) => chalk.underline(text),
+    }
+}
+
+// =============================================================================
+// Editor Theme (for pi-tui Editor component)
+// =============================================================================
+
+export function getEditorTheme(): EditorTheme {
+    const t = getTheme()
+    return {
+        borderColor: (text: string) => chalk.hex(t.border)(text),
+        selectList: {
+            selectedPrefix: (text: string) => chalk.hex(t.accent)(text),
+            selectedText: (text: string) => chalk.bgHex(t.selectedBg)(text),
+            description: (text: string) => chalk.hex(t.muted)(text),
+            scrollInfo: (text: string) => chalk.hex(t.dim)(text),
+            noMatch: (text: string) => chalk.hex(t.muted)(text),
+        },
+    }
+}
+
+// =============================================================================
+// Settings List Theme (for pi-tui SettingsList component)
+// =============================================================================
+
+export function getSettingsListTheme(): SettingsListTheme {
+    const t = getTheme()
+    return {
+        label: (text: string, selected: boolean) =>
+            selected ? chalk.hex(t.text).bold(text) : chalk.hex(t.muted)(text),
+        value: (text: string, selected: boolean) =>
+            selected ? chalk.hex(t.accent)(text) : chalk.hex(t.dim)(text),
+        description: (text: string) => chalk.hex(t.muted).italic(text),
+        cursor: chalk.hex(t.accent)("→ "),
+        hint: (text: string) => chalk.hex(t.dim)(text),
+    }
+}
+
+export function getSelectListTheme(): SelectListTheme {
+    const t = getTheme()
+    return {
+        selectedPrefix: (text: string) => chalk.hex(t.accent)(text),
+        selectedText: (text: string) => chalk.bgHex(t.selectedBg)(text),
+        description: (text: string) => chalk.hex(t.muted)(text),
+        scrollInfo: (text: string) => chalk.hex(t.dim)(text),
+        noMatch: (text: string) => chalk.hex(t.muted)(text),
+    }
+}

--- a/mastracode/src/tui/tui.ts
+++ b/mastracode/src/tui/tui.ts
@@ -207,8 +207,8 @@ ${instructions}`,
     }
 
     private resetInput(): void {
-        this.editor.onSubmit = () => {
-            void this.onSubmit(this.editor.getText())
+        this.editor.onSubmit = (text: string) => {
+            void this.onSubmit(text)
         }
         this.ui.setFocus(this.editor)
     }

--- a/mastracode/src/tui/tui.ts
+++ b/mastracode/src/tui/tui.ts
@@ -1,0 +1,1031 @@
+import type {
+    Harness,
+    HarnessEvent,
+    HarnessEventListener,
+    HarnessMessage,
+    TokenUsage,
+} from "@mastra/core/harness"
+import { execSync } from "node:child_process"
+import { Container, ProcessTerminal, Spacer, Text, TUI, visibleWidth } from "@mariozechner/pi-tui"
+import chalk from "chalk"
+import { AskQuestionInlineComponent } from "./components/inline/ask-question-inline"
+import { PlanApprovalInlineComponent } from "./components/inline/plan-approval-inline"
+import { AssistantMessageComponent } from "./components/message/assistant"
+import { UserMessageComponent } from "./components/message/user"
+import { OMMarkerComponent } from "./components/om/marker"
+import {
+    defaultOMProgressState,
+    formatObservationStatus,
+    formatReflectionStatus,
+    OMProgressComponent,
+    type OMProgressState,
+} from "./components/om/progress"
+import { ErrorDisplayComponent } from "./components/output/error-display"
+import { ShellOutputComponent } from "./components/output/shell-output"
+import { SlashCommandComponent } from "./components/output/slash-command"
+import { SystemReminderComponent } from "./components/output/system-reminder"
+import { TodoProgressComponent } from "./components/progress/todo-progress"
+import { CustomEditor } from "./components/shared/custom-editor"
+import {
+    applyGradientSweep,
+    GradientAnimator,
+} from "./components/shared/obi-loader"
+import { ModelSelectorComponent, type ModelItem } from "./components/shared/model-selector"
+import { ThreadSelectorComponent } from "./components/shared/thread-selector"
+import {
+    ToolExecutionComponentEnhanced,
+    type ToolResult,
+} from "./components/tool/execution-enhanced"
+import { ToolApprovalDialogComponent } from "./components/tool/approval-dialog"
+import { bold, fg, getEditorTheme, mastra, tintHex } from "./theme"
+
+export interface MastraTUIOptions {
+    harness: Harness<any>
+    initialMessage?: string
+    verbose?: boolean
+    appName?: string
+    version?: string
+    inlineQuestions?: boolean
+}
+
+export class MastraTUI {
+    private harness: Harness<any>
+    private options: MastraTUIOptions
+
+    private ui: TUI
+    private terminal: ProcessTerminal
+    private chatContainer: Container
+    private editorContainer: Container
+    private footer: Container
+    private editor: CustomEditor
+    private statusLine?: Text
+    private memoryStatusLine?: Text
+
+    private inlineQuestions: boolean
+    private isInitialized = false
+    private isAgentActive = false
+    private gradientAnimator?: GradientAnimator
+    private pendingNewThread = false
+    private hideThinkingBlock = true
+    private toolOutputExpanded = false
+    private lastCtrlCTime = 0
+
+    private tokenUsage: TokenUsage = {
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+    }
+    private projectRootPath = process.cwd()
+    private projectDisplayPath = process.cwd()
+    private omProgress: OMProgressState = defaultOMProgressState()
+    private omProgressComponent?: OMProgressComponent
+    private todoProgress?: TodoProgressComponent
+    private modelAuthStatus: { hasAuth: boolean; apiKeyEnvVar?: string } = {
+        hasAuth: true,
+    }
+
+    private assistantComponents = new Map<string, AssistantMessageComponent>()
+    private toolComponents = new Map<string, ToolExecutionComponentEnhanced>()
+    private allToolComponents: ToolExecutionComponentEnhanced[] = []
+    private allSlashCommandComponents: SlashCommandComponent[] = []
+    private pendingToolApproval: { toolName: string } | null = null
+    private streamingComponent?: AssistantMessageComponent
+    private streamingMessage?: HarnessMessage
+    private activeInlineQuestion?: AskQuestionInlineComponent
+    private activeInlinePlanApproval?: PlanApprovalInlineComponent
+    private unsubscribe?: () => void
+
+    private shouldExit = false
+    private readyResolver?: () => void
+    private readyPromise: Promise<void>
+
+    constructor(options: MastraTUIOptions) {
+        this.options = options
+        this.harness = options.harness
+        this.inlineQuestions = options.inlineQuestions ?? true
+
+        this.terminal = new ProcessTerminal()
+        this.ui = new TUI(this.terminal)
+        this.chatContainer = new Container()
+        this.editorContainer = new Container()
+        this.footer = new Container()
+        this.editor = new CustomEditor(this.ui, getEditorTheme())
+
+        this.readyPromise = new Promise<void>((resolve) => {
+            this.readyResolver = resolve
+        })
+
+        this.setupKeyboardShortcuts()
+    }
+
+    async run(): Promise<void> {
+        await this.init()
+        if (this.options.initialMessage) {
+            void this.fireMessage(this.options.initialMessage)
+        }
+        try {
+            await this.readyPromise
+        } finally {
+            this.stop()
+        }
+    }
+
+    stop(): void {
+        this.unsubscribe?.()
+        this.ui.stop()
+        void this.harness.destroy()
+    }
+
+    private async init(): Promise<void> {
+        if (this.isInitialized) return
+
+        await this.harness.init()
+        await this.promptForThreadSelection()
+        this.tokenUsage = this.harness.usage.get()
+        this.updateProjectInfo()
+
+        this.buildLayout()
+        this.setupEditorSubmitHandler()
+        this.setupKeyHandlers()
+        this.subscribeToHarness()
+
+        this.ui.start()
+        this.isInitialized = true
+
+        this.updateTerminalTitle()
+        await this.renderExistingMessages()
+        this.ui.requestRender()
+    }
+
+    private buildLayout(): void {
+        const appName = this.options.appName ?? "Mastra Code"
+        const version = this.options.version ?? "0.1.0"
+        const logo =
+            fg("accent", "◆") +
+            " " +
+            bold(fg("accent", appName)) +
+            fg("dim", ` v${version}`)
+        const keyStyle = (k: string) => fg("accent", k)
+        const sep = fg("dim", " · ")
+        const instructions = [
+            `  ${keyStyle("Ctrl+C")} ${fg("muted", "interrupt/clear")}${sep}${keyStyle("Ctrl+C×2")} ${fg("muted", "exit")}`,
+            `  ${keyStyle("Enter")} ${fg("muted", "while working → steer")}${sep}${keyStyle("Ctrl+F")} ${fg("muted", "→ queue follow-up")}`,
+            `  ${keyStyle("/")} ${fg("muted", "commands")}${sep}${keyStyle("!")} ${fg("muted", "shell")}${sep}${keyStyle("Ctrl+T")} ${fg("muted", "thinking")}${sep}${keyStyle("Ctrl+E")} ${fg("muted", "tools")}`,
+        ].join("\n")
+        this.ui.addChild(new Spacer(1))
+        this.ui.addChild(
+            new Text(
+                `${logo}
+${instructions}`,
+                1,
+                0,
+            ),
+        )
+        this.ui.addChild(new Spacer(1))
+        this.ui.addChild(this.chatContainer)
+
+        this.todoProgress = new TodoProgressComponent()
+        this.omProgressComponent = new OMProgressComponent(this.omProgress)
+        this.ui.addChild(this.todoProgress)
+        this.ui.addChild(this.editorContainer)
+        this.editorContainer.addChild(this.editor)
+        this.ui.addChild(this.footer)
+        this.statusLine = new Text("", 0, 0)
+        this.memoryStatusLine = new Text("", 0, 0)
+        this.footer.addChild(this.statusLine)
+        this.footer.addChild(this.memoryStatusLine)
+
+        this.updateStatusLine()
+        this.resetInput()
+    }
+
+    private resetInput(): void {
+        this.editor.onSubmit = () => {
+            void this.onSubmit(this.editor.getText())
+        }
+        this.ui.setFocus(this.editor)
+    }
+
+    private setupKeyboardShortcuts(): void {
+        this.editor.onAction("clear", () => {
+            const now = Date.now()
+            if (now - this.lastCtrlCTime < 500) {
+                this.shouldExit = true
+                this.readyResolver?.()
+                return
+            }
+            this.lastCtrlCTime = now
+            if (this.harness.isRunning()) {
+                this.harness.abort()
+            } else {
+                this.editor.setText("")
+                this.ui.requestRender()
+            }
+        })
+
+        this.editor.onAction("toggleThinking", () => {
+            this.hideThinkingBlock = !this.hideThinkingBlock
+            for (const component of this.assistantComponents.values()) {
+                component.setHideThinkingBlock(this.hideThinkingBlock)
+            }
+            this.ui.requestRender()
+        })
+
+        this.editor.onAction("expandTools", () => {
+            this.toolOutputExpanded = !this.toolOutputExpanded
+            for (const tool of this.allToolComponents) {
+                tool.setExpanded(this.toolOutputExpanded)
+            }
+            for (const slash of this.allSlashCommandComponents) {
+                slash.setExpanded(this.toolOutputExpanded)
+            }
+            this.ui.requestRender()
+        })
+    }
+
+    private setupEditorSubmitHandler(): void {
+        // Kept for parity with upstream organization.
+    }
+
+    private setupKeyHandlers(): void {
+        process.on("SIGINT", () => {
+            if (this.harness.isRunning()) {
+                this.harness.abort()
+            } else {
+                this.shouldExit = true
+                this.readyResolver?.()
+            }
+        })
+    }
+
+    private subscribeToHarness(): void {
+        const listener: HarnessEventListener = async (event) => {
+            await this.handleEvent(event)
+        }
+        this.unsubscribe = this.harness.subscribe(listener)
+    }
+
+    private updateTerminalTitle(): void {
+        const appName = this.options.appName ?? "Mastra Code"
+        const cwd = this.projectRootPath.split("/").pop() || ""
+        this.ui.terminal.setTitle(`${appName} - ${cwd}`)
+    }
+
+    private updateProjectInfo(): void {
+        const state = this.harness.state.get() as { cwd?: string } | undefined
+        this.projectRootPath = state?.cwd || process.cwd()
+
+        const homedir = process.env.HOME || process.env.USERPROFILE || ""
+        let displayPath = this.projectRootPath
+        if (homedir && displayPath.startsWith(homedir)) {
+            displayPath = `~${displayPath.slice(homedir.length)}`
+        }
+
+        const branch = this.getGitBranch(this.projectRootPath)
+        this.projectDisplayPath = branch ? `${displayPath} (${branch})` : displayPath
+    }
+
+    private getGitBranch(rootPath: string): string | undefined {
+        try {
+            const branch = execSync("git rev-parse --abbrev-ref HEAD", {
+                cwd: rootPath,
+                encoding: "utf8",
+                stdio: ["ignore", "pipe", "ignore"],
+            }).trim()
+            if (!branch || branch === "HEAD") return undefined
+            return branch
+        } catch {
+            return undefined
+        }
+    }
+
+    private async promptForThreadSelection(): Promise<void> {
+        const threads = await this.harness.threads.list()
+        if (threads.length === 0) {
+            this.pendingNewThread = true
+            return
+        }
+        const sorted = [...threads].sort(
+            (a, b) => b.updatedAt.getTime() - a.updatedAt.getTime(),
+        )
+        await this.harness.threads.switch(sorted[0]!.id)
+    }
+
+    private async renderExistingMessages(): Promise<void> {
+        this.chatContainer.clear()
+        const messages = await this.harness.threads.messages()
+        for (const message of messages) {
+            if (message.role === "user") {
+                const text = extractText(message)
+                if (text) {
+                    this.chatContainer.addChild(new UserMessageComponent(text))
+                }
+                continue
+            }
+            if (message.role === "assistant") {
+                const assistant = new AssistantMessageComponent(
+                    message,
+                    this.hideThinkingBlock,
+                )
+                this.chatContainer.addChild(assistant)
+                this.assistantComponents.set(message.id, assistant)
+            }
+        }
+    }
+
+    private updateStatusLine(): void {
+        if (!this.statusLine || !this.memoryStatusLine) return
+        const termWidth = (process.stdout.columns || 80) - 1
+        const SEP = "  "
+        const modeId = this.harness.modes.currentId()
+        const modes = this.harness.modes.list()
+        const currentMode = modes.find((m) => m.id === modeId) as
+            | { color?: string; name?: string; modelId?: string }
+            | undefined
+
+        const omStatus = this.omProgress.status
+        const isObserving = omStatus === "observing"
+        const isReflecting = omStatus === "reflecting"
+        const showOMMode = isObserving || isReflecting
+        const OBSERVER_COLOR = mastra.orange
+        const REFLECTOR_COLOR = mastra.pink
+        const mainModeColor = currentMode?.color
+        const modeColor = showOMMode
+            ? isObserving
+                ? OBSERVER_COLOR
+                : REFLECTOR_COLOR
+            : mainModeColor ?? "#7c3aed"
+        const badgeName = showOMMode
+            ? isObserving
+                ? "observe"
+                : "reflect"
+            : (currentMode?.name ?? modeId ?? "unknown")
+        const [mcr, mcg, mcb] = [
+            parseInt(modeColor.slice(1, 3), 16),
+            parseInt(modeColor.slice(3, 5), 16),
+            parseInt(modeColor.slice(5, 7), 16),
+        ]
+        let badgeBrightness = 0.9
+        if (this.gradientAnimator?.isRunning()) {
+            const fade = this.gradientAnimator.getFadeProgress()
+            if (fade < 1) {
+                const offset = this.gradientAnimator.getOffset() % 1
+                const animBrightness =
+                    0.65 + 0.3 * (0.5 + 0.5 * Math.sin(offset * Math.PI * 2 + Math.PI))
+                badgeBrightness = animBrightness + (0.9 - animBrightness) * fade
+            }
+        }
+        const [mr, mg, mb] = [
+            Math.floor(mcr * badgeBrightness),
+            Math.floor(mcg * badgeBrightness),
+            Math.floor(mcb * badgeBrightness),
+        ]
+        const modeBadge = chalk
+            .bgRgb(mr, mg, mb)
+            .hex(mastra.bg)
+            .bold(` ${badgeName.toLowerCase()} `)
+        const modeBadgeWidth = badgeName.length + 2
+
+        const modelId = this.resolveModelId(showOMMode, isObserving, isReflecting)
+        const shortModelId = modelId.includes("/") ? modelId.slice(modelId.indexOf("/") + 1) : modelId
+        const tinyModelId = shortModelId
+            .replace(/^claude-/, "")
+            .replace(/^(\w+)-(\d+)-(\d{1,2})$/, "$1 $2.$3")
+
+        const displayPath = this.projectDisplayPath
+        const styleModelId = (id: string): string => {
+            if (!this.modelAuthStatus.hasAuth) {
+                const envVar = this.modelAuthStatus.apiKeyEnvVar
+                return (
+                    fg("dim", id) +
+                    fg("error", " ✗") +
+                    fg("muted", envVar ? ` (${envVar})` : " (no key)")
+                )
+            }
+            const tintBg = tintHex(modeColor, 0.15)
+            const padded = ` ${id} `
+            if (this.gradientAnimator?.isRunning()) {
+                const fade = this.gradientAnimator.getFadeProgress()
+                if (fade < 1) {
+                    const text = applyGradientSweep(
+                        padded,
+                        this.gradientAnimator.getOffset(),
+                        modeColor,
+                        fade,
+                    )
+                    return chalk.bgHex(tintBg)(text)
+                }
+            }
+            const [r, g, b] = [
+                parseInt(modeColor.slice(1, 3), 16),
+                parseInt(modeColor.slice(3, 5), 16),
+                parseInt(modeColor.slice(5, 7), 16),
+            ]
+            const dim = 0.8
+            const styled = chalk
+                .rgb(Math.floor(r * dim), Math.floor(g * dim), Math.floor(b * dim))
+                .bold(padded)
+            return chalk.bgHex(tintBg)(styled)
+        }
+
+        let shortModeBadge = ""
+        let shortModeBadgeWidth = 0
+        if (badgeName) {
+            const shortName = badgeName.toLowerCase().charAt(0)
+            shortModeBadge = chalk.bgRgb(mr, mg, mb).hex(mastra.bg).bold(` ${shortName} `)
+            shortModeBadgeWidth = shortName.length + 2
+        }
+
+        const buildLine = (opts: {
+            modelId: string
+            memCompact?: "percentOnly" | "noBuffer" | "full"
+            showDir: boolean
+            badge?: "full" | "short"
+        }): string | null => {
+            const parts: Array<{ plain: string; styled: string }> = []
+            parts.push({
+                plain: ` ${opts.modelId} `,
+                styled: styleModelId(opts.modelId),
+            })
+
+            const msgLabelStyler =
+                this.omProgress.bufferingMessages && this.gradientAnimator?.isRunning()
+                    ? (label: string) =>
+                        applyGradientSweep(
+                            label,
+                            this.gradientAnimator!.getOffset(),
+                            OBSERVER_COLOR,
+                            this.gradientAnimator!.getFadeProgress(),
+                        )
+                    : undefined
+            const obsLabelStyler =
+                this.omProgress.bufferingObservations && this.gradientAnimator?.isRunning()
+                    ? (label: string) =>
+                        applyGradientSweep(
+                            label,
+                            this.gradientAnimator!.getOffset(),
+                            REFLECTOR_COLOR,
+                            this.gradientAnimator!.getFadeProgress(),
+                        )
+                    : undefined
+
+            const obs = formatObservationStatus(this.omProgress, opts.memCompact, msgLabelStyler)
+            const ref = formatReflectionStatus(this.omProgress, opts.memCompact, obsLabelStyler)
+            if (obs) parts.push({ plain: obs, styled: obs })
+            if (ref) parts.push({ plain: ref, styled: ref })
+
+            const tokens = `tokens:${this.tokenUsage.totalTokens}`
+            parts.push({ plain: tokens, styled: fg("muted", tokens) })
+
+            if (opts.showDir) {
+                parts.push({ plain: displayPath, styled: fg("dim", displayPath) })
+            }
+
+            const useBadge = opts.badge === "short" ? shortModeBadge : modeBadge
+            const useBadgeWidth = opts.badge === "short" ? shortModeBadgeWidth : modeBadgeWidth
+            const totalPlain =
+                useBadgeWidth +
+                parts.reduce(
+                    (sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0),
+                    0,
+                )
+            if (totalPlain > termWidth) return null
+
+            if (opts.showDir && parts.length >= 3) {
+                const left = parts[0]!
+                const center = parts.slice(1, -1)
+                const right = parts[parts.length - 1]!
+                const leftWidth = useBadgeWidth + visibleWidth(left.plain)
+                const centerWidth = center.reduce(
+                    (sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0),
+                    0,
+                )
+                const rightWidth = visibleWidth(right.plain)
+                const freeSpace = termWidth - (leftWidth + centerWidth + rightWidth)
+                const gapLeft = Math.floor(freeSpace / 2)
+                const gapRight = freeSpace - gapLeft
+                return (
+                    useBadge +
+                    left.styled +
+                    " ".repeat(Math.max(gapLeft, 1)) +
+                    center.map((p) => p.styled).join(SEP) +
+                    " ".repeat(Math.max(gapRight, 1)) +
+                    right.styled
+                )
+            }
+
+            if (opts.showDir && parts.length === 2) {
+                const mainStr = useBadge + parts[0]!.styled
+                const right = parts[1]!
+                const gap = termWidth - totalPlain
+                return mainStr + " ".repeat(gap + SEP.length) + right.styled
+            }
+
+            return useBadge + parts.map((p) => p.styled).join(SEP)
+        }
+
+        const styledLine1 =
+            buildLine({ modelId, memCompact: "full", showDir: true }) ??
+            buildLine({ modelId, memCompact: "full", showDir: false }) ??
+            buildLine({ modelId: tinyModelId, memCompact: "full", showDir: false }) ??
+            buildLine({ modelId: tinyModelId, showDir: false }) ??
+            buildLine({ modelId: tinyModelId, showDir: false, badge: "short" }) ??
+            buildLine({
+                modelId: tinyModelId,
+                memCompact: "noBuffer",
+                showDir: false,
+                badge: "short",
+            }) ??
+            buildLine({
+                modelId: tinyModelId,
+                memCompact: "percentOnly",
+                showDir: false,
+            }) ??
+            buildLine({
+                modelId: tinyModelId,
+                memCompact: "percentOnly",
+                showDir: false,
+                badge: "short",
+            }) ??
+            (shortModeBadge + styleModelId(tinyModelId))
+
+        const line2 = ""
+        this.footer.clear()
+        this.statusLine = new Text(styledLine1, 0, 0)
+        this.memoryStatusLine = new Text(line2, 0, 0)
+        this.footer.addChild(this.statusLine)
+        this.footer.addChild(this.memoryStatusLine)
+        const [br, bg, bb] = [
+            parseInt((mainModeColor ?? "#7c3aed").slice(1, 3), 16),
+            parseInt((mainModeColor ?? "#7c3aed").slice(3, 5), 16),
+            parseInt((mainModeColor ?? "#7c3aed").slice(5, 7), 16),
+        ]
+        this.editor.borderColor = (text: string) =>
+            chalk.rgb(Math.floor(br * 0.35), Math.floor(bg * 0.35), Math.floor(bb * 0.35))(text)
+    }
+
+    private async onSubmit(raw: string): Promise<void> {
+        const line = raw.trim()
+        if (!line) return
+
+        if (this.pendingToolApproval) {
+            const normalized = line.toLowerCase()
+            if (normalized === "y" || normalized === "yes") {
+                this.harness.resolveToolApprovalDecision("approve")
+                this.showInfo("approval granted")
+            } else if (normalized === "n" || normalized === "no") {
+                this.harness.resolveToolApprovalDecision("decline")
+                this.showInfo("approval denied")
+            } else {
+                this.showInfo("please enter y or n")
+                this.editor.setText("")
+                this.ui.requestRender()
+                return
+            }
+            this.pendingToolApproval = null
+            this.editor.setText("")
+            this.ui.requestRender()
+            return
+        }
+
+        if (line === "/exit" || line === "/quit") {
+            this.shouldExit = true
+            this.readyResolver?.()
+            return
+        }
+
+        if (line.startsWith("/")) {
+            const handled = await this.handleSlashCommand(line)
+            if (handled) {
+                this.editor.setText("")
+                this.ui.requestRender()
+                return
+            }
+        }
+
+        if (line.startsWith("!")) {
+            this.handleShellPassthrough(line.slice(1).trim())
+            this.editor.setText("")
+            this.ui.requestRender()
+            return
+        }
+
+        if (this.pendingNewThread) {
+            await this.harness.threads.create()
+            this.pendingNewThread = false
+        }
+
+        this.renderUserMessage(line)
+        this.editor.setText("")
+        this.ui.requestRender()
+
+        if (this.harness.isRunning()) {
+            this.harness.steer(line)
+        } else {
+            await this.fireMessage(line)
+        }
+    }
+
+    private async handleSlashCommand(input: string): Promise<boolean> {
+        if (input === "/help") {
+            this.showInfo(
+                "Commands: /help /exit /mode <id> /model list|<id> /thread new|list|switch <id>",
+            )
+            return true
+        }
+        if (input === "/thread list") {
+            const threads = await this.harness.threads.list()
+            this.chatContainer.addChild(
+                new ThreadSelectorComponent(
+                    threads,
+                    this.harness.threads.current(),
+                    async (threadId) => {
+                        await this.harness.threads.switch(threadId)
+                    },
+                ),
+            )
+            return true
+        }
+        if (input.startsWith("/thread switch ")) {
+            const id = input.slice("/thread switch ".length).trim()
+            if (id) await this.harness.threads.switch(id)
+            return true
+        }
+        if (input === "/thread new") {
+            await this.harness.threads.create()
+            return true
+        }
+        if (input === "/model list") {
+            const modes = this.harness.modes.list()
+            const items: ModelItem[] = modes.map((mode) => ({
+                id: mode.id,
+                label: mode.id,
+            }))
+            this.chatContainer.addChild(
+                new ModelSelectorComponent(
+                    items,
+                    this.harness.modes.currentId(),
+                    async (id) => {
+                        await this.harness.modes.switch(id)
+                    },
+                ),
+            )
+            return true
+        }
+        if (input.startsWith("/model ")) {
+            const id = input.slice("/model ".length).trim()
+            if (id && id !== "list") await this.harness.modes.switch(id)
+            return true
+        }
+        if (input.startsWith("/mode ")) {
+            const id = input.slice("/mode ".length).trim()
+            if (id) await this.harness.modes.switch(id)
+            return true
+        }
+
+        const slash = new SlashCommandComponent(input, "Not implemented yet")
+        this.chatContainer.addChild(slash)
+        this.allSlashCommandComponents.push(slash)
+        return true
+    }
+
+    private handleShellPassthrough(command: string): void {
+        this.chatContainer.addChild(
+            new ShellOutputComponent(
+                command,
+                "Shell passthrough is disabled in this harness prototype.",
+            ),
+        )
+    }
+
+    private async fireMessage(content: string): Promise<void> {
+        try {
+            await this.harness.send(content)
+        } catch (error) {
+            this.showError(error instanceof Error ? error.message : "Unknown error")
+        }
+    }
+
+    private async handleEvent(event: HarnessEvent): Promise<void> {
+        switch (event.type) {
+            case "agent_start":
+                this.isAgentActive = true
+                if (!this.gradientAnimator) {
+                    this.gradientAnimator = new GradientAnimator(() => {
+                        this.updateStatusLine()
+                        this.ui.requestRender()
+                    })
+                }
+                this.gradientAnimator.start()
+                this.updateStatusLine()
+                this.ui.requestRender()
+                break
+            case "agent_end":
+                this.isAgentActive = false
+                this.gradientAnimator?.fadeOut()
+                this.streamingComponent = undefined
+                this.streamingMessage = undefined
+                this.updateStatusLine()
+                this.ui.requestRender()
+                break
+            case "mode_changed":
+                this.showInfo(`mode changed: ${event.previousModeId} -> ${event.modeId}`)
+                this.updateStatusLine()
+                this.ui.requestRender()
+                break
+            case "thread_created":
+                this.showInfo(`thread created: ${event.thread.title ?? event.thread.id}`)
+                this.updateStatusLine()
+                this.ui.requestRender()
+                break
+            case "thread_changed":
+                this.showInfo(`thread switched: ${event.threadId}`)
+                await this.renderExistingMessages()
+                this.tokenUsage = this.harness.usage.get()
+                this.updateStatusLine()
+                this.ui.requestRender()
+                break
+            case "message_start":
+                this.streamingMessage = event.message
+                break
+            case "message_update": {
+                let component = this.assistantComponents.get(event.message.id)
+                if (!component) {
+                    component = new AssistantMessageComponent(
+                        event.message,
+                        this.hideThinkingBlock,
+                    )
+                    this.assistantComponents.set(event.message.id, component)
+                    this.chatContainer.addChild(component)
+                } else {
+                    component.updateContent(event.message)
+                }
+                this.streamingComponent = component
+                this.streamingMessage = event.message
+                this.ui.requestRender()
+                break
+            }
+            case "message_end":
+                this.streamingComponent = undefined
+                this.streamingMessage = undefined
+                this.ui.requestRender()
+                break
+            case "tool_start": {
+                const tool = new ToolExecutionComponentEnhanced(event.toolName, event.args)
+                this.toolComponents.set(event.toolCallId, tool)
+                this.allToolComponents.push(tool)
+                this.chatContainer.addChild(tool)
+                this.ui.requestRender()
+                break
+            }
+            case "tool_update": {
+                const tool = this.toolComponents.get(event.toolCallId)
+                if (tool) {
+                    tool.updateResult(
+                        {
+                            content: this.toText(event.partialResult),
+                            isError: false,
+                        },
+                        true,
+                    )
+                    this.ui.requestRender()
+                }
+                break
+            }
+            case "tool_end": {
+                const tool =
+                    this.toolComponents.get(event.toolCallId) ??
+                    new ToolExecutionComponentEnhanced("unknown_tool", {})
+                const result: ToolResult = {
+                    content: this.toText(event.result),
+                    isError: event.isError,
+                }
+                tool.updateResult(result, false)
+                this.toolComponents.delete(event.toolCallId)
+                this.ui.requestRender()
+                break
+            }
+            case "tool_approval_required":
+                if (this.inlineQuestions) {
+                    this.pendingToolApproval = { toolName: event.toolName }
+                    this.chatContainer.addChild(
+                        new ToolApprovalDialogComponent(event.toolName, (decision) => {
+                            this.harness.resolveToolApprovalDecision(decision)
+                        }),
+                    )
+                    this.ui.requestRender()
+                }
+                break
+            case "shell_output":
+                this.chatContainer.addChild(
+                    new ShellOutputComponent(
+                        `${event.stream} (${event.toolCallId})`,
+                        event.output,
+                    ),
+                )
+                this.ui.requestRender()
+                break
+            case "usage_update":
+                this.tokenUsage = event.usage
+                this.updateStatusLine()
+                this.ui.requestRender()
+                break
+            case "om_status":
+                this.omProgress = {
+                    ...this.omProgress,
+                    pendingTokens: event.windows.active.messages.tokens,
+                    threshold: event.windows.active.messages.threshold,
+                    thresholdPercent:
+                        (event.windows.active.messages.tokens /
+                            Math.max(1, event.windows.active.messages.threshold)) *
+                        100,
+                    observationTokens: event.windows.active.observations.tokens,
+                    reflectionThreshold: event.windows.active.observations.threshold,
+                    reflectionThresholdPercent:
+                        (event.windows.active.observations.tokens /
+                            Math.max(1, event.windows.active.observations.threshold)) *
+                        100,
+                    buffered: {
+                        observations: {
+                            status: event.windows.buffered.observations.status,
+                            chunks: event.windows.buffered.observations.chunks,
+                            messageTokens:
+                                event.windows.buffered.observations.messageTokens,
+                            projectedMessageRemoval:
+                                event.windows.buffered.observations.projectedMessageRemoval,
+                            observationTokens:
+                                event.windows.buffered.observations.observationTokens,
+                        },
+                        reflection: {
+                            status: event.windows.buffered.reflection.status,
+                            inputObservationTokens:
+                                event.windows.buffered.reflection.inputObservationTokens,
+                            observationTokens:
+                                event.windows.buffered.reflection.observationTokens,
+                        },
+                    },
+                    generationCount: event.generationCount,
+                    stepNumber: event.stepNumber,
+                }
+                this.omProgressComponent?.update(this.omProgress)
+                this.updateStatusLine()
+                this.ui.requestRender()
+                break
+            case "om_observation_start":
+                this.omProgress = {
+                    ...this.omProgress,
+                    status: "observing",
+                    observing: true,
+                    reflecting: false,
+                    cycleId: event.cycleId,
+                    startTime: Date.now(),
+                }
+                this.omProgressComponent?.update(this.omProgress)
+                this.chatContainer.addChild(
+                    new OMMarkerComponent({
+                        label: `observation start (${event.tokensToObserve} tokens)`,
+                        active: true,
+                    }),
+                )
+                this.updateStatusLine()
+                this.ui.requestRender()
+                break
+            case "om_observation_end":
+            case "om_observation_failed":
+                this.omProgress = {
+                    ...this.omProgress,
+                    status: "idle",
+                    observing: false,
+                    cycleId: undefined,
+                    startTime: undefined,
+                }
+                this.omProgressComponent?.update(this.omProgress)
+                this.updateStatusLine()
+                this.ui.requestRender()
+                break
+            case "om_reflection_start":
+                this.omProgress = {
+                    ...this.omProgress,
+                    status: "reflecting",
+                    observing: false,
+                    reflecting: true,
+                    cycleId: event.cycleId,
+                    startTime: Date.now(),
+                }
+                this.omProgressComponent?.update(this.omProgress)
+                this.updateStatusLine()
+                this.ui.requestRender()
+                break
+            case "om_reflection_end":
+            case "om_reflection_failed":
+                this.omProgress = {
+                    ...this.omProgress,
+                    status: "idle",
+                    reflecting: false,
+                    cycleId: undefined,
+                    startTime: undefined,
+                }
+                this.omProgressComponent?.update(this.omProgress)
+                this.updateStatusLine()
+                this.ui.requestRender()
+                break
+            case "om_buffering_start":
+                this.omProgress = {
+                    ...this.omProgress,
+                    bufferingMessages:
+                        event.operationType === "observation"
+                            ? true
+                            : this.omProgress.bufferingMessages,
+                    bufferingObservations:
+                        event.operationType === "reflection"
+                            ? true
+                            : this.omProgress.bufferingObservations,
+                }
+                this.omProgressComponent?.update(this.omProgress)
+                this.updateStatusLine()
+                this.ui.requestRender()
+                break
+            case "om_buffering_end":
+            case "om_buffering_failed":
+                this.omProgress = {
+                    ...this.omProgress,
+                    bufferingMessages:
+                        event.operationType === "observation"
+                            ? false
+                            : this.omProgress.bufferingMessages,
+                    bufferingObservations:
+                        event.operationType === "reflection"
+                            ? false
+                            : this.omProgress.bufferingObservations,
+                }
+                this.omProgressComponent?.update(this.omProgress)
+                this.updateStatusLine()
+                this.ui.requestRender()
+                break
+            case "info":
+                this.showInfo(event.message)
+                this.ui.requestRender()
+                break
+            case "error":
+                this.showError(event.error.message)
+                this.ui.requestRender()
+                break
+            default:
+                break
+        }
+    }
+
+    private renderUserMessage(text: string): void {
+        this.chatContainer.addChild(new UserMessageComponent(text))
+    }
+
+    private showInfo(message: string): void {
+        this.chatContainer.addChild(new SystemReminderComponent(message))
+    }
+
+    private showError(message: string): void {
+        this.chatContainer.addChild(new ErrorDisplayComponent(message))
+        this.updateStatusLine()
+    }
+
+    private resolveModelId(
+        showOMMode = false,
+        isObserving = false,
+        isReflecting = false,
+    ): string {
+        const state = this.harness.state.get() as {
+            currentModelId?: string
+            observerModelId?: string
+            reflectorModelId?: string
+        }
+        if (showOMMode && isObserving && state?.observerModelId) return state.observerModelId
+        if (showOMMode && isReflecting && state?.reflectorModelId) return state.reflectorModelId
+        if (state?.currentModelId) return state.currentModelId
+        const modes = this.harness.modes.list()
+        const current = modes.find((m) => m.id === this.harness.modes.currentId()) as
+            | { modelId?: string; observerModelId?: string; reflectorModelId?: string }
+            | undefined
+        if (showOMMode && isObserving && current?.observerModelId) return current.observerModelId
+        if (showOMMode && isReflecting && current?.reflectorModelId) return current.reflectorModelId
+        return current?.modelId || "anthropic/claude-sonnet-4-20250514"
+    }
+
+    private toText(value: unknown): string {
+        if (typeof value === "string") return value
+        if (value instanceof Error) return value.message
+        try {
+            return JSON.stringify(value)
+        } catch {
+            return String(value)
+        }
+    }
+}
+
+function extractText(message: HarnessMessage): string {
+    return message.content
+        .filter((c): c is { type: "text"; text: string } => c.type === "text")
+        .map((c) => c.text)
+        .join("\n")
+        .trim()
+}
+

--- a/mastracode/src/utils/commands/index.ts
+++ b/mastracode/src/utils/commands/index.ts
@@ -1,0 +1,15 @@
+export {
+    type SlashCommandMetadata,
+    parseCommandFile,
+    extractCommandName,
+    scanCommandDirectory,
+    loadCustomCommands,
+    getProjectCommandsDir,
+    initCommandsDirectory,
+} from "./loader"
+
+export {
+    processSlashCommand,
+    formatCommandForDisplay,
+    groupCommandsByNamespace,
+} from "./processor"

--- a/mastracode/src/utils/commands/loader.ts
+++ b/mastracode/src/utils/commands/loader.ts
@@ -1,0 +1,229 @@
+/**
+ * Slash command discovery and loading.
+ *
+ * Scans project and user directories for markdown-based slash commands.
+ * Supports YAML frontmatter for metadata and filesystem-based namespacing.
+ */
+
+import { promises as fs } from "node:fs"
+import * as path from "node:path"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SlashCommandMetadata {
+    /** Command name (e.g., "git:commit") */
+    name: string
+    /** Human-readable description */
+    description: string
+    /** The command template with variables */
+    template: string
+    /** Source file path */
+    sourcePath: string
+    /** Namespace derived from directory structure */
+    namespace?: string
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter parsing (no js-yaml dep — simple key:value)
+// ---------------------------------------------------------------------------
+
+function parseFrontmatter(raw: string): Record<string, string> {
+    const result: Record<string, string> = {}
+    for (const line of raw.split("\n")) {
+        const sep = line.indexOf(":")
+        if (sep > 0) {
+            const key = line.slice(0, sep).trim()
+            const value = line.slice(sep + 1).trim()
+            if (key && value) result[key] = value
+        }
+    }
+    return result
+}
+
+// ---------------------------------------------------------------------------
+// File parsing
+// ---------------------------------------------------------------------------
+
+export async function parseCommandFile(
+    filePath: string,
+    baseDir?: string,
+): Promise<SlashCommandMetadata | null> {
+    try {
+        const content = await fs.readFile(filePath, "utf-8")
+        const trimmedContent = content.trim()
+
+        if (!trimmedContent.startsWith("---")) {
+            const name = baseDir
+                ? extractCommandName(filePath, baseDir)
+                : path.basename(filePath, ".md")
+
+            return {
+                name,
+                description: "",
+                template: content,
+                sourcePath: filePath,
+            }
+        }
+
+        const parts = content.split("---")
+        if (parts.length < 3) return null
+
+        const frontmatter = parts[1].trim()
+        const template = parts.slice(2).join("---").trim()
+
+        const metadata = parseFrontmatter(frontmatter)
+
+        let name: string
+        if (metadata.name) {
+            name = metadata.name
+        } else if (baseDir) {
+            name = extractCommandName(filePath, baseDir)
+        } else {
+            name = path.basename(filePath, ".md")
+        }
+
+        return {
+            name,
+            description: metadata.description || "",
+            template,
+            sourcePath: filePath,
+            namespace: metadata.namespace,
+        }
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Extract command name from file path.
+ * Converts path like `git/commit.md` to `git:commit`.
+ */
+export function extractCommandName(filePath: string, baseDir: string): string {
+    const relativePath = path.relative(baseDir, filePath)
+    const dirName = path.dirname(relativePath)
+    const baseName = path.basename(relativePath, ".md")
+
+    if (dirName === "." || dirName === "") return baseName
+
+    const namespace = dirName.replace(/[\\/]/g, ":")
+    return `${namespace}:${baseName}`
+}
+
+// ---------------------------------------------------------------------------
+// Directory scanning
+// ---------------------------------------------------------------------------
+
+export async function scanCommandDirectory(
+    dirPath: string,
+): Promise<SlashCommandMetadata[]> {
+    const commands: SlashCommandMetadata[] = []
+
+    try {
+        const entries = await fs.readdir(dirPath, { withFileTypes: true })
+
+        for (const entry of entries) {
+            const fullPath = path.join(dirPath, entry.name)
+
+            if (entry.isDirectory()) {
+                const subCommands = await scanCommandDirectory(fullPath)
+                commands.push(...subCommands)
+            } else if (entry.isFile() && entry.name.endsWith(".md")) {
+                const command = await parseCommandFile(fullPath, dirPath)
+                if (command) commands.push(command)
+            }
+        }
+    } catch {
+        // Directory doesn't exist or can't be read — silently skip
+    }
+
+    return commands
+}
+
+// ---------------------------------------------------------------------------
+// Multi-source loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Load custom slash commands from all configured directories.
+ *
+ * Priority (lowest to highest):
+ *   1. ~/.opencode/command
+ *   2. ~/.claude/commands
+ *   3. ~/.mastracode/commands
+ *   4. <project>/.opencode/command
+ *   5. <project>/.claude/commands
+ *   6. <project>/.mastracode/commands
+ */
+export async function loadCustomCommands(
+    projectDir?: string,
+): Promise<SlashCommandMetadata[]> {
+    const commands: SlashCommandMetadata[] = []
+    const seenNames = new Set<string>()
+
+    const addCommands = (newCommands: SlashCommandMetadata[]) => {
+        for (const cmd of newCommands) {
+            if (!seenNames.has(cmd.name)) {
+                seenNames.add(cmd.name)
+                commands.push(cmd)
+            }
+        }
+    }
+
+    const homeDir = process.env.HOME || process.env.USERPROFILE
+
+    // User-level directories (lowest priority)
+    if (homeDir) {
+        addCommands(await scanCommandDirectory(path.join(homeDir, ".opencode", "command")))
+        addCommands(await scanCommandDirectory(path.join(homeDir, ".claude", "commands")))
+        addCommands(await scanCommandDirectory(path.join(homeDir, ".mastracode", "commands")))
+    }
+
+    // Project-level directories (highest priority)
+    if (projectDir) {
+        addCommands(await scanCommandDirectory(path.join(projectDir, ".opencode", "command")))
+        addCommands(await scanCommandDirectory(path.join(projectDir, ".claude", "commands")))
+        addCommands(await scanCommandDirectory(path.join(projectDir, ".mastracode", "commands")))
+    }
+
+    return commands
+}
+
+/**
+ * Get the commands directory path for a project.
+ */
+export function getProjectCommandsDir(projectDir: string): string {
+    return path.join(projectDir, ".mastracode", "commands")
+}
+
+/**
+ * Initialize a commands directory with an example command.
+ */
+export async function initCommandsDirectory(projectDir: string): Promise<void> {
+    const commandsDir = getProjectCommandsDir(projectDir)
+
+    try {
+        await fs.mkdir(commandsDir, { recursive: true })
+
+        const examplePath = path.join(commandsDir, "example.md")
+        const exampleContent = `---
+name: example
+description: An example slash command
+---
+
+This is an example slash command template.
+You can use variables like $ARGUMENTS or $1, $2 for positional args.
+You can also include file content with @filename.
+Shell commands with !\`command\` will be executed and output included.
+`
+
+        try {
+            await fs.access(examplePath)
+        } catch {
+            await fs.writeFile(examplePath, exampleContent, "utf-8")
+        }
+    } catch {
+        // Silently ignore initialization errors
+    }
+}

--- a/mastracode/src/utils/commands/processor.ts
+++ b/mastracode/src/utils/commands/processor.ts
@@ -1,0 +1,122 @@
+/**
+ * Slash command execution.
+ *
+ * Processes a slash command template by replacing:
+ *   - $ARGUMENTS / $1, $2, ... — user-supplied arguments
+ *   - !`command` — shell command output
+ *   - @path/to/file — file contents
+ */
+
+import { promises as fs } from "node:fs"
+import { execSync } from "node:child_process"
+import * as path from "node:path"
+import type { SlashCommandMetadata } from "./loader"
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Process a slash command template, expanding all variables.
+ */
+export async function processSlashCommand(
+    command: SlashCommandMetadata,
+    args: string[],
+    workingDir: string,
+): Promise<string> {
+    let result = command.template
+    result = replaceArguments(result, args)
+    result = await replaceShellOutput(result, workingDir)
+    result = await replaceFileReferences(result, workingDir)
+    return result
+}
+
+/**
+ * Format a command for display in help/autocomplete.
+ */
+export function formatCommandForDisplay(command: SlashCommandMetadata): string {
+    const parts = [command.name]
+    if (command.description) parts.push(`- ${command.description}`)
+    return parts.join(" ")
+}
+
+/**
+ * Group commands by namespace for display.
+ */
+export function groupCommandsByNamespace(
+    commands: SlashCommandMetadata[],
+): Map<string, SlashCommandMetadata[]> {
+    const groups = new Map<string, SlashCommandMetadata[]>()
+
+    for (const command of commands) {
+        const namespace = command.namespace || command.name.split(":")[0] || "general"
+        if (!groups.has(namespace)) groups.set(namespace, [])
+        groups.get(namespace)!.push(command)
+    }
+
+    return groups
+}
+
+// ---------------------------------------------------------------------------
+// Template expansion helpers
+// ---------------------------------------------------------------------------
+
+function replaceArguments(template: string, args: string[]): string {
+    let result = template
+
+    result = result.replace(/\$ARGUMENTS/g, args.join(" "))
+
+    args.forEach((arg, index) => {
+        const pattern = new RegExp(`\\$${index + 1}`, "g")
+        result = result.replace(pattern, arg)
+    })
+
+    // Clear unused positional arguments
+    result = result.replace(/\$\d+/g, "")
+
+    return result
+}
+
+async function replaceShellOutput(template: string, workingDir: string): Promise<string> {
+    const shellPattern = /!`([^`]+)`/g
+    const matches = [...template.matchAll(shellPattern)]
+
+    let result = template
+
+    for (const match of matches) {
+        const [fullMatch, command] = match
+        try {
+            const output = execSync(command, {
+                cwd: workingDir,
+                encoding: "utf-8",
+                timeout: 30000,
+                maxBuffer: 1024 * 1024,
+            })
+            result = result.replace(fullMatch, output.trim())
+        } catch {
+            result = result.replace(fullMatch, `[Error: Failed to execute "${command}"]`)
+        }
+    }
+
+    return result
+}
+
+async function replaceFileReferences(template: string, workingDir: string): Promise<string> {
+    const filePattern = /@([\w./-]+)/g
+    const matches = [...template.matchAll(filePattern)]
+
+    let result = template
+
+    for (const match of matches) {
+        const [fullMatch, filePath] = match
+        try {
+            const fullPath = path.resolve(workingDir, filePath)
+            const content = await fs.readFile(fullPath, "utf-8")
+            result = result.replace(fullMatch, content)
+        } catch {
+            result = result.replace(fullMatch, `[Error: Could not read "${filePath}"]`)
+        }
+    }
+
+    return result
+}

--- a/mastracode/src/utils/errors.ts
+++ b/mastracode/src/utils/errors.ts
@@ -1,0 +1,293 @@
+/**
+ * Error handling utilities.
+ *
+ * Parses API errors into user-friendly representations with
+ * categorization, retry hints, and display formatting.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ParsedError {
+    message: string
+    type: ErrorType
+    retryable: boolean
+    retryDelay?: number
+    originalError: Error
+}
+
+export type ErrorType =
+    | "rate_limit"
+    | "auth"
+    | "network"
+    | "timeout"
+    | "invalid_request"
+    | "server_error"
+    | "model_not_found"
+    | "context_length"
+    | "content_filter"
+    | "unknown"
+
+// ---------------------------------------------------------------------------
+// Error parsing
+// ---------------------------------------------------------------------------
+
+export function parseError(error: unknown): ParsedError {
+    const err = error instanceof Error ? error : new Error(String(error))
+    const message = err.message.toLowerCase()
+    const errorObj = error as Record<string, unknown>
+
+    if (
+        message.includes("rate limit") ||
+        message.includes("rate_limit") ||
+        message.includes("429") ||
+        errorObj.statusCode === 429 ||
+        errorObj.status === 429
+    ) {
+        return {
+            message: "Rate limited. Please wait a moment before trying again.",
+            type: "rate_limit",
+            retryable: true,
+            retryDelay: extractRetryAfter(errorObj) || 5000,
+            originalError: err,
+        }
+    }
+
+    if (
+        message.includes("unauthorized") ||
+        message.includes("authentication") ||
+        message.includes("invalid api key") ||
+        message.includes("invalid_api_key") ||
+        message.includes("api key") ||
+        errorObj.statusCode === 401 ||
+        errorObj.status === 401
+    ) {
+        return {
+            message: "Authentication failed. Please check your API key or login with /login.",
+            type: "auth",
+            retryable: false,
+            originalError: err,
+        }
+    }
+
+    if (errorObj.statusCode === 403 || errorObj.status === 403) {
+        return {
+            message: "Access denied. You may not have permission to use this model.",
+            type: "auth",
+            retryable: false,
+            originalError: err,
+        }
+    }
+
+    if (
+        message.includes("network") ||
+        message.includes("econnrefused") ||
+        message.includes("enotfound") ||
+        message.includes("fetch failed") ||
+        message.includes("connection")
+    ) {
+        return {
+            message: "Network error. Please check your internet connection.",
+            type: "network",
+            retryable: true,
+            retryDelay: 2000,
+            originalError: err,
+        }
+    }
+
+    if (
+        message.includes("timeout") ||
+        message.includes("timed out") ||
+        message.includes("etimedout")
+    ) {
+        return {
+            message: "Request timed out. The server may be overloaded.",
+            type: "timeout",
+            retryable: true,
+            retryDelay: 3000,
+            originalError: err,
+        }
+    }
+
+    if (
+        message.includes("model not found") ||
+        message.includes("model_not_found") ||
+        message.includes("does not exist") ||
+        message.includes("invalid model")
+    ) {
+        return {
+            message: "Model not found. Please select a different model with /models.",
+            type: "model_not_found",
+            retryable: false,
+            originalError: err,
+        }
+    }
+
+    if (
+        message.includes("context length") ||
+        message.includes("context_length") ||
+        message.includes("too many tokens") ||
+        message.includes("maximum context") ||
+        message.includes("token limit")
+    ) {
+        return {
+            message: "Message too long. Try starting a new thread with /new.",
+            type: "context_length",
+            retryable: false,
+            originalError: err,
+        }
+    }
+
+    if (
+        message.includes("content filter") ||
+        message.includes("content_filter") ||
+        message.includes("content policy") ||
+        message.includes("safety") ||
+        message.includes("prohibited")
+    ) {
+        return {
+            message: "Content was filtered by the model's safety system.",
+            type: "content_filter",
+            retryable: false,
+            originalError: err,
+        }
+    }
+
+    if (
+        message.includes("internal server") ||
+        message.includes("server error") ||
+        errorObj.statusCode === 500 ||
+        errorObj.status === 500 ||
+        errorObj.statusCode === 502 ||
+        errorObj.status === 502 ||
+        errorObj.statusCode === 503 ||
+        errorObj.status === 503
+    ) {
+        return {
+            message: "Server error. The API may be experiencing issues.",
+            type: "server_error",
+            retryable: true,
+            retryDelay: 5000,
+            originalError: err,
+        }
+    }
+
+    if (
+        message.includes("invalid request") ||
+        message.includes("bad request") ||
+        errorObj.statusCode === 400 ||
+        errorObj.status === 400
+    ) {
+        return {
+            message: `Invalid request: ${extractErrorDetail(err)}`,
+            type: "invalid_request",
+            retryable: false,
+            originalError: err,
+        }
+    }
+
+    return {
+        message: extractErrorDetail(err),
+        type: "unknown",
+        retryable: false,
+        originalError: err,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Display formatting
+// ---------------------------------------------------------------------------
+
+export function formatErrorForDisplay(parsed: ParsedError): string {
+    let display = parsed.message
+    if (parsed.retryable && parsed.retryDelay) {
+        const seconds = Math.ceil(parsed.retryDelay / 1000)
+        display += ` (retrying in ${seconds}s)`
+    }
+    return display
+}
+
+// ---------------------------------------------------------------------------
+// Retry with exponential backoff
+// ---------------------------------------------------------------------------
+
+export function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export async function withRetry<T>(
+    fn: () => Promise<T>,
+    options: {
+        maxRetries?: number
+        initialDelay?: number
+        maxDelay?: number
+        onRetry?: (error: ParsedError, attempt: number) => void
+    } = {},
+): Promise<T> {
+    const { maxRetries = 3, initialDelay = 1000, maxDelay = 30000, onRetry } = options
+
+    let lastError: ParsedError | undefined
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        try {
+            return await fn()
+        } catch (error) {
+            lastError = parseError(error)
+
+            if (!lastError.retryable || attempt === maxRetries) {
+                throw lastError.originalError
+            }
+
+            const delay = Math.min(
+                lastError.retryDelay || initialDelay * Math.pow(2, attempt),
+                maxDelay,
+            )
+
+            if (onRetry) {
+                onRetry(lastError, attempt + 1)
+            }
+
+            await sleep(delay)
+        }
+    }
+
+    throw lastError?.originalError || new Error("Retry failed")
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function extractRetryAfter(error: Record<string, unknown>): number | undefined {
+    const headers = error.headers as Record<string, unknown> | undefined
+    const retryAfter = error.retryAfter || headers?.["retry-after"]
+    if (typeof retryAfter === "number") return retryAfter * 1000
+    if (typeof retryAfter === "string") {
+        const seconds = parseInt(retryAfter, 10)
+        if (!isNaN(seconds)) return seconds * 1000
+    }
+    return undefined
+}
+
+function extractErrorDetail(error: Error): string {
+    const errorObj = error as unknown as Record<string, unknown>
+
+    if (errorObj.error && typeof errorObj.error === "object") {
+        const apiError = errorObj.error as Record<string, unknown>
+        if (apiError.message) return String(apiError.message)
+    }
+
+    if (errorObj.message) return String(errorObj.message)
+    if (errorObj.detail) return String(errorObj.detail)
+    if (errorObj.reason) return String(errorObj.reason)
+
+    let message = error.message
+    message = message.replace(/^(error|exception|failed):\s*/i, "")
+
+    if (message.length > 200) {
+        message = message.substring(0, 200) + "..."
+    }
+
+    return message || "An unknown error occurred"
+}

--- a/mastracode/src/utils/index.ts
+++ b/mastracode/src/utils/index.ts
@@ -1,0 +1,53 @@
+// Project detection, identity, storage configuration
+export {
+    type ProjectInfo,
+    type StorageConfig,
+    type OmScope,
+    detectProject,
+    getAppDataDir,
+    getDatabasePath,
+    getStorageConfig,
+    getUserId,
+    getOmScope,
+    getResourceIdOverride,
+} from "./project"
+
+// Error handling and retry
+export {
+    type ParsedError,
+    type ErrorType,
+    parseError,
+    formatErrorForDisplay,
+    sleep,
+    withRetry,
+} from "./errors"
+
+// Token estimation
+export { tokenEstimate, truncateStringForTokenEstimate } from "./tokens"
+
+// Agent instruction loading
+export {
+    type InstructionSource,
+    loadAgentInstructions,
+    formatAgentInstructions,
+} from "./instructions"
+
+// Thread locking
+export {
+    ThreadLockError,
+    acquireThreadLock,
+    releaseThreadLock,
+    getThreadLockOwner,
+    releaseAllThreadLocks,
+} from "./thread-lock"
+
+// Slash commands
+export {
+    type SlashCommandMetadata,
+    loadCustomCommands,
+    processSlashCommand,
+    formatCommandForDisplay,
+    groupCommandsByNamespace,
+    getProjectCommandsDir,
+    initCommandsDirectory,
+} from "./commands"

--- a/mastracode/src/utils/instructions.ts
+++ b/mastracode/src/utils/instructions.ts
@@ -1,0 +1,110 @@
+/**
+ * Agent instruction loading.
+ *
+ * Loads project and global agent instruction files (AGENT.md, CLAUDE.md).
+ * Prefers AGENT.md over CLAUDE.md when both exist at the same location.
+ */
+
+import { existsSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { homedir } from "node:os"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface InstructionSource {
+    path: string
+    content: string
+    scope: "global" | "project"
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const INSTRUCTION_FILES = ["AGENT.md", "CLAUDE.md"]
+
+const PROJECT_LOCATIONS = [
+    "", // project root
+    ".claude",
+    ".mastracode",
+]
+
+const GLOBAL_LOCATIONS = [
+    ".claude",
+    ".mastracode",
+    ".config/claude",
+    ".config/mastracode",
+]
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+function findInstructionFile(basePath: string): string | null {
+    for (const filename of INSTRUCTION_FILES) {
+        const fullPath = join(basePath, filename)
+        if (existsSync(fullPath)) {
+            return fullPath
+        }
+    }
+    return null
+}
+
+/**
+ * Load all agent instruction files from global and project locations.
+ * Returns an array of instruction sources, with global ones first.
+ */
+export function loadAgentInstructions(projectPath: string): InstructionSource[] {
+    const sources: InstructionSource[] = []
+    const home = homedir()
+
+    for (const location of GLOBAL_LOCATIONS) {
+        const basePath = join(home, location)
+        const filePath = findInstructionFile(basePath)
+        if (filePath) {
+            try {
+                const content = readFileSync(filePath, "utf-8").trim()
+                if (content) {
+                    sources.push({ path: filePath, content, scope: "global" })
+                    break
+                }
+            } catch {
+                // Skip unreadable files
+            }
+        }
+    }
+
+    for (const location of PROJECT_LOCATIONS) {
+        const basePath = location ? join(projectPath, location) : projectPath
+        const filePath = findInstructionFile(basePath)
+        if (filePath) {
+            try {
+                const content = readFileSync(filePath, "utf-8").trim()
+                if (content) {
+                    sources.push({ path: filePath, content, scope: "project" })
+                    break
+                }
+            } catch {
+                // Skip unreadable files
+            }
+        }
+    }
+
+    return sources
+}
+
+/**
+ * Format loaded instructions into a string for the system prompt.
+ */
+export function formatAgentInstructions(sources: InstructionSource[]): string {
+    if (sources.length === 0) return ""
+
+    const sections = sources.map((source) => {
+        const label = source.scope === "global" ? "Global" : "Project"
+        return `<!-- ${label} instructions from ${source.path} -->\n${source.content}`
+    })
+
+    return `\n# Agent Instructions\n\n${sections.join("\n\n")}\n`
+}

--- a/mastracode/src/utils/project.ts
+++ b/mastracode/src/utils/project.ts
@@ -1,13 +1,170 @@
-import path from "node:path"
+/**
+ * Project detection utilities.
+ *
+ * Detects project identity from git repo or filesystem path.
+ * Handles git worktrees by finding the main repository.
+ */
+
+import { execSync } from "node:child_process"
+import { createHash } from "node:crypto"
 import fs from "node:fs"
 import os from "node:os"
+import path from "node:path"
 
-/**
- * Get the application data directory for mastra-code
- * - macOS: ~/Library/Application Support/mastra-code
- * - Linux: ~/.local/share/mastra-code
- * - Windows: %APPDATA%/mastra-code
- */
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ProjectInfo {
+    /** Unique resource ID for this project (used for thread grouping) */
+    resourceId: string
+    /** Human-readable project name */
+    name: string
+    /** Absolute path to the project root */
+    rootPath: string
+    /** Git remote URL if available */
+    gitUrl?: string
+    /** Current git branch */
+    gitBranch?: string
+    /** Whether this is a git worktree */
+    isWorktree: boolean
+    /** Path to main git repo (different from rootPath if worktree) */
+    mainRepoPath?: string
+    /** Whether the resourceId was explicitly overridden (env var or config) */
+    resourceIdOverride?: boolean
+}
+
+export interface StorageConfig {
+    url: string
+    authToken?: string
+    isRemote: boolean
+}
+
+export type OmScope = "thread" | "resource"
+
+// ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
+
+function git(args: string, cwd: string): string | undefined {
+    try {
+        return execSync(`git ${args}`, {
+            cwd,
+            encoding: "utf-8",
+            stdio: ["pipe", "pipe", "pipe"],
+        }).trim()
+    } catch {
+        return undefined
+    }
+}
+
+function slugify(str: string): string {
+    return str
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "")
+}
+
+function shortHash(str: string): string {
+    return createHash("sha256").update(str).digest("hex").slice(0, 12)
+}
+
+function normalizeGitUrl(url: string): string {
+    return url
+        .replace(/\.git$/, "")
+        .replace(/^git@([^:]+):/, "https://$1/")
+        .replace(/^ssh:\/\/git@/, "https://")
+        .toLowerCase()
+}
+
+// ---------------------------------------------------------------------------
+// Project detection
+// ---------------------------------------------------------------------------
+
+export function detectProject(projectPath: string): ProjectInfo {
+    const absolutePath = path.resolve(projectPath)
+
+    const gitDir = git("rev-parse --git-dir", absolutePath)
+    const isGitRepo = gitDir !== undefined
+
+    let rootPath = absolutePath
+    let gitUrl: string | undefined
+    let gitBranch: string | undefined
+    let isWorktree = false
+    let mainRepoPath: string | undefined
+
+    if (isGitRepo) {
+        rootPath = git("rev-parse --show-toplevel", absolutePath) || absolutePath
+
+        const commonDir = git("rev-parse --git-common-dir", absolutePath)
+        if (commonDir && commonDir !== ".git" && commonDir !== gitDir) {
+            isWorktree = true
+            mainRepoPath = path.dirname(path.resolve(rootPath, commonDir))
+        }
+
+        gitUrl = git("remote get-url origin", absolutePath)
+        if (!gitUrl) {
+            const remotes = git("remote", absolutePath)
+            if (remotes) {
+                const firstRemote = remotes.split("\n")[0]
+                if (firstRemote) {
+                    gitUrl = git(`remote get-url ${firstRemote}`, absolutePath)
+                }
+            }
+        }
+
+        gitBranch = git("rev-parse --abbrev-ref HEAD", absolutePath)
+    }
+
+    // Check for explicit override first
+    const override = getResourceIdOverride(rootPath)
+    if (override) {
+        const baseName = gitUrl
+            ? gitUrl.split("/").pop()?.replace(/\.git$/, "") || "project"
+            : path.basename(rootPath)
+
+        return {
+            resourceId: override,
+            name: baseName,
+            rootPath,
+            gitUrl,
+            gitBranch,
+            isWorktree,
+            mainRepoPath,
+            resourceIdOverride: true,
+        }
+    }
+
+    let resourceIdSource: string
+    if (gitUrl) {
+        resourceIdSource = normalizeGitUrl(gitUrl)
+    } else if (mainRepoPath) {
+        resourceIdSource = mainRepoPath
+    } else {
+        resourceIdSource = rootPath
+    }
+
+    const baseName = gitUrl
+        ? gitUrl.split("/").pop()?.replace(/\.git$/, "") || "project"
+        : path.basename(rootPath)
+
+    const resourceId = `${slugify(baseName)}-${shortHash(resourceIdSource)}`
+
+    return {
+        resourceId,
+        name: baseName,
+        rootPath,
+        gitUrl,
+        gitBranch,
+        isWorktree,
+        mainRepoPath,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Application data directory
+// ---------------------------------------------------------------------------
+
 export function getAppDataDir(): string {
     const platform = os.platform()
     let baseDir: string
@@ -15,20 +172,166 @@ export function getAppDataDir(): string {
     if (platform === "darwin") {
         baseDir = path.join(os.homedir(), "Library", "Application Support")
     } else if (platform === "win32") {
-        baseDir =
-            process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming")
+        baseDir = process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming")
     } else {
-        // Linux and others - follow XDG spec
-        baseDir =
-            process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share")
+        baseDir = process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share")
     }
 
     const appDir = path.join(baseDir, "mastra-code")
 
-    // Ensure directory exists
     if (!fs.existsSync(appDir)) {
         fs.mkdirSync(appDir, { recursive: true })
     }
 
     return appDir
+}
+
+export function getDatabasePath(): string {
+    if (process.env.MASTRA_DB_PATH) {
+        return process.env.MASTRA_DB_PATH
+    }
+    return path.join(getAppDataDir(), "mastra.db")
+}
+
+// ---------------------------------------------------------------------------
+// Storage configuration
+// ---------------------------------------------------------------------------
+
+export function getStorageConfig(projectDir?: string): StorageConfig {
+    if (process.env.MASTRA_DB_URL) {
+        return {
+            url: process.env.MASTRA_DB_URL,
+            authToken: process.env.MASTRA_DB_AUTH_TOKEN,
+            isRemote: !process.env.MASTRA_DB_URL.startsWith("file:"),
+        }
+    }
+
+    if (projectDir) {
+        const projectConfig = loadDatabaseConfig(
+            path.join(projectDir, ".mastracode", "database.json"),
+        )
+        if (projectConfig) return projectConfig
+    }
+
+    const globalConfig = loadDatabaseConfig(
+        path.join(os.homedir(), ".mastracode", "database.json"),
+    )
+    if (globalConfig) return globalConfig
+
+    return {
+        url: `file:${getDatabasePath()}`,
+        isRemote: false,
+    }
+}
+
+function loadDatabaseConfig(filePath: string): StorageConfig | null {
+    try {
+        if (!fs.existsSync(filePath)) return null
+        const raw = fs.readFileSync(filePath, "utf-8")
+        const parsed = JSON.parse(raw)
+        if (typeof parsed?.url === "string" && parsed.url) {
+            return {
+                url: parsed.url,
+                authToken: typeof parsed.authToken === "string" ? parsed.authToken : undefined,
+                isRemote: !parsed.url.startsWith("file:"),
+            }
+        }
+        return null
+    } catch {
+        return null
+    }
+}
+
+// ---------------------------------------------------------------------------
+// User identity
+// ---------------------------------------------------------------------------
+
+export function getUserId(projectDir?: string): string {
+    if (process.env.MASTRA_USER_ID) {
+        return process.env.MASTRA_USER_ID
+    }
+
+    const cwd = projectDir || process.cwd()
+    const email = git("config user.email", cwd)
+    if (email) return email
+
+    return os.userInfo().username || "unknown"
+}
+
+// ---------------------------------------------------------------------------
+// Observational Memory scope
+// ---------------------------------------------------------------------------
+
+export function getOmScope(projectDir?: string): OmScope {
+    const envScope = process.env.MASTRA_OM_SCOPE
+    if (envScope === "thread" || envScope === "resource") {
+        return envScope
+    }
+
+    if (projectDir) {
+        const scope = loadOmScopeFromConfig(
+            path.join(projectDir, ".mastracode", "database.json"),
+        )
+        if (scope) return scope
+    }
+
+    const scope = loadOmScopeFromConfig(
+        path.join(os.homedir(), ".mastracode", "database.json"),
+    )
+    if (scope) return scope
+
+    return "thread"
+}
+
+function loadOmScopeFromConfig(filePath: string): OmScope | null {
+    try {
+        if (!fs.existsSync(filePath)) return null
+        const raw = fs.readFileSync(filePath, "utf-8")
+        const parsed = JSON.parse(raw)
+        if (parsed?.omScope === "thread" || parsed?.omScope === "resource") {
+            return parsed.omScope
+        }
+        return null
+    } catch {
+        return null
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resource ID override
+// ---------------------------------------------------------------------------
+
+export function getResourceIdOverride(projectDir?: string): string | null {
+    if (process.env.MASTRA_RESOURCE_ID) {
+        return process.env.MASTRA_RESOURCE_ID
+    }
+
+    if (projectDir) {
+        const rid = loadStringField(
+            path.join(projectDir, ".mastracode", "database.json"),
+            "resourceId",
+        )
+        if (rid) return rid
+    }
+
+    const rid = loadStringField(
+        path.join(os.homedir(), ".mastracode", "database.json"),
+        "resourceId",
+    )
+    if (rid) return rid
+
+    return null
+}
+
+function loadStringField(filePath: string, field: string): string | null {
+    try {
+        if (!fs.existsSync(filePath)) return null
+        const raw = fs.readFileSync(filePath, "utf-8")
+        const parsed = JSON.parse(raw)
+        const value = parsed?.[field]
+        if (typeof value === "string" && value) return value
+        return null
+    } catch {
+        return null
+    }
 }

--- a/mastracode/src/utils/project.ts
+++ b/mastracode/src/utils/project.ts
@@ -1,0 +1,34 @@
+import path from "node:path"
+import fs from "node:fs"
+import os from "node:os"
+
+/**
+ * Get the application data directory for mastra-code
+ * - macOS: ~/Library/Application Support/mastra-code
+ * - Linux: ~/.local/share/mastra-code
+ * - Windows: %APPDATA%/mastra-code
+ */
+export function getAppDataDir(): string {
+    const platform = os.platform()
+    let baseDir: string
+
+    if (platform === "darwin") {
+        baseDir = path.join(os.homedir(), "Library", "Application Support")
+    } else if (platform === "win32") {
+        baseDir =
+            process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming")
+    } else {
+        // Linux and others - follow XDG spec
+        baseDir =
+            process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share")
+    }
+
+    const appDir = path.join(baseDir, "mastra-code")
+
+    // Ensure directory exists
+    if (!fs.existsSync(appDir)) {
+        fs.mkdirSync(appDir, { recursive: true })
+    }
+
+    return appDir
+}

--- a/mastracode/src/utils/thread-lock.ts
+++ b/mastracode/src/utils/thread-lock.ts
@@ -1,0 +1,159 @@
+/**
+ * Thread locking.
+ *
+ * Ensures only one process writes to a thread at a time using
+ * filesystem lock files: <appDataDir>/locks/<threadId>.lock
+ * Each lock file contains the PID of the owning process.
+ * Stale locks (from crashed processes) are detected and reclaimed.
+ */
+
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { getAppDataDir } from "./project"
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+export class ThreadLockError extends Error {
+    constructor(
+        public readonly threadId: string,
+        public readonly ownerPid: number,
+    ) {
+        super(`Thread ${threadId} is locked by another process (PID ${ownerPid})`)
+        this.name = "ThreadLockError"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+function getLocksDir(): string {
+    const dir = path.join(getAppDataDir(), "locks")
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true })
+    }
+    return dir
+}
+
+function getLockPath(threadId: string): string {
+    const safeId = threadId.replace(/[^a-zA-Z0-9_-]/g, "_")
+    return path.join(getLocksDir(), `${safeId}.lock`)
+}
+
+function isProcessAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0)
+        return true
+    } catch {
+        return false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Acquire a lock for the given thread.
+ * Throws `ThreadLockError` if another live process holds the lock.
+ * Reclaims stale locks from dead processes.
+ */
+export function acquireThreadLock(threadId: string): void {
+    const lockPath = getLockPath(threadId)
+    const myPid = process.pid
+
+    if (fs.existsSync(lockPath)) {
+        try {
+            const content = fs.readFileSync(lockPath, "utf-8").trim()
+            const ownerPid = parseInt(content, 10)
+
+            if (!isNaN(ownerPid) && ownerPid !== myPid && isProcessAlive(ownerPid)) {
+                throw new ThreadLockError(threadId, ownerPid)
+            }
+        } catch (error) {
+            if (error instanceof ThreadLockError) throw error
+        }
+    }
+
+    fs.writeFileSync(lockPath, String(myPid), { mode: 0o644 })
+}
+
+/**
+ * Release the lock for the given thread (only if we own it).
+ */
+export function releaseThreadLock(threadId: string): void {
+    const lockPath = getLockPath(threadId)
+    const myPid = process.pid
+
+    try {
+        if (!fs.existsSync(lockPath)) return
+
+        const content = fs.readFileSync(lockPath, "utf-8").trim()
+        const ownerPid = parseInt(content, 10)
+
+        if (ownerPid === myPid) {
+            fs.unlinkSync(lockPath)
+        }
+    } catch {
+        // Best-effort cleanup
+    }
+}
+
+/**
+ * Check if a thread is locked by another process.
+ * Returns the PID of the owner if locked, null otherwise.
+ */
+export function getThreadLockOwner(threadId: string): number | null {
+    const lockPath = getLockPath(threadId)
+
+    try {
+        if (!fs.existsSync(lockPath)) return null
+
+        const content = fs.readFileSync(lockPath, "utf-8").trim()
+        const ownerPid = parseInt(content, 10)
+
+        if (isNaN(ownerPid)) return null
+        if (ownerPid === process.pid) return null
+        if (!isProcessAlive(ownerPid)) {
+            try {
+                fs.unlinkSync(lockPath)
+            } catch {
+                // ignore
+            }
+            return null
+        }
+
+        return ownerPid
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Release all thread locks owned by this process.
+ * Call this on process exit.
+ */
+export function releaseAllThreadLocks(): void {
+    try {
+        const locksDir = getLocksDir()
+        const files = fs.readdirSync(locksDir)
+        const myPid = String(process.pid)
+
+        for (const file of files) {
+            if (!file.endsWith(".lock")) continue
+            const lockPath = path.join(locksDir, file)
+            try {
+                const content = fs.readFileSync(lockPath, "utf-8").trim()
+                if (content === myPid) {
+                    fs.unlinkSync(lockPath)
+                }
+            } catch {
+                // Best-effort
+            }
+        }
+    } catch {
+        // Best-effort
+    }
+}

--- a/mastracode/src/utils/tokens.ts
+++ b/mastracode/src/utils/tokens.ts
@@ -1,0 +1,41 @@
+/**
+ * Token estimation utilities.
+ *
+ * Uses js-tiktoken with the o200k_base encoding (Claude/GPT-4o tokenizer)
+ * for accurate token counts — critical for OM threshold logic.
+ */
+
+import { Tiktoken } from "js-tiktoken/lite"
+import o200k_base from "js-tiktoken/ranks/o200k_base"
+
+const enc = new Tiktoken(o200k_base)
+
+function sanitizeInput(text: string | object): string {
+    if (!text) return ""
+    return (typeof text === "string" ? text : JSON.stringify(text))
+        .replaceAll("<|endoftext|>", "")
+        .replaceAll("<|endofprompt|>", "")
+}
+
+/**
+ * Count the number of tokens in a string or JSON-serializable object.
+ */
+export function tokenEstimate(text: string | object): number {
+    return enc.encode(sanitizeInput(text), "all").length
+}
+
+/**
+ * Truncate a string to approximately `desiredTokenCount` tokens.
+ * By default truncates from the start (keeps the end).
+ */
+export function truncateStringForTokenEstimate(
+    text: string,
+    desiredTokenCount: number,
+    fromEnd = true,
+): string {
+    const tokens = enc.encode(sanitizeInput(text))
+
+    if (tokens.length <= desiredTokenCount) return text
+
+    return `[Truncated ${tokens.length - desiredTokenCount} tokens]\n${enc.decode(tokens.slice(fromEnd ? -desiredTokenCount : 0, fromEnd ? undefined : desiredTokenCount))}`
+}

--- a/mastracode/tsconfig.json
+++ b/mastracode/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["es2022"],
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/mastracode/tsconfig.json
+++ b/mastracode/tsconfig.json
@@ -1,18 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "lib": ["es2022"],
-    "rootDir": "./src",
-    "outDir": "./dist",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
-  },
+  "extends": "../tsconfig.node.json",
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }

--- a/mastracode/tsup.config.ts
+++ b/mastracode/tsup.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+    entry: [
+        "src/main.ts",
+        "src/index.ts",
+        "src/tools/index.ts",
+        "src/agents/index.ts",
+    ],
+    splitting: true,
+    format: ["esm"],
+    clean: true,
+    dts: false,
+    sourcemap: true,
+    target: "es2022",
+    outDir: "dist",
+    external: [
+        "@mastra/core",
+        "@ai-sdk/anthropic",
+        "@ai-sdk/openai",
+        "@mariozechner/pi-tui",
+        "ai",
+        "chalk",
+        "cli-highlight",
+        "execa",
+        "fastest-levenshtein",
+        "js-tiktoken",
+        "strip-ansi",
+        "tree-kill",
+        "zod",
+    ],
+})

--- a/packages/core/src/harness/harness.test.ts
+++ b/packages/core/src/harness/harness.test.ts
@@ -1,0 +1,993 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { z } from 'zod';
+
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+import type { HarnessEvent, HarnessMode } from './types';
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+const testSchema = z.object({
+  currentModelId: z.string().default('test-model'),
+  counter: z.number().default(0),
+});
+
+type TestState = typeof testSchema;
+
+/** Minimal mock agent — we only need the shape, not real LLM calls. */
+function mockAgent(name = 'test-agent') {
+  return { id: name, name } as any;
+}
+
+function createTestModes(): HarnessMode<TestState>[] {
+  return [
+    {
+      id: 'plan',
+      name: 'Plan',
+      default: true,
+      agent: mockAgent('plan-agent'),
+    },
+    {
+      id: 'build',
+      name: 'Build',
+      agent: state => mockAgent(`build-${state.currentModelId}`),
+    },
+  ];
+}
+
+function createHarness(overrides?: Partial<Parameters<typeof Harness<TestState>>[0]>) {
+  const storage = new InMemoryStore();
+  return new Harness<TestState>({
+    id: 'test-harness',
+    resourceId: 'test-resource',
+    storage,
+    stateSchema: testSchema,
+    modes: createTestModes(),
+    ...overrides,
+  } as any);
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+describe('Harness', () => {
+  describe('constructor', () => {
+    it('sets id and resource from config', () => {
+      const h = createHarness();
+      expect(h.id).toBe('test-harness');
+      expect(h.getResourceId()).toBe('test-resource');
+    });
+
+    it('initializes state from schema defaults', () => {
+      const h = createHarness();
+      expect(h.state.get().currentModelId).toBe('test-model');
+      expect(h.state.get().counter).toBe(0);
+    });
+
+    it('merges initialState over schema defaults', () => {
+      const h = createHarness({
+        initialState: { counter: 42 },
+      });
+      expect(h.state.get().counter).toBe(42);
+      expect(h.state.get().currentModelId).toBe('test-model');
+    });
+
+    it('selects the default mode', () => {
+      const h = createHarness();
+      expect(h.modes.currentId()).toBe('plan');
+    });
+
+    it('falls back to first mode if none marked default', () => {
+      const h = createHarness({
+        modes: [
+          { id: 'alpha', agent: mockAgent() },
+          { id: 'beta', agent: mockAgent() },
+        ],
+      });
+      expect(h.modes.currentId()).toBe('alpha');
+    });
+
+    it('throws if no modes provided', () => {
+      expect(() => createHarness({ modes: [] })).toThrow('Harness requires at least one agent mode');
+    });
+  });
+
+  // =========================================================================
+  // Lifecycle
+  // =========================================================================
+
+  describe('init / destroy', () => {
+    it('initializes storage', async () => {
+      const storage = new InMemoryStore();
+      const initSpy = vi.spyOn(storage, 'init');
+      const h = new Harness<TestState>({
+        id: 'test',
+        resourceId: 'r',
+        storage,
+        stateSchema: testSchema,
+        modes: createTestModes(),
+      } as any);
+
+      await h.init();
+      expect(initSpy).toHaveBeenCalled();
+    });
+
+    it('destroy aborts running operations', async () => {
+      const h = createHarness();
+      await h.init();
+      await h.destroy();
+      expect(h.isRunning()).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // Event System
+  // =========================================================================
+
+  describe('event system', () => {
+    it('delivers events to subscribers', async () => {
+      const h = createHarness();
+      const events: HarnessEvent[] = [];
+      h.subscribe(e => {
+        events.push(e);
+      });
+
+      await h.state.set({ counter: 1 });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe('state_changed');
+    });
+
+    it('supports multiple subscribers', async () => {
+      const h = createHarness();
+      const a: HarnessEvent[] = [];
+      const b: HarnessEvent[] = [];
+      h.subscribe(e => {
+        a.push(e);
+      });
+      h.subscribe(e => {
+        b.push(e);
+      });
+
+      await h.state.set({ counter: 1 });
+
+      expect(a).toHaveLength(1);
+      expect(b).toHaveLength(1);
+    });
+
+    it('unsubscribe stops delivery', async () => {
+      const h = createHarness();
+      const events: HarnessEvent[] = [];
+      const unsub = h.subscribe(e => {
+        events.push(e);
+      });
+
+      await h.state.set({ counter: 1 });
+      expect(events).toHaveLength(1);
+
+      unsub();
+      await h.state.set({ counter: 2 });
+      expect(events).toHaveLength(1); // no new events
+    });
+
+    it('handles listener errors without breaking other listeners', async () => {
+      const h = createHarness();
+      const events: HarnessEvent[] = [];
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      h.subscribe(() => {
+        throw new Error('boom');
+      });
+      h.subscribe(e => {
+        events.push(e);
+      });
+
+      await h.state.set({ counter: 1 });
+
+      expect(events).toHaveLength(1);
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // =========================================================================
+  // State Management
+  // =========================================================================
+
+  describe('state management', () => {
+    it('state.get returns a read-only snapshot', async () => {
+      const h = createHarness();
+      const s1 = h.state.get();
+      await h.state.set({ counter: 99 });
+      const s2 = h.state.get();
+
+      // s1 should not be mutated
+      expect(s1.counter).toBe(0);
+      expect(s2.counter).toBe(99);
+    });
+
+    it('state.set validates against schema', async () => {
+      const h = createHarness();
+      await expect(h.state.set({ counter: 'not a number' as any })).rejects.toThrow('Invalid state update');
+    });
+
+    it('state.set emits state_changed with changedKeys', async () => {
+      const h = createHarness();
+      const events: HarnessEvent[] = [];
+      h.subscribe(e => {
+        events.push(e);
+      });
+
+      await h.state.set({ counter: 5, currentModelId: 'new-model' });
+
+      const event = events[0];
+      expect(event.type).toBe('state_changed');
+      if (event.type === 'state_changed') {
+        expect(event.changedKeys).toContain('counter');
+        expect(event.changedKeys).toContain('currentModelId');
+      }
+    });
+  });
+
+  // =========================================================================
+  // Mode Management
+  // =========================================================================
+
+  describe('mode management', () => {
+    it('modes.list returns all configured modes', () => {
+      const h = createHarness();
+      expect(h.modes.list()).toHaveLength(2);
+      expect(h.modes.list().map(m => m.id)).toEqual(['plan', 'build']);
+    });
+
+    it('modes.current returns the active mode config', () => {
+      const h = createHarness();
+      const mode = h.modes.current();
+      expect(mode.id).toBe('plan');
+      expect(mode.name).toBe('Plan');
+    });
+
+    it('modes.switch changes the current mode and emits event', async () => {
+      const h = createHarness();
+      await h.init();
+
+      const events: HarnessEvent[] = [];
+      h.subscribe(e => {
+        events.push(e);
+      });
+
+      await h.modes.switch('build');
+
+      expect(h.modes.currentId()).toBe('build');
+      const modeEvent = events.find(e => e.type === 'mode_changed');
+      expect(modeEvent).toBeDefined();
+      if (modeEvent?.type === 'mode_changed') {
+        expect(modeEvent.modeId).toBe('build');
+        expect(modeEvent.previousModeId).toBe('plan');
+      }
+    });
+
+    it('modes.switch throws for unknown mode', async () => {
+      const h = createHarness();
+      await expect(h.modes.switch('unknown')).rejects.toThrow('Mode not found: unknown');
+    });
+  });
+
+  // =========================================================================
+  // Thread Management
+  // =========================================================================
+
+  describe('thread management', () => {
+    let h: Harness<TestState>;
+
+    beforeEach(async () => {
+      h = createHarness();
+      await h.init();
+    });
+
+    it('threads.create creates and selects a new thread', async () => {
+      const thread = await h.threads.create('Test Thread');
+
+      expect(thread.id).toBeDefined();
+      expect(thread.title).toBe('Test Thread');
+      expect(thread.resourceId).toBe('test-resource');
+      expect(h.threads.current()).toBe(thread.id);
+    });
+
+    it('threads.create emits thread_created event', async () => {
+      const events: HarnessEvent[] = [];
+      h.subscribe(e => {
+        events.push(e);
+      });
+
+      await h.threads.create();
+
+      const event = events.find(e => e.type === 'thread_created');
+      expect(event).toBeDefined();
+    });
+
+    it('threads.list returns threads for current resource', async () => {
+      await h.threads.create('Thread 1');
+      await h.threads.create('Thread 2');
+
+      const threads = await h.threads.list();
+      expect(threads).toHaveLength(2);
+    });
+
+    it('threads.switch changes current thread and emits event', async () => {
+      const t1 = await h.threads.create('First');
+      const t2 = await h.threads.create('Second');
+
+      const events: HarnessEvent[] = [];
+      h.subscribe(e => {
+        events.push(e);
+      });
+
+      await h.threads.switch(t1.id);
+
+      expect(h.threads.current()).toBe(t1.id);
+      const event = events.find(e => e.type === 'thread_changed');
+      expect(event).toBeDefined();
+      if (event?.type === 'thread_changed') {
+        expect(event.threadId).toBe(t1.id);
+        expect(event.previousThreadId).toBe(t2.id);
+      }
+    });
+
+    it('threads.switch throws for non-existent thread', async () => {
+      await expect(h.threads.switch('fake-id')).rejects.toThrow('Thread not found');
+    });
+
+    it('threads.selectOrCreate creates if none exist', async () => {
+      const thread = await h.threads.selectOrCreate();
+      expect(thread.id).toBeDefined();
+      expect(h.threads.current()).toBe(thread.id);
+    });
+
+    it('threads.selectOrCreate selects most recent if threads exist', async () => {
+      const _t1 = await h.threads.create('Older');
+      // Small delay to ensure different updatedAt timestamps
+      await new Promise(r => setTimeout(r, 5));
+      const t2 = await h.threads.create('Newer');
+
+      // Reset the thread to simulate fresh start
+      (h as any)._currentThreadId = null;
+
+      const selected = await h.threads.selectOrCreate();
+      expect(selected.id).toBe(t2.id);
+    });
+
+    it('threads.rename updates the thread title', async () => {
+      await h.threads.create('Original');
+      await h.threads.rename('Renamed');
+
+      const threads = await h.threads.list();
+      expect(threads[0].title).toBe('Renamed');
+    });
+
+    it('setResourceId clears current thread', () => {
+      h.setResourceId('new-resource');
+      expect(h.getResourceId()).toBe('new-resource');
+      expect(h.threads.current()).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // Thread Metadata Persistence
+  // =========================================================================
+
+  describe('thread metadata', () => {
+    let h: Harness<TestState>;
+
+    beforeEach(async () => {
+      h = createHarness();
+      await h.init();
+    });
+
+    it('threads.persistSetting stores metadata on thread', async () => {
+      await h.threads.create();
+      await h.threads.persistSetting('myKey', 'myValue');
+
+      const threads = await h.threads.list();
+      expect(threads[0].metadata?.myKey).toBe('myValue');
+    });
+
+    it('modes.switch persists mode to thread metadata', async () => {
+      await h.threads.create();
+      await h.modes.switch('build');
+
+      const threads = await h.threads.list();
+      expect(threads[0].metadata?.currentModeId).toBe('build');
+    });
+
+    it('loadThreadMetadata restores mode on threads.switch', async () => {
+      const t1 = await h.threads.create('T1');
+      await h.modes.switch('build');
+
+      const _t2 = await h.threads.create('T2');
+      expect(h.modes.currentId()).toBe('build');
+
+      await h.modes.switch('plan');
+
+      // Switch to t1 — should restore build mode
+      await h.threads.switch(t1.id);
+      expect(h.modes.currentId()).toBe('build');
+    });
+
+    it('onThreadLoad hook is called when loading thread', async () => {
+      const onThreadLoad = vi.fn().mockReturnValue({ counter: 42 });
+      const h2 = createHarness({
+        hooks: { onThreadLoad },
+      });
+      await h2.init();
+
+      const thread = await h2.threads.create();
+      await h2.threads.persistSetting('customData', 'hello');
+
+      // Create a second thread and switch back
+      await h2.threads.create();
+      await h2.threads.switch(thread.id);
+
+      expect(onThreadLoad).toHaveBeenCalled();
+      expect(h2.state.get().counter).toBe(42);
+    });
+
+    it('onThreadCreate hook injects metadata', async () => {
+      const h2 = createHarness({
+        hooks: {
+          onThreadCreate: () => ({ customField: 'injected' }),
+        },
+      });
+      await h2.init();
+
+      await h2.threads.create();
+      const threads = await h2.threads.list();
+      expect(threads[0].metadata?.customField).toBe('injected');
+    });
+  });
+
+  // =========================================================================
+  // Token Usage
+  // =========================================================================
+
+  describe('token usage', () => {
+    it('starts at zero', () => {
+      const h = createHarness();
+      expect(h.usage.get()).toEqual({
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+      });
+    });
+
+    it('resets on new thread', async () => {
+      const h = createHarness();
+      await h.init();
+      // Manually set usage
+      (h as any)._tokenUsage = { promptTokens: 100, completionTokens: 50, totalTokens: 150 };
+
+      await h.threads.create();
+      expect(h.usage.get().totalTokens).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // Questions & Plan Approvals
+  // =========================================================================
+
+  describe('questions and plan approvals', () => {
+    it('registerQuestion + respondToQuestion resolves', async () => {
+      const h = createHarness();
+      let answer: string | undefined;
+
+      h.registerQuestion('q1', a => {
+        answer = a;
+      });
+      h.respondToQuestion('q1', 'yes');
+
+      expect(answer).toBe('yes');
+    });
+
+    it('respondToQuestion for unknown ID is a no-op', () => {
+      const h = createHarness();
+      h.respondToQuestion('unknown', 'answer');
+    });
+
+    it('registerPlanApproval + respondToPlanApproval resolves', async () => {
+      const h = createHarness();
+      let result: any;
+
+      h.registerPlanApproval('p1', r => {
+        result = r;
+      });
+      await h.respondToPlanApproval('p1', { action: 'approved' });
+
+      expect(result).toEqual({ action: 'approved' });
+    });
+  });
+
+  // =========================================================================
+  // Workspace
+  // =========================================================================
+
+  describe('workspace', () => {
+    it('hasWorkspace returns false when not configured', () => {
+      const h = createHarness();
+      expect(h.hasWorkspace()).toBe(false);
+      expect(h.isWorkspaceReady()).toBe(false);
+      expect(h.getWorkspace()).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // Session
+  // =========================================================================
+
+  describe('session', () => {
+    it('session returns current state', async () => {
+      const h = createHarness();
+      await h.init();
+
+      const s = await h.session();
+      expect(s.currentThreadId).toBeNull();
+      expect(s.currentModeId).toBe('plan');
+      expect(s.threads).toEqual([]);
+    });
+
+    it('session reflects created threads', async () => {
+      const h = createHarness();
+      await h.init();
+      await h.threads.create('Test');
+
+      const s = await h.session();
+      expect(s.threads).toHaveLength(1);
+      expect(s.currentThreadId).toBeDefined();
+    });
+  });
+
+  // =========================================================================
+  // Send & Message Listing
+  // =========================================================================
+
+  describe('send and message listing', () => {
+    function streamFromChunks(chunks: any[]): ReadableStream<any> {
+      return new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) {
+            controller.enqueue(chunk);
+          }
+          controller.close();
+        },
+      });
+    }
+
+    it('send streams text and emits lifecycle/message events', async () => {
+      const streamMock = vi.fn().mockResolvedValue({
+        fullStream: streamFromChunks([
+          {
+            type: 'text-start',
+            payload: { id: 'm-1' },
+          },
+          {
+            type: 'text-delta',
+            payload: { id: 'm-1', text: 'Hello ' },
+          },
+          {
+            type: 'text-delta',
+            payload: { id: 'm-1', text: 'world' },
+          },
+          {
+            type: 'finish',
+            payload: {
+              stepResult: { reason: 'stop' },
+              output: {
+                usage: {
+                  inputTokens: 10,
+                  outputTokens: 4,
+                  totalTokens: 14,
+                },
+              },
+            },
+          },
+        ]),
+      });
+
+      const h = createHarness({
+        modes: [
+          {
+            id: 'plan',
+            default: true,
+            agent: {
+              id: 'stream-agent',
+              name: 'Stream Agent',
+              stream: streamMock,
+            } as any,
+          },
+        ],
+      });
+      await h.init();
+
+      const events: HarnessEvent[] = [];
+      h.subscribe(e => {
+        events.push(e);
+      });
+
+      await h.send('hello');
+
+      expect(streamMock).toHaveBeenCalled();
+      expect(events.some(e => e.type === 'agent_start')).toBe(true);
+      expect(events.some(e => e.type === 'message_start')).toBe(true);
+      expect(events.some(e => e.type === 'message_update')).toBe(true);
+      expect(events.some(e => e.type === 'message_end')).toBe(true);
+      expect(events.some(e => e.type === 'agent_end')).toBe(true);
+      expect(h.usage.get().totalTokens).toBe(14);
+    });
+
+    it('send respects onBeforeSend blocking hook', async () => {
+      const streamMock = vi.fn().mockResolvedValue({
+        fullStream: streamFromChunks([]),
+      });
+
+      const h = createHarness({
+        hooks: {
+          onBeforeSend: () => ({
+            allowed: false,
+            blockReason: 'blocked',
+          }),
+        },
+        modes: [
+          {
+            id: 'plan',
+            default: true,
+            agent: {
+              id: 'stream-agent',
+              name: 'Stream Agent',
+              stream: streamMock,
+            } as any,
+          },
+        ],
+      });
+      await h.init();
+
+      const events: HarnessEvent[] = [];
+      h.subscribe(e => {
+        events.push(e);
+      });
+
+      await h.send('hello');
+
+      expect(streamMock).not.toHaveBeenCalled();
+      expect(events.some(e => e.type === 'info')).toBe(true);
+    });
+
+    it('send requires approval when policy is ask and handles decline', async () => {
+      const streamMock = vi.fn().mockResolvedValue({
+        fullStream: streamFromChunks([
+          {
+            type: 'text-start',
+            payload: { id: 'm-approve-1' },
+          },
+          {
+            type: 'tool-call-approval',
+            payload: {
+              toolCallId: 'tool-approve-1',
+              toolName: 'shell',
+              args: { command: 'rm -rf /tmp/demo' },
+            },
+          },
+          {
+            type: 'finish',
+            payload: {
+              stepResult: { reason: 'stop' },
+              output: {
+                usage: {
+                  inputTokens: 1,
+                  outputTokens: 1,
+                  totalTokens: 2,
+                },
+              },
+            },
+          },
+        ]),
+      });
+
+      const h = createHarness({
+        hooks: {
+          resolveToolApproval: () => 'ask',
+        },
+        modes: [
+          {
+            id: 'plan',
+            default: true,
+            agent: {
+              id: 'approval-agent',
+              name: 'Approval Agent',
+              stream: streamMock,
+            } as any,
+          },
+        ],
+      });
+      await h.init();
+
+      const events: HarnessEvent[] = [];
+      h.subscribe(e => {
+        events.push(e);
+      });
+
+      setTimeout(() => {
+        h.resolveToolApprovalDecision('decline');
+      }, 0);
+
+      await h.send('please execute');
+
+      expect(events.some(e => e.type === 'tool_approval_required')).toBe(true);
+      const toolEnd = events.find(e => e.type === 'tool_end');
+      expect(toolEnd).toBeDefined();
+      if (toolEnd?.type === 'tool_end') {
+        expect(toolEnd.toolCallId).toBe('tool-approve-1');
+        expect(toolEnd.isError).toBe(true);
+      }
+    });
+
+    it('send auto-denies tool when onBeforeToolUse blocks', async () => {
+      const onBeforeToolUse = vi.fn().mockResolvedValue({ allowed: false });
+      const streamMock = vi.fn().mockResolvedValue({
+        fullStream: streamFromChunks([
+          {
+            type: 'text-start',
+            payload: { id: 'm-approve-2' },
+          },
+          {
+            type: 'tool-call-approval',
+            payload: {
+              toolCallId: 'tool-approve-2',
+              toolName: 'shell',
+              args: { command: 'echo test' },
+            },
+          },
+          {
+            type: 'finish',
+            payload: {
+              stepResult: { reason: 'stop' },
+              output: {
+                usage: {
+                  inputTokens: 1,
+                  outputTokens: 1,
+                  totalTokens: 2,
+                },
+              },
+            },
+          },
+        ]),
+      });
+
+      const h = createHarness({
+        hooks: {
+          resolveToolApproval: () => 'allow',
+          onBeforeToolUse,
+        },
+        modes: [
+          {
+            id: 'plan',
+            default: true,
+            agent: {
+              id: 'approval-agent',
+              name: 'Approval Agent',
+              stream: streamMock,
+            } as any,
+          },
+        ],
+      });
+      await h.init();
+
+      const events: HarnessEvent[] = [];
+      h.subscribe(e => {
+        events.push(e);
+      });
+
+      await h.send('please execute');
+
+      expect(onBeforeToolUse).toHaveBeenCalledWith('shell', {
+        command: 'echo test',
+      });
+      const toolEnd = events.find(e => e.type === 'tool_end');
+      expect(toolEnd).toBeDefined();
+      if (toolEnd?.type === 'tool_end') {
+        expect(toolEnd.toolCallId).toBe('tool-approve-2');
+        expect(toolEnd.isError).toBe(true);
+      }
+    });
+
+    it('send supports ask + approve path without synthetic tool error', async () => {
+      const streamMock = vi.fn().mockResolvedValue({
+        fullStream: streamFromChunks([
+          {
+            type: 'text-start',
+            payload: { id: 'm-approve-3' },
+          },
+          {
+            type: 'tool-call-approval',
+            payload: {
+              toolCallId: 'tool-approve-3',
+              toolName: 'shell',
+              args: { command: 'pwd' },
+            },
+          },
+          {
+            type: 'finish',
+            payload: {
+              stepResult: { reason: 'stop' },
+              output: {
+                usage: {
+                  inputTokens: 1,
+                  outputTokens: 1,
+                  totalTokens: 2,
+                },
+              },
+            },
+          },
+        ]),
+      });
+
+      const h = createHarness({
+        hooks: {
+          resolveToolApproval: () => 'ask',
+        },
+        modes: [
+          {
+            id: 'plan',
+            default: true,
+            agent: {
+              id: 'approval-agent',
+              name: 'Approval Agent',
+              stream: streamMock,
+            } as any,
+          },
+        ],
+      });
+      await h.init();
+
+      const events: HarnessEvent[] = [];
+      h.subscribe(e => {
+        events.push(e);
+      });
+
+      setTimeout(() => {
+        h.resolveToolApprovalDecision('approve');
+      }, 0);
+
+      await h.send('please execute');
+
+      expect(events.some(e => e.type === 'tool_approval_required')).toBe(true);
+      const toolEnd = events.find(e => e.type === 'tool_end');
+      expect(toolEnd).toBeUndefined();
+    });
+
+    it('send supports deny policy without prompting user and marks stop reason tool_use', async () => {
+      const streamMock = vi.fn().mockResolvedValue({
+        fullStream: streamFromChunks([
+          {
+            type: 'text-start',
+            payload: { id: 'm-approve-4' },
+          },
+          {
+            type: 'tool-call-approval',
+            payload: {
+              toolCallId: 'tool-approve-4',
+              toolName: 'shell',
+              args: { command: 'cat /etc/passwd' },
+            },
+          },
+          {
+            type: 'finish',
+            payload: {
+              stepResult: { reason: 'stop' },
+              output: {
+                usage: {
+                  inputTokens: 1,
+                  outputTokens: 1,
+                  totalTokens: 2,
+                },
+              },
+            },
+          },
+        ]),
+      });
+
+      const h = createHarness({
+        hooks: {
+          resolveToolApproval: () => 'deny',
+        },
+        modes: [
+          {
+            id: 'plan',
+            default: true,
+            agent: {
+              id: 'approval-agent',
+              name: 'Approval Agent',
+              stream: streamMock,
+            } as any,
+          },
+        ],
+      });
+      await h.init();
+
+      const events: HarnessEvent[] = [];
+      h.subscribe(e => {
+        events.push(e);
+      });
+
+      await h.send('please execute');
+
+      expect(events.some(e => e.type === 'tool_approval_required')).toBe(false);
+      const toolEnd = events.find(e => e.type === 'tool_end');
+      expect(toolEnd).toBeDefined();
+      if (toolEnd?.type === 'tool_end') {
+        expect(toolEnd.isError).toBe(true);
+      }
+      const messageEnd = events.find(e => e.type === 'message_end');
+      expect(messageEnd).toBeDefined();
+      if (messageEnd?.type === 'message_end') {
+        expect(messageEnd.message.stopReason).toBe('tool_use');
+      }
+    });
+
+    it('threads.messages maps storage messages to HarnessMessage format', async () => {
+      const storage = new InMemoryStore();
+      const h = new Harness<TestState>({
+        id: 'test-harness',
+        resourceId: 'test-resource',
+        storage,
+        stateSchema: testSchema,
+        modes: createTestModes(),
+      } as any);
+
+      await h.init();
+      const thread = await h.threads.create('Thread');
+      const memoryStorage = await storage.getStore('memory');
+      await memoryStorage!.saveMessages({
+        messages: [
+          {
+            id: 'msg-1',
+            role: 'assistant',
+            threadId: thread.id,
+            resourceId: thread.resourceId,
+            createdAt: new Date(),
+            content: {
+              format: 2,
+              parts: [
+                { type: 'text', text: 'Hello from storage' },
+                {
+                  type: 'tool-invocation',
+                  toolInvocation: {
+                    state: 'call',
+                    toolCallId: 'tool-1',
+                    toolName: 'shell',
+                    args: { cmd: 'ls' },
+                  },
+                },
+              ],
+            },
+          } as any,
+        ],
+      });
+
+      const messages = await h.threads.messages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe('assistant');
+      expect(messages[0].content[0]).toEqual({
+        type: 'text',
+        text: 'Hello from storage',
+      });
+      expect(messages[0].content[1]).toEqual({
+        type: 'tool_call',
+        id: 'tool-1',
+        name: 'shell',
+        args: { cmd: 'ls' },
+      });
+    });
+  });
+});

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1,0 +1,1334 @@
+import type z from 'zod';
+
+import type { MastraDBMessage } from '../agent';
+import { RequestContext } from '../request-context';
+import { Workspace } from '../workspace';
+import type { WorkspaceConfig } from '../workspace';
+
+import type {
+  HarnessConfig,
+  HarnessEvent,
+  HarnessEventListener,
+  HarnessMessage,
+  HarnessMessageContent,
+  HarnessMode,
+  HarnessModeAccessor,
+  HarnessRequestContext,
+  HarnessStateAccessor,
+  HarnessStateSchema,
+  HarnessThread,
+  HarnessThreads,
+  HarnessUsageAccessor,
+  HarnessSession,
+  TokenUsage,
+} from './types';
+
+// =============================================================================
+// Harness Class
+// =============================================================================
+
+/**
+ * The Harness orchestrates multiple agent modes, shared state, memory, and storage.
+ * It's the core abstraction that a TUI (or other UI) controls to build
+ * AI coding agents.
+ *
+ * Public API is organized into namespaced sub-objects for clarity:
+ * - `harness.threads` — thread CRUD + message loading
+ * - `harness.state` — validated state get/set
+ * - `harness.modes` — mode switching
+ * - `harness.usage` — token tracking
+ *
+ * Top-level methods are reserved for the core conversation loop
+ * (`send`, `abort`, `steer`) and lifecycle (`init`, `destroy`).
+ *
+ * @example
+ * ```ts
+ * const harness = new Harness({
+ *   id: "my-coding-agent",
+ *   resourceId: "project-123",
+ *   storage: compositeStore,
+ *   stateSchema: z.object({
+ *     currentModelId: z.string().default("anthropic/claude-sonnet-4-20250514"),
+ *   }),
+ *   modes: [
+ *     {
+ *       id: "plan",
+ *       name: "Plan Mode",
+ *       default: true,
+ *       agent: (state) => planAgent,
+ *     },
+ *   ],
+ * })
+ *
+ * harness.subscribe((event) => {
+ *   if (event.type === "message_update") renderMessage(event.message)
+ * })
+ *
+ * await harness.init()
+ * await harness.threads.selectOrCreate()
+ * await harness.send("Hello!")
+ * ```
+ */
+export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
+  readonly id: string;
+
+  // -- Namespaced public API ---------------------------------------------
+  readonly threads: HarnessThreads;
+  readonly state: HarnessStateAccessor<TState>;
+  readonly modes: HarnessModeAccessor<TState>;
+  readonly usage: HarnessUsageAccessor;
+
+  // -- Config & internal state -------------------------------------------
+  private config: HarnessConfig<TState>;
+  private _state: z.infer<TState>;
+  private _currentModeId: string;
+  private _currentThreadId: string | null = null;
+  private _resourceId: string;
+  private _defaultResourceId: string;
+  private _userId: string | undefined;
+  private _isRemoteStorage: boolean;
+
+  // -- Event system -----------------------------------------------------
+  private listeners: HarnessEventListener[] = [];
+
+  // -- Operation tracking -----------------------------------------------
+  private abortController: AbortController | null = null;
+  private abortRequested: boolean = false;
+  private currentOperationId: number = 0;
+  private currentRunId: string | null = null;
+  private followUpQueue: string[] = [];
+
+  // -- Tool approval ----------------------------------------------------
+  private pendingApprovalResolve: ((decision: 'approve' | 'decline') => void) | null = null;
+
+  // -- Interactive prompts ----------------------------------------------
+  private pendingQuestions = new Map<string, (answer: string) => void>();
+  private pendingPlanApprovals = new Map<
+    string,
+    (result: { action: 'approved' | 'rejected'; feedback?: string }) => void
+  >();
+
+  // -- Token usage ------------------------------------------------------
+  private _tokenUsage: TokenUsage = {
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+  };
+
+  // -- Workspace --------------------------------------------------------
+  private _workspace: Workspace | undefined = undefined;
+  private workspaceInitialized = false;
+
+  // =====================================================================
+  // Lifecycle
+  // =====================================================================
+
+  constructor(config: HarnessConfig<TState>) {
+    this.id = config.id;
+    this.config = config;
+    this._resourceId = config.resourceId;
+    this._defaultResourceId = config.defaultResourceId ?? config.resourceId;
+    this._userId = config.userId;
+    this._isRemoteStorage = config.isRemoteStorage ?? false;
+
+    // Initialize state from schema defaults + initial overrides
+    this._state = {
+      ...this.getSchemaDefaults(),
+      ...config.initialState,
+    } as z.infer<TState>;
+
+    // Find default mode
+    const defaultMode = config.modes.find(m => m.default) ?? config.modes[0];
+    if (!defaultMode) {
+      throw new Error('Harness requires at least one agent mode');
+    }
+    this._currentModeId = defaultMode.id;
+
+    // Store pre-built workspace (config-based workspace is constructed in init())
+    if (config.workspace instanceof Workspace) {
+      this._workspace = config.workspace;
+    }
+
+    // Build namespaced public API
+    this.threads = {
+      create: title => this.createThread(title),
+      list: opts => this.listThreads(opts),
+      switch: id => this.switchThread(id),
+      rename: title => this.renameThread(title),
+      selectOrCreate: () => this.selectOrCreateThread(),
+      current: () => this._currentThreadId,
+      messages: opts => this.listMessages(opts),
+      persistSetting: (key, value) => this.persistThreadSetting(key, value),
+    };
+
+    this.state = {
+      get: () => this.getState(),
+      set: updates => this.setState(updates),
+    };
+
+    this.modes = {
+      list: () => this.getModes(),
+      switch: id => this.switchMode(id),
+      current: () => this.getCurrentMode(),
+      currentId: () => this._currentModeId,
+    };
+
+    this.usage = {
+      get: () => this.getTokenUsage(),
+    };
+  }
+
+  /**
+   * Initialize the harness — storage and optional workspace.
+   * Must be called before using the harness.
+   *
+   * Note: Does NOT auto-select a thread.
+   * Call `threads.selectOrCreate()` or `threads.create()` after init.
+   */
+  async init(): Promise<void> {
+    await this.config.storage.init();
+
+    // Initialize workspace if configured
+    if (this.config.workspace && !this.workspaceInitialized) {
+      try {
+        if (!this._workspace) {
+          this._workspace = new Workspace(this.config.workspace as WorkspaceConfig);
+        }
+
+        void this.emit({
+          type: 'workspace_status_changed',
+          status: 'initializing',
+        });
+
+        await this._workspace.init();
+        this.workspaceInitialized = true;
+
+        void this.emit({
+          type: 'workspace_status_changed',
+          status: 'ready',
+        });
+        void this.emit({
+          type: 'workspace_ready',
+          workspaceId: this._workspace.id,
+          workspaceName: this._workspace.name,
+        });
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        this._workspace = undefined;
+        this.workspaceInitialized = false;
+
+        void this.emit({
+          type: 'workspace_status_changed',
+          status: 'error',
+          error: err,
+        });
+        void this.emit({
+          type: 'workspace_error',
+          error: err,
+        });
+      }
+    }
+  }
+
+  /**
+   * Destroy the harness — clean up workspace and resources.
+   */
+  async destroy(): Promise<void> {
+    this.abort();
+
+    if (this._workspace && this.workspaceInitialized) {
+      try {
+        void this.emit({
+          type: 'workspace_status_changed',
+          status: 'destroying',
+        });
+        await this._workspace.destroy();
+        void this.emit({
+          type: 'workspace_status_changed',
+          status: 'destroyed',
+        });
+      } catch {
+        // Best-effort cleanup
+      } finally {
+        this.workspaceInitialized = false;
+      }
+    }
+  }
+
+  // =====================================================================
+  // Event System
+  // =====================================================================
+
+  /**
+   * Subscribe to harness events.
+   * Returns an unsubscribe function.
+   */
+  subscribe(listener: HarnessEventListener): () => void {
+    this.listeners.push(listener);
+    return () => {
+      const index = this.listeners.indexOf(listener);
+      if (index !== -1) {
+        this.listeners.splice(index, 1);
+      }
+    };
+  }
+
+  /** Emit an event to all listeners. */
+  private async emit(event: HarnessEvent): Promise<void> {
+    for (const listener of this.listeners) {
+      try {
+        await listener(event);
+      } catch (err) {
+        console.error('Error in harness event listener:', err);
+      }
+    }
+  }
+
+  // =====================================================================
+  // Identity & Resource
+  // =====================================================================
+
+  /**
+   * Get the current resource ID.
+   */
+  getResourceId(): string {
+    return this._resourceId;
+  }
+
+  /**
+   * Get the default (auto-detected) resource ID.
+   */
+  getDefaultResourceId(): string {
+    return this._defaultResourceId;
+  }
+
+  /**
+   * Set the resource ID (e.g., switching projects).
+   * Clears the current thread.
+   */
+  setResourceId(resourceId: string): void {
+    this._resourceId = resourceId;
+    this._currentThreadId = null;
+  }
+
+  // =====================================================================
+  // Control Flow
+  // =====================================================================
+
+  /**
+   * Send a user message to the current mode's agent and process its stream.
+   */
+  async send(
+    content: string,
+    options?: {
+      maxSteps?: number;
+    },
+  ): Promise<void> {
+    if (!content.trim()) return;
+    if (this.isRunning()) {
+      throw new Error('Harness is already running');
+    }
+
+    const beforeSendResult = await this.config.hooks?.onBeforeSend?.(content);
+    if (beforeSendResult && !beforeSendResult.allowed) {
+      if (beforeSendResult.blockReason) {
+        void this.emit({ type: 'info', message: beforeSendResult.blockReason });
+      }
+      return;
+    }
+
+    if (!this._currentThreadId) {
+      await this.selectOrCreateThread();
+    }
+
+    this.abortRequested = false;
+    this.currentOperationId += 1;
+    this.abortController = new AbortController();
+    let endReason: 'complete' | 'aborted' | 'error' = 'complete';
+
+    void this.emit({ type: 'agent_start' });
+
+    try {
+      const agent = this.getCurrentAgent();
+      const modelId = (this._state as Record<string, unknown>).currentModelId;
+      const dynamicToolsets = typeof modelId === 'string' ? this.config.getToolsets?.(modelId) : undefined;
+
+      const streamResult = await agent.stream(content, {
+        requestContext: this.buildRequestContext(),
+        memory: this._currentThreadId
+          ? {
+              thread: this._currentThreadId,
+              resource: this._resourceId,
+            }
+          : undefined,
+        toolsets: dynamicToolsets as any,
+        maxSteps: options?.maxSteps,
+      });
+
+      const result = await this.processStream(streamResult.fullStream);
+      await this.persistTokenUsage();
+
+      const afterSend = await this.config.hooks?.onAfterSend?.({
+        text: result.text,
+        stopReason: result.stopReason,
+      });
+      if (afterSend?.continueWorking) {
+        this.followUpQueue.push(afterSend.reason?.trim() || 'Continue with the next best step.');
+        void this.emit({
+          type: 'follow_up_queued',
+          count: this.followUpQueue.length,
+        });
+      }
+    } catch (error) {
+      endReason = 'error';
+      const parsed = this.config.hooks?.onError?.(error) ?? {
+        error: error instanceof Error ? error : new Error(String(error)),
+      };
+
+      void this.emit({
+        type: 'error',
+        error: parsed.error,
+        errorType: parsed.errorType,
+        retryable: parsed.retryable,
+        retryDelay: parsed.retryDelay,
+      });
+      throw parsed.error;
+    } finally {
+      this.abortController = null;
+      if (this.abortRequested) {
+        endReason = 'aborted';
+      }
+      void this.emit({ type: 'agent_end', reason: endReason });
+    }
+  }
+
+  /**
+   * Queue a follow-up steering instruction.
+   */
+  steer(instruction: string): void {
+    if (!instruction.trim()) return;
+    this.followUpQueue.push(instruction);
+    void this.emit({ type: 'follow_up_queued', count: this.followUpQueue.length });
+  }
+
+  /**
+   * Abort the current operation.
+   */
+  abort(): void {
+    if (this.abortController) {
+      this.abortRequested = true;
+      try {
+        this.abortController.abort();
+      } catch {}
+      this.abortController = null;
+    }
+  }
+
+  /**
+   * Check if an operation is currently in progress.
+   */
+  isRunning(): boolean {
+    return this.abortController !== null;
+  }
+
+  /**
+   * Get the number of queued follow-up messages.
+   */
+  getFollowUpCount(): number {
+    return this.followUpQueue.length;
+  }
+
+  // =====================================================================
+  // Tool Approval
+  // =====================================================================
+
+  /**
+   * Respond to a pending tool approval from the UI.
+   */
+  resolveToolApprovalDecision(decision: 'approve' | 'decline'): void {
+    if (this.pendingApprovalResolve) {
+      this.pendingApprovalResolve(decision);
+      this.pendingApprovalResolve = null;
+    }
+  }
+
+  // =====================================================================
+  // Questions & Plan Approvals
+  // =====================================================================
+
+  /**
+   * Register a pending question resolver (used by ask_user tools).
+   */
+  registerQuestion(questionId: string, resolve: (answer: string) => void): void {
+    this.pendingQuestions.set(questionId, resolve);
+  }
+
+  /**
+   * Resolve a pending question with the user's answer.
+   */
+  respondToQuestion(questionId: string, answer: string): void {
+    const resolve = this.pendingQuestions.get(questionId);
+    if (resolve) {
+      this.pendingQuestions.delete(questionId);
+      resolve(answer);
+    }
+  }
+
+  /**
+   * Register a pending plan approval resolver (used by submit_plan tools).
+   */
+  registerPlanApproval(
+    planId: string,
+    resolve: (result: { action: 'approved' | 'rejected'; feedback?: string }) => void,
+  ): void {
+    this.pendingPlanApprovals.set(planId, resolve);
+  }
+
+  /**
+   * Respond to a pending plan approval.
+   */
+  async respondToPlanApproval(
+    planId: string,
+    response: {
+      action: 'approved' | 'rejected';
+      feedback?: string;
+    },
+  ): Promise<void> {
+    const resolve = this.pendingPlanApprovals.get(planId);
+    if (!resolve) return;
+
+    this.pendingPlanApprovals.delete(planId);
+    resolve(response);
+  }
+
+  // =====================================================================
+  // Workspace
+  // =====================================================================
+
+  /**
+   * Get the workspace instance (if configured and initialized).
+   */
+  getWorkspace(): Workspace | undefined {
+    return this._workspace;
+  }
+
+  /**
+   * Check if a workspace is configured.
+   */
+  hasWorkspace(): boolean {
+    return this.config.workspace !== undefined;
+  }
+
+  /**
+   * Check if the workspace is initialized and ready.
+   */
+  isWorkspaceReady(): boolean {
+    return this.workspaceInitialized && this._workspace !== undefined;
+  }
+
+  // =====================================================================
+  // Session
+  // =====================================================================
+
+  /**
+   * Get current session info (for UI display).
+   */
+  async session(): Promise<HarnessSession> {
+    return {
+      currentThreadId: this._currentThreadId,
+      currentModeId: this._currentModeId,
+      threads: await this.listThreads(),
+    };
+  }
+
+  // =====================================================================
+  // State Management (private — exposed via this.state)
+  // =====================================================================
+
+  private getState(): Readonly<z.infer<TState>> {
+    return { ...this._state };
+  }
+
+  private async setState(updates: Partial<z.infer<TState>>): Promise<void> {
+    const changedKeys = Object.keys(updates);
+    const newState = { ...this._state, ...updates };
+
+    const result = this.config.stateSchema.safeParse(newState);
+    if (!result.success) {
+      throw new Error(`Invalid state update: ${result.error.message}`);
+    }
+
+    this._state = result.data as z.infer<TState>;
+
+    void this.emit({
+      type: 'state_changed',
+      state: this._state,
+      changedKeys,
+    });
+  }
+
+  /** Extract default values from Zod schema shape. */
+  private getSchemaDefaults(): Partial<z.infer<TState>> {
+    const shape = this.config.stateSchema.shape;
+    const defaults: Record<string, unknown> = {};
+
+    for (const [key, field] of Object.entries(shape)) {
+      if (field instanceof Object && '_def' in field) {
+        const def = (field as any)._def;
+        if (def.defaultValue !== undefined) {
+          defaults[key] = typeof def.defaultValue === 'function' ? def.defaultValue() : def.defaultValue;
+        }
+      }
+    }
+
+    return defaults as Partial<z.infer<TState>>;
+  }
+
+  // =====================================================================
+  // Mode Management (private — exposed via this.modes)
+  // =====================================================================
+
+  private getModes(): HarnessMode<TState>[] {
+    return this.config.modes;
+  }
+
+  private getCurrentMode(): HarnessMode<TState> {
+    const mode = this.config.modes.find(m => m.id === this._currentModeId);
+    if (!mode) {
+      throw new Error(`Mode not found: ${this._currentModeId}`);
+    }
+    return mode;
+  }
+
+  private async switchMode(modeId: string): Promise<void> {
+    const mode = this.config.modes.find(m => m.id === modeId);
+    if (!mode) {
+      throw new Error(`Mode not found: ${modeId}`);
+    }
+
+    this.abort();
+
+    const previousModeId = this._currentModeId;
+    this._currentModeId = modeId;
+
+    await this.persistThreadSetting('currentModeId', modeId);
+
+    void this.emit({
+      type: 'mode_changed',
+      modeId,
+      previousModeId,
+    });
+  }
+
+  /**
+   * Resolve the agent for the current mode.
+   * Handles both static Agent instances and dynamic factory functions.
+   */
+  private getCurrentAgent() {
+    const mode = this.getCurrentMode();
+    if (typeof mode.agent === 'function') {
+      return mode.agent(this._state);
+    }
+    return mode.agent;
+  }
+
+  // =====================================================================
+  // Thread Management (private — exposed via this.threads)
+  // =====================================================================
+
+  private async getMemoryStorage() {
+    const memoryStorage = await this.config.storage.getStore('memory');
+    if (!memoryStorage) {
+      throw new Error('Storage does not have a memory domain configured');
+    }
+    return memoryStorage;
+  }
+
+  private async createThread(title?: string): Promise<HarnessThread> {
+    const now = new Date();
+    const thread: HarnessThread = {
+      id: this.generateId(),
+      resourceId: this._resourceId,
+      title: title || 'New Thread',
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const hookMeta = this.config.hooks?.onThreadCreate?.(thread, this._state) ?? {};
+
+    const metadata: Record<string, unknown> = { ...hookMeta };
+
+    if (this._userId) {
+      metadata.createdBy = this._userId;
+    }
+
+    const memoryStorage = await this.getMemoryStorage();
+    await memoryStorage.saveThread({
+      thread: {
+        id: thread.id,
+        resourceId: thread.resourceId,
+        title: thread.title!,
+        createdAt: thread.createdAt,
+        updatedAt: thread.updatedAt,
+        metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+      },
+    });
+
+    this._currentThreadId = thread.id;
+
+    this._tokenUsage = {
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+    };
+
+    void this.emit({ type: 'thread_created', thread });
+
+    return thread;
+  }
+
+  private async switchThread(threadId: string): Promise<void> {
+    this.abort();
+
+    const memoryStorage = await this.getMemoryStorage();
+    const thread = await memoryStorage.getThreadById({ threadId });
+    if (!thread) {
+      throw new Error(`Thread not found: ${threadId}`);
+    }
+
+    const previousThreadId = this._currentThreadId;
+    this._currentThreadId = threadId;
+
+    await this.loadThreadMetadata();
+
+    void this.emit({
+      type: 'thread_changed',
+      threadId,
+      previousThreadId,
+    });
+  }
+
+  private async listThreads(options?: { allResources?: boolean; mineOnly?: boolean }): Promise<HarnessThread[]> {
+    const memoryStorage = await this.getMemoryStorage();
+
+    const mineOnly = options?.mineOnly ?? (this._isRemoteStorage && !!this._userId && !options?.allResources);
+
+    const metadataFilter: Record<string, unknown> = {};
+    if (mineOnly && this._userId) {
+      metadataFilter.createdBy = this._userId;
+    }
+
+    const filter = options?.allResources
+      ? undefined
+      : {
+          resourceId: this._resourceId,
+          ...(Object.keys(metadataFilter).length > 0 ? { metadata: metadataFilter } : {}),
+        };
+
+    const result = await memoryStorage.listThreads({
+      perPage: options?.allResources ? false : undefined,
+      filter,
+    });
+
+    return result.threads.map(thread => ({
+      id: thread.id,
+      resourceId: thread.resourceId,
+      title: thread.title,
+      createdAt: thread.createdAt,
+      updatedAt: thread.updatedAt,
+      metadata: thread.metadata,
+    }));
+  }
+
+  private async renameThread(title: string): Promise<void> {
+    if (!this._currentThreadId) return;
+
+    const memoryStorage = await this.getMemoryStorage();
+    const thread = await memoryStorage.getThreadById({
+      threadId: this._currentThreadId,
+    });
+    if (thread) {
+      await memoryStorage.saveThread({
+        thread: {
+          ...thread,
+          title,
+          updatedAt: new Date(),
+        },
+      });
+    }
+  }
+
+  private async selectOrCreateThread(): Promise<HarnessThread> {
+    const threads = await this.listThreads();
+
+    if (threads.length === 0) {
+      return await this.createThread();
+    }
+
+    const sorted = [...threads].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+
+    const mostRecent = sorted[0]!;
+    this._currentThreadId = mostRecent.id;
+    await this.loadThreadMetadata();
+
+    return mostRecent;
+  }
+
+  private async persistThreadSetting(key: string, value: unknown): Promise<void> {
+    if (!this._currentThreadId) return;
+
+    try {
+      const memoryStorage = await this.getMemoryStorage();
+      const thread = await memoryStorage.getThreadById({
+        threadId: this._currentThreadId,
+      });
+      if (thread) {
+        await memoryStorage.saveThread({
+          thread: {
+            ...thread,
+            metadata: {
+              ...thread.metadata,
+              [key]: value,
+            },
+            updatedAt: new Date(),
+          },
+        });
+      }
+    } catch {
+      // Settings persistence is not critical
+    }
+  }
+
+  private async removeThreadSetting(key: string): Promise<void> {
+    if (!this._currentThreadId) return;
+
+    try {
+      const memoryStorage = await this.getMemoryStorage();
+      const thread = await memoryStorage.getThreadById({
+        threadId: this._currentThreadId,
+      });
+      if (thread && thread.metadata) {
+        const metadata = { ...thread.metadata };
+        delete metadata[key];
+        await memoryStorage.saveThread({
+          thread: {
+            ...thread,
+            metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+            updatedAt: new Date(),
+          },
+        });
+      }
+    } catch {
+      // Settings removal is not critical
+    }
+  }
+
+  private async loadThreadMetadata(): Promise<void> {
+    if (!this._currentThreadId) {
+      this._tokenUsage = {
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+      };
+      return;
+    }
+
+    try {
+      const memoryStorage = await this.getMemoryStorage();
+      const thread = await memoryStorage.getThreadById({
+        threadId: this._currentThreadId,
+      });
+
+      const savedUsage = thread?.metadata?.tokenUsage as TokenUsage | undefined;
+      if (savedUsage) {
+        this._tokenUsage = {
+          promptTokens: savedUsage.promptTokens ?? 0,
+          completionTokens: savedUsage.completionTokens ?? 0,
+          totalTokens: savedUsage.totalTokens ?? 0,
+        };
+      } else {
+        this._tokenUsage = {
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+        };
+      }
+
+      const meta = thread?.metadata as Record<string, unknown> | undefined;
+      if (meta?.currentModeId) {
+        const savedModeId = meta.currentModeId as string;
+        const modeExists = this.config.modes.some(m => m.id === savedModeId);
+        if (modeExists && savedModeId !== this._currentModeId) {
+          const previousModeId = this._currentModeId;
+          this._currentModeId = savedModeId;
+          void this.emit({
+            type: 'mode_changed',
+            modeId: savedModeId,
+            previousModeId,
+          });
+        }
+      }
+
+      if (meta && this.config.hooks?.onThreadLoad) {
+        const updates = this.config.hooks.onThreadLoad(meta);
+        if (updates && Object.keys(updates).length > 0) {
+          await this.setState(updates);
+        }
+      }
+    } catch {
+      this._tokenUsage = {
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+      };
+    }
+  }
+
+  // =====================================================================
+  // Messages & Stream Processing
+  // =====================================================================
+
+  private buildRequestContext(): RequestContext<HarnessRequestContext<TState>> {
+    const ctx = new RequestContext<HarnessRequestContext<TState>>();
+    ctx.set('harnessId', this.id);
+    ctx.set('threadId', this._currentThreadId);
+    ctx.set('resourceId', this._resourceId);
+    ctx.set('modeId', this._currentModeId);
+    ctx.set('state', this.getState() as z.infer<TState>);
+    return ctx;
+  }
+
+  private async processStream(stream: any): Promise<{ text?: string; stopReason: string }> {
+    let message: HarnessMessage | null = null;
+    let stopReason: 'complete' | 'tool_use' | 'aborted' | 'error' = 'complete';
+    let approvalDeclined = false;
+
+    const reader = stream.getReader();
+    while (true) {
+      const { value: chunk, done } = await reader.read();
+      if (done) break;
+      const part = chunk as any;
+
+      // OM and other data chunks
+      if (typeof part.type === 'string' && part.type.startsWith('data-')) {
+        const data = (part.data ?? {}) as Record<string, unknown>;
+        switch (part.type) {
+          case 'data-om-status':
+            void this.emit({ type: 'om_status', ...(data as any) });
+            break;
+          case 'data-om-observation-start':
+            void this.emit({ type: 'om_observation_start', ...(data as any) });
+            break;
+          case 'data-om-observation-end':
+            void this.emit({ type: 'om_observation_end', ...(data as any) });
+            break;
+          case 'data-om-observation-failed':
+            void this.emit({ type: 'om_observation_failed', ...(data as any) });
+            break;
+          case 'data-om-reflection-start':
+            void this.emit({ type: 'om_reflection_start', ...(data as any) });
+            break;
+          case 'data-om-reflection-end':
+            void this.emit({ type: 'om_reflection_end', ...(data as any) });
+            break;
+          case 'data-om-reflection-failed':
+            void this.emit({ type: 'om_reflection_failed', ...(data as any) });
+            break;
+          case 'data-om-buffering-start':
+            void this.emit({ type: 'om_buffering_start', ...(data as any) });
+            break;
+          case 'data-om-buffering-end':
+            void this.emit({ type: 'om_buffering_end', ...(data as any) });
+            break;
+          case 'data-om-buffering-failed':
+            void this.emit({ type: 'om_buffering_failed', ...(data as any) });
+            break;
+          case 'data-om-activation':
+            void this.emit({ type: 'om_activation', ...(data as any) });
+            break;
+          case 'data-om-model-changed':
+            void this.emit({ type: 'om_model_changed', ...(data as any) });
+            break;
+          default:
+            break;
+        }
+        continue;
+      }
+
+      switch (part.type) {
+        case 'text-start': {
+          message = {
+            id: part.payload?.id ?? this.generateId(),
+            role: 'assistant',
+            content: [],
+            createdAt: new Date(),
+          };
+          void this.emit({ type: 'message_start', message });
+          break;
+        }
+        case 'text-delta': {
+          if (!message) {
+            message = {
+              id: part.payload?.id ?? this.generateId(),
+              role: 'assistant',
+              content: [],
+              createdAt: new Date(),
+            };
+            void this.emit({ type: 'message_start', message });
+          }
+          const textDelta = String(part.payload?.text ?? '');
+          if (textDelta) {
+            const last = message.content[message.content.length - 1];
+            if (last?.type === 'text') {
+              last.text += textDelta;
+            } else {
+              message.content.push({ type: 'text', text: textDelta });
+            }
+            void this.emit({ type: 'message_update', message });
+          }
+          break;
+        }
+        case 'reasoning-delta': {
+          if (!message) {
+            message = {
+              id: this.generateId(),
+              role: 'assistant',
+              content: [],
+              createdAt: new Date(),
+            };
+            void this.emit({ type: 'message_start', message });
+          }
+          const thinkingDelta = String(part.payload?.text ?? '');
+          if (thinkingDelta) {
+            const last = message.content[message.content.length - 1];
+            if (last?.type === 'thinking') {
+              last.thinking += thinkingDelta;
+            } else {
+              message.content.push({
+                type: 'thinking',
+                thinking: thinkingDelta,
+              });
+            }
+            void this.emit({ type: 'message_update', message });
+          }
+          break;
+        }
+        case 'tool-call': {
+          if (!message) {
+            message = {
+              id: this.generateId(),
+              role: 'assistant',
+              content: [],
+              createdAt: new Date(),
+            };
+            void this.emit({ type: 'message_start', message });
+          }
+          const toolCallId = String(part.payload?.toolCallId ?? this.generateId());
+          const toolName = String(part.payload?.toolName ?? 'unknown_tool');
+          const args = part.payload?.args;
+          message.content.push({
+            type: 'tool_call',
+            id: toolCallId,
+            name: toolName,
+            args,
+          });
+          void this.emit({
+            type: 'tool_start',
+            toolCallId,
+            toolName,
+            args,
+          });
+          void this.emit({ type: 'message_update', message });
+          break;
+        }
+        case 'tool-call-approval': {
+          const toolCallId = String(part.payload?.toolCallId ?? this.generateId());
+          const toolName = String(part.payload?.toolName ?? 'unknown_tool');
+          const args = part.payload?.args;
+          const policyDecision = this.config.hooks?.resolveToolApproval?.(toolName, args) ?? 'ask';
+          let approved = policyDecision === 'allow';
+
+          if (policyDecision === 'deny') {
+            approved = false;
+          } else if (policyDecision === 'ask') {
+            void this.emit({
+              type: 'tool_approval_required',
+              toolCallId,
+              toolName,
+              args,
+            });
+            const userDecision = await new Promise<'approve' | 'decline'>(resolve => {
+              this.pendingApprovalResolve = resolve;
+            });
+            approved = userDecision === 'approve';
+            this.pendingApprovalResolve = null;
+          }
+
+          if (approved) {
+            const beforeTool = await this.config.hooks?.onBeforeToolUse?.(toolName, args);
+            if (beforeTool && !beforeTool.allowed) {
+              approved = false;
+            }
+          }
+
+          if (!approved) {
+            approvalDeclined = true;
+            const declineMessage = 'Tool call was declined by approval policy.';
+            if (message) {
+              message.content.push({
+                type: 'tool_result',
+                id: toolCallId,
+                name: toolName,
+                result: declineMessage,
+                isError: true,
+              });
+              void this.emit({ type: 'message_update', message });
+            }
+            void this.emit({
+              type: 'tool_end',
+              toolCallId,
+              result: declineMessage,
+              isError: true,
+            });
+          }
+          break;
+        }
+        case 'tool-result': {
+          if (!message) {
+            message = {
+              id: this.generateId(),
+              role: 'assistant',
+              content: [],
+              createdAt: new Date(),
+            };
+            void this.emit({ type: 'message_start', message });
+          }
+          const toolCallId = String(part.payload?.toolCallId ?? this.generateId());
+          const toolName = String(part.payload?.toolName ?? 'unknown_tool');
+          const result = part.payload?.result;
+          const isError = Boolean(part.payload?.isError);
+          message.content.push({
+            type: 'tool_result',
+            id: toolCallId,
+            name: toolName,
+            result,
+            isError,
+          });
+          void this.emit({
+            type: 'tool_end',
+            toolCallId,
+            result,
+            isError,
+          });
+          void this.emit({ type: 'message_update', message });
+          void this.config.hooks?.onAfterToolUse?.(toolName, part.payload?.args, result, isError);
+          break;
+        }
+        case 'tool-error': {
+          const toolCallId = String(part.payload?.toolCallId ?? this.generateId());
+          const toolName = String(part.payload?.toolName ?? 'unknown_tool');
+          const errorValue = part.payload?.error;
+          void this.emit({
+            type: 'tool_end',
+            toolCallId,
+            result: errorValue,
+            isError: true,
+          });
+          void this.config.hooks?.onAfterToolUse?.(toolName, part.payload?.args, errorValue, true);
+          break;
+        }
+        case 'step-finish':
+        case 'finish': {
+          const usage = part.payload?.output?.usage;
+          const prompt = Number(usage?.inputTokens ?? usage?.promptTokens ?? 0) || 0;
+          const completion = Number(usage?.outputTokens ?? usage?.completionTokens ?? 0) || 0;
+          const total = Number(usage?.totalTokens ?? prompt + completion) || 0;
+          this._tokenUsage = {
+            promptTokens: prompt,
+            completionTokens: completion,
+            totalTokens: total,
+          };
+          void this.emit({
+            type: 'usage_update',
+            usage: this._tokenUsage,
+          });
+          if (part.type === 'finish') {
+            const reason = String(part.payload?.stepResult?.reason ?? '');
+            stopReason = reason === 'tool-calls' || reason === 'tool-use' ? 'tool_use' : 'complete';
+            if (approvalDeclined && stopReason === 'complete') {
+              stopReason = 'tool_use';
+            }
+            if (message) {
+              message.stopReason = stopReason;
+              void this.emit({ type: 'message_end', message });
+            }
+          }
+          break;
+        }
+        case 'abort': {
+          stopReason = 'aborted';
+          if (message) {
+            message.stopReason = 'aborted';
+            void this.emit({ type: 'message_end', message });
+          }
+          break;
+        }
+        case 'error': {
+          stopReason = 'error';
+          const err = part.payload?.error;
+          const messageText = err instanceof Error ? err.message : String(err);
+          if (!message) {
+            message = {
+              id: this.generateId(),
+              role: 'assistant',
+              content: [],
+              createdAt: new Date(),
+            };
+          }
+          message.errorMessage = messageText;
+          message.stopReason = 'error';
+          void this.emit({
+            type: 'error',
+            error: err instanceof Error ? err : new Error(String(messageText)),
+          });
+          void this.emit({ type: 'message_end', message });
+          break;
+        }
+        default:
+          break;
+      }
+    }
+
+    const text = message?.content
+      .filter(c => c.type === 'text')
+      .map(c => c.text)
+      .join('');
+
+    return { text, stopReason };
+  }
+
+  private async listMessages(options?: { threadId?: string }): Promise<HarnessMessage[]> {
+    const threadId = options?.threadId ?? this._currentThreadId;
+    if (!threadId) return [];
+
+    const memoryStorage = await this.getMemoryStorage();
+    const result = await memoryStorage.listMessages({
+      threadId,
+      perPage: false,
+    });
+
+    return result.messages.map(message => this.convertToHarnessMessage(message as MastraDBMessage));
+  }
+
+  private convertToHarnessMessage(message: MastraDBMessage): HarnessMessage {
+    const content: HarnessMessageContent[] = [];
+
+    for (const part of message.content.parts ?? []) {
+      if (part.type === 'text' && 'text' in part) {
+        content.push({ type: 'text', text: String(part.text ?? '') });
+        continue;
+      }
+
+      if (part.type === 'reasoning') {
+        const reasoningText = 'text' in part && typeof part.text === 'string' ? part.text : '';
+        if (reasoningText) {
+          content.push({ type: 'thinking', thinking: reasoningText });
+        }
+        continue;
+      }
+
+      if (part.type === 'tool-invocation' && 'toolInvocation' in part) {
+        const invocation = part.toolInvocation as unknown as Record<string, unknown>;
+        const toolCallId = String(invocation.toolCallId ?? this.generateId());
+        const toolName = String(invocation.toolName ?? 'unknown_tool');
+        const state = String(invocation.state ?? 'call');
+        if (state === 'result') {
+          content.push({
+            type: 'tool_result',
+            id: toolCallId,
+            name: toolName,
+            result: invocation.result,
+            isError: false,
+          });
+        } else {
+          content.push({
+            type: 'tool_call',
+            id: toolCallId,
+            name: toolName,
+            args: invocation.args,
+          });
+        }
+        continue;
+      }
+
+      if (part.type === 'file' && 'mimeType' in part && 'data' in part) {
+        const mimeType = String(part.mimeType ?? '');
+        const data = part.data;
+        if (mimeType.startsWith('image/') && typeof data === 'string') {
+          content.push({
+            type: 'image',
+            data,
+            mimeType,
+          });
+        }
+        continue;
+      }
+
+      if (typeof part.type === 'string' && part.type.startsWith('data-om-')) {
+        const data = (part as any).data ?? {};
+        if (part.type === 'data-om-observation-start') {
+          content.push({
+            type: 'om_observation_start',
+            tokensToObserve: Number(data.tokensToObserve ?? 0),
+            operationType: data.operationType,
+          });
+        } else if (part.type === 'data-om-observation-end') {
+          content.push({
+            type: 'om_observation_end',
+            tokensObserved: Number(data.tokensObserved ?? 0),
+            observationTokens: Number(data.observationTokens ?? 0),
+            durationMs: Number(data.durationMs ?? 0),
+            operationType: data.operationType,
+            observations: data.observations,
+            currentTask: data.currentTask,
+            suggestedResponse: data.suggestedResponse,
+          });
+        } else if (part.type === 'data-om-observation-failed') {
+          content.push({
+            type: 'om_observation_failed',
+            error: String(data.error ?? 'Unknown error'),
+            tokensAttempted: data.tokensAttempted != null ? Number(data.tokensAttempted) : undefined,
+            operationType: data.operationType,
+          });
+        }
+      }
+    }
+
+    return {
+      id: message.id,
+      role: message.role,
+      content,
+      createdAt: message.createdAt,
+    };
+  }
+
+  private async persistTokenUsage(): Promise<void> {
+    await this.persistThreadSetting('tokenUsage', this._tokenUsage);
+  }
+
+  // =====================================================================
+  // Token Usage (private — exposed via this.usage)
+  // =====================================================================
+
+  private getTokenUsage(): TokenUsage {
+    return { ...this._tokenUsage };
+  }
+
+  // =====================================================================
+  // Utilities
+  // =====================================================================
+
+  private generateId(): string {
+    return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+  }
+}

--- a/packages/core/src/harness/index.ts
+++ b/packages/core/src/harness/index.ts
@@ -1,5 +1,6 @@
 export { Harness } from './harness';
 export type {
+  EventOfType,
   HarnessConfig,
   HarnessEvent,
   HarnessEventListener,
@@ -10,11 +11,19 @@ export type {
   HarnessModeAccessor,
   HarnessRequestContext,
   HarnessSession,
+  HarnessStorage,
+  HarnessToolContext,
   HarnessStateAccessor,
   HarnessStateSchema,
+  StateOf,
   HarnessThread,
   HarnessThreads,
   HarnessUsageAccessor,
   ObservationalMemoryDebugEvent,
+  PendingInteraction,
+  StreamChunkHandler,
+  StreamHandlerContext,
   TokenUsage,
+  ToolPolicy,
+  TypedEventListener,
 } from './types';

--- a/packages/core/src/harness/index.ts
+++ b/packages/core/src/harness/index.ts
@@ -1,0 +1,20 @@
+export { Harness } from './harness';
+export type {
+  HarnessConfig,
+  HarnessEvent,
+  HarnessEventListener,
+  HarnessHooks,
+  HarnessMessage,
+  HarnessMessageContent,
+  HarnessMode,
+  HarnessModeAccessor,
+  HarnessRequestContext,
+  HarnessSession,
+  HarnessStateAccessor,
+  HarnessStateSchema,
+  HarnessThread,
+  HarnessThreads,
+  HarnessUsageAccessor,
+  ObservationalMemoryDebugEvent,
+  TokenUsage,
+} from './types';

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -1,0 +1,731 @@
+import type z from 'zod';
+import type { Agent } from '../agent';
+import type { MastraMemory } from '../memory';
+import type { MastraCompositeStore } from '../storage';
+import type { Workspace, WorkspaceConfig, WorkspaceStatus } from '../workspace';
+
+// =============================================================================
+// Foundational Types
+// =============================================================================
+
+/**
+ * Schema type for harness state - must be a Zod object schema.
+ */
+export type HarnessStateSchema = z.ZodObject<z.ZodRawShape>;
+
+/**
+ * Token usage statistics from the model.
+ */
+export interface TokenUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+/**
+ * Configuration for a single agent mode within the harness.
+ * Each mode represents a different "personality" or capability set.
+ */
+export interface HarnessMode<TState extends HarnessStateSchema = HarnessStateSchema> {
+  /** Unique identifier for this mode (e.g., "plan", "build", "review") */
+  id: string;
+
+  /** Human-readable name for display in TUI */
+  name?: string;
+
+  /** Whether this is the default mode when harness starts */
+  default?: boolean;
+
+  /**
+   * Default model ID for this mode (e.g., "anthropic/claude-sonnet-4-20250514").
+   * Used when no per-mode model has been explicitly selected.
+   * If not set, falls back to the global last model.
+   */
+  defaultModelId?: string;
+
+  /** Hex color for the mode badge in the status line (e.g., "#7c3aed") */
+  color?: string;
+
+  /**
+   * The agent for this mode.
+   * Can be a static Agent or a function that receives harness state.
+   */
+  agent: Agent | ((state: z.infer<TState>) => Agent);
+}
+
+/**
+ * Configuration for creating a Harness instance.
+ */
+export interface HarnessConfig<TState extends HarnessStateSchema = HarnessStateSchema> {
+  /** Unique identifier for this harness instance */
+  id: string;
+
+  /**
+   * Resource ID for grouping threads (e.g., project identifier).
+   * Threads are scoped to this resource ID.
+   * Typically derived from git URL or project path.
+   */
+  resourceId: string;
+
+  /**
+   * The auto-detected resource ID before any overrides.
+   * Used by `/resource reset` to restore the default.
+   * If not provided, defaults to `resourceId`.
+   */
+  defaultResourceId?: string;
+
+  /**
+   * User ID for thread attribution (e.g., git user.email).
+   * Stored as `createdBy` in thread metadata for multi-user visibility.
+   */
+  userId?: string;
+
+  /**
+   * Whether the storage backend is remote (e.g., Turso).
+   * Affects default behavior for thread visibility filtering.
+   */
+  isRemoteStorage?: boolean;
+
+  /** Storage backend for persistence (threads, messages, state) */
+  storage: MastraCompositeStore;
+
+  /** Zod schema defining the shape of harness state */
+  stateSchema: TState;
+
+  /** Initial state values (must conform to schema) */
+  initialState?: Partial<z.infer<TState>>;
+
+  /** Memory configuration (shared across all modes) */
+  memory?: MastraMemory;
+
+  /** Available agent modes */
+  modes: HarnessMode<TState>[];
+
+  /**
+   * Callback when observational memory emits debug events.
+   * Used by TUI to show progress indicators.
+   */
+  onObservationalMemoryEvent?: (event: ObservationalMemoryDebugEvent) => void;
+
+  /**
+   * Optional callback to provide additional toolsets at stream time.
+   * Receives the current model ID and should return a toolsets object
+   * (or undefined) to pass to agent.stream().
+   *
+   * Use this to conditionally add provider-specific tools
+   * (e.g., Anthropic web search when using Claude models).
+   */
+  getToolsets?: (modelId: string) => Record<string, Record<string, unknown>> | undefined;
+
+  /**
+   * Workspace configuration.
+   * Accepts either a pre-constructed Workspace instance or a WorkspaceConfig
+   * to have the Harness construct one internally.
+   *
+   * When provided, the Harness manages the workspace lifecycle (init/destroy)
+   * and exposes it to agents via HarnessRuntimeContext.
+   *
+   * @example Pre-built workspace
+   * ```typescript
+   * const workspace = new Workspace({ skills: ['/skills'] });
+   * const harness = new Harness({ workspace, ... });
+   * ```
+   *
+   * @example Workspace config (Harness constructs it)
+   * ```typescript
+   * const harness = new Harness({
+   *   workspace: {
+   *     filesystem: new LocalFilesystem({ basePath: './data' }),
+   *     skills: ['/skills'],
+   *   },
+   *   ...
+   * });
+   * ```
+   */
+  workspace?: Workspace | WorkspaceConfig;
+
+  /**
+   * Extension hooks for customizing harness behavior.
+   * All hooks are optional with sensible defaults.
+   *
+   * @see HarnessHooks for detailed documentation of each hook.
+   */
+  hooks?: HarnessHooks<TState>;
+}
+
+// =============================================================================
+// Threads
+// =============================================================================
+
+/**
+ * Thread metadata stored in the harness.
+ */
+export interface HarnessThread {
+  id: string;
+  resourceId: string;
+  title?: string;
+  createdAt: Date;
+  updatedAt: Date;
+  /** Token usage for this thread (persisted for status line) */
+  tokenUsage?: TokenUsage;
+  /** Optional metadata (gitBranch, etc.) — may be absent on older threads */
+  metadata?: Record<string, unknown>;
+}
+
+// =============================================================================
+// Messages
+// =============================================================================
+
+/**
+ * Simplified message type for TUI consumption.
+ * Maps from Mastra's internal message format.
+ */
+export interface HarnessMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: HarnessMessageContent[];
+  createdAt: Date;
+  /** For assistant messages */
+  stopReason?: 'complete' | 'tool_use' | 'aborted' | 'error';
+  errorMessage?: string;
+}
+
+export type HarnessMessageContent =
+  | { type: 'text'; text: string }
+  | { type: 'thinking'; thinking: string }
+  | { type: 'tool_call'; id: string; name: string; args: unknown }
+  | {
+      type: 'tool_result';
+      id: string;
+      name: string;
+      result: unknown;
+      isError: boolean;
+    }
+  | { type: 'image'; data: string; mimeType: string }
+  | {
+      type: 'om_observation_start';
+      tokensToObserve: number;
+      operationType?: 'observation' | 'reflection';
+    }
+  | {
+      type: 'om_observation_end';
+      tokensObserved: number;
+      observationTokens: number;
+      durationMs: number;
+      operationType?: 'observation' | 'reflection';
+      observations?: string;
+      currentTask?: string;
+      suggestedResponse?: string;
+    }
+  | {
+      type: 'om_observation_failed';
+      error: string;
+      tokensAttempted?: number;
+      operationType?: 'observation' | 'reflection';
+    };
+
+// =============================================================================
+// Events
+// =============================================================================
+
+/**
+ * Debug events from observational memory.
+ * Used by TUI to show progress indicators.
+ */
+export type ObservationalMemoryDebugEvent =
+  | {
+      type: 'observation_triggered';
+      pendingTokens: number;
+      threshold: number;
+    }
+  | {
+      type: 'observation_complete';
+      observationTokens: number;
+      duration: number;
+    }
+  | {
+      type: 'reflection_triggered';
+      observationTokens: number;
+      threshold: number;
+    }
+  | {
+      type: 'reflection_complete';
+      compressedTokens: number;
+      duration: number;
+    }
+  | {
+      type: 'tokens_accumulated';
+      pendingTokens: number;
+      threshold: number;
+    };
+
+/**
+ * Events emitted by the harness that the TUI can subscribe to.
+ */
+export type HarnessEvent =
+  // -- Core lifecycle ---------------------------------------------------
+  | { type: 'mode_changed'; modeId: string; previousModeId: string }
+  | {
+      type: 'model_changed';
+      modelId: string;
+      scope?: 'global' | 'thread' | 'mode';
+      modeId?: string;
+    }
+  | {
+      type: 'thread_changed';
+      threadId: string;
+      previousThreadId: string | null;
+    }
+  | { type: 'thread_created'; thread: HarnessThread }
+  | {
+      type: 'state_changed';
+      state: Record<string, unknown>;
+      changedKeys: string[];
+    }
+
+  // -- Agent lifecycle --------------------------------------------------
+  | { type: 'agent_start' }
+  | { type: 'agent_end'; reason?: 'complete' | 'aborted' | 'error' }
+
+  // -- Messages ---------------------------------------------------------
+  | { type: 'message_start'; message: HarnessMessage }
+  | { type: 'message_update'; message: HarnessMessage }
+  | { type: 'message_end'; message: HarnessMessage }
+
+  // -- Tool execution ---------------------------------------------------
+  | { type: 'tool_start'; toolCallId: string; toolName: string; args: unknown }
+  | {
+      type: 'tool_approval_required';
+      toolCallId: string;
+      toolName: string;
+      args: unknown;
+    }
+  | { type: 'tool_update'; toolCallId: string; partialResult: unknown }
+  | { type: 'tool_end'; toolCallId: string; result: unknown; isError: boolean }
+  | {
+      type: 'shell_output';
+      toolCallId: string;
+      output: string;
+      stream: 'stdout' | 'stderr';
+    }
+
+  // -- Usage & diagnostics ----------------------------------------------
+  | { type: 'usage_update'; usage: TokenUsage }
+  | { type: 'info'; message: string }
+  | {
+      type: 'error';
+      error: Error;
+      errorType?: string;
+      retryable?: boolean;
+      retryDelay?: number;
+    }
+
+  // -- Observational Memory: status & active window ---------------------
+  | {
+      type: 'om_status';
+      windows: {
+        active: {
+          messages: { tokens: number; threshold: number };
+          observations: { tokens: number; threshold: number };
+        };
+        buffered: {
+          observations: {
+            status: 'idle' | 'running' | 'complete';
+            chunks: number;
+            messageTokens: number;
+            projectedMessageRemoval: number;
+            observationTokens: number;
+          };
+          reflection: {
+            status: 'idle' | 'running' | 'complete';
+            inputObservationTokens: number;
+            observationTokens: number;
+          };
+        };
+      };
+      recordId: string;
+      threadId: string;
+      stepNumber: number;
+      generationCount: number;
+    }
+
+  // -- Observational Memory: observation lifecycle -----------------------
+  | {
+      type: 'om_observation_start';
+      cycleId: string;
+      operationType: 'observation' | 'reflection';
+      tokensToObserve: number;
+    }
+  | {
+      type: 'om_observation_end';
+      cycleId: string;
+      durationMs: number;
+      tokensObserved: number;
+      observationTokens: number;
+      observations?: string;
+      currentTask?: string;
+      suggestedResponse?: string;
+    }
+  | {
+      type: 'om_observation_failed';
+      cycleId: string;
+      error: string;
+      durationMs: number;
+    }
+
+  // -- Observational Memory: reflection lifecycle -----------------------
+  | { type: 'om_reflection_start'; cycleId: string; tokensToReflect: number }
+  | {
+      type: 'om_reflection_end';
+      cycleId: string;
+      durationMs: number;
+      compressedTokens: number;
+      observations?: string;
+    }
+  | {
+      type: 'om_reflection_failed';
+      cycleId: string;
+      error: string;
+      durationMs: number;
+    }
+  | {
+      type: 'om_model_changed';
+      role: 'observer' | 'reflector';
+      modelId: string;
+    }
+
+  // -- Observational Memory: buffering lifecycle ------------------------
+  | {
+      type: 'om_buffering_start';
+      cycleId: string;
+      operationType: 'observation' | 'reflection';
+      tokensToBuffer: number;
+    }
+  | {
+      type: 'om_buffering_end';
+      cycleId: string;
+      operationType: 'observation' | 'reflection';
+      tokensBuffered: number;
+      bufferedTokens: number;
+      observations?: string;
+    }
+  | {
+      type: 'om_buffering_failed';
+      cycleId: string;
+      operationType: 'observation' | 'reflection';
+      error: string;
+    }
+  | {
+      type: 'om_activation';
+      cycleId: string;
+      operationType: 'observation' | 'reflection';
+      chunksActivated: number;
+      tokensActivated: number;
+      observationTokens: number;
+      messagesActivated: number;
+      generationCount: number;
+    }
+
+  // -- Workspace --------------------------------------------------------
+  | {
+      type: 'workspace_status_changed';
+      status: WorkspaceStatus;
+      error?: Error;
+    }
+  | {
+      type: 'workspace_ready';
+      workspaceId: string;
+      workspaceName: string;
+    }
+  | { type: 'workspace_error'; error: Error }
+
+  // -- Subagent / task delegation ----------------------------------------
+  | {
+      type: 'subagent_start';
+      toolCallId: string;
+      agentType: string;
+      task: string;
+      modelId?: string;
+    }
+  | {
+      type: 'subagent_tool_start';
+      toolCallId: string;
+      agentType: string;
+      subToolName: string;
+      subToolArgs: unknown;
+    }
+  | {
+      type: 'subagent_tool_end';
+      toolCallId: string;
+      agentType: string;
+      subToolName: string;
+      subToolResult: unknown;
+      isError: boolean;
+    }
+  | {
+      type: 'subagent_text_delta';
+      toolCallId: string;
+      agentType: string;
+      textDelta: string;
+    }
+  | {
+      type: 'subagent_end';
+      toolCallId: string;
+      agentType: string;
+      result: string;
+      isError: boolean;
+      durationMs: number;
+    }
+  | {
+      type: 'subagent_model_changed';
+      modelId: string;
+      scope: 'global' | 'thread';
+      agentType: string;
+    }
+
+  // -- UI interactions --------------------------------------------------
+  | {
+      type: 'todo_updated';
+      todos: Array<{
+        content: string;
+        status: 'pending' | 'in_progress' | 'completed';
+        activeForm: string;
+      }>;
+    }
+  | {
+      type: 'ask_question';
+      questionId: string;
+      question: string;
+      options?: Array<{ label: string; description?: string }>;
+    }
+  | {
+      type: 'sandbox_access_request';
+      questionId: string;
+      path: string;
+      reason: string;
+    }
+  | {
+      type: 'plan_approval_required';
+      planId: string;
+      title: string;
+      plan: string;
+    }
+  | {
+      type: 'plan_approved';
+    }
+
+  // -- Misc -------------------------------------------------------------
+  | { type: 'follow_up_queued'; count: number };
+
+/**
+ * Listener function for harness events.
+ */
+export type HarnessEventListener = (event: HarnessEvent) => void | Promise<void>;
+
+// =============================================================================
+// Session
+// =============================================================================
+
+/**
+ * Snapshot of the current harness session state.
+ * Used by UIs to render thread lists, mode indicators, etc.
+ */
+export interface HarnessSession {
+  currentThreadId: string | null;
+  currentModeId: string;
+  threads: HarnessThread[];
+}
+
+// =============================================================================
+// Hooks (Extension Points)
+// =============================================================================
+
+/**
+ * Callbacks that let applications customize harness behavior
+ * without modifying the core implementation.
+ *
+ * All hooks are optional. Sensible defaults are used when omitted.
+ */
+export interface HarnessHooks<TState extends HarnessStateSchema = HarnessStateSchema> {
+  /**
+   * Decide whether a tool call should be auto-approved, prompted, or denied.
+   * Called when the stream emits a `tool-call-approval` chunk.
+   *
+   * @returns "allow" to auto-approve, "ask" to prompt the user, "deny" to auto-decline.
+   * @default Returns "ask" for all tools.
+   */
+  resolveToolApproval?: (toolName: string, args: unknown) => 'allow' | 'ask' | 'deny';
+
+  /**
+   * Validate or block a user message before it's sent to the agent.
+   * Returning `{ allowed: false }` prevents the message from being sent.
+   *
+   * @default Allows all messages.
+   */
+  onBeforeSend?: (content: string) =>
+    | {
+        allowed: boolean;
+        blockReason?: string;
+      }
+    | Promise<{
+        allowed: boolean;
+        blockReason?: string;
+      }>;
+
+  /**
+   * Inspect the agent's response after streaming completes.
+   * Returning `{ continueWorking: true }` queues a follow-up message
+   * so the agent keeps going.
+   *
+   * @default No-op.
+   */
+  onAfterSend?: (result: { text?: string; stopReason: string }) =>
+    | {
+        continueWorking?: boolean;
+        reason?: string;
+      }
+    | Promise<{
+        continueWorking?: boolean;
+        reason?: string;
+      }>;
+
+  /**
+   * Called before a tool is executed (after approval).
+   * Returning `{ allowed: false }` declines the tool call.
+   *
+   * @default Allows all tool executions.
+   */
+  onBeforeToolUse?: (toolName: string, args: unknown) => { allowed: boolean } | Promise<{ allowed: boolean }>;
+
+  /**
+   * Called after a tool finishes execution.
+   * Fire-and-forget — errors are swallowed.
+   *
+   * @default No-op.
+   */
+  onAfterToolUse?: (toolName: string, args: unknown, result: unknown, isError: boolean) => void | Promise<void>;
+
+  /**
+   * Restore app-specific state when loading a thread's metadata.
+   * Return a partial state update to merge into harness state.
+   *
+   * @default No-op (returns empty object).
+   */
+  onThreadLoad?: (metadata: Record<string, unknown>) => Partial<z.infer<TState>>;
+
+  /**
+   * Inject app-specific metadata when creating a new thread.
+   * Return additional metadata key-values to persist.
+   *
+   * @default No-op (returns empty object).
+   */
+  onThreadCreate?: (thread: HarnessThread, state: z.infer<TState>) => Record<string, unknown>;
+
+  /**
+   * Parse or classify errors for better user feedback.
+   * Return a structured error with type, retryability, etc.
+   *
+   * @default Passes through the original error.
+   */
+  onError?: (error: unknown) => {
+    error: Error;
+    errorType?: string;
+    retryable?: boolean;
+    retryDelay?: number;
+  };
+}
+
+// =============================================================================
+// Runtime Context (Serializable Only)
+// =============================================================================
+
+/**
+ * Serializable context passed to agent.stream() via RequestContext.
+ *
+ * Contains only data — no functions, no object references.
+ * Tools that need to call back into the Harness (e.g., emitEvent,
+ * registerQuestion) should close over the Harness instance at
+ * tool-construction time in the application layer.
+ */
+export interface HarnessRequestContext<TState extends HarnessStateSchema = HarnessStateSchema> {
+  /** The harness instance ID */
+  harnessId: string;
+
+  /** Current thread ID */
+  threadId: string | null;
+
+  /** Current resource ID */
+  resourceId: string;
+
+  /** Current mode ID */
+  modeId: string;
+
+  /** Snapshot of harness state at request time */
+  state: z.infer<TState>;
+}
+
+// =============================================================================
+// Namespaced API Interfaces
+// =============================================================================
+
+/**
+ * Thread management namespace.
+ * Accessible via `harness.threads`.
+ */
+export interface HarnessThreads {
+  /** Create a new thread and make it current. */
+  create(title?: string): Promise<HarnessThread>;
+  /** List threads for the current resource. */
+  list(options?: { allResources?: boolean; mineOnly?: boolean }): Promise<HarnessThread[]>;
+  /** Switch to an existing thread by ID. */
+  switch(id: string): Promise<void>;
+  /** Rename the current thread. */
+  rename(title: string): Promise<void>;
+  /** Select the most recent thread, or create one if none exist. */
+  selectOrCreate(): Promise<HarnessThread>;
+  /** Get the current thread ID (null if no thread selected). */
+  current(): string | null;
+  /** List messages for the current (or specified) thread. */
+  messages(options?: { threadId?: string }): Promise<HarnessMessage[]>;
+  /** Persist a key-value pair to the current thread's metadata. */
+  persistSetting(key: string, value: unknown): Promise<void>;
+}
+
+/**
+ * State management namespace.
+ * Accessible via `harness.state`.
+ */
+export interface HarnessStateAccessor<TState extends HarnessStateSchema = HarnessStateSchema> {
+  /** Get a read-only snapshot of the current state. */
+  get(): Readonly<z.infer<TState>>;
+  /** Update state (validated against schema). Emits state_changed event. */
+  set(updates: Partial<z.infer<TState>>): Promise<void>;
+}
+
+/**
+ * Mode management namespace.
+ * Accessible via `harness.modes`.
+ */
+export interface HarnessModeAccessor<TState extends HarnessStateSchema = HarnessStateSchema> {
+  /** Get all available modes. */
+  list(): HarnessMode<TState>[];
+  /** Switch to a different mode by ID. Aborts any in-progress generation. */
+  switch(id: string): Promise<void>;
+  /** Get the current mode configuration. */
+  current(): HarnessMode<TState>;
+  /** Get the current mode ID. */
+  currentId(): string;
+}
+
+/**
+ * Token usage namespace.
+ * Accessible via `harness.usage`.
+ */
+export interface HarnessUsageAccessor {
+  /** Get cumulative token usage for the current thread. */
+  get(): TokenUsage;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1157,6 +1157,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../packages/core
+      '@mastra/libsql':
+        specifier: ^1.4.0
+        version: 1.4.0(@mastra/core@packages+core)
       ai:
         specifier: ^6.0.50
         version: 6.0.69(zod@4.3.6)
@@ -9999,6 +10002,12 @@ packages:
   '@mariozechner/pi-tui@0.52.12':
     resolution: {integrity: sha512-QQ4LUlAYKN2BvT3EMU63+kYLlIkyr706+rUFBGWvkiT8ZyMy5if3oaVJpO5qAndsMB+MaUnttIBPh3iHiaJ01g==}
     engines: {node: '>=20.0.0'}
+
+  '@mastra/libsql@1.4.0':
+    resolution: {integrity: sha512-7Ea6goCQpFxubKUp1+49reiEbbakP8WM7JHO3TZ4aQJBZKvf0wqTEoAKF0mMkDTcqN5C8QnrufThaYBbGHSHrA==}
+    engines: {node: '>=22.13.0'}
+    peerDependencies:
+      '@mastra/core': '>=1.4.0-0 <2.0.0-0'
 
   '@mastra/mcp@1.0.0':
     resolution: {integrity: sha512-g+N3L61Sq4dQGLjMlQmVAnAPVOi1fJHmSe+gJxamxTGJ/r8Tdl6Za0gOj4faSeDUAn2sim0dCz2FEDjXDvoDsQ==}
@@ -28461,6 +28470,14 @@ snapshots:
       get-east-asian-width: 1.4.0
       marked: 15.0.12
       mime-types: 3.0.1
+
+  '@mastra/libsql@1.4.0(@mastra/core@packages+core)':
+    dependencies:
+      '@libsql/client': 0.15.15
+      '@mastra/core': link:packages/core
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@mastra/mcp@1.0.0(@mastra/core@packages+core)(@types/json-schema@7.0.15)(zod@3.25.76)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     vitest:
       specifier: 4.0.16
       version: 4.0.16
+    zod:
+      specifier: ^4.3.6
+      version: 4.3.6
 
 overrides:
   typescript: ^5.9.3
@@ -232,7 +235,7 @@ importers:
     dependencies:
       firebase-admin:
         specifier: ^13.4.0
-        version: 13.5.0(encoding@0.1.13)
+        version: 13.5.0
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -1133,6 +1136,46 @@ importers:
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.56.3(@types/node@22.19.7))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+
+  mastracode:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.23
+        version: 3.0.44(zod@4.3.6)
+      '@ai-sdk/openai':
+        specifier: ^3.0.21
+        version: 3.0.29(zod@4.3.6)
+      '@mariozechner/pi-tui':
+        specifier: ^0.52.12
+        version: 0.52.12
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../packages/core
+      ai:
+        specifier: ^6.0.50
+        version: 6.0.69(zod@4.3.6)
+      chalk:
+        specifier: ^5.6.2
+        version: 5.6.2
+      cli-highlight:
+        specifier: ^2.1.11
+        version: 2.1.11
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: 22.19.7
+        version: 22.19.7
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -5976,6 +6019,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/anthropic@3.0.44':
+    resolution: {integrity: sha512-ke1NldgohWJ7sWLqm9Um9TVIOrtg8Y8AecWeB6PgaLt+paTPisAsyNfe8FNOVusuv58ugLBqY/78AkhUmbjXHA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/azure@2.0.74':
     resolution: {integrity: sha512-0xmtnkrkONyskkbIRXi5hQ+23QUeSjBNiZSGlQ3SydCktUQo1ziyao0AQRwj/tx3z4+RhoQtpDT2nVAr2sknDA==}
     engines: {node: '>=18'}
@@ -6102,6 +6151,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai@3.0.29':
+    resolution: {integrity: sha512-ugVTIVpuSLKTjzSPe1F1DWiblJT/lwrrHx0OZEKjpMk/EYP6j6VD/F7SJqM1dsqOJryeBCJWFbUzLNqc99PrMA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/perplexity@2.0.23':
     resolution: {integrity: sha512-aiaRvnc6mhQZKhTTSXPCjPH8Iqr5D/PfCN1hgVP/3RGTBbJtsd9HemIBSABeSdAKbsMH/PwJxgnqH75HEamcBA==}
     engines: {node: '>=18'}
@@ -6159,6 +6214,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.15':
+    resolution: {integrity: sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@1.0.9':
     resolution: {integrity: sha512-jie6ZJT2ZR0uVOVCDc9R2xCX5I/Dum/wEK28lx21PJx6ZnFAN9EzD2WsPhcDWfCgGx3OAZZ0GyM3CEobXpa9LA==}
     engines: {node: '>=18'}
@@ -6181,6 +6242,10 @@ packages:
 
   '@ai-sdk/provider@3.0.7':
     resolution: {integrity: sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@1.2.12':
@@ -9910,6 +9975,10 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
+  '@mariozechner/pi-tui@0.52.12':
+    resolution: {integrity: sha512-QQ4LUlAYKN2BvT3EMU63+kYLlIkyr706+rUFBGWvkiT8ZyMy5if3oaVJpO5qAndsMB+MaUnttIBPh3iHiaJ01g==}
+    engines: {node: '>=20.0.0'}
+
   '@mastra/mcp@1.0.0':
     resolution: {integrity: sha512-g+N3L61Sq4dQGLjMlQmVAnAPVOi1fJHmSe+gJxamxTGJ/r8Tdl6Za0gOj4faSeDUAn2sim0dCz2FEDjXDvoDsQ==}
     engines: {node: '>=22.13.0'}
@@ -13362,6 +13431,9 @@ packages:
   '@types/memcached@2.2.10':
     resolution: {integrity: sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==}
 
+  '@types/mime-types@2.1.4':
+    resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
+
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
@@ -15011,6 +15083,11 @@ packages:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
 
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+
   cli-progress@3.12.0:
     resolution: {integrity: sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==}
     engines: {node: '>=4'}
@@ -15039,6 +15116,9 @@ packages:
   clipboardy@3.0.0:
     resolution: {integrity: sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -18214,6 +18294,11 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
@@ -19230,8 +19315,17 @@ packages:
   parse-numeric-range@1.3.0:
     resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
 
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -22567,9 +22661,17 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -22701,6 +22803,12 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/anthropic@3.0.44(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.15(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/azure@2.0.74(zod@3.25.76)':
     dependencies:
       '@ai-sdk/openai': 2.0.72(zod@3.25.76)
@@ -22769,6 +22877,13 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
+  '@ai-sdk/gateway@3.0.32(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.7
+      '@ai-sdk/provider-utils': 4.0.13(zod@4.3.6)
+      '@vercel/oidc': 3.1.0
+      zod: 4.3.6
+
   '@ai-sdk/google@1.2.22(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
@@ -22835,6 +22950,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.1(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/openai@3.0.29(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.15(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/perplexity@2.0.23(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
@@ -22899,6 +23020,20 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 3.25.76
 
+  '@ai-sdk/provider-utils@4.0.13(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.7
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.15(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
   '@ai-sdk/provider@1.0.9':
     dependencies:
       json-schema: 0.4.0
@@ -22920,6 +23055,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.7':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
 
@@ -27557,7 +27696,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google-cloud/firestore@7.11.6(encoding@0.1.13)':
+  '@google-cloud/firestore@7.11.6':
     dependencies:
       '@opentelemetry/api': 1.9.0
       fast-deep-equal: 3.1.3
@@ -28281,6 +28420,14 @@ snapshots:
       tinyglobby: 0.2.15
 
   '@marijn/find-cluster-break@1.0.2': {}
+
+  '@mariozechner/pi-tui@0.52.12':
+    dependencies:
+      '@types/mime-types': 2.1.4
+      chalk: 5.6.2
+      get-east-asian-width: 1.4.0
+      marked: 15.0.12
+      mime-types: 3.0.1
 
   '@mastra/mcp@1.0.0(@mastra/core@packages+core)(@types/json-schema@7.0.15)(zod@3.25.76)':
     dependencies:
@@ -32636,6 +32783,8 @@ snapshots:
     dependencies:
       '@types/node': 22.19.7
 
+  '@types/mime-types@2.1.4': {}
+
   '@types/mime@1.3.5': {}
 
   '@types/mongodb@4.0.7(socks@2.8.7)':
@@ -33781,6 +33930,14 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
+  ai@6.0.69(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.32(zod@4.3.6)
+      '@ai-sdk/provider': 3.0.7
+      '@ai-sdk/provider-utils': 4.0.13(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
+
   ajv-draft-04@1.0.0(ajv@8.13.0):
     optionalDependencies:
       ajv: 8.13.0
@@ -34621,6 +34778,15 @@ snapshots:
     dependencies:
       restore-cursor: 5.1.0
 
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.0
+
   cli-progress@3.12.0:
     dependencies:
       string-width: 4.2.3
@@ -34649,6 +34815,12 @@ snapshots:
       arch: 2.2.0
       execa: 5.1.1
       is-wsl: 2.2.0
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   cliui@8.0.1:
     dependencies:
@@ -36469,7 +36641,7 @@ snapshots:
       pkg-types: 1.3.1
       yaml: 2.8.1
 
-  firebase-admin@13.5.0(encoding@0.1.13):
+  firebase-admin@13.5.0:
     dependencies:
       '@fastify/busboy': 3.2.0
       '@firebase/database-compat': 2.1.0
@@ -36483,7 +36655,7 @@ snapshots:
       node-forge: 1.3.2
       uuid: 11.1.0
     optionalDependencies:
-      '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
+      '@google-cloud/firestore': 7.11.6
       '@google-cloud/storage': 7.19.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
@@ -38470,6 +38642,8 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
+  marked@15.0.12: {}
+
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
@@ -39935,10 +40109,18 @@ snapshots:
 
   parse-numeric-range@1.3.0: {}
 
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
       domhandler: 5.0.3
       parse5: 7.3.0
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
 
   parse5@7.3.0:
     dependencies:
@@ -43975,7 +44157,19 @@ snapshots:
 
   yaml@2.8.1: {}
 
+  yargs-parser@20.2.9: {}
+
   yargs-parser@21.1.1: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yargs@17.7.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,7 +112,7 @@ importers:
         version: 7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   auth/auth0:
     dependencies:
@@ -149,7 +149,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   auth/better-auth:
     dependencies:
@@ -189,7 +189,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   auth/clerk:
     dependencies:
@@ -229,7 +229,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   auth/firebase:
     dependencies:
@@ -266,7 +266,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   auth/supabase:
     dependencies:
@@ -303,7 +303,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   auth/workos:
     dependencies:
@@ -343,7 +343,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   client-sdks/ai-sdk:
     devDependencies:
@@ -385,7 +385,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -443,7 +443,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -534,7 +534,7 @@ importers:
         version: 4.5.4(@types/node@22.19.7)(rollup@4.55.3)(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -598,7 +598,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   deployers/cloudflare:
     dependencies:
@@ -656,7 +656,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       wrangler:
         specifier: ^4.54.0
         version: 4.58.0
@@ -708,7 +708,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   deployers/vercel:
     dependencies:
@@ -751,7 +751,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   docs:
     dependencies:
@@ -959,7 +959,7 @@ importers:
         version: 4.11.7
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
     devDependencies:
       typescript:
         specifier: ^5.9.3
@@ -979,7 +979,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   e2e-tests/client-js/zod-v4:
     dependencies:
@@ -995,7 +995,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   e2e-tests/workspace-compat:
     devDependencies:
@@ -1019,7 +1019,7 @@ importers:
         version: 10.3.1
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   explorations/longmemeval:
     dependencies:
@@ -1107,7 +1107,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   integrations/opencode:
     dependencies:
@@ -1141,7 +1141,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   mastracode:
     dependencies:
@@ -1166,6 +1166,21 @@ importers:
       cli-highlight:
         specifier: ^2.1.11
         version: 2.1.11
+      execa:
+        specifier: ^9.6.1
+        version: 9.6.1
+      fastest-levenshtein:
+        specifier: ^1.0.16
+        version: 1.0.16
+      js-tiktoken:
+        specifier: ^1.0.21
+        version: 1.0.21
+      strip-ansi:
+        specifier: ^7.1.2
+        version: 7.1.2
+      tree-kill:
+        specifier: ^1.2.2
+        version: 1.2.2
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1173,6 +1188,12 @@ importers:
       '@types/node':
         specifier: 22.19.7
         version: 22.19.7
+      '@types/strip-ansi':
+        specifier: ^5.2.1
+        version: 5.2.1
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(@microsoft/api-extractor@7.56.3(@types/node@22.19.7))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.1)
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -1181,7 +1202,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   observability/_test-utils:
     devDependencies:
@@ -1199,7 +1220,7 @@ importers:
         version: 4.0.12(vitest@4.0.16)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   observability/arize:
     dependencies:
@@ -1257,7 +1278,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   observability/braintrust:
     dependencies:
@@ -1303,7 +1324,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   observability/datadog:
     dependencies:
@@ -1349,7 +1370,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   observability/laminar:
     dependencies:
@@ -1401,7 +1422,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   observability/langfuse:
     dependencies:
@@ -1444,7 +1465,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   observability/langsmith:
     dependencies:
@@ -1493,7 +1514,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -1535,7 +1556,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -1636,7 +1657,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
     optionalDependencies:
       '@grpc/grpc-js':
         specifier: ^1.14.3
@@ -1732,7 +1753,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/_changeset-cli:
     dependencies:
@@ -1814,7 +1835,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/_config:
     dependencies:
@@ -1894,7 +1915,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/_types-builder:
     dependencies:
@@ -2193,7 +2214,7 @@ importers:
         version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -2239,7 +2260,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/cli:
     dependencies:
@@ -2360,7 +2381,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/codemod:
     dependencies:
@@ -2409,7 +2430,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/core:
     dependencies:
@@ -2602,7 +2623,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -2808,7 +2829,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -2857,7 +2878,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -2915,7 +2936,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -2961,7 +2982,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -3004,7 +3025,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/mcp:
     dependencies:
@@ -3077,7 +3098,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -3150,7 +3171,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/mcp-registry-registry:
     dependencies:
@@ -3214,7 +3235,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/memory:
     dependencies:
@@ -3293,7 +3314,7 @@ importers:
         version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/playground:
     dependencies:
@@ -3354,16 +3375,16 @@ importers:
         version: 19.2.2(@types/react@19.2.2)
       '@vitejs/plugin-react':
         specifier: ^5.1.2
-        version: 5.1.2(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 5.1.2(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       autoprefixer:
         specifier: ^10.4.24
         version: 10.4.24(postcss@8.5.6)
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
-        version: 7.0.1(eslint@9.39.2(jiti@1.21.7))
+        version: 7.0.1(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-refresh:
         specifier: ^0.4.24
-        version: 0.4.24(eslint@9.39.2(jiti@1.21.7))
+        version: 0.4.24(eslint@9.39.2(jiti@2.6.1))
       globals:
         specifier: ^16.5.0
         version: 16.5.0
@@ -3381,10 +3402,10 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.51.0
-        version: 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+        version: 8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^7.3.0
-        version: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/playground-ui:
     dependencies:
@@ -3601,10 +3622,10 @@ importers:
         version: link:../schema-compat
       '@storybook/addon-docs':
         specifier: ^9.1.16
-        version: 9.1.16(@types/react@19.2.2)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
+        version: 9.1.16(@types/react@19.2.2)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
       '@storybook/react-vite':
         specifier: ^9.1.16
-        version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.55.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.55.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       '@tailwindcss/container-queries':
         specifier: ^0.1.1
         version: 0.1.1(tailwindcss@3.4.18(tsx@4.21.0)(yaml@2.8.1))
@@ -3634,7 +3655,7 @@ importers:
         version: 7.7.1
       '@vitejs/plugin-react':
         specifier: ^5.1.2
-        version: 5.1.2(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 5.1.2(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       '@vitest/ui':
         specifier: 'catalog:'
         version: 4.0.12(vitest@4.0.16)
@@ -3655,7 +3676,7 @@ importers:
         version: 8.1.2(rollup@4.55.3)
       storybook:
         specifier: ^9.1.10
-        version: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.4.0
@@ -3667,16 +3688,16 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.0
-        version: 7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@22.19.7)(rollup@4.55.3)(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 4.5.4(@types/node@22.19.7)(rollup@4.55.3)(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       vite-plugin-lib-inject-css:
         specifier: ^2.2.2
-        version: 2.2.2(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+        version: 2.2.2(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/rag:
     dependencies:
@@ -3746,7 +3767,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -3813,7 +3834,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -3871,7 +3892,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -3932,7 +3953,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   server-adapters/_test-utils:
     dependencies:
@@ -4287,7 +4308,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/chroma:
     dependencies:
@@ -4327,7 +4348,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/clickhouse:
     dependencies:
@@ -4367,7 +4388,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/cloudflare:
     dependencies:
@@ -4416,7 +4437,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/cloudflare-d1:
     dependencies:
@@ -4465,7 +4486,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/convex:
     dependencies:
@@ -4508,7 +4529,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/couchbase:
     dependencies:
@@ -4548,7 +4569,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/duckdb:
     dependencies:
@@ -4591,7 +4612,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/dynamodb:
     dependencies:
@@ -4637,7 +4658,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/elasticsearch:
     dependencies:
@@ -4677,7 +4698,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/lance:
     dependencies:
@@ -4720,7 +4741,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/libsql:
     dependencies:
@@ -4760,7 +4781,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/mongodb:
     dependencies:
@@ -4809,7 +4830,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/mssql:
     dependencies:
@@ -4852,7 +4873,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/opensearch:
     dependencies:
@@ -4892,7 +4913,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/pg:
     dependencies:
@@ -4941,7 +4962,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/pinecone:
     dependencies:
@@ -4984,7 +5005,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/qdrant:
     dependencies:
@@ -5024,7 +5045,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/s3vectors:
     dependencies:
@@ -5070,7 +5091,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/turbopuffer:
     dependencies:
@@ -5113,7 +5134,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/upstash:
     dependencies:
@@ -5159,7 +5180,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   stores/vectorize:
     dependencies:
@@ -5199,7 +5220,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   voice/azure:
     dependencies:
@@ -5236,7 +5257,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   voice/cloudflare:
     dependencies:
@@ -5276,7 +5297,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -5319,7 +5340,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   voice/elevenlabs:
     dependencies:
@@ -5359,7 +5380,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   voice/gladia:
     devDependencies:
@@ -5395,7 +5416,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -5441,7 +5462,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   voice/google-gemini-live-api:
     dependencies:
@@ -5496,7 +5517,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   voice/murf:
     dependencies:
@@ -5536,7 +5557,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   voice/openai:
     dependencies:
@@ -5576,7 +5597,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   voice/openai-realtime-api:
     dependencies:
@@ -5622,7 +5643,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -5662,7 +5683,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   voice/sarvam:
     devDependencies:
@@ -5695,7 +5716,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -5738,7 +5759,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   workflows/inngest:
     dependencies:
@@ -5838,7 +5859,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   workspaces/_test-utils:
     devDependencies:
@@ -5853,7 +5874,7 @@ importers:
         version: 4.0.12(vitest@4.0.16)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   workspaces/e2b:
     dependencies:
@@ -5902,7 +5923,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   workspaces/gcs:
     dependencies:
@@ -5945,7 +5966,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   workspaces/s3:
     dependencies:
@@ -5988,7 +6009,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+        version: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
 packages:
 
@@ -13578,6 +13599,10 @@ packages:
   '@types/string-similarity@4.0.2':
     resolution: {integrity: sha512-LkJQ/jsXtCVMK+sKYAmX/8zEq+/46f1PTQw7YtmQwb74jemS1SlNLmARM2Zml9DgdDTWKAtc5L13WorpHPDjDA==}
 
+  '@types/strip-ansi@5.2.1':
+    resolution: {integrity: sha512-1l5iM0LBkVU8JXxnIoBqNvg+yyOXxPeN6DNoD+7A9AN1B8FhYPSeIXgyNqwIqg1uzipTgVC2hmuDzB0u9qw/PA==}
+    deprecated: This is a stub types definition. strip-ansi provides its own type definitions, so you do not need this installed.
+
   '@types/swagger-ui-express@4.1.8':
     resolution: {integrity: sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==}
 
@@ -16410,6 +16435,10 @@ packages:
 
   fastembed@1.14.4:
     resolution: {integrity: sha512-ZU9hpQRkYKPD/k0A6NzFe/Z9voSU3Saxve/1kLY9aS9iyUJYLJPI/3gsDgRA9uxwIMi8w7/tjH1lRW8K1N+wWA==}
+
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
@@ -27473,11 +27502,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2(jiti@1.21.7))':
-    dependencies:
-      eslint: 9.39.2(jiti@1.21.7)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
@@ -28075,6 +28099,15 @@ snapshots:
       '@types/node': 22.19.7
       '@types/yargs': 17.0.35
       chalk: 4.1.2
+
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      glob: 10.5.0
+      magic-string: 0.30.21
+      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
@@ -31973,18 +32006,25 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-docs@9.1.16(@types/react@19.2.2)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))':
+  '@storybook/addon-docs@9.1.16(@types/react@19.2.2)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.2)(react@19.2.3)
-      '@storybook/csf-plugin': 9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
+      '@storybook/csf-plugin': 9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
       '@storybook/icons': 1.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@storybook/react-dom-shim': 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
+      '@storybook/react-dom-shim': 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
+
+  '@storybook/builder-vite@9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@storybook/csf-plugin': 9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
+      storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      ts-dedent: 2.2.0
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   '@storybook/builder-vite@9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
@@ -31992,6 +32032,11 @@ snapshots:
       storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
       ts-dedent: 2.2.0
       vite: 7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+
+  '@storybook/csf-plugin@9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))':
+    dependencies:
+      storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      unplugin: 1.16.1
 
   '@storybook/csf-plugin@9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))':
     dependencies:
@@ -32005,11 +32050,37 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
+  '@storybook/react-dom-shim@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))':
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+
   '@storybook/react-dom-shim@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))':
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+
+  '@storybook/react-vite@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.55.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@rollup/pluginutils': 5.3.0(rollup@4.55.3)
+      '@storybook/builder-vite': 9.1.16(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@storybook/react': 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(typescript@5.9.3)
+      find-up: 7.0.0
+      magic-string: 0.30.21
+      react: 19.2.3
+      react-docgen: 8.0.2
+      react-dom: 19.2.3(react@19.2.3)
+      resolve: 1.22.11
+      storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      tsconfig-paths: 4.2.0
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+      - typescript
 
   '@storybook/react-vite@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.55.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
@@ -32030,6 +32101,16 @@ snapshots:
       - rollup
       - supports-color
       - typescript
+
+  '@storybook/react@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(typescript@5.9.3)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      storybook: 9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@storybook/react@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)))(typescript@5.9.3)':
     dependencies:
@@ -32966,6 +33047,10 @@ snapshots:
 
   '@types/string-similarity@4.0.2': {}
 
+  '@types/strip-ansi@5.2.1':
+    dependencies:
+      strip-ansi: 7.1.2
+
   '@types/swagger-ui-express@4.1.8':
     dependencies:
       '@types/express': 5.0.5
@@ -33003,22 +33088,6 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.51.0
-      '@typescript-eslint/type-utils': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.51.0
-      eslint: 9.39.2(jiti@1.21.7)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -33031,18 +33100,6 @@ snapshots:
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.51.0
-      '@typescript-eslint/types': 8.51.0
-      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.51.0
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -33077,18 +33134,6 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.51.0
-      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@1.21.7)
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/type-utils@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.51.0
@@ -33114,17 +33159,6 @@ snapshots:
       semver: 7.7.3
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@1.21.7))
-      '@typescript-eslint/scope-manager': 8.51.0
-      '@typescript-eslint/types': 8.51.0
-      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -33501,7 +33535,7 @@ snapshots:
       magicast: 0.5.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -33512,7 +33546,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
-      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -33533,6 +33567,15 @@ snapshots:
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
+  '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.7(@types/node@22.19.7)(typescript@5.9.3)
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+
   '@vitest/mocker@3.2.4(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -33541,6 +33584,15 @@ snapshots:
     optionalDependencies:
       msw: 2.12.7(@types/node@22.19.7)(typescript@5.9.3)
       vite: 7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+
+  '@vitest/mocker@4.0.16(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.0.16
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.7(@types/node@22.19.7)(typescript@5.9.3)
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   '@vitest/mocker@4.0.16(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
@@ -33624,7 +33676,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -34349,7 +34401,7 @@ snapshots:
       pg: 8.16.3
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   better-call@1.1.8(zod@4.3.6):
     dependencies:
@@ -36026,17 +36078,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@1.21.7)):
-    dependencies:
-      '@babel/core': 7.28.6
-      '@babel/parser': 7.28.6
-      eslint: 9.39.2(jiti@1.21.7)
-      hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.28.6
@@ -36048,9 +36089,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-refresh@0.4.24(eslint@9.39.2(jiti@1.21.7)):
+  eslint-plugin-react-refresh@0.4.24(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
-      eslint: 9.39.2(jiti@1.21.7)
+      eslint: 9.39.2(jiti@2.6.1)
 
   eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
@@ -36127,47 +36168,6 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
-
-  eslint@9.39.2(jiti@1.21.7):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2(jiti@1.21.7))
-      '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.21.1
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.39.2
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.7
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.6.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 1.21.7
-    transitivePeerDependencies:
-      - supports-color
 
   eslint@9.39.2(jiti@2.6.1):
     dependencies:
@@ -36476,6 +36476,8 @@ snapshots:
       onnxruntime-node: 1.21.0
       progress: 2.0.3
       tar: 6.2.1
+
+  fastest-levenshtein@1.0.16: {}
 
   fastify-plugin@5.1.0: {}
 
@@ -42370,6 +42372,30 @@ snapshots:
 
   stoppable@1.1.0: {}
 
+  storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/spy': 3.2.4
+      better-opn: 3.0.2
+      esbuild: 0.25.11
+      esbuild-register: 3.6.0(esbuild@0.25.11)
+      recast: 0.23.11
+      semver: 7.7.3
+      ws: 8.19.0
+    optionalDependencies:
+      prettier: 3.7.4
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - bufferutil
+      - msw
+      - supports-color
+      - utf-8-validate
+      - vite
+
   storybook@9.1.13(@testing-library/dom@10.4.1)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(prettier@3.7.4)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)):
     dependencies:
       '@storybook/global': 5.0.0
@@ -43093,17 +43119,6 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript-eslint@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.51.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@1.21.7)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   typescript-eslint@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
@@ -43603,6 +43618,25 @@ snapshots:
       - tsx
       - yaml
 
+  vite-plugin-dts@4.5.4(@types/node@22.19.7)(rollup@4.55.3)(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)):
+    dependencies:
+      '@microsoft/api-extractor': 7.56.3(@types/node@22.19.7)
+      '@rollup/pluginutils': 5.3.0(rollup@4.55.3)
+      '@volar/typescript': 2.4.23
+      '@vue/language-core': 2.2.0(typescript@5.9.3)
+      compare-versions: 6.1.1
+      debug: 4.4.3
+      kolorist: 1.8.0
+      local-pkg: 1.1.2
+      magic-string: 0.30.21
+      typescript: 5.9.3
+    optionalDependencies:
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - rollup
+      - supports-color
+
   vite-plugin-dts@4.5.4(@types/node@22.19.7)(rollup@4.55.3)(typescript@5.9.3)(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)):
     dependencies:
       '@microsoft/api-extractor': 7.56.3(@types/node@22.19.7)
@@ -43622,12 +43656,12 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-lib-inject-css@2.2.2(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)):
+  vite-plugin-lib-inject-css@2.2.2(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)):
     dependencies:
       '@ast-grep/napi': 0.36.3
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
 
   vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
@@ -43751,7 +43785,47 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12(vitest@4.0.16))(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1):
+  vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1):
+    dependencies:
+      '@vitest/expect': 4.0.16
+      '@vitest/mocker': 4.0.16(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.0.16
+      '@vitest/runner': 4.0.16
+      '@vitest/snapshot': 4.0.16
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.0(@types/node@22.19.7)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.19.7
+      '@vitest/ui': 4.0.12(vitest@4.0.16)
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.7)(@vitest/ui@4.0.12)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.16
       '@vitest/mocker': 4.0.16(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(vite@7.3.0(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1160,6 +1160,9 @@ importers:
       '@mastra/libsql':
         specifier: ^1.4.0
         version: 1.4.0(@mastra/core@packages+core)
+      '@mastra/memory':
+        specifier: workspace:*
+        version: link:../packages/memory
       ai:
         specifier: ^6.0.50
         version: 6.0.69(zod@4.3.6)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - mastracode
   - docs
   - packages/_vendored/*
   - packages/*


### PR DESCRIPTION
## Summary

- **Harness primitive** (`packages/core/src/harness/`) — generic orchestration layer for AI coding agents with namespaced API (threads, state, modes, usage), event system, stream processing, tool approval flow, and observational memory integration
- **MastraCode CLI** (`mastracode/`) — first consumer of the Harness, porting the standalone mastra-code repo into the monorepo with full TUI, agents, tools, prompts, auth, and utilities
- Comprehensive test suite for the core Harness (993 lines)

## What's included

### Core Harness (`packages/core/src/harness/`)
- `Harness` class with namespaced public API (`threads`, `state`, `modes`, `usage`)
- Stream processing for text, reasoning, tool calls, tool approval, OM events
- Extension hooks (`resolveToolApproval`, `onBeforeSend`, `onAfterSend`, `onError`, etc.)
- Workspace integration support
- Full type definitions for events, messages, threads, sessions

### MastraCode (`mastracode/`)
- **TUI**: Full pi-tui terminal interface with 1:1 visual parity from original repo
- **Agents**: Subagent system (explore, plan, execute) with registry
- **Tools**: grep, shell, file-editor (fuzzy replacement), web-search, subagent spawning, ask-user, todo, submit-plan, sandbox-access
- **Prompts**: Base + mode-specific (build, plan, fast) prompt system
- **Auth**: Claude Max OAuth + OpenAI Codex OAuth providers
- **Utils**: Project detection, error handling, token estimation, slash commands, thread locking, agent instructions
- **Permissions**: Granular tool permission management with session grants

## Test plan

- [x] Core Harness unit tests pass (`packages/core/src/harness/harness.test.ts`)
- [x] `pnpm build` succeeds for mastracode (tsup, 4 entry points)
- [ ] Manual TUI testing (`pnpm --dir mastracode start`)
- [ ] Integration testing with real model providers


Made with [Cursor](https://cursor.com)