### PR TITLE
fix: remove experimental feature gate for datasets in sidebar

### DIFF
--- a/.changeset/remove-datasets-experimental-gate.md
+++ b/.changeset/remove-datasets-experimental-gate.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Show Datasets nav link without requiring EXPERIMENTAL_FEATURES flag

--- a/.changeset/remove-datasets-experimental-gate.md
+++ b/.changeset/remove-datasets-experimental-gate.md
@@ -2,4 +2,4 @@
 '@internal/playground': patch
 ---
 
-Show Datasets nav link without requiring EXPERIMENTAL_FEATURES flag
+Removed experimental gate that hid the Datasets navigation link in the studio sidebar

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -27,7 +27,6 @@ import {
   MastraVersionFooter,
   useMastraPlatform,
   NavLink,
-  useExperimentalFeatures,
 } from '@mastra/playground-ui';
 
 const mainNavigation: NavSection[] = [
@@ -175,12 +174,8 @@ export function AppSidebar() {
 
   const hideCloudCta = window?.MASTRA_HIDE_CLOUD_CTA === 'true';
   const { isMastraPlatform } = useMastraPlatform();
-  const { experimentalFeaturesEnabled } = useExperimentalFeatures();
 
   const filterPlatformLink = (link: NavLink) => {
-    if (link.name === 'Datasets' && !experimentalFeaturesEnabled) {
-      return false;
-    }
     if (isMastraPlatform) {
       return link.isOnMastraPlatform;
     }


### PR DESCRIPTION
Datasets nav link was hidden behind the `EXPERIMENTAL_FEATURES` env var. This removes that conditional so datasets always show in the studio sidebar.

The `isExperimental` badge on the nav item and the server-side `assertDatasetsAvailable()` version guard are left as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Datasets navigation link in the playground sidebar is now visible without enabling an experimental features flag, so users on Mastra and non-Mastra platforms can access Datasets as appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->