### PR TITLE
feat(core): add toModelOutput support to agent loop

### DIFF
--- a/.changeset/to-model-output-support.md
+++ b/.changeset/to-model-output-support.md
@@ -3,3 +3,25 @@
 ---
 
 Added `toModelOutput` support to the agent loop. Tool definitions can now include a `toModelOutput` function that transforms the raw tool result before it's sent to the model, while preserving the raw result in storage. This matches the AI SDK `toModelOutput` convention — the function receives the raw output directly and returns `{ type: 'text', value: string }` or `{ type: 'content', value: ContentPart[] }`.
+
+```ts
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+const weatherTool = createTool({
+  id: 'weather',
+  inputSchema: z.object({ city: z.string() }),
+  execute: async ({ city }) => ({
+    city,
+    temperature: 72,
+    conditions: 'sunny',
+    humidity: 45,
+    raw_sensor_data: [0.12, 0.45, 0.78],
+  }),
+  // The model sees a concise summary instead of the full JSON
+  toModelOutput: (output) => ({
+    type: 'text',
+    value: `${output.city}: ${output.temperature}°F, ${output.conditions}`,
+  }),
+});
+```

--- a/.changeset/to-model-output-support.md
+++ b/.changeset/to-model-output-support.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added `toModelOutput` support to the agent loop. Tool definitions can now include a `toModelOutput` function that transforms the raw tool result before it's sent to the model, while preserving the raw result in storage. This matches the AI SDK `toModelOutput` convention — the function receives the raw output directly and returns `{ type: 'text', value: string }` or `{ type: 'content', value: ContentPart[] }`.

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -1,6 +1,7 @@
 import { convertToCoreMessages as convertToCoreMessagesV4 } from '@internal/ai-sdk-v4';
 import type { CoreMessage as CoreMessageV4, UIMessage as UIMessageV4 } from '@internal/ai-sdk-v4';
 import * as AIV5 from '@internal/ai-sdk-v5';
+import type { ToolSet } from '@internal/ai-sdk-v5';
 
 import { AIV4Adapter, AIV5Adapter } from '../adapters';
 import type { AdapterContext } from '../adapters';
@@ -151,10 +152,11 @@ export function aiV5UIMessagesToAIV5ModelMessages(
   messages: AIV5Type.UIMessage[],
   dbMessages: MastraDBMessage[],
   filterIncompleteToolCalls = false,
+  tools?: ToolSet,
 ): AIV5Type.ModelMessage[] {
   const sanitized = sanitizeV5UIMessages(messages, filterIncompleteToolCalls);
   const preprocessed = addStartStepPartsForAIV5(sanitized);
-  const result = AIV5.convertToModelMessages(preprocessed);
+  const result = AIV5.convertToModelMessages(preprocessed, { tools });
 
   // Restore message-level providerOptions from metadata.providerMetadata
   // This preserves providerOptions through the DB → UI → Model conversion

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -1,7 +1,6 @@
 import { convertToCoreMessages as convertToCoreMessagesV4 } from '@internal/ai-sdk-v4';
 import type { CoreMessage as CoreMessageV4, UIMessage as UIMessageV4 } from '@internal/ai-sdk-v4';
 import * as AIV5 from '@internal/ai-sdk-v5';
-import type { ToolSet } from '@internal/ai-sdk-v5';
 
 import { AIV4Adapter, AIV5Adapter } from '../adapters';
 import type { AdapterContext } from '../adapters';
@@ -152,11 +151,50 @@ export function aiV5UIMessagesToAIV5ModelMessages(
   messages: AIV5Type.UIMessage[],
   dbMessages: MastraDBMessage[],
   filterIncompleteToolCalls = false,
-  tools?: ToolSet,
 ): AIV5Type.ModelMessage[] {
   const sanitized = sanitizeV5UIMessages(messages, filterIncompleteToolCalls);
   const preprocessed = addStartStepPartsForAIV5(sanitized);
-  const result = AIV5.convertToModelMessages(preprocessed, { tools });
+  const result = AIV5.convertToModelMessages(preprocessed);
+
+  // Build a lookup of toolCallId → stored modelOutput from providerMetadata.mastra.modelOutput.
+  // This allows toModelOutput results computed at tool execution time to be preserved
+  // in the model prompt without re-running the transformation.
+  const storedModelOutputs = new Map<string, unknown>();
+  for (const dbMsg of dbMessages) {
+    if (dbMsg.content?.format === 2 && dbMsg.content.parts) {
+      for (const part of dbMsg.content.parts) {
+        if (
+          part.type === 'tool-invocation' &&
+          part.toolInvocation?.state === 'result' &&
+          part.providerMetadata?.mastra &&
+          typeof part.providerMetadata.mastra === 'object' &&
+          'modelOutput' in (part.providerMetadata.mastra as Record<string, unknown>)
+        ) {
+          storedModelOutputs.set(
+            part.toolInvocation.toolCallId,
+            (part.providerMetadata.mastra as Record<string, unknown>).modelOutput,
+          );
+        }
+      }
+    }
+  }
+
+  // Apply stored modelOutput to tool-result parts in model messages
+  if (storedModelOutputs.size > 0) {
+    for (const modelMsg of result) {
+      if (modelMsg.role === 'tool' && Array.isArray(modelMsg.content)) {
+        for (let i = 0; i < modelMsg.content.length; i++) {
+          const part = modelMsg.content[i]!;
+          if (part.type === 'tool-result' && storedModelOutputs.has(part.toolCallId)) {
+            modelMsg.content[i] = {
+              ...part,
+              output: storedModelOutputs.get(part.toolCallId) as any,
+            };
+          }
+        }
+      }
+    }
+  }
 
   // Restore message-level providerOptions from metadata.providerMetadata
   // This preserves providerOptions through the DB → UI → Model conversion

--- a/packages/core/src/agent/message-list/merge/MessageMerger.ts
+++ b/packages/core/src/agent/message-list/merge/MessageMerger.ts
@@ -99,6 +99,13 @@ export class MessageMerger {
                 ...part.toolInvocation.args,
               },
             };
+            // Preserve providerMetadata from the result part (e.g. toModelOutput stored at mastra.modelOutput)
+            if (part.providerMetadata) {
+              existingCallPart.providerMetadata = {
+                ...existingCallPart.providerMetadata,
+                ...part.providerMetadata,
+              };
+            }
             if (!latestMessage.content.toolInvocations) {
               latestMessage.content.toolInvocations = [];
             }

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1,7 +1,6 @@
 import type { LanguageModelV2Prompt } from '@ai-sdk/provider-v5';
 import type { LanguageModelV1Prompt, CoreMessage as CoreMessageV4 } from '@internal/ai-sdk-v4';
 import type * as AIV4Type from '@internal/ai-sdk-v4';
-import type { ToolSet } from '@internal/ai-sdk-v5';
 import { v4 as randomUUID } from '@lukeed/uuid';
 
 import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
@@ -366,15 +365,14 @@ export class MessageList {
           downloadConcurrency?: number;
           downloadRetries?: number;
           supportedUrls?: Record<string, RegExp[]>;
-          tools?: ToolSet;
         } = {
           downloadConcurrency: 10,
           downloadRetries: 3,
         },
       ): Promise<LanguageModelV2Prompt> => {
         // Filter incomplete tool calls when sending messages TO the LLM
-        // Pass tools so convertToModelMessages can apply toModelOutput transformations
-        const modelMessages = convertAIV5UIToModelMessages(this.all.aiV5.ui(), this.messages, true, options?.tools);
+        // Stored toModelOutput results from providerMetadata are applied automatically
+        const modelMessages = convertAIV5UIToModelMessages(this.all.aiV5.ui(), this.messages, true);
         const systemMessages = convertAIV4CoreToAIV5ModelMessages(
           [...this.systemMessages, ...Object.values(this.taggedSystemMessages).flat()],
           `system`,

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1,6 +1,7 @@
 import type { LanguageModelV2Prompt } from '@ai-sdk/provider-v5';
 import type { LanguageModelV1Prompt, CoreMessage as CoreMessageV4 } from '@internal/ai-sdk-v4';
 import type * as AIV4Type from '@internal/ai-sdk-v4';
+import type { ToolSet } from '@internal/ai-sdk-v5';
 import { v4 as randomUUID } from '@lukeed/uuid';
 
 import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
@@ -365,13 +366,15 @@ export class MessageList {
           downloadConcurrency?: number;
           downloadRetries?: number;
           supportedUrls?: Record<string, RegExp[]>;
+          tools?: ToolSet;
         } = {
           downloadConcurrency: 10,
           downloadRetries: 3,
         },
       ): Promise<LanguageModelV2Prompt> => {
         // Filter incomplete tool calls when sending messages TO the LLM
-        const modelMessages = convertAIV5UIToModelMessages(this.all.aiV5.ui(), this.messages, true);
+        // Pass tools so convertToModelMessages can apply toModelOutput transformations
+        const modelMessages = convertAIV5UIToModelMessages(this.all.aiV5.ui(), this.messages, true, options?.tools);
         const systemMessages = convertAIV4CoreToAIV5ModelMessages(
           [...this.systemMessages, ...Object.values(this.taggedSystemMessages).flat()],
           `system`,

--- a/packages/core/src/agent/workflows/prepare-stream/schema.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/schema.ts
@@ -43,6 +43,7 @@ const coreToolSchema = z.object({
   ]),
   outputSchema: z.union([z.record(z.string(), z.any()), z.any()]).optional(),
   execute: z.optional(z.function(z.tuple([z.any(), z.any()]), z.promise(z.any()))),
+  toModelOutput: z.optional(z.function(z.tuple([z.any()]), z.any())),
   type: z.union([z.literal('function'), z.literal('provider-defined'), z.undefined()]).optional(),
   args: z.record(z.string(), z.any()).optional(),
 });

--- a/packages/core/src/loop/test-utils/tools.ts
+++ b/packages/core/src/loop/test-utils/tools.ts
@@ -920,4 +920,132 @@ export function toolsTests({ loopFn, runId }: { loopFn: typeof loop; runId: stri
       expect(textChunks.length).toBeGreaterThan(0);
     });
   });
+
+  describe('toModelOutput', () => {
+    it('should call toModelOutput and use transformed output in subsequent model prompt', async () => {
+      const messageList = createMessageListWithUserMessage();
+      const toModelOutputCalls: unknown[] = [];
+      const stepInputs: any[] = [];
+
+      let responseCount = 0;
+      const result = await loopFn({
+        methodType: 'stream',
+        runId,
+        models: [
+          {
+            id: 'test-model',
+            maxRetries: 0,
+            model: new MockLanguageModelV2({
+              doStream: async ({ prompt, tools, toolChoice }) => {
+                stepInputs.push({ prompt, tools, toolChoice });
+
+                switch (responseCount++) {
+                  case 0: {
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'response-metadata',
+                          id: 'id-0',
+                          modelId: 'mock-model-id',
+                          timestamp: new Date(0),
+                        },
+                        {
+                          type: 'tool-call',
+                          id: 'call-1',
+                          toolCallId: 'call-1',
+                          toolName: 'weather',
+                          input: `{ "city": "Seattle" }`,
+                        },
+                        {
+                          type: 'finish',
+                          finishReason: 'tool-calls',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  }
+                  case 1: {
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'response-metadata',
+                          id: 'id-1',
+                          modelId: 'mock-model-id',
+                          timestamp: new Date(1000),
+                        },
+                        { type: 'text-start', id: 'text-1' },
+                        { type: 'text-delta', id: 'text-1', delta: 'The weather is nice.' },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: testUsage,
+                        },
+                      ]),
+                    };
+                  }
+                  default:
+                    throw new Error(`Unexpected response count: ${responseCount}`);
+                }
+              },
+            }),
+          },
+        ],
+        tools: {
+          weather: {
+            inputSchema: z.object({ city: z.string() }),
+            execute: async ({ city }: { city: string }) => ({
+              city,
+              temperature: 72,
+              conditions: 'sunny',
+              humidity: 45,
+              wind_speed: 12,
+              raw_sensor_data: { sensor_id: 'wx-001', readings: [71.8, 72.1, 72.0] },
+            }),
+            toModelOutput: (output: unknown) => {
+              toModelOutputCalls.push(output);
+              const data = output as any;
+              return {
+                type: 'text' as const,
+                value: `Weather in ${data.city}: ${data.temperature}F, ${data.conditions}`,
+              };
+            },
+          },
+        },
+        messageList,
+        stopWhen: stepCountIs(3),
+        ...defaultSettings(),
+        _internal: {
+          now: mockValues(0, 100, 500, 600, 1000),
+          generateId: mockId({ prefix: 'id' }),
+        },
+      });
+
+      await result.consumeStream();
+
+      // toModelOutput should have been called with the raw tool result
+      expect(toModelOutputCalls).toHaveLength(1);
+      expect(toModelOutputCalls[0]).toEqual({
+        city: 'Seattle',
+        temperature: 72,
+        conditions: 'sunny',
+        humidity: 45,
+        wind_speed: 12,
+        raw_sensor_data: { sensor_id: 'wx-001', readings: [71.8, 72.1, 72.0] },
+      });
+
+      // The second model call's prompt should contain the transformed output
+      expect(stepInputs).toHaveLength(2);
+      const secondPrompt = stepInputs[1].prompt;
+      const toolMessage = secondPrompt.find((m: any) => m.role === 'tool');
+      expect(toolMessage).toBeDefined();
+
+      const toolResult = toolMessage.content.find((p: any) => p.type === 'tool-result');
+      expect(toolResult).toBeDefined();
+      expect(toolResult.output).toEqual({
+        type: 'text',
+        value: `Weather in Seattle: 72F, sunny`,
+      });
+    });
+  });
 }

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -703,7 +703,6 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           downloadRetries,
           downloadConcurrency,
           supportedUrls: resolvedSupportedUrls,
-          tools,
         };
         let inputMessages = await messageList.get.all.aiV5.llmPrompt(messageListPromptArgs);
 

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -703,6 +703,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           downloadRetries,
           downloadConcurrency,
           supportedUrls: resolvedSupportedUrls,
+          tools,
         };
         let inputMessages = await messageList.get.all.aiV5.llmPrompt(messageListPromptArgs);
 

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -390,3 +390,284 @@ describe('createLLMMappingStep HITL behavior', () => {
     expect(result.stepResult.isContinued).toBe(false);
   });
 });
+
+describe('createLLMMappingStep toModelOutput', () => {
+  let controller: { enqueue: Mock };
+  let messageList: MessageList;
+  let llmExecutionStep: any;
+  let bail: Mock;
+  let getStepResult: Mock;
+
+  const createExecuteParams = (
+    inputData: ToolCallOutput[],
+  ): ExecuteFunctionParams<{}, ToolCallOutput[], any, any, any> => ({
+    runId: 'test-run',
+    workflowId: 'test-workflow',
+    mastra: {} as any,
+    requestContext: new RequestContext(),
+    state: {},
+    setState: vi.fn(),
+    retryCount: 1,
+    tracingContext: {} as any,
+    getInitData: vi.fn(),
+    getStepResult,
+    suspend: vi.fn(),
+    bail,
+    abort: vi.fn(),
+    engine: 'default' as any,
+    abortSignal: new AbortController().signal,
+    writer: new ToolStream({
+      prefix: 'tool',
+      callId: 'test-call-id',
+      name: 'test-tool',
+      runId: 'test-run',
+    }),
+    validateSchemas: false,
+    inputData,
+    [PUBSUB_SYMBOL]: {} as any,
+    [STREAM_FORMAT_SYMBOL]: undefined,
+  });
+
+  beforeEach(() => {
+    controller = { enqueue: vi.fn() };
+
+    messageList = {
+      get: {
+        all: { aiV5: { model: () => [] } },
+        input: { aiV5: { model: () => [] } },
+        response: { aiV5: { model: () => [] } },
+      },
+      add: vi.fn(),
+    } as unknown as MessageList;
+
+    llmExecutionStep = createStep({
+      id: 'test-llm-execution',
+      inputSchema: z.any(),
+      outputSchema: z.any(),
+      execute: async () => ({
+        stepResult: { isContinued: true, reason: undefined },
+        metadata: {},
+      }),
+    });
+
+    bail = vi.fn(data => data);
+    getStepResult = vi.fn(() => ({
+      stepResult: { isContinued: true, reason: undefined },
+      metadata: {},
+    }));
+  });
+
+  it('should call toModelOutput and store result on providerMetadata.mastra.modelOutput', async () => {
+    const toModelOutputMock = vi.fn((output: unknown) => ({
+      type: 'text',
+      value: `Transformed: ${JSON.stringify(output)}`,
+    }));
+
+    const llmMappingStep = createLLMMappingStep(
+      {
+        models: {} as any,
+        controller,
+        messageList,
+        runId: 'test-run',
+        _internal: { generateId: () => 'test-message-id' },
+        tools: {
+          weather: {
+            execute: async () => ({ temperature: 72 }),
+            toModelOutput: toModelOutputMock,
+            inputSchema: z.object({ city: z.string() }),
+          },
+        },
+      } as any,
+      llmExecutionStep,
+    );
+
+    const inputData: ToolCallOutput[] = [
+      {
+        toolCallId: 'call-1',
+        toolName: 'weather',
+        args: { city: 'NYC' },
+        result: { temperature: 72, conditions: 'sunny' },
+      },
+    ];
+
+    await llmMappingStep.execute(createExecuteParams(inputData));
+
+    // toModelOutput should have been called with the raw result
+    expect(toModelOutputMock).toHaveBeenCalledWith({ temperature: 72, conditions: 'sunny' });
+
+    // The message added to messageList should have providerMetadata.mastra.modelOutput
+    expect(messageList.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({
+          parts: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'tool-invocation',
+              toolInvocation: expect.objectContaining({
+                toolCallId: 'call-1',
+                result: { temperature: 72, conditions: 'sunny' }, // raw result preserved
+              }),
+              providerMetadata: expect.objectContaining({
+                mastra: expect.objectContaining({
+                  modelOutput: {
+                    type: 'text',
+                    value: 'Transformed: {"temperature":72,"conditions":"sunny"}',
+                  },
+                }),
+              }),
+            }),
+          ]),
+        }),
+      }),
+      'response',
+    );
+  });
+
+  it('should NOT call toModelOutput for tools without it defined', async () => {
+    const llmMappingStep = createLLMMappingStep(
+      {
+        models: {} as any,
+        controller,
+        messageList,
+        runId: 'test-run',
+        _internal: { generateId: () => 'test-message-id' },
+        tools: {
+          plainTool: {
+            execute: async () => ({ done: true }),
+            inputSchema: z.object({ input: z.string() }),
+          },
+        },
+      } as any,
+      llmExecutionStep,
+    );
+
+    const inputData: ToolCallOutput[] = [
+      {
+        toolCallId: 'call-1',
+        toolName: 'plainTool',
+        args: { input: 'test' },
+        result: { done: true },
+      },
+    ];
+
+    await llmMappingStep.execute(createExecuteParams(inputData));
+
+    // Message should NOT have providerMetadata on the part
+    expect(messageList.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({
+          parts: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'tool-invocation',
+              toolInvocation: expect.objectContaining({
+                toolCallId: 'call-1',
+                result: { done: true },
+              }),
+            }),
+          ]),
+        }),
+      }),
+      'response',
+    );
+
+    // providerMetadata should not be set on the part
+    const addedMessage = (messageList.add as Mock).mock.calls[0]![0];
+    const part = addedMessage.content.parts[0];
+    expect(part.providerMetadata).toBeUndefined();
+  });
+
+  it('should call toModelOutput for mixed tools (only the ones that define it)', async () => {
+    const toModelOutputMock = vi.fn((output: unknown) => ({
+      type: 'text',
+      value: 'transformed',
+    }));
+
+    const llmMappingStep = createLLMMappingStep(
+      {
+        models: {} as any,
+        controller,
+        messageList,
+        runId: 'test-run',
+        _internal: { generateId: () => 'test-message-id' },
+        tools: {
+          withTransform: {
+            execute: async () => ({ data: 'raw' }),
+            toModelOutput: toModelOutputMock,
+            inputSchema: z.object({}),
+          },
+          withoutTransform: {
+            execute: async () => ({ data: 'raw' }),
+            inputSchema: z.object({}),
+          },
+        },
+      } as any,
+      llmExecutionStep,
+    );
+
+    const inputData: ToolCallOutput[] = [
+      {
+        toolCallId: 'call-1',
+        toolName: 'withTransform',
+        args: {},
+        result: { data: 'raw' },
+      },
+      {
+        toolCallId: 'call-2',
+        toolName: 'withoutTransform',
+        args: {},
+        result: { data: 'raw' },
+      },
+    ];
+
+    await llmMappingStep.execute(createExecuteParams(inputData));
+
+    expect(toModelOutputMock).toHaveBeenCalledTimes(1);
+    expect(toModelOutputMock).toHaveBeenCalledWith({ data: 'raw' });
+
+    const addedMessage = (messageList.add as Mock).mock.calls[0]![0];
+    const parts = addedMessage.content.parts;
+
+    // First tool should have modelOutput
+    expect(parts[0].providerMetadata?.mastra?.modelOutput).toEqual({
+      type: 'text',
+      value: 'transformed',
+    });
+
+    // Second tool should NOT have providerMetadata
+    expect(parts[1].providerMetadata).toBeUndefined();
+  });
+
+  it('should NOT call toModelOutput when tool result is null/undefined', async () => {
+    const toModelOutputMock = vi.fn();
+
+    const llmMappingStep = createLLMMappingStep(
+      {
+        models: {} as any,
+        controller,
+        messageList,
+        runId: 'test-run',
+        _internal: { generateId: () => 'test-message-id' },
+        tools: {
+          hitlTool: {
+            toModelOutput: toModelOutputMock,
+            inputSchema: z.object({}),
+          },
+        },
+      } as any,
+      llmExecutionStep,
+    );
+
+    const inputData: ToolCallOutput[] = [
+      {
+        toolCallId: 'call-1',
+        toolName: 'hitlTool',
+        args: {},
+        result: undefined, // HITL — no result yet
+      },
+    ];
+
+    await llmMappingStep.execute(createExecuteParams(inputData));
+
+    // toModelOutput should NOT be called for undefined results
+    expect(toModelOutputMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -576,7 +576,7 @@ describe('createLLMMappingStep toModelOutput', () => {
   });
 
   it('should call toModelOutput for mixed tools (only the ones that define it)', async () => {
-    const toModelOutputMock = vi.fn((output: unknown) => ({
+    const toModelOutputMock = vi.fn((_output: unknown) => ({
       type: 'text',
       value: 'transformed',
     }));

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -99,6 +99,30 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
     execute: async ({ inputData, getStepResult, bail }) => {
       const initialResult = getStepResult(llmExecutionStep);
 
+      // Compute toModelOutput for a successful tool call and return providerMetadata
+      // with the result stored at mastra.modelOutput
+      async function getProviderMetadataWithModelOutput(toolCall: {
+        toolName: string;
+        result?: unknown;
+        providerMetadata?: Record<string, unknown>;
+      }) {
+        const tool = rest.tools?.[toolCall.toolName];
+        const toModelOutput = (tool as any)?.toModelOutput;
+        let modelOutput: unknown;
+        if (toModelOutput && toolCall.result !== undefined) {
+          modelOutput = await toModelOutput(toolCall.result);
+        }
+
+        const providerMetadata = {
+          ...toolCall.providerMetadata,
+          ...(modelOutput !== undefined
+            ? { mastra: { ...(toolCall.providerMetadata as any)?.mastra, modelOutput } }
+            : {}),
+        };
+        const hasMetadata = Object.keys(providerMetadata).length > 0;
+        return hasMetadata ? providerMetadata : undefined;
+      }
+
       if (inputData?.some(toolCall => toolCall?.result === undefined)) {
         const errorResults = inputData.filter(toolCall => toolCall?.error);
 
@@ -187,17 +211,22 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
               role: 'assistant' as const,
               content: {
                 format: 2,
-                parts: successfulResults.map(toolCall => ({
-                  type: 'tool-invocation' as const,
-                  toolInvocation: {
-                    state: 'result' as const,
-                    toolCallId: toolCall.toolCallId,
-                    toolName: toolCall.toolName,
-                    args: toolCall.args,
-                    result: toolCall.result,
-                  },
-                  ...(toolCall.providerMetadata ? { providerMetadata: toolCall.providerMetadata } : {}),
-                })),
+                parts: await Promise.all(
+                  successfulResults.map(async toolCall => {
+                    const providerMetadata = await getProviderMetadataWithModelOutput(toolCall);
+                    return {
+                      type: 'tool-invocation' as const,
+                      toolInvocation: {
+                        state: 'result' as const,
+                        toolCallId: toolCall.toolCallId,
+                        toolName: toolCall.toolName,
+                        args: toolCall.args,
+                        result: toolCall.result,
+                      },
+                      ...(providerMetadata ? { providerMetadata } : {}),
+                    };
+                  }),
+                ),
               },
               createdAt: new Date(),
             };
@@ -270,19 +299,22 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
           role: 'assistant' as const,
           content: {
             format: 2,
-            parts: inputData.map(toolCall => {
-              return {
-                type: 'tool-invocation' as const,
-                toolInvocation: {
-                  state: 'result' as const,
-                  toolCallId: toolCall.toolCallId,
-                  toolName: toolCall.toolName,
-                  args: toolCall.args,
-                  result: toolCall.result,
-                },
-                ...(toolCall.providerMetadata ? { providerMetadata: toolCall.providerMetadata } : {}),
-              };
-            }),
+            parts: await Promise.all(
+              inputData.map(async toolCall => {
+                const providerMetadata = await getProviderMetadataWithModelOutput(toolCall);
+                return {
+                  type: 'tool-invocation' as const,
+                  toolInvocation: {
+                    state: 'result' as const,
+                    toolCallId: toolCall.toolCallId,
+                    toolName: toolCall.toolName,
+                    args: toolCall.args,
+                    result: toolCall.result,
+                  },
+                  ...(providerMetadata ? { providerMetadata } : {}),
+                };
+              }),
+            ),
           },
           createdAt: new Date(),
         };

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -215,6 +215,7 @@ export class CoreToolBuilder extends MastraBase {
               this.logType,
             )
           : undefined,
+        toModelOutput: 'toModelOutput' in this.originalTool ? this.originalTool.toModelOutput : undefined,
       } as unknown as (CoreTool & { id: `${string}.${string}` }) | undefined;
     }
 
@@ -661,6 +662,7 @@ export class CoreToolBuilder extends MastraBase {
       outputSchema: processedOutputSchema,
       providerOptions: 'providerOptions' in this.originalTool ? this.originalTool.providerOptions : undefined,
       mcp: 'mcp' in this.originalTool ? this.originalTool.mcp : undefined,
+      toModelOutput: 'toModelOutput' in this.originalTool ? this.originalTool.toModelOutput : undefined,
     } as unknown as CoreTool;
   }
 }

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -138,6 +138,12 @@ export class Tool<
   providerOptions?: Record<string, Record<string, unknown>>;
 
   /**
+   * Optional function to transform the tool's raw output before sending it to the model.
+   * The raw result is still available for application logic; only the model sees the transformed version.
+   */
+  toModelOutput?: (output: unknown) => unknown;
+
+  /**
    * Optional MCP-specific properties including annotations and metadata.
    * Only relevant when the tool is being used in an MCP context.
    * @example
@@ -183,6 +189,7 @@ export class Tool<
     this.mastra = opts.mastra;
     this.requireApproval = opts.requireApproval || false;
     this.providerOptions = opts.providerOptions;
+    this.toModelOutput = opts.toModelOutput;
     this.mcp = opts.mcp;
 
     // Tools receive two parameters:

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -141,7 +141,7 @@ export class Tool<
    * Optional function to transform the tool's raw output before sending it to the model.
    * The raw result is still available for application logic; only the model sees the transformed version.
    */
-  toModelOutput?: (output: unknown) => unknown;
+  toModelOutput?: (output: TSchemaOut) => unknown;
 
   /**
    * Optional MCP-specific properties including annotations and metadata.

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -200,7 +200,7 @@ export type CoreTool = {
    * Receives the raw tool output and returns a transformed representation.
    * Passed through from the original tool definition.
    */
-  toModelOutput?: (output: unknown) => unknown | PromiseLike<unknown>;
+  toModelOutput?: (output: unknown) => unknown;
 } & (
   | {
       type?: 'function' | undefined;
@@ -238,7 +238,7 @@ export type InternalCoreTool = {
    * Receives the raw tool output and returns a transformed representation.
    * Passed through from the original tool definition.
    */
-  toModelOutput?: (output: unknown) => unknown | PromiseLike<unknown>;
+  toModelOutput?: (output: unknown) => unknown;
 } & (
   | {
       type?: 'function' | undefined;
@@ -319,7 +319,7 @@ export interface ToolAction<
    * Receives the raw tool output and returns a transformed representation.
    * Passed through from the original tool definition.
    */
-  toModelOutput?: (output: unknown) => unknown | PromiseLike<unknown>;
+  toModelOutput?: (output: unknown) => unknown;
   // Execute signature with unified context type
   // First parameter: raw input data (validated against inputSchema)
   // Second parameter: unified execution context with all metadata

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -319,7 +319,7 @@ export interface ToolAction<
    * Receives the raw tool output and returns a transformed representation.
    * Passed through from the original tool definition.
    */
-  toModelOutput?: (output: unknown) => unknown;
+  toModelOutput?: (output: TSchemaOut) => unknown;
   // Execute signature with unified context type
   // First parameter: raw input data (validated against inputSchema)
   // Second parameter: unified execution context with all metadata

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -197,13 +197,10 @@ export type CoreTool = {
   mcp?: MCPToolProperties;
   /**
    * Optional function to transform tool output before returning to the model.
+   * Receives the raw tool output and returns a transformed representation.
    * Passed through from the original tool definition.
    */
-  toModelOutput?: (options: {
-    toolCallId: string;
-    input: any;
-    output: any;
-  }) => unknown | PromiseLike<unknown>;
+  toModelOutput?: (output: unknown) => unknown | PromiseLike<unknown>;
 } & (
   | {
       type?: 'function' | undefined;
@@ -238,13 +235,10 @@ export type InternalCoreTool = {
   mcp?: MCPToolProperties;
   /**
    * Optional function to transform tool output before returning to the model.
+   * Receives the raw tool output and returns a transformed representation.
    * Passed through from the original tool definition.
    */
-  toModelOutput?: (options: {
-    toolCallId: string;
-    input: any;
-    output: any;
-  }) => unknown | PromiseLike<unknown>;
+  toModelOutput?: (output: unknown) => unknown | PromiseLike<unknown>;
 } & (
   | {
       type?: 'function' | undefined;
@@ -322,13 +316,10 @@ export interface ToolAction<
   mcp?: MCPToolProperties;
   /**
    * Optional function to transform tool output before returning to the model.
+   * Receives the raw tool output and returns a transformed representation.
    * Passed through from the original tool definition.
    */
-  toModelOutput?: (options: {
-    toolCallId: string;
-    input: any;
-    output: any;
-  }) => unknown | PromiseLike<unknown>;
+  toModelOutput?: (output: unknown) => unknown | PromiseLike<unknown>;
   // Execute signature with unified context type
   // First parameter: raw input data (validated against inputSchema)
   // Second parameter: unified execution context with all metadata

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -195,6 +195,15 @@ export type CoreTool = {
    * Only populated when the tool is being used in an MCP context.
    */
   mcp?: MCPToolProperties;
+  /**
+   * Optional function to transform tool output before returning to the model.
+   * Passed through from the original tool definition.
+   */
+  toModelOutput?: (options: {
+    toolCallId: string;
+    input: any;
+    output: any;
+  }) => unknown | PromiseLike<unknown>;
 } & (
   | {
       type?: 'function' | undefined;
@@ -227,6 +236,15 @@ export type InternalCoreTool = {
    * Only populated when the tool is being used in an MCP context.
    */
   mcp?: MCPToolProperties;
+  /**
+   * Optional function to transform tool output before returning to the model.
+   * Passed through from the original tool definition.
+   */
+  toModelOutput?: (options: {
+    toolCallId: string;
+    input: any;
+    output: any;
+  }) => unknown | PromiseLike<unknown>;
 } & (
   | {
       type?: 'function' | undefined;
@@ -302,6 +320,15 @@ export interface ToolAction<
    * Only populated when the tool is being used in an MCP context.
    */
   mcp?: MCPToolProperties;
+  /**
+   * Optional function to transform tool output before returning to the model.
+   * Passed through from the original tool definition.
+   */
+  toModelOutput?: (options: {
+    toolCallId: string;
+    input: any;
+    output: any;
+  }) => unknown | PromiseLike<unknown>;
   // Execute signature with unified context type
   // First parameter: raw input data (validated against inputSchema)
   // Second parameter: unified execution context with all metadata

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -1103,4 +1103,121 @@ describe('Memory', () => {
       expect(writeIndexName).toContain('384');
     });
   });
+
+  describe('toModelOutput persistence', () => {
+    it('should preserve raw tool result in storage and apply toModelOutput when building prompt', async () => {
+      const memory = new Memory({
+        storage: new InMemoryStore(),
+      });
+      const resourceId = 'tmo-resource';
+      const threadId = 'tmo-thread';
+
+      // Create thread
+      await memory.saveThread({
+        thread: {
+          id: threadId,
+          resourceId,
+          title: 'toModelOutput test',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+
+      // Save messages with a tool result
+      const messages: MastraDBMessage[] = [
+        {
+          id: 'tmo-msg-1',
+          threadId,
+          resourceId,
+          role: 'user',
+          content: { format: 2, parts: [{ type: 'text', text: 'What is the weather?' }] },
+          createdAt: new Date('2024-01-01T10:00:00Z'),
+        },
+        {
+          id: 'tmo-msg-2',
+          threadId,
+          resourceId,
+          role: 'assistant',
+          content: {
+            format: 2,
+            parts: [
+              {
+                type: 'tool-invocation',
+                toolInvocation: {
+                  state: 'result',
+                  toolCallId: 'call-1',
+                  toolName: 'getWeather',
+                  args: { city: 'NYC' },
+                  result: {
+                    temperature: 72,
+                    conditions: 'sunny',
+                    humidity: 45,
+                    windSpeed: 12,
+                    forecast: [
+                      { day: 'Monday', high: 75, low: 60 },
+                      { day: 'Tuesday', high: 70, low: 55 },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+          createdAt: new Date('2024-01-01T10:01:00Z'),
+        },
+      ];
+
+      await memory.saveMessages({ messages });
+
+      // Load messages back from storage
+      const { messages: loadedMessages } = await memory.recall({
+        threadId,
+        resourceId,
+      });
+
+      // Verify raw result is preserved in storage
+      expect(loadedMessages).toHaveLength(2);
+      const toolMsg = loadedMessages[1]!;
+      expect(toolMsg.content).toHaveProperty('format', 2);
+      const parts = (toolMsg.content as any).parts;
+      expect(parts[0].type).toBe('tool-invocation');
+      expect(parts[0].toolInvocation.result).toEqual({
+        temperature: 72,
+        conditions: 'sunny',
+        humidity: 45,
+        windSpeed: 12,
+        forecast: [
+          { day: 'Monday', high: 75, low: 60 },
+          { day: 'Tuesday', high: 70, low: 55 },
+        ],
+      });
+
+      // Create a MessageList from loaded messages and call llmPrompt with tools
+      const list = new MessageList({ threadId, resourceId }).add(loadedMessages, 'memory');
+
+      // Without tools — no toModelOutput applied, result is default json
+      const promptWithout = await list.get.all.aiV5.llmPrompt();
+      const toolResultWithout = promptWithout.flatMap((m: any) => m.content).find((p: any) => p.type === 'tool-result');
+      expect(toolResultWithout).toBeDefined();
+      expect(toolResultWithout.output.type).toBe('json');
+
+      // With tools + toModelOutput — transformed output
+      const promptWith = await list.get.all.aiV5.llmPrompt({
+        tools: {
+          getWeather: {
+            execute: async () => ({}),
+            toModelOutput: (output: any) => ({
+              type: 'text',
+              value: `${output.temperature}°F, ${output.conditions}`,
+            }),
+          },
+        } as any,
+      });
+      const toolResultWith = promptWith.flatMap((m: any) => m.content).find((p: any) => p.type === 'tool-result');
+      expect(toolResultWith).toBeDefined();
+      expect(toolResultWith.output).toEqual({
+        type: 'text',
+        value: '72°F, sunny',
+      });
+    });
+  });
 });


### PR DESCRIPTION
Adds support for `toModelOutput` on tools, which lets you transform what the model sees from a tool result without changing the raw result stored in messages.

`toModelOutput` runs once at tool execution time and the result is stored on `providerMetadata.mastra.modelOutput`. When building the prompt, the stored output is substituted into the `tool-result` part — no re-running the transformation on every turn.

```ts
const weatherTool = createTool({
  id: 'getWeather',
  // ...
  execute: async ({ context }) => {
    // raw result stored in messages
    return { temperature: 72, humidity: 45, conditions: 'sunny', forecast: [...] };
  },
  toModelOutput: (output) => {
    // compact version for the model's context
    return { type: 'text', value: `${output.temperature}°F, ${output.conditions}` };
  },
});
```

Also aligns the `toModelOutput` type signature with AI SDK v5 (`(output: unknown) => unknown` instead of the previous `({ toolCallId, input, output }) => unknown`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools can provide an optional toModelOutput transformation; transformed outputs are used in model prompts while original results remain stored.
  * Stored transformed outputs are restored into prompts to avoid re-computing tool outputs at prompt time.

* **Bug Fixes**
  * Merging and storage now preserve provider metadata so transformed outputs remain available for prompts.

* **Tests**
  * Added extensive tests for transformation application, persistence, selective overrides, and prompt generation.

* **Chores**
  * Minor package version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->