### PR TITLE
docs: clarify CloudExporter requires a Mastra Cloud project

### DIFF
--- a/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/cloud.mdx
@@ -15,8 +15,9 @@ The `CloudExporter` sends traces to Mastra Cloud for centralized monitoring and 
 ### Prerequisites
 
 1. **Mastra Cloud Account**: Sign up at [cloud.mastra.ai](https://cloud.mastra.ai)
-2. **Access Token**: Generate in Mastra Cloud → Settings → API Tokens
-3. **Environment Variables**: Set your credentials:
+2. **Mastra Cloud Project**: Create a project in Mastra Cloud. Traces are scoped per project, so even if you only want observability, you need a project to act as the destination for your traces.
+3. **Access Token**: Generate in your project's sidebar under **Project Settings → Access Tokens**
+4. **Environment Variables**: Set your credentials:
 
 ```bash title=".env"
 MASTRA_CLOUD_ACCESS_TOKEN=mst_xxxxxxxxxxxxxxxx
@@ -97,13 +98,17 @@ new CloudExporter({
 ### Mastra Cloud Dashboard
 
 1. Navigate to [cloud.mastra.ai](https://cloud.mastra.ai)
-2. Select your project
-3. Go to Observability → Traces
+2. Select the project associated with your access token
+3. Go to **Observability → Traces**
 4. Use filters to find specific traces:
    - Service name
    - Time range
    - Trace ID
    - Error status
+
+:::note
+Traces are scoped to the project that issued the access token. To view traces, make sure you're viewing the same project you generated the token from.
+:::
 
 ### Features
 

--- a/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/cloud-exporter.mdx
@@ -57,7 +57,7 @@ Extends `BaseExporterConfig`, which includes:
 
 The exporter reads these environment variables if not provided in config:
 
-- `MASTRA_CLOUD_ACCESS_TOKEN` - Access token for authentication
+- `MASTRA_CLOUD_ACCESS_TOKEN` - Project-scoped access token for authentication (generate in your Mastra Cloud project under **Project Settings → Access Tokens**)
 - `MASTRA_CLOUD_TRACES_ENDPOINT` - Custom endpoint (defaults to `https://api.mastra.ai/ai/spans/publish`)
 
 ## Properties


### PR DESCRIPTION
## Summary
- Updated CloudExporter docs to clarify that a Mastra Cloud **project** is required, even if you only want observability
- Fixed the access token generation path from "Settings → API Tokens" to **Project Settings → Access Tokens**
- Added a note that traces are scoped to the project that issued the token

## Test plan
- [ ] Verify the docs page renders correctly at `/docs/observability/tracing/exporters/cloud`
- [ ] Verify the reference page renders correctly at `/reference/observability/tracing/exporters/cloud-exporter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)