### PR TITLE
fix(playground-ui): fix drag offset in dataset column mapping dialog

### DIFF
--- a/.changeset/cute-forks-accept.md
+++ b/.changeset/cute-forks-accept.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed dragged column appearing offset from cursor when mapping CSV columns in dataset import dialog

--- a/packages/playground-ui/src/domains/datasets/components/csv-import/column-mapping-step.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/csv-import/column-mapping-step.tsx
@@ -1,5 +1,6 @@
 import { DragDropContext, Draggable, DropResult, Droppable } from '@hello-pangea/dnd';
 import { GripVertical } from 'lucide-react';
+import { createPortal } from 'react-dom';
 import { Icon } from '@/ds/icons';
 import { ColumnMapping, FieldType } from '../../hooks/use-column-mapping';
 
@@ -82,30 +83,40 @@ export function ColumnMappingStep({ headers, mapping, onMappingChange }: ColumnM
 
                     {columnsInZone.map((column, index) => (
                       <Draggable key={column} draggableId={column} index={index}>
-                        {(provided, snapshot) => (
-                          <div
-                            ref={provided.innerRef}
-                            {...provided.draggableProps}
-                            style={provided.draggableProps.style}
-                            className={`
-                              inline-flex items-center gap-1.5 px-2.5 py-1.5
-                              rounded-md text-sm font-medium
-                              bg-surface2 text-neutral1
-                              transition-all
-                              ${snapshot.isDragging ? 'shadow-lg ring-2 ring-accent1/30' : 'hover:bg-surface3'}
-                            `}
-                          >
-                            <span
-                              {...provided.dragHandleProps}
-                              className="text-neutral4 cursor-grab active:cursor-grabbing"
+                        {(provided, snapshot) => {
+                          const child = (
+                            <div
+                              ref={provided.innerRef}
+                              {...provided.draggableProps}
+                              style={provided.draggableProps.style}
+                              className={`
+                                inline-flex items-center gap-1.5 px-2.5 py-1.5
+                                rounded-md text-sm font-medium
+                                bg-surface2 text-neutral1
+                                transition-all
+                                ${snapshot.isDragging ? 'shadow-lg ring-2 ring-accent1/30' : 'hover:bg-surface3'}
+                              `}
                             >
-                              <Icon>
-                                <GripVertical className="h-3.5 w-3.5" />
-                              </Icon>
-                            </span>
-                            <span>{column}</span>
-                          </div>
-                        )}
+                              <span
+                                {...provided.dragHandleProps}
+                                className="text-neutral4 cursor-grab active:cursor-grabbing"
+                              >
+                                <Icon>
+                                  <GripVertical className="h-3.5 w-3.5" />
+                                </Icon>
+                              </span>
+                              <span>{column}</span>
+                            </div>
+                          );
+
+                          // Portal dragged item to document.body to avoid
+                          // offset issues from Radix Dialog portal + scrollable container
+                          if (snapshot.isDragging) {
+                            return createPortal(child, document.body);
+                          }
+
+                          return child;
+                        }}
                       </Draggable>
                     ))}
 


### PR DESCRIPTION
When dragging CSV columns in the dataset import "Map Columns" dialog, the dragged item renders far from the cursor. This happens because `@hello-pangea/dnd` miscalculates position when inside a Radix Dialog portal + scrollable container.

Fixed by portaling the dragged element to `document.body` during drag via `createPortal`, so position math isn't affected by the dialog's scroll context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed column offset issue when dragging columns during CSV dataset import mapping. Columns now align correctly when being repositioned in the import dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->