### PR TITLE
fix: use batch insert for dataset CSV/JSON import

### DIFF
--- a/.changeset/fix-dataset-import-versioning.md
+++ b/.changeset/fix-dataset-import-versioning.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fix dataset import creating a new version per item. CSV and JSON import dialogs now use the batch insert endpoint so all imported items land on a single version.


### PR DESCRIPTION
The CSV and JSON import dialogs were calling `addItem` in a loop — one API call per row. Each call bumped the dataset version, so importing 50 items created 50 versions.

Switched both dialogs to use the existing `batchInsertItems` mutation, which sends all items in a single request. The server handles this atomically with one version bump.

Before:
```ts
for (let i = 0; i < items.length; i++) {
  await addItem.mutateAsync({ datasetId, input, groundTruth, metadata });
}
```

After:
```ts
await batchInsertItems.mutateAsync({ datasetId, items });
```

Also removed the cancel button and `shouldCancel` state since there's no longer a loop to cancel mid-flight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dataset import versioning to record all imported items under a single version instead of creating separate versions per item
  * Simplified import dialog behavior by removing cancellation confirmation and Cancel button from the import step

<!-- end of auto-generated comment: release notes by coderabbit.ai -->