### PR TITLE
 feat(core): support dynamic filesystem resolution via requestContext in Workspace

### DIFF
--- a/.changeset/dynamic-filesystem-resolver.md
+++ b/.changeset/dynamic-filesystem-resolver.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added support for dynamic filesystem resolution via `requestContext` in Workspace. The `filesystem` config now accepts a resolver function `({ requestContext }) => WorkspaceFilesystem`, allowing a single Workspace instance to serve different filesystems per request. Auto-injected workspace tools resolve the filesystem at execution time, with runtime read-only enforcement for dynamically resolved filesystems. Fixes #13133.

--- a/.changeset/dynamic-filesystem-resolver.md
+++ b/.changeset/dynamic-filesystem-resolver.md
@@ -2,4 +2,9 @@
 '@mastra/core': minor
 ---
 
-Added support for dynamic filesystem resolution via `requestContext` in Workspace. The `filesystem` config now accepts a resolver function `({ requestContext }) => WorkspaceFilesystem`, allowing a single Workspace instance to serve different filesystems per request. Auto-injected workspace tools resolve the filesystem at execution time, with runtime read-only enforcement for dynamically resolved filesystems. Fixes #13133.
+The Workspace `filesystem` option now accepts a resolver function in addition to a static instance.
+
+**Before:** `filesystem: WorkspaceFilesystem` (static, same filesystem for every request)
+**After:** `filesystem: WorkspaceFilesystem | (({ requestContext }) => WorkspaceFilesystem)` (static or per-request)
+
+This enables per-request filesystem routing from a single Workspace — useful for multi-tenant setups, role-based access (e.g. admin vs user directories), and scoped filesystem permissions without creating separate Workspace instances. Fixes #13133.

--- a/.changeset/dynamic-filesystem-resolver.md
+++ b/.changeset/dynamic-filesystem-resolver.md
@@ -7,4 +7,4 @@ The Workspace `filesystem` option now accepts a resolver function in addition to
 **Before:** `filesystem: WorkspaceFilesystem` (static, same filesystem for every request)
 **After:** `filesystem: WorkspaceFilesystem | (({ requestContext }) => WorkspaceFilesystem)` (static or per-request)
 
-This enables per-request filesystem routing from a single Workspace — useful for multi-tenant setups, role-based access (e.g. admin vs user directories), and scoped filesystem permissions without creating separate Workspace instances. Fixes #13133.
+This enables per-request filesystem routing from a single Workspace — useful for multi-tenant setups, role-based access (e.g. admin vs user directories), and scoped filesystem permissions without creating separate Workspace instances.

--- a/docs/src/content/en/docs/workspace/filesystem.mdx
+++ b/docs/src/content/en/docs/workspace/filesystem.mdx
@@ -106,6 +106,64 @@ const workspace = new Workspace({
 
 When `contained` is `false`, absolute paths are treated as real filesystem paths with no restriction.
 
+## Dynamic filesystem
+
+The `filesystem` option accepts a resolver function instead of a static instance. The resolver receives `requestContext` and returns a filesystem per request, allowing a single workspace to serve different filesystems based on the caller's identity, role, or tenant.
+
+```typescript title="src/mastra/workspaces.ts"
+import { Agent } from '@mastra/core/agent'
+import { Workspace, LocalFilesystem } from '@mastra/core/workspace'
+
+const workspace = new Workspace({
+  // highlight-start
+  filesystem: ({ requestContext }) => {
+    const role = requestContext.get('agent-role')
+    return new LocalFilesystem({
+      basePath: `/workspaces/${role}`,
+      readOnly: role !== 'admin',
+    })
+  },
+  // highlight-end
+})
+
+const agent = new Agent({
+  id: 'multi-role-agent',
+  model: 'openai/gpt-4o',
+  workspace,
+})
+```
+
+Each request resolves its own filesystem at tool execution time:
+
+```typescript
+import { RequestContext } from '@mastra/core/request-context'
+
+// Admin request — reads and writes from /workspaces/admin/
+const adminCtx = new RequestContext([['agent-role', 'admin']])
+await agent.generate('Write report.txt with Q4 results', { requestContext: adminCtx })
+
+// Viewer request — reads from /workspaces/viewer/, writes are blocked
+const viewerCtx = new RequestContext([['agent-role', 'viewer']])
+await agent.generate('Read info.txt', { requestContext: viewerCtx })
+```
+
+The resolver can also be asynchronous, for example to look up configuration from a database:
+
+```typescript
+const workspace = new Workspace({
+  filesystem: async ({ requestContext }) => {
+    const tenantConfig = await db.getTenant(requestContext.get('tenant-id'))
+    return new LocalFilesystem({ basePath: tenantConfig.storagePath })
+  },
+})
+```
+
+:::note
+
+`filesystem` and `mounts` are mutually exclusive. You cannot use a resolver function together with `mounts` in the same workspace.
+
+:::
+
 ## Read-only mode
 
 To prevent agents from modifying files, enable read-only mode:
@@ -120,7 +178,9 @@ const workspace = new Workspace({
 })
 ```
 
-When read-only, write tools (`write_file`, `edit_file`, `delete`, `mkdir`) aren't added to the agent's toolset. The agent can still read and list files.
+With a static filesystem, write tools (`write_file`, `edit_file`, `delete`, `mkdir`) are excluded from the agent's toolset entirely. The agent can still read and list files.
+
+When using a [dynamic filesystem](#dynamic-filesystem), write tools are always included because `readOnly` isn't known until the resolver runs. Instead, write operations are blocked at runtime — the tool returns an error if the resolved filesystem is read-only.
 
 ## Mounts and `CompositeFilesystem`
 

--- a/docs/src/content/en/docs/workspace/filesystem.mdx
+++ b/docs/src/content/en/docs/workspace/filesystem.mdx
@@ -117,7 +117,7 @@ import { Workspace, LocalFilesystem } from '@mastra/core/workspace'
 const workspace = new Workspace({
   // highlight-start
   filesystem: ({ requestContext }) => {
-    const role = requestContext.get('agent-role')
+    const role = requestContext.get('agent-role') || 'guest'
     return new LocalFilesystem({
       basePath: `/workspaces/${role}`,
       readOnly: role !== 'admin',

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -164,6 +164,24 @@ const workspace = new Workspace({
 
 The agent receives the `execute_command` tool.
 
+### Dynamic filesystem (per-request)
+
+Pass a resolver function to `filesystem` to return a different filesystem per request. This is useful for multi-tenant applications or multi-role agents where each request needs a different storage root or different permissions.
+
+```typescript
+const workspace = new Workspace({
+  filesystem: ({ requestContext }) => {
+    const role = requestContext.get('agent-role')
+    return new LocalFilesystem({
+      basePath: `/workspaces/${role}`,
+      readOnly: role !== 'admin',
+    })
+  },
+})
+```
+
+One workspace instance serves all requests. The resolver runs at tool execution time, so each request gets its own filesystem. See [dynamic filesystem](/docs/workspace/filesystem#dynamic-filesystem) for details.
+
 ### Which pattern should I use?
 
 | Scenario | Pattern |
@@ -173,6 +191,7 @@ The agent receives the `execute_command` tool.
 | Multiple cloud providers in one sandbox | `mounts` + `sandbox` (one mount per provider) |
 | Agent reads/writes files, no command execution needed | `filesystem` only |
 | Agent runs commands, no file tools needed | `sandbox` only |
+| Multi-role or multi-tenant agent with per-request storage | `filesystem` with resolver function |
 
 ## Tool configuration
 

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -171,7 +171,7 @@ Pass a resolver function to `filesystem` to return a different filesystem per re
 ```typescript
 const workspace = new Workspace({
   filesystem: ({ requestContext }) => {
-    const role = requestContext.get('agent-role')
+    const role = requestContext.get('agent-role') || 'guest'
     return new LocalFilesystem({
       basePath: `/workspaces/${role}`,
       readOnly: role !== 'admin',

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -51,7 +51,8 @@ const workspace = new Workspace({
   {
     name: 'filesystem',
     type: 'WorkspaceFilesystem | WorkspaceFilesystemResolver',
-    description: 'Filesystem provider instance, or a resolver function that receives `requestContext` and returns a filesystem per request. See [dynamic filesystem](/docs/workspace/filesystem#dynamic-filesystem).',
+    description:
+      'Filesystem provider instance, or a resolver function that receives `requestContext` and returns a filesystem per request. See [dynamic filesystem](/docs/workspace/filesystem#dynamic-filesystem).',
     isOptional: true,
   },
   {
@@ -244,7 +245,8 @@ Tool names must be unique across all workspace tools. Setting a custom name that
   {
     name: 'filesystem',
     type: 'WorkspaceFilesystem | undefined',
-    description: 'The static filesystem provider. Returns `undefined` when a resolver function is configured — use `hasFilesystemConfig()` to check availability.',
+    description:
+      'The static filesystem provider. Returns `undefined` when a resolver function is configured — use `hasFilesystemConfig()` to check availability.',
   },
   {
     name: 'sandbox',

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -50,8 +50,8 @@ const workspace = new Workspace({
   },
   {
     name: 'filesystem',
-    type: 'WorkspaceFilesystem',
-    description: 'Filesystem provider instance (e.g., LocalFilesystem)',
+    type: 'WorkspaceFilesystem | WorkspaceFilesystemResolver',
+    description: 'Filesystem provider instance, or a resolver function that receives `requestContext` and returns a filesystem per request. See [dynamic filesystem](/docs/workspace/filesystem#dynamic-filesystem).',
     isOptional: true,
   },
   {
@@ -244,7 +244,7 @@ Tool names must be unique across all workspace tools. Setting a custom name that
   {
     name: 'filesystem',
     type: 'WorkspaceFilesystem | undefined',
-    description: 'The filesystem provider',
+    description: 'The static filesystem provider. Returns `undefined` when a resolver function is configured — use `hasFilesystemConfig()` to check availability.',
   },
   {
     name: 'sandbox',
@@ -410,6 +410,45 @@ workspace.setToolsConfig(undefined)
 ]}
 />
 
+### Dynamic filesystem
+
+#### `hasFilesystemConfig()`
+
+Check whether a filesystem is configured, either as a static instance or a resolver function. Use this instead of checking `workspace.filesystem` directly, because a resolver-based workspace returns `undefined` from the `filesystem` property.
+
+```typescript
+if (workspace.hasFilesystemConfig()) {
+  // Filesystem tools are available
+}
+```
+
+**Returns:** `boolean`
+
+#### `resolveFilesystem({ requestContext })`
+
+Resolve the filesystem for a given request context. When a resolver function is configured, calls it with the provided `requestContext`. When a static filesystem is configured, returns it directly. Returns `undefined` if no filesystem is configured.
+
+```typescript
+import { RequestContext } from '@mastra/core/request-context'
+
+const ctx = new RequestContext([['agent-role', 'admin']])
+const fs = await workspace.resolveFilesystem({ requestContext: ctx })
+```
+
+**Parameters:**
+
+<PropertiesTable
+  content={[
+  {
+    name: 'requestContext',
+    type: 'RequestContext',
+    description: 'The request context to pass to the resolver function.',
+  },
+]}
+/>
+
+**Returns:** `Promise<WorkspaceFilesystem | undefined>`
+
 ## Agent tools
 
 A workspace provides tools to agents based on what's configured.
@@ -429,7 +468,7 @@ Added when a filesystem is configured:
 | `mastra_workspace_mkdir` | Create a directory. Creates parent directories automatically if they don't exist. |
 | `mastra_workspace_grep` | Search file contents using regex patterns. Supports glob filtering, context lines, and case-insensitive search. |
 
-Write tools (`write_file`, `edit_file`, `delete`, `mkdir`) are excluded when the filesystem is in read-only mode.
+With a static filesystem, write tools (`write_file`, `edit_file`, `delete`, `mkdir`) are excluded when the filesystem is in read-only mode. With a [dynamic filesystem](/docs/workspace/filesystem#dynamic-filesystem), write tools are always included and read-only is enforced at runtime.
 
 ### Sandbox tools
 

--- a/packages/core/src/agent/__tests__/workspace-tool-context.test.ts
+++ b/packages/core/src/agent/__tests__/workspace-tool-context.test.ts
@@ -719,6 +719,11 @@ describe('Workspace tools receive workspace via ToolOptions fallback (GH-14203)'
         content: [{ type: 'text', text: 'done' }],
         warnings: [],
       }),
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      }),
     });
 
     const agent = new Agent({
@@ -749,6 +754,138 @@ describe('Workspace tools receive workspace via ToolOptions fallback (GH-14203)'
     expect(result).toBeDefined();
     expect(typeof result).toBe('string');
     expect(result).toContain('hello.txt');
+  });
+});
+
+describe('Dynamic filesystem resolver in auto-injected workspace tools', () => {
+  let tempDirA: string;
+  let tempDirB: string;
+
+  beforeEach(async () => {
+    tempDirA = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-dynfs-a-'));
+    tempDirB = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-dynfs-b-'));
+  });
+
+  afterEach(async () => {
+    for (const dir of [tempDirA, tempDirB]) {
+      try {
+        await fs.rm(dir, { recursive: true, force: true });
+      } catch {
+        // Ignore
+      }
+    }
+  });
+
+  it('should resolve filesystem per-request in auto-injected read_file tool', async () => {
+    // Create different content in each directory
+    await fs.writeFile(path.join(tempDirA, 'config.txt'), 'admin config');
+    await fs.writeFile(path.join(tempDirB, 'config.txt'), 'user config');
+
+    // Single workspace with dynamic filesystem resolver
+    const workspace = new Workspace({
+      id: 'dynamic-fs-workspace',
+      filesystem: ({ requestContext }: { requestContext: RequestContext }) => {
+        const role = requestContext.get('role') as string;
+        return role === 'admin'
+          ? new LocalFilesystem({ basePath: tempDirA })
+          : new LocalFilesystem({ basePath: tempDirB });
+      },
+    });
+
+    // Mock model that calls mastra_workspace_read_file
+    const readFileMockModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'tool-calls',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        content: [
+          {
+            type: 'tool-call',
+            toolCallType: 'function',
+            toolCallId: 'call-read-1',
+            toolName: 'mastra_workspace_read_file',
+            input: '{"path":"config.txt","showLineNumbers":false}',
+          },
+        ],
+        warnings: [],
+      }),
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'dynamic-fs-agent',
+      name: 'Dynamic FS Agent',
+      instructions: 'You are an agent with dynamic filesystem.',
+      model: readFileMockModel,
+      workspace,
+    });
+
+    // Call as admin — should read from tempDirA
+    const adminCtx = new RequestContext([['role', 'admin']]);
+    const adminResponse = await agent.generate('Read config', { requestContext: adminCtx });
+    const adminResult = adminResponse.toolResults.find((r: any) => r.payload.toolName === 'mastra_workspace_read_file')
+      ?.payload?.result;
+    expect(adminResult).toContain('admin config');
+
+    // Call as user — should read from tempDirB
+    const userCtx = new RequestContext([['role', 'user']]);
+    const userResponse = await agent.generate('Read config', { requestContext: userCtx });
+    const userResult = userResponse.toolResults.find((r: any) => r.payload.toolName === 'mastra_workspace_read_file')
+      ?.payload?.result;
+    expect(userResult).toContain('user config');
+  });
+
+  it('should block writes on read-only resolved filesystem via auto-injected tools', async () => {
+    // Single workspace that resolves to read-only filesystem
+    const workspace = new Workspace({
+      id: 'readonly-resolver-workspace',
+      filesystem: () => new LocalFilesystem({ basePath: tempDirA, readOnly: true }),
+    });
+
+    // Mock model that calls mastra_workspace_write_file
+    const writeFileMockModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'tool-calls',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        content: [
+          {
+            type: 'tool-call',
+            toolCallType: 'function',
+            toolCallId: 'call-write-1',
+            toolName: 'mastra_workspace_write_file',
+            input: '{"path":"test.txt","content":"should fail"}',
+          },
+        ],
+        warnings: [],
+      }),
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'readonly-resolver-agent',
+      name: 'ReadOnly Resolver Agent',
+      instructions: 'You are an agent.',
+      model: writeFileMockModel,
+      workspace,
+    });
+
+    await agent.generate('Write a file', { requestContext: new RequestContext() });
+
+    // Verify the file was NOT created — readOnly enforcement blocked the write
+    const fileExists = await fs.access(path.join(tempDirA, 'test.txt')).then(
+      () => true,
+      () => false,
+    );
+    expect(fileExists).toBe(false);
   });
 });
 

--- a/packages/core/src/agent/__tests__/workspace-tool-context.test.ts
+++ b/packages/core/src/agent/__tests__/workspace-tool-context.test.ts
@@ -829,6 +829,7 @@ describe('Dynamic filesystem resolver in auto-injected workspace tools', () => {
     const adminResponse = await agent.generate('Read config', { requestContext: adminCtx });
     const adminResult = adminResponse.toolResults.find((r: any) => r.payload.toolName === 'mastra_workspace_read_file')
       ?.payload?.result;
+    // Tool returns a string containing the file content
     expect(adminResult).toContain('admin config');
 
     // Call as user — should read from tempDirB
@@ -880,11 +881,12 @@ describe('Dynamic filesystem resolver in auto-injected workspace tools', () => {
 
     await agent.generate('Write a file', { requestContext: new RequestContext() });
 
-    // Verify the file was NOT created — readOnly enforcement blocked the write
-    const fileExists = await fs.access(path.join(tempDirA, 'test.txt')).then(
-      () => true,
-      () => false,
-    );
+    // The tool error is caught by the framework — verify the write was blocked
+    // The file should NOT exist (read-only enforcement prevented the write)
+    const fileExists = await fs
+      .access(path.join(tempDirA, 'test.txt'))
+      .then(() => true)
+      .catch(() => false);
     expect(fileExists).toBe(false);
   });
 });

--- a/packages/core/src/workspace/tools/__tests__/dynamic-filesystem.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/dynamic-filesystem.test.ts
@@ -5,7 +5,6 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 import { RequestContext } from '../../../request-context';
 import { WORKSPACE_TOOLS } from '../../constants';
-import { WorkspaceError } from '../../errors';
 import { LocalFilesystem } from '../../filesystem';
 import { Workspace } from '../../workspace';
 import { createWorkspaceTools } from '../tools';

--- a/packages/core/src/workspace/tools/__tests__/dynamic-filesystem.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/dynamic-filesystem.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { RequestContext } from '../../../request-context';
 import { WORKSPACE_TOOLS } from '../../constants';
@@ -127,5 +127,47 @@ describe('dynamic filesystem tools', () => {
     );
 
     expect(result).toContain('hello');
+  });
+
+  it('should resolve the configured filesystem even when requestContext is omitted', async () => {
+    await fs.writeFile(path.join(tempDir, 'hello.txt'), 'hello');
+
+    const workspace = new Workspace({
+      filesystem: () => new LocalFilesystem({ basePath: tempDir }),
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute({
+      path: 'hello.txt',
+      showLineNumbers: false,
+    });
+
+    expect(result).toContain('hello');
+  });
+
+  it('should emit filesystem metadata for dynamically resolved filesystems', async () => {
+    await fs.writeFile(path.join(tempDir, 'hello.txt'), 'hello');
+    const custom = vi.fn(async () => {});
+
+    const workspace = new Workspace({
+      filesystem: () => new LocalFilesystem({ basePath: tempDir, readOnly: true }),
+    });
+    const tools = await createWorkspaceTools(workspace);
+
+    await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'hello.txt', showLineNumbers: false },
+      { requestContext: new RequestContext(), writer: { custom } },
+    );
+
+    expect(custom).toHaveBeenCalledTimes(1);
+    expect(custom.mock.calls[0]?.[0]).toMatchObject({
+      type: 'data-workspace-metadata',
+      data: {
+        filesystem: {
+          provider: 'local',
+          readOnly: true,
+        },
+      },
+    });
   });
 });

--- a/packages/core/src/workspace/tools/__tests__/dynamic-filesystem.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/dynamic-filesystem.test.ts
@@ -20,11 +20,11 @@ describe('dynamic filesystem tools', () => {
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
   });
 
-  it('should create filesystem tools when workspace has a filesystem resolver', () => {
+  it('should create filesystem tools when workspace has a filesystem resolver', async () => {
     const resolver = () => new LocalFilesystem({ basePath: tempDir });
     const workspace = new Workspace({ filesystem: resolver });
 
-    const tools = createWorkspaceTools(workspace);
+    const tools = await createWorkspaceTools(workspace);
 
     expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.READ_FILE);
     expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE);
@@ -39,7 +39,7 @@ describe('dynamic filesystem tools', () => {
 
     const resolver = () => new LocalFilesystem({ basePath: tempDir });
     const workspace = new Workspace({ filesystem: resolver });
-    const tools = createWorkspaceTools(workspace);
+    const tools = await createWorkspaceTools(workspace);
 
     const ctx = { requestContext: new RequestContext() };
     const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
@@ -62,7 +62,7 @@ describe('dynamic filesystem tools', () => {
         return role === 'admin' ? new LocalFilesystem({ basePath: dirA }) : new LocalFilesystem({ basePath: dirB });
       };
       const workspace = new Workspace({ filesystem: resolver });
-      const tools = createWorkspaceTools(workspace);
+      const tools = await createWorkspaceTools(workspace);
 
       const adminResult = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
         { path: 'data.txt', showLineNumbers: false },
@@ -84,7 +84,7 @@ describe('dynamic filesystem tools', () => {
   it('should block writes on read-only resolved filesystem at execution time', async () => {
     const resolver = () => new LocalFilesystem({ basePath: tempDir, readOnly: true });
     const workspace = new Workspace({ filesystem: resolver });
-    const tools = createWorkspaceTools(workspace);
+    const tools = await createWorkspaceTools(workspace);
 
     const ctx = { requestContext: new RequestContext() };
 
@@ -118,7 +118,7 @@ describe('dynamic filesystem tools', () => {
 
     const resolver = () => new LocalFilesystem({ basePath: tempDir, readOnly: true });
     const workspace = new Workspace({ filesystem: resolver });
-    const tools = createWorkspaceTools(workspace);
+    const tools = await createWorkspaceTools(workspace);
 
     const ctx = { requestContext: new RequestContext() };
     const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(

--- a/packages/core/src/workspace/tools/__tests__/dynamic-filesystem.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/dynamic-filesystem.test.ts
@@ -1,0 +1,132 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { RequestContext } from '../../../request-context';
+import { WORKSPACE_TOOLS } from '../../constants';
+import { WorkspaceError } from '../../errors';
+import { LocalFilesystem } from '../../filesystem';
+import { Workspace } from '../../workspace';
+import { createWorkspaceTools } from '../tools';
+
+describe('dynamic filesystem tools', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-dynfs-tools-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('should create filesystem tools when workspace has a filesystem resolver', () => {
+    const resolver = () => new LocalFilesystem({ basePath: tempDir });
+    const workspace = new Workspace({ filesystem: resolver });
+
+    const tools = createWorkspaceTools(workspace);
+
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.READ_FILE);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.DELETE);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.FILE_STAT);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.MKDIR);
+  });
+
+  it('should resolve filesystem from requestContext during tool execution', async () => {
+    await fs.writeFile(path.join(tempDir, 'hello.txt'), 'dynamic content');
+
+    const resolver = () => new LocalFilesystem({ basePath: tempDir });
+    const workspace = new Workspace({ filesystem: resolver });
+    const tools = createWorkspaceTools(workspace);
+
+    const ctx = { requestContext: new RequestContext() };
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'hello.txt', showLineNumbers: false },
+      ctx,
+    );
+
+    expect(result).toContain('dynamic content');
+  });
+
+  it('should resolve different filesystems per request', async () => {
+    const dirA = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-tool-a-'));
+    const dirB = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-tool-b-'));
+    try {
+      await fs.writeFile(path.join(dirA, 'data.txt'), 'admin data');
+      await fs.writeFile(path.join(dirB, 'data.txt'), 'user data');
+
+      const resolver = ({ requestContext }: { requestContext: RequestContext }) => {
+        const role = requestContext.get('role') as string;
+        return role === 'admin' ? new LocalFilesystem({ basePath: dirA }) : new LocalFilesystem({ basePath: dirB });
+      };
+      const workspace = new Workspace({ filesystem: resolver });
+      const tools = createWorkspaceTools(workspace);
+
+      const adminResult = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+        { path: 'data.txt', showLineNumbers: false },
+        { requestContext: new RequestContext([['role', 'admin']]) },
+      );
+      const userResult = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+        { path: 'data.txt', showLineNumbers: false },
+        { requestContext: new RequestContext([['role', 'user']]) },
+      );
+
+      expect(adminResult).toContain('admin data');
+      expect(userResult).toContain('user data');
+    } finally {
+      await fs.rm(dirA, { recursive: true, force: true });
+      await fs.rm(dirB, { recursive: true, force: true });
+    }
+  });
+
+  it('should block writes on read-only resolved filesystem at execution time', async () => {
+    const resolver = () => new LocalFilesystem({ basePath: tempDir, readOnly: true });
+    const workspace = new Workspace({ filesystem: resolver });
+    const tools = createWorkspaceTools(workspace);
+
+    const ctx = { requestContext: new RequestContext() };
+
+    // write_file should throw WorkspaceReadOnlyError
+    await expect(
+      tools[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE].execute({ path: 'test.txt', content: 'fail' }, ctx),
+    ).rejects.toThrow(/read.only/i);
+
+    // edit_file should throw WorkspaceReadOnlyError
+    await fs.writeFile(path.join(tempDir, 'existing.txt'), 'content');
+    await expect(
+      tools[WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE].execute(
+        { path: 'existing.txt', old_string: 'content', new_string: 'new' },
+        ctx,
+      ),
+    ).rejects.toThrow(/read.only/i);
+
+    // delete should throw WorkspaceReadOnlyError
+    await expect(tools[WORKSPACE_TOOLS.FILESYSTEM.DELETE].execute({ path: 'existing.txt' }, ctx)).rejects.toThrow(
+      /read.only/i,
+    );
+
+    // mkdir should throw WorkspaceReadOnlyError
+    await expect(tools[WORKSPACE_TOOLS.FILESYSTEM.MKDIR].execute({ path: 'newdir' }, ctx)).rejects.toThrow(
+      /read.only/i,
+    );
+  });
+
+  it('should allow reads on read-only resolved filesystem', async () => {
+    await fs.writeFile(path.join(tempDir, 'readable.txt'), 'hello');
+
+    const resolver = () => new LocalFilesystem({ basePath: tempDir, readOnly: true });
+    const workspace = new Workspace({ filesystem: resolver });
+    const tools = createWorkspaceTools(workspace);
+
+    const ctx = { requestContext: new RequestContext() };
+    const result = await tools[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE].execute(
+      { path: 'readable.txt', showLineNumbers: false },
+      ctx,
+    );
+
+    expect(result).toContain('hello');
+  });
+});

--- a/packages/core/src/workspace/tools/helpers.ts
+++ b/packages/core/src/workspace/tools/helpers.ts
@@ -60,7 +60,7 @@ export function requireSandbox(context: ToolExecutionContext): {
  */
 export async function emitWorkspaceMetadata(context: ToolExecutionContext, toolName: string) {
   const workspace = requireWorkspace(context);
-  const info = await workspace.getInfo();
+  const info = await workspace.getInfo({ requestContext: context?.requestContext });
   const toolCallId = context?.agent?.toolCallId;
   await context?.writer?.custom({
     type: 'data-workspace-metadata',

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -7,6 +7,7 @@
  * into the tool execution context.
  */
 
+import { RequestContext } from '../../request-context';
 import type { WorkspaceToolName } from '../constants';
 import { WORKSPACE_TOOLS } from '../constants';
 import { FileNotFoundError, FileReadRequiredError } from '../errors';
@@ -65,6 +66,13 @@ async function resolveDynamicValue<TContext>(
     console.warn('[Workspace Tools] Dynamic config function threw, using safe default:', error);
     return safeDefault;
   }
+}
+
+function hasFilesystemConfig(workspace: Workspace): boolean {
+  if (typeof (workspace as any)?.hasFilesystemConfig === 'function') {
+    return (workspace as any).hasFilesystemConfig();
+  }
+  return !!workspace.filesystem;
 }
 
 /**
@@ -158,8 +166,9 @@ export async function resolveToolConfig(
  * Falls back to the workspace as-is when a static filesystem is available.
  */
 async function resolveEffectiveWorkspace(workspace: Workspace, context: any): Promise<Workspace> {
-  if (!workspace.filesystem && workspace.hasFilesystemConfig() && context?.requestContext) {
-    const resolvedFs = await workspace.resolveFilesystem({ requestContext: context.requestContext });
+  if (!workspace.filesystem && hasFilesystemConfig(workspace)) {
+    const requestContext = context?.requestContext ?? new RequestContext();
+    const resolvedFs = await workspace.resolveFilesystem({ requestContext });
     if (resolvedFs) {
       return new Proxy(workspace, {
         get(target: any, prop: string | symbol) {
@@ -386,7 +395,7 @@ export async function createWorkspaceTools(
   };
 
   // Filesystem tools — add when filesystem is available (static instance or resolver function)
-  if (workspace.hasFilesystemConfig()) {
+  if (hasFilesystemConfig(workspace)) {
     await addTool(WORKSPACE_TOOLS.FILESYSTEM.READ_FILE, readFileTool, { readTrackerMode: 'read' });
     await addTool(WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE, writeFileTool, {
       requireWrite: true,

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -11,7 +11,7 @@ import type { WorkspaceToolName } from '../constants';
 import { WORKSPACE_TOOLS } from '../constants';
 import { FileNotFoundError, FileReadRequiredError } from '../errors';
 import { InMemoryFileReadTracker, InMemoryFileWriteLock } from '../filesystem';
-import type { FileReadTracker, FileWriteLock } from '../filesystem';
+import type { FileReadTracker, FileWriteLock, WorkspaceFilesystem } from '../filesystem';
 import type { Workspace } from '../workspace';
 import { isAstGrepAvailable, astEditTool } from './ast-edit';
 import { deleteFileTool } from './delete-file';
@@ -152,6 +152,43 @@ export async function resolveToolConfig(
 // ---------------------------------------------------------------------------
 
 /**
+ * Resolve the effective workspace for tool execution. When a dynamic filesystem
+ * resolver is configured (no static filesystem), resolves the filesystem from
+ * requestContext and returns a proxy workspace that exposes it via `.filesystem`.
+ * Falls back to the workspace as-is when a static filesystem is available.
+ */
+async function resolveEffectiveWorkspace(workspace: Workspace, context: any): Promise<Workspace> {
+  if (!workspace.filesystem && workspace.hasFilesystemConfig() && context?.requestContext) {
+    const resolvedFs = await workspace.resolveFilesystem({ requestContext: context.requestContext });
+    if (resolvedFs) {
+      return new Proxy(workspace, {
+        get(target: any, prop: string | symbol) {
+          if (prop === 'filesystem') return resolvedFs;
+          return target[prop];
+        },
+      });
+    }
+  }
+  return workspace;
+}
+
+/**
+ * Clone a standalone tool with config overrides and inject workspace into context.
+ * When the workspace uses a dynamic filesystem resolver, the filesystem is resolved
+ * from requestContext and made available via the workspace proxy.
+ */
+function wrapTool(tool: any, workspace: Workspace): any {
+  return {
+    ...tool,
+    execute: async (input: any, context: any = {}) => {
+      const effectiveWorkspace = await resolveEffectiveWorkspace(context?.workspace ?? workspace, context);
+      const enrichedContext = { ...context, workspace: effectiveWorkspace };
+      return tool.execute(input, enrichedContext);
+    },
+  };
+}
+
+/**
  * Wrap a tool with read-before-write tracking (readTracker).
  *
  * - mode 'read': records the read after execution
@@ -167,19 +204,23 @@ function wrapWithReadTracker(
   return {
     ...tool,
     execute: async (input: any, context: any = {}) => {
+      const effectiveWorkspace = await resolveEffectiveWorkspace(context?.workspace ?? workspace, context);
+      let enrichedContext: any = { ...context, workspace: effectiveWorkspace };
+      const fs: WorkspaceFilesystem | undefined = effectiveWorkspace.filesystem;
+
       // Pre-execution: enforce read-before-write policy and/or attach
       // optimistic-concurrency mtime for write tools.
-      if (mode === 'write') {
+      if (mode === 'write' && fs) {
         // Optimistic concurrency: attach the mtime from the last read
         // *before* stat so it's preserved even when the file has been
         // deleted externally (stat throws FileNotFoundError).
         const record = readTracker.getReadRecord(input.path);
         if (record) {
-          context = { ...context, __expectedMtime: record.modifiedAtRead };
+          enrichedContext = { ...enrichedContext, __expectedMtime: record.modifiedAtRead };
         }
 
         try {
-          const stat = await workspace.filesystem!.stat(input.path);
+          const stat = await fs.stat(input.path);
 
           // Policy gate: require the agent to have read the file first.
           // Only evaluate when explicitly configured (opt-in policy).
@@ -187,7 +228,7 @@ function wrapWithReadTracker(
           if (config.requireReadBeforeWrite !== undefined) {
             const shouldRequireRead = await resolveDynamicValue(
               config.requireReadBeforeWrite,
-              { args: input, requestContext: context.requestContext ?? {}, workspace },
+              { args: input, requestContext: enrichedContext.requestContext ?? {}, workspace: effectiveWorkspace },
               true,
             );
             if (shouldRequireRead) {
@@ -207,12 +248,12 @@ function wrapWithReadTracker(
         }
       }
 
-      const result = await tool.execute(input, context);
+      const result = await tool.execute(input, enrichedContext);
 
       // Post-execution: track reads / clear write records
-      if (mode === 'read') {
+      if (mode === 'read' && fs) {
         try {
-          const stat = await workspace.filesystem!.stat(input.path);
+          const stat = await fs.stat(input.path);
           readTracker.recordRead(input.path, stat.modifiedAt);
         } catch {
           // Ignore stat errors for tracking
@@ -318,6 +359,8 @@ export async function createWorkspaceTools(
 
     if (opts?.readTrackerMode) {
       wrapped = wrapWithReadTracker(wrapped, workspace, readTracker, config, opts.readTrackerMode);
+    } else {
+      wrapped = wrapTool(wrapped, workspace);
     }
 
     // Write lock is outermost — serializes the entire enriched execute pipeline
@@ -342,8 +385,8 @@ export async function createWorkspaceTools(
     tools[exposedName] = wrapped;
   };
 
-  // Filesystem tools
-  if (workspace.filesystem) {
+  // Filesystem tools — add when filesystem is available (static instance or resolver function)
+  if (workspace.hasFilesystemConfig()) {
     await addTool(WORKSPACE_TOOLS.FILESYSTEM.READ_FILE, readFileTool, { readTrackerMode: 'read' });
     await addTool(WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE, writeFileTool, {
       requireWrite: true,

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -2194,6 +2194,118 @@ Line 3 conclusion`;
   });
 
   // ===========================================================================
+  // Dynamic Filesystem (resolver function)
+  // ===========================================================================
+  describe('dynamic filesystem', () => {
+    it('should accept a filesystem resolver function', () => {
+      const resolver = ({ requestContext }: { requestContext: RequestContext }) => {
+        const role = requestContext.get('role') as string;
+        return new LocalFilesystem({ basePath: tempDir + '/' + role });
+      };
+      const workspace = new Workspace({ filesystem: resolver });
+
+      expect(workspace.hasFilesystemConfig()).toBe(true);
+      // Static getter returns undefined when using resolver
+      expect(workspace.filesystem).toBeUndefined();
+    });
+
+    it('should resolve different filesystems based on requestContext', async () => {
+      const dirA = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-dyn-a-'));
+      const dirB = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-dyn-b-'));
+      try {
+        await fs.writeFile(path.join(dirA, 'file.txt'), 'from A');
+        await fs.writeFile(path.join(dirB, 'file.txt'), 'from B');
+
+        const resolver = ({ requestContext }: { requestContext: RequestContext }) => {
+          const role = requestContext.get('role') as string;
+          return role === 'admin' ? new LocalFilesystem({ basePath: dirA }) : new LocalFilesystem({ basePath: dirB });
+        };
+        const workspace = new Workspace({ filesystem: resolver });
+
+        const adminCtx = new RequestContext([['role', 'admin']]);
+        const userCtx = new RequestContext([['role', 'user']]);
+
+        const adminFs = await workspace.resolveFilesystem({ requestContext: adminCtx });
+        const userFs = await workspace.resolveFilesystem({ requestContext: userCtx });
+
+        const adminContent = await adminFs!.readFile('file.txt', { encoding: 'utf-8' });
+        const userContent = await userFs!.readFile('file.txt', { encoding: 'utf-8' });
+
+        expect(adminContent).toBe('from A');
+        expect(userContent).toBe('from B');
+      } finally {
+        await fs.rm(dirA, { recursive: true, force: true });
+        await fs.rm(dirB, { recursive: true, force: true });
+      }
+    });
+
+    it('should support async resolver functions', async () => {
+      const resolver = async ({ requestContext: _requestContext }: { requestContext: RequestContext }) => {
+        // Simulate async work (e.g., looking up config)
+        await new Promise(resolve => setTimeout(resolve, 1));
+        return new LocalFilesystem({ basePath: tempDir });
+      };
+      const workspace = new Workspace({ filesystem: resolver });
+
+      const ctx = new RequestContext();
+      const resolved = await workspace.resolveFilesystem({ requestContext: ctx });
+
+      expect(resolved).toBeDefined();
+      expect(resolved!.provider).toBe('local');
+    });
+
+    it('should fall back to static filesystem in resolveFilesystem', async () => {
+      const staticFs = new LocalFilesystem({ basePath: tempDir });
+      const workspace = new Workspace({ filesystem: staticFs });
+
+      const ctx = new RequestContext();
+      const resolved = await workspace.resolveFilesystem({ requestContext: ctx });
+
+      expect(resolved).toBe(staticFs);
+    });
+
+    it('should throw when using both filesystem resolver and mounts', () => {
+      const resolver = () => new LocalFilesystem({ basePath: tempDir });
+      expect(
+        () =>
+          new Workspace({
+            filesystem: resolver,
+            mounts: {
+              '/a': new LocalFilesystem({ basePath: tempDir }),
+            },
+          }),
+      ).toThrow('Cannot use both "filesystem" and "mounts"');
+    });
+
+    it('should not throw NO_PROVIDERS when only filesystem resolver is provided', () => {
+      const resolver = () => new LocalFilesystem({ basePath: tempDir });
+      const workspace = new Workspace({ filesystem: resolver });
+
+      expect(workspace.hasFilesystemConfig()).toBe(true);
+      expect(workspace.status).toBe('pending');
+    });
+
+    it('should return undefined from resolveFilesystem when no filesystem configured', async () => {
+      const sandbox = new LocalSandbox({ workingDirectory: tempDir });
+      const workspace = new Workspace({ sandbox });
+
+      const ctx = new RequestContext();
+      const resolved = await workspace.resolveFilesystem({ requestContext: ctx });
+
+      expect(resolved).toBeUndefined();
+    });
+
+    it('should not propagate logger when using resolver', () => {
+      const resolver = () => new LocalFilesystem({ basePath: tempDir });
+      const workspace = new Workspace({ filesystem: resolver });
+
+      const mockLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as any;
+      // Should not throw — no static filesystem instance to set logger on
+      expect(() => workspace.__setLogger(mockLogger)).not.toThrow();
+    });
+  });
+
+  // ===========================================================================
   // Lifecycle error handling
   // ===========================================================================
   describe('lifecycle error handling', () => {

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -2277,6 +2277,15 @@ Line 3 conclusion`;
       ).toThrow('Cannot use both "filesystem" and "mounts"');
     });
 
+    it('should throw when a class constructor is passed instead of an instance or resolver', () => {
+      expect(
+        () =>
+          new Workspace({
+            filesystem: LocalFilesystem as any,
+          }),
+      ).toThrow('class constructor');
+    });
+
     it('should not throw NO_PROVIDERS when only filesystem resolver is provided', () => {
       const resolver = () => new LocalFilesystem({ basePath: tempDir });
       const workspace = new Workspace({ filesystem: resolver });

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -59,6 +59,14 @@ import type { WorkspaceStatus } from './types';
 // =============================================================================
 
 /**
+ * A function that resolves a WorkspaceFilesystem dynamically based on request context.
+ * Called on each tool invocation, allowing different filesystems per request.
+ */
+export type WorkspaceFilesystemResolver = (context: {
+  requestContext: RequestContext;
+}) => WorkspaceFilesystem | Promise<WorkspaceFilesystem>;
+
+/**
  * Configuration for creating a Workspace.
  * Users pass provider instances directly.
  *
@@ -78,11 +86,15 @@ export interface WorkspaceConfig<
   name?: string;
 
   /**
-   * Filesystem provider instance.
-   * Use LocalFilesystem for a folder on disk, or AgentFS for Turso-backed storage.
-   * Extend MastraFilesystem for automatic logger integration.
+   * Filesystem provider instance, or a resolver function for dynamic per-request filesystems.
+   *
+   * Static: Pass a LocalFilesystem, AgentFS, or any WorkspaceFilesystem instance.
+   * Dynamic: Pass a function `({ requestContext }) => WorkspaceFilesystem` to resolve
+   * a different filesystem per request. The resolver is called at tool execution time.
+   *
+   * Extend MastraFilesystem for automatic logger integration (static instances only).
    */
-  filesystem?: TFilesystem;
+  filesystem?: TFilesystem | WorkspaceFilesystemResolver;
 
   /**
    * Sandbox provider instance.
@@ -411,6 +423,7 @@ export class Workspace<
 
   private _status: WorkspaceStatus = 'pending';
   private readonly _fs?: WorkspaceFilesystem;
+  private readonly _filesystemResolver?: WorkspaceFilesystemResolver;
   private readonly _sandbox?: WorkspaceSandbox;
   private readonly _config: WorkspaceConfig<TFilesystem, TSandbox, TMounts>;
   private readonly _searchEngine?: SearchEngine;
@@ -455,6 +468,9 @@ export class Workspace<
           this._sandbox.mounts.setOnMount(config.onMount);
         }
       }
+    } else if (typeof config.filesystem === 'function') {
+      // Dynamic filesystem resolver — stored separately, no static _fs instance
+      this._filesystemResolver = config.filesystem as WorkspaceFilesystemResolver;
     } else {
       this._fs = config.filesystem;
     }
@@ -530,7 +546,7 @@ export class Workspace<
 
     // Validate at least one provider is given
     // Note: skills alone is also valid - uses LocalSkillSource for read-only skills
-    if (!this._fs && !this._sandbox && !this.hasSkillsConfig()) {
+    if (!this._fs && !this._filesystemResolver && !this._sandbox && !this.hasSkillsConfig()) {
       throw new WorkspaceError('Workspace requires at least a filesystem, sandbox, or skills', 'NO_PROVIDERS');
     }
   }
@@ -605,6 +621,30 @@ export class Workspace<
    */
   setToolsConfig(config: WorkspaceToolsConfig | undefined): void {
     this._config.tools = config;
+  }
+
+  /**
+   * Returns true if a filesystem is configured, either as a static instance or a resolver function.
+   */
+  hasFilesystemConfig(): boolean {
+    return this._fs !== undefined || this._filesystemResolver !== undefined;
+  }
+
+  /**
+   * Resolve the filesystem for a given request context.
+   * When a resolver function is configured, calls it with the provided requestContext.
+   * When a static filesystem is configured, returns it directly.
+   * Returns undefined if no filesystem is configured.
+   */
+  async resolveFilesystem({
+    requestContext,
+  }: {
+    requestContext: RequestContext;
+  }): Promise<WorkspaceFilesystem | undefined> {
+    if (this._filesystemResolver) {
+      return await this._filesystemResolver({ requestContext });
+    }
+    return this._fs;
   }
 
   /**
@@ -1046,6 +1086,7 @@ export class Workspace<
     this._logger = logger;
 
     // Propagate logger to filesystem provider if it extends MastraFilesystem
+    // Skip when using a resolver — no static instance to set logger on
     if (this._fs instanceof MastraFilesystem) {
       this._fs.__setLogger(logger);
     }

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -32,7 +32,7 @@
 
 import * as path from 'node:path';
 import type { IMastraLogger } from '../logger';
-import type { RequestContext } from '../request-context';
+import { RequestContext } from '../request-context';
 import type { MastraVector } from '../vector';
 
 import { WorkspaceError, SearchNotAvailableError } from './errors';
@@ -855,11 +855,16 @@ export class Workspace<
     }
   }
 
-  private async getAllFiles(dir: string, depth: number = 0, maxDepth: number = 10): Promise<string[]> {
-    if (!this._fs || depth >= maxDepth) return [];
+  private async getAllFiles(
+    dir: string,
+    depth: number = 0,
+    maxDepth: number = 10,
+    filesystem: WorkspaceFilesystem | undefined = this._fs,
+  ): Promise<string[]> {
+    if (!filesystem || depth >= maxDepth) return [];
 
     const files: string[] = [];
-    const entries = await this._fs.readdir(dir);
+    const entries = await filesystem.readdir(dir);
 
     for (const entry of entries) {
       const fullPath = dir === '.' || dir === '' ? entry.name : `${dir}/${entry.name}`;
@@ -867,7 +872,7 @@ export class Workspace<
         files.push(fullPath);
       } else if (entry.type === 'directory' && !entry.isSymlink) {
         // Skip symlink directories to prevent infinite recursion from cycles
-        files.push(...(await this.getAllFiles(fullPath, depth + 1, maxDepth)));
+        files.push(...(await this.getAllFiles(fullPath, depth + 1, maxDepth, filesystem)));
       }
     }
 
@@ -942,7 +947,7 @@ export class Workspace<
    * Get workspace information.
    * @param options.includeFileCount - Whether to count total files (can be slow for large workspaces)
    */
-  async getInfo(options?: { includeFileCount?: boolean }): Promise<WorkspaceInfo> {
+  async getInfo(options?: { includeFileCount?: boolean; requestContext?: RequestContext }): Promise<WorkspaceInfo> {
     const info: WorkspaceInfo = {
       id: this.id,
       name: this.name,
@@ -951,13 +956,19 @@ export class Workspace<
       lastAccessedAt: this.lastAccessedAt,
     };
 
-    if (this._fs) {
-      const fsInfo = await this._fs.getInfo?.();
+    const filesystem =
+      this._fs ??
+      (this._filesystemResolver
+        ? await this.resolveFilesystem({ requestContext: options?.requestContext ?? new RequestContext() })
+        : undefined);
+
+    if (filesystem) {
+      const fsInfo = await filesystem.getInfo?.();
       info.filesystem = {
-        id: fsInfo?.id ?? this._fs.id,
-        name: fsInfo?.name ?? this._fs.name,
-        provider: fsInfo?.provider ?? this._fs.provider,
-        readOnly: fsInfo?.readOnly ?? this._fs.readOnly,
+        id: fsInfo?.id ?? filesystem.id,
+        name: fsInfo?.name ?? filesystem.name,
+        provider: fsInfo?.provider ?? filesystem.provider,
+        readOnly: fsInfo?.readOnly ?? filesystem.readOnly,
         status: fsInfo?.status,
         error: fsInfo?.error,
         icon: fsInfo?.icon,
@@ -966,7 +977,7 @@ export class Workspace<
 
       if (options?.includeFileCount) {
         try {
-          const files = await this.getAllFiles('.');
+          const files = await this.getAllFiles('.', 0, 10, filesystem);
           info.filesystem.totalFiles = files.length;
         } catch {
           // Ignore errors - filesystem may not support listing

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -469,6 +469,14 @@ export class Workspace<
         }
       }
     } else if (typeof config.filesystem === 'function') {
+      // Reject class constructors — a common mistake is passing the class itself instead of an instance
+      if (/^class\s/.test(Function.prototype.toString.call(config.filesystem))) {
+        throw new WorkspaceError(
+          'filesystem received a class constructor instead of an instance or resolver function. ' +
+            'Pass an instance (e.g., new LocalFilesystem(...)) or a resolver function (({ requestContext }) => fs).',
+          'INVALID_CONFIG',
+        );
+      }
       // Dynamic filesystem resolver — stored separately, no static _fs instance
       this._filesystemResolver = config.filesystem as WorkspaceFilesystemResolver;
     } else {


### PR DESCRIPTION
## Description

Workspace options like skills, instructions, model, tools, and memory already support dynamic functions that receive `requestContext`, but the filesystem only accepted a static instance.  

This PR adds support for a resolver function  
`({ requestContext }) => WorkspaceFilesystem`, allowing a single Workspace instance to serve different filesystems per request.  

This enables multi-role agents to scope each role to a different filesystem root or permissions.

### Key Changes
- Added `WorkspaceFilesystemResolver` type and widened filesystem config to accept it  
- Added `hasFilesystemConfig()` and `resolveFilesystem()` public methods on `Workspace`  
- All auto-injected workspace tools now resolve filesystem dynamically at execution time via a Proxy  
- Runtime `readOnly` enforcement for dynamically resolved filesystems on write/edit/delete/mkdir tools  
- Class constructor guard — passing `LocalFilesystem` (class) instead of `new LocalFilesystem(...)` throws a clear error  
- Fully backward compatible — static filesystem works exactly as before  

## Related Issue(s)

Fixes #13133

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace filesystem can be a static instance or a per-request resolver for dynamic routing.
  * New APIs to detect and resolve per-request filesystems at runtime (hasFilesystemConfig, resolveFilesystem).
  * Workspace tools receive execution context so filesystem selection occurs per request.
  * Write tools remain visible for dynamic filesystems; writes are blocked at runtime when filesystem is read-only.

* **Tests**
  * Added tests for per-request filesystem resolution and read-only enforcement.

* **Documentation**
  * Docs updated with dynamic filesystem guidance and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->