### PR TITLE
fix(core): preserve reasoning items across multi-step tool calls for Azure OpenAI

### DIFF
--- a/.changeset/giant-cats-dig.md
+++ b/.changeset/giant-cats-dig.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed multi-step tool calling dropping reasoning items for Azure OpenAI. The cache key generator now looks for itemId under any provider key in providerMetadata (not just openai), and empty reasoning parts with providerMetadata are no longer silently dropped during message conversion.

--- a/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
+++ b/packages/core/src/agent/message-list/adapters/AIV5Adapter.ts
@@ -172,7 +172,7 @@ export class AIV5Adapter {
               return p;
             }, '') ??
               '');
-          if (text || part.details?.length) {
+          if (text || part.details?.length || part.providerMetadata) {
             const v5UIPart: AIV5Type.ReasoningUIPart = {
               type: 'reasoning' as const,
               text: text || '',

--- a/packages/core/src/agent/message-list/tests/multi-step-reasoning-merge.test.ts
+++ b/packages/core/src/agent/message-list/tests/multi-step-reasoning-merge.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests that multi-step tool calling preserves reasoning items across steps.
+ *
+ * When reasoning text is empty (common with Azure OpenAI reasoning models),
+ * the CacheKeyGenerator must use provider-agnostic itemId lookup to produce
+ * distinct cache keys per step, and the AIV5Adapter must preserve empty
+ * reasoning parts that carry providerMetadata.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { MessageList } from '../message-list';
+import type { MastraDBMessage } from '../state/types';
+
+// Use realistic timestamps where user message comes first chronologically.
+// This matters because MessageList sorts messages by createdAt after each add,
+// which affects the shouldMerge logic (checks the last message in the sorted array).
+const baseTime = Date.now();
+const timestamps = {
+  user: new Date(baseTime),
+  step1: new Date(baseTime + 100),
+  step1Result: new Date(baseTime + 200),
+  step2: new Date(baseTime + 300),
+  step2Result: new Date(baseTime + 400),
+};
+
+describe('Multi-step tool calling preserves reasoning items', () => {
+  it('should preserve empty reasoning items with Azure providerMetadata across steps', () => {
+    const messageList = new MessageList({ threadId: 'test-thread' });
+
+    messageList.add(
+      {
+        id: 'user-msg-1',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'Add 3 and 5, then multiply the result by 4.' }] },
+        createdAt: timestamps.user,
+      } as MastraDBMessage,
+      'input',
+    );
+
+    // Step 1: empty reasoning with Azure itemId + tool-call
+    messageList.add(
+      {
+        id: 'step1-msg',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'reasoning',
+              reasoning: '',
+              details: [],
+              providerMetadata: { azure: { itemId: 'rs_azure_step1' } },
+            },
+            {
+              type: 'tool-invocation',
+              toolInvocation: { toolCallId: 'call_add', toolName: 'add', state: 'call', args: { a: 3, b: 5 } },
+            },
+          ],
+        },
+        createdAt: timestamps.step1,
+      } as MastraDBMessage,
+      'response',
+    );
+
+    // Tool result for step 1
+    messageList.add(
+      {
+        id: 'step1-result-msg',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                toolCallId: 'call_add',
+                toolName: 'add',
+                state: 'result',
+                args: { a: 3, b: 5 },
+                result: { result: 8 },
+              },
+            },
+          ],
+        },
+        createdAt: timestamps.step1Result,
+      } as MastraDBMessage,
+      'response',
+    );
+
+    // Step 2: empty reasoning with DIFFERENT Azure itemId + tool-call
+    messageList.add(
+      {
+        id: 'step2-msg',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'reasoning',
+              reasoning: '',
+              details: [],
+              providerMetadata: { azure: { itemId: 'rs_azure_step2' } },
+            },
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                toolCallId: 'call_multiply',
+                toolName: 'multiply',
+                state: 'call',
+                args: { a: 8, b: 4 },
+              },
+            },
+          ],
+        },
+        createdAt: timestamps.step2,
+      } as MastraDBMessage,
+      'response',
+    );
+
+    // Tool result for step 2
+    messageList.add(
+      {
+        id: 'step2-result-msg',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                toolCallId: 'call_multiply',
+                toolName: 'multiply',
+                state: 'result',
+                args: { a: 8, b: 4 },
+                result: { result: 32 },
+              },
+            },
+          ],
+        },
+        createdAt: timestamps.step2Result,
+      } as MastraDBMessage,
+      'response',
+    );
+
+    const modelMessages = messageList.get.all.aiV5.model();
+    const assistantMessages = modelMessages.filter(m => m.role === 'assistant');
+    const toolMessages = modelMessages.filter(m => m.role === 'tool');
+
+    // EXPECTED: 2 assistant + 2 tool messages (one pair per step)
+    expect(assistantMessages).toHaveLength(2);
+    expect(toolMessages).toHaveLength(2);
+
+    // Each assistant message must have its own reasoning item
+    for (const msg of assistantMessages) {
+      const hasReasoning = Array.isArray(msg.content) && msg.content.some((p: any) => p.type === 'reasoning');
+      expect(hasReasoning).toBe(true);
+    }
+
+    // Total reasoning items across all model messages must be 2
+    const allReasoningParts = modelMessages.flatMap(m =>
+      Array.isArray(m.content) ? m.content.filter((p: any) => p.type === 'reasoning') : [],
+    );
+    expect(allReasoningParts).toHaveLength(2);
+  });
+});

--- a/packages/core/src/loop/loop.test.ts
+++ b/packages/core/src/loop/loop.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, afterEach, describe, vi } from 'vitest';
 import { loop } from './loop';
+import { multiStepReasoningTests } from './multi-step-reasoning.test-utils';
 import { fullStreamTests } from './test-utils/fullStream';
 import { generateTextTestsV5 } from './test-utils/generateText';
 import { optionsTests } from './test-utils/options';
@@ -27,6 +28,7 @@ describe('Loop Tests', () => {
     optionsTests({ loopFn: loop, runId: 'test-run-id' });
     generateTextTestsV5({ loopFn: loop, runId: 'test-run-id' });
     toolsTests({ loopFn: loop, runId: 'test-run-id' });
+    multiStepReasoningTests({ loopFn: loop, runId: 'test-run-id' });
 
     streamObjectTests({ loopFn: loop, runId: 'test-run-id' });
   });

--- a/packages/core/src/loop/multi-step-reasoning.test-utils.ts
+++ b/packages/core/src/loop/multi-step-reasoning.test-utils.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests that multi-step tool calling with reasoning models preserves separate
+ * assistant messages per step when reasoning text is empty (Azure-style).
+ * Without the fix, empty reasoning items get identical cache keys, causing
+ * deduplication to drop them during cross-step merge.
+ */
+import type { LanguageModelV2CallOptions } from '@ai-sdk/provider-v5';
+import { stepCountIs } from '@internal/ai-sdk-v5';
+import { convertArrayToReadableStream, mockId, mockValues } from '@internal/ai-sdk-v5/test';
+import { beforeEach, describe, expect, it } from 'vitest';
+import z from 'zod';
+import type { loop } from './loop';
+import { MastraLanguageModelV2Mock as MockLanguageModelV2 } from './test-utils/MastraLanguageModelV2Mock';
+import { createMessageListWithUserMessage, testUsage } from './test-utils/utils';
+
+export function multiStepReasoningTests({ loopFn, runId }: { loopFn: typeof loop; runId: string }) {
+  describe('multi-step reasoning with tool calls', () => {
+    let stepInputs: LanguageModelV2CallOptions[];
+    let result: Awaited<ReturnType<typeof loop>>;
+
+    beforeEach(() => {
+      stepInputs = [];
+    });
+
+    /**
+     * 3-step flow with empty reasoning (Azure-style):
+     * Step 1: empty reasoning + tool-call(add) → tool-result
+     * Step 2: empty reasoning + tool-call(multiply) → tool-result
+     * Step 3: text response
+     *
+     * The reasoning items have different providerMetadata.azure.itemId values
+     * but empty text. Without the fix, CacheKeyGenerator produces identical
+     * keys and dedup drops the second reasoning item.
+     */
+    describe('3 steps with empty reasoning text (Azure-style)', () => {
+      beforeEach(async () => {
+        const messageList = createMessageListWithUserMessage();
+        let responseCount = 0;
+
+        result = await loopFn({
+          methodType: 'stream',
+          runId,
+          models: [
+            {
+              id: 'test-model',
+              maxRetries: 0,
+              model: new MockLanguageModelV2({
+                doStream: async ({ prompt, tools, toolChoice }) => {
+                  stepInputs.push({ prompt, tools, toolChoice });
+
+                  switch (responseCount++) {
+                    case 0: {
+                      return {
+                        stream: convertArrayToReadableStream([
+                          {
+                            type: 'response-metadata',
+                            id: 'id-0',
+                            modelId: 'mock-model-id',
+                            timestamp: new Date(0),
+                          },
+                          {
+                            type: 'reasoning-start',
+                            id: 'rs-1',
+                            providerMetadata: { azure: { itemId: 'rs-1' } },
+                          },
+                          {
+                            type: 'reasoning-end',
+                            id: 'rs-1',
+                            providerMetadata: { azure: { itemId: 'rs-1' } },
+                          },
+                          {
+                            type: 'tool-call',
+                            id: 'call-add',
+                            toolCallId: 'call-add',
+                            toolName: 'add',
+                            input: '{ "a": 3, "b": 5 }',
+                          },
+                          {
+                            type: 'finish',
+                            finishReason: 'tool-calls',
+                            usage: testUsage,
+                          },
+                        ]),
+                        response: { headers: { call: '1' } },
+                      };
+                    }
+                    case 1: {
+                      return {
+                        stream: convertArrayToReadableStream([
+                          {
+                            type: 'response-metadata',
+                            id: 'id-1',
+                            modelId: 'mock-model-id',
+                            timestamp: new Date(1000),
+                          },
+                          {
+                            type: 'reasoning-start',
+                            id: 'rs-2',
+                            providerMetadata: { azure: { itemId: 'rs-2' } },
+                          },
+                          {
+                            type: 'reasoning-end',
+                            id: 'rs-2',
+                            providerMetadata: { azure: { itemId: 'rs-2' } },
+                          },
+                          {
+                            type: 'tool-call',
+                            id: 'call-multiply',
+                            toolCallId: 'call-multiply',
+                            toolName: 'multiply',
+                            input: '{ "a": 8, "b": 4 }',
+                          },
+                          {
+                            type: 'finish',
+                            finishReason: 'tool-calls',
+                            usage: testUsage,
+                          },
+                        ]),
+                        response: { headers: { call: '2' } },
+                      };
+                    }
+                    case 2: {
+                      return {
+                        stream: convertArrayToReadableStream([
+                          {
+                            type: 'response-metadata',
+                            id: 'id-2',
+                            modelId: 'mock-model-id',
+                            timestamp: new Date(2000),
+                          },
+                          { type: 'text-start', id: 'text-1' },
+                          { type: 'text-delta', id: 'text-1', delta: 'The result is 32.' },
+                          { type: 'text-end', id: 'text-1' },
+                          {
+                            type: 'finish',
+                            finishReason: 'stop',
+                            usage: testUsage,
+                          },
+                        ]),
+                        response: { headers: { call: '3' } },
+                      };
+                    }
+                    default:
+                      throw new Error(`Unexpected response count: ${responseCount}`);
+                  }
+                },
+              }),
+            },
+          ],
+          tools: {
+            add: {
+              inputSchema: z.object({ a: z.number(), b: z.number() }),
+              execute: async ({ a, b }: { a: number; b: number }) => ({ result: a + b }),
+            },
+            multiply: {
+              inputSchema: z.object({ a: z.number(), b: z.number() }),
+              execute: async ({ a, b }: { a: number; b: number }) => ({ result: a * b }),
+            },
+          },
+          messageList,
+          options: {},
+          stopWhen: stepCountIs(5),
+          _internal: {
+            now: mockValues(0, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000),
+            generateId: mockId({ prefix: 'id' }),
+          },
+          agentId: 'agent-id',
+        });
+      });
+
+      it('step 3 prompt should preserve both empty reasoning items with separate assistant messages', async () => {
+        await result.consumeStream();
+
+        const step3Prompt = stepInputs[2]?.prompt;
+        expect(step3Prompt).toBeDefined();
+
+        const assistantMessages = step3Prompt!.filter(m => m.role === 'assistant');
+
+        // CRITICAL: There must be 2 separate assistant messages
+        expect(assistantMessages).toHaveLength(2);
+
+        // Each assistant message must have a reasoning part
+        for (const msg of assistantMessages) {
+          const hasReasoning = Array.isArray(msg.content)
+            ? msg.content.some((p: any) => p.type === 'reasoning')
+            : false;
+          expect(hasReasoning).toBe(true);
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
When using `@ai-sdk/azure` v3+ with reasoning models and multi-step tool calls, the second (and subsequent) reasoning items were silently dropped, causing Azure OpenAI to reject requests with: "Item 'fc_...' of type 'function_call' was provided without its required preceding item of type 'reasoning'."

`@ai-sdk/azure` v3 switched the default model from Chat Completions to the Responses API, which uses a dynamic `providerKey` derived from `config.provider`. For Azure, reasoning items arrive as `providerMetadata: { azure: { itemId: "rs_..." } }` instead of `providerMetadata: { openai: { itemId: "rs_..." } }`.

Two things were broken:

**CacheKeyGenerator** only checked `providerMetadata.openai.itemId` when generating cache keys for reasoning parts. Empty reasoning items (common with reasoning models) all produced the same key `"reasoning0"`, so `pushNewPart()` dedup dropped subsequent ones. Now iterates all provider keys to find `itemId`:

```ts
// before — only openai
if (partAny.providerMetadata?.openai?.itemId) {
  cacheKey += `|${partAny.providerMetadata.openai.itemId}`;
}

// after — any provider
for (const key of Object.keys(metadata)) {
  if (metadata[key]?.itemId) {
    cacheKey += `|${metadata[key].itemId}`;
    break;
  }
}
```

**AIV5Adapter** dropped empty reasoning parts (no text, no details) even when they carried `providerMetadata` needed by the API. Now preserves them:

```ts
// before
if (text || part.details?.length) { ... }

// after
if (text || part.details?.length || part.providerMetadata) { ... }
```

Fixes #12775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed multi-step tool calling dropping reasoning items when using Azure OpenAI
* Improved cache key generation to support any provider type, not limited to OpenAI
* Fixed empty reasoning parts with provider metadata being incorrectly discarded during message conversion
* Enhanced test coverage for multi-step tool calling and reasoning scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->