### PR TITLE
fix(playground): use full-page navigation for /swagger-ui route

### DIFF
--- a/packages/playground/src/domains/workflows/workflow-header.tsx
+++ b/packages/playground/src/domains/workflows/workflow-header.tsx
@@ -57,7 +57,7 @@ export function WorkflowHeader({
         </HeaderGroup>
 
         <HeaderAction>
-          <Button as={Link} target="_blank" to="/swagger-ui">
+          <Button as="a" target="_blank" href="/swagger-ui">
             <Icon>
               <ApiIcon />
             </Icon>

--- a/packages/playground/src/lib/framework.tsx
+++ b/packages/playground/src/lib/framework.tsx
@@ -2,8 +2,22 @@ import { forwardRef } from 'react';
 import { Link as RouterLink } from 'react-router';
 import { LinkComponent, LinkComponentProps } from '@mastra/playground-ui';
 
+// Routes served by the Hono server, not the React Router SPA.
+// These need full-page navigation via a plain <a> tag.
+const SERVER_ROUTE_PREFIXES = ['/swagger-ui', '/openapi.json'];
+
 export const Link: LinkComponent = forwardRef<HTMLAnchorElement, LinkComponentProps>(
   ({ children, href, ...props }, ref) => {
+    const isServerRoute = href && SERVER_ROUTE_PREFIXES.some(prefix => href.startsWith(prefix));
+
+    if (isServerRoute) {
+      return (
+        <a ref={ref} href={href} {...props}>
+          {children}
+        </a>
+      );
+    }
+
     return (
       <RouterLink ref={ref} to={href} viewTransition {...props}>
         {children}


### PR DESCRIPTION
The `/swagger-ui` link in the studio sidebar was using React Router's `<Link>` component, which does client-side navigation. Since `/swagger-ui` is a server-side Hono route (not in the React Router route table), clicking it resulted in a 404. Refreshing the page worked because the browser made a full HTTP request to the server.

The fix detects server-side route prefixes (`/swagger-ui`, `/openapi.json`) in the playground's `Link` wrapper and renders a plain `<a>` tag instead, triggering a full-page navigation to the server.

```tsx
// before — React Router intercepts and can't find the route
<RouterLink to="/swagger-ui">...</RouterLink>

// after — plain anchor triggers full-page navigation to the Hono server
<a href="/swagger-ui">...</a>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated navigation handling for Swagger UI and OpenAPI documentation to use full-page navigation instead of in-app routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->