### PR TITLE
feat(workspace-tools): raw text tool outputs to reduce token usage

### DIFF
--- a/packages/playground-ui/src/lib/ai-ui/tools/tool-fallback.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/tool-fallback.tsx
@@ -112,6 +112,7 @@ const ToolFallbackInner = ({ toolName, result, args, metadata, toolCallId, ...pr
   const isListFiles = toolName === WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES;
 
   if (isListFiles) {
+    const listFilesOutput = Array.isArray(result) ? result : result?.output || result?.toolOutput || [];
     return (
       <FileTreeBadge
         toolName={toolName}
@@ -121,6 +122,7 @@ const ToolFallbackInner = ({ toolName, result, args, metadata, toolCallId, ...pr
         toolCallId={toolCallId}
         toolApprovalMetadata={toolApprovalMetadata}
         isNetwork={isNetwork ?? false}
+        toolOutput={listFilesOutput}
         toolCalled={toolCalled}
       />
     );

--- a/packages/workspace-tools/src/index-content.ts
+++ b/packages/workspace-tools/src/index-content.ts
@@ -11,14 +11,20 @@ export const indexContentTool = createTool({
     content: z.string().describe('The text content to index'),
     metadata: z.record(z.unknown()).optional().describe('Optional metadata to store with the document'),
   }),
-  outputSchema: z.object({
-    success: z.boolean(),
-    path: z.string().describe('The indexed document ID'),
-  }),
   execute: async ({ path, content, metadata }, context) => {
     const workspace = requireWorkspace(context);
 
     await workspace.index(path, content, { metadata });
-    return { success: true, path };
+
+    await context?.writer?.custom({
+      type: 'data-workspace-metadata',
+      data: {
+        toolName: WORKSPACE_TOOLS.SEARCH.INDEX,
+        path,
+        workspace: { id: workspace.id, name: workspace.name },
+      },
+    });
+
+    return `Indexed ${path}`;
   },
 });


### PR DESCRIPTION
## Summary

- Remove `outputSchema` from all 10 workspace tools in `@mastra/workspace-tools` — AI SDK treats return as raw text
- Return CLI-style strings from `execute` functions (tree, cat -n, grep formats)
- Emit `data-workspace-metadata` chunks via `context.writer.custom()` for UI metadata sideband
- Playground UI badges handle both string results (workspace-tools) and object results (core built-in tools)

**Core built-in tools are unchanged** — no breaking changes to `@mastra/core`.

## Per-Tool Output Formats

| Tool | Return format |
|------|------|
| `read_file` | `path (size bytes)\n<line-numbered content>` |
| `write_file` | `Wrote X bytes to path` |
| `edit_file` | `Replaced N occurrence(s) in path` or error message |
| `list_files` | `tree\n\nsummary` |
| `delete` | `Deleted path` |
| `file_stat` | `path Type: file Size: X bytes Modified: ISO` or `path: not found` |
| `mkdir` | `Created directory path` |
| `search` | grep-like format with result count |
| `index` | `Indexed path` |
| `execute_command` | stdout text, or `stdout\nstderr\nExit code: N` on failure |

## Data Chunk Sideband

All tools emit a `data-workspace-metadata` chunk (filtered before LLM by `output-converter.ts`) with structured metadata for the UI:

```typescript
await context?.writer?.custom({
  type: 'data-workspace-metadata',
  data: {
    toolName: string,
    workspace?: { id?, name? },
    filesystem?: { id?, name?, provider? },
    // + tool-specific fields
  },
});
```

## Test plan

- [x] workspace-tools package builds
- [x] playground-ui builds  
- [x] `createWorkspaceTools` tests pass (5/5)
- [x] Core workspace tool tests still pass (47/47)
- [x] Core workspace safety tests still pass (20/20)
- [ ] Manual test in studio: verify list_files badge renders tree + summary correctly with string result
- [ ] Manual test in studio: verify sandbox execution badge handles string result

Closes COR-525