### PR TITLE
fix(core): export AnyWorkspace type for typed workspace generics

### DIFF
--- a/.changeset/any-workspace-type.md
+++ b/.changeset/any-workspace-type.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Export `AnyWorkspace` type from `@mastra/core/workspace` for accepting any Workspace regardless of generic parameters. Updates Agent and Mastra to use `AnyWorkspace` so workspaces with typed mounts/sandbox (e.g. E2BSandbox, GCSFilesystem) are accepted without type errors.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -57,7 +57,7 @@ import type { MastraVoice } from '../voice';
 import { DefaultVoice } from '../voice';
 import { createWorkflow, createStep, isProcessor } from '../workflows';
 import type { AnyWorkflow, OutputWriter, Step, WorkflowResult } from '../workflows';
-import type { Workspace } from '../workspace';
+import type { AnyWorkspace } from '../workspace';
 import { createWorkspaceTools } from '../workspace';
 import type { SkillFormat } from '../workspace/skills';
 import { zodToJsonSchema } from '../zod-to-json';
@@ -153,7 +153,7 @@ export class Agent<
   #scorers: DynamicArgument<MastraScorers>;
   #agents: DynamicArgument<Record<string, Agent>>;
   #voice: MastraVoice;
-  #workspace?: DynamicArgument<Workspace | undefined>;
+  #workspace?: DynamicArgument<AnyWorkspace | undefined>;
   #inputProcessors?: DynamicArgument<InputProcessorOrWorkflow[]>;
   #outputProcessors?: DynamicArgument<OutputProcessorOrWorkflow[]>;
   #maxProcessorRetries?: number;
@@ -859,7 +859,7 @@ export class Agent<
    */
   public async getWorkspace({
     requestContext = new RequestContext(),
-  }: { requestContext?: RequestContext } = {}): Promise<Workspace | undefined> {
+  }: { requestContext?: RequestContext } = {}): Promise<AnyWorkspace | undefined> {
     // If agent has its own workspace configured, use it
     if (this.#workspace) {
       if (typeof this.#workspace !== 'function') {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -34,7 +34,7 @@ import type { ToolAction, VercelTool, VercelToolV5 } from '../tools';
 import type { DynamicArgument } from '../types';
 import type { MastraVoice } from '../voice';
 import type { Workflow } from '../workflows';
-import type { Workspace } from '../workspace';
+import type { AnyWorkspace } from '../workspace';
 import type { SkillFormat } from '../workspace/skills';
 import type { Agent } from './agent';
 import type { AgentExecutionOptions, NetworkOptions } from './agent.types';
@@ -237,7 +237,7 @@ export interface AgentConfig<
    * Workspace for file storage and code execution.
    * When configured, workspace tools are automatically injected into the agent.
    */
-  workspace?: DynamicArgument<Workspace | undefined>;
+  workspace?: DynamicArgument<AnyWorkspace | undefined>;
   /**
    * Input processors that can modify or validate messages before they are processed by the agent.
    * These can be individual processors (implementing `processInput` or `processInputStep`) or

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -33,7 +33,7 @@ import type { MastraIdGenerator, IdGeneratorContext } from '../types';
 import type { MastraVector } from '../vector';
 import type { AnyWorkflow, Workflow } from '../workflows';
 import { WorkflowEventProcessor } from '../workflows/evented/workflow-event-processor';
-import type { Workspace } from '../workspace';
+import type { AnyWorkspace } from '../workspace';
 import { createOnScorerHook } from './hooks';
 
 /**
@@ -230,7 +230,7 @@ export interface Config<
    * Agents inherit this workspace unless they have their own configured.
    * Skills are accessed via workspace.skills when skills is configured.
    */
-  workspace?: Workspace;
+  workspace?: AnyWorkspace;
 
   /**
    * Custom model router gateways for accessing LLM providers.
@@ -323,8 +323,8 @@ export class Mastra<
   #processorConfigurations: Map<string, Array<{ processor: Processor; agentId: string; type: 'input' | 'output' }>> =
     new Map();
   #memory?: TMemory;
-  #workspace?: Workspace;
-  #workspaces: Record<string, Workspace> = {};
+  #workspace?: AnyWorkspace;
+  #workspaces: Record<string, AnyWorkspace> = {};
   #server?: ServerConfig;
   #serverAdapter?: MastraServerBase;
   #mcpServers?: TMCPServers;
@@ -1183,7 +1183,7 @@ export class Mastra<
    * }
    * ```
    */
-  public getWorkspace(): Workspace | undefined {
+  public getWorkspace(): AnyWorkspace | undefined {
     return this.#workspace;
   }
 
@@ -1198,7 +1198,7 @@ export class Mastra<
    * const files = await workspace.filesystem.readdir('/');
    * ```
    */
-  public getWorkspaceById(id: string): Workspace {
+  public getWorkspaceById(id: string): AnyWorkspace {
     const workspace = this.#workspaces[id];
     if (!workspace) {
       const error = new MastraError({
@@ -1229,7 +1229,7 @@ export class Mastra<
    * }
    * ```
    */
-  public listWorkspaces(): Record<string, Workspace> {
+  public listWorkspaces(): Record<string, AnyWorkspace> {
     return { ...this.#workspaces };
   }
 
@@ -1249,7 +1249,7 @@ export class Mastra<
    * mastra.addWorkspace(workspace);
    * ```
    */
-  public addWorkspace(workspace: Workspace, key?: string): void {
+  public addWorkspace(workspace: AnyWorkspace, key?: string): void {
     if (!workspace) {
       throw createUndefinedPrimitiveError('workspace', workspace, key);
     }

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -269,6 +269,12 @@ export interface WorkspaceConfig<
 // Re-export WorkspaceStatus from types
 export type { WorkspaceStatus } from './types';
 
+/**
+ * A Workspace with any combination of filesystem, sandbox, and mounts.
+ * Use this when you need to accept any Workspace regardless of its generic parameters.
+ */
+export type AnyWorkspace = Workspace<WorkspaceFilesystem | undefined, WorkspaceSandbox | undefined, any>;
+
 // =============================================================================
 // Path Context Types
 // =============================================================================


### PR DESCRIPTION
## Summary
- Exports `AnyWorkspace` type from `@mastra/core/workspace` that widens the mounts generic to `any`
- Updates Agent and Mastra to use `AnyWorkspace` so workspaces with concrete mount/sandbox types (e.g. `E2BSandbox`, `GCSFilesystem`) are accepted without type errors

The `Workspace` class has 3 generic parameters (filesystem, sandbox, mounts) that default to narrow types. Previously, `Agent` and `Mastra` used bare `Workspace` which defaulted `TMounts` to `undefined`, rejecting workspaces with typed mounts.

## Test plan
- [x] Existing workspace tests pass (76 tests)
- [x] Verify the developer-agent example in `examples/unified-workspace` no longer has type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public AnyWorkspace type alias to accept workspaces with any configuration (including typed mounts and sandboxes).
  * Agent and Mastra now accept AnyWorkspace, improving type flexibility when supplying workspaces across the API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->