### PR TITLE
fix(core,server): persist partial assistant messages when client disconnects mid-stream

### DIFF
--- a/.changeset/fix-persist-messages-on-client-disconnect.md
+++ b/.changeset/fix-persist-messages-on-client-disconnect.md
@@ -1,0 +1,12 @@
+---
+"@mastra/core": patch
+"@mastra/server": patch
+---
+
+Fixed a bug where partial assistant messages were lost when a client disconnects mid-stream (e.g. browser refresh during response). Three issues were causing this:
+
+- **No `case 'abort':` handler in stream transformer**: `MastraModelOutput` only handled `finish` and `error` chunks — the `abort` chunk produced on client disconnect was silently ignored, so `runOutputProcessors()` (which triggers `MessageHistory` → `storage.saveMessages()`) never ran.
+
+- **Abort detection missed provider-specific errors**: The check relied on `isAbortError()` which only matches standard `AbortError`. Providers like Groq throw "Client connection prematurely closed" instead, so the abort chunk was never produced. Now any error while `abortSignal.aborted` is true is treated as an abort.
+
+- **Server stream handlers never called `consumeStream()`**: The stream wasn't consumed to completion when the HTTP response was cancelled by client disconnect. Added `consumeStream()` in the stream, approve-tool-call, and decline-tool-call handlers.

--- a/.changeset/fix-persist-messages-on-client-disconnect.md
+++ b/.changeset/fix-persist-messages-on-client-disconnect.md
@@ -3,10 +3,12 @@
 "@mastra/server": patch
 ---
 
-Fixed a bug where partial assistant messages were lost when a client disconnects mid-stream (e.g. browser refresh during response). Three issues were causing this:
+Partial assistant replies are now preserved when a client disconnects mid-stream (e.g. browser refresh or network drop). Previously, messages were silently lost — now whatever the agent generated before the disconnect is saved to message history and visible when the user returns.
 
-- **No `case 'abort':` handler in stream transformer**: `MastraModelOutput` only handled `finish` and `error` chunks — the `abort` chunk produced on client disconnect was silently ignored, so `runOutputProcessors()` (which triggers `MessageHistory` → `storage.saveMessages()`) never ran.
+Three changes:
 
-- **Abort detection missed provider-specific errors**: The check relied on `isAbortError()` which only matches standard `AbortError`. Providers like Groq throw "Client connection prematurely closed" instead, so the abort chunk was never produced. Now any error while `abortSignal.aborted` is true is treated as an abort.
+- Added abort handling in the stream transformer so partial responses are persisted on disconnect instead of being silently dropped.
+- Broadened abort detection to work with all providers. Some providers throw non-standard errors on disconnect (e.g. "Client connection prematurely closed") that were not previously recognized as aborts.
+- Server stream handlers now consume the stream to completion in the background, ensuring persistence callbacks execute even when the HTTP response is cancelled.
 
-- **Server stream handlers never called `consumeStream()`**: The stream wasn't consumed to completion when the HTTP response was cancelled by client disconnect. Added `consumeStream()` in the stream, approve-tool-call, and decline-tool-call handlers.
+Fixes #6715.

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -7655,7 +7655,12 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
             },
             {
               "from": "AGENT",
-              "payload": {},
+              "payload": {
+                "originalError": {
+                  "message": "The user aborted a request.",
+                  "name": "AbortError",
+                },
+              },
               "runId": "test-run-id",
               "type": "abort",
             },
@@ -7674,8 +7679,27 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                       ],
                       "role": "user",
                     },
+                    {
+                      "content": [
+                        {
+                          "text": "Hello",
+                          "type": "text",
+                        },
+                      ],
+                      "role": "assistant",
+                    },
                   ],
-                  "nonUser": [],
+                  "nonUser": [
+                    {
+                      "content": [
+                        {
+                          "text": "Hello",
+                          "type": "text",
+                        },
+                      ],
+                      "role": "assistant",
+                    },
+                  ],
                   "user": [
                     {
                       "content": [
@@ -8186,7 +8210,12 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
             },
             {
               "from": "AGENT",
-              "payload": {},
+              "payload": {
+                "originalError": {
+                  "message": "The user aborted a request.",
+                  "name": "AbortError",
+                },
+              },
               "runId": "test-run-id",
               "type": "abort",
             },

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -888,7 +888,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             });
           }
 
-          if (isAbortError(error) && options?.abortSignal?.aborted) {
+          if (options?.abortSignal?.aborted) {
             await options?.onAbort?.({
               steps: inputData?.output?.steps ?? [],
             });

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -1191,7 +1191,7 @@ export const STREAM_GENERATE_ROUTE = createRoute({
 
       // Consume stream in background to ensure onFinish callbacks execute
       // even if the client disconnects mid-stream
-      streamResult.consumeStream?.().catch(console.error);
+      streamResult.consumeStream?.().catch(err => mastra.getLogger().error('Error consuming stream', { error: err }));
 
       return streamResult.fullStream;
     } catch (error) {
@@ -1250,7 +1250,7 @@ export const APPROVE_TOOL_CALL_ROUTE = createRoute({
 
       // Consume stream in background to ensure onFinish callbacks execute
       // even if the client disconnects mid-stream
-      streamResult.consumeStream?.().catch(console.error);
+      streamResult.consumeStream?.().catch(err => mastra.getLogger().error('Error consuming stream', { error: err }));
 
       return streamResult.fullStream;
     } catch (error) {
@@ -1294,7 +1294,7 @@ export const DECLINE_TOOL_CALL_ROUTE = createRoute({
 
       // Consume stream in background to ensure onFinish callbacks execute
       // even if the client disconnects mid-stream
-      streamResult.consumeStream?.().catch(console.error);
+      streamResult.consumeStream?.().catch(err => mastra.getLogger().error('Error consuming stream', { error: err }));
 
       return streamResult.fullStream;
     } catch (error) {

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -1189,6 +1189,10 @@ export const STREAM_GENERATE_ROUTE = createRoute({
         abortSignal,
       });
 
+      // Consume stream in background to ensure onFinish callbacks execute
+      // even if the client disconnects mid-stream
+      streamResult.consumeStream?.().catch(console.error);
+
       return streamResult.fullStream;
     } catch (error) {
       return handleError(error, 'error streaming agent response');
@@ -1244,6 +1248,10 @@ export const APPROVE_TOOL_CALL_ROUTE = createRoute({
         abortSignal,
       });
 
+      // Consume stream in background to ensure onFinish callbacks execute
+      // even if the client disconnects mid-stream
+      streamResult.consumeStream?.().catch(console.error);
+
       return streamResult.fullStream;
     } catch (error) {
       return handleError(error, 'error approving tool call');
@@ -1283,6 +1291,10 @@ export const DECLINE_TOOL_CALL_ROUTE = createRoute({
         ...params,
         abortSignal,
       });
+
+      // Consume stream in background to ensure onFinish callbacks execute
+      // even if the client disconnects mid-stream
+      streamResult.consumeStream?.().catch(console.error);
 
       return streamResult.fullStream;
     } catch (error) {


### PR DESCRIPTION
## Description

Fixes an issue where partial assistant responses were lost when a client disconnected mid-stream (for example, due to a browser refresh). Previously, only the user message was saved to the database because abort events were not properly handled and provider-specific disconnect errors were missed.

This PR ensures that:
- Abort events are correctly detected and handled.
- Partial assistant output is reconstructed and saved.
- Streams are fully consumed even if the HTTP connection is cancelled.

As a result, partial assistant messages are now persisted and visible after a reload.

---

## Related Issue(s)

Fixes #6715

---

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

---

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed a critical issue where partial assistant messages could be lost when clients disconnect during message streaming. Enhanced stream handling and message persistence to ensure all messages are properly saved, even when connections are interrupted mid-stream or in error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->