### PR TITLE
fix(memory): improve reflection compression reliability

### DIFF
--- a/.changeset/fix-om-reflection-compression.md
+++ b/.changeset/fix-om-reflection-compression.md
@@ -2,9 +2,8 @@
 '@mastra/memory': patch
 ---
 
-fix(memory): improve reflection compression reliability
+- Reflection retry logic now attempts compression up to level 3, so reflections more consistently shrink to meet token limits
+- Default target compression reduced from 50% to 25% (`sliceTokenEstimate * 0.75`), making automatic trimming less aggressive
+- `tokensBuffered` marker now reports the actual slice size rather than total observation tokens, giving accurate size monitoring
 
-- Refactor reflection retry logic to escalate through compression levels 0-3 (previously capped at 2)
-- Add level 3 "critical compression" guidance for cases where prior levels fail
-- Reduce default compression target from 50% to 25% reduction (sliceTokenEstimate * 0.75)
-- Fix tokensBuffered marker to report actual slice size instead of total observation tokens
+These changes reduce failed reflections and make reported metrics match what is actually being processed.

--- a/.changeset/fix-om-reflection-compression.md
+++ b/.changeset/fix-om-reflection-compression.md
@@ -1,0 +1,10 @@
+---
+'@mastra/memory': patch
+---
+
+fix(memory): improve reflection compression reliability
+
+- Refactor reflection retry logic to escalate through compression levels 0-3 (previously capped at 2)
+- Add level 3 "critical compression" guidance for cases where prior levels fail
+- Reduce default compression target from 50% to 25% reduction (sliceTokenEstimate * 0.75)
+- Fix tokensBuffered marker to report actual slice size instead of total observation tokens

--- a/packages/memory/src/processors/observational-memory/reflector-agent.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-agent.ts
@@ -127,7 +127,7 @@ export const REFLECTOR_SYSTEM_PROMPT = buildReflectorSystemPrompt();
  * - Level 1: Gentle compression guidance (original wording — "slightly more" goes a long way for LLMs)
  * - Level 2: Aggressive compression guidance (stronger push when level 1 didn't work)
  */
-export const COMPRESSION_GUIDANCE: Record<0 | 1 | 2, string> = {
+export const COMPRESSION_GUIDANCE: Record<0 | 1 | 2 | 3, string> = {
   0: '',
   1: `
 ## COMPRESSION REQUIRED
@@ -158,6 +158,21 @@ Please re-process with much more aggressive compression:
 
 Your current detail level was a 10/10, lets aim for a 6/10 detail level.
 `,
+  3: `
+## CRITICAL COMPRESSION REQUIRED
+
+Your previous reflections have failed to compress sufficiently after multiple attempts.
+
+Please re-process with maximum compression:
+- Summarize the oldest observations (first 50-70%) into brief high-level paragraphs — only key facts, decisions, and outcomes
+- For the most recent observations (last 30-50%), retain important details but still use a condensed style
+- Ruthlessly merge related observations — if 10 observations are about the same topic, combine into 1-2 lines
+- Drop procedural details (tool calls, retries, intermediate steps) — keep only final outcomes
+- Drop observations that are no longer relevant or have been superseded by newer information
+- Preserve: names, dates, decisions, errors, user preferences, and architectural choices
+
+Your current detail level was a 10/10, lets aim for a 4/10 detail level.
+`,
 };
 
 /**
@@ -171,11 +186,11 @@ export const COMPRESSION_RETRY_PROMPT = COMPRESSION_GUIDANCE[1];
 export function buildReflectorPrompt(
   observations: string,
   manualPrompt?: string,
-  compressionLevel?: boolean | 0 | 1 | 2,
+  compressionLevel?: boolean | 0 | 1 | 2 | 3,
   skipContinuationHints?: boolean,
 ): string {
   // Normalize: boolean `true` maps to level 1 for backwards compat
-  const level: 0 | 1 | 2 = typeof compressionLevel === 'number' ? compressionLevel : compressionLevel ? 1 : 0;
+  const level: 0 | 1 | 2 | 3 = typeof compressionLevel === 'number' ? compressionLevel : compressionLevel ? 1 : 0;
 
   let prompt = `## OBSERVATIONS TO REFLECT ON
 


### PR DESCRIPTION
Reflection compression was failing when observations were near 100% of the threshold. With `bufferActivation: 0.5`, slicing 20k tokens and asking for 50% compression (target 10k) was too aggressive — the reflector couldn't compress that much and returned essentially uncompressed output.

Three fixes:

**Compression target**: changed from `sliceTokenEstimate * bufferActivation` (50% reduction) to `sliceTokenEstimate * 0.75` (25% reduction). Much more achievable.

**Retry loop**: refactored from a single retry to a loop that escalates through compression levels 0→1→2→3. Previously buffered reflection maxed out at level 2. Added level 3 with more aggressive guidance (4/10 detail level).

**Marker fix**: `tokensBuffered` in the buffering end marker was reporting total observation tokens instead of the actual slice size sent to the reflector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reflection-based compression reliability with iterative retries up to a new maximum level to reduce failures.
  * Corrected token reporting so buffered memory sizes in start/end markers reflect actual slice estimates.

* **Improvements**
  * Updated compression target calculations (now a 75% target of slice estimates) for more consistent buffering and metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->