### PR TITLE
fix(server-adapters): use text/event-stream for SSE streaming responses

### DIFF
--- a/.changeset/fast-vans-talk.md
+++ b/.changeset/fast-vans-talk.md
@@ -1,0 +1,8 @@
+---
+'@mastra/express': patch
+'@mastra/fastify': patch
+'@mastra/hono': patch
+'@mastra/koa': patch
+---
+
+Fixed SSE streaming to use proper `text/event-stream` Content-Type instead of `text/plain`. This prevents proxies, CDNs, and HTTP clients (like Postman) from buffering the entire response before delivering it. SSE streams now also include `Cache-Control: no-cache`, `Connection: keep-alive`, and `X-Accel-Buffering: no` headers for reliable progressive chunk delivery.

--- a/.changeset/grumpy-sheep-listen.md
+++ b/.changeset/grumpy-sheep-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/express': patch
+---
+
+Fixed SSE streaming to use proper `text/event-stream` Content-Type instead of `text/plain`. This prevents proxies, CDNs, and HTTP clients (like Postman) from buffering the entire response before delivering it. SSE streams now also include `Cache-Control: no-cache`, `Connection: keep-alive`, and `X-Accel-Buffering: no` headers for reliable progressive chunk delivery.

--- a/.changeset/grumpy-sheep-listen.md
+++ b/.changeset/grumpy-sheep-listen.md
@@ -2,4 +2,4 @@
 '@mastra/express': patch
 ---
 
-Fixed SSE streaming to use proper `text/event-stream` Content-Type instead of `text/plain`. This prevents proxies, CDNs, and HTTP clients (like Postman) from buffering the entire response before delivering it. SSE streams now also include `Cache-Control: no-cache`, `Connection: keep-alive`, and `X-Accel-Buffering: no` headers for reliable progressive chunk delivery.
+Fixed SSE streaming to use proper `text/event-stream` Content-Type instead of `text/plain` (fixes [#12620](https://github.com/mastra-ai/mastra/issues/12620)). This prevents proxies, CDNs, and HTTP clients (like Postman) from buffering the entire response before delivering it. SSE streams now also include `Cache-Control: no-cache`, `Connection: keep-alive`, and `X-Accel-Buffering: no` headers for reliable progressive chunk delivery.

--- a/.changeset/public-eels-change.md
+++ b/.changeset/public-eels-change.md
@@ -2,4 +2,4 @@
 '@mastra/fastify': patch
 ---
 
-Fixed SSE streaming to use proper `text/event-stream` Content-Type instead of `text/plain`. This prevents proxies, CDNs, and HTTP clients (like Postman) from buffering the entire response before delivering it. SSE streams now also include `Cache-Control: no-cache`, `Connection: keep-alive`, and `X-Accel-Buffering: no` headers for reliable progressive chunk delivery.
+Fixed SSE streaming to use proper `text/event-stream` Content-Type instead of `text/plain` (fixes [#12620](https://github.com/mastra-ai/mastra/issues/12620)). This prevents proxies, CDNs, and HTTP clients (like Postman) from buffering the entire response before delivering it. SSE streams now also include `Cache-Control: no-cache`, `Connection: keep-alive`, and `X-Accel-Buffering: no` headers for reliable progressive chunk delivery.

--- a/.changeset/public-eels-change.md
+++ b/.changeset/public-eels-change.md
@@ -1,0 +1,5 @@
+---
+'@mastra/fastify': patch
+---
+
+Fixed SSE streaming to use proper `text/event-stream` Content-Type instead of `text/plain`. This prevents proxies, CDNs, and HTTP clients (like Postman) from buffering the entire response before delivering it. SSE streams now also include `Cache-Control: no-cache`, `Connection: keep-alive`, and `X-Accel-Buffering: no` headers for reliable progressive chunk delivery.

--- a/.changeset/upset-seas-stop.md
+++ b/.changeset/upset-seas-stop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/hono': patch
+---
+
+Fixed SSE streaming to use proper `text/event-stream` Content-Type instead of `text/plain`. This prevents proxies, CDNs, and HTTP clients (like Postman) from buffering the entire response before delivering it. SSE streams now also include `Cache-Control: no-cache`, `Connection: keep-alive`, and `X-Accel-Buffering: no` headers for reliable progressive chunk delivery.

--- a/.changeset/upset-seas-stop.md
+++ b/.changeset/upset-seas-stop.md
@@ -2,4 +2,4 @@
 '@mastra/hono': patch
 ---
 
-Fixed SSE streaming to use proper `text/event-stream` Content-Type instead of `text/plain`. This prevents proxies, CDNs, and HTTP clients (like Postman) from buffering the entire response before delivering it. SSE streams now also include `Cache-Control: no-cache`, `Connection: keep-alive`, and `X-Accel-Buffering: no` headers for reliable progressive chunk delivery.
+Fixed SSE streaming to use proper `text/event-stream` Content-Type instead of `text/plain` (fixes [#12620](https://github.com/mastra-ai/mastra/issues/12620)). This prevents proxies, CDNs, and HTTP clients (like Postman) from buffering the entire response before delivering it. SSE streams now also include `Cache-Control: no-cache`, `Connection: keep-alive`, and `X-Accel-Buffering: no` headers for reliable progressive chunk delivery.

--- a/.changeset/yummy-carrots-ring.md
+++ b/.changeset/yummy-carrots-ring.md
@@ -2,4 +2,4 @@
 '@mastra/koa': patch
 ---
 
-Fixed SSE streaming to use proper `text/event-stream` Content-Type instead of `text/plain`. This prevents proxies, CDNs, and HTTP clients (like Postman) from buffering the entire response before delivering it. SSE streams now also include `Cache-Control: no-cache`, `Connection: keep-alive`, and `X-Accel-Buffering: no` headers for reliable progressive chunk delivery.
+Fixed SSE streaming to use proper `text/event-stream` Content-Type instead of `text/plain` (fixes [#12620](https://github.com/mastra-ai/mastra/issues/12620)). This prevents proxies, CDNs, and HTTP clients (like Postman) from buffering the entire response before delivering it. SSE streams now also include `Cache-Control: no-cache`, `Connection: keep-alive`, and `X-Accel-Buffering: no` headers for reliable progressive chunk delivery.

--- a/.changeset/yummy-carrots-ring.md
+++ b/.changeset/yummy-carrots-ring.md
@@ -1,7 +1,4 @@
 ---
-'@mastra/express': patch
-'@mastra/fastify': patch
-'@mastra/hono': patch
 '@mastra/koa': patch
 ---
 

--- a/server-adapters/express/src/__tests__/express-adapter.test.ts
+++ b/server-adapters/express/src/__tests__/express-adapter.test.ts
@@ -101,7 +101,10 @@ describe('Express Server Adapter', () => {
         // Check if stream response
         const contentType = response.headers.get('content-type') || '';
         const transferEncoding = response.headers.get('transfer-encoding') || '';
-        const isStream = contentType.includes('text/plain') || transferEncoding === 'chunked';
+        const isStream =
+          contentType.includes('text/plain') ||
+          contentType.includes('text/event-stream') ||
+          transferEncoding === 'chunked';
 
         if (isStream && response.body) {
           // Return stream response
@@ -388,6 +391,136 @@ describe('Express Server Adapter', () => {
       const textDelta = chunks.find(c => c.type === 'text-delta');
       expect(textDelta).toBeDefined();
       expect(textDelta.textDelta).toBe('Hello');
+    });
+  });
+
+  describe('SSE Headers', () => {
+    let context: AdapterTestContext;
+    let server: Server | null = null;
+
+    beforeEach(async () => {
+      context = await createDefaultTestContext();
+    });
+
+    afterEach(async () => {
+      if (server) {
+        await new Promise<void>(resolve => {
+          server!.close(() => resolve());
+        });
+        server = null;
+      }
+    });
+
+    it('should set Content-Type to text/event-stream for SSE streams', async () => {
+      const app = express();
+      app.use(express.json());
+
+      const adapter = new MastraServer({
+        app,
+        mastra: context.mastra,
+      });
+
+      const testRoute: ServerRoute<any, any, any> = {
+        method: 'POST',
+        path: '/test/sse-headers',
+        responseType: 'stream',
+        streamFormat: 'sse',
+        handler: async () => createStreamWithSensitiveData('v2'),
+      };
+
+      app.use(adapter.createContextMiddleware());
+      await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+      server = await new Promise<Server>(resolve => {
+        const s = app.listen(0, () => resolve(s));
+      });
+
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Failed to get server address');
+      }
+      const port = address.port;
+
+      const response = await fetch(`http://localhost:${port}/test/sse-headers`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(200);
+
+      // SSE streams MUST use text/event-stream Content-Type
+      // This signals to proxies, CDNs, and clients that the response should not be buffered
+      const contentType = response.headers.get('content-type');
+      expect(contentType).toBe('text/event-stream');
+
+      // SSE streams should include Cache-Control: no-cache to prevent proxy buffering
+      const cacheControl = response.headers.get('cache-control');
+      expect(cacheControl).toBe('no-cache');
+
+      // SSE streams should include Connection: keep-alive
+      const connection = response.headers.get('connection');
+      expect(connection).toBe('keep-alive');
+
+      // SSE streams should include X-Accel-Buffering: no for nginx reverse proxies
+      const xAccelBuffering = response.headers.get('x-accel-buffering');
+      expect(xAccelBuffering).toBe('no');
+
+      // Consume the stream to avoid hanging
+      await consumeSSEStream(response.body);
+    });
+
+    it('should keep Content-Type as text/plain for non-SSE streams', async () => {
+      const app = express();
+      app.use(express.json());
+
+      const adapter = new MastraServer({
+        app,
+        mastra: context.mastra,
+      });
+
+      // Use 'stream' format (not 'sse') — this should keep text/plain
+      const testRoute: ServerRoute<any, any, any> = {
+        method: 'POST',
+        path: '/test/plain-stream',
+        responseType: 'stream',
+        streamFormat: 'stream',
+        handler: async () => createStreamWithSensitiveData('v2'),
+      };
+
+      app.use(adapter.createContextMiddleware());
+      await adapter.registerRoute(app, testRoute, { prefix: '' });
+
+      server = await new Promise<Server>(resolve => {
+        const s = app.listen(0, () => resolve(s));
+      });
+
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Failed to get server address');
+      }
+      const port = address.port;
+
+      const response = await fetch(`http://localhost:${port}/test/plain-stream`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      expect(response.status).toBe(200);
+
+      // Non-SSE streams should keep text/plain
+      const contentType = response.headers.get('content-type');
+      expect(contentType).toBe('text/plain');
+
+      // Consume the stream to avoid hanging
+      const reader = response.body?.getReader();
+      if (reader) {
+        while (true) {
+          const { done } = await reader.read();
+          if (done) break;
+        }
+      }
     });
   });
 

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -96,10 +96,18 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
     };
   }
   async stream(route: ServerRoute, res: Response, result: { fullStream: ReadableStream }): Promise<void> {
-    res.setHeader('Content-Type', 'text/plain');
-    res.setHeader('Transfer-Encoding', 'chunked');
-
     const streamFormat = route.streamFormat || 'stream';
+
+    if (streamFormat === 'sse') {
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Connection', 'keep-alive');
+      res.setHeader('X-Accel-Buffering', 'no');
+    } else {
+      res.setHeader('Content-Type', 'text/plain');
+    }
+    res.setHeader('Transfer-Encoding', 'chunked');
+    res.flushHeaders();
 
     const readableStream = result instanceof ReadableStream ? result : result.fullStream;
     const reader = readableStream.getReader();

--- a/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
+++ b/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
@@ -88,7 +88,10 @@ describe('Fastify Server Adapter', () => {
         // Check if stream response
         const contentType = response.headers.get('content-type') || '';
         const transferEncoding = response.headers.get('transfer-encoding') || '';
-        const isStream = contentType.includes('text/plain') || transferEncoding === 'chunked';
+        const isStream =
+          contentType.includes('text/plain') ||
+          contentType.includes('text/event-stream') ||
+          transferEncoding === 'chunked';
 
         if (isStream && response.body) {
           // Return stream response

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -112,15 +112,27 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
     // This is required when writing directly to reply.raw
     reply.hijack();
 
+    const streamFormat = route.streamFormat || 'stream';
+
     // Write headers directly to the raw response, merging existing headers (like CORS)
     // with our stream-specific headers
+    const sseHeaders =
+      streamFormat === 'sse'
+        ? {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            Connection: 'keep-alive',
+            'X-Accel-Buffering': 'no',
+          }
+        : {
+            'Content-Type': 'text/plain',
+          };
+
     reply.raw.writeHead(200, {
       ...existingHeaders,
-      'Content-Type': 'text/plain',
+      ...sseHeaders,
       'Transfer-Encoding': 'chunked',
     });
-
-    const streamFormat = route.streamFormat || 'stream';
 
     const readableStream = result instanceof ReadableStream ? result : result.fullStream;
     const reader = readableStream.getReader();

--- a/server-adapters/hono/src/__tests__/hono-adapter.test.ts
+++ b/server-adapters/hono/src/__tests__/hono-adapter.test.ts
@@ -87,7 +87,10 @@ describe('Hono Server Adapter', () => {
 
       // Parse response
       const contentType = response.headers?.get('content-type') || '';
-      const isStream = contentType.includes('text/plain') || response.headers?.get('transfer-encoding') === 'chunked';
+      const isStream =
+        contentType.includes('text/plain') ||
+        contentType.includes('text/event-stream') ||
+        response.headers?.get('transfer-encoding') === 'chunked';
 
       // Extract headers
       const headers: Record<string, string> = {};

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -167,7 +167,9 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
             }
           }
 
-          await stream.write('data: [DONE]\n\n');
+          if (streamFormat === 'sse') {
+            await stream.write('data: [DONE]\n\n');
+          }
         } catch (error) {
           this.mastra.getLogger()?.error('Error in stream processing', {
             error: error instanceof Error ? { message: error.message, stack: error.stack } : error,

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -128,10 +128,17 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
     };
   }
   async stream(route: ServerRoute, res: Context, result: { fullStream: ReadableStream }): Promise<any> {
-    res.header('Content-Type', 'text/plain');
-    res.header('Transfer-Encoding', 'chunked');
-
     const streamFormat = route.streamFormat || 'stream';
+
+    if (streamFormat === 'sse') {
+      res.header('Content-Type', 'text/event-stream');
+      res.header('Cache-Control', 'no-cache');
+      res.header('Connection', 'keep-alive');
+      res.header('X-Accel-Buffering', 'no');
+    } else {
+      res.header('Content-Type', 'text/plain');
+    }
+    res.header('Transfer-Encoding', 'chunked');
 
     return stream(
       res,

--- a/server-adapters/koa/src/__tests__/koa-adapter.test.ts
+++ b/server-adapters/koa/src/__tests__/koa-adapter.test.ts
@@ -101,7 +101,10 @@ describe('Koa Server Adapter', () => {
         // Check if stream response
         const contentType = response.headers.get('content-type') || '';
         const transferEncoding = response.headers.get('transfer-encoding') || '';
-        const isStream = contentType.includes('text/plain') || transferEncoding === 'chunked';
+        const isStream =
+          contentType.includes('text/plain') ||
+          contentType.includes('text/event-stream') ||
+          transferEncoding === 'chunked';
 
         if (isStream && response.body) {
           // Return stream response

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -210,13 +210,25 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
     // Tell Koa we're handling the response ourselves
     ctx.respond = false;
 
+    const streamFormat = route.streamFormat || 'stream';
+
     // Set status and headers via ctx.res directly since we're bypassing Koa's response
+    const sseHeaders =
+      streamFormat === 'sse'
+        ? {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            Connection: 'keep-alive',
+            'X-Accel-Buffering': 'no',
+          }
+        : {
+            'Content-Type': 'text/plain',
+          };
+
     ctx.res.writeHead(200, {
-      'Content-Type': 'text/plain',
+      ...sseHeaders,
       'Transfer-Encoding': 'chunked',
     });
-
-    const streamFormat = route.streamFormat || 'stream';
 
     const readableStream = result instanceof ReadableStream ? result : result.fullStream;
     const reader = readableStream.getReader();


### PR DESCRIPTION
Fixes #12620

SSE streaming endpoints (`/api/agents/:agentId/stream`, etc.) were using `Content-Type: text/plain`, which caused HTTP clients like Postman and reverse proxies (nginx) to buffer the entire response before delivering it to the client.

Now when `streamFormat` is `'sse'`, all four server adapters (Express, Fastify, Hono, Koa) set proper SSE headers:

```
Content-Type: text/event-stream
Cache-Control: no-cache
Connection: keep-alive
X-Accel-Buffering: no
```

Non-SSE streams (`streamFormat: 'stream'`) keep `text/plain` for backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSE streaming: use text/event-stream and add SSE headers (Cache-Control: no-cache, Connection: keep-alive, X-Accel-Buffering: no) to avoid proxy/CDN buffering.
  * Improved detection of streaming responses so SSE is correctly identified across adapters.
  * Stream framing now emits SSE-style "data:" payloads for SSE and preserves existing framing for plain streams.

* **Tests**
  * Added tests verifying SSE headers and stream behavior; expanded stream-detection assertions to include SSE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->