### PR TITLE
fix(playground): React error #310 crash with observational memory in studio

### DIFF
--- a/.changeset/breezy-hoops-switch.md
+++ b/.changeset/breezy-hoops-switch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed React error #310 crash when using observational memory in Mastra Studio. The chat view would crash when observation markers appeared alongside regular tool calls during streaming.

--- a/packages/playground-ui/src/lib/ai-ui/tools/__tests__/tool-fallback-hooks.test.ts
+++ b/packages/playground-ui/src/lib/ai-ui/tools/__tests__/tool-fallback-hooks.test.ts
@@ -22,9 +22,7 @@ describe('ToolFallbackInner - Rules of Hooks (issue #12726)', () => {
 
   it('should not have hook calls after the early return for observation markers', () => {
     // Find the ToolFallbackInner component
-    const componentStartIdx = lines.findIndex(line =>
-      line.includes('const ToolFallbackInner'),
-    );
+    const componentStartIdx = lines.findIndex(line => line.includes('const ToolFallbackInner'));
     expect(componentStartIdx, 'Could not find ToolFallbackInner component').toBeGreaterThan(-1);
 
     // Find the early return for 'mastra-memory-om-observation'
@@ -81,9 +79,7 @@ describe('ToolFallbackInner - Rules of Hooks (issue #12726)', () => {
 
   it('should call hooks unconditionally at the top of ToolFallbackInner', () => {
     // Find ToolFallbackInner
-    const componentStartIdx = lines.findIndex(line =>
-      line.includes('const ToolFallbackInner'),
-    );
+    const componentStartIdx = lines.findIndex(line => line.includes('const ToolFallbackInner'));
 
     // Find the arrow function body start `=> {`
     let bodyStartIdx = -1;

--- a/packages/playground-ui/src/lib/ai-ui/tools/__tests__/tool-fallback-hooks.test.ts
+++ b/packages/playground-ui/src/lib/ai-ui/tools/__tests__/tool-fallback-hooks.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Regression test for GitHub issue #12726
+ *
+ * React error #310: "Rendered more hooks than during the previous render"
+ *
+ * Root cause: ToolFallbackInner in tool-fallback.tsx has an early return at line 34
+ * for `toolName === 'mastra-memory-om-observation'` that returns BEFORE any hooks
+ * are called. When React reuses the same fiber position (e.g., during streaming
+ * when tool call lists change), a ToolFallbackInner instance that previously
+ * rendered with a non-OM toolName (calling hooks: useActivatedSkills, useEffect,
+ * useWorkflowStream) gets re-rendered with the OM toolName (0 hooks), or vice
+ * versa, causing React to detect a hook count mismatch and throw error #310.
+ */
+describe('ToolFallbackInner - Rules of Hooks (issue #12726)', () => {
+  const sourceFile = resolve(__dirname, '../tool-fallback.tsx');
+  const source = readFileSync(sourceFile, 'utf-8');
+  const lines = source.split('\n');
+
+  it('should not have hook calls after the early return for observation markers', () => {
+    // Find the ToolFallbackInner component
+    const componentStartIdx = lines.findIndex(line =>
+      line.includes('const ToolFallbackInner'),
+    );
+    expect(componentStartIdx, 'Could not find ToolFallbackInner component').toBeGreaterThan(-1);
+
+    // Find the early return for 'mastra-memory-om-observation'
+    let earlyReturnLine = -1;
+    for (let i = componentStartIdx; i < lines.length; i++) {
+      if (lines[i].includes('mastra-memory-om-observation')) {
+        // Find the return statement in this block
+        for (let j = i; j < Math.min(i + 5, lines.length); j++) {
+          if (lines[j].trim().startsWith('return')) {
+            earlyReturnLine = j + 1; // 1-indexed
+            break;
+          }
+        }
+        break;
+      }
+    }
+    expect(earlyReturnLine, 'Could not find early return for observation markers').toBeGreaterThan(-1);
+
+    // Find the end of the ToolFallbackInner component (closing `};`)
+    // We look for a `};` at the same indentation level as the const declaration
+    let componentEndIdx = lines.length;
+    for (let i = componentStartIdx + 1; i < lines.length; i++) {
+      if (lines[i].trimStart() === '};' || lines[i] === '};') {
+        componentEndIdx = i;
+        break;
+      }
+    }
+
+    // Find all hook calls AFTER the early return, within the component
+    const hookPattern = /\buse[A-Z]\w*\s*[(<]/;
+    const hooksAfterReturn: { line: number; text: string }[] = [];
+
+    for (let i = earlyReturnLine; i < componentEndIdx; i++) {
+      const trimmed = lines[i].trim();
+      // Skip comments and string literals
+      if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) continue;
+
+      if (hookPattern.test(trimmed)) {
+        hooksAfterReturn.push({ line: i + 1, text: trimmed });
+      }
+    }
+
+    // This should FAIL: hooks are called after an early return, violating Rules of Hooks
+    expect(
+      hooksAfterReturn,
+      `Found ${hooksAfterReturn.length} hook call(s) after early return at line ${earlyReturnLine}.\n` +
+        `This violates React's Rules of Hooks and causes error #310 (issue #12726).\n` +
+        `When toolName changes between 'mastra-memory-om-observation' and other values,\n` +
+        `the early return skips these hooks, causing a hook count mismatch.\n\n` +
+        `Fix: Move all hooks to the top of ToolFallbackInner, before the early return.\n\n` +
+        hooksAfterReturn.map(h => `  Line ${h.line}: ${h.text}`).join('\n'),
+    ).toHaveLength(0);
+  });
+
+  it('should call hooks unconditionally at the top of ToolFallbackInner', () => {
+    // Find ToolFallbackInner
+    const componentStartIdx = lines.findIndex(line =>
+      line.includes('const ToolFallbackInner'),
+    );
+
+    // Find the arrow function body start `=> {`
+    let bodyStartIdx = -1;
+    for (let i = componentStartIdx; i < lines.length; i++) {
+      if (lines[i].includes('=> {')) {
+        bodyStartIdx = i;
+        break;
+      }
+    }
+    expect(bodyStartIdx, 'Could not find ToolFallbackInner body').toBeGreaterThan(-1);
+
+    // The first non-comment, non-blank line after the function body opening should
+    // NOT be a conditional statement (if/switch). It should be hook calls.
+    let firstStatementIdx = -1;
+    for (let i = bodyStartIdx + 1; i < lines.length; i++) {
+      const trimmed = lines[i].trim();
+      if (trimmed === '' || trimmed.startsWith('//') || trimmed.startsWith('*')) continue;
+      firstStatementIdx = i;
+      break;
+    }
+    expect(firstStatementIdx).toBeGreaterThan(-1);
+
+    const firstStatement = lines[firstStatementIdx].trim();
+    // The first statement should NOT be a conditional (if/switch)
+    // It should be a hook call or variable declaration that uses a hook
+    expect(
+      firstStatement.startsWith('if ') || firstStatement.startsWith('if(') || firstStatement.startsWith('switch'),
+      `First statement in ToolFallbackInner is a conditional: "${firstStatement}"\n` +
+        `This means hooks below it may be skipped, violating React's Rules of Hooks.\n` +
+        `Hooks must be called unconditionally at the top of the component.`,
+    ).toBe(false);
+  });
+});

--- a/packages/playground-ui/src/lib/ai-ui/tools/tool-fallback.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/tool-fallback.tsx
@@ -17,11 +17,6 @@ export interface ToolFallbackProps extends ToolCallMessagePartProps<any, any> {
 }
 
 export const ToolFallback = ({ toolName, result, args, ...props }: ToolFallbackProps) => {
-  // Handle OM observation markers - they don't need WorkflowRunProvider
-  if (toolName === 'mastra-memory-om-observation') {
-    return <ToolFallbackInner toolName={toolName} result={result} args={args} {...props} />;
-  }
-
   return (
     <WorkflowRunProvider workflowId={''} withoutTimeTravel>
       <ToolFallbackInner toolName={toolName} result={result} args={args} {...props} />
@@ -30,19 +25,21 @@ export const ToolFallback = ({ toolName, result, args, ...props }: ToolFallbackP
 };
 
 const ToolFallbackInner = ({ toolName, result, args, metadata, toolCallId, ...props }: ToolFallbackProps) => {
-  // Handle OM observation markers first - render as ObservationMarkerBadge
-  if (toolName === 'mastra-memory-om-observation') {
-    return <ObservationMarkerBadge toolName={toolName} args={args} metadata={metadata} />;
-  }
-
+  // Hooks must be called unconditionally at the top (React Rules of Hooks, issue #12726)
   const { activateSkill } = useActivatedSkills();
 
-  // Detect skill activation tool calls
   useEffect(() => {
     if (toolName === 'skill-activate' && result?.success && args?.name) {
       activateSkill(args.name);
     }
   }, [toolName, result, args, activateSkill]);
+
+  useWorkflowStream(result);
+
+  // Handle OM observation markers - render as ObservationMarkerBadge
+  if (toolName === 'mastra-memory-om-observation') {
+    return <ObservationMarkerBadge toolName={toolName} args={args} metadata={metadata} />;
+  }
 
   // We need to handle the stream data even if the workflow is not resolved yet
   // The response from the fetch request resolving the workflow might theoretically
@@ -70,8 +67,6 @@ const ToolFallbackInner = ({ toolName, result, args, metadata, toolCallId, ...pr
   const suspendedToolMetadata = suspendedTools ? suspendedTools?.[toolName] : undefined;
 
   const toolCalled = metadata?.mode === 'network' && metadata?.hasMoreMessages ? true : undefined;
-
-  useWorkflowStream(result);
 
   if (isAgent) {
     return (


### PR DESCRIPTION
Fixes #12726

`ToolFallbackInner` had an early return for `mastra-memory-om-observation` tool calls **before** any hooks were called. During streaming, when React reused fiber positions for different tool types, the hook count changed between renders (0 vs 3), causing React error #310.

Before:
```tsx
const ToolFallbackInner = ({ toolName, ... }) => {
  if (toolName === 'mastra-memory-om-observation') {
    return <ObservationMarkerBadge ... />;  // 0 hooks
  }
  const { activateSkill } = useActivatedSkills();  // hook 1
  useEffect(() => { ... });                         // hook 2
  useWorkflowStream(result);                        // hook 3
```

After:
```tsx
const ToolFallbackInner = ({ toolName, ... }) => {
  const { activateSkill } = useActivatedSkills();   // hook 1
  useEffect(() => { ... });                          // hook 2
  useWorkflowStream(result);                         // hook 3

  if (toolName === 'mastra-memory-om-observation') {
    return <ObservationMarkerBadge ... />;  // hooks already called
  }
```

Also ensures `WorkflowRunProvider` always wraps `ToolFallbackInner` so `useWorkflowStream` has valid context on the OM path. Added a regression test that statically validates hook ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in Mastra Studio when observational memory appears alongside tool calls during streaming.

* **Tests**
  * Added regression tests to ensure React hook usage remains correct in the affected component.

* **Chores**
  * Added a patch release entry for the UI package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->