### PR TITLE
feat(core): pass through experimental_toToolResultContent for multi-m…

### DIFF
--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -661,6 +661,10 @@ export class CoreToolBuilder extends MastraBase {
       outputSchema: processedOutputSchema,
       providerOptions: 'providerOptions' in this.originalTool ? this.originalTool.providerOptions : undefined,
       mcp: 'mcp' in this.originalTool ? this.originalTool.mcp : undefined,
+      experimental_toToolResultContent:
+        'experimental_toToolResultContent' in this.originalTool
+          ? this.originalTool.experimental_toToolResultContent
+          : undefined,
     } as unknown as CoreTool;
   }
 }

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -158,6 +158,15 @@ export class Tool<
   mcp?: MCPToolProperties;
 
   /**
+   * Optional function to convert tool output into multi-modal content blocks
+   * for the model (e.g., images, files). When provided, the AI SDK uses this
+   * to set `experimental_content` on tool result message parts.
+   */
+  experimental_toToolResultContent?: (
+    result: TSchemaOut,
+  ) => Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType?: string }>;
+
+  /**
    * Creates a new Tool instance with input validation wrapper.
    *
    * @param opts - Tool configuration and execute function
@@ -184,6 +193,7 @@ export class Tool<
     this.requireApproval = opts.requireApproval || false;
     this.providerOptions = opts.providerOptions;
     this.mcp = opts.mcp;
+    this.experimental_toToolResultContent = opts.experimental_toToolResultContent;
 
     // Tools receive two parameters:
     // 1. input - The raw, validated input data

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -201,6 +201,12 @@ export type CoreTool = {
    * Only populated when the tool is being used in an MCP context.
    */
   mcp?: MCPToolProperties;
+  /**
+   * Optional function to convert tool output into multi-modal content blocks for the model.
+   */
+  experimental_toToolResultContent?: (
+    result: any,
+  ) => Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType?: string }>;
 } & (
   | {
       type?: 'function' | undefined;
@@ -233,6 +239,12 @@ export type InternalCoreTool = {
    * Only populated when the tool is being used in an MCP context.
    */
   mcp?: MCPToolProperties;
+  /**
+   * Optional function to convert tool output into multi-modal content blocks for the model.
+   */
+  experimental_toToolResultContent?: (
+    result: any,
+  ) => Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType?: string }>;
 } & (
   | {
       type?: 'function' | undefined;
@@ -331,6 +343,22 @@ export interface ToolAction<
    * ```
    */
   providerOptions?: Record<string, Record<string, unknown>>;
+  /**
+   * Optional function to convert tool output into multi-modal content blocks
+   * for the model (e.g., images, files). When provided, the AI SDK uses this
+   * to set `experimental_content` on tool result message parts.
+   *
+   * @example
+   * ```typescript
+   * experimental_toToolResultContent: (result) => [
+   *   { type: 'text', text: result.text },
+   *   { type: 'image', data: result.base64, mimeType: 'image/png' },
+   * ]
+   * ```
+   */
+  experimental_toToolResultContent?: (
+    result: TSchemaOut,
+  ) => Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType?: string }>;
   onInputStart?: (options: ToolCallOptions) => void | PromiseLike<void>;
   onInputDelta?: (
     options: {


### PR DESCRIPTION
## Description
Pass through `experimental_toToolResultContent` for multi-modal tool results

Enable tools to return multi-modal content (images, files) back to the model as native content blocks in tool results. The AI SDK supports `experimental_toToolResultContent` on tool definitions, but CoreToolBuilder.build() was not passing this property through during the Mastra → AI SDK tool conversion, causing it to be silently dropped.

Changes:
- Add `experimental_toToolResultContent` to the ToolAction interface
- Store the property in the Tool class constructor
- Pass it through in CoreToolBuilder.build() using the same pattern as providerOptions and mcp
- Add the property to CoreTool and InternalCoreTool types


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced experimental support for converting tool results into multi-modal content blocks, enabling tools to return both text and image formats for enhanced model consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->