### PR TITLE
docs: move Observational Memory above Working Memory and Semantic Recall in sidebar

### DIFF
--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -220,6 +220,14 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'memory/observational-memory',
+          label: 'Observational Memory',
+          customProps: {
+            tags: ['new'],
+          },
+        },
+        {
+          type: 'doc',
           id: 'memory/working-memory',
           label: 'Working Memory',
         },
@@ -227,14 +235,6 @@ const sidebars = {
           type: 'doc',
           id: 'memory/semantic-recall',
           label: 'Semantic Recall',
-        },
-        {
-          type: 'doc',
-          id: 'memory/observational-memory',
-          label: 'Observational Memory',
-          customProps: {
-            tags: ['new'],
-          },
         },
         {
           type: 'doc',


### PR DESCRIPTION
Moves Observational Memory up in the docs sidebar so it appears right after Message History, before Working Memory and Semantic Recall

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized documentation navigation structure for improved content discoverability.
  * Added "Observational Memory" documentation section marked as new content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->