### PR TITLE
Hide Dataset Item Hitory panel when Item is tedited

### DIFF
--- a/.changeset/plain-apples-admire.md
+++ b/.changeset/plain-apples-admire.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Hide Dataset Item History panel when item is edited

--- a/packages/playground/src/pages/datasets/dataset/item/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/index.tsx
@@ -292,8 +292,8 @@ function DatasetItemPage() {
               </MainHeader.Column>
             </MainHeader>
 
-            <Columns className="grid-cols-[1fr_auto]">
-              <Column withRightSeparator={true}>
+            <Columns className={isEditing ? 'grid-cols-1' : 'grid-cols-[1fr_auto]'}>
+              <Column withRightSeparator={!isEditing}>
                 {isDeleted && latestVersion && (
                   <Alert variant="destructive">
                     <AlertTitle>This item was deleted at version v{latestVersion.datasetVersion}</AlertTitle>
@@ -333,18 +333,20 @@ function DatasetItemPage() {
                   )
                 )}
               </Column>
-              <Column>
-                <DatasetItemVersionsPanel
-                  datasetId={datasetId}
-                  itemId={itemId}
-                  onClose={() => {}}
-                  onVersionSelect={handleVersionSelect}
-                  onCompareVersionsClick={(versionIds: string[]) => {
-                    navigate(`/datasets/${datasetId}/items/${itemId}/versions?ids=${versionIds.join(',')}`);
-                  }}
-                  activeVersion={selectedVersion?.datasetVersion ?? null}
-                />
-              </Column>
+              {!isEditing && (
+                <Column>
+                  <DatasetItemVersionsPanel
+                    datasetId={datasetId}
+                    itemId={itemId}
+                    onClose={() => {}}
+                    onVersionSelect={handleVersionSelect}
+                    onCompareVersionsClick={(versionIds: string[]) => {
+                      navigate(`/datasets/${datasetId}/items/${itemId}/versions?ids=${versionIds.join(',')}`);
+                    }}
+                    activeVersion={selectedVersion?.datasetVersion ?? null}
+                  />
+                </Column>
+              )}
             </Columns>
           </div>
         </div>


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* The Dataset Item History panel now hides when editing items, and the interface automatically switches to a single-column layout for improved focus during edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->