### PR TITLE
feat(workspace): add @mastra/workspace-tools package

### DIFF
--- a/.changeset/workspace-tools-package.md
+++ b/.changeset/workspace-tools-package.md
@@ -1,0 +1,8 @@
+---
+'@mastra/core': patch
+'@mastra/workspace-tools': patch
+---
+
+Add `@mastra/workspace-tools` package with standalone workspace tool exports that can be versioned independently from core. Tools use `context.workspace` instead of closure-captured references.
+
+Core: `WorkspaceConfig.tools` now accepts tool overrides (`Record<string, Tool>` or `({ workspace }) => Record<string, Tool>`) in addition to the existing `WorkspaceToolsConfig`.

--- a/.changeset/workspace-tools-package.md
+++ b/.changeset/workspace-tools-package.md
@@ -5,4 +5,4 @@
 
 Add `@mastra/workspace-tools` package with standalone workspace tool exports that can be versioned independently from core. Tools use `context.workspace` instead of closure-captured references.
 
-Core: `WorkspaceConfig.tools` now accepts tool overrides (`Record<string, Tool>` or `({ workspace }) => Record<string, Tool>`) in addition to the existing `WorkspaceToolsConfig`.
+Core: `WorkspaceConfig.tools` now accepts tool overrides (`Record<string, Tool>` or `({ workspace, requestContext }) => Record<string, Tool>`) in addition to the existing `WorkspaceToolsConfig`. Added `workspace.getTools({ requestContext })` for resolving tools at request time.

--- a/examples/unified-workspace/package.json
+++ b/examples/unified-workspace/package.json
@@ -12,6 +12,7 @@
     "@mastra/gcs": "latest",
     "@mastra/s3": "latest",
     "@mastra/fastembed": "^1.0.0",
+    "@mastra/workspace-tools": "latest",
     "@mastra/libsql": "latest",
     "@mastra/memory": "latest",
     "@mastra/observability": "latest",
@@ -31,6 +32,7 @@
       "@mastra/client-js": "link:../../client-sdks/client-js",
       "@mastra/observability": "link:../../observability/mastra",
       "@mastra/fastembed": "link:../../packages/fastembed",
+      "@mastra/workspace-tools": "link:../../packages/workspace-tools",
       "mastra": "link:../../packages/cli"
     }
   },

--- a/examples/unified-workspace/pnpm-lock.yaml
+++ b/examples/unified-workspace/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   '@mastra/client-js': link:../../client-sdks/client-js
   '@mastra/observability': link:../../observability/mastra
   '@mastra/fastembed': link:../../packages/fastembed
+  '@mastra/workspace-tools': link:../../packages/workspace-tools
   mastra: link:../../packages/cli
 
 importers:
@@ -50,6 +51,9 @@ importers:
       '@mastra/s3':
         specifier: link:../../workspaces/s3
         version: link:../../workspaces/s3
+      '@mastra/workspace-tools':
+        specifier: link:../../packages/workspace-tools
+        version: link:../../packages/workspace-tools
       ai:
         specifier: ^6.0.1
         version: 6.0.38(zod@3.25.76)

--- a/examples/unified-workspace/src/mastra/agents/developer-agent.ts
+++ b/examples/unified-workspace/src/mastra/agents/developer-agent.ts
@@ -2,10 +2,11 @@ import { Agent } from '@mastra/core/agent';
 import { fastembed } from '@mastra/fastembed';
 import { LibSQLVector } from '@mastra/libsql';
 import { Memory } from '@mastra/memory';
-import { LocalFilesystem, Workspace, WORKSPACE_TOOLS } from '@mastra/core/workspace';
+import { LocalFilesystem, Workspace } from '@mastra/core/workspace';
 import { E2BSandbox } from '@mastra/e2b';
 import { GCSFilesystem } from '@mastra/gcs';
 import { S3Filesystem } from '@mastra/s3';
+import { createWorkspaceTools } from '@mastra/workspace-tools';
 
 /**
  * Developer agent - inherits globalWorkspace from Mastra instance.
@@ -69,11 +70,6 @@ export const developerAgent = new Agent({
       id: 'developer-e2b-sandbox',
     }),
     skills: ['/.agents/skills', '/local/skills', '/r2/skills'],
-    tools: {
-      [WORKSPACE_TOOLS.FILESYSTEM.DELETE]: {
-        enabled: true,
-        requireApproval: true,
-      },
-    },
+    tools: createWorkspaceTools,
   }),
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -58,7 +58,6 @@ import { DefaultVoice } from '../voice';
 import { createWorkflow, createStep, isProcessor } from '../workflows';
 import type { AnyWorkflow, OutputWriter, Step, WorkflowResult } from '../workflows';
 import type { AnyWorkspace } from '../workspace';
-import { createWorkspaceTools } from '../workspace';
 import type { SkillFormat } from '../workspace/skills';
 import { zodToJsonSchema } from '../zod-to-json';
 import { AgentLegacyHandler } from './agent-legacy';
@@ -1873,7 +1872,7 @@ export class Agent<
       return convertedWorkspaceTools;
     }
 
-    const workspaceTools = createWorkspaceTools(workspace);
+    const workspaceTools = workspace.getTools({ requestContext });
 
     if (Object.keys(workspaceTools).length > 0) {
       this.logger.debug(`[Agent:${this.name}] - Adding workspace tools: ${Object.keys(workspaceTools).join(', ')}`, {

--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -26,22 +26,6 @@ export {
 
 // Tools
 export { createWorkspaceTools, resolveToolConfig, type WorkspaceToolConfig, type WorkspaceToolsConfig } from './tools';
-export { formatAsTree } from './tools';
-
-// Line Utilities
-export {
-  extractLines,
-  extractLinesWithLimit,
-  formatWithLineNumbers,
-  charIndexToLineNumber,
-  charRangeToLineRange,
-  countOccurrences,
-  replaceString,
-  StringNotFoundError,
-  StringNotUniqueError,
-  type LineRange,
-} from './line-utils';
-
 // Lifecycle
 export * from './lifecycle';
 

--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -26,6 +26,21 @@ export {
 
 // Tools
 export { createWorkspaceTools, resolveToolConfig, type WorkspaceToolConfig, type WorkspaceToolsConfig } from './tools';
+export { formatAsTree } from './tools';
+
+// Line Utilities
+export {
+  extractLines,
+  extractLinesWithLimit,
+  formatWithLineNumbers,
+  charIndexToLineNumber,
+  charRangeToLineRange,
+  countOccurrences,
+  replaceString,
+  StringNotFoundError,
+  StringNotUniqueError,
+  type LineRange,
+} from './line-utils';
 
 // Lifecycle
 export * from './lifecycle';

--- a/packages/core/src/workspace/tools/tools.test.ts
+++ b/packages/core/src/workspace/tools/tools.test.ts
@@ -858,7 +858,7 @@ describe('createWorkspaceTools', () => {
       expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.READ_FILE);
     });
 
-    it('getToolOverrides returns undefined for config objects', () => {
+    it('getToolsConfig returns config for config objects', () => {
       const workspace = new Workspace({
         filesystem: new LocalFilesystem({ basePath: tempDir }),
         tools: {
@@ -867,11 +867,10 @@ describe('createWorkspaceTools', () => {
         },
       });
 
-      expect(workspace.getToolOverrides()).toBeUndefined();
       expect(workspace.getToolsConfig()).toEqual({ enabled: true, requireApproval: false });
     });
 
-    it('getToolOverrides returns tools for tool override objects', () => {
+    it('getToolsConfig returns tool overrides as-is', () => {
       const customTool = {
         id: 'my_tool',
         description: 'My tool',
@@ -883,8 +882,8 @@ describe('createWorkspaceTools', () => {
         tools: { my_tool: customTool } as any,
       });
 
-      expect(workspace.getToolOverrides()).toBeDefined();
-      expect(workspace.getToolsConfig()).toBeUndefined();
+      // getToolsConfig returns the raw value — createWorkspaceTools handles detection
+      expect(workspace.getToolsConfig()).toBeDefined();
     });
 
     it('should resolve function-based tool overrides with workspace context', () => {

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -74,10 +74,20 @@ export function resolveToolConfig(
 /**
  * Creates workspace tools that will be auto-injected into agents.
  *
+ * If the workspace has tool overrides (e.g. from `@mastra/workspace-tools`),
+ * those are returned directly. Otherwise, the built-in closure-based tools
+ * are created using the workspace's tool configuration.
+ *
  * @param workspace - The workspace instance to bind tools to
  * @returns Record of workspace tools
  */
 export function createWorkspaceTools(workspace: Workspace) {
+  // If tool overrides are provided, return them directly
+  const toolOverrides = workspace.getToolOverrides();
+  if (toolOverrides) {
+    return toolOverrides;
+  }
+
   const tools: Record<string, any> = {};
   const toolsConfig = workspace.getToolsConfig();
   const isReadOnly = workspace.filesystem?.readOnly ?? false;

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -274,7 +274,7 @@ export interface WorkspaceConfig<
     | WorkspaceToolsConfig
     | Record<string, Tool<any, any, any, any>>
     | ((context: {
-        workspace: Workspace<TFilesystem, TSandbox, TMounts>;
+        workspace: Workspace;
         requestContext?: RequestContext;
       }) => Record<string, Tool<any, any, any, any>>);
 
@@ -509,10 +509,7 @@ export class Workspace<
   getToolsConfig():
     | WorkspaceToolsConfig
     | Record<string, Tool<any, any, any, any>>
-    | ((context: {
-        workspace: Workspace<TFilesystem, TSandbox, TMounts>;
-        requestContext?: RequestContext;
-      }) => Record<string, Tool<any, any, any, any>>)
+    | ((context: { workspace: Workspace; requestContext?: RequestContext }) => Record<string, Tool<any, any, any, any>>)
     | undefined {
     return this._config.tools;
   }
@@ -537,7 +534,7 @@ export class Workspace<
 
     // Function config: call with workspace + requestContext
     if (typeof rawConfig === 'function') {
-      return rawConfig({ workspace: this, requestContext: options?.requestContext });
+      return rawConfig({ workspace: this as unknown as Workspace, requestContext: options?.requestContext });
     }
 
     // Direct tool overrides (Record<string, Tool>): return as-is

--- a/packages/workspace-tools/package.json
+++ b/packages/workspace-tools/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@mastra/workspace-tools",
+  "version": "0.0.0",
+  "description": "Workspace tools for Mastra agents — file operations, command execution, and search",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "build:watch": "pnpm build:lib --watch",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "peerDependencies": {
+    "@mastra/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.2",
+    "vitest": "^3.0.0",
+    "zod": "^3.24.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/workspace-tools/src/create-workspace-tools.test.ts
+++ b/packages/workspace-tools/src/create-workspace-tools.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+
+import { createWorkspaceTools } from './create-workspace-tools';
+
+describe('createWorkspaceTools', () => {
+  it('should return all tools when no options provided', () => {
+    const tools = createWorkspaceTools();
+
+    expect(Object.keys(tools)).toHaveLength(10);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.READ_FILE);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.DELETE);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.FILE_STAT);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.MKDIR);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.SEARCH.SEARCH);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.SEARCH.INDEX);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND);
+  });
+
+  it('should filter tools with include', () => {
+    const tools = createWorkspaceTools({
+      include: [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE, WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE],
+    });
+
+    expect(Object.keys(tools)).toHaveLength(2);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.READ_FILE);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE);
+  });
+
+  it('should filter tools with exclude', () => {
+    const tools = createWorkspaceTools({
+      exclude: [WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND],
+    });
+
+    expect(Object.keys(tools)).toHaveLength(9);
+    expect(tools).not.toHaveProperty(WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND);
+  });
+
+  it('should apply exclude after include', () => {
+    const tools = createWorkspaceTools({
+      include: [
+        WORKSPACE_TOOLS.FILESYSTEM.READ_FILE,
+        WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE,
+        WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE,
+      ],
+      exclude: [WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE],
+    });
+
+    expect(Object.keys(tools)).toHaveLength(2);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.READ_FILE);
+    expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE);
+    expect(tools).not.toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE);
+  });
+
+  it('should return tools with execute functions', () => {
+    const tools = createWorkspaceTools();
+
+    for (const tool of Object.values(tools)) {
+      expect(typeof tool.execute).toBe('function');
+    }
+  });
+});

--- a/packages/workspace-tools/src/create-workspace-tools.ts
+++ b/packages/workspace-tools/src/create-workspace-tools.ts
@@ -1,0 +1,87 @@
+import type { Tool } from '@mastra/core/tools';
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+
+import { deleteFileTool } from './delete-file';
+import { editFileTool } from './edit-file';
+import { executeCommandTool } from './execute-command';
+import { fileStatTool } from './file-stat';
+import { indexContentTool } from './index-content';
+import { listFilesTool } from './list-files';
+import { mkdirTool } from './mkdir';
+import { readFileTool } from './read-file';
+import { searchTool } from './search';
+import { writeFileTool } from './write-file';
+
+const ALL_TOOLS: Record<string, Tool<any, any, any>> = {
+  [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: readFileTool,
+  [WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]: writeFileTool,
+  [WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE]: editFileTool,
+  [WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES]: listFilesTool,
+  [WORKSPACE_TOOLS.FILESYSTEM.DELETE]: deleteFileTool,
+  [WORKSPACE_TOOLS.FILESYSTEM.FILE_STAT]: fileStatTool,
+  [WORKSPACE_TOOLS.FILESYSTEM.MKDIR]: mkdirTool,
+  [WORKSPACE_TOOLS.SEARCH.SEARCH]: searchTool,
+  [WORKSPACE_TOOLS.SEARCH.INDEX]: indexContentTool,
+  [WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]: executeCommandTool,
+};
+
+export interface CreateWorkspaceToolsOptions {
+  /**
+   * Which tools to include. If omitted, all tools are included.
+   * Use tool IDs from WORKSPACE_TOOLS constants, or pass tool names directly.
+   */
+  include?: string[];
+
+  /**
+   * Which tools to exclude. Applied after `include`.
+   */
+  exclude?: string[];
+}
+
+/**
+ * Creates a record of workspace tools for use with Mastra agents.
+ *
+ * @example
+ * ```typescript
+ * import { createWorkspaceTools } from '@mastra/workspace-tools';
+ *
+ * // All tools
+ * const agent = new Agent({
+ *   tools: createWorkspaceTools(),
+ *   workspace: new Workspace({ filesystem }),
+ * });
+ *
+ * // Only specific tools
+ * const agent = new Agent({
+ *   tools: createWorkspaceTools({
+ *     include: ['mastra_workspace_read_file', 'mastra_workspace_write_file'],
+ *   }),
+ *   workspace: new Workspace({ filesystem }),
+ * });
+ *
+ * // All except some
+ * const agent = new Agent({
+ *   tools: createWorkspaceTools({
+ *     exclude: ['mastra_workspace_execute_command'],
+ *   }),
+ *   workspace: new Workspace({ filesystem }),
+ * });
+ * ```
+ */
+export function createWorkspaceTools(
+  options?: CreateWorkspaceToolsOptions,
+): Record<string, Tool<any, any, any>> {
+  let tools = { ...ALL_TOOLS };
+
+  if (options?.include) {
+    const includeSet = new Set(options.include);
+    tools = Object.fromEntries(Object.entries(tools).filter(([key]) => includeSet.has(key)));
+  }
+
+  if (options?.exclude) {
+    const excludeSet = new Set(options.exclude);
+    tools = Object.fromEntries(Object.entries(tools).filter(([key]) => !excludeSet.has(key)));
+  }
+
+  return tools;
+}

--- a/packages/workspace-tools/src/delete-file.ts
+++ b/packages/workspace-tools/src/delete-file.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+import { createTool } from '@mastra/core/tools';
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+import { WorkspaceReadOnlyError } from '@mastra/core/workspace';
+import { requireFilesystem } from './helpers';
+
+export const deleteFileTool = createTool({
+  id: WORKSPACE_TOOLS.FILESYSTEM.DELETE,
+  description: 'Delete a file or directory from the workspace filesystem',
+  inputSchema: z.object({
+    path: z.string().describe('The path to the file or directory to delete'),
+    recursive: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe('If true, delete directories and their contents recursively. Required for non-empty directories.'),
+  }),
+  outputSchema: z.object({
+    success: z.boolean(),
+    path: z.string(),
+  }),
+  execute: async ({ path, recursive }, context) => {
+    const { filesystem } = requireFilesystem(context);
+
+    if (filesystem.readOnly) {
+      throw new WorkspaceReadOnlyError('delete');
+    }
+
+    const stat = await filesystem.stat(path);
+    if (stat.type === 'directory') {
+      await filesystem.rmdir(path, { recursive, force: recursive });
+    } else {
+      await filesystem.deleteFile(path);
+    }
+    return { success: true, path };
+  },
+});

--- a/packages/workspace-tools/src/edit-file.ts
+++ b/packages/workspace-tools/src/edit-file.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import { createTool } from '@mastra/core/tools';
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+import { WorkspaceReadOnlyError } from '@mastra/core/workspace';
+import { replaceString, StringNotFoundError, StringNotUniqueError } from '@mastra/core/workspace';
+import { requireFilesystem } from './helpers';
+
+export const editFileTool = createTool({
+  id: WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE,
+  description: `Edit a file by replacing specific text. The old_string must match exactly and be unique in the file.
+
+Usage:
+- Read the file first to get the exact text to replace.
+- By default, ${WORKSPACE_TOOLS.FILESYSTEM.READ_FILE} output includes line number prefixes (e.g., "     1→"). Ensure you preserve the exact indentation as it appears AFTER the arrow. Never include any part of the line number prefix in old_string or new_string.
+- Include enough surrounding context (multiple lines) to make old_string unique. If it still isn't unique, include more lines.
+- Use replace_all only when intentionally replacing all occurrences.`,
+  inputSchema: z.object({
+    path: z.string().describe('The path to the file to edit'),
+    old_string: z.string().describe('The exact text to find and replace. Must be unique in the file.'),
+    new_string: z.string().describe('The text to replace old_string with'),
+    replace_all: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe('If true, replace all occurrences. If false (default), old_string must be unique.'),
+  }),
+  outputSchema: z.object({
+    success: z.boolean(),
+    path: z.string().describe('The path to the edited file'),
+    replacements: z.number().describe('Number of replacements made'),
+    error: z.string().optional().describe('Error message if the edit failed'),
+  }),
+  execute: async ({ path, old_string, new_string, replace_all }, context) => {
+    const { filesystem } = requireFilesystem(context);
+
+    if (filesystem.readOnly) {
+      throw new WorkspaceReadOnlyError('edit_file');
+    }
+
+    try {
+      const content = await filesystem.readFile(path, { encoding: 'utf-8' });
+
+      if (typeof content !== 'string') {
+        return {
+          success: false,
+          path,
+          replacements: 0,
+          error: 'Cannot edit binary files. Use workspace_write_file instead.',
+        };
+      }
+
+      const result = replaceString(content, old_string, new_string, replace_all);
+      await filesystem.writeFile(path, result.content, { overwrite: true });
+
+      return {
+        success: true,
+        path,
+        replacements: result.replacements,
+      };
+    } catch (error) {
+      if (error instanceof StringNotFoundError) {
+        return {
+          success: false,
+          path,
+          replacements: 0,
+          error: error.message,
+        };
+      }
+      if (error instanceof StringNotUniqueError) {
+        return {
+          success: false,
+          path,
+          replacements: 0,
+          error: error.message,
+        };
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/workspace-tools/src/edit-file.ts
+++ b/packages/workspace-tools/src/edit-file.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { createTool } from '@mastra/core/tools';
 import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
 import { WorkspaceReadOnlyError } from '@mastra/core/workspace';
-import { replaceString, StringNotFoundError, StringNotUniqueError } from '@mastra/core/workspace';
+import { replaceString, StringNotFoundError, StringNotUniqueError } from './line-utils';
 import { requireFilesystem } from './helpers';
 
 export const editFileTool = createTool({

--- a/packages/workspace-tools/src/errors.ts
+++ b/packages/workspace-tools/src/errors.ts
@@ -1,0 +1,8 @@
+import { WorkspaceError } from '@mastra/core/workspace';
+
+export class WorkspaceNotAvailableError extends WorkspaceError {
+  constructor() {
+    super('Workspace not available. Ensure the agent has a workspace configured.', 'NO_WORKSPACE');
+    this.name = 'WorkspaceNotAvailableError';
+  }
+}

--- a/packages/workspace-tools/src/execute-command.ts
+++ b/packages/workspace-tools/src/execute-command.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod';
+import { createTool } from '@mastra/core/tools';
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+import { SandboxFeatureNotSupportedError } from '@mastra/core/workspace';
+import { requireSandbox } from './helpers';
+
+export const executeCommandTool = createTool({
+  id: WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND,
+  description: `Execute a shell command in the workspace sandbox.
+
+Usage:
+- Verify parent directories exist before running commands that create files or directories.
+- Always quote file paths that contain spaces (e.g., cd "/path/with spaces").
+- Use the timeout parameter to limit execution time. Behavior when omitted depends on the sandbox provider.
+- Use cwd to set the working directory, or commands run from the sandbox default.`,
+  inputSchema: z.object({
+    command: z.string().describe('The command to execute (e.g., "ls", "npm", "python")'),
+    args: z.array(z.string()).nullish().default([]).describe('Arguments to pass to the command'),
+    timeout: z.number().nullish().describe('Maximum execution time in milliseconds. Example: 60000 for 1 minute.'),
+    cwd: z.string().nullish().describe('Working directory for the command'),
+  }),
+  outputSchema: z.object({
+    success: z.boolean().describe('Whether the command executed successfully (exit code 0)'),
+    stdout: z.string().describe('Standard output from the command'),
+    stderr: z.string().describe('Standard error output'),
+    exitCode: z.number().describe('Exit code (0 = success)'),
+    executionTimeMs: z.number().describe('How long the execution took in milliseconds'),
+  }),
+  execute: async ({ command, args, timeout, cwd }, context) => {
+    const { workspace, sandbox } = requireSandbox(context);
+
+    if (!sandbox.executeCommand) {
+      throw new SandboxFeatureNotSupportedError('executeCommand');
+    }
+
+    const getExecutionMetadata = () => ({
+      workspace: {
+        id: workspace.id,
+        name: workspace.name,
+      },
+      sandbox: {
+        id: sandbox.id,
+        name: sandbox.name,
+        provider: sandbox.provider,
+        status: sandbox.status,
+      },
+    });
+
+    const startedAt = Date.now();
+    try {
+      const result = await sandbox.executeCommand(command, args ?? [], {
+        timeout: timeout ?? undefined,
+        cwd: cwd ?? undefined,
+        onStdout: async (data: string) => {
+          await context?.writer?.write({
+            type: 'sandbox-stdout',
+            data,
+            timestamp: Date.now(),
+            metadata: getExecutionMetadata(),
+          });
+        },
+        onStderr: async (data: string) => {
+          await context?.writer?.write({
+            type: 'sandbox-stderr',
+            data,
+            timestamp: Date.now(),
+            metadata: getExecutionMetadata(),
+          });
+        },
+      });
+
+      await context?.writer?.write({
+        type: 'sandbox-exit',
+        exitCode: result.exitCode,
+        success: result.success,
+        executionTimeMs: result.executionTimeMs,
+        metadata: getExecutionMetadata(),
+      });
+
+      return {
+        success: result.success,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        exitCode: result.exitCode,
+        executionTimeMs: result.executionTimeMs,
+      };
+    } catch (error) {
+      await context?.writer?.write({
+        type: 'sandbox-exit',
+        exitCode: -1,
+        success: false,
+        executionTimeMs: Date.now() - startedAt,
+        metadata: getExecutionMetadata(),
+      });
+      throw error;
+    }
+  },
+});

--- a/packages/workspace-tools/src/file-stat.ts
+++ b/packages/workspace-tools/src/file-stat.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import { createTool } from '@mastra/core/tools';
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+import { FileNotFoundError } from '@mastra/core/workspace';
+import { requireFilesystem } from './helpers';
+
+export const fileStatTool = createTool({
+  id: WORKSPACE_TOOLS.FILESYSTEM.FILE_STAT,
+  description:
+    'Get file or directory metadata from the workspace. Returns existence, type, size, and modification time.',
+  inputSchema: z.object({
+    path: z.string().describe('The path to check'),
+  }),
+  outputSchema: z.object({
+    exists: z.boolean().describe('Whether the path exists'),
+    type: z.enum(['file', 'directory', 'none']).describe('The type of the path if it exists'),
+    size: z.number().optional().describe('Size in bytes (for files)'),
+    modifiedAt: z.string().optional().describe('Last modification time (ISO string)'),
+  }),
+  execute: async ({ path }, context) => {
+    const { filesystem } = requireFilesystem(context);
+
+    try {
+      const stat = await filesystem.stat(path);
+      return {
+        exists: true,
+        type: stat.type,
+        size: stat.size,
+        modifiedAt: stat.modifiedAt.toISOString(),
+      };
+    } catch (error) {
+      if (error instanceof FileNotFoundError) {
+        return { exists: false, type: 'none' as const };
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/workspace-tools/src/helpers.ts
+++ b/packages/workspace-tools/src/helpers.ts
@@ -1,0 +1,57 @@
+/**
+ * Workspace Tool Helpers
+ *
+ * Runtime assertions for extracting workspace resources from tool execution context.
+ */
+
+import type { ToolExecutionContext } from '@mastra/core/tools';
+import {
+  FilesystemNotAvailableError,
+  SandboxNotAvailableError,
+  type Workspace,
+  type WorkspaceFilesystem,
+  type WorkspaceSandbox,
+} from '@mastra/core/workspace';
+
+import { WorkspaceNotAvailableError } from './errors';
+
+/**
+ * Extract workspace from tool execution context.
+ * Throws if workspace is not available.
+ */
+export function requireWorkspace(context: ToolExecutionContext): Workspace {
+  if (!context?.workspace) {
+    throw new WorkspaceNotAvailableError();
+  }
+  return context.workspace;
+}
+
+/**
+ * Extract filesystem from workspace in tool execution context.
+ * Throws if workspace or filesystem is not available.
+ */
+export function requireFilesystem(context: ToolExecutionContext): {
+  workspace: Workspace;
+  filesystem: WorkspaceFilesystem;
+} {
+  const workspace = requireWorkspace(context);
+  if (!workspace.filesystem) {
+    throw new FilesystemNotAvailableError();
+  }
+  return { workspace, filesystem: workspace.filesystem };
+}
+
+/**
+ * Extract sandbox from workspace in tool execution context.
+ * Throws if workspace or sandbox is not available.
+ */
+export function requireSandbox(context: ToolExecutionContext): {
+  workspace: Workspace;
+  sandbox: WorkspaceSandbox;
+} {
+  const workspace = requireWorkspace(context);
+  if (!workspace.sandbox) {
+    throw new SandboxNotAvailableError();
+  }
+  return { workspace, sandbox: workspace.sandbox };
+}

--- a/packages/workspace-tools/src/index-content.ts
+++ b/packages/workspace-tools/src/index-content.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { createTool } from '@mastra/core/tools';
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+import { requireWorkspace } from './helpers';
+
+export const indexContentTool = createTool({
+  id: WORKSPACE_TOOLS.SEARCH.INDEX,
+  description: 'Index content for search. The path becomes the document ID in search results.',
+  inputSchema: z.object({
+    path: z.string().describe('The document ID/path for search results'),
+    content: z.string().describe('The text content to index'),
+    metadata: z.record(z.unknown()).optional().describe('Optional metadata to store with the document'),
+  }),
+  outputSchema: z.object({
+    success: z.boolean(),
+    path: z.string().describe('The indexed document ID'),
+  }),
+  execute: async ({ path, content, metadata }, context) => {
+    const workspace = requireWorkspace(context);
+
+    await workspace.index(path, content, { metadata });
+    return { success: true, path };
+  },
+});

--- a/packages/workspace-tools/src/index.ts
+++ b/packages/workspace-tools/src/index.ts
@@ -1,0 +1,20 @@
+// Factory
+export { createWorkspaceTools, type CreateWorkspaceToolsOptions } from './create-workspace-tools';
+
+// Individual tools
+export { readFileTool } from './read-file';
+export { writeFileTool } from './write-file';
+export { editFileTool } from './edit-file';
+export { listFilesTool } from './list-files';
+export { deleteFileTool } from './delete-file';
+export { fileStatTool } from './file-stat';
+export { mkdirTool } from './mkdir';
+export { searchTool } from './search';
+export { indexContentTool } from './index-content';
+export { executeCommandTool } from './execute-command';
+
+// Helpers
+export { requireWorkspace, requireFilesystem, requireSandbox } from './helpers';
+
+// Errors
+export { WorkspaceNotAvailableError } from './errors';

--- a/packages/workspace-tools/src/list-files.ts
+++ b/packages/workspace-tools/src/list-files.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod';
+import { createTool } from '@mastra/core/tools';
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+import { requireFilesystem } from './helpers';
+import { formatAsTree } from '@mastra/core/workspace';
+
+export const listFilesTool = createTool({
+  id: WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES,
+  description: `List files and directories in the workspace filesystem.
+Returns a tree-style view (like the Unix "tree" command) for easy visualization.
+The output is displayed to the user as a tree-like structure in the tool result.
+Options mirror common tree command flags for familiarity.
+
+Examples:
+- List root: { path: "/" }
+- Deep listing: { path: "/src", maxDepth: 5 }
+- Directories only: { path: "/", dirsOnly: true }
+- Exclude node_modules: { path: "/", exclude: "node_modules" }
+- Find TypeScript files: { path: "/src", pattern: "**/*.ts" }
+- Find config files: { path: "/", pattern: "*.config.{js,ts}" }
+- Multiple patterns: { path: "/", pattern: ["**/*.ts", "**/*.tsx"] }`,
+  inputSchema: z.object({
+    path: z.string().default('/').describe('Directory path to list'),
+    maxDepth: z
+      .number()
+      .optional()
+      .default(3)
+      .describe('Maximum depth to descend (default: 3). Similar to tree -L flag.'),
+    showHidden: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe('Show hidden files starting with "." (default: false). Similar to tree -a flag.'),
+    dirsOnly: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe('List directories only, no files (default: false). Similar to tree -d flag.'),
+    exclude: z.string().optional().describe('Pattern to exclude (e.g., "node_modules"). Similar to tree -I flag.'),
+    extension: z.string().optional().describe('Filter by file extension (e.g., ".ts"). Similar to tree -P flag.'),
+    pattern: z
+      .union([z.string(), z.array(z.string())])
+      .optional()
+      .describe(
+        'Glob pattern(s) to filter files. Examples: "**/*.ts", "src/**/*.test.ts", "*.config.{js,ts}". Directories always pass through.',
+      ),
+  }),
+  outputSchema: z.object({
+    tree: z.string().describe('Tree-style directory listing'),
+    summary: z.string().describe('Summary of directories and files (e.g., "3 directories, 12 files")'),
+    metadata: z
+      .object({
+        workspace: z
+          .object({
+            id: z.string().optional(),
+            name: z.string().optional(),
+          })
+          .optional(),
+        filesystem: z
+          .object({
+            id: z.string().optional(),
+            name: z.string().optional(),
+            provider: z.string().optional(),
+          })
+          .optional(),
+      })
+      .optional()
+      .describe('Metadata about the workspace and filesystem'),
+  }),
+  execute: async ({ path = '/', maxDepth = 3, showHidden, dirsOnly, exclude, extension, pattern }, context) => {
+    const { workspace, filesystem } = requireFilesystem(context);
+
+    const result = await formatAsTree(filesystem, path, {
+      maxDepth,
+      showHidden,
+      dirsOnly,
+      exclude: exclude || undefined,
+      extension: extension || undefined,
+      pattern: pattern || undefined,
+    });
+
+    const metadata = {
+      workspace: {
+        id: workspace.id,
+        name: workspace.name,
+      },
+      filesystem: {
+        id: filesystem.id,
+        name: filesystem.name,
+        provider: filesystem.provider,
+      },
+    };
+
+    return {
+      tree: result.tree,
+      summary: result.summary,
+      metadata,
+    };
+  },
+});

--- a/packages/workspace-tools/src/list-files.ts
+++ b/packages/workspace-tools/src/list-files.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { createTool } from '@mastra/core/tools';
 import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
 import { requireFilesystem } from './helpers';
-import { formatAsTree } from '@mastra/core/workspace';
+import { formatAsTree } from './tree-formatter';
 
 export const listFilesTool = createTool({
   id: WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES,

--- a/packages/workspace-tools/src/mkdir.ts
+++ b/packages/workspace-tools/src/mkdir.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { createTool } from '@mastra/core/tools';
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+import { WorkspaceReadOnlyError } from '@mastra/core/workspace';
+import { requireFilesystem } from './helpers';
+
+export const mkdirTool = createTool({
+  id: WORKSPACE_TOOLS.FILESYSTEM.MKDIR,
+  description: 'Create a directory in the workspace filesystem',
+  inputSchema: z.object({
+    path: z.string().describe('The path of the directory to create'),
+    recursive: z
+      .boolean()
+      .optional()
+      .default(true)
+      .describe('Whether to create parent directories if they do not exist'),
+  }),
+  outputSchema: z.object({
+    success: z.boolean(),
+    path: z.string(),
+  }),
+  execute: async ({ path, recursive }, context) => {
+    const { filesystem } = requireFilesystem(context);
+
+    if (filesystem.readOnly) {
+      throw new WorkspaceReadOnlyError('mkdir');
+    }
+
+    await filesystem.mkdir(path, { recursive });
+    return { success: true, path };
+  },
+});

--- a/packages/workspace-tools/src/read-file.ts
+++ b/packages/workspace-tools/src/read-file.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { createTool } from '@mastra/core/tools';
 import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
-import { extractLinesWithLimit, formatWithLineNumbers } from '@mastra/core/workspace';
+import { extractLinesWithLimit, formatWithLineNumbers } from './line-utils';
 import { requireFilesystem } from './helpers';
 
 export const readFileTool = createTool({

--- a/packages/workspace-tools/src/read-file.ts
+++ b/packages/workspace-tools/src/read-file.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+import { createTool } from '@mastra/core/tools';
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+import { extractLinesWithLimit, formatWithLineNumbers } from '@mastra/core/workspace';
+import { requireFilesystem } from './helpers';
+
+export const readFileTool = createTool({
+  id: WORKSPACE_TOOLS.FILESYSTEM.READ_FILE,
+  description:
+    'Read the contents of a file from the workspace filesystem. Use offset/limit parameters to read specific line ranges for large files.',
+  inputSchema: z.object({
+    path: z.string().describe('The path to the file to read (e.g., "/data/config.json")'),
+    encoding: z
+      .enum(['utf-8', 'utf8', 'base64', 'hex', 'binary'])
+      .optional()
+      .describe('The encoding to use when reading the file. Defaults to utf-8 for text files.'),
+    offset: z
+      .number()
+      .optional()
+      .describe('Line number to start reading from (1-indexed). If omitted, starts from line 1.'),
+    limit: z.number().optional().describe('Maximum number of lines to read. If omitted, reads to the end of the file.'),
+    showLineNumbers: z
+      .boolean()
+      .optional()
+      .default(true)
+      .describe('Whether to prefix each line with its line number (default: true)'),
+  }),
+  outputSchema: z.object({
+    content: z.string().describe('The file contents (with optional line number prefixes)'),
+    size: z.number().describe('The file size in bytes'),
+    path: z.string().describe('The full path to the file'),
+    lines: z
+      .object({
+        start: z.number().describe('First line number returned'),
+        end: z.number().describe('Last line number returned'),
+      })
+      .optional()
+      .describe('Line range information (when offset/limit used)'),
+    totalLines: z.number().optional().describe('Total number of lines in the file'),
+  }),
+  execute: async ({ path, encoding, offset, limit, showLineNumbers }, context) => {
+    const { filesystem } = requireFilesystem(context);
+
+    const effectiveEncoding = (encoding as BufferEncoding) ?? 'utf-8';
+    const fullContent = await filesystem.readFile(path, { encoding: effectiveEncoding });
+    const stat = await filesystem.stat(path);
+
+    const isTextEncoding = !encoding || encoding === 'utf-8' || encoding === 'utf8';
+
+    if (!isTextEncoding) {
+      return {
+        content: fullContent,
+        size: stat.size,
+        path: stat.path,
+      };
+    }
+
+    if (typeof fullContent !== 'string') {
+      return {
+        content: fullContent.toString('base64'),
+        size: stat.size,
+        path: stat.path,
+      };
+    }
+
+    const hasLineRange = offset !== undefined || limit !== undefined;
+    const result = extractLinesWithLimit(fullContent, offset, limit);
+
+    const shouldShowLineNumbers = showLineNumbers !== false;
+    const formattedContent = shouldShowLineNumbers
+      ? formatWithLineNumbers(result.content, result.lines.start)
+      : result.content;
+
+    return {
+      content: formattedContent,
+      size: stat.size,
+      path: stat.path,
+      ...(hasLineRange && {
+        lines: result.lines,
+        totalLines: result.totalLines,
+      }),
+    };
+  },
+});

--- a/packages/workspace-tools/src/search.ts
+++ b/packages/workspace-tools/src/search.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+import { createTool } from '@mastra/core/tools';
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+import { requireWorkspace } from './helpers';
+
+export const searchTool = createTool({
+  id: WORKSPACE_TOOLS.SEARCH.SEARCH,
+  description:
+    'Search indexed content in the workspace. Supports keyword (BM25), semantic (vector), and hybrid search modes.',
+  inputSchema: z.object({
+    query: z.string().describe('The search query string'),
+    topK: z.number().optional().default(5).describe('Maximum number of results to return'),
+    mode: z
+      .enum(['bm25', 'vector', 'hybrid'])
+      .optional()
+      .describe('Search mode: bm25 for keyword search, vector for semantic search, hybrid for both combined'),
+    minScore: z.number().optional().describe('Minimum score threshold (0-1 for normalized scores)'),
+  }),
+  outputSchema: z.object({
+    results: z.array(
+      z.object({
+        id: z.string().describe('Document/file path'),
+        content: z.string().describe('The matching content'),
+        score: z.number().describe('Relevance score'),
+        lineRange: z
+          .object({
+            start: z.number(),
+            end: z.number(),
+          })
+          .optional()
+          .describe('Line range where query terms were found'),
+      }),
+    ),
+    count: z.number().describe('Number of results returned'),
+    mode: z.string().describe('The search mode that was used'),
+  }),
+  execute: async ({ query, topK, mode, minScore }, context) => {
+    const workspace = requireWorkspace(context);
+
+    const results = await workspace.search(query, {
+      topK,
+      mode: mode as 'bm25' | 'vector' | 'hybrid' | undefined,
+      minScore,
+    });
+
+    return {
+      results: results.map(r => ({
+        id: r.id,
+        content: r.content,
+        score: r.score,
+        lineRange: r.lineRange,
+      })),
+      count: results.length,
+      mode: mode ?? (workspace.canHybrid ? 'hybrid' : workspace.canVector ? 'vector' : 'bm25'),
+    };
+  },
+});

--- a/packages/workspace-tools/src/tree-formatter.ts
+++ b/packages/workspace-tools/src/tree-formatter.ts
@@ -1,0 +1,222 @@
+/**
+ * Tree Formatter
+ *
+ * Formats directory structures as ASCII tree output.
+ * Works with any WorkspaceFilesystem implementation.
+ */
+
+import type { WorkspaceFilesystem, FileEntry } from '@mastra/core/workspace';
+import { createGlobMatcher, type GlobMatcher } from '@mastra/core/workspace';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface TreeOptions {
+  /** Maximum recursion depth (default: Infinity). Similar to tree's -L flag. */
+  maxDepth?: number;
+  /** Show hidden files/directories starting with '.' (default: false). Similar to tree's -a flag. */
+  showHidden?: boolean;
+  /** List directories only, no files (default: false). Similar to tree's -d flag. */
+  dirsOnly?: boolean;
+  /** Pattern to exclude from listing (e.g., 'node_modules'). Similar to tree's -I flag. */
+  exclude?: string | string[];
+  /** Filter by file extension (e.g., '.ts'). Similar to tree's -P flag. */
+  extension?: string | string[];
+  /** Glob pattern(s) to filter files. Matches against paths relative to the listed directory. Directories always pass through so their contents can be checked. */
+  pattern?: string | string[];
+}
+
+export interface TreeResult {
+  /** ASCII tree representation */
+  tree: string;
+  /** Human-readable summary (e.g., "3 directories, 12 files") */
+  summary: string;
+  /** Number of directories found */
+  dirCount: number;
+  /** Number of files found */
+  fileCount: number;
+  /** Whether output was truncated due to maxDepth */
+  truncated: boolean;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const BRANCH = '├── ';
+const LAST_BRANCH = '└── ';
+const VERTICAL = '│   ';
+const SPACE = '    ';
+
+// =============================================================================
+// Tree Formatting
+// =============================================================================
+
+/**
+ * Format a directory as an ASCII tree.
+ *
+ * @param fs - WorkspaceFilesystem implementation
+ * @param path - Root path to format
+ * @param options - Formatting options
+ * @returns Tree result with formatted string and counts
+ */
+export async function formatAsTree(fs: WorkspaceFilesystem, path: string, options?: TreeOptions): Promise<TreeResult> {
+  const maxDepth = options?.maxDepth ?? Infinity;
+  const showHidden = options?.showHidden ?? false;
+  const dirsOnly = options?.dirsOnly ?? false;
+  const exclude = options?.exclude;
+  const extension = options?.extension;
+  const pattern = options?.pattern;
+
+  // Compile glob matcher once before the walk (if pattern provided)
+  let globMatcher: GlobMatcher | undefined;
+  if (pattern) {
+    const patterns = Array.isArray(pattern) ? pattern : [pattern];
+    globMatcher = createGlobMatcher(patterns, { dot: showHidden });
+  }
+
+  const lines: string[] = ['.'];
+  let dirCount = 0;
+  let fileCount = 0;
+  let truncated = false;
+
+  /**
+   * Build tree recursively
+   */
+  async function buildTree(currentPath: string, prefix: string, depth: number): Promise<void> {
+    if (depth >= maxDepth) {
+      truncated = true;
+      return;
+    }
+
+    let entries: FileEntry[];
+    try {
+      entries = await fs.readdir(currentPath);
+    } catch (error) {
+      // At root level (depth 0), propagate errors so users see auth/access issues
+      // For subdirectories, silently skip (permission issues on nested dirs are common)
+      if (depth === 0) {
+        throw error;
+      }
+      return;
+    }
+
+    // Filter entries
+    let filtered = entries;
+
+    // Filter hidden files unless showHidden
+    if (!showHidden) {
+      filtered = filtered.filter(e => !e.name.startsWith('.'));
+    }
+
+    // Filter by exclude pattern (like tree's -I flag)
+    if (exclude) {
+      const patterns = Array.isArray(exclude) ? exclude : [exclude];
+      filtered = filtered.filter(e => {
+        return !patterns.some(pattern => e.name.includes(pattern));
+      });
+    }
+
+    // Filter to directories only (like tree's -d flag)
+    if (dirsOnly) {
+      filtered = filtered.filter(e => e.type === 'directory');
+    }
+
+    // Filter by extension (only affects files, directories always pass)
+    if (extension && !dirsOnly) {
+      const extensions = Array.isArray(extension) ? extension : [extension];
+      filtered = filtered.filter(e => {
+        if (e.type === 'directory') return true;
+        return extensions.some(ext => {
+          // Support both '.ts' and 'ts' formats
+          const normalizedExt = ext.startsWith('.') ? ext : `.${ext}`;
+          return e.name.endsWith(normalizedExt);
+        });
+      });
+    }
+
+    // Filter by glob pattern (only affects files, directories always pass)
+    if (globMatcher && !dirsOnly) {
+      filtered = filtered.filter(e => {
+        if (e.type === 'directory') return true;
+        // Build relative path from the root of the tree walk
+        const entryPath = currentPath === path ? e.name : `${currentPath === '/' ? '' : currentPath}/${e.name}`;
+        // Strip the root path prefix to make it relative
+        let relativePath: string;
+        if (path === '/' || path === '') {
+          relativePath = entryPath.startsWith('/') ? entryPath.slice(1) : entryPath;
+        } else {
+          relativePath = entryPath.startsWith(path + '/') ? entryPath.slice(path.length + 1) : entryPath;
+          // If entryPath starts with path but no slash (shouldn't happen), fall back
+          if (!relativePath) relativePath = entryPath;
+        }
+        return globMatcher!(relativePath);
+      });
+    }
+
+    // Sort: directories first, then alphabetically (ASCII order to match native tree's strcmp)
+    filtered.sort((a, b) => {
+      if (a.type === 'directory' && b.type !== 'directory') return -1;
+      if (a.type !== 'directory' && b.type === 'directory') return 1;
+      return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+    });
+
+    for (let i = 0; i < filtered.length; i++) {
+      const entry = filtered[i]!;
+      const isLast = i === filtered.length - 1;
+      const connector = isLast ? LAST_BRANCH : BRANCH;
+      const childPrefix = prefix + (isLast ? SPACE : VERTICAL);
+
+      // Format entry name, including symlink target if present
+      const displayName =
+        entry.isSymlink && entry.symlinkTarget ? `${entry.name} -> ${entry.symlinkTarget}` : entry.name;
+
+      lines.push(prefix + connector + displayName);
+
+      if (entry.type === 'directory') {
+        dirCount++;
+        // Don't recurse into symlinks (matches native tree behavior)
+        // This also prevents infinite loops from circular symlinks
+        if (!entry.isSymlink) {
+          const childPath = joinPath(currentPath, entry.name);
+          await buildTree(childPath, childPrefix, depth + 1);
+        }
+      } else {
+        fileCount++;
+      }
+    }
+  }
+
+  await buildTree(path, '', 0);
+
+  // Build summary
+  const dirPart = dirCount === 1 ? '1 directory' : `${dirCount} directories`;
+  const filePart = fileCount === 1 ? '1 file' : `${fileCount} files`;
+  let summary = `${dirPart}, ${filePart}`;
+  if (truncated) {
+    summary += ` (truncated at depth ${maxDepth})`;
+  }
+
+  return {
+    tree: lines.join('\n'),
+    summary,
+    dirCount,
+    fileCount,
+    truncated,
+  };
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Join path segments, handling root paths correctly
+ */
+function joinPath(base: string, name: string): string {
+  if (base === '/' || base === '') {
+    return `/${name}`;
+  }
+  return `${base}/${name}`;
+}

--- a/packages/workspace-tools/src/write-file.ts
+++ b/packages/workspace-tools/src/write-file.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { createTool } from '@mastra/core/tools';
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+import { WorkspaceReadOnlyError } from '@mastra/core/workspace';
+import { requireFilesystem } from './helpers';
+
+export const writeFileTool = createTool({
+  id: WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE,
+  description: 'Write content to a file in the workspace filesystem. Creates parent directories if needed.',
+  inputSchema: z.object({
+    path: z.string().describe('The path where to write the file (e.g., "/data/output.txt")'),
+    content: z.string().describe('The content to write to the file'),
+    overwrite: z.boolean().optional().default(true).describe('Whether to overwrite the file if it already exists'),
+  }),
+  outputSchema: z.object({
+    success: z.boolean(),
+    path: z.string().describe('The path where the file was written'),
+    size: z.number().describe('The size of the written content in bytes'),
+  }),
+  execute: async ({ path, content, overwrite }, context) => {
+    const { filesystem } = requireFilesystem(context);
+
+    if (filesystem.readOnly) {
+      throw new WorkspaceReadOnlyError('write_file');
+    }
+
+    await filesystem.writeFile(path, content, { overwrite });
+
+    return {
+      success: true,
+      path,
+      size: Buffer.byteLength(content, 'utf-8'),
+    };
+  },
+});

--- a/packages/workspace-tools/tsconfig.build.json
+++ b/packages/workspace-tools/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/packages/workspace-tools/tsconfig.json
+++ b/packages/workspace-tools/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/packages/workspace-tools/tsup.config.ts
+++ b/packages/workspace-tools/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/packages/workspace-tools/vitest.config.ts
+++ b/packages/workspace-tools/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: 'unit:packages/workspace-tools',
+          environment: 'node',
+          include: ['src/**/*.test.ts'],
+          testTimeout: 30000,
+        },
+      },
+    ],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3833,6 +3833,27 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
 
+  packages/workspace-tools:
+    devDependencies:
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../core
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@microsoft/api-extractor@7.56.3(@types/node@22.19.7))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.7)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.1)
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
+
   pubsub/google-cloud-pubsub:
     dependencies:
       '@google-cloud/pubsub':


### PR DESCRIPTION
## Summary
- New `@mastra/workspace-tools` package (v0.0.0) with 10 standalone tool exports that can be versioned independently from core
- Added `workspace.getTools({ requestContext })` — single API for resolving workspace tools at request time, handling all config forms (function, Record<string, Tool>, WorkspaceToolsConfig)
- `WorkspaceConfig.tools` accepts tool overrides: static `Record<string, Tool>`, or dynamic `({ workspace, requestContext }) => Record<string, Tool>`
- `createWorkspaceTools` from `@mastra/workspace-tools` accepts `{ workspace, requestContext }` and auto-filters tools based on workspace capabilities (has filesystem? sandbox? search?)
- Moved line-utils and tree-formatter out of core's public API into `@mastra/workspace-tools` (implementation details, not public API)
- Server uses `workspace.getTools()` with fallback for older core versions

### Usage
```typescript
import { createWorkspaceTools } from '@mastra/workspace-tools';

// As function ref — auto-filters based on workspace capabilities at request time
new Workspace({
  filesystem: new LocalFilesystem({ basePath: './workspace' }),
  sandbox: new E2BSandbox(),
  tools: createWorkspaceTools,
})

// Static — all tools
new Workspace({
  tools: createWorkspaceTools(),
})

// Static — filtered
new Workspace({
  tools: createWorkspaceTools({ exclude: ['mastra_workspace_execute_command'] }),
})

// Dynamic — custom logic with requestContext
new Workspace({
  tools: ({ workspace, requestContext }) => createWorkspaceTools({
    workspace,
    exclude: workspace.sandbox ? [] : ['mastra_workspace_execute_command'],
  }),
})
```

## Test plan
- [x] Core workspace tools tests (47 passing)
- [x] Core workspace safety tests (20 passing)
- [x] Workspace-tools package tests (5 passing)
- [x] Core build passes
- [x] Server build passes
- [ ] Manual testing