### PR TITLE
fix(core): use structural typing for ZodLikeSchema to prevent tsc OOM

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,6 +16,7 @@
     "@internal/*",
     "!mastra",
     "!create-mastra",
+    "!mastracode",
     "!@mastra/*",
     "!@internal/playground"
   ]

--- a/.changeset/giant-books-refuse.md
+++ b/.changeset/giant-books-refuse.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed TypeScript type generation hanging or running out of memory when packages depend on @mastra/core tool types. Changed ZodLikeSchema from a nominal union type to structural typing, which prevents TypeScript from performing deep comparisons of zod v3/v4 type trees during generic inference.

--- a/e2e-tests/pkg-outputs/bundle.test.ts
+++ b/e2e-tests/pkg-outputs/bundle.test.ts
@@ -84,11 +84,11 @@ describe.for(
 
   it.skipIf(
     pkgJson.name === 'mastra' ||
-    pkgJson.name === 'create-mastra' ||
-    pkgJson.name === '@mastra/client-js' ||
-    pkgJson.name === '@mastra/opencode' ||
-    pkgJson.name === 'mastracode' ||
-    !pkgJson.name.startsWith('@mastra/'),
+      pkgJson.name === 'create-mastra' ||
+      pkgJson.name === '@mastra/client-js' ||
+      pkgJson.name === '@mastra/opencode' ||
+      pkgJson.name === 'mastracode' ||
+      !pkgJson.name.startsWith('@mastra/'),
   )('should have @mastra/core as a peer dependency if used', async () => {
     const hasMastraCoreAsDependency = pkgJson?.dependencies?.['@mastra/core'];
     expect(hasMastraCoreAsDependency).toBe(undefined);

--- a/mastracode/src/agents/instructions.ts
+++ b/mastracode/src/agents/instructions.ts
@@ -1,28 +1,26 @@
-import type { HarnessRuntimeContext } from "../harness/types.js"
-import type { stateSchema } from "../schema.js"
-import type { PromptContext } from "./prompts/index.js"
-import { buildFullPrompt } from "./prompts/index.js"
+import type { HarnessRuntimeContext } from '../harness/types.js';
+import type { stateSchema } from '../schema.js';
+import type { PromptContext } from './prompts/index.js';
+import { buildFullPrompt } from './prompts/index.js';
 
 export function getDynamicInstructions({ requestContext }: { requestContext: { get(key: string): unknown } }) {
-    const harnessContext = requestContext.get("harness") as
-        | HarnessRuntimeContext<typeof stateSchema>
-        | undefined
-    const state = harnessContext?.state
-    const modeId = harnessContext?.modeId ?? "build"
+  const harnessContext = requestContext.get('harness') as HarnessRuntimeContext<typeof stateSchema> | undefined;
+  const state = harnessContext?.state;
+  const modeId = harnessContext?.modeId ?? 'build';
 
-    const promptCtx: PromptContext = {
-        projectPath: state?.projectPath ?? process.cwd(),
-        projectName: state?.projectName ?? "",
-        gitBranch: state?.gitBranch,
-        platform: process.platform,
-        date: new Date().toISOString().split("T")[0]!,
-        mode: modeId,
-        activePlan: state?.activePlan ?? null,
-        modeId: modeId,
-        currentDate: new Date().toISOString().split("T")[0]!,
-        workingDir: state?.projectPath ?? process.cwd(),
-        state: state,
-    }
+  const promptCtx: PromptContext = {
+    projectPath: state?.projectPath ?? process.cwd(),
+    projectName: state?.projectName ?? '',
+    gitBranch: state?.gitBranch,
+    platform: process.platform,
+    date: new Date().toISOString().split('T')[0]!,
+    mode: modeId,
+    activePlan: state?.activePlan ?? null,
+    modeId: modeId,
+    currentDate: new Date().toISOString().split('T')[0]!,
+    workingDir: state?.projectPath ?? process.cwd(),
+    state: state,
+  };
 
-    return buildFullPrompt(promptCtx)
+  return buildFullPrompt(promptCtx);
 }

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -1,38 +1,36 @@
-import type { RequestContext } from "@mastra/core/request-context"
-import type { MastraCompositeStore } from "@mastra/core/storage"
-import { Memory } from "@mastra/memory"
-import { DEFAULT_OM_MODEL_ID, DEFAULT_OBS_THRESHOLD, DEFAULT_REF_THRESHOLD } from "../constants"
-import type { HarnessRuntimeContext } from "../harness/types"
-import type { stateSchema } from "../schema"
-import { getOmScope } from "../utils/project"
-import { resolveModel } from "./model"
-
+import type { RequestContext } from '@mastra/core/request-context';
+import type { MastraCompositeStore } from '@mastra/core/storage';
+import { Memory } from '@mastra/memory';
+import { DEFAULT_OM_MODEL_ID, DEFAULT_OBS_THRESHOLD, DEFAULT_REF_THRESHOLD } from '../constants';
+import type { HarnessRuntimeContext } from '../harness/types';
+import type { stateSchema } from '../schema';
+import { getOmScope } from '../utils/project';
+import { resolveModel } from './model';
 
 // Cache for Memory instances by threshold config
-let cachedMemory: Memory | null = null
-let cachedMemoryKey: string | null = null
+let cachedMemory: Memory | null = null;
+let cachedMemoryKey: string | null = null;
 
 // =============================================================================
 // Create Memory with Observational Memory support
 // =============================================================================
 
-
 // Mutable OM state — updated by harness event listeners, read by OM config
 // functions. We use this instead of requestContext because Mastra's OM system
 // does NOT propagate requestContext to observer/reflector agent.generate() calls.
 export const omState = {
-    observerModelId: DEFAULT_OM_MODEL_ID,
-    reflectorModelId: DEFAULT_OM_MODEL_ID,
-    obsThreshold: DEFAULT_OBS_THRESHOLD,
-    refThreshold: DEFAULT_REF_THRESHOLD,
-}
+  observerModelId: DEFAULT_OM_MODEL_ID,
+  reflectorModelId: DEFAULT_OM_MODEL_ID,
+  obsThreshold: DEFAULT_OBS_THRESHOLD,
+  refThreshold: DEFAULT_REF_THRESHOLD,
+};
 
 /**
  * Dynamic model function for Observer agent.
  * Reads from module-level omState (kept in sync by harness events).
  */
 function getObserverModel() {
-    return resolveModel(omState.observerModelId)
+  return resolveModel(omState.observerModelId);
 }
 
 /**
@@ -40,9 +38,8 @@ function getObserverModel() {
  * Reads from module-level omState (kept in sync by harness events).
  */
 function getReflectorModel() {
-    return resolveModel(omState.reflectorModelId)
+  return resolveModel(omState.reflectorModelId);
 }
-
 
 /**
  * Dynamic memory factory function.
@@ -50,57 +47,51 @@ function getReflectorModel() {
  * Caches instance and reuses if config unchanged.
  */
 export function getDynamicMemory(storage: MastraCompositeStore) {
-    return ({
-        requestContext,
-    }: {
-        requestContext: RequestContext
-    }) => {
-        const ctx = requestContext.get("harness") as
-            | HarnessRuntimeContext<typeof stateSchema>
-            | undefined
-        const state = ctx?.getState?.()
+  return ({ requestContext }: { requestContext: RequestContext }) => {
+    const ctx = requestContext.get('harness') as HarnessRuntimeContext<typeof stateSchema> | undefined;
+    const state = ctx?.getState?.();
 
-        // Resolved OM scope (read once at startup, can be changed via config)
-        const omScope = getOmScope(state?.projectPath)
+    // Resolved OM scope (read once at startup, can be changed via config)
+    const omScope = getOmScope(state?.projectPath);
 
-        const obsThreshold = state?.observationThreshold ?? omState.obsThreshold
-        const refThreshold = state?.reflectionThreshold ?? omState.refThreshold
+    const obsThreshold = state?.observationThreshold ?? omState.obsThreshold;
+    const refThreshold = state?.reflectionThreshold ?? omState.refThreshold;
 
-        const cacheKey = `${obsThreshold}:${refThreshold}:${omScope}`
-        if (cachedMemory && cachedMemoryKey === cacheKey) {
-            return cachedMemory
-        }
-
-        cachedMemory = new Memory({
-            storage,
-            options: {
-                observationalMemory: {
-                    enabled: true,
-                    scope: omScope,
-                    observation: {
-                        bufferTokens: 1 / 10,
-                        bufferActivation: 4 / 5,
-                        model: getObserverModel,
-                        messageTokens: obsThreshold,
-                        blockAfter: 1,
-                        modelSettings: {
-                            maxOutputTokens: 60000,
-                        },
-                    },
-                    reflection: {
-                        bufferActivation: 1 / 2,
-                        blockAfter: 1.1,
-                        model: getReflectorModel,
-                        observationTokens: refThreshold,
-                        modelSettings: {
-                            maxOutputTokens: 60000,
-                        },
-                    },
-                },
-            },
-        })
-        cachedMemoryKey = cacheKey
-
-        return cachedMemory
+    const cacheKey = `${obsThreshold}:${refThreshold}:${omScope}`;
+    if (cachedMemory && cachedMemoryKey === cacheKey) {
+      return cachedMemory;
     }
+
+    cachedMemory = new Memory({
+      storage,
+      options: {
+        observationalMemory: {
+          enabled: true,
+          scope: omScope,
+          observation: {
+            bufferTokens: 1 / 10,
+            bufferActivation: 4 / 5,
+            model: getObserverModel,
+            messageTokens: obsThreshold,
+            blockAfter: 1,
+            modelSettings: {
+              maxOutputTokens: 60000,
+            },
+          },
+          reflection: {
+            bufferActivation: 1 / 2,
+            blockAfter: 1.1,
+            model: getReflectorModel,
+            observationTokens: refThreshold,
+            modelSettings: {
+              maxOutputTokens: 60000,
+            },
+          },
+        },
+      },
+    });
+    cachedMemoryKey = cacheKey;
+
+    return cachedMemory;
+  };
 }

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -5,6 +5,7 @@ import { DEFAULT_OM_MODEL_ID, DEFAULT_OBS_THRESHOLD, DEFAULT_REF_THRESHOLD } fro
 import type { HarnessRuntimeContext } from "../harness/types"
 import type { stateSchema } from "../schema"
 import { getOmScope } from "../utils/project"
+import { resolveModel } from "./model"
 
 
 // Cache for Memory instances by threshold config

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -1,8 +1,11 @@
 import { createAnthropic } from "@ai-sdk/anthropic"
 import { ModelRouterLanguageModel } from "@mastra/core/llm"
+import type { RequestContext } from "@mastra/core/request-context"
 import { AuthStorage } from "../auth/storage.js"
+import type { HarnessRuntimeContext } from "../harness/types.js"
 import { opencodeClaudeMaxProvider } from "../providers/claude-max.js"
 import { openaiCodexProvider } from "../providers/openai-codex.js"
+import type { stateSchema } from "../schema.js"
 
 const authStorage = new AuthStorage()
 

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -1,13 +1,13 @@
-import { createAnthropic } from "@ai-sdk/anthropic"
-import { ModelRouterLanguageModel } from "@mastra/core/llm"
-import type { RequestContext } from "@mastra/core/request-context"
-import { AuthStorage } from "../auth/storage.js"
-import type { HarnessRuntimeContext } from "../harness/types.js"
-import { opencodeClaudeMaxProvider } from "../providers/claude-max.js"
-import { openaiCodexProvider } from "../providers/openai-codex.js"
-import type { stateSchema } from "../schema.js"
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { ModelRouterLanguageModel } from '@mastra/core/llm';
+import type { RequestContext } from '@mastra/core/request-context';
+import { AuthStorage } from '../auth/storage.js';
+import type { HarnessRuntimeContext } from '../harness/types.js';
+import { opencodeClaudeMaxProvider } from '../providers/claude-max.js';
+import { openaiCodexProvider } from '../providers/openai-codex.js';
+import type { stateSchema } from '../schema.js';
 
-const authStorage = new AuthStorage()
+const authStorage = new AuthStorage();
 
 /**
  * Resolve a model ID to the correct provider instance.
@@ -19,45 +19,39 @@ const authStorage = new AuthStorage()
  * - For all other providers: Uses Mastra's model router (models.dev gateway)
  */
 export function resolveModel(modelId: string) {
-    const isAnthropicModel = modelId.startsWith("anthropic/")
-    const isOpenAIModel = modelId.startsWith("openai/")
-    const isMoonshotModel = modelId.startsWith("moonshotai/")
+  const isAnthropicModel = modelId.startsWith('anthropic/');
+  const isOpenAIModel = modelId.startsWith('openai/');
+  const isMoonshotModel = modelId.startsWith('moonshotai/');
 
-    if (isMoonshotModel) {
-        if (!process.env.MOONSHOT_AI_API_KEY) {
-            throw new Error(`Need MOONSHOT_AI_API_KEY`)
-        }
-        return createAnthropic({
-            apiKey: process.env.MOONSHOT_AI_API_KEY!,
-            baseURL: "https://api.moonshot.ai/anthropic/v1",
-            name: "moonshotai.anthropicv1",
-        })(modelId.substring("moonshotai/".length))
-    } else if (isAnthropicModel) {
-        return opencodeClaudeMaxProvider(modelId.substring(`anthropic/`.length))
-    } else if (isOpenAIModel && authStorage.isLoggedIn("openai-codex")) {
-        return openaiCodexProvider(modelId.substring(`openai/`.length))
-    } else {
-        return new ModelRouterLanguageModel(modelId)
+  if (isMoonshotModel) {
+    if (!process.env.MOONSHOT_AI_API_KEY) {
+      throw new Error(`Need MOONSHOT_AI_API_KEY`);
     }
+    return createAnthropic({
+      apiKey: process.env.MOONSHOT_AI_API_KEY!,
+      baseURL: 'https://api.moonshot.ai/anthropic/v1',
+      name: 'moonshotai.anthropicv1',
+    })(modelId.substring('moonshotai/'.length));
+  } else if (isAnthropicModel) {
+    return opencodeClaudeMaxProvider(modelId.substring(`anthropic/`.length));
+  } else if (isOpenAIModel && authStorage.isLoggedIn('openai-codex')) {
+    return openaiCodexProvider(modelId.substring(`openai/`.length));
+  } else {
+    return new ModelRouterLanguageModel(modelId);
+  }
 }
 
 /**
  * Dynamic model function that reads the current model from harness state.
  * This allows runtime model switching via the /models picker.
  */
-export function getDynamicModel({
-    requestContext,
-}: {
-    requestContext: RequestContext
-}) {
-    const harnessContext = requestContext.get("harness") as
-        | HarnessRuntimeContext<typeof stateSchema>
-        | undefined
+export function getDynamicModel({ requestContext }: { requestContext: RequestContext }) {
+  const harnessContext = requestContext.get('harness') as HarnessRuntimeContext<typeof stateSchema> | undefined;
 
-    const modelId = harnessContext?.state?.currentModelId
-    if (!modelId) {
-        throw new Error("No model selected. Use /models to select a model first.")
-    }
+  const modelId = harnessContext?.state?.currentModelId;
+  if (!modelId) {
+    throw new Error('No model selected. Use /models to select a model first.');
+  }
 
-    return resolveModel(modelId)
+  return resolveModel(modelId);
 }

--- a/mastracode/src/agents/prompts/agent-instructions.ts
+++ b/mastracode/src/agents/prompts/agent-instructions.ts
@@ -3,31 +3,26 @@
  * Prefers AGENT.md over CLAUDE.md when both exist at the same location.
  */
 
-import { existsSync, readFileSync } from "node:fs"
-import { homedir } from "node:os"
-import { join } from "node:path"
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 
 // Filenames to check, in order of preference
-const INSTRUCTION_FILES = ["AGENT.md", "CLAUDE.md"]
+const INSTRUCTION_FILES = ['AGENT.md', 'CLAUDE.md'];
 
 // Locations to scan (relative to project root or home)
 const PROJECT_LOCATIONS = [
-	"", // project root
-	".claude",
-	".mastracode",
-]
+  '', // project root
+  '.claude',
+  '.mastracode',
+];
 
-const GLOBAL_LOCATIONS = [
-	".claude",
-	".mastracode",
-	".config/claude",
-	".config/mastracode",
-]
+const GLOBAL_LOCATIONS = ['.claude', '.mastracode', '.config/claude', '.config/mastracode'];
 
 interface InstructionSource {
-	path: string
-	content: string
-	scope: "global" | "project"
+  path: string;
+  content: string;
+  scope: 'global' | 'project';
 }
 
 /**
@@ -35,72 +30,70 @@ interface InstructionSource {
  * Prefers AGENT.md over CLAUDE.md.
  */
 function findInstructionFile(basePath: string): string | null {
-	for (const filename of INSTRUCTION_FILES) {
-		const fullPath = join(basePath, filename)
-		if (existsSync(fullPath)) {
-			return fullPath
-		}
-	}
-	return null
+  for (const filename of INSTRUCTION_FILES) {
+    const fullPath = join(basePath, filename);
+    if (existsSync(fullPath)) {
+      return fullPath;
+    }
+  }
+  return null;
 }
 
 /**
  * Load all agent instruction files from global and project locations.
  * Returns an array of instruction sources, with global ones first.
  */
-export function loadAgentInstructions(
-	projectPath: string,
-): InstructionSource[] {
-	const sources: InstructionSource[] = []
-	const home = homedir()
+export function loadAgentInstructions(projectPath: string): InstructionSource[] {
+  const sources: InstructionSource[] = [];
+  const home = homedir();
 
-	// Load global instructions first
-	for (const location of GLOBAL_LOCATIONS) {
-		const basePath = join(home, location)
-		const filePath = findInstructionFile(basePath)
-		if (filePath) {
-			try {
-				const content = readFileSync(filePath, "utf-8").trim()
-				if (content) {
-					sources.push({ path: filePath, content, scope: "global" })
-					break // Only use first found global instruction file
-				}
-			} catch {
-				// Skip unreadable files
-			}
-		}
-	}
+  // Load global instructions first
+  for (const location of GLOBAL_LOCATIONS) {
+    const basePath = join(home, location);
+    const filePath = findInstructionFile(basePath);
+    if (filePath) {
+      try {
+        const content = readFileSync(filePath, 'utf-8').trim();
+        if (content) {
+          sources.push({ path: filePath, content, scope: 'global' });
+          break; // Only use first found global instruction file
+        }
+      } catch {
+        // Skip unreadable files
+      }
+    }
+  }
 
-	// Load project instructions
-	for (const location of PROJECT_LOCATIONS) {
-		const basePath = location ? join(projectPath, location) : projectPath
-		const filePath = findInstructionFile(basePath)
-		if (filePath) {
-			try {
-				const content = readFileSync(filePath, "utf-8").trim()
-				if (content) {
-					sources.push({ path: filePath, content, scope: "project" })
-					break // Only use first found project instruction file
-				}
-			} catch {
-				// Skip unreadable files
-			}
-		}
-	}
+  // Load project instructions
+  for (const location of PROJECT_LOCATIONS) {
+    const basePath = location ? join(projectPath, location) : projectPath;
+    const filePath = findInstructionFile(basePath);
+    if (filePath) {
+      try {
+        const content = readFileSync(filePath, 'utf-8').trim();
+        if (content) {
+          sources.push({ path: filePath, content, scope: 'project' });
+          break; // Only use first found project instruction file
+        }
+      } catch {
+        // Skip unreadable files
+      }
+    }
+  }
 
-	return sources
+  return sources;
 }
 
 /**
  * Format loaded instructions into a string for the system prompt.
  */
 export function formatAgentInstructions(sources: InstructionSource[]): string {
-	if (sources.length === 0) return ""
+  if (sources.length === 0) return '';
 
-	const sections = sources.map((source) => {
-		const label = source.scope === "global" ? "Global" : "Project"
-		return `<!-- ${label} instructions from ${source.path} -->\n${source.content}`
-	})
+  const sections = sources.map(source => {
+    const label = source.scope === 'global' ? 'Global' : 'Project';
+    return `<!-- ${label} instructions from ${source.path} -->\n${source.content}`;
+  });
 
-	return `\n# Agent Instructions\n\n${sections.join("\n\n")}\n`
+  return `\n# Agent Instructions\n\n${sections.join('\n\n')}\n`;
 }

--- a/mastracode/src/agents/prompts/base.ts
+++ b/mastracode/src/agents/prompts/base.ts
@@ -4,22 +4,22 @@
  */
 
 export interface PromptContext {
-	projectPath: string
-	projectName: string
-	gitBranch?: string
-	platform: string
-	date: string
-	mode: string
-	activePlan?: { title: string; plan: string; approvedAt: string } | null
+  projectPath: string;
+  projectName: string;
+  gitBranch?: string;
+  platform: string;
+  date: string;
+  mode: string;
+  activePlan?: { title: string; plan: string; approvedAt: string } | null;
 }
 
 export function buildBasePrompt(ctx: PromptContext): string {
-	return `You are Mastra Code, an interactive CLI coding agent that helps users with software engineering tasks.
+  return `You are Mastra Code, an interactive CLI coding agent that helps users with software engineering tasks.
 
 # Environment
 Working directory: ${ctx.projectPath}
 Project: ${ctx.projectName}
-${ctx.gitBranch ? `Git branch: ${ctx.gitBranch}` : "Not a git repository"}
+${ctx.gitBranch ? `Git branch: ${ctx.gitBranch}` : 'Not a git repository'}
 Platform: ${ctx.platform}
 Date: ${ctx.date}
 Current mode: ${ctx.mode}
@@ -154,5 +154,5 @@ Use \`gh pr create\`. Include a summary of what changed and a test plan.
 # File Access & Sandbox
 
 By default, you can only access files within the current project directory. If you get a "Permission denied" or "Access denied" error when trying to read, write, or access files outside the project root, do NOT keep retrying. Instead, tell the user to run the \`/sandbox\` command to add the external directory to the allowed paths for this thread. Once they do, you will be able to access it.
-`
+`;
 }

--- a/mastracode/src/agents/prompts/build.ts
+++ b/mastracode/src/agents/prompts/build.ts
@@ -2,7 +2,7 @@
  * Build mode prompt — full tool access, make changes and verify.
  */
 
-import type { PromptContext } from "./base.js"
+import type { PromptContext } from './base.js';
 
 /**
  * Dynamic build mode prompt function.
@@ -10,9 +10,9 @@ import type { PromptContext } from "./base.js"
  * knows exactly what to implement.
  */
 export function buildModePromptFn(ctx: PromptContext): string {
-	if (ctx.activePlan) {
-		return (
-			`# Approved Plan
+  if (ctx.activePlan) {
+    return (
+      `# Approved Plan
 
 **${ctx.activePlan.title}**
 
@@ -23,9 +23,9 @@ ${ctx.activePlan.plan}
 Implement the approved plan above. Follow the steps in order and verify each step works before moving on.
 
 ` + buildModePrompt
-		)
-	}
-	return buildModePrompt
+    );
+  }
+  return buildModePrompt;
 }
 
 export const buildModePrompt = `
@@ -78,4 +78,4 @@ When something breaks:
 - Don't commit unless asked — just report what you changed
 - Before committing, verify the code compiles and passes lint
 - Use descriptive branch names: \`feat/...\`, \`fix/...\`, \`refactor/...\`
-`
+`;

--- a/mastracode/src/agents/prompts/fast.ts
+++ b/mastracode/src/agents/prompts/fast.ts
@@ -19,4 +19,4 @@ You are in FAST mode. Optimize for speed and brevity.
 - If the user asks about THIS project's code, use tools to look it up — don't guess.
 - If the user asks for a quick edit and you know the file, read it and edit it. Don't ask for confirmation.
 - One tool call to read + one to edit is ideal. Minimize round trips.
-`
+`;

--- a/mastracode/src/agents/prompts/index.ts
+++ b/mastracode/src/agents/prompts/index.ts
@@ -2,89 +2,73 @@
  * Prompt system — exports the prompt builder and mode-specific prompts.
  */
 
-export { buildBasePrompt } from "./base.js"
-export { buildModePrompt, buildModePromptFn } from "./build.js"
-export { planModePrompt } from "./plan.js"
-export { fastModePrompt } from "./fast.js"
+export { buildBasePrompt } from './base.js';
+export { buildModePrompt, buildModePromptFn } from './build.js';
+export { planModePrompt } from './plan.js';
+export { fastModePrompt } from './fast.js';
 
-import {
-	loadAgentInstructions,
-	formatAgentInstructions,
-} from "./agent-instructions.js"
-import {
-	buildBasePrompt
-	
-} from "./base.js"
-import type {PromptContext as BasePromptContext} from "./base.js";
-import { buildModePromptFn } from "./build.js"
-import { fastModePrompt } from "./fast.js"
-import { planModePrompt } from "./plan.js"
+import { loadAgentInstructions, formatAgentInstructions } from './agent-instructions.js';
+import { buildBasePrompt } from './base.js';
+import type { PromptContext as BasePromptContext } from './base.js';
+import { buildModePromptFn } from './build.js';
+import { fastModePrompt } from './fast.js';
+import { planModePrompt } from './plan.js';
 
 // Extended prompt context that includes runtime information
 export interface PromptContext extends BasePromptContext {
-	modeId: string
-	state?: any
-	currentDate: string
-	workingDir: string
-	availableTools?: string // Mode-specific available tools
+  modeId: string;
+  state?: any;
+  currentDate: string;
+  workingDir: string;
+  availableTools?: string; // Mode-specific available tools
 }
 
 const modePrompts: Record<string, string | ((ctx: PromptContext) => string)> = {
-	build: buildModePromptFn,
-	plan: planModePrompt,
-	fast: fastModePrompt,
-}
+  build: buildModePromptFn,
+  plan: planModePrompt,
+  fast: fastModePrompt,
+};
 
 /**
  * Build the full system prompt for a given mode and context.
  * Combines the base prompt with mode-specific instructions.
  */
 export function buildFullPrompt(ctx: PromptContext): string {
-	// Map new context to base context
-	const baseCtx: BasePromptContext = {
-		projectPath: ctx.workingDir,
-		projectName: ctx.projectName || "unknown",
-		gitBranch: ctx.gitBranch,
-		platform: process.platform,
-		date: ctx.currentDate,
-		mode: ctx.modeId,
-		activePlan: ctx.state?.activePlan,
-	}
+  // Map new context to base context
+  const baseCtx: BasePromptContext = {
+    projectPath: ctx.workingDir,
+    projectName: ctx.projectName || 'unknown',
+    gitBranch: ctx.gitBranch,
+    platform: process.platform,
+    date: ctx.currentDate,
+    mode: ctx.modeId,
+    activePlan: ctx.state?.activePlan,
+  };
 
-	const base = buildBasePrompt(baseCtx)
-	const entry = modePrompts[ctx.modeId] || modePrompts.build
-	const modeSpecific = typeof entry === "function" ? entry(ctx) : entry
+  const base = buildBasePrompt(baseCtx);
+  const entry = modePrompts[ctx.modeId] || modePrompts.build;
+  const modeSpecific = typeof entry === 'function' ? entry(ctx) : entry;
 
-	// Add available tools section if provided
-	let toolsSection = ""
-	if (ctx.availableTools) {
-		toolsSection = `\n# Available Tools for ${ctx.modeId} mode:\n${ctx.availableTools}\n`
-	}
+  // Add available tools section if provided
+  let toolsSection = '';
+  if (ctx.availableTools) {
+    toolsSection = `\n# Available Tools for ${ctx.modeId} mode:\n${ctx.availableTools}\n`;
+  }
 
-	// Inject current todo state so agent doesn't lose track after OM truncation
-	let todoSection = ""
-	const todos = ctx.state?.todos as
-		| { content: string; status: string; activeForm: string }[]
-		| undefined
-	if (todos && todos.length > 0) {
-		const lines = todos.map((t) => {
-			const icon =
-				t.status === "completed" ? "✓" : t.status === "in_progress" ? "▸" : "○"
-			return `  ${icon} [${t.status}] ${t.content}`
-		})
-		todoSection = `\n<current-task-list>\n${lines.join("\n")}\n</current-task-list>\n`
-	}
+  // Inject current todo state so agent doesn't lose track after OM truncation
+  let todoSection = '';
+  const todos = ctx.state?.todos as { content: string; status: string; activeForm: string }[] | undefined;
+  if (todos && todos.length > 0) {
+    const lines = todos.map(t => {
+      const icon = t.status === 'completed' ? '✓' : t.status === 'in_progress' ? '▸' : '○';
+      return `  ${icon} [${t.status}] ${t.content}`;
+    });
+    todoSection = `\n<current-task-list>\n${lines.join('\n')}\n</current-task-list>\n`;
+  }
 
-	// Load and inject agent instructions from AGENT.md/CLAUDE.md files
-	const instructionSources = loadAgentInstructions(ctx.workingDir)
-	const instructionsSection = formatAgentInstructions(instructionSources)
+  // Load and inject agent instructions from AGENT.md/CLAUDE.md files
+  const instructionSources = loadAgentInstructions(ctx.workingDir);
+  const instructionsSection = formatAgentInstructions(instructionSources);
 
-	return (
-		base +
-		toolsSection +
-		todoSection +
-		instructionsSection +
-		"\n" +
-		modeSpecific
-	)
+  return base + toolsSection + todoSection + instructionsSection + '\n' + modeSpecific;
 }

--- a/mastracode/src/agents/prompts/plan.ts
+++ b/mastracode/src/agents/prompts/plan.ts
@@ -70,4 +70,4 @@ The user will see the plan rendered inline and can:
 - **Request changes** — provides feedback for you to revise and resubmit
 
 Do NOT start implementing until the plan is approved. If rejected with feedback, revise the plan and call \`submit_plan\` again.
-`
+`;

--- a/mastracode/src/agents/subagents/execute.ts
+++ b/mastracode/src/agents/subagents/execute.ts
@@ -5,12 +5,12 @@
  * read and write tools to complete it. It can modify files, run commands,
  * and perform actual development work within a constrained scope.
  */
-import type { SubagentDefinition } from "./types.js"
+import type { SubagentDefinition } from './types.js';
 
 export const executeSubagent: SubagentDefinition = {
-	id: "execute",
-	name: "Execute",
-	instructions: `You are a focused execution agent. Your job is to complete a specific, well-defined task by making the necessary changes to the codebase.
+  id: 'execute',
+  name: 'Execute',
+  instructions: `You are a focused execution agent. Your job is to complete a specific, well-defined task by making the necessary changes to the codebase.
 
 ## Rules
 - You have FULL ACCESS to read, write, and execute within your task scope.
@@ -43,18 +43,18 @@ End with a structured summary:
 . **Changes**: Files modified/created
 . **Verification**: How you verified it works
 . **Notes**: Follow-up needed (if any)`,
-	allowedTools: [
-		// Read tools
-		"view",
-		"search_content",
-		"find_files",
-		// Write tools
-		"string_replace_lsp",
-		"write_file",
-		// Execution tool
-		"execute_command",
-		// Task tracking
-		"todo_write",
-		"todo_check",
-	],
-}
+  allowedTools: [
+    // Read tools
+    'view',
+    'search_content',
+    'find_files',
+    // Write tools
+    'string_replace_lsp',
+    'write_file',
+    // Execution tool
+    'execute_command',
+    // Task tracking
+    'todo_write',
+    'todo_check',
+  ],
+};

--- a/mastracode/src/agents/subagents/explore.ts
+++ b/mastracode/src/agents/subagents/explore.ts
@@ -5,12 +5,12 @@
  * "understand how module Y works") and uses read-only tools to explore
  * the codebase, then returns a concise summary of its findings.
  */
-import type { SubagentDefinition } from "./types.js"
+import type { SubagentDefinition } from './types.js';
 
 export const exploreSubagent: SubagentDefinition = {
-	id: "explore",
-	name: "Explore",
-	instructions: `You are an expert code explorer. Your job is to investigate a codebase and answer a specific question or gather specific information.
+  id: 'explore',
+  name: 'Explore',
+  instructions: `You are an expert code explorer. Your job is to investigate a codebase and answer a specific question or gather specific information.
 
 ## Rules
 - You have READ-ONLY access. You cannot modify files or run commands.
@@ -36,5 +36,5 @@ End with a structured summary:
 . **Details**: Additional context if needed
 
 Keep your summary under 300 words.`,
-	allowedTools: ["view", "search_content", "find_files"],
-}
+  allowedTools: ['view', 'search_content', 'find_files'],
+};

--- a/mastracode/src/agents/subagents/index.ts
+++ b/mastracode/src/agents/subagents/index.ts
@@ -1,78 +1,85 @@
 /**
  * Subagent registry — maps subagent IDs to their definitions.
  */
-import { createViewTool, createExecuteCommandTool, createGrepTool, createGlobTool, createWriteFileTool, createSubagentTool, stringReplaceLspTool, todoWriteTool, todoCheckTool } from "../../tools/index.js"
-import { resolveModel } from "../model.js"
-import { executeSubagent } from "./execute.js"
-import { exploreSubagent } from "./explore.js"
-import { planSubagent } from "./plan.js"
-import type { SubagentDefinition } from "./types.js"
+import {
+  createViewTool,
+  createExecuteCommandTool,
+  createGrepTool,
+  createGlobTool,
+  createWriteFileTool,
+  createSubagentTool,
+  stringReplaceLspTool,
+  todoWriteTool,
+  todoCheckTool,
+} from '../../tools/index.js';
+import { resolveModel } from '../model.js';
+import { executeSubagent } from './execute.js';
+import { exploreSubagent } from './explore.js';
+import { planSubagent } from './plan.js';
+import type { SubagentDefinition } from './types.js';
 
 /** All registered subagent definitions, keyed by ID. */
 const subagentRegistry: Record<string, SubagentDefinition> = {
-	explore: exploreSubagent,
-	plan: planSubagent,
-	execute: executeSubagent,
-}
+  explore: exploreSubagent,
+  plan: planSubagent,
+  execute: executeSubagent,
+};
 
 /**
  * Look up a subagent definition by ID.
  * Returns undefined if not found.
  */
-export function getSubagentDefinition(
-	id: string,
-): SubagentDefinition | undefined {
-	return subagentRegistry[id]
+export function getSubagentDefinition(id: string): SubagentDefinition | undefined {
+  return subagentRegistry[id];
 }
 
 /**
  * Get all registered subagent IDs (for tool description / validation).
  */
 export function getSubagentIds(): string[] {
-	return Object.keys(subagentRegistry)
+  return Object.keys(subagentRegistry);
 }
 
-
 export function getSubagentTools(projectPath: string) {
-	// Create tools with project root
-	const viewTool = createViewTool(projectPath)
-	const executeCommandTool = createExecuteCommandTool(projectPath)
-	const grepTool = createGrepTool(projectPath)
-	const globTool = createGlobTool(projectPath)
-	const writeFileTool = createWriteFileTool(projectPath)
+  // Create tools with project root
+  const viewTool = createViewTool(projectPath);
+  const executeCommandTool = createExecuteCommandTool(projectPath);
+  const grepTool = createGrepTool(projectPath);
+  const globTool = createGlobTool(projectPath);
+  const writeFileTool = createWriteFileTool(projectPath);
 
-	// The subagent tool needs tools and resolveModel to spawn subagents.
-	// We pass all tools that subagents might need based on their type.
-	const subagentTool = createSubagentTool({
-		tools: {
-			// Read-only tools (for explore, plan)
-			view: viewTool,
-			search_content: grepTool,
-			find_files: globTool,
-			// Write tools (for execute)
-			string_replace_lsp: stringReplaceLspTool,
-			write_file: writeFileTool,
-			execute_command: executeCommandTool,
-			// Task tracking (for execute)
-			todo_write: todoWriteTool,
-			todo_check: todoCheckTool,
-		},
-		resolveModel,
-	})
+  // The subagent tool needs tools and resolveModel to spawn subagents.
+  // We pass all tools that subagents might need based on their type.
+  const subagentTool = createSubagentTool({
+    tools: {
+      // Read-only tools (for explore, plan)
+      view: viewTool,
+      search_content: grepTool,
+      find_files: globTool,
+      // Write tools (for execute)
+      string_replace_lsp: stringReplaceLspTool,
+      write_file: writeFileTool,
+      execute_command: executeCommandTool,
+      // Task tracking (for execute)
+      todo_write: todoWriteTool,
+      todo_check: todoCheckTool,
+    },
+    resolveModel,
+  });
 
-	// Read-only subagent tool for plan mode — no execute type allowed
-	const subagentToolReadOnly = createSubagentTool({
-		tools: {
-			view: viewTool,
-			search_content: grepTool,
-			find_files: globTool,
-		},
-		resolveModel,
-		allowedAgentTypes: ["explore", "plan"],
-	})
+  // Read-only subagent tool for plan mode — no execute type allowed
+  const subagentToolReadOnly = createSubagentTool({
+    tools: {
+      view: viewTool,
+      search_content: grepTool,
+      find_files: globTool,
+    },
+    resolveModel,
+    allowedAgentTypes: ['explore', 'plan'],
+  });
 
-	return {
-		tool: subagentTool,
-		toolReadOnly: subagentToolReadOnly,
-	}
+  return {
+    tool: subagentTool,
+    toolReadOnly: subagentToolReadOnly,
+  };
 }

--- a/mastracode/src/agents/subagents/plan.ts
+++ b/mastracode/src/agents/subagents/plan.ts
@@ -5,12 +5,12 @@
  * implementation plan. It can read the codebase to understand existing
  * patterns and architecture, but cannot modify anything.
  */
-import type { SubagentDefinition } from "./types.js"
+import type { SubagentDefinition } from './types.js';
 
 export const planSubagent: SubagentDefinition = {
-	id: "plan",
-	name: "Plan",
-	instructions: `You are an expert software architect and planner. Your job is to analyze a codebase and produce a detailed implementation plan for a given task.
+  id: 'plan',
+  name: 'Plan',
+  instructions: `You are an expert software architect and planner. Your job is to analyze a codebase and produce a detailed implementation plan for a given task.
 
 ## Rules
 - You have READ-ONLY access. You cannot modify files or run commands.
@@ -38,5 +38,5 @@ Structure your plan as:
 . **Risks**: Potential issues or edge cases (if any)
 
 Be specific about code locations (file paths, function names, line numbers). Keep the plan actionable and under 500 words.`,
-	allowedTools: ["view", "search_content", "find_files"],
-}
+  allowedTools: ['view', 'search_content', 'find_files'],
+};

--- a/mastracode/src/agents/subagents/types.ts
+++ b/mastracode/src/agents/subagents/types.ts
@@ -7,19 +7,19 @@
  */
 
 export interface SubagentDefinition {
-	/** Unique identifier for this subagent type (e.g., "explore", "plan") */
-	id: string
+  /** Unique identifier for this subagent type (e.g., "explore", "plan") */
+  id: string;
 
-	/** Human-readable name shown in tool output */
-	name: string
+  /** Human-readable name shown in tool output */
+  name: string;
 
-	/** System prompt for this subagent */
-	instructions: string
+  /** System prompt for this subagent */
+  instructions: string;
 
-	/**
-	 * Which tool IDs this subagent may use.
-	 * These are keys from the parent agent's tool registry
-	 * (e.g., "view", "search_content", "find_files").
-	 */
-	allowedTools: string[]
+  /**
+   * Which tool IDs this subagent may use.
+   * These are keys from the parent agent's tool registry
+   * (e.g., "view", "search_content", "find_files").
+   */
+  allowedTools: string[];
 }

--- a/mastracode/src/agents/tools.ts
+++ b/mastracode/src/agents/tools.ts
@@ -1,99 +1,96 @@
-import { createAnthropic } from "@ai-sdk/anthropic"
-import type { RequestContext } from "@mastra/core/request-context"
-import type { HarnessRuntimeContext } from "../harness/types"
-import type { MCPManager } from "../mcp"
-import type { stateSchema } from "../schema"
+import { createAnthropic } from '@ai-sdk/anthropic';
+import type { RequestContext } from '@mastra/core/request-context';
+import type { HarnessRuntimeContext } from '../harness/types';
+import type { MCPManager } from '../mcp';
+import type { stateSchema } from '../schema';
 import {
-    createViewTool,
-    createGrepTool,
-    createGlobTool,
-    createExecuteCommandTool,
-    createWriteFileTool,
-    createWebSearchTool,
-    createWebExtractTool,
-    hasTavilyKey,
-    stringReplaceLspTool,
-    astSmartEditTool,
-    submitPlanTool,
-    todoWriteTool,
-    todoCheckTool,
-    askUserTool,
-    requestSandboxAccessTool,
-} from "../tools"
-import { getSubagentTools } from "./subagents/index.js"
+  createViewTool,
+  createGrepTool,
+  createGlobTool,
+  createExecuteCommandTool,
+  createWriteFileTool,
+  createWebSearchTool,
+  createWebExtractTool,
+  hasTavilyKey,
+  stringReplaceLspTool,
+  astSmartEditTool,
+  submitPlanTool,
+  todoWriteTool,
+  todoCheckTool,
+  askUserTool,
+  requestSandboxAccessTool,
+} from '../tools';
+import { getSubagentTools } from './subagents/index.js';
 
 export function createDynamicTools(mcpManager?: MCPManager) {
-    return function getDynamicTools({ requestContext }: { requestContext: RequestContext }) {
-        const ctx = requestContext.get("harness") as
-            | HarnessRuntimeContext<typeof stateSchema>
-            | undefined
-        const state = ctx?.getState?.()
-        const modeId = ctx?.modeId ?? "build"
+  return function getDynamicTools({ requestContext }: { requestContext: RequestContext }) {
+    const ctx = requestContext.get('harness') as HarnessRuntimeContext<typeof stateSchema> | undefined;
+    const state = ctx?.getState?.();
+    const modeId = ctx?.modeId ?? 'build';
 
-        const modelId = state?.currentModelId
-        const isAnthropicModel = modelId?.startsWith("anthropic/")
+    const modelId = state?.currentModelId;
+    const isAnthropicModel = modelId?.startsWith('anthropic/');
 
-        const projectPath = state?.projectPath ?? ""
-        const { tool: subagentTool, toolReadOnly: subagentToolReadOnly } = getSubagentTools(projectPath)
+    const projectPath = state?.projectPath ?? '';
+    const { tool: subagentTool, toolReadOnly: subagentToolReadOnly } = getSubagentTools(projectPath);
 
-        // Instantiate project-scoped tools
-        const viewTool = createViewTool(projectPath)
-        const grepTool = createGrepTool(projectPath)
-        const globTool = createGlobTool(projectPath)
-        const executeCommandTool = createExecuteCommandTool(projectPath)
-        const writeFileTool = createWriteFileTool(projectPath)
+    // Instantiate project-scoped tools
+    const viewTool = createViewTool(projectPath);
+    const grepTool = createGrepTool(projectPath);
+    const globTool = createGlobTool(projectPath);
+    const executeCommandTool = createExecuteCommandTool(projectPath);
+    const writeFileTool = createWriteFileTool(projectPath);
 
-        // Build tool set based on mode
-        // NOTE: Tool names "grep" and "glob" are reserved by Anthropic's OAuth
-        // validation (they match Claude Code's internal tools). We use
-        // "search_content" and "find_files" to avoid the collision.
-        const tools: Record<string, any> = {
-            // Read-only tools — always available
-            view: viewTool,
-            search_content: grepTool,
-            find_files: globTool,
-            execute_command: executeCommandTool,
-            // Subagent delegation — read-only in plan mode
-            subagent: modeId === "plan" ? subagentToolReadOnly : subagentTool,
-            // Todo tracking — always available (planning tool, not a write tool)
-            todo_write: todoWriteTool,
-            todo_check: todoCheckTool,
-            // User interaction — always available
-            ask_user: askUserTool,
-            request_sandbox_access: requestSandboxAccessTool,
-        }
+    // Build tool set based on mode
+    // NOTE: Tool names "grep" and "glob" are reserved by Anthropic's OAuth
+    // validation (they match Claude Code's internal tools). We use
+    // "search_content" and "find_files" to avoid the collision.
+    const tools: Record<string, any> = {
+      // Read-only tools — always available
+      view: viewTool,
+      search_content: grepTool,
+      find_files: globTool,
+      execute_command: executeCommandTool,
+      // Subagent delegation — read-only in plan mode
+      subagent: modeId === 'plan' ? subagentToolReadOnly : subagentTool,
+      // Todo tracking — always available (planning tool, not a write tool)
+      todo_write: todoWriteTool,
+      todo_check: todoCheckTool,
+      // User interaction — always available
+      ask_user: askUserTool,
+      request_sandbox_access: requestSandboxAccessTool,
+    };
 
-        // Write tools — NOT available in plan mode
-        if (modeId !== "plan") {
-            tools.string_replace_lsp = stringReplaceLspTool
-            tools.ast_smart_edit = astSmartEditTool
-            tools.write_file = writeFileTool
-        }
-
-        // Plan submission — only available in plan mode
-        if (modeId === "plan") {
-            tools.submit_plan = submitPlanTool
-        }
-        // Web tools — prefer Tavily when available (avoids Anthropic native
-        // web_search provider tool which can cause stream freezes). Fall back
-        // to Anthropic's native web search via getToolsets() for Anthropic models.
-        // Note: hasTavilyKey() is checked at request time, not module load time,
-        // so the key can be set after startup and still be picked up.
-        if (hasTavilyKey()) {
-            tools.web_search = createWebSearchTool()
-            tools.web_extract = createWebExtractTool()
-        } else if (isAnthropicModel) {
-            const anthropic = createAnthropic({})
-            tools.web_search = anthropic.tools.webSearch_20250305()
-        }
-
-        // MCP server tools — injected from connected servers
-        if (mcpManager) {
-            const mcpTools = mcpManager.getTools()
-            Object.assign(tools, mcpTools)
-        }
-
-        return tools
-
+    // Write tools — NOT available in plan mode
+    if (modeId !== 'plan') {
+      tools.string_replace_lsp = stringReplaceLspTool;
+      tools.ast_smart_edit = astSmartEditTool;
+      tools.write_file = writeFileTool;
     }
+
+    // Plan submission — only available in plan mode
+    if (modeId === 'plan') {
+      tools.submit_plan = submitPlanTool;
+    }
+    // Web tools — prefer Tavily when available (avoids Anthropic native
+    // web_search provider tool which can cause stream freezes). Fall back
+    // to Anthropic's native web search via getToolsets() for Anthropic models.
+    // Note: hasTavilyKey() is checked at request time, not module load time,
+    // so the key can be set after startup and still be picked up.
+    if (hasTavilyKey()) {
+      tools.web_search = createWebSearchTool();
+      tools.web_extract = createWebExtractTool();
+    } else if (isAnthropicModel) {
+      const anthropic = createAnthropic({});
+      tools.web_search = anthropic.tools.webSearch_20250305();
+    }
+
+    // MCP server tools — injected from connected servers
+    if (mcpManager) {
+      const mcpTools = mcpManager.getTools();
+      Object.assign(tools, mcpTools);
+    }
+
+    return tools;
+  };
 }

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -6,7 +6,6 @@ import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace
 import type { HarnessRuntimeContext } from '../harness/types';
 import type { stateSchema } from '../schema';
 
-
 // =============================================================================
 // Create Workspace with Skills
 // =============================================================================
@@ -17,114 +16,100 @@ import type { stateSchema } from '../schema';
 // 3. Global: ~/.mastracode/skills (user-wide mastracode skills)
 // 4. Global: ~/.claude/skills (user-wide Claude Code skills)
 
-const mastraCodeLocalSkillsPath = path.join(
-    process.cwd(),
-    ".mastracode",
-    "skills",
-)
+const mastraCodeLocalSkillsPath = path.join(process.cwd(), '.mastracode', 'skills');
 
-const claudeLocalSkillsPath = path.join(process.cwd(), ".claude", "skills")
+const claudeLocalSkillsPath = path.join(process.cwd(), '.claude', 'skills');
 
-const mastraCodeGlobalSkillsPath = path.join(
-    os.homedir(),
-    ".mastracode",
-    "skills",
-)
+const mastraCodeGlobalSkillsPath = path.join(os.homedir(), '.mastracode', 'skills');
 
-const claudeGlobalSkillsPath = path.join(os.homedir(), ".claude", "skills")
+const claudeGlobalSkillsPath = path.join(os.homedir(), '.claude', 'skills');
 
 // Mastra's LocalSkillSource.readdir uses Node's Dirent.isDirectory() which
 // returns false for symlinks. Tools like `npx skills add` install skills as
 // symlinks, so we need to resolve them. For each symlinked skill directory,
 // we add the real (resolved) parent path as an additional skill scan path.
 function collectSkillPaths(skillsDirs: string[]): string[] {
-    const paths: string[] = []
-    const seen = new Set<string>()
+  const paths: string[] = [];
+  const seen = new Set<string>();
 
-    for (const skillsDir of skillsDirs) {
-        if (!fs.existsSync(skillsDir)) continue
+  for (const skillsDir of skillsDirs) {
+    if (!fs.existsSync(skillsDir)) continue;
 
-        // Always add the directory itself
-        const resolved = fs.realpathSync(skillsDir)
-        if (!seen.has(resolved)) {
-            seen.add(resolved)
-            paths.push(skillsDir)
-        }
-
-        // Check for symlinked skill subdirectories and add their real parents
-        try {
-            const entries = fs.readdirSync(skillsDir, { withFileTypes: true })
-            for (const entry of entries) {
-                if (entry.isSymbolicLink()) {
-                    const linkPath = path.join(skillsDir, entry.name)
-                    const realPath = fs.realpathSync(linkPath)
-                    const stat = fs.statSync(realPath)
-                    if (stat.isDirectory()) {
-                        // Add the real parent directory as a skill path
-                        // so Mastra discovers it as a regular directory
-                        const realParent = path.dirname(realPath)
-                        if (!seen.has(realParent)) {
-                            seen.add(realParent)
-                            paths.push(realParent)
-                        }
-                    }
-                }
-            }
-        } catch {
-            // Ignore errors during symlink resolution
-        }
+    // Always add the directory itself
+    const resolved = fs.realpathSync(skillsDir);
+    if (!seen.has(resolved)) {
+      seen.add(resolved);
+      paths.push(skillsDir);
     }
 
-    return paths
+    // Check for symlinked skill subdirectories and add their real parents
+    try {
+      const entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isSymbolicLink()) {
+          const linkPath = path.join(skillsDir, entry.name);
+          const realPath = fs.realpathSync(linkPath);
+          const stat = fs.statSync(realPath);
+          if (stat.isDirectory()) {
+            // Add the real parent directory as a skill path
+            // so Mastra discovers it as a regular directory
+            const realParent = path.dirname(realPath);
+            if (!seen.has(realParent)) {
+              seen.add(realParent);
+              paths.push(realParent);
+            }
+          }
+        }
+      }
+    } catch {
+      // Ignore errors during symlink resolution
+    }
+  }
+
+  return paths;
 }
 
 const skillPaths = collectSkillPaths([
-    mastraCodeLocalSkillsPath,
-    claudeLocalSkillsPath,
-    mastraCodeGlobalSkillsPath,
-    claudeGlobalSkillsPath,
-])
-
+  mastraCodeLocalSkillsPath,
+  claudeLocalSkillsPath,
+  mastraCodeGlobalSkillsPath,
+  claudeGlobalSkillsPath,
+]);
 
 export function getDynamicWorkspace({ requestContext }: { requestContext: RequestContext }) {
-    const ctx = requestContext.get("harness") as
-        | HarnessRuntimeContext<typeof stateSchema>
-        | undefined
-    const state = ctx?.getState?.()
-    const projectPath = state?.projectPath
+  const ctx = requestContext.get('harness') as HarnessRuntimeContext<typeof stateSchema> | undefined;
+  const state = ctx?.getState?.();
+  const projectPath = state?.projectPath;
 
-    if (!projectPath) {
-        throw new Error("Project path is required")
-    }
+  if (!projectPath) {
+    throw new Error('Project path is required');
+  }
 
-    // Sync filesystem's allowedPaths with sandbox-granted paths from harness state
-    const sandboxPaths = state?.sandboxAllowedPaths ?? []
+  // Sync filesystem's allowedPaths with sandbox-granted paths from harness state
+  const sandboxPaths = state?.sandboxAllowedPaths ?? [];
 
-    const workspace = new Workspace({
-        id: "mastra-code-workspace",
-        name: "Mastra Code Workspace",
-        filesystem: new LocalFilesystem({
-            basePath: projectPath,
-            allowedPaths: skillPaths,
-        }),
-        sandbox: new LocalSandbox({
-            workingDirectory: projectPath,
-            env: process.env,
-        }),
-        ...(skillPaths.length > 0 ? { skills: skillPaths } : {}),
-    })
+  const workspace = new Workspace({
+    id: 'mastra-code-workspace',
+    name: 'Mastra Code Workspace',
+    filesystem: new LocalFilesystem({
+      basePath: projectPath,
+      allowedPaths: skillPaths,
+    }),
+    sandbox: new LocalSandbox({
+      workingDirectory: projectPath,
+      env: process.env,
+    }),
+    ...(skillPaths.length > 0 ? { skills: skillPaths } : {}),
+  });
 
-    workspace.filesystem.setAllowedPaths([
-        ...skillPaths,
-        ...sandboxPaths.map((p: string) => path.resolve(p)),
-    ])
+  workspace.filesystem.setAllowedPaths([...skillPaths, ...sandboxPaths.map((p: string) => path.resolve(p))]);
 
-    return workspace
+  return workspace;
 }
 
 if (skillPaths.length > 0) {
-    console.info(`Skills loaded from:`)
-    for (const p of skillPaths) {
-        console.info(`  - ${p}`)
-    }
+  console.info(`Skills loaded from:`);
+  for (const p of skillPaths) {
+    console.info(`  - ${p}`);
+  }
 }

--- a/mastracode/src/auth/index.ts
+++ b/mastracode/src/auth/index.ts
@@ -2,6 +2,6 @@
  * OAuth credential management for AI providers.
  */
 
-export * from "./types.js"
-export * from "./storage.js"
-export { anthropicOAuthProvider } from "./providers/anthropic.js"
+export * from './types.js';
+export * from './storage.js';
+export { anthropicOAuthProvider } from './providers/anthropic.js';

--- a/mastracode/src/auth/pkce.ts
+++ b/mastracode/src/auth/pkce.ts
@@ -7,11 +7,11 @@
  * Encode bytes as base64url string.
  */
 function base64urlEncode(bytes: Uint8Array): string {
-	let binary = ""
-	for (const byte of bytes) {
-		binary += String.fromCharCode(byte)
-	}
-	return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "")
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
 }
 
 /**
@@ -19,19 +19,19 @@ function base64urlEncode(bytes: Uint8Array): string {
  * Uses Web Crypto API for cross-platform compatibility.
  */
 export async function generatePKCE(): Promise<{
-	verifier: string
-	challenge: string
+  verifier: string;
+  challenge: string;
 }> {
-	// Generate random verifier
-	const verifierBytes = new Uint8Array(32)
-	crypto.getRandomValues(verifierBytes)
-	const verifier = base64urlEncode(verifierBytes)
+  // Generate random verifier
+  const verifierBytes = new Uint8Array(32);
+  crypto.getRandomValues(verifierBytes);
+  const verifier = base64urlEncode(verifierBytes);
 
-	// Compute SHA-256 challenge
-	const encoder = new TextEncoder()
-	const data = encoder.encode(verifier)
-	const hashBuffer = await crypto.subtle.digest("SHA-256", data)
-	const challenge = base64urlEncode(new Uint8Array(hashBuffer))
+  // Compute SHA-256 challenge
+  const encoder = new TextEncoder();
+  const data = encoder.encode(verifier);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const challenge = base64urlEncode(new Uint8Array(hashBuffer));
 
-	return { verifier, challenge }
+  return { verifier, challenge };
 }

--- a/mastracode/src/auth/providers/anthropic.ts
+++ b/mastracode/src/auth/providers/anthropic.ts
@@ -5,139 +5,133 @@
  * https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/utils/oauth/anthropic.ts
  */
 
-import { generatePKCE } from "../pkce.js"
-import type {
-	OAuthCredentials,
-	OAuthLoginCallbacks,
-	OAuthProviderInterface,
-} from "../types.js"
+import { generatePKCE } from '../pkce.js';
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } from '../types.js';
 
-const decode = (s: string) => atob(s)
-const CLIENT_ID = decode("OWQxYzI1MGEtZTYxYi00NGQ5LTg4ZWQtNTk0NGQxOTYyZjVl")
-const AUTHORIZE_URL = "https://claude.ai/oauth/authorize"
-const TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
-const REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
-const SCOPES = "org:create_api_key user:profile user:inference"
+const decode = (s: string) => atob(s);
+const CLIENT_ID = decode('OWQxYzI1MGEtZTYxYi00NGQ5LTg4ZWQtNTk0NGQxOTYyZjVl');
+const AUTHORIZE_URL = 'https://claude.ai/oauth/authorize';
+const TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token';
+const REDIRECT_URI = 'https://console.anthropic.com/oauth/code/callback';
+const SCOPES = 'org:create_api_key user:profile user:inference';
 
 /**
  * Login with Anthropic OAuth (device code flow)
  */
 export async function loginAnthropic(
-	onAuthUrl: (url: string) => void,
-	onPromptCode: () => Promise<string>,
+  onAuthUrl: (url: string) => void,
+  onPromptCode: () => Promise<string>,
 ): Promise<OAuthCredentials> {
-	const { verifier, challenge } = await generatePKCE()
+  const { verifier, challenge } = await generatePKCE();
 
-	// Build authorization URL
-	const authParams = new URLSearchParams({
-		code: "true",
-		client_id: CLIENT_ID,
-		response_type: "code",
-		redirect_uri: REDIRECT_URI,
-		scope: SCOPES,
-		code_challenge: challenge,
-		code_challenge_method: "S256",
-		state: verifier,
-	})
+  // Build authorization URL
+  const authParams = new URLSearchParams({
+    code: 'true',
+    client_id: CLIENT_ID,
+    response_type: 'code',
+    redirect_uri: REDIRECT_URI,
+    scope: SCOPES,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    state: verifier,
+  });
 
-	const authUrl = `${AUTHORIZE_URL}?${authParams.toString()}`
+  const authUrl = `${AUTHORIZE_URL}?${authParams.toString()}`;
 
-	// Notify caller with URL to open
-	onAuthUrl(authUrl)
+  // Notify caller with URL to open
+  onAuthUrl(authUrl);
 
-	// Wait for user to paste authorization code (format: code#state)
-	const authCode = await onPromptCode()
-	const splits = authCode.split("#")
-	const code = splits[0]
-	const state = splits[1]
+  // Wait for user to paste authorization code (format: code#state)
+  const authCode = await onPromptCode();
+  const splits = authCode.split('#');
+  const code = splits[0];
+  const state = splits[1];
 
-	// Exchange code for tokens
-	const tokenResponse = await fetch(TOKEN_URL, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({
-			grant_type: "authorization_code",
-			client_id: CLIENT_ID,
-			code: code,
-			state: state,
-			redirect_uri: REDIRECT_URI,
-			code_verifier: verifier,
-		}),
-	})
+  // Exchange code for tokens
+  const tokenResponse = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      grant_type: 'authorization_code',
+      client_id: CLIENT_ID,
+      code: code,
+      state: state,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: verifier,
+    }),
+  });
 
-	if (!tokenResponse.ok) {
-		const error = await tokenResponse.text()
-		throw new Error(`Token exchange failed: ${error}`)
-	}
+  if (!tokenResponse.ok) {
+    const error = await tokenResponse.text();
+    throw new Error(`Token exchange failed: ${error}`);
+  }
 
-	const tokenData = (await tokenResponse.json()) as {
-		access_token: string
-		refresh_token: string
-		expires_in: number
-	}
+  const tokenData = (await tokenResponse.json()) as {
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+  };
 
-	// Calculate expiry time (current time + expires_in seconds - 5 min buffer)
-	const expiresAt = Date.now() + tokenData.expires_in * 1000 - 5 * 60 * 1000
+  // Calculate expiry time (current time + expires_in seconds - 5 min buffer)
+  const expiresAt = Date.now() + tokenData.expires_in * 1000 - 5 * 60 * 1000;
 
-	return {
-		refresh: tokenData.refresh_token,
-		access: tokenData.access_token,
-		expires: expiresAt,
-	}
+  return {
+    refresh: tokenData.refresh_token,
+    access: tokenData.access_token,
+    expires: expiresAt,
+  };
 }
 
 /**
  * Refresh Anthropic OAuth token
  */
-export async function refreshAnthropicToken(
-	refreshToken: string,
-): Promise<OAuthCredentials> {
-	const response = await fetch(TOKEN_URL, {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({
-			grant_type: "refresh_token",
-			client_id: CLIENT_ID,
-			refresh_token: refreshToken,
-		}),
-	})
+export async function refreshAnthropicToken(refreshToken: string): Promise<OAuthCredentials> {
+  const response = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'refresh_token',
+      client_id: CLIENT_ID,
+      refresh_token: refreshToken,
+    }),
+  });
 
-	if (!response.ok) {
-		const error = await response.text()
-		throw new Error(`Anthropic token refresh failed: ${error}`)
-	}
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Anthropic token refresh failed: ${error}`);
+  }
 
-	const data = (await response.json()) as {
-		access_token: string
-		refresh_token: string
-		expires_in: number
-	}
+  const data = (await response.json()) as {
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+  };
 
-	return {
-		refresh: data.refresh_token,
-		access: data.access_token,
-		expires: Date.now() + data.expires_in * 1000 - 5 * 60 * 1000,
-	}
+  return {
+    refresh: data.refresh_token,
+    access: data.access_token,
+    expires: Date.now() + data.expires_in * 1000 - 5 * 60 * 1000,
+  };
 }
 
 export const anthropicOAuthProvider: OAuthProviderInterface = {
-	id: "anthropic",
-	name: "Anthropic (Claude Pro/Max)",
+  id: 'anthropic',
+  name: 'Anthropic (Claude Pro/Max)',
 
-	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
-		return loginAnthropic(
-			(url) => callbacks.onAuth({ url }),
-			() => callbacks.onPrompt({ message: "Paste the authorization code:" }),
-		)
-	},
+  async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+    return loginAnthropic(
+      url => callbacks.onAuth({ url }),
+      () => callbacks.onPrompt({ message: 'Paste the authorization code:' }),
+    );
+  },
 
-	async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-		return refreshAnthropicToken(credentials.refresh)
-	},
+  async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+    return refreshAnthropicToken(credentials.refresh);
+  },
 
-	getApiKey(credentials: OAuthCredentials): string {
-		return credentials.access
-	},
-}
+  getApiKey(credentials: OAuthCredentials): string {
+    return credentials.access;
+  },
+};

--- a/mastracode/src/auth/providers/openai-codex.ts
+++ b/mastracode/src/auth/providers/openai-codex.ts
@@ -9,35 +9,27 @@
  */
 
 // NEVER convert to top-level imports - breaks browser/Vite builds (web-ui)
-let _randomBytes: ((size: number) => Buffer) | null = null
+let _randomBytes: ((size: number) => Buffer) | null = null;
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-let _http: typeof import("node:http") | null = null
-if (
-	typeof process !== "undefined" &&
-	(process.versions?.node || process.versions?.bun)
-) {
-	import("node:crypto").then((m) => {
-		_randomBytes = m.randomBytes
-	})
-	import("node:http").then((m) => {
-		_http = m
-	})
+let _http: typeof import('node:http') | null = null;
+if (typeof process !== 'undefined' && (process.versions?.node || process.versions?.bun)) {
+  import('node:crypto').then(m => {
+    _randomBytes = m.randomBytes;
+  });
+  import('node:http').then(m => {
+    _http = m;
+  });
 }
 
-import { generatePKCE } from "../pkce.js"
-import type {
-	OAuthCredentials,
-	OAuthLoginCallbacks,
-	OAuthPrompt,
-	OAuthProviderInterface,
-} from "../types.js"
+import { generatePKCE } from '../pkce.js';
+import type { OAuthCredentials, OAuthLoginCallbacks, OAuthPrompt, OAuthProviderInterface } from '../types.js';
 
-const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
-const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize"
-const TOKEN_URL = "https://auth.openai.com/oauth/token"
-const REDIRECT_URI = "http://localhost:1455/auth/callback"
-const SCOPE = "openid profile email offline_access"
-const JWT_CLAIM_PATH = "https://api.openai.com/auth"
+const CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+const AUTHORIZE_URL = 'https://auth.openai.com/oauth/authorize';
+const TOKEN_URL = 'https://auth.openai.com/oauth/token';
+const REDIRECT_URI = 'http://localhost:1455/auth/callback';
+const SCOPE = 'openid profile email offline_access';
+const JWT_CLAIM_PATH = 'https://api.openai.com/auth';
 
 const SUCCESS_HTML = `<!doctype html>
 <html lang="en">
@@ -49,287 +41,266 @@ const SUCCESS_HTML = `<!doctype html>
 <body>
   <p>Authentication successful. Return to your terminal to continue.</p>
 </body>
-</html>`
+</html>`;
 
 type TokenSuccess = {
-	type: "success"
-	access: string
-	refresh: string
-	expires: number
-}
-type TokenFailure = { type: "failed" }
-type TokenResult = TokenSuccess | TokenFailure
+  type: 'success';
+  access: string;
+  refresh: string;
+  expires: number;
+};
+type TokenFailure = { type: 'failed' };
+type TokenResult = TokenSuccess | TokenFailure;
 
 type JwtPayload = {
-	[JWT_CLAIM_PATH]?: {
-		chatgpt_account_id?: string
-	}
-	[key: string]: unknown
-}
+  [JWT_CLAIM_PATH]?: {
+    chatgpt_account_id?: string;
+  };
+  [key: string]: unknown;
+};
 
 function createState(): string {
-	if (!_randomBytes) {
-		throw new Error(
-			"OpenAI Codex OAuth is only available in Node.js environments",
-		)
-	}
-	return _randomBytes(16).toString("hex")
+  if (!_randomBytes) {
+    throw new Error('OpenAI Codex OAuth is only available in Node.js environments');
+  }
+  return _randomBytes(16).toString('hex');
 }
 
 function parseAuthorizationInput(input: string): {
-	code?: string
-	state?: string
+  code?: string;
+  state?: string;
 } {
-	const value = input.trim()
-	if (!value) return {}
+  const value = input.trim();
+  if (!value) return {};
 
-	try {
-		const url = new URL(value)
-		return {
-			code: url.searchParams.get("code") ?? undefined,
-			state: url.searchParams.get("state") ?? undefined,
-		}
-	} catch {
-		// not a URL
-	}
+  try {
+    const url = new URL(value);
+    return {
+      code: url.searchParams.get('code') ?? undefined,
+      state: url.searchParams.get('state') ?? undefined,
+    };
+  } catch {
+    // not a URL
+  }
 
-	if (value.includes("#")) {
-		const [code, state] = value.split("#", 2)
-		return { code, state }
-	}
+  if (value.includes('#')) {
+    const [code, state] = value.split('#', 2);
+    return { code, state };
+  }
 
-	if (value.includes("code=")) {
-		const params = new URLSearchParams(value)
-		return {
-			code: params.get("code") ?? undefined,
-			state: params.get("state") ?? undefined,
-		}
-	}
+  if (value.includes('code=')) {
+    const params = new URLSearchParams(value);
+    return {
+      code: params.get('code') ?? undefined,
+      state: params.get('state') ?? undefined,
+    };
+  }
 
-	return { code: value }
+  return { code: value };
 }
 
 function decodeJwt(token: string): JwtPayload | null {
-	try {
-		const parts = token.split(".")
-		if (parts.length !== 3) return null
-		const payload = parts[1] ?? ""
-		const decoded = atob(payload)
-		return JSON.parse(decoded) as JwtPayload
-	} catch {
-		return null
-	}
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    const payload = parts[1] ?? '';
+    const decoded = atob(payload);
+    return JSON.parse(decoded) as JwtPayload;
+  } catch {
+    return null;
+  }
 }
 
 async function exchangeAuthorizationCode(
-	code: string,
-	verifier: string,
-	redirectUri: string = REDIRECT_URI,
+  code: string,
+  verifier: string,
+  redirectUri: string = REDIRECT_URI,
 ): Promise<TokenResult> {
-	const response = await fetch(TOKEN_URL, {
-		method: "POST",
-		headers: { "Content-Type": "application/x-www-form-urlencoded" },
-		body: new URLSearchParams({
-			grant_type: "authorization_code",
-			client_id: CLIENT_ID,
-			code,
-			code_verifier: verifier,
-			redirect_uri: redirectUri,
-		}),
-	})
+  const response = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: CLIENT_ID,
+      code,
+      code_verifier: verifier,
+      redirect_uri: redirectUri,
+    }),
+  });
 
-	if (!response.ok) {
-		const text = await response.text().catch(() => "")
-		console.error("[openai-codex] code->token failed:", response.status, text)
-		return { type: "failed" }
-	}
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    console.error('[openai-codex] code->token failed:', response.status, text);
+    return { type: 'failed' };
+  }
 
-	const json = (await response.json()) as {
-		access_token?: string
-		refresh_token?: string
-		expires_in?: number
-	}
+  const json = (await response.json()) as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+  };
 
-	if (
-		!json.access_token ||
-		!json.refresh_token ||
-		typeof json.expires_in !== "number"
-	) {
-		console.error("[openai-codex] token response missing fields:", json)
-		return { type: "failed" }
-	}
+  if (!json.access_token || !json.refresh_token || typeof json.expires_in !== 'number') {
+    console.error('[openai-codex] token response missing fields:', json);
+    return { type: 'failed' };
+  }
 
-	return {
-		type: "success",
-		access: json.access_token,
-		refresh: json.refresh_token,
-		expires: Date.now() + json.expires_in * 1000,
-	}
+  return {
+    type: 'success',
+    access: json.access_token,
+    refresh: json.refresh_token,
+    expires: Date.now() + json.expires_in * 1000,
+  };
 }
 
 async function refreshAccessToken(refreshToken: string): Promise<TokenResult> {
-	try {
-		const response = await fetch(TOKEN_URL, {
-			method: "POST",
-			headers: { "Content-Type": "application/x-www-form-urlencoded" },
-			body: new URLSearchParams({
-				grant_type: "refresh_token",
-				refresh_token: refreshToken,
-				client_id: CLIENT_ID,
-			}),
-		})
+  try {
+    const response = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: CLIENT_ID,
+      }),
+    });
 
-		if (!response.ok) {
-			const text = await response.text().catch(() => "")
-			console.error(
-				"[openai-codex] Token refresh failed:",
-				response.status,
-				text,
-			)
-			return { type: "failed" }
-		}
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      console.error('[openai-codex] Token refresh failed:', response.status, text);
+      return { type: 'failed' };
+    }
 
-		const json = (await response.json()) as {
-			access_token?: string
-			refresh_token?: string
-			expires_in?: number
-		}
+    const json = (await response.json()) as {
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+    };
 
-		if (
-			!json.access_token ||
-			!json.refresh_token ||
-			typeof json.expires_in !== "number"
-		) {
-			console.error(
-				"[openai-codex] Token refresh response missing fields:",
-				json,
-			)
-			return { type: "failed" }
-		}
+    if (!json.access_token || !json.refresh_token || typeof json.expires_in !== 'number') {
+      console.error('[openai-codex] Token refresh response missing fields:', json);
+      return { type: 'failed' };
+    }
 
-		return {
-			type: "success",
-			access: json.access_token,
-			refresh: json.refresh_token,
-			expires: Date.now() + json.expires_in * 1000,
-		}
-	} catch (error) {
-		console.error("[openai-codex] Token refresh error:", error)
-		return { type: "failed" }
-	}
+    return {
+      type: 'success',
+      access: json.access_token,
+      refresh: json.refresh_token,
+      expires: Date.now() + json.expires_in * 1000,
+    };
+  } catch (error) {
+    console.error('[openai-codex] Token refresh error:', error);
+    return { type: 'failed' };
+  }
 }
 
 async function createAuthorizationFlow(
-	originator: string = "pi",
+  originator: string = 'pi',
 ): Promise<{ verifier: string; state: string; url: string }> {
-	const { verifier, challenge } = await generatePKCE()
-	const state = createState()
+  const { verifier, challenge } = await generatePKCE();
+  const state = createState();
 
-	const url = new URL(AUTHORIZE_URL)
-	url.searchParams.set("response_type", "code")
-	url.searchParams.set("client_id", CLIENT_ID)
-	url.searchParams.set("redirect_uri", REDIRECT_URI)
-	url.searchParams.set("scope", SCOPE)
-	url.searchParams.set("code_challenge", challenge)
-	url.searchParams.set("code_challenge_method", "S256")
-	url.searchParams.set("state", state)
-	url.searchParams.set("id_token_add_organizations", "true")
-	url.searchParams.set("codex_cli_simplified_flow", "true")
-	url.searchParams.set("originator", originator)
+  const url = new URL(AUTHORIZE_URL);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', CLIENT_ID);
+  url.searchParams.set('redirect_uri', REDIRECT_URI);
+  url.searchParams.set('scope', SCOPE);
+  url.searchParams.set('code_challenge', challenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', state);
+  url.searchParams.set('id_token_add_organizations', 'true');
+  url.searchParams.set('codex_cli_simplified_flow', 'true');
+  url.searchParams.set('originator', originator);
 
-	return { verifier, state, url: url.toString() }
+  return { verifier, state, url: url.toString() };
 }
 
 type OAuthServerInfo = {
-	close: () => void
-	cancelWait: () => void
-	waitForCode: () => Promise<{ code: string } | null>
-}
+  close: () => void;
+  cancelWait: () => void;
+  waitForCode: () => Promise<{ code: string } | null>;
+};
 
 function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
-	if (!_http) {
-		throw new Error(
-			"OpenAI Codex OAuth is only available in Node.js environments",
-		)
-	}
-	let lastCode: string | null = null
-	let cancelled = false
-	const server = _http.createServer((req, res) => {
-		try {
-			const url = new URL(req.url || "", "http://localhost")
-			if (url.pathname !== "/auth/callback") {
-				res.statusCode = 404
-				res.end("Not found")
-				return
-			}
-			if (url.searchParams.get("state") !== state) {
-				res.statusCode = 400
-				res.end("State mismatch")
-				return
-			}
-			const code = url.searchParams.get("code")
-			if (!code) {
-				res.statusCode = 400
-				res.end("Missing authorization code")
-				return
-			}
-			res.statusCode = 200
-			res.setHeader("Content-Type", "text/html; charset=utf-8")
-			res.end(SUCCESS_HTML)
-			lastCode = code
-		} catch {
-			res.statusCode = 500
-			res.end("Internal error")
-		}
-	})
+  if (!_http) {
+    throw new Error('OpenAI Codex OAuth is only available in Node.js environments');
+  }
+  let lastCode: string | null = null;
+  let cancelled = false;
+  const server = _http.createServer((req, res) => {
+    try {
+      const url = new URL(req.url || '', 'http://localhost');
+      if (url.pathname !== '/auth/callback') {
+        res.statusCode = 404;
+        res.end('Not found');
+        return;
+      }
+      if (url.searchParams.get('state') !== state) {
+        res.statusCode = 400;
+        res.end('State mismatch');
+        return;
+      }
+      const code = url.searchParams.get('code');
+      if (!code) {
+        res.statusCode = 400;
+        res.end('Missing authorization code');
+        return;
+      }
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.end(SUCCESS_HTML);
+      lastCode = code;
+    } catch {
+      res.statusCode = 500;
+      res.end('Internal error');
+    }
+  });
 
-	return new Promise((resolve) => {
-		server
-			.listen(1455, "127.0.0.1", () => {
-				resolve({
-					close: () => server.close(),
-					cancelWait: () => {
-						cancelled = true
-					},
-					waitForCode: async () => {
-						const sleep = () => new Promise((r) => setTimeout(r, 100))
-						for (let i = 0; i < 600; i += 1) {
-							if (lastCode) return { code: lastCode }
-							if (cancelled) return null
-							await sleep()
-						}
-						return null
-					},
-				})
-			})
-			.on("error", (err: NodeJS.ErrnoException) => {
-				console.error(
-					"[openai-codex] Failed to bind http://127.0.0.1:1455 (",
-					err.code,
-					") Falling back to manual paste.",
-				)
-				resolve({
-					close: () => {
-						try {
-							server.close()
-						} catch {
-							// ignore
-						}
-					},
-					cancelWait: () => {},
-					waitForCode: async () => null,
-				})
-			})
-	})
+  return new Promise(resolve => {
+    server
+      .listen(1455, '127.0.0.1', () => {
+        resolve({
+          close: () => server.close(),
+          cancelWait: () => {
+            cancelled = true;
+          },
+          waitForCode: async () => {
+            const sleep = () => new Promise(r => setTimeout(r, 100));
+            for (let i = 0; i < 600; i += 1) {
+              if (lastCode) return { code: lastCode };
+              if (cancelled) return null;
+              await sleep();
+            }
+            return null;
+          },
+        });
+      })
+      .on('error', (err: NodeJS.ErrnoException) => {
+        console.error(
+          '[openai-codex] Failed to bind http://127.0.0.1:1455 (',
+          err.code,
+          ') Falling back to manual paste.',
+        );
+        resolve({
+          close: () => {
+            try {
+              server.close();
+            } catch {
+              // ignore
+            }
+          },
+          cancelWait: () => {},
+          waitForCode: async () => null,
+        });
+      });
+  });
 }
 
 function getAccountId(accessToken: string): string | null {
-	const payload = decodeJwt(accessToken)
-	const auth = payload?.[JWT_CLAIM_PATH]
-	const accountId = auth?.chatgpt_account_id
-	return typeof accountId === "string" && accountId.length > 0
-		? accountId
-		: null
+  const payload = decodeJwt(accessToken);
+  const auth = payload?.[JWT_CLAIM_PATH];
+  const accountId = auth?.chatgpt_account_id;
+  return typeof accountId === 'string' && accountId.length > 0 ? accountId : null;
 }
 
 /**
@@ -344,160 +315,156 @@ function getAccountId(accessToken: string): string | null {
  * @param options.originator - OAuth originator parameter (defaults to "pi")
  */
 export async function loginOpenAICodex(options: {
-	onAuth: (info: { url: string; instructions?: string }) => void
-	onPrompt: (prompt: OAuthPrompt) => Promise<string>
-	onProgress?: (message: string) => void
-	onManualCodeInput?: () => Promise<string>
-	originator?: string
+  onAuth: (info: { url: string; instructions?: string }) => void;
+  onPrompt: (prompt: OAuthPrompt) => Promise<string>;
+  onProgress?: (message: string) => void;
+  onManualCodeInput?: () => Promise<string>;
+  originator?: string;
 }): Promise<OAuthCredentials> {
-	const { verifier, state, url } = await createAuthorizationFlow(
-		options.originator,
-	)
-	const server = await startLocalOAuthServer(state)
+  const { verifier, state, url } = await createAuthorizationFlow(options.originator);
+  const server = await startLocalOAuthServer(state);
 
-	options.onAuth({
-		url,
-		instructions: "A browser window should open. Complete login to finish.",
-	})
+  options.onAuth({
+    url,
+    instructions: 'A browser window should open. Complete login to finish.',
+  });
 
-	let code: string | undefined
-	try {
-		if (options.onManualCodeInput) {
-			// Race between browser callback and manual input
-			let manualCode: string | undefined
-			let manualError: Error | undefined
-			const manualPromise = options
-				.onManualCodeInput()
-				.then((input) => {
-					manualCode = input
-					server.cancelWait()
-				})
-				.catch((err) => {
-					manualError = err instanceof Error ? err : new Error(String(err))
-					server.cancelWait()
-				})
+  let code: string | undefined;
+  try {
+    if (options.onManualCodeInput) {
+      // Race between browser callback and manual input
+      let manualCode: string | undefined;
+      let manualError: Error | undefined;
+      const manualPromise = options
+        .onManualCodeInput()
+        .then(input => {
+          manualCode = input;
+          server.cancelWait();
+        })
+        .catch(err => {
+          manualError = err instanceof Error ? err : new Error(String(err));
+          server.cancelWait();
+        });
 
-			const result = await server.waitForCode()
+      const result = await server.waitForCode();
 
-			// If manual input was cancelled, throw that error
-			if (manualError) {
-				throw manualError
-			}
+      // If manual input was cancelled, throw that error
+      if (manualError) {
+        throw manualError;
+      }
 
-			if (result?.code) {
-				// Browser callback won
-				code = result.code
-			} else if (manualCode) {
-				// Manual input won (or callback timed out and user had entered code)
-				const parsed = parseAuthorizationInput(manualCode)
-				if (parsed.state && parsed.state !== state) {
-					throw new Error("State mismatch")
-				}
-				code = parsed.code
-			}
+      if (result?.code) {
+        // Browser callback won
+        code = result.code;
+      } else if (manualCode) {
+        // Manual input won (or callback timed out and user had entered code)
+        const parsed = parseAuthorizationInput(manualCode);
+        if (parsed.state && parsed.state !== state) {
+          throw new Error('State mismatch');
+        }
+        code = parsed.code;
+      }
 
-			// If still no code, wait for manual promise to complete and try that
-			if (!code) {
-				await manualPromise
-				if (manualError) {
-					throw manualError
-				}
-				if (manualCode) {
-					const parsed = parseAuthorizationInput(manualCode)
-					if (parsed.state && parsed.state !== state) {
-						throw new Error("State mismatch")
-					}
-					code = parsed.code
-				}
-			}
-		} else {
-			// Original flow: wait for callback, then prompt if needed
-			const result = await server.waitForCode()
-			if (result?.code) {
-				code = result.code
-			}
-		}
+      // If still no code, wait for manual promise to complete and try that
+      if (!code) {
+        await manualPromise;
+        if (manualError) {
+          throw manualError;
+        }
+        if (manualCode) {
+          const parsed = parseAuthorizationInput(manualCode);
+          if (parsed.state && parsed.state !== state) {
+            throw new Error('State mismatch');
+          }
+          code = parsed.code;
+        }
+      }
+    } else {
+      // Original flow: wait for callback, then prompt if needed
+      const result = await server.waitForCode();
+      if (result?.code) {
+        code = result.code;
+      }
+    }
 
-		// Fallback to onPrompt if still no code
-		if (!code) {
-			const input = await options.onPrompt({
-				message: "Paste the authorization code (or full redirect URL):",
-			})
-			const parsed = parseAuthorizationInput(input)
-			if (parsed.state && parsed.state !== state) {
-				throw new Error("State mismatch")
-			}
-			code = parsed.code
-		}
+    // Fallback to onPrompt if still no code
+    if (!code) {
+      const input = await options.onPrompt({
+        message: 'Paste the authorization code (or full redirect URL):',
+      });
+      const parsed = parseAuthorizationInput(input);
+      if (parsed.state && parsed.state !== state) {
+        throw new Error('State mismatch');
+      }
+      code = parsed.code;
+    }
 
-		if (!code) {
-			throw new Error("Missing authorization code")
-		}
+    if (!code) {
+      throw new Error('Missing authorization code');
+    }
 
-		const tokenResult = await exchangeAuthorizationCode(code, verifier)
-		if (tokenResult.type !== "success") {
-			throw new Error("Token exchange failed")
-		}
+    const tokenResult = await exchangeAuthorizationCode(code, verifier);
+    if (tokenResult.type !== 'success') {
+      throw new Error('Token exchange failed');
+    }
 
-		const accountId = getAccountId(tokenResult.access)
-		if (!accountId) {
-			throw new Error("Failed to extract accountId from token")
-		}
+    const accountId = getAccountId(tokenResult.access);
+    if (!accountId) {
+      throw new Error('Failed to extract accountId from token');
+    }
 
-		return {
-			access: tokenResult.access,
-			refresh: tokenResult.refresh,
-			expires: tokenResult.expires,
-			accountId,
-		}
-	} finally {
-		server.close()
-	}
+    return {
+      access: tokenResult.access,
+      refresh: tokenResult.refresh,
+      expires: tokenResult.expires,
+      accountId,
+    };
+  } finally {
+    server.close();
+  }
 }
 
 /**
  * Refresh OpenAI Codex OAuth token
  */
-export async function refreshOpenAICodexToken(
-	refreshToken: string,
-): Promise<OAuthCredentials> {
-	const result = await refreshAccessToken(refreshToken)
-	if (result.type !== "success") {
-		throw new Error("Failed to refresh OpenAI Codex token")
-	}
+export async function refreshOpenAICodexToken(refreshToken: string): Promise<OAuthCredentials> {
+  const result = await refreshAccessToken(refreshToken);
+  if (result.type !== 'success') {
+    throw new Error('Failed to refresh OpenAI Codex token');
+  }
 
-	const accountId = getAccountId(result.access)
-	if (!accountId) {
-		throw new Error("Failed to extract accountId from token")
-	}
+  const accountId = getAccountId(result.access);
+  if (!accountId) {
+    throw new Error('Failed to extract accountId from token');
+  }
 
-	return {
-		access: result.access,
-		refresh: result.refresh,
-		expires: result.expires,
-		accountId,
-	}
+  return {
+    access: result.access,
+    refresh: result.refresh,
+    expires: result.expires,
+    accountId,
+  };
 }
 
 export const openaiCodexOAuthProvider: OAuthProviderInterface = {
-	id: "openai-codex",
-	name: "ChatGPT Plus/Pro (Codex Subscription)",
-	usesCallbackServer: true,
+  id: 'openai-codex',
+  name: 'ChatGPT Plus/Pro (Codex Subscription)',
+  usesCallbackServer: true,
 
-	async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
-		return loginOpenAICodex({
-			onAuth: callbacks.onAuth,
-			onPrompt: callbacks.onPrompt,
-			onProgress: callbacks.onProgress,
-			onManualCodeInput: callbacks.onManualCodeInput,
-		})
-	},
+  async login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+    return loginOpenAICodex({
+      onAuth: callbacks.onAuth,
+      onPrompt: callbacks.onPrompt,
+      onProgress: callbacks.onProgress,
+      onManualCodeInput: callbacks.onManualCodeInput,
+    });
+  },
 
-	async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-		return refreshOpenAICodexToken(credentials.refresh)
-	},
+  async refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials> {
+    return refreshOpenAICodexToken(credentials.refresh);
+  },
 
-	getApiKey(credentials: OAuthCredentials): string {
-		return credentials.access
-	},
-}
+  getApiKey(credentials: OAuthCredentials): string {
+    return credentials.access;
+  },
+};

--- a/mastracode/src/auth/storage.ts
+++ b/mastracode/src/auth/storage.ts
@@ -4,289 +4,278 @@
  * Also stores global preferences like last used model.
  */
 
-import {
-	existsSync,
-	mkdirSync,
-	readFileSync,
-	writeFileSync,
-	chmodSync,
-} from "node:fs"
-import { dirname, join } from "node:path"
-import { getAppDataDir } from "../utils/project.js"
-import { anthropicOAuthProvider } from "./providers/anthropic.js"
-import { openaiCodexOAuthProvider } from "./providers/openai-codex.js"
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { getAppDataDir } from '../utils/project.js';
+import { anthropicOAuthProvider } from './providers/anthropic.js';
+import { openaiCodexOAuthProvider } from './providers/openai-codex.js';
 import type {
-	AuthCredential,
-	AuthStorageData,
-	OAuthLoginCallbacks,
-	OAuthProviderId,
-	OAuthProviderInterface,
-} from "./types.js"
+  AuthCredential,
+  AuthStorageData,
+  OAuthLoginCallbacks,
+  OAuthProviderId,
+  OAuthProviderInterface,
+} from './types.js';
 
 /**
  * Best/default models for each OAuth provider.
  * Used when auto-selecting a model after login.
  */
 export const PROVIDER_DEFAULT_MODELS: Record<OAuthProviderId, string> = {
-	anthropic: "anthropic/claude-opus-4-6",
-	"openai-codex": "openai/gpt-5.3-codex",
-}
+  anthropic: 'anthropic/claude-opus-4-6',
+  'openai-codex': 'openai/gpt-5.3-codex',
+};
 
 // Provider registry
 const oauthProviderRegistry = new Map<string, OAuthProviderInterface>([
-	[anthropicOAuthProvider.id, anthropicOAuthProvider],
-	[openaiCodexOAuthProvider.id, openaiCodexOAuthProvider],
-])
+  [anthropicOAuthProvider.id, anthropicOAuthProvider],
+  [openaiCodexOAuthProvider.id, openaiCodexOAuthProvider],
+]);
 
 /**
  * Get an OAuth provider by ID
  */
-export function getOAuthProvider(
-	id: OAuthProviderId,
-): OAuthProviderInterface | undefined {
-	return oauthProviderRegistry.get(id)
+export function getOAuthProvider(id: OAuthProviderId): OAuthProviderInterface | undefined {
+  return oauthProviderRegistry.get(id);
 }
 
 /**
  * Get all registered OAuth providers
  */
 export function getOAuthProviders(): OAuthProviderInterface[] {
-	return Array.from(oauthProviderRegistry.values())
+  return Array.from(oauthProviderRegistry.values());
 }
 
 /**
  * Credential storage backed by a JSON file.
  */
 export class AuthStorage {
-	private data: AuthStorageData = {}
+  private data: AuthStorageData = {};
 
-	constructor(private authPath: string = join(getAppDataDir(), "auth.json")) {
-		this.reload()
-	}
+  constructor(private authPath: string = join(getAppDataDir(), 'auth.json')) {
+    this.reload();
+  }
 
-	/**
-	 * Reload credentials from disk.
-	 */
-	reload(): void {
-		if (!existsSync(this.authPath)) {
-			this.data = {}
-			return
-		}
-		try {
-			this.data = JSON.parse(readFileSync(this.authPath, "utf-8"))
-		} catch {
-			this.data = {}
-		}
-	}
+  /**
+   * Reload credentials from disk.
+   */
+  reload(): void {
+    if (!existsSync(this.authPath)) {
+      this.data = {};
+      return;
+    }
+    try {
+      this.data = JSON.parse(readFileSync(this.authPath, 'utf-8'));
+    } catch {
+      this.data = {};
+    }
+  }
 
-	/**
-	 * Save credentials to disk.
-	 */
-	private save(): void {
-		const dir = dirname(this.authPath)
-		if (!existsSync(dir)) {
-			mkdirSync(dir, { recursive: true, mode: 0o700 })
-		}
-		writeFileSync(this.authPath, JSON.stringify(this.data, null, 2), "utf-8")
-		chmodSync(this.authPath, 0o600)
-	}
+  /**
+   * Save credentials to disk.
+   */
+  private save(): void {
+    const dir = dirname(this.authPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+    writeFileSync(this.authPath, JSON.stringify(this.data, null, 2), 'utf-8');
+    chmodSync(this.authPath, 0o600);
+  }
 
-	/**
-	 * Get credential for a provider.
-	 */
-	get(provider: string): AuthCredential | undefined {
-		return this.data[provider] ?? undefined
-	}
+  /**
+   * Get credential for a provider.
+   */
+  get(provider: string): AuthCredential | undefined {
+    return this.data[provider] ?? undefined;
+  }
 
-	/**
-	 * Set credential for a provider.
-	 */
-	set(provider: string, credential: AuthCredential): void {
-		this.data[provider] = credential
-		this.save()
-	}
+  /**
+   * Set credential for a provider.
+   */
+  set(provider: string, credential: AuthCredential): void {
+    this.data[provider] = credential;
+    this.save();
+  }
 
-	/**
-	 * Remove credential for a provider.
-	 */
-	remove(provider: string): void {
-		delete this.data[provider]
-		this.save()
-	}
+  /**
+   * Remove credential for a provider.
+   */
+  remove(provider: string): void {
+    delete this.data[provider];
+    this.save();
+  }
 
-	/**
-	 * List all providers with credentials.
-	 */
-	list(): string[] {
-		return Object.keys(this.data)
-	}
+  /**
+   * List all providers with credentials.
+   */
+  list(): string[] {
+    return Object.keys(this.data);
+  }
 
-	/**
-	 * Check if credentials exist for a provider.
-	 */
-	has(provider: string): boolean {
-		return provider in this.data
-	}
+  /**
+   * Check if credentials exist for a provider.
+   */
+  has(provider: string): boolean {
+    return provider in this.data;
+  }
 
-	/**
-	 * Check if logged in via OAuth for a provider.
-	 */
-	isLoggedIn(provider: string): boolean {
-		const cred = this.data[provider]
-		return cred?.type === "oauth"
-	}
+  /**
+   * Check if logged in via OAuth for a provider.
+   */
+  isLoggedIn(provider: string): boolean {
+    const cred = this.data[provider];
+    return cred?.type === 'oauth';
+  }
 
-	/**
-	 * Login to an OAuth provider.
-	 */
-	async login(
-		providerId: OAuthProviderId,
-		callbacks: OAuthLoginCallbacks,
-	): Promise<void> {
-		const provider = getOAuthProvider(providerId)
-		if (!provider) {
-			throw new Error(`Unknown OAuth provider: ${providerId}`)
-		}
+  /**
+   * Login to an OAuth provider.
+   */
+  async login(providerId: OAuthProviderId, callbacks: OAuthLoginCallbacks): Promise<void> {
+    const provider = getOAuthProvider(providerId);
+    if (!provider) {
+      throw new Error(`Unknown OAuth provider: ${providerId}`);
+    }
 
-		const credentials = await provider.login(callbacks)
-		this.set(providerId, { type: "oauth", ...credentials })
-	}
+    const credentials = await provider.login(callbacks);
+    this.set(providerId, { type: 'oauth', ...credentials });
+  }
 
-	/**
-	 * Logout from a provider.
-	 */
-	logout(provider: string): void {
-		this.remove(provider)
-	}
+  /**
+   * Logout from a provider.
+   */
+  logout(provider: string): void {
+    this.remove(provider);
+  }
 
-	/**
-	 * Get API key for a provider, auto-refreshing OAuth tokens if needed.
-	 */
-	async getApiKey(providerId: string): Promise<string | undefined> {
-		const cred = this.data[providerId]
+  /**
+   * Get API key for a provider, auto-refreshing OAuth tokens if needed.
+   */
+  async getApiKey(providerId: string): Promise<string | undefined> {
+    const cred = this.data[providerId];
 
-		if (cred?.type === "api_key") {
-			return cred.key
-		}
+    if (cred?.type === 'api_key') {
+      return cred.key;
+    }
 
-		if (cred?.type === "oauth") {
-			const provider = getOAuthProvider(providerId)
-			if (!provider) {
-				return undefined
-			}
+    if (cred?.type === 'oauth') {
+      const provider = getOAuthProvider(providerId);
+      if (!provider) {
+        return undefined;
+      }
 
-			// Check if token needs refresh
-			if (Date.now() >= cred.expires) {
-				try {
-					const newCreds = await provider.refreshToken(cred)
-					this.set(providerId, { type: "oauth", ...newCreds })
-					return provider.getApiKey(newCreds)
-				} catch {
-					// Refresh failed - user needs to re-login
-					return undefined
-				}
-			}
+      // Check if token needs refresh
+      if (Date.now() >= cred.expires) {
+        try {
+          const newCreds = await provider.refreshToken(cred);
+          this.set(providerId, { type: 'oauth', ...newCreds });
+          return provider.getApiKey(newCreds);
+        } catch {
+          // Refresh failed - user needs to re-login
+          return undefined;
+        }
+      }
 
-			return provider.getApiKey(cred)
-		}
+      return provider.getApiKey(cred);
+    }
 
-		return undefined
-	}
+    return undefined;
+  }
 
-	/**
-	 * Get the last used model ID (global preference).
-	 */
-	getLastModelId(): string | undefined {
-		return (this.data as any)._lastModelId
-	}
+  /**
+   * Get the last used model ID (global preference).
+   */
+  getLastModelId(): string | undefined {
+    return (this.data as any)._lastModelId;
+  }
 
-	/**
-	 * Set the last used model ID (global preference).
-	 */
-	setLastModelId(modelId: string): void {
-		;(this.data as any)._lastModelId = modelId
-		this.save()
-	}
+  /**
+   * Set the last used model ID (global preference).
+   */
+  setLastModelId(modelId: string): void {
+    (this.data as any)._lastModelId = modelId;
+    this.save();
+  }
 
-	/**
-	 * Get the global model ID for a specific mode.
-	 * @param modeId Mode ID (e.g., "build", "plan", "explore")
-	 */
-	getModeModelId(modeId: string): string | undefined {
-		return (this.data as any)[`_modeModelId_${modeId}`]
-	}
+  /**
+   * Get the global model ID for a specific mode.
+   * @param modeId Mode ID (e.g., "build", "plan", "explore")
+   */
+  getModeModelId(modeId: string): string | undefined {
+    return (this.data as any)[`_modeModelId_${modeId}`];
+  }
 
-	/**
-	 * Set the global model ID for a specific mode.
-	 * @param modeId Mode ID (e.g., "build", "plan", "explore")
-	 * @param modelId Full model ID
-	 */
-	setModeModelId(modeId: string, modelId: string): void {
-		;(this.data as any)[`_modeModelId_${modeId}`] = modelId
-		this.save()
-	}
+  /**
+   * Set the global model ID for a specific mode.
+   * @param modeId Mode ID (e.g., "build", "plan", "explore")
+   * @param modelId Full model ID
+   */
+  setModeModelId(modeId: string, modelId: string): void {
+    (this.data as any)[`_modeModelId_${modeId}`] = modelId;
+    this.save();
+  }
 
-	/**
-	 * Get the global subagent model ID for an agent type.
-	 * @param agentType Optional agent type (explore, plan, execute)
-	 */
-	getSubagentModelId(agentType?: string): string | undefined {
-		if (agentType) {
-			return (this.data as any)[`_subagentModelId_${agentType}`]
-		}
-		return (this.data as any)._subagentModelId
-	}
+  /**
+   * Get the global subagent model ID for an agent type.
+   * @param agentType Optional agent type (explore, plan, execute)
+   */
+  getSubagentModelId(agentType?: string): string | undefined {
+    if (agentType) {
+      return (this.data as any)[`_subagentModelId_${agentType}`];
+    }
+    return (this.data as any)._subagentModelId;
+  }
 
-	/**
-	 * Set the global subagent model ID for an agent type.
-	 * @param modelId Full model ID
-	 * @param agentType Optional agent type (explore, plan, execute)
-	 */
-	setSubagentModelId(modelId: string, agentType?: string): void {
-		if (agentType) {
-			;(this.data as any)[`_subagentModelId_${agentType}`] = modelId
-		} else {
-			;(this.data as any)._subagentModelId = modelId
-		}
-		this.save()
-	}
+  /**
+   * Set the global subagent model ID for an agent type.
+   * @param modelId Full model ID
+   * @param agentType Optional agent type (explore, plan, execute)
+   */
+  setSubagentModelId(modelId: string, agentType?: string): void {
+    if (agentType) {
+      (this.data as any)[`_subagentModelId_${agentType}`] = modelId;
+    } else {
+      (this.data as any)._subagentModelId = modelId;
+    }
+    this.save();
+  }
 
-	/**
-	 * Get the default model for a provider after login.
-	 */
-	getDefaultModelForProvider(providerId: OAuthProviderId): string | undefined {
-		return PROVIDER_DEFAULT_MODELS[providerId]
-	}
+  /**
+   * Get the default model for a provider after login.
+   */
+  getDefaultModelForProvider(providerId: OAuthProviderId): string | undefined {
+    return PROVIDER_DEFAULT_MODELS[providerId];
+  }
 
-	// ===========================================================================
-	// Model Usage Ranking
-	// ===========================================================================
+  // ===========================================================================
+  // Model Usage Ranking
+  // ===========================================================================
 
-	private getModelRanks(): Record<string, number> {
-		return (this.data as any)._modelRanks ?? {}
-	}
+  private getModelRanks(): Record<string, number> {
+    return (this.data as any)._modelRanks ?? {};
+  }
 
-	/**
-	 * Get the use count for a model (0 if never used).
-	 */
-	getModelUseCount(modelId: string): number {
-		return this.getModelRanks()[modelId] ?? 0
-	}
+  /**
+   * Get the use count for a model (0 if never used).
+   */
+  getModelUseCount(modelId: string): number {
+    return this.getModelRanks()[modelId] ?? 0;
+  }
 
-	/**
-	 * Get all model use counts.
-	 */
-	getAllModelUseCounts(): Record<string, number> {
-		return { ...this.getModelRanks() }
-	}
+  /**
+   * Get all model use counts.
+   */
+  getAllModelUseCounts(): Record<string, number> {
+    return { ...this.getModelRanks() };
+  }
 
-	/**
-	 * Increment the use count for a model and persist.
-	 */
-	incrementModelUseCount(modelId: string): void {
-		const ranks = this.getModelRanks()
-		ranks[modelId] = (ranks[modelId] ?? 0) + 1
-		;(this.data as any)._modelRanks = ranks
-		this.save()
-	}
+  /**
+   * Increment the use count for a model and persist.
+   */
+  incrementModelUseCount(modelId: string): void {
+    const ranks = this.getModelRanks();
+    ranks[modelId] = (ranks[modelId] ?? 0) + 1;
+    (this.data as any)._modelRanks = ranks;
+    this.save();
+  }
 }

--- a/mastracode/src/auth/types.ts
+++ b/mastracode/src/auth/types.ts
@@ -3,59 +3,59 @@
  */
 
 export interface OAuthCredentials {
-	refresh: string
-	access: string
-	expires: number
-	[key: string]: unknown
+  refresh: string;
+  access: string;
+  expires: number;
+  [key: string]: unknown;
 }
 
-export type OAuthProviderId = string
+export type OAuthProviderId = string;
 
 export interface OAuthAuthInfo {
-	url: string
-	instructions?: string
+  url: string;
+  instructions?: string;
 }
 
 export interface OAuthPrompt {
-	message: string
-	placeholder?: string
-	allowEmpty?: boolean
+  message: string;
+  placeholder?: string;
+  allowEmpty?: boolean;
 }
 
 export interface OAuthLoginCallbacks {
-	onAuth: (info: OAuthAuthInfo) => void
-	onPrompt: (prompt: OAuthPrompt) => Promise<string>
-	onProgress?: (message: string) => void
-	onManualCodeInput?: () => Promise<string>
-	signal?: AbortSignal
+  onAuth: (info: OAuthAuthInfo) => void;
+  onPrompt: (prompt: OAuthPrompt) => Promise<string>;
+  onProgress?: (message: string) => void;
+  onManualCodeInput?: () => Promise<string>;
+  signal?: AbortSignal;
 }
 
 export interface OAuthProviderInterface {
-	readonly id: OAuthProviderId
-	readonly name: string
+  readonly id: OAuthProviderId;
+  readonly name: string;
 
-	/** Whether this provider uses a local callback server (vs manual code paste) */
-	readonly usesCallbackServer?: boolean
+  /** Whether this provider uses a local callback server (vs manual code paste) */
+  readonly usesCallbackServer?: boolean;
 
-	/** Run the login flow, return credentials to persist */
-	login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials>
+  /** Run the login flow, return credentials to persist */
+  login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials>;
 
-	/** Refresh expired credentials, return updated credentials to persist */
-	refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials>
+  /** Refresh expired credentials, return updated credentials to persist */
+  refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials>;
 
-	/** Convert credentials to API key string for the provider */
-	getApiKey(credentials: OAuthCredentials): string
+  /** Convert credentials to API key string for the provider */
+  getApiKey(credentials: OAuthCredentials): string;
 }
 
 export type ApiKeyCredential = {
-	type: "api_key"
-	key: string
-}
+  type: 'api_key';
+  key: string;
+};
 
 export type OAuthCredential = {
-	type: "oauth"
-} & OAuthCredentials
+  type: 'oauth';
+} & OAuthCredentials;
 
-export type AuthCredential = ApiKeyCredential | OAuthCredential
+export type AuthCredential = ApiKeyCredential | OAuthCredential;
 
-export type AuthStorageData = Record<string, AuthCredential>
+export type AuthStorageData = Record<string, AuthCredential>;

--- a/mastracode/src/clipboard/index.ts
+++ b/mastracode/src/clipboard/index.ts
@@ -5,14 +5,14 @@
  * Uses synchronous execution (execSync) since this only runs on paste events.
  */
 
-import { execSync } from "node:child_process"
-import { readFileSync, unlinkSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { execSync } from 'node:child_process';
+import { readFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 export interface ClipboardImage {
-	data: string // base64-encoded image data
-	mimeType: string
+  data: string; // base64-encoded image data
+  mimeType: string;
 }
 
 /**
@@ -20,17 +20,17 @@ export interface ClipboardImage {
  * Returns null if no image data is found or extraction fails.
  */
 export function getClipboardImage(): ClipboardImage | null {
-	try {
-		if (process.platform === "darwin") {
-			return getMacClipboardImage()
-		}
-		if (process.platform === "linux") {
-			return getLinuxClipboardImage()
-		}
-		return null
-	} catch {
-		return null
-	}
+  try {
+    if (process.platform === 'darwin') {
+      return getMacClipboardImage();
+    }
+    if (process.platform === 'linux') {
+      return getLinuxClipboardImage();
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 // =============================================================================
@@ -38,60 +38,60 @@ export function getClipboardImage(): ClipboardImage | null {
 // =============================================================================
 
 function getMacClipboardImage(): ClipboardImage | null {
-	// Check clipboard types
-	let clipInfo: string
-	try {
-		clipInfo = execSync("osascript -e 'clipboard info'", {
-			encoding: "utf-8",
-			timeout: 3000,
-			stdio: ["pipe", "pipe", "pipe"],
-		})
-	} catch {
-		return null
-	}
+  // Check clipboard types
+  let clipInfo: string;
+  try {
+    clipInfo = execSync("osascript -e 'clipboard info'", {
+      encoding: 'utf-8',
+      timeout: 3000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch {
+    return null;
+  }
 
-	// Look for image types: PNGf (PNG), TIFF, or public.png
-	const hasPng = clipInfo.includes("PNGf") || clipInfo.includes("public.png")
-	const hasTiff = clipInfo.includes("TIFF")
+  // Look for image types: PNGf (PNG), TIFF, or public.png
+  const hasPng = clipInfo.includes('PNGf') || clipInfo.includes('public.png');
+  const hasTiff = clipInfo.includes('TIFF');
 
-	if (!hasPng && !hasTiff) {
-		return null
-	}
+  if (!hasPng && !hasTiff) {
+    return null;
+  }
 
-	// Extract image data to temp file
-	const tmpFile = join(tmpdir(), `mastra-clipboard-${Date.now()}.png`)
+  // Extract image data to temp file
+  const tmpFile = join(tmpdir(), `mastra-clipboard-${Date.now()}.png`);
 
-	try {
-		// Prefer PNG if available, otherwise convert TIFF
-		const clipboardClass = hasPng ? "PNGf" : "TIFF"
-		const script = `
+  try {
+    // Prefer PNG if available, otherwise convert TIFF
+    const clipboardClass = hasPng ? 'PNGf' : 'TIFF';
+    const script = `
 			set theImage to the clipboard as «class ${clipboardClass}»
 			set theFile to open for access POSIX file "${tmpFile}" with write permission
 			write theImage to theFile
 			close access theFile
-		`
-		execSync(`osascript -e '${script.replace(/'/g, "'\\''")}'`, {
-			timeout: 5000,
-			stdio: ["pipe", "pipe", "pipe"],
-		})
+		`;
+    execSync(`osascript -e '${script.replace(/'/g, "'\\''")}'`, {
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
 
-		// Read the file as base64
-		const buffer = readFileSync(tmpFile)
-		const base64 = buffer.toString("base64")
+    // Read the file as base64
+    const buffer = readFileSync(tmpFile);
+    const base64 = buffer.toString('base64');
 
-		return {
-			data: base64,
-			mimeType: hasPng ? "image/png" : "image/tiff",
-		}
-	} catch {
-		return null
-	} finally {
-		try {
-			unlinkSync(tmpFile)
-		} catch {
-			// ignore cleanup errors
-		}
-	}
+    return {
+      data: base64,
+      mimeType: hasPng ? 'image/png' : 'image/tiff',
+    };
+  } catch {
+    return null;
+  } finally {
+    try {
+      unlinkSync(tmpFile);
+    } catch {
+      // ignore cleanup errors
+    }
+  }
 }
 
 // =============================================================================
@@ -99,72 +99,72 @@ function getMacClipboardImage(): ClipboardImage | null {
 // =============================================================================
 
 function getLinuxClipboardImage(): ClipboardImage | null {
-	// Try xclip first, then wl-paste (Wayland)
-	return getLinuxClipboardImageXclip() ?? getLinuxClipboardImageWlPaste()
+  // Try xclip first, then wl-paste (Wayland)
+  return getLinuxClipboardImageXclip() ?? getLinuxClipboardImageWlPaste();
 }
 
 function getLinuxClipboardImageXclip(): ClipboardImage | null {
-	try {
-		// Check available targets
-		const targets = execSync("xclip -selection clipboard -target TARGETS -o", {
-			encoding: "utf-8",
-			timeout: 3000,
-			stdio: ["pipe", "pipe", "pipe"],
-		})
+  try {
+    // Check available targets
+    const targets = execSync('xclip -selection clipboard -target TARGETS -o', {
+      encoding: 'utf-8',
+      timeout: 3000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
 
-		if (!targets.includes("image/png")) {
-			return null
-		}
+    if (!targets.includes('image/png')) {
+      return null;
+    }
 
-		// Extract PNG data
-		const buffer = execSync("xclip -selection clipboard -target image/png -o", {
-			timeout: 5000,
-			stdio: ["pipe", "pipe", "pipe"],
-			maxBuffer: 50 * 1024 * 1024, // 50MB max
-		})
+    // Extract PNG data
+    const buffer = execSync('xclip -selection clipboard -target image/png -o', {
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      maxBuffer: 50 * 1024 * 1024, // 50MB max
+    });
 
-		if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
-			return null
-		}
+    if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+      return null;
+    }
 
-		return {
-			data: buffer.toString("base64"),
-			mimeType: "image/png",
-		}
-	} catch {
-		return null
-	}
+    return {
+      data: buffer.toString('base64'),
+      mimeType: 'image/png',
+    };
+  } catch {
+    return null;
+  }
 }
 
 function getLinuxClipboardImageWlPaste(): ClipboardImage | null {
-	try {
-		// Check if wl-paste is available and clipboard has image
-		const types = execSync("wl-paste --list-types", {
-			encoding: "utf-8",
-			timeout: 3000,
-			stdio: ["pipe", "pipe", "pipe"],
-		})
+  try {
+    // Check if wl-paste is available and clipboard has image
+    const types = execSync('wl-paste --list-types', {
+      encoding: 'utf-8',
+      timeout: 3000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
 
-		if (!types.includes("image/png")) {
-			return null
-		}
+    if (!types.includes('image/png')) {
+      return null;
+    }
 
-		// Extract PNG data
-		const buffer = execSync("wl-paste --type image/png", {
-			timeout: 5000,
-			stdio: ["pipe", "pipe", "pipe"],
-			maxBuffer: 50 * 1024 * 1024,
-		})
+    // Extract PNG data
+    const buffer = execSync('wl-paste --type image/png', {
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      maxBuffer: 50 * 1024 * 1024,
+    });
 
-		if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
-			return null
-		}
+    if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+      return null;
+    }
 
-		return {
-			data: buffer.toString("base64"),
-			mimeType: "image/png",
-		}
-	} catch {
-		return null
-	}
+    return {
+      data: buffer.toString('base64'),
+      mimeType: 'image/png',
+    };
+  } catch {
+    return null;
+  }
 }

--- a/mastracode/src/constants.ts
+++ b/mastracode/src/constants.ts
@@ -1,6 +1,6 @@
 // Default OM model - using gemini-2.5-flash for efficiency
-export const DEFAULT_OM_MODEL_ID = process.env.DEFAULT_OM_MODEL_ID ?? "google/gemini-2.5-flash"
+export const DEFAULT_OM_MODEL_ID = process.env.DEFAULT_OM_MODEL_ID ?? 'google/gemini-2.5-flash';
 
 // Default OM thresholds — per-thread overrides are loaded from thread metadata
-export const DEFAULT_OBS_THRESHOLD = 40_000
-export const DEFAULT_REF_THRESHOLD = 50_000
+export const DEFAULT_OBS_THRESHOLD = 40_000;
+export const DEFAULT_REF_THRESHOLD = 50_000;

--- a/mastracode/src/harness/harness.ts
+++ b/mastracode/src/harness/harness.ts
@@ -1,45 +1,33 @@
-import { appendFileSync } from "node:fs"
-import { join } from "node:path"
-import type { Agent, MastraMessageContentV2 } from "@mastra/core/agent"
-import type { StorageThreadType } from "@mastra/core/memory"
-import { RequestContext } from "@mastra/core/request-context"
-import { Workspace } from "@mastra/core/workspace"
-import type { WorkspaceConfig } from "@mastra/core/workspace"
-import type { z } from "zod"
+import { appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Agent, MastraMessageContentV2 } from '@mastra/core/agent';
+import type { StorageThreadType } from '@mastra/core/memory';
+import { RequestContext } from '@mastra/core/request-context';
+import { Workspace } from '@mastra/core/workspace';
+import type { WorkspaceConfig } from '@mastra/core/workspace';
+import type { z } from 'zod';
 
-import {
-	AuthStorage,
-	getOAuthProviders
-	
-	
-} from "../auth/index.js"
-import type {OAuthProviderInterface, OAuthLoginCallbacks} from "../auth/index.js";
-import type { HookManager } from "../hooks/index.js"
-import type { MCPManager } from "../mcp/index.js"
-import {
-	
-	
-	SessionGrants,
-	resolveApproval,
-	createDefaultRules,
-	getToolCategory
-} from "../permissions.js"
-import type {PermissionRules, ToolCategory} from "../permissions.js";
-import { parseError  } from "../utils/errors.js"
-import { acquireThreadLock, releaseThreadLock } from "../utils/thread-lock.js"
+import { AuthStorage, getOAuthProviders } from '../auth/index.js';
+import type { OAuthProviderInterface, OAuthLoginCallbacks } from '../auth/index.js';
+import type { HookManager } from '../hooks/index.js';
+import type { MCPManager } from '../mcp/index.js';
+import { SessionGrants, resolveApproval, createDefaultRules, getToolCategory } from '../permissions.js';
+import type { PermissionRules, ToolCategory } from '../permissions.js';
+import { parseError } from '../utils/errors.js';
+import { acquireThreadLock, releaseThreadLock } from '../utils/thread-lock.js';
 import type {
-	HeartbeatHandler,
-	HarnessConfig,
-	HarnessEvent,
-	HarnessEventListener,
-	HarnessMessage,
-	HarnessMessageContent,
-	HarnessMode,
-	HarnessRuntimeContext,
-	HarnessSession,
-	HarnessStateSchema,
-	HarnessThread,
-} from "./types"
+  HeartbeatHandler,
+  HarnessConfig,
+  HarnessEvent,
+  HarnessEventListener,
+  HarnessMessage,
+  HarnessMessageContent,
+  HarnessMode,
+  HarnessRuntimeContext,
+  HarnessSession,
+  HarnessStateSchema,
+  HarnessThread,
+} from './types';
 
 // =============================================================================
 /**
@@ -48,15 +36,15 @@ import type {
  * so we check .message, .error.message, and String() representation.
  */
 function errorContains(error: unknown, needle: string): boolean {
-	const errObj = error as Record<string, unknown>
-	const texts = [
-		String(error),
-		typeof errObj?.message === "string" ? errObj.message : "",
-		typeof (errObj?.error as Record<string, unknown>)?.message === "string"
-			? String((errObj.error as Record<string, unknown>).message)
-			: "",
-	]
-	return texts.some((t) => t.includes(needle))
+  const errObj = error as Record<string, unknown>;
+  const texts = [
+    String(error),
+    typeof errObj?.message === 'string' ? errObj.message : '',
+    typeof (errObj?.error as Record<string, unknown>)?.message === 'string'
+      ? String((errObj.error as Record<string, unknown>).message)
+      : '',
+  ];
+  return texts.some(t => t.includes(needle));
 }
 
 // Harness Class
@@ -116,2914 +104,2753 @@ function errorContains(error: unknown, needle: string): boolean {
  * ```
  */
 export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
-	readonly id: string
-
-	private config: HarnessConfig<TState>
-	private state: z.infer<TState>
-	private currentModeId: string
-	private currentThreadId: string | null = null
-	private resourceId: string
-	private defaultResourceId: string
-	private userId: string | undefined
-	private isRemoteStorage: boolean
-	private listeners: HarnessEventListener[] = []
-	private abortController: AbortController | null = null
-	private abortRequested: boolean = false
-	private currentRunId: string | null = null
-	private currentOperationId: number = 0
-	private followUpQueue: string[] = []
-	private pendingApprovalResolve:
-		| ((decision: "approve" | "decline" | "always_allow_category") => void)
-		| null = null
-	private workspace: Workspace | undefined = undefined
-	private workspaceFn:
-		| ((ctx: {
-				requestContext: RequestContext
-		  }) => Promise<Workspace | undefined> | Workspace | undefined)
-		| undefined = undefined
-	private workspaceInitialized = false
-	private hookManager: HookManager | undefined
-	private mcpManager: MCPManager | undefined
-	private sessionGrants = new SessionGrants()
-	private streamDebug = !!process.env.MASTRA_STREAM_DEBUG
-	private heartbeatTimers = new Map<
-		string,
-		{ timer: NodeJS.Timeout; shutdown?: () => void | Promise<void> }
-	>()
-	private pendingQuestions = new Map<string, (answer: string) => void>()
-	private pendingPlanApprovals = new Map<
-		string,
-		(result: { action: "approved" | "rejected"; feedback?: string }) => void
-	>()
-	private tokenUsage: {
-		promptTokens: number
-		completionTokens: number
-		totalTokens: number
-	} = {
-		promptTokens: 0,
-		completionTokens: 0,
-		totalTokens: 0,
-	}
-	constructor(config: HarnessConfig<TState>) {
-		this.id = config.id
-		this.config = config
-		this.resourceId = config.resourceId
-		this.defaultResourceId = config.defaultResourceId ?? config.resourceId
-		this.userId = config.userId
-		this.isRemoteStorage = config.isRemoteStorage ?? false
-
-		// Initialize state from schema defaults + initial state
-		this.state = {
-			...this.getSchemaDefaults(),
-			...config.initialState,
-		} as z.infer<TState>
-		// Find default mode
-		const defaultMode = config.modes.find((m) => m.default) ?? config.modes[0]
-		if (!defaultMode) {
-			throw new Error("Harness requires at least one agent mode")
-		}
-		this.currentModeId = defaultMode.id
-
-		// Store workspace: pre-built instance, dynamic factory, or config (constructed in init())
-		if (config.workspace instanceof Workspace) {
-			this.workspace = config.workspace
-		} else if (typeof config.workspace === "function") {
-			this.workspaceFn = config.workspace
-		}
-
-		// Store hook manager and MCP manager
-		this.hookManager = config.hookManager
-		this.mcpManager = config.mcpManager
-
-		// Seed model from mode default or global last model if not set
-		const currentModel = (this.state as any).currentModelId
-		if (!currentModel) {
-			const lastModelId = config.authStorage?.getLastModelId()
-			const seedModel = lastModelId || defaultMode.defaultModelId
-			if (seedModel) {
-				this.setState({ currentModelId: seedModel } as unknown as Partial<z.infer<TState>>)
-			}
-		}
-	}
-
-	// ===========================================================================
-	// Initialization
-	// ===========================================================================
-	/**
-	 * Initialize the harness - loads persisted state.
-	 * Must be called before using the harness.
-	 *
-	 * Note: Does NOT auto-select a thread. Call selectThread() or createThread() after init.
-	 */
-	async init(): Promise<void> {
-		// Initialize storage
-		await this.config.storage.init()
-
-		// Load persisted state from storage (if we have a state storage mechanism)
-		// For now, we use the initial state from config
-		// TODO: Add state persistence via storage.getStore('agents') or custom domain
-
-		// Initialize workspace if configured (skip for dynamic factory — resolved per-request)
-		if (this.config.workspace && !this.workspaceInitialized && !this.workspaceFn) {
-			try {
-				// Construct workspace from config if not already a Workspace instance
-				if (!this.workspace) {
-					this.workspace = new Workspace(
-						this.config.workspace as WorkspaceConfig,
-					)
-				}
-
-				this.emit({
-					type: "workspace_status_changed",
-					status: "initializing",
-				})
-
-				await this.workspace.init()
-				this.workspaceInitialized = true
-
-				this.emit({
-					type: "workspace_status_changed",
-					status: "ready",
-				})
-				this.emit({
-					type: "workspace_ready",
-					workspaceId: this.workspace.id,
-					workspaceName: this.workspace.name,
-				})
-			} catch (error) {
-				const err = error instanceof Error ? error : new Error(String(error))
-				console.warn("Workspace initialization failed:", err.message)
-				this.workspace = undefined
-				this.workspaceInitialized = false
-
-				this.emit({
-					type: "workspace_status_changed",
-					status: "error",
-					error: err,
-				})
-				this.emit({
-					type: "workspace_error",
-					error: err,
-				})
-			}
-		}
-
-		// Start heartbeat handlers
-		this.startHeartbeats()
-	}
-
-	/**
-	 * Select the most recent thread, or create one if none exist.
-	 * Convenience method for simple initialization.
-	 */
-	async selectOrCreateThread(): Promise<HarnessThread> {
-		const threads = await this.listThreads()
-
-		if (threads.length === 0) {
-			// createThread handles lock acquisition internally
-			return await this.createThread()
-		}
-
-		// Use the most recently updated thread
-		const sortedThreads = [...threads].sort(
-			(a, b) => b.updatedAt.getTime() - a.updatedAt.getTime(),
-		)
-        // Acquire lock on the thread
-        acquireThreadLock(sortedThreads[0]!.id)
-        this.currentThreadId = sortedThreads[0]!.id
-
-        // Load token usage and model ID for this thread
-        await this.loadThreadMetadata()
-
-        return sortedThreads[0]!
-	}
-
-	/**
-	 * Get the memory storage domain.
-	 * Throws if storage doesn't have a memory domain.
-	 */
-	private async getMemoryStorage(): Promise<
-		NonNullable<
-			Awaited<ReturnType<typeof this.config.storage.getStore<"memory">>>
-		>
-	> {
-		const memoryStorage = await this.config.storage.getStore("memory")
-		if (!memoryStorage) {
-			throw new Error("Storage does not have a memory domain configured")
-		}
-		return memoryStorage
-	}
-
-	// ===========================================================================
-	// State Management
-	// ===========================================================================
-
-	/**
-	 * Get current harness state (read-only snapshot).
-	 */
-	getState(): Readonly<z.infer<TState>> {
-		return { ...this.state }
-	}
-
-	/**
-	 * Update harness state. Validates against schema.
-	 * Emits state_changed event.
-	 */
-	async setState(updates: Partial<z.infer<TState>>): Promise<void> {
-		const changedKeys = Object.keys(updates)
-		const newState = { ...this.state, ...updates }
-
-		// Validate against schema
-		const result = this.config.stateSchema.safeParse(newState)
-		if (!result.success) {
-			throw new Error(`Invalid state update: ${result.error.message}`)
-		}
-
-		this.state = result.data as z.infer<TState>
-
-		// Persist specific state keys to thread metadata
-		if ("todos" in updates) {
-			// Only persist todos if they have items, otherwise remove from metadata
-			if (Array.isArray(updates.todos) && updates.todos.length > 0) {
-				this.persistThreadSetting("todos", updates.todos).catch(() => {})
-			} else {
-				// Remove todos from metadata when empty
-				this.removeThreadSetting("todos").catch(() => {})
-			}
-		}
-
-		this.emit({
-			type: "state_changed",
-			state: this.state,
-			changedKeys,
-		})
-	}
-
-	private getSchemaDefaults(): Partial<z.infer<TState>> {
-		// Extract defaults from Zod schema
-		const shape = this.config.stateSchema.shape
-		const defaults: Record<string, unknown> = {}
-
-		for (const [key, field] of Object.entries(shape)) {
-			if (field instanceof Object && "_def" in field) {
-				const def = (field as any)._def
-				if (def.defaultValue !== undefined) {
-					defaults[key] =
-						typeof def.defaultValue === "function"
-							? def.defaultValue()
-							: def.defaultValue
-				}
-			}
-		}
-
-		return defaults as Partial<z.infer<TState>>
-	}
-
-	// ===========================================================================
-	// Mode Management
-	// ===========================================================================
-
-	/**
-	 * Get all available modes.
-	 */
-	getModes(): HarnessMode<TState>[] {
-		return this.config.modes
-	}
-
-	/**
-	 * Get the hook manager (if configured).
-	 */
-	getHookManager(): HookManager | undefined {
-		return this.hookManager
-	}
-
-	/**
-	 * Get the MCP manager (if configured).
-	 */
-	getMcpManager(): MCPManager | undefined {
-		return this.mcpManager
-	}
-
-	/**
-	 * Register a pending question resolver.
-	 * Called by the ask_user tool to register a promise resolver
-	 * that will be resolved when the user answers in the TUI.
-	 */
-	registerQuestion(
-		questionId: string,
-		resolve: (answer: string) => void,
-	): void {
-		this.pendingQuestions.set(questionId, resolve)
-	}
-
-	/**
-	 * Resolve a pending question with the user's answer.
-	 * Called by the TUI when the user selects an option or submits text.
-	 */
-	respondToQuestion(questionId: string, answer: string): void {
-		const resolve = this.pendingQuestions.get(questionId)
-		if (resolve) {
-			this.pendingQuestions.delete(questionId)
-			resolve(answer)
-		}
-	}
-
-	/**
-	 * Register a pending plan approval resolver.
-	 * Called by the submit_plan tool to register a promise resolver.
-	 */
-	registerPlanApproval(
-		planId: string,
-		resolve: (result: {
-			action: "approved" | "rejected"
-			feedback?: string
-		}) => void,
-	): void {
-		this.pendingPlanApprovals.set(planId, resolve)
-	}
-
-	/**
-	 * Respond to a pending plan approval.
-	 * On approval: switches to Build mode, then resolves the promise.
-	 * On rejection: resolves with feedback (stays in Plan mode).
-	 */
-	async respondToPlanApproval(
-		planId: string,
-		response: { action: "approved" | "rejected"; feedback?: string },
-	): Promise<void> {
-		const resolve = this.pendingPlanApprovals.get(planId)
-		if (!resolve) return
-
-		this.pendingPlanApprovals.delete(planId)
-
-		// Resolve first so the plan approval component can update its UI
-		resolve(response)
-
-		if (response.action === "approved") {
-			await this.switchMode("build")
-			// Note: The TUI handles triggering the build agent via system reminder
-			// after this method completes, ensuring proper message ordering
-		}
-	}
-
-	/**
-	 * Get current mode ID.
-	 */
-	getCurrentModeId(): string {
-		return this.currentModeId
-	}
-
-	/**
-	 * Get current mode configuration.
-	 */
-	getCurrentMode(): HarnessMode<TState> {
-		const mode = this.config.modes.find((m) => m.id === this.currentModeId)
-		if (!mode) {
-			throw new Error(`Mode not found: ${this.currentModeId}`)
-		}
-		return mode
-	}
-	/**
-	 * Switch to a different mode.
-	 * Aborts any in-progress generation.
-	 * Also switches to the mode's stored model (or its default).
-	 */
-	async switchMode(modeId: string): Promise<void> {
-		const mode = this.config.modes.find((m) => m.id === modeId)
-		if (!mode) {
-			throw new Error(`Mode not found: ${modeId}`)
-		}
-
-		// Abort current operation if any
-		this.abort()
-
-		// Save current model to the outgoing mode before switching
-		const currentModelId = this.getCurrentModelId()
-		if (currentModelId) {
-			await this.persistThreadSetting(
-				`modeModelId_${this.currentModeId}`,
-				currentModelId,
-			)
-		}
-
-		const previousModeId = this.currentModeId
-		this.currentModeId = modeId
-
-		// Persist mode to thread metadata
-		await this.persistThreadSetting("currentModeId", modeId)
-
-		// Load the incoming mode's model
-		const modeModelId = await this.loadModeModelId(modeId)
-		if (modeModelId) {
-			this.setState({ currentModelId: modeModelId } as unknown as Partial<z.infer<TState>>)
-			this.emit({ type: "model_changed", modelId: modeModelId } as HarnessEvent)
-		}
-
-		this.emit({
-			type: "mode_changed",
-			modeId,
-			previousModeId,
-		})
-	}
-
-	/**
-	 * Load the stored model ID for a specific mode.
-	 * Falls back to: thread metadata → global per-mode → mode's defaultModelId → global last model → current model.
-	 */
-	private async loadModeModelId(modeId: string): Promise<string | null> {
-		// 1. Check thread metadata for per-mode model
-		if (this.currentThreadId) {
-			try {
-				const memoryStorage = await this.getMemoryStorage()
-				const thread = await memoryStorage.getThreadById({
-					threadId: this.currentThreadId,
-				})
-				const meta = thread?.metadata as Record<string, unknown> | undefined
-				const stored = meta?.[`modeModelId_${modeId}`] as string | undefined
-				if (stored) return stored
-			} catch {
-				// Fall through to defaults
-			}
-		}
-
-		// 2. Check global per-mode model from auth storage
-		const globalModeModel = this.config.authStorage?.getModeModelId(modeId)
-		if (globalModeModel) return globalModeModel
-
-		// 3. Fall back to mode's defaultModelId
-		const mode = this.config.modes.find((m) => m.id === modeId)
-		if (mode?.defaultModelId) return mode.defaultModelId
-
-		// 4. Fall back to global last model
-		const lastModelId = this.config.authStorage?.getLastModelId()
-		if (lastModelId) return lastModelId
-
-		// 5. Keep current model
-		return null
-	}
-	/**
-	 * Get the agent for the current mode.
-	 * Resolves dynamic agent functions with current state.
-	 */
-	private getCurrentAgent(): Agent {
-		const mode = this.getCurrentMode()
-		if (typeof mode.agent === "function") {
-			return mode.agent(this.state)
-		}
-		return mode.agent
-	}
-
-	/**
-	 * Get the current model name/ID.
-	 * Returns a short display name extracted from the model ID in state.
-	 */
-	getModelName(): string {
-		const modelId = this.getCurrentModelId()
-		if (modelId === "unknown") return modelId
-
-		// Extract just the model name from "provider/model" format
-		const parts = modelId.split("/")
-		return parts[parts.length - 1] || modelId
-	}
-
-	/**
-	 * Get the full model ID (e.g., "anthropic/claude-sonnet-4").
-	 * Reads from harness state (set via switchModel()).
-	 */
-	getFullModelId(): string {
-		return this.getCurrentModelId()
-	}
-
-	/**
-	 * Check if the current model has authentication configured (env var or OAuth).
-	 * Returns { hasAuth, apiKeyEnvVar } for the current model's provider.
-	 */
-	async getCurrentModelAuthStatus(): Promise<{
-		hasAuth: boolean
-		apiKeyEnvVar?: string
-	}> {
-		const modelId = this.getCurrentModelId()
-		const provider = modelId.split("/")[0]
-		if (!provider) return { hasAuth: true }
-
-		// Check OAuth
-		const providerToOAuthId: Record<string, string> = {
-			anthropic: "anthropic",
-			openai: "openai-codex",
-		}
-		const oauthId = providerToOAuthId[provider]
-		if (oauthId && this.config.authStorage?.isLoggedIn(oauthId)) {
-			return { hasAuth: true }
-		}
-
-		// Check env var via registry
-		try {
-			const { PROVIDER_REGISTRY } = await import("@mastra/core/llm")
-			const registry = PROVIDER_REGISTRY as Record<
-				string,
-				{ apiKeyEnvVar?: string }
-			>
-			const providerConfig = registry[provider]
-			const apiKeyEnvVar = providerConfig?.apiKeyEnvVar
-			if (apiKeyEnvVar && process.env[apiKeyEnvVar]) {
-				return { hasAuth: true }
-			}
-			return { hasAuth: false, apiKeyEnvVar: apiKeyEnvVar || undefined }
-		} catch {
-			return { hasAuth: true } // Can't check, assume OK
-		}
-	}
-
-	/**
-	 * Get list of available models from Mastra's provider registry.
-	 * Returns models grouped by provider, with API key availability info.
-	 */
-	async getAvailableModels(): Promise<
-		Array<{
-			id: string
-			provider: string
-			modelName: string
-			hasApiKey: boolean
-			apiKeyEnvVar?: string
-			useCount: number
-		}>
-	> {
-		try {
-			// Import from the public @mastra/core/llm export
-			const { PROVIDER_REGISTRY } = await import("@mastra/core/llm")
-
-			if (!PROVIDER_REGISTRY) {
-				console.warn("Provider registry not available")
-				return []
-			}
-
-			// PROVIDER_REGISTRY is a Proxy - use Object.keys to get providers
-			// Cast to Record<string, any> to allow string indexing
-			const registry = PROVIDER_REGISTRY as Record<
-				string,
-				{ models?: string[]; name?: string; apiKeyEnvVar?: string }
-			>
-			const providers = Object.keys(registry)
-			const useCounts = this.config.authStorage?.getAllModelUseCounts() ?? {}
-			const models: Array<{
-				id: string
-				provider: string
-				modelName: string
-				hasApiKey: boolean
-				apiKeyEnvVar?: string
-				useCount: number
-			}> = []
-			// Map model provider prefixes to OAuth provider IDs
-			const providerToOAuthId: Record<string, string> = {
-				anthropic: "anthropic",
-				openai: "openai-codex",
-			}
-
-			for (const provider of providers) {
-				const providerConfig = registry[provider]
-				// Check if API key is available via env var OR OAuth
-				const apiKeyEnvVar = providerConfig?.apiKeyEnvVar
-				const hasEnvKey = apiKeyEnvVar ? !!process.env[apiKeyEnvVar] : false
-				const oauthId = providerToOAuthId[provider]
-				const hasOAuth = oauthId
-					? (this.config.authStorage?.isLoggedIn(oauthId) ?? false)
-					: false
-				const hasApiKey = hasEnvKey || hasOAuth
-
-				// Each provider config has a 'models' array
-				if (providerConfig?.models && Array.isArray(providerConfig.models)) {
-					for (const modelName of providerConfig.models) {
-						const id = `${provider}/${modelName}`
-						models.push({
-							id,
-							provider,
-							modelName,
-							hasApiKey,
-							apiKeyEnvVar: apiKeyEnvVar || undefined,
-							useCount: useCounts[id] ?? 0,
-						})
-					}
-				}
-			}
-
-			return models
-		} catch (error) {
-			console.warn("Failed to load available models:", error)
-			return []
-		}
-	}
-	/**
-	 * Switch to a different model at runtime.
-	 * Updates the harness state which the dynamic model function reads.
-	 * Also saves per-mode and as global "last model" for new threads.
-	 * @param modelId Full model ID (e.g., "anthropic/claude-sonnet-4-20250514")
-	 */
-	/**
-	 * Switch the main agent model for a specific mode.
-	 * @param modelId Full model ID (e.g., "anthropic/claude-sonnet-4-20250514")
-	 * @param scope "global" for global default, "thread" for thread-specific setting
-	 * @param modeId Mode ID (defaults to current mode)
-	 */
-	async switchModel(
-		modelId: string,
-		scope: "global" | "thread" = "thread",
-		modeId?: string,
-	): Promise<void> {
-		const targetModeId = modeId ?? this.currentModeId
-
-		// Update current state for immediate effect if this is the current mode
-		if (targetModeId === this.currentModeId) {
-			this.setState({ currentModelId: modelId } as unknown as Partial<z.infer<TState>>)
-		}
-
-		// Persist based on scope
-		if (scope === "global") {
-			// Global default for this mode - save to auth storage
-			this.config.authStorage?.setModeModelId(targetModeId, modelId)
-		} else {
-			// Thread-specific setting for this mode - save to thread metadata
-			await this.persistThreadSetting(`modeModelId_${targetModeId}`, modelId)
-		}
-
-		// Always bump use count for ranking
-		this.config.authStorage?.incrementModelUseCount(modelId)
-
-		// Emit event so TUI can update status line
-		this.emit({
-			type: "model_changed",
-			modelId,
-			scope,
-			modeId: targetModeId,
-		} as HarnessEvent)
-	}
-	/**
-	 * Get the current model ID from state.
-	 * Returns empty string if no model is selected.
-	 */
-	getCurrentModelId(): string {
-		const state = this.getState() as { currentModelId?: string }
-		return state.currentModelId ?? ""
-	}
-
-	/**
-	 * Check if a model is currently selected.
-	 */
-	hasModelSelected(): boolean {
-		return this.getCurrentModelId() !== ""
-	}
-
-	// =========================================================================
-	// Observational Memory Model Management
-	// =========================================================================
-
-	/**
-	 * Get the current Observer model ID from state.
-	 */
-	getObserverModelId(): string {
-		const state = this.getState() as { observerModelId?: string }
-		return state.observerModelId ?? "google/gemini-2.5-flash"
-	}
-
-	/**
-	 * Get the current Reflector model ID from state.
-	 */
-	getReflectorModelId(): string {
-		const state = this.getState() as { reflectorModelId?: string }
-		return state.reflectorModelId ?? "google/gemini-2.5-flash"
-	}
-	/**
-	 * Switch the Observer model.
-	 * @param modelId Full model ID (e.g., "google/gemini-2.5-flash")
-	 */
-	async switchObserverModel(modelId: string): Promise<void> {
-		this.setState({ observerModelId: modelId } as unknown as Partial<z.infer<TState>>)
-		await this.persistThreadSetting("observerModelId", modelId)
-
-		this.emit({
-			type: "om_model_changed",
-			role: "observer",
-			modelId,
-		} as HarnessEvent)
-	}
-
-	/**
-	 * Switch the Reflector model.
-	 * @param modelId Full model ID (e.g., "google/gemini-2.5-flash")
-	 */
-	async switchReflectorModel(modelId: string): Promise<void> {
-		this.setState({ reflectorModelId: modelId } as unknown as Partial<z.infer<TState>>)
-		await this.persistThreadSetting("reflectorModelId", modelId)
-
-		this.emit({
-			type: "om_model_changed",
-			role: "reflector",
-			modelId,
-		} as HarnessEvent)
-	}
-
-	// =========================================================================
-	// Subagent Model Management
-	// =========================================================================
-
-	/**
-	 * Get the subagent model ID for a specific agent type.
-	 * Falls back to: per-type thread model → per-type global model → null.
-	 * @param agentType Optional agent type (explore, plan, execute)
-	 */
-	async getSubagentModelId(agentType?: string): Promise<string | null> {
-		// 1. Check thread metadata for per-type subagent model
-		if (agentType && this.currentThreadId) {
-			try {
-				const memoryStorage = await this.getMemoryStorage()
-				const thread = await memoryStorage.getThreadById({
-					threadId: this.currentThreadId,
-				})
-				const meta = thread?.metadata as Record<string, unknown> | undefined
-
-				const perTypeThread = meta?.[`subagentModelId_${agentType}`] as
-					| string
-					| undefined
-				if (perTypeThread) return perTypeThread
-			} catch {
-				// Fall through
-			}
-		}
-
-		// 2. Check global per-type subagent model from auth storage
-		if (agentType) {
-			const perTypeGlobal =
-				this.config.authStorage?.getSubagentModelId(agentType)
-			if (perTypeGlobal) return perTypeGlobal
-		}
-
-		// 3. No configured subagent model — caller should use defaults
-		return null
-	}
-
-	/**
-	 * Set the subagent model ID.
-	 * @param modelId Full model ID (e.g., "anthropic/claude-sonnet-4-20250514")
-	 * @param scope "global" for global default, "thread" for thread-level default
-	 * @param agentType Agent type (explore, plan, execute)
-	 */
-	async setSubagentModelId(
-		modelId: string,
-		scope: "global" | "thread" = "thread",
-		agentType?: string,
-	): Promise<void> {
-		if (!agentType) {
-			throw new Error("agentType is required for setSubagentModelId")
-		}
-
-		if (scope === "global") {
-			// Persist to auth storage (global preference per agent type)
-			this.config.authStorage?.setSubagentModelId(modelId, agentType)
-		} else {
-			// Persist thread-level subagent model per agent type
-			await this.persistThreadSetting(`subagentModelId_${agentType}`, modelId)
-		}
-
-		this.emit({
-			type: "subagent_model_changed",
-			modelId,
-			scope,
-			agentType,
-		} as HarnessEvent)
-	}
-
-	/**
-	 * Get YOLO mode state.
-	 */
-	getYoloMode(): boolean {
-		return (this.state as any)?.yolo === true
-	}
-	/**
-	 * Toggle YOLO mode (auto-approve all tool calls).
-	 */
-	setYoloMode(enabled: boolean): void {
-		this.setState({ yolo: enabled } as unknown as Partial<z.infer<TState>>)
-		this.persistThreadSetting("yolo", enabled).catch(() => {})
-		// When toggling YOLO off, reset session grants so user starts fresh
-		if (!enabled) {
-			this.sessionGrants.reset()
-		}
-	}
-
-	// =========================================================================
-	// Permissions
-	// =========================================================================
-
-	/**
-	 * Get the effective permission rules from state, with defaults.
-	 */
-	private getPermissionRules(): PermissionRules {
-		const stored = (this.state as any)?.permissionRules
-		const rules = createDefaultRules()
-		if (stored?.categories) {
-			Object.assign(rules.categories, stored.categories)
-		}
-		if (stored?.tools) {
-			Object.assign(rules.tools, stored.tools)
-		}
-		return rules
-	}
-
-	/**
-	 * Resolve whether a tool call should be allowed, prompted, or denied.
-	 * YOLO mode overrides everything to "allow".
-	 */
-	private resolveToolApproval(toolName: string): "allow" | "ask" | "deny" {
-		if (this.getState().yolo === true) return "allow"
-		return resolveApproval(
-			toolName,
-			this.getPermissionRules(),
-			this.sessionGrants,
-		)
-	}
-
-	/**
-	 * Grant a session-scoped "always allow" for a tool's category.
-	 */
-	grantSessionCategory(category: ToolCategory): void {
-		this.sessionGrants.allowCategory(category)
-	}
-
-	/**
-	 * Grant a session-scoped "always allow" for a specific tool.
-	 */
-	grantSessionTool(toolName: string): void {
-		this.sessionGrants.allowTool(toolName)
-	}
-
-	/**
-	 * Get the tool category for display purposes.
-	 */
-	getToolCategory(toolName: string): ToolCategory | null {
-		return getToolCategory(toolName)
-	}
-
-	/**
-	 * Get current session grants for display.
-	 */
-	getSessionGrants(): { categories: ToolCategory[]; tools: string[] } {
-		return {
-			categories: this.sessionGrants.getGrantedCategories(),
-			tools: this.sessionGrants.getGrantedTools(),
-		}
-	}
-
-	/**
-	 * Update a category policy in the persisted permission rules.
-	 */
-	setPermissionCategory(
-		category: ToolCategory,
-		policy: "allow" | "ask" | "deny",
-	): void {
-        const rules = this.getPermissionRules()
-        rules.categories[category] = policy
-        this.setState({ permissionRules: rules } as unknown as Partial<z.infer<TState>>)
-	}
-
-	/**
-	 * Update a per-tool policy in the persisted permission rules.
-	 */
-	setPermissionTool(toolName: string, policy: "allow" | "ask" | "deny"): void {
-        const rules = this.getPermissionRules()
-        rules.tools[toolName] = policy
-        this.setState({ permissionRules: rules } as unknown as Partial<z.infer<TState>>)
-	}
-
-	/**
-	 * Get current permission rules for display.
-	 */
-	getPermissionRules_public(): PermissionRules {
-		return this.getPermissionRules()
-	}
-
-	// =========================================================================
-	// Thinking Level
-	// =========================================================================
-
-	/**
-	 * Get the current thinking level.
-	 */
-	getThinkingLevel(): string {
-		const state = this.getState() as { thinkingLevel?: string }
-		return state.thinkingLevel ?? "off"
-	}
-
-	/**
-	 * Set the thinking level and persist to thread metadata.
-	 * @param level One of: "off", "minimal", "low", "medium", "high"
-	 */
-	async setThinkingLevel(level: string): Promise<void> {
-		this.setState({ thinkingLevel: level } as unknown as Partial<z.infer<TState>>)
-		await this.persistThreadSetting("thinkingLevel", level)
-	}
-
-	// =========================================================================
-	// OM Threshold Settings
-	// =========================================================================
-
-	/**
-	 * Get the current observation threshold from state.
-	 */
-	getObservationThreshold(): number {
-		const state = this.getState() as { observationThreshold?: number }
-		return state.observationThreshold ?? 30_000
-	}
-
-	/**
-	 * Get the current reflection threshold from state.
-	 */
-	getReflectionThreshold(): number {
-		const state = this.getState() as { reflectionThreshold?: number }
-		return state.reflectionThreshold ?? 40_000
-	}
-
-	/**
-	 * Set the observation threshold and persist to thread metadata.
-	 * Note: Takes effect on next restart since OM thresholds are set at construction time.
-	 */
-	async setObservationThreshold(value: number): Promise<void> {
-		this.setState({ observationThreshold: value } as unknown as Partial<z.infer<TState>>)
-		await this.persistThreadSetting("observationThreshold", value)
-	}
-
-	/**
-	 * Set the reflection threshold and persist to thread metadata.
-	 * Note: Takes effect on next restart since OM thresholds are set at construction time.
-	 */
-	async setReflectionThreshold(value: number): Promise<void> {
-		this.setState({ reflectionThreshold: value } as unknown as Partial<z.infer<TState>>)
-		await this.persistThreadSetting("reflectionThreshold", value)
-	}
-
-	/**
-	 * Get current cumulative token usage for this thread.
-	 */
-	getTokenUsage(): {
-		promptTokens: number
-		completionTokens: number
-		totalTokens: number
-	} {
-		return { ...this.tokenUsage }
-	}
-
-	/**
-	 * Persist token usage to thread metadata.
-	 */
-	private async persistTokenUsage(): Promise<void> {
-		if (!this.currentThreadId) return
-
-		try {
-			const memoryStorage = await this.getMemoryStorage()
-			const thread = await memoryStorage.getThreadById({
-				threadId: this.currentThreadId,
-			})
-			if (thread) {
-				await memoryStorage.saveThread({
-					thread: {
-						...thread,
-						metadata: {
-							...thread.metadata,
-							tokenUsage: this.tokenUsage,
-						},
-						updatedAt: new Date(),
-					},
-				})
-			}
-		} catch {
-			// Silently fail - token persistence is not critical
-		}
-	}
-	/**
-	 * Persist a key-value pair to the current thread's metadata.
-	 */
-	async persistThreadSetting(key: string, value: unknown): Promise<void> {
-		if (!this.currentThreadId) return
-
-		try {
-			const memoryStorage = await this.getMemoryStorage()
-			const thread = await memoryStorage.getThreadById({
-				threadId: this.currentThreadId,
-			})
-			if (thread) {
-				await memoryStorage.saveThread({
-					thread: {
-						...thread,
-						metadata: {
-							...thread.metadata,
-							[key]: value,
-						},
-						updatedAt: new Date(),
-					},
-				})
-			}
-		} catch {
-			// Silently fail - settings persistence is not critical
-		}
-	}
-
-	/**
-	 * Remove a key from the current thread's metadata.
-	 */
-	private async removeThreadSetting(key: string): Promise<void> {
-		if (!this.currentThreadId) return
-
-		try {
-			const memoryStorage = await this.getMemoryStorage()
-			const thread = await memoryStorage.getThreadById({
-				threadId: this.currentThreadId,
-			})
-			if (thread && thread.metadata) {
-				const metadata = { ...thread.metadata }
-				delete metadata[key]
-				await memoryStorage.saveThread({
-					thread: {
-						...thread,
-						metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
-						updatedAt: new Date(),
-					},
-				})
-			}
-		} catch {
-			// Silently fail - settings removal is not critical
-		}
-	}
-
-	private async persistModelId(modelId: string): Promise<void> {
-		await this.persistThreadSetting("currentModelId", modelId)
-	}
-	/**
-	 * Load token usage and model ID from thread metadata.
-	 */
-	private async loadThreadMetadata(): Promise<void> {
-		if (!this.currentThreadId) {
-			this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
-			return
-		}
-
-		try {
-			const memoryStorage = await this.getMemoryStorage()
-			const thread = await memoryStorage.getThreadById({
-				threadId: this.currentThreadId,
-			})
-
-			// Load token usage
-			const savedUsage = thread?.metadata?.tokenUsage as
-				| typeof this.tokenUsage
-				| undefined
-			if (savedUsage) {
-				this.tokenUsage = {
-					promptTokens: savedUsage.promptTokens ?? 0,
-					completionTokens: savedUsage.completionTokens ?? 0,
-					totalTokens: savedUsage.totalTokens ?? 0,
-				}
-			} else {
-				this.tokenUsage = {
-					promptTokens: 0,
-					completionTokens: 0,
-					totalTokens: 0,
-				}
-			}
-			// Load saved settings from thread metadata
-			const meta = thread?.metadata as Record<string, unknown> | undefined
-			const updates: Record<string, unknown> = {}
-
-			// Prefer per-mode model ID, fall back to global currentModelId
-			const modeModelKey = `modeModelId_${this.currentModeId}`
-			if (meta?.[modeModelKey]) {
-				updates.currentModelId = meta[modeModelKey]
-			} else if (meta?.currentModelId) {
-				updates.currentModelId = meta.currentModelId
-			}
-
-			if (meta?.observerModelId) updates.observerModelId = meta.observerModelId
-			if (meta?.reflectorModelId)
-				updates.reflectorModelId = meta.reflectorModelId
-			if (meta?.observationThreshold)
-				updates.observationThreshold = meta.observationThreshold
-			if (meta?.reflectionThreshold)
-				updates.reflectionThreshold = meta.reflectionThreshold
-			if (meta?.thinkingLevel) updates.thinkingLevel = meta.thinkingLevel
-			if (typeof meta?.yolo === "boolean") updates.yolo = meta.yolo
-			if (typeof meta?.escapeAsCancel === "boolean")
-				updates.escapeAsCancel = meta.escapeAsCancel
-			if (
-				meta?.sandboxAllowedPaths &&
-				Array.isArray(meta.sandboxAllowedPaths)
-			) {
-				updates.sandboxAllowedPaths = meta.sandboxAllowedPaths
-			}
-			// Load subagent model (thread-level)
-			if (meta?.subagentModelId) updates.subagentModelId = meta.subagentModelId
-			// Only load todos if they exist and have items
-			if (meta?.todos && Array.isArray(meta.todos) && meta.todos.length > 0) {
-				updates.todos = meta.todos
-			}
-
-			// Restore mode (must happen before model loading since model is per-mode)
-			if (meta?.currentModeId) {
-				const savedModeId = meta.currentModeId as string
-				const modeExists = this.config.modes.some((m) => m.id === savedModeId)
-				if (modeExists && savedModeId !== this.currentModeId) {
-					this.currentModeId = savedModeId
-					// Re-resolve the per-mode model key now that mode is restored
-					const modeModelKey = `modeModelId_${savedModeId}`
-					if (meta[modeModelKey]) {
-						updates.currentModelId = meta[modeModelKey]
-					}
-					this.emit({
-						type: "mode_changed",
-						modeId: savedModeId,
-                        previousModeId:
-                            this.config.modes.find((m) => m.default)?.id ||
-                            this.config.modes[0]!.id,
-					})
-				}
-			}
-            if (Object.keys(updates).length > 0) {
-                this.setState(updates as unknown as Partial<z.infer<TState>>)
-            }
-
-			// Load OM progress from storage record
-			await this.loadOMProgress()
-		} catch {
-			this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
-		}
-	}
-	/**
-	 * Load Observational Memory status from storage and emit an om_status event.
-	 * Called on thread load/switch so the TUI status line reflects current state.
-	 * Also callable by the TUI after subscribing to ensure initial state is populated.
-	 */
-	async loadOMProgress(): Promise<void> {
-		if (!this.currentThreadId) return
-
-		try {
-			const memoryStorage = await this.getMemoryStorage()
-			const record = await memoryStorage.getObservationalMemory(
-				this.currentThreadId,
-				this.resourceId,
-			)
-
-			if (!record) return
-
-			// Extract thresholds from the record's config
-			const config = record.config as
-				| {
-						observationThreshold?: number | { min: number; max: number }
-						reflectionThreshold?: number | { min: number; max: number }
-				  }
-				| undefined
-
-			const getThreshold = (
-				val: number | { min: number; max: number } | undefined,
-				fallback: number,
-			): number => {
-				if (!val) return fallback
-				if (typeof val === "number") return val
-				return val.max
-			}
-
-			const observationThreshold = getThreshold(
-				config?.observationThreshold,
-				30_000,
-			)
-			const reflectionThreshold = getThreshold(
-				config?.reflectionThreshold,
-				40_000,
-			)
-
-			// Defaults from the OM record
-			let messageTokens = record.pendingMessageTokens ?? 0
-			let observationTokens = record.observationTokenCount ?? 0
-			let bufferedObs = {
-				status: "idle" as "idle" | "running" | "complete",
-				chunks: 0,
-				messageTokens: 0,
-				projectedMessageRemoval: 0,
-				observationTokens: 0,
-			}
-			let bufferedRef = {
-				status: "idle" as "idle" | "running" | "complete",
-				inputObservationTokens: 0,
-				observationTokens: 0,
-			}
-			let generationCount = 0
-			let stepNumber = 0
-
-			// Scan recent messages for the most recent data-om-status part
-			const messagesResult = await memoryStorage.listMessages({
-				threadId: this.currentThreadId,
-				perPage: 70,
-				page: 0,
-				orderBy: { field: "createdAt", direction: "DESC" },
-			})
-			const messages = messagesResult.messages
-			let foundStatus = false
-			for (const msg of messages) {
-				if (msg.role !== "assistant") continue
-				const content = msg.content as MastraMessageContentV2 | string
-				if (typeof content === "string" || !content?.parts) continue
-
-				for (let i = content.parts.length - 1; i >= 0; i--) {
-					const part = content.parts[i] as {
-						type?: string
-						data?: Record<string, any>
-					}
-					if (part.type === "data-om-status" && part.data?.windows) {
-						const w = part.data.windows
-						messageTokens = w.active?.messages?.tokens ?? messageTokens
-						observationTokens =
-							w.active?.observations?.tokens ?? observationTokens
-						// Override thresholds if present in the status
-						const msgThresh = w.active?.messages?.threshold
-						const obsThresh = w.active?.observations?.threshold
-						if (msgThresh)
-							Object.assign(config ?? {}, { observationThreshold: msgThresh })
-						if (obsThresh)
-							Object.assign(config ?? {}, { reflectionThreshold: obsThresh })
-						// Buffered state
-						const bo = w.buffered?.observations
-						if (bo) {
-							bufferedObs = {
-								status: bo.status ?? "idle",
-								chunks: bo.chunks ?? 0,
-								messageTokens: bo.messageTokens ?? 0,
-								projectedMessageRemoval: bo.projectedMessageRemoval ?? 0,
-								observationTokens: bo.observationTokens ?? 0,
-							}
-						}
-						const br = w.buffered?.reflection
-						if (br) {
-							bufferedRef = {
-								status: br.status ?? "idle",
-								inputObservationTokens: br.inputObservationTokens ?? 0,
-								observationTokens: br.observationTokens ?? 0,
-							}
-						}
-						generationCount = part.data.generationCount ?? 0
-						stepNumber = part.data.stepNumber ?? 0
-						foundStatus = true
-						break
-					}
-				}
-				if (foundStatus) break
-			}
-
-			this.emit({
-				type: "om_status",
-				windows: {
-					active: {
-						messages: {
-							tokens: messageTokens,
-							threshold: observationThreshold,
-						},
-						observations: {
-							tokens: observationTokens,
-							threshold: reflectionThreshold,
-						},
-					},
-					buffered: {
-						observations: bufferedObs,
-						reflection: bufferedRef,
-					},
-				},
-				recordId: (record as any).id ?? "",
-				threadId: this.currentThreadId,
-				stepNumber,
-				generationCount,
-			})
-		} catch {
-			// OM not available or not initialized — that's fine
-		}
-	}
-
-	// ===========================================================================
-	// Thread Management
-	// ===========================================================================
-
-	/**
-	 * Get current thread ID.
-	 */
-	getCurrentThreadId(): string | null {
-		return this.currentThreadId
-	}
-	/**
-	 * Get current resource ID.
-	 */
-	getResourceId(): string {
-		return this.resourceId
-	}
-
-	/**
-	 * Get the auto-detected resource ID (before any overrides).
-	 */
-	getDefaultResourceId(): string {
-		return this.defaultResourceId
-	}
-
-	/**
-	 * Get current user ID (for thread attribution).
-	 */
-	getUserId(): string | undefined {
-		return this.userId
-	}
-
-	/**
-	 * Whether the storage backend is remote.
-	 */
-	getIsRemoteStorage(): boolean {
-		return this.isRemoteStorage
-	}
-	/**
-	 * Set the current resource ID (for switching between projects/resources).
-	 */
-	setResourceId(resourceId: string): void {
-		this.resourceId = resourceId
-		this.currentThreadId = null
-	}
-
-	/**
-	 * Get distinct resource IDs from all existing threads.
-	 * Useful for showing a list of known resources to pick from.
-	 */
-	async getKnownResourceIds(): Promise<string[]> {
-		const threads = await this.listThreads({
-			allResources: true,
-			allPaths: true,
-		})
-		const ids = new Set<string>()
-		for (const t of threads) {
-			ids.add(t.resourceId)
-		}
-		// Put the current resource ID first, then sort the rest
-		const sorted = [...ids].filter((id) => id !== this.resourceId).sort()
-		return [this.resourceId, ...sorted]
-	}
-
-	/**
-	 * Create a new thread.
-	 * Uses the global "last model" if available, otherwise uses initial state.
-	 */
-	async createThread(title?: string): Promise<HarnessThread> {
-		const now = new Date()
-		const thread: HarnessThread = {
-			id: this.generateId(),
-			resourceId: this.resourceId,
-			title: title || "New Thread",
-			createdAt: now,
-			updatedAt: now,
-		}
-		// Resolve model for this mode:
-		// 1. Current in-memory model (already set by switchMode/switchModel)
-		// 2. Current mode's defaultModelId
-		// 3. Global "last model" (user's most recent choice across sessions)
-		const currentStateModel = (this.state as any).currentModelId
-		const currentMode = this.getCurrentMode()
-		const lastModelId = this.config.authStorage?.getLastModelId()
-		const modelId =
-			currentStateModel || currentMode.defaultModelId || lastModelId
-		// Build metadata with both global and per-mode model ID
-		const metadata: Record<string, unknown> = {}
-		if (modelId) {
-			metadata.currentModelId = modelId
-			metadata[`modeModelId_${this.currentModeId}`] = modelId
-		}
-		// Inherit resource-level settings from the most recent thread
-		try {
-			const existingThreads = await this.listThreads()
-			if (existingThreads.length > 0) {
-				const sorted = [...existingThreads].sort(
-					(a, b) => b.updatedAt.getTime() - a.updatedAt.getTime(),
-				)
-                const prevMeta = sorted[0]!.metadata as
-                    | Record<string, unknown>
-                    | undefined
-				if (prevMeta) {
-					if (typeof prevMeta.yolo === "boolean") {
-						metadata.yolo = prevMeta.yolo
-						this.setState({ yolo: prevMeta.yolo } as unknown as Partial<z.infer<TState>>)
-					}
-					if (typeof prevMeta.escapeAsCancel === "boolean") {
-						metadata.escapeAsCancel = prevMeta.escapeAsCancel
-                        this.setState({
-                            escapeAsCancel: prevMeta.escapeAsCancel,
-                        } as unknown as Partial<z.infer<TState>>)
-					}
-				}
-			}
-		} catch {
-			// Non-critical — proceed without inheriting
-		}
-
-		// Store project path for directory-aware thread filtering (worktrees, etc.)
-		const projectPath = (this.state as any)?.projectPath
-		if (projectPath) {
-			metadata.projectPath = projectPath
-		}
-
-		// Store user identity for multi-user thread attribution
-		if (this.userId) {
-			metadata.createdBy = this.userId
-		}
-
-		// Persist thread to storage with model ID
-		const memoryStorage = await this.getMemoryStorage()
-		await memoryStorage.saveThread({
-			thread: {
-				id: thread.id,
-				resourceId: thread.resourceId,
-				title: thread.title!,
-				createdAt: thread.createdAt,
-				updatedAt: thread.updatedAt,
-				metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
-			},
-		})
-		// Release lock on previous thread, acquire lock on new one
-		if (this.currentThreadId) {
-			releaseThreadLock(this.currentThreadId)
-		}
-		acquireThreadLock(thread.id)
-
-		// Also switch to this new thread
-		this.currentThreadId = thread.id
-
-		// Set the model in state (only if not already set)
-		if (modelId && !currentStateModel) {
-			this.setState({ currentModelId: modelId } as unknown as Partial<z.infer<TState>>)
-		}
-
-		// Reset token usage for new thread
-		this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
-
-		this.emit({ type: "thread_created", thread })
-
-		return thread
-	}
-	/**
-	 * Rename the current thread.
-	 */
-	async renameThread(title: string): Promise<void> {
-		if (!this.currentThreadId) return
-
-		const memoryStorage = await this.getMemoryStorage()
-		const thread = await memoryStorage.getThreadById({
-			threadId: this.currentThreadId,
-		})
-		if (thread) {
-			await memoryStorage.saveThread({
-				thread: {
-					...thread,
-					title,
-					updatedAt: new Date(),
-				},
-			})
-		}
-	}
-
-	/**
-	 * Switch to a different thread.
-	 */
-	async switchThread(threadId: string): Promise<void> {
-		// Abort current operation if any
-		this.abort()
-
-		// Verify thread exists
-		const memoryStorage = await this.getMemoryStorage()
-		const thread = await memoryStorage.getThreadById({ threadId })
-		if (!thread) {
-			throw new Error(`Thread not found: ${threadId}`)
-		}
-
-		// Acquire lock on new thread before releasing old one
-		acquireThreadLock(threadId)
-
-		const previousThreadId = this.currentThreadId
-		if (previousThreadId) {
-			releaseThreadLock(previousThreadId)
-		}
-		this.currentThreadId = threadId
-
-		// Load token usage and model ID for this thread
-		await this.loadThreadMetadata()
-
-		this.emit({
-			type: "thread_changed",
-			threadId,
-			previousThreadId,
-		})
-	}
-	/**
-	 * List threads. By default lists only threads for the current resource AND project path.
-	 * Pass `allResources: true` to list threads across all resources.
-	 * Pass `allPaths: true` to list threads across all paths for the current resource.
-	 * Pass `mineOnly: true` to filter to threads created by the current user.
-	 * When using remote storage, `mineOnly` defaults to `true`.
-	 */
-	async listThreads(options?: {
-		allResources?: boolean
-		allPaths?: boolean
-		mineOnly?: boolean
-	}): Promise<HarnessThread[]> {
-		const memoryStorage = await this.getMemoryStorage()
-		const projectPath = (this.state as any)?.projectPath as string | undefined
-
-		// Default mineOnly to true when remote storage + user ID are available
-		const mineOnly =
-			options?.mineOnly ??
-			(this.isRemoteStorage && !!this.userId && !options?.allResources)
-
-		const metadataFilter: Record<string, unknown> = {}
-		if (!options?.allPaths && projectPath) {
-			metadataFilter.projectPath = projectPath
-		}
-		if (mineOnly && this.userId) {
-			metadataFilter.createdBy = this.userId
-		}
-
-		const filter:
-			| { resourceId?: string; metadata?: Record<string, unknown> }
-			| undefined = options?.allResources
-			? undefined
-			: {
-					resourceId: this.resourceId,
-					...(Object.keys(metadataFilter).length > 0
-						? { metadata: metadataFilter }
-						: {}),
-				}
-
-		const result = await memoryStorage.listThreads({
-			perPage: options?.allResources ? false : undefined,
-			filter,
-		})
-
-		return result.threads.map((thread: StorageThreadType) => ({
-			id: thread.id,
-			resourceId: thread.resourceId,
-			title: thread.title,
-			createdAt: thread.createdAt,
-			updatedAt: thread.updatedAt,
-			metadata: thread.metadata,
-		}))
-	}
-
-	// ===========================================================================
-	// Message Handling
-	// ===========================================================================
-
-	/**
-	 * Send a message to the current agent.
-	 * Streams the response and emits events.
-	 *
-	 * Uses an operation ID to safely handle steer (abort + re-send):
-	 * if a newer operation supersedes this one, events and cleanup are skipped.
-	 */
-	async sendMessage(
-		content: string,
-		options?: {
-			images?: Array<{ data: string; mimeType: string }>
-		},
-	): Promise<void> {
-		// Run UserPromptSubmit hooks (blocking)
-		if (this.hookManager) {
-			const hookResult = await this.hookManager.runUserPromptSubmit(content)
-			for (const warning of hookResult.warnings) {
-				this.emit({ type: "error", error: new Error(`[hook] ${warning}`) })
-			}
-			if (!hookResult.allowed) {
-				this.emit({
-					type: "error",
-					error: new Error(
-						`Message blocked by hook: ${hookResult.blockReason || "Policy violation"}`,
-					),
-				})
-				return
-			}
-		}
-
-		// Ensure we have a thread
-		if (!this.currentThreadId) {
-			const thread = await this.createThread()
-			this.currentThreadId = thread.id
-		}
-
-		// Tag this operation so steer() can safely supersede it
-		const operationId = ++this.currentOperationId
-
-		// Create abort controller for this operation
-		this.abortController = new AbortController()
-		const agent = this.getCurrentAgent()
-
-		this.emit({ type: "agent_start" })
-
-		try {
-			// Build request context for tools
-			const requestContext = await this.buildRequestContext()
-			// Stream the response
-			const streamOptions: Record<string, unknown> = {
-				memory: {
-					thread: this.currentThreadId,
-					resource: this.resourceId,
-				},
-				abortSignal: this.abortController.signal,
-				requestContext,
-				maxSteps: 1000,
-				requireToolApproval: this.getYoloMode() !== true,
-				modelSettings: {
-					temperature: 1,
-				},
-			}
-
-			// Add provider-specific toolsets (e.g., Anthropic web search)
-			if (this.config.getToolsets) {
-				const modelId = this.getCurrentModelId()
-				const toolsets = this.config.getToolsets(modelId)
-				if (toolsets) {
-					streamOptions.toolsets = toolsets
-				}
-			}
-
-			// Build message input: multimodal if images present, string otherwise
-			let messageInput: string | Record<string, unknown> = content
-			if (options?.images?.length) {
-				messageInput = {
-					role: "user",
-					content: [
-						{ type: "text", text: content },
-						...options.images.map((img) => ({
-							type: "file",
-							data: img.data,
-							mediaType: img.mimeType,
-						})),
-					],
-				}
-			}
-
-			const response = await agent.stream(
-				messageInput as any,
-				streamOptions as any,
-			)
-			// Process the stream. Tool approvals are handled inline via
-			// the permission system and TUI dialog.
-			let result = await this.processStream(response)
-
-			const lastMessage = result.message
-
-			// Run Stop hooks (blocking: exit 2 = agent keeps working)
-			if (this.hookManager && this.currentOperationId === operationId) {
-				const assistantText =
-					lastMessage?.content
-						?.filter(
-							(c): c is { type: "text"; text: string } => c.type === "text",
-						)
-						.map((c) => c.text)
-						.join("") || undefined
-
-				const stopResult = await this.hookManager.runStop(
-					assistantText,
-					"complete",
-				)
-				for (const warning of stopResult.warnings) {
-					this.emit({ type: "error", error: new Error(`[hook] ${warning}`) })
-				}
-				if (!stopResult.allowed) {
-					// Hook says agent should keep working
-					this.followUpQueue.unshift(
-						stopResult.blockReason ||
-							"A hook has requested that you continue working.",
-					)
-					return
-				}
-			}
-
-			// Only emit completion if not superseded by steer
-			if (this.currentOperationId === operationId) {
-				// Check if abort was requested - stream may complete gracefully even after abort
-				const reason = this.abortRequested ? "aborted" : "complete"
-				this.emit({ type: "agent_end", reason })
-			}
-		} catch (error) {
-			// If superseded by steer, silently exit
-			if (this.currentOperationId !== operationId) return
-
-			if (error instanceof Error && error.name === "AbortError") {
-				// Aborted - emit end event with aborted status
-				this.emit({ type: "agent_end", reason: "aborted" })
-			} else if (
-				error instanceof Error &&
-				error.message.match(/^Tool .+ not found$/)
-			) {
-				// Model hallucinated a tool name — recover by sending a corrective
-				// follow-up so the agent can retry with the right tool
-				const badTool = error.message
-					.replace("Tool ", "")
-					.replace(" not found", "")
-				this.emit({
-					type: "error",
-					error: new Error(
-						`Unknown tool "${badTool}". Shell commands must be run via execute_command.`,
-					),
-					retryable: true,
-				})
-				this.followUpQueue.push(
-					`[System] Your previous tool call used "${badTool}" which is not a valid tool. ` +
-						`Shell commands like git, npm, etc. must be run via the execute_command tool. ` +
-						`Please retry with the correct tool name.`,
-				)
-				this.emit({ type: "agent_end", reason: "error" })
-			} else if (
-				errorContains(error, "must end with a user message") ||
-				errorContains(error, "assistant message prefill")
-			) {
-				// Conversation ends with an assistant message (e.g. after
-				// OM activation) — inject a synthetic user message
-				// and retry so the model can continue.
-				this.followUpQueue.unshift("<continue>")
-				this.emit({
-					type: "error",
-					error: new Error("Prefill rejection — patching chat and retrying"),
-					retryable: true,
-				})
-				this.emit({ type: "agent_end", reason: "error" })
-			} else {
-				// Parse the error for better user feedback
-				const parsed = parseError(error)
-				this.emit({
-					type: "error",
-					error: parsed.originalError,
-					errorType: parsed.type,
-					retryable: parsed.retryable,
-					retryDelay: parsed.retryDelay,
-				})
-				this.emit({ type: "agent_end", reason: "error" })
-			}
-		} finally {
-			// Only clean up if this is still the current operation
-			if (this.currentOperationId === operationId) {
-				this.abortController = null
-				this.abortRequested = false
-			}
-
-			// Process follow-up queue after this operation completes
-			if (
-				this.currentOperationId === operationId &&
-				this.followUpQueue.length > 0
-			) {
-				const next = this.followUpQueue.shift()!
-				await this.sendMessage(next)
-			}
-		}
-	}
-	/**
-	 * Get message history for the current thread.
-	 */
-	async getMessages(options?: { limit?: number }): Promise<HarnessMessage[]> {
-		if (!this.currentThreadId) {
-			return []
-		}
-		return this.getMessagesForThread(this.currentThreadId, options)
-	}
-
-	/**
-	 * Get message history for a specific thread.
-	 * @param options.limit - Max number of most recent messages to fetch. Omit or pass undefined for all.
-	 */
-	async getMessagesForThread(
-		threadId: string,
-		options?: { limit?: number },
-	): Promise<HarnessMessage[]> {
-		const memoryStorage = await this.getMemoryStorage()
-		const limit = options?.limit
-
-		if (limit) {
-			// Fetch the last N messages by querying DESC and reversing
-			const result = await memoryStorage.listMessages({
-				threadId,
-				perPage: limit,
-				page: 0,
-				orderBy: { field: "createdAt", direction: "DESC" },
-			})
-			return result.messages
-				.map((msg) => this.convertToHarnessMessage(msg))
-				.reverse()
-		}
-
-		const result = await memoryStorage.listMessages({
-			threadId,
-			perPage: false,
-		})
-		return result.messages.map((msg) => this.convertToHarnessMessage(msg))
-	}
-
-	/**
-	 * Get the first user message for a thread (for previews).
-	 */
-	async getFirstUserMessageForThread(
-		threadId: string,
-	): Promise<HarnessMessage | null> {
-		const memoryStorage = await this.getMemoryStorage()
-		// Fetch a small batch from the beginning — first user message is usually in the first few
-		const result = await memoryStorage.listMessages({
-			threadId,
-			perPage: 5,
-			page: 0,
-			orderBy: { field: "createdAt", direction: "ASC" },
-		})
-		const userMsg = result.messages.find((m) => m.role === "user")
-		return userMsg ? this.convertToHarnessMessage(userMsg) : null
-	}
-
-	/**
-	 * Convert a Mastra DB message to a HarnessMessage.
-	 */
-	private convertToHarnessMessage(msg: {
-		id: string
-		role: "user" | "assistant" | "system"
-		createdAt: Date
-		content: {
-			parts: Array<{
-				type: string
-				text?: string
-				reasoning?: string
-				toolCallId?: string
-				toolName?: string
-				args?: unknown
-				result?: unknown
-				isError?: boolean
-				// Nested tool invocation structure from Mastra storage
-				toolInvocation?: {
-					state: string
-					toolCallId: string
-					toolName: string
-					args?: unknown
-					result?: unknown
-					isError?: boolean
-				}
-				[key: string]: unknown
-			}>
-		}
-	}): HarnessMessage {
-		const content: HarnessMessageContent[] = []
-
-		for (const part of msg.content.parts) {
-			if (part.type.startsWith(`data-`)) {
-				part
-			}
-			switch (part.type) {
-				case "text":
-					if (part.text) {
-						content.push({ type: "text", text: part.text })
-					}
-					break
-				case "reasoning":
-					if (part.reasoning) {
-						content.push({ type: "thinking", thinking: part.reasoning })
-					}
-					break
-				case "tool-invocation":
-					// Handle nested toolInvocation structure from Mastra storage
-					if (part.toolInvocation) {
-						const inv = part.toolInvocation
-						// Add tool_call
-						content.push({
-							type: "tool_call",
-							id: inv.toolCallId,
-							name: inv.toolName,
-							args: inv.args,
-						})
-						// If it has a result, add tool_result too
-						if (inv.state === "result" && inv.result !== undefined) {
-							content.push({
-								type: "tool_result",
-								id: inv.toolCallId,
-								name: inv.toolName,
-								result: inv.result,
-								isError: inv.isError ?? false,
-							})
-						}
-					}
-					// Also handle flat structure
-					else if (part.toolCallId && part.toolName) {
-						content.push({
-							type: "tool_call",
-							id: part.toolCallId,
-							name: part.toolName,
-							args: part.args,
-						})
-					}
-					break
-				case "tool-call":
-					if (part.toolCallId && part.toolName) {
-						content.push({
-							type: "tool_call",
-							id: part.toolCallId,
-							name: part.toolName,
-							args: part.args,
-						})
-					}
-					break
-				case "tool-result":
-					if (part.toolCallId && part.toolName) {
-						content.push({
-							type: "tool_result",
-							id: part.toolCallId,
-							name: part.toolName,
-							result: part.result,
-							isError: part.isError ?? false,
-						})
-					}
-					break
-				case "data-om-observation-start": {
-					const data = (part as { data?: Record<string, unknown> }).data ?? {}
-					content.push({
-						type: "om_observation_start",
-						tokensToObserve: (data.tokensToObserve as number) ?? 0,
-						operationType:
-							(data.operationType as "observation" | "reflection") ??
-							"observation",
-					})
-					break
-				}
-				case "data-om-observation-end": {
-					const data = (part as { data?: Record<string, unknown> }).data ?? {}
-					content.push({
-						type: "om_observation_end",
-						tokensObserved: (data.tokensObserved as number) ?? 0,
-						observationTokens: (data.observationTokens as number) ?? 0,
-						durationMs: (data.durationMs as number) ?? 0,
-						operationType:
-							(data.operationType as "observation" | "reflection") ??
-							"observation",
-						observations: (data.observations as string) ?? undefined,
-						currentTask: (data.currentTask as string) ?? undefined,
-						suggestedResponse: (data.suggestedResponse as string) ?? undefined,
-					})
-					break
-				}
-				case "data-om-observation-failed": {
-					const data = (part as { data?: Record<string, unknown> }).data ?? {}
-					content.push({
-						type: "om_observation_failed",
-						error: (data.error as string) ?? "Unknown error",
-						tokensAttempted: (data.tokensAttempted as number) ?? 0,
-						operationType:
-							(data.operationType as "observation" | "reflection") ??
-							"observation",
-					})
-					break
-				}
-				// Skip other part types (step-start, data-om-status, etc.)
-			}
-		}
-
-		return {
-			id: msg.id,
-			role: msg.role,
-			content,
-			createdAt: msg.createdAt,
-		}
-	}
-
-	// ===========================================================================
-	// Control
-	// ===========================================================================
-
-	/**
-	 * Abort the current operation (message generation, tool execution).
-	 */
-	abort(): void {
-		if (this.abortController) {
-			this.abortRequested = true
-			try {
-				this.abortController.abort()
-			} catch {}
-			this.abortController = null
-		}
-	}
-	/**
-	 * Steer the agent mid-stream: aborts current run and sends a new message.
-	 * The new message interrupts the agent after the current tool completes.
-	 */
-	async steer(content: string): Promise<void> {
-		// Abort current operation if running
-		this.abort()
-		// Clear any pending follow-ups (steer overrides them)
-		this.followUpQueue = []
-		// Send the new message immediately
-		await this.sendMessage(content)
-	}
-
-	/**
-	 * Queue a follow-up message to be processed after the current operation completes.
-	 * If not streaming, sends immediately.
-	 */
-	async followUp(content: string): Promise<void> {
-		if (this.isRunning()) {
-			this.followUpQueue.push(content)
-			this.emit({
-				type: "follow_up_queued",
-				count: this.followUpQueue.length,
-			})
-		} else {
-			await this.sendMessage(content)
-		}
-	}
-
-	/**
-	 * Get the number of queued follow-up messages.
-	 */
-	getFollowUpCount(): number {
-		return this.followUpQueue.length
-	}
-
-	/**
-	 * Check if an operation is currently in progress.
-	 */
-	isRunning(): boolean {
-		return this.abortController !== null
-	}
-
-	/**
-	 * Get the current run ID (for tool approval flows).
-	 */
-	getCurrentRunId(): string | null {
-		return this.currentRunId
-	}
-	/**
-	 * Respond to a pending tool approval from the TUI.
-	 */
-	resolveToolApprovalDecision(
-		decision: "approve" | "decline" | "always_allow_category",
-	): void {
-		if (this.pendingApprovalResolve) {
-			this.pendingApprovalResolve(decision)
-			this.pendingApprovalResolve = null
-		}
-	}
-	/**
-	 * Approve a tool call and resume the suspended stream.
-	 * Called from within processStream — reuses the existing abortController.
-	 */
-	private async handleToolApprove(toolCallId?: string): Promise<{
-		message: HarnessMessage
-	}> {
-		if (!this.currentRunId) {
-			throw new Error("No active run to approve tool call for")
-		}
-
-		const agent = this.getCurrentAgent()
-		if (!this.abortController) {
-			this.abortController = new AbortController()
-		}
-		function getRandomInteger(min: number, max: number) {
-			// Ensure min and max are treated as integers for the calculation
-			min = Math.ceil(min)
-			max = Math.floor(max)
-			// The formula for inclusive range: Math.floor(Math.random() * (max - min + 1)) + min
-			return Math.floor(Math.random() * (max - min + 1)) + min
-		}
-		await new Promise((res) => setTimeout(res, getRandomInteger(1000, 2000)))
-
-		const response = await agent.approveToolCall({
-			runId: this.currentRunId,
-			toolCallId,
-			memory: this.currentThreadId
-				? {
-						thread: this.currentThreadId,
-						resource: this.resourceId,
-					}
-				: undefined,
-			abortSignal: this.abortController.signal,
-			requestContext: await this.buildRequestContext(),
-		})
-
-		return await this.processStream(response)
-	}
-
-	/**
-	 * Decline a tool call and resume the suspended stream.
-	 * Called from within processStream — reuses the existing abortController.
-	 */
-	private async handleToolDecline(toolCallId?: string): Promise<{
-		message: HarnessMessage
-	}> {
-		if (!this.currentRunId) {
-			throw new Error("No active run to decline tool call for")
-		}
-
-		const agent = this.getCurrentAgent()
-		if (!this.abortController) {
-			this.abortController = new AbortController()
-		}
-
-		const response = await agent.declineToolCall({
-			runId: this.currentRunId,
-			toolCallId,
-			memory: this.currentThreadId
-				? {
-						thread: this.currentThreadId,
-						resource: this.resourceId,
-					}
-				: undefined,
-			abortSignal: this.abortController.signal,
-			requestContext: await this.buildRequestContext(),
-		})
-
-		return await this.processStream(response)
-	}
-	/**
-	 * Process a stream response (shared between sendMessage and tool approval).
-	 */
-	private async processStream(response: {
-		fullStream: AsyncIterable<any>
-	}): Promise<{
-		message: HarnessMessage
-	}> {
-		let currentMessage: HarnessMessage = {
-			id: this.generateId(),
-			role: "assistant",
-			content: [],
-			createdAt: new Date(),
-		}
-
-		const textContentById = new Map<string, { index: number; text: string }>()
-		const thinkingContentById = new Map<
-			string,
-			{ index: number; text: string }
-		>()
-		const debugFile = this.streamDebug
-			? join(process.cwd(), "stream-debug.jsonl")
-			: null
-
-		for await (const chunk of response.fullStream) {
-			if (debugFile) {
-				try {
-					appendFileSync(debugFile, JSON.stringify(chunk) + "\n")
-				} catch {}
-			}
-			if ("runId" in chunk && chunk.runId) {
-				this.currentRunId = chunk.runId
-			}
-			switch (chunk.type) {
-				case "text-start": {
-					const textIndex = currentMessage.content.length
-					currentMessage.content.push({ type: "text", text: "" })
-					textContentById.set(chunk.payload.id, { index: textIndex, text: "" })
-					this.emit({ type: "message_start", message: { ...currentMessage } })
-					break
-				}
-
-				case "text-delta": {
-					const textState = textContentById.get(chunk.payload.id)
-					if (textState) {
-						textState.text += chunk.payload.text
-						const textContent = currentMessage.content[textState.index]
-						if (textContent && textContent.type === "text") {
-							textContent.text = textState.text
-						}
-						this.emit({
-							type: "message_update",
-							message: { ...currentMessage },
-						})
-					}
-					break
-				}
-
-				case "reasoning-start": {
-					const thinkingIndex = currentMessage.content.length
-					currentMessage.content.push({ type: "thinking", thinking: "" })
-					thinkingContentById.set(chunk.payload.id, {
-						index: thinkingIndex,
-						text: "",
-					})
-					this.emit({ type: "message_update", message: { ...currentMessage } })
-					break
-				}
-
-				case "reasoning-delta": {
-					const thinkingState = thinkingContentById.get(chunk.payload.id)
-					if (thinkingState) {
-						thinkingState.text += chunk.payload.text
-						const thinkingContent = currentMessage.content[thinkingState.index]
-						if (thinkingContent && thinkingContent.type === "thinking") {
-							thinkingContent.thinking = thinkingState.text
-						}
-						this.emit({
-							type: "message_update",
-							message: { ...currentMessage },
-						})
-					}
-					break
-				}
-
-				case "tool-call": {
-					const toolCall = chunk.payload
-					currentMessage.content.push({
-						type: "tool_call",
-						id: toolCall.toolCallId,
-						name: toolCall.toolName,
-						args: toolCall.args,
-					})
-					this.emit({
-						type: "tool_start",
-						toolCallId: toolCall.toolCallId,
-						toolName: toolCall.toolName,
-						args: toolCall.args,
-					})
-					this.emit({ type: "message_update", message: { ...currentMessage } })
-					break
-				}
-
-				case "tool-result": {
-					const toolResult = chunk.payload
-					currentMessage.content.push({
-						type: "tool_result",
-						id: toolResult.toolCallId,
-						name: toolResult.toolName,
-						result: toolResult.result,
-						isError: toolResult.isError ?? false,
-					})
-					this.emit({
-						type: "tool_end",
-						toolCallId: toolResult.toolCallId,
-						result: toolResult.result,
-						isError: toolResult.isError ?? false,
-					})
-					this.emit({ type: "message_update", message: { ...currentMessage } })
-
-					// PostToolUse hooks (fire and forget)
-					if (this.hookManager) {
-						const toolCall = currentMessage.content.find(
-							(c) => c.type === "tool_call" && c.id === toolResult.toolCallId,
-						)
-						if (toolCall && toolCall.type === "tool_call") {
-							this.hookManager
-								.runPostToolUse(
-									toolCall.name,
-									toolCall.args,
-									toolResult.result,
-									toolResult.isError ?? false,
-								)
-								.catch(() => {})
-						}
-					}
-					break
-				}
-
-				case "tool-error": {
-					const toolError = chunk.payload
-					this.emit({
-						type: "tool_end",
-						toolCallId: toolError.toolCallId,
-						result: toolError.error,
-						isError: true,
-					})
-					break
-				}
-				case "tool-call-approval": {
-					const toolCallId = chunk.payload.toolCallId
-					const toolName = chunk.payload.toolName
-					const toolArgs = chunk.payload.args
-					// The stream is now suspended — no more chunks will arrive
-					// until approveToolCall() or declineToolCall() is called.
-
-					let action: "allow" | "deny" | "ask" = "ask"
-
-					// Run PreToolUse hooks first
-					if (this.hookManager) {
-						const hookResult = await this.hookManager.runPreToolUse(
-							toolName,
-							toolArgs,
-						)
-						for (const warning of hookResult.warnings) {
-							this.emit({
-								type: "error",
-								error: new Error(`[hook] ${warning}`),
-							})
-						}
-						if (!hookResult.allowed) {
-							action = "deny"
-						}
-					}
-					// Resolve via YOLO / permission rules / session grants
-					if (action !== "deny") {
-						action = this.resolveToolApproval(toolName)
-					}
-
-					if (action === "allow") {
-						// Auto-approve: resume the stream and process it
-						const result = await this.handleToolApprove(toolCallId)
-						currentMessage = result.message
-						// Stream is done after approval handling
-						return { message: currentMessage }
-					} else if (action === "deny") {
-						// Auto-deny: decline and process the resumed stream
-						const result = await this.handleToolDecline(toolCallId)
-						currentMessage = result.message
-						return { message: currentMessage }
-					} else {
-						// Ask the user — emit event and wait for decision
-						const category = getToolCategory(toolName)
-
-						this.emit({
-							type: "tool_approval_required",
-							toolCallId,
-							toolName,
-							args: toolArgs,
-						})
-
-						// Wait for TUI to call resolveToolApprovalDecision()
-						const decision = await new Promise<
-							"approve" | "decline" | "always_allow_category"
-						>((resolve) => {
-							this.pendingApprovalResolve = resolve
-						})
-
-						if (decision === "always_allow_category" && category) {
-							this.sessionGrants.allowCategory(category)
-						}
-
-						if (
-							decision === "approve" ||
-							decision === "always_allow_category"
-						) {
-							const result = await this.handleToolApprove(toolCallId)
-							currentMessage = result.message
-							return { message: currentMessage }
-						} else {
-							const result = await this.handleToolDecline(toolCallId)
-							currentMessage = result.message
-							return { message: currentMessage }
-						}
-					}
-				}
-				case "error": {
-					const streamError =
-						chunk.payload.error instanceof Error
-							? chunk.payload.error
-							: new Error(String(chunk.payload.error))
-
-					if (
-						errorContains(streamError, "must end with a user message") ||
-						errorContains(streamError, "assistant message prefill")
-					) {
-						// Prefill error from stream — inject synthetic user message and retry
-						this.followUpQueue.unshift("<continue>")
-						this.emit({
-							type: "error",
-							error: new Error(
-								"Prefill rejection — patching chat and retrying",
-							),
-							retryable: true,
-						})
-						break
-					}
-
-					this.emit({
-						type: "error",
-						error: streamError,
-					})
-					break
-				}
-				case "step-finish": {
-					// Extract usage from step-finish payload
-					const usage = chunk.payload?.output?.usage
-					if (usage) {
-						const promptTokens = usage.promptTokens ?? 0
-						const completionTokens = usage.completionTokens ?? 0
-						const totalTokens = promptTokens + completionTokens
-
-						// Update cumulative token usage
-						this.tokenUsage.promptTokens += promptTokens
-						this.tokenUsage.completionTokens += completionTokens
-						this.tokenUsage.totalTokens += totalTokens
-
-						// Persist to thread metadata (fire and forget)
-						this.persistTokenUsage().catch(() => {})
-
-						this.emit({
-							type: "usage_update",
-							usage: {
-								promptTokens,
-								completionTokens,
-								totalTokens,
-							},
-						})
-					}
-					break
-				}
-				case "finish": {
-					const finishReason = chunk.payload.stepResult?.reason
-					if (finishReason === "stop" || finishReason === "end-turn") {
-						currentMessage.stopReason = "complete"
-					} else if (finishReason === "tool-calls") {
-						currentMessage.stopReason = "tool_use"
-					} else {
-						currentMessage.stopReason = "complete"
-					}
-					this.emit({ type: "info", message: `finish reason: ${finishReason}` })
-					break
-				}
-				// Observational Memory data parts
-				// NOTE: OM data parts arrive as { type, data: { ... } } — NOT { type, payload }
-				case "data-om-status": {
-					const d = (chunk as any).data as Record<string, any> | undefined
-					if (d?.windows) {
-						const w = d.windows
-						const active = w.active ?? {}
-						const msgs = active.messages ?? {}
-						const obs = active.observations ?? {}
-						const buffObs = w.buffered?.observations ?? {}
-						const buffRef = w.buffered?.reflection ?? {}
-
-						// Emit new om_status event
-						this.emit({
-							type: "om_status",
-							windows: {
-								active: {
-									messages: {
-										tokens: msgs.tokens ?? 0,
-										threshold: msgs.threshold ?? 0,
-									},
-									observations: {
-										tokens: obs.tokens ?? 0,
-										threshold: obs.threshold ?? 0,
-									},
-								},
-								buffered: {
-									observations: {
-										status: buffObs.status ?? "idle",
-										chunks: buffObs.chunks ?? 0,
-										messageTokens: buffObs.messageTokens ?? 0,
-										projectedMessageRemoval:
-											buffObs.projectedMessageRemoval ?? 0,
-										observationTokens: buffObs.observationTokens ?? 0,
-									},
-									reflection: {
-										status: buffRef.status ?? "idle",
-										inputObservationTokens: buffRef.inputObservationTokens ?? 0,
-										observationTokens: buffRef.observationTokens ?? 0,
-									},
-								},
-							},
-							recordId: d.recordId ?? "",
-							threadId: d.threadId ?? "",
-							stepNumber: d.stepNumber ?? 0,
-							generationCount: d.generationCount ?? 0,
-						})
-					}
-					break
-				}
-				case "data-om-observation-start": {
-					const payload = (chunk as any).data as Record<string, any> | undefined
-					if (payload && payload.cycleId) {
-						if (payload.operationType === "observation") {
-							this.emit({
-								type: "om_observation_start",
-								cycleId: payload.cycleId,
-								operationType: payload.operationType,
-								tokensToObserve: payload.tokensToObserve ?? 0,
-							})
-						} else if (payload.operationType === "reflection") {
-							this.emit({
-								type: "om_reflection_start",
-								cycleId: payload.cycleId,
-								tokensToReflect: payload.tokensToObserve ?? 0,
-							})
-						}
-					}
-					break
-				}
-				case "data-om-observation-end": {
-					const payload = chunk.data
-					if (payload && payload.cycleId) {
-						// Use operationType to distinguish reflection from observation
-						if (payload.operationType === "reflection") {
-							this.emit({
-								type: "om_reflection_end",
-								cycleId: payload.cycleId,
-								durationMs: payload.durationMs ?? 0,
-								compressedTokens: payload.observationTokens ?? 0,
-								observations: payload.observations,
-							})
-						} else {
-							this.emit({
-								type: "om_observation_end",
-								cycleId: payload.cycleId,
-								durationMs: payload.durationMs ?? 0,
-								tokensObserved: payload.tokensObserved ?? 0,
-								observationTokens: payload.observationTokens ?? 0,
-								observations: payload.observations,
-								currentTask: payload.currentTask,
-								suggestedResponse: payload.suggestedResponse,
-							})
-						}
-					}
-					break
-				}
-
-				case "data-om-observation-failed": {
-					const payload = (chunk as any).data as Record<string, any> | undefined
-					if (payload) {
-						if (payload.operationType === "reflection") {
-							this.emit({
-								type: "om_reflection_failed",
-								cycleId: payload.cycleId ?? "unknown",
-								error: payload.error ?? "Unknown error",
-								durationMs: payload.durationMs ?? 0,
-							})
-						} else {
-							this.emit({
-								type: "om_observation_failed",
-								cycleId: payload.cycleId ?? "unknown",
-								error: payload.error ?? "Unknown error",
-								durationMs: payload.durationMs ?? 0,
-							})
-						}
-					}
-					break
-				}
-				// Async buffering lifecycle
-				case "data-om-buffering-start": {
-					const payload = (chunk as any).data as Record<string, any> | undefined
-					if (payload && payload.cycleId) {
-						this.emit({
-							type: "om_buffering_start",
-							cycleId: payload.cycleId,
-							operationType: payload.operationType ?? "observation",
-							tokensToBuffer: payload.tokensToBuffer ?? 0,
-						})
-					}
-					break
-				}
-
-				case "data-om-buffering-end": {
-					const payload = (chunk as any).data as Record<string, any> | undefined
-					if (payload && payload.cycleId) {
-						this.emit({
-							type: "om_buffering_end",
-							cycleId: payload.cycleId,
-							operationType: payload.operationType ?? "observation",
-							tokensBuffered: payload.tokensBuffered ?? 0,
-							bufferedTokens: payload.bufferedTokens ?? 0,
-							observations: payload.observations,
-						})
-					}
-					break
-				}
-
-				case "data-om-buffering-failed": {
-					const payload = (chunk as any).data as Record<string, any> | undefined
-					if (payload && payload.cycleId) {
-						this.emit({
-							type: "om_buffering_failed",
-							cycleId: payload.cycleId,
-							operationType: payload.operationType ?? "observation",
-							error: payload.error ?? "Unknown error",
-						})
-					}
-					break
-				}
-
-				case "data-om-activation": {
-					const payload = (chunk as any).data as Record<string, any> | undefined
-					if (payload && payload.cycleId) {
-						this.emit({
-							type: "om_activation",
-							cycleId: payload.cycleId,
-							operationType: payload.operationType ?? "observation",
-							chunksActivated: payload.chunksActivated ?? 0,
-							tokensActivated: payload.tokensActivated ?? 0,
-							observationTokens: payload.observationTokens ?? 0,
-							messagesActivated: payload.messagesActivated ?? 0,
-							generationCount: payload.generationCount ?? 0,
-						})
-					}
-					break
-				}
-
-				default:
-					break
-			}
-		}
-
-		this.emit({ type: "message_end", message: currentMessage })
-		return { message: currentMessage }
-	}
-
-	// ===========================================================================
-	// Event System
-	// ===========================================================================
-
-	/**
-	 * Subscribe to harness events.
-	 * Returns an unsubscribe function.
-	 */
-	subscribe(listener: HarnessEventListener): () => void {
-		this.listeners.push(listener)
-		return () => {
-			const index = this.listeners.indexOf(listener)
-			if (index !== -1) {
-				this.listeners.splice(index, 1)
-			}
-		}
-	}
-
-	private async emit(event: HarnessEvent): Promise<void> {
-		for (const listener of this.listeners) {
-			try {
-				await listener(event)
-			} catch (err) {
-				console.error("Error in harness event listener:", err)
-			}
-		}
-	}
-
-	// ===========================================================================
-	// Runtime Context
-	// ===========================================================================
-
-	/**
-	 * Build request context for agent execution.
-	 * Tools can access harness state via requestContext.get('harness').
-	 */
-	private async buildRequestContext(): Promise<RequestContext> {
-        const harnessContext: HarnessRuntimeContext<TState> = {
-            harnessId: this.id,
-            state: this.getState() as z.infer<TState>,
-            getState: () => this.getState() as z.infer<TState>,
-			setState: (updates) => this.setState(updates),
-			threadId: this.currentThreadId,
-			resourceId: this.resourceId,
-			modeId: this.currentModeId,
-			abortSignal: this.abortController?.signal,
-			workspace: this.workspace,
-			emitEvent: (event) => this.emit(event),
-			registerQuestion: (questionId, resolve) =>
-				this.registerQuestion(questionId, resolve),
-			registerPlanApproval: (planId, resolve) =>
-				this.registerPlanApproval(planId, resolve),
-			getSubagentModelId: (agentType?: string) =>
-				this.getSubagentModelId(agentType),
-		}
-
-		const requestContext = new RequestContext([["harness", harnessContext]])
-        // Resolve dynamic workspace factory with the built request context
-        if (this.workspaceFn) {
-            harnessContext.workspace = await Promise.resolve(
-                this.workspaceFn({ requestContext: requestContext as any }),
-            )
+  readonly id: string;
+
+  private config: HarnessConfig<TState>;
+  private state: z.infer<TState>;
+  private currentModeId: string;
+  private currentThreadId: string | null = null;
+  private resourceId: string;
+  private defaultResourceId: string;
+  private userId: string | undefined;
+  private isRemoteStorage: boolean;
+  private listeners: HarnessEventListener[] = [];
+  private abortController: AbortController | null = null;
+  private abortRequested: boolean = false;
+  private currentRunId: string | null = null;
+  private currentOperationId: number = 0;
+  private followUpQueue: string[] = [];
+  private pendingApprovalResolve: ((decision: 'approve' | 'decline' | 'always_allow_category') => void) | null = null;
+  private workspace: Workspace | undefined = undefined;
+  private workspaceFn:
+    | ((ctx: { requestContext: RequestContext }) => Promise<Workspace | undefined> | Workspace | undefined)
+    | undefined = undefined;
+  private workspaceInitialized = false;
+  private hookManager: HookManager | undefined;
+  private mcpManager: MCPManager | undefined;
+  private sessionGrants = new SessionGrants();
+  private streamDebug = !!process.env.MASTRA_STREAM_DEBUG;
+  private heartbeatTimers = new Map<string, { timer: NodeJS.Timeout; shutdown?: () => void | Promise<void> }>();
+  private pendingQuestions = new Map<string, (answer: string) => void>();
+  private pendingPlanApprovals = new Map<
+    string,
+    (result: { action: 'approved' | 'rejected'; feedback?: string }) => void
+  >();
+  private tokenUsage: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  } = {
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+  };
+  constructor(config: HarnessConfig<TState>) {
+    this.id = config.id;
+    this.config = config;
+    this.resourceId = config.resourceId;
+    this.defaultResourceId = config.defaultResourceId ?? config.resourceId;
+    this.userId = config.userId;
+    this.isRemoteStorage = config.isRemoteStorage ?? false;
+
+    // Initialize state from schema defaults + initial state
+    this.state = {
+      ...this.getSchemaDefaults(),
+      ...config.initialState,
+    } as z.infer<TState>;
+    // Find default mode
+    const defaultMode = config.modes.find(m => m.default) ?? config.modes[0];
+    if (!defaultMode) {
+      throw new Error('Harness requires at least one agent mode');
+    }
+    this.currentModeId = defaultMode.id;
+
+    // Store workspace: pre-built instance, dynamic factory, or config (constructed in init())
+    if (config.workspace instanceof Workspace) {
+      this.workspace = config.workspace;
+    } else if (typeof config.workspace === 'function') {
+      this.workspaceFn = config.workspace;
+    }
+
+    // Store hook manager and MCP manager
+    this.hookManager = config.hookManager;
+    this.mcpManager = config.mcpManager;
+
+    // Seed model from mode default or global last model if not set
+    const currentModel = (this.state as any).currentModelId;
+    if (!currentModel) {
+      const lastModelId = config.authStorage?.getLastModelId();
+      const seedModel = lastModelId || defaultMode.defaultModelId;
+      if (seedModel) {
+        this.setState({ currentModelId: seedModel } as unknown as Partial<z.infer<TState>>);
+      }
+    }
+  }
+
+  // ===========================================================================
+  // Initialization
+  // ===========================================================================
+  /**
+   * Initialize the harness - loads persisted state.
+   * Must be called before using the harness.
+   *
+   * Note: Does NOT auto-select a thread. Call selectThread() or createThread() after init.
+   */
+  async init(): Promise<void> {
+    // Initialize storage
+    await this.config.storage.init();
+
+    // Load persisted state from storage (if we have a state storage mechanism)
+    // For now, we use the initial state from config
+    // TODO: Add state persistence via storage.getStore('agents') or custom domain
+
+    // Initialize workspace if configured (skip for dynamic factory — resolved per-request)
+    if (this.config.workspace && !this.workspaceInitialized && !this.workspaceFn) {
+      try {
+        // Construct workspace from config if not already a Workspace instance
+        if (!this.workspace) {
+          this.workspace = new Workspace(this.config.workspace as WorkspaceConfig);
         }
 
-        return requestContext as any
-	}
+        this.emit({
+          type: 'workspace_status_changed',
+          status: 'initializing',
+        });
 
-	// ===========================================================================
-	// Session Info
-	// ===========================================================================
+        await this.workspace.init();
+        this.workspaceInitialized = true;
 
-	/**
-	 * Get current session info (for TUI display).
-	 */
-	async getSession(): Promise<HarnessSession> {
-		return {
-			currentThreadId: this.currentThreadId,
-			currentModeId: this.currentModeId,
-			threads: await this.listThreads(),
-		}
-	}
-	// ===========================================================================
-	// Authentication
-	// ===========================================================================
+        this.emit({
+          type: 'workspace_status_changed',
+          status: 'ready',
+        });
+        this.emit({
+          type: 'workspace_ready',
+          workspaceId: this.workspace.id,
+          workspaceName: this.workspace.name,
+        });
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        console.warn('Workspace initialization failed:', err.message);
+        this.workspace = undefined;
+        this.workspaceInitialized = false;
 
-	/**
-	 * Get the auth storage instance.
-	 * Creates a default instance if not provided in config.
-	 */
-	getAuthStorage(): AuthStorage {
-		if (!this.config.authStorage) {
-			this.config.authStorage = new AuthStorage()
-		}
-		return this.config.authStorage
-	}
+        this.emit({
+          type: 'workspace_status_changed',
+          status: 'error',
+          error: err,
+        });
+        this.emit({
+          type: 'workspace_error',
+          error: err,
+        });
+      }
+    }
 
-	/**
-	 * Get all available OAuth providers.
-	 */
-	getOAuthProviders(): OAuthProviderInterface[] {
-		return getOAuthProviders()
-	}
+    // Start heartbeat handlers
+    this.startHeartbeats();
+  }
 
-	/**
-	 * Check if a provider is logged in (has OAuth credentials).
-	 */
-	isLoggedIn(providerId: string): boolean {
-		return this.getAuthStorage().isLoggedIn(providerId)
-	}
+  /**
+   * Select the most recent thread, or create one if none exist.
+   * Convenience method for simple initialization.
+   */
+  async selectOrCreateThread(): Promise<HarnessThread> {
+    const threads = await this.listThreads();
 
-	/**
-	 * Check if a provider has any credentials (OAuth or API key).
-	 */
-	hasCredentials(providerId: string): boolean {
-		return this.getAuthStorage().has(providerId)
-	}
+    if (threads.length === 0) {
+      // createThread handles lock acquisition internally
+      return await this.createThread();
+    }
 
-	/**
-	 * Get all logged-in provider IDs.
-	 */
-	getLoggedInProviders(): string[] {
-		const providers = this.getOAuthProviders()
-		return providers.filter((p) => this.isLoggedIn(p.id)).map((p) => p.id)
-	}
+    // Use the most recently updated thread
+    const sortedThreads = [...threads].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+    // Acquire lock on the thread
+    acquireThreadLock(sortedThreads[0]!.id);
+    this.currentThreadId = sortedThreads[0]!.id;
 
-	/**
-	 * Perform OAuth login for a provider.
-	 */
-	async login(
-		providerId: string,
-		callbacks: OAuthLoginCallbacks,
-	): Promise<void> {
-		await this.getAuthStorage().login(providerId, callbacks)
-	}
+    // Load token usage and model ID for this thread
+    await this.loadThreadMetadata();
 
-	/**
-	 * Logout from a provider.
-	 */
-	logout(providerId: string): void {
-		this.getAuthStorage().logout(providerId)
-	}
+    return sortedThreads[0]!;
+  }
 
-	/**
-	 * Get API key for a provider (from OAuth credentials or env).
-	 * Auto-refreshes OAuth tokens if needed.
-	 */
-	async getApiKey(providerId: string): Promise<string | undefined> {
-		return this.getAuthStorage().getApiKey(providerId)
-	}
+  /**
+   * Get the memory storage domain.
+   * Throws if storage doesn't have a memory domain.
+   */
+  private async getMemoryStorage(): Promise<
+    NonNullable<Awaited<ReturnType<typeof this.config.storage.getStore<'memory'>>>>
+  > {
+    const memoryStorage = await this.config.storage.getStore('memory');
+    if (!memoryStorage) {
+      throw new Error('Storage does not have a memory domain configured');
+    }
+    return memoryStorage;
+  }
 
-	// ===========================================================================
-	// Workspace
-	// ===========================================================================
+  // ===========================================================================
+  // State Management
+  // ===========================================================================
 
-	/**
-	 * Get the workspace instance (if configured and initialized).
-	 * Returns undefined if no workspace was configured or if init failed.
-	 */
-	getWorkspace(): Workspace | undefined {
-		return this.workspace
-	}
+  /**
+   * Get current harness state (read-only snapshot).
+   */
+  getState(): Readonly<z.infer<TState>> {
+    return { ...this.state };
+  }
 
-	/**
-	 * Check if a workspace is configured (regardless of init status).
-	 * Returns true for static workspaces, workspace configs, and dynamic factories.
-	 */
-	hasWorkspace(): boolean {
-		return this.config.workspace !== undefined
-	}
+  /**
+   * Update harness state. Validates against schema.
+   * Emits state_changed event.
+   */
+  async setState(updates: Partial<z.infer<TState>>): Promise<void> {
+    const changedKeys = Object.keys(updates);
+    const newState = { ...this.state, ...updates };
 
-	/**
-	 * Check if the workspace is initialized and ready.
-	 * Dynamic workspace factories are always considered ready since they
-	 * resolve per-request and don't require upfront initialization.
-	 */
-	isWorkspaceReady(): boolean {
-		if (this.workspaceFn) return true
-		return this.workspaceInitialized && this.workspace !== undefined
-	}
+    // Validate against schema
+    const result = this.config.stateSchema.safeParse(newState);
+    if (!result.success) {
+      throw new Error(`Invalid state update: ${result.error.message}`);
+    }
 
-	// ===========================================================================
-	// Heartbeat Handlers
-	// ===========================================================================
+    this.state = result.data as z.infer<TState>;
 
-	/**
-	 * Start all configured heartbeat handlers.
-	 * Called automatically during `init()`.
-	 */
-	private startHeartbeats(): void {
-		const handlers = this.config.heartbeatHandlers
-		if (!handlers?.length) return
+    // Persist specific state keys to thread metadata
+    if ('todos' in updates) {
+      // Only persist todos if they have items, otherwise remove from metadata
+      if (Array.isArray(updates.todos) && updates.todos.length > 0) {
+        this.persistThreadSetting('todos', updates.todos).catch(() => {});
+      } else {
+        // Remove todos from metadata when empty
+        this.removeThreadSetting('todos').catch(() => {});
+      }
+    }
 
-		for (const hb of handlers) {
-			if (this.heartbeatTimers.has(hb.id)) continue
+    this.emit({
+      type: 'state_changed',
+      state: this.state,
+      changedKeys,
+    });
+  }
 
-			const run = async () => {
-				try {
-					await hb.handler()
-				} catch (error) {
-					console.error(`[Heartbeat:${hb.id}] failed:`, error)
-				}
-			}
+  private getSchemaDefaults(): Partial<z.infer<TState>> {
+    // Extract defaults from Zod schema
+    const shape = this.config.stateSchema.shape;
+    const defaults: Record<string, unknown> = {};
 
-			if (hb.immediate !== false) {
-				run()
-			}
+    for (const [key, field] of Object.entries(shape)) {
+      if (field instanceof Object && '_def' in field) {
+        const def = (field as any)._def;
+        if (def.defaultValue !== undefined) {
+          defaults[key] = typeof def.defaultValue === 'function' ? def.defaultValue() : def.defaultValue;
+        }
+      }
+    }
 
-			const timer = setInterval(run, hb.intervalMs)
-			timer.unref()
-			this.heartbeatTimers.set(hb.id, { timer, shutdown: hb.shutdown })
-		}
-	}
+    return defaults as Partial<z.infer<TState>>;
+  }
 
-	/**
-	 * Register a heartbeat handler dynamically (after init).
-	 * If a handler with the same id already exists, it is replaced.
-	 */
-	registerHeartbeat(handler: HeartbeatHandler): void {
-		this.removeHeartbeat(handler.id)
+  // ===========================================================================
+  // Mode Management
+  // ===========================================================================
 
-		const run = async () => {
-			try {
-				await handler.handler()
-			} catch (error) {
-				console.error(`[Heartbeat:${handler.id}] failed:`, error)
-			}
-		}
+  /**
+   * Get all available modes.
+   */
+  getModes(): HarnessMode<TState>[] {
+    return this.config.modes;
+  }
 
-		if (handler.immediate !== false) {
-			run()
-		}
+  /**
+   * Get the hook manager (if configured).
+   */
+  getHookManager(): HookManager | undefined {
+    return this.hookManager;
+  }
 
-		const timer = setInterval(run, handler.intervalMs)
-		timer.unref()
-		this.heartbeatTimers.set(handler.id, { timer, shutdown: handler.shutdown })
-	}
+  /**
+   * Get the MCP manager (if configured).
+   */
+  getMcpManager(): MCPManager | undefined {
+    return this.mcpManager;
+  }
 
-	/**
-	 * Remove a heartbeat handler by id. Calls its shutdown hook if present.
-	 */
-	async removeHeartbeat(id: string): Promise<void> {
-		const entry = this.heartbeatTimers.get(id)
-		if (entry) {
-			clearInterval(entry.timer)
-			this.heartbeatTimers.delete(id)
-			try {
-				await entry.shutdown?.()
-			} catch (error) {
-				console.error(`[Heartbeat:${id}] shutdown failed:`, error)
-			}
-		}
-	}
+  /**
+   * Register a pending question resolver.
+   * Called by the ask_user tool to register a promise resolver
+   * that will be resolved when the user answers in the TUI.
+   */
+  registerQuestion(questionId: string, resolve: (answer: string) => void): void {
+    this.pendingQuestions.set(questionId, resolve);
+  }
 
-	/**
-	 * Stop all heartbeat handlers and run their shutdown hooks. Call during shutdown.
-	 */
-	async stopHeartbeats(): Promise<void> {
-		const entries = [...this.heartbeatTimers.entries()]
-		this.heartbeatTimers.clear()
+  /**
+   * Resolve a pending question with the user's answer.
+   * Called by the TUI when the user selects an option or submits text.
+   */
+  respondToQuestion(questionId: string, answer: string): void {
+    const resolve = this.pendingQuestions.get(questionId);
+    if (resolve) {
+      this.pendingQuestions.delete(questionId);
+      resolve(answer);
+    }
+  }
 
-		for (const [id, entry] of entries) {
-			clearInterval(entry.timer)
-			try {
-				await entry.shutdown?.()
-			} catch (error) {
-				console.error(`[Heartbeat:${id}] shutdown failed:`, error)
-			}
-		}
-	}
+  /**
+   * Register a pending plan approval resolver.
+   * Called by the submit_plan tool to register a promise resolver.
+   */
+  registerPlanApproval(
+    planId: string,
+    resolve: (result: { action: 'approved' | 'rejected'; feedback?: string }) => void,
+  ): void {
+    this.pendingPlanApprovals.set(planId, resolve);
+  }
 
-	/**
-	 * Destroy the workspace and clean up resources.
-	 * Can be called during harness shutdown for proper cleanup.
-	 * No-op for dynamic workspace factories (they are ephemeral per-request).
-	 */
-	async destroyWorkspace(): Promise<void> {
-		if (this.workspaceFn) return
-		if (this.workspace && this.workspaceInitialized) {
-			try {
-				this.emit({
-					type: "workspace_status_changed",
-					status: "destroying",
-				})
-				await this.workspace.destroy()
-				this.emit({
-					type: "workspace_status_changed",
-					status: "destroyed",
-				})
-			} catch (error) {
-				console.warn("Workspace destroy failed:", error)
-			} finally {
-				this.workspaceInitialized = false
-			}
-		}
-	}
+  /**
+   * Respond to a pending plan approval.
+   * On approval: switches to Build mode, then resolves the promise.
+   * On rejection: resolves with feedback (stays in Plan mode).
+   */
+  async respondToPlanApproval(
+    planId: string,
+    response: { action: 'approved' | 'rejected'; feedback?: string },
+  ): Promise<void> {
+    const resolve = this.pendingPlanApprovals.get(planId);
+    if (!resolve) return;
 
-	// ===========================================================================
-	// Utilities
-	// ===========================================================================
-	/**
-	 * Release the lock on the current thread.
-	 * Call this when the process is exiting.
-	 */
-	releaseCurrentThreadLock(): void {
-		if (this.currentThreadId) {
-			releaseThreadLock(this.currentThreadId)
-		}
-	}
+    this.pendingPlanApprovals.delete(planId);
 
-	private generateId(): string {
-		return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
-	}
+    // Resolve first so the plan approval component can update its UI
+    resolve(response);
+
+    if (response.action === 'approved') {
+      await this.switchMode('build');
+      // Note: The TUI handles triggering the build agent via system reminder
+      // after this method completes, ensuring proper message ordering
+    }
+  }
+
+  /**
+   * Get current mode ID.
+   */
+  getCurrentModeId(): string {
+    return this.currentModeId;
+  }
+
+  /**
+   * Get current mode configuration.
+   */
+  getCurrentMode(): HarnessMode<TState> {
+    const mode = this.config.modes.find(m => m.id === this.currentModeId);
+    if (!mode) {
+      throw new Error(`Mode not found: ${this.currentModeId}`);
+    }
+    return mode;
+  }
+  /**
+   * Switch to a different mode.
+   * Aborts any in-progress generation.
+   * Also switches to the mode's stored model (or its default).
+   */
+  async switchMode(modeId: string): Promise<void> {
+    const mode = this.config.modes.find(m => m.id === modeId);
+    if (!mode) {
+      throw new Error(`Mode not found: ${modeId}`);
+    }
+
+    // Abort current operation if any
+    this.abort();
+
+    // Save current model to the outgoing mode before switching
+    const currentModelId = this.getCurrentModelId();
+    if (currentModelId) {
+      await this.persistThreadSetting(`modeModelId_${this.currentModeId}`, currentModelId);
+    }
+
+    const previousModeId = this.currentModeId;
+    this.currentModeId = modeId;
+
+    // Persist mode to thread metadata
+    await this.persistThreadSetting('currentModeId', modeId);
+
+    // Load the incoming mode's model
+    const modeModelId = await this.loadModeModelId(modeId);
+    if (modeModelId) {
+      this.setState({ currentModelId: modeModelId } as unknown as Partial<z.infer<TState>>);
+      this.emit({ type: 'model_changed', modelId: modeModelId } as HarnessEvent);
+    }
+
+    this.emit({
+      type: 'mode_changed',
+      modeId,
+      previousModeId,
+    });
+  }
+
+  /**
+   * Load the stored model ID for a specific mode.
+   * Falls back to: thread metadata → global per-mode → mode's defaultModelId → global last model → current model.
+   */
+  private async loadModeModelId(modeId: string): Promise<string | null> {
+    // 1. Check thread metadata for per-mode model
+    if (this.currentThreadId) {
+      try {
+        const memoryStorage = await this.getMemoryStorage();
+        const thread = await memoryStorage.getThreadById({
+          threadId: this.currentThreadId,
+        });
+        const meta = thread?.metadata as Record<string, unknown> | undefined;
+        const stored = meta?.[`modeModelId_${modeId}`] as string | undefined;
+        if (stored) return stored;
+      } catch {
+        // Fall through to defaults
+      }
+    }
+
+    // 2. Check global per-mode model from auth storage
+    const globalModeModel = this.config.authStorage?.getModeModelId(modeId);
+    if (globalModeModel) return globalModeModel;
+
+    // 3. Fall back to mode's defaultModelId
+    const mode = this.config.modes.find(m => m.id === modeId);
+    if (mode?.defaultModelId) return mode.defaultModelId;
+
+    // 4. Fall back to global last model
+    const lastModelId = this.config.authStorage?.getLastModelId();
+    if (lastModelId) return lastModelId;
+
+    // 5. Keep current model
+    return null;
+  }
+  /**
+   * Get the agent for the current mode.
+   * Resolves dynamic agent functions with current state.
+   */
+  private getCurrentAgent(): Agent {
+    const mode = this.getCurrentMode();
+    if (typeof mode.agent === 'function') {
+      return mode.agent(this.state);
+    }
+    return mode.agent;
+  }
+
+  /**
+   * Get the current model name/ID.
+   * Returns a short display name extracted from the model ID in state.
+   */
+  getModelName(): string {
+    const modelId = this.getCurrentModelId();
+    if (modelId === 'unknown') return modelId;
+
+    // Extract just the model name from "provider/model" format
+    const parts = modelId.split('/');
+    return parts[parts.length - 1] || modelId;
+  }
+
+  /**
+   * Get the full model ID (e.g., "anthropic/claude-sonnet-4").
+   * Reads from harness state (set via switchModel()).
+   */
+  getFullModelId(): string {
+    return this.getCurrentModelId();
+  }
+
+  /**
+   * Check if the current model has authentication configured (env var or OAuth).
+   * Returns { hasAuth, apiKeyEnvVar } for the current model's provider.
+   */
+  async getCurrentModelAuthStatus(): Promise<{
+    hasAuth: boolean;
+    apiKeyEnvVar?: string;
+  }> {
+    const modelId = this.getCurrentModelId();
+    const provider = modelId.split('/')[0];
+    if (!provider) return { hasAuth: true };
+
+    // Check OAuth
+    const providerToOAuthId: Record<string, string> = {
+      anthropic: 'anthropic',
+      openai: 'openai-codex',
+    };
+    const oauthId = providerToOAuthId[provider];
+    if (oauthId && this.config.authStorage?.isLoggedIn(oauthId)) {
+      return { hasAuth: true };
+    }
+
+    // Check env var via registry
+    try {
+      const { PROVIDER_REGISTRY } = await import('@mastra/core/llm');
+      const registry = PROVIDER_REGISTRY as Record<string, { apiKeyEnvVar?: string }>;
+      const providerConfig = registry[provider];
+      const apiKeyEnvVar = providerConfig?.apiKeyEnvVar;
+      if (apiKeyEnvVar && process.env[apiKeyEnvVar]) {
+        return { hasAuth: true };
+      }
+      return { hasAuth: false, apiKeyEnvVar: apiKeyEnvVar || undefined };
+    } catch {
+      return { hasAuth: true }; // Can't check, assume OK
+    }
+  }
+
+  /**
+   * Get list of available models from Mastra's provider registry.
+   * Returns models grouped by provider, with API key availability info.
+   */
+  async getAvailableModels(): Promise<
+    Array<{
+      id: string;
+      provider: string;
+      modelName: string;
+      hasApiKey: boolean;
+      apiKeyEnvVar?: string;
+      useCount: number;
+    }>
+  > {
+    try {
+      // Import from the public @mastra/core/llm export
+      const { PROVIDER_REGISTRY } = await import('@mastra/core/llm');
+
+      if (!PROVIDER_REGISTRY) {
+        console.warn('Provider registry not available');
+        return [];
+      }
+
+      // PROVIDER_REGISTRY is a Proxy - use Object.keys to get providers
+      // Cast to Record<string, any> to allow string indexing
+      const registry = PROVIDER_REGISTRY as Record<string, { models?: string[]; name?: string; apiKeyEnvVar?: string }>;
+      const providers = Object.keys(registry);
+      const useCounts = this.config.authStorage?.getAllModelUseCounts() ?? {};
+      const models: Array<{
+        id: string;
+        provider: string;
+        modelName: string;
+        hasApiKey: boolean;
+        apiKeyEnvVar?: string;
+        useCount: number;
+      }> = [];
+      // Map model provider prefixes to OAuth provider IDs
+      const providerToOAuthId: Record<string, string> = {
+        anthropic: 'anthropic',
+        openai: 'openai-codex',
+      };
+
+      for (const provider of providers) {
+        const providerConfig = registry[provider];
+        // Check if API key is available via env var OR OAuth
+        const apiKeyEnvVar = providerConfig?.apiKeyEnvVar;
+        const hasEnvKey = apiKeyEnvVar ? !!process.env[apiKeyEnvVar] : false;
+        const oauthId = providerToOAuthId[provider];
+        const hasOAuth = oauthId ? (this.config.authStorage?.isLoggedIn(oauthId) ?? false) : false;
+        const hasApiKey = hasEnvKey || hasOAuth;
+
+        // Each provider config has a 'models' array
+        if (providerConfig?.models && Array.isArray(providerConfig.models)) {
+          for (const modelName of providerConfig.models) {
+            const id = `${provider}/${modelName}`;
+            models.push({
+              id,
+              provider,
+              modelName,
+              hasApiKey,
+              apiKeyEnvVar: apiKeyEnvVar || undefined,
+              useCount: useCounts[id] ?? 0,
+            });
+          }
+        }
+      }
+
+      return models;
+    } catch (error) {
+      console.warn('Failed to load available models:', error);
+      return [];
+    }
+  }
+  /**
+   * Switch to a different model at runtime.
+   * Updates the harness state which the dynamic model function reads.
+   * Also saves per-mode and as global "last model" for new threads.
+   * @param modelId Full model ID (e.g., "anthropic/claude-sonnet-4-20250514")
+   */
+  /**
+   * Switch the main agent model for a specific mode.
+   * @param modelId Full model ID (e.g., "anthropic/claude-sonnet-4-20250514")
+   * @param scope "global" for global default, "thread" for thread-specific setting
+   * @param modeId Mode ID (defaults to current mode)
+   */
+  async switchModel(modelId: string, scope: 'global' | 'thread' = 'thread', modeId?: string): Promise<void> {
+    const targetModeId = modeId ?? this.currentModeId;
+
+    // Update current state for immediate effect if this is the current mode
+    if (targetModeId === this.currentModeId) {
+      this.setState({ currentModelId: modelId } as unknown as Partial<z.infer<TState>>);
+    }
+
+    // Persist based on scope
+    if (scope === 'global') {
+      // Global default for this mode - save to auth storage
+      this.config.authStorage?.setModeModelId(targetModeId, modelId);
+    } else {
+      // Thread-specific setting for this mode - save to thread metadata
+      await this.persistThreadSetting(`modeModelId_${targetModeId}`, modelId);
+    }
+
+    // Always bump use count for ranking
+    this.config.authStorage?.incrementModelUseCount(modelId);
+
+    // Emit event so TUI can update status line
+    this.emit({
+      type: 'model_changed',
+      modelId,
+      scope,
+      modeId: targetModeId,
+    } as HarnessEvent);
+  }
+  /**
+   * Get the current model ID from state.
+   * Returns empty string if no model is selected.
+   */
+  getCurrentModelId(): string {
+    const state = this.getState() as { currentModelId?: string };
+    return state.currentModelId ?? '';
+  }
+
+  /**
+   * Check if a model is currently selected.
+   */
+  hasModelSelected(): boolean {
+    return this.getCurrentModelId() !== '';
+  }
+
+  // =========================================================================
+  // Observational Memory Model Management
+  // =========================================================================
+
+  /**
+   * Get the current Observer model ID from state.
+   */
+  getObserverModelId(): string {
+    const state = this.getState() as { observerModelId?: string };
+    return state.observerModelId ?? 'google/gemini-2.5-flash';
+  }
+
+  /**
+   * Get the current Reflector model ID from state.
+   */
+  getReflectorModelId(): string {
+    const state = this.getState() as { reflectorModelId?: string };
+    return state.reflectorModelId ?? 'google/gemini-2.5-flash';
+  }
+  /**
+   * Switch the Observer model.
+   * @param modelId Full model ID (e.g., "google/gemini-2.5-flash")
+   */
+  async switchObserverModel(modelId: string): Promise<void> {
+    this.setState({ observerModelId: modelId } as unknown as Partial<z.infer<TState>>);
+    await this.persistThreadSetting('observerModelId', modelId);
+
+    this.emit({
+      type: 'om_model_changed',
+      role: 'observer',
+      modelId,
+    } as HarnessEvent);
+  }
+
+  /**
+   * Switch the Reflector model.
+   * @param modelId Full model ID (e.g., "google/gemini-2.5-flash")
+   */
+  async switchReflectorModel(modelId: string): Promise<void> {
+    this.setState({ reflectorModelId: modelId } as unknown as Partial<z.infer<TState>>);
+    await this.persistThreadSetting('reflectorModelId', modelId);
+
+    this.emit({
+      type: 'om_model_changed',
+      role: 'reflector',
+      modelId,
+    } as HarnessEvent);
+  }
+
+  // =========================================================================
+  // Subagent Model Management
+  // =========================================================================
+
+  /**
+   * Get the subagent model ID for a specific agent type.
+   * Falls back to: per-type thread model → per-type global model → null.
+   * @param agentType Optional agent type (explore, plan, execute)
+   */
+  async getSubagentModelId(agentType?: string): Promise<string | null> {
+    // 1. Check thread metadata for per-type subagent model
+    if (agentType && this.currentThreadId) {
+      try {
+        const memoryStorage = await this.getMemoryStorage();
+        const thread = await memoryStorage.getThreadById({
+          threadId: this.currentThreadId,
+        });
+        const meta = thread?.metadata as Record<string, unknown> | undefined;
+
+        const perTypeThread = meta?.[`subagentModelId_${agentType}`] as string | undefined;
+        if (perTypeThread) return perTypeThread;
+      } catch {
+        // Fall through
+      }
+    }
+
+    // 2. Check global per-type subagent model from auth storage
+    if (agentType) {
+      const perTypeGlobal = this.config.authStorage?.getSubagentModelId(agentType);
+      if (perTypeGlobal) return perTypeGlobal;
+    }
+
+    // 3. No configured subagent model — caller should use defaults
+    return null;
+  }
+
+  /**
+   * Set the subagent model ID.
+   * @param modelId Full model ID (e.g., "anthropic/claude-sonnet-4-20250514")
+   * @param scope "global" for global default, "thread" for thread-level default
+   * @param agentType Agent type (explore, plan, execute)
+   */
+  async setSubagentModelId(modelId: string, scope: 'global' | 'thread' = 'thread', agentType?: string): Promise<void> {
+    if (!agentType) {
+      throw new Error('agentType is required for setSubagentModelId');
+    }
+
+    if (scope === 'global') {
+      // Persist to auth storage (global preference per agent type)
+      this.config.authStorage?.setSubagentModelId(modelId, agentType);
+    } else {
+      // Persist thread-level subagent model per agent type
+      await this.persistThreadSetting(`subagentModelId_${agentType}`, modelId);
+    }
+
+    this.emit({
+      type: 'subagent_model_changed',
+      modelId,
+      scope,
+      agentType,
+    } as HarnessEvent);
+  }
+
+  /**
+   * Get YOLO mode state.
+   */
+  getYoloMode(): boolean {
+    return (this.state as any)?.yolo === true;
+  }
+  /**
+   * Toggle YOLO mode (auto-approve all tool calls).
+   */
+  setYoloMode(enabled: boolean): void {
+    this.setState({ yolo: enabled } as unknown as Partial<z.infer<TState>>);
+    this.persistThreadSetting('yolo', enabled).catch(() => {});
+    // When toggling YOLO off, reset session grants so user starts fresh
+    if (!enabled) {
+      this.sessionGrants.reset();
+    }
+  }
+
+  // =========================================================================
+  // Permissions
+  // =========================================================================
+
+  /**
+   * Get the effective permission rules from state, with defaults.
+   */
+  private getPermissionRules(): PermissionRules {
+    const stored = (this.state as any)?.permissionRules;
+    const rules = createDefaultRules();
+    if (stored?.categories) {
+      Object.assign(rules.categories, stored.categories);
+    }
+    if (stored?.tools) {
+      Object.assign(rules.tools, stored.tools);
+    }
+    return rules;
+  }
+
+  /**
+   * Resolve whether a tool call should be allowed, prompted, or denied.
+   * YOLO mode overrides everything to "allow".
+   */
+  private resolveToolApproval(toolName: string): 'allow' | 'ask' | 'deny' {
+    if (this.getState().yolo === true) return 'allow';
+    return resolveApproval(toolName, this.getPermissionRules(), this.sessionGrants);
+  }
+
+  /**
+   * Grant a session-scoped "always allow" for a tool's category.
+   */
+  grantSessionCategory(category: ToolCategory): void {
+    this.sessionGrants.allowCategory(category);
+  }
+
+  /**
+   * Grant a session-scoped "always allow" for a specific tool.
+   */
+  grantSessionTool(toolName: string): void {
+    this.sessionGrants.allowTool(toolName);
+  }
+
+  /**
+   * Get the tool category for display purposes.
+   */
+  getToolCategory(toolName: string): ToolCategory | null {
+    return getToolCategory(toolName);
+  }
+
+  /**
+   * Get current session grants for display.
+   */
+  getSessionGrants(): { categories: ToolCategory[]; tools: string[] } {
+    return {
+      categories: this.sessionGrants.getGrantedCategories(),
+      tools: this.sessionGrants.getGrantedTools(),
+    };
+  }
+
+  /**
+   * Update a category policy in the persisted permission rules.
+   */
+  setPermissionCategory(category: ToolCategory, policy: 'allow' | 'ask' | 'deny'): void {
+    const rules = this.getPermissionRules();
+    rules.categories[category] = policy;
+    this.setState({ permissionRules: rules } as unknown as Partial<z.infer<TState>>);
+  }
+
+  /**
+   * Update a per-tool policy in the persisted permission rules.
+   */
+  setPermissionTool(toolName: string, policy: 'allow' | 'ask' | 'deny'): void {
+    const rules = this.getPermissionRules();
+    rules.tools[toolName] = policy;
+    this.setState({ permissionRules: rules } as unknown as Partial<z.infer<TState>>);
+  }
+
+  /**
+   * Get current permission rules for display.
+   */
+  getPermissionRules_public(): PermissionRules {
+    return this.getPermissionRules();
+  }
+
+  // =========================================================================
+  // Thinking Level
+  // =========================================================================
+
+  /**
+   * Get the current thinking level.
+   */
+  getThinkingLevel(): string {
+    const state = this.getState() as { thinkingLevel?: string };
+    return state.thinkingLevel ?? 'off';
+  }
+
+  /**
+   * Set the thinking level and persist to thread metadata.
+   * @param level One of: "off", "minimal", "low", "medium", "high"
+   */
+  async setThinkingLevel(level: string): Promise<void> {
+    this.setState({ thinkingLevel: level } as unknown as Partial<z.infer<TState>>);
+    await this.persistThreadSetting('thinkingLevel', level);
+  }
+
+  // =========================================================================
+  // OM Threshold Settings
+  // =========================================================================
+
+  /**
+   * Get the current observation threshold from state.
+   */
+  getObservationThreshold(): number {
+    const state = this.getState() as { observationThreshold?: number };
+    return state.observationThreshold ?? 30_000;
+  }
+
+  /**
+   * Get the current reflection threshold from state.
+   */
+  getReflectionThreshold(): number {
+    const state = this.getState() as { reflectionThreshold?: number };
+    return state.reflectionThreshold ?? 40_000;
+  }
+
+  /**
+   * Set the observation threshold and persist to thread metadata.
+   * Note: Takes effect on next restart since OM thresholds are set at construction time.
+   */
+  async setObservationThreshold(value: number): Promise<void> {
+    this.setState({ observationThreshold: value } as unknown as Partial<z.infer<TState>>);
+    await this.persistThreadSetting('observationThreshold', value);
+  }
+
+  /**
+   * Set the reflection threshold and persist to thread metadata.
+   * Note: Takes effect on next restart since OM thresholds are set at construction time.
+   */
+  async setReflectionThreshold(value: number): Promise<void> {
+    this.setState({ reflectionThreshold: value } as unknown as Partial<z.infer<TState>>);
+    await this.persistThreadSetting('reflectionThreshold', value);
+  }
+
+  /**
+   * Get current cumulative token usage for this thread.
+   */
+  getTokenUsage(): {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  } {
+    return { ...this.tokenUsage };
+  }
+
+  /**
+   * Persist token usage to thread metadata.
+   */
+  private async persistTokenUsage(): Promise<void> {
+    if (!this.currentThreadId) return;
+
+    try {
+      const memoryStorage = await this.getMemoryStorage();
+      const thread = await memoryStorage.getThreadById({
+        threadId: this.currentThreadId,
+      });
+      if (thread) {
+        await memoryStorage.saveThread({
+          thread: {
+            ...thread,
+            metadata: {
+              ...thread.metadata,
+              tokenUsage: this.tokenUsage,
+            },
+            updatedAt: new Date(),
+          },
+        });
+      }
+    } catch {
+      // Silently fail - token persistence is not critical
+    }
+  }
+  /**
+   * Persist a key-value pair to the current thread's metadata.
+   */
+  async persistThreadSetting(key: string, value: unknown): Promise<void> {
+    if (!this.currentThreadId) return;
+
+    try {
+      const memoryStorage = await this.getMemoryStorage();
+      const thread = await memoryStorage.getThreadById({
+        threadId: this.currentThreadId,
+      });
+      if (thread) {
+        await memoryStorage.saveThread({
+          thread: {
+            ...thread,
+            metadata: {
+              ...thread.metadata,
+              [key]: value,
+            },
+            updatedAt: new Date(),
+          },
+        });
+      }
+    } catch {
+      // Silently fail - settings persistence is not critical
+    }
+  }
+
+  /**
+   * Remove a key from the current thread's metadata.
+   */
+  private async removeThreadSetting(key: string): Promise<void> {
+    if (!this.currentThreadId) return;
+
+    try {
+      const memoryStorage = await this.getMemoryStorage();
+      const thread = await memoryStorage.getThreadById({
+        threadId: this.currentThreadId,
+      });
+      if (thread && thread.metadata) {
+        const metadata = { ...thread.metadata };
+        delete metadata[key];
+        await memoryStorage.saveThread({
+          thread: {
+            ...thread,
+            metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+            updatedAt: new Date(),
+          },
+        });
+      }
+    } catch {
+      // Silently fail - settings removal is not critical
+    }
+  }
+
+  private async persistModelId(modelId: string): Promise<void> {
+    await this.persistThreadSetting('currentModelId', modelId);
+  }
+  /**
+   * Load token usage and model ID from thread metadata.
+   */
+  private async loadThreadMetadata(): Promise<void> {
+    if (!this.currentThreadId) {
+      this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+      return;
+    }
+
+    try {
+      const memoryStorage = await this.getMemoryStorage();
+      const thread = await memoryStorage.getThreadById({
+        threadId: this.currentThreadId,
+      });
+
+      // Load token usage
+      const savedUsage = thread?.metadata?.tokenUsage as typeof this.tokenUsage | undefined;
+      if (savedUsage) {
+        this.tokenUsage = {
+          promptTokens: savedUsage.promptTokens ?? 0,
+          completionTokens: savedUsage.completionTokens ?? 0,
+          totalTokens: savedUsage.totalTokens ?? 0,
+        };
+      } else {
+        this.tokenUsage = {
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+        };
+      }
+      // Load saved settings from thread metadata
+      const meta = thread?.metadata as Record<string, unknown> | undefined;
+      const updates: Record<string, unknown> = {};
+
+      // Prefer per-mode model ID, fall back to global currentModelId
+      const modeModelKey = `modeModelId_${this.currentModeId}`;
+      if (meta?.[modeModelKey]) {
+        updates.currentModelId = meta[modeModelKey];
+      } else if (meta?.currentModelId) {
+        updates.currentModelId = meta.currentModelId;
+      }
+
+      if (meta?.observerModelId) updates.observerModelId = meta.observerModelId;
+      if (meta?.reflectorModelId) updates.reflectorModelId = meta.reflectorModelId;
+      if (meta?.observationThreshold) updates.observationThreshold = meta.observationThreshold;
+      if (meta?.reflectionThreshold) updates.reflectionThreshold = meta.reflectionThreshold;
+      if (meta?.thinkingLevel) updates.thinkingLevel = meta.thinkingLevel;
+      if (typeof meta?.yolo === 'boolean') updates.yolo = meta.yolo;
+      if (typeof meta?.escapeAsCancel === 'boolean') updates.escapeAsCancel = meta.escapeAsCancel;
+      if (meta?.sandboxAllowedPaths && Array.isArray(meta.sandboxAllowedPaths)) {
+        updates.sandboxAllowedPaths = meta.sandboxAllowedPaths;
+      }
+      // Load subagent model (thread-level)
+      if (meta?.subagentModelId) updates.subagentModelId = meta.subagentModelId;
+      // Only load todos if they exist and have items
+      if (meta?.todos && Array.isArray(meta.todos) && meta.todos.length > 0) {
+        updates.todos = meta.todos;
+      }
+
+      // Restore mode (must happen before model loading since model is per-mode)
+      if (meta?.currentModeId) {
+        const savedModeId = meta.currentModeId as string;
+        const modeExists = this.config.modes.some(m => m.id === savedModeId);
+        if (modeExists && savedModeId !== this.currentModeId) {
+          this.currentModeId = savedModeId;
+          // Re-resolve the per-mode model key now that mode is restored
+          const modeModelKey = `modeModelId_${savedModeId}`;
+          if (meta[modeModelKey]) {
+            updates.currentModelId = meta[modeModelKey];
+          }
+          this.emit({
+            type: 'mode_changed',
+            modeId: savedModeId,
+            previousModeId: this.config.modes.find(m => m.default)?.id || this.config.modes[0]!.id,
+          });
+        }
+      }
+      if (Object.keys(updates).length > 0) {
+        this.setState(updates as unknown as Partial<z.infer<TState>>);
+      }
+
+      // Load OM progress from storage record
+      await this.loadOMProgress();
+    } catch {
+      this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+    }
+  }
+  /**
+   * Load Observational Memory status from storage and emit an om_status event.
+   * Called on thread load/switch so the TUI status line reflects current state.
+   * Also callable by the TUI after subscribing to ensure initial state is populated.
+   */
+  async loadOMProgress(): Promise<void> {
+    if (!this.currentThreadId) return;
+
+    try {
+      const memoryStorage = await this.getMemoryStorage();
+      const record = await memoryStorage.getObservationalMemory(this.currentThreadId, this.resourceId);
+
+      if (!record) return;
+
+      // Extract thresholds from the record's config
+      const config = record.config as
+        | {
+            observationThreshold?: number | { min: number; max: number };
+            reflectionThreshold?: number | { min: number; max: number };
+          }
+        | undefined;
+
+      const getThreshold = (val: number | { min: number; max: number } | undefined, fallback: number): number => {
+        if (!val) return fallback;
+        if (typeof val === 'number') return val;
+        return val.max;
+      };
+
+      const observationThreshold = getThreshold(config?.observationThreshold, 30_000);
+      const reflectionThreshold = getThreshold(config?.reflectionThreshold, 40_000);
+
+      // Defaults from the OM record
+      let messageTokens = record.pendingMessageTokens ?? 0;
+      let observationTokens = record.observationTokenCount ?? 0;
+      let bufferedObs = {
+        status: 'idle' as 'idle' | 'running' | 'complete',
+        chunks: 0,
+        messageTokens: 0,
+        projectedMessageRemoval: 0,
+        observationTokens: 0,
+      };
+      let bufferedRef = {
+        status: 'idle' as 'idle' | 'running' | 'complete',
+        inputObservationTokens: 0,
+        observationTokens: 0,
+      };
+      let generationCount = 0;
+      let stepNumber = 0;
+
+      // Scan recent messages for the most recent data-om-status part
+      const messagesResult = await memoryStorage.listMessages({
+        threadId: this.currentThreadId,
+        perPage: 70,
+        page: 0,
+        orderBy: { field: 'createdAt', direction: 'DESC' },
+      });
+      const messages = messagesResult.messages;
+      let foundStatus = false;
+      for (const msg of messages) {
+        if (msg.role !== 'assistant') continue;
+        const content = msg.content as MastraMessageContentV2 | string;
+        if (typeof content === 'string' || !content?.parts) continue;
+
+        for (let i = content.parts.length - 1; i >= 0; i--) {
+          const part = content.parts[i] as {
+            type?: string;
+            data?: Record<string, any>;
+          };
+          if (part.type === 'data-om-status' && part.data?.windows) {
+            const w = part.data.windows;
+            messageTokens = w.active?.messages?.tokens ?? messageTokens;
+            observationTokens = w.active?.observations?.tokens ?? observationTokens;
+            // Override thresholds if present in the status
+            const msgThresh = w.active?.messages?.threshold;
+            const obsThresh = w.active?.observations?.threshold;
+            if (msgThresh) Object.assign(config ?? {}, { observationThreshold: msgThresh });
+            if (obsThresh) Object.assign(config ?? {}, { reflectionThreshold: obsThresh });
+            // Buffered state
+            const bo = w.buffered?.observations;
+            if (bo) {
+              bufferedObs = {
+                status: bo.status ?? 'idle',
+                chunks: bo.chunks ?? 0,
+                messageTokens: bo.messageTokens ?? 0,
+                projectedMessageRemoval: bo.projectedMessageRemoval ?? 0,
+                observationTokens: bo.observationTokens ?? 0,
+              };
+            }
+            const br = w.buffered?.reflection;
+            if (br) {
+              bufferedRef = {
+                status: br.status ?? 'idle',
+                inputObservationTokens: br.inputObservationTokens ?? 0,
+                observationTokens: br.observationTokens ?? 0,
+              };
+            }
+            generationCount = part.data.generationCount ?? 0;
+            stepNumber = part.data.stepNumber ?? 0;
+            foundStatus = true;
+            break;
+          }
+        }
+        if (foundStatus) break;
+      }
+
+      this.emit({
+        type: 'om_status',
+        windows: {
+          active: {
+            messages: {
+              tokens: messageTokens,
+              threshold: observationThreshold,
+            },
+            observations: {
+              tokens: observationTokens,
+              threshold: reflectionThreshold,
+            },
+          },
+          buffered: {
+            observations: bufferedObs,
+            reflection: bufferedRef,
+          },
+        },
+        recordId: (record as any).id ?? '',
+        threadId: this.currentThreadId,
+        stepNumber,
+        generationCount,
+      });
+    } catch {
+      // OM not available or not initialized — that's fine
+    }
+  }
+
+  // ===========================================================================
+  // Thread Management
+  // ===========================================================================
+
+  /**
+   * Get current thread ID.
+   */
+  getCurrentThreadId(): string | null {
+    return this.currentThreadId;
+  }
+  /**
+   * Get current resource ID.
+   */
+  getResourceId(): string {
+    return this.resourceId;
+  }
+
+  /**
+   * Get the auto-detected resource ID (before any overrides).
+   */
+  getDefaultResourceId(): string {
+    return this.defaultResourceId;
+  }
+
+  /**
+   * Get current user ID (for thread attribution).
+   */
+  getUserId(): string | undefined {
+    return this.userId;
+  }
+
+  /**
+   * Whether the storage backend is remote.
+   */
+  getIsRemoteStorage(): boolean {
+    return this.isRemoteStorage;
+  }
+  /**
+   * Set the current resource ID (for switching between projects/resources).
+   */
+  setResourceId(resourceId: string): void {
+    this.resourceId = resourceId;
+    this.currentThreadId = null;
+  }
+
+  /**
+   * Get distinct resource IDs from all existing threads.
+   * Useful for showing a list of known resources to pick from.
+   */
+  async getKnownResourceIds(): Promise<string[]> {
+    const threads = await this.listThreads({
+      allResources: true,
+      allPaths: true,
+    });
+    const ids = new Set<string>();
+    for (const t of threads) {
+      ids.add(t.resourceId);
+    }
+    // Put the current resource ID first, then sort the rest
+    const sorted = [...ids].filter(id => id !== this.resourceId).sort();
+    return [this.resourceId, ...sorted];
+  }
+
+  /**
+   * Create a new thread.
+   * Uses the global "last model" if available, otherwise uses initial state.
+   */
+  async createThread(title?: string): Promise<HarnessThread> {
+    const now = new Date();
+    const thread: HarnessThread = {
+      id: this.generateId(),
+      resourceId: this.resourceId,
+      title: title || 'New Thread',
+      createdAt: now,
+      updatedAt: now,
+    };
+    // Resolve model for this mode:
+    // 1. Current in-memory model (already set by switchMode/switchModel)
+    // 2. Current mode's defaultModelId
+    // 3. Global "last model" (user's most recent choice across sessions)
+    const currentStateModel = (this.state as any).currentModelId;
+    const currentMode = this.getCurrentMode();
+    const lastModelId = this.config.authStorage?.getLastModelId();
+    const modelId = currentStateModel || currentMode.defaultModelId || lastModelId;
+    // Build metadata with both global and per-mode model ID
+    const metadata: Record<string, unknown> = {};
+    if (modelId) {
+      metadata.currentModelId = modelId;
+      metadata[`modeModelId_${this.currentModeId}`] = modelId;
+    }
+    // Inherit resource-level settings from the most recent thread
+    try {
+      const existingThreads = await this.listThreads();
+      if (existingThreads.length > 0) {
+        const sorted = [...existingThreads].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+        const prevMeta = sorted[0]!.metadata as Record<string, unknown> | undefined;
+        if (prevMeta) {
+          if (typeof prevMeta.yolo === 'boolean') {
+            metadata.yolo = prevMeta.yolo;
+            this.setState({ yolo: prevMeta.yolo } as unknown as Partial<z.infer<TState>>);
+          }
+          if (typeof prevMeta.escapeAsCancel === 'boolean') {
+            metadata.escapeAsCancel = prevMeta.escapeAsCancel;
+            this.setState({
+              escapeAsCancel: prevMeta.escapeAsCancel,
+            } as unknown as Partial<z.infer<TState>>);
+          }
+        }
+      }
+    } catch {
+      // Non-critical — proceed without inheriting
+    }
+
+    // Store project path for directory-aware thread filtering (worktrees, etc.)
+    const projectPath = (this.state as any)?.projectPath;
+    if (projectPath) {
+      metadata.projectPath = projectPath;
+    }
+
+    // Store user identity for multi-user thread attribution
+    if (this.userId) {
+      metadata.createdBy = this.userId;
+    }
+
+    // Persist thread to storage with model ID
+    const memoryStorage = await this.getMemoryStorage();
+    await memoryStorage.saveThread({
+      thread: {
+        id: thread.id,
+        resourceId: thread.resourceId,
+        title: thread.title!,
+        createdAt: thread.createdAt,
+        updatedAt: thread.updatedAt,
+        metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+      },
+    });
+    // Release lock on previous thread, acquire lock on new one
+    if (this.currentThreadId) {
+      releaseThreadLock(this.currentThreadId);
+    }
+    acquireThreadLock(thread.id);
+
+    // Also switch to this new thread
+    this.currentThreadId = thread.id;
+
+    // Set the model in state (only if not already set)
+    if (modelId && !currentStateModel) {
+      this.setState({ currentModelId: modelId } as unknown as Partial<z.infer<TState>>);
+    }
+
+    // Reset token usage for new thread
+    this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+
+    this.emit({ type: 'thread_created', thread });
+
+    return thread;
+  }
+  /**
+   * Rename the current thread.
+   */
+  async renameThread(title: string): Promise<void> {
+    if (!this.currentThreadId) return;
+
+    const memoryStorage = await this.getMemoryStorage();
+    const thread = await memoryStorage.getThreadById({
+      threadId: this.currentThreadId,
+    });
+    if (thread) {
+      await memoryStorage.saveThread({
+        thread: {
+          ...thread,
+          title,
+          updatedAt: new Date(),
+        },
+      });
+    }
+  }
+
+  /**
+   * Switch to a different thread.
+   */
+  async switchThread(threadId: string): Promise<void> {
+    // Abort current operation if any
+    this.abort();
+
+    // Verify thread exists
+    const memoryStorage = await this.getMemoryStorage();
+    const thread = await memoryStorage.getThreadById({ threadId });
+    if (!thread) {
+      throw new Error(`Thread not found: ${threadId}`);
+    }
+
+    // Acquire lock on new thread before releasing old one
+    acquireThreadLock(threadId);
+
+    const previousThreadId = this.currentThreadId;
+    if (previousThreadId) {
+      releaseThreadLock(previousThreadId);
+    }
+    this.currentThreadId = threadId;
+
+    // Load token usage and model ID for this thread
+    await this.loadThreadMetadata();
+
+    this.emit({
+      type: 'thread_changed',
+      threadId,
+      previousThreadId,
+    });
+  }
+  /**
+   * List threads. By default lists only threads for the current resource AND project path.
+   * Pass `allResources: true` to list threads across all resources.
+   * Pass `allPaths: true` to list threads across all paths for the current resource.
+   * Pass `mineOnly: true` to filter to threads created by the current user.
+   * When using remote storage, `mineOnly` defaults to `true`.
+   */
+  async listThreads(options?: {
+    allResources?: boolean;
+    allPaths?: boolean;
+    mineOnly?: boolean;
+  }): Promise<HarnessThread[]> {
+    const memoryStorage = await this.getMemoryStorage();
+    const projectPath = (this.state as any)?.projectPath as string | undefined;
+
+    // Default mineOnly to true when remote storage + user ID are available
+    const mineOnly = options?.mineOnly ?? (this.isRemoteStorage && !!this.userId && !options?.allResources);
+
+    const metadataFilter: Record<string, unknown> = {};
+    if (!options?.allPaths && projectPath) {
+      metadataFilter.projectPath = projectPath;
+    }
+    if (mineOnly && this.userId) {
+      metadataFilter.createdBy = this.userId;
+    }
+
+    const filter: { resourceId?: string; metadata?: Record<string, unknown> } | undefined = options?.allResources
+      ? undefined
+      : {
+          resourceId: this.resourceId,
+          ...(Object.keys(metadataFilter).length > 0 ? { metadata: metadataFilter } : {}),
+        };
+
+    const result = await memoryStorage.listThreads({
+      perPage: options?.allResources ? false : undefined,
+      filter,
+    });
+
+    return result.threads.map((thread: StorageThreadType) => ({
+      id: thread.id,
+      resourceId: thread.resourceId,
+      title: thread.title,
+      createdAt: thread.createdAt,
+      updatedAt: thread.updatedAt,
+      metadata: thread.metadata,
+    }));
+  }
+
+  // ===========================================================================
+  // Message Handling
+  // ===========================================================================
+
+  /**
+   * Send a message to the current agent.
+   * Streams the response and emits events.
+   *
+   * Uses an operation ID to safely handle steer (abort + re-send):
+   * if a newer operation supersedes this one, events and cleanup are skipped.
+   */
+  async sendMessage(
+    content: string,
+    options?: {
+      images?: Array<{ data: string; mimeType: string }>;
+    },
+  ): Promise<void> {
+    // Run UserPromptSubmit hooks (blocking)
+    if (this.hookManager) {
+      const hookResult = await this.hookManager.runUserPromptSubmit(content);
+      for (const warning of hookResult.warnings) {
+        this.emit({ type: 'error', error: new Error(`[hook] ${warning}`) });
+      }
+      if (!hookResult.allowed) {
+        this.emit({
+          type: 'error',
+          error: new Error(`Message blocked by hook: ${hookResult.blockReason || 'Policy violation'}`),
+        });
+        return;
+      }
+    }
+
+    // Ensure we have a thread
+    if (!this.currentThreadId) {
+      const thread = await this.createThread();
+      this.currentThreadId = thread.id;
+    }
+
+    // Tag this operation so steer() can safely supersede it
+    const operationId = ++this.currentOperationId;
+
+    // Create abort controller for this operation
+    this.abortController = new AbortController();
+    const agent = this.getCurrentAgent();
+
+    this.emit({ type: 'agent_start' });
+
+    try {
+      // Build request context for tools
+      const requestContext = await this.buildRequestContext();
+      // Stream the response
+      const streamOptions: Record<string, unknown> = {
+        memory: {
+          thread: this.currentThreadId,
+          resource: this.resourceId,
+        },
+        abortSignal: this.abortController.signal,
+        requestContext,
+        maxSteps: 1000,
+        requireToolApproval: this.getYoloMode() !== true,
+        modelSettings: {
+          temperature: 1,
+        },
+      };
+
+      // Add provider-specific toolsets (e.g., Anthropic web search)
+      if (this.config.getToolsets) {
+        const modelId = this.getCurrentModelId();
+        const toolsets = this.config.getToolsets(modelId);
+        if (toolsets) {
+          streamOptions.toolsets = toolsets;
+        }
+      }
+
+      // Build message input: multimodal if images present, string otherwise
+      let messageInput: string | Record<string, unknown> = content;
+      if (options?.images?.length) {
+        messageInput = {
+          role: 'user',
+          content: [
+            { type: 'text', text: content },
+            ...options.images.map(img => ({
+              type: 'file',
+              data: img.data,
+              mediaType: img.mimeType,
+            })),
+          ],
+        };
+      }
+
+      const response = await agent.stream(messageInput as any, streamOptions as any);
+      // Process the stream. Tool approvals are handled inline via
+      // the permission system and TUI dialog.
+      let result = await this.processStream(response);
+
+      const lastMessage = result.message;
+
+      // Run Stop hooks (blocking: exit 2 = agent keeps working)
+      if (this.hookManager && this.currentOperationId === operationId) {
+        const assistantText =
+          lastMessage?.content
+            ?.filter((c): c is { type: 'text'; text: string } => c.type === 'text')
+            .map(c => c.text)
+            .join('') || undefined;
+
+        const stopResult = await this.hookManager.runStop(assistantText, 'complete');
+        for (const warning of stopResult.warnings) {
+          this.emit({ type: 'error', error: new Error(`[hook] ${warning}`) });
+        }
+        if (!stopResult.allowed) {
+          // Hook says agent should keep working
+          this.followUpQueue.unshift(stopResult.blockReason || 'A hook has requested that you continue working.');
+          return;
+        }
+      }
+
+      // Only emit completion if not superseded by steer
+      if (this.currentOperationId === operationId) {
+        // Check if abort was requested - stream may complete gracefully even after abort
+        const reason = this.abortRequested ? 'aborted' : 'complete';
+        this.emit({ type: 'agent_end', reason });
+      }
+    } catch (error) {
+      // If superseded by steer, silently exit
+      if (this.currentOperationId !== operationId) return;
+
+      if (error instanceof Error && error.name === 'AbortError') {
+        // Aborted - emit end event with aborted status
+        this.emit({ type: 'agent_end', reason: 'aborted' });
+      } else if (error instanceof Error && error.message.match(/^Tool .+ not found$/)) {
+        // Model hallucinated a tool name — recover by sending a corrective
+        // follow-up so the agent can retry with the right tool
+        const badTool = error.message.replace('Tool ', '').replace(' not found', '');
+        this.emit({
+          type: 'error',
+          error: new Error(`Unknown tool "${badTool}". Shell commands must be run via execute_command.`),
+          retryable: true,
+        });
+        this.followUpQueue.push(
+          `[System] Your previous tool call used "${badTool}" which is not a valid tool. ` +
+            `Shell commands like git, npm, etc. must be run via the execute_command tool. ` +
+            `Please retry with the correct tool name.`,
+        );
+        this.emit({ type: 'agent_end', reason: 'error' });
+      } else if (
+        errorContains(error, 'must end with a user message') ||
+        errorContains(error, 'assistant message prefill')
+      ) {
+        // Conversation ends with an assistant message (e.g. after
+        // OM activation) — inject a synthetic user message
+        // and retry so the model can continue.
+        this.followUpQueue.unshift('<continue>');
+        this.emit({
+          type: 'error',
+          error: new Error('Prefill rejection — patching chat and retrying'),
+          retryable: true,
+        });
+        this.emit({ type: 'agent_end', reason: 'error' });
+      } else {
+        // Parse the error for better user feedback
+        const parsed = parseError(error);
+        this.emit({
+          type: 'error',
+          error: parsed.originalError,
+          errorType: parsed.type,
+          retryable: parsed.retryable,
+          retryDelay: parsed.retryDelay,
+        });
+        this.emit({ type: 'agent_end', reason: 'error' });
+      }
+    } finally {
+      // Only clean up if this is still the current operation
+      if (this.currentOperationId === operationId) {
+        this.abortController = null;
+        this.abortRequested = false;
+      }
+
+      // Process follow-up queue after this operation completes
+      if (this.currentOperationId === operationId && this.followUpQueue.length > 0) {
+        const next = this.followUpQueue.shift()!;
+        await this.sendMessage(next);
+      }
+    }
+  }
+  /**
+   * Get message history for the current thread.
+   */
+  async getMessages(options?: { limit?: number }): Promise<HarnessMessage[]> {
+    if (!this.currentThreadId) {
+      return [];
+    }
+    return this.getMessagesForThread(this.currentThreadId, options);
+  }
+
+  /**
+   * Get message history for a specific thread.
+   * @param options.limit - Max number of most recent messages to fetch. Omit or pass undefined for all.
+   */
+  async getMessagesForThread(threadId: string, options?: { limit?: number }): Promise<HarnessMessage[]> {
+    const memoryStorage = await this.getMemoryStorage();
+    const limit = options?.limit;
+
+    if (limit) {
+      // Fetch the last N messages by querying DESC and reversing
+      const result = await memoryStorage.listMessages({
+        threadId,
+        perPage: limit,
+        page: 0,
+        orderBy: { field: 'createdAt', direction: 'DESC' },
+      });
+      return result.messages.map(msg => this.convertToHarnessMessage(msg)).reverse();
+    }
+
+    const result = await memoryStorage.listMessages({
+      threadId,
+      perPage: false,
+    });
+    return result.messages.map(msg => this.convertToHarnessMessage(msg));
+  }
+
+  /**
+   * Get the first user message for a thread (for previews).
+   */
+  async getFirstUserMessageForThread(threadId: string): Promise<HarnessMessage | null> {
+    const memoryStorage = await this.getMemoryStorage();
+    // Fetch a small batch from the beginning — first user message is usually in the first few
+    const result = await memoryStorage.listMessages({
+      threadId,
+      perPage: 5,
+      page: 0,
+      orderBy: { field: 'createdAt', direction: 'ASC' },
+    });
+    const userMsg = result.messages.find(m => m.role === 'user');
+    return userMsg ? this.convertToHarnessMessage(userMsg) : null;
+  }
+
+  /**
+   * Convert a Mastra DB message to a HarnessMessage.
+   */
+  private convertToHarnessMessage(msg: {
+    id: string;
+    role: 'user' | 'assistant' | 'system';
+    createdAt: Date;
+    content: {
+      parts: Array<{
+        type: string;
+        text?: string;
+        reasoning?: string;
+        toolCallId?: string;
+        toolName?: string;
+        args?: unknown;
+        result?: unknown;
+        isError?: boolean;
+        // Nested tool invocation structure from Mastra storage
+        toolInvocation?: {
+          state: string;
+          toolCallId: string;
+          toolName: string;
+          args?: unknown;
+          result?: unknown;
+          isError?: boolean;
+        };
+        [key: string]: unknown;
+      }>;
+    };
+  }): HarnessMessage {
+    const content: HarnessMessageContent[] = [];
+
+    for (const part of msg.content.parts) {
+      if (part.type.startsWith(`data-`)) {
+        part;
+      }
+      switch (part.type) {
+        case 'text':
+          if (part.text) {
+            content.push({ type: 'text', text: part.text });
+          }
+          break;
+        case 'reasoning':
+          if (part.reasoning) {
+            content.push({ type: 'thinking', thinking: part.reasoning });
+          }
+          break;
+        case 'tool-invocation':
+          // Handle nested toolInvocation structure from Mastra storage
+          if (part.toolInvocation) {
+            const inv = part.toolInvocation;
+            // Add tool_call
+            content.push({
+              type: 'tool_call',
+              id: inv.toolCallId,
+              name: inv.toolName,
+              args: inv.args,
+            });
+            // If it has a result, add tool_result too
+            if (inv.state === 'result' && inv.result !== undefined) {
+              content.push({
+                type: 'tool_result',
+                id: inv.toolCallId,
+                name: inv.toolName,
+                result: inv.result,
+                isError: inv.isError ?? false,
+              });
+            }
+          }
+          // Also handle flat structure
+          else if (part.toolCallId && part.toolName) {
+            content.push({
+              type: 'tool_call',
+              id: part.toolCallId,
+              name: part.toolName,
+              args: part.args,
+            });
+          }
+          break;
+        case 'tool-call':
+          if (part.toolCallId && part.toolName) {
+            content.push({
+              type: 'tool_call',
+              id: part.toolCallId,
+              name: part.toolName,
+              args: part.args,
+            });
+          }
+          break;
+        case 'tool-result':
+          if (part.toolCallId && part.toolName) {
+            content.push({
+              type: 'tool_result',
+              id: part.toolCallId,
+              name: part.toolName,
+              result: part.result,
+              isError: part.isError ?? false,
+            });
+          }
+          break;
+        case 'data-om-observation-start': {
+          const data = (part as { data?: Record<string, unknown> }).data ?? {};
+          content.push({
+            type: 'om_observation_start',
+            tokensToObserve: (data.tokensToObserve as number) ?? 0,
+            operationType: (data.operationType as 'observation' | 'reflection') ?? 'observation',
+          });
+          break;
+        }
+        case 'data-om-observation-end': {
+          const data = (part as { data?: Record<string, unknown> }).data ?? {};
+          content.push({
+            type: 'om_observation_end',
+            tokensObserved: (data.tokensObserved as number) ?? 0,
+            observationTokens: (data.observationTokens as number) ?? 0,
+            durationMs: (data.durationMs as number) ?? 0,
+            operationType: (data.operationType as 'observation' | 'reflection') ?? 'observation',
+            observations: (data.observations as string) ?? undefined,
+            currentTask: (data.currentTask as string) ?? undefined,
+            suggestedResponse: (data.suggestedResponse as string) ?? undefined,
+          });
+          break;
+        }
+        case 'data-om-observation-failed': {
+          const data = (part as { data?: Record<string, unknown> }).data ?? {};
+          content.push({
+            type: 'om_observation_failed',
+            error: (data.error as string) ?? 'Unknown error',
+            tokensAttempted: (data.tokensAttempted as number) ?? 0,
+            operationType: (data.operationType as 'observation' | 'reflection') ?? 'observation',
+          });
+          break;
+        }
+        // Skip other part types (step-start, data-om-status, etc.)
+      }
+    }
+
+    return {
+      id: msg.id,
+      role: msg.role,
+      content,
+      createdAt: msg.createdAt,
+    };
+  }
+
+  // ===========================================================================
+  // Control
+  // ===========================================================================
+
+  /**
+   * Abort the current operation (message generation, tool execution).
+   */
+  abort(): void {
+    if (this.abortController) {
+      this.abortRequested = true;
+      try {
+        this.abortController.abort();
+      } catch {}
+      this.abortController = null;
+    }
+  }
+  /**
+   * Steer the agent mid-stream: aborts current run and sends a new message.
+   * The new message interrupts the agent after the current tool completes.
+   */
+  async steer(content: string): Promise<void> {
+    // Abort current operation if running
+    this.abort();
+    // Clear any pending follow-ups (steer overrides them)
+    this.followUpQueue = [];
+    // Send the new message immediately
+    await this.sendMessage(content);
+  }
+
+  /**
+   * Queue a follow-up message to be processed after the current operation completes.
+   * If not streaming, sends immediately.
+   */
+  async followUp(content: string): Promise<void> {
+    if (this.isRunning()) {
+      this.followUpQueue.push(content);
+      this.emit({
+        type: 'follow_up_queued',
+        count: this.followUpQueue.length,
+      });
+    } else {
+      await this.sendMessage(content);
+    }
+  }
+
+  /**
+   * Get the number of queued follow-up messages.
+   */
+  getFollowUpCount(): number {
+    return this.followUpQueue.length;
+  }
+
+  /**
+   * Check if an operation is currently in progress.
+   */
+  isRunning(): boolean {
+    return this.abortController !== null;
+  }
+
+  /**
+   * Get the current run ID (for tool approval flows).
+   */
+  getCurrentRunId(): string | null {
+    return this.currentRunId;
+  }
+  /**
+   * Respond to a pending tool approval from the TUI.
+   */
+  resolveToolApprovalDecision(decision: 'approve' | 'decline' | 'always_allow_category'): void {
+    if (this.pendingApprovalResolve) {
+      this.pendingApprovalResolve(decision);
+      this.pendingApprovalResolve = null;
+    }
+  }
+  /**
+   * Approve a tool call and resume the suspended stream.
+   * Called from within processStream — reuses the existing abortController.
+   */
+  private async handleToolApprove(toolCallId?: string): Promise<{
+    message: HarnessMessage;
+  }> {
+    if (!this.currentRunId) {
+      throw new Error('No active run to approve tool call for');
+    }
+
+    const agent = this.getCurrentAgent();
+    if (!this.abortController) {
+      this.abortController = new AbortController();
+    }
+    function getRandomInteger(min: number, max: number) {
+      // Ensure min and max are treated as integers for the calculation
+      min = Math.ceil(min);
+      max = Math.floor(max);
+      // The formula for inclusive range: Math.floor(Math.random() * (max - min + 1)) + min
+      return Math.floor(Math.random() * (max - min + 1)) + min;
+    }
+    await new Promise(res => setTimeout(res, getRandomInteger(1000, 2000)));
+
+    const response = await agent.approveToolCall({
+      runId: this.currentRunId,
+      toolCallId,
+      memory: this.currentThreadId
+        ? {
+            thread: this.currentThreadId,
+            resource: this.resourceId,
+          }
+        : undefined,
+      abortSignal: this.abortController.signal,
+      requestContext: await this.buildRequestContext(),
+    });
+
+    return await this.processStream(response);
+  }
+
+  /**
+   * Decline a tool call and resume the suspended stream.
+   * Called from within processStream — reuses the existing abortController.
+   */
+  private async handleToolDecline(toolCallId?: string): Promise<{
+    message: HarnessMessage;
+  }> {
+    if (!this.currentRunId) {
+      throw new Error('No active run to decline tool call for');
+    }
+
+    const agent = this.getCurrentAgent();
+    if (!this.abortController) {
+      this.abortController = new AbortController();
+    }
+
+    const response = await agent.declineToolCall({
+      runId: this.currentRunId,
+      toolCallId,
+      memory: this.currentThreadId
+        ? {
+            thread: this.currentThreadId,
+            resource: this.resourceId,
+          }
+        : undefined,
+      abortSignal: this.abortController.signal,
+      requestContext: await this.buildRequestContext(),
+    });
+
+    return await this.processStream(response);
+  }
+  /**
+   * Process a stream response (shared between sendMessage and tool approval).
+   */
+  private async processStream(response: { fullStream: AsyncIterable<any> }): Promise<{
+    message: HarnessMessage;
+  }> {
+    let currentMessage: HarnessMessage = {
+      id: this.generateId(),
+      role: 'assistant',
+      content: [],
+      createdAt: new Date(),
+    };
+
+    const textContentById = new Map<string, { index: number; text: string }>();
+    const thinkingContentById = new Map<string, { index: number; text: string }>();
+    const debugFile = this.streamDebug ? join(process.cwd(), 'stream-debug.jsonl') : null;
+
+    for await (const chunk of response.fullStream) {
+      if (debugFile) {
+        try {
+          appendFileSync(debugFile, JSON.stringify(chunk) + '\n');
+        } catch {}
+      }
+      if ('runId' in chunk && chunk.runId) {
+        this.currentRunId = chunk.runId;
+      }
+      switch (chunk.type) {
+        case 'text-start': {
+          const textIndex = currentMessage.content.length;
+          currentMessage.content.push({ type: 'text', text: '' });
+          textContentById.set(chunk.payload.id, { index: textIndex, text: '' });
+          this.emit({ type: 'message_start', message: { ...currentMessage } });
+          break;
+        }
+
+        case 'text-delta': {
+          const textState = textContentById.get(chunk.payload.id);
+          if (textState) {
+            textState.text += chunk.payload.text;
+            const textContent = currentMessage.content[textState.index];
+            if (textContent && textContent.type === 'text') {
+              textContent.text = textState.text;
+            }
+            this.emit({
+              type: 'message_update',
+              message: { ...currentMessage },
+            });
+          }
+          break;
+        }
+
+        case 'reasoning-start': {
+          const thinkingIndex = currentMessage.content.length;
+          currentMessage.content.push({ type: 'thinking', thinking: '' });
+          thinkingContentById.set(chunk.payload.id, {
+            index: thinkingIndex,
+            text: '',
+          });
+          this.emit({ type: 'message_update', message: { ...currentMessage } });
+          break;
+        }
+
+        case 'reasoning-delta': {
+          const thinkingState = thinkingContentById.get(chunk.payload.id);
+          if (thinkingState) {
+            thinkingState.text += chunk.payload.text;
+            const thinkingContent = currentMessage.content[thinkingState.index];
+            if (thinkingContent && thinkingContent.type === 'thinking') {
+              thinkingContent.thinking = thinkingState.text;
+            }
+            this.emit({
+              type: 'message_update',
+              message: { ...currentMessage },
+            });
+          }
+          break;
+        }
+
+        case 'tool-call': {
+          const toolCall = chunk.payload;
+          currentMessage.content.push({
+            type: 'tool_call',
+            id: toolCall.toolCallId,
+            name: toolCall.toolName,
+            args: toolCall.args,
+          });
+          this.emit({
+            type: 'tool_start',
+            toolCallId: toolCall.toolCallId,
+            toolName: toolCall.toolName,
+            args: toolCall.args,
+          });
+          this.emit({ type: 'message_update', message: { ...currentMessage } });
+          break;
+        }
+
+        case 'tool-result': {
+          const toolResult = chunk.payload;
+          currentMessage.content.push({
+            type: 'tool_result',
+            id: toolResult.toolCallId,
+            name: toolResult.toolName,
+            result: toolResult.result,
+            isError: toolResult.isError ?? false,
+          });
+          this.emit({
+            type: 'tool_end',
+            toolCallId: toolResult.toolCallId,
+            result: toolResult.result,
+            isError: toolResult.isError ?? false,
+          });
+          this.emit({ type: 'message_update', message: { ...currentMessage } });
+
+          // PostToolUse hooks (fire and forget)
+          if (this.hookManager) {
+            const toolCall = currentMessage.content.find(c => c.type === 'tool_call' && c.id === toolResult.toolCallId);
+            if (toolCall && toolCall.type === 'tool_call') {
+              this.hookManager
+                .runPostToolUse(toolCall.name, toolCall.args, toolResult.result, toolResult.isError ?? false)
+                .catch(() => {});
+            }
+          }
+          break;
+        }
+
+        case 'tool-error': {
+          const toolError = chunk.payload;
+          this.emit({
+            type: 'tool_end',
+            toolCallId: toolError.toolCallId,
+            result: toolError.error,
+            isError: true,
+          });
+          break;
+        }
+        case 'tool-call-approval': {
+          const toolCallId = chunk.payload.toolCallId;
+          const toolName = chunk.payload.toolName;
+          const toolArgs = chunk.payload.args;
+          // The stream is now suspended — no more chunks will arrive
+          // until approveToolCall() or declineToolCall() is called.
+
+          let action: 'allow' | 'deny' | 'ask' = 'ask';
+
+          // Run PreToolUse hooks first
+          if (this.hookManager) {
+            const hookResult = await this.hookManager.runPreToolUse(toolName, toolArgs);
+            for (const warning of hookResult.warnings) {
+              this.emit({
+                type: 'error',
+                error: new Error(`[hook] ${warning}`),
+              });
+            }
+            if (!hookResult.allowed) {
+              action = 'deny';
+            }
+          }
+          // Resolve via YOLO / permission rules / session grants
+          if (action !== 'deny') {
+            action = this.resolveToolApproval(toolName);
+          }
+
+          if (action === 'allow') {
+            // Auto-approve: resume the stream and process it
+            const result = await this.handleToolApprove(toolCallId);
+            currentMessage = result.message;
+            // Stream is done after approval handling
+            return { message: currentMessage };
+          } else if (action === 'deny') {
+            // Auto-deny: decline and process the resumed stream
+            const result = await this.handleToolDecline(toolCallId);
+            currentMessage = result.message;
+            return { message: currentMessage };
+          } else {
+            // Ask the user — emit event and wait for decision
+            const category = getToolCategory(toolName);
+
+            this.emit({
+              type: 'tool_approval_required',
+              toolCallId,
+              toolName,
+              args: toolArgs,
+            });
+
+            // Wait for TUI to call resolveToolApprovalDecision()
+            const decision = await new Promise<'approve' | 'decline' | 'always_allow_category'>(resolve => {
+              this.pendingApprovalResolve = resolve;
+            });
+
+            if (decision === 'always_allow_category' && category) {
+              this.sessionGrants.allowCategory(category);
+            }
+
+            if (decision === 'approve' || decision === 'always_allow_category') {
+              const result = await this.handleToolApprove(toolCallId);
+              currentMessage = result.message;
+              return { message: currentMessage };
+            } else {
+              const result = await this.handleToolDecline(toolCallId);
+              currentMessage = result.message;
+              return { message: currentMessage };
+            }
+          }
+        }
+        case 'error': {
+          const streamError =
+            chunk.payload.error instanceof Error ? chunk.payload.error : new Error(String(chunk.payload.error));
+
+          if (
+            errorContains(streamError, 'must end with a user message') ||
+            errorContains(streamError, 'assistant message prefill')
+          ) {
+            // Prefill error from stream — inject synthetic user message and retry
+            this.followUpQueue.unshift('<continue>');
+            this.emit({
+              type: 'error',
+              error: new Error('Prefill rejection — patching chat and retrying'),
+              retryable: true,
+            });
+            break;
+          }
+
+          this.emit({
+            type: 'error',
+            error: streamError,
+          });
+          break;
+        }
+        case 'step-finish': {
+          // Extract usage from step-finish payload
+          const usage = chunk.payload?.output?.usage;
+          if (usage) {
+            const promptTokens = usage.promptTokens ?? 0;
+            const completionTokens = usage.completionTokens ?? 0;
+            const totalTokens = promptTokens + completionTokens;
+
+            // Update cumulative token usage
+            this.tokenUsage.promptTokens += promptTokens;
+            this.tokenUsage.completionTokens += completionTokens;
+            this.tokenUsage.totalTokens += totalTokens;
+
+            // Persist to thread metadata (fire and forget)
+            this.persistTokenUsage().catch(() => {});
+
+            this.emit({
+              type: 'usage_update',
+              usage: {
+                promptTokens,
+                completionTokens,
+                totalTokens,
+              },
+            });
+          }
+          break;
+        }
+        case 'finish': {
+          const finishReason = chunk.payload.stepResult?.reason;
+          if (finishReason === 'stop' || finishReason === 'end-turn') {
+            currentMessage.stopReason = 'complete';
+          } else if (finishReason === 'tool-calls') {
+            currentMessage.stopReason = 'tool_use';
+          } else {
+            currentMessage.stopReason = 'complete';
+          }
+          this.emit({ type: 'info', message: `finish reason: ${finishReason}` });
+          break;
+        }
+        // Observational Memory data parts
+        // NOTE: OM data parts arrive as { type, data: { ... } } — NOT { type, payload }
+        case 'data-om-status': {
+          const d = (chunk as any).data as Record<string, any> | undefined;
+          if (d?.windows) {
+            const w = d.windows;
+            const active = w.active ?? {};
+            const msgs = active.messages ?? {};
+            const obs = active.observations ?? {};
+            const buffObs = w.buffered?.observations ?? {};
+            const buffRef = w.buffered?.reflection ?? {};
+
+            // Emit new om_status event
+            this.emit({
+              type: 'om_status',
+              windows: {
+                active: {
+                  messages: {
+                    tokens: msgs.tokens ?? 0,
+                    threshold: msgs.threshold ?? 0,
+                  },
+                  observations: {
+                    tokens: obs.tokens ?? 0,
+                    threshold: obs.threshold ?? 0,
+                  },
+                },
+                buffered: {
+                  observations: {
+                    status: buffObs.status ?? 'idle',
+                    chunks: buffObs.chunks ?? 0,
+                    messageTokens: buffObs.messageTokens ?? 0,
+                    projectedMessageRemoval: buffObs.projectedMessageRemoval ?? 0,
+                    observationTokens: buffObs.observationTokens ?? 0,
+                  },
+                  reflection: {
+                    status: buffRef.status ?? 'idle',
+                    inputObservationTokens: buffRef.inputObservationTokens ?? 0,
+                    observationTokens: buffRef.observationTokens ?? 0,
+                  },
+                },
+              },
+              recordId: d.recordId ?? '',
+              threadId: d.threadId ?? '',
+              stepNumber: d.stepNumber ?? 0,
+              generationCount: d.generationCount ?? 0,
+            });
+          }
+          break;
+        }
+        case 'data-om-observation-start': {
+          const payload = (chunk as any).data as Record<string, any> | undefined;
+          if (payload && payload.cycleId) {
+            if (payload.operationType === 'observation') {
+              this.emit({
+                type: 'om_observation_start',
+                cycleId: payload.cycleId,
+                operationType: payload.operationType,
+                tokensToObserve: payload.tokensToObserve ?? 0,
+              });
+            } else if (payload.operationType === 'reflection') {
+              this.emit({
+                type: 'om_reflection_start',
+                cycleId: payload.cycleId,
+                tokensToReflect: payload.tokensToObserve ?? 0,
+              });
+            }
+          }
+          break;
+        }
+        case 'data-om-observation-end': {
+          const payload = chunk.data;
+          if (payload && payload.cycleId) {
+            // Use operationType to distinguish reflection from observation
+            if (payload.operationType === 'reflection') {
+              this.emit({
+                type: 'om_reflection_end',
+                cycleId: payload.cycleId,
+                durationMs: payload.durationMs ?? 0,
+                compressedTokens: payload.observationTokens ?? 0,
+                observations: payload.observations,
+              });
+            } else {
+              this.emit({
+                type: 'om_observation_end',
+                cycleId: payload.cycleId,
+                durationMs: payload.durationMs ?? 0,
+                tokensObserved: payload.tokensObserved ?? 0,
+                observationTokens: payload.observationTokens ?? 0,
+                observations: payload.observations,
+                currentTask: payload.currentTask,
+                suggestedResponse: payload.suggestedResponse,
+              });
+            }
+          }
+          break;
+        }
+
+        case 'data-om-observation-failed': {
+          const payload = (chunk as any).data as Record<string, any> | undefined;
+          if (payload) {
+            if (payload.operationType === 'reflection') {
+              this.emit({
+                type: 'om_reflection_failed',
+                cycleId: payload.cycleId ?? 'unknown',
+                error: payload.error ?? 'Unknown error',
+                durationMs: payload.durationMs ?? 0,
+              });
+            } else {
+              this.emit({
+                type: 'om_observation_failed',
+                cycleId: payload.cycleId ?? 'unknown',
+                error: payload.error ?? 'Unknown error',
+                durationMs: payload.durationMs ?? 0,
+              });
+            }
+          }
+          break;
+        }
+        // Async buffering lifecycle
+        case 'data-om-buffering-start': {
+          const payload = (chunk as any).data as Record<string, any> | undefined;
+          if (payload && payload.cycleId) {
+            this.emit({
+              type: 'om_buffering_start',
+              cycleId: payload.cycleId,
+              operationType: payload.operationType ?? 'observation',
+              tokensToBuffer: payload.tokensToBuffer ?? 0,
+            });
+          }
+          break;
+        }
+
+        case 'data-om-buffering-end': {
+          const payload = (chunk as any).data as Record<string, any> | undefined;
+          if (payload && payload.cycleId) {
+            this.emit({
+              type: 'om_buffering_end',
+              cycleId: payload.cycleId,
+              operationType: payload.operationType ?? 'observation',
+              tokensBuffered: payload.tokensBuffered ?? 0,
+              bufferedTokens: payload.bufferedTokens ?? 0,
+              observations: payload.observations,
+            });
+          }
+          break;
+        }
+
+        case 'data-om-buffering-failed': {
+          const payload = (chunk as any).data as Record<string, any> | undefined;
+          if (payload && payload.cycleId) {
+            this.emit({
+              type: 'om_buffering_failed',
+              cycleId: payload.cycleId,
+              operationType: payload.operationType ?? 'observation',
+              error: payload.error ?? 'Unknown error',
+            });
+          }
+          break;
+        }
+
+        case 'data-om-activation': {
+          const payload = (chunk as any).data as Record<string, any> | undefined;
+          if (payload && payload.cycleId) {
+            this.emit({
+              type: 'om_activation',
+              cycleId: payload.cycleId,
+              operationType: payload.operationType ?? 'observation',
+              chunksActivated: payload.chunksActivated ?? 0,
+              tokensActivated: payload.tokensActivated ?? 0,
+              observationTokens: payload.observationTokens ?? 0,
+              messagesActivated: payload.messagesActivated ?? 0,
+              generationCount: payload.generationCount ?? 0,
+            });
+          }
+          break;
+        }
+
+        default:
+          break;
+      }
+    }
+
+    this.emit({ type: 'message_end', message: currentMessage });
+    return { message: currentMessage };
+  }
+
+  // ===========================================================================
+  // Event System
+  // ===========================================================================
+
+  /**
+   * Subscribe to harness events.
+   * Returns an unsubscribe function.
+   */
+  subscribe(listener: HarnessEventListener): () => void {
+    this.listeners.push(listener);
+    return () => {
+      const index = this.listeners.indexOf(listener);
+      if (index !== -1) {
+        this.listeners.splice(index, 1);
+      }
+    };
+  }
+
+  private async emit(event: HarnessEvent): Promise<void> {
+    for (const listener of this.listeners) {
+      try {
+        await listener(event);
+      } catch (err) {
+        console.error('Error in harness event listener:', err);
+      }
+    }
+  }
+
+  // ===========================================================================
+  // Runtime Context
+  // ===========================================================================
+
+  /**
+   * Build request context for agent execution.
+   * Tools can access harness state via requestContext.get('harness').
+   */
+  private async buildRequestContext(): Promise<RequestContext> {
+    const harnessContext: HarnessRuntimeContext<TState> = {
+      harnessId: this.id,
+      state: this.getState() as z.infer<TState>,
+      getState: () => this.getState() as z.infer<TState>,
+      setState: updates => this.setState(updates),
+      threadId: this.currentThreadId,
+      resourceId: this.resourceId,
+      modeId: this.currentModeId,
+      abortSignal: this.abortController?.signal,
+      workspace: this.workspace,
+      emitEvent: event => this.emit(event),
+      registerQuestion: (questionId, resolve) => this.registerQuestion(questionId, resolve),
+      registerPlanApproval: (planId, resolve) => this.registerPlanApproval(planId, resolve),
+      getSubagentModelId: (agentType?: string) => this.getSubagentModelId(agentType),
+    };
+
+    const requestContext = new RequestContext([['harness', harnessContext]]);
+    // Resolve dynamic workspace factory with the built request context
+    if (this.workspaceFn) {
+      harnessContext.workspace = await Promise.resolve(this.workspaceFn({ requestContext: requestContext as any }));
+    }
+
+    return requestContext as any;
+  }
+
+  // ===========================================================================
+  // Session Info
+  // ===========================================================================
+
+  /**
+   * Get current session info (for TUI display).
+   */
+  async getSession(): Promise<HarnessSession> {
+    return {
+      currentThreadId: this.currentThreadId,
+      currentModeId: this.currentModeId,
+      threads: await this.listThreads(),
+    };
+  }
+  // ===========================================================================
+  // Authentication
+  // ===========================================================================
+
+  /**
+   * Get the auth storage instance.
+   * Creates a default instance if not provided in config.
+   */
+  getAuthStorage(): AuthStorage {
+    if (!this.config.authStorage) {
+      this.config.authStorage = new AuthStorage();
+    }
+    return this.config.authStorage;
+  }
+
+  /**
+   * Get all available OAuth providers.
+   */
+  getOAuthProviders(): OAuthProviderInterface[] {
+    return getOAuthProviders();
+  }
+
+  /**
+   * Check if a provider is logged in (has OAuth credentials).
+   */
+  isLoggedIn(providerId: string): boolean {
+    return this.getAuthStorage().isLoggedIn(providerId);
+  }
+
+  /**
+   * Check if a provider has any credentials (OAuth or API key).
+   */
+  hasCredentials(providerId: string): boolean {
+    return this.getAuthStorage().has(providerId);
+  }
+
+  /**
+   * Get all logged-in provider IDs.
+   */
+  getLoggedInProviders(): string[] {
+    const providers = this.getOAuthProviders();
+    return providers.filter(p => this.isLoggedIn(p.id)).map(p => p.id);
+  }
+
+  /**
+   * Perform OAuth login for a provider.
+   */
+  async login(providerId: string, callbacks: OAuthLoginCallbacks): Promise<void> {
+    await this.getAuthStorage().login(providerId, callbacks);
+  }
+
+  /**
+   * Logout from a provider.
+   */
+  logout(providerId: string): void {
+    this.getAuthStorage().logout(providerId);
+  }
+
+  /**
+   * Get API key for a provider (from OAuth credentials or env).
+   * Auto-refreshes OAuth tokens if needed.
+   */
+  async getApiKey(providerId: string): Promise<string | undefined> {
+    return this.getAuthStorage().getApiKey(providerId);
+  }
+
+  // ===========================================================================
+  // Workspace
+  // ===========================================================================
+
+  /**
+   * Get the workspace instance (if configured and initialized).
+   * Returns undefined if no workspace was configured or if init failed.
+   */
+  getWorkspace(): Workspace | undefined {
+    return this.workspace;
+  }
+
+  /**
+   * Check if a workspace is configured (regardless of init status).
+   * Returns true for static workspaces, workspace configs, and dynamic factories.
+   */
+  hasWorkspace(): boolean {
+    return this.config.workspace !== undefined;
+  }
+
+  /**
+   * Check if the workspace is initialized and ready.
+   * Dynamic workspace factories are always considered ready since they
+   * resolve per-request and don't require upfront initialization.
+   */
+  isWorkspaceReady(): boolean {
+    if (this.workspaceFn) return true;
+    return this.workspaceInitialized && this.workspace !== undefined;
+  }
+
+  // ===========================================================================
+  // Heartbeat Handlers
+  // ===========================================================================
+
+  /**
+   * Start all configured heartbeat handlers.
+   * Called automatically during `init()`.
+   */
+  private startHeartbeats(): void {
+    const handlers = this.config.heartbeatHandlers;
+    if (!handlers?.length) return;
+
+    for (const hb of handlers) {
+      if (this.heartbeatTimers.has(hb.id)) continue;
+
+      const run = async () => {
+        try {
+          await hb.handler();
+        } catch (error) {
+          console.error(`[Heartbeat:${hb.id}] failed:`, error);
+        }
+      };
+
+      if (hb.immediate !== false) {
+        run();
+      }
+
+      const timer = setInterval(run, hb.intervalMs);
+      timer.unref();
+      this.heartbeatTimers.set(hb.id, { timer, shutdown: hb.shutdown });
+    }
+  }
+
+  /**
+   * Register a heartbeat handler dynamically (after init).
+   * If a handler with the same id already exists, it is replaced.
+   */
+  registerHeartbeat(handler: HeartbeatHandler): void {
+    this.removeHeartbeat(handler.id);
+
+    const run = async () => {
+      try {
+        await handler.handler();
+      } catch (error) {
+        console.error(`[Heartbeat:${handler.id}] failed:`, error);
+      }
+    };
+
+    if (handler.immediate !== false) {
+      run();
+    }
+
+    const timer = setInterval(run, handler.intervalMs);
+    timer.unref();
+    this.heartbeatTimers.set(handler.id, { timer, shutdown: handler.shutdown });
+  }
+
+  /**
+   * Remove a heartbeat handler by id. Calls its shutdown hook if present.
+   */
+  async removeHeartbeat(id: string): Promise<void> {
+    const entry = this.heartbeatTimers.get(id);
+    if (entry) {
+      clearInterval(entry.timer);
+      this.heartbeatTimers.delete(id);
+      try {
+        await entry.shutdown?.();
+      } catch (error) {
+        console.error(`[Heartbeat:${id}] shutdown failed:`, error);
+      }
+    }
+  }
+
+  /**
+   * Stop all heartbeat handlers and run their shutdown hooks. Call during shutdown.
+   */
+  async stopHeartbeats(): Promise<void> {
+    const entries = [...this.heartbeatTimers.entries()];
+    this.heartbeatTimers.clear();
+
+    for (const [id, entry] of entries) {
+      clearInterval(entry.timer);
+      try {
+        await entry.shutdown?.();
+      } catch (error) {
+        console.error(`[Heartbeat:${id}] shutdown failed:`, error);
+      }
+    }
+  }
+
+  /**
+   * Destroy the workspace and clean up resources.
+   * Can be called during harness shutdown for proper cleanup.
+   * No-op for dynamic workspace factories (they are ephemeral per-request).
+   */
+  async destroyWorkspace(): Promise<void> {
+    if (this.workspaceFn) return;
+    if (this.workspace && this.workspaceInitialized) {
+      try {
+        this.emit({
+          type: 'workspace_status_changed',
+          status: 'destroying',
+        });
+        await this.workspace.destroy();
+        this.emit({
+          type: 'workspace_status_changed',
+          status: 'destroyed',
+        });
+      } catch (error) {
+        console.warn('Workspace destroy failed:', error);
+      } finally {
+        this.workspaceInitialized = false;
+      }
+    }
+  }
+
+  // ===========================================================================
+  // Utilities
+  // ===========================================================================
+  /**
+   * Release the lock on the current thread.
+   * Call this when the process is exiting.
+   */
+  releaseCurrentThreadLock(): void {
+    if (this.currentThreadId) {
+      releaseThreadLock(this.currentThreadId);
+    }
+  }
+
+  private generateId(): string {
+    return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+  }
 }

--- a/mastracode/src/harness/index.ts
+++ b/mastracode/src/harness/index.ts
@@ -1,20 +1,20 @@
 // Export the Harness class and types
-export { Harness } from "./harness"
+export { Harness } from './harness';
 export type {
-	HeartbeatHandler,
-	HarnessConfig,
-	HarnessEvent,
-	HarnessEventListener,
-	HarnessMessage,
-	HarnessMessageContent,
-	HarnessMode,
-	HarnessRuntimeContext,
-	HarnessSession,
-	HarnessStateSchema,
-	HarnessThread,
-	ObservationalMemoryDebugEvent,
-	TokenUsage,
-} from "./types"
+  HeartbeatHandler,
+  HarnessConfig,
+  HarnessEvent,
+  HarnessEventListener,
+  HarnessMessage,
+  HarnessMessageContent,
+  HarnessMode,
+  HarnessRuntimeContext,
+  HarnessSession,
+  HarnessStateSchema,
+  HarnessThread,
+  ObservationalMemoryDebugEvent,
+  TokenUsage,
+} from './types';
 
 // Re-export workspace types for convenience
-export type { WorkspaceStatus } from "@mastra/core/workspace"
+export type { WorkspaceStatus } from '@mastra/core/workspace';

--- a/mastracode/src/harness/types.ts
+++ b/mastracode/src/harness/types.ts
@@ -1,16 +1,12 @@
-import type { Agent } from "@mastra/core/agent"
-import type { MastraMemory } from "@mastra/core/memory"
-import type { MastraCompositeStore } from "@mastra/core/storage"
-import type { DynamicArgument } from "@mastra/core/types"
-import type {
-	Workspace,
-	WorkspaceConfig,
-	WorkspaceStatus,
-} from "@mastra/core/workspace"
-import type { z } from "zod"
-import type { AuthStorage } from "../auth/storage.js"
-import type { HookManager } from "../hooks/index.js"
-import type { MCPManager } from "../mcp/index.js"
+import type { Agent } from '@mastra/core/agent';
+import type { MastraMemory } from '@mastra/core/memory';
+import type { MastraCompositeStore } from '@mastra/core/storage';
+import type { DynamicArgument } from '@mastra/core/types';
+import type { Workspace, WorkspaceConfig, WorkspaceStatus } from '@mastra/core/workspace';
+import type { z } from 'zod';
+import type { AuthStorage } from '../auth/storage.js';
+import type { HookManager } from '../hooks/index.js';
+import type { MCPManager } from '../mcp/index.js';
 
 // =============================================================================
 // Heartbeat Handlers
@@ -21,16 +17,16 @@ import type { MCPManager } from "../mcp/index.js"
  * Heartbeat handlers start during `init()` and are cleaned up on `stopHeartbeats()`.
  */
 export interface HeartbeatHandler {
-	/** Unique identifier for this handler (used for dedup and logging) */
-	id: string
-	/** Interval in milliseconds between invocations */
-	intervalMs: number
-	/** The function to run on each tick */
-	handler: () => void | Promise<void>
-	/** Whether to run the handler immediately on start (default: true) */
-	immediate?: boolean
-	/** Called when the handler is removed or all heartbeats are stopped */
-	shutdown?: () => void | Promise<void>
+  /** Unique identifier for this handler (used for dedup and logging) */
+  id: string;
+  /** Interval in milliseconds between invocations */
+  intervalMs: number;
+  /** The function to run on each tick */
+  handler: () => void | Promise<void>;
+  /** Whether to run the handler immediately on start (default: true) */
+  immediate?: boolean;
+  /** Called when the handler is removed or all heartbeats are stopped */
+  shutdown?: () => void | Promise<void>;
 }
 
 // =============================================================================
@@ -41,174 +37,168 @@ export interface HeartbeatHandler {
  * Configuration for a single agent mode within the harness.
  * Each mode represents a different "personality" or capability set.
  */
-export interface HarnessMode<
-	TState extends HarnessStateSchema = HarnessStateSchema,
-> {
-	/** Unique identifier for this mode (e.g., "plan", "build", "review") */
-	id: string
+export interface HarnessMode<TState extends HarnessStateSchema = HarnessStateSchema> {
+  /** Unique identifier for this mode (e.g., "plan", "build", "review") */
+  id: string;
 
-	/** Human-readable name for display in TUI */
-	name?: string
+  /** Human-readable name for display in TUI */
+  name?: string;
 
-	/** Whether this is the default mode when harness starts */
-	default?: boolean
+  /** Whether this is the default mode when harness starts */
+  default?: boolean;
 
-	/**
-	 * Default model ID for this mode (e.g., "anthropic/claude-sonnet-4-20250514").
-	 * Used when no per-mode model has been explicitly selected.
-	 * If not set, falls back to the global last model.
-	 */
-	defaultModelId?: string
+  /**
+   * Default model ID for this mode (e.g., "anthropic/claude-sonnet-4-20250514").
+   * Used when no per-mode model has been explicitly selected.
+   * If not set, falls back to the global last model.
+   */
+  defaultModelId?: string;
 
-	/** Hex color for the mode badge in the status line (e.g., "#7c3aed") */
-	color?: string
+  /** Hex color for the mode badge in the status line (e.g., "#7c3aed") */
+  color?: string;
 
-	/**
-	 * The agent for this mode.
-	 * Can be a static Agent or a function that receives harness state.
-	 */
-	agent: Agent | ((state: z.infer<TState>) => Agent)
+  /**
+   * The agent for this mode.
+   * Can be a static Agent or a function that receives harness state.
+   */
+  agent: Agent | ((state: z.infer<TState>) => Agent);
 }
 
 /**
  * Schema type for harness state - must be a Zod object schema.
  */
-export type HarnessStateSchema = z.ZodObject<z.ZodRawShape>
+export type HarnessStateSchema = z.ZodObject<z.ZodRawShape>;
 
 /**
  * Configuration for creating a Harness instance.
  */
-export interface HarnessConfig<
-	TState extends HarnessStateSchema = HarnessStateSchema,
-> {
-	/** Unique identifier for this harness instance */
-	id: string
-	/**
-	 * Resource ID for grouping threads (e.g., project identifier).
-	 * Threads are scoped to this resource ID.
-	 * Typically derived from git URL or project path.
-	 */
-	resourceId: string
+export interface HarnessConfig<TState extends HarnessStateSchema = HarnessStateSchema> {
+  /** Unique identifier for this harness instance */
+  id: string;
+  /**
+   * Resource ID for grouping threads (e.g., project identifier).
+   * Threads are scoped to this resource ID.
+   * Typically derived from git URL or project path.
+   */
+  resourceId: string;
 
-	/**
-	 * The auto-detected resource ID before any overrides.
-	 * Used by `/resource reset` to restore the default.
-	 * If not provided, defaults to `resourceId`.
-	 */
-	defaultResourceId?: string
+  /**
+   * The auto-detected resource ID before any overrides.
+   * Used by `/resource reset` to restore the default.
+   * If not provided, defaults to `resourceId`.
+   */
+  defaultResourceId?: string;
 
-	/**
-	 * User ID for thread attribution (e.g., git user.email).
-	 * Stored as `createdBy` in thread metadata for multi-user visibility.
-	 */
-	userId?: string
+  /**
+   * User ID for thread attribution (e.g., git user.email).
+   * Stored as `createdBy` in thread metadata for multi-user visibility.
+   */
+  userId?: string;
 
-	/**
-	 * Whether the storage backend is remote (e.g., Turso).
-	 * Affects default behavior for thread visibility filtering.
-	 */
-	isRemoteStorage?: boolean
+  /**
+   * Whether the storage backend is remote (e.g., Turso).
+   * Affects default behavior for thread visibility filtering.
+   */
+  isRemoteStorage?: boolean;
 
-	/** Storage backend for persistence (threads, messages, state) */
-	storage: MastraCompositeStore
+  /** Storage backend for persistence (threads, messages, state) */
+  storage: MastraCompositeStore;
 
-	/** Zod schema defining the shape of harness state */
-	stateSchema: TState
+  /** Zod schema defining the shape of harness state */
+  stateSchema: TState;
 
-	/** Initial state values (must conform to schema) */
-	initialState?: Partial<z.infer<TState>>
+  /** Initial state values (must conform to schema) */
+  initialState?: Partial<z.infer<TState>>;
 
-	/** Memory configuration (shared across all modes) */
-	memory?: MastraMemory
+  /** Memory configuration (shared across all modes) */
+  memory?: MastraMemory;
 
-	/** Available agent modes */
-	modes: HarnessMode<TState>[]
+  /** Available agent modes */
+  modes: HarnessMode<TState>[];
 
-	/**
-	 * Callback when observational memory emits debug events.
-	 * Used by TUI to show progress indicators.
-	 */
-	onObservationalMemoryEvent?: (event: ObservationalMemoryDebugEvent) => void
+  /**
+   * Callback when observational memory emits debug events.
+   * Used by TUI to show progress indicators.
+   */
+  onObservationalMemoryEvent?: (event: ObservationalMemoryDebugEvent) => void;
 
-	/**
-	 * Auth storage for OAuth credentials.
-	 * If not provided, a default instance will be created.
-	 */
-	authStorage?: AuthStorage
+  /**
+   * Auth storage for OAuth credentials.
+   * If not provided, a default instance will be created.
+   */
+  authStorage?: AuthStorage;
 
-	/**
-	 * Optional callback to provide additional toolsets at stream time.
-	 * Receives the current model ID and should return a toolsets object
-	 * (or undefined) to pass to agent.stream().
-	 *
-	 * Use this to conditionally add provider-specific tools
-	 * (e.g., Anthropic web search when using Claude models).
-	 */
-	getToolsets?: (
-		modelId: string,
-	) => Record<string, Record<string, unknown>> | undefined
+  /**
+   * Optional callback to provide additional toolsets at stream time.
+   * Receives the current model ID and should return a toolsets object
+   * (or undefined) to pass to agent.stream().
+   *
+   * Use this to conditionally add provider-specific tools
+   * (e.g., Anthropic web search when using Claude models).
+   */
+  getToolsets?: (modelId: string) => Record<string, Record<string, unknown>> | undefined;
 
-	/**
-	 * Workspace configuration.
-	 * Accepts a pre-constructed Workspace instance, a WorkspaceConfig for
-	 * Harness to construct internally, or a dynamic factory function that
-	 * receives the request context and returns a Workspace per-request.
-	 *
-	 * When using a static Workspace or WorkspaceConfig, the Harness manages
-	 * the workspace lifecycle (init/destroy).
-	 *
-	 * When using a dynamic factory, the Harness calls it during each request
-	 * to resolve the workspace from current state (e.g., sandboxAllowedPaths).
-	 *
-	 * @example Pre-built workspace
-	 * ```typescript
-	 * const workspace = new Workspace({ skills: ['/skills'] });
-	 * const harness = new Harness({ workspace, ... });
-	 * ```
-	 *
-	 * @example Workspace config (Harness constructs it)
-	 * ```typescript
-	 * const harness = new Harness({
-	 *   workspace: {
-	 *     filesystem: new LocalFilesystem({ basePath: './data' }),
-	 *     skills: ['/skills'],
-	 *   },
-	 *   ...
-	 * });
-	 * ```
-	 *
-	 * @example Dynamic workspace (function, same as Agent)
-	 * ```typescript
-	 * const harness = new Harness({
-	 *   workspace: ({ requestContext }) => {
-	 *     const state = requestContext.get('harness')?.getState();
-	 *     return new Workspace({
-	 *       filesystem: new LocalFilesystem({ basePath: state.projectPath }),
-	 *     });
-	 *   },
-	 *   ...
-	 * });
-	 * ```
-	 */
-	workspace?: DynamicArgument<Workspace | undefined> | WorkspaceConfig
+  /**
+   * Workspace configuration.
+   * Accepts a pre-constructed Workspace instance, a WorkspaceConfig for
+   * Harness to construct internally, or a dynamic factory function that
+   * receives the request context and returns a Workspace per-request.
+   *
+   * When using a static Workspace or WorkspaceConfig, the Harness manages
+   * the workspace lifecycle (init/destroy).
+   *
+   * When using a dynamic factory, the Harness calls it during each request
+   * to resolve the workspace from current state (e.g., sandboxAllowedPaths).
+   *
+   * @example Pre-built workspace
+   * ```typescript
+   * const workspace = new Workspace({ skills: ['/skills'] });
+   * const harness = new Harness({ workspace, ... });
+   * ```
+   *
+   * @example Workspace config (Harness constructs it)
+   * ```typescript
+   * const harness = new Harness({
+   *   workspace: {
+   *     filesystem: new LocalFilesystem({ basePath: './data' }),
+   *     skills: ['/skills'],
+   *   },
+   *   ...
+   * });
+   * ```
+   *
+   * @example Dynamic workspace (function, same as Agent)
+   * ```typescript
+   * const harness = new Harness({
+   *   workspace: ({ requestContext }) => {
+   *     const state = requestContext.get('harness')?.getState();
+   *     return new Workspace({
+   *       filesystem: new LocalFilesystem({ basePath: state.projectPath }),
+   *     });
+   *   },
+   *   ...
+   * });
+   * ```
+   */
+  workspace?: DynamicArgument<Workspace | undefined> | WorkspaceConfig;
 
-	/**
-	 * Hook manager for lifecycle event interception.
-	 * If provided, hooks fire at tool use, message send, stop, and session events.
-	 */
-	hookManager?: HookManager
+  /**
+   * Hook manager for lifecycle event interception.
+   * If provided, hooks fire at tool use, message send, stop, and session events.
+   */
+  hookManager?: HookManager;
 
-	/**
-	 * MCP manager for external tool server connections.
-	 * If provided, MCP-provided tools are available to agents.
-	 */
-	mcpManager?: MCPManager
+  /**
+   * MCP manager for external tool server connections.
+   * If provided, MCP-provided tools are available to agents.
+   */
+  mcpManager?: MCPManager;
 
-	/**
-	 * Periodic heartbeat handlers started during `init()`.
-	 * Use for background tasks like gateway sync, cache refresh, etc.
-	 */
-	heartbeatHandlers?: HeartbeatHandler[]
+  /**
+   * Periodic heartbeat handlers started during `init()`.
+   * Use for background tasks like gateway sync, cache refresh, etc.
+   */
+  heartbeatHandlers?: HeartbeatHandler[];
 }
 
 // =============================================================================
@@ -219,24 +209,24 @@ export interface HarnessConfig<
  * Thread metadata stored in the harness.
  */
 export interface HarnessThread {
-	id: string
-	resourceId: string
-	title?: string
-	createdAt: Date
-	updatedAt: Date
-	/** Token usage for this thread (persisted for status line) */
-	tokenUsage?: TokenUsage
-	/** Optional metadata (gitBranch, etc.) — may be absent on older threads */
-	metadata?: Record<string, unknown>
+  id: string;
+  resourceId: string;
+  title?: string;
+  createdAt: Date;
+  updatedAt: Date;
+  /** Token usage for this thread (persisted for status line) */
+  tokenUsage?: TokenUsage;
+  /** Optional metadata (gitBranch, etc.) — may be absent on older threads */
+  metadata?: Record<string, unknown>;
 }
 
 /**
  * Session info for the current harness instance.
  */
 export interface HarnessSession {
-	currentThreadId: string | null
-	currentModeId: string
-	threads: HarnessThread[]
+  currentThreadId: string | null;
+  currentModeId: string;
+  threads: HarnessThread[];
 }
 
 // =============================================================================
@@ -247,257 +237,257 @@ export interface HarnessSession {
  * Token usage statistics from the model.
  */
 export interface TokenUsage {
-	promptTokens: number
-	completionTokens: number
-	totalTokens: number
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
 }
 
 /**
  * Events emitted by the harness that the TUI can subscribe to.
  */
 export type HarnessEvent =
-	| { type: "mode_changed"; modeId: string; previousModeId: string }
-	| {
-			type: "model_changed"
-			modelId: string
-			scope?: "global" | "thread" | "mode"
-			modeId?: string
-	  }
-	| {
-			type: "thread_changed"
-			threadId: string
-			previousThreadId: string | null
-	  }
-	| { type: "thread_created"; thread: HarnessThread }
-	| {
-			type: "state_changed"
-			state: Record<string, unknown>
-			changedKeys: string[]
-	  }
-	| { type: "agent_start" }
-	| { type: "agent_end"; reason?: "complete" | "aborted" | "error" }
-	| { type: "message_start"; message: HarnessMessage }
-	| { type: "message_update"; message: HarnessMessage }
-	| { type: "message_end"; message: HarnessMessage }
-	| { type: "tool_start"; toolCallId: string; toolName: string; args: unknown }
-	| {
-			type: "tool_approval_required"
-			toolCallId: string
-			toolName: string
-			args: unknown
-	  }
-	| { type: "tool_update"; toolCallId: string; partialResult: unknown }
-	| { type: "tool_end"; toolCallId: string; result: unknown; isError: boolean }
-	| {
-			type: "shell_output"
-			toolCallId: string
-			output: string
-			stream: "stdout" | "stderr"
-	  }
-	| { type: "usage_update"; usage: TokenUsage }
-	| { type: "info"; message: string }
-	| {
-			type: "error"
-			error: Error
-			errorType?: string
-			retryable?: boolean
-			retryDelay?: number
-	  }
-	// Observational Memory events
-	| {
-			type: "om_status"
-			windows: {
-				active: {
-					messages: { tokens: number; threshold: number }
-					observations: { tokens: number; threshold: number }
-				}
-				buffered: {
-					observations: {
-						status: "idle" | "running" | "complete"
-						chunks: number
-						messageTokens: number
-						projectedMessageRemoval: number
-						observationTokens: number
-					}
-					reflection: {
-						status: "idle" | "running" | "complete"
-						inputObservationTokens: number
-						observationTokens: number
-					}
-				}
-			}
-			recordId: string
-			threadId: string
-			stepNumber: number
-			generationCount: number
-	  }
-	| {
-			type: "om_observation_start"
-			cycleId: string
-			operationType: "observation" | "reflection"
-			tokensToObserve: number
-	  }
-	| {
-			type: "om_observation_end"
-			cycleId: string
-			durationMs: number
-			tokensObserved: number
-			observationTokens: number
-			observations?: string
-			currentTask?: string
-			suggestedResponse?: string
-	  }
-	| {
-			type: "om_observation_failed"
-			cycleId: string
-			error: string
-			durationMs: number
-	  }
-	| { type: "om_reflection_start"; cycleId: string; tokensToReflect: number }
-	| {
-			type: "om_reflection_end"
-			cycleId: string
-			durationMs: number
-			compressedTokens: number
-			observations?: string
-	  }
-	| {
-			type: "om_reflection_failed"
-			cycleId: string
-			error: string
-			durationMs: number
-	  }
-	| {
-			type: "om_model_changed"
-			role: "observer" | "reflector"
-			modelId: string
-	  }
-	// Buffering lifecycle events
-	| {
-			type: "om_buffering_start"
-			cycleId: string
-			operationType: "observation" | "reflection"
-			tokensToBuffer: number
-	  }
-	| {
-			type: "om_buffering_end"
-			cycleId: string
-			operationType: "observation" | "reflection"
-			tokensBuffered: number
-			bufferedTokens: number
-			observations?: string
-	  }
-	| {
-			type: "om_buffering_failed"
-			cycleId: string
-			operationType: "observation" | "reflection"
-			error: string
-	  }
-	| {
-			type: "om_activation"
-			cycleId: string
-			operationType: "observation" | "reflection"
-			chunksActivated: number
-			tokensActivated: number
-			observationTokens: number
-			messagesActivated: number
-			generationCount: number
-	  }
-	| { type: "follow_up_queued"; count: number }
-	// Workspace events
-	| {
-			type: "workspace_status_changed"
-			status: WorkspaceStatus
-			error?: Error
-	  }
-	| {
-			type: "workspace_ready"
-			workspaceId: string
-			workspaceName: string
-	  }
-	| { type: "workspace_error"; error: Error }
-	// Subagent / Task delegation events
-	| {
-			type: "subagent_start"
-			toolCallId: string
-			agentType: string
-			task: string
-			modelId?: string
-	  }
-	| {
-			type: "subagent_tool_start"
-			toolCallId: string
-			agentType: string
-			subToolName: string
-			subToolArgs: unknown
-	  }
-	| {
-			type: "subagent_tool_end"
-			toolCallId: string
-			agentType: string
-			subToolName: string
-			subToolResult: unknown
-			isError: boolean
-	  }
-	| {
-			type: "subagent_text_delta"
-			toolCallId: string
-			agentType: string
-			textDelta: string
-	  }
-	| {
-			type: "subagent_end"
-			toolCallId: string
-			agentType: string
-			result: string
-			isError: boolean
-			durationMs: number
-	  }
-	// Subagent model changed event
-	| {
-			type: "subagent_model_changed"
-			modelId: string
-			scope: "global" | "thread"
-			agentType: string
-	  }
-	// Todo list events
-	| {
-			type: "todo_updated"
-			todos: Array<{
-				content: string
-				status: "pending" | "in_progress" | "completed"
-				activeForm: string
-			}>
-	  }
-	// Ask question events
-	| {
-			type: "ask_question"
-			questionId: string
-			question: string
-			options?: Array<{ label: string; description?: string }>
-	  }
-	// Sandbox access request events
-	| {
-			type: "sandbox_access_request"
-			questionId: string
-			path: string
-			reason: string
-	  }
-	// Plan approval events
-	| {
-			type: "plan_approval_required"
-			planId: string
-			title: string
-			plan: string
-	  }
-	| {
-			type: "plan_approved"
-	  }
+  | { type: 'mode_changed'; modeId: string; previousModeId: string }
+  | {
+      type: 'model_changed';
+      modelId: string;
+      scope?: 'global' | 'thread' | 'mode';
+      modeId?: string;
+    }
+  | {
+      type: 'thread_changed';
+      threadId: string;
+      previousThreadId: string | null;
+    }
+  | { type: 'thread_created'; thread: HarnessThread }
+  | {
+      type: 'state_changed';
+      state: Record<string, unknown>;
+      changedKeys: string[];
+    }
+  | { type: 'agent_start' }
+  | { type: 'agent_end'; reason?: 'complete' | 'aborted' | 'error' }
+  | { type: 'message_start'; message: HarnessMessage }
+  | { type: 'message_update'; message: HarnessMessage }
+  | { type: 'message_end'; message: HarnessMessage }
+  | { type: 'tool_start'; toolCallId: string; toolName: string; args: unknown }
+  | {
+      type: 'tool_approval_required';
+      toolCallId: string;
+      toolName: string;
+      args: unknown;
+    }
+  | { type: 'tool_update'; toolCallId: string; partialResult: unknown }
+  | { type: 'tool_end'; toolCallId: string; result: unknown; isError: boolean }
+  | {
+      type: 'shell_output';
+      toolCallId: string;
+      output: string;
+      stream: 'stdout' | 'stderr';
+    }
+  | { type: 'usage_update'; usage: TokenUsage }
+  | { type: 'info'; message: string }
+  | {
+      type: 'error';
+      error: Error;
+      errorType?: string;
+      retryable?: boolean;
+      retryDelay?: number;
+    }
+  // Observational Memory events
+  | {
+      type: 'om_status';
+      windows: {
+        active: {
+          messages: { tokens: number; threshold: number };
+          observations: { tokens: number; threshold: number };
+        };
+        buffered: {
+          observations: {
+            status: 'idle' | 'running' | 'complete';
+            chunks: number;
+            messageTokens: number;
+            projectedMessageRemoval: number;
+            observationTokens: number;
+          };
+          reflection: {
+            status: 'idle' | 'running' | 'complete';
+            inputObservationTokens: number;
+            observationTokens: number;
+          };
+        };
+      };
+      recordId: string;
+      threadId: string;
+      stepNumber: number;
+      generationCount: number;
+    }
+  | {
+      type: 'om_observation_start';
+      cycleId: string;
+      operationType: 'observation' | 'reflection';
+      tokensToObserve: number;
+    }
+  | {
+      type: 'om_observation_end';
+      cycleId: string;
+      durationMs: number;
+      tokensObserved: number;
+      observationTokens: number;
+      observations?: string;
+      currentTask?: string;
+      suggestedResponse?: string;
+    }
+  | {
+      type: 'om_observation_failed';
+      cycleId: string;
+      error: string;
+      durationMs: number;
+    }
+  | { type: 'om_reflection_start'; cycleId: string; tokensToReflect: number }
+  | {
+      type: 'om_reflection_end';
+      cycleId: string;
+      durationMs: number;
+      compressedTokens: number;
+      observations?: string;
+    }
+  | {
+      type: 'om_reflection_failed';
+      cycleId: string;
+      error: string;
+      durationMs: number;
+    }
+  | {
+      type: 'om_model_changed';
+      role: 'observer' | 'reflector';
+      modelId: string;
+    }
+  // Buffering lifecycle events
+  | {
+      type: 'om_buffering_start';
+      cycleId: string;
+      operationType: 'observation' | 'reflection';
+      tokensToBuffer: number;
+    }
+  | {
+      type: 'om_buffering_end';
+      cycleId: string;
+      operationType: 'observation' | 'reflection';
+      tokensBuffered: number;
+      bufferedTokens: number;
+      observations?: string;
+    }
+  | {
+      type: 'om_buffering_failed';
+      cycleId: string;
+      operationType: 'observation' | 'reflection';
+      error: string;
+    }
+  | {
+      type: 'om_activation';
+      cycleId: string;
+      operationType: 'observation' | 'reflection';
+      chunksActivated: number;
+      tokensActivated: number;
+      observationTokens: number;
+      messagesActivated: number;
+      generationCount: number;
+    }
+  | { type: 'follow_up_queued'; count: number }
+  // Workspace events
+  | {
+      type: 'workspace_status_changed';
+      status: WorkspaceStatus;
+      error?: Error;
+    }
+  | {
+      type: 'workspace_ready';
+      workspaceId: string;
+      workspaceName: string;
+    }
+  | { type: 'workspace_error'; error: Error }
+  // Subagent / Task delegation events
+  | {
+      type: 'subagent_start';
+      toolCallId: string;
+      agentType: string;
+      task: string;
+      modelId?: string;
+    }
+  | {
+      type: 'subagent_tool_start';
+      toolCallId: string;
+      agentType: string;
+      subToolName: string;
+      subToolArgs: unknown;
+    }
+  | {
+      type: 'subagent_tool_end';
+      toolCallId: string;
+      agentType: string;
+      subToolName: string;
+      subToolResult: unknown;
+      isError: boolean;
+    }
+  | {
+      type: 'subagent_text_delta';
+      toolCallId: string;
+      agentType: string;
+      textDelta: string;
+    }
+  | {
+      type: 'subagent_end';
+      toolCallId: string;
+      agentType: string;
+      result: string;
+      isError: boolean;
+      durationMs: number;
+    }
+  // Subagent model changed event
+  | {
+      type: 'subagent_model_changed';
+      modelId: string;
+      scope: 'global' | 'thread';
+      agentType: string;
+    }
+  // Todo list events
+  | {
+      type: 'todo_updated';
+      todos: Array<{
+        content: string;
+        status: 'pending' | 'in_progress' | 'completed';
+        activeForm: string;
+      }>;
+    }
+  // Ask question events
+  | {
+      type: 'ask_question';
+      questionId: string;
+      question: string;
+      options?: Array<{ label: string; description?: string }>;
+    }
+  // Sandbox access request events
+  | {
+      type: 'sandbox_access_request';
+      questionId: string;
+      path: string;
+      reason: string;
+    }
+  // Plan approval events
+  | {
+      type: 'plan_approval_required';
+      planId: string;
+      title: string;
+      plan: string;
+    }
+  | {
+      type: 'plan_approved';
+    };
 
 /**
  * Listener function for harness events.
  */
-export type HarnessEventListener = (event: HarnessEvent) => void | Promise<void>
+export type HarnessEventListener = (event: HarnessEvent) => void | Promise<void>;
 
 // =============================================================================
 // Messages
@@ -508,48 +498,48 @@ export type HarnessEventListener = (event: HarnessEvent) => void | Promise<void>
  * Maps from Mastra's internal message format.
  */
 export interface HarnessMessage {
-	id: string
-	role: "user" | "assistant" | "system"
-	content: HarnessMessageContent[]
-	createdAt: Date
-	/** For assistant messages */
-	stopReason?: "complete" | "tool_use" | "aborted" | "error"
-	errorMessage?: string
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: HarnessMessageContent[];
+  createdAt: Date;
+  /** For assistant messages */
+  stopReason?: 'complete' | 'tool_use' | 'aborted' | 'error';
+  errorMessage?: string;
 }
 
 export type HarnessMessageContent =
-	| { type: "text"; text: string }
-	| { type: "thinking"; thinking: string }
-	| { type: "tool_call"; id: string; name: string; args: unknown }
-	| {
-			type: "tool_result"
-			id: string
-			name: string
-			result: unknown
-			isError: boolean
-	  }
-	| { type: "image"; data: string; mimeType: string }
-	| {
-			type: "om_observation_start"
-			tokensToObserve: number
-			operationType?: "observation" | "reflection"
-	  }
-	| {
-			type: "om_observation_end"
-			tokensObserved: number
-			observationTokens: number
-			durationMs: number
-			operationType?: "observation" | "reflection"
-			observations?: string
-			currentTask?: string
-			suggestedResponse?: string
-	  }
-	| {
-			type: "om_observation_failed"
-			error: string
-			tokensAttempted?: number
-			operationType?: "observation" | "reflection"
-	  }
+  | { type: 'text'; text: string }
+  | { type: 'thinking'; thinking: string }
+  | { type: 'tool_call'; id: string; name: string; args: unknown }
+  | {
+      type: 'tool_result';
+      id: string;
+      name: string;
+      result: unknown;
+      isError: boolean;
+    }
+  | { type: 'image'; data: string; mimeType: string }
+  | {
+      type: 'om_observation_start';
+      tokensToObserve: number;
+      operationType?: 'observation' | 'reflection';
+    }
+  | {
+      type: 'om_observation_end';
+      tokensObserved: number;
+      observationTokens: number;
+      durationMs: number;
+      operationType?: 'observation' | 'reflection';
+      observations?: string;
+      currentTask?: string;
+      suggestedResponse?: string;
+    }
+  | {
+      type: 'om_observation_failed';
+      error: string;
+      tokensAttempted?: number;
+      operationType?: 'observation' | 'reflection';
+    };
 
 // =============================================================================
 // Observational Memory
@@ -560,31 +550,31 @@ export type HarnessMessageContent =
  * Used by TUI to show progress indicators.
  */
 export type ObservationalMemoryDebugEvent =
-	| {
-			type: "observation_triggered"
-			pendingTokens: number
-			threshold: number
-	  }
-	| {
-			type: "observation_complete"
-			observationTokens: number
-			duration: number
-	  }
-	| {
-			type: "reflection_triggered"
-			observationTokens: number
-			threshold: number
-	  }
-	| {
-			type: "reflection_complete"
-			compressedTokens: number
-			duration: number
-	  }
-	| {
-			type: "tokens_accumulated"
-			pendingTokens: number
-			threshold: number
-	  }
+  | {
+      type: 'observation_triggered';
+      pendingTokens: number;
+      threshold: number;
+    }
+  | {
+      type: 'observation_complete';
+      observationTokens: number;
+      duration: number;
+    }
+  | {
+      type: 'reflection_triggered';
+      observationTokens: number;
+      threshold: number;
+    }
+  | {
+      type: 'reflection_complete';
+      compressedTokens: number;
+      duration: number;
+    }
+  | {
+      type: 'tokens_accumulated';
+      pendingTokens: number;
+      threshold: number;
+    };
 
 // =============================================================================
 // Runtime Context
@@ -594,58 +584,50 @@ export type ObservationalMemoryDebugEvent =
  * Context available to tools via Mastra's runtimeContext.
  * Tools can access harness state and methods through this.
  */
-export interface HarnessRuntimeContext<
-	TState extends HarnessStateSchema = HarnessStateSchema,
-> {
-	/** The harness instance ID */
-	harnessId: string
+export interface HarnessRuntimeContext<TState extends HarnessStateSchema = HarnessStateSchema> {
+  /** The harness instance ID */
+  harnessId: string;
 
-	/** Current harness state (read-only snapshot) */
-	state: z.infer<TState>
+  /** Current harness state (read-only snapshot) */
+  state: z.infer<TState>;
 
-	/** Get the current harness state (live, not snapshot) */
-	getState: () => z.infer<TState>
+  /** Get the current harness state (live, not snapshot) */
+  getState: () => z.infer<TState>;
 
-	/** Update harness state */
-	setState: (updates: Partial<z.infer<TState>>) => Promise<void>
+  /** Update harness state */
+  setState: (updates: Partial<z.infer<TState>>) => Promise<void>;
 
-	/** Current thread ID */
-	threadId: string | null
+  /** Current thread ID */
+  threadId: string | null;
 
-	/** Current resource ID */
-	resourceId: string
+  /** Current resource ID */
+  resourceId: string;
 
-	/** Current mode ID */
-	modeId: string
+  /** Current mode ID */
+  modeId: string;
 
-	/** Abort signal for the current operation */
-	abortSignal?: AbortSignal
+  /** Abort signal for the current operation */
+  abortSignal?: AbortSignal;
 
-	/** Workspace instance (if configured on the Harness) */
-	workspace?: Workspace
+  /** Workspace instance (if configured on the Harness) */
+  workspace?: Workspace;
 
-	/** Emit a harness event (used by tools like task to forward subagent events) */
-	emitEvent?: (event: HarnessEvent) => void
+  /** Emit a harness event (used by tools like task to forward subagent events) */
+  emitEvent?: (event: HarnessEvent) => void;
 
-	/** Register a pending question resolver (used by ask_user tool) */
-	registerQuestion?: (
-		questionId: string,
-		resolve: (answer: string) => void,
-	) => void
+  /** Register a pending question resolver (used by ask_user tool) */
+  registerQuestion?: (questionId: string, resolve: (answer: string) => void) => void;
 
-	/** Register a pending plan approval resolver (used by submit_plan tool) */
-	registerPlanApproval?: (
-		planId: string,
-		resolve: (result: {
-			action: "approved" | "rejected"
-			feedback?: string
-		}) => void,
-	) => void
+  /** Register a pending plan approval resolver (used by submit_plan tool) */
+  registerPlanApproval?: (
+    planId: string,
+    resolve: (result: { action: 'approved' | 'rejected'; feedback?: string }) => void,
+  ) => void;
 
-	/**
-	 * Get the configured subagent model ID for a specific agent type.
-	 * @param agentType The agent type (explore, plan, execute)
-	 * Returns the model ID to use for subagents, or null to use defaults.
-	 */
-	getSubagentModelId?: (agentType?: string) => Promise<string | null>
+  /**
+   * Get the configured subagent model ID for a specific agent type.
+   * @param agentType The agent type (explore, plan, execute)
+   * Returns the model ID to use for subagents, or null to use defaults.
+   */
+  getSubagentModelId?: (agentType?: string) => Promise<string | null>;
 }

--- a/mastracode/src/hooks/config.ts
+++ b/mastracode/src/hooks/config.ts
@@ -4,81 +4,81 @@
  * Global hooks run first, project hooks append.
  */
 
-import * as fs from "node:fs"
-import * as os from "node:os"
-import * as path from "node:path"
-import type { HooksConfig, HookDefinition, HookEventName } from "./types.js"
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { HooksConfig, HookDefinition, HookEventName } from './types.js';
 
 const VALID_EVENTS: HookEventName[] = [
-	"PreToolUse",
-	"PostToolUse",
-	"Stop",
-	"UserPromptSubmit",
-	"SessionStart",
-	"SessionEnd",
-]
+  'PreToolUse',
+  'PostToolUse',
+  'Stop',
+  'UserPromptSubmit',
+  'SessionStart',
+  'SessionEnd',
+];
 
 export function loadHooksConfig(projectDir: string): HooksConfig {
-	const globalPath = getGlobalHooksPath()
-	const projectPath = getProjectHooksPath(projectDir)
+  const globalPath = getGlobalHooksPath();
+  const projectPath = getProjectHooksPath(projectDir);
 
-	const globalConfig = loadSingleConfig(globalPath)
-	const projectConfig = loadSingleConfig(projectPath)
+  const globalConfig = loadSingleConfig(globalPath);
+  const projectConfig = loadSingleConfig(projectPath);
 
-	return mergeConfigs(globalConfig, projectConfig)
+  return mergeConfigs(globalConfig, projectConfig);
 }
 
 export function getProjectHooksPath(projectDir: string): string {
-	return path.join(projectDir, ".mastracode", "hooks.json")
+  return path.join(projectDir, '.mastracode', 'hooks.json');
 }
 
 export function getGlobalHooksPath(): string {
-	return path.join(os.homedir(), ".mastracode", "hooks.json")
+  return path.join(os.homedir(), '.mastracode', 'hooks.json');
 }
 
 function loadSingleConfig(filePath: string): HooksConfig {
-	try {
-		if (!fs.existsSync(filePath)) return {}
-		const raw = fs.readFileSync(filePath, "utf-8")
-		return validateConfig(JSON.parse(raw))
-	} catch {
-		return {}
-	}
+  try {
+    if (!fs.existsSync(filePath)) return {};
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    return validateConfig(JSON.parse(raw));
+  } catch {
+    return {};
+  }
 }
 
 function validateConfig(raw: unknown): HooksConfig {
-	if (!raw || typeof raw !== "object") return {}
+  if (!raw || typeof raw !== 'object') return {};
 
-	const config: HooksConfig = {}
-	const obj = raw as Record<string, unknown>
+  const config: HooksConfig = {};
+  const obj = raw as Record<string, unknown>;
 
-	for (const event of VALID_EVENTS) {
-		if (Array.isArray(obj[event])) {
-			const hooks = (obj[event] as unknown[]).filter(isValidHook)
-			if (hooks.length > 0) {
-				config[event] = hooks
-			}
-		}
-	}
+  for (const event of VALID_EVENTS) {
+    if (Array.isArray(obj[event])) {
+      const hooks = (obj[event] as unknown[]).filter(isValidHook);
+      if (hooks.length > 0) {
+        config[event] = hooks;
+      }
+    }
+  }
 
-	return config
+  return config;
 }
 
 function isValidHook(raw: unknown): raw is HookDefinition {
-	if (!raw || typeof raw !== "object") return false
-	const obj = raw as Record<string, unknown>
-	return obj.type === "command" && typeof obj.command === "string"
+  if (!raw || typeof raw !== 'object') return false;
+  const obj = raw as Record<string, unknown>;
+  return obj.type === 'command' && typeof obj.command === 'string';
 }
 
 function mergeConfigs(global: HooksConfig, project: HooksConfig): HooksConfig {
-	const merged: HooksConfig = {}
+  const merged: HooksConfig = {};
 
-	for (const event of VALID_EVENTS) {
-		const combined = [...(global[event] ?? []), ...(project[event] ?? [])]
-		if (combined.length > 0) {
-			merged[event] = combined
-		}
-	}
+  for (const event of VALID_EVENTS) {
+    const combined = [...(global[event] ?? []), ...(project[event] ?? [])];
+    if (combined.length > 0) {
+      merged[event] = combined;
+    }
+  }
 
-	return merged
+  return merged;
 }

--- a/mastracode/src/hooks/executor.ts
+++ b/mastracode/src/hooks/executor.ts
@@ -3,175 +3,158 @@
  * Spawns shell commands, handles stdin/stdout/exit-code protocol.
  */
 
-import { spawn } from "node:child_process"
-import type {
-	HookDefinition,
-	HookStdin,
-	HookResult,
-	HookStdout,
-	HookEventResult,
-} from "./types.js"
-import { isBlockingEvent } from "./types.js"
+import { spawn } from 'node:child_process';
+import type { HookDefinition, HookStdin, HookResult, HookStdout, HookEventResult } from './types.js';
+import { isBlockingEvent } from './types.js';
 
-const DEFAULT_TIMEOUT = 10_000
+const DEFAULT_TIMEOUT = 10_000;
 
-export async function executeHook(
-	hook: HookDefinition,
-	stdinPayload: HookStdin,
-): Promise<HookResult> {
-	const timeout = hook.timeout ?? DEFAULT_TIMEOUT
-	const startTime = Date.now()
+export async function executeHook(hook: HookDefinition, stdinPayload: HookStdin): Promise<HookResult> {
+  const timeout = hook.timeout ?? DEFAULT_TIMEOUT;
+  const startTime = Date.now();
 
-	return new Promise<HookResult>((resolve) => {
-		const isWindows = process.platform === "win32"
-		const shell = isWindows ? "cmd" : "/bin/sh"
-		const shellArgs = isWindows ? ["/c", hook.command] : ["-c", hook.command]
+  return new Promise<HookResult>(resolve => {
+    const isWindows = process.platform === 'win32';
+    const shell = isWindows ? 'cmd' : '/bin/sh';
+    const shellArgs = isWindows ? ['/c', hook.command] : ['-c', hook.command];
 
-		const child = spawn(shell, shellArgs, {
-			stdio: ["pipe", "pipe", "pipe"],
-			cwd: stdinPayload.cwd,
-			env: {
-				...process.env,
-				MASTRA_HOOK_EVENT: stdinPayload.hook_event_name,
-			},
-		})
+    const child = spawn(shell, shellArgs, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: stdinPayload.cwd,
+      env: {
+        ...process.env,
+        MASTRA_HOOK_EVENT: stdinPayload.hook_event_name,
+      },
+    });
 
-		let stdout = ""
-		let stderr = ""
-		let timedOut = false
-		let resolved = false
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let resolved = false;
 
-		const timer = setTimeout(() => {
-			timedOut = true
-			child.kill("SIGKILL")
-		}, timeout)
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, timeout);
 
-		child.stdout?.on("data", (data: Buffer) => {
-			stdout += data.toString()
-		})
+    child.stdout?.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
 
-		child.stderr?.on("data", (data: Buffer) => {
-			stderr += data.toString()
-		})
+    child.stderr?.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
 
-		child.on("close", (exitCode) => {
-			clearTimeout(timer)
-			if (resolved) return
-			resolved = true
+    child.on('close', exitCode => {
+      clearTimeout(timer);
+      if (resolved) return;
+      resolved = true;
 
-			let parsedStdout: HookStdout | undefined
-			if (stdout.trim()) {
-				try {
-					parsedStdout = JSON.parse(stdout.trim()) as HookStdout
-				} catch {
-					// Not valid JSON — ignore
-				}
-			}
+      let parsedStdout: HookStdout | undefined;
+      if (stdout.trim()) {
+        try {
+          parsedStdout = JSON.parse(stdout.trim()) as HookStdout;
+        } catch {
+          // Not valid JSON — ignore
+        }
+      }
 
-			resolve({
-				hook,
-				exitCode: exitCode ?? 1,
-				stdout: parsedStdout,
-				stderr: stderr.trim() || undefined,
-				timedOut,
-				durationMs: Date.now() - startTime,
-			})
-		})
+      resolve({
+        hook,
+        exitCode: exitCode ?? 1,
+        stdout: parsedStdout,
+        stderr: stderr.trim() || undefined,
+        timedOut,
+        durationMs: Date.now() - startTime,
+      });
+    });
 
-		child.on("error", (error) => {
-			clearTimeout(timer)
-			if (resolved) return
-			resolved = true
+    child.on('error', error => {
+      clearTimeout(timer);
+      if (resolved) return;
+      resolved = true;
 
-			resolve({
-				hook,
-				exitCode: 1,
-				stderr: error.message,
-				timedOut: false,
-				durationMs: Date.now() - startTime,
-			})
-		})
+      resolve({
+        hook,
+        exitCode: 1,
+        stderr: error.message,
+        timedOut: false,
+        durationMs: Date.now() - startTime,
+      });
+    });
 
-		try {
-			child.stdin?.write(JSON.stringify(stdinPayload))
-			child.stdin?.end()
-		} catch {
-			// stdin write failure — process continues
-		}
-	})
+    try {
+      child.stdin?.write(JSON.stringify(stdinPayload));
+      child.stdin?.end();
+    } catch {
+      // stdin write failure — process continues
+    }
+  });
 }
 
-export function matchesHook(
-	hook: HookDefinition,
-	context: { tool_name?: string },
-): boolean {
-	if (!hook.matcher) return true
+export function matchesHook(hook: HookDefinition, context: { tool_name?: string }): boolean {
+  if (!hook.matcher) return true;
 
-	if (hook.matcher.tool_name) {
-		if (!context.tool_name) return false
-		try {
-			return new RegExp(hook.matcher.tool_name).test(context.tool_name)
-		} catch {
-			return false
-		}
-	}
+  if (hook.matcher.tool_name) {
+    if (!context.tool_name) return false;
+    try {
+      return new RegExp(hook.matcher.tool_name).test(context.tool_name);
+    } catch {
+      return false;
+    }
+  }
 
-	return true
+  return true;
 }
 
 export async function runHooksForEvent(
-	hooks: HookDefinition[],
-	stdinPayload: HookStdin,
-	matchContext: { tool_name?: string } = {},
+  hooks: HookDefinition[],
+  stdinPayload: HookStdin,
+  matchContext: { tool_name?: string } = {},
 ): Promise<HookEventResult> {
-	const results: HookResult[] = []
-	const warnings: string[] = []
-	let additionalContext: string | undefined
+  const results: HookResult[] = [];
+  const warnings: string[] = [];
+  let additionalContext: string | undefined;
 
-	const applicable = hooks.filter((h) => matchesHook(h, matchContext))
-	if (applicable.length === 0) {
-		return { allowed: true, results: [], warnings: [] }
-	}
+  const applicable = hooks.filter(h => matchesHook(h, matchContext));
+  if (applicable.length === 0) {
+    return { allowed: true, results: [], warnings: [] };
+  }
 
-	const blocking = isBlockingEvent(stdinPayload.hook_event_name)
+  const blocking = isBlockingEvent(stdinPayload.hook_event_name);
 
-	for (const hook of applicable) {
-		const result = await executeHook(hook, stdinPayload)
-		results.push(result)
+  for (const hook of applicable) {
+    const result = await executeHook(hook, stdinPayload);
+    results.push(result);
 
-		if (result.stdout?.additionalContext) {
-			additionalContext = additionalContext
-				? `${additionalContext}\n${result.stdout.additionalContext}`
-				: result.stdout.additionalContext
-		}
+    if (result.stdout?.additionalContext) {
+      additionalContext = additionalContext
+        ? `${additionalContext}\n${result.stdout.additionalContext}`
+        : result.stdout.additionalContext;
+    }
 
-		if (result.timedOut) {
-			warnings.push(
-				`Hook timed out after ${hook.timeout ?? DEFAULT_TIMEOUT}ms: ${hook.command}`,
-			)
-			continue
-		}
+    if (result.timedOut) {
+      warnings.push(`Hook timed out after ${hook.timeout ?? DEFAULT_TIMEOUT}ms: ${hook.command}`);
+      continue;
+    }
 
-		if (result.exitCode === 2 && blocking) {
-			const reason =
-				result.stdout?.reason ||
-				result.stderr ||
-				`Blocked by hook: ${hook.description || hook.command}`
+    if (result.exitCode === 2 && blocking) {
+      const reason = result.stdout?.reason || result.stderr || `Blocked by hook: ${hook.description || hook.command}`;
 
-			return {
-				allowed: false,
-				blockReason: reason,
-				additionalContext,
-				results,
-				warnings,
-			}
-		}
+      return {
+        allowed: false,
+        blockReason: reason,
+        additionalContext,
+        results,
+        warnings,
+      };
+    }
 
-		if (result.exitCode === 0) continue
+    if (result.exitCode === 0) continue;
 
-		const warnMsg = result.stderr || `Hook exited with code ${result.exitCode}`
-		warnings.push(`${hook.description || hook.command}: ${warnMsg}`)
-	}
+    const warnMsg = result.stderr || `Hook exited with code ${result.exitCode}`;
+    warnings.push(`${hook.description || hook.command}: ${warnMsg}`);
+  }
 
-	return { allowed: true, additionalContext, results, warnings }
+  return { allowed: true, additionalContext, results, warnings };
 }

--- a/mastracode/src/hooks/index.ts
+++ b/mastracode/src/hooks/index.ts
@@ -1,25 +1,21 @@
-export { HookManager } from "./manager.js"
-export {
-	loadHooksConfig,
-	getProjectHooksPath,
-	getGlobalHooksPath,
-} from "./config.js"
-export { executeHook, runHooksForEvent, matchesHook } from "./executor.js"
-export { isBlockingEvent } from "./types.js"
+export { HookManager } from './manager.js';
+export { loadHooksConfig, getProjectHooksPath, getGlobalHooksPath } from './config.js';
+export { executeHook, runHooksForEvent, matchesHook } from './executor.js';
+export { isBlockingEvent } from './types.js';
 export type {
-	HookEventName,
-	HookDefinition,
-	HookMatcher,
-	HooksConfig,
-	HookStdin,
-	HookStdinBase,
-	HookStdinToolEvent,
-	HookStdinUserPrompt,
-	HookStdinStop,
-	HookStdinSession,
-	HookStdinNotification,
-	HookStdout,
-	HookResult,
-	HookEventResult,
-	BlockingHookEvent,
-} from "./types.js"
+  HookEventName,
+  HookDefinition,
+  HookMatcher,
+  HooksConfig,
+  HookStdin,
+  HookStdinBase,
+  HookStdinToolEvent,
+  HookStdinUserPrompt,
+  HookStdinStop,
+  HookStdinSession,
+  HookStdinNotification,
+  HookStdout,
+  HookResult,
+  HookEventResult,
+  BlockingHookEvent,
+} from './types.js';

--- a/mastracode/src/hooks/manager.ts
+++ b/mastracode/src/hooks/manager.ts
@@ -2,186 +2,179 @@
  * HookManager — high-level orchestration for the hooks system.
  * Created once at startup, provides methods for each lifecycle event.
  */
-import {
-	loadHooksConfig,
-	getProjectHooksPath,
-	getGlobalHooksPath,
-} from "./config.js"
-import { runHooksForEvent } from "./executor.js"
+import { loadHooksConfig, getProjectHooksPath, getGlobalHooksPath } from './config.js';
+import { runHooksForEvent } from './executor.js';
 import type {
-	HooksConfig,
-	HookEventResult,
-	HookStdinToolEvent,
-	HookStdinUserPrompt,
-	HookStdinStop,
-	HookStdinSession,
-	HookStdinNotification,
-} from "./types.js"
+  HooksConfig,
+  HookEventResult,
+  HookStdinToolEvent,
+  HookStdinUserPrompt,
+  HookStdinStop,
+  HookStdinSession,
+  HookStdinNotification,
+} from './types.js';
 
 export class HookManager {
-	private config: HooksConfig
-	private projectDir: string
-	private sessionId: string
+  private config: HooksConfig;
+  private projectDir: string;
+  private sessionId: string;
 
-	constructor(projectDir: string, sessionId: string) {
-		this.projectDir = projectDir
-		this.sessionId = sessionId
-		this.config = loadHooksConfig(projectDir)
-	}
+  constructor(projectDir: string, sessionId: string) {
+    this.projectDir = projectDir;
+    this.sessionId = sessionId;
+    this.config = loadHooksConfig(projectDir);
+  }
 
-	reload(): void {
-		this.config = loadHooksConfig(this.projectDir)
-	}
+  reload(): void {
+    this.config = loadHooksConfig(this.projectDir);
+  }
 
-	setSessionId(sessionId: string): void {
-		this.sessionId = sessionId
-	}
+  setSessionId(sessionId: string): void {
+    this.sessionId = sessionId;
+  }
 
-	hasHooks(): boolean {
-		return Object.keys(this.config).length > 0
-	}
+  hasHooks(): boolean {
+    return Object.keys(this.config).length > 0;
+  }
 
-	getConfig(): HooksConfig {
-		return this.config
-	}
+  getConfig(): HooksConfig {
+    return this.config;
+  }
 
-	getConfigPaths(): { project: string; global: string } {
-		return {
-			project: getProjectHooksPath(this.projectDir),
-			global: getGlobalHooksPath(),
-		}
-	}
+  getConfigPaths(): { project: string; global: string } {
+    return {
+      project: getProjectHooksPath(this.projectDir),
+      global: getGlobalHooksPath(),
+    };
+  }
 
-	// =========================================================================
-	// Event Methods
-	// =========================================================================
+  // =========================================================================
+  // Event Methods
+  // =========================================================================
 
-	async runPreToolUse(
-		toolName: string,
-		toolInput: unknown,
-	): Promise<HookEventResult> {
-		const hooks = this.config.PreToolUse
-		if (!hooks || hooks.length === 0) {
-			return { allowed: true, results: [], warnings: [] }
-		}
+  async runPreToolUse(toolName: string, toolInput: unknown): Promise<HookEventResult> {
+    const hooks = this.config.PreToolUse;
+    if (!hooks || hooks.length === 0) {
+      return { allowed: true, results: [], warnings: [] };
+    }
 
-		const stdin: HookStdinToolEvent = {
-			session_id: this.sessionId,
-			cwd: this.projectDir,
-			hook_event_name: "PreToolUse",
-			tool_name: toolName,
-			tool_input: toolInput,
-		}
+    const stdin: HookStdinToolEvent = {
+      session_id: this.sessionId,
+      cwd: this.projectDir,
+      hook_event_name: 'PreToolUse',
+      tool_name: toolName,
+      tool_input: toolInput,
+    };
 
-		return runHooksForEvent(hooks, stdin, { tool_name: toolName })
-	}
+    return runHooksForEvent(hooks, stdin, { tool_name: toolName });
+  }
 
-	async runPostToolUse(
-		toolName: string,
-		toolInput: unknown,
-		toolOutput: unknown,
-		toolError: boolean,
-	): Promise<HookEventResult> {
-		const hooks = this.config.PostToolUse
-		if (!hooks || hooks.length === 0) {
-			return { allowed: true, results: [], warnings: [] }
-		}
+  async runPostToolUse(
+    toolName: string,
+    toolInput: unknown,
+    toolOutput: unknown,
+    toolError: boolean,
+  ): Promise<HookEventResult> {
+    const hooks = this.config.PostToolUse;
+    if (!hooks || hooks.length === 0) {
+      return { allowed: true, results: [], warnings: [] };
+    }
 
-		const stdin: HookStdinToolEvent = {
-			session_id: this.sessionId,
-			cwd: this.projectDir,
-			hook_event_name: "PostToolUse",
-			tool_name: toolName,
-			tool_input: toolInput,
-			tool_output: toolOutput,
-			tool_error: toolError,
-		}
+    const stdin: HookStdinToolEvent = {
+      session_id: this.sessionId,
+      cwd: this.projectDir,
+      hook_event_name: 'PostToolUse',
+      tool_name: toolName,
+      tool_input: toolInput,
+      tool_output: toolOutput,
+      tool_error: toolError,
+    };
 
-		return runHooksForEvent(hooks, stdin, { tool_name: toolName })
-	}
+    return runHooksForEvent(hooks, stdin, { tool_name: toolName });
+  }
 
-	async runUserPromptSubmit(userMessage: string): Promise<HookEventResult> {
-		const hooks = this.config.UserPromptSubmit
-		if (!hooks || hooks.length === 0) {
-			return { allowed: true, results: [], warnings: [] }
-		}
+  async runUserPromptSubmit(userMessage: string): Promise<HookEventResult> {
+    const hooks = this.config.UserPromptSubmit;
+    if (!hooks || hooks.length === 0) {
+      return { allowed: true, results: [], warnings: [] };
+    }
 
-		const stdin: HookStdinUserPrompt = {
-			session_id: this.sessionId,
-			cwd: this.projectDir,
-			hook_event_name: "UserPromptSubmit",
-			user_message: userMessage,
-		}
+    const stdin: HookStdinUserPrompt = {
+      session_id: this.sessionId,
+      cwd: this.projectDir,
+      hook_event_name: 'UserPromptSubmit',
+      user_message: userMessage,
+    };
 
-		return runHooksForEvent(hooks, stdin)
-	}
+    return runHooksForEvent(hooks, stdin);
+  }
 
-	async runStop(
-		assistantMessage: string | undefined,
-		stopReason: "complete" | "aborted" | "error",
-	): Promise<HookEventResult> {
-		const hooks = this.config.Stop
-		if (!hooks || hooks.length === 0) {
-			return { allowed: true, results: [], warnings: [] }
-		}
+  async runStop(
+    assistantMessage: string | undefined,
+    stopReason: 'complete' | 'aborted' | 'error',
+  ): Promise<HookEventResult> {
+    const hooks = this.config.Stop;
+    if (!hooks || hooks.length === 0) {
+      return { allowed: true, results: [], warnings: [] };
+    }
 
-		const stdin: HookStdinStop = {
-			session_id: this.sessionId,
-			cwd: this.projectDir,
-			hook_event_name: "Stop",
-			assistant_message: assistantMessage,
-			stop_reason: stopReason,
-		}
+    const stdin: HookStdinStop = {
+      session_id: this.sessionId,
+      cwd: this.projectDir,
+      hook_event_name: 'Stop',
+      assistant_message: assistantMessage,
+      stop_reason: stopReason,
+    };
 
-		return runHooksForEvent(hooks, stdin)
-	}
+    return runHooksForEvent(hooks, stdin);
+  }
 
-	async runSessionStart(): Promise<HookEventResult> {
-		const hooks = this.config.SessionStart
-		if (!hooks || hooks.length === 0) {
-			return { allowed: true, results: [], warnings: [] }
-		}
+  async runSessionStart(): Promise<HookEventResult> {
+    const hooks = this.config.SessionStart;
+    if (!hooks || hooks.length === 0) {
+      return { allowed: true, results: [], warnings: [] };
+    }
 
-		const stdin: HookStdinSession = {
-			session_id: this.sessionId,
-			cwd: this.projectDir,
-			hook_event_name: "SessionStart",
-		}
+    const stdin: HookStdinSession = {
+      session_id: this.sessionId,
+      cwd: this.projectDir,
+      hook_event_name: 'SessionStart',
+    };
 
-		return runHooksForEvent(hooks, stdin)
-	}
-	async runSessionEnd(): Promise<HookEventResult> {
-		const hooks = this.config.SessionEnd
-		if (!hooks || hooks.length === 0) {
-			return { allowed: true, results: [], warnings: [] }
-		}
+    return runHooksForEvent(hooks, stdin);
+  }
+  async runSessionEnd(): Promise<HookEventResult> {
+    const hooks = this.config.SessionEnd;
+    if (!hooks || hooks.length === 0) {
+      return { allowed: true, results: [], warnings: [] };
+    }
 
-		const stdin: HookStdinSession = {
-			session_id: this.sessionId,
-			cwd: this.projectDir,
-			hook_event_name: "SessionEnd",
-		}
+    const stdin: HookStdinSession = {
+      session_id: this.sessionId,
+      cwd: this.projectDir,
+      hook_event_name: 'SessionEnd',
+    };
 
-		return runHooksForEvent(hooks, stdin)
-	}
+    return runHooksForEvent(hooks, stdin);
+  }
 
-	/**
-	 * Fire notification hooks (non-blocking, fire-and-forget).
-	 * Called when the TUI is waiting for user input.
-	 */
-	runNotification(reason: string, message?: string): void {
-		const hooks = this.config.Notification
-		if (!hooks || hooks.length === 0) return
+  /**
+   * Fire notification hooks (non-blocking, fire-and-forget).
+   * Called when the TUI is waiting for user input.
+   */
+  runNotification(reason: string, message?: string): void {
+    const hooks = this.config.Notification;
+    if (!hooks || hooks.length === 0) return;
 
-		const stdin: HookStdinNotification = {
-			session_id: this.sessionId,
-			cwd: this.projectDir,
-			hook_event_name: "Notification",
-			reason,
-			message,
-		}
+    const stdin: HookStdinNotification = {
+      session_id: this.sessionId,
+      cwd: this.projectDir,
+      hook_event_name: 'Notification',
+      reason,
+      message,
+    };
 
-		// Fire-and-forget — don't await
-		runHooksForEvent(hooks, stdin).catch(() => {})
-	}
+    // Fire-and-forget — don't await
+    runHooksForEvent(hooks, stdin).catch(() => {});
+  }
 }

--- a/mastracode/src/hooks/types.ts
+++ b/mastracode/src/hooks/types.ts
@@ -7,22 +7,18 @@
 // Hook Event Names
 // =============================================================================
 export type HookEventName =
-	| "PreToolUse"
-	| "PostToolUse"
-	| "Stop"
-	| "UserPromptSubmit"
-	| "SessionStart"
-	| "SessionEnd"
-	| "Notification"
+  | 'PreToolUse'
+  | 'PostToolUse'
+  | 'Stop'
+  | 'UserPromptSubmit'
+  | 'SessionStart'
+  | 'SessionEnd'
+  | 'Notification';
 
-export type BlockingHookEvent = "PreToolUse" | "Stop" | "UserPromptSubmit"
+export type BlockingHookEvent = 'PreToolUse' | 'Stop' | 'UserPromptSubmit';
 
-export function isBlockingEvent(
-	event: HookEventName,
-): event is BlockingHookEvent {
-	return (
-		event === "PreToolUse" || event === "Stop" || event === "UserPromptSubmit"
-	)
+export function isBlockingEvent(event: HookEventName): event is BlockingHookEvent {
+  return event === 'PreToolUse' || event === 'Stop' || event === 'UserPromptSubmit';
 }
 
 // =============================================================================
@@ -30,30 +26,30 @@ export function isBlockingEvent(
 // =============================================================================
 
 export interface HookMatcher {
-	/** Regex pattern matched against tool_name (PreToolUse/PostToolUse only). */
-	tool_name?: string
+  /** Regex pattern matched against tool_name (PreToolUse/PostToolUse only). */
+  tool_name?: string;
 }
 
 export interface HookDefinition {
-	/** Hook type. Only "command" supported in phase 1. */
-	type: "command"
-	/** Shell command to execute via /bin/sh -c. */
-	command: string
-	/** Optional matcher to filter when this hook runs. */
-	matcher?: HookMatcher
-	/** Timeout in ms. Default 10000. Process killed after timeout. */
-	timeout?: number
-	/** Human-readable description for /hooks display. */
-	description?: string
+  /** Hook type. Only "command" supported in phase 1. */
+  type: 'command';
+  /** Shell command to execute via /bin/sh -c. */
+  command: string;
+  /** Optional matcher to filter when this hook runs. */
+  matcher?: HookMatcher;
+  /** Timeout in ms. Default 10000. Process killed after timeout. */
+  timeout?: number;
+  /** Human-readable description for /hooks display. */
+  description?: string;
 }
 export interface HooksConfig {
-	PreToolUse?: HookDefinition[]
-	PostToolUse?: HookDefinition[]
-	Stop?: HookDefinition[]
-	UserPromptSubmit?: HookDefinition[]
-	SessionStart?: HookDefinition[]
-	SessionEnd?: HookDefinition[]
-	Notification?: HookDefinition[]
+  PreToolUse?: HookDefinition[];
+  PostToolUse?: HookDefinition[];
+  Stop?: HookDefinition[];
+  UserPromptSubmit?: HookDefinition[];
+  SessionStart?: HookDefinition[];
+  SessionEnd?: HookDefinition[];
+  Notification?: HookDefinition[];
 }
 
 // =============================================================================
@@ -61,56 +57,56 @@ export interface HooksConfig {
 // =============================================================================
 
 export interface HookStdinBase {
-	session_id: string
-	cwd: string
-	hook_event_name: HookEventName
+  session_id: string;
+  cwd: string;
+  hook_event_name: HookEventName;
 }
 
 export interface HookStdinToolEvent extends HookStdinBase {
-	hook_event_name: "PreToolUse" | "PostToolUse"
-	tool_name: string
-	tool_input: unknown
-	tool_output?: unknown
-	tool_error?: boolean
+  hook_event_name: 'PreToolUse' | 'PostToolUse';
+  tool_name: string;
+  tool_input: unknown;
+  tool_output?: unknown;
+  tool_error?: boolean;
 }
 
 export interface HookStdinUserPrompt extends HookStdinBase {
-	hook_event_name: "UserPromptSubmit"
-	user_message: string
+  hook_event_name: 'UserPromptSubmit';
+  user_message: string;
 }
 
 export interface HookStdinStop extends HookStdinBase {
-	hook_event_name: "Stop"
-	assistant_message?: string
-	stop_reason: "complete" | "aborted" | "error"
+  hook_event_name: 'Stop';
+  assistant_message?: string;
+  stop_reason: 'complete' | 'aborted' | 'error';
 }
 export interface HookStdinSession extends HookStdinBase {
-	hook_event_name: "SessionStart" | "SessionEnd"
+  hook_event_name: 'SessionStart' | 'SessionEnd';
 }
 
 export interface HookStdinNotification extends HookStdinBase {
-	hook_event_name: "Notification"
-	/** Why the notification fired: agent_done, ask_question, tool_approval, plan_approval, sandbox_access */
-	reason: string
-	/** Optional human-readable message for the notification. */
-	message?: string
+  hook_event_name: 'Notification';
+  /** Why the notification fired: agent_done, ask_question, tool_approval, plan_approval, sandbox_access */
+  reason: string;
+  /** Optional human-readable message for the notification. */
+  message?: string;
 }
 
 export type HookStdin =
-	| HookStdinToolEvent
-	| HookStdinUserPrompt
-	| HookStdinStop
-	| HookStdinSession
-	| HookStdinNotification
+  | HookStdinToolEvent
+  | HookStdinUserPrompt
+  | HookStdinStop
+  | HookStdinSession
+  | HookStdinNotification;
 
 // =============================================================================
 // Stdout Protocol (JSON read from hook process)
 // =============================================================================
 
 export interface HookStdout {
-	decision?: "allow" | "block"
-	reason?: string
-	additionalContext?: string
+  decision?: 'allow' | 'block';
+  reason?: string;
+  additionalContext?: string;
 }
 
 // =============================================================================
@@ -118,18 +114,18 @@ export interface HookStdout {
 // =============================================================================
 
 export interface HookResult {
-	hook: HookDefinition
-	exitCode: number
-	stdout?: HookStdout
-	stderr?: string
-	timedOut: boolean
-	durationMs: number
+  hook: HookDefinition;
+  exitCode: number;
+  stdout?: HookStdout;
+  stderr?: string;
+  timedOut: boolean;
+  durationMs: number;
 }
 
 export interface HookEventResult {
-	allowed: boolean
-	blockReason?: string
-	additionalContext?: string
-	results: HookResult[]
-	warnings: string[]
+  allowed: boolean;
+  blockReason?: string;
+  additionalContext?: string;
+  results: HookResult[];
+  warnings: string[];
 }

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -1,177 +1,161 @@
-import { Mastra } from "@mastra/core"
-import { Agent } from "@mastra/core/agent"
-import { noopLogger } from "@mastra/core/logger"
-import { LibSQLStore } from "@mastra/libsql"
+import { Mastra } from '@mastra/core';
+import { Agent } from '@mastra/core/agent';
+import { noopLogger } from '@mastra/core/logger';
+import { LibSQLStore } from '@mastra/libsql';
 
-import { getDynamicInstructions } from "./agents/instructions.js"
-import { getDynamicMemory, omState } from "./agents/memory.js"
-import { getDynamicModel } from "./agents/model.js"
-import { createDynamicTools } from "./agents/tools.js"
-import { getDynamicWorkspace } from "./agents/workspace.js"
-import { AuthStorage } from "./auth/storage.js"
-import { DEFAULT_OBS_THRESHOLD, DEFAULT_REF_THRESHOLD } from "./constants.js"
-import { Harness } from "./harness/harness.js"
-import { HookManager } from "./hooks/index.js"
-import { MCPManager } from "./mcp/index.js"
-import {
-	setAuthStorage,
-} from "./providers/claude-max.js"
-import {
-	setAuthStorage as setOpenAIAuthStorage,
-} from "./providers/openai-codex.js"
-import { stateSchema } from "./schema.js"
-import { mastra } from "./tui/theme.js"
-import { syncGateways } from "./utils/gateway-sync.js"
-import {
-	detectProject,
-	getStorageConfig,
-	getUserId,
-	getResourceIdOverride,
-} from "./utils/project.js"
+import { getDynamicInstructions } from './agents/instructions.js';
+import { getDynamicMemory, omState } from './agents/memory.js';
+import { getDynamicModel } from './agents/model.js';
+import { createDynamicTools } from './agents/tools.js';
+import { getDynamicWorkspace } from './agents/workspace.js';
+import { AuthStorage } from './auth/storage.js';
+import { DEFAULT_OBS_THRESHOLD, DEFAULT_REF_THRESHOLD } from './constants.js';
+import { Harness } from './harness/harness.js';
+import { HookManager } from './hooks/index.js';
+import { MCPManager } from './mcp/index.js';
+import { setAuthStorage } from './providers/claude-max.js';
+import { setAuthStorage as setOpenAIAuthStorage } from './providers/openai-codex.js';
+import { stateSchema } from './schema.js';
+import { mastra } from './tui/theme.js';
+import { syncGateways } from './utils/gateway-sync.js';
+import { detectProject, getStorageConfig, getUserId, getResourceIdOverride } from './utils/project.js';
 
 export function createMastraCode() {
-	// Auth storage (shared with Claude Max / OpenAI providers and Harness)
-	const authStorage = new AuthStorage()
-	setAuthStorage(authStorage)
-	setOpenAIAuthStorage(authStorage)
+  // Auth storage (shared with Claude Max / OpenAI providers and Harness)
+  const authStorage = new AuthStorage();
+  setAuthStorage(authStorage);
+  setOpenAIAuthStorage(authStorage);
 
-	// Project detection
-	const project = detectProject(process.cwd())
-	const autoDetectedResourceId = project.resourceId
+  // Project detection
+  const project = detectProject(process.cwd());
+  const autoDetectedResourceId = project.resourceId;
 
-	const resourceIdOverride = getResourceIdOverride(project.rootPath)
-	if (resourceIdOverride) {
-		project.resourceId = resourceIdOverride
-		project.resourceIdOverride = true
-	}
+  const resourceIdOverride = getResourceIdOverride(project.rootPath);
+  if (resourceIdOverride) {
+    project.resourceId = resourceIdOverride;
+    project.resourceIdOverride = true;
+  }
 
-	console.info(`Project: ${project.name}`)
-	console.info(
-		`Resource ID: ${project.resourceId}${project.resourceIdOverride ? " (override)" : ""}`,
-	)
-	if (project.gitBranch) console.info(`Branch: ${project.gitBranch}`)
-	if (project.isWorktree) console.info(`Worktree of: ${project.mainRepoPath}`)
+  console.info(`Project: ${project.name}`);
+  console.info(`Resource ID: ${project.resourceId}${project.resourceIdOverride ? ' (override)' : ''}`);
+  if (project.gitBranch) console.info(`Branch: ${project.gitBranch}`);
+  if (project.isWorktree) console.info(`Worktree of: ${project.mainRepoPath}`);
 
-	const userId = getUserId(project.rootPath)
-	console.info(`User: ${userId}`)
-	console.info("--------------------------------")
+  const userId = getUserId(project.rootPath);
+  console.info(`User: ${userId}`);
+  console.info('--------------------------------');
 
-	// Storage
-	const storageConfig = getStorageConfig(project.rootPath)
-	const storage = new LibSQLStore({
-		id: "mastra-code-storage",
-		url: storageConfig.url,
-		...(storageConfig.authToken ? { authToken: storageConfig.authToken } : {}),
-	})
+  // Storage
+  const storageConfig = getStorageConfig(project.rootPath);
+  const storage = new LibSQLStore({
+    id: 'mastra-code-storage',
+    url: storageConfig.url,
+    ...(storageConfig.authToken ? { authToken: storageConfig.authToken } : {}),
+  });
 
-	const memory = getDynamicMemory(storage)
+  const memory = getDynamicMemory(storage);
 
-	// MCP
-	const mcpManager = new MCPManager(project.rootPath)
+  // MCP
+  const mcpManager = new MCPManager(project.rootPath);
 
-	// Agent
-	const codeAgent = new Agent({
-		id: "code-agent",
-		name: "Code Agent",
-		instructions: getDynamicInstructions,
-		model: getDynamicModel,
-		memory,
-		workspace: getDynamicWorkspace,
-		tools: createDynamicTools(mcpManager),
-	})
+  // Agent
+  const codeAgent = new Agent({
+    id: 'code-agent',
+    name: 'Code Agent',
+    instructions: getDynamicInstructions,
+    model: getDynamicModel,
+    memory,
+    workspace: getDynamicWorkspace,
+    tools: createDynamicTools(mcpManager),
+  });
 
-	const mastraInstance = new Mastra({
-		agents: { codeAgent },
-		storage,
-	})
-	mastraInstance.getLogger = () => noopLogger as any
-	codeAgent.__setLogger(noopLogger)
+  const mastraInstance = new Mastra({
+    agents: { codeAgent },
+    storage,
+  });
+  mastraInstance.getLogger = () => noopLogger as any;
+  codeAgent.__setLogger(noopLogger);
 
-	// Hooks
-	const hookManager = new HookManager(project.rootPath, "session-init")
+  // Hooks
+  const hookManager = new HookManager(project.rootPath, 'session-init');
 
-	if (hookManager.hasHooks()) {
-		const hookConfig = hookManager.getConfig()
-		const hookCount = Object.values(hookConfig).reduce(
-			(sum, hooks) => sum + (hooks?.length ?? 0),
-			0,
-		)
-		console.info(`Hooks: ${hookCount} hook(s) configured`)
-	}
+  if (hookManager.hasHooks()) {
+    const hookConfig = hookManager.getConfig();
+    const hookCount = Object.values(hookConfig).reduce((sum, hooks) => sum + (hooks?.length ?? 0), 0);
+    console.info(`Hooks: ${hookCount} hook(s) configured`);
+  }
 
-	// Harness
-	const harness = new Harness({
-		id: "mastra-code",
-		resourceId: project.resourceId,
-		defaultResourceId: autoDetectedResourceId,
-		userId,
-		isRemoteStorage: storageConfig.isRemote,
-		storage,
-		stateSchema,
-		initialState: {
-			projectPath: project.rootPath,
-			projectName: project.name,
-			gitBranch: project.gitBranch,
-		},
-		workspace: getDynamicWorkspace,
-		hookManager,
-		mcpManager,
-		modes: [
-			{
-				id: "build",
-				name: "Build",
-				default: true,
-				defaultModelId: "anthropic/claude-opus-4-6",
-				color: mastra.purple,
-				agent: codeAgent,
-			},
-			{
-				id: "plan",
-				name: "Plan",
-				defaultModelId: "openai/gpt-5.2-codex",
-				color: mastra.blue,
-				agent: codeAgent,
-			},
-			{
-				id: "fast",
-				name: "Fast",
-				defaultModelId: "cerebras/zai-glm-4.7",
-				color: mastra.green,
-				agent: codeAgent,
-			},
-		],
-		authStorage,
-		heartbeatHandlers: [
-			{
-				id: "gateway-sync",
-				intervalMs: 5 * 60 * 1000,
-				handler: () => syncGateways(),
-			},
-		],
-	})
+  // Harness
+  const harness = new Harness({
+    id: 'mastra-code',
+    resourceId: project.resourceId,
+    defaultResourceId: autoDetectedResourceId,
+    userId,
+    isRemoteStorage: storageConfig.isRemote,
+    storage,
+    stateSchema,
+    initialState: {
+      projectPath: project.rootPath,
+      projectName: project.name,
+      gitBranch: project.gitBranch,
+    },
+    workspace: getDynamicWorkspace,
+    hookManager,
+    mcpManager,
+    modes: [
+      {
+        id: 'build',
+        name: 'Build',
+        default: true,
+        defaultModelId: 'anthropic/claude-opus-4-6',
+        color: mastra.purple,
+        agent: codeAgent,
+      },
+      {
+        id: 'plan',
+        name: 'Plan',
+        defaultModelId: 'openai/gpt-5.2-codex',
+        color: mastra.blue,
+        agent: codeAgent,
+      },
+      {
+        id: 'fast',
+        name: 'Fast',
+        defaultModelId: 'cerebras/zai-glm-4.7',
+        color: mastra.green,
+        agent: codeAgent,
+      },
+    ],
+    authStorage,
+    heartbeatHandlers: [
+      {
+        id: 'gateway-sync',
+        intervalMs: 5 * 60 * 1000,
+        handler: () => syncGateways(),
+      },
+    ],
+  });
 
-	// Keep omModelState in sync with harness state changes
-	harness.subscribe((event) => {
-		if (event.type === "om_model_changed") {
-			const { role, modelId } = event as {
-				type: string
-				role: string
-				modelId: string
-			}
-			if (role === "observer") omState.observerModelId = modelId
-			if (role === "reflector") omState.reflectorModelId = modelId
-		} else if (event.type === "thread_changed") {
-			omState.observerModelId = harness.getObserverModelId()
-			omState.reflectorModelId = harness.getReflectorModelId()
-			omState.obsThreshold =
-				harness.getState().observationThreshold ?? DEFAULT_OBS_THRESHOLD
-			omState.refThreshold =
-				harness.getState().reflectionThreshold ?? DEFAULT_REF_THRESHOLD
-			hookManager.setSessionId((event as any).threadId)
-		} else if (event.type === "thread_created") {
-			hookManager.setSessionId((event as any).thread.id)
-		}
-	})
+  // Keep omModelState in sync with harness state changes
+  harness.subscribe(event => {
+    if (event.type === 'om_model_changed') {
+      const { role, modelId } = event as {
+        type: string;
+        role: string;
+        modelId: string;
+      };
+      if (role === 'observer') omState.observerModelId = modelId;
+      if (role === 'reflector') omState.reflectorModelId = modelId;
+    } else if (event.type === 'thread_changed') {
+      omState.observerModelId = harness.getObserverModelId();
+      omState.reflectorModelId = harness.getReflectorModelId();
+      omState.obsThreshold = harness.getState().observationThreshold ?? DEFAULT_OBS_THRESHOLD;
+      omState.refThreshold = harness.getState().reflectionThreshold ?? DEFAULT_REF_THRESHOLD;
+      hookManager.setSessionId((event as any).threadId);
+    } else if (event.type === 'thread_created') {
+      hookManager.setSessionId((event as any).thread.id);
+    }
+  });
 
-	return { harness, mcpManager }
+  return { harness, mcpManager };
 }

--- a/mastracode/src/ipc/ipc-reporter.ts
+++ b/mastracode/src/ipc/ipc-reporter.ts
@@ -1,42 +1,37 @@
 // Stub IPC reporter for TUI mode - just logs to console or no-ops
 
-export type IPCMessageType =
-	| "shell-output"
-	| "token-limits"
-	| "agent-event"
-	| "tool-call"
-	| "tool-result"
+export type IPCMessageType = 'shell-output' | 'token-limits' | 'agent-event' | 'tool-call' | 'tool-result';
 
 export interface IPCMessage {
-	type: IPCMessageType
-	data: unknown
-	timestamp: number
+  type: IPCMessageType;
+  data: unknown;
+  timestamp: number;
 }
 
 class IPCReporter {
-	private enabled: boolean
+  private enabled: boolean;
 
-	constructor() {
-		// Disable IPC in TUI mode - we handle output differently
-		this.enabled = false
-	}
+  constructor() {
+    // Disable IPC in TUI mode - we handle output differently
+    this.enabled = false;
+  }
 
-	send(type: IPCMessageType, data: unknown) {
-		if (!this.enabled) {
-			return
-		}
+  send(type: IPCMessageType, data: unknown) {
+    if (!this.enabled) {
+      return;
+    }
 
-		const message: IPCMessage = {
-			type,
-			data,
-			timestamp: Date.now(),
-		}
+    const message: IPCMessage = {
+      type,
+      data,
+      timestamp: Date.now(),
+    };
 
-		if (process.send) {
-			process.send(message)
-		}
-	}
+    if (process.send) {
+      process.send(message);
+    }
+  }
 }
 
 // Export singleton instance
-export const ipcReporter = new IPCReporter()
+export const ipcReporter = new IPCReporter();

--- a/mastracode/src/lsp/__tests__/string-replace-lsp.test.ts
+++ b/mastracode/src/lsp/__tests__/string-replace-lsp.test.ts
@@ -1,123 +1,121 @@
-import * as fs from "node:fs"
-import * as path from "node:path"
-import { describe, it, expect, afterAll, afterEach } from "vitest"
-import { stringReplaceLspTool } from "../../tools/string-replace-lsp.js"
-import { lspManager } from "../manager.js"
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, it, expect, afterAll, afterEach } from 'vitest';
+import { stringReplaceLspTool } from '../../tools/string-replace-lsp.js';
+import { lspManager } from '../manager.js';
 
-const projectRoot = path.resolve(import.meta.dirname, "../../../")
+const projectRoot = path.resolve(import.meta.dirname, '../../../');
 
 // Create temp files inside the project so the LSP can find tsconfig.json/package.json
-const tmpDir = path.join(projectRoot, ".test-tmp")
+const tmpDir = path.join(projectRoot, '.test-tmp');
 
 function tmpFile(name: string): string {
-	return path.join(tmpDir, name)
+  return path.join(tmpDir, name);
 }
 
 function writeTmpFile(name: string, content: string): string {
-	const filePath = tmpFile(name)
-	fs.mkdirSync(path.dirname(filePath), { recursive: true })
-	fs.writeFileSync(filePath, content, "utf-8")
-	return filePath
+  const filePath = tmpFile(name);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf-8');
+  return filePath;
 }
 
 afterEach(() => {
-	// Close all documents to avoid stale state between tests
-	const files = fs.existsSync(tmpDir)
-		? fs.readdirSync(tmpDir).filter((f) => f.endsWith(".ts"))
-		: []
-	for (const file of files) {
-		lspManager.closeDocument(tmpFile(file))
-	}
-})
+  // Close all documents to avoid stale state between tests
+  const files = fs.existsSync(tmpDir) ? fs.readdirSync(tmpDir).filter(f => f.endsWith('.ts')) : [];
+  for (const file of files) {
+    lspManager.closeDocument(tmpFile(file));
+  }
+});
 
 afterAll(async () => {
-	// Clean up temp files
-	if (fs.existsSync(tmpDir)) {
-		fs.rmSync(tmpDir, { recursive: true })
-	}
-	await lspManager.shutdownAll()
-})
+  // Clean up temp files
+  if (fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true });
+  }
+  await lspManager.shutdownAll();
+});
 
-describe("string_replace_lsp", () => {
-	it("edits a file and returns LSP diagnostics for a type error", async () => {
-		const filePath = writeTmpFile(
-			"type-error.ts",
-			`const message: string = "hello world"
+describe('string_replace_lsp', () => {
+  it('edits a file and returns LSP diagnostics for a type error', async () => {
+    const filePath = writeTmpFile(
+      'type-error.ts',
+      `const message: string = "hello world"
 export function greet(): string {
   return message
 }
 `,
-		)
+    );
 
-		// Introduce a type error: change the return type to number but keep returning a string
-		const result = await stringReplaceLspTool.execute({
-			path: filePath,
-			old_str: `export function greet(): string {
+    // Introduce a type error: change the return type to number but keep returning a string
+    const result = await stringReplaceLspTool.execute({
+      path: filePath,
+      old_str: `export function greet(): string {
   return message
 }`,
-			new_str: `export function greet(): number {
+      new_str: `export function greet(): number {
   return message
 }`,
-		})
+    });
 
-		// The edit should succeed
-		expect(result).toHaveProperty("content")
-		const text = (result as any).content[0].text as string
-		expect(text).toContain("has been edited")
+    // The edit should succeed
+    expect(result).toHaveProperty('content');
+    const text = (result as any).content[0].text as string;
+    expect(text).toContain('has been edited');
 
-		// Should contain LSP diagnostics with a type error
-		expect(text).toContain("LSP Diagnostics")
-		expect(text).toMatch(/[Ee]rror/)
-		// The diagnostic should mention the type mismatch
-		expect(text).toMatch(/string.*not assignable.*number|Type.*not assignable/)
-	}, 30000)
+    // Should contain LSP diagnostics with a type error
+    expect(text).toContain('LSP Diagnostics');
+    expect(text).toMatch(/[Ee]rror/);
+    // The diagnostic should mention the type mismatch
+    expect(text).toMatch(/string.*not assignable.*number|Type.*not assignable/);
+  }, 30000);
 
-	it("edits a file and returns no errors for a valid change", async () => {
-		const filePath = writeTmpFile(
-			"valid-change.ts",
-			`export const greeting: string = "hello"
+  it('edits a file and returns no errors for a valid change', async () => {
+    const filePath = writeTmpFile(
+      'valid-change.ts',
+      `export const greeting: string = "hello"
 `,
-		)
+    );
 
-		// Make a valid change: rename the variable value
-		const result = await stringReplaceLspTool.execute({
-			path: filePath,
-			old_str: `export const greeting: string = "hello"`,
-			new_str: `export const greeting: string = "goodbye"`,
-		})
+    // Make a valid change: rename the variable value
+    const result = await stringReplaceLspTool.execute({
+      path: filePath,
+      old_str: `export const greeting: string = "hello"`,
+      new_str: `export const greeting: string = "goodbye"`,
+    });
 
-		expect(result).toHaveProperty("content")
-		const text = (result as any).content[0].text as string
-		expect(text).toContain("has been edited")
+    expect(result).toHaveProperty('content');
+    const text = (result as any).content[0].text as string;
+    expect(text).toContain('has been edited');
 
-		// Should have diagnostics section with no errors
-		expect(text).toContain("LSP Diagnostics")
-		expect(text).toContain("No errors or warnings")
-	}, 30000)
+    // Should have diagnostics section with no errors
+    expect(text).toContain('LSP Diagnostics');
+    expect(text).toContain('No errors or warnings');
+  }, 30000);
 
-	it("returns diagnostics for an undefined variable", async () => {
-		const filePath = writeTmpFile(
-			"undefined-var.ts",
-			`export function add(a: number, b: number): number {
+  it('returns diagnostics for an undefined variable', async () => {
+    const filePath = writeTmpFile(
+      'undefined-var.ts',
+      `export function add(a: number, b: number): number {
   return a + b
 }
 `,
-		)
+    );
 
-		// Introduce a reference to an undefined variable
-		const result = await stringReplaceLspTool.execute({
-			path: filePath,
-			old_str: `  return a + b`,
-			new_str: `  return a + b + c`,
-		})
+    // Introduce a reference to an undefined variable
+    const result = await stringReplaceLspTool.execute({
+      path: filePath,
+      old_str: `  return a + b`,
+      new_str: `  return a + b + c`,
+    });
 
-		expect(result).toHaveProperty("content")
-		const text = (result as any).content[0].text as string
-		expect(text).toContain("has been edited")
+    expect(result).toHaveProperty('content');
+    const text = (result as any).content[0].text as string;
+    expect(text).toContain('has been edited');
 
-		// Should report the undefined variable
-		expect(text).toContain("LSP Diagnostics")
-		expect(text).toMatch(/[Ee]rror/)
-		expect(text).toMatch(/cannot find name|Cannot find name/i)
-	}, 30000)
-})
+    // Should report the undefined variable
+    expect(text).toContain('LSP Diagnostics');
+    expect(text).toMatch(/[Ee]rror/);
+    expect(text).toMatch(/cannot find name|Cannot find name/i);
+  }, 30000);
+});

--- a/mastracode/src/lsp/client.ts
+++ b/mastracode/src/lsp/client.ts
@@ -1,410 +1,381 @@
-import type { ChildProcess } from "node:child_process"
-import {
-	StreamMessageReader,
-	StreamMessageWriter,
-	createMessageConnection,
-} from "vscode-jsonrpc/node"
-import type { MessageConnection } from "vscode-jsonrpc/node"
-import {
-	TextDocumentIdentifier,
-	Position,
-} from "vscode-languageserver-protocol"
-import type { Diagnostic } from "vscode-languageserver-protocol"
-import type { LSPServerInfo } from "./server"
+import type { ChildProcess } from 'node:child_process';
+import { StreamMessageReader, StreamMessageWriter, createMessageConnection } from 'vscode-jsonrpc/node';
+import type { MessageConnection } from 'vscode-jsonrpc/node';
+import { TextDocumentIdentifier, Position } from 'vscode-languageserver-protocol';
+import type { Diagnostic } from 'vscode-languageserver-protocol';
+import type { LSPServerInfo } from './server';
 
 /**
  * LSP Client wrapper for JSON-RPC communication
  */
 export class LSPClient {
-	private connection: MessageConnection | null = null
-	private process: ChildProcess | null = null
-	private serverInfo: LSPServerInfo
-	private workspaceRoot: string
-	private diagnostics: Map<string, Diagnostic[]> = new Map()
-	private initializationOptions: any = null
+  private connection: MessageConnection | null = null;
+  private process: ChildProcess | null = null;
+  private serverInfo: LSPServerInfo;
+  private workspaceRoot: string;
+  private diagnostics: Map<string, Diagnostic[]> = new Map();
+  private initializationOptions: any = null;
 
-	constructor(serverInfo: LSPServerInfo, workspaceRoot: string) {
-		this.serverInfo = serverInfo
-		this.workspaceRoot = workspaceRoot
-	}
+  constructor(serverInfo: LSPServerInfo, workspaceRoot: string) {
+    this.serverInfo = serverInfo;
+    this.workspaceRoot = workspaceRoot;
+  }
 
-	/**
-	 * Initialize the LSP connection
-	 */
-	async initialize(): Promise<void> {
-		const spawnResult = await this.serverInfo.spawn(this.workspaceRoot)
+  /**
+   * Initialize the LSP connection
+   */
+  async initialize(): Promise<void> {
+    const spawnResult = await this.serverInfo.spawn(this.workspaceRoot);
 
-		if (!spawnResult) {
-			throw new Error("Failed to spawn LSP server")
-		}
+    if (!spawnResult) {
+      throw new Error('Failed to spawn LSP server');
+    }
 
-		// Handle both ChildProcess and { process: ChildProcess, initialization? } formats
-		let initializationOptions: any = undefined
-		if ("process" in spawnResult) {
-			this.process = spawnResult.process
-			initializationOptions = spawnResult.initialization
-		} else {
-			this.process = spawnResult
-		}
+    // Handle both ChildProcess and { process: ChildProcess, initialization? } formats
+    let initializationOptions: any = undefined;
+    if ('process' in spawnResult) {
+      this.process = spawnResult.process;
+      initializationOptions = spawnResult.initialization;
+    } else {
+      this.process = spawnResult;
+    }
 
-		if (!this.process.stdin || !this.process.stdout) {
-			throw new Error("Failed to create LSP process with proper stdio")
-		}
+    if (!this.process.stdin || !this.process.stdout) {
+      throw new Error('Failed to create LSP process with proper stdio');
+    }
 
-		const reader = new StreamMessageReader(this.process.stdout)
-		const writer = new StreamMessageWriter(this.process.stdin)
-		this.connection = createMessageConnection(reader, writer)
+    const reader = new StreamMessageReader(this.process.stdout);
+    const writer = new StreamMessageWriter(this.process.stdin);
+    this.connection = createMessageConnection(reader, writer);
 
-		// Handle connection errors (e.g., ERR_STREAM_DESTROYED during shutdown)
-		this.connection.onError((error) => {
-			// Silently ignore stream destroyed errors during shutdown
-			const errorObj = error?.[0] as any
-			if (errorObj?.code !== "ERR_STREAM_DESTROYED") {
-			}
-		})
+    // Handle connection errors (e.g., ERR_STREAM_DESTROYED during shutdown)
+    this.connection.onError(error => {
+      // Silently ignore stream destroyed errors during shutdown
+      const errorObj = error?.[0] as any;
+      if (errorObj?.code !== 'ERR_STREAM_DESTROYED') {
+      }
+    });
 
-		// Set up diagnostic listener before starting connection
+    // Set up diagnostic listener before starting connection
 
-		this.connection.onNotification(
-			"textDocument/publishDiagnostics",
-			(params: any) => {
-				if (params.diagnostics && params.diagnostics.length > 0) {
-				}
-				this.diagnostics.set(params.uri, params.diagnostics)
-			},
-		)
-		;(this.connection as any).onNotification(
-			(_method: string, _params: any) => {},
-		)
+    this.connection.onNotification('textDocument/publishDiagnostics', (params: any) => {
+      if (params.diagnostics && params.diagnostics.length > 0) {
+      }
+      this.diagnostics.set(params.uri, params.diagnostics);
+    });
+    (this.connection as any).onNotification((_method: string, _params: any) => {});
 
-		this.connection.listen()
+    this.connection.listen();
 
-		// Capture stderr for debugging
-		if (this.process.stderr) {
-			this.process.stderr.on("data", (_data) => {})
-		}
+    // Capture stderr for debugging
+    if (this.process.stderr) {
+      this.process.stderr.on('data', _data => {});
+    }
 
-		// Handle process errors
-		this.process.on("error", (_error) => {})
+    // Handle process errors
+    this.process.on('error', _error => {});
 
-		this.process.on("exit", (_code, _signal) => {})
+    this.process.on('exit', (_code, _signal) => {});
 
-		// Send initialize request matching OpenCode's structure
-		const initParams: any = {
-			processId: process.pid,
-			rootUri: `file://${this.workspaceRoot}`,
-			workspaceFolders: [
-				{
-					name: "workspace",
-					uri: `file://${this.workspaceRoot}`,
-				},
-			],
-			capabilities: {
-				window: {
-					workDoneProgress: true,
-				},
-				workspace: {
-					configuration: true,
-				},
-				textDocument: {
-					publishDiagnostics: {
-						relatedInformation: true,
-						tagSupport: {
-							valueSet: [1, 2],
-						},
-						versionSupport: false,
-					},
-					synchronization: {
-						didOpen: true,
-						didChange: true,
-						dynamicRegistration: false,
-						willSave: false,
-						willSaveWaitUntil: false,
-						didSave: false,
-					},
-					completion: {
-						dynamicRegistration: false,
-						completionItem: {
-							snippetSupport: false,
-							commitCharactersSupport: false,
-							documentationFormat: ["markdown", "plaintext"],
-							deprecatedSupport: false,
-							preselectSupport: false,
-						},
-					},
-					definition: {
-						dynamicRegistration: false,
-						linkSupport: true,
-					},
-					typeDefinition: {
-						dynamicRegistration: false,
-						linkSupport: true,
-					},
-					implementation: {
-						dynamicRegistration: false,
-						linkSupport: true,
-					},
-					references: {
-						dynamicRegistration: false,
-					},
-					documentHighlight: {
-						dynamicRegistration: false,
-					},
-					documentSymbol: {
-						dynamicRegistration: false,
-						hierarchicalDocumentSymbolSupport: true,
-					},
-					codeAction: {
-						dynamicRegistration: false,
-						codeActionLiteralSupport: {
-							codeActionKind: {
-								valueSet: [
-									"quickfix",
-									"refactor",
-									"refactor.extract",
-									"refactor.inline",
-									"refactor.rewrite",
-									"source",
-									"source.organizeImports",
-								],
-							},
-						},
-					},
-					hover: {
-						dynamicRegistration: false,
-						contentFormat: ["markdown", "plaintext"],
-					},
-				},
-			},
-		}
+    // Send initialize request matching OpenCode's structure
+    const initParams: any = {
+      processId: process.pid,
+      rootUri: `file://${this.workspaceRoot}`,
+      workspaceFolders: [
+        {
+          name: 'workspace',
+          uri: `file://${this.workspaceRoot}`,
+        },
+      ],
+      capabilities: {
+        window: {
+          workDoneProgress: true,
+        },
+        workspace: {
+          configuration: true,
+        },
+        textDocument: {
+          publishDiagnostics: {
+            relatedInformation: true,
+            tagSupport: {
+              valueSet: [1, 2],
+            },
+            versionSupport: false,
+          },
+          synchronization: {
+            didOpen: true,
+            didChange: true,
+            dynamicRegistration: false,
+            willSave: false,
+            willSaveWaitUntil: false,
+            didSave: false,
+          },
+          completion: {
+            dynamicRegistration: false,
+            completionItem: {
+              snippetSupport: false,
+              commitCharactersSupport: false,
+              documentationFormat: ['markdown', 'plaintext'],
+              deprecatedSupport: false,
+              preselectSupport: false,
+            },
+          },
+          definition: {
+            dynamicRegistration: false,
+            linkSupport: true,
+          },
+          typeDefinition: {
+            dynamicRegistration: false,
+            linkSupport: true,
+          },
+          implementation: {
+            dynamicRegistration: false,
+            linkSupport: true,
+          },
+          references: {
+            dynamicRegistration: false,
+          },
+          documentHighlight: {
+            dynamicRegistration: false,
+          },
+          documentSymbol: {
+            dynamicRegistration: false,
+            hierarchicalDocumentSymbolSupport: true,
+          },
+          codeAction: {
+            dynamicRegistration: false,
+            codeActionLiteralSupport: {
+              codeActionKind: {
+                valueSet: [
+                  'quickfix',
+                  'refactor',
+                  'refactor.extract',
+                  'refactor.inline',
+                  'refactor.rewrite',
+                  'source',
+                  'source.organizeImports',
+                ],
+              },
+            },
+          },
+          hover: {
+            dynamicRegistration: false,
+            contentFormat: ['markdown', 'plaintext'],
+          },
+        },
+      },
+    };
 
-		// Add initialization options if provided by the server
-		if (initializationOptions) {
-			initParams.initializationOptions = initializationOptions
-			this.initializationOptions = initializationOptions
-		}
+    // Add initialization options if provided by the server
+    if (initializationOptions) {
+      initParams.initializationOptions = initializationOptions;
+      this.initializationOptions = initializationOptions;
+    }
 
-		// Add workspace/configuration request handler like OpenCode
-		this.connection.onRequest("workspace/configuration", (params: any) => {
-			return params.items?.map(() => ({})) || []
-		})
+    // Add workspace/configuration request handler like OpenCode
+    this.connection.onRequest('workspace/configuration', (params: any) => {
+      return params.items?.map(() => ({})) || [];
+    });
 
-		// Handle window/workDoneProgress/create requests
-		this.connection.onRequest(
-			"window/workDoneProgress/create",
-			(_params: any) => {
-				return null
-			},
-		)
+    // Handle window/workDoneProgress/create requests
+    this.connection.onRequest('window/workDoneProgress/create', (_params: any) => {
+      return null;
+    });
 
-		await Promise.race([
-			this.connection.sendRequest("initialize", initParams),
-			new Promise((_, reject) =>
-				setTimeout(
-					() => reject(new Error("LSP initialize request timed out")),
-					10000,
-				),
-			),
-		])
+    await Promise.race([
+      this.connection.sendRequest('initialize', initParams),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('LSP initialize request timed out')), 10000)),
+    ]);
 
-		// Send initialized notification with empty object like OpenCode
-		this.connection.sendNotification("initialized", {})
+    // Send initialized notification with empty object like OpenCode
+    this.connection.sendNotification('initialized', {});
 
-		// Send workspace/didChangeConfiguration with initialization options like OpenCode
-		if (this.initializationOptions) {
-			this.connection.sendNotification("workspace/didChangeConfiguration", {
-				settings: this.initializationOptions,
-			})
-		} else {
-			this.connection.sendNotification("workspace/didChangeConfiguration", {
-				settings: {},
-			})
-		}
-	}
+    // Send workspace/didChangeConfiguration with initialization options like OpenCode
+    if (this.initializationOptions) {
+      this.connection.sendNotification('workspace/didChangeConfiguration', {
+        settings: this.initializationOptions,
+      });
+    } else {
+      this.connection.sendNotification('workspace/didChangeConfiguration', {
+        settings: {},
+      });
+    }
+  }
 
-	/**
-	 * Notify the server that a document has been opened
-	 */
-	notifyOpen(filePath: string, content: string, languageId: string): void {
-		if (!this.connection) return
+  /**
+   * Notify the server that a document has been opened
+   */
+  notifyOpen(filePath: string, content: string, languageId: string): void {
+    if (!this.connection) return;
 
-		const uri = `file://${filePath}`
+    const uri = `file://${filePath}`;
 
-		// Clear diagnostics for this file before sending didOpen (like OpenCode does)
-		this.diagnostics.delete(uri)
+    // Clear diagnostics for this file before sending didOpen (like OpenCode does)
+    this.diagnostics.delete(uri);
 
-		this.connection.sendNotification("textDocument/didOpen", {
-			textDocument: {
-				uri,
-				languageId,
-				version: 0,
-				text: content,
-			},
-		})
-	}
+    this.connection.sendNotification('textDocument/didOpen', {
+      textDocument: {
+        uri,
+        languageId,
+        version: 0,
+        text: content,
+      },
+    });
+  }
 
-	/**
-	 * Notify the server that a document has changed
-	 */
-	notifyChange(filePath: string, content: string, version: number): void {
-		if (!this.connection) return
+  /**
+   * Notify the server that a document has changed
+   */
+  notifyChange(filePath: string, content: string, version: number): void {
+    if (!this.connection) return;
 
-		this.connection.sendNotification("textDocument/didChange", {
-			textDocument: {
-				uri: `file://${filePath}`,
-				version,
-			},
-			contentChanges: [{ text: content }],
-		})
-	}
+    this.connection.sendNotification('textDocument/didChange', {
+      textDocument: {
+        uri: `file://${filePath}`,
+        version,
+      },
+      contentChanges: [{ text: content }],
+    });
+  }
 
-	/**
-	 * Wait for diagnostics to be available for a specific file
-	 * @param waitForChange If true, waits for diagnostics to change from their initial state
-	 */
-	async waitForDiagnostics(
-		filePath: string,
-		timeoutMs: number = 5000,
-		waitForChange: boolean = false,
-	): Promise<Diagnostic[]> {
-		if (!this.connection) return []
+  /**
+   * Wait for diagnostics to be available for a specific file
+   * @param waitForChange If true, waits for diagnostics to change from their initial state
+   */
+  async waitForDiagnostics(
+    filePath: string,
+    timeoutMs: number = 5000,
+    waitForChange: boolean = false,
+  ): Promise<Diagnostic[]> {
+    if (!this.connection) return [];
 
-		const uri = `file://${filePath}`
-		const startTime = Date.now()
-		const initialDiagnostics = this.diagnostics.get(uri)
-		const initialCount = initialDiagnostics?.length || 0
+    const uri = `file://${filePath}`;
+    const startTime = Date.now();
+    const initialDiagnostics = this.diagnostics.get(uri);
+    const initialCount = initialDiagnostics?.length || 0;
 
-		// Poll for diagnostics to be updated
-		while (Date.now() - startTime < timeoutMs) {
-			const currentDiagnostics = this.diagnostics.get(uri)
-			const currentCount = currentDiagnostics?.length || 0
+    // Poll for diagnostics to be updated
+    while (Date.now() - startTime < timeoutMs) {
+      const currentDiagnostics = this.diagnostics.get(uri);
+      const currentCount = currentDiagnostics?.length || 0;
 
-			// If waiting for change, check if diagnostics have changed
-			if (waitForChange) {
-				if (currentDiagnostics !== undefined && currentCount !== initialCount) {
-					return currentDiagnostics
-				}
-			} else {
-				// Return if we have diagnostics (even if empty array)
-				if (currentDiagnostics !== undefined) {
-					return currentDiagnostics
-				}
-			}
+      // If waiting for change, check if diagnostics have changed
+      if (waitForChange) {
+        if (currentDiagnostics !== undefined && currentCount !== initialCount) {
+          return currentDiagnostics;
+        }
+      } else {
+        // Return if we have diagnostics (even if empty array)
+        if (currentDiagnostics !== undefined) {
+          return currentDiagnostics;
+        }
+      }
 
-			await new Promise((resolve) => setTimeout(resolve, 100))
-		}
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
 
-		return waitForChange ? initialDiagnostics || [] : []
-	}
+    return waitForChange ? initialDiagnostics || [] : [];
+  }
 
-	/**
-	 * Get hover information for a position
-	 */
-	async getHover(
-		filePath: string,
-		line: number,
-		character: number,
-	): Promise<any> {
-		if (!this.connection) return null
+  /**
+   * Get hover information for a position
+   */
+  async getHover(filePath: string, line: number, character: number): Promise<any> {
+    if (!this.connection) return null;
 
-		try {
-			return await this.connection.sendRequest("textDocument/hover", {
-				textDocument: TextDocumentIdentifier.create(`file://${filePath}`),
-				position: Position.create(line, character),
-			})
-		} catch {
-			return null
-		}
-	}
+    try {
+      return await this.connection.sendRequest('textDocument/hover', {
+        textDocument: TextDocumentIdentifier.create(`file://${filePath}`),
+        position: Position.create(line, character),
+      });
+    } catch {
+      return null;
+    }
+  }
 
-	/**
-	 * Get diagnostics for a specific file
-	 */
-	getDiagnostics(filePath: string): Diagnostic[] {
-		const uri = `file://${filePath}`
-		return this.diagnostics.get(uri) || []
-	}
+  /**
+   * Get diagnostics for a specific file
+   */
+  getDiagnostics(filePath: string): Diagnostic[] {
+    const uri = `file://${filePath}`;
+    return this.diagnostics.get(uri) || [];
+  }
 
-	/**
-	 * Get all diagnostics from all files
-	 */
-	getAllDiagnostics(): Diagnostic[] {
-		const allDiagnostics: Diagnostic[] = []
-		for (const diagnostics of this.diagnostics.values()) {
-			allDiagnostics.push(...diagnostics)
-		}
-		return allDiagnostics
-	}
+  /**
+   * Get all diagnostics from all files
+   */
+  getAllDiagnostics(): Diagnostic[] {
+    const allDiagnostics: Diagnostic[] = [];
+    for (const diagnostics of this.diagnostics.values()) {
+      allDiagnostics.push(...diagnostics);
+    }
+    return allDiagnostics;
+  }
 
-	/**
-	 * Notify server that a file was closed
-	 */
-	notifyClose(filePath: string): void {
-		if (!this.connection) return
+  /**
+   * Notify server that a file was closed
+   */
+  notifyClose(filePath: string): void {
+    if (!this.connection) return;
 
-		const uri = `file://${filePath}`
+    const uri = `file://${filePath}`;
 
-		// Clear diagnostics for this file
-		this.diagnostics.delete(uri)
+    // Clear diagnostics for this file
+    this.diagnostics.delete(uri);
 
-		// Send didClose notification
-		this.connection.sendNotification("textDocument/didClose", {
-			textDocument: TextDocumentIdentifier.create(uri),
-		})
-	}
+    // Send didClose notification
+    this.connection.sendNotification('textDocument/didClose', {
+      textDocument: TextDocumentIdentifier.create(uri),
+    });
+  }
 
-	/**
-	 * Restart the LSP client
-	 */
-	async restart(): Promise<void> {
-		await this.shutdown()
+  /**
+   * Restart the LSP client
+   */
+  async restart(): Promise<void> {
+    await this.shutdown();
 
-		// Re-initialize (this will re-spawn the server)
-		await this.initialize()
-	}
+    // Re-initialize (this will re-spawn the server)
+    await this.initialize();
+  }
 
-	/**
-	 * Shutdown the connection
-	 */
-	async shutdown(): Promise<void> {
-		if (this.connection) {
-			try {
-				// Only send shutdown request if the process is still alive
-				const processAlive = this.process && !this.process.killed
-				if (processAlive) {
-					await Promise.race([
-						this.connection.sendRequest("shutdown"),
-						new Promise((_, reject) =>
-							setTimeout(
-								() => reject(new Error("Shutdown request timed out")),
-								1000,
-							),
-						),
-					])
-					this.connection.sendNotification("exit")
-				}
-			} catch {
-				// Ignore shutdown errors (process may have already crashed)
-			}
-			try {
-				this.connection.dispose()
-			} catch {
-				// Ignore dispose errors (stream may already be destroyed)
-			}
-			this.connection = null
-		}
+  /**
+   * Shutdown the connection
+   */
+  async shutdown(): Promise<void> {
+    if (this.connection) {
+      try {
+        // Only send shutdown request if the process is still alive
+        const processAlive = this.process && !this.process.killed;
+        if (processAlive) {
+          await Promise.race([
+            this.connection.sendRequest('shutdown'),
+            new Promise((_, reject) => setTimeout(() => reject(new Error('Shutdown request timed out')), 1000)),
+          ]);
+          this.connection.sendNotification('exit');
+        }
+      } catch {
+        // Ignore shutdown errors (process may have already crashed)
+      }
+      try {
+        this.connection.dispose();
+      } catch {
+        // Ignore dispose errors (stream may already be destroyed)
+      }
+      this.connection = null;
+    }
 
-		if (this.process) {
-			try {
-				if (!this.process.killed) {
-					this.process.kill()
-				}
-			} catch {
-				// Ignore kill errors
-			}
-			this.process = null
-		}
+    if (this.process) {
+      try {
+        if (!this.process.killed) {
+          this.process.kill();
+        }
+      } catch {
+        // Ignore kill errors
+      }
+      this.process = null;
+    }
 
-		this.diagnostics = new Map()
-	}
+    this.diagnostics = new Map();
+  }
 }

--- a/mastracode/src/lsp/index.ts
+++ b/mastracode/src/lsp/index.ts
@@ -1,3 +1,3 @@
-export { LSPClient } from "./client.js"
-export { getServersForFile } from "./server.js"
-export { lspManager } from "./manager.js"
+export { LSPClient } from './client.js';
+export { getServersForFile } from './server.js';
+export { lspManager } from './manager.js';

--- a/mastracode/src/lsp/language.ts
+++ b/mastracode/src/lsp/language.ts
@@ -2,58 +2,58 @@
  * Maps file extensions to LSP language identifiers
  */
 export const LANGUAGE_EXTENSIONS: Record<string, string> = {
-	// TypeScript/JavaScript
-	".ts": "typescript",
-	".tsx": "typescriptreact",
-	".js": "javascript",
-	".jsx": "javascriptreact",
-	".mjs": "javascript",
-	".cjs": "javascript",
+  // TypeScript/JavaScript
+  '.ts': 'typescript',
+  '.tsx': 'typescriptreact',
+  '.js': 'javascript',
+  '.jsx': 'javascriptreact',
+  '.mjs': 'javascript',
+  '.cjs': 'javascript',
 
-	// Python
-	".py": "python",
-	".pyi": "python",
+  // Python
+  '.py': 'python',
+  '.pyi': 'python',
 
-	// Go
-	".go": "go",
+  // Go
+  '.go': 'go',
 
-	// Rust
-	".rs": "rust",
+  // Rust
+  '.rs': 'rust',
 
-	// C/C++
-	".c": "c",
-	".cpp": "cpp",
-	".cc": "cpp",
-	".cxx": "cpp",
-	".h": "c",
-	".hpp": "cpp",
+  // C/C++
+  '.c': 'c',
+  '.cpp': 'cpp',
+  '.cc': 'cpp',
+  '.cxx': 'cpp',
+  '.h': 'c',
+  '.hpp': 'cpp',
 
-	// Java
-	".java": "java",
+  // Java
+  '.java': 'java',
 
-	// JSON
-	".json": "json",
-	".jsonc": "jsonc",
+  // JSON
+  '.json': 'json',
+  '.jsonc': 'jsonc',
 
-	// YAML
-	".yaml": "yaml",
-	".yml": "yaml",
+  // YAML
+  '.yaml': 'yaml',
+  '.yml': 'yaml',
 
-	// Markdown
-	".md": "markdown",
+  // Markdown
+  '.md': 'markdown',
 
-	// HTML/CSS
-	".html": "html",
-	".css": "css",
-	".scss": "scss",
-	".sass": "sass",
-	".less": "less",
-}
+  // HTML/CSS
+  '.html': 'html',
+  '.css': 'css',
+  '.scss': 'scss',
+  '.sass': 'sass',
+  '.less': 'less',
+};
 
 /**
  * Get LSP language ID for a file path
  */
 export function getLanguageId(filePath: string): string | undefined {
-	const ext = filePath.substring(filePath.lastIndexOf("."))
-	return LANGUAGE_EXTENSIONS[ext]
+  const ext = filePath.substring(filePath.lastIndexOf('.'));
+  return LANGUAGE_EXTENSIONS[ext];
 }

--- a/mastracode/src/lsp/manager.ts
+++ b/mastracode/src/lsp/manager.ts
@@ -1,140 +1,126 @@
-import { LSPClient } from "./client.js"
-import { getServersForFile } from "./server.js"
+import { LSPClient } from './client.js';
+import { getServersForFile } from './server.js';
 
 /**
  * Singleton LSP client manager that keeps clients alive and reuses them
  * across tool calls for better performance and accuracy
  */
 class LSPManager {
-	private clients: Map<string, LSPClient> = new Map()
-	private initializationPromises: Map<string, Promise<void>> = new Map()
+  private clients: Map<string, LSPClient> = new Map();
+  private initializationPromises: Map<string, Promise<void>> = new Map();
 
-	/**
-	 * Get or create an LSP client for a file
-	 * Returns null if no LSP server is available for the file
-	 */
-	async getClient(
-		filePath: string,
-		workspaceRoot: string,
-	): Promise<LSPClient | null> {
-		const servers = getServersForFile(filePath, workspaceRoot)
-		if (servers.length === 0) {
-			return null
-		}
+  /**
+   * Get or create an LSP client for a file
+   * Returns null if no LSP server is available for the file
+   */
+  async getClient(filePath: string, workspaceRoot: string): Promise<LSPClient | null> {
+    const servers = getServersForFile(filePath, workspaceRoot);
+    if (servers.length === 0) {
+      return null;
+    }
 
-		// Use the first matching server (prioritize TypeScript/JavaScript)
-		const serverInfo =
-			servers.find(
-				(s) =>
-					s.languageIds.includes("typescript") ||
-					s.languageIds.includes("javascript") ||
-					s.languageIds.includes("python") ||
-					s.languageIds.includes("go"),
-			) || servers[0]
-        // Create a unique key for this server + workspace combination
-        if (!serverInfo) {
-            return null
-        }
-        const key = `${serverInfo.name}:${workspaceRoot}`
+    // Use the first matching server (prioritize TypeScript/JavaScript)
+    const serverInfo =
+      servers.find(
+        s =>
+          s.languageIds.includes('typescript') ||
+          s.languageIds.includes('javascript') ||
+          s.languageIds.includes('python') ||
+          s.languageIds.includes('go'),
+      ) || servers[0];
+    // Create a unique key for this server + workspace combination
+    if (!serverInfo) {
+      return null;
+    }
+    const key = `${serverInfo.name}:${workspaceRoot}`;
 
-        // Return existing client if available
-        if (this.clients.has(key)) {
-            return this.clients.get(key)!
-        }
+    // Return existing client if available
+    if (this.clients.has(key)) {
+      return this.clients.get(key)!;
+    }
 
-        // If initialization is in progress, wait for it
-        if (this.initializationPromises.has(key)) {
-            await this.initializationPromises.get(key)
-            return this.clients.get(key) || null
-        }
+    // If initialization is in progress, wait for it
+    if (this.initializationPromises.has(key)) {
+      await this.initializationPromises.get(key);
+      return this.clients.get(key) || null;
+    }
 
-        // Create and initialize new client with a timeout to prevent indefinite hangs
-        // (e.g., npx resolution issues in pnpm-linked projects)
-        const initPromise = (async () => {
-            const client = new LSPClient(serverInfo, workspaceRoot)
-			await client.initialize()
-			this.clients.set(key, client)
-		})()
+    // Create and initialize new client with a timeout to prevent indefinite hangs
+    // (e.g., npx resolution issues in pnpm-linked projects)
+    const initPromise = (async () => {
+      const client = new LSPClient(serverInfo, workspaceRoot);
+      await client.initialize();
+      this.clients.set(key, client);
+    })();
 
-		this.initializationPromises.set(key, initPromise)
+    this.initializationPromises.set(key, initPromise);
 
-		try {
-			await Promise.race([
-				initPromise,
-				new Promise<void>((_, reject) =>
-					setTimeout(
-						() => reject(new Error("LSP client initialization timed out")),
-						15000,
-					),
-				),
-			])
-			return this.clients.get(key) || null
-		} catch {
-			// If initialization timed out or failed, clean up
-			this.clients.delete(key)
-			return null
-		} finally {
-			this.initializationPromises.delete(key)
-		}
-	}
+    try {
+      await Promise.race([
+        initPromise,
+        new Promise<void>((_, reject) =>
+          setTimeout(() => reject(new Error('LSP client initialization timed out')), 15000),
+        ),
+      ]);
+      return this.clients.get(key) || null;
+    } catch {
+      // If initialization timed out or failed, clean up
+      this.clients.delete(key);
+      return null;
+    } finally {
+      this.initializationPromises.delete(key);
+    }
+  }
 
-	/**
-	 * Shutdown a specific client
-	 */
-	async shutdownClient(
-		workspaceRoot: string,
-		serverName?: string,
-	): Promise<void> {
-		const keysToRemove: string[] = []
+  /**
+   * Shutdown a specific client
+   */
+  async shutdownClient(workspaceRoot: string, serverName?: string): Promise<void> {
+    const keysToRemove: string[] = [];
 
-		for (const [key, client] of this.clients.entries()) {
-			if (
-				key.includes(workspaceRoot) &&
-				(!serverName || key.startsWith(serverName))
-			) {
-				await client.shutdown()
-				keysToRemove.push(key)
-			}
-		}
+    for (const [key, client] of this.clients.entries()) {
+      if (key.includes(workspaceRoot) && (!serverName || key.startsWith(serverName))) {
+        await client.shutdown();
+        keysToRemove.push(key);
+      }
+    }
 
-		for (const key of keysToRemove) {
-			this.clients.delete(key)
-		}
-	}
+    for (const key of keysToRemove) {
+      this.clients.delete(key);
+    }
+  }
 
-	/**
-	 * Shutdown all clients
-	 */
-	async shutdownAll(): Promise<void> {
-		const shutdownPromises = Array.from(this.clients.values()).map((client) =>
-			client.shutdown(),
-		)
-		await Promise.all(shutdownPromises)
-		this.clients.clear()
-		this.initializationPromises.clear()
-	}
+  /**
+   * Shutdown all clients
+   */
+  async shutdownAll(): Promise<void> {
+    const shutdownPromises = Array.from(this.clients.values()).map(client => client.shutdown());
+    await Promise.all(shutdownPromises);
+    this.clients.clear();
+    this.initializationPromises.clear();
+  }
 
-	/**
-	 * Get the number of active clients
-	 */
-	getActiveClientCount(): number {
-		return this.clients.size
-	}
+  /**
+   * Get the number of active clients
+   */
+  getActiveClientCount(): number {
+    return this.clients.size;
+  }
 
-	/**
-	 * Close a document in all active clients
-	 * This is useful for tests that reuse the same file path
-	 */
-	closeDocument(filePath: string): void {
-		for (const client of this.clients.values()) {
-			try {
-				client.notifyClose(filePath)
-			} catch {
-				// Ignore errors if document wasn't open
-			}
-		}
-	}
+  /**
+   * Close a document in all active clients
+   * This is useful for tests that reuse the same file path
+   */
+  closeDocument(filePath: string): void {
+    for (const client of this.clients.values()) {
+      try {
+        client.notifyClose(filePath);
+      } catch {
+        // Ignore errors if document wasn't open
+      }
+    }
+  }
 }
 
 // Export singleton instance
-export const lspManager = new LSPManager()
+export const lspManager = new LSPManager();

--- a/mastracode/src/lsp/server.ts
+++ b/mastracode/src/lsp/server.ts
@@ -1,222 +1,164 @@
-import type { ChildProcess } from "node:child_process";
-import { spawn } from "node:child_process"
-import { existsSync } from "node:fs"
-import { createRequire } from "node:module"
-import path, { join } from "node:path"
-import { pathToFileURL } from "node:url"
-import { getLanguageId } from "./language"
+import type { ChildProcess } from 'node:child_process';
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path, { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { getLanguageId } from './language';
 
 /**
  * LSP Server definition and spawning logic
  */
 export interface LSPServerInfo {
-	id: string
-	name: string
-	languageIds: string[]
-	root: (cwd: string) => string | null
-	spawn: (
-		root: string,
-	) =>
-		| ChildProcess
-		| Promise<{ process: ChildProcess; initialization?: any } | undefined>
+  id: string;
+  name: string;
+  languageIds: string[];
+  root: (cwd: string) => string | null;
+  spawn: (root: string) => ChildProcess | Promise<{ process: ChildProcess; initialization?: any } | undefined>;
 }
 
 /**
  * Find the nearest project root directory
  */
 export function findNearestRoot(cwd: string, markers: string[]): string | null {
-	let current = cwd
+  let current = cwd;
 
-	while (current !== "/") {
-		for (const marker of markers) {
-			if (existsSync(join(current, marker))) {
-				return current
-			}
-		}
+  while (current !== '/') {
+    for (const marker of markers) {
+      if (existsSync(join(current, marker))) {
+        return current;
+      }
+    }
 
-		const parent = join(current, "..")
-		if (parent === current) break
-		current = parent
-	}
+    const parent = join(current, '..');
+    if (parent === current) break;
+    current = parent;
+  }
 
-	return null
+  return null;
 }
 
 /**
  * Built-in LSP server definitions
  */
 export const BUILTIN_SERVERS: Record<string, LSPServerInfo> = {
-	typescript: {
-		id: "typescript",
-		name: "TypeScript Language Server",
-		languageIds: [
-			"typescript",
-			"typescriptreact",
-			"javascript",
-			"javascriptreact",
-		],
-		root: (cwd: string) =>
-			findNearestRoot(cwd, ["tsconfig.json", "package.json"]),
-		spawn: async (root: string) => {
-			// Try to resolve TypeScript from the project directory
-			const requireFromRoot = createRequire(
-				pathToFileURL(path.join(root, "package.json")),
-			)
-			let tsserver: string | undefined
-			try {
-				tsserver = requireFromRoot.resolve("typescript/lib/tsserver.js")
-			} catch {
-				tsserver = undefined
-			}
-			if (!tsserver) {
-				return undefined
-			}
+  typescript: {
+    id: 'typescript',
+    name: 'TypeScript Language Server',
+    languageIds: ['typescript', 'typescriptreact', 'javascript', 'javascriptreact'],
+    root: (cwd: string) => findNearestRoot(cwd, ['tsconfig.json', 'package.json']),
+    spawn: async (root: string) => {
+      // Try to resolve TypeScript from the project directory
+      const requireFromRoot = createRequire(pathToFileURL(path.join(root, 'package.json')));
+      let tsserver: string | undefined;
+      try {
+        tsserver = requireFromRoot.resolve('typescript/lib/tsserver.js');
+      } catch {
+        tsserver = undefined;
+      }
+      if (!tsserver) {
+        return undefined;
+      }
 
-			// Resolve typescript-language-server binary directly to avoid npx hangs
-			// (npx can hang indefinitely in projects with pnpm links)
-			const localBin = join(
-				root,
-				"node_modules",
-				".bin",
-				"typescript-language-server",
-			)
-			const cwdBin = join(
-				process.cwd(),
-				"node_modules",
-				".bin",
-				"typescript-language-server",
-			)
-			let tslsBinary: string
-			if (existsSync(localBin)) {
-				tslsBinary = localBin
-			} else if (existsSync(cwdBin)) {
-				tslsBinary = cwdBin
-			} else {
-				// Fall back to npx as last resort, but this may hang with pnpm links
-				tslsBinary = "npx"
-			}
+      // Resolve typescript-language-server binary directly to avoid npx hangs
+      // (npx can hang indefinitely in projects with pnpm links)
+      const localBin = join(root, 'node_modules', '.bin', 'typescript-language-server');
+      const cwdBin = join(process.cwd(), 'node_modules', '.bin', 'typescript-language-server');
+      let tslsBinary: string;
+      if (existsSync(localBin)) {
+        tslsBinary = localBin;
+      } else if (existsSync(cwdBin)) {
+        tslsBinary = cwdBin;
+      } else {
+        // Fall back to npx as last resort, but this may hang with pnpm links
+        tslsBinary = 'npx';
+      }
 
-			const args =
-				tslsBinary === "npx"
-					? ["typescript-language-server", "--stdio"]
-					: ["--stdio"]
+      const args = tslsBinary === 'npx' ? ['typescript-language-server', '--stdio'] : ['--stdio'];
 
-			const proc = spawn(tslsBinary, args, {
-				cwd: root,
-				stdio: ["pipe", "pipe", "pipe"],
-			})
+      const proc = spawn(tslsBinary, args, {
+        cwd: root,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
 
-			return {
-				process: proc,
-				initialization: {
-					tsserver: {
-						path: tsserver,
-						logVerbosity: "off",
-					},
-				},
-			}
-		},
-	},
+      return {
+        process: proc,
+        initialization: {
+          tsserver: {
+            path: tsserver,
+            logVerbosity: 'off',
+          },
+        },
+      };
+    },
+  },
 
-	eslint: {
-		id: "eslint",
-		name: "ESLint Language Server",
-		languageIds: [
-			"typescript",
-			"typescriptreact",
-			"javascript",
-			"javascriptreact",
-		],
-		root: (cwd: string) =>
-			findNearestRoot(cwd, [
-				"package.json",
-				".eslintrc.js",
-				".eslintrc.json",
-				".eslintrc.yml",
-				".eslintrc.yaml",
-			]),
-		spawn: (root: string) => {
-			const binaryPath = join(
-				process.cwd(),
-				"node_modules",
-				".bin",
-				"eslint-lsp",
-			)
-			return spawn(binaryPath, ["--stdio"], {
-				cwd: root,
-				stdio: ["pipe", "pipe", "pipe"],
-			})
-		},
-	},
+  eslint: {
+    id: 'eslint',
+    name: 'ESLint Language Server',
+    languageIds: ['typescript', 'typescriptreact', 'javascript', 'javascriptreact'],
+    root: (cwd: string) =>
+      findNearestRoot(cwd, ['package.json', '.eslintrc.js', '.eslintrc.json', '.eslintrc.yml', '.eslintrc.yaml']),
+    spawn: (root: string) => {
+      const binaryPath = join(process.cwd(), 'node_modules', '.bin', 'eslint-lsp');
+      return spawn(binaryPath, ['--stdio'], {
+        cwd: root,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    },
+  },
 
-	python: {
-		id: "python",
-		name: "Python Language Server (Pyright)",
-		languageIds: ["python"],
-		root: (cwd: string) =>
-			findNearestRoot(cwd, [
-				"pyproject.toml",
-				"setup.py",
-				"requirements.txt",
-				".git",
-			]),
-		spawn: (root: string) => {
-			// Try node_modules first, then fall back to system PATH
-			const localPath = join(
-				process.cwd(),
-				"node_modules",
-				".bin",
-				"pyright-langserver",
-			)
-			const binaryPath = existsSync(localPath)
-				? localPath
-				: "pyright-langserver"
-			return spawn(binaryPath, ["--stdio"], {
-				cwd: root,
-				stdio: ["pipe", "pipe", "pipe"],
-			})
-		},
-	},
+  python: {
+    id: 'python',
+    name: 'Python Language Server (Pyright)',
+    languageIds: ['python'],
+    root: (cwd: string) => findNearestRoot(cwd, ['pyproject.toml', 'setup.py', 'requirements.txt', '.git']),
+    spawn: (root: string) => {
+      // Try node_modules first, then fall back to system PATH
+      const localPath = join(process.cwd(), 'node_modules', '.bin', 'pyright-langserver');
+      const binaryPath = existsSync(localPath) ? localPath : 'pyright-langserver';
+      return spawn(binaryPath, ['--stdio'], {
+        cwd: root,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    },
+  },
 
-	go: {
-		id: "go",
-		name: "Go Language Server (gopls)",
-		languageIds: ["go"],
-		root: (cwd: string) => findNearestRoot(cwd, ["go.mod", ".git"]),
-		spawn: (root: string) => {
-			return spawn("gopls", ["serve"], {
-				cwd: root,
-				stdio: ["pipe", "pipe", "pipe"],
-			})
-		},
-	},
+  go: {
+    id: 'go',
+    name: 'Go Language Server (gopls)',
+    languageIds: ['go'],
+    root: (cwd: string) => findNearestRoot(cwd, ['go.mod', '.git']),
+    spawn: (root: string) => {
+      return spawn('gopls', ['serve'], {
+        cwd: root,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    },
+  },
 
-	rust: {
-		id: "rust",
-		name: "Rust Language Server (rust-analyzer)",
-		languageIds: ["rust"],
-		root: (cwd: string) => findNearestRoot(cwd, ["Cargo.toml", ".git"]),
-		spawn: (root: string) => {
-			return spawn("rust-analyzer", ["--stdio"], {
-				cwd: root,
-				stdio: ["pipe", "pipe", "pipe"],
-			})
-		},
-	},
-}
+  rust: {
+    id: 'rust',
+    name: 'Rust Language Server (rust-analyzer)',
+    languageIds: ['rust'],
+    root: (cwd: string) => findNearestRoot(cwd, ['Cargo.toml', '.git']),
+    spawn: (root: string) => {
+      return spawn('rust-analyzer', ['--stdio'], {
+        cwd: root,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    },
+  },
+};
 
 /**
  * Get all servers that can handle a file
  */
-export function getServersForFile(
-	filePath: string,
-	cwd: string,
-): LSPServerInfo[] {
-	const languageId = getLanguageId(filePath)
-	if (!languageId) return []
+export function getServersForFile(filePath: string, cwd: string): LSPServerInfo[] {
+  const languageId = getLanguageId(filePath);
+  if (!languageId) return [];
 
-	return Object.values(BUILTIN_SERVERS).filter(
-		(server) =>
-			server.languageIds.includes(languageId) && server.root(cwd) !== null,
-	)
+  return Object.values(BUILTIN_SERVERS).filter(
+    server => server.languageIds.includes(languageId) && server.root(cwd) !== null,
+  );
 }

--- a/mastracode/src/lsp/workspace.ts
+++ b/mastracode/src/lsp/workspace.ts
@@ -1,18 +1,18 @@
-import * as fs from "node:fs"
-import * as path from "node:path"
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 /**
  * Workspace markers that indicate the root of a project
  */
 const WORKSPACE_MARKERS = [
-	"package.json",
-	"tsconfig.json",
-	"pyproject.toml",
-	"go.mod",
-	".git",
-	"Cargo.toml",
-	"composer.json",
-]
+  'package.json',
+  'tsconfig.json',
+  'pyproject.toml',
+  'go.mod',
+  '.git',
+  'Cargo.toml',
+  'composer.json',
+];
 
 /**
  * Find the workspace root by walking up from the file path
@@ -22,52 +22,52 @@ const WORKSPACE_MARKERS = [
  * (e.g., packages/core) over the monorepo root.
  */
 export function findWorkspaceRoot(filePath: string): string {
-	let currentDir = path.dirname(path.resolve(filePath))
-	const root = path.parse(currentDir).root
+  let currentDir = path.dirname(path.resolve(filePath));
+  const root = path.parse(currentDir).root;
 
-	// First, find the closest tsconfig.json or package.json
-	// This handles monorepos where the actual project is in a subdirectory
-	let closestProjectRoot: string | null = null
-	let searchDir = currentDir
+  // First, find the closest tsconfig.json or package.json
+  // This handles monorepos where the actual project is in a subdirectory
+  let closestProjectRoot: string | null = null;
+  let searchDir = currentDir;
 
-	while (searchDir !== root) {
-		const hasTsConfig = fs.existsSync(path.join(searchDir, "tsconfig.json"))
-		const hasPackageJson = fs.existsSync(path.join(searchDir, "package.json"))
+  while (searchDir !== root) {
+    const hasTsConfig = fs.existsSync(path.join(searchDir, 'tsconfig.json'));
+    const hasPackageJson = fs.existsSync(path.join(searchDir, 'package.json'));
 
-		if (hasTsConfig || hasPackageJson) {
-			closestProjectRoot = searchDir
-			break
-		}
+    if (hasTsConfig || hasPackageJson) {
+      closestProjectRoot = searchDir;
+      break;
+    }
 
-		const parentDir = path.dirname(searchDir)
-		if (parentDir === searchDir) {
-			break
-		}
-		searchDir = parentDir
-	}
+    const parentDir = path.dirname(searchDir);
+    if (parentDir === searchDir) {
+      break;
+    }
+    searchDir = parentDir;
+  }
 
-	// If we found a project root, return it
-	if (closestProjectRoot) {
-		return closestProjectRoot
-	}
+  // If we found a project root, return it
+  if (closestProjectRoot) {
+    return closestProjectRoot;
+  }
 
-	// Otherwise, fall back to looking for any workspace marker
-	currentDir = path.dirname(path.resolve(filePath))
-	while (currentDir !== root) {
-		for (const marker of WORKSPACE_MARKERS) {
-			const markerPath = path.join(currentDir, marker)
-			if (fs.existsSync(markerPath)) {
-				return currentDir
-			}
-		}
+  // Otherwise, fall back to looking for any workspace marker
+  currentDir = path.dirname(path.resolve(filePath));
+  while (currentDir !== root) {
+    for (const marker of WORKSPACE_MARKERS) {
+      const markerPath = path.join(currentDir, marker);
+      if (fs.existsSync(markerPath)) {
+        return currentDir;
+      }
+    }
 
-		const parentDir = path.dirname(currentDir)
-		if (parentDir === currentDir) {
-			break
-		}
-		currentDir = parentDir
-	}
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+    currentDir = parentDir;
+  }
 
-	// Fallback to the directory containing the file
-	return path.dirname(path.resolve(filePath))
+  // Fallback to the directory containing the file
+  return path.dirname(path.resolve(filePath));
 }

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -1,89 +1,80 @@
 /**
  * Main entry point for Mastra Code TUI.
  */
-import * as fs from "node:fs"
-import * as path from "node:path"
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
-import { MastraTUI } from "./tui/index.js"
-import { getAppDataDir } from "./utils/project.js"
-import { releaseAllThreadLocks } from "./utils/thread-lock.js"
-import { createMastraCode } from "./index.js"
+import { MastraTUI } from './tui/index.js';
+import { getAppDataDir } from './utils/project.js';
+import { releaseAllThreadLocks } from './utils/thread-lock.js';
+import { createMastraCode } from './index.js';
 
-const { harness, mcpManager } = createMastraCode()
+const { harness, mcpManager } = createMastraCode();
 
 const tui = new MastraTUI({
-	harness,
-	appName: "Mastra Code",
-	version: "0.1.0",
-	inlineQuestions: true,
-})
+  harness,
+  appName: 'Mastra Code',
+  version: '0.1.0',
+  inlineQuestions: true,
+});
 
 async function main() {
-	if (mcpManager.hasServers()) {
-		await mcpManager.init()
-		const statuses = mcpManager.getServerStatuses()
-		const connected = statuses.filter((s) => s.connected)
-		const failed = statuses.filter((s) => !s.connected)
-		const totalTools = connected.reduce((sum, s) => sum + s.toolCount, 0)
-		console.info(
-			`MCP: ${connected.length} server(s) connected, ${totalTools} tool(s)`,
-		)
-		for (const s of failed) {
-			console.info(`MCP: Failed to connect to "${s.name}": ${s.error}`)
-		}
-	}
+  if (mcpManager.hasServers()) {
+    await mcpManager.init();
+    const statuses = mcpManager.getServerStatuses();
+    const connected = statuses.filter(s => s.connected);
+    const failed = statuses.filter(s => !s.connected);
+    const totalTools = connected.reduce((sum, s) => sum + s.toolCount, 0);
+    console.info(`MCP: ${connected.length} server(s) connected, ${totalTools} tool(s)`);
+    for (const s of failed) {
+      console.info(`MCP: Failed to connect to "${s.name}": ${s.error}`);
+    }
+  }
 
-	const logFile = path.join(getAppDataDir(), "debug.log")
-	const logStream = fs.createWriteStream(logFile, { flags: "a" })
-	const fmt = (a: unknown): string => {
-		if (typeof a === "string") return a
-		if (a instanceof Error) return `${a.name}: ${a.message}`
-		try {
-			return JSON.stringify(a)
-		} catch {
-			return String(a)
-		}
-	}
-	const originalConsoleError = console.error.bind(console)
-	console.error = (...args: unknown[]) => {
-		logStream.write(
-			`[ERROR] ${new Date().toISOString()} ${args.map(fmt).join(" ")}\n`,
-		)
-	}
-	console.warn = (...args: unknown[]) => {
-		logStream.write(
-			`[WARN] ${new Date().toISOString()} ${args.map(fmt).join(" ")}\n`,
-		)
-	}
+  const logFile = path.join(getAppDataDir(), 'debug.log');
+  const logStream = fs.createWriteStream(logFile, { flags: 'a' });
+  const fmt = (a: unknown): string => {
+    if (typeof a === 'string') return a;
+    if (a instanceof Error) return `${a.name}: ${a.message}`;
+    try {
+      return JSON.stringify(a);
+    } catch {
+      return String(a);
+    }
+  };
+  const originalConsoleError = console.error.bind(console);
+  console.error = (...args: unknown[]) => {
+    logStream.write(`[ERROR] ${new Date().toISOString()} ${args.map(fmt).join(' ')}\n`);
+  };
+  console.warn = (...args: unknown[]) => {
+    logStream.write(`[WARN] ${new Date().toISOString()} ${args.map(fmt).join(' ')}\n`);
+  };
 
-	tui.run().catch((error) => {
-		originalConsoleError("Fatal error:", error)
-		process.exit(1)
-	})
+  tui.run().catch(error => {
+    originalConsoleError('Fatal error:', error);
+    process.exit(1);
+  });
 }
 
-process.on("beforeExit", async () => {
-	await Promise.all([
-		mcpManager.disconnect(),
-		harness.stopHeartbeats(),
-	])
-})
+process.on('beforeExit', async () => {
+  await Promise.all([mcpManager.disconnect(), harness.stopHeartbeats()]);
+});
 
 const cleanup = () => {
-	harness.releaseCurrentThreadLock()
-	releaseAllThreadLocks()
-}
-process.on("exit", cleanup)
-process.on("SIGINT", () => {
-	cleanup()
-	process.exit(0)
-})
-process.on("SIGTERM", () => {
-	cleanup()
-	process.exit(0)
-})
+  harness.releaseCurrentThreadLock();
+  releaseAllThreadLocks();
+};
+process.on('exit', cleanup);
+process.on('SIGINT', () => {
+  cleanup();
+  process.exit(0);
+});
+process.on('SIGTERM', () => {
+  cleanup();
+  process.exit(0);
+});
 
-main().catch((error) => {
-	console.error("Fatal error:", error)
-	process.exit(1)
-})
+main().catch(error => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/mastracode/src/mcp/config.ts
+++ b/mastracode/src/mcp/config.ts
@@ -8,90 +8,89 @@
  * Project overrides global by server name. Claude Code config is lowest priority.
  */
 
-import * as fs from "node:fs"
-import * as os from "node:os"
-import * as path from "node:path"
-import type { McpConfig, McpServerConfig } from "./types.js"
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { McpConfig, McpServerConfig } from './types.js';
 
 export function loadMcpConfig(projectDir: string): McpConfig {
-	const claudeConfig = loadClaudeSettings(projectDir)
-	const globalConfig = loadSingleConfig(getGlobalMcpPath())
-	const projectConfig = loadSingleConfig(getProjectMcpPath(projectDir))
+  const claudeConfig = loadClaudeSettings(projectDir);
+  const globalConfig = loadSingleConfig(getGlobalMcpPath());
+  const projectConfig = loadSingleConfig(getProjectMcpPath(projectDir));
 
-	return mergeConfigs(claudeConfig, globalConfig, projectConfig)
+  return mergeConfigs(claudeConfig, globalConfig, projectConfig);
 }
 
 export function getProjectMcpPath(projectDir: string): string {
-	return path.join(projectDir, ".mastracode", "mcp.json")
+  return path.join(projectDir, '.mastracode', 'mcp.json');
 }
 
 export function getGlobalMcpPath(): string {
-	return path.join(os.homedir(), ".mastracode", "mcp.json")
+  return path.join(os.homedir(), '.mastracode', 'mcp.json');
 }
 
 export function getClaudeSettingsPath(projectDir: string): string {
-	return path.join(projectDir, ".claude", "settings.local.json")
+  return path.join(projectDir, '.claude', 'settings.local.json');
 }
 
 function loadSingleConfig(filePath: string): McpConfig {
-	try {
-		if (!fs.existsSync(filePath)) return {}
-		const raw = fs.readFileSync(filePath, "utf-8")
-		return validateConfig(JSON.parse(raw))
-	} catch {
-		return {}
-	}
+  try {
+    if (!fs.existsSync(filePath)) return {};
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    return validateConfig(JSON.parse(raw));
+  } catch {
+    return {};
+  }
 }
 
 function loadClaudeSettings(projectDir: string): McpConfig {
-	try {
-		const filePath = getClaudeSettingsPath(projectDir)
-		if (!fs.existsSync(filePath)) return {}
-		const raw = fs.readFileSync(filePath, "utf-8")
-		const parsed = JSON.parse(raw)
-		// Claude Code stores mcpServers at the top level of settings
-		if (parsed?.mcpServers && typeof parsed.mcpServers === "object") {
-			return validateConfig({ mcpServers: parsed.mcpServers })
-		}
-		return {}
-	} catch {
-		return {}
-	}
+  try {
+    const filePath = getClaudeSettingsPath(projectDir);
+    if (!fs.existsSync(filePath)) return {};
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    // Claude Code stores mcpServers at the top level of settings
+    if (parsed?.mcpServers && typeof parsed.mcpServers === 'object') {
+      return validateConfig({ mcpServers: parsed.mcpServers });
+    }
+    return {};
+  } catch {
+    return {};
+  }
 }
 
 function validateConfig(raw: unknown): McpConfig {
-	if (!raw || typeof raw !== "object") return {}
-	const obj = raw as Record<string, unknown>
+  if (!raw || typeof raw !== 'object') return {};
+  const obj = raw as Record<string, unknown>;
 
-	if (!obj.mcpServers || typeof obj.mcpServers !== "object") return {}
+  if (!obj.mcpServers || typeof obj.mcpServers !== 'object') return {};
 
-	const servers: Record<string, McpServerConfig> = {}
-	const rawServers = obj.mcpServers as Record<string, unknown>
+  const servers: Record<string, McpServerConfig> = {};
+  const rawServers = obj.mcpServers as Record<string, unknown>;
 
-	for (const [name, entry] of Object.entries(rawServers)) {
-		if (isValidServerConfig(entry)) {
-			servers[name] = {
-				command: (entry as Record<string, unknown>).command as string,
-				args: Array.isArray((entry as Record<string, unknown>).args)
-					? ((entry as Record<string, unknown>).args as string[])
-					: undefined,
-				env:
-					typeof (entry as Record<string, unknown>).env === "object" &&
-					(entry as Record<string, unknown>).env !== null
-						? ((entry as Record<string, unknown>).env as Record<string, string>)
-						: undefined,
-			}
-		}
-	}
+  for (const [name, entry] of Object.entries(rawServers)) {
+    if (isValidServerConfig(entry)) {
+      servers[name] = {
+        command: (entry as Record<string, unknown>).command as string,
+        args: Array.isArray((entry as Record<string, unknown>).args)
+          ? ((entry as Record<string, unknown>).args as string[])
+          : undefined,
+        env:
+          typeof (entry as Record<string, unknown>).env === 'object' && (entry as Record<string, unknown>).env !== null
+            ? ((entry as Record<string, unknown>).env as Record<string, string>)
+            : undefined,
+      };
+    }
+  }
 
-	if (Object.keys(servers).length === 0) return {}
-	return { mcpServers: servers }
+  if (Object.keys(servers).length === 0) return {};
+  return { mcpServers: servers };
 }
 
 function isValidServerConfig(raw: unknown): boolean {
-	if (!raw || typeof raw !== "object") return false
-	const obj = raw as Record<string, unknown>
-	return typeof obj.command === "string"
+  if (!raw || typeof raw !== 'object') return false;
+  const obj = raw as Record<string, unknown>;
+  return typeof obj.command === 'string';
 }
 
 /**
@@ -99,16 +98,16 @@ function isValidServerConfig(raw: unknown): boolean {
  * Later configs override earlier by server name.
  */
 function mergeConfigs(...configs: McpConfig[]): McpConfig {
-	const merged: Record<string, McpServerConfig> = {}
+  const merged: Record<string, McpServerConfig> = {};
 
-	for (const config of configs) {
-		if (config.mcpServers) {
-			for (const [name, server] of Object.entries(config.mcpServers)) {
-				merged[name] = server
-			}
-		}
-	}
+  for (const config of configs) {
+    if (config.mcpServers) {
+      for (const [name, server] of Object.entries(config.mcpServers)) {
+        merged[name] = server;
+      }
+    }
+  }
 
-	if (Object.keys(merged).length === 0) return {}
-	return { mcpServers: merged }
+  if (Object.keys(merged).length === 0) return {};
+  return { mcpServers: merged };
 }

--- a/mastracode/src/mcp/index.ts
+++ b/mastracode/src/mcp/index.ts
@@ -1,8 +1,3 @@
-export { MCPManager } from "./manager.js"
-export {
-	loadMcpConfig,
-	getProjectMcpPath,
-	getGlobalMcpPath,
-	getClaudeSettingsPath,
-} from "./config.js"
-export type { McpConfig, McpServerConfig, McpServerStatus } from "./types.js"
+export { MCPManager } from './manager.js';
+export { loadMcpConfig, getProjectMcpPath, getGlobalMcpPath, getClaudeSettingsPath } from './config.js';
+export type { McpConfig, McpServerConfig, McpServerStatus } from './types.js';

--- a/mastracode/src/mcp/manager.ts
+++ b/mastracode/src/mcp/manager.ts
@@ -6,162 +6,149 @@
  * namespaces tools as serverName_toolName automatically.
  */
 
-import { MCPClient } from "@mastra/mcp"
-import {
-	loadMcpConfig,
-	getProjectMcpPath,
-	getGlobalMcpPath,
-	getClaudeSettingsPath,
-} from "./config.js"
-import type { McpConfig, McpServerStatus } from "./types.js"
+import { MCPClient } from '@mastra/mcp';
+import { loadMcpConfig, getProjectMcpPath, getGlobalMcpPath, getClaudeSettingsPath } from './config.js';
+import type { McpConfig, McpServerStatus } from './types.js';
 
 export class MCPManager {
-	private config: McpConfig
-	private projectDir: string
-	private client: MCPClient | null = null
-	private tools: Record<string, any> = {}
-	private serverStatuses: Map<string, McpServerStatus> = new Map()
-	private initialized = false
+  private config: McpConfig;
+  private projectDir: string;
+  private client: MCPClient | null = null;
+  private tools: Record<string, any> = {};
+  private serverStatuses: Map<string, McpServerStatus> = new Map();
+  private initialized = false;
 
-	constructor(projectDir: string) {
-		this.projectDir = projectDir
-		this.config = loadMcpConfig(projectDir)
-	}
+  constructor(projectDir: string) {
+    this.projectDir = projectDir;
+    this.config = loadMcpConfig(projectDir);
+  }
 
-	/**
-	 * Connect to all configured MCP servers and collect their tools.
-	 * Errors on individual servers are caught and logged, not thrown.
-	 */
-	async init(): Promise<void> {
-		if (this.initialized) return
+  /**
+   * Connect to all configured MCP servers and collect their tools.
+   * Errors on individual servers are caught and logged, not thrown.
+   */
+  async init(): Promise<void> {
+    if (this.initialized) return;
 
-		const servers = this.config.mcpServers
-		if (!servers || Object.keys(servers).length === 0) {
-			this.initialized = true
-			return
-		}
+    const servers = this.config.mcpServers;
+    if (!servers || Object.keys(servers).length === 0) {
+      this.initialized = true;
+      return;
+    }
 
-		// Build server definitions for MCPClient
-		const serverDefs: Record<
-			string,
-			{ command: string; args?: string[]; env?: Record<string, string> }
-		> = {}
-		for (const [name, cfg] of Object.entries(servers)) {
-			serverDefs[name] = {
-				command: cfg.command,
-				args: cfg.args,
-				env: cfg.env,
-			}
-		}
+    // Build server definitions for MCPClient
+    const serverDefs: Record<string, { command: string; args?: string[]; env?: Record<string, string> }> = {};
+    for (const [name, cfg] of Object.entries(servers)) {
+      serverDefs[name] = {
+        command: cfg.command,
+        args: cfg.args,
+        env: cfg.env,
+      };
+    }
 
-		try {
-			this.client = new MCPClient({
-				id: "mastra-code-mcp",
-				servers: serverDefs,
-			})
+    try {
+      this.client = new MCPClient({
+        id: 'mastra-code-mcp',
+        servers: serverDefs,
+      });
 
-			// listTools() connects to servers and returns namespaced tools
-			// Tool names are serverName_toolName (handled by MCPClient)
-			this.tools = await this.client.listTools()
+      // listTools() connects to servers and returns namespaced tools
+      // Tool names are serverName_toolName (handled by MCPClient)
+      this.tools = await this.client.listTools();
 
-			// Derive per-server status from tool names
-			for (const name of Object.keys(servers)) {
-				const prefix = `${name}_`
-				const serverToolNames = Object.keys(this.tools).filter((t) =>
-					t.startsWith(prefix),
-				)
-				this.serverStatuses.set(name, {
-					name,
-					connected: true,
-					toolCount: serverToolNames.length,
-					toolNames: serverToolNames,
-				})
-			}
-		} catch (error) {
-			const errMsg = error instanceof Error ? error.message : String(error)
+      // Derive per-server status from tool names
+      for (const name of Object.keys(servers)) {
+        const prefix = `${name}_`;
+        const serverToolNames = Object.keys(this.tools).filter(t => t.startsWith(prefix));
+        this.serverStatuses.set(name, {
+          name,
+          connected: true,
+          toolCount: serverToolNames.length,
+          toolNames: serverToolNames,
+        });
+      }
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
 
-			// If MCPClient throws at top level, mark all servers as failed
-			for (const name of Object.keys(servers)) {
-				this.serverStatuses.set(name, {
-					name,
-					connected: false,
-					toolCount: 0,
-					toolNames: [],
-					error: errMsg,
-				})
-			}
-		}
+      // If MCPClient throws at top level, mark all servers as failed
+      for (const name of Object.keys(servers)) {
+        this.serverStatuses.set(name, {
+          name,
+          connected: false,
+          toolCount: 0,
+          toolNames: [],
+          error: errMsg,
+        });
+      }
+    }
 
-		this.initialized = true
-	}
+    this.initialized = true;
+  }
 
-	/**
-	 * Disconnect all servers, reload config from disk, reconnect.
-	 */
-	async reload(): Promise<void> {
-		await this.disconnect()
-		this.config = loadMcpConfig(this.projectDir)
-		this.tools = {}
-		this.serverStatuses.clear()
-		this.initialized = false
-		await this.init()
-	}
+  /**
+   * Disconnect all servers, reload config from disk, reconnect.
+   */
+  async reload(): Promise<void> {
+    await this.disconnect();
+    this.config = loadMcpConfig(this.projectDir);
+    this.tools = {};
+    this.serverStatuses.clear();
+    this.initialized = false;
+    await this.init();
+  }
 
-	/**
-	 * Disconnect from all MCP servers and clean up.
-	 */
-	async disconnect(): Promise<void> {
-		if (this.client) {
-			try {
-				await this.client.disconnect()
-			} catch {
-				// Ignore disconnect errors
-			}
-			this.client = null
-		}
-	}
+  /**
+   * Disconnect from all MCP servers and clean up.
+   */
+  async disconnect(): Promise<void> {
+    if (this.client) {
+      try {
+        await this.client.disconnect();
+      } catch {
+        // Ignore disconnect errors
+      }
+      this.client = null;
+    }
+  }
 
-	/**
-	 * Get all tools from connected MCP servers.
-	 * Returns a Record<string, ToolAction> compatible with Mastra's agent tools.
-	 * Tool names are serverName_toolName (namespaced by MCPClient).
-	 */
-	getTools(): Record<string, any> {
-		return { ...this.tools }
-	}
+  /**
+   * Get all tools from connected MCP servers.
+   * Returns a Record<string, ToolAction> compatible with Mastra's agent tools.
+   * Tool names are serverName_toolName (namespaced by MCPClient).
+   */
+  getTools(): Record<string, any> {
+    return { ...this.tools };
+  }
 
-	/**
-	 * Check if any MCP servers are configured.
-	 */
-	hasServers(): boolean {
-		return (
-			this.config.mcpServers !== undefined &&
-			Object.keys(this.config.mcpServers).length > 0
-		)
-	}
+  /**
+   * Check if any MCP servers are configured.
+   */
+  hasServers(): boolean {
+    return this.config.mcpServers !== undefined && Object.keys(this.config.mcpServers).length > 0;
+  }
 
-	/**
-	 * Get status of all servers.
-	 */
-	getServerStatuses(): McpServerStatus[] {
-		return Array.from(this.serverStatuses.values())
-	}
+  /**
+   * Get status of all servers.
+   */
+  getServerStatuses(): McpServerStatus[] {
+    return Array.from(this.serverStatuses.values());
+  }
 
-	/**
-	 * Get config file paths for display.
-	 */
-	getConfigPaths(): { project: string; global: string; claude: string } {
-		return {
-			project: getProjectMcpPath(this.projectDir),
-			global: getGlobalMcpPath(),
-			claude: getClaudeSettingsPath(this.projectDir),
-		}
-	}
+  /**
+   * Get config file paths for display.
+   */
+  getConfigPaths(): { project: string; global: string; claude: string } {
+    return {
+      project: getProjectMcpPath(this.projectDir),
+      global: getGlobalMcpPath(),
+      claude: getClaudeSettingsPath(this.projectDir),
+    };
+  }
 
-	/**
-	 * Get the merged config.
-	 */
-	getConfig(): McpConfig {
-		return this.config
-	}
+  /**
+   * Get the merged config.
+   */
+  getConfig(): McpConfig {
+    return this.config;
+  }
 }

--- a/mastracode/src/mcp/types.ts
+++ b/mastracode/src/mcp/types.ts
@@ -8,12 +8,12 @@
  * Uses Claude Code's format for compatibility.
  */
 export interface McpServerConfig {
-	/** The command to launch the MCP server process */
-	command: string
-	/** Arguments for the command */
-	args?: string[]
-	/** Environment variables to set for the server process */
-	env?: Record<string, string>
+  /** The command to launch the MCP server process */
+  command: string;
+  /** Arguments for the command */
+  args?: string[];
+  /** Environment variables to set for the server process */
+  env?: Record<string, string>;
 }
 
 /**
@@ -21,21 +21,21 @@ export interface McpServerConfig {
  * Maps server names to their config.
  */
 export interface McpConfig {
-	mcpServers?: Record<string, McpServerConfig>
+  mcpServers?: Record<string, McpServerConfig>;
 }
 
 /**
  * Runtime status of a connected MCP server.
  */
 export interface McpServerStatus {
-	/** Server name (from config key) */
-	name: string
-	/** Whether the server is currently connected */
-	connected: boolean
-	/** Number of tools provided by this server */
-	toolCount: number
-	/** List of tool names provided */
-	toolNames: string[]
-	/** Error message if connection failed */
-	error?: string
+  /** Server name (from config key) */
+  name: string;
+  /** Whether the server is currently connected */
+  connected: boolean;
+  /** Number of tools provided by this server */
+  toolCount: number;
+  /** List of tool names provided */
+  toolNames: string[];
+  /** Error message if connection failed */
+  error?: string;
 }

--- a/mastracode/src/permissions.ts
+++ b/mastracode/src/permissions.ts
@@ -10,116 +10,107 @@
 // Categories
 // ---------------------------------------------------------------------------
 
-export type ToolCategory = "read" | "edit" | "execute" | "mcp"
+export type ToolCategory = 'read' | 'edit' | 'execute' | 'mcp';
 
-export const TOOL_CATEGORIES: Record<
-	ToolCategory,
-	{ label: string; description: string }
-> = {
-	read: {
-		label: "Read",
-		description: "Read files, search, list directories",
-	},
-	edit: {
-		label: "Edit",
-		description: "Create, modify, or delete files",
-	},
-	execute: {
-		label: "Execute",
-		description: "Run shell commands",
-	},
-	mcp: {
-		label: "MCP",
-		description: "External MCP server tools",
-	},
-}
+export const TOOL_CATEGORIES: Record<ToolCategory, { label: string; description: string }> = {
+  read: {
+    label: 'Read',
+    description: 'Read files, search, list directories',
+  },
+  edit: {
+    label: 'Edit',
+    description: 'Create, modify, or delete files',
+  },
+  execute: {
+    label: 'Execute',
+    description: 'Run shell commands',
+  },
+  mcp: {
+    label: 'MCP',
+    description: 'External MCP server tools',
+  },
+};
 
 // ---------------------------------------------------------------------------
 // Tool → Category mapping
 // ---------------------------------------------------------------------------
 
 const TOOL_CATEGORY_MAP: Record<string, ToolCategory> = {
-	// Read-only tools — always safe
-	view: "read",
-	search_content: "read",
-	find_files: "read",
-	web_search: "read",
-	"web-search": "read",
-	web_extract: "read",
-	"web-extract": "read",
-	// Edit tools — modify files
-	string_replace_lsp: "edit",
-	ast_smart_edit: "edit",
-	write_file: "edit",
-	subagent: "edit",
+  // Read-only tools — always safe
+  view: 'read',
+  search_content: 'read',
+  find_files: 'read',
+  web_search: 'read',
+  'web-search': 'read',
+  web_extract: 'read',
+  'web-extract': 'read',
+  // Edit tools — modify files
+  string_replace_lsp: 'edit',
+  ast_smart_edit: 'edit',
+  write_file: 'edit',
+  subagent: 'edit',
 
-	// Execute tools — run arbitrary commands
-	execute_command: "execute",
+  // Execute tools — run arbitrary commands
+  execute_command: 'execute',
 
-	// Interactive / planning tools — always allowed (no category needed)
-	// ask_user, todo_write, todo_check, submit_plan, request_sandbox_access
-}
+  // Interactive / planning tools — always allowed (no category needed)
+  // ask_user, todo_write, todo_check, submit_plan, request_sandbox_access
+};
 
 // Tools that never need approval regardless of policy
-const ALWAYS_ALLOW_TOOLS = new Set([
-	"ask_user",
-	"todo_write",
-	"todo_check",
-	"submit_plan",
-	"request_sandbox_access",
-])
+const ALWAYS_ALLOW_TOOLS = new Set(['ask_user', 'todo_write', 'todo_check', 'submit_plan', 'request_sandbox_access']);
 
 /**
  * Get the category for a tool, or null if the tool is always-allowed.
  */
 export function getToolCategory(toolName: string): ToolCategory | null {
-	if (ALWAYS_ALLOW_TOOLS.has(toolName)) return null
-	return TOOL_CATEGORY_MAP[toolName] ?? "mcp"
+  if (ALWAYS_ALLOW_TOOLS.has(toolName)) return null;
+  return TOOL_CATEGORY_MAP[toolName] ?? 'mcp';
 }
 
 /**
  * Get the list of known tools for a given category.
  */
 export function getToolsForCategory(category: ToolCategory): string[] {
-	return Object.entries(TOOL_CATEGORY_MAP)
-		.filter(([, cat]) => cat === category)
-		.map(([tool]) => tool)
+  return Object.entries(TOOL_CATEGORY_MAP)
+    .filter(([, cat]) => cat === category)
+    .map(([tool]) => tool);
 }
 
 // ---------------------------------------------------------------------------
 // Policies
 // ---------------------------------------------------------------------------
 
-export type PermissionPolicy = "allow" | "ask" | "deny"
+export type PermissionPolicy = 'allow' | 'ask' | 'deny';
 
 export interface PermissionRules {
-	/** Policy per category. Missing categories default to their DEFAULT_POLICIES value. */
-	categories: Partial<Record<ToolCategory, PermissionPolicy>>
-	/** Per-tool overrides. Tool name → policy. Takes precedence over category. */
-	tools: Record<string, PermissionPolicy>
+  /** Policy per category. Missing categories default to their DEFAULT_POLICIES value. */
+  categories: Partial<Record<ToolCategory, PermissionPolicy>>;
+  /** Per-tool overrides. Tool name → policy. Takes precedence over category. */
+  tools: Record<string, PermissionPolicy>;
 }
 
 /** Default policies when no rules are configured (YOLO=false equivalent). */
 export const DEFAULT_POLICIES: Record<ToolCategory, PermissionPolicy> = {
-	read: "allow",
-	edit: "ask",
-	execute: "ask",
-	mcp: "ask",
-}
+  read: 'allow',
+  edit: 'ask',
+  execute: 'ask',
+  mcp: 'ask',
+};
 
 /** YOLO-mode policies — everything auto-allowed. */
 export const YOLO_POLICIES: Record<ToolCategory, PermissionPolicy> = {
-	read: "allow",
-	edit: "allow",
-	execute: "allow",
-	mcp: "allow",
-}
+  read: 'allow',
+  edit: 'allow',
+  execute: 'allow',
+  mcp: 'allow',
+};
 
 export function createDefaultRules(): PermissionRules {
-	return {
-		categories: { ...DEFAULT_POLICIES },
-		tools: {},
-	}
+  return {
+    categories: { ...DEFAULT_POLICIES },
+    tools: {},
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -127,42 +118,40 @@ export function createDefaultRules(): PermissionRules {
 // ---------------------------------------------------------------------------
 
 export class SessionGrants {
-	private grantedCategories = new Set<ToolCategory>()
-	private grantedTools = new Set<string>()
+  private grantedCategories = new Set<ToolCategory>();
+  private grantedTools = new Set<string>();
 
-	allowCategory(category: ToolCategory): void {
-		this.grantedCategories.add(category)
-	}
+  allowCategory(category: ToolCategory): void {
+    this.grantedCategories.add(category);
+  }
 
-	allowTool(toolName: string): void {
-		this.grantedTools.add(toolName)
-	}
+  allowTool(toolName: string): void {
+    this.grantedTools.add(toolName);
+  }
 
-	isGranted(toolName: string, category: ToolCategory): boolean {
-		return (
-			this.grantedTools.has(toolName) || this.grantedCategories.has(category)
-		)
-	}
+  isGranted(toolName: string, category: ToolCategory): boolean {
+    return this.grantedTools.has(toolName) || this.grantedCategories.has(category);
+  }
 
-	reset(): void {
-		this.grantedCategories.clear()
-		this.grantedTools.clear()
-	}
+  reset(): void {
+    this.grantedCategories.clear();
+    this.grantedTools.clear();
+  }
 
-	getGrantedCategories(): ToolCategory[] {
-		return [...this.grantedCategories]
-	}
+  getGrantedCategories(): ToolCategory[] {
+    return [...this.grantedCategories];
+  }
 
-	getGrantedTools(): string[] {
-		return [...this.grantedTools]
-	}
+  getGrantedTools(): string[] {
+    return [...this.grantedTools];
+  }
 }
 
 // ---------------------------------------------------------------------------
 // Decision engine
 // ---------------------------------------------------------------------------
 
-export type ApprovalDecision = "allow" | "ask" | "deny"
+export type ApprovalDecision = 'allow' | 'ask' | 'deny';
 
 /**
  * Determine whether a tool call should be allowed, prompted, or denied.
@@ -175,25 +164,25 @@ export type ApprovalDecision = "allow" | "ask" | "deny"
  *  5. Fallback → "ask"
  */
 export function resolveApproval(
-	toolName: string,
-	rules: PermissionRules,
-	sessionGrants: SessionGrants,
+  toolName: string,
+  rules: PermissionRules,
+  sessionGrants: SessionGrants,
 ): ApprovalDecision {
-	// 1. Always-allowed tools
-	const category = getToolCategory(toolName)
-	if (category === null) return "allow"
+  // 1. Always-allowed tools
+  const category = getToolCategory(toolName);
+  if (category === null) return 'allow';
 
-	// 2. Per-tool override
-	const toolPolicy = rules.tools[toolName]
-	if (toolPolicy) return toolPolicy
+  // 2. Per-tool override
+  const toolPolicy = rules.tools[toolName];
+  if (toolPolicy) return toolPolicy;
 
-	// 3. Session grants
-	if (sessionGrants.isGranted(toolName, category)) return "allow"
+  // 3. Session grants
+  if (sessionGrants.isGranted(toolName, category)) return 'allow';
 
-	// 4. Category policy
-	const categoryPolicy = rules.categories[category]
-	if (categoryPolicy) return categoryPolicy
+  // 4. Category policy
+  const categoryPolicy = rules.categories[category];
+  if (categoryPolicy) return categoryPolicy;
 
-	// 5. Default policy for category
-	return DEFAULT_POLICIES[category] ?? "ask"
+  // 5. Default policy for category
+  return DEFAULT_POLICIES[category] ?? 'ask';
 }

--- a/mastracode/src/providers/claude-max.ts
+++ b/mastracode/src/providers/claude-max.ts
@@ -5,34 +5,33 @@
  * The OAuth endpoint requires a specific system message to be present.
  */
 
-import { createAnthropic } from "@ai-sdk/anthropic"
-import type { MastraModelConfig } from "@mastra/core/llm"
-import { wrapLanguageModel  } from "ai"
-import type {LanguageModelMiddleware} from "ai";
-import { AuthStorage } from "../auth/storage.js"
+import { createAnthropic } from '@ai-sdk/anthropic';
+import type { MastraModelConfig } from '@mastra/core/llm';
+import { wrapLanguageModel } from 'ai';
+import type { LanguageModelMiddleware } from 'ai';
+import { AuthStorage } from '../auth/storage.js';
 
 // Required for Claude Max plan OAuth - the endpoint checks for this system message
-const claudeCodeIdentity =
-	"You are Claude Code, Anthropic's official CLI for Claude."
+const claudeCodeIdentity = "You are Claude Code, Anthropic's official CLI for Claude.";
 
 // Singleton auth storage instance
-let authStorageInstance: AuthStorage | null = null
+let authStorageInstance: AuthStorage | null = null;
 
 /**
  * Get or create the shared AuthStorage instance
  */
 export function getAuthStorage(): AuthStorage {
-	if (!authStorageInstance) {
-		authStorageInstance = new AuthStorage()
-	}
-	return authStorageInstance
+  if (!authStorageInstance) {
+    authStorageInstance = new AuthStorage();
+  }
+  return authStorageInstance;
 }
 
 /**
  * Set a custom AuthStorage instance (useful for TUI integration)
  */
 export function setAuthStorage(storage: AuthStorage): void {
-	authStorageInstance = storage
+  authStorageInstance = storage;
 }
 
 /**
@@ -40,24 +39,24 @@ export function setAuthStorage(storage: AuthStorage): void {
  * Required for Claude Max OAuth authentication
  */
 const claudeCodeMiddleware: LanguageModelMiddleware = {
-	specificationVersion: "v3",
-	transformParams: async ({ params }) => {
-		// Prepend the Claude Code identity as the first system message
-		const systemMessage = {
-			role: "system" as const,
-			content: claudeCodeIdentity,
-		}
+  specificationVersion: 'v3',
+  transformParams: async ({ params }) => {
+    // Prepend the Claude Code identity as the first system message
+    const systemMessage = {
+      role: 'system' as const,
+      content: claudeCodeIdentity,
+    };
 
-		if (params.temperature) {
-			delete params.topP
-		}
+    if (params.temperature) {
+      delete params.topP;
+    }
 
-		return {
-			...params,
-			prompt: [systemMessage, ...params.prompt],
-		}
-	},
-}
+    return {
+      ...params,
+      prompt: [systemMessage, ...params.prompt],
+    };
+  },
+};
 
 /**
  * Prompt caching middleware for Anthropic
@@ -71,123 +70,118 @@ const claudeCodeMiddleware: LanguageModelMiddleware = {
  * - Conversation history up to the last message
  */
 const promptCacheMiddleware: LanguageModelMiddleware = {
-	specificationVersion: "v3",
-	transformParams: async ({ params }) => {
-		const prompt = [...params.prompt]
+  specificationVersion: 'v3',
+  transformParams: async ({ params }) => {
+    const prompt = [...params.prompt];
 
-		const cacheControl = { type: "ephemeral" as const, ttl: "5m" as const }
+    const cacheControl = { type: 'ephemeral' as const, ttl: '5m' as const };
 
-		// Helper to add cache control to a message's last content part
-		const addCacheToMessage = (msg: any) => {
-			// For system messages with string content
-			if (typeof msg.content === "string") {
-				return {
-					...msg,
-					providerOptions: {
-						...msg.providerOptions,
-						anthropic: { ...msg.providerOptions?.anthropic, cacheControl },
-					},
-				}
-			}
+    // Helper to add cache control to a message's last content part
+    const addCacheToMessage = (msg: any) => {
+      // For system messages with string content
+      if (typeof msg.content === 'string') {
+        return {
+          ...msg,
+          providerOptions: {
+            ...msg.providerOptions,
+            anthropic: { ...msg.providerOptions?.anthropic, cacheControl },
+          },
+        };
+      }
 
-			// For messages with array content, add to last part
-			if (Array.isArray(msg.content) && msg.content.length > 0) {
-				const content = [...msg.content]
-				const lastPart = content[content.length - 1]
-				content[content.length - 1] = {
-					...lastPart,
-					providerOptions: {
-						...lastPart.providerOptions,
-						anthropic: { ...lastPart.providerOptions?.anthropic, cacheControl },
-					},
-				}
-				return { ...msg, content }
-			}
+      // For messages with array content, add to last part
+      if (Array.isArray(msg.content) && msg.content.length > 0) {
+        const content = [...msg.content];
+        const lastPart = content[content.length - 1];
+        content[content.length - 1] = {
+          ...lastPart,
+          providerOptions: {
+            ...lastPart.providerOptions,
+            anthropic: { ...lastPart.providerOptions?.anthropic, cacheControl },
+          },
+        };
+        return { ...msg, content };
+      }
 
-			return msg
-		}
+      return msg;
+    };
 
-		// Find the last system message index
-		let lastSystemIdx = -1
-		for (let i = prompt.length - 1; i >= 0; i--) {
-			if ((prompt[i] as any).role === "system") {
-				lastSystemIdx = i
-				break
-			}
-		}
+    // Find the last system message index
+    let lastSystemIdx = -1;
+    for (let i = prompt.length - 1; i >= 0; i--) {
+      if ((prompt[i] as any).role === 'system') {
+        lastSystemIdx = i;
+        break;
+      }
+    }
 
-		// Add cache breakpoint to last system message
-		if (lastSystemIdx >= 0) {
-			prompt[lastSystemIdx] = addCacheToMessage(prompt[lastSystemIdx])
-		}
+    // Add cache breakpoint to last system message
+    if (lastSystemIdx >= 0) {
+      prompt[lastSystemIdx] = addCacheToMessage(prompt[lastSystemIdx]);
+    }
 
-		// Add cache breakpoint to the most recent message (last in array)
-		const lastIdx = prompt.length - 1
-		if (lastIdx >= 0 && lastIdx !== lastSystemIdx) {
-			prompt[lastIdx] = addCacheToMessage(prompt[lastIdx])
-		}
+    // Add cache breakpoint to the most recent message (last in array)
+    const lastIdx = prompt.length - 1;
+    if (lastIdx >= 0 && lastIdx !== lastSystemIdx) {
+      prompt[lastIdx] = addCacheToMessage(prompt[lastIdx]);
+    }
 
-		return { ...params, prompt }
-	},
-}
+    return { ...params, prompt };
+  },
+};
 
 /**
  * Creates an Anthropic model using Claude Max OAuth authentication
  * Uses OAuth tokens from AuthStorage (auto-refreshes when needed)
  */
-export function opencodeClaudeMaxProvider(
-	modelId: string = "claude-sonnet-4-20250514",
-): MastraModelConfig {
-	// Test environment: use API key
-	if (process.env.NODE_ENV === "test" || process.env.VITEST) {
-		const anthropic = createAnthropic({
-			apiKey: process.env.ANTHROPIC_API_KEY || "test-api-key",
-		})
-		return wrapLanguageModel({
-			model: anthropic(modelId),
-			middleware: [claudeCodeMiddleware, promptCacheMiddleware],
-		})
-	}
+export function opencodeClaudeMaxProvider(modelId: string = 'claude-sonnet-4-20250514'): MastraModelConfig {
+  // Test environment: use API key
+  if (process.env.NODE_ENV === 'test' || process.env.VITEST) {
+    const anthropic = createAnthropic({
+      apiKey: process.env.ANTHROPIC_API_KEY || 'test-api-key',
+    });
+    return wrapLanguageModel({
+      model: anthropic(modelId),
+      middleware: [claudeCodeMiddleware, promptCacheMiddleware],
+    });
+  }
 
-	// Custom fetch that handles OAuth
-	const oauthFetch = async (
-		url: string | URL | Request,
-		init?: Parameters<typeof fetch>[1],
-	) => {
-		const authStorage = getAuthStorage()
+  // Custom fetch that handles OAuth
+  const oauthFetch = async (url: string | URL | Request, init?: Parameters<typeof fetch>[1]) => {
+    const authStorage = getAuthStorage();
 
-		// Reload from disk to handle multi-instance refresh
-		authStorage.reload()
+    // Reload from disk to handle multi-instance refresh
+    authStorage.reload();
 
-		// Get access token (auto-refreshes if expired)
-		const accessToken = await authStorage.getApiKey("anthropic")
+    // Get access token (auto-refreshes if expired)
+    const accessToken = await authStorage.getApiKey('anthropic');
 
-		if (!accessToken) {
-			throw new Error("Not logged in to Anthropic. Run /login first.")
-		}
+    if (!accessToken) {
+      throw new Error('Not logged in to Anthropic. Run /login first.');
+    }
 
-		// Make request with OAuth headers
-		return fetch(url, {
-			...init,
-			headers: {
-				Authorization: `Bearer ${accessToken}`,
-				"anthropic-beta":
-					"oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
-				"anthropic-version": "2023-06-01",
-			},
-		})
-	}
+    // Make request with OAuth headers
+    return fetch(url, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'anthropic-beta':
+          'oauth-2025-04-20,claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14',
+        'anthropic-version': '2023-06-01',
+      },
+    });
+  };
 
-	const anthropic = createAnthropic({
-		// Provide a dummy API key - the actual auth is handled via OAuth in oauthFetch
-		// This prevents the SDK from throwing "API key is missing" at model creation time
-		apiKey: "oauth-placeholder",
-		fetch: oauthFetch as any,
-	})
+  const anthropic = createAnthropic({
+    // Provide a dummy API key - the actual auth is handled via OAuth in oauthFetch
+    // This prevents the SDK from throwing "API key is missing" at model creation time
+    apiKey: 'oauth-placeholder',
+    fetch: oauthFetch as any,
+  });
 
-	// Wrap with middleware to inject Claude Code identity and enable prompt caching
-	return wrapLanguageModel({
-		model: anthropic(modelId),
-		middleware: [claudeCodeMiddleware, promptCacheMiddleware],
-	})
+  // Wrap with middleware to inject Claude Code identity and enable prompt caching
+  return wrapLanguageModel({
+    model: anthropic(modelId),
+    middleware: [claudeCodeMiddleware, promptCacheMiddleware],
+  });
 }

--- a/mastracode/src/providers/openai-codex.ts
+++ b/mastracode/src/providers/openai-codex.ts
@@ -8,67 +8,67 @@
  * https://github.com/sst/opencode/blob/main/packages/opencode/src/plugin/codex.ts
  */
 
-import { createOpenAI } from "@ai-sdk/openai"
-import type { MastraModelConfig } from "@mastra/core/llm"
-import { wrapLanguageModel  } from "ai"
-import type {LanguageModelMiddleware} from "ai";
-import { AuthStorage } from "../auth/storage.js"
+import { createOpenAI } from '@ai-sdk/openai';
+import type { MastraModelConfig } from '@mastra/core/llm';
+import { wrapLanguageModel } from 'ai';
+import type { LanguageModelMiddleware } from 'ai';
+import { AuthStorage } from '../auth/storage.js';
 
 // Codex API endpoint (not standard OpenAI API)
-const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
+const CODEX_API_ENDPOINT = 'https://chatgpt.com/backend-api/codex/responses';
 
 // Singleton auth storage instance (shared with claude-max.ts)
-let authStorageInstance: AuthStorage | null = null
+let authStorageInstance: AuthStorage | null = null;
 
 /**
  * Get or create the shared AuthStorage instance
  */
 export function getAuthStorage(): AuthStorage {
-	if (!authStorageInstance) {
-		authStorageInstance = new AuthStorage()
-	}
-	return authStorageInstance
+  if (!authStorageInstance) {
+    authStorageInstance = new AuthStorage();
+  }
+  return authStorageInstance;
 }
 
 /**
  * Set a custom AuthStorage instance (useful for TUI integration)
  */
 export function setAuthStorage(storage: AuthStorage): void {
-	authStorageInstance = storage
+  authStorageInstance = storage;
 }
 
 // Default instructions for Codex API (required)
 const CODEX_INSTRUCTIONS = `You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
 
-IMPORTANT: You should be concise, direct, and helpful. Focus on solving the user's problem efficiently.`
+IMPORTANT: You should be concise, direct, and helpful. Focus on solving the user's problem efficiently.`;
 
 /**
  * Middleware for OpenAI Codex - handles any special transformations needed
  */
 const openaiCodexMiddleware: LanguageModelMiddleware = {
-	specificationVersion: "v3",
-	transformParams: async ({ params }) => {
-		// Remove topP if temperature is set (OpenAI doesn't like both)
-		if (params.temperature) {
-			delete params.topP
-		}
+  specificationVersion: 'v3',
+  transformParams: async ({ params }) => {
+    // Remove topP if temperature is set (OpenAI doesn't like both)
+    if (params.temperature) {
+      delete params.topP;
+    }
 
-		// Codex API requires specific settings via providerOptions
-		// Use type assertion to satisfy JSONValue constraints
-		params.providerOptions = {
-			...params.providerOptions,
-			openai: {
-				...(params.providerOptions?.openai ?? {}),
-				// Codex API requires instructions
-				instructions: CODEX_INSTRUCTIONS,
-				// Codex API requires store to be false
-				store: false,
-			},
-		} as typeof params.providerOptions
+    // Codex API requires specific settings via providerOptions
+    // Use type assertion to satisfy JSONValue constraints
+    params.providerOptions = {
+      ...params.providerOptions,
+      openai: {
+        ...(params.providerOptions?.openai ?? {}),
+        // Codex API requires instructions
+        instructions: CODEX_INSTRUCTIONS,
+        // Codex API requires store to be false
+        store: false,
+      },
+    } as typeof params.providerOptions;
 
-		return params
-	},
-}
+    return params;
+  },
+};
 
 /**
  * Creates an OpenAI model using ChatGPT OAuth authentication
@@ -77,114 +77,102 @@ const openaiCodexMiddleware: LanguageModelMiddleware = {
  * IMPORTANT: This uses the Codex API endpoint, not the standard OpenAI API.
  * URLs are rewritten from /v1/responses or /chat/completions to the Codex endpoint.
  */
-export function openaiCodexProvider(
-	modelId: string = "codex-mini-latest",
-): MastraModelConfig {
-	// Test environment: use API key
-	if (process.env.NODE_ENV === "test" || process.env.VITEST) {
-		const openai = createOpenAI({
-			apiKey: process.env.OPENAI_API_KEY || "test-api-key",
-		})
-		return wrapLanguageModel({
-			model: openai.responses(modelId),
-			middleware: [openaiCodexMiddleware],
-		})
-	}
+export function openaiCodexProvider(modelId: string = 'codex-mini-latest'): MastraModelConfig {
+  // Test environment: use API key
+  if (process.env.NODE_ENV === 'test' || process.env.VITEST) {
+    const openai = createOpenAI({
+      apiKey: process.env.OPENAI_API_KEY || 'test-api-key',
+    });
+    return wrapLanguageModel({
+      model: openai.responses(modelId),
+      middleware: [openaiCodexMiddleware],
+    });
+  }
 
-	// Custom fetch that handles OAuth and URL rewriting
-	const oauthFetch = async (
-		url: string | URL | Request,
-		init?: Parameters<typeof fetch>[1],
-	) => {
-		const authStorage = getAuthStorage()
+  // Custom fetch that handles OAuth and URL rewriting
+  const oauthFetch = async (url: string | URL | Request, init?: Parameters<typeof fetch>[1]) => {
+    const authStorage = getAuthStorage();
 
-		// Reload from disk to handle multi-instance refresh
-		authStorage.reload()
+    // Reload from disk to handle multi-instance refresh
+    authStorage.reload();
 
-		// Get credentials (includes accountId)
-		const cred = authStorage.get("openai-codex")
+    // Get credentials (includes accountId)
+    const cred = authStorage.get('openai-codex');
 
-		if (!cred || cred.type !== "oauth") {
-			throw new Error("Not logged in to OpenAI Codex. Run /login first.")
-		}
+    if (!cred || cred.type !== 'oauth') {
+      throw new Error('Not logged in to OpenAI Codex. Run /login first.');
+    }
 
-		// Check if token needs refresh
-		let accessToken = cred.access
-		if (Date.now() >= cred.expires) {
-			// Token expired, need to refresh via getApiKey which handles refresh
-			const refreshedToken = await authStorage.getApiKey("openai-codex")
-			if (!refreshedToken) {
-				throw new Error(
-					"Failed to refresh OpenAI Codex token. Please /login again.",
-				)
-			}
-			accessToken = refreshedToken
-			// Reload to get updated accountId
-			authStorage.reload()
-		}
+    // Check if token needs refresh
+    let accessToken = cred.access;
+    if (Date.now() >= cred.expires) {
+      // Token expired, need to refresh via getApiKey which handles refresh
+      const refreshedToken = await authStorage.getApiKey('openai-codex');
+      if (!refreshedToken) {
+        throw new Error('Failed to refresh OpenAI Codex token. Please /login again.');
+      }
+      accessToken = refreshedToken;
+      // Reload to get updated accountId
+      authStorage.reload();
+    }
 
-		// Get accountId from credentials
-		const accountId = (cred as any).accountId as string | undefined
+    // Get accountId from credentials
+    const accountId = (cred as any).accountId as string | undefined;
 
-		// Build headers - remove any existing authorization header first
-		const headers = new Headers()
-		if (init?.headers) {
-			if (init.headers instanceof Headers) {
-				init.headers.forEach((value, key) => {
-					if (key.toLowerCase() !== "authorization") {
-						headers.set(key, value)
-					}
-				})
-            } else if (Array.isArray(init.headers)) {
-                for (const [key, value] of init.headers) {
-                    if (key!.toLowerCase() !== "authorization" && value !== undefined) {
-                        headers.set(key!, String(value))
-                    }
-                }
-            } else {
-				for (const [key, value] of Object.entries(init.headers)) {
-					if (key.toLowerCase() !== "authorization" && value !== undefined) {
-						headers.set(key, String(value))
-					}
-				}
-			}
-		}
+    // Build headers - remove any existing authorization header first
+    const headers = new Headers();
+    if (init?.headers) {
+      if (init.headers instanceof Headers) {
+        init.headers.forEach((value, key) => {
+          if (key.toLowerCase() !== 'authorization') {
+            headers.set(key, value);
+          }
+        });
+      } else if (Array.isArray(init.headers)) {
+        for (const [key, value] of init.headers) {
+          if (key!.toLowerCase() !== 'authorization' && value !== undefined) {
+            headers.set(key!, String(value));
+          }
+        }
+      } else {
+        for (const [key, value] of Object.entries(init.headers)) {
+          if (key.toLowerCase() !== 'authorization' && value !== undefined) {
+            headers.set(key, String(value));
+          }
+        }
+      }
+    }
 
-		// Set authorization header with access token
-		headers.set("Authorization", `Bearer ${accessToken}`)
+    // Set authorization header with access token
+    headers.set('Authorization', `Bearer ${accessToken}`);
 
-		// Set ChatGPT-Account-Id header for organization subscriptions
-		if (accountId) {
-			headers.set("ChatGPT-Account-Id", accountId)
-		}
+    // Set ChatGPT-Account-Id header for organization subscriptions
+    if (accountId) {
+      headers.set('ChatGPT-Account-Id', accountId);
+    }
 
-		// Rewrite URL to Codex endpoint if it's a chat/responses request
-		const parsed =
-			url instanceof URL
-				? url
-				: new URL(typeof url === "string" ? url : (url as Request).url)
+    // Rewrite URL to Codex endpoint if it's a chat/responses request
+    const parsed = url instanceof URL ? url : new URL(typeof url === 'string' ? url : (url as Request).url);
 
-		const shouldRewrite =
-			parsed.pathname.includes("/v1/responses") ||
-			parsed.pathname.includes("/chat/completions")
-		const finalUrl = shouldRewrite ? new URL(CODEX_API_ENDPOINT) : parsed
+    const shouldRewrite = parsed.pathname.includes('/v1/responses') || parsed.pathname.includes('/chat/completions');
+    const finalUrl = shouldRewrite ? new URL(CODEX_API_ENDPOINT) : parsed;
 
-		return fetch(finalUrl, {
-			...init,
-			headers,
-		})
-	}
+    return fetch(finalUrl, {
+      ...init,
+      headers,
+    });
+  };
 
-	const openai = createOpenAI({
-		// Use a dummy API key since we're using OAuth
-		apiKey: "oauth-dummy-key",
-		fetch: oauthFetch as any,
-	})
+  const openai = createOpenAI({
+    // Use a dummy API key since we're using OAuth
+    apiKey: 'oauth-dummy-key',
+    fetch: oauthFetch as any,
+  });
 
-	// Use the responses API for Codex models
-	// Wrap with middleware
-	return wrapLanguageModel({
-		model: openai.responses(modelId),
-		middleware: [openaiCodexMiddleware],
-	})
+  // Use the responses API for Codex models
+  // Wrap with middleware
+  return wrapLanguageModel({
+    model: openai.responses(modelId),
+    middleware: [openaiCodexMiddleware],
+  });
 }

--- a/mastracode/src/providers/openai-codex.ts
+++ b/mastracode/src/providers/openai-codex.ts
@@ -135,13 +135,13 @@ export function openaiCodexProvider(
 						headers.set(key, value)
 					}
 				})
-			} else if (Array.isArray(init.headers)) {
-				for (const [key, value] of init.headers) {
-					if (key.toLowerCase() !== "authorization" && value !== undefined) {
-						headers.set(key, String(value))
-					}
-				}
-			} else {
+            } else if (Array.isArray(init.headers)) {
+                for (const [key, value] of init.headers) {
+                    if (key!.toLowerCase() !== "authorization" && value !== undefined) {
+                        headers.set(key!, String(value))
+                    }
+                }
+            } else {
 				for (const [key, value] of Object.entries(init.headers)) {
 					if (key.toLowerCase() !== "authorization" && value !== undefined) {
 						headers.set(key, String(value))

--- a/mastracode/src/schema.ts
+++ b/mastracode/src/schema.ts
@@ -25,7 +25,7 @@ export const stateSchema = z.object({
             categories: z.record(z.string(), z.enum(["allow", "ask", "deny"])).default({}),
             tools: z.record(z.string(), z.enum(["allow", "ask", "deny"])).default({}),
         })
-        .default({}),
+        .default({ categories: {}, tools: {} }),
     // Smart editing mode — use AST-based analysis for code edits
     smartEditing: z.boolean().default(true),
     // Notification mode — alert when TUI needs user attention

--- a/mastracode/src/schema.ts
+++ b/mastracode/src/schema.ts
@@ -1,54 +1,54 @@
-import { z } from "zod";
-import { DEFAULT_OM_MODEL_ID } from "./constants";
+import { z } from 'zod';
+import { DEFAULT_OM_MODEL_ID } from './constants';
 
 export const stateSchema = z.object({
-    projectPath: z.string().optional(),
-    projectName: z.string().optional(),
-    gitBranch: z.string().optional(),
-    lastCommand: z.string().optional(),
-    currentModelId: z.string().default(""),
-    // Subagent model settings (per-thread/per-mode)
-    subagentModelId: z.string().optional(), // Thread-level default for subagents
-    // Observational Memory model settings
-    observerModelId: z.string().default(DEFAULT_OM_MODEL_ID),
-    reflectorModelId: z.string().default(DEFAULT_OM_MODEL_ID),
-    // Observational Memory threshold settings
-    observationThreshold: z.number().default(30_000),
-    reflectionThreshold: z.number().default(40_000),
-    // Thinking level for extended thinking (Anthropic models)
-    thinkingLevel: z.string().default("off"),
-    // YOLO mode — auto-approve all tool calls
-    yolo: z.boolean().default(false),
-    // Permission rules — per-category and per-tool approval policies
-    permissionRules: z
-        .object({
-            categories: z.record(z.string(), z.enum(["allow", "ask", "deny"])).default({}),
-            tools: z.record(z.string(), z.enum(["allow", "ask", "deny"])).default({}),
-        })
-        .default({ categories: {}, tools: {} }),
-    // Smart editing mode — use AST-based analysis for code edits
-    smartEditing: z.boolean().default(true),
-    // Notification mode — alert when TUI needs user attention
-    notifications: z.enum(["bell", "system", "both", "off"]).default("off"),
-    // Todo list (persisted per-thread)
-    todos: z
-        .array(
-            z.object({
-                content: z.string(),
-                status: z.enum(["pending", "in_progress", "completed"]),
-                activeForm: z.string(),
-            }),
-        )
-        .default([]),
-    // Sandbox allowed paths (per-thread, absolute paths allowed in addition to project root)
-    sandboxAllowedPaths: z.array(z.string()).default([]),
-    // Active plan (set when a plan is approved in Plan mode)
-    activePlan: z
-        .object({
-            title: z.string(),
-            plan: z.string(),
-            approvedAt: z.string(),
-        })
-        .nullable()
-        .default(null),
-})
+  projectPath: z.string().optional(),
+  projectName: z.string().optional(),
+  gitBranch: z.string().optional(),
+  lastCommand: z.string().optional(),
+  currentModelId: z.string().default(''),
+  // Subagent model settings (per-thread/per-mode)
+  subagentModelId: z.string().optional(), // Thread-level default for subagents
+  // Observational Memory model settings
+  observerModelId: z.string().default(DEFAULT_OM_MODEL_ID),
+  reflectorModelId: z.string().default(DEFAULT_OM_MODEL_ID),
+  // Observational Memory threshold settings
+  observationThreshold: z.number().default(30_000),
+  reflectionThreshold: z.number().default(40_000),
+  // Thinking level for extended thinking (Anthropic models)
+  thinkingLevel: z.string().default('off'),
+  // YOLO mode — auto-approve all tool calls
+  yolo: z.boolean().default(false),
+  // Permission rules — per-category and per-tool approval policies
+  permissionRules: z
+    .object({
+      categories: z.record(z.string(), z.enum(['allow', 'ask', 'deny'])).default({}),
+      tools: z.record(z.string(), z.enum(['allow', 'ask', 'deny'])).default({}),
+    })
+    .default({ categories: {}, tools: {} }),
+  // Smart editing mode — use AST-based analysis for code edits
+  smartEditing: z.boolean().default(true),
+  // Notification mode — alert when TUI needs user attention
+  notifications: z.enum(['bell', 'system', 'both', 'off']).default('off'),
+  // Todo list (persisted per-thread)
+  todos: z
+    .array(
+      z.object({
+        content: z.string(),
+        status: z.enum(['pending', 'in_progress', 'completed']),
+        activeForm: z.string(),
+      }),
+    )
+    .default([]),
+  // Sandbox allowed paths (per-thread, absolute paths allowed in addition to project root)
+  sandboxAllowedPaths: z.array(z.string()).default([]),
+  // Active plan (set when a plan is approved in Plan mode)
+  activePlan: z
+    .object({
+      title: z.string(),
+      plan: z.string(),
+      approvedAt: z.string(),
+    })
+    .nullable()
+    .default(null),
+});

--- a/mastracode/src/tools/__tests__/file-editor.test.ts
+++ b/mastracode/src/tools/__tests__/file-editor.test.ts
@@ -1,215 +1,187 @@
-import * as fs from "node:fs"
-import * as path from "node:path"
-import { describe, it, expect, afterAll, afterEach } from "vitest"
-import { sharedFileEditor } from "../file-editor.js"
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, it, expect, afterAll, afterEach } from 'vitest';
+import { sharedFileEditor } from '../file-editor.js';
 
-const projectRoot = path.resolve(import.meta.dirname, "../../..")
-const tmpDir = path.join(projectRoot, ".test-tmp-editor")
+const projectRoot = path.resolve(import.meta.dirname, '../../..');
+const tmpDir = path.join(projectRoot, '.test-tmp-editor');
 
 function tmpFile(name: string): string {
-	return path.join(tmpDir, name)
+  return path.join(tmpDir, name);
 }
 
 function writeTmpFile(name: string, content: string): string {
-	const filePath = tmpFile(name)
-	fs.mkdirSync(path.dirname(filePath), { recursive: true })
-	fs.writeFileSync(filePath, content, "utf-8")
-	return filePath
+  const filePath = tmpFile(name);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf-8');
+  return filePath;
 }
 
 afterEach(() => {
-	if (fs.existsSync(tmpDir)) {
-		fs.rmSync(tmpDir, { recursive: true })
-	}
-})
+  if (fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true });
+  }
+});
 
 afterAll(() => {
-	if (fs.existsSync(tmpDir)) {
-		fs.rmSync(tmpDir, { recursive: true })
-	}
-})
+  if (fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true });
+  }
+});
 
-describe("FileEditor.strReplace whitespace-agnostic matching", () => {
-	it("matches when old_str uses spaces but file uses tabs", async () => {
-		const filePath = writeTmpFile(
-			"tabs-vs-spaces.ts",
-			`function hello() {\n\tconst x = 1\n\tconst y = 2\n\treturn x + y\n}\n`,
-		)
+describe('FileEditor.strReplace whitespace-agnostic matching', () => {
+  it('matches when old_str uses spaces but file uses tabs', async () => {
+    const filePath = writeTmpFile(
+      'tabs-vs-spaces.ts',
+      `function hello() {\n\tconst x = 1\n\tconst y = 2\n\treturn x + y\n}\n`,
+    );
 
-		const result = await sharedFileEditor.strReplace({
-			path: filePath,
-			old_str: `function hello() {\n    const x = 1\n    const y = 2\n    return x + y\n}`,
-			new_str: `function hello() {\n\tconst x = 10\n\tconst y = 20\n\treturn x + y\n}`,
-		})
+    const result = await sharedFileEditor.strReplace({
+      path: filePath,
+      old_str: `function hello() {\n    const x = 1\n    const y = 2\n    return x + y\n}`,
+      new_str: `function hello() {\n\tconst x = 10\n\tconst y = 20\n\treturn x + y\n}`,
+    });
 
-		expect(result).toContain("has been edited")
-		const content = fs.readFileSync(filePath, "utf-8")
-		expect(content).toContain("const x = 10")
-		expect(content).toContain("const y = 20")
-	})
+    expect(result).toContain('has been edited');
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('const x = 10');
+    expect(content).toContain('const y = 20');
+  });
 
-	it("matches multi-line blocks with mixed indentation (tabs in file, spaces in old_str)", async () => {
-		const filePath = writeTmpFile(
-			"mixed-indent.ts",
-			[
-				"\tprivate renderTodos(",
-				"\t\ttodos: TodoItem[],",
-				"\t\tinsertIndex = -1,",
-				"\t): void {",
-				"\t\tconst MAX_VISIBLE = 4",
-				"\t\tconst visible = todos.slice(0, MAX_VISIBLE)",
-				"",
-				"\t\tif (insertIndex >= 0) {",
-				"\t\t\tthis.container.splice(insertIndex, 0)",
-				"\t\t} else {",
-				"\t\t\tthis.container.push()",
-				"\t\t}",
-				"\t}",
-				"",
-			].join("\n"),
-		)
+  it('matches multi-line blocks with mixed indentation (tabs in file, spaces in old_str)', async () => {
+    const filePath = writeTmpFile(
+      'mixed-indent.ts',
+      [
+        '\tprivate renderTodos(',
+        '\t\ttodos: TodoItem[],',
+        '\t\tinsertIndex = -1,',
+        '\t): void {',
+        '\t\tconst MAX_VISIBLE = 4',
+        '\t\tconst visible = todos.slice(0, MAX_VISIBLE)',
+        '',
+        '\t\tif (insertIndex >= 0) {',
+        '\t\t\tthis.container.splice(insertIndex, 0)',
+        '\t\t} else {',
+        '\t\t\tthis.container.push()',
+        '\t\t}',
+        '\t}',
+        '',
+      ].join('\n'),
+    );
 
-		const result = await sharedFileEditor.strReplace({
-			path: filePath,
-			old_str: [
-				"    private renderTodos(",
-				"        todos: TodoItem[],",
-				"        insertIndex = -1,",
-				"    ): void {",
-				"        const MAX_VISIBLE = 4",
-				"        const visible = todos.slice(0, MAX_VISIBLE)",
-				"",
-				"        if (insertIndex >= 0) {",
-			].join("\n"),
-			new_str: [
-				"\tprivate renderTodos(",
-				"\t\ttodos: TodoItem[],",
-				"\t\tinsertIndex = -1,",
-				"\t\tcollapsed = false,",
-				"\t): void {",
-				"\t\tconst MAX_VISIBLE = 4",
-				"\t\tconst visible = collapsed ? todos.slice(0, MAX_VISIBLE) : todos",
-				"",
-				"\t\tif (insertIndex >= 0) {",
-			].join("\n"),
-		})
+    const result = await sharedFileEditor.strReplace({
+      path: filePath,
+      old_str: [
+        '    private renderTodos(',
+        '        todos: TodoItem[],',
+        '        insertIndex = -1,',
+        '    ): void {',
+        '        const MAX_VISIBLE = 4',
+        '        const visible = todos.slice(0, MAX_VISIBLE)',
+        '',
+        '        if (insertIndex >= 0) {',
+      ].join('\n'),
+      new_str: [
+        '\tprivate renderTodos(',
+        '\t\ttodos: TodoItem[],',
+        '\t\tinsertIndex = -1,',
+        '\t\tcollapsed = false,',
+        '\t): void {',
+        '\t\tconst MAX_VISIBLE = 4',
+        '\t\tconst visible = collapsed ? todos.slice(0, MAX_VISIBLE) : todos',
+        '',
+        '\t\tif (insertIndex >= 0) {',
+      ].join('\n'),
+    });
 
-		expect(result).toContain("has been edited")
-		const content = fs.readFileSync(filePath, "utf-8")
-		expect(content).toContain("collapsed = false")
-		expect(content).toContain("collapsed ? todos.slice")
-	})
+    expect(result).toContain('has been edited');
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('collapsed = false');
+    expect(content).toContain('collapsed ? todos.slice');
+  });
 
-	it("matches when old_str has different amounts of whitespace than file", async () => {
-		const filePath = writeTmpFile(
-			"extra-spaces.ts",
-			`if (  x  ===  true  ) {\n    doSomething()\n}\n`,
-		)
+  it('matches when old_str has different amounts of whitespace than file', async () => {
+    const filePath = writeTmpFile('extra-spaces.ts', `if (  x  ===  true  ) {\n    doSomething()\n}\n`);
 
-		const result = await sharedFileEditor.strReplace({
-			path: filePath,
-			old_str: `if (x === true) {\n    doSomething()\n}`,
-			new_str: `if (x === false) {\n    doSomething()\n}`,
-		})
+    const result = await sharedFileEditor.strReplace({
+      path: filePath,
+      old_str: `if (x === true) {\n    doSomething()\n}`,
+      new_str: `if (x === false) {\n    doSomething()\n}`,
+    });
 
-		expect(result).toContain("has been edited")
-		const content = fs.readFileSync(filePath, "utf-8")
-		expect(content).toContain("false")
-	})
+    expect(result).toContain('has been edited');
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('false');
+  });
 
-	it("exact match still takes priority over whitespace-normalized match", async () => {
-		const filePath = writeTmpFile(
-			"exact-priority.ts",
-			`const a = 1\nconst b = 2\nconst c = 3\n`,
-		)
+  it('exact match still takes priority over whitespace-normalized match', async () => {
+    const filePath = writeTmpFile('exact-priority.ts', `const a = 1\nconst b = 2\nconst c = 3\n`);
 
-		const result = await sharedFileEditor.strReplace({
-			path: filePath,
-			old_str: `const b = 2`,
-			new_str: `const b = 99`,
-		})
+    const result = await sharedFileEditor.strReplace({
+      path: filePath,
+      old_str: `const b = 2`,
+      new_str: `const b = 99`,
+    });
 
-		expect(result).toContain("has been edited")
-		const content = fs.readFileSync(filePath, "utf-8")
-		expect(content).toContain("const b = 99")
-		// Other lines untouched
-		expect(content).toContain("const a = 1")
-		expect(content).toContain("const c = 3")
-	})
-	it("uses new_str as-is without reindenting when whitespace-agnostic match", async () => {
-		// File uses tabs
-		const filePath = writeTmpFile(
-			"no-reindent.ts",
-			[
-				"class Foo {",
-				"\tprivate bar() {",
-				"\t\tconst x = 1",
-				"\t\treturn x",
-				"\t}",
-				"}",
-				"",
-			].join("\n"),
-		)
+    expect(result).toContain('has been edited');
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('const b = 99');
+    // Other lines untouched
+    expect(content).toContain('const a = 1');
+    expect(content).toContain('const c = 3');
+  });
+  it('uses new_str as-is without reindenting when whitespace-agnostic match', async () => {
+    // File uses tabs
+    const filePath = writeTmpFile(
+      'no-reindent.ts',
+      ['class Foo {', '\tprivate bar() {', '\t\tconst x = 1', '\t\treturn x', '\t}', '}', ''].join('\n'),
+    );
 
-		// old_str uses spaces (won't exact-match), new_str uses tabs
-		const result = await sharedFileEditor.strReplace({
-			path: filePath,
-			old_str: [
-				"    private bar() {",
-				"        const x = 1",
-				"        return x",
-				"    }",
-			].join("\n"),
-			new_str: [
-				"\tprivate bar() {",
-				"\t\tconst x = 1",
-				"\t\tconst y = 2",
-				"\t\treturn x + y",
-				"\t}",
-			].join("\n"),
-		})
+    // old_str uses spaces (won't exact-match), new_str uses tabs
+    const result = await sharedFileEditor.strReplace({
+      path: filePath,
+      old_str: ['    private bar() {', '        const x = 1', '        return x', '    }'].join('\n'),
+      new_str: ['\tprivate bar() {', '\t\tconst x = 1', '\t\tconst y = 2', '\t\treturn x + y', '\t}'].join('\n'),
+    });
 
-		expect(result).toContain("has been edited")
-		const content = fs.readFileSync(filePath, "utf-8")
-		// new_str used as-is (tabs)
-		expect(content).toContain("\t\tconst y = 2")
-		expect(content).toContain("\t\treturn x + y")
-	})
+    expect(result).toContain('has been edited');
+    const content = fs.readFileSync(filePath, 'utf-8');
+    // new_str used as-is (tabs)
+    expect(content).toContain('\t\tconst y = 2');
+    expect(content).toContain('\t\treturn x + y');
+  });
 
-	it("handles a realistic 30+ line block with tab/space mismatch", async () => {
-		// Simulate a real file with tabs
-		const fileLines: string[] = []
-		for (let i = 0; i < 50; i++) {
-			fileLines.push(`\tline${i}: ${i},`)
-		}
-		const filePath = writeTmpFile(
-			"large-block.ts",
-			`const obj = {\n${fileLines.join("\n")}\n}\n`,
-		)
+  it('handles a realistic 30+ line block with tab/space mismatch', async () => {
+    // Simulate a real file with tabs
+    const fileLines: string[] = [];
+    for (let i = 0; i < 50; i++) {
+      fileLines.push(`\tline${i}: ${i},`);
+    }
+    const filePath = writeTmpFile('large-block.ts', `const obj = {\n${fileLines.join('\n')}\n}\n`);
 
-		// old_str with spaces instead of tabs, targeting lines 10-40
-		const oldLines: string[] = []
-		for (let i = 10; i < 40; i++) {
-			oldLines.push(`    line${i}: ${i},`)
-		}
+    // old_str with spaces instead of tabs, targeting lines 10-40
+    const oldLines: string[] = [];
+    for (let i = 10; i < 40; i++) {
+      oldLines.push(`    line${i}: ${i},`);
+    }
 
-		const newLines: string[] = []
-		for (let i = 10; i < 40; i++) {
-			newLines.push(`\tline${i}: ${i * 10},`)
-		}
+    const newLines: string[] = [];
+    for (let i = 10; i < 40; i++) {
+      newLines.push(`\tline${i}: ${i * 10},`);
+    }
 
-		const result = await sharedFileEditor.strReplace({
-			path: filePath,
-			old_str: oldLines.join("\n"),
-			new_str: newLines.join("\n"),
-		})
+    const result = await sharedFileEditor.strReplace({
+      path: filePath,
+      old_str: oldLines.join('\n'),
+      new_str: newLines.join('\n'),
+    });
 
-		expect(result).toContain("has been edited")
-		const content = fs.readFileSync(filePath, "utf-8")
-		expect(content).toContain("line10: 100,")
-		expect(content).toContain("line39: 390,")
-		// Untouched lines
-		expect(content).toContain("line0: 0,")
-		expect(content).toContain("line49: 49,")
-	})
-})
+    expect(result).toContain('has been edited');
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('line10: 100,');
+    expect(content).toContain('line39: 390,');
+    // Untouched lines
+    expect(content).toContain('line0: 0,');
+    expect(content).toContain('line49: 49,');
+  });
+});

--- a/mastracode/src/tools/ask-user.ts
+++ b/mastracode/src/tools/ask-user.ts
@@ -4,70 +4,58 @@
  * The tool pauses execution while the dialog is shown.
  */
 
-import { createTool } from "@mastra/core/tools"
-import { z } from "zod/v3"
-import type { HarnessRuntimeContext } from "../harness/types.js"
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod/v3';
+import type { HarnessRuntimeContext } from '../harness/types.js';
 
-let questionCounter = 0
+let questionCounter = 0;
 
 export const askUserTool = createTool({
-	id: "ask_user",
-	description: `Ask the user a question and wait for their response. Use this when you need clarification, want to validate assumptions, or need the user to make a decision between options. Provide options for structured choices (2-4 options), or omit them for open-ended questions.`,
-	inputSchema: z.object({
-		question: z
-			.string()
-			.min(1)
-			.describe("The question to ask the user. Should be clear and specific."),
-		options: z
-			.array(
-				z.object({
-					label: z
-						.string()
-						.describe("Short display text for this option (1-5 words)"),
-					description: z
-						.string()
-						.optional()
-						.describe("Explanation of what this option means"),
-				}),
-			)
-			.optional()
-			.describe(
-				"Optional choices. If provided, shows a selection list. If omitted, shows a free-text input.",
-			),
-	}),
-	execute: async ({ question, options }, context) => {
-		try {
-			const harnessCtx = context?.requestContext?.get("harness") as
-				| HarnessRuntimeContext
-				| undefined
+  id: 'ask_user',
+  description: `Ask the user a question and wait for their response. Use this when you need clarification, want to validate assumptions, or need the user to make a decision between options. Provide options for structured choices (2-4 options), or omit them for open-ended questions.`,
+  inputSchema: z.object({
+    question: z.string().min(1).describe('The question to ask the user. Should be clear and specific.'),
+    options: z
+      .array(
+        z.object({
+          label: z.string().describe('Short display text for this option (1-5 words)'),
+          description: z.string().optional().describe('Explanation of what this option means'),
+        }),
+      )
+      .optional()
+      .describe('Optional choices. If provided, shows a selection list. If omitted, shows a free-text input.'),
+  }),
+  execute: async ({ question, options }, context) => {
+    try {
+      const harnessCtx = context?.requestContext?.get('harness') as HarnessRuntimeContext | undefined;
 
-			if (!harnessCtx?.emitEvent || !harnessCtx?.registerQuestion) {
-				return {
-					content: `[Question for user]: ${question}${options ? "\nOptions: " + options.map((o) => o.label).join(", ") : ""}`,
-					isError: false,
-				}
-			}
+      if (!harnessCtx?.emitEvent || !harnessCtx?.registerQuestion) {
+        return {
+          content: `[Question for user]: ${question}${options ? '\nOptions: ' + options.map(o => o.label).join(', ') : ''}`,
+          isError: false,
+        };
+      }
 
-			const questionId = `q_${++questionCounter}_${Date.now()}`
+      const questionId = `q_${++questionCounter}_${Date.now()}`;
 
-			// Create a promise that resolves when the user answers in the TUI
-			const answer = await new Promise<string>((resolve) => {
-				// Register the resolver so respondToQuestion() can resolve it
-				harnessCtx.registerQuestion!(questionId, resolve)
+      // Create a promise that resolves when the user answers in the TUI
+      const answer = await new Promise<string>(resolve => {
+        // Register the resolver so respondToQuestion() can resolve it
+        harnessCtx.registerQuestion!(questionId, resolve);
 
-				// Emit event — TUI will show the dialog
-				harnessCtx.emitEvent!({
-					type: "ask_question",
-					questionId,
-					question,
-					options,
-				} as any)
-			})
+        // Emit event — TUI will show the dialog
+        harnessCtx.emitEvent!({
+          type: 'ask_question',
+          questionId,
+          question,
+          options,
+        } as any);
+      });
 
-			return { content: `User answered: ${answer}`, isError: false }
-		} catch (error) {
-			const msg = error instanceof Error ? error.message : "Unknown error"
-			return { content: `Failed to ask user: ${msg}`, isError: true }
-		}
-	},
-})
+      return { content: `User answered: ${answer}`, isError: false };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      return { content: `Failed to ask user: ${msg}`, isError: true };
+    }
+  },
+});

--- a/mastracode/src/tools/ast-smart-edit.ts
+++ b/mastracode/src/tools/ast-smart-edit.ts
@@ -1,58 +1,40 @@
-import { readFileSync, writeFileSync } from "node:fs"
-import { resolve } from "node:path"
-import { parse, Lang } from "@ast-grep/napi"
-import { createTool } from "@mastra/core/tools"
-import { z } from "zod/v3"
-import { assertPathAllowed, getAllowedPathsFromContext } from "./utils.js"
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parse, Lang } from '@ast-grep/napi';
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod/v3';
+import { assertPathAllowed, getAllowedPathsFromContext } from './utils.js';
 
 // Get the project root from the working directory
-const getProjectRoot = () => process.cwd()
+const getProjectRoot = () => process.cwd();
 
 const astSmartEditSchema = z.object({
-	path: z.string().describe("File path relative to project root"),
-	pattern: z
-		.string()
-		.optional()
-		.describe("AST pattern to search for (supports $VARIABLE placeholders)"),
-	replacement: z
-		.string()
-		.optional()
-		.describe("Replacement pattern (can use captured $VARIABLES)"),
-	selector: z
-		.string()
-		.optional()
-		.describe(
-			'CSS-like selector for AST nodes (e.g., "FunctionDeclaration", "CallExpression[callee.name=console]")',
-		),
-	transform: z
-		.enum([
-			"add-import",
-			"remove-import",
-			"rename-function",
-			"rename-variable",
-			"extract-function",
-			"inline-variable",
-		])
-		.optional()
-		.describe("Type of transformation to apply"),
-	targetName: z
-		.string()
-		.optional()
-		.describe("Name of the target element (for rename operations)"),
-	newName: z.string().optional().describe("New name (for rename operations)"),
-	importSpec: z
-		.object({
-			module: z.string(),
-			names: z.array(z.string()),
-			isDefault: z.boolean().optional(),
-		})
-		.optional()
-		.describe("Import specification for add-import transform"),
-})
+  path: z.string().describe('File path relative to project root'),
+  pattern: z.string().optional().describe('AST pattern to search for (supports $VARIABLE placeholders)'),
+  replacement: z.string().optional().describe('Replacement pattern (can use captured $VARIABLES)'),
+  selector: z
+    .string()
+    .optional()
+    .describe('CSS-like selector for AST nodes (e.g., "FunctionDeclaration", "CallExpression[callee.name=console]")'),
+  transform: z
+    .enum(['add-import', 'remove-import', 'rename-function', 'rename-variable', 'extract-function', 'inline-variable'])
+    .optional()
+    .describe('Type of transformation to apply'),
+  targetName: z.string().optional().describe('Name of the target element (for rename operations)'),
+  newName: z.string().optional().describe('New name (for rename operations)'),
+  importSpec: z
+    .object({
+      module: z.string(),
+      names: z.array(z.string()),
+      isDefault: z.boolean().optional(),
+    })
+    .optional()
+    .describe('Import specification for add-import transform'),
+});
 
 export const astSmartEditTool = createTool({
-	id: "ast_smart_edit",
-	description: `Edit code using AST-based analysis for intelligent transformations.
+  id: 'ast_smart_edit',
+  description: `Edit code using AST-based analysis for intelligent transformations.
     
 Supports various code transformations:
 - Pattern-based search and replace with syntax awareness
@@ -65,434 +47,402 @@ Examples:
 - Add import: { transform: 'add-import', importSpec: { module: 'react', names: ['useState'] } }
 - Rename function: { transform: 'rename-function', targetName: 'oldFunc', newName: 'newFunc' }
 - Pattern replace: { pattern: 'console.log($ARG)', replacement: 'logger.debug($ARG)' }`,
-	// requireApproval: true,
-	inputSchema: astSmartEditSchema,
-	execute: async (
-		{
-			path,
-			pattern,
-			replacement,
-			selector,
-			transform,
-			targetName,
-			newName,
-			importSpec,
-		},
-		toolContext,
-	) => {
-		try {
-			const projectRoot = getProjectRoot()
-			const filePath = resolve(projectRoot, path)
+  // requireApproval: true,
+  inputSchema: astSmartEditSchema,
+  execute: async (
+    { path, pattern, replacement, selector, transform, targetName, newName, importSpec },
+    toolContext,
+  ) => {
+    try {
+      const projectRoot = getProjectRoot();
+      const filePath = resolve(projectRoot, path);
 
-			// Security: ensure the path is within the project root or allowed paths
-			const allowedPaths = getAllowedPathsFromContext(toolContext)
-			assertPathAllowed(filePath, projectRoot, allowedPaths)
+      // Security: ensure the path is within the project root or allowed paths
+      const allowedPaths = getAllowedPathsFromContext(toolContext);
+      assertPathAllowed(filePath, projectRoot, allowedPaths);
 
-			// Read the file
-			const content = readFileSync(filePath, "utf-8")
+      // Read the file
+      const content = readFileSync(filePath, 'utf-8');
 
-			// Determine the language from file extension
-			const lang = getLanguageFromPath(path)
+      // Determine the language from file extension
+      const lang = getLanguageFromPath(path);
 
-			// Parse the AST
-			const ast = parse(lang, content)
-			const root = ast.root()
+      // Parse the AST
+      const ast = parse(lang, content);
+      const root = ast.root();
 
-			let modifiedContent = content
-			let changes: string[] = []
+      let modifiedContent = content;
+      let changes: string[] = [];
 
-			// Handle different transformation types
-			if (transform) {
-				switch (transform) {
-					case "add-import":
-						if (!importSpec) {
-							throw new Error("importSpec is required for add-import transform")
-						}
-						modifiedContent = addImport(content, root, importSpec)
-						changes.push(`Added import from '${importSpec.module}'`)
-						break
+      // Handle different transformation types
+      if (transform) {
+        switch (transform) {
+          case 'add-import':
+            if (!importSpec) {
+              throw new Error('importSpec is required for add-import transform');
+            }
+            modifiedContent = addImport(content, root, importSpec);
+            changes.push(`Added import from '${importSpec.module}'`);
+            break;
 
-					case "remove-import":
-						if (!targetName) {
-							throw new Error(
-								"targetName is required for remove-import transform",
-							)
-						}
-						modifiedContent = removeImport(content, root, targetName)
-						changes.push(`Removed import '${targetName}'`)
-						break
+          case 'remove-import':
+            if (!targetName) {
+              throw new Error('targetName is required for remove-import transform');
+            }
+            modifiedContent = removeImport(content, root, targetName);
+            changes.push(`Removed import '${targetName}'`);
+            break;
 
-					case "rename-function":
-						if (!targetName || !newName) {
-							throw new Error(
-								"targetName and newName are required for rename-function transform",
-							)
-						}
-						const funcResult = renameFunction(
-							content,
-							root,
-							targetName,
-							newName,
-						)
-						modifiedContent = funcResult.content
-						changes.push(
-							`Renamed function '${targetName}' to '${newName}' (${funcResult.count} occurrences)`,
-						)
-						break
+          case 'rename-function':
+            if (!targetName || !newName) {
+              throw new Error('targetName and newName are required for rename-function transform');
+            }
+            const funcResult = renameFunction(content, root, targetName, newName);
+            modifiedContent = funcResult.content;
+            changes.push(`Renamed function '${targetName}' to '${newName}' (${funcResult.count} occurrences)`);
+            break;
 
-					case "rename-variable":
-						if (!targetName || !newName) {
-							throw new Error(
-								"targetName and newName are required for rename-variable transform",
-							)
-						}
-						const varResult = renameVariable(content, root, targetName, newName)
-						modifiedContent = varResult.content
-						changes.push(
-							`Renamed variable '${targetName}' to '${newName}' (${varResult.count} occurrences)`,
-						)
-						break
+          case 'rename-variable':
+            if (!targetName || !newName) {
+              throw new Error('targetName and newName are required for rename-variable transform');
+            }
+            const varResult = renameVariable(content, root, targetName, newName);
+            modifiedContent = varResult.content;
+            changes.push(`Renamed variable '${targetName}' to '${newName}' (${varResult.count} occurrences)`);
+            break;
 
-					default:
-						throw new Error(`Unsupported transform: ${transform}`)
-				}
-			} else if (pattern && replacement !== undefined) {
-				// Pattern-based replacement
-				const result = patternReplace(content, root, pattern, replacement)
-				modifiedContent = result.content
-				changes.push(`Replaced ${result.count} occurrences of pattern`)
-			} else if (selector) {
-				// Selector-based query (just return matches for now)
-				const matches = root.findAll(selector)
-				const matchInfo = matches.map((match: any) => ({
-					text: match.text(),
-					range: match.range(),
-					kind: match.kind(),
-				}))
+          default:
+            throw new Error(`Unsupported transform: ${transform}`);
+        }
+      } else if (pattern && replacement !== undefined) {
+        // Pattern-based replacement
+        const result = patternReplace(content, root, pattern, replacement);
+        modifiedContent = result.content;
+        changes.push(`Replaced ${result.count} occurrences of pattern`);
+      } else if (selector) {
+        // Selector-based query (just return matches for now)
+        const matches = root.findAll(selector);
+        const matchInfo = matches.map((match: any) => ({
+          text: match.text(),
+          range: match.range(),
+          kind: match.kind(),
+        }));
 
-				return {
-					matches: matchInfo.length,
-					details: matchInfo.slice(0, 10), // Limit to first 10 matches
-				}
-			} else {
-				throw new Error(
-					"Must provide either transform, pattern/replacement, or selector",
-				)
-			}
+        return {
+          matches: matchInfo.length,
+          details: matchInfo.slice(0, 10), // Limit to first 10 matches
+        };
+      } else {
+        throw new Error('Must provide either transform, pattern/replacement, or selector');
+      }
 
-			// Write the modified content back
-			if (modifiedContent !== content) {
-				writeFileSync(filePath, modifiedContent, "utf-8")
-			}
+      // Write the modified content back
+      if (modifiedContent !== content) {
+        writeFileSync(filePath, modifiedContent, 'utf-8');
+      }
 
-			return {
-				success: true,
-				changes,
-				modified: modifiedContent !== content,
-			}
-		} catch (error: any) {
-			return {
-				error: error.message,
-				stack: error.stack,
-			}
-		}
-	},
-})
+      return {
+        success: true,
+        changes,
+        modified: modifiedContent !== content,
+      };
+    } catch (error: any) {
+      return {
+        error: error.message,
+        stack: error.stack,
+      };
+    }
+  },
+});
 
 function getLanguageFromPath(path: string): Lang {
-	const ext = path.split(".").pop()?.toLowerCase()
-	switch (ext) {
-		case "ts":
-		case "tsx":
-			return Lang.TypeScript
-		case "js":
-		case "jsx":
-			return Lang.JavaScript
-		// Note: These languages might not be available in the current version of ast-grep
-		// case 'py':
-		//     return Lang.Python;
-		// case 'rs':
-		//     return Lang.Rust;
-		// case 'go':
-		//     return Lang.Go;
-		// case 'java':
-		//     return Lang.Java;
-		// case 'cpp':
-		// case 'cc':
-		// case 'cxx':
-		//     return Lang.Cpp;
-		// case 'c':
-		//     return Lang.C;
-		// case 'cs':
-		//     return Lang.CSharp;
-		case "html":
-			return Lang.Html
-		case "css":
-			return Lang.Css
-		default:
-			// Default to TypeScript for unknown extensions
-			return Lang.TypeScript
-	}
+  const ext = path.split('.').pop()?.toLowerCase();
+  switch (ext) {
+    case 'ts':
+    case 'tsx':
+      return Lang.TypeScript;
+    case 'js':
+    case 'jsx':
+      return Lang.JavaScript;
+    // Note: These languages might not be available in the current version of ast-grep
+    // case 'py':
+    //     return Lang.Python;
+    // case 'rs':
+    //     return Lang.Rust;
+    // case 'go':
+    //     return Lang.Go;
+    // case 'java':
+    //     return Lang.Java;
+    // case 'cpp':
+    // case 'cc':
+    // case 'cxx':
+    //     return Lang.Cpp;
+    // case 'c':
+    //     return Lang.C;
+    // case 'cs':
+    //     return Lang.CSharp;
+    case 'html':
+      return Lang.Html;
+    case 'css':
+      return Lang.Css;
+    default:
+      // Default to TypeScript for unknown extensions
+      return Lang.TypeScript;
+  }
 }
 
 function addImport(
-	content: string,
-	root: any,
-	importSpec: { module: string; names: string[]; isDefault?: boolean },
+  content: string,
+  root: any,
+  importSpec: { module: string; names: string[]; isDefault?: boolean },
 ): string {
-	const { module, names, isDefault } = importSpec
+  const { module, names, isDefault } = importSpec;
 
-	// Find existing imports
-	const imports = root.findAll("ImportDeclaration")
+  // Find existing imports
+  const imports = root.findAll('ImportDeclaration');
 
-	// Check if import already exists
-	const existingImport = imports.find((imp: any) => {
-		const source = imp.getMatch("source")?.text()
-		return source?.includes(module)
-	})
+  // Check if import already exists
+  const existingImport = imports.find((imp: any) => {
+    const source = imp.getMatch('source')?.text();
+    return source?.includes(module);
+  });
 
-	if (existingImport) {
-		// TODO: Merge with existing import
-		return content
-	}
+  if (existingImport) {
+    // TODO: Merge with existing import
+    return content;
+  }
 
-	// Create new import statement
-	let importStatement: string
-	if (isDefault && names.length === 1) {
-		importStatement = `import ${names[0]} from '${module}';`
-	} else if (isDefault && names.length > 1) {
-		importStatement = `import ${names[0]}, { ${names.slice(1).join(", ")} } from '${module}';`
-	} else {
-		importStatement = `import { ${names.join(", ")} } from '${module}';`
-	}
+  // Create new import statement
+  let importStatement: string;
+  if (isDefault && names.length === 1) {
+    importStatement = `import ${names[0]} from '${module}';`;
+  } else if (isDefault && names.length > 1) {
+    importStatement = `import ${names[0]}, { ${names.slice(1).join(', ')} } from '${module}';`;
+  } else {
+    importStatement = `import { ${names.join(', ')} } from '${module}';`;
+  }
 
-	// Find the position to insert the import
-	if (imports.length > 0) {
-		// Add after last import
-		const lastImport = imports[imports.length - 1]
-		const pos = lastImport.range().end.index
-		return content.slice(0, pos) + "\n" + importStatement + content.slice(pos)
-	} else {
-		// Add at the beginning of the file
-		return importStatement + "\n\n" + content
-	}
+  // Find the position to insert the import
+  if (imports.length > 0) {
+    // Add after last import
+    const lastImport = imports[imports.length - 1];
+    const pos = lastImport.range().end.index;
+    return content.slice(0, pos) + '\n' + importStatement + content.slice(pos);
+  } else {
+    // Add at the beginning of the file
+    return importStatement + '\n\n' + content;
+  }
 }
 
 function removeImport(content: string, root: any, targetName: string): string {
-	const imports = root.findAll("ImportDeclaration")
+  const imports = root.findAll('ImportDeclaration');
 
-	for (const imp of imports) {
-		const source = imp.getMatch("source")?.text()
-		if (source?.includes(targetName)) {
-			const range = imp.range()
-			// Remove the import line including the newline
-			const start = range.start.index
-			let end = range.end.index
-			if (content[end] === "\n") end++
+  for (const imp of imports) {
+    const source = imp.getMatch('source')?.text();
+    if (source?.includes(targetName)) {
+      const range = imp.range();
+      // Remove the import line including the newline
+      const start = range.start.index;
+      let end = range.end.index;
+      if (content[end] === '\n') end++;
 
-			return content.slice(0, start) + content.slice(end)
-		}
-	}
+      return content.slice(0, start) + content.slice(end);
+    }
+  }
 
-	return content
+  return content;
 }
 
 function renameFunction(
-	content: string,
-	root: any,
-	oldName: string,
-	newName: string,
+  content: string,
+  root: any,
+  oldName: string,
+  newName: string,
 ): { content: string; count: number } {
-	let modifiedContent = content
-	let count = 0
+  let modifiedContent = content;
+  let count = 0;
 
-	// Find function declarations using pattern matching
-	const funcDecls = root.findAll(`function ${oldName}`)
-	const funcExprs = root.findAll({
-		rule: {
-			pattern: `const $VAR = function ${oldName}`,
-		},
-	})
-	const arrowFuncs = root.findAll({
-		rule: {
-			pattern: `const ${oldName} = ($PARAMS) => $BODY`,
-		},
-	})
+  // Find function declarations using pattern matching
+  const funcDecls = root.findAll(`function ${oldName}`);
+  const funcExprs = root.findAll({
+    rule: {
+      pattern: `const $VAR = function ${oldName}`,
+    },
+  });
+  const arrowFuncs = root.findAll({
+    rule: {
+      pattern: `const ${oldName} = ($PARAMS) => $BODY`,
+    },
+  });
 
-	// Find all call expressions using pattern
-	const calls = root.findAll(`${oldName}($ARGS)`)
+  // Find all call expressions using pattern
+  const calls = root.findAll(`${oldName}($ARGS)`);
 
-	// Collect all positions to replace (in reverse order to maintain positions)
-	const replacements: Array<{ start: number; end: number; text: string }> = []
+  // Collect all positions to replace (in reverse order to maintain positions)
+  const replacements: Array<{ start: number; end: number; text: string }> = [];
 
-	// Add function declarations
-	for (const decl of funcDecls) {
-		// For function declarations, we need to find the identifier child
-		const children = decl.children()
-		for (const child of children) {
-			if (child.kind() === "identifier" && child.text() === oldName) {
-				const range = child.range()
-				replacements.push({
-					start: range.start.index,
-					end: range.end.index,
-					text: newName,
-				})
-				count++
-				break
-			}
-		}
-	}
+  // Add function declarations
+  for (const decl of funcDecls) {
+    // For function declarations, we need to find the identifier child
+    const children = decl.children();
+    for (const child of children) {
+      if (child.kind() === 'identifier' && child.text() === oldName) {
+        const range = child.range();
+        replacements.push({
+          start: range.start.index,
+          end: range.end.index,
+          text: newName,
+        });
+        count++;
+        break;
+      }
+    }
+  }
 
-	// Add function expressions and arrow functions
-	for (const expr of [...funcExprs, ...arrowFuncs]) {
-		// Extract the function name from the matched expression
-		const identifiers = expr.findAll("identifier")
-		for (const id of identifiers) {
-			if (id.text() === oldName) {
-				const range = id.range()
-				replacements.push({
-					start: range.start.index,
-					end: range.end.index,
-					text: newName,
-				})
-				count++
-				break // Only replace the first occurrence (the function name)
-			}
-		}
-	}
+  // Add function expressions and arrow functions
+  for (const expr of [...funcExprs, ...arrowFuncs]) {
+    // Extract the function name from the matched expression
+    const identifiers = expr.findAll('identifier');
+    for (const id of identifiers) {
+      if (id.text() === oldName) {
+        const range = id.range();
+        replacements.push({
+          start: range.start.index,
+          end: range.end.index,
+          text: newName,
+        });
+        count++;
+        break; // Only replace the first occurrence (the function name)
+      }
+    }
+  }
 
-	// Add all call expressions
-	for (const call of calls) {
-		// The call pattern matches the entire call, so we need to find the function name part
-		const callText = call.text()
-		if (callText.startsWith(oldName + "(")) {
-			const range = call.range()
-			replacements.push({
-				start: range.start.index,
-				end: range.start.index + oldName.length,
-				text: newName,
-			})
-			count++
-		}
-	}
+  // Add all call expressions
+  for (const call of calls) {
+    // The call pattern matches the entire call, so we need to find the function name part
+    const callText = call.text();
+    if (callText.startsWith(oldName + '(')) {
+      const range = call.range();
+      replacements.push({
+        start: range.start.index,
+        end: range.start.index + oldName.length,
+        text: newName,
+      });
+      count++;
+    }
+  }
 
-	// Sort replacements in reverse order
-	replacements.sort((a, b) => b.start - a.start)
+  // Sort replacements in reverse order
+  replacements.sort((a, b) => b.start - a.start);
 
-	// Apply replacements
-	for (const { start, end, text } of replacements) {
-		modifiedContent =
-			modifiedContent.slice(0, start) + text + modifiedContent.slice(end)
-	}
+  // Apply replacements
+  for (const { start, end, text } of replacements) {
+    modifiedContent = modifiedContent.slice(0, start) + text + modifiedContent.slice(end);
+  }
 
-	return { content: modifiedContent, count }
+  return { content: modifiedContent, count };
 }
 
 function renameVariable(
-	content: string,
-	root: any,
-	oldName: string,
-	newName: string,
+  content: string,
+  root: any,
+  oldName: string,
+  newName: string,
 ): { content: string; count: number } {
-	let modifiedContent = content
-	let count = 0
+  let modifiedContent = content;
+  let count = 0;
 
-	// Find all identifiers using the $ID pattern
-	const refs = root.findAll("$ID")
+  // Find all identifiers using the $ID pattern
+  const refs = root.findAll('$ID');
 
-	// Collect all positions to replace
-	const replacements: Array<{ start: number; end: number; text: string }> = []
+  // Collect all positions to replace
+  const replacements: Array<{ start: number; end: number; text: string }> = [];
 
-	// Process all references that match our target name
-	for (const ref of refs) {
-		if (ref.text() === oldName) {
-			const range = ref.range()
-			replacements.push({
-				start: range.start.index,
-				end: range.end.index,
-				text: newName,
-			})
-			count++
-		}
-	}
+  // Process all references that match our target name
+  for (const ref of refs) {
+    if (ref.text() === oldName) {
+      const range = ref.range();
+      replacements.push({
+        start: range.start.index,
+        end: range.end.index,
+        text: newName,
+      });
+      count++;
+    }
+  }
 
-	// Sort replacements in reverse order
-	replacements.sort((a, b) => b.start - a.start)
+  // Sort replacements in reverse order
+  replacements.sort((a, b) => b.start - a.start);
 
-	// Apply replacements
-	for (const { start, end, text } of replacements) {
-		modifiedContent =
-			modifiedContent.slice(0, start) + text + modifiedContent.slice(end)
-	}
+  // Apply replacements
+  for (const { start, end, text } of replacements) {
+    modifiedContent = modifiedContent.slice(0, start) + text + modifiedContent.slice(end);
+  }
 
-	return { content: modifiedContent, count }
+  return { content: modifiedContent, count };
 }
 
 function patternReplace(
-	content: string,
-	root: any,
-	pattern: string,
-	replacement: string,
+  content: string,
+  root: any,
+  pattern: string,
+  replacement: string,
 ): { content: string; count: number } {
-	let modifiedContent = content
-	let count = 0
+  let modifiedContent = content;
+  let count = 0;
 
-	try {
-		// Use ast-grep's pattern matching
-		const matches = root.findAll({
-			rule: {
-				pattern: pattern,
-			},
-		})
+  try {
+    // Use ast-grep's pattern matching
+    const matches = root.findAll({
+      rule: {
+        pattern: pattern,
+      },
+    });
 
-		// Collect replacements
-		const replacements: Array<{ start: number; end: number; text: string }> = []
+    // Collect replacements
+    const replacements: Array<{ start: number; end: number; text: string }> = [];
 
-		for (const match of matches) {
-			const range = match.range()
+    for (const match of matches) {
+      const range = match.range();
 
-			// Extract metavariables from the pattern
-			const metaVarRegex = /\$(\w+)/g
-			const metaVars = [...pattern.matchAll(metaVarRegex)].map((m) => m[1])
+      // Extract metavariables from the pattern
+      const metaVarRegex = /\$(\w+)/g;
+      const metaVars = [...pattern.matchAll(metaVarRegex)].map(m => m[1]);
 
-			// Build replacement text with variable substitution
-			let replacementText = replacement
+      // Build replacement text with variable substitution
+      let replacementText = replacement;
 
-			for (const varName of metaVars) {
-				// Get the matched node for this metavariable
-				const matchedNode = match.getMatch(varName)
-				if (matchedNode) {
-					const matchedText = matchedNode.text()
-					// Replace all occurrences of $VARNAME with the matched text
-					replacementText = replacementText.replace(
-						new RegExp(`\\$${varName}`, "g"),
-						matchedText,
-					)
-				}
-			}
+      for (const varName of metaVars) {
+        // Get the matched node for this metavariable
+        const matchedNode = match.getMatch(varName);
+        if (matchedNode) {
+          const matchedText = matchedNode.text();
+          // Replace all occurrences of $VARNAME with the matched text
+          replacementText = replacementText.replace(new RegExp(`\\$${varName}`, 'g'), matchedText);
+        }
+      }
 
-			replacements.push({
-				start: range.start.index,
-				end: range.end.index,
-				text: replacementText,
-			})
-			count++
-		}
+      replacements.push({
+        start: range.start.index,
+        end: range.end.index,
+        text: replacementText,
+      });
+      count++;
+    }
 
-		// Sort replacements in reverse order
-		replacements.sort((a, b) => b.start - a.start)
+    // Sort replacements in reverse order
+    replacements.sort((a, b) => b.start - a.start);
 
-		// Apply replacements
-		for (const { start, end, text } of replacements) {
-			modifiedContent =
-				modifiedContent.slice(0, start) + text + modifiedContent.slice(end)
-		}
-	} catch {
-		// Fallback to simple string replacement if pattern matching fails
-		const regex = new RegExp(pattern.replace(/\$\w+/g, "(.+)"), "g")
-		modifiedContent = content.replace(regex, replacement)
-		count = (content.match(regex) || []).length
-	}
+    // Apply replacements
+    for (const { start, end, text } of replacements) {
+      modifiedContent = modifiedContent.slice(0, start) + text + modifiedContent.slice(end);
+    }
+  } catch {
+    // Fallback to simple string replacement if pattern matching fails
+    const regex = new RegExp(pattern.replace(/\$\w+/g, '(.+)'), 'g');
+    modifiedContent = content.replace(regex, replacement);
+    count = (content.match(regex) || []).length;
+  }
 
-	return { content: modifiedContent, count }
+  return { content: modifiedContent, count };
 }

--- a/mastracode/src/tools/file-editor.ts
+++ b/mastracode/src/tools/file-editor.ts
@@ -352,26 +352,26 @@ export class FileEditor {
 				}
 				// this line is equal to the first line in our from replacement. Lets check each following line to see if we match
 				const firstDistance = distance(oldLines[0] || "", normLine || "")
-				const firstPercentDiff = (firstDistance / (normLine?.length || 0)) * 100
-				if (
-					isSingleLineReplacement &&
-					(normLine === oldLines[0] || normLine.includes(oldLines[0]))
-				) {
+                const firstPercentDiff = (firstDistance / (normLine?.length || 0)) * 100
+                if (
+                    isSingleLineReplacement &&
+                    (normLine === oldLines[0] || normLine.includes(oldLines[0]!))
+                ) {
 					bestMatch.start = index
 					bestMatch.type = "replace-in-line"
 					continue
 				}
-				if (oldLines[0] === normLine || firstPercentDiff < 5) {
-					let isMatching = true
-					let matchingLineCount = 0
-					for (const [matchIndex, oldLine] of oldLines.entries()) {
-						const innerNormLine = normFileLines[index + matchIndex]
-						const innerDistance = distance(
-							oldLine,
-							normFileLines[index + matchIndex],
-						)
-						const innerPercentDiff =
-							(innerDistance / innerNormLine.length) * 100
+                if (oldLines[0] === normLine || firstPercentDiff < 5) {
+                    let isMatching = true
+                    let matchingLineCount = 0
+                    for (const [matchIndex, oldLine] of oldLines.entries()) {
+                        const innerNormLine = normFileLines[index + matchIndex]!
+                        const innerDistance = distance(
+                            oldLine,
+                            normFileLines[index + matchIndex]!,
+                        )
+                        const innerPercentDiff =
+                            (innerDistance / innerNormLine.length) * 100
 						const remainingLines = oldLines.length - matchingLineCount
 						const percentLinesRemaining =
 							(remainingLines / oldLines.length) * 100
@@ -432,13 +432,13 @@ ${divergedMessage ? divergedMessage : ``}Try adjusting your input or the file co
 				const [firstNew, ...restNew] = newStr ? newStr.split("\n") : []
 				const newFileLines = [
 					...fileLines.slice(0, bestMatch.start),
-					...(restNew?.length
-						? [firstNew, ...restNew]
-						: [
-								fileLines
-									.at(bestMatch.start)
-									?.replace(oldLinesOriginal[0], firstNew || "") ?? "",
-							]),
+                    ...(restNew?.length
+                        ? [firstNew, ...restNew]
+                        : [
+                                fileLines
+                                    .at(bestMatch.start)
+                                    ?.replace(oldLinesOriginal[0]!, firstNew || "") ?? "",
+                            ]),
 					...fileLines.slice(bestMatch.start + 1),
 				]
 				newFileContent = newFileLines.join("\n")

--- a/mastracode/src/tools/file-editor.ts
+++ b/mastracode/src/tools/file-editor.ts
@@ -1,525 +1,455 @@
-import { exec } from "node:child_process"
-import { promises as fs } from "node:fs"
-import { promisify } from "node:util"
-import { distance } from "fastest-levenshtein"
+import { exec } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { promisify } from 'node:util';
+import { distance } from 'fastest-levenshtein';
 
 function removeWhitespace(str: string): string {
-	return str
-		.replace(/\t/g, "") // tabs to spaces
-		.replace(/ +/g, "") // collapse multiple spaces
-		.replace(/^ +| +$/gm, "") // trim each line
-		.replace(/\r?\n/g, "\n")
-		.replace(/\s/g, "")
+  return str
+    .replace(/\t/g, '') // tabs to spaces
+    .replace(/ +/g, '') // collapse multiple spaces
+    .replace(/^ +| +$/gm, '') // trim each line
+    .replace(/\r?\n/g, '\n')
+    .replace(/\s/g, '');
 }
 
 function removeVaryingChars(str: string): string {
-	return (
-		removeWhitespace(str)
-			.replaceAll(`\n`, ``)
-			.replaceAll(`'`, ``)
-			.replaceAll(`"`, ``)
-			.replaceAll("`", ``)
-			// .replaceAll(`;`, ``) // this sometimes causes an extra ; to be printed!
-			.replaceAll(`\\r`, ``)
-	)
+  return (
+    removeWhitespace(str)
+      .replaceAll(`\n`, ``)
+      .replaceAll(`'`, ``)
+      .replaceAll(`"`, ``)
+      .replaceAll('`', ``)
+      // .replaceAll(`;`, ``) // this sometimes causes an extra ; to be printed!
+      .replaceAll(`\\r`, ``)
+  );
 }
 
 import {
-	SNIPPET_LINES,
-	readFile,
-	writeFile,
-	makeOutput,
-	validatePath,
-	withFileLock,
-	// truncateText
-} from "./utils"
-const realExecAsync = promisify(exec)
+  SNIPPET_LINES,
+  readFile,
+  writeFile,
+  makeOutput,
+  validatePath,
+  withFileLock,
+  // truncateText
+} from './utils';
+const realExecAsync = promisify(exec);
 
 interface ViewArgs {
-	path: string
-	view_range?: [number, number]
+  path: string;
+  view_range?: [number, number];
 }
 
 interface CreateArgs {
-	path: string
-	file_text: string
+  path: string;
+  file_text: string;
 }
 
 interface StrReplaceArgs {
-	path: string
-	old_str: string
-	new_str: string
-	start_line?: number
+  path: string;
+  old_str: string;
+  new_str: string;
+  start_line?: number;
 }
 
 interface InsertArgs {
-	path: string
-	insert_line: number
-	new_str: string
+  path: string;
+  insert_line: number;
+  new_str: string;
 }
 
 export class FileEditor {
-	private execAsync: typeof realExecAsync
+  private execAsync: typeof realExecAsync;
 
-	constructor() {
-		this.execAsync = realExecAsync
-	}
+  constructor() {
+    this.execAsync = realExecAsync;
+  }
 
-	async view(args: ViewArgs) {
-		await validatePath("view", args.path)
-		if (await this.isDirectory(args.path)) {
-			if (args.view_range) {
-				return "The `view_range` parameter is not allowed when `path` points to a directory."
-			}
-			const { stdout, stderr } = await this.execAsync(
-				`find "${args.path}" -maxdepth 2 -not -path '*/\\.*'`,
-			)
-			if (stderr) return stderr
-			return `Here's the files and directories up to 2 levels deep in ${args.path}, excluding hidden items:\n${stdout}\n`
-		}
-		const fileContent = await readFile(args.path)
-		if (args.view_range) {
-			const fileLines = fileContent.split("\n")
-			const nLinesFile = fileLines.length
-			const [start] = args.view_range
-			let [, end] = args.view_range
-			if (start < 1 || start > nLinesFile) {
-				return `Invalid \`view_range\`: ${args.view_range}. Its first element \`${start}\` should be within the range of lines of the file: [1, ${nLinesFile}]`
-			}
-			if (end !== -1) {
-				if (end > nLinesFile) {
-					end = nLinesFile
-					// throw new ToolError(
-					//     `Invalid \`view_range\`: ${args.view_range}. Its second element \`${end}\` should be smaller than the number of lines in the file: \`${nLinesFile}\``
-					// );
-				}
-				if (end < start) {
-					return `Invalid \`view_range\`: ${args.view_range}. Its second element \`${end}\` should be larger or equal than its first \`${start}\``
-				}
-			}
-			const selectedLines =
-				end === -1
-					? fileLines.slice(start - 1)
-					: fileLines.slice(start - 1, end)
-			return makeOutput(selectedLines.join("\n"), String(args.path), start)
-		}
-		return makeOutput(fileContent, String(args.path))
-	}
-	async create(args: CreateArgs) {
-		await validatePath("create", args.path)
-		await writeFile(args.path, args.file_text)
-		return `File created successfully at: ${args.path}`
-	}
-	// undoubleEscape(input) {
-	//     return input.replace(/("([^"\\]|\\.)*"|'([^'\\]|\\.)*'|`([^`\\]|\\.)*`|\/([^\/\\\n]|\\.)+\/[gimsuy]*)|\\n|\\r|\\t|\\"|\\'|\\`/g, (match) => {
-	//         if (match.startsWith('"') ||
-	//             match.startsWith("'") ||
-	//             match.startsWith("`") ||
-	//             match.startsWith("/")) {
-	//             return match; // skip unescaping inside strings, backticks, or regex literals
-	//         }
-	//         // outside of those: unescape
-	//         return match
-	//             .replace(/\\n/g, "\n")
-	//             .replace(/\\r/g, "\r")
-	//             .replace(/\\t/g, "\t")
-	//             .replace(/\\"/g, '"')
-	//             .replace(/\\'/g, "'")
-	//             .replace(/\\`/g, "`");
-	//     });
-	// }
-	async strReplace(args: StrReplaceArgs) {
-		await validatePath("string_replace", args.path)
-		if (args.old_str === args.new_str) {
-			return `Received the same string for old_str and new_str`
-		}
-		// Queue concurrent edits to the same file
-		return withFileLock(args.path, async () => {
-			const fileContent = await readFile(args.path)
-			// First, try exact match with the raw string (no processing)
-			// This handles cases where the search/replace should work exactly as provided
-			if (fileContent.includes(args.old_str)) {
-				// Exact match found! Use simple string replacement
-				const processedNewStr = args.new_str || ""
-				const newFileContent = fileContent
-					.split(args.old_str)
-					.join(processedNewStr)
-				await writeFile(args.path, newFileContent)
-				return `The file ${args.path} has been edited. `
-			}
+  async view(args: ViewArgs) {
+    await validatePath('view', args.path);
+    if (await this.isDirectory(args.path)) {
+      if (args.view_range) {
+        return 'The `view_range` parameter is not allowed when `path` points to a directory.';
+      }
+      const { stdout, stderr } = await this.execAsync(`find "${args.path}" -maxdepth 2 -not -path '*/\\.*'`);
+      if (stderr) return stderr;
+      return `Here's the files and directories up to 2 levels deep in ${args.path}, excluding hidden items:\n${stdout}\n`;
+    }
+    const fileContent = await readFile(args.path);
+    if (args.view_range) {
+      const fileLines = fileContent.split('\n');
+      const nLinesFile = fileLines.length;
+      const [start] = args.view_range;
+      let [, end] = args.view_range;
+      if (start < 1 || start > nLinesFile) {
+        return `Invalid \`view_range\`: ${args.view_range}. Its first element \`${start}\` should be within the range of lines of the file: [1, ${nLinesFile}]`;
+      }
+      if (end !== -1) {
+        if (end > nLinesFile) {
+          end = nLinesFile;
+          // throw new ToolError(
+          //     `Invalid \`view_range\`: ${args.view_range}. Its second element \`${end}\` should be smaller than the number of lines in the file: \`${nLinesFile}\``
+          // );
+        }
+        if (end < start) {
+          return `Invalid \`view_range\`: ${args.view_range}. Its second element \`${end}\` should be larger or equal than its first \`${start}\``;
+        }
+      }
+      const selectedLines = end === -1 ? fileLines.slice(start - 1) : fileLines.slice(start - 1, end);
+      return makeOutput(selectedLines.join('\n'), String(args.path), start);
+    }
+    return makeOutput(fileContent, String(args.path));
+  }
+  async create(args: CreateArgs) {
+    await validatePath('create', args.path);
+    await writeFile(args.path, args.file_text);
+    return `File created successfully at: ${args.path}`;
+  }
+  // undoubleEscape(input) {
+  //     return input.replace(/("([^"\\]|\\.)*"|'([^'\\]|\\.)*'|`([^`\\]|\\.)*`|\/([^\/\\\n]|\\.)+\/[gimsuy]*)|\\n|\\r|\\t|\\"|\\'|\\`/g, (match) => {
+  //         if (match.startsWith('"') ||
+  //             match.startsWith("'") ||
+  //             match.startsWith("`") ||
+  //             match.startsWith("/")) {
+  //             return match; // skip unescaping inside strings, backticks, or regex literals
+  //         }
+  //         // outside of those: unescape
+  //         return match
+  //             .replace(/\\n/g, "\n")
+  //             .replace(/\\r/g, "\r")
+  //             .replace(/\\t/g, "\t")
+  //             .replace(/\\"/g, '"')
+  //             .replace(/\\'/g, "'")
+  //             .replace(/\\`/g, "`");
+  //     });
+  // }
+  async strReplace(args: StrReplaceArgs) {
+    await validatePath('string_replace', args.path);
+    if (args.old_str === args.new_str) {
+      return `Received the same string for old_str and new_str`;
+    }
+    // Queue concurrent edits to the same file
+    return withFileLock(args.path, async () => {
+      const fileContent = await readFile(args.path);
+      // First, try exact match with the raw string (no processing)
+      // This handles cases where the search/replace should work exactly as provided
+      if (fileContent.includes(args.old_str)) {
+        // Exact match found! Use simple string replacement
+        const processedNewStr = args.new_str || '';
+        const newFileContent = fileContent.split(args.old_str).join(processedNewStr);
+        await writeFile(args.path, newFileContent);
+        return `The file ${args.path} has been edited. `;
+      }
 
-			// Try whitespace-normalized exact match before falling back to fuzzy matching
-			// This handles cases where the only difference is whitespace/indentation
-			// while preserving all escaping (e.g., \\n stays as \\n)
-			const normalizeWhitespace = (str: string) =>
-				str.replace(/\s+/g, " ").trim()
-			const normalizedOldStr = normalizeWhitespace(args.old_str)
-			const normalizedContent = normalizeWhitespace(fileContent)
+      // Try whitespace-normalized exact match before falling back to fuzzy matching
+      // This handles cases where the only difference is whitespace/indentation
+      // while preserving all escaping (e.g., \\n stays as \\n)
+      const normalizeWhitespace = (str: string) => str.replace(/\s+/g, ' ').trim();
+      const normalizedOldStr = normalizeWhitespace(args.old_str);
+      const normalizedContent = normalizeWhitespace(fileContent);
 
-			if (normalizedContent.includes(normalizedOldStr)) {
-				// Find the actual position in the original content by searching for the pattern
-				// We need to find where the whitespace-normalized match occurs in the original
-				const lines = fileContent.split("\n")
-				let bestMatch = { start: -1, end: -1, content: "" }
+      if (normalizedContent.includes(normalizedOldStr)) {
+        // Find the actual position in the original content by searching for the pattern
+        // We need to find where the whitespace-normalized match occurs in the original
+        const lines = fileContent.split('\n');
+        let bestMatch = { start: -1, end: -1, content: '' };
 
-				// Use original old_str line count (not normalized, which collapses \n)
-				const originalOldLineCount = args.old_str.split("\n").length
-				// Allow some slack for whitespace differences
-				const maxWindow = originalOldLineCount + 5
-				// Try to find the matching section by comparing normalized versions
-				for (let i = 0; i < lines.length; i++) {
-					for (let j = i; j <= Math.min(i + maxWindow, lines.length - 1); j++) {
-						const candidate = lines.slice(i, j + 1).join("\n")
-						if (normalizeWhitespace(candidate) === normalizedOldStr) {
-							bestMatch = { start: i, end: j, content: candidate }
-							break
-						}
-					}
-					if (bestMatch.start !== -1) break
-				}
-				if (bestMatch.start !== -1) {
-					const beforeLines = lines.slice(0, bestMatch.start)
-					const afterLines = lines.slice(bestMatch.end + 1)
-					const newFileContent = [
-						...beforeLines,
-						args.new_str || "",
-						...afterLines,
-					].join("\n")
+        // Use original old_str line count (not normalized, which collapses \n)
+        const originalOldLineCount = args.old_str.split('\n').length;
+        // Allow some slack for whitespace differences
+        const maxWindow = originalOldLineCount + 5;
+        // Try to find the matching section by comparing normalized versions
+        for (let i = 0; i < lines.length; i++) {
+          for (let j = i; j <= Math.min(i + maxWindow, lines.length - 1); j++) {
+            const candidate = lines.slice(i, j + 1).join('\n');
+            if (normalizeWhitespace(candidate) === normalizedOldStr) {
+              bestMatch = { start: i, end: j, content: candidate };
+              break;
+            }
+          }
+          if (bestMatch.start !== -1) break;
+        }
+        if (bestMatch.start !== -1) {
+          const beforeLines = lines.slice(0, bestMatch.start);
+          const afterLines = lines.slice(bestMatch.end + 1);
+          const newFileContent = [...beforeLines, args.new_str || '', ...afterLines].join('\n');
 
-					// Save the file
-					await writeFile(args.path, newFileContent)
+          // Save the file
+          await writeFile(args.path, newFileContent);
 
-					// Find the line number for the snippet
-					const fileLines = newFileContent.split("\n")
-					const startLine = Math.max(0, bestMatch.start - SNIPPET_LINES)
-					const endLine = Math.min(
-						fileLines.length,
-						bestMatch.start +
-							SNIPPET_LINES +
-							(args.new_str || "").split("\n").length,
-					)
-					const snippet = fileLines.slice(startLine, endLine).join("\n")
-					let successMsg = `The file ${args.path} has been edited. `
-					successMsg += makeOutput(
-						snippet,
-						`a snippet of ${args.path}`,
-						startLine + 1,
-					)
-					successMsg +=
-						"Review the changes and make sure they are as expected. Edit the file again if necessary."
-					return successMsg
-				}
-			}
+          // Find the line number for the snippet
+          const fileLines = newFileContent.split('\n');
+          const startLine = Math.max(0, bestMatch.start - SNIPPET_LINES);
+          const endLine = Math.min(
+            fileLines.length,
+            bestMatch.start + SNIPPET_LINES + (args.new_str || '').split('\n').length,
+          );
+          const snippet = fileLines.slice(startLine, endLine).join('\n');
+          let successMsg = `The file ${args.path} has been edited. `;
+          successMsg += makeOutput(snippet, `a snippet of ${args.path}`, startLine + 1);
+          successMsg += 'Review the changes and make sure they are as expected. Edit the file again if necessary.';
+          return successMsg;
+        }
+      }
 
-			// If exact match and whitespace-normalized match both fail, proceed with fuzzy whitespace-agnostic matching
-			// First apply undoubleEscape for the fuzzy matching
-			const processedOldStr = args.old_str
-			const processedNewStr = args.new_str || ""
-			// Remove leading line numbers and whitespace from each line
-			const removeLeadingLineNumbers = (str: string): string => {
-				return str
-					.split("\n")
-					.map((line) => line.replace(/^\s*\d+\s*/, ""))
-					.join("\n")
-			}
-			let oldStr = removeLeadingLineNumbers(processedOldStr)
-			let newStr = removeLeadingLineNumbers(processedNewStr)
-			if (oldStr.startsWith(`\\\n`)) {
-				oldStr = oldStr.substring(`\\\n`.length)
-			}
-			if (newStr.startsWith(`\\\n`)) {
-				newStr = newStr.substring(`\\\n`.length)
-			}
-			const startLineArg =
-				typeof args.start_line === `number`
-					? Math.max(args.start_line - 5, 0) // - 3 cause llms are not precise
-					: undefined
-			// Split and normalize
-			const oldLinesSplit = oldStr.split("\n")
-			const oldLinesOriginal = oldLinesSplit.filter((l, i) => {
-				if (i === 0) return removeWhitespace(l) !== ``
-				if (i + 1 !== oldLinesSplit.length) return true
-				// only keep last item if it's not an empty string
-				return removeWhitespace(l) !== ``
-			})
-			const oldLines = oldLinesOriginal.map(removeWhitespace)
-			const split = (str: string): string[] => {
-				return str.split("\n").map((l: string) => l.replaceAll(`\n`, `\\n`))
-			}
-			const fileLines = split(fileContent)
-			const normFileLines = fileLines.map(removeWhitespace)
-			const bestMatch: {
-				start: number
-				avgDist: number
-				type: string
-				end?: number
-			} = {
-				start: -1,
-				avgDist: Infinity,
-				type: "replace-lines",
-			}
-			const isSingleLineReplacement = oldLines.length === 1
-			const matchLineNumbers = normFileLines
-				.map((l: string, index: number) =>
-					l === oldLines[0] ? index + 1 : null,
-				)
-				.filter(Boolean)
-			if (
-				isSingleLineReplacement &&
-				matchLineNumbers.length > 1 &&
-				!startLineArg
-			) {
-				return `Single line search string "${oldLines[0]}" has too many matches. This will result in innacurate replacements. Found ${matchLineNumbers.length} matches. Pass start_line to choose one. Found on lines ${matchLineNumbers.join(`, `)}`
-			}
-			let divergedMessage
-			let divergenceAfterX = 0
-			const fileNoSpace = removeVaryingChars(fileContent)
-			const oldStringNoSpace = removeVaryingChars(oldStr)
-			if (fileNoSpace.includes(oldStringNoSpace.substring(0, -1))) {
-				let oldStringNoSpaceBuffer = oldStringNoSpace
-				let startIndex = null
-				let endIndex = null
-				for (const [index, line] of split(fileContent).entries()) {
-					if (
-						startIndex === null &&
-						typeof startLineArg !== `undefined` &&
-						index + 1 > startLineArg + 50 // allow for llm to be off by 50 lines lmao
-					) {
-						continue
-					}
-					if (typeof startLineArg !== `undefined` && index < startLineArg) {
-						continue
-					}
-					const lineNoSpace = removeVaryingChars(line)
-					if (lineNoSpace === `` && !startIndex) continue
-					const startsWith = oldStringNoSpaceBuffer.startsWith(lineNoSpace)
-					const startsWithNoDanglingCommaTho =
-						!startsWith &&
-						lineNoSpace.endsWith(`,`) &&
-						oldStringNoSpaceBuffer
-							.substring(lineNoSpace.length - 1)
-							.startsWith(`)`) &&
-						oldStringNoSpaceBuffer.startsWith(
-							lineNoSpace.substring(0, lineNoSpace.length - 1),
-						)
-					if (
-						startsWith ||
-						// allow for missing dangling comma (common in JS/TS, harmless in other languages)
-						startsWithNoDanglingCommaTho
-					) {
-						if (startIndex === null) {
-							startIndex = index
-						}
-						oldStringNoSpaceBuffer = oldStringNoSpaceBuffer.substring(
-							startsWithNoDanglingCommaTho
-								? lineNoSpace.length - 1 // remove the comma
-								: lineNoSpace.length,
-						)
-						if (oldStringNoSpaceBuffer.length === 0 && startIndex !== null) {
-							endIndex = index
-							break
-						}
-					} else if (startIndex !== null) {
-						// diverged from a partial match. reset
-						startIndex = null
-						oldStringNoSpaceBuffer = oldStringNoSpace
-					}
-				}
-				if (startIndex !== null && endIndex !== null) {
-					bestMatch.start = startIndex
-					bestMatch.end = endIndex
-				}
-			}
-			for (const [index, normLine] of normFileLines.entries()) {
-				if (!normLine) continue
-				// we already matched above!
-				if (bestMatch.end) break
-				if (typeof startLineArg !== `undefined` && index + 1 < startLineArg)
-					continue
-				// if there's a start line it must match within the next 50 lines
-				if (
-					typeof startLineArg !== `undefined` &&
-					index + 1 > startLineArg + 50
-				)
-					continue
-				if (
-					typeof startLineArg !== `undefined` &&
-					index + 1 > startLineArg + 5 &&
-					isSingleLineReplacement
-				) {
-					// only break early for single line replacements.. if the llm added a line number to start from + multiple lines to match, often it gets confused about the line numbers, so keep going until the end.
-					break
-				}
-				// this line is equal to the first line in our from replacement. Lets check each following line to see if we match
-				const firstDistance = distance(oldLines[0] || "", normLine || "")
-                const firstPercentDiff = (firstDistance / (normLine?.length || 0)) * 100
-                if (
-                    isSingleLineReplacement &&
-                    (normLine === oldLines[0] || normLine.includes(oldLines[0]!))
-                ) {
-					bestMatch.start = index
-					bestMatch.type = "replace-in-line"
-					continue
-				}
-                if (oldLines[0] === normLine || firstPercentDiff < 5) {
-                    let isMatching = true
-                    let matchingLineCount = 0
-                    for (const [matchIndex, oldLine] of oldLines.entries()) {
-                        const innerNormLine = normFileLines[index + matchIndex]!
-                        const innerDistance = distance(
-                            oldLine,
-                            normFileLines[index + matchIndex]!,
-                        )
-                        const innerPercentDiff =
-                            (innerDistance / innerNormLine.length) * 100
-						const remainingLines = oldLines.length - matchingLineCount
-						const percentLinesRemaining =
-							(remainingLines / oldLines.length) * 100
-						const isMatch = oldLine === innerNormLine || innerPercentDiff < 5
-						const fewLinesAreLeft =
-							oldLines.length >= 30 && percentLinesRemaining < 1
-						if (isMatch || fewLinesAreLeft) {
-							matchingLineCount++
-						} else {
-							const message = `old_str matching diverged after ${matchingLineCount} matching lines.\nExpected line from old_str: \`${oldLinesOriginal[matchIndex]}\` (line ${matchIndex + 1} in old_str), found line: \`${fileLines[index + matchIndex]}\` (line ${index + 1 + matchIndex} in file). ${remainingLines - 1} lines remained to compare but they were not checked due to this line not matching.\n\nHere are the lines that did match up until the old_str diverged:\n\n${oldLinesOriginal.slice(0, matchIndex).join(`\n`)}\n\nHere are the remaining lines you would've had to provide for the old_str to match:\n\n${fileLines
-								.slice(index + matchIndex, index + matchIndex + remainingLines)
-								.join(`\n`)}`
-							// tell the llm about the longest matching string so it can adjust the next input
-							if (matchingLineCount > divergenceAfterX) {
-								divergenceAfterX = matchingLineCount
-								divergedMessage = message
-							}
-							isMatching = false
-							break
-						}
-					}
-					if (isMatching) {
-						bestMatch.start = index
-						break
-					}
-				}
-			}
-			if (
-				bestMatch.start === -1 &&
-				(isSingleLineReplacement || oldStr === `\n`) &&
-				newStr === `` &&
-				typeof startLineArg === `number`
-			) {
-				// we're just deleting a line
-				bestMatch.start = startLineArg
-				bestMatch.type = "delete-line"
-			}
-			let newFileContent = ``
-			if (bestMatch.start === -1) {
-				return `No replacement was performed. No sufficiently close match for old_str found in ${args.path}.
-${divergedMessage ? divergedMessage : ``}Try adjusting your input or the file content.`
-			}
-			if (bestMatch.type === `replace-lines`) {
-				// Replace the original lines in fileLines from bestMatch.start to bestMatch.start + oldLines.length
-				const newFileLines = [
-					...fileLines.slice(0, bestMatch.start),
-					...(newStr ? newStr.split("\n") : []),
-					...fileLines.slice(
-						bestMatch.end
-							? bestMatch.end + 1
-							: bestMatch.start + oldLines.length,
-					),
-				]
-				// console.log({ newFileLines });
-				newFileContent = newFileLines.join("\n")
-				await writeFile(args.path, newFileContent)
-			} else if (bestMatch.type === `replace-in-line`) {
-				const [firstNew, ...restNew] = newStr ? newStr.split("\n") : []
-				const newFileLines = [
-					...fileLines.slice(0, bestMatch.start),
-                    ...(restNew?.length
-                        ? [firstNew, ...restNew]
-                        : [
-                                fileLines
-                                    .at(bestMatch.start)
-                                    ?.replace(oldLinesOriginal[0]!, firstNew || "") ?? "",
-                            ]),
-					...fileLines.slice(bestMatch.start + 1),
-				]
-				newFileContent = newFileLines.join("\n")
-				await writeFile(args.path, newFileContent)
-			} else if (bestMatch.type === `delete-line`) {
-				const newFileLines = [
-					...fileLines.slice(0, bestMatch.start),
-					...fileLines.slice(bestMatch.start + 1),
-				]
-				newFileContent = newFileLines.join("\n")
-				await writeFile(args.path, newFileContent)
-			}
-			// Find the line number for the snippet
-			const replacementLine = bestMatch.start + 1
-			const startLine = Math.max(0, replacementLine - SNIPPET_LINES)
-			const endLine =
-				replacementLine + SNIPPET_LINES + newStr.split("\n").length
-			const snippet = newFileContent
-				.split("\n")
-				.slice(startLine, endLine + 1)
-				.join("\n")
-			let successMsg = `The file ${args.path} has been edited. `
-			successMsg += makeOutput(
-				snippet,
-				`a snippet of ${args.path}`,
-				startLine + 1,
-			)
-			successMsg +=
-				"Review the changes and make sure they are as expected. Edit the file again if necessary."
-			return successMsg
-		}) // end withFileLock
-	}
-	async insert(args: InsertArgs) {
-		await validatePath("insert", args.path)
-		const fileContent = await readFile(args.path)
-		const newStr = args.new_str
-		const fileLines = fileContent.split("\n")
-		const nLinesFile = fileLines.length
-		if (args.insert_line < 0 || args.insert_line > nLinesFile) {
-			return `Invalid \`insert_line\` parameter: ${args.insert_line}. It should be within the range of lines of the file: [0, ${nLinesFile}]`
-		}
-		const newStrLines = newStr.split("\n")
-		const newFileLines = [
-			...fileLines.slice(0, args.insert_line + 1),
-			...newStrLines,
-			...fileLines.slice(args.insert_line + 1),
-		]
-		const snippetLines = [
-			...fileLines.slice(
-				Math.max(0, args.insert_line - SNIPPET_LINES),
-				args.insert_line + 1,
-			),
-			...newStrLines,
-			...fileLines.slice(
-				args.insert_line + 1,
-				args.insert_line + SNIPPET_LINES,
-			),
-		]
-		const newFileContent = newFileLines.join("\n")
-		const snippet = snippetLines.join("\n")
-		await writeFile(args.path, newFileContent)
-		let successMsg = `The file ${args.path} has been edited. `
-		successMsg += makeOutput(
-			snippet,
-			"a snippet of the edited file",
-			Math.max(1, args.insert_line - SNIPPET_LINES + 1),
-		)
-		successMsg +=
-			"Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary."
-		return successMsg
-	}
+      // If exact match and whitespace-normalized match both fail, proceed with fuzzy whitespace-agnostic matching
+      // First apply undoubleEscape for the fuzzy matching
+      const processedOldStr = args.old_str;
+      const processedNewStr = args.new_str || '';
+      // Remove leading line numbers and whitespace from each line
+      const removeLeadingLineNumbers = (str: string): string => {
+        return str
+          .split('\n')
+          .map(line => line.replace(/^\s*\d+\s*/, ''))
+          .join('\n');
+      };
+      let oldStr = removeLeadingLineNumbers(processedOldStr);
+      let newStr = removeLeadingLineNumbers(processedNewStr);
+      if (oldStr.startsWith(`\\\n`)) {
+        oldStr = oldStr.substring(`\\\n`.length);
+      }
+      if (newStr.startsWith(`\\\n`)) {
+        newStr = newStr.substring(`\\\n`.length);
+      }
+      const startLineArg =
+        typeof args.start_line === `number`
+          ? Math.max(args.start_line - 5, 0) // - 3 cause llms are not precise
+          : undefined;
+      // Split and normalize
+      const oldLinesSplit = oldStr.split('\n');
+      const oldLinesOriginal = oldLinesSplit.filter((l, i) => {
+        if (i === 0) return removeWhitespace(l) !== ``;
+        if (i + 1 !== oldLinesSplit.length) return true;
+        // only keep last item if it's not an empty string
+        return removeWhitespace(l) !== ``;
+      });
+      const oldLines = oldLinesOriginal.map(removeWhitespace);
+      const split = (str: string): string[] => {
+        return str.split('\n').map((l: string) => l.replaceAll(`\n`, `\\n`));
+      };
+      const fileLines = split(fileContent);
+      const normFileLines = fileLines.map(removeWhitespace);
+      const bestMatch: {
+        start: number;
+        avgDist: number;
+        type: string;
+        end?: number;
+      } = {
+        start: -1,
+        avgDist: Infinity,
+        type: 'replace-lines',
+      };
+      const isSingleLineReplacement = oldLines.length === 1;
+      const matchLineNumbers = normFileLines
+        .map((l: string, index: number) => (l === oldLines[0] ? index + 1 : null))
+        .filter(Boolean);
+      if (isSingleLineReplacement && matchLineNumbers.length > 1 && !startLineArg) {
+        return `Single line search string "${oldLines[0]}" has too many matches. This will result in innacurate replacements. Found ${matchLineNumbers.length} matches. Pass start_line to choose one. Found on lines ${matchLineNumbers.join(`, `)}`;
+      }
+      let divergedMessage;
+      let divergenceAfterX = 0;
+      const fileNoSpace = removeVaryingChars(fileContent);
+      const oldStringNoSpace = removeVaryingChars(oldStr);
+      if (fileNoSpace.includes(oldStringNoSpace.substring(0, -1))) {
+        let oldStringNoSpaceBuffer = oldStringNoSpace;
+        let startIndex = null;
+        let endIndex = null;
+        for (const [index, line] of split(fileContent).entries()) {
+          if (
+            startIndex === null &&
+            typeof startLineArg !== `undefined` &&
+            index + 1 > startLineArg + 50 // allow for llm to be off by 50 lines lmao
+          ) {
+            continue;
+          }
+          if (typeof startLineArg !== `undefined` && index < startLineArg) {
+            continue;
+          }
+          const lineNoSpace = removeVaryingChars(line);
+          if (lineNoSpace === `` && !startIndex) continue;
+          const startsWith = oldStringNoSpaceBuffer.startsWith(lineNoSpace);
+          const startsWithNoDanglingCommaTho =
+            !startsWith &&
+            lineNoSpace.endsWith(`,`) &&
+            oldStringNoSpaceBuffer.substring(lineNoSpace.length - 1).startsWith(`)`) &&
+            oldStringNoSpaceBuffer.startsWith(lineNoSpace.substring(0, lineNoSpace.length - 1));
+          if (
+            startsWith ||
+            // allow for missing dangling comma (common in JS/TS, harmless in other languages)
+            startsWithNoDanglingCommaTho
+          ) {
+            if (startIndex === null) {
+              startIndex = index;
+            }
+            oldStringNoSpaceBuffer = oldStringNoSpaceBuffer.substring(
+              startsWithNoDanglingCommaTho
+                ? lineNoSpace.length - 1 // remove the comma
+                : lineNoSpace.length,
+            );
+            if (oldStringNoSpaceBuffer.length === 0 && startIndex !== null) {
+              endIndex = index;
+              break;
+            }
+          } else if (startIndex !== null) {
+            // diverged from a partial match. reset
+            startIndex = null;
+            oldStringNoSpaceBuffer = oldStringNoSpace;
+          }
+        }
+        if (startIndex !== null && endIndex !== null) {
+          bestMatch.start = startIndex;
+          bestMatch.end = endIndex;
+        }
+      }
+      for (const [index, normLine] of normFileLines.entries()) {
+        if (!normLine) continue;
+        // we already matched above!
+        if (bestMatch.end) break;
+        if (typeof startLineArg !== `undefined` && index + 1 < startLineArg) continue;
+        // if there's a start line it must match within the next 50 lines
+        if (typeof startLineArg !== `undefined` && index + 1 > startLineArg + 50) continue;
+        if (typeof startLineArg !== `undefined` && index + 1 > startLineArg + 5 && isSingleLineReplacement) {
+          // only break early for single line replacements.. if the llm added a line number to start from + multiple lines to match, often it gets confused about the line numbers, so keep going until the end.
+          break;
+        }
+        // this line is equal to the first line in our from replacement. Lets check each following line to see if we match
+        const firstDistance = distance(oldLines[0] || '', normLine || '');
+        const firstPercentDiff = (firstDistance / (normLine?.length || 0)) * 100;
+        if (isSingleLineReplacement && (normLine === oldLines[0] || normLine.includes(oldLines[0]!))) {
+          bestMatch.start = index;
+          bestMatch.type = 'replace-in-line';
+          continue;
+        }
+        if (oldLines[0] === normLine || firstPercentDiff < 5) {
+          let isMatching = true;
+          let matchingLineCount = 0;
+          for (const [matchIndex, oldLine] of oldLines.entries()) {
+            const innerNormLine = normFileLines[index + matchIndex]!;
+            const innerDistance = distance(oldLine, normFileLines[index + matchIndex]!);
+            const innerPercentDiff = (innerDistance / innerNormLine.length) * 100;
+            const remainingLines = oldLines.length - matchingLineCount;
+            const percentLinesRemaining = (remainingLines / oldLines.length) * 100;
+            const isMatch = oldLine === innerNormLine || innerPercentDiff < 5;
+            const fewLinesAreLeft = oldLines.length >= 30 && percentLinesRemaining < 1;
+            if (isMatch || fewLinesAreLeft) {
+              matchingLineCount++;
+            } else {
+              const message = `old_str matching diverged after ${matchingLineCount} matching lines.\nExpected line from old_str: \`${oldLinesOriginal[matchIndex]}\` (line ${matchIndex + 1} in old_str), found line: \`${fileLines[index + matchIndex]}\` (line ${index + 1 + matchIndex} in file). ${remainingLines - 1} lines remained to compare but they were not checked due to this line not matching.\n\nHere are the lines that did match up until the old_str diverged:\n\n${oldLinesOriginal.slice(0, matchIndex).join(`\n`)}\n\nHere are the remaining lines you would've had to provide for the old_str to match:\n\n${fileLines
+                .slice(index + matchIndex, index + matchIndex + remainingLines)
+                .join(`\n`)}`;
+              // tell the llm about the longest matching string so it can adjust the next input
+              if (matchingLineCount > divergenceAfterX) {
+                divergenceAfterX = matchingLineCount;
+                divergedMessage = message;
+              }
+              isMatching = false;
+              break;
+            }
+          }
+          if (isMatching) {
+            bestMatch.start = index;
+            break;
+          }
+        }
+      }
+      if (
+        bestMatch.start === -1 &&
+        (isSingleLineReplacement || oldStr === `\n`) &&
+        newStr === `` &&
+        typeof startLineArg === `number`
+      ) {
+        // we're just deleting a line
+        bestMatch.start = startLineArg;
+        bestMatch.type = 'delete-line';
+      }
+      let newFileContent = ``;
+      if (bestMatch.start === -1) {
+        return `No replacement was performed. No sufficiently close match for old_str found in ${args.path}.
+${divergedMessage ? divergedMessage : ``}Try adjusting your input or the file content.`;
+      }
+      if (bestMatch.type === `replace-lines`) {
+        // Replace the original lines in fileLines from bestMatch.start to bestMatch.start + oldLines.length
+        const newFileLines = [
+          ...fileLines.slice(0, bestMatch.start),
+          ...(newStr ? newStr.split('\n') : []),
+          ...fileLines.slice(bestMatch.end ? bestMatch.end + 1 : bestMatch.start + oldLines.length),
+        ];
+        // console.log({ newFileLines });
+        newFileContent = newFileLines.join('\n');
+        await writeFile(args.path, newFileContent);
+      } else if (bestMatch.type === `replace-in-line`) {
+        const [firstNew, ...restNew] = newStr ? newStr.split('\n') : [];
+        const newFileLines = [
+          ...fileLines.slice(0, bestMatch.start),
+          ...(restNew?.length
+            ? [firstNew, ...restNew]
+            : [fileLines.at(bestMatch.start)?.replace(oldLinesOriginal[0]!, firstNew || '') ?? '']),
+          ...fileLines.slice(bestMatch.start + 1),
+        ];
+        newFileContent = newFileLines.join('\n');
+        await writeFile(args.path, newFileContent);
+      } else if (bestMatch.type === `delete-line`) {
+        const newFileLines = [...fileLines.slice(0, bestMatch.start), ...fileLines.slice(bestMatch.start + 1)];
+        newFileContent = newFileLines.join('\n');
+        await writeFile(args.path, newFileContent);
+      }
+      // Find the line number for the snippet
+      const replacementLine = bestMatch.start + 1;
+      const startLine = Math.max(0, replacementLine - SNIPPET_LINES);
+      const endLine = replacementLine + SNIPPET_LINES + newStr.split('\n').length;
+      const snippet = newFileContent
+        .split('\n')
+        .slice(startLine, endLine + 1)
+        .join('\n');
+      let successMsg = `The file ${args.path} has been edited. `;
+      successMsg += makeOutput(snippet, `a snippet of ${args.path}`, startLine + 1);
+      successMsg += 'Review the changes and make sure they are as expected. Edit the file again if necessary.';
+      return successMsg;
+    }); // end withFileLock
+  }
+  async insert(args: InsertArgs) {
+    await validatePath('insert', args.path);
+    const fileContent = await readFile(args.path);
+    const newStr = args.new_str;
+    const fileLines = fileContent.split('\n');
+    const nLinesFile = fileLines.length;
+    if (args.insert_line < 0 || args.insert_line > nLinesFile) {
+      return `Invalid \`insert_line\` parameter: ${args.insert_line}. It should be within the range of lines of the file: [0, ${nLinesFile}]`;
+    }
+    const newStrLines = newStr.split('\n');
+    const newFileLines = [
+      ...fileLines.slice(0, args.insert_line + 1),
+      ...newStrLines,
+      ...fileLines.slice(args.insert_line + 1),
+    ];
+    const snippetLines = [
+      ...fileLines.slice(Math.max(0, args.insert_line - SNIPPET_LINES), args.insert_line + 1),
+      ...newStrLines,
+      ...fileLines.slice(args.insert_line + 1, args.insert_line + SNIPPET_LINES),
+    ];
+    const newFileContent = newFileLines.join('\n');
+    const snippet = snippetLines.join('\n');
+    await writeFile(args.path, newFileContent);
+    let successMsg = `The file ${args.path} has been edited. `;
+    successMsg += makeOutput(
+      snippet,
+      'a snippet of the edited file',
+      Math.max(1, args.insert_line - SNIPPET_LINES + 1),
+    );
+    successMsg +=
+      'Review the changes and make sure they are as expected (correct indentation, no duplicate lines, etc). Edit the file again if necessary.';
+    return successMsg;
+  }
 
-	async isDirectory(filePath: string) {
-		try {
-			const stats = await fs.stat(filePath)
-			return stats.isDirectory()
-		} catch {
-			return false
-		}
-	}
+  async isDirectory(filePath: string) {
+    try {
+      const stats = await fs.stat(filePath);
+      return stats.isDirectory();
+    } catch {
+      return false;
+    }
+  }
 }
 
 // Singleton instance of FileEditor
-export const sharedFileEditor = new FileEditor()
+export const sharedFileEditor = new FileEditor();

--- a/mastracode/src/tools/file-view.ts
+++ b/mastracode/src/tools/file-view.ts
@@ -188,36 +188,35 @@ Usage notes:
 
 				// Handle file viewing
 				const fileContent = await readFile(absolutePath)
+                if (view_range) {
+                    const fileLines = fileContent.split("\n")
+                    const nLinesFile = fileLines.length
+                    let [start, end] = view_range as [number, number]
 
-				if (view_range) {
-					const fileLines = fileContent.split("\n")
-					const nLinesFile = fileLines.length
-					let [start, end] = view_range
+                    // Validate start line
+                    if (start < 1 || start > nLinesFile) {
+                        throw new Error(
+                            `Invalid \`view_range\`: ${view_range}. Its first element \`${start}\` should be within the range of lines of the file: [1, ${nLinesFile}]`,
+                        )
+                    }
 
-					// Validate start line
-					if (start < 1 || start > nLinesFile) {
-						throw new Error(
-							`Invalid \`view_range\`: ${view_range}. Its first element \`${start}\` should be within the range of lines of the file: [1, ${nLinesFile}]`,
-						)
-					}
+                    // Handle end line
+                    if (end !== -1) {
+                        if (end > nLinesFile) {
+                            end = nLinesFile
+                        }
+                        if (end < start) {
+                            throw new Error(
+                                `Invalid \`view_range\`: ${view_range}. Its second element \`${end}\` should be larger or equal than its first \`${start}\``,
+                            )
+                        }
+                    }
 
-					// Handle end line
-					if (end !== -1) {
-						if (end > nLinesFile) {
-							end = nLinesFile
-						}
-						if (end < start) {
-							throw new Error(
-								`Invalid \`view_range\`: ${view_range}. Its second element \`${end}\` should be larger or equal than its first \`${start}\``,
-							)
-						}
-					}
-
-					// Extract selected lines
-					const selectedLines =
-						end === -1
-							? fileLines.slice(start - 1)
-							: fileLines.slice(start - 1, end)
+                    // Extract selected lines
+                    const selectedLines =
+                        end === -1
+                            ? fileLines.slice(start - 1)
+                            : fileLines.slice(start - 1, end)
 
 					const output = makeOutput(
 						selectedLines.join("\n"),

--- a/mastracode/src/tools/file-view.ts
+++ b/mastracode/src/tools/file-view.ts
@@ -1,124 +1,111 @@
-import { exec } from "node:child_process"
-import { promises as fs } from "node:fs"
-import { homedir } from "node:os"
-import * as path from "node:path"
-import { promisify } from "node:util"
-import { createTool } from "@mastra/core/tools"
-import { z } from "zod/v3"
-import { truncateStringForTokenEstimate } from "../utils/token-estimator"
-import { assertPathAllowed, getAllowedPathsFromContext } from "./utils.js"
+import { exec } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import * as path from 'node:path';
+import { promisify } from 'node:util';
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod/v3';
+import { truncateStringForTokenEstimate } from '../utils/token-estimator';
+import { assertPathAllowed, getAllowedPathsFromContext } from './utils.js';
 
-const execAsync = promisify(exec)
+const execAsync = promisify(exec);
 
 // Maximum tokens for view tool output
-const MAX_VIEW_TOKENS = 3_000
+const MAX_VIEW_TOKENS = 3_000;
 
 /**
  * Shorten an absolute path for display to save tokens
  * Priority: relative to cwd > ~/path > absolute
  */
 function shortenPath(absolutePath: string, cwd: string): string {
-	// If path is under cwd, make it relative
-	if (absolutePath.startsWith(cwd + "/")) {
-		return absolutePath.slice(cwd.length + 1)
-	}
-	if (absolutePath === cwd) {
-		return "."
-	}
+  // If path is under cwd, make it relative
+  if (absolutePath.startsWith(cwd + '/')) {
+    return absolutePath.slice(cwd.length + 1);
+  }
+  if (absolutePath === cwd) {
+    return '.';
+  }
 
-	// If path is under home, use ~/
-	const home = homedir()
-	if (absolutePath.startsWith(home + "/")) {
-		return "~" + absolutePath.slice(home.length)
-	}
-	if (absolutePath === home) {
-		return "~"
-	}
+  // If path is under home, use ~/
+  const home = homedir();
+  if (absolutePath.startsWith(home + '/')) {
+    return '~' + absolutePath.slice(home.length);
+  }
+  if (absolutePath === home) {
+    return '~';
+  }
 
-	// Otherwise return as-is
-	return absolutePath
+  // Otherwise return as-is
+  return absolutePath;
 }
 
 /**
  * Format file content with line numbers (like `cat -n`)
  */
-function makeOutput(
-	fileContent: string,
-	fileDescriptor: string,
-	initLine = 1,
-	expandTabs = true,
-): string {
-	if (expandTabs) {
-		fileContent = fileContent.replace(/\t/g, "    ")
-	}
-	const lines = fileContent.split("\n")
-	const numberedLines = lines
-		.map((line, i) => `${(i + initLine).toString().padStart(6)}\t${line}`)
-		.join("\n")
-	return `Here's the result of running \`cat -n\` on ${fileDescriptor}:\n${numberedLines}\n`
+function makeOutput(fileContent: string, fileDescriptor: string, initLine = 1, expandTabs = true): string {
+  if (expandTabs) {
+    fileContent = fileContent.replace(/\t/g, '    ');
+  }
+  const lines = fileContent.split('\n');
+  const numberedLines = lines.map((line, i) => `${(i + initLine).toString().padStart(6)}\t${line}`).join('\n');
+  return `Here's the result of running \`cat -n\` on ${fileDescriptor}:\n${numberedLines}\n`;
 }
 
 /**
  * Read file content
  */
 async function readFile(filePath: string): Promise<string> {
-	try {
-		return await fs.readFile(filePath, "utf8")
-	} catch (e) {
-		const error = e instanceof Error ? e : new Error("Unknown error")
-		throw new Error(`Failed to read ${filePath}: ${error.message}`)
-	}
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch (e) {
+    const error = e instanceof Error ? e : new Error('Unknown error');
+    throw new Error(`Failed to read ${filePath}: ${error.message}`);
+  }
 }
 
 /**
  * Check if path is a directory
  */
 async function isDirectory(filePath: string): Promise<boolean> {
-	try {
-		const stats = await fs.stat(filePath)
-		return stats.isDirectory()
-	} catch {
-		return false
-	}
+  try {
+    const stats = await fs.stat(filePath);
+    return stats.isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 /**
  * Validate path exists and is accessible
  */
 async function validatePath(command: string, filePath: string): Promise<void> {
-	const absolutePath = path.isAbsolute(filePath)
-		? filePath
-		: path.join(process.cwd(), filePath)
+  const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(process.cwd(), filePath);
 
-	if (!path.isAbsolute(filePath)) {
-		filePath = absolutePath
-	}
+  if (!path.isAbsolute(filePath)) {
+    filePath = absolutePath;
+  }
 
-	try {
-		const stats = await fs.stat(filePath)
-		if (stats.isDirectory() && command !== "view") {
-			throw new Error(
-				`The path ${filePath} is a directory and only the \`view\` command can be used on directories`,
-			)
-		}
-	} catch (e) {
-		const error = e instanceof Error ? e : new Error("Unknown error")
-		if ("code" in error && error.code === "ENOENT") {
-			throw new Error(
-				`The path ${filePath} does not exist. Please provide a valid path.`,
-			)
-		}
-		throw error
-	}
+  try {
+    const stats = await fs.stat(filePath);
+    if (stats.isDirectory() && command !== 'view') {
+      throw new Error(`The path ${filePath} is a directory and only the \`view\` command can be used on directories`);
+    }
+  } catch (e) {
+    const error = e instanceof Error ? e : new Error('Unknown error');
+    if ('code' in error && error.code === 'ENOENT') {
+      throw new Error(`The path ${filePath} does not exist. Please provide a valid path.`);
+    }
+    throw error;
+  }
 }
 
 /**
  * Create the view tool for viewing file contents or directory listings
  */
 export function createViewTool(projectRoot?: string) {
-	return createTool({
-		id: "view",
-		description: `Read file contents with line numbers, or list directory contents. Paths are relative to the project root.
+  return createTool({
+    id: 'view',
+    description: `Read file contents with line numbers, or list directory contents. Paths are relative to the project root.
 
 Usage notes:
 - Use this to read files BEFORE editing them. Never modify code you haven't read.
@@ -127,136 +114,105 @@ Usage notes:
 - Output includes line numbers (like cat -n) for easy reference.
 - When NOT to use this tool: for searching file contents (use grep), for finding files by name (use glob).
 - Output is truncated if the file is very large. Use view_range to see specific sections.`,
-		inputSchema: z.object({
-			path: z
-				.string()
-				.describe("Path to the file or directory (relative to project root)"),
-			view_range: z
-				.array(z.number())
-				.length(2)
-				.optional()
-				.describe("Optional range of lines to view [start, end]"),
-		}),
-        execute: async (context, toolContext) => {
-            try {
-                const { path: filePath, view_range } = context
-                const root = projectRoot || process.cwd()
+    inputSchema: z.object({
+      path: z.string().describe('Path to the file or directory (relative to project root)'),
+      view_range: z.array(z.number()).length(2).optional().describe('Optional range of lines to view [start, end]'),
+    }),
+    execute: async (context, toolContext) => {
+      try {
+        const { path: filePath, view_range } = context;
+        const root = projectRoot || process.cwd();
 
-                // Resolve relative to projectRoot if provided, otherwise relative to process.cwd()
-                const absolutePath = path.resolve(root, filePath)
+        // Resolve relative to projectRoot if provided, otherwise relative to process.cwd()
+        const absolutePath = path.resolve(root, filePath);
 
-                // Security: ensure the path is within the project root or allowed paths
-                const allowedPaths = getAllowedPathsFromContext(toolContext)
-                assertPathAllowed(absolutePath, root, allowedPaths)
+        // Security: ensure the path is within the project root or allowed paths
+        const allowedPaths = getAllowedPathsFromContext(toolContext);
+        assertPathAllowed(absolutePath, root, allowedPaths);
 
-                await validatePath("view", absolutePath)
+        await validatePath('view', absolutePath);
 
-				// Handle directory listing
-				if (await isDirectory(absolutePath)) {
-					if (view_range) {
-						throw new Error(
-							"The `view_range` parameter is not allowed when `path` points to a directory.",
-						)
-					}
+        // Handle directory listing
+        if (await isDirectory(absolutePath)) {
+          if (view_range) {
+            throw new Error('The `view_range` parameter is not allowed when `path` points to a directory.');
+          }
 
-					const { stdout, stderr } = await execAsync(
-						`find "${absolutePath}" -maxdepth 2 -not -path '*/\\.*'`,
-					)
+          const { stdout, stderr } = await execAsync(`find "${absolutePath}" -maxdepth 2 -not -path '*/\\.*'`);
 
-					if (stderr) {
-						throw new Error(stderr)
-					}
+          if (stderr) {
+            throw new Error(stderr);
+          }
 
-					// Shorten paths in output to save tokens
-					const cwd = projectRoot || process.cwd()
-					const shortenedPaths = stdout
-						.split("\n")
-						.map((line) => (line.trim() ? shortenPath(line.trim(), cwd) : ""))
-						.join("\n")
+          // Shorten paths in output to save tokens
+          const cwd = projectRoot || process.cwd();
+          const shortenedPaths = stdout
+            .split('\n')
+            .map(line => (line.trim() ? shortenPath(line.trim(), cwd) : ''))
+            .join('\n');
 
-					const displayPath = shortenPath(absolutePath, cwd)
-					const dirOutput = `Here's the files and directories up to 2 levels deep in ${displayPath}, excluding hidden items:\n${shortenedPaths}\n`
-					return {
-						content: truncateStringForTokenEstimate(
-							dirOutput,
-							MAX_VIEW_TOKENS,
-							false,
-						),
-						isError: false,
-					}
-				}
+          const displayPath = shortenPath(absolutePath, cwd);
+          const dirOutput = `Here's the files and directories up to 2 levels deep in ${displayPath}, excluding hidden items:\n${shortenedPaths}\n`;
+          return {
+            content: truncateStringForTokenEstimate(dirOutput, MAX_VIEW_TOKENS, false),
+            isError: false,
+          };
+        }
 
-				// Handle file viewing
-				const fileContent = await readFile(absolutePath)
-                if (view_range) {
-                    const fileLines = fileContent.split("\n")
-                    const nLinesFile = fileLines.length
-                    let [start, end] = view_range as [number, number]
+        // Handle file viewing
+        const fileContent = await readFile(absolutePath);
+        if (view_range) {
+          const fileLines = fileContent.split('\n');
+          const nLinesFile = fileLines.length;
+          let [start, end] = view_range as [number, number];
 
-                    // Validate start line
-                    if (start < 1 || start > nLinesFile) {
-                        throw new Error(
-                            `Invalid \`view_range\`: ${view_range}. Its first element \`${start}\` should be within the range of lines of the file: [1, ${nLinesFile}]`,
-                        )
-                    }
+          // Validate start line
+          if (start < 1 || start > nLinesFile) {
+            throw new Error(
+              `Invalid \`view_range\`: ${view_range}. Its first element \`${start}\` should be within the range of lines of the file: [1, ${nLinesFile}]`,
+            );
+          }
 
-                    // Handle end line
-                    if (end !== -1) {
-                        if (end > nLinesFile) {
-                            end = nLinesFile
-                        }
-                        if (end < start) {
-                            throw new Error(
-                                `Invalid \`view_range\`: ${view_range}. Its second element \`${end}\` should be larger or equal than its first \`${start}\``,
-                            )
-                        }
-                    }
+          // Handle end line
+          if (end !== -1) {
+            if (end > nLinesFile) {
+              end = nLinesFile;
+            }
+            if (end < start) {
+              throw new Error(
+                `Invalid \`view_range\`: ${view_range}. Its second element \`${end}\` should be larger or equal than its first \`${start}\``,
+              );
+            }
+          }
 
-                    // Extract selected lines
-                    const selectedLines =
-                        end === -1
-                            ? fileLines.slice(start - 1)
-                            : fileLines.slice(start - 1, end)
+          // Extract selected lines
+          const selectedLines = end === -1 ? fileLines.slice(start - 1) : fileLines.slice(start - 1, end);
 
-					const output = makeOutput(
-						selectedLines.join("\n"),
-						String(filePath),
-						start,
-					)
-					return {
-						// Truncate from end (keep the start of the range the user requested)
-						content: truncateStringForTokenEstimate(
-							output,
-							MAX_VIEW_TOKENS,
-							false,
-						),
-						isError: false,
-					}
-				}
+          const output = makeOutput(selectedLines.join('\n'), String(filePath), start);
+          return {
+            // Truncate from end (keep the start of the range the user requested)
+            content: truncateStringForTokenEstimate(output, MAX_VIEW_TOKENS, false),
+            isError: false,
+          };
+        }
 
-				const fileLines = fileContent.split("\n")
-				const output = makeOutput(fileContent, String(filePath))
-				const truncated = truncateStringForTokenEstimate(
-					output,
-					MAX_VIEW_TOKENS,
-					false,
-				)
-				const wasTruncated = truncated !== output
-				return {
-					content: wasTruncated
-						? truncated +
-							`\n\n... ${fileLines.length} total lines in file. Use view_range to see specific sections.`
-						: truncated,
-					isError: false,
-				}
-			} catch (error) {
-				const errorMessage =
-					error instanceof Error ? error.message : "Unknown error occurred"
-				return {
-					content: errorMessage,
-					isError: true,
-				}
-			}
-		},
-	})
+        const fileLines = fileContent.split('\n');
+        const output = makeOutput(fileContent, String(filePath));
+        const truncated = truncateStringForTokenEstimate(output, MAX_VIEW_TOKENS, false);
+        const wasTruncated = truncated !== output;
+        return {
+          content: wasTruncated
+            ? truncated + `\n\n... ${fileLines.length} total lines in file. Use view_range to see specific sections.`
+            : truncated,
+          isError: false,
+        };
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+        return {
+          content: errorMessage,
+          isError: true,
+        };
+      }
+    },
+  });
 }

--- a/mastracode/src/tools/glob.ts
+++ b/mastracode/src/tools/glob.ts
@@ -159,16 +159,16 @@ function globToRegex(pattern: string): RegExp {
 				regexStr += pattern.slice(i, end + 1)
 				i = end + 1
 			} else {
-				regexStr += escapeRegex(c)
-				i++
-			}
-		} else {
-			regexStr += escapeRegex(c)
-			i++
-		}
-	}
+                regexStr += escapeRegex(c!)
+                i++
+            }
+        } else {
+            regexStr += escapeRegex(c!)
+            i++
+        }
+    }
 
-	return new RegExp("^" + regexStr + "$")
+    return new RegExp("^" + regexStr + "$")
 }
 
 function escapeRegex(s: string): string {

--- a/mastracode/src/tools/glob.ts
+++ b/mastracode/src/tools/glob.ts
@@ -1,199 +1,188 @@
 /**
  * Glob tool — fast file pattern matching.
  */
-import * as fs from "node:fs"
-import * as path from "node:path"
-import { createTool } from "@mastra/core/tools"
-import { execa } from "execa"
-import { z } from "zod/v3"
-import { truncateStringForTokenEstimate } from "../utils/token-estimator.js"
-import { assertPathAllowed, getAllowedPathsFromContext } from "./utils.js"
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createTool } from '@mastra/core/tools';
+import { execa } from 'execa';
+import { z } from 'zod/v3';
+import { truncateStringForTokenEstimate } from '../utils/token-estimator.js';
+import { assertPathAllowed, getAllowedPathsFromContext } from './utils.js';
 
-const MAX_GLOB_TOKENS = 2_000
+const MAX_GLOB_TOKENS = 2_000;
 
 /**
  * Simple glob matching using `find` + `git ls-files` for .gitignore respect.
  * We prefer git ls-files when inside a git repo since it respects .gitignore.
  */
-async function matchGlob(
-	pattern: string,
-	searchPath: string,
-	root: string,
-): Promise<string[]> {
-	// Check if we're in a git repo
-	let isGit = false
-	try {
-		await execa("git", ["rev-parse", "--git-dir"], { cwd: root })
-		isGit = true
-	} catch {
-		// Not a git repo
-	}
+async function matchGlob(pattern: string, searchPath: string, root: string): Promise<string[]> {
+  // Check if we're in a git repo
+  let isGit = false;
+  try {
+    await execa('git', ['rev-parse', '--git-dir'], { cwd: root });
+    isGit = true;
+  } catch {
+    // Not a git repo
+  }
 
-	if (isGit) {
-		// Use git ls-files which respects .gitignore
-		// --cached = tracked files, --others --exclude-standard = untracked but not ignored
-		const args = ["ls-files", "--cached", "--others", "--exclude-standard"]
+  if (isGit) {
+    // Use git ls-files which respects .gitignore
+    // --cached = tracked files, --others --exclude-standard = untracked but not ignored
+    const args = ['ls-files', '--cached', '--others', '--exclude-standard'];
 
-		const result = await execa("git", args, {
-			cwd: searchPath,
-			reject: false,
-			timeout: 10_000,
-		})
+    const result = await execa('git', args, {
+      cwd: searchPath,
+      reject: false,
+      timeout: 10_000,
+    });
 
-		if (result.exitCode !== 0) {
-			// Fall back to find
-			return matchGlobWithFind(pattern, searchPath)
-		}
+    if (result.exitCode !== 0) {
+      // Fall back to find
+      return matchGlobWithFind(pattern, searchPath);
+    }
 
-		const allFiles = result.stdout
-			.split("\n")
-			.filter((f) => f.trim())
-			.map((f) => path.resolve(searchPath, f))
+    const allFiles = result.stdout
+      .split('\n')
+      .filter(f => f.trim())
+      .map(f => path.resolve(searchPath, f));
 
-		// Apply the glob pattern as a simple filter
-		return filterByGlob(allFiles, pattern, searchPath)
-	}
+    // Apply the glob pattern as a simple filter
+    return filterByGlob(allFiles, pattern, searchPath);
+  }
 
-	return matchGlobWithFind(pattern, searchPath)
+  return matchGlobWithFind(pattern, searchPath);
 }
 
 /**
  * Fallback: use find command for non-git directories.
  */
-async function matchGlobWithFind(
-	pattern: string,
-	searchPath: string,
-): Promise<string[]> {
-	// Convert common glob patterns to find arguments
-	// For simple patterns like "*.ts", use -name
-	// For path patterns like "src/**/*.ts", we'll list all and filter
-	const result = await execa(
-		"find",
-		[
-			searchPath,
-			"-type",
-			"f",
-			"-not",
-			"-path",
-			"*/node_modules/*",
-			"-not",
-			"-path",
-			"*/.git/*",
-			"-not",
-			"-path",
-			"*/dist/*",
-			"-not",
-			"-path",
-			"*/.next/*",
-		],
-		{ reject: false, timeout: 10_000 },
-	)
+async function matchGlobWithFind(pattern: string, searchPath: string): Promise<string[]> {
+  // Convert common glob patterns to find arguments
+  // For simple patterns like "*.ts", use -name
+  // For path patterns like "src/**/*.ts", we'll list all and filter
+  const result = await execa(
+    'find',
+    [
+      searchPath,
+      '-type',
+      'f',
+      '-not',
+      '-path',
+      '*/node_modules/*',
+      '-not',
+      '-path',
+      '*/.git/*',
+      '-not',
+      '-path',
+      '*/dist/*',
+      '-not',
+      '-path',
+      '*/.next/*',
+    ],
+    { reject: false, timeout: 10_000 },
+  );
 
-	if (result.exitCode !== 0) return []
+  if (result.exitCode !== 0) return [];
 
-	const allFiles = result.stdout.split("\n").filter((f) => f.trim())
-	return filterByGlob(allFiles, pattern, searchPath)
+  const allFiles = result.stdout.split('\n').filter(f => f.trim());
+  return filterByGlob(allFiles, pattern, searchPath);
 }
 
 /**
  * Filter file paths by a glob-like pattern.
  * Supports: *, **, ?, and {a,b} alternatives.
  */
-function filterByGlob(
-	files: string[],
-	pattern: string,
-	basePath: string,
-): string[] {
-	const regex = globToRegex(pattern)
+function filterByGlob(files: string[], pattern: string, basePath: string): string[] {
+  const regex = globToRegex(pattern);
 
-	return files.filter((file) => {
-		// Test against relative path from basePath
-		const rel = path.relative(basePath, file)
-		return regex.test(rel)
-	})
+  return files.filter(file => {
+    // Test against relative path from basePath
+    const rel = path.relative(basePath, file);
+    return regex.test(rel);
+  });
 }
 
 /**
  * Convert a glob pattern to a regex.
  */
 function globToRegex(pattern: string): RegExp {
-	let regexStr = ""
-	let i = 0
+  let regexStr = '';
+  let i = 0;
 
-	while (i < pattern.length) {
-		const c = pattern[i]
+  while (i < pattern.length) {
+    const c = pattern[i];
 
-		if (c === "*") {
-			if (pattern[i + 1] === "*") {
-				// ** matches any number of path segments
-				if (pattern[i + 2] === "/") {
-					regexStr += "(?:.+/)?"
-					i += 3
-				} else {
-					regexStr += ".*"
-					i += 2
-				}
-			} else {
-				// * matches anything except /
-				regexStr += "[^/]*"
-				i++
-			}
-		} else if (c === "?") {
-			regexStr += "[^/]"
-			i++
-		} else if (c === "{") {
-			// {a,b,c} alternatives
-			const end = pattern.indexOf("}", i)
-			if (end !== -1) {
-				const alternatives = pattern.slice(i + 1, end).split(",")
-				regexStr += "(?:" + alternatives.map(escapeRegex).join("|") + ")"
-				i = end + 1
-			} else {
-				regexStr += escapeRegex(c)
-				i++
-			}
-		} else if (c === "[") {
-			// Character classes - pass through
-			const end = pattern.indexOf("]", i)
-			if (end !== -1) {
-				regexStr += pattern.slice(i, end + 1)
-				i = end + 1
-			} else {
-                regexStr += escapeRegex(c!)
-                i++
-            }
+    if (c === '*') {
+      if (pattern[i + 1] === '*') {
+        // ** matches any number of path segments
+        if (pattern[i + 2] === '/') {
+          regexStr += '(?:.+/)?';
+          i += 3;
         } else {
-            regexStr += escapeRegex(c!)
-            i++
+          regexStr += '.*';
+          i += 2;
         }
+      } else {
+        // * matches anything except /
+        regexStr += '[^/]*';
+        i++;
+      }
+    } else if (c === '?') {
+      regexStr += '[^/]';
+      i++;
+    } else if (c === '{') {
+      // {a,b,c} alternatives
+      const end = pattern.indexOf('}', i);
+      if (end !== -1) {
+        const alternatives = pattern.slice(i + 1, end).split(',');
+        regexStr += '(?:' + alternatives.map(escapeRegex).join('|') + ')';
+        i = end + 1;
+      } else {
+        regexStr += escapeRegex(c);
+        i++;
+      }
+    } else if (c === '[') {
+      // Character classes - pass through
+      const end = pattern.indexOf(']', i);
+      if (end !== -1) {
+        regexStr += pattern.slice(i, end + 1);
+        i = end + 1;
+      } else {
+        regexStr += escapeRegex(c!);
+        i++;
+      }
+    } else {
+      regexStr += escapeRegex(c!);
+      i++;
     }
+  }
 
-    return new RegExp("^" + regexStr + "$")
+  return new RegExp('^' + regexStr + '$');
 }
 
 function escapeRegex(s: string): string {
-	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**
  * Get file modification time for sorting.
  */
 async function getModTime(filePath: string): Promise<number> {
-	try {
-		const stat = await fs.promises.stat(filePath)
-		return stat.mtimeMs
-	} catch {
-		return 0
-	}
+  try {
+    const stat = await fs.promises.stat(filePath);
+    return stat.mtimeMs;
+  } catch {
+    return 0;
+  }
 }
 
 /**
  * Create the glob tool for finding files by name pattern.
  */
 export function createGlobTool(projectRoot?: string) {
-	return createTool({
-		id: "find_files",
-		description: `Find files matching a glob pattern. Returns file paths sorted by modification time (most recent first).
+  return createTool({
+    id: 'find_files',
+    description: `Find files matching a glob pattern. Returns file paths sorted by modification time (most recent first).
 
 Usage notes:
 - Use this to find files by name or path pattern. NEVER use execute_command with find or ls for file search.
@@ -205,71 +194,59 @@ Usage notes:
   - "*.{js,ts}" — JS and TS files in the root
   - "**/package.json" — all package.json files
   - "src/components/**" — everything under src/components/`,
-		inputSchema: z.object({
-			pattern: z
-				.string()
-				.describe(
-					'Glob pattern to match files (e.g., "**/*.ts", "src/**/*.test.*")',
-				),
-			path: z
-				.string()
-				.optional()
-				.describe(
-					"Directory to search in (relative to project root). Defaults to project root.",
-				),
-		}),
-        execute: async (context, toolContext) => {
-            try {
-                const root = projectRoot || process.cwd()
-                const searchPath = context.path
-                    ? path.resolve(root, context.path)
-                    : root
+    inputSchema: z.object({
+      pattern: z.string().describe('Glob pattern to match files (e.g., "**/*.ts", "src/**/*.test.*")'),
+      path: z
+        .string()
+        .optional()
+        .describe('Directory to search in (relative to project root). Defaults to project root.'),
+    }),
+    execute: async (context, toolContext) => {
+      try {
+        const root = projectRoot || process.cwd();
+        const searchPath = context.path ? path.resolve(root, context.path) : root;
 
-                // Security: ensure the search path is within the project root or allowed paths
-                const allowedPaths = getAllowedPathsFromContext(toolContext)
-                assertPathAllowed(searchPath, root, allowedPaths)
+        // Security: ensure the search path is within the project root or allowed paths
+        const allowedPaths = getAllowedPathsFromContext(toolContext);
+        assertPathAllowed(searchPath, root, allowedPaths);
 
-				const matches = await matchGlob(context.pattern, searchPath, root)
+        const matches = await matchGlob(context.pattern, searchPath, root);
 
-				if (matches.length === 0) {
-					return {
-						content: `No files found matching pattern: ${context.pattern}`,
-						isError: false,
-					}
-				}
+        if (matches.length === 0) {
+          return {
+            content: `No files found matching pattern: ${context.pattern}`,
+            isError: false,
+          };
+        }
 
-				// Get modification times for sorting
-				const withTimes = await Promise.all(
-					matches.map(async (f) => ({
-						path: f,
-						mtime: await getModTime(f),
-					})),
-				)
+        // Get modification times for sorting
+        const withTimes = await Promise.all(
+          matches.map(async f => ({
+            path: f,
+            mtime: await getModTime(f),
+          })),
+        );
 
-				// Sort by modification time, most recent first
-				withTimes.sort((a, b) => b.mtime - a.mtime)
+        // Sort by modification time, most recent first
+        withTimes.sort((a, b) => b.mtime - a.mtime);
 
-				// Make paths relative to project root
-				const relativePaths = withTimes.map((f) => path.relative(root, f.path))
+        // Make paths relative to project root
+        const relativePaths = withTimes.map(f => path.relative(root, f.path));
 
-				const header = `Found ${relativePaths.length} file${relativePaths.length !== 1 ? "s" : ""} matching "${context.pattern}":\n\n`
-				const listing = relativePaths.join("\n")
+        const header = `Found ${relativePaths.length} file${relativePaths.length !== 1 ? 's' : ''} matching "${context.pattern}":\n\n`;
+        const listing = relativePaths.join('\n');
 
-				return {
-					content: truncateStringForTokenEstimate(
-						header + listing,
-						MAX_GLOB_TOKENS,
-						false,
-					),
-					isError: false,
-				}
-			} catch (error) {
-				const msg = error instanceof Error ? error.message : "Unknown error"
-				return {
-					content: `glob failed: ${msg}`,
-					isError: true,
-				}
-			}
-		},
-	})
+        return {
+          content: truncateStringForTokenEstimate(header + listing, MAX_GLOB_TOKENS, false),
+          isError: false,
+        };
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: `glob failed: ${msg}`,
+          isError: true,
+        };
+      }
+    },
+  });
 }

--- a/mastracode/src/tools/grep.ts
+++ b/mastracode/src/tools/grep.ts
@@ -1,38 +1,38 @@
 /**
  * Grep tool — fast content search using ripgrep (rg) with Node.js fallback.
  */
-import * as path from "node:path"
-import { createTool } from "@mastra/core/tools"
-import { execa } from "execa"
-import { z } from "zod/v3"
-import { truncateStringForTokenEstimate } from "../utils/token-estimator.js"
-import { assertPathAllowed, getAllowedPathsFromContext } from "./utils.js"
+import * as path from 'node:path';
+import { createTool } from '@mastra/core/tools';
+import { execa } from 'execa';
+import { z } from 'zod/v3';
+import { truncateStringForTokenEstimate } from '../utils/token-estimator.js';
+import { assertPathAllowed, getAllowedPathsFromContext } from './utils.js';
 
-const MAX_GREP_TOKENS = 3_000
+const MAX_GREP_TOKENS = 3_000;
 
 /**
  * Check if ripgrep is available on the system.
  */
-let rgAvailable: boolean | null = null
+let rgAvailable: boolean | null = null;
 async function hasRipgrep(): Promise<boolean> {
-	if (rgAvailable !== null) return rgAvailable
-	try {
-		await execa("rg", ["--version"])
-		rgAvailable = true
-	} catch {
-		rgAvailable = false
-	}
-	return rgAvailable
+  if (rgAvailable !== null) return rgAvailable;
+  try {
+    await execa('rg', ['--version']);
+    rgAvailable = true;
+  } catch {
+    rgAvailable = false;
+  }
+  return rgAvailable;
 }
 
 /**
  * Create the grep tool for searching file contents.
  */
 export function createGrepTool(projectRoot?: string) {
-	return createTool({
-		id: "search_content",
-		// requireApproval: true,
-		description: `Search file contents using regex patterns. Returns matching lines with file paths and line numbers.
+  return createTool({
+    id: 'search_content',
+    // requireApproval: true,
+    description: `Search file contents using regex patterns. Returns matching lines with file paths and line numbers.
 
 Usage notes:
 - Use this for ALL content search (finding functions, variables, error messages, imports, etc.)
@@ -42,175 +42,141 @@ Usage notes:
 - Use \`contextLines\` to see surrounding code for each match
 - Results are sorted by file path for readability
 - Output is truncated if too large — narrow your search with a more specific pattern or glob filter`,
-		inputSchema: z.object({
-			pattern: z
-				.string()
-				.describe("Regex pattern to search for in file contents"),
-			path: z
-				.string()
-				.optional()
-				.describe(
-					"Directory or file to search in (relative to project root). Defaults to project root.",
-				),
-			glob: z
-				.string()
-				.optional()
-				.describe(
-					'Glob pattern to filter files (e.g., "*.ts", "*.{js,jsx}", "test/**")',
-				),
-			contextLines: z
-				.number()
-				.optional()
-				.describe(
-					"Number of lines to show before and after each match (default: 0)",
-				),
-			maxResults: z
-				.number()
-				.optional()
-				.describe("Maximum number of matching lines to return (default: 100)"),
-			caseSensitive: z
-				.boolean()
-				.optional()
-				.describe("Whether the search is case-sensitive (default: true)"),
-		}),
-		execute: async (context, toolContext) => {
-			try {
-				const root = projectRoot || process.cwd()
-				const searchPath = context.path
-					? path.resolve(root, context.path)
-					: root
+    inputSchema: z.object({
+      pattern: z.string().describe('Regex pattern to search for in file contents'),
+      path: z
+        .string()
+        .optional()
+        .describe('Directory or file to search in (relative to project root). Defaults to project root.'),
+      glob: z.string().optional().describe('Glob pattern to filter files (e.g., "*.ts", "*.{js,jsx}", "test/**")'),
+      contextLines: z.number().optional().describe('Number of lines to show before and after each match (default: 0)'),
+      maxResults: z.number().optional().describe('Maximum number of matching lines to return (default: 100)'),
+      caseSensitive: z.boolean().optional().describe('Whether the search is case-sensitive (default: true)'),
+    }),
+    execute: async (context, toolContext) => {
+      try {
+        const root = projectRoot || process.cwd();
+        const searchPath = context.path ? path.resolve(root, context.path) : root;
 
-				// Security: ensure the search path is within the project root or allowed paths
-				const allowedPaths = getAllowedPathsFromContext(toolContext)
-				assertPathAllowed(searchPath, root, allowedPaths)
-				const maxResults = context.maxResults ?? 100
-				const contextLines = context.contextLines ?? 0
-				const caseSensitive = context.caseSensitive ?? true
+        // Security: ensure the search path is within the project root or allowed paths
+        const allowedPaths = getAllowedPathsFromContext(toolContext);
+        assertPathAllowed(searchPath, root, allowedPaths);
+        const maxResults = context.maxResults ?? 100;
+        const contextLines = context.contextLines ?? 0;
+        const caseSensitive = context.caseSensitive ?? true;
 
-				const useRg = await hasRipgrep()
+        const useRg = await hasRipgrep();
 
-				let output: string
+        let output: string;
 
-				if (useRg) {
-					// Build ripgrep command
-					const args: string[] = [
-						"--line-number",
-						"--no-heading",
-						"--color=never",
-						"--max-count",
-						String(maxResults),
-					]
+        if (useRg) {
+          // Build ripgrep command
+          const args: string[] = ['--line-number', '--no-heading', '--color=never', '--max-count', String(maxResults)];
 
-					if (!caseSensitive) args.push("--ignore-case")
-					if (contextLines > 0) {
-						args.push("--context", String(contextLines))
-					}
-					if (context.glob) {
-						args.push("--glob", context.glob)
-					}
+          if (!caseSensitive) args.push('--ignore-case');
+          if (contextLines > 0) {
+            args.push('--context', String(contextLines));
+          }
+          if (context.glob) {
+            args.push('--glob', context.glob);
+          }
 
-					args.push("--", context.pattern, searchPath)
+          args.push('--', context.pattern, searchPath);
 
-					const result = await execa("rg", args, {
-						reject: false,
-						timeout: 15_000,
-						cwd: root,
-					})
+          const result = await execa('rg', args, {
+            reject: false,
+            timeout: 15_000,
+            cwd: root,
+          });
 
-					if (result.exitCode === 1) {
-						// No matches found
-						return {
-							content: `No matches found for pattern: ${context.pattern}`,
-							isError: false,
-						}
-					}
-					if (result.exitCode !== 0 && result.exitCode !== 1) {
-						return {
-							content: `grep error: ${result.stderr || "Unknown error"}`,
-							isError: true,
-						}
-					}
+          if (result.exitCode === 1) {
+            // No matches found
+            return {
+              content: `No matches found for pattern: ${context.pattern}`,
+              isError: false,
+            };
+          }
+          if (result.exitCode !== 0 && result.exitCode !== 1) {
+            return {
+              content: `grep error: ${result.stderr || 'Unknown error'}`,
+              isError: true,
+            };
+          }
 
-					output = result.stdout || ""
-				} else {
-					// Fallback to grep
-					const args: string[] = ["-r", "-n", "--color=never"]
+          output = result.stdout || '';
+        } else {
+          // Fallback to grep
+          const args: string[] = ['-r', '-n', '--color=never'];
 
-					if (!caseSensitive) args.push("-i")
-					if (contextLines > 0) {
-						args.push(`-C${contextLines}`)
-					}
-					if (context.glob) {
-						args.push(`--include=${context.glob}`)
-					}
+          if (!caseSensitive) args.push('-i');
+          if (contextLines > 0) {
+            args.push(`-C${contextLines}`);
+          }
+          if (context.glob) {
+            args.push(`--include=${context.glob}`);
+          }
 
-					args.push("--", context.pattern, searchPath)
+          args.push('--', context.pattern, searchPath);
 
-					const result = await execa("grep", args, {
-						reject: false,
-						timeout: 15_000,
-						cwd: root,
-					})
+          const result = await execa('grep', args, {
+            reject: false,
+            timeout: 15_000,
+            cwd: root,
+          });
 
-					if (result.exitCode === 1) {
-						return {
-							content: `No matches found for pattern: ${context.pattern}`,
-							isError: false,
-						}
-					}
-					if (result.exitCode !== 0 && result.exitCode !== 1) {
-						return {
-							content: `grep error: ${result.stderr || "Unknown error"}`,
-							isError: true,
-						}
-					}
+          if (result.exitCode === 1) {
+            return {
+              content: `No matches found for pattern: ${context.pattern}`,
+              isError: false,
+            };
+          }
+          if (result.exitCode !== 0 && result.exitCode !== 1) {
+            return {
+              content: `grep error: ${result.stderr || 'Unknown error'}`,
+              isError: true,
+            };
+          }
 
-					output = result.stdout || ""
+          output = result.stdout || '';
 
-					// Truncate to maxResults lines (grep doesn't have --max-count for recursive)
-					const lines = output.split("\n")
-					if (lines.length > maxResults) {
-						output =
-							lines.slice(0, maxResults).join("\n") +
-							`\n... (${lines.length - maxResults} more matches, narrow your search)`
-					}
-				}
+          // Truncate to maxResults lines (grep doesn't have --max-count for recursive)
+          const lines = output.split('\n');
+          if (lines.length > maxResults) {
+            output =
+              lines.slice(0, maxResults).join('\n') +
+              `\n... (${lines.length - maxResults} more matches, narrow your search)`;
+          }
+        }
 
-				// Make paths relative to project root for readability
-				const relativized = output
-					.split("\n")
-					.map((line) => {
-						if (line.startsWith(root + "/")) {
-							return line.slice(root.length + 1)
-						}
-						if (line.startsWith(root)) {
-							return line.slice(root.length)
-						}
-						return line
-					})
-					.join("\n")
+        // Make paths relative to project root for readability
+        const relativized = output
+          .split('\n')
+          .map(line => {
+            if (line.startsWith(root + '/')) {
+              return line.slice(root.length + 1);
+            }
+            if (line.startsWith(root)) {
+              return line.slice(root.length);
+            }
+            return line;
+          })
+          .join('\n');
 
-				const matchCount = relativized
-					.split("\n")
-					.filter((l) => l.trim() && !l.startsWith("--")).length
+        const matchCount = relativized.split('\n').filter(l => l.trim() && !l.startsWith('--')).length;
 
-				const header = `Found ${matchCount} match${matchCount !== 1 ? "es" : ""} for "${context.pattern}":\n\n`
+        const header = `Found ${matchCount} match${matchCount !== 1 ? 'es' : ''} for "${context.pattern}":\n\n`;
 
-				return {
-					content: truncateStringForTokenEstimate(
-						header + relativized,
-						MAX_GREP_TOKENS,
-						false,
-					),
-					isError: false,
-				}
-			} catch (error) {
-				const msg = error instanceof Error ? error.message : "Unknown error"
-				return {
-					content: `grep failed: ${msg}`,
-					isError: true,
-				}
-			}
-		},
-	})
+        return {
+          content: truncateStringForTokenEstimate(header + relativized, MAX_GREP_TOKENS, false),
+          isError: false,
+        };
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: `grep failed: ${msg}`,
+          isError: true,
+        };
+      }
+    },
+  });
 }

--- a/mastracode/src/tools/index.ts
+++ b/mastracode/src/tools/index.ts
@@ -2,24 +2,20 @@
  * Tool exports for Mastra Code
  */
 
-export { createViewTool } from "./file-view"
-export { createExecuteCommandTool, executeCommandTool } from "./shell"
-export { stringReplaceLspTool } from "./string-replace-lsp"
-export {
-	createWebSearchTool,
-	createWebExtractTool,
-	hasTavilyKey,
-} from "./web-search"
-export { createGrepTool } from "./grep"
-export { createGlobTool } from "./glob"
-export { createWriteFileTool } from "./write"
-export { createSubagentTool } from "./subagent"
-export type { SubagentToolDeps } from "./subagent"
-export { todoWriteTool } from "./todo"
-export type { TodoItem } from "./todo"
-export { todoCheckTool } from "./todo-check"
-export { askUserTool } from "./ask-user"
-export { submitPlanTool } from "./submit-plan"
-export type { PlanApprovalResult } from "./submit-plan"
-export { astSmartEditTool } from "./ast-smart-edit"
-export { requestSandboxAccessTool } from "./request-sandbox-access"
+export { createViewTool } from './file-view';
+export { createExecuteCommandTool, executeCommandTool } from './shell';
+export { stringReplaceLspTool } from './string-replace-lsp';
+export { createWebSearchTool, createWebExtractTool, hasTavilyKey } from './web-search';
+export { createGrepTool } from './grep';
+export { createGlobTool } from './glob';
+export { createWriteFileTool } from './write';
+export { createSubagentTool } from './subagent';
+export type { SubagentToolDeps } from './subagent';
+export { todoWriteTool } from './todo';
+export type { TodoItem } from './todo';
+export { todoCheckTool } from './todo-check';
+export { askUserTool } from './ask-user';
+export { submitPlanTool } from './submit-plan';
+export type { PlanApprovalResult } from './submit-plan';
+export { astSmartEditTool } from './ast-smart-edit';
+export { requestSandboxAccessTool } from './request-sandbox-access';

--- a/mastracode/src/tools/request-sandbox-access.ts
+++ b/mastracode/src/tools/request-sandbox-access.ts
@@ -71,16 +71,15 @@ export const requestSandboxAccessTool = createTool({
 			const approved =
 				answer.toLowerCase().startsWith("y") ||
 				answer.toLowerCase() === "approve"
-
-			if (approved) {
-				// Add to allowed paths
-				const currentAllowed =
-					harnessCtx.getState?.()?.sandboxAllowedPaths ?? []
-				if (!currentAllowed.includes(absolutePath)) {
-					harnessCtx.setState?.({
-						sandboxAllowedPaths: [...currentAllowed, absolutePath],
-					})
-				}
+            if (approved) {
+                // Add to allowed paths
+                const currentAllowed =
+                    (harnessCtx.getState?.()?.sandboxAllowedPaths as string[] | undefined) ?? []
+                if (!currentAllowed.includes(absolutePath)) {
+                    harnessCtx.setState?.({
+                        sandboxAllowedPaths: [...currentAllowed, absolutePath],
+                    })
+                }
 				return {
 					content: `Access granted: "${absolutePath}" has been added to allowed paths. You can now access files in this directory.`,
 					isError: false,

--- a/mastracode/src/tools/request-sandbox-access.ts
+++ b/mastracode/src/tools/request-sandbox-access.ts
@@ -3,99 +3,86 @@
  * The user can approve or deny the request via TUI dialog.
  */
 
-import * as path from "node:path"
-import { createTool } from "@mastra/core/tools"
-import { z } from "zod/v3"
-import type { HarnessRuntimeContext } from "../harness/types.js"
-import { isPathAllowed, getAllowedPathsFromContext } from "./utils.js"
+import * as path from 'node:path';
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod/v3';
+import type { HarnessRuntimeContext } from '../harness/types.js';
+import { isPathAllowed, getAllowedPathsFromContext } from './utils.js';
 
-let requestCounter = 0
+let requestCounter = 0;
 
 export const requestSandboxAccessTool = createTool({
-	id: "request_sandbox_access",
-	description: `Request permission to access a directory outside the current project. Use this when you need to read or write files in a directory that is not within the project root. The user will be prompted to approve or deny the request.`,
-	inputSchema: z.object({
-		path: z
-			.string()
-			.min(1)
-			.describe("The absolute path to the directory you need access to."),
-		reason: z
-			.string()
-			.min(1)
-			.describe("Brief explanation of why you need access to this directory."),
-	}),
-	execute: async ({ path: requestedPath, reason }, context) => {
-		try {
-			const harnessCtx = context?.requestContext?.get("harness") as
-				| HarnessRuntimeContext
-				| undefined
+  id: 'request_sandbox_access',
+  description: `Request permission to access a directory outside the current project. Use this when you need to read or write files in a directory that is not within the project root. The user will be prompted to approve or deny the request.`,
+  inputSchema: z.object({
+    path: z.string().min(1).describe('The absolute path to the directory you need access to.'),
+    reason: z.string().min(1).describe('Brief explanation of why you need access to this directory.'),
+  }),
+  execute: async ({ path: requestedPath, reason }, context) => {
+    try {
+      const harnessCtx = context?.requestContext?.get('harness') as HarnessRuntimeContext | undefined;
 
-			// Resolve to absolute path
-			const absolutePath = path.isAbsolute(requestedPath)
-				? requestedPath
-				: path.resolve(process.cwd(), requestedPath)
+      // Resolve to absolute path
+      const absolutePath = path.isAbsolute(requestedPath) ? requestedPath : path.resolve(process.cwd(), requestedPath);
 
-			// Check if already allowed
-			const projectRoot = process.cwd()
-			const allowedPaths = getAllowedPathsFromContext(context)
-			if (isPathAllowed(absolutePath, projectRoot, allowedPaths)) {
-				return {
-					content: `Access already granted: "${absolutePath}" is within the project root or allowed paths.`,
-					isError: false,
-				}
-			}
+      // Check if already allowed
+      const projectRoot = process.cwd();
+      const allowedPaths = getAllowedPathsFromContext(context);
+      if (isPathAllowed(absolutePath, projectRoot, allowedPaths)) {
+        return {
+          content: `Access already granted: "${absolutePath}" is within the project root or allowed paths.`,
+          isError: false,
+        };
+      }
 
-			if (!harnessCtx?.emitEvent || !harnessCtx?.registerQuestion) {
-				return {
-					content: `Cannot request sandbox access: TUI context not available. The user should manually run /sandbox add ${absolutePath}`,
-					isError: true,
-				}
-			}
+      if (!harnessCtx?.emitEvent || !harnessCtx?.registerQuestion) {
+        return {
+          content: `Cannot request sandbox access: TUI context not available. The user should manually run /sandbox add ${absolutePath}`,
+          isError: true,
+        };
+      }
 
-			const questionId = `sandbox_${++requestCounter}_${Date.now()}`
+      const questionId = `sandbox_${++requestCounter}_${Date.now()}`;
 
-			// Create a promise that resolves when the user answers in the TUI
-			const answer = await new Promise<string>((resolve) => {
-				// Register the resolver so respondToQuestion() can resolve it
-				harnessCtx.registerQuestion!(questionId, resolve)
+      // Create a promise that resolves when the user answers in the TUI
+      const answer = await new Promise<string>(resolve => {
+        // Register the resolver so respondToQuestion() can resolve it
+        harnessCtx.registerQuestion!(questionId, resolve);
 
-				// Emit event — TUI will show the dialog
-				harnessCtx.emitEvent!({
-					type: "sandbox_access_request",
-					questionId,
-					path: absolutePath,
-					reason,
-				} as any)
-			})
+        // Emit event — TUI will show the dialog
+        harnessCtx.emitEvent!({
+          type: 'sandbox_access_request',
+          questionId,
+          path: absolutePath,
+          reason,
+        } as any);
+      });
 
-			const approved =
-				answer.toLowerCase().startsWith("y") ||
-				answer.toLowerCase() === "approve"
-            if (approved) {
-                // Add to allowed paths
-                const currentAllowed =
-                    (harnessCtx.getState?.()?.sandboxAllowedPaths as string[] | undefined) ?? []
-                if (!currentAllowed.includes(absolutePath)) {
-                    harnessCtx.setState?.({
-                        sandboxAllowedPaths: [...currentAllowed, absolutePath],
-                    })
-                }
-				return {
-					content: `Access granted: "${absolutePath}" has been added to allowed paths. You can now access files in this directory.`,
-					isError: false,
-				}
-			} else {
-				return {
-					content: `Access denied: The user declined access to "${absolutePath}".`,
-					isError: false,
-				}
-			}
-		} catch (error) {
-			const msg = error instanceof Error ? error.message : "Unknown error"
-			return {
-				content: `Failed to request sandbox access: ${msg}`,
-				isError: true,
-			}
-		}
-	},
-})
+      const approved = answer.toLowerCase().startsWith('y') || answer.toLowerCase() === 'approve';
+      if (approved) {
+        // Add to allowed paths
+        const currentAllowed = (harnessCtx.getState?.()?.sandboxAllowedPaths as string[] | undefined) ?? [];
+        if (!currentAllowed.includes(absolutePath)) {
+          harnessCtx.setState?.({
+            sandboxAllowedPaths: [...currentAllowed, absolutePath],
+          });
+        }
+        return {
+          content: `Access granted: "${absolutePath}" has been added to allowed paths. You can now access files in this directory.`,
+          isError: false,
+        };
+      } else {
+        return {
+          content: `Access denied: The user declined access to "${absolutePath}".`,
+          isError: false,
+        };
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        content: `Failed to request sandbox access: ${msg}`,
+        isError: true,
+      };
+    }
+  },
+});

--- a/mastracode/src/tools/shell.ts
+++ b/mastracode/src/tools/shell.ts
@@ -1,106 +1,97 @@
-import * as path from "node:path"
-import { createTool } from "@mastra/core/tools"
-import { execa, ExecaError } from "execa"
-import stripAnsi from "strip-ansi"
-import treeKill from "tree-kill"
-import { z } from "zod/v3"
-import { ipcReporter } from "../ipc/ipc-reporter.js"
-import { truncateStringForTokenEstimate } from "../utils/token-estimator"
-import { isPathAllowed, getAllowedPathsFromContext } from "./utils.js"
-
+import * as path from 'node:path';
+import { createTool } from '@mastra/core/tools';
+import { execa, ExecaError } from 'execa';
+import stripAnsi from 'strip-ansi';
+import treeKill from 'tree-kill';
+import { z } from 'zod/v3';
+import { ipcReporter } from '../ipc/ipc-reporter.js';
+import { truncateStringForTokenEstimate } from '../utils/token-estimator';
+import { isPathAllowed, getAllowedPathsFromContext } from './utils.js';
 
 // Global registry for pending terminal IDs (keyed by confirmationId)
-const pendingTerminalIds = new Map<string, string>()
+const pendingTerminalIds = new Map<string, string>();
 
-export function setPendingTerminalId(
-	confirmationId: string,
-	terminalId: string,
-) {
-	pendingTerminalIds.set(confirmationId, terminalId)
+export function setPendingTerminalId(confirmationId: string, terminalId: string) {
+  pendingTerminalIds.set(confirmationId, terminalId);
 }
 
-export function getPendingTerminalId(
-	confirmationId: string,
-): string | undefined {
-	return pendingTerminalIds.get(confirmationId)
+export function getPendingTerminalId(confirmationId: string): string | undefined {
+  return pendingTerminalIds.get(confirmationId);
 }
 
 export function clearPendingTerminalId(confirmationId: string) {
-	pendingTerminalIds.delete(confirmationId)
+  pendingTerminalIds.delete(confirmationId);
 }
 
 // Track active subprocesses to clean up on exit
-const activeSubprocesses = new Set<number>()
-let cleanupHandlersRegistered = false
+const activeSubprocesses = new Set<number>();
+let cleanupHandlersRegistered = false;
 
 // Register global cleanup handlers to kill all active subprocesses on exit
 function registerCleanupHandlers() {
-	if (cleanupHandlersRegistered) return
-	cleanupHandlersRegistered = true
+  if (cleanupHandlersRegistered) return;
+  cleanupHandlersRegistered = true;
 
-	const killAllSubprocesses = () => {
-		for (const pid of activeSubprocesses) {
-			try {
-				// Kill the entire process group
-				process.kill(-pid, "SIGKILL")
-			} catch {
-				// Process may already be dead
-			}
+  const killAllSubprocesses = () => {
+    for (const pid of activeSubprocesses) {
+      try {
+        // Kill the entire process group
+        process.kill(-pid, 'SIGKILL');
+      } catch {
+        // Process may already be dead
+      }
 
-			// Also use tree-kill for nested children
-			treeKill(pid, "SIGKILL", () => {
-				// Ignore errors
-			})
-		}
-		activeSubprocesses.clear()
-	}
+      // Also use tree-kill for nested children
+      treeKill(pid, 'SIGKILL', () => {
+        // Ignore errors
+      });
+    }
+    activeSubprocesses.clear();
+  };
 
-	// Handle normal exit
-	process.on("exit", () => {
-		killAllSubprocesses()
-	})
+  // Handle normal exit
+  process.on('exit', () => {
+    killAllSubprocesses();
+  });
 
-	// Handle SIGINT (Ctrl+C)
-	process.on("SIGINT", () => {
-		killAllSubprocesses()
-		process.exit(0)
-	})
+  // Handle SIGINT (Ctrl+C)
+  process.on('SIGINT', () => {
+    killAllSubprocesses();
+    process.exit(0);
+  });
 
-	// Handle SIGTERM
-	process.on("SIGTERM", () => {
-		killAllSubprocesses()
-		process.exit(0)
-	})
+  // Handle SIGTERM
+  process.on('SIGTERM', () => {
+    killAllSubprocesses();
+    process.exit(0);
+  });
 }
 
 // Helper to apply tail to output
 function applyTail(output: string, tailLines?: number): string {
-	if (!tailLines || tailLines <= 0) return output
-	const lines = output.split("\n")
-	if (lines.length <= tailLines) return output
-	return lines.slice(-tailLines).join("\n")
+  if (!tailLines || tailLines <= 0) return output;
+  const lines = output.split('\n');
+  if (lines.length <= tailLines) return output;
+  return lines.slice(-tailLines).join('\n');
 }
 
 // Schema for command execution - matching MCP reference exactly
 const ExecuteCommandSchema = z.object({
-	command: z.string().describe("Full shell command to execute"),
-	cwd: z
-		.string()
-		.optional()
-		.describe("Working directory for command execution"),
-	timeout: z
-		.number()
-		.optional()
-		.describe(
-			"The number of seconds until the shell command should be killed if it hasn't exited yet. Defaults to 30 seconds",
-		),
-})
+  command: z.string().describe('Full shell command to execute'),
+  cwd: z.string().optional().describe('Working directory for command execution'),
+  timeout: z
+    .number()
+    .optional()
+    .describe(
+      "The number of seconds until the shell command should be killed if it hasn't exited yet. Defaults to 30 seconds",
+    ),
+});
 
 // Function to create the execute command tool with optional project root
 export function createExecuteCommandTool(projectRoot?: string) {
-	return createTool({
-		id: "execute_command",
-		description: `Execute a shell command in the local system.
+  return createTool({
+    id: 'execute_command',
+    description: `Execute a shell command in the local system.
 
 Usage notes:
 - Use for: git commands, npm/pnpm, docker, build tools, test runners, linters, and other terminal operations.
@@ -109,482 +100,458 @@ Usage notes:
 - Output is stripped of ANSI codes and truncated if too long. Pipe to "| tail -N" for long outputs.
 - Be careful with destructive commands. Never run git push --force, git reset --hard, or rm -rf without explicit user request.
 - For interactive commands that need user input, they will fail. Set CI=true is already forced.`,
-		inputSchema: ExecuteCommandSchema,
-		// requireApproval: true,
-		execute: async (context, toolContext) => {
-			let { command } = context
-			let extractedTail: number | undefined
-            // Extract `| tail -N` or `| tail -n N` from command if present
-            // This allows streaming all output to user while only returning last N lines to agent
-            const tailPipeMatch = command.match(/\|\s*tail\s+(?:-n\s+)?(-?\d+)\s*$/)
-            if (tailPipeMatch) {
-                const tailLines = Math.abs(parseInt(tailPipeMatch[1]!, 10))
-				if (tailLines > 0) {
-					extractedTail = tailLines
-					// Remove the tail pipe from the command
-					command = command
-						.replace(/\|\s*tail\s+(?:-n\s+)?-?\d+\s*$/, "")
-						.trim()
-				}
-			}
+    inputSchema: ExecuteCommandSchema,
+    // requireApproval: true,
+    execute: async (context, toolContext) => {
+      let { command } = context;
+      let extractedTail: number | undefined;
+      // Extract `| tail -N` or `| tail -n N` from command if present
+      // This allows streaming all output to user while only returning last N lines to agent
+      const tailPipeMatch = command.match(/\|\s*tail\s+(?:-n\s+)?(-?\d+)\s*$/);
+      if (tailPipeMatch) {
+        const tailLines = Math.abs(parseInt(tailPipeMatch[1]!, 10));
+        if (tailLines > 0) {
+          extractedTail = tailLines;
+          // Remove the tail pipe from the command
+          command = command.replace(/\|\s*tail\s+(?:-n\s+)?-?\d+\s*$/, '').trim();
+        }
+      }
 
-			// Use provided cwd, fall back to project root, then process.cwd()
-			const cwd = context.cwd || projectRoot || process.cwd()
-			const root = projectRoot || process.cwd()
+      // Use provided cwd, fall back to project root, then process.cwd()
+      const cwd = context.cwd || projectRoot || process.cwd();
+      const root = projectRoot || process.cwd();
 
-			// Security: if a custom cwd was provided, ensure it's within the project root or allowed paths
-			if (context.cwd) {
-				const allowedPaths = getAllowedPathsFromContext(toolContext)
-				const resolvedCwd = path.resolve(context.cwd)
-				if (!isPathAllowed(resolvedCwd, root, allowedPaths)) {
-					return {
-						content: [
-							{
-								type: "text" as const,
-								text: `Error: cwd "${resolvedCwd}" is outside the project root "${root}". Use /sandbox to add additional allowed paths.`,
-							},
-						],
-						isError: true,
-					}
-				}
-			}
+      // Security: if a custom cwd was provided, ensure it's within the project root or allowed paths
+      if (context.cwd) {
+        const allowedPaths = getAllowedPathsFromContext(toolContext);
+        const resolvedCwd = path.resolve(context.cwd);
+        if (!isPathAllowed(resolvedCwd, root, allowedPaths)) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Error: cwd "${resolvedCwd}" is outside the project root "${root}". Use /sandbox to add additional allowed paths.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      }
 
-			if (!command.includes(cwd) && cwd !== process.cwd()) {
-				ipcReporter.send(`shell-output`, {
-					output: `\n# ${cwd}`,
-					type: `stdout`,
-					style: { fg: "grey" },
-				})
-			}
-			ipcReporter.send(`shell-output`, {
-				output: `\n\n$ ${command}\n\n`,
-				type: `stdout`,
-				style: { fg: "green" },
-			})
+      if (!command.includes(cwd) && cwd !== process.cwd()) {
+        ipcReporter.send(`shell-output`, {
+          output: `\n# ${cwd}`,
+          type: `stdout`,
+          style: { fg: 'grey' },
+        });
+      }
+      ipcReporter.send(`shell-output`, {
+        output: `\n\n$ ${command}\n\n`,
+        type: `stdout`,
+        style: { fg: 'green' },
+      });
 
-			// Check if we're in ACP mode - stream output via tool_call_update notifications
-			const isACPMode = process.argv.includes("--acp-internal")
-			if (isACPMode) {
-				const { getGlobalConfirmationId } =
-					await import("./wrap-with-confirmation.js")
+      // Check if we're in ACP mode - stream output via tool_call_update notifications
+      const isACPMode = process.argv.includes('--acp-internal');
+      if (isACPMode) {
+        const { getGlobalConfirmationId } = await import('./wrap-with-confirmation.js');
 
-				const _confirmationId = getGlobalConfirmationId()
+        const _confirmationId = getGlobalConfirmationId();
 
-				try {
-					// Use execa to run the command with streaming
-					const { execa } = await import("execa")
+        try {
+          // Use execa to run the command with streaming
+          const { execa } = await import('execa');
 
-					let stdout = ""
-					let stderr = ""
-					let combined = ""
+          let stdout = '';
+          let stderr = '';
+          let combined = '';
 
-					const timeout = context.timeout ? context.timeout * 1000 : 30000
-					const subprocess = execa(command, [], {
-						shell: true,
-						cwd,
-						all: true,
-						buffer: true,
-						reject: false,
-						timeout,
-					})
+          const timeout = context.timeout ? context.timeout * 1000 : 30000;
+          const subprocess = execa(command, [], {
+            shell: true,
+            cwd,
+            all: true,
+            buffer: true,
+            reject: false,
+            timeout,
+          });
 
-					// Stream stdout chunks
-					if (subprocess.stdout) {
-						subprocess.stdout.on("data", (chunk: Buffer) => {
-							const text = chunk.toString()
-							ipcReporter.send(`shell-output`, { output: text, type: `stdout` })
-							stdout += text
-							combined += text
-						})
-					}
+          // Stream stdout chunks
+          if (subprocess.stdout) {
+            subprocess.stdout.on('data', (chunk: Buffer) => {
+              const text = chunk.toString();
+              ipcReporter.send(`shell-output`, { output: text, type: `stdout` });
+              stdout += text;
+              combined += text;
+            });
+          }
 
-					// Stream stderr chunks
-					if (subprocess.stderr) {
-						subprocess.stderr.on("data", (chunk: Buffer) => {
-							const text = chunk.toString()
-							ipcReporter.send(`shell-output`, { output: text, type: `stderr` })
+          // Stream stderr chunks
+          if (subprocess.stderr) {
+            subprocess.stderr.on('data', (chunk: Buffer) => {
+              const text = chunk.toString();
+              ipcReporter.send(`shell-output`, { output: text, type: `stderr` });
 
-							stderr += text
-							combined += text
-						})
-					}
+              stderr += text;
+              combined += text;
+            });
+          }
 
-					// Wait for completion
-					const result = await subprocess
+          // Wait for completion
+          const result = await subprocess;
 
-					if (result.timedOut || (result?.exitCode && result.exitCode > 0)) {
-						ipcReporter.send(`shell-output`, {
-							output: `\nExited with code ${result.exitCode}${result.timedOut ? `\nTimed out after ${timeout}ms` : ``}\n\n`,
-							type: "stdout",
-							style: { fg: "grey" },
-						})
-					}
+          if (result.timedOut || (result?.exitCode && result.exitCode > 0)) {
+            ipcReporter.send(`shell-output`, {
+              output: `\nExited with code ${result.exitCode}${result.timedOut ? `\nTimed out after ${timeout}ms` : ``}\n\n`,
+              type: 'stdout',
+              style: { fg: 'grey' },
+            });
+          }
 
-					return {
-						stdout: extractedTail ? applyTail(stdout, extractedTail) : stdout,
-						stderr: extractedTail ? applyTail(stderr, extractedTail) : stderr,
-						combined: extractedTail
-							? applyTail(combined, extractedTail)
-							: combined,
-						exitCode: result.exitCode || 0,
-						signal: result.signal,
-						timedOut: result.timedOut || false,
-						command,
-						cwd,
-						duration: 0, // execa doesn't provide duration
-					}
-				} catch (error) {
-					throw new Error(
-						`Command execution failed: ${error instanceof Error ? error.message : String(error)}`,
-					)
-				}
-			}
+          return {
+            stdout: extractedTail ? applyTail(stdout, extractedTail) : stdout,
+            stderr: extractedTail ? applyTail(stderr, extractedTail) : stderr,
+            combined: extractedTail ? applyTail(combined, extractedTail) : combined,
+            exitCode: result.exitCode || 0,
+            signal: result.signal,
+            timedOut: result.timedOut || false,
+            command,
+            cwd,
+            duration: 0, // execa doesn't provide duration
+          };
+        } catch (error) {
+          throw new Error(`Command execution failed: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
 
-			// console.log(`\n🔧 Executing: ${command}`)
-			// console.log(`📁 Working directory: ${cwd}`)
-			// if (projectRoot && !context.cwd) {
-			//   console.log(`   (using project root from frontmatter)`)
-			// }
-			// console.log('----------------------------------------')
-			const timeoutMS = context.timeout ? context.timeout * 1000 : 30_000
-			// console.log({ timeoutMS })
+      // console.log(`\n🔧 Executing: ${command}`)
+      // console.log(`📁 Working directory: ${cwd}`)
+      // if (projectRoot && !context.cwd) {
+      //   console.log(`   (using project root from frontmatter)`)
+      // }
+      // console.log('----------------------------------------')
+      const timeoutMS = context.timeout ? context.timeout * 1000 : 30_000;
+      // console.log({ timeoutMS })
 
-			let timeoutHandle: NodeJS.Timeout | undefined
-			let manuallyKilled = false
-			let abortedBySignal = false
-			let subprocess: ReturnType<typeof execa> | undefined
-			let capturedOutput = "" // Track output ourselves for abort case
+      let timeoutHandle: NodeJS.Timeout | undefined;
+      let manuallyKilled = false;
+      let abortedBySignal = false;
+      let subprocess: ReturnType<typeof execa> | undefined;
+      let capturedOutput = ''; // Track output ourselves for abort case
 
-			// Get abort signal and emit function from harness context
-			const harnessCtx = (toolContext as any)?.requestContext?.get("harness")
-			const abortSignal = harnessCtx?.abortSignal as AbortSignal | undefined
-			const emitEvent = harnessCtx?.emitEvent as
-				| ((event: {
-					type: "shell_output"
-					toolCallId: string
-					output: string
-					stream: "stdout" | "stderr"
-				}) => void)
-				| undefined
-			const toolCallId = (toolContext as any)?.agent?.toolCallId as
-				| string
-				| undefined
+      // Get abort signal and emit function from harness context
+      const harnessCtx = (toolContext as any)?.requestContext?.get('harness');
+      const abortSignal = harnessCtx?.abortSignal as AbortSignal | undefined;
+      const emitEvent = harnessCtx?.emitEvent as
+        | ((event: { type: 'shell_output'; toolCallId: string; output: string; stream: 'stdout' | 'stderr' }) => void)
+        | undefined;
+      const toolCallId = (toolContext as any)?.agent?.toolCallId as string | undefined;
 
-			// Define abort handler outside try block so it's accessible in catch
-			const abortHandler = () => {
-				if (subprocess?.pid) {
-					abortedBySignal = true
-					try {
-						process.kill(-subprocess.pid, "SIGKILL")
-					} catch {
-						treeKill(subprocess.pid, "SIGKILL", () => { })
-					}
-				}
-			}
+      // Define abort handler outside try block so it's accessible in catch
+      const abortHandler = () => {
+        if (subprocess?.pid) {
+          abortedBySignal = true;
+          try {
+            process.kill(-subprocess.pid, 'SIGKILL');
+          } catch {
+            treeKill(subprocess.pid, 'SIGKILL', () => {});
+          }
+        }
+      };
 
-			try {
-				// Create the subprocess with environment variables to force color output
-				// and use inherit for stdio to preserve TTY context
-				subprocess = execa(command, {
-					cwd,
-					shell: true,
-					stdio: ["pipe", "pipe", "pipe"], // all piped — TUI owns the terminal
-					buffer: true, // Buffer output for return value
-					all: true, // Combine stdout and stderr
-					env: {
-						// PATH: process.env.PATH,
-						...process.env,
-						FORCE_COLOR: "1", // Force color output for most Node.js tools
-						CLICOLOR_FORCE: "1", // Force color for BSD tools
-						TERM: process.env.TERM || "xterm-256color", // Ensure TERM is set
-						CI: "true", // Prevent interactive prompts
-						NONINTERACTIVE: "1", // Alternative for some tools
-						DEBIAN_FRONTEND: "noninteractive", // For apt-get and similar
-					},
-					// Tell execa to handle the output as if it's a TTY
-					stripFinalNewline: false,
-					timeout: timeoutMS,
-					forceKillAfterDelay: 100,
-					killSignal: "SIGKILL",
-					cleanup: true,
-					detached: true, // Create a new process group so we can kill all children
-				})
+      try {
+        // Create the subprocess with environment variables to force color output
+        // and use inherit for stdio to preserve TTY context
+        subprocess = execa(command, {
+          cwd,
+          shell: true,
+          stdio: ['pipe', 'pipe', 'pipe'], // all piped — TUI owns the terminal
+          buffer: true, // Buffer output for return value
+          all: true, // Combine stdout and stderr
+          env: {
+            // PATH: process.env.PATH,
+            ...process.env,
+            FORCE_COLOR: '1', // Force color output for most Node.js tools
+            CLICOLOR_FORCE: '1', // Force color for BSD tools
+            TERM: process.env.TERM || 'xterm-256color', // Ensure TERM is set
+            CI: 'true', // Prevent interactive prompts
+            NONINTERACTIVE: '1', // Alternative for some tools
+            DEBIAN_FRONTEND: 'noninteractive', // For apt-get and similar
+          },
+          // Tell execa to handle the output as if it's a TTY
+          stripFinalNewline: false,
+          timeout: timeoutMS,
+          forceKillAfterDelay: 100,
+          killSignal: 'SIGKILL',
+          cleanup: true,
+          detached: true, // Create a new process group so we can kill all children
+        });
 
-				// console.log(`shell pid ${subprocess.pid}`)
+        // console.log(`shell pid ${subprocess.pid}`)
 
-				// Register cleanup handlers and track this subprocess
-				registerCleanupHandlers()
-				if (subprocess.pid) {
-					activeSubprocesses.add(subprocess.pid)
-				}
+        // Register cleanup handlers and track this subprocess
+        registerCleanupHandlers();
+        if (subprocess.pid) {
+          activeSubprocesses.add(subprocess.pid);
+        }
 
-				// Set up a timeout handler to kill the process tree
-				if (timeoutMS && subprocess.pid) {
-					timeoutHandle = setTimeout(() => {
-						if (subprocess?.pid) {
-							// console.error(`\n⏱️  Timeout reached, killing process group ${subprocess.pid}...`)
-							manuallyKilled = true
-							try {
-								// Kill the entire process group by using negative PID
-								// This works because we set detached: true
-								process.kill(-subprocess.pid, "SIGKILL")
-							} catch {
-								// console.error(`Failed to kill process group: ${err}`)
-								// Fallback to tree-kill
-								treeKill(subprocess.pid, "SIGKILL")
-							}
-						}
-					}, timeoutMS - 100) // Kill 100ms before execa's timeout
-				}
+        // Set up a timeout handler to kill the process tree
+        if (timeoutMS && subprocess.pid) {
+          timeoutHandle = setTimeout(() => {
+            if (subprocess?.pid) {
+              // console.error(`\n⏱️  Timeout reached, killing process group ${subprocess.pid}...`)
+              manuallyKilled = true;
+              try {
+                // Kill the entire process group by using negative PID
+                // This works because we set detached: true
+                process.kill(-subprocess.pid, 'SIGKILL');
+              } catch {
+                // console.error(`Failed to kill process group: ${err}`)
+                // Fallback to tree-kill
+                treeKill(subprocess.pid, 'SIGKILL');
+              }
+            }
+          }, timeoutMS - 100); // Kill 100ms before execa's timeout
+        }
 
-				// Set up abort signal handler to kill subprocess on Ctrl+C
-				if (abortSignal) {
-					abortSignal.addEventListener("abort", abortHandler)
-				}
-				// Capture stdout/stderr and stream to TUI via harness events
-				if (subprocess.stdout) {
-					subprocess.stdout.on(`data`, (chunk: Buffer) => {
-						const text = chunk.toString()
-						capturedOutput += text
-						ipcReporter.send(`shell-output`, { output: text, type: `stdout` })
-						// Emit shell_output event for TUI streaming
-						if (emitEvent && toolCallId) {
-							emitEvent({
-								type: "shell_output",
-								toolCallId,
-								output: text,
-								stream: "stdout",
-							})
-						}
-					})
-				}
+        // Set up abort signal handler to kill subprocess on Ctrl+C
+        if (abortSignal) {
+          abortSignal.addEventListener('abort', abortHandler);
+        }
+        // Capture stdout/stderr and stream to TUI via harness events
+        if (subprocess.stdout) {
+          subprocess.stdout.on(`data`, (chunk: Buffer) => {
+            const text = chunk.toString();
+            capturedOutput += text;
+            ipcReporter.send(`shell-output`, { output: text, type: `stdout` });
+            // Emit shell_output event for TUI streaming
+            if (emitEvent && toolCallId) {
+              emitEvent({
+                type: 'shell_output',
+                toolCallId,
+                output: text,
+                stream: 'stdout',
+              });
+            }
+          });
+        }
 
-				if (subprocess.stderr) {
-					subprocess.stderr.on(`data`, (chunk: Buffer) => {
-						const text = chunk.toString()
-						capturedOutput += text
-						ipcReporter.send(`shell-output`, { output: text, type: `stderr` })
-						// Emit shell_output event for TUI streaming
-						if (emitEvent && toolCallId) {
-							emitEvent({
-								type: "shell_output",
-								toolCallId,
-								output: text,
-								stream: "stderr",
-							})
-						}
-					})
-				}
+        if (subprocess.stderr) {
+          subprocess.stderr.on(`data`, (chunk: Buffer) => {
+            const text = chunk.toString();
+            capturedOutput += text;
+            ipcReporter.send(`shell-output`, { output: text, type: `stderr` });
+            // Emit shell_output event for TUI streaming
+            if (emitEvent && toolCallId) {
+              emitEvent({
+                type: 'shell_output',
+                toolCallId,
+                output: text,
+                stream: 'stderr',
+              });
+            }
+          });
+        }
 
-				// Wait for completion
-				const result = await subprocess
+        // Wait for completion
+        const result = await subprocess;
 
-				// Clean up abort listener
-				if (abortSignal) {
-					abortSignal.removeEventListener("abort", abortHandler)
-				}
+        // Clean up abort listener
+        if (abortSignal) {
+          abortSignal.removeEventListener('abort', abortHandler);
+        }
 
-				// Check if aborted
-				if (abortedBySignal) {
-					ipcReporter.send(`shell-output`, {
-						output: `\nAborted by user\n`,
-						style: { fg: "yellow" },
-						type: "stdout",
-					})
+        // Check if aborted
+        if (abortedBySignal) {
+          ipcReporter.send(`shell-output`, {
+            output: `\nAborted by user\n`,
+            style: { fg: 'yellow' },
+            type: 'stdout',
+          });
 
-					// Clear the timeout
-					if (timeoutHandle) {
-						clearTimeout(timeoutHandle)
-					}
+          // Clear the timeout
+          if (timeoutHandle) {
+            clearTimeout(timeoutHandle);
+          }
 
-					// Use our captured output (more reliable than result.all on SIGKILL)
-					let cleanOutput = stripAnsi(capturedOutput)
-					if (extractedTail) {
-						cleanOutput = applyTail(cleanOutput, extractedTail)
-					}
+          // Use our captured output (more reliable than result.all on SIGKILL)
+          let cleanOutput = stripAnsi(capturedOutput);
+          if (extractedTail) {
+            cleanOutput = applyTail(cleanOutput, extractedTail);
+          }
 
-					return {
-						content: [
-							{
-								type: "text" as const,
-								text: cleanOutput.trim()
-									? `[User aborted command]\n\nPartial output:\n${truncateStringForTokenEstimate(cleanOutput, 1_000)}`
-									: "[User aborted command]",
-							},
-						],
-						isError: true,
-					}
-				}
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: cleanOutput.trim()
+                  ? `[User aborted command]\n\nPartial output:\n${truncateStringForTokenEstimate(cleanOutput, 1_000)}`
+                  : '[User aborted command]',
+              },
+            ],
+            isError: true,
+          };
+        }
 
-				ipcReporter.send(`shell-output`, {
-					output: `\nExited with code ${result.exitCode}${result.timedOut ? `\nTimed out after ${timeoutMS}ms` : ``}\n`,
-					style: { fg: "grey" },
-					type: "stdout",
-				})
+        ipcReporter.send(`shell-output`, {
+          output: `\nExited with code ${result.exitCode}${result.timedOut ? `\nTimed out after ${timeoutMS}ms` : ``}\n`,
+          style: { fg: 'grey' },
+          type: 'stdout',
+        });
 
-				// Clear the timeout if command completed successfully
-				if (timeoutHandle) {
-					clearTimeout(timeoutHandle)
-				}
+        // Clear the timeout if command completed successfully
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle);
+        }
 
-				// console.log('\n✅ Command completed successfully')
-				// console.log('----------------------------------------\n')
+        // console.log('\n✅ Command completed successfully')
+        // console.log('----------------------------------------\n')
 
-				// Strip ANSI codes from the output for the LLM
-				// Since we have all: true, result.all contains the interleaved output
-				const rawOutput =
-					result.all ||
-					result.stdout ||
-					result.stderr ||
-					"Command executed successfully with no output"
-				let cleanOutput = stripAnsi(
-					typeof rawOutput === "string" ? rawOutput : rawOutput.toString(),
-				)
+        // Strip ANSI codes from the output for the LLM
+        // Since we have all: true, result.all contains the interleaved output
+        const rawOutput =
+          result.all || result.stdout || result.stderr || 'Command executed successfully with no output';
+        let cleanOutput = stripAnsi(typeof rawOutput === 'string' ? rawOutput : rawOutput.toString());
 
-				// Apply tail if specified
-				if (extractedTail) {
-					cleanOutput = applyTail(cleanOutput, extractedTail)
-				}
+        // Apply tail if specified
+        if (extractedTail) {
+          cleanOutput = applyTail(cleanOutput, extractedTail);
+        }
 
-				return {
-					content: [
-						{
-							type: "text",
-							// only allow xk tokens of output
-							text: truncateStringForTokenEstimate(cleanOutput, 2_000),
-						},
-					],
-					isError: false,
-				}
-			} catch (error: any) {
-				// console.error('\n❌ Command failed')
-				// console.error('----------------------------------------\n')
-				// Clean up abort listener and timeout handle on error
-				if (abortSignal) {
-					abortSignal.removeEventListener("abort", abortHandler)
-				}
-				if (timeoutHandle) {
-					clearTimeout(timeoutHandle)
-				}
+        return {
+          content: [
+            {
+              type: 'text',
+              // only allow xk tokens of output
+              text: truncateStringForTokenEstimate(cleanOutput, 2_000),
+            },
+          ],
+          isError: false,
+        };
+      } catch (error: any) {
+        // console.error('\n❌ Command failed')
+        // console.error('----------------------------------------\n')
+        // Clean up abort listener and timeout handle on error
+        if (abortSignal) {
+          abortSignal.removeEventListener('abort', abortHandler);
+        }
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle);
+        }
 
-				// Check if aborted by user
-				if (abortedBySignal) {
-					let cleanOutput = stripAnsi(capturedOutput)
-					if (extractedTail) {
-						cleanOutput = applyTail(cleanOutput, extractedTail)
-					}
+        // Check if aborted by user
+        if (abortedBySignal) {
+          let cleanOutput = stripAnsi(capturedOutput);
+          if (extractedTail) {
+            cleanOutput = applyTail(cleanOutput, extractedTail);
+          }
 
-					return {
-						content: [
-							{
-								type: "text" as const,
-								text: cleanOutput.trim()
-									? `[User aborted command]\n\nPartial output:\n${truncateStringForTokenEstimate(cleanOutput, 1_000)}`
-									: "[User aborted command]",
-							},
-						],
-						isError: true,
-					}
-				}
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: cleanOutput.trim()
+                  ? `[User aborted command]\n\nPartial output:\n${truncateStringForTokenEstimate(cleanOutput, 1_000)}`
+                  : '[User aborted command]',
+              },
+            ],
+            isError: true,
+          };
+        }
 
-				// Strip ANSI codes from error message for the LLM
-				let cleanError = ""
+        // Strip ANSI codes from error message for the LLM
+        let cleanError = '';
 
-				if (error instanceof ExecaError) {
-					const causeMessage = (error.cause as Error)?.message || ""
-					const stderr = error.stderr ? stripAnsi(error.stderr) : ""
-					const stdout = error.stdout ? stripAnsi(error.stdout) : ""
-					const all = error.all ? stripAnsi(error.all) : ""
-					const isTimeout = error.timedOut || error.isCanceled || manuallyKilled
+        if (error instanceof ExecaError) {
+          const causeMessage = (error.cause as Error)?.message || '';
+          const stderr = error.stderr ? stripAnsi(error.stderr) : '';
+          const stdout = error.stdout ? stripAnsi(error.stdout) : '';
+          const all = error.all ? stripAnsi(error.all) : '';
+          const isTimeout = error.timedOut || error.isCanceled || manuallyKilled;
 
-					// Combine all error information with clear labels
-					const parts = []
-					if (isTimeout) {
-						parts.push(`Error: command timed out after ${timeoutMS}ms`)
-					} else if (causeMessage) {
-						parts.push(`Error: ${stripAnsi(causeMessage)}`)
-					}
+          // Combine all error information with clear labels
+          const parts = [];
+          if (isTimeout) {
+            parts.push(`Error: command timed out after ${timeoutMS}ms`);
+          } else if (causeMessage) {
+            parts.push(`Error: ${stripAnsi(causeMessage)}`);
+          }
 
-					if (all) {
-						parts.push(`Output: ${all}`)
-					} else {
-						if (stderr) parts.push(`STDERR: ${stderr}`)
-						if (stdout) parts.push(`STDOUT: ${stdout}`)
-					}
+          if (all) {
+            parts.push(`Output: ${all}`);
+          } else {
+            if (stderr) parts.push(`STDERR: ${stderr}`);
+            if (stdout) parts.push(`STDOUT: ${stdout}`);
+          }
 
-					cleanError = parts.join("\n\n")
-				} else {
-					// Safely check if error has a message property
-					try {
-						if (
-							error &&
-							typeof error === "object" &&
-							"message" in error &&
-							typeof error.message === "string"
-						) {
-							cleanError = error.message
-						} else {
-							cleanError = String(error)
-						}
-					} catch {
-						cleanError = String(error)
-					}
-				}
+          cleanError = parts.join('\n\n');
+        } else {
+          // Safely check if error has a message property
+          try {
+            if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string') {
+              cleanError = error.message;
+            } else {
+              cleanError = String(error);
+            }
+          } catch {
+            cleanError = String(error);
+          }
+        }
 
-				return {
-					content: [
-						{
-							type: "text",
-							// only allow xk tokens of output
-							text: truncateStringForTokenEstimate(cleanError, 2_000),
-						},
-					],
-					isError: true,
-				}
-			} finally {
-				// console.log(`shell command finally executed`)
+        return {
+          content: [
+            {
+              type: 'text',
+              // only allow xk tokens of output
+              text: truncateStringForTokenEstimate(cleanError, 2_000),
+            },
+          ],
+          isError: true,
+        };
+      } finally {
+        // console.log(`shell command finally executed`)
 
-				// Remove subprocess from tracking
-				if (subprocess && subprocess.pid) {
-					activeSubprocesses.delete(subprocess.pid)
-				}
+        // Remove subprocess from tracking
+        if (subprocess && subprocess.pid) {
+          activeSubprocesses.delete(subprocess.pid);
+        }
 
-				// Always kill any remaining child processes to prevent dangling processes
-				// This is especially important for commands with pipes (e.g., npm test | head)
-				// where the pipe may terminate early but leave child processes running
-				if (subprocess && subprocess.pid) {
-					try {
-						// First try to kill the process group
-						process.kill(-subprocess.pid, "SIGKILL")
-					} catch {
-						// Process group may already be dead, that's fine
-					}
+        // Always kill any remaining child processes to prevent dangling processes
+        // This is especially important for commands with pipes (e.g., npm test | head)
+        // where the pipe may terminate early but leave child processes running
+        if (subprocess && subprocess.pid) {
+          try {
+            // First try to kill the process group
+            process.kill(-subprocess.pid, 'SIGKILL');
+          } catch {
+            // Process group may already be dead, that's fine
+          }
 
-					// Also use tree-kill to ensure all nested children are killed
-					// This handles cases where child processes spawn their own children
-					// (e.g., npm spawning vitest workers)
-					const pid = subprocess?.pid
-					if (pid) {
-						try {
-							await new Promise<void>((resolve) => {
-								treeKill(pid, "SIGKILL", (err) => {
-									if (err && err.message !== "No such process") {
-										// tree-kill error (non-fatal)
-									}
-									resolve()
-								})
-							})
-						} catch {
-							// Ignore errors from tree-kill
-						}
-					}
-				}
-			}
-		},
-	})
+          // Also use tree-kill to ensure all nested children are killed
+          // This handles cases where child processes spawn their own children
+          // (e.g., npm spawning vitest workers)
+          const pid = subprocess?.pid;
+          if (pid) {
+            try {
+              await new Promise<void>(resolve => {
+                treeKill(pid, 'SIGKILL', err => {
+                  if (err && err.message !== 'No such process') {
+                    // tree-kill error (non-fatal)
+                  }
+                  resolve();
+                });
+              });
+            } catch {
+              // Ignore errors from tree-kill
+            }
+          }
+        }
+      }
+    },
+  });
 }
 
 // Default export for backward compatibility
-export const executeCommandTool = createExecuteCommandTool()
+export const executeCommandTool = createExecuteCommandTool();
 
-export default executeCommandTool
+export default executeCommandTool;

--- a/mastracode/src/tools/shell.ts
+++ b/mastracode/src/tools/shell.ts
@@ -114,12 +114,11 @@ Usage notes:
 		execute: async (context, toolContext) => {
 			let { command } = context
 			let extractedTail: number | undefined
-
-			// Extract `| tail -N` or `| tail -n N` from command if present
-			// This allows streaming all output to user while only returning last N lines to agent
-			const tailPipeMatch = command.match(/\|\s*tail\s+(?:-n\s+)?(-?\d+)\s*$/)
-			if (tailPipeMatch) {
-				const tailLines = Math.abs(parseInt(tailPipeMatch[1], 10))
+            // Extract `| tail -N` or `| tail -n N` from command if present
+            // This allows streaming all output to user while only returning last N lines to agent
+            const tailPipeMatch = command.match(/\|\s*tail\s+(?:-n\s+)?(-?\d+)\s*$/)
+            if (tailPipeMatch) {
+                const tailLines = Math.abs(parseInt(tailPipeMatch[1]!, 10))
 				if (tailLines > 0) {
 					extractedTail = tailLines
 					// Remove the tail pipe from the command

--- a/mastracode/src/tools/string-replace-lsp.ts
+++ b/mastracode/src/tools/string-replace-lsp.ts
@@ -1,16 +1,16 @@
-import * as fs from "node:fs"
-import * as path from "node:path"
-import { createTool } from "@mastra/core/tools"
-import { z } from "zod/v3"
-import { lspManager } from "../lsp/manager.js"
-import { findWorkspaceRoot } from "../lsp/workspace.js"
-import { truncateStringForTokenEstimate } from "../utils/token-estimator.js"
-import { sharedFileEditor } from "./file-editor.js"
-import { assertPathAllowed, getAllowedPathsFromContext } from "./utils.js"
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod/v3';
+import { lspManager } from '../lsp/manager.js';
+import { findWorkspaceRoot } from '../lsp/workspace.js';
+import { truncateStringForTokenEstimate } from '../utils/token-estimator.js';
+import { sharedFileEditor } from './file-editor.js';
+import { assertPathAllowed, getAllowedPathsFromContext } from './utils.js';
 
 export const stringReplaceLspTool = createTool({
-	id: "string_replace_lsp",
-	description: `Edit a file by replacing exact text matches. Returns Language Server Protocol (LSP) diagnostics to show any errors/warnings introduced by your edit.
+  id: 'string_replace_lsp',
+  description: `Edit a file by replacing exact text matches. Returns Language Server Protocol (LSP) diagnostics to show any errors/warnings introduced by your edit.
 
 Usage notes:
 - You MUST use the view tool to read a file before editing it. Never edit blind.
@@ -20,119 +20,103 @@ Usage notes:
 - Use start_line to narrow the search to a specific region of the file.
 - After editing, real LSP diagnostics are returned (TypeScript errors, linting warnings, etc).
 - For creating NEW files, use the write_file tool instead.`,
-	// requireApproval: true,
-	inputSchema: z.object({
-		path: z.string(),
-		old_str: z.string(),
-		new_str: z.string().optional(),
-		start_line: z.number().optional(),
-	}),
-	async execute(context, toolContext) {
-		const { path: filePath, old_str, new_str, start_line } = context
+  // requireApproval: true,
+  inputSchema: z.object({
+    path: z.string(),
+    old_str: z.string(),
+    new_str: z.string().optional(),
+    start_line: z.number().optional(),
+  }),
+  async execute(context, toolContext) {
+    const { path: filePath, old_str, new_str, start_line } = context;
 
-		try {
-			// Convert relative paths to absolute (same logic as validatePath in utils.ts)
-			const absoluteFilePath = path.isAbsolute(filePath)
-				? filePath
-				: path.join(process.cwd(), filePath)
+    try {
+      // Convert relative paths to absolute (same logic as validatePath in utils.ts)
+      const absoluteFilePath = path.isAbsolute(filePath) ? filePath : path.join(process.cwd(), filePath);
 
-			// Security: ensure the path is within the project root or allowed paths
-			const root = process.cwd()
-			const allowedPaths = getAllowedPathsFromContext(toolContext)
-			assertPathAllowed(absoluteFilePath, root, allowedPaths)
+      // Security: ensure the path is within the project root or allowed paths
+      const root = process.cwd();
+      const allowedPaths = getAllowedPathsFromContext(toolContext);
+      assertPathAllowed(absoluteFilePath, root, allowedPaths);
 
-			// Call the FileEditor strReplace method
-			const result = await sharedFileEditor.strReplace({
-				path: filePath,
-				old_str,
-				new_str: new_str || "",
-				start_line,
-			})
+      // Call the FileEditor strReplace method
+      const result = await sharedFileEditor.strReplace({
+        path: filePath,
+        old_str,
+        new_str: new_str || '',
+        start_line,
+      });
 
-			// Get LSP diagnostics
-			let diagnosticOutput = ""
-			try {
-				const workspaceRoot = findWorkspaceRoot(absoluteFilePath)
-				const client = await lspManager.getClient(
-					absoluteFilePath,
-					workspaceRoot,
-				)
-				if (client) {
-					// Read the modified file content
-					const contentNew = fs.readFileSync(absoluteFilePath, "utf-8")
-					const languageId = path.extname(absoluteFilePath).slice(1)
+      // Get LSP diagnostics
+      let diagnosticOutput = '';
+      try {
+        const workspaceRoot = findWorkspaceRoot(absoluteFilePath);
+        const client = await lspManager.getClient(absoluteFilePath, workspaceRoot);
+        if (client) {
+          // Read the modified file content
+          const contentNew = fs.readFileSync(absoluteFilePath, 'utf-8');
+          const languageId = path.extname(absoluteFilePath).slice(1);
 
-					client.notifyOpen(absoluteFilePath, contentNew, languageId)
-					client.notifyChange(absoluteFilePath, contentNew, 1)
+          client.notifyOpen(absoluteFilePath, contentNew, languageId);
+          client.notifyChange(absoluteFilePath, contentNew, 1);
 
-					const diagnostics = await client
-						.waitForDiagnostics(absoluteFilePath, 3000)
-						.catch(() => [])
+          const diagnostics = await client.waitForDiagnostics(absoluteFilePath, 3000).catch(() => []);
 
-					if (diagnostics.length > 0) {
-						// Deduplicate diagnostics by location + message
-						const seen = new Set<string>()
-						const dedup = diagnostics.filter((d) => {
-							const key = `${d.severity}:${d.range.start.line}:${d.range.start.character}:${d.message}`
-							if (seen.has(key)) return false
-							seen.add(key)
-							return true
-						})
+          if (diagnostics.length > 0) {
+            // Deduplicate diagnostics by location + message
+            const seen = new Set<string>();
+            const dedup = diagnostics.filter(d => {
+              const key = `${d.severity}:${d.range.start.line}:${d.range.start.character}:${d.message}`;
+              if (seen.has(key)) return false;
+              seen.add(key);
+              return true;
+            });
 
-						const errors = dedup.filter((d) => d.severity === 1)
-						const warnings = dedup.filter((d) => d.severity === 2)
-						const info = dedup.filter((d) => d.severity === 3)
-						const hints = dedup.filter((d) => d.severity === 4)
+            const errors = dedup.filter(d => d.severity === 1);
+            const warnings = dedup.filter(d => d.severity === 2);
+            const info = dedup.filter(d => d.severity === 3);
+            const hints = dedup.filter(d => d.severity === 4);
 
-						const formatDiags = (items: typeof dedup) =>
-							items
-								.map(
-									(d) =>
-										`  ${d.range.start.line + 1}:${d.range.start.character + 1} - ${d.message}`,
-								)
-								.join("\n")
+            const formatDiags = (items: typeof dedup) =>
+              items.map(d => `  ${d.range.start.line + 1}:${d.range.start.character + 1} - ${d.message}`).join('\n');
 
-						let diagnosticText = ""
-						if (errors.length > 0) {
-							diagnosticText += `\nErrors:\n${formatDiags(errors)}`
-						}
-						if (warnings.length > 0) {
-							diagnosticText += `\nWarnings:\n${formatDiags(warnings)}`
-						}
-						if (info.length > 0) {
-							diagnosticText += `\nInfo:\n${formatDiags(info)}`
-						}
-						if (hints.length > 0) {
-							diagnosticText += `\nHints:\n${formatDiags(hints)}`
-						}
+            let diagnosticText = '';
+            if (errors.length > 0) {
+              diagnosticText += `\nErrors:\n${formatDiags(errors)}`;
+            }
+            if (warnings.length > 0) {
+              diagnosticText += `\nWarnings:\n${formatDiags(warnings)}`;
+            }
+            if (info.length > 0) {
+              diagnosticText += `\nInfo:\n${formatDiags(info)}`;
+            }
+            if (hints.length > 0) {
+              diagnosticText += `\nHints:\n${formatDiags(hints)}`;
+            }
 
-						if (diagnosticText) {
-							diagnosticOutput = truncateStringForTokenEstimate(
-								`\n\nLSP Diagnostics:${diagnosticText}`,
-								500,
-								false,
-							)
-						}
-					} else {
-						diagnosticOutput = `\n\nLSP Diagnostics:\nNo errors or warnings`
-					}
-				}
-			} catch {
-				// LSP errors are non-fatal — diagnostics just won't be available
-			}
+            if (diagnosticText) {
+              diagnosticOutput = truncateStringForTokenEstimate(`\n\nLSP Diagnostics:${diagnosticText}`, 500, false);
+            }
+          } else {
+            diagnosticOutput = `\n\nLSP Diagnostics:\nNo errors or warnings`;
+          }
+        }
+      } catch {
+        // LSP errors are non-fatal — diagnostics just won't be available
+      }
 
-			return {
-				content: [
-					{
-						type: "text",
-						text: result + diagnosticOutput,
-					},
-				],
-			}
-		} catch (e) {
-			return {
-				error: e instanceof Error ? e.message : JSON.stringify(e, null, 2),
-			}
-		}
-	},
-})
+      return {
+        content: [
+          {
+            type: 'text',
+            text: result + diagnosticOutput,
+          },
+        ],
+      };
+    } catch (e) {
+      return {
+        error: e instanceof Error ? e.message : JSON.stringify(e, null, 2),
+      };
+    }
+  },
+});

--- a/mastracode/src/tools/subagent.ts
+++ b/mastracode/src/tools/subagent.ts
@@ -207,17 +207,17 @@ Use this tool when:
 							break
 
 						case "tool-result": {
-							const isErr = chunk.payload.isError ?? false
-							// Update the last matching tool call
-							for (let i = toolCallLog.length - 1; i >= 0; i--) {
-								if (
-									toolCallLog[i].name === chunk.payload.toolName &&
-									toolCallLog[i].isError === undefined
-								) {
-									toolCallLog[i].isError = isErr
-									break
-								}
-							}
+                            const isErr = chunk.payload.isError ?? false
+                            // Update the last matching tool call
+                            for (let i = toolCallLog.length - 1; i >= 0; i--) {
+                                if (
+                                    toolCallLog[i]!.name === chunk.payload.toolName &&
+                                    toolCallLog[i]!.isError === undefined
+                                ) {
+                                    toolCallLog[i]!.isError = isErr
+                                    break
+                                }
+                            }
 							emitEvent?.({
 								type: "subagent_tool_end",
 								toolCallId,
@@ -357,19 +357,18 @@ export function parseSubagentMeta(content: string): {
 		/\n<subagent-meta modelId="([^"]*)" durationMs="(\d+)" tools="([^"]*)" \/>$/,
 	)
 	if (!match) return { text: content }
+    const text = content.slice(0, match.index!)
+    const modelId = match[1]!
+    const durationMs = parseInt(match[2]!, 10)
+    const toolCalls = match[3]
+        ? match[3]
+                .split(",")
+                .filter(Boolean)
+                .map((entry) => {
+                    const [name, status] = entry.split(":")
+                    return { name: name!, isError: status === "err" }
+                })
+        : []
 
-	const text = content.slice(0, match.index!)
-	const modelId = match[1]
-	const durationMs = parseInt(match[2], 10)
-	const toolCalls = match[3]
-		? match[3]
-				.split(",")
-				.filter(Boolean)
-				.map((entry) => {
-					const [name, status] = entry.split(":")
-					return { name, isError: status === "err" }
-				})
-		: []
-
-	return { text, modelId, durationMs, toolCalls }
+    return { text, modelId, durationMs, toolCalls }
 }

--- a/mastracode/src/tools/subagent.ts
+++ b/mastracode/src/tools/subagent.ts
@@ -8,64 +8,62 @@
  * Stream events are forwarded to the parent harness so the TUI can show
  * real-time subagent activity (tool calls, text deltas, etc.).
  */
-import { Agent } from "@mastra/core/agent"
-import { createTool } from "@mastra/core/tools"
-import { z } from "zod/v3"
-import { getSubagentDefinition, getSubagentIds } from "../agents/subagents/index.js"
-import type { HarnessRuntimeContext } from "../harness/types.js"
+import { Agent } from '@mastra/core/agent';
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod/v3';
+import { getSubagentDefinition, getSubagentIds } from '../agents/subagents/index.js';
+import type { HarnessRuntimeContext } from '../harness/types.js';
 
 export interface SubagentToolDeps {
-	/**
-	 * The full tool registry from the parent agent.
-	 * The subagent will receive a subset based on its allowedTools.
-	 */
-	tools: Record<string, any>
+  /**
+   * The full tool registry from the parent agent.
+   * The subagent will receive a subset based on its allowedTools.
+   */
+  tools: Record<string, any>;
 
-	/**
-	 * Function to resolve a model ID to a language model instance.
-	 * Shared with the parent agent so subagents use the same providers.
-	 */
-	resolveModel: (modelId: string) => any
+  /**
+   * Function to resolve a model ID to a language model instance.
+   * Shared with the parent agent so subagents use the same providers.
+   */
+  resolveModel: (modelId: string) => any;
 
-	/**
-	 * Model ID to use for subagent tasks.
-	 * Defaults to a fast model to keep costs down.
-	 */
-	defaultModelId?: string
+  /**
+   * Model ID to use for subagent tasks.
+   * Defaults to a fast model to keep costs down.
+   */
+  defaultModelId?: string;
 
-	/**
-	 * Restrict which agent types can be spawned.
-	 * If not provided, all registered agent types are available.
-	 */
-	allowedAgentTypes?: string[]
+  /**
+   * Restrict which agent types can be spawned.
+   * If not provided, all registered agent types are available.
+   */
+  allowedAgentTypes?: string[];
 }
 
 // Default model for subagent tasks — fast and cheap
-const DEFAULT_SUBAGENT_MODEL = "anthropic/claude-opus-4-6"
+const DEFAULT_SUBAGENT_MODEL = 'anthropic/claude-opus-4-6';
 // Explore subagents can use Cerebras for speed when available
-const EXPLORE_SUBAGENT_MODEL = DEFAULT_SUBAGENT_MODEL
+const EXPLORE_SUBAGENT_MODEL = DEFAULT_SUBAGENT_MODEL;
 
 export function createSubagentTool(deps: SubagentToolDeps) {
-	const allAgentTypes = getSubagentIds()
-	const validAgentTypes = deps.allowedAgentTypes
-		? allAgentTypes.filter((t) => deps.allowedAgentTypes!.includes(t))
-		: allAgentTypes
+  const allAgentTypes = getSubagentIds();
+  const validAgentTypes = deps.allowedAgentTypes
+    ? allAgentTypes.filter(t => deps.allowedAgentTypes!.includes(t))
+    : allAgentTypes;
 
-	const typeDescriptions: Record<string, string> = {
-		explore: `- **explore**: Read-only codebase exploration. Has access to view, search_content, and find_files. Use for questions like "find all usages of X", "how does module Y work", "what files are related to Z".`,
-		plan: `- **plan**: Read-only analysis and planning. Same tools as explore. Use for "create an implementation plan for X", "analyze the architecture of Y".`,
-		execute: `- **execute**: Task execution with write capabilities. Has access to all tools including string_replace_lsp, write_file, and execute_command. Use for "implement feature X", "fix bug Y", "refactor module Z".`,
-	}
+  const typeDescriptions: Record<string, string> = {
+    explore: `- **explore**: Read-only codebase exploration. Has access to view, search_content, and find_files. Use for questions like "find all usages of X", "how does module Y work", "what files are related to Z".`,
+    plan: `- **plan**: Read-only analysis and planning. Same tools as explore. Use for "create an implementation plan for X", "analyze the architecture of Y".`,
+    execute: `- **execute**: Task execution with write capabilities. Has access to all tools including string_replace_lsp, write_file, and execute_command. Use for "implement feature X", "fix bug Y", "refactor module Z".`,
+  };
 
-	const availableTypesDocs = validAgentTypes
-		.map((t) => typeDescriptions[t] ?? `- **${t}**`)
-		.join("\n")
+  const availableTypesDocs = validAgentTypes.map(t => typeDescriptions[t] ?? `- **${t}**`).join('\n');
 
-	const hasExecute = validAgentTypes.includes("execute")
+  const hasExecute = validAgentTypes.includes('execute');
 
-	return createTool({
-		id: "subagent",
-		description: `Delegate a focused task to a specialized subagent. The subagent runs independently with a constrained toolset, then returns its findings as text.
+  return createTool({
+    id: 'subagent',
+    description: `Delegate a focused task to a specialized subagent. The subagent runs independently with a constrained toolset, then returns its findings as text.
 
 Available agent types:
 ${availableTypesDocs}
@@ -74,257 +72,231 @@ The subagent runs in its own context — it does NOT see the parent conversation
 
 Use this tool when:
 - You want to run multiple investigations in parallel
-- The task is self-contained and can be delegated${hasExecute ? "\n- You want to perform a focused implementation task (execute type)" : ""}`,
-		inputSchema: z.object({
-			agentType: z
-				.enum(validAgentTypes as [string, ...string[]])
-				.describe("Type of subagent to spawn"),
-			task: z
-				.string()
-				.describe(
-					"Clear, self-contained description of what the subagent should do. Include all relevant context — the subagent cannot see the parent conversation.",
-				),
-			modelId: z
-				.string()
-				.optional()
-				.describe(
-					`Model ID to use for this task. Defaults to ${DEFAULT_SUBAGENT_MODEL}.`,
-				),
-		}),
-		execute: async ({ agentType, task, modelId }, context) => {
-			const definition = getSubagentDefinition(agentType)
-			if (!definition) {
-				return {
-					content: `Unknown agent type: ${agentType}. Valid types: ${validAgentTypes.join(", ")}`,
-					isError: true,
-				}
-			}
+- The task is self-contained and can be delegated${hasExecute ? '\n- You want to perform a focused implementation task (execute type)' : ''}`,
+    inputSchema: z.object({
+      agentType: z.enum(validAgentTypes as [string, ...string[]]).describe('Type of subagent to spawn'),
+      task: z
+        .string()
+        .describe(
+          'Clear, self-contained description of what the subagent should do. Include all relevant context — the subagent cannot see the parent conversation.',
+        ),
+      modelId: z.string().optional().describe(`Model ID to use for this task. Defaults to ${DEFAULT_SUBAGENT_MODEL}.`),
+    }),
+    execute: async ({ agentType, task, modelId }, context) => {
+      const definition = getSubagentDefinition(agentType);
+      if (!definition) {
+        return {
+          content: `Unknown agent type: ${agentType}. Valid types: ${validAgentTypes.join(', ')}`,
+          isError: true,
+        };
+      }
 
-			// Get emit function and abort signal from harness context (if available)
-			const harnessCtx = context?.requestContext?.get("harness") as
-				| HarnessRuntimeContext
-				| undefined
-			const emitEvent = harnessCtx?.emitEvent
-			const abortSignal = harnessCtx?.abortSignal
-			// toolCallId from the parent agent's tool invocation
-			const toolCallId = context?.agent?.toolCallId ?? "unknown"
+      // Get emit function and abort signal from harness context (if available)
+      const harnessCtx = context?.requestContext?.get('harness') as HarnessRuntimeContext | undefined;
+      const emitEvent = harnessCtx?.emitEvent;
+      const abortSignal = harnessCtx?.abortSignal;
+      // toolCallId from the parent agent's tool invocation
+      const toolCallId = context?.agent?.toolCallId ?? 'unknown';
 
-			// Build the constrained tool set
-			const subagentTools: Record<string, any> = {}
-			for (const toolId of definition.allowedTools) {
-				if (deps.tools[toolId]) {
-					subagentTools[toolId] = deps.tools[toolId]
-				}
-			}
+      // Build the constrained tool set
+      const subagentTools: Record<string, any> = {};
+      for (const toolId of definition.allowedTools) {
+        if (deps.tools[toolId]) {
+          subagentTools[toolId] = deps.tools[toolId];
+        }
+      }
 
-			// Resolve the model with the following precedence:
-			// 1. Explicit modelId from tool call
-			// 2. Configured subagent model for this agent type (thread or global)
-			// 3. Deps default model
-			// 4. Type-specific defaults (Cerebras for explore if available)
-			const defaultForType =
-				agentType === "explore"
-					? EXPLORE_SUBAGENT_MODEL
-					: DEFAULT_SUBAGENT_MODEL
+      // Resolve the model with the following precedence:
+      // 1. Explicit modelId from tool call
+      // 2. Configured subagent model for this agent type (thread or global)
+      // 3. Deps default model
+      // 4. Type-specific defaults (Cerebras for explore if available)
+      const defaultForType = agentType === 'explore' ? EXPLORE_SUBAGENT_MODEL : DEFAULT_SUBAGENT_MODEL;
 
-			// Check for configured subagent model from harness (per-type)
-			const configuredSubagentModel =
-				await harnessCtx?.getSubagentModelId?.(agentType)
+      // Check for configured subagent model from harness (per-type)
+      const configuredSubagentModel = await harnessCtx?.getSubagentModelId?.(agentType);
 
-			const resolvedModelId =
-				modelId ??
-				configuredSubagentModel ??
-				deps.defaultModelId ??
-				defaultForType
-			let model: any
-			try {
-				model = deps.resolveModel(resolvedModelId)
-			} catch (err) {
-				return {
-					content: `Failed to resolve model "${resolvedModelId}": ${err instanceof Error ? err.message : String(err)}`,
-					isError: true,
-				}
-			}
+      const resolvedModelId = modelId ?? configuredSubagentModel ?? deps.defaultModelId ?? defaultForType;
+      let model: any;
+      try {
+        model = deps.resolveModel(resolvedModelId);
+      } catch (err) {
+        return {
+          content: `Failed to resolve model "${resolvedModelId}": ${err instanceof Error ? err.message : String(err)}`,
+          isError: true,
+        };
+      }
 
-			// Create a fresh agent with constrained tools
-			const subagent = new Agent({
-				id: `subagent-${definition.id}`,
-				name: `${definition.name} Subagent`,
-				instructions: definition.instructions,
-				model,
-				tools: subagentTools,
-			})
+      // Create a fresh agent with constrained tools
+      const subagent = new Agent({
+        id: `subagent-${definition.id}`,
+        name: `${definition.name} Subagent`,
+        instructions: definition.instructions,
+        model,
+        tools: subagentTools,
+      });
 
-			const startTime = Date.now()
+      const startTime = Date.now();
 
-			// Notify TUI that subagent is starting
-			emitEvent?.({
-				type: "subagent_start",
-				toolCallId,
-				agentType,
-				task,
-				modelId: resolvedModelId,
-			})
+      // Notify TUI that subagent is starting
+      emitEvent?.({
+        type: 'subagent_start',
+        toolCallId,
+        agentType,
+        task,
+        modelId: resolvedModelId,
+      });
 
-			// Track partial output in case of abort
-			let partialText = ""
-			// Track tool calls for metadata embedding
-			const toolCallLog: Array<{ name: string; isError?: boolean }> = []
+      // Track partial output in case of abort
+      let partialText = '';
+      // Track tool calls for metadata embedding
+      const toolCallLog: Array<{ name: string; isError?: boolean }> = [];
 
-			try {
-				const response = await subagent.stream(task, {
-					maxSteps: 50,
-					abortSignal,
-				})
+      try {
+        const response = await subagent.stream(task, {
+          maxSteps: 50,
+          abortSignal,
+        });
 
-				// Consume the fullStream to forward events to the TUI
-				const reader = response.fullStream.getReader()
+        // Consume the fullStream to forward events to the TUI
+        const reader = response.fullStream.getReader();
 
-				while (true) {
-					const { done, value: chunk } = await reader.read()
-					if (done) break
+        while (true) {
+          const { done, value: chunk } = await reader.read();
+          if (done) break;
 
-					switch (chunk.type) {
-						case "text-delta":
-							partialText += chunk.payload.text
-							emitEvent?.({
-								type: "subagent_text_delta",
-								toolCallId,
-								agentType,
-								textDelta: chunk.payload.text,
-							})
-							break
+          switch (chunk.type) {
+            case 'text-delta':
+              partialText += chunk.payload.text;
+              emitEvent?.({
+                type: 'subagent_text_delta',
+                toolCallId,
+                agentType,
+                textDelta: chunk.payload.text,
+              });
+              break;
 
-						case "tool-call":
-							toolCallLog.push({ name: chunk.payload.toolName })
-							emitEvent?.({
-								type: "subagent_tool_start",
-								toolCallId,
-								agentType,
-								subToolName: chunk.payload.toolName,
-								subToolArgs: chunk.payload.args,
-							})
-							break
+            case 'tool-call':
+              toolCallLog.push({ name: chunk.payload.toolName });
+              emitEvent?.({
+                type: 'subagent_tool_start',
+                toolCallId,
+                agentType,
+                subToolName: chunk.payload.toolName,
+                subToolArgs: chunk.payload.args,
+              });
+              break;
 
-						case "tool-result": {
-                            const isErr = chunk.payload.isError ?? false
-                            // Update the last matching tool call
-                            for (let i = toolCallLog.length - 1; i >= 0; i--) {
-                                if (
-                                    toolCallLog[i]!.name === chunk.payload.toolName &&
-                                    toolCallLog[i]!.isError === undefined
-                                ) {
-                                    toolCallLog[i]!.isError = isErr
-                                    break
-                                }
-                            }
-							emitEvent?.({
-								type: "subagent_tool_end",
-								toolCallId,
-								agentType,
-								subToolName: chunk.payload.toolName,
-								subToolResult: chunk.payload.result,
-								isError: isErr,
-							})
-							break
-						}
-					}
-				}
+            case 'tool-result': {
+              const isErr = chunk.payload.isError ?? false;
+              // Update the last matching tool call
+              for (let i = toolCallLog.length - 1; i >= 0; i--) {
+                if (toolCallLog[i]!.name === chunk.payload.toolName && toolCallLog[i]!.isError === undefined) {
+                  toolCallLog[i]!.isError = isErr;
+                  break;
+                }
+              }
+              emitEvent?.({
+                type: 'subagent_tool_end',
+                toolCallId,
+                agentType,
+                subToolName: chunk.payload.toolName,
+                subToolResult: chunk.payload.result,
+                isError: isErr,
+              });
+              break;
+            }
+          }
+        }
 
-				// Check if we were aborted
-				if (abortSignal?.aborted) {
-					const durationMs = Date.now() - startTime
-					const abortResult = partialText
-						? `[Aborted by user]\n\nPartial output:\n${partialText}`
-						: "[Aborted by user]"
+        // Check if we were aborted
+        if (abortSignal?.aborted) {
+          const durationMs = Date.now() - startTime;
+          const abortResult = partialText
+            ? `[Aborted by user]\n\nPartial output:\n${partialText}`
+            : '[Aborted by user]';
 
-					emitEvent?.({
-						type: "subagent_end",
-						toolCallId,
-						agentType,
-						result: abortResult,
-						isError: false,
-						durationMs,
-					})
+          emitEvent?.({
+            type: 'subagent_end',
+            toolCallId,
+            agentType,
+            result: abortResult,
+            isError: false,
+            durationMs,
+          });
 
-					return {
-						content: abortResult,
-						isError: false,
-					}
-				}
+          return {
+            content: abortResult,
+            isError: false,
+          };
+        }
 
-				// Use getFullOutput to get the authoritative final text
-				const fullOutput = await response.getFullOutput()
-				const resultText = fullOutput.text || partialText
+        // Use getFullOutput to get the authoritative final text
+        const fullOutput = await response.getFullOutput();
+        const resultText = fullOutput.text || partialText;
 
-				const durationMs = Date.now() - startTime
-				emitEvent?.({
-					type: "subagent_end",
-					toolCallId,
-					agentType,
-					result: resultText,
-					isError: false,
-					durationMs,
-				})
+        const durationMs = Date.now() - startTime;
+        emitEvent?.({
+          type: 'subagent_end',
+          toolCallId,
+          agentType,
+          result: resultText,
+          isError: false,
+          durationMs,
+        });
 
-				const meta = buildSubagentMeta(resolvedModelId, durationMs, toolCallLog)
-				return {
-					content: resultText + meta,
-					isError: false,
-				}
-			} catch (err) {
-				const isAbort =
-					err instanceof Error &&
-					(err.name === "AbortError" ||
-						err.message?.includes("abort") ||
-						err.message?.includes("cancel"))
-				const durationMs = Date.now() - startTime
+        const meta = buildSubagentMeta(resolvedModelId, durationMs, toolCallLog);
+        return {
+          content: resultText + meta,
+          isError: false,
+        };
+      } catch (err) {
+        const isAbort =
+          err instanceof Error &&
+          (err.name === 'AbortError' || err.message?.includes('abort') || err.message?.includes('cancel'));
+        const durationMs = Date.now() - startTime;
 
-				if (isAbort) {
-					// Return partial output on abort
-					const abortResult = partialText
-						? `[Aborted by user]\n\nPartial output:\n${partialText}`
-						: "[Aborted by user]"
+        if (isAbort) {
+          // Return partial output on abort
+          const abortResult = partialText
+            ? `[Aborted by user]\n\nPartial output:\n${partialText}`
+            : '[Aborted by user]';
 
-					emitEvent?.({
-						type: "subagent_end",
-						toolCallId,
-						agentType,
-						result: abortResult,
-						isError: false, // Not an error, just aborted
-						durationMs,
-					})
+          emitEvent?.({
+            type: 'subagent_end',
+            toolCallId,
+            agentType,
+            result: abortResult,
+            isError: false, // Not an error, just aborted
+            durationMs,
+          });
 
-					const meta = buildSubagentMeta(
-						resolvedModelId,
-						durationMs,
-						toolCallLog,
-					)
-					return {
-						content: abortResult + meta,
-						isError: false,
-					}
-				}
+          const meta = buildSubagentMeta(resolvedModelId, durationMs, toolCallLog);
+          return {
+            content: abortResult + meta,
+            isError: false,
+          };
+        }
 
-				const message = err instanceof Error ? err.message : String(err)
+        const message = err instanceof Error ? err.message : String(err);
 
-				emitEvent?.({
-					type: "subagent_end",
-					toolCallId,
-					agentType,
-					result: message,
-					isError: true,
-					durationMs,
-				})
+        emitEvent?.({
+          type: 'subagent_end',
+          toolCallId,
+          agentType,
+          result: message,
+          isError: true,
+          durationMs,
+        });
 
-				const meta = buildSubagentMeta(resolvedModelId, durationMs, toolCallLog)
-				return {
-					content: `Subagent "${definition.name}" failed: ${message}` + meta,
-					isError: true,
-				}
-			}
-		},
-	})
+        const meta = buildSubagentMeta(resolvedModelId, durationMs, toolCallLog);
+        return {
+          content: `Subagent "${definition.name}" failed: ${message}` + meta,
+          isError: true,
+        };
+      }
+    },
+  });
 }
 
 /**
@@ -333,14 +305,12 @@ Use this tool when:
  * when loading from history (where live events aren't available).
  */
 function buildSubagentMeta(
-	modelId: string,
-	durationMs: number,
-	toolCalls: Array<{ name: string; isError?: boolean }>,
+  modelId: string,
+  durationMs: number,
+  toolCalls: Array<{ name: string; isError?: boolean }>,
 ): string {
-	const tools = toolCalls
-		.map((tc) => `${tc.name}:${tc.isError ? "err" : "ok"}`)
-		.join(",")
-	return `\n<subagent-meta modelId="${modelId}" durationMs="${durationMs}" tools="${tools}" />`
+  const tools = toolCalls.map(tc => `${tc.name}:${tc.isError ? 'err' : 'ok'}`).join(',');
+  return `\n<subagent-meta modelId="${modelId}" durationMs="${durationMs}" tools="${tools}" />`;
 }
 
 /**
@@ -348,27 +318,25 @@ function buildSubagentMeta(
  * Returns the metadata and the cleaned result text (without the tag).
  */
 export function parseSubagentMeta(content: string): {
-	text: string
-	modelId?: string
-	durationMs?: number
-	toolCalls?: Array<{ name: string; isError: boolean }>
+  text: string;
+  modelId?: string;
+  durationMs?: number;
+  toolCalls?: Array<{ name: string; isError: boolean }>;
 } {
-	const match = content.match(
-		/\n<subagent-meta modelId="([^"]*)" durationMs="(\d+)" tools="([^"]*)" \/>$/,
-	)
-	if (!match) return { text: content }
-    const text = content.slice(0, match.index!)
-    const modelId = match[1]!
-    const durationMs = parseInt(match[2]!, 10)
-    const toolCalls = match[3]
-        ? match[3]
-                .split(",")
-                .filter(Boolean)
-                .map((entry) => {
-                    const [name, status] = entry.split(":")
-                    return { name: name!, isError: status === "err" }
-                })
-        : []
+  const match = content.match(/\n<subagent-meta modelId="([^"]*)" durationMs="(\d+)" tools="([^"]*)" \/>$/);
+  if (!match) return { text: content };
+  const text = content.slice(0, match.index!);
+  const modelId = match[1]!;
+  const durationMs = parseInt(match[2]!, 10);
+  const toolCalls = match[3]
+    ? match[3]
+        .split(',')
+        .filter(Boolean)
+        .map(entry => {
+          const [name, status] = entry.split(':');
+          return { name: name!, isError: status === 'err' };
+        })
+    : [];
 
-    return { text, modelId, durationMs, toolCalls }
+  return { text, modelId, durationMs, toolCalls };
 }

--- a/mastracode/src/tools/submit-plan.ts
+++ b/mastracode/src/tools/submit-plan.ts
@@ -5,78 +5,69 @@
  * Follows the same async Promise pattern as ask_user.
  */
 
-import { createTool } from "@mastra/core/tools"
-import { z } from "zod/v3"
-import type { HarnessRuntimeContext } from "../harness/types.js"
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod/v3';
+import type { HarnessRuntimeContext } from '../harness/types.js';
 
-let planCounter = 0
+let planCounter = 0;
 
 export interface PlanApprovalResult {
-	action: "approved" | "rejected"
-	feedback?: string
+  action: 'approved' | 'rejected';
+  feedback?: string;
 }
 
 export const submitPlanTool = createTool({
-	id: "submit_plan",
-	description: `Submit a completed implementation plan for user review. The plan will be rendered as markdown and the user can approve, reject, or request changes. Use this when your exploration is complete and you have a concrete plan ready for review. On approval, the system automatically switches to Build mode so you can implement.`,
-	inputSchema: z.object({
-		title: z
-			.string()
-			.optional()
-			.describe("Short title for the plan (e.g., 'Add dark mode toggle')"),
-		plan: z
-			.string()
-			.min(1)
-			.describe(
-				"The full plan content in markdown format. Should include Overview, Steps, and Verification sections.",
-			),
-	}),
-	execute: async ({ title, plan }, context) => {
-		try {
-			const harnessCtx = context?.requestContext?.get("harness") as
-				| HarnessRuntimeContext
-				| undefined
+  id: 'submit_plan',
+  description: `Submit a completed implementation plan for user review. The plan will be rendered as markdown and the user can approve, reject, or request changes. Use this when your exploration is complete and you have a concrete plan ready for review. On approval, the system automatically switches to Build mode so you can implement.`,
+  inputSchema: z.object({
+    title: z.string().optional().describe("Short title for the plan (e.g., 'Add dark mode toggle')"),
+    plan: z
+      .string()
+      .min(1)
+      .describe('The full plan content in markdown format. Should include Overview, Steps, and Verification sections.'),
+  }),
+  execute: async ({ title, plan }, context) => {
+    try {
+      const harnessCtx = context?.requestContext?.get('harness') as HarnessRuntimeContext | undefined;
 
-			if (!harnessCtx?.emitEvent || !harnessCtx?.registerPlanApproval) {
-				// Fallback: return the plan as text (no TUI available)
-				return {
-					content: `[Plan submitted for review]\n\nTitle: ${title || "Implementation Plan"}\n\n${plan}`,
-					isError: false,
-				}
-			}
+      if (!harnessCtx?.emitEvent || !harnessCtx?.registerPlanApproval) {
+        // Fallback: return the plan as text (no TUI available)
+        return {
+          content: `[Plan submitted for review]\n\nTitle: ${title || 'Implementation Plan'}\n\n${plan}`,
+          isError: false,
+        };
+      }
 
-			const planId = `plan_${++planCounter}_${Date.now()}`
+      const planId = `plan_${++planCounter}_${Date.now()}`;
 
-			// Block until user approves or rejects
-			const result = await new Promise<PlanApprovalResult>((resolve) => {
-				harnessCtx.registerPlanApproval!(planId, resolve)
+      // Block until user approves or rejects
+      const result = await new Promise<PlanApprovalResult>(resolve => {
+        harnessCtx.registerPlanApproval!(planId, resolve);
 
-				harnessCtx.emitEvent!({
-					type: "plan_approval_required",
-					planId,
-					title: title || "Implementation Plan",
-					plan,
-				} as any)
-			})
+        harnessCtx.emitEvent!({
+          type: 'plan_approval_required',
+          planId,
+          title: title || 'Implementation Plan',
+          plan,
+        } as any);
+      });
 
-			if (result.action === "approved") {
-				return {
-					content:
-						"Plan approved. The system has switched to Build mode. Proceed with implementation following the approved plan.",
-					isError: false,
-				}
-			}
+      if (result.action === 'approved') {
+        return {
+          content:
+            'Plan approved. The system has switched to Build mode. Proceed with implementation following the approved plan.',
+          isError: false,
+        };
+      }
 
-			const feedback = result.feedback
-				? `\n\nUser feedback: ${result.feedback}`
-				: ""
-			return {
-				content: `Plan was not approved. The user wants revisions.${feedback}\n\nPlease revise the plan based on the feedback and submit again with submit_plan.`,
-				isError: false,
-			}
-		} catch (error) {
-			const msg = error instanceof Error ? error.message : "Unknown error"
-			return { content: `Failed to submit plan: ${msg}`, isError: true }
-		}
-	},
-})
+      const feedback = result.feedback ? `\n\nUser feedback: ${result.feedback}` : '';
+      return {
+        content: `Plan was not approved. The user wants revisions.${feedback}\n\nPlease revise the plan based on the feedback and submit again with submit_plan.`,
+        isError: false,
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      return { content: `Failed to submit plan: ${msg}`, isError: true };
+    }
+  },
+});

--- a/mastracode/src/tools/todo-check.ts
+++ b/mastracode/src/tools/todo-check.ts
@@ -2,97 +2,92 @@
  * TodoCheck tool — checks the completion status of the current todo list.
  * Helps the agent determine if all tasks are completed before ending work.
  */
-import { createTool } from "@mastra/core/tools"
-import { z } from "zod/v3"
-import type { HarnessRuntimeContext } from "../harness/types.js"
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod/v3';
+import type { HarnessRuntimeContext } from '../harness/types.js';
 
 export const todoCheckTool = createTool({
-	id: "todo_check",
-	description: `Check the completion status of your current todo list. Use this before deciding to end work on a task to ensure all todos are completed.
+  id: 'todo_check',
+  description: `Check the completion status of your current todo list. Use this before deciding to end work on a task to ensure all todos are completed.
 
 Returns:
 - Total number of todos
 - Number of completed, in progress, and pending tasks
 - List of incomplete tasks (if any)
 - Boolean indicating if all tasks are done`,
-	inputSchema: z.object({}), // No input needed
-	execute: async ({}, context) => {
-		try {
-			const harnessCtx = context?.requestContext?.get("harness") as
-				| HarnessRuntimeContext
-				| undefined
+  inputSchema: z.object({}), // No input needed
+  execute: async ({}, context) => {
+    try {
+      const harnessCtx = context?.requestContext?.get('harness') as HarnessRuntimeContext | undefined;
 
-			if (!harnessCtx) {
-				return {
-					content: "Unable to access todo list (no harness context)",
-					isError: true,
-				}
-			}
+      if (!harnessCtx) {
+        return {
+          content: 'Unable to access todo list (no harness context)',
+          isError: true,
+        };
+      }
 
-			// Get current state which includes todos
-			// Use getState() for live state instead of the snapshot
-			const state = harnessCtx.getState
-				? harnessCtx.getState()
-				: harnessCtx.state
-			const typedState = state as {
-				todos?: Array<{
-					content: string
-					status: "pending" | "in_progress" | "completed"
-					activeForm: string
-				}>
-			}
+      // Get current state which includes todos
+      // Use getState() for live state instead of the snapshot
+      const state = harnessCtx.getState ? harnessCtx.getState() : harnessCtx.state;
+      const typedState = state as {
+        todos?: Array<{
+          content: string;
+          status: 'pending' | 'in_progress' | 'completed';
+          activeForm: string;
+        }>;
+      };
 
-			const todos = typedState.todos || []
+      const todos = typedState.todos || [];
 
-			if (todos.length === 0) {
-				return {
-					content:
-						"No todos found. Consider using todo_write to create a task list for complex work.",
-					isError: false,
-				}
-			}
+      if (todos.length === 0) {
+        return {
+          content: 'No todos found. Consider using todo_write to create a task list for complex work.',
+          isError: false,
+        };
+      }
 
-			// Calculate statistics
-			const completed = todos.filter((t) => t.status === "completed")
-			const inProgress = todos.filter((t) => t.status === "in_progress")
-			const pending = todos.filter((t) => t.status === "pending")
-			const incomplete = [...inProgress, ...pending]
-			const allDone = incomplete.length === 0
+      // Calculate statistics
+      const completed = todos.filter(t => t.status === 'completed');
+      const inProgress = todos.filter(t => t.status === 'in_progress');
+      const pending = todos.filter(t => t.status === 'pending');
+      const incomplete = [...inProgress, ...pending];
+      const allDone = incomplete.length === 0;
 
-			// Build detailed response
-			let response = `Todo Status: [${completed.length}/${todos.length} completed]\n`
-			response += `- Completed: ${completed.length}\n`
-			response += `- In Progress: ${inProgress.length}\n`
-			response += `- Pending: ${pending.length}\n`
-			response += `\nAll tasks completed: ${allDone ? "✓ YES" : "✗ NO"}`
+      // Build detailed response
+      let response = `Todo Status: [${completed.length}/${todos.length} completed]\n`;
+      response += `- Completed: ${completed.length}\n`;
+      response += `- In Progress: ${inProgress.length}\n`;
+      response += `- Pending: ${pending.length}\n`;
+      response += `\nAll tasks completed: ${allDone ? '✓ YES' : '✗ NO'}`;
 
-			if (!allDone) {
-				response += "\n\nIncomplete tasks:"
-				if (inProgress.length > 0) {
-					response += "\n\nIn Progress:"
-					inProgress.forEach((t) => {
-						response += `\n- ${t.content}`
-					})
-				}
-				if (pending.length > 0) {
-					response += "\n\nPending:"
-					pending.forEach((t) => {
-						response += `\n- ${t.content}`
-					})
-				}
-				response += "\n\nContinue working on these tasks before ending."
-			}
+      if (!allDone) {
+        response += '\n\nIncomplete tasks:';
+        if (inProgress.length > 0) {
+          response += '\n\nIn Progress:';
+          inProgress.forEach(t => {
+            response += `\n- ${t.content}`;
+          });
+        }
+        if (pending.length > 0) {
+          response += '\n\nPending:';
+          pending.forEach(t => {
+            response += `\n- ${t.content}`;
+          });
+        }
+        response += '\n\nContinue working on these tasks before ending.';
+      }
 
-			return {
-				content: response,
-				isError: false,
-			}
-		} catch (error) {
-			const msg = error instanceof Error ? error.message : "Unknown error"
-			return {
-				content: `Failed to check todos: ${msg}`,
-				isError: true,
-			}
-		}
-	},
-})
+      return {
+        content: response,
+        isError: false,
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        content: `Failed to check todos: ${msg}`,
+        isError: true,
+      };
+    }
+  },
+});

--- a/mastracode/src/tools/todo.ts
+++ b/mastracode/src/tools/todo.ts
@@ -2,33 +2,24 @@
  * TodoWrite tool — manages a structured task list for the coding session.
  * Full-replacement semantics: each call replaces the entire todo list.
  */
-import { createTool } from "@mastra/core/tools"
-import { z } from "zod/v3"
-import type { HarnessRuntimeContext } from "../harness/types.js"
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod/v3';
+import type { HarnessRuntimeContext } from '../harness/types.js';
 
 const todoItemSchema = z.object({
-	content: z
-		.string()
-		.min(1)
-		.describe(
-			"Task description in imperative form (e.g., 'Fix authentication bug')",
-		),
-	status: z
-		.enum(["pending", "in_progress", "completed"])
-		.describe("Current task status"),
-	activeForm: z
-		.string()
-		.min(1)
-		.describe(
-			"Present continuous form shown during execution (e.g., 'Fixing authentication bug')",
-		),
-})
+  content: z.string().min(1).describe("Task description in imperative form (e.g., 'Fix authentication bug')"),
+  status: z.enum(['pending', 'in_progress', 'completed']).describe('Current task status'),
+  activeForm: z
+    .string()
+    .min(1)
+    .describe("Present continuous form shown during execution (e.g., 'Fixing authentication bug')"),
+});
 
-export type TodoItem = z.infer<typeof todoItemSchema>
+export type TodoItem = z.infer<typeof todoItemSchema>;
 
 export const todoWriteTool = createTool({
-	id: "todo_write",
-	description: `Create and manage a structured task list for your current coding session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.
+  id: 'todo_write',
+  description: `Create and manage a structured task list for your current coding session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.
 
 Usage:
 - Pass the FULL todo list each time (replaces previous list)
@@ -41,47 +32,45 @@ States:
 - pending: Not yet started
 - in_progress: Currently working on (limit to ONE)
 - completed: Finished successfully`,
-	inputSchema: z.object({
-		todos: z.array(todoItemSchema).describe("The complete updated todo list"),
-	}),
-	execute: async ({ todos }, context) => {
-		try {
-			const harnessCtx = context?.requestContext?.get("harness") as
-				| HarnessRuntimeContext
-				| undefined
+  inputSchema: z.object({
+    todos: z.array(todoItemSchema).describe('The complete updated todo list'),
+  }),
+  execute: async ({ todos }, context) => {
+    try {
+      const harnessCtx = context?.requestContext?.get('harness') as HarnessRuntimeContext | undefined;
 
-            if (harnessCtx) {
-                // Always update state
-                await harnessCtx.setState({ todos })
-                
-                // Always emit event immediately for real-time updates
-                // The TUI will handle deduplication if needed
-                harnessCtx.emitEvent?.({
-                    type: "todo_updated",
-                    todos,
-                } as any)
-            }
+      if (harnessCtx) {
+        // Always update state
+        await harnessCtx.setState({ todos });
 
-			// Build summary for the model's context
-			const completed = todos.filter((t) => t.status === "completed").length
-			const inProgress = todos.find((t) => t.status === "in_progress")
-			const total = todos.length
+        // Always emit event immediately for real-time updates
+        // The TUI will handle deduplication if needed
+        harnessCtx.emitEvent?.({
+          type: 'todo_updated',
+          todos,
+        } as any);
+      }
 
-			let summary = `Todos updated: [${completed}/${total} completed]`
-			if (inProgress) {
-				summary += `\nCurrently: ${inProgress.activeForm}`
-			}
+      // Build summary for the model's context
+      const completed = todos.filter(t => t.status === 'completed').length;
+      const inProgress = todos.find(t => t.status === 'in_progress');
+      const total = todos.length;
 
-			return {
-				content: summary,
-				isError: false,
-			}
-		} catch (error) {
-			const msg = error instanceof Error ? error.message : "Unknown error"
-			return {
-				content: `Failed to update todos: ${msg}`,
-				isError: true,
-			}
-		}
-	},
-})
+      let summary = `Todos updated: [${completed}/${total} completed]`;
+      if (inProgress) {
+        summary += `\nCurrently: ${inProgress.activeForm}`;
+      }
+
+      return {
+        content: summary,
+        isError: false,
+      };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      return {
+        content: `Failed to update todos: ${msg}`,
+        isError: true,
+      };
+    }
+  },
+});

--- a/mastracode/src/tools/types.ts
+++ b/mastracode/src/tools/types.ts
@@ -1,6 +1,6 @@
 export class ToolError extends Error {
-	constructor(message: string) {
-		super(message)
-		this.name = "ToolError"
-	}
+  constructor(message: string) {
+    super(message);
+    this.name = 'ToolError';
+  }
 }

--- a/mastracode/src/tools/utils.ts
+++ b/mastracode/src/tools/utils.ts
@@ -1,134 +1,110 @@
-import { promises as fs } from "node:fs"
-import * as path from "node:path"
-import { truncateStringForTokenEstimate } from "../utils/token-estimator.js"
-import { ToolError } from "./types.js"
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { truncateStringForTokenEstimate } from '../utils/token-estimator.js';
+import { ToolError } from './types.js';
 
 // Per-file write queue to serialize concurrent writes
-const fileWriteQueues = new Map<string, Promise<unknown>>()
+const fileWriteQueues = new Map<string, Promise<unknown>>();
 
-async function withWriteLock<T>(
-	filePath: string,
-	fn: () => Promise<T>,
-): Promise<T> {
-	const normalizedPath = path.resolve(filePath)
+async function withWriteLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+  const normalizedPath = path.resolve(filePath);
 
-	// Get the current queue for this file (or a resolved promise if none)
-	const currentQueue = fileWriteQueues.get(normalizedPath) ?? Promise.resolve()
+  // Get the current queue for this file (or a resolved promise if none)
+  const currentQueue = fileWriteQueues.get(normalizedPath) ?? Promise.resolve();
 
-	// Create a new promise that waits for the current queue, then runs our fn
-	let resolve: (value: T) => void
-	let reject: (error: unknown) => void
-	const ourPromise = new Promise<T>((res, rej) => {
-		resolve = res
-		reject = rej
-	})
+  // Create a new promise that waits for the current queue, then runs our fn
+  let resolve: (value: T) => void;
+  let reject: (error: unknown) => void;
+  const ourPromise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
 
-	// Chain our operation onto the queue
-	const queuePromise = currentQueue
-		.catch(() => {}) // Ignore errors from previous operations
-		.then(async () => {
-			try {
-				const result = await fn()
-				resolve(result)
-			} catch (error) {
-				reject(error)
-			}
-		})
+  // Chain our operation onto the queue
+  const queuePromise = currentQueue
+    .catch(() => {}) // Ignore errors from previous operations
+    .then(async () => {
+      try {
+        const result = await fn();
+        resolve(result);
+      } catch (error) {
+        reject(error);
+      }
+    });
 
-	// Update the queue
-	fileWriteQueues.set(normalizedPath, queuePromise)
+  // Update the queue
+  fileWriteQueues.set(normalizedPath, queuePromise);
 
-	// Clean up when our operation completes
-	queuePromise.finally(() => {
-		// Only delete if we're still the last in queue
-		if (fileWriteQueues.get(normalizedPath) === queuePromise) {
-			fileWriteQueues.delete(normalizedPath)
-		}
-	})
+  // Clean up when our operation completes
+  queuePromise.finally(() => {
+    // Only delete if we're still the last in queue
+    if (fileWriteQueues.get(normalizedPath) === queuePromise) {
+      fileWriteQueues.delete(normalizedPath);
+    }
+  });
 
-	return ourPromise
+  return ourPromise;
 }
 
-export const SNIPPET_LINES = 4
+export const SNIPPET_LINES = 4;
 export async function readFile(filePath: string): Promise<string> {
-	try {
-		return await fs.readFile(filePath, "utf8")
-	} catch (e) {
-		const error = e instanceof Error ? e : new Error("Unknown error")
-		throw new Error(`Failed to read ${filePath}: ${error.message}`)
-	}
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch (e) {
+    const error = e instanceof Error ? e : new Error('Unknown error');
+    throw new Error(`Failed to read ${filePath}: ${error.message}`);
+  }
 }
-export async function writeFile(
-	filePath: string,
-	content: string,
-): Promise<void> {
-	try {
-		await fs.mkdir(path.dirname(filePath), { recursive: true })
-		await fs.writeFile(filePath, content, "utf8")
-	} catch (e) {
-		const error = e instanceof Error ? e : new Error("Unknown error")
-		throw new Error(`Failed to write to ${filePath}: ${error.message}`)
-	}
+export async function writeFile(filePath: string, content: string): Promise<void> {
+  try {
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, content, 'utf8');
+  } catch (e) {
+    const error = e instanceof Error ? e : new Error('Unknown error');
+    throw new Error(`Failed to write to ${filePath}: ${error.message}`);
+  }
 }
 
 // Export the lock for operations that need to serialize read-modify-write
-export { withWriteLock as withFileLock }
-export function makeOutput(
-	fileContent: string,
-	fileDescriptor: string,
-	initLine = 1,
-	expandTabs = true,
-): string {
-	if (expandTabs) {
-		fileContent = fileContent.replace(/\t/g, "    ")
-	}
-	// Convert absolute paths to relative paths from cwd for token efficiency
-	const displayPath = path.isAbsolute(fileDescriptor)
-		? path.relative(process.cwd(), fileDescriptor)
-		: fileDescriptor
-	const lines = fileContent.split("\n")
-	const numberedLines = lines
-		.map((line, i) => `${(i + initLine).toString().padStart(6)}\t${line}`)
-		.join("\n")
-	return `Here's the result of running \`cat -n\` on ${displayPath}:\n${truncateStringForTokenEstimate(numberedLines, 500, false)}\n`
+export { withWriteLock as withFileLock };
+export function makeOutput(fileContent: string, fileDescriptor: string, initLine = 1, expandTabs = true): string {
+  if (expandTabs) {
+    fileContent = fileContent.replace(/\t/g, '    ');
+  }
+  // Convert absolute paths to relative paths from cwd for token efficiency
+  const displayPath = path.isAbsolute(fileDescriptor) ? path.relative(process.cwd(), fileDescriptor) : fileDescriptor;
+  const lines = fileContent.split('\n');
+  const numberedLines = lines.map((line, i) => `${(i + initLine).toString().padStart(6)}\t${line}`).join('\n');
+  return `Here's the result of running \`cat -n\` on ${displayPath}:\n${truncateStringForTokenEstimate(numberedLines, 500, false)}\n`;
 }
-export async function validatePath(
-	command: string,
-	filePath: string,
-): Promise<void> {
-	const absolutePath = path.isAbsolute(filePath)
-		? filePath
-		: path.join(process.cwd(), filePath)
-	if (!path.isAbsolute(filePath)) {
-		filePath = absolutePath
-	}
-	try {
-		const stats = await fs.stat(filePath)
-		if (stats.isDirectory() && command !== "view") {
-			throw new ToolError(
-				`The path ${filePath} is a directory and only the \`view\` command can be used on directories`,
-			)
-		}
-		if (command === "create" && stats.isFile()) {
-			throw new ToolError(
-				`File already exists at: ${filePath}. Cannot overwrite files using command \`create\``,
-			)
-		}
-	} catch (e) {
-		const error = e instanceof Error ? e : new Error("Unknown error")
-		if ("code" in error && error.code === "ENOENT" && command !== "create") {
-			throw new ToolError(
-				`The path ${filePath} does not exist. Please provide a valid path.`,
-			)
-		}
-		if (command !== "create") {
-			throw error
-		}
-	}
+export async function validatePath(command: string, filePath: string): Promise<void> {
+  const absolutePath = path.isAbsolute(filePath) ? filePath : path.join(process.cwd(), filePath);
+  if (!path.isAbsolute(filePath)) {
+    filePath = absolutePath;
+  }
+  try {
+    const stats = await fs.stat(filePath);
+    if (stats.isDirectory() && command !== 'view') {
+      throw new ToolError(
+        `The path ${filePath} is a directory and only the \`view\` command can be used on directories`,
+      );
+    }
+    if (command === 'create' && stats.isFile()) {
+      throw new ToolError(`File already exists at: ${filePath}. Cannot overwrite files using command \`create\``);
+    }
+  } catch (e) {
+    const error = e instanceof Error ? e : new Error('Unknown error');
+    if ('code' in error && error.code === 'ENOENT' && command !== 'create') {
+      throw new ToolError(`The path ${filePath} does not exist. Please provide a valid path.`);
+    }
+    if (command !== 'create') {
+      throw error;
+    }
+  }
 }
 export function truncateText(text: string, maxLength = 1000): string {
-	if (text.length <= maxLength) return text
-	return text.slice(0, maxLength) + "... (truncated)"
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength) + '... (truncated)';
 }
 
 /**
@@ -137,39 +113,27 @@ export function truncateText(text: string, maxLength = 1000): string {
  *
  * Returns `true` when access should be **allowed**.
  */
-export function isPathAllowed(
-	targetPath: string,
-	projectRoot: string,
-	allowedPaths: string[] = [],
-): boolean {
-	const resolved = path.resolve(targetPath)
-	const roots = [projectRoot, ...allowedPaths].map((p) => path.resolve(p))
+export function isPathAllowed(targetPath: string, projectRoot: string, allowedPaths: string[] = []): boolean {
+  const resolved = path.resolve(targetPath);
+  const roots = [projectRoot, ...allowedPaths].map(p => path.resolve(p));
 
-	return roots.some(
-		(root) => resolved === root || resolved.startsWith(root + path.sep),
-	)
+  return roots.some(root => resolved === root || resolved.startsWith(root + path.sep));
 }
 
 /**
  * Guard that throws a descriptive error when a path is not allowed.
  * Designed to be called early in each tool's `execute` function.
  */
-export function assertPathAllowed(
-	targetPath: string,
-	projectRoot: string,
-	allowedPaths: string[] = [],
-): void {
-	if (!isPathAllowed(targetPath, projectRoot, allowedPaths)) {
-		const resolvedTarget = path.resolve(targetPath)
-		const resolvedRoot = path.resolve(projectRoot)
-		throw new ToolError(
-			`Access denied: "${resolvedTarget}" is outside the project root "${resolvedRoot}"` +
-				(allowedPaths.length
-					? ` and allowed paths [${allowedPaths.join(", ")}]`
-					: "") +
-				`. Use /sandbox to add additional allowed paths.`,
-		)
-	}
+export function assertPathAllowed(targetPath: string, projectRoot: string, allowedPaths: string[] = []): void {
+  if (!isPathAllowed(targetPath, projectRoot, allowedPaths)) {
+    const resolvedTarget = path.resolve(targetPath);
+    const resolvedRoot = path.resolve(projectRoot);
+    throw new ToolError(
+      `Access denied: "${resolvedTarget}" is outside the project root "${resolvedRoot}"` +
+        (allowedPaths.length ? ` and allowed paths [${allowedPaths.join(', ')}]` : '') +
+        `. Use /sandbox to add additional allowed paths.`,
+    );
+  }
 }
 
 /**
@@ -177,20 +141,14 @@ export function assertPathAllowed(
  * Returns an empty array when the context is unavailable (e.g. in tests).
  */
 export function getAllowedPathsFromContext(
-	toolContext:
-		| { requestContext?: { get: (key: string) => unknown } }
-		| undefined,
+  toolContext: { requestContext?: { get: (key: string) => unknown } } | undefined,
 ): string[] {
-	if (!toolContext?.requestContext) return []
-	const harnessCtx = toolContext.requestContext.get("harness") as
-		| {
-				state?: { sandboxAllowedPaths?: string[] }
-				getState?: () => { sandboxAllowedPaths?: string[] }
-		  }
-		| undefined
-	return (
-		harnessCtx?.getState?.()?.sandboxAllowedPaths ??
-		harnessCtx?.state?.sandboxAllowedPaths ??
-		[]
-	)
+  if (!toolContext?.requestContext) return [];
+  const harnessCtx = toolContext.requestContext.get('harness') as
+    | {
+        state?: { sandboxAllowedPaths?: string[] };
+        getState?: () => { sandboxAllowedPaths?: string[] };
+      }
+    | undefined;
+  return harnessCtx?.getState?.()?.sandboxAllowedPaths ?? harnessCtx?.state?.sandboxAllowedPaths ?? [];
 }

--- a/mastracode/src/tools/web-search.ts
+++ b/mastracode/src/tools/web-search.ts
@@ -170,15 +170,15 @@ export function createWebExtractTool() {
 						}),
 					),
 				}
-			} catch {
-				return {
-					results: [],
-					failedResults: context.urls.map((url) => ({
-						url,
-						error: String(error),
-					})),
-				}
-			}
+            } catch (error) {
+                return {
+                    results: [],
+                    failedResults: context.urls.map((url) => ({
+                        url,
+                        error: String(error),
+                    })),
+                }
+            }
 		},
 	})
 }

--- a/mastracode/src/tools/web-search.ts
+++ b/mastracode/src/tools/web-search.ts
@@ -1,18 +1,18 @@
-import { createTool } from "@mastra/core/tools"
-import { tavily } from "@tavily/core"
-import { z } from "zod"
+import { createTool } from '@mastra/core/tools';
+import { tavily } from '@tavily/core';
+import { z } from 'zod';
 
-const MIN_RELEVANCE_SCORE = 0.25
+const MIN_RELEVANCE_SCORE = 0.25;
 
 // Lazily cached Tavily client — created on first use when the API key is available.
-let cachedTavilyClient: ReturnType<typeof tavily> | null = null
+let cachedTavilyClient: ReturnType<typeof tavily> | null = null;
 
 function getTavilyClient() {
-	if (cachedTavilyClient) return cachedTavilyClient
-	const apiKey = process.env.TAVILY_API_KEY
-	if (!apiKey) return null
-	cachedTavilyClient = tavily({ apiKey })
-	return cachedTavilyClient
+  if (cachedTavilyClient) return cachedTavilyClient;
+  const apiKey = process.env.TAVILY_API_KEY;
+  if (!apiKey) return null;
+  cachedTavilyClient = tavily({ apiKey });
+  return cachedTavilyClient;
 }
 
 /**
@@ -21,164 +21,136 @@ function getTavilyClient() {
  * to Anthropic's native web search.
  */
 export function hasTavilyKey(): boolean {
-	return !!process.env.TAVILY_API_KEY
+  return !!process.env.TAVILY_API_KEY;
 }
 
 export function createWebSearchTool() {
-	return createTool({
-		id: "web-search",
-		description:
-			"Search the web for information. Use this to find documentation, look up error messages, check package APIs, or research any topic. Returns relevant web results with content snippets and optionally images.",
-		inputSchema: z.object({
-			query: z.string().describe("The search query"),
-			searchDepth: z
-				.enum(["basic", "advanced"])
-				.optional()
-				.default("basic")
-				.describe(
-					"Search depth - 'basic' for quick searches, 'advanced' for more thorough results",
-				),
-			maxResults: z
-				.number()
-				.optional()
-				.default(10)
-				.describe("Maximum number of results to return"),
-			includeImages: z
-				.boolean()
-				.optional()
-				.default(false)
-				.describe("Whether to include related images in results"),
-		}),
-		outputSchema: z.object({
-			results: z.array(
-				z.object({
-					title: z.string(),
-					url: z.string(),
-					content: z.string(),
-				}),
-			),
-			images: z.array(z.string()).optional(),
-			answer: z.string().optional(),
-		}),
-		execute: async (context) => {
-			const tavilyClient = getTavilyClient()
-			if (!tavilyClient) {
-				return { results: [], images: [], answer: undefined }
-			}
-			try {
-				const response = await tavilyClient.search(context.query, {
-					searchDepth: context.searchDepth || "basic",
-					maxResults: context.maxResults || 10,
-					includeAnswer: true,
-					includeImages: context.includeImages || false,
-				})
+  return createTool({
+    id: 'web-search',
+    description:
+      'Search the web for information. Use this to find documentation, look up error messages, check package APIs, or research any topic. Returns relevant web results with content snippets and optionally images.',
+    inputSchema: z.object({
+      query: z.string().describe('The search query'),
+      searchDepth: z
+        .enum(['basic', 'advanced'])
+        .optional()
+        .default('basic')
+        .describe("Search depth - 'basic' for quick searches, 'advanced' for more thorough results"),
+      maxResults: z.number().optional().default(10).describe('Maximum number of results to return'),
+      includeImages: z.boolean().optional().default(false).describe('Whether to include related images in results'),
+    }),
+    outputSchema: z.object({
+      results: z.array(
+        z.object({
+          title: z.string(),
+          url: z.string(),
+          content: z.string(),
+        }),
+      ),
+      images: z.array(z.string()).optional(),
+      answer: z.string().optional(),
+    }),
+    execute: async context => {
+      const tavilyClient = getTavilyClient();
+      if (!tavilyClient) {
+        return { results: [], images: [], answer: undefined };
+      }
+      try {
+        const response = await tavilyClient.search(context.query, {
+          searchDepth: context.searchDepth || 'basic',
+          maxResults: context.maxResults || 10,
+          includeAnswer: true,
+          includeImages: context.includeImages || false,
+        });
 
-				const filteredResults = response.results.filter(
-					(r) => (r.score ?? 1) >= MIN_RELEVANCE_SCORE,
-				)
+        const filteredResults = response.results.filter(r => (r.score ?? 1) >= MIN_RELEVANCE_SCORE);
 
-				return {
-					results: filteredResults.map((r) => ({
-						title: r.title,
-						url: r.url,
-						content: r.content,
-					})),
-					images: (response.images || [])
-						.map((img: { url?: string } | string) =>
-							typeof img === "string" ? img : img.url || "",
-						)
-						.filter(Boolean),
-					answer: response.answer,
-				}
-			} catch {
-				return {
-					results: [],
-					images: [],
-					answer: undefined,
-				}
-			}
-		},
-	})
+        return {
+          results: filteredResults.map(r => ({
+            title: r.title,
+            url: r.url,
+            content: r.content,
+          })),
+          images: (response.images || [])
+            .map((img: { url?: string } | string) => (typeof img === 'string' ? img : img.url || ''))
+            .filter(Boolean),
+          answer: response.answer,
+        };
+      } catch {
+        return {
+          results: [],
+          images: [],
+          answer: undefined,
+        };
+      }
+    },
+  });
 }
 
 export function createWebExtractTool() {
-	return createTool({
-		id: "web-extract",
-		description:
-			"Extract content from one or more URLs. Use this to read web pages, documentation, articles, or any URL. Returns the raw content in markdown format. You can provide up to 20 URLs at once.",
-		inputSchema: z.object({
-			urls: z
-				.array(z.string())
-				.min(1)
-				.max(20)
-				.describe("URLs to extract content from (max 20)"),
-			extractDepth: z
-				.enum(["basic", "advanced"])
-				.optional()
-				.default("basic")
-				.describe(
-					"Extraction depth - 'basic' for simple text, 'advanced' for JS-rendered pages",
-				),
-			includeImages: z
-				.boolean()
-				.optional()
-				.default(false)
-				.describe("Whether to include extracted image URLs"),
-		}),
-		outputSchema: z.object({
-			results: z.array(
-				z.object({
-					url: z.string(),
-					rawContent: z.string(),
-				}),
-			),
-			failedResults: z.array(
-				z.object({
-					url: z.string(),
-					error: z.string(),
-				}),
-			),
-		}),
-		execute: async (context) => {
-			const tavilyClient = getTavilyClient()
-			if (!tavilyClient) {
-				return {
-					results: [],
-					failedResults: context.urls.map((url) => ({
-						url,
-						error: "TAVILY_API_KEY not configured",
-					})),
-				}
-			}
-			try {
-				const response = await tavilyClient.extract(context.urls, {
-					extractDepth: context.extractDepth || "basic",
-					includeImages: context.includeImages || false,
-				})
+  return createTool({
+    id: 'web-extract',
+    description:
+      'Extract content from one or more URLs. Use this to read web pages, documentation, articles, or any URL. Returns the raw content in markdown format. You can provide up to 20 URLs at once.',
+    inputSchema: z.object({
+      urls: z.array(z.string()).min(1).max(20).describe('URLs to extract content from (max 20)'),
+      extractDepth: z
+        .enum(['basic', 'advanced'])
+        .optional()
+        .default('basic')
+        .describe("Extraction depth - 'basic' for simple text, 'advanced' for JS-rendered pages"),
+      includeImages: z.boolean().optional().default(false).describe('Whether to include extracted image URLs'),
+    }),
+    outputSchema: z.object({
+      results: z.array(
+        z.object({
+          url: z.string(),
+          rawContent: z.string(),
+        }),
+      ),
+      failedResults: z.array(
+        z.object({
+          url: z.string(),
+          error: z.string(),
+        }),
+      ),
+    }),
+    execute: async context => {
+      const tavilyClient = getTavilyClient();
+      if (!tavilyClient) {
+        return {
+          results: [],
+          failedResults: context.urls.map(url => ({
+            url,
+            error: 'TAVILY_API_KEY not configured',
+          })),
+        };
+      }
+      try {
+        const response = await tavilyClient.extract(context.urls, {
+          extractDepth: context.extractDepth || 'basic',
+          includeImages: context.includeImages || false,
+        });
 
-				return {
-					results: (response.results || []).map(
-						(r: { url: string; rawContent: string }) => ({
-							url: r.url,
-							rawContent: r.rawContent,
-						}),
-					),
-					failedResults: (response.failedResults || []).map(
-						(r: { url: string; error: string }) => ({
-							url: r.url,
-							error: r.error,
-						}),
-					),
-				}
-            } catch (error) {
-                return {
-                    results: [],
-                    failedResults: context.urls.map((url) => ({
-                        url,
-                        error: String(error),
-                    })),
-                }
-            }
-		},
-	})
+        return {
+          results: (response.results || []).map((r: { url: string; rawContent: string }) => ({
+            url: r.url,
+            rawContent: r.rawContent,
+          })),
+          failedResults: (response.failedResults || []).map((r: { url: string; error: string }) => ({
+            url: r.url,
+            error: r.error,
+          })),
+        };
+      } catch (error) {
+        return {
+          results: [],
+          failedResults: context.urls.map(url => ({
+            url,
+            error: String(error),
+          })),
+        };
+      }
+    },
+  });
 }

--- a/mastracode/src/tools/wrap-with-confirmation.ts
+++ b/mastracode/src/tools/wrap-with-confirmation.ts
@@ -1,11 +1,11 @@
 // Stub for confirmation tracking - not used in TUI mode
 
-let globalConfirmationId: string | null = null
+let globalConfirmationId: string | null = null;
 
 export function setGlobalConfirmationId(id: string | null) {
-	globalConfirmationId = id
+  globalConfirmationId = id;
 }
 
 export function getGlobalConfirmationId(): string | null {
-	return globalConfirmationId
+  return globalConfirmationId;
 }

--- a/mastracode/src/tools/write.ts
+++ b/mastracode/src/tools/write.ts
@@ -1,19 +1,19 @@
 /**
  * Write tool — create new files or overwrite existing ones.
  */
-import * as fs from "node:fs"
-import * as path from "node:path"
-import { createTool } from "@mastra/core/tools"
-import { z } from "zod/v3"
-import { assertPathAllowed, getAllowedPathsFromContext } from "./utils.js"
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod/v3';
+import { assertPathAllowed, getAllowedPathsFromContext } from './utils.js';
 
 /**
  * Create the write_file tool for creating/overwriting files.
  */
 export function createWriteFileTool(projectRoot?: string) {
-	return createTool({
-		id: "write_file",
-		description: `Create a new file or overwrite an existing file with the given content.
+  return createTool({
+    id: 'write_file',
+    description: `Create a new file or overwrite an existing file with the given content.
 
 Usage notes:
 - Use this to create NEW files. For editing existing files, prefer string_replace_lsp.
@@ -22,56 +22,54 @@ Usage notes:
 - The path is relative to the project root directory.
 - NEVER create files unless absolutely necessary. Prefer editing existing files.
 - Do not create documentation files (README, *.md) unless the user explicitly asks.`,
-		// requireApproval: true,
-		inputSchema: z.object({
-			path: z
-				.string()
-				.describe("File path to write to (relative to project root)"),
-			content: z.string().describe("The full content to write to the file"),
-		}),
-		execute: async (context, toolContext) => {
-			try {
-				const root = projectRoot || process.cwd()
-				const filePath = context.path
-				const absolutePath = path.resolve(root, filePath)
-				const allowedPaths = getAllowedPathsFromContext(toolContext)
+    // requireApproval: true,
+    inputSchema: z.object({
+      path: z.string().describe('File path to write to (relative to project root)'),
+      content: z.string().describe('The full content to write to the file'),
+    }),
+    execute: async (context, toolContext) => {
+      try {
+        const root = projectRoot || process.cwd();
+        const filePath = context.path;
+        const absolutePath = path.resolve(root, filePath);
+        const allowedPaths = getAllowedPathsFromContext(toolContext);
 
-				// Security: ensure the path is within the project root or allowed paths
-				assertPathAllowed(absolutePath, root, allowedPaths)
+        // Security: ensure the path is within the project root or allowed paths
+        assertPathAllowed(absolutePath, root, allowedPaths);
 
-				// Check if file exists
-				const exists = fs.existsSync(absolutePath)
+        // Check if file exists
+        const exists = fs.existsSync(absolutePath);
 
-				// Create parent directories if needed
-				const dir = path.dirname(absolutePath)
-				if (!fs.existsSync(dir)) {
-					fs.mkdirSync(dir, { recursive: true })
-				}
+        // Create parent directories if needed
+        const dir = path.dirname(absolutePath);
+        if (!fs.existsSync(dir)) {
+          fs.mkdirSync(dir, { recursive: true });
+        }
 
-				// Write the file
-				fs.writeFileSync(absolutePath, context.content, "utf-8")
+        // Write the file
+        fs.writeFileSync(absolutePath, context.content, 'utf-8');
 
-				const lineCount = context.content.split("\n").length
-				const relPath = path.relative(root, absolutePath)
+        const lineCount = context.content.split('\n').length;
+        const relPath = path.relative(root, absolutePath);
 
-				if (exists) {
-					return {
-						content: `Overwrote ${relPath} (${lineCount} lines)`,
-						isError: false,
-					}
-				} else {
-					return {
-						content: `Created ${relPath} (${lineCount} lines)`,
-						isError: false,
-					}
-				}
-			} catch (error) {
-				const msg = error instanceof Error ? error.message : "Unknown error"
-				return {
-					content: `write_file failed: ${msg}`,
-					isError: true,
-				}
-			}
-		},
-	})
+        if (exists) {
+          return {
+            content: `Overwrote ${relPath} (${lineCount} lines)`,
+            isError: false,
+          };
+        } else {
+          return {
+            content: `Created ${relPath} (${lineCount} lines)`,
+            isError: false,
+          };
+        }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: `write_file failed: ${msg}`,
+          isError: true,
+        };
+      }
+    },
+  });
 }

--- a/mastracode/src/tui/components/ask-question-dialog.ts
+++ b/mastracode/src/tui/components/ask-question-dialog.ts
@@ -4,120 +4,97 @@
  * Used by the ask_user tool to collect structured answers from the user.
  */
 
-import {
-	Box,
-	
-	getEditorKeybindings,
-	Input,
-	SelectList,
-	
-	Spacer,
-	Text
-} from "@mariozechner/pi-tui"
-import type {Focusable, SelectItem} from "@mariozechner/pi-tui";
-import { bg, fg, bold, getSelectListTheme } from "../theme.js"
+import { Box, getEditorKeybindings, Input, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
+import type { Focusable, SelectItem } from '@mariozechner/pi-tui';
+import { bg, fg, bold, getSelectListTheme } from '../theme.js';
 
 export interface AskQuestionDialogOptions {
-	question: string
-	options?: Array<{ label: string; description?: string }>
-	onSubmit: (answer: string) => void
-	onCancel: () => void
+  question: string;
+  options?: Array<{ label: string; description?: string }>;
+  onSubmit: (answer: string) => void;
+  onCancel: () => void;
 }
 
 export class AskQuestionDialogComponent extends Box implements Focusable {
-	private selectList?: SelectList
-	private input?: Input
-	private onSubmit: (answer: string) => void
-	private onCancel: () => void
+  private selectList?: SelectList;
+  private input?: Input;
+  private onSubmit: (answer: string) => void;
+  private onCancel: () => void;
 
-	private _focused = false
-	get focused(): boolean {
-		return this._focused
-	}
-	set focused(value: boolean) {
-		this._focused = value
-		if (this.input) this.input.focused = value
-	}
+  private _focused = false;
+  get focused(): boolean {
+    return this._focused;
+  }
+  set focused(value: boolean) {
+    this._focused = value;
+    if (this.input) this.input.focused = value;
+  }
 
-	constructor(options: AskQuestionDialogOptions) {
-		super(2, 1, (text) => bg("overlayBg", text))
+  constructor(options: AskQuestionDialogOptions) {
+    super(2, 1, text => bg('overlayBg', text));
 
-		this.onSubmit = options.onSubmit
-		this.onCancel = options.onCancel
+    this.onSubmit = options.onSubmit;
+    this.onCancel = options.onCancel;
 
-		// Title
-		this.addChild(new Text(bold(fg("accent", "Question")), 0, 0))
-		this.addChild(new Spacer(1))
+    // Title
+    this.addChild(new Text(bold(fg('accent', 'Question')), 0, 0));
+    this.addChild(new Spacer(1));
 
-		// Question text (may be multi-line)
-		for (const line of options.question.split("\n")) {
-			this.addChild(new Text(fg("text", line), 0, 0))
-		}
-		this.addChild(new Spacer(1))
+    // Question text (may be multi-line)
+    for (const line of options.question.split('\n')) {
+      this.addChild(new Text(fg('text', line), 0, 0));
+    }
+    this.addChild(new Spacer(1));
 
-		if (options.options && options.options.length > 0) {
-			this.buildSelectMode(options.options)
-		} else {
-			this.buildInputMode()
-		}
-	}
+    if (options.options && options.options.length > 0) {
+      this.buildSelectMode(options.options);
+    } else {
+      this.buildInputMode();
+    }
+  }
 
-	private buildSelectMode(
-		opts: Array<{ label: string; description?: string }>,
-	): void {
-		const items: SelectItem[] = opts.map((opt) => ({
-			value: opt.label,
-			label: opt.description
-				? `  ${opt.label}  ${fg("dim", opt.description)}`
-				: `  ${opt.label}`,
-		}))
+  private buildSelectMode(opts: Array<{ label: string; description?: string }>): void {
+    const items: SelectItem[] = opts.map(opt => ({
+      value: opt.label,
+      label: opt.description ? `  ${opt.label}  ${fg('dim', opt.description)}` : `  ${opt.label}`,
+    }));
 
-		this.selectList = new SelectList(
-			items,
-			Math.min(items.length, 8),
-			getSelectListTheme(),
-		)
+    this.selectList = new SelectList(items, Math.min(items.length, 8), getSelectListTheme());
 
-		this.selectList.onSelect = (item: SelectItem) => {
-			this.onSubmit(item.value)
-		}
-		this.selectList.onCancel = this.onCancel
+    this.selectList.onSelect = (item: SelectItem) => {
+      this.onSubmit(item.value);
+    };
+    this.selectList.onCancel = this.onCancel;
 
-		this.addChild(this.selectList)
-		this.addChild(new Spacer(1))
-		this.addChild(
-			new Text(
-				fg("dim", "  ↑↓ to navigate · Enter to select · Esc to skip"),
-				0,
-				0,
-			),
-		)
-	}
+    this.addChild(this.selectList);
+    this.addChild(new Spacer(1));
+    this.addChild(new Text(fg('dim', '  ↑↓ to navigate · Enter to select · Esc to skip'), 0, 0));
+  }
 
-	private buildInputMode(): void {
-		this.input = new Input()
-		this.input.onSubmit = (value: string) => {
-			const trimmed = value.trim()
-			if (trimmed) {
-				this.onSubmit(trimmed)
-			}
-		}
+  private buildInputMode(): void {
+    this.input = new Input();
+    this.input.onSubmit = (value: string) => {
+      const trimmed = value.trim();
+      if (trimmed) {
+        this.onSubmit(trimmed);
+      }
+    };
 
-		this.addChild(this.input)
-		this.addChild(new Spacer(1))
-		this.addChild(new Text(fg("dim", "  Enter to submit · Esc to skip"), 0, 0))
-	}
+    this.addChild(this.input);
+    this.addChild(new Spacer(1));
+    this.addChild(new Text(fg('dim', '  Enter to submit · Esc to skip'), 0, 0));
+  }
 
-	handleInput(data: string): void {
-		if (this.selectList) {
-			this.selectList.handleInput(data)
-		} else if (this.input) {
-			const kb = getEditorKeybindings()
-			if (kb.matches(data, "selectCancel")) {
-				this.onCancel()
-				return
-			}
-			this.input.handleInput(data)
-		}
-	}
+  handleInput(data: string): void {
+    if (this.selectList) {
+      this.selectList.handleInput(data);
+    } else if (this.input) {
+      const kb = getEditorKeybindings();
+      if (kb.matches(data, 'selectCancel')) {
+        this.onCancel();
+        return;
+      }
+      this.input.handleInput(data);
+    }
+  }
 }

--- a/mastracode/src/tui/components/ask-question-inline.ts
+++ b/mastracode/src/tui/components/ask-question-inline.ts
@@ -4,197 +4,153 @@
  * directly in the conversation flow instead of as an overlay dialog.
  */
 
-import {
-	Box,
-	Container,
-	
-	getEditorKeybindings,
-	Input,
-	SelectList,
-	
-	Spacer,
-	Text
-	
-} from "@mariozechner/pi-tui"
-import type {Focusable, SelectItem, TUI} from "@mariozechner/pi-tui";
-import { theme, getSelectListTheme } from "../theme.js"
+import { Box, Container, getEditorKeybindings, Input, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
+import type { Focusable, SelectItem, TUI } from '@mariozechner/pi-tui';
+import { theme, getSelectListTheme } from '../theme.js';
 
 export interface AskQuestionInlineOptions {
-	question: string
-	options?: Array<{ label: string; description?: string }>
-	/** Format the text shown after an answer is selected. Defaults to `question → answer`. */
-	formatResult?: (answer: string) => string
-	/** If provided, determines whether an answer should be shown with error styling (red ✗). */
-	isNegativeAnswer?: (answer: string) => boolean
-	onSubmit: (answer: string) => void
-	onCancel: () => void
+  question: string;
+  options?: Array<{ label: string; description?: string }>;
+  /** Format the text shown after an answer is selected. Defaults to `question → answer`. */
+  formatResult?: (answer: string) => string;
+  /** If provided, determines whether an answer should be shown with error styling (red ✗). */
+  isNegativeAnswer?: (answer: string) => boolean;
+  onSubmit: (answer: string) => void;
+  onCancel: () => void;
 }
 
 export class AskQuestionInlineComponent extends Container implements Focusable {
-	private contentBox: Box
-	private selectList?: SelectList
-	private input?: Input
-	private onSubmit: (answer: string) => void
-	private onCancel: () => void
-	private formatResult?: (answer: string) => string
-	private isNegativeAnswer?: (answer: string) => boolean
-	private answered = false
-	private questionText: string
+  private contentBox: Box;
+  private selectList?: SelectList;
+  private input?: Input;
+  private onSubmit: (answer: string) => void;
+  private onCancel: () => void;
+  private formatResult?: (answer: string) => string;
+  private isNegativeAnswer?: (answer: string) => boolean;
+  private answered = false;
+  private questionText: string;
 
-	private _focused = false
-	get focused(): boolean {
-		return this._focused
-	}
-	set focused(value: boolean) {
-		this._focused = value
-		if (!this.answered && this.input) {
-			this.input.focused = value
-		}
-	}
+  private _focused = false;
+  get focused(): boolean {
+    return this._focused;
+  }
+  set focused(value: boolean) {
+    this._focused = value;
+    if (!this.answered && this.input) {
+      this.input.focused = value;
+    }
+  }
 
-	constructor(options: AskQuestionInlineOptions, _ui: TUI) {
-		super()
+  constructor(options: AskQuestionInlineOptions, _ui: TUI) {
+    super();
 
-		this.onSubmit = options.onSubmit
-		this.onCancel = options.onCancel
-		this.formatResult = options.formatResult
-		this.isNegativeAnswer = options.isNegativeAnswer
-		this.questionText = options.question
+    this.onSubmit = options.onSubmit;
+    this.onCancel = options.onCancel;
+    this.formatResult = options.formatResult;
+    this.isNegativeAnswer = options.isNegativeAnswer;
+    this.questionText = options.question;
 
-		// Add spacing above
-		this.addChild(new Spacer(1))
+    // Add spacing above
+    this.addChild(new Spacer(1));
 
-		// Create box with accent border for the question
-		this.contentBox = new Box(1, 1, (text: string) =>
-			theme.bg("toolPendingBg", text),
-		)
-		this.addChild(this.contentBox)
+    // Create box with accent border for the question
+    this.contentBox = new Box(1, 1, (text: string) => theme.bg('toolPendingBg', text));
+    this.addChild(this.contentBox);
 
-		// Question header
-		this.contentBox.addChild(
-			new Text(theme.bold(theme.fg("accent", "❓ Question")), 0, 0),
-		)
-		this.contentBox.addChild(new Spacer(1))
+    // Question header
+    this.contentBox.addChild(new Text(theme.bold(theme.fg('accent', '❓ Question')), 0, 0));
+    this.contentBox.addChild(new Spacer(1));
 
-		// Question text (may be multi-line)
-		for (const line of options.question.split("\n")) {
-			this.contentBox.addChild(new Text(theme.fg("text", line), 0, 0))
-		}
-		this.contentBox.addChild(new Spacer(1))
+    // Question text (may be multi-line)
+    for (const line of options.question.split('\n')) {
+      this.contentBox.addChild(new Text(theme.fg('text', line), 0, 0));
+    }
+    this.contentBox.addChild(new Spacer(1));
 
-		if (options.options && options.options.length > 0) {
-			this.buildSelectMode(options.options)
-		} else {
-			this.buildInputMode()
-		}
-	}
+    if (options.options && options.options.length > 0) {
+      this.buildSelectMode(options.options);
+    } else {
+      this.buildInputMode();
+    }
+  }
 
-	private buildSelectMode(
-		opts: Array<{ label: string; description?: string }>,
-	): void {
-		const items: SelectItem[] = opts.map((opt) => ({
-			value: opt.label,
-			label: opt.description
-				? `  ${opt.label}  ${theme.fg("dim", opt.description)}`
-				: `  ${opt.label}`,
-		}))
+  private buildSelectMode(opts: Array<{ label: string; description?: string }>): void {
+    const items: SelectItem[] = opts.map(opt => ({
+      value: opt.label,
+      label: opt.description ? `  ${opt.label}  ${theme.fg('dim', opt.description)}` : `  ${opt.label}`,
+    }));
 
-		this.selectList = new SelectList(
-			items,
-			Math.min(items.length, 8),
-			getSelectListTheme(),
-		)
+    this.selectList = new SelectList(items, Math.min(items.length, 8), getSelectListTheme());
 
-		this.selectList.onSelect = (item: SelectItem) => {
-			this.handleAnswer(item.value)
-		}
-		this.selectList.onCancel = () => {
-			this.handleCancel()
-		}
+    this.selectList.onSelect = (item: SelectItem) => {
+      this.handleAnswer(item.value);
+    };
+    this.selectList.onCancel = () => {
+      this.handleCancel();
+    };
 
-		this.contentBox.addChild(this.selectList)
-		this.contentBox.addChild(new Spacer(1))
-		this.contentBox.addChild(
-			new Text(
-				theme.fg("dim", "↑↓ to navigate · Enter to select · Esc to skip"),
-				0,
-				0,
-			),
-		)
-	}
+    this.contentBox.addChild(this.selectList);
+    this.contentBox.addChild(new Spacer(1));
+    this.contentBox.addChild(new Text(theme.fg('dim', '↑↓ to navigate · Enter to select · Esc to skip'), 0, 0));
+  }
 
-	private buildInputMode(): void {
-		this.input = new Input()
-		this.input.onSubmit = (value: string) => {
-			const trimmed = value.trim()
-			if (trimmed) {
-				this.handleAnswer(trimmed)
-			}
-		}
+  private buildInputMode(): void {
+    this.input = new Input();
+    this.input.onSubmit = (value: string) => {
+      const trimmed = value.trim();
+      if (trimmed) {
+        this.handleAnswer(trimmed);
+      }
+    };
 
-		this.contentBox.addChild(this.input)
-		this.contentBox.addChild(new Spacer(1))
-		this.contentBox.addChild(
-			new Text(theme.fg("dim", "Enter to submit · Esc to skip"), 0, 0),
-		)
-	}
+    this.contentBox.addChild(this.input);
+    this.contentBox.addChild(new Spacer(1));
+    this.contentBox.addChild(new Text(theme.fg('dim', 'Enter to submit · Esc to skip'), 0, 0));
+  }
 
-	private handleAnswer(answer: string): void {
-		if (this.answered) return
-		this.answered = true
+  private handleAnswer(answer: string): void {
+    if (this.answered) return;
+    this.answered = true;
 
-		const isNegative = this.isNegativeAnswer?.(answer) ?? false
+    const isNegative = this.isNegativeAnswer?.(answer) ?? false;
 
-		this.contentBox.clear()
-		this.contentBox.setBgFn((text: string) =>
-			theme.bg(isNegative ? "toolErrorBg" : "toolSuccessBg", text),
-		)
+    this.contentBox.clear();
+    this.contentBox.setBgFn((text: string) => theme.bg(isNegative ? 'toolErrorBg' : 'toolSuccessBg', text));
 
-		const resultText = this.formatResult
-			? this.formatResult(answer)
-			: `${this.questionText} → ${answer}`
+    const resultText = this.formatResult ? this.formatResult(answer) : `${this.questionText} → ${answer}`;
 
-		const icon = isNegative ? theme.fg("error", "✗") : theme.fg("success", "✓")
+    const icon = isNegative ? theme.fg('error', '✗') : theme.fg('success', '✓');
 
-		this.contentBox.addChild(
-			new Text(theme.fg("text", `${icon} ${resultText}`), 0, 0),
-		)
+    this.contentBox.addChild(new Text(theme.fg('text', `${icon} ${resultText}`), 0, 0));
 
-		this.onSubmit(answer)
-	}
+    this.onSubmit(answer);
+  }
 
-	private handleCancel(): void {
-		if (this.answered) return
-		this.answered = true
+  private handleCancel(): void {
+    if (this.answered) return;
+    this.answered = true;
 
-		this.contentBox.clear()
-		this.contentBox.setBgFn((text: string) => theme.bg("toolErrorBg", text))
-		this.contentBox.addChild(
-			new Text(
-				theme.fg(
-					"dim",
-					`${theme.fg("error", "✗")} ${this.questionText} (cancelled)`,
-				),
-				0,
-				0,
-			),
-		)
+    this.contentBox.clear();
+    this.contentBox.setBgFn((text: string) => theme.bg('toolErrorBg', text));
+    this.contentBox.addChild(
+      new Text(theme.fg('dim', `${theme.fg('error', '✗')} ${this.questionText} (cancelled)`), 0, 0),
+    );
 
-		this.onCancel()
-	}
+    this.onCancel();
+  }
 
-	handleInput(data: string): void {
-		if (this.answered) return
+  handleInput(data: string): void {
+    if (this.answered) return;
 
-		if (this.selectList) {
-			this.selectList.handleInput(data)
-		} else if (this.input) {
-			const kb = getEditorKeybindings()
-			if (kb.matches(data, "selectCancel")) {
-				this.handleCancel()
-				return
-			}
-			this.input.handleInput(data)
-		}
-	}
+    if (this.selectList) {
+      this.selectList.handleInput(data);
+    } else if (this.input) {
+      const kb = getEditorKeybindings();
+      if (kb.matches(data, 'selectCancel')) {
+        this.handleCancel();
+        return;
+      }
+      this.input.handleInput(data);
+    }
+  }
 }

--- a/mastracode/src/tui/components/assistant-message.ts
+++ b/mastracode/src/tui/components/assistant-message.ts
@@ -2,147 +2,121 @@
  * Component that renders an assistant message with streaming support.
  */
 
-import fs from "node:fs"
-import path from "node:path"
-import {
-	Container,
-	Markdown,
-	
-	Spacer,
-	Text
-} from "@mariozechner/pi-tui"
-import type {MarkdownTheme} from "@mariozechner/pi-tui";
-import type { HarnessMessage } from "../../harness/types.js"
-import { getMarkdownTheme, theme } from "../theme.js"
+import fs from 'node:fs';
+import path from 'node:path';
+import { Container, Markdown, Spacer, Text } from '@mariozechner/pi-tui';
+import type { MarkdownTheme } from '@mariozechner/pi-tui';
+import type { HarnessMessage } from '../../harness/types.js';
+import { getMarkdownTheme, theme } from '../theme.js';
 
-let _compId = 0
+let _compId = 0;
 function asmDebugLog(...args: unknown[]) {
-	if (process.env.DEBUG_MASTRA_CODE !== `true`) {
-		return
-	}
-	const line = `[ASM ${new Date().toISOString()}] ${args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ")}\n`
-	try {
-		fs.appendFileSync(path.join(process.cwd(), "tui-debug.log"), line)
-	} catch {}
+  if (process.env.DEBUG_MASTRA_CODE !== `true`) {
+    return;
+  }
+  const line = `[ASM ${new Date().toISOString()}] ${args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')}\n`;
+  try {
+    fs.appendFileSync(path.join(process.cwd(), 'tui-debug.log'), line);
+  } catch {}
 }
 
 export class AssistantMessageComponent extends Container {
-	private contentContainer: Container
-	private hideThinkingBlock: boolean
-	private markdownTheme: MarkdownTheme
-	private lastMessage?: HarnessMessage
-	private _id: number
+  private contentContainer: Container;
+  private hideThinkingBlock: boolean;
+  private markdownTheme: MarkdownTheme;
+  private lastMessage?: HarnessMessage;
+  private _id: number;
 
-	constructor(
-		message?: HarnessMessage,
-		hideThinkingBlock = false,
-		markdownTheme: MarkdownTheme = getMarkdownTheme(),
-	) {
-		super()
-		this._id = ++_compId
+  constructor(message?: HarnessMessage, hideThinkingBlock = false, markdownTheme: MarkdownTheme = getMarkdownTheme()) {
+    super();
+    this._id = ++_compId;
 
-		this.hideThinkingBlock = hideThinkingBlock
-		this.markdownTheme = markdownTheme
+    this.hideThinkingBlock = hideThinkingBlock;
+    this.markdownTheme = markdownTheme;
 
-		// Container for text/thinking content
-		this.contentContainer = new Container()
-		this.addChild(this.contentContainer)
+    // Container for text/thinking content
+    this.contentContainer = new Container();
+    this.addChild(this.contentContainer);
 
-		asmDebugLog(`COMP#${this._id} CREATED`)
+    asmDebugLog(`COMP#${this._id} CREATED`);
 
-		if (message) {
-			this.updateContent(message)
-		}
-	}
+    if (message) {
+      this.updateContent(message);
+    }
+  }
 
-	override invalidate(): void {
-		super.invalidate()
-		if (this.lastMessage) {
-			const summary = this.lastMessage.content
-				.map((c) => (c.type === "text" ? `text(${c.text.length}ch)` : c.type))
-				.join(", ")
-			asmDebugLog(`COMP#${this._id} INVALIDATE lastMessage=[${summary}]`)
-			this.updateContent(this.lastMessage)
-		}
-	}
+  override invalidate(): void {
+    super.invalidate();
+    if (this.lastMessage) {
+      const summary = this.lastMessage.content
+        .map(c => (c.type === 'text' ? `text(${c.text.length}ch)` : c.type))
+        .join(', ');
+      asmDebugLog(`COMP#${this._id} INVALIDATE lastMessage=[${summary}]`);
+      this.updateContent(this.lastMessage);
+    }
+  }
 
-	setHideThinkingBlock(hide: boolean): void {
-		this.hideThinkingBlock = hide
-	}
+  setHideThinkingBlock(hide: boolean): void {
+    this.hideThinkingBlock = hide;
+  }
 
-	updateContent(message: HarnessMessage): void {
-		// Deep copy the message to prevent mutation from the harness's shared content array
-		this.lastMessage = {
-			...message,
-			content: message.content.map((c) => ({ ...c })),
-		}
+  updateContent(message: HarnessMessage): void {
+    // Deep copy the message to prevent mutation from the harness's shared content array
+    this.lastMessage = {
+      ...message,
+      content: message.content.map(c => ({ ...c })),
+    };
 
-		// Clear content container
-		this.contentContainer.clear()
+    // Clear content container
+    this.contentContainer.clear();
 
-		const hasVisibleContent = message.content.some(
-			(c) =>
-				(c.type === "text" && c.text.trim()) ||
-				(c.type === "thinking" && c.thinking.trim()),
-		)
+    const hasVisibleContent = message.content.some(
+      c => (c.type === 'text' && c.text.trim()) || (c.type === 'thinking' && c.thinking.trim()),
+    );
 
-		if (hasVisibleContent) {
-			this.contentContainer.addChild(new Spacer(1))
-		}
-        // Render content in order
-        for (let i = 0; i < message.content.length; i++) {
-            const content = message.content[i]!
+    if (hasVisibleContent) {
+      this.contentContainer.addChild(new Spacer(1));
+    }
+    // Render content in order
+    for (let i = 0; i < message.content.length; i++) {
+      const content = message.content[i]!;
 
-            if (content.type === "text" && (content as any).text.trim()) {
-                // Assistant text messages - trim the text
-                this.contentContainer.addChild(
-                    new Markdown((content as any).text.trim(), 1, 0, this.markdownTheme),
-                )
-            } else if (content.type === "thinking" && (content as any).thinking.trim()) {
-                // Check if there's text content after this thinking block
-                const hasTextAfter = message.content
-                    .slice(i + 1)
-                    .some((c) => c.type === "text" && (c as any).text.trim())
+      if (content.type === 'text' && (content as any).text.trim()) {
+        // Assistant text messages - trim the text
+        this.contentContainer.addChild(new Markdown((content as any).text.trim(), 1, 0, this.markdownTheme));
+      } else if (content.type === 'thinking' && (content as any).thinking.trim()) {
+        // Check if there's text content after this thinking block
+        const hasTextAfter = message.content.slice(i + 1).some(c => c.type === 'text' && (c as any).text.trim());
 
-                if (this.hideThinkingBlock) {
-                    // Show static "Thinking..." label when hidden
-                    this.contentContainer.addChild(
-                        new Text(
-                            theme.italic(theme.fg("thinkingText", "Thinking...")),
-                            1,
-                            0,
-                        ),
-                    )
-                    if (hasTextAfter) {
-                        this.contentContainer.addChild(new Spacer(1))
-                    }
-                } else {
-                    // Thinking traces in thinkingText color, italic
-                    this.contentContainer.addChild(
-                        new Markdown((content as any).thinking.trim(), 1, 0, this.markdownTheme, {
-                            color: (text: string) => theme.fg("thinkingText", text),
-                            italic: true,
-                        }),
-                    )
-                    this.contentContainer.addChild(new Spacer(1))
-                }
-            }
-			// Skip tool_call and tool_result - those are rendered by ToolExecutionComponent
-		}
+        if (this.hideThinkingBlock) {
+          // Show static "Thinking..." label when hidden
+          this.contentContainer.addChild(new Text(theme.italic(theme.fg('thinkingText', 'Thinking...')), 1, 0));
+          if (hasTextAfter) {
+            this.contentContainer.addChild(new Spacer(1));
+          }
+        } else {
+          // Thinking traces in thinkingText color, italic
+          this.contentContainer.addChild(
+            new Markdown((content as any).thinking.trim(), 1, 0, this.markdownTheme, {
+              color: (text: string) => theme.fg('thinkingText', text),
+              italic: true,
+            }),
+          );
+          this.contentContainer.addChild(new Spacer(1));
+        }
+      }
+      // Skip tool_call and tool_result - those are rendered by ToolExecutionComponent
+    }
 
-		// Check if aborted or error - show after partial content
-		if (message.stopReason === "aborted") {
-			const abortMessage = message.errorMessage || "Interrupted"
-			this.contentContainer.addChild(new Spacer(1))
-			this.contentContainer.addChild(
-				new Text(theme.fg("error", abortMessage), 1, 0),
-			)
-		} else if (message.stopReason === "error") {
-			const errorMsg = message.errorMessage || "Unknown error"
-			this.contentContainer.addChild(new Spacer(1))
-			this.contentContainer.addChild(
-				new Text(theme.fg("error", `Error: ${errorMsg}`), 1, 0),
-			)
-		}
-	}
+    // Check if aborted or error - show after partial content
+    if (message.stopReason === 'aborted') {
+      const abortMessage = message.errorMessage || 'Interrupted';
+      this.contentContainer.addChild(new Spacer(1));
+      this.contentContainer.addChild(new Text(theme.fg('error', abortMessage), 1, 0));
+    } else if (message.stopReason === 'error') {
+      const errorMsg = message.errorMessage || 'Unknown error';
+      this.contentContainer.addChild(new Spacer(1));
+      this.contentContainer.addChild(new Text(theme.fg('error', `Error: ${errorMsg}`), 1, 0));
+    }
+  }
 }

--- a/mastracode/src/tui/components/assistant-message.ts
+++ b/mastracode/src/tui/components/assistant-message.ts
@@ -89,45 +89,44 @@ export class AssistantMessageComponent extends Container {
 		if (hasVisibleContent) {
 			this.contentContainer.addChild(new Spacer(1))
 		}
+        // Render content in order
+        for (let i = 0; i < message.content.length; i++) {
+            const content = message.content[i]!
 
-		// Render content in order
-		for (let i = 0; i < message.content.length; i++) {
-			const content = message.content[i]
+            if (content.type === "text" && (content as any).text.trim()) {
+                // Assistant text messages - trim the text
+                this.contentContainer.addChild(
+                    new Markdown((content as any).text.trim(), 1, 0, this.markdownTheme),
+                )
+            } else if (content.type === "thinking" && (content as any).thinking.trim()) {
+                // Check if there's text content after this thinking block
+                const hasTextAfter = message.content
+                    .slice(i + 1)
+                    .some((c) => c.type === "text" && (c as any).text.trim())
 
-			if (content.type === "text" && content.text.trim()) {
-				// Assistant text messages - trim the text
-				this.contentContainer.addChild(
-					new Markdown(content.text.trim(), 1, 0, this.markdownTheme),
-				)
-			} else if (content.type === "thinking" && content.thinking.trim()) {
-				// Check if there's text content after this thinking block
-				const hasTextAfter = message.content
-					.slice(i + 1)
-					.some((c) => c.type === "text" && c.text.trim())
-
-				if (this.hideThinkingBlock) {
-					// Show static "Thinking..." label when hidden
-					this.contentContainer.addChild(
-						new Text(
-							theme.italic(theme.fg("thinkingText", "Thinking...")),
-							1,
-							0,
-						),
-					)
-					if (hasTextAfter) {
-						this.contentContainer.addChild(new Spacer(1))
-					}
-				} else {
-					// Thinking traces in thinkingText color, italic
-					this.contentContainer.addChild(
-						new Markdown(content.thinking.trim(), 1, 0, this.markdownTheme, {
-							color: (text: string) => theme.fg("thinkingText", text),
-							italic: true,
-						}),
-					)
-					this.contentContainer.addChild(new Spacer(1))
-				}
-			}
+                if (this.hideThinkingBlock) {
+                    // Show static "Thinking..." label when hidden
+                    this.contentContainer.addChild(
+                        new Text(
+                            theme.italic(theme.fg("thinkingText", "Thinking...")),
+                            1,
+                            0,
+                        ),
+                    )
+                    if (hasTextAfter) {
+                        this.contentContainer.addChild(new Spacer(1))
+                    }
+                } else {
+                    // Thinking traces in thinkingText color, italic
+                    this.contentContainer.addChild(
+                        new Markdown((content as any).thinking.trim(), 1, 0, this.markdownTheme, {
+                            color: (text: string) => theme.fg("thinkingText", text),
+                            italic: true,
+                        }),
+                    )
+                    this.contentContainer.addChild(new Spacer(1))
+                }
+            }
 			// Skip tool_call and tool_result - those are rendered by ToolExecutionComponent
 		}
 

--- a/mastracode/src/tui/components/collapsible.ts
+++ b/mastracode/src/tui/components/collapsible.ts
@@ -134,10 +134,10 @@ export class CollapsibleFileViewer extends CollapsibleComponent {
 		options: Partial<CollapsibleOptions>,
 		ui: TUI,
 	) {
-		let lines = content.split("\n").map((line) => line.trimEnd())
+        let lines = content.split("\n").map((line) => line.trimEnd())
 
-		// Remove "Here's the result of running `cat -n`..." header if present
-		if (lines.length > 0 && lines[0].includes("Here's the result of running")) {
+        // Remove "Here's the result of running `cat -n`..." header if present
+        if (lines.length > 0 && lines[0]!.includes("Here's the result of running")) {
 			lines = lines.slice(1)
 		}
 

--- a/mastracode/src/tui/components/collapsible.ts
+++ b/mastracode/src/tui/components/collapsible.ts
@@ -3,334 +3,304 @@
  * Can be used to wrap any content that should be expandable/collapsible.
  */
 
-import { Container, Text  } from "@mariozechner/pi-tui"
-import type {TUI} from "@mariozechner/pi-tui";
-import { highlight } from "cli-highlight"
-import { theme } from "../theme.js"
+import { Container, Text } from '@mariozechner/pi-tui';
+import type { TUI } from '@mariozechner/pi-tui';
+import { highlight } from 'cli-highlight';
+import { theme } from '../theme.js';
 
 export interface CollapsibleOptions {
-	/** Initial expanded state */
-	expanded?: boolean
-	/** Header text or component */
-	header: string | Container
-	/** Summary shown when collapsed */
-	summary?: string
-	/** Max lines to show when collapsed (0 = fully collapsed) */
-	collapsedLines?: number
-	/** Max lines to show when expanded */
-	expandedLines?: number
-	/** Whether to show line count in header */
-	showLineCount?: boolean
+  /** Initial expanded state */
+  expanded?: boolean;
+  /** Header text or component */
+  header: string | Container;
+  /** Summary shown when collapsed */
+  summary?: string;
+  /** Max lines to show when collapsed (0 = fully collapsed) */
+  collapsedLines?: number;
+  /** Max lines to show when expanded */
+  expandedLines?: number;
+  /** Whether to show line count in header */
+  showLineCount?: boolean;
 }
 
 export class CollapsibleComponent extends Container {
-	private expanded: boolean
-	private header: string | Container
-	protected summary?: string
-	private content: string[] = []
-	private options: CollapsibleOptions
-	private ui: TUI
+  private expanded: boolean;
+  private header: string | Container;
+  protected summary?: string;
+  private content: string[] = [];
+  private options: CollapsibleOptions;
+  private ui: TUI;
 
-	constructor(options: CollapsibleOptions, ui: TUI) {
-		super()
-		this.options = {
-			expanded: false,
-			collapsedLines: 10,
-			expandedLines: 100,
-			showLineCount: true,
-			...options,
-		}
-		this.expanded = this.options.expanded ?? false
-		this.header = options.header
-		this.summary = options.summary
-		this.ui = ui
-		this.updateDisplay()
-	}
+  constructor(options: CollapsibleOptions, ui: TUI) {
+    super();
+    this.options = {
+      expanded: false,
+      collapsedLines: 10,
+      expandedLines: 100,
+      showLineCount: true,
+      ...options,
+    };
+    this.expanded = this.options.expanded ?? false;
+    this.header = options.header;
+    this.summary = options.summary;
+    this.ui = ui;
+    this.updateDisplay();
+  }
 
-	setContent(content: string | string[]): void {
-		this.content = Array.isArray(content) ? content : content.split("\n")
-		this.updateDisplay()
-	}
+  setContent(content: string | string[]): void {
+    this.content = Array.isArray(content) ? content : content.split('\n');
+    this.updateDisplay();
+  }
 
-	isExpanded(): boolean {
-		return this.expanded
-	}
+  isExpanded(): boolean {
+    return this.expanded;
+  }
 
-	setExpanded(expanded: boolean): void {
-		this.expanded = expanded
-		this.updateDisplay()
-	}
+  setExpanded(expanded: boolean): void {
+    this.expanded = expanded;
+    this.updateDisplay();
+  }
 
-	toggle(): void {
-		this.expanded = !this.expanded
-		this.updateDisplay()
-	}
+  toggle(): void {
+    this.expanded = !this.expanded;
+    this.updateDisplay();
+  }
 
-	private updateDisplay(): void {
-		this.clear()
+  private updateDisplay(): void {
+    this.clear();
 
-		const lineCount =
-			this.options.showLineCount && this.content.length > 0
-				? theme.fg("muted", ` (${this.content.length} lines)`)
-				: ""
+    const lineCount =
+      this.options.showLineCount && this.content.length > 0 ? theme.fg('muted', ` (${this.content.length} lines)`) : '';
 
-		const headerText =
-			typeof this.header === "string"
-				? `${this.header}${lineCount}`
-				: this.header
+    const headerText = typeof this.header === 'string' ? `${this.header}${lineCount}` : this.header;
 
-		if (typeof headerText === "string") {
-			this.addChild(new Text(headerText, 0, 0))
-		} else {
-			this.addChild(headerText)
-		}
+    if (typeof headerText === 'string') {
+      this.addChild(new Text(headerText, 0, 0));
+    } else {
+      this.addChild(headerText);
+    }
 
-		// Show summary when collapsed if provided
-		if (!this.expanded && this.summary) {
-			this.addChild(new Text(theme.fg("muted", this.summary), 0, 0))
-			return
-		}
+    // Show summary when collapsed if provided
+    if (!this.expanded && this.summary) {
+      this.addChild(new Text(theme.fg('muted', this.summary), 0, 0));
+      return;
+    }
 
-		// Show content
-		if (this.content.length === 0) return
+    // Show content
+    if (this.content.length === 0) return;
 
-		const maxLines = this.expanded
-			? this.options.expandedLines!
-			: this.options.collapsedLines!
+    const maxLines = this.expanded ? this.options.expandedLines! : this.options.collapsedLines!;
 
-		if (maxLines === 0 && !this.expanded) {
-			// Fully collapsed, show nothing
-			return
-		}
+    if (maxLines === 0 && !this.expanded) {
+      // Fully collapsed, show nothing
+      return;
+    }
 
-		const linesToShow = Math.min(this.content.length, maxLines)
-		const hasMore = this.content.length > maxLines
+    const linesToShow = Math.min(this.content.length, maxLines);
+    const hasMore = this.content.length > maxLines;
 
-		// Add content lines
-		for (let i = 0; i < linesToShow; i++) {
-			this.addChild(new Text(this.content[i], 0, 0))
-		}
+    // Add content lines
+    for (let i = 0; i < linesToShow; i++) {
+      this.addChild(new Text(this.content[i], 0, 0));
+    }
 
-		// Show truncation indicator
-		if (hasMore) {
-			const remaining = this.content.length - linesToShow
-			const action = this.expanded ? "collapse" : "expand"
-			const hint = theme.fg(
-				"muted",
-				`... ${remaining} more lines (Ctrl+E to ${action} all)`,
-			)
-			this.addChild(new Text(hint, 0, 0))
-		}
-	}
+    // Show truncation indicator
+    if (hasMore) {
+      const remaining = this.content.length - linesToShow;
+      const action = this.expanded ? 'collapse' : 'expand';
+      const hint = theme.fg('muted', `... ${remaining} more lines (Ctrl+E to ${action} all)`);
+      this.addChild(new Text(hint, 0, 0));
+    }
+  }
 }
 
 /**
  * File viewer with collapsible content
  */
 export class CollapsibleFileViewer extends CollapsibleComponent {
-	constructor(
-		path: string,
-		content: string,
-		options: Partial<CollapsibleOptions>,
-		ui: TUI,
-	) {
-        let lines = content.split("\n").map((line) => line.trimEnd())
+  constructor(path: string, content: string, options: Partial<CollapsibleOptions>, ui: TUI) {
+    let lines = content.split('\n').map(line => line.trimEnd());
 
-        // Remove "Here's the result of running `cat -n`..." header if present
-        if (lines.length > 0 && lines[0]!.includes("Here's the result of running")) {
-			lines = lines.slice(1)
-		}
+    // Remove "Here's the result of running `cat -n`..." header if present
+    if (lines.length > 0 && lines[0]!.includes("Here's the result of running")) {
+      lines = lines.slice(1);
+    }
 
-		// Strip line numbers from cat -n format: "   123\tcode" -> "code"
-		const lineNumberRegex = /^\s*\d+\t/
-		const codeLines = lines.map((line) => line.replace(lineNumberRegex, ""))
+    // Strip line numbers from cat -n format: "   123\tcode" -> "code"
+    const lineNumberRegex = /^\s*\d+\t/;
+    const codeLines = lines.map(line => line.replace(lineNumberRegex, ''));
 
-		// Remove trailing empty lines
-		while (codeLines.length > 0 && codeLines[codeLines.length - 1] === "") {
-			codeLines.pop()
-		}
+    // Remove trailing empty lines
+    while (codeLines.length > 0 && codeLines[codeLines.length - 1] === '') {
+      codeLines.pop();
+    }
 
-		// Apply syntax highlighting
-		let highlightedLines = codeLines
-		try {
-			const highlighted = highlight(codeLines.join("\n"), {
-				language: getLanguageFromPath(path),
-				ignoreIllegals: true,
-			})
-			highlightedLines = highlighted.split("\n")
-		} catch {
-			// If highlighting fails, use original content
-		}
+    // Apply syntax highlighting
+    let highlightedLines = codeLines;
+    try {
+      const highlighted = highlight(codeLines.join('\n'), {
+        language: getLanguageFromPath(path),
+        ignoreIllegals: true,
+      });
+      highlightedLines = highlighted.split('\n');
+    } catch {
+      // If highlighting fails, use original content
+    }
 
-		const header = `${theme.bold(theme.fg("toolTitle", "📄 view"))} ${theme.fg("accent", path)}`
+    const header = `${theme.bold(theme.fg('toolTitle', '📄 view'))} ${theme.fg('accent', path)}`;
 
-		super(
-			{
-				header,
-				collapsedLines: 20,
-				expandedLines: 200,
-				showLineCount: true,
-				...options,
-			},
-			ui,
-		)
+    super(
+      {
+        header,
+        collapsedLines: 20,
+        expandedLines: 200,
+        showLineCount: true,
+        ...options,
+      },
+      ui,
+    );
 
-		this.setContent(highlightedLines)
-	}
+    this.setContent(highlightedLines);
+  }
 }
 
 /** Map file extensions to highlight.js language names */
 function getLanguageFromPath(path: string): string | undefined {
-	const ext = path.split(".").pop()?.toLowerCase()
-	const langMap: Record<string, string> = {
-		ts: "typescript",
-		tsx: "typescript",
-		js: "javascript",
-		jsx: "javascript",
-		mjs: "javascript",
-		cjs: "javascript",
-		json: "json",
-		md: "markdown",
-		py: "python",
-		rb: "ruby",
-		rs: "rust",
-		go: "go",
-		java: "java",
-		kt: "kotlin",
-		swift: "swift",
-		c: "c",
-		cpp: "cpp",
-		h: "c",
-		hpp: "cpp",
-		cs: "csharp",
-		php: "php",
-		sh: "bash",
-		bash: "bash",
-		zsh: "bash",
-		fish: "bash",
-		yml: "yaml",
-		yaml: "yaml",
-		toml: "ini",
-		ini: "ini",
-		xml: "xml",
-		html: "html",
-		htm: "html",
-		css: "css",
-		scss: "scss",
-		sass: "scss",
-		less: "less",
-		sql: "sql",
-		graphql: "graphql",
-		gql: "graphql",
-		dockerfile: "dockerfile",
-		makefile: "makefile",
-		cmake: "cmake",
-		vue: "vue",
-		svelte: "xml",
-	}
-	return ext ? langMap[ext] : undefined
+  const ext = path.split('.').pop()?.toLowerCase();
+  const langMap: Record<string, string> = {
+    ts: 'typescript',
+    tsx: 'typescript',
+    js: 'javascript',
+    jsx: 'javascript',
+    mjs: 'javascript',
+    cjs: 'javascript',
+    json: 'json',
+    md: 'markdown',
+    py: 'python',
+    rb: 'ruby',
+    rs: 'rust',
+    go: 'go',
+    java: 'java',
+    kt: 'kotlin',
+    swift: 'swift',
+    c: 'c',
+    cpp: 'cpp',
+    h: 'c',
+    hpp: 'cpp',
+    cs: 'csharp',
+    php: 'php',
+    sh: 'bash',
+    bash: 'bash',
+    zsh: 'bash',
+    fish: 'bash',
+    yml: 'yaml',
+    yaml: 'yaml',
+    toml: 'ini',
+    ini: 'ini',
+    xml: 'xml',
+    html: 'html',
+    htm: 'html',
+    css: 'css',
+    scss: 'scss',
+    sass: 'scss',
+    less: 'less',
+    sql: 'sql',
+    graphql: 'graphql',
+    gql: 'graphql',
+    dockerfile: 'dockerfile',
+    makefile: 'makefile',
+    cmake: 'cmake',
+    vue: 'vue',
+    svelte: 'xml',
+  };
+  return ext ? langMap[ext] : undefined;
 }
 
 /**
  * Diff viewer with collapsible hunks
  */
 export class CollapsibleDiffViewer extends CollapsibleComponent {
-	private oldContent: string
-	private newContent: string
+  private oldContent: string;
+  private newContent: string;
 
-	constructor(
-		path: string,
-		oldContent: string,
-		newContent: string,
-		options: Partial<CollapsibleOptions>,
-		ui: TUI,
-	) {
-		const header = `${theme.bold(theme.fg("toolTitle", "✏️ edit"))} ${theme.fg("accent", path)}`
+  constructor(path: string, oldContent: string, newContent: string, options: Partial<CollapsibleOptions>, ui: TUI) {
+    const header = `${theme.bold(theme.fg('toolTitle', '✏️ edit'))} ${theme.fg('accent', path)}`;
 
-		super(
-			{
-				header,
-				collapsedLines: 15,
-				expandedLines: 100,
-				showLineCount: false,
-				...options,
-			},
-			ui,
-		)
+    super(
+      {
+        header,
+        collapsedLines: 15,
+        expandedLines: 100,
+        showLineCount: false,
+        ...options,
+      },
+      ui,
+    );
 
-		this.oldContent = oldContent
-		this.newContent = newContent
-		this.generateDiff()
-	}
+    this.oldContent = oldContent;
+    this.newContent = newContent;
+    this.generateDiff();
+  }
 
-	private generateDiff(): void {
-		const oldLines = this.oldContent.split("\n")
-		const newLines = this.newContent.split("\n")
-		const diff: string[] = []
+  private generateDiff(): void {
+    const oldLines = this.oldContent.split('\n');
+    const newLines = this.newContent.split('\n');
+    const diff: string[] = [];
 
-		// Simple line-by-line diff (in production, use a proper diff algorithm)
-		const maxLines = Math.max(oldLines.length, newLines.length)
-		let addedCount = 0
-		let removedCount = 0
+    // Simple line-by-line diff (in production, use a proper diff algorithm)
+    const maxLines = Math.max(oldLines.length, newLines.length);
+    let addedCount = 0;
+    let removedCount = 0;
 
-		for (let i = 0; i < maxLines; i++) {
-			if (i >= oldLines.length) {
-				diff.push(theme.fg("success", `+ ${newLines[i]}`))
-				addedCount++
-			} else if (i >= newLines.length) {
-				diff.push(theme.fg("error", `- ${oldLines[i]}`))
-				removedCount++
-			} else if (oldLines[i] !== newLines[i]) {
-				diff.push(theme.fg("error", `- ${oldLines[i]}`))
-				diff.push(theme.fg("success", `+ ${newLines[i]}`))
-				addedCount++
-				removedCount++
-			} else {
-				// Context line
-				diff.push(theme.fg("muted", `  ${oldLines[i]}`))
-			}
-		}
+    for (let i = 0; i < maxLines; i++) {
+      if (i >= oldLines.length) {
+        diff.push(theme.fg('success', `+ ${newLines[i]}`));
+        addedCount++;
+      } else if (i >= newLines.length) {
+        diff.push(theme.fg('error', `- ${oldLines[i]}`));
+        removedCount++;
+      } else if (oldLines[i] !== newLines[i]) {
+        diff.push(theme.fg('error', `- ${oldLines[i]}`));
+        diff.push(theme.fg('success', `+ ${newLines[i]}`));
+        addedCount++;
+        removedCount++;
+      } else {
+        // Context line
+        diff.push(theme.fg('muted', `  ${oldLines[i]}`));
+      }
+    }
 
-		this.summary = `+${addedCount} -${removedCount} lines changed`
-		this.setContent(diff)
-	}
+    this.summary = `+${addedCount} -${removedCount} lines changed`;
+    this.setContent(diff);
+  }
 }
 
 /**
  * Command output viewer with collapsible sections
  */
 export class CollapsibleCommandOutput extends CollapsibleComponent {
-	constructor(
-		command: string,
-		output: string,
-		exitCode: number,
-		options: Partial<CollapsibleOptions>,
-		ui: TUI,
-	) {
-		const status =
-			exitCode === 0
-				? theme.fg("success", "✓")
-				: theme.fg("error", `✗ (exit ${exitCode})`)
+  constructor(command: string, output: string, exitCode: number, options: Partial<CollapsibleOptions>, ui: TUI) {
+    const status = exitCode === 0 ? theme.fg('success', '✓') : theme.fg('error', `✗ (exit ${exitCode})`);
 
-		const header = `${theme.bold(theme.fg("toolTitle", "command"))} ${theme.fg("accent", command)} ${status}`
+    const header = `${theme.bold(theme.fg('toolTitle', 'command'))} ${theme.fg('accent', command)} ${status}`;
 
-		// Clean up output
-		const lines = output.split("\n").map((line) => line.trimEnd())
-		while (lines.length > 0 && lines[lines.length - 1] === "") {
-			lines.pop()
-		}
+    // Clean up output
+    const lines = output.split('\n').map(line => line.trimEnd());
+    while (lines.length > 0 && lines[lines.length - 1] === '') {
+      lines.pop();
+    }
 
-		super(
-			{
-				header,
-				collapsedLines: exitCode === 0 ? 10 : 50, // Show more on error
-				expandedLines: 500,
-				showLineCount: true,
-				...options,
-			},
-			ui,
-		)
+    super(
+      {
+        header,
+        collapsedLines: exitCode === 0 ? 10 : 50, // Show more on error
+        expandedLines: 500,
+        showLineCount: true,
+        ...options,
+      },
+      ui,
+    );
 
-		this.setContent(lines)
-	}
+    this.setContent(lines);
+  }
 }

--- a/mastracode/src/tui/components/custom-editor.ts
+++ b/mastracode/src/tui/components/custom-editor.ts
@@ -2,171 +2,159 @@
  * Custom editor that handles app-level keybindings for Mastra Code.
  */
 
-import {
-	Editor,
-	matchesKey
-	
-	
-} from "@mariozechner/pi-tui"
-import type {EditorTheme, TUI} from "@mariozechner/pi-tui";
-import {
-	getClipboardImage
-	
-} from "../../clipboard/index.js"
-import type {ClipboardImage} from "../../clipboard/index.js";
+import { Editor, matchesKey } from '@mariozechner/pi-tui';
+import type { EditorTheme, TUI } from '@mariozechner/pi-tui';
+import { getClipboardImage } from '../../clipboard/index.js';
+import type { ClipboardImage } from '../../clipboard/index.js';
 
-const PASTE_START = "\x1b[200~"
-const PASTE_END = "\x1b[201~"
+const PASTE_START = '\x1b[200~';
+const PASTE_END = '\x1b[201~';
 export type AppAction =
-	| "clear" // Ctrl+C or Escape - interrupt
-	| "exit" // Ctrl+D - exit when empty
-	| "undo" // Ctrl+Z - undo last clear
-	| "toggleThinking" // Ctrl+T
-	| "expandTools" // Ctrl+E
-	| "followUp" // Alt+Enter - queue follow-up while streaming
-	| "cycleMode" // Shift+Tab - cycle harness modes
-	| "toggleYolo" // Ctrl+Y - toggle YOLO mode
+  | 'clear' // Ctrl+C or Escape - interrupt
+  | 'exit' // Ctrl+D - exit when empty
+  | 'undo' // Ctrl+Z - undo last clear
+  | 'toggleThinking' // Ctrl+T
+  | 'expandTools' // Ctrl+E
+  | 'followUp' // Alt+Enter - queue follow-up while streaming
+  | 'cycleMode' // Shift+Tab - cycle harness modes
+  | 'toggleYolo'; // Ctrl+Y - toggle YOLO mode
 
 export class CustomEditor extends Editor {
-	private actionHandlers: Map<AppAction, () => void> = new Map()
+  private actionHandlers: Map<AppAction, () => void> = new Map();
 
-	/** Handler for Ctrl+D when editor is empty */
-	public onCtrlD?: () => void
+  /** Handler for Ctrl+D when editor is empty */
+  public onCtrlD?: () => void;
 
-	/** Whether Escape triggers clear (default true) */
-	public escapeEnabled = true
+  /** Whether Escape triggers clear (default true) */
+  public escapeEnabled = true;
 
-	/** Called when clipboard image data is pasted */
-	public onImagePaste?: (image: ClipboardImage) => void
+  /** Called when clipboard image data is pasted */
+  public onImagePaste?: (image: ClipboardImage) => void;
 
-	/** Tracks when we're swallowing paste content that was intercepted as an image */
-	private _imagePasteIntercepted = false
+  /** Tracks when we're swallowing paste content that was intercepted as an image */
+  private _imagePasteIntercepted = false;
 
-	constructor(tui: TUI, theme: EditorTheme) {
-		super(tui, theme)
-	}
+  constructor(tui: TUI, theme: EditorTheme) {
+    super(tui, theme);
+  }
 
-	/**
-	 * Register a handler for an app action.
-	 */
-	onAction(action: AppAction, handler: () => void): void {
-		this.actionHandlers.set(action, handler)
-	}
+  /**
+   * Register a handler for an app action.
+   */
+  onAction(action: AppAction, handler: () => void): void {
+    this.actionHandlers.set(action, handler);
+  }
 
-	handleInput(data: string): void {
-		// If we intercepted a paste as image, swallow remaining paste data
-		if (this._imagePasteIntercepted) {
-			if (data.includes(PASTE_END)) {
-				this._imagePasteIntercepted = false
-				const afterPaste = data.substring(
-					data.indexOf(PASTE_END) + PASTE_END.length,
-				)
-				if (afterPaste.length > 0) {
-					this.handleInput(afterPaste)
-				}
-			}
-			return
-		}
+  handleInput(data: string): void {
+    // If we intercepted a paste as image, swallow remaining paste data
+    if (this._imagePasteIntercepted) {
+      if (data.includes(PASTE_END)) {
+        this._imagePasteIntercepted = false;
+        const afterPaste = data.substring(data.indexOf(PASTE_END) + PASTE_END.length);
+        if (afterPaste.length > 0) {
+          this.handleInput(afterPaste);
+        }
+      }
+      return;
+    }
 
-		// Detect paste start → check clipboard for image
-		if (data.includes(PASTE_START) && this.onImagePaste) {
-			const clipboardImage = getClipboardImage()
-			if (clipboardImage) {
-				this.onImagePaste(clipboardImage)
-				// Swallow the paste text content
-				if (data.includes(PASTE_END)) {
-					const afterPaste = data.substring(
-						data.indexOf(PASTE_END) + PASTE_END.length,
-					)
-					if (afterPaste.length > 0) {
-						this.handleInput(afterPaste)
-					}
-				} else {
-					this._imagePasteIntercepted = true
-				}
-				return
-			}
-		}
+    // Detect paste start → check clipboard for image
+    if (data.includes(PASTE_START) && this.onImagePaste) {
+      const clipboardImage = getClipboardImage();
+      if (clipboardImage) {
+        this.onImagePaste(clipboardImage);
+        // Swallow the paste text content
+        if (data.includes(PASTE_END)) {
+          const afterPaste = data.substring(data.indexOf(PASTE_END) + PASTE_END.length);
+          if (afterPaste.length > 0) {
+            this.handleInput(afterPaste);
+          }
+        } else {
+          this._imagePasteIntercepted = true;
+        }
+        return;
+      }
+    }
 
-		// Ctrl+C - interrupt
-		if (matchesKey(data, "ctrl+c")) {
-			const handler = this.actionHandlers.get("clear")
-			if (handler) {
-				handler()
-				return
-			}
-		}
-		// Escape - same as Ctrl+C (abort generation) if enabled
-		if (matchesKey(data, "escape") && this.escapeEnabled) {
-			const handler = this.actionHandlers.get("clear")
-			if (handler) {
-				handler()
-				return
-			}
-		}
+    // Ctrl+C - interrupt
+    if (matchesKey(data, 'ctrl+c')) {
+      const handler = this.actionHandlers.get('clear');
+      if (handler) {
+        handler();
+        return;
+      }
+    }
+    // Escape - same as Ctrl+C (abort generation) if enabled
+    if (matchesKey(data, 'escape') && this.escapeEnabled) {
+      const handler = this.actionHandlers.get('clear');
+      if (handler) {
+        handler();
+        return;
+      }
+    }
 
-		// Ctrl+D - exit when editor is empty
-		if (matchesKey(data, "ctrl+d")) {
-			if (this.getText().length === 0) {
-				const handler = this.onCtrlD ?? this.actionHandlers.get("exit")
-				if (handler) handler()
-			}
-			return // Always consume
-		}
-		// Ctrl+Z - undo last clear
-		if (matchesKey(data, "ctrl+z")) {
-			const handler = this.actionHandlers.get("undo")
-			if (handler) {
-				handler()
-				return
-			}
-		}
+    // Ctrl+D - exit when editor is empty
+    if (matchesKey(data, 'ctrl+d')) {
+      if (this.getText().length === 0) {
+        const handler = this.onCtrlD ?? this.actionHandlers.get('exit');
+        if (handler) handler();
+      }
+      return; // Always consume
+    }
+    // Ctrl+Z - undo last clear
+    if (matchesKey(data, 'ctrl+z')) {
+      const handler = this.actionHandlers.get('undo');
+      if (handler) {
+        handler();
+        return;
+      }
+    }
 
-		// Ctrl+T - toggle thinking
-		if (matchesKey(data, "ctrl+t")) {
-			const handler = this.actionHandlers.get("toggleThinking")
-			if (handler) {
-				handler()
-				return
-			}
-		}
+    // Ctrl+T - toggle thinking
+    if (matchesKey(data, 'ctrl+t')) {
+      const handler = this.actionHandlers.get('toggleThinking');
+      if (handler) {
+        handler();
+        return;
+      }
+    }
 
-		// Ctrl+E - expand tools
-		if (matchesKey(data, "ctrl+e")) {
-			const handler = this.actionHandlers.get("expandTools")
-			if (handler) {
-				handler()
-				return
-			}
-		}
+    // Ctrl+E - expand tools
+    if (matchesKey(data, 'ctrl+e')) {
+      const handler = this.actionHandlers.get('expandTools');
+      if (handler) {
+        handler();
+        return;
+      }
+    }
 
-		// Ctrl+F - follow-up (queue message while streaming)
-		if (matchesKey(data, "ctrl+f")) {
-			const handler = this.actionHandlers.get("followUp")
-			if (handler) {
-				handler()
-				return
-			}
-		}
-		// Shift+Tab - cycle harness modes
-		if (matchesKey(data, "shift+tab")) {
-			const handler = this.actionHandlers.get("cycleMode")
-			if (handler) {
-				handler()
-				return
-			}
-		}
+    // Ctrl+F - follow-up (queue message while streaming)
+    if (matchesKey(data, 'ctrl+f')) {
+      const handler = this.actionHandlers.get('followUp');
+      if (handler) {
+        handler();
+        return;
+      }
+    }
+    // Shift+Tab - cycle harness modes
+    if (matchesKey(data, 'shift+tab')) {
+      const handler = this.actionHandlers.get('cycleMode');
+      if (handler) {
+        handler();
+        return;
+      }
+    }
 
-		// Ctrl+Y - toggle YOLO mode
-		if (matchesKey(data, "ctrl+y")) {
-			const handler = this.actionHandlers.get("toggleYolo")
-			if (handler) {
-				handler()
-				return
-			}
-		}
+    // Ctrl+Y - toggle YOLO mode
+    if (matchesKey(data, 'ctrl+y')) {
+      const handler = this.actionHandlers.get('toggleYolo');
+      if (handler) {
+        handler();
+        return;
+      }
+    }
 
-		// Pass to parent for editor handling
-		super.handleInput(data)
-	}
+    // Pass to parent for editor handling
+    super.handleInput(data);
+  }
 }

--- a/mastracode/src/tui/components/diff-output.ts
+++ b/mastracode/src/tui/components/diff-output.ts
@@ -2,79 +2,73 @@
  * Component that renders git diff output with syntax highlighting.
  */
 
-import { Container, Spacer, Text } from "@mariozechner/pi-tui"
-import chalk from "chalk"
-import { fg, bold, mastra } from "../theme.js"
+import { Container, Spacer, Text } from '@mariozechner/pi-tui';
+import chalk from 'chalk';
+import { fg, bold, mastra } from '../theme.js';
 
 // const removedColor = chalk.hex("#dc6868") // soft red
-const addedColor = chalk.hex("#5cb85c") // soft green
-const hunkHeaderColor = chalk.hex("#61afef") // cyan-blue
-const fileHeaderColor = chalk.bold.hex("#c678dd") // bold purple
-const removedColor = chalk.hex(mastra.red)
+const addedColor = chalk.hex('#5cb85c'); // soft green
+const hunkHeaderColor = chalk.hex('#61afef'); // cyan-blue
+const fileHeaderColor = chalk.bold.hex('#c678dd'); // bold purple
+const removedColor = chalk.hex(mastra.red);
 // const addedColor = chalk.hex(mastra.green)
 // const hunkHeaderColor = chalk.hex(mastra.blue)
 // const fileHeaderColor = chalk.bold.hex(mastra.purple)
-const metaColor = chalk.hex(mastra.mainGray)
+const metaColor = chalk.hex(mastra.mainGray);
 
 function colorizeDiffLine(line: string): string {
-	// Unified diff headers
-	if (line.startsWith("+++") || line.startsWith("---")) {
-		return fileHeaderColor(line)
-	}
-	if (line.startsWith("diff ")) {
-		return fileHeaderColor(line)
-	}
-	if (line.startsWith("@@")) {
-		return hunkHeaderColor(line)
-	}
-	if (line.startsWith("+")) {
-		return addedColor(line)
-	}
-	if (line.startsWith("-")) {
-		return removedColor(line)
-	}
-	if (
-		line.startsWith("index ") ||
-		line.startsWith("new file") ||
-		line.startsWith("deleted file") ||
-		line.startsWith("similarity") ||
-		line.startsWith("rename")
-	) {
-		return metaColor(line)
-	}
-	// --stat lines: " file | 5 +++--" or summary "2 files changed, ..."
-	const statMatch = line.match(/^(.+\|.+?)(\++)([-]*)$/)
-	if (statMatch) {
-		return statMatch[1] + addedColor(statMatch[2]) + removedColor(statMatch[3])
-	}
-	if (/^\s*\d+ files? changed/.test(line)) {
-		return line
-			.replace(/(\d+ insertions?\(\+\))/, addedColor("$1"))
-			.replace(/(\d+ deletions?\(-\))/, removedColor("$1"))
-	}
-	return line
+  // Unified diff headers
+  if (line.startsWith('+++') || line.startsWith('---')) {
+    return fileHeaderColor(line);
+  }
+  if (line.startsWith('diff ')) {
+    return fileHeaderColor(line);
+  }
+  if (line.startsWith('@@')) {
+    return hunkHeaderColor(line);
+  }
+  if (line.startsWith('+')) {
+    return addedColor(line);
+  }
+  if (line.startsWith('-')) {
+    return removedColor(line);
+  }
+  if (
+    line.startsWith('index ') ||
+    line.startsWith('new file') ||
+    line.startsWith('deleted file') ||
+    line.startsWith('similarity') ||
+    line.startsWith('rename')
+  ) {
+    return metaColor(line);
+  }
+  // --stat lines: " file | 5 +++--" or summary "2 files changed, ..."
+  const statMatch = line.match(/^(.+\|.+?)(\++)([-]*)$/);
+  if (statMatch) {
+    return statMatch[1] + addedColor(statMatch[2]) + removedColor(statMatch[3]);
+  }
+  if (/^\s*\d+ files? changed/.test(line)) {
+    return line
+      .replace(/(\d+ insertions?\(\+\))/, addedColor('$1'))
+      .replace(/(\d+ deletions?\(-\))/, removedColor('$1'));
+  }
+  return line;
 }
 
 export class DiffOutputComponent extends Container {
-	constructor(command: string, diffOutput: string) {
-		super()
-		this.addChild(new Spacer(1))
+  constructor(command: string, diffOutput: string) {
+    super();
+    this.addChild(new Spacer(1));
 
-		// Command header
-		this.addChild(
-			new Text(
-				`${fg("success", "✓")} ${bold(fg("muted", "$"))} ${fg("text", command)}`,
-				1,
-				0,
-			),
-		)
+    // Command header
+    this.addChild(new Text(`${fg('success', '✓')} ${bold(fg('muted', '$'))} ${fg('text', command)}`, 1, 0));
 
-		const output = diffOutput.trimEnd()
-		if (output) {
-			const lines = output.split("\n")
-			for (const line of lines) {
-				this.addChild(new Text(`  ${colorizeDiffLine(line)}`, 0, 0))
-			}
-		}
-	}
+    const output = diffOutput.trimEnd();
+    if (output) {
+      const lines = output.split('\n');
+      for (const line of lines) {
+        this.addChild(new Text(`  ${colorizeDiffLine(line)}`, 0, 0));
+      }
+    }
+  }
 }

--- a/mastracode/src/tui/components/error-display.ts
+++ b/mastracode/src/tui/components/error-display.ts
@@ -3,275 +3,235 @@
  * syntax highlighting, and smart summarization.
  */
 
-import { Container, Text, Spacer  } from "@mariozechner/pi-tui"
-import type {TUI} from "@mariozechner/pi-tui";
-import { fg, bold, bg } from "../theme.js"
-import { CollapsibleComponent } from "./collapsible.js"
+import { Container, Text, Spacer } from '@mariozechner/pi-tui';
+import type { TUI } from '@mariozechner/pi-tui';
+import { fg, bold, bg } from '../theme.js';
+import { CollapsibleComponent } from './collapsible.js';
 
 export interface ErrorInfo {
-	message: string
-	name?: string
-	stack?: string
-	code?: string
-	file?: string
-	line?: number
-	column?: number
-	context?: {
-		before?: string[]
-		line?: string
-		after?: string[]
-	}
+  message: string;
+  name?: string;
+  stack?: string;
+  code?: string;
+  file?: string;
+  line?: number;
+  column?: number;
+  context?: {
+    before?: string[];
+    line?: string;
+    after?: string[];
+  };
 }
 
 /**
  * Parse error information from various error formats
  */
 function parseErrorInfo(error: Error | string): ErrorInfo {
-	if (typeof error === "string") {
-		// Try to parse error-like string
-		const lines = error.split("\n").filter((line) => line.trim())
-		const firstLine = lines[0] || ""
+  if (typeof error === 'string') {
+    // Try to parse error-like string
+    const lines = error.split('\n').filter(line => line.trim());
+    const firstLine = lines[0] || '';
 
-		// Check for shell command errors
-		if (firstLine.includes("command not found")) {
-			const cmdMatch = firstLine.match(/(\w+):\s*command not found/)
-			return {
-				name: "CommandNotFoundError",
-				message: cmdMatch
-					? `'${cmdMatch[1]}' is not a recognized command`
-					: firstLine,
-			}
-		}
+    // Check for shell command errors
+    if (firstLine.includes('command not found')) {
+      const cmdMatch = firstLine.match(/(\w+):\s*command not found/);
+      return {
+        name: 'CommandNotFoundError',
+        message: cmdMatch ? `'${cmdMatch[1]}' is not a recognized command` : firstLine,
+      };
+    }
 
-		// Check for "Output:" prefix (from tool execution)
-		const cleanedError = error.replace(/^Output:\s*/m, "")
-		const cleanedLines = cleanedError.split("\n").filter((line) => line.trim())
+    // Check for "Output:" prefix (from tool execution)
+    const cleanedError = error.replace(/^Output:\s*/m, '');
+    const cleanedLines = cleanedError.split('\n').filter(line => line.trim());
 
-		// Match Node.js error patterns
-		const nodeErrorMatch = cleanedError.match(
-			/^([A-Z][a-zA-Z]*Error):\s*(.+)$/m,
-		)
-		if (nodeErrorMatch) {
-			// Extract stack trace
-			const stackLines = cleanedLines.filter((line) => line.match(/^\s*at\s+/))
-            return {
-                name: nodeErrorMatch[1]!,
-                message: nodeErrorMatch[2]!,
-                stack: stackLines.length > 0 ? stackLines.join("\n") : undefined,
-            }
-		}
+    // Match Node.js error patterns
+    const nodeErrorMatch = cleanedError.match(/^([A-Z][a-zA-Z]*Error):\s*(.+)$/m);
+    if (nodeErrorMatch) {
+      // Extract stack trace
+      const stackLines = cleanedLines.filter(line => line.match(/^\s*at\s+/));
+      return {
+        name: nodeErrorMatch[1]!,
+        message: nodeErrorMatch[2]!,
+        stack: stackLines.length > 0 ? stackLines.join('\n') : undefined,
+      };
+    }
 
-		// Match common error patterns
-		const errorMatch = firstLine.match(/^([A-Z][a-zA-Z]*Error):\s*(.+)$/)
-        if (errorMatch) {
-            return {
-                name: errorMatch[1]!,
-                message: errorMatch[2]!,
-                stack: lines.slice(1).join("\n"),
-            }
-        }
+    // Match common error patterns
+    const errorMatch = firstLine.match(/^([A-Z][a-zA-Z]*Error):\s*(.+)$/);
+    if (errorMatch) {
+      return {
+        name: errorMatch[1]!,
+        message: errorMatch[2]!,
+        stack: lines.slice(1).join('\n'),
+      };
+    }
 
-		// Extract file location if present
-		const fileMatch = error.match(/at\s+(.+?):(\d+):?(\d+)?/)
+    // Extract file location if present
+    const fileMatch = error.match(/at\s+(.+?):(\d+):?(\d+)?/);
 
-		return {
-			message: cleanedLines[0] || firstLine,
-			stack:
-				cleanedLines.length > 1 ? cleanedLines.slice(1).join("\n") : undefined,
-			file: fileMatch?.[1],
-			line: fileMatch?.[2] ? parseInt(fileMatch[2]) : undefined,
-			column: fileMatch?.[3] ? parseInt(fileMatch[3]) : undefined,
-		}
-	}
+    return {
+      message: cleanedLines[0] || firstLine,
+      stack: cleanedLines.length > 1 ? cleanedLines.slice(1).join('\n') : undefined,
+      file: fileMatch?.[1],
+      line: fileMatch?.[2] ? parseInt(fileMatch[2]) : undefined,
+      column: fileMatch?.[3] ? parseInt(fileMatch[3]) : undefined,
+    };
+  }
 
-	// Error object
-	return {
-		name: error.name,
-		message: error.message,
-		stack: error.stack,
-		code: (error as any).code,
-	}
+  // Error object
+  return {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+    code: (error as any).code,
+  };
 }
 
 /**
  * Format stack trace lines with syntax highlighting
  */
 function formatStackTrace(stack: string): string[] {
-	const lines = stack.split("\n")
-	return lines.map((line) => {
-		// Highlight file paths
-		if (line.match(/^\s*at\s+/)) {
-			return line.replace(
-				/(\s+at\s+)([^(]+)(\s*\()([^)]+)(\))/,
-				(match, at, fn, open, loc, close) =>
-					`${fg("muted", at)}${fg("function", fn)}${fg("muted", open)}${fg("path", loc)}${fg("muted", close)}`,
-			)
-		}
+  const lines = stack.split('\n');
+  return lines.map(line => {
+    // Highlight file paths
+    if (line.match(/^\s*at\s+/)) {
+      return line.replace(
+        /(\s+at\s+)([^(]+)(\s*\()([^)]+)(\))/,
+        (match, at, fn, open, loc, close) =>
+          `${fg('muted', at)}${fg('function', fn)}${fg('muted', open)}${fg('path', loc)}${fg('muted', close)}`,
+      );
+    }
 
-		// Mute empty lines and framework traces
-		if (!line.trim() || line.includes("node_modules")) {
-			return fg("muted", line)
-		}
+    // Mute empty lines and framework traces
+    if (!line.trim() || line.includes('node_modules')) {
+      return fg('muted', line);
+    }
 
-		return line
-	})
+    return line;
+  });
 }
 
 /**
  * Collapsible stack trace component
  */
 class CollapsibleStackTrace extends CollapsibleComponent {
-	constructor(stack: string, options: { expanded?: boolean } = {}, ui: TUI) {
-		super(
-			{
-				header: "Stack Trace",
-				expanded: options.expanded ?? false,
-				collapsedLines: 5,
-				expandedLines: 100,
-				showLineCount: true,
-			},
-			ui,
-		)
+  constructor(stack: string, options: { expanded?: boolean } = {}, ui: TUI) {
+    super(
+      {
+        header: 'Stack Trace',
+        expanded: options.expanded ?? false,
+        collapsedLines: 5,
+        expandedLines: 100,
+        showLineCount: true,
+      },
+      ui,
+    );
 
-		// Format and set the content
-		const formattedLines = formatStackTrace(stack)
-		this.setContent(formattedLines.join("\n"))
-	}
+    // Format and set the content
+    const formattedLines = formatStackTrace(stack);
+    this.setContent(formattedLines.join('\n'));
+  }
 }
 
 /**
  * Enhanced error display component
  */
 export class ErrorDisplayComponent extends Container {
-	constructor(
-		private error: Error | string,
-		private options: {
-			showStack?: boolean
-			showContext?: boolean
-			expanded?: boolean
-		} = {},
-		private ui: TUI,
-	) {
-		super()
-		this.build()
-	}
+  constructor(
+    private error: Error | string,
+    private options: {
+      showStack?: boolean;
+      showContext?: boolean;
+      expanded?: boolean;
+    } = {},
+    private ui: TUI,
+  ) {
+    super();
+    this.build();
+  }
 
-	private build(): void {
-		const info = parseErrorInfo(this.error)
+  private build(): void {
+    const info = parseErrorInfo(this.error);
 
-		// Add a visible border around the entire error display
-		const borderTop = new Text(
-			fg("error", "┌─ Error ─" + "─".repeat(50) + "┐"),
-			0,
-			0,
-		)
-		this.addChild(borderTop)
+    // Add a visible border around the entire error display
+    const borderTop = new Text(fg('error', '┌─ Error ─' + '─'.repeat(50) + '┐'), 0, 0);
+    this.addChild(borderTop);
 
-		// Error header container with background
-		const errorContainer = new Container()
+    // Error header container with background
+    const errorContainer = new Container();
 
-		// Add a colored background to the error message
-		const errorBg = (text: string) => bg("errorBg", text)
+    // Add a colored background to the error message
+    const errorBg = (text: string) => bg('errorBg', text);
 
-		// Error type and message with proper formatting
-		if (info.name && info.name !== "Error") {
-			const typeLine = new Container()
-			typeLine.addChild(new Text("│ ", 0, 0))
-			typeLine.addChild(
-				new Text(errorBg(` ${bold(fg("error", info.name))} `), 0, 0),
-			)
-			errorContainer.addChild(typeLine)
-		}
+    // Error type and message with proper formatting
+    if (info.name && info.name !== 'Error') {
+      const typeLine = new Container();
+      typeLine.addChild(new Text('│ ', 0, 0));
+      typeLine.addChild(new Text(errorBg(` ${bold(fg('error', info.name))} `), 0, 0));
+      errorContainer.addChild(typeLine);
+    }
 
-		// Error message
-		const msgLine = new Container()
-		msgLine.addChild(new Text("│ ", 0, 0))
-		msgLine.addChild(new Text(bold(info.message), 0, 0))
-		errorContainer.addChild(msgLine)
+    // Error message
+    const msgLine = new Container();
+    msgLine.addChild(new Text('│ ', 0, 0));
+    msgLine.addChild(new Text(bold(info.message), 0, 0));
+    errorContainer.addChild(msgLine);
 
-		// File location if available
-		if (info.file && info.line) {
-			const location = `${info.file}:${info.line}${info.column ? `:${info.column}` : ""}`
-			errorContainer.addChild(new Text(fg("muted", `  at ${location}`), 0, 0))
-		}
+    // File location if available
+    if (info.file && info.line) {
+      const location = `${info.file}:${info.line}${info.column ? `:${info.column}` : ''}`;
+      errorContainer.addChild(new Text(fg('muted', `  at ${location}`), 0, 0));
+    }
 
-		this.addChild(errorContainer)
+    this.addChild(errorContainer);
 
-		// Code context if available
-		if (this.options.showContext && info.context) {
-			this.addChild(new Spacer(1))
-			this.addChild(this.createCodeContext(info.context, info.line))
-		}
+    // Code context if available
+    if (this.options.showContext && info.context) {
+      this.addChild(new Spacer(1));
+      this.addChild(this.createCodeContext(info.context, info.line));
+    }
 
-		// Stack trace (collapsible)
-		if (this.options.showStack && info.stack) {
-			this.addChild(new Spacer(1))
-			this.addChild(
-				new CollapsibleStackTrace(
-					info.stack,
-					{ expanded: this.options.expanded },
-					this.ui,
-				),
-			)
-		}
+    // Stack trace (collapsible)
+    if (this.options.showStack && info.stack) {
+      this.addChild(new Spacer(1));
+      this.addChild(new CollapsibleStackTrace(info.stack, { expanded: this.options.expanded }, this.ui));
+    }
 
-		// Add bottom border
-		const borderBottom = new Text(fg("error", "└" + "─".repeat(60) + "┘"), 0, 0)
-		this.addChild(borderBottom)
-	}
+    // Add bottom border
+    const borderBottom = new Text(fg('error', '└' + '─'.repeat(60) + '┘'), 0, 0);
+    this.addChild(borderBottom);
+  }
 
-	private createCodeContext(
-		context: NonNullable<ErrorInfo["context"]>,
-		errorLine?: number,
-	): Container {
-		const container = new Container()
-		const codeBlock = new Container()
+  private createCodeContext(context: NonNullable<ErrorInfo['context']>, errorLine?: number): Container {
+    const container = new Container();
+    const codeBlock = new Container();
 
-		// Add a header
-		codeBlock.addChild(new Text(fg("muted", "Code context:"), 0, 0))
+    // Add a header
+    codeBlock.addChild(new Text(fg('muted', 'Code context:'), 0, 0));
 
-		// Before lines
-		if (context.before) {
-			context.before.forEach((line, i) => {
-				const lineNum = errorLine
-					? errorLine - context.before!.length + i
-					: i + 1
-				codeBlock.addChild(
-					new Text(
-						fg("muted", `${lineNum.toString().padStart(4)} │ ${line}`),
-						0,
-						0,
-					),
-				)
-			})
-		}
+    // Before lines
+    if (context.before) {
+      context.before.forEach((line, i) => {
+        const lineNum = errorLine ? errorLine - context.before!.length + i : i + 1;
+        codeBlock.addChild(new Text(fg('muted', `${lineNum.toString().padStart(4)} │ ${line}`), 0, 0));
+      });
+    }
 
-		// Error line (highlighted)
-		if (context.line && errorLine) {
-			codeBlock.addChild(
-				new Text(
-					fg("error", `${errorLine.toString().padStart(4)} │ ${context.line}`),
-					0,
-					0,
-				),
-			)
-		}
+    // Error line (highlighted)
+    if (context.line && errorLine) {
+      codeBlock.addChild(new Text(fg('error', `${errorLine.toString().padStart(4)} │ ${context.line}`), 0, 0));
+    }
 
-		// After lines
-		if (context.after) {
-			context.after.forEach((line, i) => {
-				const lineNum = errorLine ? errorLine + i + 1 : i + 1
-				codeBlock.addChild(
-					new Text(
-						fg("muted", `${lineNum.toString().padStart(4)} │ ${line}`),
-						0,
-						0,
-					),
-				)
-			})
-		}
+    // After lines
+    if (context.after) {
+      context.after.forEach((line, i) => {
+        const lineNum = errorLine ? errorLine + i + 1 : i + 1;
+        codeBlock.addChild(new Text(fg('muted', `${lineNum.toString().padStart(4)} │ ${line}`), 0, 0));
+      });
+    }
 
-		container.addChild(codeBlock)
-		return container
-	}
+    container.addChild(codeBlock);
+    return container;
+  }
 }

--- a/mastracode/src/tui/components/error-display.ts
+++ b/mastracode/src/tui/components/error-display.ts
@@ -54,23 +54,22 @@ function parseErrorInfo(error: Error | string): ErrorInfo {
 		if (nodeErrorMatch) {
 			// Extract stack trace
 			const stackLines = cleanedLines.filter((line) => line.match(/^\s*at\s+/))
-
-			return {
-				name: nodeErrorMatch[1],
-				message: nodeErrorMatch[2],
-				stack: stackLines.length > 0 ? stackLines.join("\n") : undefined,
-			}
+            return {
+                name: nodeErrorMatch[1]!,
+                message: nodeErrorMatch[2]!,
+                stack: stackLines.length > 0 ? stackLines.join("\n") : undefined,
+            }
 		}
 
 		// Match common error patterns
 		const errorMatch = firstLine.match(/^([A-Z][a-zA-Z]*Error):\s*(.+)$/)
-		if (errorMatch) {
-			return {
-				name: errorMatch[1],
-				message: errorMatch[2],
-				stack: lines.slice(1).join("\n"),
-			}
-		}
+        if (errorMatch) {
+            return {
+                name: errorMatch[1]!,
+                message: errorMatch[2]!,
+                stack: lines.slice(1).join("\n"),
+            }
+        }
 
 		// Extract file location if present
 		const fileMatch = error.match(/at\s+(.+?):(\d+):?(\d+)?/)

--- a/mastracode/src/tui/components/login-dialog.ts
+++ b/mastracode/src/tui/components/login-dialog.ts
@@ -2,161 +2,142 @@
  * Login dialog component - handles OAuth login flow UI
  */
 
-import { exec } from "node:child_process"
-import {
-	Box,
-	Container,
-	
-	getEditorKeybindings,
-	Input,
-	Spacer,
-	Text
-	
-} from "@mariozechner/pi-tui"
-import type {Focusable, TUI} from "@mariozechner/pi-tui";
-import { getOAuthProviders } from "../../auth/index.js"
-import { bg, fg } from "../theme.js"
+import { exec } from 'node:child_process';
+import { Box, Container, getEditorKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
+import type { Focusable, TUI } from '@mariozechner/pi-tui';
+import { getOAuthProviders } from '../../auth/index.js';
+import { bg, fg } from '../theme.js';
 
 export class LoginDialogComponent extends Box implements Focusable {
-	private contentContainer: Container
-	private input: Input
-	private tui: TUI
-	private abortController = new AbortController()
-	private inputResolver?: (value: string) => void
-	private inputRejecter?: (error: Error) => void
+  private contentContainer: Container;
+  private input: Input;
+  private tui: TUI;
+  private abortController = new AbortController();
+  private inputResolver?: (value: string) => void;
+  private inputRejecter?: (error: Error) => void;
 
-	// Focusable implementation
-	private _focused = false
-	get focused(): boolean {
-		return this._focused
-	}
-	set focused(value: boolean) {
-		this._focused = value
-		this.input.focused = value
-	}
+  // Focusable implementation
+  private _focused = false;
+  get focused(): boolean {
+    return this._focused;
+  }
+  set focused(value: boolean) {
+    this._focused = value;
+    this.input.focused = value;
+  }
 
-	constructor(
-		tui: TUI,
-		providerId: string,
-		private onComplete: (success: boolean, message?: string) => void,
-	) {
-		// Box with padding and background
-		super(2, 1, (text) => bg("overlayBg", text))
-		this.tui = tui
+  constructor(
+    tui: TUI,
+    providerId: string,
+    private onComplete: (success: boolean, message?: string) => void,
+  ) {
+    // Box with padding and background
+    super(2, 1, text => bg('overlayBg', text));
+    this.tui = tui;
 
-		const providerInfo = getOAuthProviders().find((p) => p.id === providerId)
-		const providerName = providerInfo?.name || providerId
+    const providerInfo = getOAuthProviders().find(p => p.id === providerId);
+    const providerName = providerInfo?.name || providerId;
 
-		// Title
-		this.addChild(new Text(fg("warning", `Login to ${providerName}`)))
-		this.addChild(new Spacer(1))
+    // Title
+    this.addChild(new Text(fg('warning', `Login to ${providerName}`)));
+    this.addChild(new Spacer(1));
 
-		// Dynamic content area
-		this.contentContainer = new Container()
-		this.addChild(this.contentContainer)
+    // Dynamic content area
+    this.contentContainer = new Container();
+    this.addChild(this.contentContainer);
 
-		// Input (always present, used when needed)
-		this.input = new Input()
-		this.input.onSubmit = () => {
-			if (this.inputResolver) {
-				this.inputResolver(this.input.getValue())
-				this.inputResolver = undefined
-				this.inputRejecter = undefined
-			}
-		}
-		this.input.onEscape = () => {
-			this.cancel()
-		}
-	}
+    // Input (always present, used when needed)
+    this.input = new Input();
+    this.input.onSubmit = () => {
+      if (this.inputResolver) {
+        this.inputResolver(this.input.getValue());
+        this.inputResolver = undefined;
+        this.inputRejecter = undefined;
+      }
+    };
+    this.input.onEscape = () => {
+      this.cancel();
+    };
+  }
 
-	get signal(): AbortSignal {
-		return this.abortController.signal
-	}
+  get signal(): AbortSignal {
+    return this.abortController.signal;
+  }
 
-	private cancel(): void {
-		try {
-			this.abortController.abort()
-		} catch {}
-		if (this.inputRejecter) {
-			this.inputRejecter(new Error("Login cancelled"))
-			this.inputResolver = undefined
-			this.inputRejecter = undefined
-		}
-		this.onComplete(false, "Login cancelled")
-	}
+  private cancel(): void {
+    try {
+      this.abortController.abort();
+    } catch {}
+    if (this.inputRejecter) {
+      this.inputRejecter(new Error('Login cancelled'));
+      this.inputResolver = undefined;
+      this.inputRejecter = undefined;
+    }
+    this.onComplete(false, 'Login cancelled');
+  }
 
-	/**
-	 * Called by onAuth callback - show URL and optional instructions
-	 */
-	showAuth(url: string, instructions?: string): void {
-		this.contentContainer.clear()
+  /**
+   * Called by onAuth callback - show URL and optional instructions
+   */
+  showAuth(url: string, instructions?: string): void {
+    this.contentContainer.clear();
 
-		this.contentContainer.addChild(new Text(fg("accent", url)))
+    this.contentContainer.addChild(new Text(fg('accent', url)));
 
-		const clickHint =
-			process.platform === "darwin" ? "Cmd+click to open" : "Ctrl+click to open"
-		const hyperlink = `\x1b]8;;${url}\x07${clickHint}\x1b]8;;\x07`
-		this.contentContainer.addChild(new Text(fg("muted", hyperlink)))
+    const clickHint = process.platform === 'darwin' ? 'Cmd+click to open' : 'Ctrl+click to open';
+    const hyperlink = `\x1b]8;;${url}\x07${clickHint}\x1b]8;;\x07`;
+    this.contentContainer.addChild(new Text(fg('muted', hyperlink)));
 
-		if (instructions) {
-			this.contentContainer.addChild(new Spacer(1))
-			this.contentContainer.addChild(new Text(fg("warning", instructions)))
-		}
+    if (instructions) {
+      this.contentContainer.addChild(new Spacer(1));
+      this.contentContainer.addChild(new Text(fg('warning', instructions)));
+    }
 
-		// Try to open browser
-		const openCmd =
-			process.platform === "darwin"
-				? "open"
-				: process.platform === "win32"
-					? "start"
-					: "xdg-open"
-		exec(`${openCmd} "${url}"`)
+    // Try to open browser
+    const openCmd = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+    exec(`${openCmd} "${url}"`);
 
-		this.tui.requestRender()
-	}
+    this.tui.requestRender();
+  }
 
-	/**
-	 * Called by onPrompt callback - show prompt and wait for input
-	 */
-	showPrompt(message: string, placeholder?: string): Promise<string> {
-		this.contentContainer.addChild(new Spacer(1))
-		this.contentContainer.addChild(new Text(fg("text", message)))
-		if (placeholder) {
-			this.contentContainer.addChild(
-				new Text(fg("muted", `e.g., ${placeholder}`)),
-			)
-		}
-		this.contentContainer.addChild(this.input)
-		this.contentContainer.addChild(
-			new Text(fg("muted", "(Escape to cancel, Enter to submit)")),
-		)
+  /**
+   * Called by onPrompt callback - show prompt and wait for input
+   */
+  showPrompt(message: string, placeholder?: string): Promise<string> {
+    this.contentContainer.addChild(new Spacer(1));
+    this.contentContainer.addChild(new Text(fg('text', message)));
+    if (placeholder) {
+      this.contentContainer.addChild(new Text(fg('muted', `e.g., ${placeholder}`)));
+    }
+    this.contentContainer.addChild(this.input);
+    this.contentContainer.addChild(new Text(fg('muted', '(Escape to cancel, Enter to submit)')));
 
-		this.input.setValue("")
-		this.tui.requestRender()
+    this.input.setValue('');
+    this.tui.requestRender();
 
-		return new Promise((resolve, reject) => {
-			this.inputResolver = resolve
-			this.inputRejecter = reject
-		})
-	}
+    return new Promise((resolve, reject) => {
+      this.inputResolver = resolve;
+      this.inputRejecter = reject;
+    });
+  }
 
-	/**
-	 * Show progress message
-	 */
-	showProgress(message: string): void {
-		this.contentContainer.addChild(new Text(fg("muted", message)))
-		this.tui.requestRender()
-	}
+  /**
+   * Show progress message
+   */
+  showProgress(message: string): void {
+    this.contentContainer.addChild(new Text(fg('muted', message)));
+    this.tui.requestRender();
+  }
 
-	handleInput(data: string): void {
-		const kb = getEditorKeybindings()
+  handleInput(data: string): void {
+    const kb = getEditorKeybindings();
 
-		if (kb.matches(data, "selectCancel")) {
-			this.cancel()
-			return
-		}
+    if (kb.matches(data, 'selectCancel')) {
+      this.cancel();
+      return;
+    }
 
-		// Pass to input
-		this.input.handleInput(data)
-	}
+    // Pass to input
+    this.input.handleInput(data);
+  }
 }

--- a/mastracode/src/tui/components/login-selector.ts
+++ b/mastracode/src/tui/components/login-selector.ts
@@ -2,137 +2,119 @@
  * OAuth provider selector component for /login and /logout commands
  */
 
-import {
-	Box,
-	Container,
-	getEditorKeybindings,
-	Spacer,
-	Text,
-} from "@mariozechner/pi-tui"
-import type { OAuthProviderInterface } from "../../auth/types.js"
-import { bg, fg } from "../theme.js"
+import { Box, Container, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
+import type { OAuthProviderInterface } from '../../auth/types.js';
+import { bg, fg } from '../theme.js';
 
 /**
  * Interface for auth provider that the selector needs.
  * Can be satisfied by Harness or AuthStorage.
  */
 export interface AuthProviderSource {
-	getOAuthProviders(): OAuthProviderInterface[]
-	isLoggedIn(providerId: string): boolean
+  getOAuthProviders(): OAuthProviderInterface[];
+  isLoggedIn(providerId: string): boolean;
 }
 
 export class LoginSelectorComponent extends Box {
-	private listContainer: Container
-	private allProviders: { id: string; name: string }[] = []
-	private selectedIndex: number = 0
-	private mode: "login" | "logout"
-	private authSource: AuthProviderSource
-	private onSelectCallback: (providerId: string) => void
-	private onCancelCallback: () => void
+  private listContainer: Container;
+  private allProviders: { id: string; name: string }[] = [];
+  private selectedIndex: number = 0;
+  private mode: 'login' | 'logout';
+  private authSource: AuthProviderSource;
+  private onSelectCallback: (providerId: string) => void;
+  private onCancelCallback: () => void;
 
-	constructor(
-		mode: "login" | "logout",
-		authSource: AuthProviderSource,
-		onSelect: (providerId: string) => void,
-		onCancel: () => void,
-	) {
-		// Box with padding and background
-		super(2, 1, (text) => bg("overlayBg", text))
+  constructor(
+    mode: 'login' | 'logout',
+    authSource: AuthProviderSource,
+    onSelect: (providerId: string) => void,
+    onCancel: () => void,
+  ) {
+    // Box with padding and background
+    super(2, 1, text => bg('overlayBg', text));
 
-		this.mode = mode
-		this.authSource = authSource
-		this.onSelectCallback = onSelect
-		this.onCancelCallback = onCancel
+    this.mode = mode;
+    this.authSource = authSource;
+    this.onSelectCallback = onSelect;
+    this.onCancelCallback = onCancel;
 
-		// Load all OAuth providers
-		this.loadProviders()
+    // Load all OAuth providers
+    this.loadProviders();
 
-		// Add title
-		const title =
-			mode === "login"
-				? "Select provider to login:"
-				: "Select provider to logout:"
-		this.addChild(new Text(fg("text", title)))
-		this.addChild(new Spacer(1))
+    // Add title
+    const title = mode === 'login' ? 'Select provider to login:' : 'Select provider to logout:';
+    this.addChild(new Text(fg('text', title)));
+    this.addChild(new Spacer(1));
 
-		// Create list container
-		this.listContainer = new Container()
-		this.addChild(this.listContainer)
+    // Create list container
+    this.listContainer = new Container();
+    this.addChild(this.listContainer);
 
-		this.addChild(new Spacer(1))
-		this.addChild(
-			new Text(fg("muted", "Press Enter to select, Escape to cancel")),
-		)
+    this.addChild(new Spacer(1));
+    this.addChild(new Text(fg('muted', 'Press Enter to select, Escape to cancel')));
 
-		// Initial render
-		this.updateList()
-	}
+    // Initial render
+    this.updateList();
+  }
 
-	private loadProviders(): void {
-		this.allProviders = this.authSource
-			.getOAuthProviders()
-			.map((p) => ({ id: p.id, name: p.name }))
-	}
+  private loadProviders(): void {
+    this.allProviders = this.authSource.getOAuthProviders().map(p => ({ id: p.id, name: p.name }));
+  }
 
-	private updateList(): void {
-		this.listContainer.clear()
+  private updateList(): void {
+    this.listContainer.clear();
 
-		for (let i = 0; i < this.allProviders.length; i++) {
-			const provider = this.allProviders[i]
-			if (!provider) continue
+    for (let i = 0; i < this.allProviders.length; i++) {
+      const provider = this.allProviders[i];
+      if (!provider) continue;
 
-			const isSelected = i === this.selectedIndex
+      const isSelected = i === this.selectedIndex;
 
-			// Check if user is logged in for this provider
-			const isLoggedIn = this.authSource.isLoggedIn(provider.id)
-			const statusIndicator = isLoggedIn ? fg("success", " ✓ logged in") : ""
+      // Check if user is logged in for this provider
+      const isLoggedIn = this.authSource.isLoggedIn(provider.id);
+      const statusIndicator = isLoggedIn ? fg('success', ' ✓ logged in') : '';
 
-			let line = ""
-			if (isSelected) {
-				line = fg("accent", "→ " + provider.name) + statusIndicator
-			} else {
-				line = "  " + provider.name + statusIndicator
-			}
+      let line = '';
+      if (isSelected) {
+        line = fg('accent', '→ ' + provider.name) + statusIndicator;
+      } else {
+        line = '  ' + provider.name + statusIndicator;
+      }
 
-			this.listContainer.addChild(new Text(line))
-		}
+      this.listContainer.addChild(new Text(line));
+    }
 
-		// Show "no providers" if empty
-		if (this.allProviders.length === 0) {
-			const message =
-				this.mode === "login"
-					? "No OAuth providers available"
-					: "No OAuth providers logged in. Use /login first."
-			this.listContainer.addChild(new Text(fg("muted", message)))
-		}
-	}
+    // Show "no providers" if empty
+    if (this.allProviders.length === 0) {
+      const message =
+        this.mode === 'login' ? 'No OAuth providers available' : 'No OAuth providers logged in. Use /login first.';
+      this.listContainer.addChild(new Text(fg('muted', message)));
+    }
+  }
 
-	handleInput(keyData: string): void {
-		const kb = getEditorKeybindings()
+  handleInput(keyData: string): void {
+    const kb = getEditorKeybindings();
 
-		// Up arrow
-		if (kb.matches(keyData, "selectUp")) {
-			this.selectedIndex = Math.max(0, this.selectedIndex - 1)
-			this.updateList()
-		}
-		// Down arrow
-		else if (kb.matches(keyData, "selectDown")) {
-			this.selectedIndex = Math.min(
-				this.allProviders.length - 1,
-				this.selectedIndex + 1,
-			)
-			this.updateList()
-		}
-		// Enter
-		else if (kb.matches(keyData, "selectConfirm")) {
-			const selectedProvider = this.allProviders[this.selectedIndex]
-			if (selectedProvider) {
-				this.onSelectCallback(selectedProvider.id)
-			}
-		}
-		// Escape or Ctrl+C
-		else if (kb.matches(keyData, "selectCancel")) {
-			this.onCancelCallback()
-		}
-	}
+    // Up arrow
+    if (kb.matches(keyData, 'selectUp')) {
+      this.selectedIndex = Math.max(0, this.selectedIndex - 1);
+      this.updateList();
+    }
+    // Down arrow
+    else if (kb.matches(keyData, 'selectDown')) {
+      this.selectedIndex = Math.min(this.allProviders.length - 1, this.selectedIndex + 1);
+      this.updateList();
+    }
+    // Enter
+    else if (kb.matches(keyData, 'selectConfirm')) {
+      const selectedProvider = this.allProviders[this.selectedIndex];
+      if (selectedProvider) {
+        this.onSelectCallback(selectedProvider.id);
+      }
+    }
+    // Escape or Ctrl+C
+    else if (kb.matches(keyData, 'selectCancel')) {
+      this.onCancelCallback();
+    }
+  }
 }

--- a/mastracode/src/tui/components/model-selector.ts
+++ b/mastracode/src/tui/components/model-selector.ts
@@ -3,52 +3,42 @@
  * Uses pi-tui overlay pattern with search and fuzzy filtering.
  */
 
-import {
-	Box,
-	Container,
-	
-	fuzzyFilter,
-	getEditorKeybindings,
-	Input,
-	Spacer,
-	Text
-	
-} from "@mariozechner/pi-tui"
-import type {Focusable, TUI} from "@mariozechner/pi-tui";
-import { bg, fg, bold } from "../theme.js"
+import { Box, Container, fuzzyFilter, getEditorKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
+import type { Focusable, TUI } from '@mariozechner/pi-tui';
+import { bg, fg, bold } from '../theme.js';
 
 // =============================================================================
 // Types
 // =============================================================================
 
 export interface ModelItem {
-	/** Full model ID (e.g., "anthropic/claude-sonnet-4") */
-	id: string
-	/** Provider name (e.g., "anthropic") */
-	provider: string
-	/** Model name without provider (e.g., "claude-sonnet-4") */
-	modelName: string
-	/** Whether the API key for this provider is available */
-	hasApiKey: boolean
-	/** Environment variable name for the API key (e.g., "ANTHROPIC_API_KEY") */
-	apiKeyEnvVar?: string
-	/** Number of times this model has been selected (for ranking) */
-	useCount?: number
+  /** Full model ID (e.g., "anthropic/claude-sonnet-4") */
+  id: string;
+  /** Provider name (e.g., "anthropic") */
+  provider: string;
+  /** Model name without provider (e.g., "claude-sonnet-4") */
+  modelName: string;
+  /** Whether the API key for this provider is available */
+  hasApiKey: boolean;
+  /** Environment variable name for the API key (e.g., "ANTHROPIC_API_KEY") */
+  apiKeyEnvVar?: string;
+  /** Number of times this model has been selected (for ranking) */
+  useCount?: number;
 }
 
 export interface ModelSelectorOptions {
-	/** TUI instance for rendering */
-	tui: TUI
-	/** List of available models */
-	models: ModelItem[]
-	/** Currently selected model ID */
-	currentModelId?: string
-	/** Optional title for the selector */
-	title?: string
-	/** Callback when a model is selected */
-	onSelect: (model: ModelItem) => void
-	/** Callback when selection is cancelled */
-	onCancel: () => void
+  /** TUI instance for rendering */
+  tui: TUI;
+  /** List of available models */
+  models: ModelItem[];
+  /** Currently selected model ID */
+  currentModelId?: string;
+  /** Optional title for the selector */
+  title?: string;
+  /** Callback when a model is selected */
+  onSelect: (model: ModelItem) => void;
+  /** Callback when selection is cancelled */
+  onCancel: () => void;
 }
 
 // =============================================================================
@@ -56,273 +46,235 @@ export interface ModelSelectorOptions {
 // =============================================================================
 
 export class ModelSelectorComponent extends Box implements Focusable {
-	private searchInput!: Input
-	private listContainer!: Container
-	private allModels: ModelItem[]
-	private filteredModels: ModelItem[]
-	private selectedIndex = 0
-	private currentModelId?: string
-	private onSelectCallback: (model: ModelItem) => void
-	private onCancelCallback: () => void
-	private tui: TUI
-	private title: string
+  private searchInput!: Input;
+  private listContainer!: Container;
+  private allModels: ModelItem[];
+  private filteredModels: ModelItem[];
+  private selectedIndex = 0;
+  private currentModelId?: string;
+  private onSelectCallback: (model: ModelItem) => void;
+  private onCancelCallback: () => void;
+  private tui: TUI;
+  private title: string;
 
-	// Focusable implementation
-	private _focused = false
-	get focused(): boolean {
-		return this._focused
-	}
-	set focused(value: boolean) {
-		this._focused = value
-		this.searchInput.focused = value
-	}
+  // Focusable implementation
+  private _focused = false;
+  get focused(): boolean {
+    return this._focused;
+  }
+  set focused(value: boolean) {
+    this._focused = value;
+    this.searchInput.focused = value;
+  }
 
-	constructor(options: ModelSelectorOptions) {
-		// Box with padding and background
-		super(2, 1, (text) => bg("overlayBg", text))
+  constructor(options: ModelSelectorOptions) {
+    // Box with padding and background
+    super(2, 1, text => bg('overlayBg', text));
 
-		this.tui = options.tui
-		this.title = options.title ?? "Select Model"
-		this.allModels = this.sortModels(options.models, options.currentModelId)
-		this.currentModelId = options.currentModelId
-		this.onSelectCallback = options.onSelect
-		this.onCancelCallback = options.onCancel
-		this.filteredModels = this.allModels
+    this.tui = options.tui;
+    this.title = options.title ?? 'Select Model';
+    this.allModels = this.sortModels(options.models, options.currentModelId);
+    this.currentModelId = options.currentModelId;
+    this.onSelectCallback = options.onSelect;
+    this.onCancelCallback = options.onCancel;
+    this.filteredModels = this.allModels;
 
-		// Build UI
-		this.buildUI()
-	}
+    // Build UI
+    this.buildUI();
+  }
 
-	private buildUI(): void {
-		// Title
-		this.addChild(new Text(bold(fg("accent", this.title)), 0, 0))
-		this.addChild(new Spacer(1))
+  private buildUI(): void {
+    // Title
+    this.addChild(new Text(bold(fg('accent', this.title)), 0, 0));
+    this.addChild(new Spacer(1));
 
-		// Hint
-		this.addChild(
-			new Text(
-				fg("muted", "Type to search • ↑↓ navigate • Enter select • Esc cancel"),
-				0,
-				0,
-			),
-		)
-		this.addChild(new Spacer(1))
+    // Hint
+    this.addChild(new Text(fg('muted', 'Type to search • ↑↓ navigate • Enter select • Esc cancel'), 0, 0));
+    this.addChild(new Spacer(1));
 
-		// Search input (Input has built-in "> " prompt)
-		this.searchInput = new Input()
-		this.searchInput.onSubmit = () => {
-			if (this.hasCustomItem && this.selectedIndex === 0) {
-				const query = this.searchInput.getValue().trim()
-				if (query) this.handleSelect(this.makeCustomModelItem(query))
-			} else {
-				const modelIndex = this.hasCustomItem
-					? this.selectedIndex - 1
-					: this.selectedIndex
-				const selected = this.filteredModels[modelIndex]
-				if (selected) this.handleSelect(selected)
-			}
-		}
-		this.addChild(this.searchInput)
-		this.addChild(new Spacer(1))
+    // Search input (Input has built-in "> " prompt)
+    this.searchInput = new Input();
+    this.searchInput.onSubmit = () => {
+      if (this.hasCustomItem && this.selectedIndex === 0) {
+        const query = this.searchInput.getValue().trim();
+        if (query) this.handleSelect(this.makeCustomModelItem(query));
+      } else {
+        const modelIndex = this.hasCustomItem ? this.selectedIndex - 1 : this.selectedIndex;
+        const selected = this.filteredModels[modelIndex];
+        if (selected) this.handleSelect(selected);
+      }
+    };
+    this.addChild(this.searchInput);
+    this.addChild(new Spacer(1));
 
-		// List container
-		this.listContainer = new Container()
-		this.addChild(this.listContainer)
+    // List container
+    this.listContainer = new Container();
+    this.addChild(this.listContainer);
 
-		// Initial render
-		this.updateList()
-	}
+    // Initial render
+    this.updateList();
+  }
 
-	private sortModels(
-		models: ModelItem[],
-		currentModelId?: string,
-	): ModelItem[] {
-		const sorted = [...models]
+  private sortModels(models: ModelItem[], currentModelId?: string): ModelItem[] {
+    const sorted = [...models];
 
-		// Sort: current first, then API key available, then by use count (desc), then alphabetical
-		sorted.sort((a, b) => {
-			// Current model always first
-			const aIsCurrent = a.id === currentModelId
-			const bIsCurrent = b.id === currentModelId
-			if (aIsCurrent && !bIsCurrent) return -1
-			if (!aIsCurrent && bIsCurrent) return 1
+    // Sort: current first, then API key available, then by use count (desc), then alphabetical
+    sorted.sort((a, b) => {
+      // Current model always first
+      const aIsCurrent = a.id === currentModelId;
+      const bIsCurrent = b.id === currentModelId;
+      if (aIsCurrent && !bIsCurrent) return -1;
+      if (!aIsCurrent && bIsCurrent) return 1;
 
-			// Models with API keys come before those without
-			if (a.hasApiKey && !b.hasApiKey) return -1
-			if (!a.hasApiKey && b.hasApiKey) return 1
+      // Models with API keys come before those without
+      if (a.hasApiKey && !b.hasApiKey) return -1;
+      if (!a.hasApiKey && b.hasApiKey) return 1;
 
-			// Then by use count (higher = first)
-			const aCount = a.useCount ?? 0
-			const bCount = b.useCount ?? 0
-			if (aCount !== bCount) return bCount - aCount
+      // Then by use count (higher = first)
+      const aCount = a.useCount ?? 0;
+      const bCount = b.useCount ?? 0;
+      if (aCount !== bCount) return bCount - aCount;
 
-			// Then by provider
-			const providerCompare = a.provider.localeCompare(b.provider)
-			if (providerCompare !== 0) return providerCompare
+      // Then by provider
+      const providerCompare = a.provider.localeCompare(b.provider);
+      if (providerCompare !== 0) return providerCompare;
 
-			// Then by model name
-			return a.modelName.localeCompare(b.modelName)
-		})
+      // Then by model name
+      return a.modelName.localeCompare(b.modelName);
+    });
 
-		return sorted
-	}
+    return sorted;
+  }
 
-	/** Whether the custom "Use: ..." item is showing at the top */
-	private hasCustomItem = false
+  /** Whether the custom "Use: ..." item is showing at the top */
+  private hasCustomItem = false;
 
-	private filterModels(query: string): void {
-		// Apply fuzzy filter if there's a query, otherwise show all
-		// Sorting already puts models with API keys first
-		this.filteredModels = query
-			? fuzzyFilter(
-					this.allModels,
-					query,
-					(m) => `${m.id} ${m.provider} ${m.modelName}`,
-				)
-			: this.allModels
+  private filterModels(query: string): void {
+    // Apply fuzzy filter if there's a query, otherwise show all
+    // Sorting already puts models with API keys first
+    this.filteredModels = query
+      ? fuzzyFilter(this.allModels, query, m => `${m.id} ${m.provider} ${m.modelName}`)
+      : this.allModels;
 
-		// Show "Use: query" custom item when query looks like a model ID
-		// and doesn't exactly match the top result
-		const trimmed = query.trim()
-		this.hasCustomItem =
-			trimmed.length > 0 && this.filteredModels[0]?.id !== trimmed
+    // Show "Use: query" custom item when query looks like a model ID
+    // and doesn't exactly match the top result
+    const trimmed = query.trim();
+    this.hasCustomItem = trimmed.length > 0 && this.filteredModels[0]?.id !== trimmed;
 
-		const totalItems = this.filteredModels.length + (this.hasCustomItem ? 1 : 0)
-		this.selectedIndex = Math.min(
-			this.selectedIndex,
-			Math.max(0, totalItems - 1),
-		)
-		this.updateList()
-	}
+    const totalItems = this.filteredModels.length + (this.hasCustomItem ? 1 : 0);
+    this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, totalItems - 1));
+    this.updateList();
+  }
 
-	private makeCustomModelItem(id: string): ModelItem {
-		const parts = id.split("/")
-		const provider = parts.length > 1 ? parts[0]! : "custom"
-		const modelName = parts.length > 1 ? parts.slice(1).join("/") : id
-		return { id, provider, modelName, hasApiKey: true }
-	}
+  private makeCustomModelItem(id: string): ModelItem {
+    const parts = id.split('/');
+    const provider = parts.length > 1 ? parts[0]! : 'custom';
+    const modelName = parts.length > 1 ? parts.slice(1).join('/') : id;
+    return { id, provider, modelName, hasApiKey: true };
+  }
 
-	private updateList(): void {
-		this.listContainer.clear()
+  private updateList(): void {
+    this.listContainer.clear();
 
-		const totalItems = this.filteredModels.length + (this.hasCustomItem ? 1 : 0)
-		const maxVisible = 12
-		const startIndex = Math.max(
-			0,
-			Math.min(
-				this.selectedIndex - Math.floor(maxVisible / 2),
-				totalItems - maxVisible,
-			),
-		)
-		const endIndex = Math.min(startIndex + maxVisible, totalItems)
+    const totalItems = this.filteredModels.length + (this.hasCustomItem ? 1 : 0);
+    const maxVisible = 12;
+    const startIndex = Math.max(0, Math.min(this.selectedIndex - Math.floor(maxVisible / 2), totalItems - maxVisible));
+    const endIndex = Math.min(startIndex + maxVisible, totalItems);
 
-		for (let i = startIndex; i < endIndex; i++) {
-			// First item is the custom "Use: ..." entry when active
-			if (this.hasCustomItem && i === 0) {
-				const query = this.searchInput.getValue().trim()
-				const isSelected = this.selectedIndex === 0
-				const line = isSelected
-					? fg("accent", "→ ") + bold(fg("accent", `Use: ${query}`))
-					: "  " + fg("muted", `Use: ${query}`)
-				this.listContainer.addChild(new Text(line, 0, 0))
-				continue
-			}
+    for (let i = startIndex; i < endIndex; i++) {
+      // First item is the custom "Use: ..." entry when active
+      if (this.hasCustomItem && i === 0) {
+        const query = this.searchInput.getValue().trim();
+        const isSelected = this.selectedIndex === 0;
+        const line = isSelected
+          ? fg('accent', '→ ') + bold(fg('accent', `Use: ${query}`))
+          : '  ' + fg('muted', `Use: ${query}`);
+        this.listContainer.addChild(new Text(line, 0, 0));
+        continue;
+      }
 
-			// Offset into filteredModels (subtract 1 when custom item is present)
-			const modelIndex = this.hasCustomItem ? i - 1 : i
-			const item = this.filteredModels[modelIndex]
-			if (!item) continue
+      // Offset into filteredModels (subtract 1 when custom item is present)
+      const modelIndex = this.hasCustomItem ? i - 1 : i;
+      const item = this.filteredModels[modelIndex];
+      if (!item) continue;
 
-			const isSelected = i === this.selectedIndex
-			const isCurrent = item.id === this.currentModelId
-			const checkmark = isCurrent ? fg("success", " ✓") : ""
-			const noKeyIndicator = !item.hasApiKey
-				? fg("error", " ✗") +
-					fg(
-						"muted",
-						item.apiKeyEnvVar ? ` (${item.apiKeyEnvVar})` : " (no key)",
-					)
-				: ""
+      const isSelected = i === this.selectedIndex;
+      const isCurrent = item.id === this.currentModelId;
+      const checkmark = isCurrent ? fg('success', ' ✓') : '';
+      const noKeyIndicator = !item.hasApiKey
+        ? fg('error', ' ✗') + fg('muted', item.apiKeyEnvVar ? ` (${item.apiKeyEnvVar})` : ' (no key)')
+        : '';
 
-			let line = ""
-			if (isSelected) {
-				line = fg("accent", "→ " + item.id) + checkmark + noKeyIndicator
-			} else {
-				const modelText = item.hasApiKey ? item.id : fg("muted", item.id)
-				line = "  " + modelText + checkmark + noKeyIndicator
-			}
+      let line = '';
+      if (isSelected) {
+        line = fg('accent', '→ ' + item.id) + checkmark + noKeyIndicator;
+      } else {
+        const modelText = item.hasApiKey ? item.id : fg('muted', item.id);
+        line = '  ' + modelText + checkmark + noKeyIndicator;
+      }
 
-			this.listContainer.addChild(new Text(line, 0, 0))
-		}
+      this.listContainer.addChild(new Text(line, 0, 0));
+    }
 
-		// Scroll indicator
-		if (startIndex > 0 || endIndex < totalItems) {
-			const scrollInfo = fg(
-				"muted",
-				`(${this.selectedIndex + 1}/${totalItems})`,
-			)
-			this.listContainer.addChild(new Text(scrollInfo, 0, 0))
-		}
+    // Scroll indicator
+    if (startIndex > 0 || endIndex < totalItems) {
+      const scrollInfo = fg('muted', `(${this.selectedIndex + 1}/${totalItems})`);
+      this.listContainer.addChild(new Text(scrollInfo, 0, 0));
+    }
 
-		// Empty state
-		if (totalItems === 0) {
-			this.listContainer.addChild(
-				new Text(fg("muted", "No matching models"), 0, 0),
-			)
-		}
-	}
+    // Empty state
+    if (totalItems === 0) {
+      this.listContainer.addChild(new Text(fg('muted', 'No matching models'), 0, 0));
+    }
+  }
 
-	handleInput(keyData: string): void {
-		const kb = getEditorKeybindings()
+  handleInput(keyData: string): void {
+    const kb = getEditorKeybindings();
 
-		const totalItems = this.filteredModels.length + (this.hasCustomItem ? 1 : 0)
+    const totalItems = this.filteredModels.length + (this.hasCustomItem ? 1 : 0);
 
-		// Up arrow
-		if (kb.matches(keyData, "selectUp")) {
-			if (totalItems === 0) return
-			this.selectedIndex =
-				this.selectedIndex === 0 ? totalItems - 1 : this.selectedIndex - 1
-			this.updateList()
-			this.tui.requestRender()
-		}
-		// Down arrow
-		else if (kb.matches(keyData, "selectDown")) {
-			if (totalItems === 0) return
-			this.selectedIndex =
-				this.selectedIndex === totalItems - 1 ? 0 : this.selectedIndex + 1
-			this.updateList()
-			this.tui.requestRender()
-		}
-		// Enter
-		else if (kb.matches(keyData, "selectConfirm")) {
-			if (this.hasCustomItem && this.selectedIndex === 0) {
-				const query = this.searchInput.getValue().trim()
-				if (query) this.handleSelect(this.makeCustomModelItem(query))
-			} else {
-				const modelIndex = this.hasCustomItem
-					? this.selectedIndex - 1
-					: this.selectedIndex
-				const selected = this.filteredModels[modelIndex]
-				if (selected) this.handleSelect(selected)
-			}
-		}
-		// Escape or Ctrl+C
-		else if (kb.matches(keyData, "selectCancel")) {
-			this.onCancelCallback()
-		}
-		// Pass everything else to search input
-		else {
-			this.searchInput.handleInput(keyData)
-			this.filterModels(this.searchInput.getValue())
-			this.tui.requestRender()
-		}
-	}
+    // Up arrow
+    if (kb.matches(keyData, 'selectUp')) {
+      if (totalItems === 0) return;
+      this.selectedIndex = this.selectedIndex === 0 ? totalItems - 1 : this.selectedIndex - 1;
+      this.updateList();
+      this.tui.requestRender();
+    }
+    // Down arrow
+    else if (kb.matches(keyData, 'selectDown')) {
+      if (totalItems === 0) return;
+      this.selectedIndex = this.selectedIndex === totalItems - 1 ? 0 : this.selectedIndex + 1;
+      this.updateList();
+      this.tui.requestRender();
+    }
+    // Enter
+    else if (kb.matches(keyData, 'selectConfirm')) {
+      if (this.hasCustomItem && this.selectedIndex === 0) {
+        const query = this.searchInput.getValue().trim();
+        if (query) this.handleSelect(this.makeCustomModelItem(query));
+      } else {
+        const modelIndex = this.hasCustomItem ? this.selectedIndex - 1 : this.selectedIndex;
+        const selected = this.filteredModels[modelIndex];
+        if (selected) this.handleSelect(selected);
+      }
+    }
+    // Escape or Ctrl+C
+    else if (kb.matches(keyData, 'selectCancel')) {
+      this.onCancelCallback();
+    }
+    // Pass everything else to search input
+    else {
+      this.searchInput.handleInput(keyData);
+      this.filterModels(this.searchInput.getValue());
+      this.tui.requestRender();
+    }
+  }
 
-	private handleSelect(model: ModelItem): void {
-		this.onSelectCallback(model)
-	}
+  private handleSelect(model: ModelItem): void {
+    this.onSelectCallback(model);
+  }
 
-	getSearchInput(): Input {
-		return this.searchInput
-	}
+  getSearchInput(): Input {
+    return this.searchInput;
+  }
 }

--- a/mastracode/src/tui/components/multi-step-progress.ts
+++ b/mastracode/src/tui/components/multi-step-progress.ts
@@ -249,11 +249,10 @@ export class MultiStepProgressComponent extends Container {
 			return chalk.hex(mastra.purple)(bar) // Mastra purple
 		}
 	}
-
-	private getSpinner(): string {
-		const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
-		return frames[this.spinnerFrame]
-	}
+    private getSpinner(): string {
+        const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+        return frames[this.spinnerFrame]!
+    }
 
 	private formatDuration(ms: number): string {
 		const seconds = Math.floor(ms / 1000)

--- a/mastracode/src/tui/components/multi-step-progress.ts
+++ b/mastracode/src/tui/components/multi-step-progress.ts
@@ -3,27 +3,27 @@
  * Shows detailed progress with steps, timing, and visual feedback.
  */
 
-import { Container, Text, Spacer } from "@mariozechner/pi-tui"
-import chalk from "chalk"
-import { fg, bold, mastra } from "../theme.js"
+import { Container, Text, Spacer } from '@mariozechner/pi-tui';
+import chalk from 'chalk';
+import { fg, bold, mastra } from '../theme.js';
 
 export interface ProgressStep {
-	id: string
-	title: string
-	description?: string
-	status: "pending" | "active" | "completed" | "failed" | "skipped"
-	progress?: number // 0-100 for active steps
-	startTime?: number
-	endTime?: number
-	error?: string
+  id: string;
+  title: string;
+  description?: string;
+  status: 'pending' | 'active' | 'completed' | 'failed' | 'skipped';
+  progress?: number; // 0-100 for active steps
+  startTime?: number;
+  endTime?: number;
+  error?: string;
 }
 
 export interface MultiStepProgressOptions {
-	title: string
-	showTimings?: boolean
-	showStepNumbers?: boolean
-	collapsedByDefault?: boolean
-	estimatedTime?: number // Total estimated time in ms
+  title: string;
+  showTimings?: boolean;
+  showStepNumbers?: boolean;
+  collapsedByDefault?: boolean;
+  estimatedTime?: number; // Total estimated time in ms
 }
 
 /**
@@ -36,254 +36,236 @@ export interface MultiStepProgressOptions {
  * - Error states with details
  */
 export class MultiStepProgressComponent extends Container {
-	private steps: ProgressStep[] = []
-	private options: Required<Omit<MultiStepProgressOptions, "estimatedTime">> & {
-		estimatedTime?: number
-	}
-	private isCollapsed: boolean
-	private startTime: number
-	private spinnerFrame = 0
-	private lastRenderTime = 0
+  private steps: ProgressStep[] = [];
+  private options: Required<Omit<MultiStepProgressOptions, 'estimatedTime'>> & {
+    estimatedTime?: number;
+  };
+  private isCollapsed: boolean;
+  private startTime: number;
+  private spinnerFrame = 0;
+  private lastRenderTime = 0;
 
-	constructor(options: MultiStepProgressOptions) {
-		super()
-		this.options = {
-			showTimings: true,
-			showStepNumbers: true,
-			collapsedByDefault: false,
-			...options,
-		}
-		this.isCollapsed = this.options.collapsedByDefault
-		this.startTime = Date.now()
-	}
+  constructor(options: MultiStepProgressOptions) {
+    super();
+    this.options = {
+      showTimings: true,
+      showStepNumbers: true,
+      collapsedByDefault: false,
+      ...options,
+    };
+    this.isCollapsed = this.options.collapsedByDefault;
+    this.startTime = Date.now();
+  }
 
-	/**
-	 * Update the list of steps and re-render.
-	 */
-	updateSteps(steps: ProgressStep[]): void {
-		this.steps = steps
-		this.rebuild()
-	}
+  /**
+   * Update the list of steps and re-render.
+   */
+  updateSteps(steps: ProgressStep[]): void {
+    this.steps = steps;
+    this.rebuild();
+  }
 
-	/**
-	 * Update a single step by ID.
-	 */
-	updateStep(id: string, updates: Partial<ProgressStep>): void {
-		const step = this.steps.find((s) => s.id === id)
-		if (step) {
-			Object.assign(step, updates)
-			if (updates.status === "active" && !step.startTime) {
-				step.startTime = Date.now()
-			} else if (
-				(updates.status === "completed" || updates.status === "failed") &&
-				!step.endTime
-			) {
-				step.endTime = Date.now()
-			}
-			this.rebuild()
-		}
-	}
+  /**
+   * Update a single step by ID.
+   */
+  updateStep(id: string, updates: Partial<ProgressStep>): void {
+    const step = this.steps.find(s => s.id === id);
+    if (step) {
+      Object.assign(step, updates);
+      if (updates.status === 'active' && !step.startTime) {
+        step.startTime = Date.now();
+      } else if ((updates.status === 'completed' || updates.status === 'failed') && !step.endTime) {
+        step.endTime = Date.now();
+      }
+      this.rebuild();
+    }
+  }
 
-	/**
-	 * Add a new step to the progress.
-	 */
-	addStep(step: ProgressStep): void {
-		this.steps.push(step)
-		this.rebuild()
-	}
+  /**
+   * Add a new step to the progress.
+   */
+  addStep(step: ProgressStep): void {
+    this.steps.push(step);
+    this.rebuild();
+  }
 
-	/**
-	 * Toggle collapsed/expanded state.
-	 */
-	toggleCollapsed(): void {
-		this.isCollapsed = !this.isCollapsed
-		this.rebuild()
-	}
+  /**
+   * Toggle collapsed/expanded state.
+   */
+  toggleCollapsed(): void {
+    this.isCollapsed = !this.isCollapsed;
+    this.rebuild();
+  }
 
-	private rebuild(): void {
-		this.clear()
+  private rebuild(): void {
+    this.clear();
 
-		// Don't render if no steps
-		if (this.steps.length === 0) return
+    // Don't render if no steps
+    if (this.steps.length === 0) return;
 
-		const now = Date.now()
+    const now = Date.now();
 
-		// Update spinner animation frame
-		if (now - this.lastRenderTime > 100) {
-			this.spinnerFrame = (this.spinnerFrame + 1) % 10
-			this.lastRenderTime = now
-		}
-
-		// Calculate overall progress
-		const completed = this.steps.filter((s) => s.status === "completed").length
-		const failed = this.steps.filter((s) => s.status === "failed").length
-		const active = this.steps.filter((s) => s.status === "active").length
-		const total = this.steps.length
-		const overallProgress = Math.round((completed / total) * 100)
-
-		// Header with title and overall progress
-		const progressBar = this.renderProgressBar(overallProgress, 20)
-		const elapsed = this.formatDuration(now - this.startTime)
-		const headerText = `${bold(fg("accent", this.options.title))} ${progressBar} ${overallProgress}% (${elapsed})`
-
-		this.addChild(new Spacer(1))
-		this.addChild(new Text(headerText, 0, 0))
-
-		// Show collapsed summary or full detail
-		if (this.isCollapsed) {
-			// Summary line showing active step
-			const activeStep = this.steps.find((s) => s.status === "active")
-			if (activeStep) {
-				const spinner = this.getSpinner()
-				const summaryText = `  ${spinner} ${activeStep.title}${activeStep.progress ? ` (${activeStep.progress}%)` : ""}`
-				this.addChild(new Text(chalk.yellow(summaryText), 0, 0))
-			} else if (failed > 0) {
-				this.addChild(
-					new Text(
-						chalk.red(`  ✗ ${failed} step${failed > 1 ? "s" : ""} failed`),
-						0,
-						0,
-					),
-				)
-			} else if (completed === total) {
-				this.addChild(new Text(chalk.green("  ✓ All steps completed"), 0, 0))
-			}
-		} else {
-			// Full detail view
-			this.steps.forEach((step, index) => {
-				const stepLine = this.formatStepLine(step, index)
-				this.addChild(new Text(stepLine, 0, 0))
-
-				// Show progress bar for active steps
-				if (step.status === "active" && step.progress !== undefined) {
-					const stepProgressBar = this.renderProgressBar(step.progress, 30)
-					this.addChild(
-						new Text(`      ${stepProgressBar} ${step.progress}%`, 0, 0),
-					)
-				}
-
-				// Show error details for failed steps
-				if (step.status === "failed" && step.error) {
-					const errorLines = step.error.split("\n")
-					errorLines.forEach((line) => {
-						this.addChild(new Text(chalk.red(`      ${line}`), 0, 0))
-					})
-				}
-			})
-
-			// Show estimated time remaining if available
-			if (this.options.estimatedTime && active > 0) {
-				const elapsed = now - this.startTime
-				const estimatedRemaining = Math.max(
-					0,
-					this.options.estimatedTime - elapsed,
-				)
-				if (estimatedRemaining > 0) {
-					const remaining = this.formatDuration(estimatedRemaining)
-					this.addChild(
-						new Text(chalk.dim(`  Est. time remaining: ${remaining}`), 0, 0),
-					)
-				}
-			}
-		}
-	}
-
-	private formatStepLine(step: ProgressStep, index: number): string {
-		const indent = "  "
-		const stepNum = this.options.showStepNumbers ? `${index + 1}. ` : ""
-
-		let icon: string
-		let color: (text: string) => string
-
-		switch (step.status) {
-			case "completed":
-				icon = chalk.green("✓")
-				color = chalk.green
-				break
-			case "active":
-				icon = chalk.yellow(this.getSpinner())
-				color = chalk.yellow.bold
-				break
-			case "failed":
-				icon = chalk.red("✗")
-				color = chalk.red
-				break
-			case "skipped":
-				icon = chalk.dim("—")
-				color = chalk.dim
-				break
-			case "pending":
-			default:
-				icon = chalk.dim("○")
-				color = chalk.dim
-				break
-		}
-
-		let text = `${indent}${icon} ${stepNum}${step.title}`
-
-		// Add timing info if enabled and available
-		if (this.options.showTimings && step.startTime) {
-			if (step.endTime) {
-				const duration = this.formatDuration(step.endTime - step.startTime)
-				text += chalk.dim(` (${duration})`)
-			} else if (step.status === "active") {
-				const elapsed = this.formatDuration(Date.now() - step.startTime)
-				text += chalk.dim(` (${elapsed})`)
-			}
-		}
-
-		return color(text)
-	}
-
-	private renderProgressBar(percent: number, width: number): string {
-		const filled = Math.round((percent / 100) * width)
-		const empty = width - filled
-		const bar = "█".repeat(filled) + "░".repeat(empty)
-
-		// Color based on progress — Mastra brand colors
-		if (percent === 100) {
-			return chalk.hex(mastra.green)(bar) // Mastra green
-		} else if (percent >= 75) {
-			return chalk.hex(mastra.yellow)(bar) // Mastra yellow
-		} else {
-			return chalk.hex(mastra.purple)(bar) // Mastra purple
-		}
-	}
-    private getSpinner(): string {
-        const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
-        return frames[this.spinnerFrame]!
+    // Update spinner animation frame
+    if (now - this.lastRenderTime > 100) {
+      this.spinnerFrame = (this.spinnerFrame + 1) % 10;
+      this.lastRenderTime = now;
     }
 
-	private formatDuration(ms: number): string {
-		const seconds = Math.floor(ms / 1000)
-		if (seconds < 60) {
-			return `${seconds}s`
-		}
-		const minutes = Math.floor(seconds / 60)
-		const remainingSeconds = seconds % 60
-		if (minutes < 60) {
-			return remainingSeconds > 0
-				? `${minutes}m ${remainingSeconds}s`
-				: `${minutes}m`
-		}
-		const hours = Math.floor(minutes / 60)
-		const remainingMinutes = minutes % 60
-		return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`
-	}
+    // Calculate overall progress
+    const completed = this.steps.filter(s => s.status === 'completed').length;
+    const failed = this.steps.filter(s => s.status === 'failed').length;
+    const active = this.steps.filter(s => s.status === 'active').length;
+    const total = this.steps.length;
+    const overallProgress = Math.round((completed / total) * 100);
 
-	/**
-	 * Handle keyboard input for expanding/collapsing.
-	 */
-	handleInput(data: string): boolean {
-		if (data === " " || data === "\r") {
-			this.toggleCollapsed()
-			return true
-		}
-		return false
-	}
+    // Header with title and overall progress
+    const progressBar = this.renderProgressBar(overallProgress, 20);
+    const elapsed = this.formatDuration(now - this.startTime);
+    const headerText = `${bold(fg('accent', this.options.title))} ${progressBar} ${overallProgress}% (${elapsed})`;
 
-	render(maxWidth: number): string[] {
-		this.rebuild()
-		return super.render(maxWidth)
-	}
+    this.addChild(new Spacer(1));
+    this.addChild(new Text(headerText, 0, 0));
+
+    // Show collapsed summary or full detail
+    if (this.isCollapsed) {
+      // Summary line showing active step
+      const activeStep = this.steps.find(s => s.status === 'active');
+      if (activeStep) {
+        const spinner = this.getSpinner();
+        const summaryText = `  ${spinner} ${activeStep.title}${activeStep.progress ? ` (${activeStep.progress}%)` : ''}`;
+        this.addChild(new Text(chalk.yellow(summaryText), 0, 0));
+      } else if (failed > 0) {
+        this.addChild(new Text(chalk.red(`  ✗ ${failed} step${failed > 1 ? 's' : ''} failed`), 0, 0));
+      } else if (completed === total) {
+        this.addChild(new Text(chalk.green('  ✓ All steps completed'), 0, 0));
+      }
+    } else {
+      // Full detail view
+      this.steps.forEach((step, index) => {
+        const stepLine = this.formatStepLine(step, index);
+        this.addChild(new Text(stepLine, 0, 0));
+
+        // Show progress bar for active steps
+        if (step.status === 'active' && step.progress !== undefined) {
+          const stepProgressBar = this.renderProgressBar(step.progress, 30);
+          this.addChild(new Text(`      ${stepProgressBar} ${step.progress}%`, 0, 0));
+        }
+
+        // Show error details for failed steps
+        if (step.status === 'failed' && step.error) {
+          const errorLines = step.error.split('\n');
+          errorLines.forEach(line => {
+            this.addChild(new Text(chalk.red(`      ${line}`), 0, 0));
+          });
+        }
+      });
+
+      // Show estimated time remaining if available
+      if (this.options.estimatedTime && active > 0) {
+        const elapsed = now - this.startTime;
+        const estimatedRemaining = Math.max(0, this.options.estimatedTime - elapsed);
+        if (estimatedRemaining > 0) {
+          const remaining = this.formatDuration(estimatedRemaining);
+          this.addChild(new Text(chalk.dim(`  Est. time remaining: ${remaining}`), 0, 0));
+        }
+      }
+    }
+  }
+
+  private formatStepLine(step: ProgressStep, index: number): string {
+    const indent = '  ';
+    const stepNum = this.options.showStepNumbers ? `${index + 1}. ` : '';
+
+    let icon: string;
+    let color: (text: string) => string;
+
+    switch (step.status) {
+      case 'completed':
+        icon = chalk.green('✓');
+        color = chalk.green;
+        break;
+      case 'active':
+        icon = chalk.yellow(this.getSpinner());
+        color = chalk.yellow.bold;
+        break;
+      case 'failed':
+        icon = chalk.red('✗');
+        color = chalk.red;
+        break;
+      case 'skipped':
+        icon = chalk.dim('—');
+        color = chalk.dim;
+        break;
+      case 'pending':
+      default:
+        icon = chalk.dim('○');
+        color = chalk.dim;
+        break;
+    }
+
+    let text = `${indent}${icon} ${stepNum}${step.title}`;
+
+    // Add timing info if enabled and available
+    if (this.options.showTimings && step.startTime) {
+      if (step.endTime) {
+        const duration = this.formatDuration(step.endTime - step.startTime);
+        text += chalk.dim(` (${duration})`);
+      } else if (step.status === 'active') {
+        const elapsed = this.formatDuration(Date.now() - step.startTime);
+        text += chalk.dim(` (${elapsed})`);
+      }
+    }
+
+    return color(text);
+  }
+
+  private renderProgressBar(percent: number, width: number): string {
+    const filled = Math.round((percent / 100) * width);
+    const empty = width - filled;
+    const bar = '█'.repeat(filled) + '░'.repeat(empty);
+
+    // Color based on progress — Mastra brand colors
+    if (percent === 100) {
+      return chalk.hex(mastra.green)(bar); // Mastra green
+    } else if (percent >= 75) {
+      return chalk.hex(mastra.yellow)(bar); // Mastra yellow
+    } else {
+      return chalk.hex(mastra.purple)(bar); // Mastra purple
+    }
+  }
+  private getSpinner(): string {
+    const frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+    return frames[this.spinnerFrame]!;
+  }
+
+  private formatDuration(ms: number): string {
+    const seconds = Math.floor(ms / 1000);
+    if (seconds < 60) {
+      return `${seconds}s`;
+    }
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    if (minutes < 60) {
+      return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
+    }
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+  }
+
+  /**
+   * Handle keyboard input for expanding/collapsing.
+   */
+  handleInput(data: string): boolean {
+    if (data === ' ' || data === '\r') {
+      this.toggleCollapsed();
+      return true;
+    }
+    return false;
+  }
+
+  render(maxWidth: number): string[] {
+    this.rebuild();
+    return super.render(maxWidth);
+  }
 }

--- a/mastracode/src/tui/components/obi-loader.ts
+++ b/mastracode/src/tui/components/obi-loader.ts
@@ -1,23 +1,19 @@
-import chalk from "chalk"
+import chalk from 'chalk';
 
-const GRADIENT_WIDTH = 30 // Width of the bright spot as percentage of total text
-const BASE_COLOR = [124, 58, 237] // #b588fe Mastra purple is too washed out, using #7c3aed
-const MIN_BRIGHTNESS = 0.45 // Dimmest characters (0-1)
+const GRADIENT_WIDTH = 30; // Width of the bright spot as percentage of total text
+const BASE_COLOR = [124, 58, 237]; // #b588fe Mastra purple is too washed out, using #7c3aed
+const MIN_BRIGHTNESS = 0.45; // Dimmest characters (0-1)
 
 /**
  * Parse a hex color string to [r, g, b].
  */
 function hexToRgb(hex: string): [number, number, number] {
-	const h = hex.replace("#", "")
-	return [
-		parseInt(h.slice(0, 2), 16),
-		parseInt(h.slice(2, 4), 16),
-		parseInt(h.slice(4, 6), 16),
-	]
+  const h = hex.replace('#', '');
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
 }
 
 /** Idle brightness target for fade-out interpolation */
-const IDLE_BRIGHTNESS = 0.8
+const IDLE_BRIGHTNESS = 0.8;
 
 /**
  * Applies a sweeping gradient animation to a plain text string.
@@ -29,46 +25,39 @@ const IDLE_BRIGHTNESS = 0.8
  * @param fadeProgress - 0 = full animation, 1 = fully idle (flattens gradient)
  * @returns Chalk-colored string
  */
-export function applyGradientSweep(
-	text: string,
-	offset: number,
-	color?: string,
-	fadeProgress = 0,
-): string {
-	const chars = [...text]
-	const totalChars = chars.length
-	if (totalChars === 0) return text
+export function applyGradientSweep(text: string, offset: number, color?: string, fadeProgress = 0): string {
+  const chars = [...text];
+  const totalChars = chars.length;
+  if (totalChars === 0) return text;
 
-	const baseColor = color ? hexToRgb(color) : BASE_COLOR
-	const gradientCenter = (offset % 1) * 100
+  const baseColor = color ? hexToRgb(color) : BASE_COLOR;
+  const gradientCenter = (offset % 1) * 100;
 
-	return chars
-		.map((char, i) => {
-			if (char === " ") return " "
+  return chars
+    .map((char, i) => {
+      if (char === ' ') return ' ';
 
-			const charPosition = (i / totalChars) * 100
-			let distance = Math.abs(charPosition - gradientCenter)
+      const charPosition = (i / totalChars) * 100;
+      let distance = Math.abs(charPosition - gradientCenter);
 
-			// Wrap-around for smooth cycling
-			if (distance > 50) {
-				distance = 100 - distance
-			}
+      // Wrap-around for smooth cycling
+      if (distance > 50) {
+        distance = 100 - distance;
+      }
 
-			const normalizedDistance = Math.min(distance / (GRADIENT_WIDTH / 2), 1)
-			const animBrightness =
-				MIN_BRIGHTNESS + (1 - MIN_BRIGHTNESS) * (1 - normalizedDistance)
+      const normalizedDistance = Math.min(distance / (GRADIENT_WIDTH / 2), 1);
+      const animBrightness = MIN_BRIGHTNESS + (1 - MIN_BRIGHTNESS) * (1 - normalizedDistance);
 
-			// Interpolate toward idle brightness as fade progresses
-			const brightness =
-				animBrightness + (IDLE_BRIGHTNESS - animBrightness) * fadeProgress
+      // Interpolate toward idle brightness as fade progresses
+      const brightness = animBrightness + (IDLE_BRIGHTNESS - animBrightness) * fadeProgress;
 
-			const r = Math.floor(baseColor[0]! * brightness)
-			const g = Math.floor(baseColor[1]! * brightness)
-			const b = Math.floor(baseColor[2]! * brightness)
+      const r = Math.floor(baseColor[0]! * brightness);
+      const g = Math.floor(baseColor[1]! * brightness);
+      const b = Math.floor(baseColor[2]! * brightness);
 
-			return chalk.rgb(r, g, b)(char)
-		})
-		.join("")
+      return chalk.rgb(r, g, b)(char);
+    })
+    .join('');
 }
 
 /**
@@ -77,85 +66,85 @@ export function applyGradientSweep(
  * On each tick, call `getOffset()` to get the current sweep position.
  */
 export class GradientAnimator {
-	private offset = 0
-	private intervalId: ReturnType<typeof setInterval> | null = null
-	private onTick: () => void
-	private _isFadingOut = false
-	private _isFadingIn = false
-	private _fadeProgress = 0 // 0 = full animation, 1 = fully idle
+  private offset = 0;
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private onTick: () => void;
+  private _isFadingOut = false;
+  private _isFadingIn = false;
+  private _fadeProgress = 0; // 0 = full animation, 1 = fully idle
 
-	constructor(onTick: () => void) {
-		this.onTick = onTick
-	}
+  constructor(onTick: () => void) {
+    this.onTick = onTick;
+  }
 
-	start(): void {
-		if (this.intervalId && !this._isFadingOut) return
-		// Cancel any ongoing fade-out
-		if (this.intervalId) {
-			clearInterval(this.intervalId)
-			this.intervalId = null
-		}
-		this._isFadingOut = false
-		this._isFadingIn = true
-		this._fadeProgress = 1 // Start from idle, fade toward full animation
-		this.offset = 0
-		this.intervalId = setInterval(() => {
-			this.offset += 0.03 // Speed: full sweep in ~55 ticks
-			if (this._isFadingIn) {
-				this._fadeProgress -= 0.06 // ~17 steps over ~500ms
-				if (this._fadeProgress <= 0) {
-					this._fadeProgress = 0
-					this._isFadingIn = false
-				}
-			}
-			this.onTick()
-		}, 80)
-	}
+  start(): void {
+    if (this.intervalId && !this._isFadingOut) return;
+    // Cancel any ongoing fade-out
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+    this._isFadingOut = false;
+    this._isFadingIn = true;
+    this._fadeProgress = 1; // Start from idle, fade toward full animation
+    this.offset = 0;
+    this.intervalId = setInterval(() => {
+      this.offset += 0.03; // Speed: full sweep in ~55 ticks
+      if (this._isFadingIn) {
+        this._fadeProgress -= 0.06; // ~17 steps over ~500ms
+        if (this._fadeProgress <= 0) {
+          this._fadeProgress = 0;
+          this._isFadingIn = false;
+        }
+      }
+      this.onTick();
+    }, 80);
+  }
 
-	/**
-	 * Smoothly fade the gradient to idle state over ~500ms.
-	 */
-	fadeOut(): void {
-		if (!this.intervalId) return
-		if (this._isFadingOut) return
-		this._isFadingOut = true
-		this._fadeProgress = 0
-		// Replace the animation interval with a fade interval
-		clearInterval(this.intervalId)
-		this.intervalId = setInterval(() => {
-			this._fadeProgress += 0.08 // ~12 steps over ~500ms
-			if (this._fadeProgress >= 1) {
-				this._fadeProgress = 1
-				this.stop()
-			}
-			this.onTick()
-		}, 40)
-	}
+  /**
+   * Smoothly fade the gradient to idle state over ~500ms.
+   */
+  fadeOut(): void {
+    if (!this.intervalId) return;
+    if (this._isFadingOut) return;
+    this._isFadingOut = true;
+    this._fadeProgress = 0;
+    // Replace the animation interval with a fade interval
+    clearInterval(this.intervalId);
+    this.intervalId = setInterval(() => {
+      this._fadeProgress += 0.08; // ~12 steps over ~500ms
+      if (this._fadeProgress >= 1) {
+        this._fadeProgress = 1;
+        this.stop();
+      }
+      this.onTick();
+    }, 40);
+  }
 
-	stop(): void {
-		if (this.intervalId) {
-			clearInterval(this.intervalId)
-			this.intervalId = null
-		}
-		this._isFadingOut = false
-		this._fadeProgress = 0
-		this.offset = 0
-	}
+  stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+    this._isFadingOut = false;
+    this._fadeProgress = 0;
+    this.offset = 0;
+  }
 
-	getOffset(): number {
-		return this.offset
-	}
+  getOffset(): number {
+    return this.offset;
+  }
 
-	/** 0 = full animation, 1 = fully idle. Use to interpolate colors. */
-	getFadeProgress(): number {
-		return this._fadeProgress
-	}
+  /** 0 = full animation, 1 = fully idle. Use to interpolate colors. */
+  getFadeProgress(): number {
+    return this._fadeProgress;
+  }
 
-	isFadingOut(): boolean {
-		return this._isFadingOut
-	}
+  isFadingOut(): boolean {
+    return this._isFadingOut;
+  }
 
-	isRunning(): boolean {
-		return this.intervalId !== null
-	}
+  isRunning(): boolean {
+    return this.intervalId !== null;
+  }
 }

--- a/mastracode/src/tui/components/om-marker.ts
+++ b/mastracode/src/tui/components/om-marker.ts
@@ -3,155 +3,132 @@
  * Supports updating in-place (start → end/failed).
  */
 
-import { Container, Text, Spacer } from "@mariozechner/pi-tui"
-import { fg } from "../theme.js"
+import { Container, Text, Spacer } from '@mariozechner/pi-tui';
+import { fg } from '../theme.js';
 
 /**
  * Format token count for display (e.g., 7234 -> "7.2k", 234 -> "0.2k", 0 -> "0")
  */
 function formatTokens(tokens: number): string {
-	if (tokens === 0) return "0"
-	const k = tokens / 1000
-	return k % 1 === 0 ? `${k}k` : `${k.toFixed(1)}k`
+  if (tokens === 0) return '0';
+  const k = tokens / 1000;
+  return k % 1 === 0 ? `${k}k` : `${k.toFixed(1)}k`;
 }
 export type OMMarkerData =
-	| {
-			type: "om_observation_start"
-			tokensToObserve: number
-			operationType?: "observation" | "reflection"
-	  }
-	| {
-			type: "om_observation_end"
-			tokensObserved: number
-			observationTokens: number
-			durationMs: number
-			operationType?: "observation" | "reflection"
-	  }
-	| {
-			type: "om_observation_failed"
-			error: string
-			tokensAttempted?: number
-			operationType?: "observation" | "reflection"
-	  }
-	| {
-			type: "om_buffering_start"
-			operationType: "observation" | "reflection"
-			tokensToBuffer: number
-	  }
-	| {
-			type: "om_buffering_end"
-			operationType: "observation" | "reflection"
-			tokensBuffered: number
-			bufferedTokens: number
-			observations?: string
-	  }
-	| {
-			type: "om_buffering_failed"
-			operationType: "observation" | "reflection"
-			error: string
-	  }
-	| {
-			type: "om_activation"
-			operationType: "observation" | "reflection"
-			tokensActivated: number
-			observationTokens: number
-	  }
+  | {
+      type: 'om_observation_start';
+      tokensToObserve: number;
+      operationType?: 'observation' | 'reflection';
+    }
+  | {
+      type: 'om_observation_end';
+      tokensObserved: number;
+      observationTokens: number;
+      durationMs: number;
+      operationType?: 'observation' | 'reflection';
+    }
+  | {
+      type: 'om_observation_failed';
+      error: string;
+      tokensAttempted?: number;
+      operationType?: 'observation' | 'reflection';
+    }
+  | {
+      type: 'om_buffering_start';
+      operationType: 'observation' | 'reflection';
+      tokensToBuffer: number;
+    }
+  | {
+      type: 'om_buffering_end';
+      operationType: 'observation' | 'reflection';
+      tokensBuffered: number;
+      bufferedTokens: number;
+      observations?: string;
+    }
+  | {
+      type: 'om_buffering_failed';
+      operationType: 'observation' | 'reflection';
+      error: string;
+    }
+  | {
+      type: 'om_activation';
+      operationType: 'observation' | 'reflection';
+      tokensActivated: number;
+      observationTokens: number;
+    };
 
 /**
  * Renders an inline OM observation marker in the chat history.
  * Can be updated in-place to transition from start → end/failed.
  */
 export class OMMarkerComponent extends Container {
-	private textChild: Text
+  private textChild: Text;
 
-	constructor(data: OMMarkerData) {
-		super()
-		// Add 1 line of padding above
-		this.addChild(new Spacer(1))
-		this.textChild = new Text(formatMarker(data), 0, 0)
-		this.addChild(this.textChild)
-	}
+  constructor(data: OMMarkerData) {
+    super();
+    // Add 1 line of padding above
+    this.addChild(new Spacer(1));
+    this.textChild = new Text(formatMarker(data), 0, 0);
+    this.addChild(this.textChild);
+  }
 
-	/**
-	 * Update the marker in-place (e.g., from start → end).
-	 */
-	update(data: OMMarkerData): void {
-		this.textChild.setText(formatMarker(data))
-	}
+  /**
+   * Update the marker in-place (e.g., from start → end).
+   */
+  update(data: OMMarkerData): void {
+    this.textChild.setText(formatMarker(data));
+  }
 }
 function formatMarker(data: OMMarkerData): string {
-	const isReflection = data.operationType === "reflection"
-	const label = isReflection ? "Reflection" : "Observation"
+  const isReflection = data.operationType === 'reflection';
+  const label = isReflection ? 'Reflection' : 'Observation';
 
-	switch (data.type) {
-		case "om_observation_start": {
-			const tokens =
-				data.tokensToObserve > 0
-					? ` ~${formatTokens(data.tokensToObserve)} tokens`
-					: ""
-			return fg("muted", `  🧠 ${label} in progress${tokens}...`)
-		}
-		case "om_observation_end": {
-			const observed = formatTokens(data.tokensObserved)
-			const compressed = formatTokens(data.observationTokens)
-			const ratio =
-				data.tokensObserved > 0 && data.observationTokens > 0
-					? `${Math.round(data.tokensObserved / data.observationTokens)}x`
-					: ""
-			const duration = (data.durationMs / 1000).toFixed(1)
-			const ratioStr = ratio ? ` (${ratio} compression)` : ""
-			return fg(
-				"success",
-				`  🧠 Observed: ${observed} → ${compressed} tokens${ratioStr} in ${duration}s ✓`,
-			)
-		}
-		case "om_observation_failed": {
-			const tokens = data.tokensAttempted
-				? ` (${formatTokens(data.tokensAttempted)} tokens)`
-				: ""
-			return fg("error", `  ✗ ${label} failed${tokens}: ${data.error}`)
-		}
-		case "om_buffering_start": {
-			const tokens =
-				data.tokensToBuffer > 0
-					? ` ~${formatTokens(data.tokensToBuffer)} tokens`
-					: ""
-			return fg("muted", `  ⟳ Buffering ${label.toLowerCase()}${tokens}...`)
-		}
-		case "om_buffering_end": {
-			const input = formatTokens(data.tokensBuffered)
-			// For observations: bufferedTokens is cumulative total, not this cycle's output.
-			// Estimate output from observations string (~4 chars/token).
-			// For reflections: bufferedTokens IS the output token count.
-			const outputTokens =
-				data.operationType === "observation" && data.observations
-					? Math.round(data.observations.length / 4)
-					: data.bufferedTokens
-			const output = formatTokens(outputTokens)
-			const ratio =
-				data.tokensBuffered > 0 && outputTokens > 0
-					? ` (${Math.round(data.tokensBuffered / outputTokens)}x)`
-					: ""
-			return fg(
-				"success",
-				`  ✓ Buffered ${label.toLowerCase()}: ${input} → ${output} tokens${ratio}`,
-			)
-		}
-		case "om_buffering_failed": {
-			return fg(
-				"error",
-				`  ✗ Buffering ${label.toLowerCase()} failed: ${data.error}`,
-			)
-		}
-		case "om_activation": {
-			const kind =
-				data.operationType === "reflection" ? "reflection" : "observations"
-			const msgTokens = formatTokens(data.tokensActivated)
-			const obsTokens = formatTokens(data.observationTokens)
-			return fg(
-				"success",
-				`  ✓ Activated ${kind}: -${msgTokens} msg tokens, +${obsTokens} obs tokens`,
-			)
-		}
-	}
+  switch (data.type) {
+    case 'om_observation_start': {
+      const tokens = data.tokensToObserve > 0 ? ` ~${formatTokens(data.tokensToObserve)} tokens` : '';
+      return fg('muted', `  🧠 ${label} in progress${tokens}...`);
+    }
+    case 'om_observation_end': {
+      const observed = formatTokens(data.tokensObserved);
+      const compressed = formatTokens(data.observationTokens);
+      const ratio =
+        data.tokensObserved > 0 && data.observationTokens > 0
+          ? `${Math.round(data.tokensObserved / data.observationTokens)}x`
+          : '';
+      const duration = (data.durationMs / 1000).toFixed(1);
+      const ratioStr = ratio ? ` (${ratio} compression)` : '';
+      return fg('success', `  🧠 Observed: ${observed} → ${compressed} tokens${ratioStr} in ${duration}s ✓`);
+    }
+    case 'om_observation_failed': {
+      const tokens = data.tokensAttempted ? ` (${formatTokens(data.tokensAttempted)} tokens)` : '';
+      return fg('error', `  ✗ ${label} failed${tokens}: ${data.error}`);
+    }
+    case 'om_buffering_start': {
+      const tokens = data.tokensToBuffer > 0 ? ` ~${formatTokens(data.tokensToBuffer)} tokens` : '';
+      return fg('muted', `  ⟳ Buffering ${label.toLowerCase()}${tokens}...`);
+    }
+    case 'om_buffering_end': {
+      const input = formatTokens(data.tokensBuffered);
+      // For observations: bufferedTokens is cumulative total, not this cycle's output.
+      // Estimate output from observations string (~4 chars/token).
+      // For reflections: bufferedTokens IS the output token count.
+      const outputTokens =
+        data.operationType === 'observation' && data.observations
+          ? Math.round(data.observations.length / 4)
+          : data.bufferedTokens;
+      const output = formatTokens(outputTokens);
+      const ratio =
+        data.tokensBuffered > 0 && outputTokens > 0 ? ` (${Math.round(data.tokensBuffered / outputTokens)}x)` : '';
+      return fg('success', `  ✓ Buffered ${label.toLowerCase()}: ${input} → ${output} tokens${ratio}`);
+    }
+    case 'om_buffering_failed': {
+      return fg('error', `  ✗ Buffering ${label.toLowerCase()} failed: ${data.error}`);
+    }
+    case 'om_activation': {
+      const kind = data.operationType === 'reflection' ? 'reflection' : 'observations';
+      const msgTokens = formatTokens(data.tokensActivated);
+      const obsTokens = formatTokens(data.observationTokens);
+      return fg('success', `  ✓ Activated ${kind}: -${msgTokens} msg tokens, +${obsTokens} obs tokens`);
+    }
+  }
 }

--- a/mastracode/src/tui/components/om-output.ts
+++ b/mastracode/src/tui/components/om-output.ts
@@ -5,279 +5,244 @@
  * Includes marker info (emoji, compression stats) in the footer.
  */
 
-import { Container, Text, Spacer } from "@mariozechner/pi-tui"
-import chalk from "chalk"
-import { mastra } from "../theme.js"
+import { Container, Text, Spacer } from '@mariozechner/pi-tui';
+import chalk from 'chalk';
+import { mastra } from '../theme.js';
 
-const OBSERVER_COLOR = "#f59e0b"
-const REFLECTOR_COLOR = "#ef4444"
-const COLLAPSED_LINES = 10
+const OBSERVER_COLOR = '#f59e0b';
+const REFLECTOR_COLOR = '#ef4444';
+const COLLAPSED_LINES = 10;
 
 function formatTokens(tokens: number): string {
-	if (tokens === 0) return "0"
-	const k = tokens / 1000
-	return k % 1 === 0 ? `${k}k` : `${k.toFixed(1)}k`
+  if (tokens === 0) return '0';
+  const k = tokens / 1000;
+  return k % 1 === 0 ? `${k}k` : `${k.toFixed(1)}k`;
 }
 
 /** Truncate a string with ANSI codes to a visible width */
 function truncateAnsi(str: string, maxWidth: number): string {
-	 
-	const ansiRegex = /\x1b\[[0-9;]*m/g
-	let visibleLength = 0
-	let result = ""
-	let lastIndex = 0
-	let match: RegExpExecArray | null
+  const ansiRegex = /\x1b\[[0-9;]*m/g;
+  let visibleLength = 0;
+  let result = '';
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
 
-	while ((match = ansiRegex.exec(str)) !== null) {
-		const textBefore = str.slice(lastIndex, match.index)
-		for (const char of textBefore) {
-			if (visibleLength >= maxWidth) break
-			result += char
-			visibleLength++
-		}
-		if (visibleLength >= maxWidth) break
-		result += match[0]
-		lastIndex = match.index + match[0].length
-	}
+  while ((match = ansiRegex.exec(str)) !== null) {
+    const textBefore = str.slice(lastIndex, match.index);
+    for (const char of textBefore) {
+      if (visibleLength >= maxWidth) break;
+      result += char;
+      visibleLength++;
+    }
+    if (visibleLength >= maxWidth) break;
+    result += match[0];
+    lastIndex = match.index + match[0].length;
+  }
 
-	const remaining = str.slice(lastIndex)
-	for (const char of remaining) {
-		if (visibleLength >= maxWidth) break
-		result += char
-		visibleLength++
-	}
+  const remaining = str.slice(lastIndex);
+  for (const char of remaining) {
+    if (visibleLength >= maxWidth) break;
+    result += char;
+    visibleLength++;
+  }
 
-	if (visibleLength >= maxWidth) {
-		result += "\x1b[0m"
-	}
-	return result
+  if (visibleLength >= maxWidth) {
+    result += '\x1b[0m';
+  }
+  return result;
 }
 
 /**
  * Soft-wrap an array of lines to fit within maxWidth, preserving words where possible.
  * Returns groups where each group corresponds to one original line split into wrapped segments.
  */
-function softWrapLines(
-	lines: string[],
-	maxWidth: number,
-): { groups: string[][]; flat: string[] } {
-	const groups: string[][] = []
-	const flat: string[] = []
-	for (const line of lines) {
-		if (line.length <= maxWidth) {
-			groups.push([line])
-			flat.push(line)
-			continue
-		}
-		// Word-wrap: break at spaces when possible
-		const group: string[] = []
-		let remaining = line
-		while (remaining.length > maxWidth) {
-			let breakAt = remaining.lastIndexOf(" ", maxWidth)
-			if (breakAt <= 0) {
-				breakAt = maxWidth
-			}
-			const segment = remaining.slice(0, breakAt)
-			group.push(segment)
-			flat.push(segment)
-			remaining = remaining.slice(breakAt).replace(/^ /, "")
-		}
-		if (remaining.length > 0) {
-			group.push(remaining)
-			flat.push(remaining)
-		}
-		groups.push(group)
-	}
-	return { groups, flat }
+function softWrapLines(lines: string[], maxWidth: number): { groups: string[][]; flat: string[] } {
+  const groups: string[][] = [];
+  const flat: string[] = [];
+  for (const line of lines) {
+    if (line.length <= maxWidth) {
+      groups.push([line]);
+      flat.push(line);
+      continue;
+    }
+    // Word-wrap: break at spaces when possible
+    const group: string[] = [];
+    let remaining = line;
+    while (remaining.length > maxWidth) {
+      let breakAt = remaining.lastIndexOf(' ', maxWidth);
+      if (breakAt <= 0) {
+        breakAt = maxWidth;
+      }
+      const segment = remaining.slice(0, breakAt);
+      group.push(segment);
+      flat.push(segment);
+      remaining = remaining.slice(breakAt).replace(/^ /, '');
+    }
+    if (remaining.length > 0) {
+      group.push(remaining);
+      flat.push(remaining);
+    }
+    groups.push(group);
+  }
+  return { groups, flat };
 }
 
-export type OMOutputType = "observation" | "reflection"
+export type OMOutputType = 'observation' | 'reflection';
 
 export interface OMOutputData {
-	type: OMOutputType
-	observations: string
-	currentTask?: string
-	suggestedResponse?: string
-	durationMs?: number
-	tokensObserved?: number
-	observationTokens?: number
-	compressedTokens?: number
+  type: OMOutputType;
+  observations: string;
+  currentTask?: string;
+  suggestedResponse?: string;
+  durationMs?: number;
+  tokensObserved?: number;
+  observationTokens?: number;
+  compressedTokens?: number;
 }
 
 export class OMOutputComponent extends Container {
-	private data: OMOutputData
-	private expanded: boolean = false
+  private data: OMOutputData;
+  private expanded: boolean = false;
 
-	constructor(data: OMOutputData) {
-		super()
-		this.data = data
-		this.rebuild()
-	}
+  constructor(data: OMOutputData) {
+    super();
+    this.data = data;
+    this.rebuild();
+  }
 
-	setExpanded(expanded: boolean): void {
-		this.expanded = expanded
-		this.rebuild()
-	}
+  setExpanded(expanded: boolean): void {
+    this.expanded = expanded;
+    this.rebuild();
+  }
 
-	toggleExpanded(): void {
-		this.setExpanded(!this.expanded)
-	}
-	private rebuild(): void {
-		this.clear()
-		this.addChild(new Spacer(1))
+  toggleExpanded(): void {
+    this.setExpanded(!this.expanded);
+  }
+  private rebuild(): void {
+    this.clear();
+    this.addChild(new Spacer(1));
 
-		const isReflection = this.data.type === "reflection"
-		const color = isReflection ? REFLECTOR_COLOR : OBSERVER_COLOR
-		const border = (char: string) => chalk.bold.hex(color)(char)
+    const isReflection = this.data.type === 'reflection';
+    const color = isReflection ? REFLECTOR_COLOR : OBSERVER_COLOR;
+    const border = (char: string) => chalk.bold.hex(color)(char);
 
-		const termWidth = process.stdout.columns || 80
-		const maxLineWidth = termWidth - 6 // "│ " prefix + buffer
-		// Soft-wrap all original lines to terminal width
-		const originalLines = this.data.observations.split("\n")
-		const { groups, flat: wrappedLines } = softWrapLines(
-			originalLines,
-			maxLineWidth,
-		)
-		const originalLineCount = originalLines.length
-		const wrappedLineCount = wrappedLines.length
+    const termWidth = process.stdout.columns || 80;
+    const maxLineWidth = termWidth - 6; // "│ " prefix + buffer
+    // Soft-wrap all original lines to terminal width
+    const originalLines = this.data.observations.split('\n');
+    const { groups, flat: wrappedLines } = softWrapLines(originalLines, maxLineWidth);
+    const originalLineCount = originalLines.length;
+    const wrappedLineCount = wrappedLines.length;
 
-		// Build footer text with marker info (emoji + compression stats)
-		const footerText = this.buildFooterText(color)
+    // Build footer text with marker info (emoji + compression stats)
+    const footerText = this.buildFooterText(color);
 
-		// Top border
-		this.addChild(new Text(border("┌──"), 0, 0))
+    // Top border
+    this.addChild(new Text(border('┌──'), 0, 0));
 
-		// Content lines with left border
-		let truncated = false
-		const borderedLines: string[] = []
-		if (!this.expanded && wrappedLineCount > COLLAPSED_LINES + 1) {
-			// Collect head groups until we hit ~half the budget
-			const headBudget = Math.ceil(COLLAPSED_LINES / 2)
-			const headLines: string[] = []
-			let headGroupCount = 0
-			for (const group of groups) {
-				if (
-					headLines.length + group.length > headBudget &&
-					headLines.length > 0
-				)
-					break
-				headLines.push(...group)
-				headGroupCount++
-			}
+    // Content lines with left border
+    let truncated = false;
+    const borderedLines: string[] = [];
+    if (!this.expanded && wrappedLineCount > COLLAPSED_LINES + 1) {
+      // Collect head groups until we hit ~half the budget
+      const headBudget = Math.ceil(COLLAPSED_LINES / 2);
+      const headLines: string[] = [];
+      let headGroupCount = 0;
+      for (const group of groups) {
+        if (headLines.length + group.length > headBudget && headLines.length > 0) break;
+        headLines.push(...group);
+        headGroupCount++;
+      }
 
-			// Collect tail groups from the end until we hit the other half
-			const tailBudget = COLLAPSED_LINES - headLines.length
-            const tailLines: string[] = []
-            let tailGroupStart = groups.length
-            for (let i = groups.length - 1; i >= headGroupCount; i--) {
-                if (
-                    tailLines.length + groups[i]!.length > tailBudget &&
-                    tailLines.length > 0
-                )
-                    break
-                tailLines.unshift(...groups[i]!)
-				tailGroupStart = i
-			}
+      // Collect tail groups from the end until we hit the other half
+      const tailBudget = COLLAPSED_LINES - headLines.length;
+      const tailLines: string[] = [];
+      let tailGroupStart = groups.length;
+      for (let i = groups.length - 1; i >= headGroupCount; i--) {
+        if (tailLines.length + groups[i]!.length > tailBudget && tailLines.length > 0) break;
+        tailLines.unshift(...groups[i]!);
+        tailGroupStart = i;
+      }
 
-			const hiddenGroups = tailGroupStart - headGroupCount
-			truncated = hiddenGroups > 0
+      const hiddenGroups = tailGroupStart - headGroupCount;
+      truncated = hiddenGroups > 0;
 
-			if (truncated) {
-				for (const line of headLines) {
-					borderedLines.push(
-						border("│") + " " + chalk.hex(mastra.specialGray)(line),
-					)
-				}
-				borderedLines.push(
-					border("│") +
-						" " +
-						chalk.hex(mastra.mainGray)(
-							`... ${originalLineCount} lines total (ctrl+e to expand)`,
-						),
-				)
-				for (const line of tailLines) {
-					borderedLines.push(
-						border("│") + " " + chalk.hex(mastra.specialGray)(line),
-					)
-				}
-			} else {
-				// Edge case: all groups fit when snapped to boundaries
-				for (const line of wrappedLines) {
-					borderedLines.push(
-						border("│") + " " + chalk.hex(mastra.specialGray)(line),
-					)
-				}
-			}
-		} else {
-			for (const line of wrappedLines) {
-				borderedLines.push(
-					border("│") + " " + chalk.hex(mastra.specialGray)(line),
-				)
-			}
-		}
+      if (truncated) {
+        for (const line of headLines) {
+          borderedLines.push(border('│') + ' ' + chalk.hex(mastra.specialGray)(line));
+        }
+        borderedLines.push(
+          border('│') + ' ' + chalk.hex(mastra.mainGray)(`... ${originalLineCount} lines total (ctrl+e to expand)`),
+        );
+        for (const line of tailLines) {
+          borderedLines.push(border('│') + ' ' + chalk.hex(mastra.specialGray)(line));
+        }
+      } else {
+        // Edge case: all groups fit when snapped to boundaries
+        for (const line of wrappedLines) {
+          borderedLines.push(border('│') + ' ' + chalk.hex(mastra.specialGray)(line));
+        }
+      }
+    } else {
+      for (const line of wrappedLines) {
+        borderedLines.push(border('│') + ' ' + chalk.hex(mastra.specialGray)(line));
+      }
+    }
 
-		const displayOutput = borderedLines.join("\n")
-		if (displayOutput.trim()) {
-			this.addChild(new Text(displayOutput, 0, 0))
-		}
+    const displayOutput = borderedLines.join('\n');
+    if (displayOutput.trim()) {
+      this.addChild(new Text(displayOutput, 0, 0));
+    }
 
-		// Current task / suggested response sections
-		if (this.data.currentTask && (this.expanded || !truncated)) {
-			const taskLine =
-				border("│") +
-				" " +
-				chalk.hex(color).bold("Current task: ") +
-				chalk.hex(mastra.specialGray)(this.data.currentTask)
-			this.addChild(new Text(truncateAnsi(taskLine, termWidth - 2), 0, 0))
-		}
+    // Current task / suggested response sections
+    if (this.data.currentTask && (this.expanded || !truncated)) {
+      const taskLine =
+        border('│') +
+        ' ' +
+        chalk.hex(color).bold('Current task: ') +
+        chalk.hex(mastra.specialGray)(this.data.currentTask);
+      this.addChild(new Text(truncateAnsi(taskLine, termWidth - 2), 0, 0));
+    }
 
-		if (this.data.suggestedResponse && (this.expanded || !truncated)) {
-			const sugLine =
-				border("│") +
-				" " +
-				chalk.hex(color).bold("Suggested response: ") +
-				chalk.hex(mastra.specialGray)(this.data.suggestedResponse)
-			this.addChild(new Text(truncateAnsi(sugLine, termWidth - 2), 0, 0))
-		}
+    if (this.data.suggestedResponse && (this.expanded || !truncated)) {
+      const sugLine =
+        border('│') +
+        ' ' +
+        chalk.hex(color).bold('Suggested response: ') +
+        chalk.hex(mastra.specialGray)(this.data.suggestedResponse);
+      this.addChild(new Text(truncateAnsi(sugLine, termWidth - 2), 0, 0));
+    }
 
-		// Bottom border with footer
-		this.addChild(new Text(`${border("└──")} ${footerText}`, 0, 0))
-	}
+    // Bottom border with footer
+    this.addChild(new Text(`${border('└──')} ${footerText}`, 0, 0));
+  }
 
-	private buildFooterText(color: string): string {
-		const isReflection = this.data.type === "reflection"
-		const emoji = "🧠"
+  private buildFooterText(color: string): string {
+    const isReflection = this.data.type === 'reflection';
+    const emoji = '🧠';
 
-		if (isReflection) {
-			// Reflection: "🧠 Reflected: Xk → Yk tokens (Zx compression) in Ns ✓"
-			const observed = formatTokens(this.data.tokensObserved ?? 0)
-			const compressed = formatTokens(
-				this.data.compressedTokens ?? this.data.observationTokens ?? 0,
-			)
-			const ratio =
-				(this.data.tokensObserved ?? 0) > 0 &&
-				(this.data.compressedTokens ?? this.data.observationTokens ?? 0) > 0
-					? `${Math.round((this.data.tokensObserved ?? 0) / (this.data.compressedTokens ?? this.data.observationTokens ?? 1))}x`
-					: ""
-			const durationStr = this.data.durationMs
-				? ` in ${(this.data.durationMs / 1000).toFixed(1)}s`
-				: ""
-			const ratioStr = ratio ? ` (${ratio} compression)` : ""
-			return `${emoji} ${chalk.hex(color)(`Reflected: ${observed} → ${compressed} tokens${ratioStr}${durationStr}`)} ${chalk.hex(mastra.green)("✓")}`
-		} else {
-			// Observation: "🧠 Observed: Xk → Yk tokens (Zx compression) in Ns ✓"
-			const observed = formatTokens(this.data.tokensObserved ?? 0)
-			const compressed = formatTokens(this.data.observationTokens ?? 0)
-			const ratio =
-				(this.data.tokensObserved ?? 0) > 0 &&
-				(this.data.observationTokens ?? 0) > 0
-					? `${Math.round((this.data.tokensObserved ?? 0) / (this.data.observationTokens ?? 1))}x`
-					: ""
-			const durationStr = this.data.durationMs
-				? ` in ${(this.data.durationMs / 1000).toFixed(1)}s`
-				: ""
-			const ratioStr = ratio ? ` (${ratio} compression)` : ""
-			return `${emoji} ${chalk.hex(color)(`Observed: ${observed} → ${compressed} tokens${ratioStr}${durationStr}`)} ${chalk.hex(mastra.green)("✓")}`
-		}
-	}
+    if (isReflection) {
+      // Reflection: "🧠 Reflected: Xk → Yk tokens (Zx compression) in Ns ✓"
+      const observed = formatTokens(this.data.tokensObserved ?? 0);
+      const compressed = formatTokens(this.data.compressedTokens ?? this.data.observationTokens ?? 0);
+      const ratio =
+        (this.data.tokensObserved ?? 0) > 0 && (this.data.compressedTokens ?? this.data.observationTokens ?? 0) > 0
+          ? `${Math.round((this.data.tokensObserved ?? 0) / (this.data.compressedTokens ?? this.data.observationTokens ?? 1))}x`
+          : '';
+      const durationStr = this.data.durationMs ? ` in ${(this.data.durationMs / 1000).toFixed(1)}s` : '';
+      const ratioStr = ratio ? ` (${ratio} compression)` : '';
+      return `${emoji} ${chalk.hex(color)(`Reflected: ${observed} → ${compressed} tokens${ratioStr}${durationStr}`)} ${chalk.hex(mastra.green)('✓')}`;
+    } else {
+      // Observation: "🧠 Observed: Xk → Yk tokens (Zx compression) in Ns ✓"
+      const observed = formatTokens(this.data.tokensObserved ?? 0);
+      const compressed = formatTokens(this.data.observationTokens ?? 0);
+      const ratio =
+        (this.data.tokensObserved ?? 0) > 0 && (this.data.observationTokens ?? 0) > 0
+          ? `${Math.round((this.data.tokensObserved ?? 0) / (this.data.observationTokens ?? 1))}x`
+          : '';
+      const durationStr = this.data.durationMs ? ` in ${(this.data.durationMs / 1000).toFixed(1)}s` : '';
+      const ratioStr = ratio ? ` (${ratio} compression)` : '';
+      return `${emoji} ${chalk.hex(color)(`Observed: ${observed} → ${compressed} tokens${ratioStr}${durationStr}`)} ${chalk.hex(mastra.green)('✓')}`;
+    }
+  }
 }

--- a/mastracode/src/tui/components/om-output.ts
+++ b/mastracode/src/tui/components/om-output.ts
@@ -167,15 +167,15 @@ export class OMOutputComponent extends Container {
 
 			// Collect tail groups from the end until we hit the other half
 			const tailBudget = COLLAPSED_LINES - headLines.length
-			const tailLines: string[] = []
-			let tailGroupStart = groups.length
-			for (let i = groups.length - 1; i >= headGroupCount; i--) {
-				if (
-					tailLines.length + groups[i].length > tailBudget &&
-					tailLines.length > 0
-				)
-					break
-				tailLines.unshift(...groups[i])
+            const tailLines: string[] = []
+            let tailGroupStart = groups.length
+            for (let i = groups.length - 1; i >= headGroupCount; i--) {
+                if (
+                    tailLines.length + groups[i]!.length > tailBudget &&
+                    tailLines.length > 0
+                )
+                    break
+                tailLines.unshift(...groups[i]!)
 				tailGroupStart = i
 			}
 

--- a/mastracode/src/tui/components/om-progress.ts
+++ b/mastracode/src/tui/components/om-progress.ts
@@ -180,13 +180,12 @@ export class OMProgressComponent extends Container {
 			return chalk.hex(mastra.darkGray)(bar) // Mastra dark gray
 		}
 	}
-
-	private spinnerFrame = 0
-	private getSpinner(): string {
-		const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
-		this.spinnerFrame = (this.spinnerFrame + 1) % frames.length
-		return frames[this.spinnerFrame]
-	}
+    private spinnerFrame = 0
+    private getSpinner(): string {
+        const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+        this.spinnerFrame = (this.spinnerFrame + 1) % frames.length
+        return frames[this.spinnerFrame]!
+    }
 
 	render(maxWidth: number): string[] {
 		this.updateDisplay()

--- a/mastracode/src/tui/components/om-progress.ts
+++ b/mastracode/src/tui/components/om-progress.ts
@@ -2,69 +2,69 @@
  * Observational Memory progress indicator component.
  * Shows when OM is observing or reflecting on conversation history.
  */
-import { Container, Text } from "@mariozechner/pi-tui"
-import chalk from "chalk"
-import { fg, mastra } from "../theme.js"
-export type OMStatus = "idle" | "observing" | "reflecting"
+import { Container, Text } from '@mariozechner/pi-tui';
+import chalk from 'chalk';
+import { fg, mastra } from '../theme.js';
+export type OMStatus = 'idle' | 'observing' | 'reflecting';
 
-export type OMBufferedStatus = "idle" | "running" | "complete"
+export type OMBufferedStatus = 'idle' | 'running' | 'complete';
 
 export interface OMProgressState {
-	status: OMStatus
-	// Active window tokens/thresholds (from data-om-status)
-	pendingTokens: number
-	threshold: number
-	thresholdPercent: number
-	observationTokens: number
-	reflectionThreshold: number
-	reflectionThresholdPercent: number
-	// Buffered state (from data-om-status)
-	buffered: {
-		observations: {
-			status: OMBufferedStatus
-			chunks: number
-			messageTokens: number
-			projectedMessageRemoval: number
-			observationTokens: number
-		}
-		reflection: {
-			status: OMBufferedStatus
-			inputObservationTokens: number
-			observationTokens: number
-		}
-	}
-	generationCount: number
-	stepNumber: number
-	cycleId?: string
-	startTime?: number
+  status: OMStatus;
+  // Active window tokens/thresholds (from data-om-status)
+  pendingTokens: number;
+  threshold: number;
+  thresholdPercent: number;
+  observationTokens: number;
+  reflectionThreshold: number;
+  reflectionThresholdPercent: number;
+  // Buffered state (from data-om-status)
+  buffered: {
+    observations: {
+      status: OMBufferedStatus;
+      chunks: number;
+      messageTokens: number;
+      projectedMessageRemoval: number;
+      observationTokens: number;
+    };
+    reflection: {
+      status: OMBufferedStatus;
+      inputObservationTokens: number;
+      observationTokens: number;
+    };
+  };
+  generationCount: number;
+  stepNumber: number;
+  cycleId?: string;
+  startTime?: number;
 }
 
 export function defaultOMProgressState(): OMProgressState {
-	return {
-		status: "idle",
-		pendingTokens: 0,
-		threshold: 30000,
-		thresholdPercent: 0,
-		observationTokens: 0,
-		reflectionThreshold: 40000,
-		reflectionThresholdPercent: 0,
-		buffered: {
-			observations: {
-				status: "idle",
-				chunks: 0,
-				messageTokens: 0,
-				projectedMessageRemoval: 0,
-				observationTokens: 0,
-			},
-			reflection: {
-				status: "idle",
-				inputObservationTokens: 0,
-				observationTokens: 0,
-			},
-		},
-		generationCount: 0,
-		stepNumber: 0,
-	}
+  return {
+    status: 'idle',
+    pendingTokens: 0,
+    threshold: 30000,
+    thresholdPercent: 0,
+    observationTokens: 0,
+    reflectionThreshold: 40000,
+    reflectionThresholdPercent: 0,
+    buffered: {
+      observations: {
+        status: 'idle',
+        chunks: 0,
+        messageTokens: 0,
+        projectedMessageRemoval: 0,
+        observationTokens: 0,
+      },
+      reflection: {
+        status: 'idle',
+        inputObservationTokens: 0,
+        observationTokens: 0,
+      },
+    },
+    generationCount: 0,
+    stepNumber: 0,
+  };
 }
 
 /**
@@ -72,146 +72,138 @@ export function defaultOMProgressState(): OMProgressState {
  * Shows a compact indicator when observation/reflection is happening.
  */
 export class OMProgressComponent extends Container {
-	private state: OMProgressState = defaultOMProgressState()
-	private statusText: Text
+  private state: OMProgressState = defaultOMProgressState();
+  private statusText: Text;
 
-	constructor() {
-		super()
-		this.statusText = new Text("")
-		this.children.push(this.statusText)
-	}
+  constructor() {
+    super();
+    this.statusText = new Text('');
+    this.children.push(this.statusText);
+  }
 
-	updateProgress(progress: {
-		pendingTokens: number
-		threshold: number
-		thresholdPercent: number
-		observationTokens: number
-		reflectionThreshold: number
-		reflectionThresholdPercent: number
-	}): void {
-		this.state.pendingTokens = progress.pendingTokens
-		this.state.threshold = progress.threshold
-		this.state.thresholdPercent = progress.thresholdPercent
-		this.state.observationTokens = progress.observationTokens
-		this.state.reflectionThreshold = progress.reflectionThreshold
-		this.state.reflectionThresholdPercent = progress.reflectionThresholdPercent
-		this.updateDisplay()
-	}
+  updateProgress(progress: {
+    pendingTokens: number;
+    threshold: number;
+    thresholdPercent: number;
+    observationTokens: number;
+    reflectionThreshold: number;
+    reflectionThresholdPercent: number;
+  }): void {
+    this.state.pendingTokens = progress.pendingTokens;
+    this.state.threshold = progress.threshold;
+    this.state.thresholdPercent = progress.thresholdPercent;
+    this.state.observationTokens = progress.observationTokens;
+    this.state.reflectionThreshold = progress.reflectionThreshold;
+    this.state.reflectionThresholdPercent = progress.reflectionThresholdPercent;
+    this.updateDisplay();
+  }
 
-	startObservation(cycleId: string, _tokensToObserve: number): void {
-		this.state.status = "observing"
-		this.state.cycleId = cycleId
-		this.state.startTime = Date.now()
-		this.updateDisplay()
-	}
+  startObservation(cycleId: string, _tokensToObserve: number): void {
+    this.state.status = 'observing';
+    this.state.cycleId = cycleId;
+    this.state.startTime = Date.now();
+    this.updateDisplay();
+  }
 
-	endObservation(): void {
-		this.state.status = "idle"
-		this.state.cycleId = undefined
-		this.state.startTime = undefined
-		this.updateDisplay()
-	}
+  endObservation(): void {
+    this.state.status = 'idle';
+    this.state.cycleId = undefined;
+    this.state.startTime = undefined;
+    this.updateDisplay();
+  }
 
-	startReflection(cycleId: string): void {
-		this.state.status = "reflecting"
-		this.state.cycleId = cycleId
-		this.state.startTime = Date.now()
-		this.updateDisplay()
-	}
+  startReflection(cycleId: string): void {
+    this.state.status = 'reflecting';
+    this.state.cycleId = cycleId;
+    this.state.startTime = Date.now();
+    this.updateDisplay();
+  }
 
-	endReflection(): void {
-		this.state.status = "idle"
-		this.state.cycleId = undefined
-		this.state.startTime = undefined
-		this.updateDisplay()
-	}
+  endReflection(): void {
+    this.state.status = 'idle';
+    this.state.cycleId = undefined;
+    this.state.startTime = undefined;
+    this.updateDisplay();
+  }
 
-	failOperation(): void {
-		this.state.status = "idle"
-		this.state.cycleId = undefined
-		this.state.startTime = undefined
-		this.updateDisplay()
-	}
+  failOperation(): void {
+    this.state.status = 'idle';
+    this.state.cycleId = undefined;
+    this.state.startTime = undefined;
+    this.updateDisplay();
+  }
 
-	getStatus(): OMStatus {
-		return this.state.status
-	}
+  getStatus(): OMStatus {
+    return this.state.status;
+  }
 
-	private updateDisplay(): void {
-		if (this.state.status === "idle") {
-			// Show threshold progress when idle (if any pending tokens)
-			if (this.state.thresholdPercent > 0) {
-				const percent = Math.round(this.state.thresholdPercent)
-				const bar = this.renderProgressBar(percent, 10)
-				this.statusText.setText(fg("muted", `OM ${bar} ${percent}%`))
-			} else {
-				this.statusText.setText("")
-			}
-		} else if (this.state.status === "observing") {
-			const elapsed = this.state.startTime
-				? Math.round((Date.now() - this.state.startTime) / 1000)
-				: 0
-			const spinner = this.getSpinner()
-			this.statusText.setText(
-				chalk.hex(mastra.orange)(`${spinner} Observing... ${elapsed}s`),
-			)
-		} else if (this.state.status === "reflecting") {
-			const elapsed = this.state.startTime
-				? Math.round((Date.now() - this.state.startTime) / 1000)
-				: 0
-			const spinner = this.getSpinner()
-			this.statusText.setText(
-				chalk.hex(mastra.pink)(`${spinner} Reflecting... ${elapsed}s`),
-			)
-		}
-	}
-
-	private renderProgressBar(percent: number, width: number): string {
-		const filled = Math.min(width, Math.round((percent / 100) * width))
-		const empty = width - filled
-		const bar = "━".repeat(filled) + "─".repeat(empty)
-
-		// Color based on threshold proximity — Mastra brand colors
-		if (percent >= 90) {
-			return chalk.hex(mastra.red)(bar) // Mastra red
-		} else if (percent >= 70) {
-			return chalk.hex(mastra.orange)(bar) // Mastra orange
-		} else {
-			return chalk.hex(mastra.darkGray)(bar) // Mastra dark gray
-		}
-	}
-    private spinnerFrame = 0
-    private getSpinner(): string {
-        const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
-        this.spinnerFrame = (this.spinnerFrame + 1) % frames.length
-        return frames[this.spinnerFrame]!
+  private updateDisplay(): void {
+    if (this.state.status === 'idle') {
+      // Show threshold progress when idle (if any pending tokens)
+      if (this.state.thresholdPercent > 0) {
+        const percent = Math.round(this.state.thresholdPercent);
+        const bar = this.renderProgressBar(percent, 10);
+        this.statusText.setText(fg('muted', `OM ${bar} ${percent}%`));
+      } else {
+        this.statusText.setText('');
+      }
+    } else if (this.state.status === 'observing') {
+      const elapsed = this.state.startTime ? Math.round((Date.now() - this.state.startTime) / 1000) : 0;
+      const spinner = this.getSpinner();
+      this.statusText.setText(chalk.hex(mastra.orange)(`${spinner} Observing... ${elapsed}s`));
+    } else if (this.state.status === 'reflecting') {
+      const elapsed = this.state.startTime ? Math.round((Date.now() - this.state.startTime) / 1000) : 0;
+      const spinner = this.getSpinner();
+      this.statusText.setText(chalk.hex(mastra.pink)(`${spinner} Reflecting... ${elapsed}s`));
     }
+  }
 
-	render(maxWidth: number): string[] {
-		this.updateDisplay()
-		return this.statusText.render(maxWidth)
-	}
+  private renderProgressBar(percent: number, width: number): string {
+    const filled = Math.min(width, Math.round((percent / 100) * width));
+    const empty = width - filled;
+    const bar = '━'.repeat(filled) + '─'.repeat(empty);
+
+    // Color based on threshold proximity — Mastra brand colors
+    if (percent >= 90) {
+      return chalk.hex(mastra.red)(bar); // Mastra red
+    } else if (percent >= 70) {
+      return chalk.hex(mastra.orange)(bar); // Mastra orange
+    } else {
+      return chalk.hex(mastra.darkGray)(bar); // Mastra dark gray
+    }
+  }
+  private spinnerFrame = 0;
+  private getSpinner(): string {
+    const frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+    this.spinnerFrame = (this.spinnerFrame + 1) % frames.length;
+    return frames[this.spinnerFrame]!;
+  }
+
+  render(maxWidth: number): string[] {
+    this.updateDisplay();
+    return this.statusText.render(maxWidth);
+  }
 }
 
 /** Format token count without k suffix (e.g., 7234 -> "7.2", 200 -> "0.2", 0 -> "0") */
 function formatTokensValue(n: number): string {
-	if (n === 0) return "0"
-	const k = n / 1000
-	const s = k.toFixed(1)
-	return s.endsWith(".0") ? s.slice(0, -2) : s
+  if (n === 0) return '0';
+  const k = n / 1000;
+  const s = k.toFixed(1);
+  return s.endsWith('.0') ? s.slice(0, -2) : s;
 }
 
 /** Format token threshold with k suffix (e.g., 30000 -> "30k", 40000 -> "40k") */
 function formatTokensThreshold(n: number): string {
-	const k = n / 1000
-	const s = k.toFixed(1)
-	return (s.endsWith(".0") ? s.slice(0, -2) : s) + "k"
+  const k = n / 1000;
+  const s = k.toFixed(1);
+  return (s.endsWith('.0') ? s.slice(0, -2) : s) + 'k';
 }
 
 function colorByPercent(text: string, percent: number): string {
-	if (percent >= 90) return chalk.hex(mastra.red)(text) // Mastra red
-	if (percent >= 70) return chalk.hex(mastra.orange)(text) // Mastra orange
-	return chalk.hex(mastra.darkGray)(text) // Mastra dark gray
+  if (percent >= 90) return chalk.hex(mastra.red)(text); // Mastra red
+  if (percent >= 70) return chalk.hex(mastra.orange)(text); // Mastra orange
+  return chalk.hex(mastra.darkGray)(text); // Mastra dark gray
 }
 /**
  * Format OM observation threshold for status bar.
@@ -225,28 +217,25 @@ function colorByPercent(text: string, percent: number): string {
  *                      Receives the raw label string, returns styled string.
  */
 export function formatObservationStatus(
-	state: OMProgressState,
-	compact?: "percentOnly" | "noBuffer" | "full",
-	labelStyler?: (label: string) => string,
+  state: OMProgressState,
+  compact?: 'percentOnly' | 'noBuffer' | 'full',
+  labelStyler?: (label: string) => string,
 ): string {
-	// Status is now shown in the mode badge, so just show the metrics
-	const percent = Math.round(state.thresholdPercent)
-	const pct = colorByPercent(`${percent}%`, percent)
-	const defaultStyler = (s: string) => chalk.hex(mastra.specialGray)(s)
-	const styleLabel = labelStyler ?? defaultStyler
-	if (compact === "percentOnly") {
-		return styleLabel("msg ") + pct
-	}
-	const label = compact === "full" ? "messages" : "msg"
-	const fraction = `${formatTokensValue(state.pendingTokens)}/${formatTokensThreshold(state.threshold)}`
-	const buffered =
-		compact !== "noBuffer" &&
-		state.buffered.observations.projectedMessageRemoval > 0
-			? chalk.hex("#555")(
-					` ↓${formatTokensThreshold(state.buffered.observations.projectedMessageRemoval)}`,
-				)
-			: ""
-	return styleLabel(`${label} `) + colorByPercent(fraction, percent) + buffered
+  // Status is now shown in the mode badge, so just show the metrics
+  const percent = Math.round(state.thresholdPercent);
+  const pct = colorByPercent(`${percent}%`, percent);
+  const defaultStyler = (s: string) => chalk.hex(mastra.specialGray)(s);
+  const styleLabel = labelStyler ?? defaultStyler;
+  if (compact === 'percentOnly') {
+    return styleLabel('msg ') + pct;
+  }
+  const label = compact === 'full' ? 'messages' : 'msg';
+  const fraction = `${formatTokensValue(state.pendingTokens)}/${formatTokensThreshold(state.threshold)}`;
+  const buffered =
+    compact !== 'noBuffer' && state.buffered.observations.projectedMessageRemoval > 0
+      ? chalk.hex('#555')(` ↓${formatTokensThreshold(state.buffered.observations.projectedMessageRemoval)}`)
+      : '';
+  return styleLabel(`${label} `) + colorByPercent(fraction, percent) + buffered;
 }
 /**
  * Format OM reflection threshold for status bar.
@@ -260,33 +249,31 @@ export function formatObservationStatus(
  *                      Receives the raw label string, returns styled string.
  */
 export function formatReflectionStatus(
-	state: OMProgressState,
-	compact?: "percentOnly" | "noBuffer" | "full",
-	labelStyler?: (label: string) => string,
+  state: OMProgressState,
+  compact?: 'percentOnly' | 'noBuffer' | 'full',
+  labelStyler?: (label: string) => string,
 ): string {
-	// Status is now shown in the mode badge, so just show the metrics
-	const percent = Math.round(state.reflectionThresholdPercent)
-	const pct = colorByPercent(`${percent}%`, percent)
-	const defaultStyler = (s: string) => chalk.hex(mastra.specialGray)(s)
-	const styleLabel = labelStyler ?? defaultStyler
-	const label = styleLabel(compact === "full" ? "memory" : "mem") + " "
-	if (compact === "percentOnly") {
-		return label + pct
-	}
-	const fraction = `${formatTokensValue(state.observationTokens)}/${formatTokensThreshold(state.reflectionThreshold)}`
-	const savings =
-		state.buffered.reflection.inputObservationTokens -
-		state.buffered.reflection.observationTokens
-	const buffered =
-		compact !== "noBuffer" && state.buffered.reflection.status === "complete"
-			? chalk.hex("#555")(` ↓${formatTokensThreshold(savings)}`)
-			: ""
-	return label + colorByPercent(fraction, percent) + buffered
+  // Status is now shown in the mode badge, so just show the metrics
+  const percent = Math.round(state.reflectionThresholdPercent);
+  const pct = colorByPercent(`${percent}%`, percent);
+  const defaultStyler = (s: string) => chalk.hex(mastra.specialGray)(s);
+  const styleLabel = labelStyler ?? defaultStyler;
+  const label = styleLabel(compact === 'full' ? 'memory' : 'mem') + ' ';
+  if (compact === 'percentOnly') {
+    return label + pct;
+  }
+  const fraction = `${formatTokensValue(state.observationTokens)}/${formatTokensThreshold(state.reflectionThreshold)}`;
+  const savings = state.buffered.reflection.inputObservationTokens - state.buffered.reflection.observationTokens;
+  const buffered =
+    compact !== 'noBuffer' && state.buffered.reflection.status === 'complete'
+      ? chalk.hex('#555')(` ↓${formatTokensThreshold(savings)}`)
+      : '';
+  return label + colorByPercent(fraction, percent) + buffered;
 }
 
 /**
  * @deprecated Use formatObservationStatus and formatReflectionStatus instead
  */
 export function formatOMStatus(state: OMProgressState): string {
-	return formatObservationStatus(state)
+  return formatObservationStatus(state);
 }

--- a/mastracode/src/tui/components/om-settings.ts
+++ b/mastracode/src/tui/components/om-settings.ts
@@ -76,10 +76,10 @@ function parseTokenInput(input: string): number | null {
 	if (!trimmed) return null
 
 	// Match patterns like "30k", "30", "30000", "1.5k"
-	const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*k?$/)
-	if (!match) return null
+    const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*k?$/)
+    if (!match) return null
 
-	const num = parseFloat(match[1])
+    const num = parseFloat(match[1]!)
 	if (isNaN(num) || num <= 0) return null
 
 	// "30k" → 30,000

--- a/mastracode/src/tui/components/om-settings.ts
+++ b/mastracode/src/tui/components/om-settings.ts
@@ -7,91 +7,77 @@
  */
 
 import {
-	Box,
-	Container,
-	
-	fuzzyFilter,
-	getEditorKeybindings,
-	Input,
-	SelectList,
-	
-	
-	SettingsList,
-	Spacer,
-	Text
-	
-} from "@mariozechner/pi-tui"
-import type {Focusable, SelectItem, SettingItem, TUI} from "@mariozechner/pi-tui";
-import {
-	fg,
-	bg,
-	bold,
-	getSettingsListTheme,
-	getSelectListTheme,
-} from "../theme.js"
+  Box,
+  Container,
+  fuzzyFilter,
+  getEditorKeybindings,
+  Input,
+  SelectList,
+  SettingsList,
+  Spacer,
+  Text,
+} from '@mariozechner/pi-tui';
+import type { Focusable, SelectItem, SettingItem, TUI } from '@mariozechner/pi-tui';
+import { fg, bg, bold, getSettingsListTheme, getSelectListTheme } from '../theme.js';
 
 // =============================================================================
 // Types
 // =============================================================================
 
 export interface OMSettingsConfig {
-	observerModelId: string
-	reflectorModelId: string
-	observationThreshold: number
-	reflectionThreshold: number
+  observerModelId: string;
+  reflectorModelId: string;
+  observationThreshold: number;
+  reflectionThreshold: number;
 }
 
 export interface OMSettingsCallbacks {
-	onObserverModelChange: (modelId: string) => void
-	onReflectorModelChange: (modelId: string) => void
-	onObservationThresholdChange: (value: number) => void
-	onReflectionThresholdChange: (value: number) => void
-	onClose: () => void
+  onObserverModelChange: (modelId: string) => void;
+  onReflectorModelChange: (modelId: string) => void;
+  onObservationThresholdChange: (value: number) => void;
+  onReflectionThresholdChange: (value: number) => void;
+  onClose: () => void;
 }
 
 export interface ModelOption {
-	id: string
-	label: string
+  id: string;
+  label: string;
 }
 
 // =============================================================================
 // Threshold presets (in tokens)
 // =============================================================================
 
-const OBSERVATION_THRESHOLDS = [
-	5_000, 10_000, 15_000, 20_000, 30_000, 50_000, 75_000, 100_000,
-]
+const OBSERVATION_THRESHOLDS = [5_000, 10_000, 15_000, 20_000, 30_000, 50_000, 75_000, 100_000];
 
-const REFLECTION_THRESHOLDS = [
-	10_000, 20_000, 30_000, 40_000, 60_000, 80_000, 100_000, 150_000,
-]
+const REFLECTION_THRESHOLDS = [10_000, 20_000, 30_000, 40_000, 60_000, 80_000, 100_000, 150_000];
 
 function formatTokens(n: number): string {
-	if (n >= 1000) return `${(n / 1000).toFixed(0)}k`
-	return String(n)
+  if (n >= 1000) return `${(n / 1000).toFixed(0)}k`;
+  return String(n);
 }
 
 function parseTokenInput(input: string): number | null {
-	const trimmed = input.trim().toLowerCase()
-	if (!trimmed) return null
+  const trimmed = input.trim().toLowerCase();
+  if (!trimmed) return null;
 
-	// Match patterns like "30k", "30", "30000", "1.5k"
-    const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*k?$/)
-    if (!match) return null
+  // Match patterns like "30k", "30", "30000", "1.5k"
+  const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*k?$/);
+  if (!match) return null;
 
-    const num = parseFloat(match[1]!)
-	if (isNaN(num) || num <= 0) return null
+  const num = parseFloat(match[1]!);
+  if (isNaN(num) || num <= 0) return null;
 
-	// "30k" → 30,000
-	if (trimmed.endsWith("k")) {
-		return num * 1000
-	}
-	// Small numbers (< 500) assumed to be in thousands: "30" → 30,000
-	if (num < 500) {
-		return num * 1000
-	}
-	// Large numbers used as-is: "30000" → 30,000
-	return num
+  // "30k" → 30,000
+  if (trimmed.endsWith('k')) {
+    return num * 1000;
+  }
+  // Small numbers (< 500) assumed to be in thousands: "30" → 30,000
+  if (num < 500) {
+    return num * 1000;
+  }
+  // Large numbers used as-is: "30000" → 30,000
+  return num;
 }
 
 // =============================================================================
@@ -99,105 +85,89 @@ function parseTokenInput(input: string): number | null {
 // =============================================================================
 
 class ThresholdSubmenu extends Container {
-	private input: Input
-	private selectList: SelectList
-	private onDone: (value: number) => void
-	private onBack: () => void
-	private inInputMode = true
+  private input: Input;
+  private selectList: SelectList;
+  private onDone: (value: number) => void;
+  private onBack: () => void;
+  private inInputMode = true;
 
-	constructor(
-		title: string,
-		currentValue: number,
-		presets: number[],
-		onDone: (value: number) => void,
-		onBack: () => void,
-	) {
-		super()
-		this.onDone = onDone
-		this.onBack = onBack
+  constructor(
+    title: string,
+    currentValue: number,
+    presets: number[],
+    onDone: (value: number) => void,
+    onBack: () => void,
+  ) {
+    super();
+    this.onDone = onDone;
+    this.onBack = onBack;
 
-		this.addChild(new Text(bold(fg("accent", title)), 0, 0))
-		this.addChild(new Spacer(1))
+    this.addChild(new Text(bold(fg('accent', title)), 0, 0));
+    this.addChild(new Spacer(1));
 
-		// Input for custom value — type a number like 30 for 30k
-		this.addChild(
-			new Text(
-				fg("muted", "  _k tokens (type a number, e.g. 30 for 30k):"),
-				0,
-				0,
-			),
-		)
-		this.input = new Input()
-		this.addChild(this.input)
-		this.addChild(new Spacer(1))
+    // Input for custom value — type a number like 30 for 30k
+    this.addChild(new Text(fg('muted', '  _k tokens (type a number, e.g. 30 for 30k):'), 0, 0));
+    this.input = new Input();
+    this.addChild(this.input);
+    this.addChild(new Spacer(1));
 
-		// Preset list
-		this.addChild(new Text(fg("muted", "  Or pick a preset:"), 0, 0))
+    // Preset list
+    this.addChild(new Text(fg('muted', '  Or pick a preset:'), 0, 0));
 
-		const items: SelectItem[] = presets.map((p) => ({
-			value: String(p),
-			label: `  ${formatTokens(p)} tokens`,
-		}))
+    const items: SelectItem[] = presets.map(p => ({
+      value: String(p),
+      label: `  ${formatTokens(p)} tokens`,
+    }));
 
-		this.selectList = new SelectList(
-			items,
-			Math.min(items.length, 8),
-			getSelectListTheme(),
-		)
+    this.selectList = new SelectList(items, Math.min(items.length, 8), getSelectListTheme());
 
-		// Pre-select current value
-		const currentIndex = presets.indexOf(currentValue)
-		if (currentIndex !== -1) {
-			this.selectList.setSelectedIndex(currentIndex)
-		}
+    // Pre-select current value
+    const currentIndex = presets.indexOf(currentValue);
+    if (currentIndex !== -1) {
+      this.selectList.setSelectedIndex(currentIndex);
+    }
 
-		this.selectList.onSelect = (item: SelectItem) => {
-			this.onDone(parseInt(item.value, 10))
-		}
-		this.selectList.onCancel = onBack
+    this.selectList.onSelect = (item: SelectItem) => {
+      this.onDone(parseInt(item.value, 10));
+    };
+    this.selectList.onCancel = onBack;
 
-		this.addChild(this.selectList)
-		this.addChild(new Spacer(1))
-		this.addChild(
-			new Text(
-				fg("dim", "  Enter to confirm · ↓ for presets · Esc to go back"),
-				0,
-				0,
-			),
-		)
-	}
+    this.addChild(this.selectList);
+    this.addChild(new Spacer(1));
+    this.addChild(new Text(fg('dim', '  Enter to confirm · ↓ for presets · Esc to go back'), 0, 0));
+  }
 
-	handleInput(data: string): void {
-		if (this.inInputMode) {
-			// Enter — submit the typed value
-			if (data === "\r" || data === "\n") {
-				const parsed = parseTokenInput(this.input.getValue())
-				if (parsed) {
-					this.onDone(parsed)
-				}
-				return
-			}
+  handleInput(data: string): void {
+    if (this.inInputMode) {
+      // Enter — submit the typed value
+      if (data === '\r' || data === '\n') {
+        const parsed = parseTokenInput(this.input.getValue());
+        if (parsed) {
+          this.onDone(parsed);
+        }
+        return;
+      }
 
-			// Escape
-			if (data === "\x1b" || data === "\x1b\x1b") {
-				this.onBack()
-				return
-			}
+      // Escape
+      if (data === '\x1b' || data === '\x1b\x1b') {
+        this.onBack();
+        return;
+      }
 
-			// Down arrow — switch to preset list
-			if (data === "\x1b[B") {
-				this.inInputMode = false
-				return
-			}
+      // Down arrow — switch to preset list
+      if (data === '\x1b[B') {
+        this.inInputMode = false;
+        return;
+      }
 
-			// Delegate to input (numbers, backspace, etc.)
-			this.input.handleInput(data)
-		} else {
-			// In preset list mode
-			// Escape — go back (handled by selectList.onCancel)
-			this.selectList.handleInput(data)
-		}
-	}
+      // Delegate to input (numbers, backspace, etc.)
+      this.input.handleInput(data);
+    } else {
+      // In preset list mode
+      // Escape — go back (handled by selectList.onCancel)
+      this.selectList.handleInput(data);
+    }
+  }
 }
 
 // =============================================================================
@@ -205,138 +175,113 @@ class ThresholdSubmenu extends Container {
 // =============================================================================
 
 class ModelSelectSubmenu extends Container {
-	private searchInput: Input
-	private listContainer: Container
-	private allModels: ModelOption[]
-	private filteredModels: ModelOption[]
-	private selectedIndex = 0
-	private currentModelId: string
-	private onSelect: (modelId: string) => void
-	private onCancel: () => void
-	private tui: TUI
+  private searchInput: Input;
+  private listContainer: Container;
+  private allModels: ModelOption[];
+  private filteredModels: ModelOption[];
+  private selectedIndex = 0;
+  private currentModelId: string;
+  private onSelect: (modelId: string) => void;
+  private onCancel: () => void;
+  private tui: TUI;
 
-	constructor(
-		title: string,
-		models: ModelOption[],
-		currentModelId: string,
-		onSelect: (modelId: string) => void,
-		onCancel: () => void,
-		tui: TUI,
-	) {
-		super()
-		this.allModels = models
-		this.filteredModels = models
-		this.currentModelId = currentModelId
-		this.onSelect = onSelect
-		this.onCancel = onCancel
-		this.tui = tui
+  constructor(
+    title: string,
+    models: ModelOption[],
+    currentModelId: string,
+    onSelect: (modelId: string) => void,
+    onCancel: () => void,
+    tui: TUI,
+  ) {
+    super();
+    this.allModels = models;
+    this.filteredModels = models;
+    this.currentModelId = currentModelId;
+    this.onSelect = onSelect;
+    this.onCancel = onCancel;
+    this.tui = tui;
 
-		this.addChild(new Text(bold(fg("accent", title)), 0, 0))
-		this.addChild(new Spacer(1))
-		this.addChild(
-			new Text(
-				fg("muted", "Type to search · ↑↓ navigate · Enter select · Esc back"),
-				0,
-				0,
-			),
-		)
-		this.addChild(new Spacer(1))
+    this.addChild(new Text(bold(fg('accent', title)), 0, 0));
+    this.addChild(new Spacer(1));
+    this.addChild(new Text(fg('muted', 'Type to search · ↑↓ navigate · Enter select · Esc back'), 0, 0));
+    this.addChild(new Spacer(1));
 
-		this.searchInput = new Input()
-		this.addChild(this.searchInput)
-		this.addChild(new Spacer(1))
+    this.searchInput = new Input();
+    this.addChild(this.searchInput);
+    this.addChild(new Spacer(1));
 
-		this.listContainer = new Container()
-		this.addChild(this.listContainer)
+    this.listContainer = new Container();
+    this.addChild(this.listContainer);
 
-		// Pre-select current model
-		const currentIndex = models.findIndex((m) => m.id === currentModelId)
-		if (currentIndex !== -1) {
-			this.selectedIndex = currentIndex
-		}
+    // Pre-select current model
+    const currentIndex = models.findIndex(m => m.id === currentModelId);
+    if (currentIndex !== -1) {
+      this.selectedIndex = currentIndex;
+    }
 
-		this.updateList()
-	}
+    this.updateList();
+  }
 
-	private filterModels(query: string): void {
-		this.filteredModels = query
-			? fuzzyFilter(this.allModels, query, (m) => `${m.id} ${m.label}`)
-			: this.allModels
+  private filterModels(query: string): void {
+    this.filteredModels = query ? fuzzyFilter(this.allModels, query, m => `${m.id} ${m.label}`) : this.allModels;
 
-		this.selectedIndex = Math.min(
-			this.selectedIndex,
-			Math.max(0, this.filteredModels.length - 1),
-		)
-		this.updateList()
-	}
+    this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.filteredModels.length - 1));
+    this.updateList();
+  }
 
-	private updateList(): void {
-		this.listContainer.clear()
+  private updateList(): void {
+    this.listContainer.clear();
 
-		const maxVisible = 10
-		const total = this.filteredModels.length
-		const startIndex = Math.max(
-			0,
-			Math.min(
-				this.selectedIndex - Math.floor(maxVisible / 2),
-				total - maxVisible,
-			),
-		)
-		const endIndex = Math.min(startIndex + maxVisible, total)
+    const maxVisible = 10;
+    const total = this.filteredModels.length;
+    const startIndex = Math.max(0, Math.min(this.selectedIndex - Math.floor(maxVisible / 2), total - maxVisible));
+    const endIndex = Math.min(startIndex + maxVisible, total);
 
-		for (let i = startIndex; i < endIndex; i++) {
-			const item = this.filteredModels[i]!
-			const isSelected = i === this.selectedIndex
-			const isCurrent = item.id === this.currentModelId
-			const checkmark = isCurrent ? fg("success", " ✓") : ""
+    for (let i = startIndex; i < endIndex; i++) {
+      const item = this.filteredModels[i]!;
+      const isSelected = i === this.selectedIndex;
+      const isCurrent = item.id === this.currentModelId;
+      const checkmark = isCurrent ? fg('success', ' ✓') : '';
 
-			const line = isSelected
-				? fg("accent", `→ ${item.label}`) + checkmark
-				: `  ${item.label}` + checkmark
+      const line = isSelected ? fg('accent', `→ ${item.label}`) + checkmark : `  ${item.label}` + checkmark;
 
-			this.listContainer.addChild(new Text(line, 0, 0))
-		}
+      this.listContainer.addChild(new Text(line, 0, 0));
+    }
 
-		if (startIndex > 0 || endIndex < total) {
-			this.listContainer.addChild(
-				new Text(fg("muted", `(${this.selectedIndex + 1}/${total})`), 0, 0),
-			)
-		}
+    if (startIndex > 0 || endIndex < total) {
+      this.listContainer.addChild(new Text(fg('muted', `(${this.selectedIndex + 1}/${total})`), 0, 0));
+    }
 
-		if (total === 0) {
-			this.listContainer.addChild(
-				new Text(fg("muted", "No matching models"), 0, 0),
-			)
-		}
-	}
+    if (total === 0) {
+      this.listContainer.addChild(new Text(fg('muted', 'No matching models'), 0, 0));
+    }
+  }
 
-	handleInput(data: string): void {
-		const kb = getEditorKeybindings()
-		const total = this.filteredModels.length
+  handleInput(data: string): void {
+    const kb = getEditorKeybindings();
+    const total = this.filteredModels.length;
 
-		if (kb.matches(data, "selectUp")) {
-			if (total === 0) return
-			this.selectedIndex =
-				this.selectedIndex === 0 ? total - 1 : this.selectedIndex - 1
-			this.updateList()
-			this.tui.requestRender()
-		} else if (kb.matches(data, "selectDown")) {
-			if (total === 0) return
-			this.selectedIndex =
-				this.selectedIndex === total - 1 ? 0 : this.selectedIndex + 1
-			this.updateList()
-			this.tui.requestRender()
-		} else if (kb.matches(data, "selectConfirm")) {
-			const selected = this.filteredModels[this.selectedIndex]
-			if (selected) this.onSelect(selected.id)
-		} else if (kb.matches(data, "selectCancel")) {
-			this.onCancel()
-		} else {
-			this.searchInput.handleInput(data)
-			this.filterModels(this.searchInput.getValue())
-			this.tui.requestRender()
-		}
-	}
+    if (kb.matches(data, 'selectUp')) {
+      if (total === 0) return;
+      this.selectedIndex = this.selectedIndex === 0 ? total - 1 : this.selectedIndex - 1;
+      this.updateList();
+      this.tui.requestRender();
+    } else if (kb.matches(data, 'selectDown')) {
+      if (total === 0) return;
+      this.selectedIndex = this.selectedIndex === total - 1 ? 0 : this.selectedIndex + 1;
+      this.updateList();
+      this.tui.requestRender();
+    } else if (kb.matches(data, 'selectConfirm')) {
+      const selected = this.filteredModels[this.selectedIndex];
+      if (selected) this.onSelect(selected.id);
+    } else if (kb.matches(data, 'selectCancel')) {
+      this.onCancel();
+    } else {
+      this.searchInput.handleInput(data);
+      this.filterModels(this.searchInput.getValue());
+      this.tui.requestRender();
+    }
+  }
 }
 
 // =============================================================================
@@ -344,130 +289,122 @@ class ModelSelectSubmenu extends Container {
 // =============================================================================
 
 export class OMSettingsComponent extends Box implements Focusable {
-	private settingsList: SettingsList
+  private settingsList: SettingsList;
 
-	// Focusable implementation
-	private _focused = false
-	get focused(): boolean {
-		return this._focused
-	}
-	set focused(value: boolean) {
-		this._focused = value
-	}
+  // Focusable implementation
+  private _focused = false;
+  get focused(): boolean {
+    return this._focused;
+  }
+  set focused(value: boolean) {
+    this._focused = value;
+  }
 
-	constructor(
-		config: OMSettingsConfig,
-		callbacks: OMSettingsCallbacks,
-		models: ModelOption[],
-		tui: TUI,
-	) {
-		super(2, 1, (text: string) => bg("overlayBg", text))
+  constructor(config: OMSettingsConfig, callbacks: OMSettingsCallbacks, models: ModelOption[], tui: TUI) {
+    super(2, 1, (text: string) => bg('overlayBg', text));
 
-		// Title
-		this.addChild(
-			new Text(bold(fg("accent", "Observational Memory Settings")), 0, 0),
-		)
-		this.addChild(new Spacer(1))
+    // Title
+    this.addChild(new Text(bold(fg('accent', 'Observational Memory Settings')), 0, 0));
+    this.addChild(new Spacer(1));
 
-		// Build settings items
-		const items: SettingItem[] = [
-			{
-				id: "observer-model",
-				label: "Observer model",
-				description: "Model used for observing and summarizing message history",
-				currentValue: getShortModelName(config.observerModelId),
-				submenu: (_currentValue, done) =>
-					new ModelSelectSubmenu(
-						"Observer Model",
-						models,
-						config.observerModelId,
-						(modelId) => {
-							config.observerModelId = modelId
-							callbacks.onObserverModelChange(modelId)
-							done(getShortModelName(modelId))
-						},
-						() => done(),
-						tui,
-					),
-			},
-			{
-				id: "reflector-model",
-				label: "Reflector model",
-				description:
-					"Model used for compressing observations when they grow too large",
-				currentValue: getShortModelName(config.reflectorModelId),
-				submenu: (_currentValue, done) =>
-					new ModelSelectSubmenu(
-						"Reflector Model",
-						models,
-						config.reflectorModelId,
-						(modelId) => {
-							config.reflectorModelId = modelId
-							callbacks.onReflectorModelChange(modelId)
-							done(getShortModelName(modelId))
-						},
-						() => done(),
-						tui,
-					),
-			},
-			{
-				id: "obs-threshold",
-				label: "Observation threshold",
-				description:
-					"Token count before triggering observation. " +
-					"Lower = more frequent, higher = more context before observing",
-				currentValue: formatTokens(config.observationThreshold),
-				submenu: (_currentValue, done) =>
-					new ThresholdSubmenu(
-						"Observation Threshold",
-						config.observationThreshold,
-						OBSERVATION_THRESHOLDS,
-						(value) => {
-							config.observationThreshold = value
-							callbacks.onObservationThresholdChange(value)
-							done(formatTokens(value))
-						},
-						() => done(),
-					),
-			},
-			{
-				id: "ref-threshold",
-				label: "Reflection threshold",
-				description:
-					"Token count of observations before triggering compression. " +
-					"Lower = more frequent, higher = more observations before compressing",
-				currentValue: formatTokens(config.reflectionThreshold),
-				submenu: (_currentValue, done) =>
-					new ThresholdSubmenu(
-						"Reflection Threshold",
-						config.reflectionThreshold,
-						REFLECTION_THRESHOLDS,
-						(value) => {
-							config.reflectionThreshold = value
-							callbacks.onReflectionThresholdChange(value)
-							done(formatTokens(value))
-						},
-						() => done(),
-					),
-			},
-		]
+    // Build settings items
+    const items: SettingItem[] = [
+      {
+        id: 'observer-model',
+        label: 'Observer model',
+        description: 'Model used for observing and summarizing message history',
+        currentValue: getShortModelName(config.observerModelId),
+        submenu: (_currentValue, done) =>
+          new ModelSelectSubmenu(
+            'Observer Model',
+            models,
+            config.observerModelId,
+            modelId => {
+              config.observerModelId = modelId;
+              callbacks.onObserverModelChange(modelId);
+              done(getShortModelName(modelId));
+            },
+            () => done(),
+            tui,
+          ),
+      },
+      {
+        id: 'reflector-model',
+        label: 'Reflector model',
+        description: 'Model used for compressing observations when they grow too large',
+        currentValue: getShortModelName(config.reflectorModelId),
+        submenu: (_currentValue, done) =>
+          new ModelSelectSubmenu(
+            'Reflector Model',
+            models,
+            config.reflectorModelId,
+            modelId => {
+              config.reflectorModelId = modelId;
+              callbacks.onReflectorModelChange(modelId);
+              done(getShortModelName(modelId));
+            },
+            () => done(),
+            tui,
+          ),
+      },
+      {
+        id: 'obs-threshold',
+        label: 'Observation threshold',
+        description:
+          'Token count before triggering observation. ' +
+          'Lower = more frequent, higher = more context before observing',
+        currentValue: formatTokens(config.observationThreshold),
+        submenu: (_currentValue, done) =>
+          new ThresholdSubmenu(
+            'Observation Threshold',
+            config.observationThreshold,
+            OBSERVATION_THRESHOLDS,
+            value => {
+              config.observationThreshold = value;
+              callbacks.onObservationThresholdChange(value);
+              done(formatTokens(value));
+            },
+            () => done(),
+          ),
+      },
+      {
+        id: 'ref-threshold',
+        label: 'Reflection threshold',
+        description:
+          'Token count of observations before triggering compression. ' +
+          'Lower = more frequent, higher = more observations before compressing',
+        currentValue: formatTokens(config.reflectionThreshold),
+        submenu: (_currentValue, done) =>
+          new ThresholdSubmenu(
+            'Reflection Threshold',
+            config.reflectionThreshold,
+            REFLECTION_THRESHOLDS,
+            value => {
+              config.reflectionThreshold = value;
+              callbacks.onReflectionThresholdChange(value);
+              done(formatTokens(value));
+            },
+            () => done(),
+          ),
+      },
+    ];
 
-		this.settingsList = new SettingsList(
-			items,
-			10,
-			getSettingsListTheme(),
-			(_id, _newValue) => {
-				// All changes handled via submenu callbacks
-			},
-			callbacks.onClose,
-		)
+    this.settingsList = new SettingsList(
+      items,
+      10,
+      getSettingsListTheme(),
+      (_id, _newValue) => {
+        // All changes handled via submenu callbacks
+      },
+      callbacks.onClose,
+    );
 
-		this.addChild(this.settingsList)
-	}
+    this.addChild(this.settingsList);
+  }
 
-	handleInput(data: string): void {
-		this.settingsList.handleInput(data)
-	}
+  handleInput(data: string): void {
+    this.settingsList.handleInput(data);
+  }
 }
 
 // =============================================================================
@@ -475,7 +412,7 @@ export class OMSettingsComponent extends Box implements Focusable {
 // =============================================================================
 
 function getShortModelName(modelId: string): string {
-	if (!modelId) return "(none)"
-	const parts = modelId.split("/")
-	return parts.length > 1 ? parts.slice(1).join("/") : modelId
+  if (!modelId) return '(none)';
+  const parts = modelId.split('/');
+  return parts.length > 1 ? parts.slice(1).join('/') : modelId;
 }

--- a/mastracode/src/tui/components/plan-approval-inline.ts
+++ b/mastracode/src/tui/components/plan-approval-inline.ts
@@ -4,217 +4,183 @@
  * directly in the conversation flow.
  */
 
-import {
-	Box,
-	Container,
-	
-	getEditorKeybindings,
-	Input,
-	Markdown,
-	SelectList,
-	
-	Spacer,
-	Text
-	
-} from "@mariozechner/pi-tui"
-import type {Focusable, SelectItem, TUI} from "@mariozechner/pi-tui";
-import { theme, getSelectListTheme, getMarkdownTheme } from "../theme.js"
+import { Box, Container, getEditorKeybindings, Input, Markdown, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
+import type { Focusable, SelectItem, TUI } from '@mariozechner/pi-tui';
+import { theme, getSelectListTheme, getMarkdownTheme } from '../theme.js';
 
 export interface PlanApprovalInlineOptions {
-	planId: string
-	title: string
-	plan: string
-	onApprove: () => void
-	onReject: (feedback?: string) => void
+  planId: string;
+  title: string;
+  plan: string;
+  onApprove: () => void;
+  onReject: (feedback?: string) => void;
 }
 
-export class PlanApprovalInlineComponent
-	extends Container
-	implements Focusable
-{
-	private contentBox: Box
-	private selectList?: SelectList
-	private feedbackInput?: Input
-	private onApprove: () => void
-	private onReject: (feedback?: string) => void
-	private resolved = false
-	private mode: "select" | "feedback" = "select"
-	private planTitle: string
-	private planContent: string
+export class PlanApprovalInlineComponent extends Container implements Focusable {
+  private contentBox: Box;
+  private selectList?: SelectList;
+  private feedbackInput?: Input;
+  private onApprove: () => void;
+  private onReject: (feedback?: string) => void;
+  private resolved = false;
+  private mode: 'select' | 'feedback' = 'select';
+  private planTitle: string;
+  private planContent: string;
 
-	private _focused = false
-	get focused(): boolean {
-		return this._focused
-	}
-	set focused(value: boolean) {
-		this._focused = value
-		if (this.mode === "feedback" && this.feedbackInput) {
-			this.feedbackInput.focused = value
-		}
-	}
+  private _focused = false;
+  get focused(): boolean {
+    return this._focused;
+  }
+  set focused(value: boolean) {
+    this._focused = value;
+    if (this.mode === 'feedback' && this.feedbackInput) {
+      this.feedbackInput.focused = value;
+    }
+  }
 
-	constructor(options: PlanApprovalInlineOptions, _ui: TUI) {
-		super()
-		this.onApprove = options.onApprove
-		this.onReject = options.onReject
-		this.planTitle = options.title
-		this.planContent = options.plan
+  constructor(options: PlanApprovalInlineOptions, _ui: TUI) {
+    super();
+    this.onApprove = options.onApprove;
+    this.onReject = options.onReject;
+    this.planTitle = options.title;
+    this.planContent = options.plan;
 
-		this.addChild(new Spacer(1))
+    this.addChild(new Spacer(1));
 
-		// Main content box with pending background
-		this.contentBox = new Box(1, 1, (text: string) =>
-			theme.bg("toolPendingBg", text),
-		)
-		this.addChild(this.contentBox)
+    // Main content box with pending background
+    this.contentBox = new Box(1, 1, (text: string) => theme.bg('toolPendingBg', text));
+    this.addChild(this.contentBox);
 
-		// Plan title header
-		this.contentBox.addChild(
-			new Text(theme.bold(theme.fg("accent", `Plan: ${options.title}`)), 0, 0),
-		)
-		this.contentBox.addChild(new Spacer(1))
+    // Plan title header
+    this.contentBox.addChild(new Text(theme.bold(theme.fg('accent', `Plan: ${options.title}`)), 0, 0));
+    this.contentBox.addChild(new Spacer(1));
 
-		// Render plan as markdown
-		const md = new Markdown(options.plan, 1, 0, getMarkdownTheme())
-		this.contentBox.addChild(md)
-		this.contentBox.addChild(new Spacer(1))
+    // Render plan as markdown
+    const md = new Markdown(options.plan, 1, 0, getMarkdownTheme());
+    this.contentBox.addChild(md);
+    this.contentBox.addChild(new Spacer(1));
 
-		// Action selector
-		const items: SelectItem[] = [
-			{
-				value: "approve",
-				label: `  ${theme.fg("success", "Approve")} ${theme.fg("dim", "— switch to Build mode and implement")}`,
-			},
-			{
-				value: "reject",
-				label: `  ${theme.fg("error", "Reject")} ${theme.fg("dim", "— stay in Plan mode")}`,
-			},
-			{
-				value: "edit",
-				label: `  ${theme.fg("warning", "Request changes")} ${theme.fg("dim", "— provide feedback")}`,
-			},
-		]
+    // Action selector
+    const items: SelectItem[] = [
+      {
+        value: 'approve',
+        label: `  ${theme.fg('success', 'Approve')} ${theme.fg('dim', '— switch to Build mode and implement')}`,
+      },
+      {
+        value: 'reject',
+        label: `  ${theme.fg('error', 'Reject')} ${theme.fg('dim', '— stay in Plan mode')}`,
+      },
+      {
+        value: 'edit',
+        label: `  ${theme.fg('warning', 'Request changes')} ${theme.fg('dim', '— provide feedback')}`,
+      },
+    ];
 
-		this.selectList = new SelectList(items, items.length, getSelectListTheme())
+    this.selectList = new SelectList(items, items.length, getSelectListTheme());
 
-		this.selectList.onSelect = (item: SelectItem) => {
-			this.handleSelection(item.value)
-		}
-		this.selectList.onCancel = () => {
-			this.handleReject()
-		}
+    this.selectList.onSelect = (item: SelectItem) => {
+      this.handleSelection(item.value);
+    };
+    this.selectList.onCancel = () => {
+      this.handleReject();
+    };
 
-		this.contentBox.addChild(this.selectList)
-		this.contentBox.addChild(new Spacer(1))
-		this.contentBox.addChild(
-			new Text(
-				theme.fg("dim", "Up/Down navigate  Enter select  Esc reject"),
-				0,
-				0,
-			),
-		)
-	}
+    this.contentBox.addChild(this.selectList);
+    this.contentBox.addChild(new Spacer(1));
+    this.contentBox.addChild(new Text(theme.fg('dim', 'Up/Down navigate  Enter select  Esc reject'), 0, 0));
+  }
 
-	private handleSelection(value: string): void {
-		if (this.resolved) return
+  private handleSelection(value: string): void {
+    if (this.resolved) return;
 
-		switch (value) {
-			case "approve":
-				this.handleApprove()
-				break
-			case "reject":
-				this.handleReject()
-				break
-			case "edit":
-				this.switchToFeedbackMode()
-				break
-		}
-	}
+    switch (value) {
+      case 'approve':
+        this.handleApprove();
+        break;
+      case 'reject':
+        this.handleReject();
+        break;
+      case 'edit':
+        this.switchToFeedbackMode();
+        break;
+    }
+  }
 
-	private handleApprove(): void {
-		if (this.resolved) return
-		this.resolved = true
-		this.showResult("Approved", true)
-		this.onApprove()
-	}
+  private handleApprove(): void {
+    if (this.resolved) return;
+    this.resolved = true;
+    this.showResult('Approved', true);
+    this.onApprove();
+  }
 
-	private handleReject(feedback?: string): void {
-		if (this.resolved) return
-		this.resolved = true
-		this.showResult(feedback ? `Rejected — ${feedback}` : "Rejected", false)
-		this.onReject(feedback)
-	}
+  private handleReject(feedback?: string): void {
+    if (this.resolved) return;
+    this.resolved = true;
+    this.showResult(feedback ? `Rejected — ${feedback}` : 'Rejected', false);
+    this.onReject(feedback);
+  }
 
-	private switchToFeedbackMode(): void {
-		this.mode = "feedback"
-		this.selectList = undefined
+  private switchToFeedbackMode(): void {
+    this.mode = 'feedback';
+    this.selectList = undefined;
 
-		// Rebuild content box with feedback input
-		this.contentBox.clear()
-		this.contentBox.addChild(
-			new Text(theme.fg("accent", "Provide feedback for revision:"), 0, 0),
-		)
-		this.contentBox.addChild(new Spacer(1))
+    // Rebuild content box with feedback input
+    this.contentBox.clear();
+    this.contentBox.addChild(new Text(theme.fg('accent', 'Provide feedback for revision:'), 0, 0));
+    this.contentBox.addChild(new Spacer(1));
 
-		this.feedbackInput = new Input()
-		this.feedbackInput.focused = this._focused
-		this.feedbackInput.onSubmit = (value: string) => {
-			const trimmed = value.trim()
-			this.handleReject(trimmed || undefined)
-		}
-		this.feedbackInput.onEscape = () => {
-			this.handleReject()
-		}
+    this.feedbackInput = new Input();
+    this.feedbackInput.focused = this._focused;
+    this.feedbackInput.onSubmit = (value: string) => {
+      const trimmed = value.trim();
+      this.handleReject(trimmed || undefined);
+    };
+    this.feedbackInput.onEscape = () => {
+      this.handleReject();
+    };
 
-		this.contentBox.addChild(this.feedbackInput)
-		this.contentBox.addChild(new Spacer(1))
-		this.contentBox.addChild(
-			new Text(
-				theme.fg(
-					"dim",
-					"Enter to submit feedback  Esc to reject without feedback",
-				),
-				0,
-				0,
-			),
-		)
-	}
+    this.contentBox.addChild(this.feedbackInput);
+    this.contentBox.addChild(new Spacer(1));
+    this.contentBox.addChild(
+      new Text(theme.fg('dim', 'Enter to submit feedback  Esc to reject without feedback'), 0, 0),
+    );
+  }
 
-	private showResult(status: string, isApproved: boolean): void {
-		this.contentBox.clear()
-		const bgColor = isApproved ? "toolSuccessBg" : "toolErrorBg"
-		this.contentBox.setBgFn((text: string) => theme.bg(bgColor, text))
+  private showResult(status: string, isApproved: boolean): void {
+    this.contentBox.clear();
+    const bgColor = isApproved ? 'toolSuccessBg' : 'toolErrorBg';
+    this.contentBox.setBgFn((text: string) => theme.bg(bgColor, text));
 
-		// Status header with icon
-		const icon = isApproved ? theme.fg("success", "✓") : theme.fg("error", "✗")
-		this.contentBox.addChild(
-			new Text(
-				`${icon} ${theme.bold(theme.fg("accent", `Plan: ${this.planTitle}`))} ${theme.fg("dim", `— ${status}`)}`,
-				0,
-				0,
-			),
-		)
-		this.contentBox.addChild(new Spacer(1))
+    // Status header with icon
+    const icon = isApproved ? theme.fg('success', '✓') : theme.fg('error', '✗');
+    this.contentBox.addChild(
+      new Text(
+        `${icon} ${theme.bold(theme.fg('accent', `Plan: ${this.planTitle}`))} ${theme.fg('dim', `— ${status}`)}`,
+        0,
+        0,
+      ),
+    );
+    this.contentBox.addChild(new Spacer(1));
 
-		// Re-render plan as markdown
-		const md = new Markdown(this.planContent, 1, 0, getMarkdownTheme())
-		this.contentBox.addChild(md)
-	}
+    // Re-render plan as markdown
+    const md = new Markdown(this.planContent, 1, 0, getMarkdownTheme());
+    this.contentBox.addChild(md);
+  }
 
-	handleInput(data: string): void {
-		if (this.resolved) return
+  handleInput(data: string): void {
+    if (this.resolved) return;
 
-		if (this.mode === "feedback" && this.feedbackInput) {
-			const kb = getEditorKeybindings()
-			if (kb.matches(data, "selectCancel")) {
-				this.handleReject()
-				return
-			}
-			this.feedbackInput.handleInput(data)
-		} else if (this.selectList) {
-			this.selectList.handleInput(data)
-		}
-	}
+    if (this.mode === 'feedback' && this.feedbackInput) {
+      const kb = getEditorKeybindings();
+      if (kb.matches(data, 'selectCancel')) {
+        this.handleReject();
+        return;
+      }
+      this.feedbackInput.handleInput(data);
+    } else if (this.selectList) {
+      this.selectList.handleInput(data);
+    }
+  }
 }
 
 /**
@@ -222,43 +188,37 @@ export class PlanApprovalInlineComponent
  * Shows the plan content with approval/rejection status.
  */
 export interface PlanResultOptions {
-	title: string
-	plan: string
-	isApproved: boolean
-	feedback?: string
+  title: string;
+  plan: string;
+  isApproved: boolean;
+  feedback?: string;
 }
 
 export class PlanResultComponent extends Container {
-	constructor(options: PlanResultOptions) {
-		super()
+  constructor(options: PlanResultOptions) {
+    super();
 
-		this.addChild(new Spacer(1))
+    this.addChild(new Spacer(1));
 
-		const bgColor = options.isApproved ? "toolSuccessBg" : "toolErrorBg"
-		const contentBox = new Box(1, 1, (text: string) => theme.bg(bgColor, text))
-		this.addChild(contentBox)
+    const bgColor = options.isApproved ? 'toolSuccessBg' : 'toolErrorBg';
+    const contentBox = new Box(1, 1, (text: string) => theme.bg(bgColor, text));
+    this.addChild(contentBox);
 
-		// Status header with icon
-		const icon = options.isApproved
-			? theme.fg("success", "✓")
-			: theme.fg("error", "✗")
-		const status = options.isApproved
-			? "Approved"
-			: options.feedback
-				? `Rejected — ${options.feedback}`
-				: "Rejected"
+    // Status header with icon
+    const icon = options.isApproved ? theme.fg('success', '✓') : theme.fg('error', '✗');
+    const status = options.isApproved ? 'Approved' : options.feedback ? `Rejected — ${options.feedback}` : 'Rejected';
 
-		contentBox.addChild(
-			new Text(
-				`${icon} ${theme.bold(theme.fg("accent", `Plan: ${options.title}`))} ${theme.fg("dim", `— ${status}`)}`,
-				0,
-				0,
-			),
-		)
-		contentBox.addChild(new Spacer(1))
+    contentBox.addChild(
+      new Text(
+        `${icon} ${theme.bold(theme.fg('accent', `Plan: ${options.title}`))} ${theme.fg('dim', `— ${status}`)}`,
+        0,
+        0,
+      ),
+    );
+    contentBox.addChild(new Spacer(1));
 
-		// Render plan as markdown
-		const md = new Markdown(options.plan, 1, 0, getMarkdownTheme())
-		contentBox.addChild(md)
-	}
+    // Render plan as markdown
+    const md = new Markdown(options.plan, 1, 0, getMarkdownTheme());
+    contentBox.addChild(md);
+  }
 }

--- a/mastracode/src/tui/components/settings.ts
+++ b/mastracode/src/tui/components/settings.ts
@@ -6,43 +6,27 @@
  * Changes apply immediately — Esc closes the panel.
  */
 
-import {
-	Box,
-	
-	SelectList,
-	
-	
-	SettingsList,
-	Spacer,
-	Text
-	
-} from "@mariozechner/pi-tui"
-import type {Focusable, SelectItem, SettingItem} from "@mariozechner/pi-tui";
-import type { NotificationMode } from "../notify.js"
-import {
-	fg,
-	bg,
-	bold,
-	getSettingsListTheme,
-	getSelectListTheme,
-} from "../theme.js"
+import { Box, SelectList, SettingsList, Spacer, Text } from '@mariozechner/pi-tui';
+import type { Focusable, SelectItem, SettingItem } from '@mariozechner/pi-tui';
+import type { NotificationMode } from '../notify.js';
+import { fg, bg, bold, getSettingsListTheme, getSelectListTheme } from '../theme.js';
 
 // =============================================================================
 // Types
 // =============================================================================
 export interface SettingsConfig {
-	notifications: NotificationMode
-	yolo: boolean
-	thinkingLevel: string
-	escapeAsCancel: boolean
+  notifications: NotificationMode;
+  yolo: boolean;
+  thinkingLevel: string;
+  escapeAsCancel: boolean;
 }
 
 export interface SettingsCallbacks {
-	onNotificationsChange: (mode: NotificationMode) => void
-	onYoloChange: (enabled: boolean) => void
-	onThinkingLevelChange: (level: string) => void
-	onEscapeAsCancelChange: (enabled: boolean) => void
-	onClose: () => void
+  onNotificationsChange: (mode: NotificationMode) => void;
+  onYoloChange: (enabled: boolean) => void;
+  onThinkingLevelChange: (level: string) => void;
+  onEscapeAsCancelChange: (enabled: boolean) => void;
+  onClose: () => void;
 }
 
 // =============================================================================
@@ -50,24 +34,19 @@ export interface SettingsCallbacks {
 // =============================================================================
 
 class SelectSubmenu extends SelectList {
-	constructor(
-		items: SelectItem[],
-		currentValue: string,
-		onSelect: (value: string) => void,
-		onBack: () => void,
-	) {
-		super(items, Math.min(items.length, 8), getSelectListTheme())
+  constructor(items: SelectItem[], currentValue: string, onSelect: (value: string) => void, onBack: () => void) {
+    super(items, Math.min(items.length, 8), getSelectListTheme());
 
-		const currentIndex = items.findIndex((i) => i.value === currentValue)
-		if (currentIndex !== -1) {
-			this.setSelectedIndex(currentIndex)
-		}
+    const currentIndex = items.findIndex(i => i.value === currentValue);
+    if (currentIndex !== -1) {
+      this.setSelectedIndex(currentIndex);
+    }
 
-		this.onSelect = (item: SelectItem) => {
-			onSelect(item.value)
-		}
-		this.onCancel = onBack
-	}
+    this.onSelect = (item: SelectItem) => {
+      onSelect(item.value);
+    };
+    this.onCancel = onBack;
+  }
 }
 
 // =============================================================================
@@ -75,166 +54,162 @@ class SelectSubmenu extends SelectList {
 // =============================================================================
 
 export class SettingsComponent extends Box implements Focusable {
-	private settingsList: SettingsList
-	private _focused = false
+  private settingsList: SettingsList;
+  private _focused = false;
 
-	get focused(): boolean {
-		return this._focused
-	}
-	set focused(value: boolean) {
-		this._focused = value
-	}
+  get focused(): boolean {
+    return this._focused;
+  }
+  set focused(value: boolean) {
+    this._focused = value;
+  }
 
-	constructor(config: SettingsConfig, callbacks: SettingsCallbacks) {
-		super(2, 1, (text: string) => bg("overlayBg", text))
+  constructor(config: SettingsConfig, callbacks: SettingsCallbacks) {
+    super(2, 1, (text: string) => bg('overlayBg', text));
 
-		// Title
-		this.addChild(new Text(bold(fg("accent", "Settings")), 0, 0))
-		this.addChild(new Spacer(1))
+    // Title
+    this.addChild(new Text(bold(fg('accent', 'Settings')), 0, 0));
+    this.addChild(new Spacer(1));
 
-		// Build settings items
-		const notificationModes: {
-			value: NotificationMode
-			label: string
-			desc: string
-		}[] = [
-			{ value: "off", label: "Off", desc: "No notifications" },
-			{ value: "bell", label: "Bell", desc: "Terminal bell (\\x07)" },
-			{ value: "system", label: "System", desc: "Native OS notification" },
-			{ value: "both", label: "Both", desc: "Bell + system notification" },
-		]
+    // Build settings items
+    const notificationModes: {
+      value: NotificationMode;
+      label: string;
+      desc: string;
+    }[] = [
+      { value: 'off', label: 'Off', desc: 'No notifications' },
+      { value: 'bell', label: 'Bell', desc: 'Terminal bell (\\x07)' },
+      { value: 'system', label: 'System', desc: 'Native OS notification' },
+      { value: 'both', label: 'Both', desc: 'Bell + system notification' },
+    ];
 
-		const thinkingLevels: { value: string; label: string; desc: string }[] = [
-			{ value: "off", label: "Off", desc: "No extended thinking" },
-			{ value: "minimal", label: "Minimal", desc: "~1k budget tokens" },
-			{ value: "low", label: "Low", desc: "~4k budget tokens" },
-			{ value: "medium", label: "Medium", desc: "~10k budget tokens" },
-			{ value: "high", label: "High", desc: "~32k budget tokens" },
-		]
+    const thinkingLevels: { value: string; label: string; desc: string }[] = [
+      { value: 'off', label: 'Off', desc: 'No extended thinking' },
+      { value: 'minimal', label: 'Minimal', desc: '~1k budget tokens' },
+      { value: 'low', label: 'Low', desc: '~4k budget tokens' },
+      { value: 'medium', label: 'Medium', desc: '~10k budget tokens' },
+      { value: 'high', label: 'High', desc: '~32k budget tokens' },
+    ];
 
-		const getNotifLabel = (mode: NotificationMode) =>
-			notificationModes.find((m) => m.value === mode)?.label ?? mode
+    const getNotifLabel = (mode: NotificationMode) => notificationModes.find(m => m.value === mode)?.label ?? mode;
 
-		const getThinkingLabel = (level: string) =>
-			thinkingLevels.find((l) => l.value === level)?.label ?? level
+    const getThinkingLabel = (level: string) => thinkingLevels.find(l => l.value === level)?.label ?? level;
 
-		const items: SettingItem[] = [
-			{
-				id: "notifications",
-				label: "Notifications",
-				description: "How to alert when the agent needs attention",
-				currentValue: getNotifLabel(config.notifications),
-				submenu: (_currentValue, done) =>
-					new SelectSubmenu(
-						notificationModes.map((m) => ({
-							value: m.value,
-							label: `  ${m.label}`,
-							description: m.desc,
-						})),
-						config.notifications,
-						(value) => {
-							config.notifications = value as NotificationMode
-							callbacks.onNotificationsChange(config.notifications)
-							done(getNotifLabel(config.notifications))
-						},
-						() => done(),
-					),
-			},
-			{
-				id: "yolo",
-				label: "YOLO mode",
-				description: "Auto-approve all tool calls without confirmation",
-				currentValue: config.yolo ? "On" : "Off",
-				submenu: (_currentValue, done) =>
-					new SelectSubmenu(
-						[
-							{
-								value: "on",
-								label: "  On",
-								description: "Auto-approve all tools",
-							},
-							{
-								value: "off",
-								label: "  Off",
-								description: "Require approval for tools",
-							},
-						],
-						config.yolo ? "on" : "off",
-						(value) => {
-							config.yolo = value === "on"
-							callbacks.onYoloChange(config.yolo)
-							done(config.yolo ? "On" : "Off")
-						},
-						() => done(),
-					),
-			},
-			{
-				id: "thinking",
-				label: "Thinking level",
-				description:
-					"Extended thinking budget for Anthropic models (currently disabled)",
-				currentValue: getThinkingLabel(config.thinkingLevel),
-				submenu: (_currentValue, done) =>
-					new SelectSubmenu(
-						thinkingLevels.map((l) => ({
-							value: l.value,
-							label: `  ${l.label}`,
-							description: l.desc,
-						})),
-						config.thinkingLevel,
-						(value) => {
-							config.thinkingLevel = value
-							callbacks.onThinkingLevelChange(value)
-							done(getThinkingLabel(value))
-						},
-						() => done(),
-					),
-			},
-			{
-				id: "escapeAsCancel",
-				label: "Escape cancels",
-				description:
-					"Use Escape to cancel/clear (Ctrl+C always works). Ctrl+Z undoes a clear.",
-				currentValue: config.escapeAsCancel ? "On" : "Off",
-				submenu: (_currentValue, done) =>
-					new SelectSubmenu(
-						[
-							{
-								value: "on",
-								label: "  On",
-								description: "Escape clears input / aborts",
-							},
-							{
-								value: "off",
-								label: "  Off",
-								description: "Only Ctrl+C clears / aborts",
-							},
-						],
-						config.escapeAsCancel ? "on" : "off",
-						(value) => {
-							config.escapeAsCancel = value === "on"
-							callbacks.onEscapeAsCancelChange(config.escapeAsCancel)
-							done(config.escapeAsCancel ? "On" : "Off")
-						},
-						() => done(),
-					),
-			},
-		]
+    const items: SettingItem[] = [
+      {
+        id: 'notifications',
+        label: 'Notifications',
+        description: 'How to alert when the agent needs attention',
+        currentValue: getNotifLabel(config.notifications),
+        submenu: (_currentValue, done) =>
+          new SelectSubmenu(
+            notificationModes.map(m => ({
+              value: m.value,
+              label: `  ${m.label}`,
+              description: m.desc,
+            })),
+            config.notifications,
+            value => {
+              config.notifications = value as NotificationMode;
+              callbacks.onNotificationsChange(config.notifications);
+              done(getNotifLabel(config.notifications));
+            },
+            () => done(),
+          ),
+      },
+      {
+        id: 'yolo',
+        label: 'YOLO mode',
+        description: 'Auto-approve all tool calls without confirmation',
+        currentValue: config.yolo ? 'On' : 'Off',
+        submenu: (_currentValue, done) =>
+          new SelectSubmenu(
+            [
+              {
+                value: 'on',
+                label: '  On',
+                description: 'Auto-approve all tools',
+              },
+              {
+                value: 'off',
+                label: '  Off',
+                description: 'Require approval for tools',
+              },
+            ],
+            config.yolo ? 'on' : 'off',
+            value => {
+              config.yolo = value === 'on';
+              callbacks.onYoloChange(config.yolo);
+              done(config.yolo ? 'On' : 'Off');
+            },
+            () => done(),
+          ),
+      },
+      {
+        id: 'thinking',
+        label: 'Thinking level',
+        description: 'Extended thinking budget for Anthropic models (currently disabled)',
+        currentValue: getThinkingLabel(config.thinkingLevel),
+        submenu: (_currentValue, done) =>
+          new SelectSubmenu(
+            thinkingLevels.map(l => ({
+              value: l.value,
+              label: `  ${l.label}`,
+              description: l.desc,
+            })),
+            config.thinkingLevel,
+            value => {
+              config.thinkingLevel = value;
+              callbacks.onThinkingLevelChange(value);
+              done(getThinkingLabel(value));
+            },
+            () => done(),
+          ),
+      },
+      {
+        id: 'escapeAsCancel',
+        label: 'Escape cancels',
+        description: 'Use Escape to cancel/clear (Ctrl+C always works). Ctrl+Z undoes a clear.',
+        currentValue: config.escapeAsCancel ? 'On' : 'Off',
+        submenu: (_currentValue, done) =>
+          new SelectSubmenu(
+            [
+              {
+                value: 'on',
+                label: '  On',
+                description: 'Escape clears input / aborts',
+              },
+              {
+                value: 'off',
+                label: '  Off',
+                description: 'Only Ctrl+C clears / aborts',
+              },
+            ],
+            config.escapeAsCancel ? 'on' : 'off',
+            value => {
+              config.escapeAsCancel = value === 'on';
+              callbacks.onEscapeAsCancelChange(config.escapeAsCancel);
+              done(config.escapeAsCancel ? 'On' : 'Off');
+            },
+            () => done(),
+          ),
+      },
+    ];
 
-		this.settingsList = new SettingsList(
-			items,
-			10,
-			getSettingsListTheme(),
-			(_id, _newValue) => {
-				// All changes handled via submenu callbacks
-			},
-			callbacks.onClose,
-		)
+    this.settingsList = new SettingsList(
+      items,
+      10,
+      getSettingsListTheme(),
+      (_id, _newValue) => {
+        // All changes handled via submenu callbacks
+      },
+      callbacks.onClose,
+    );
 
-		this.addChild(this.settingsList)
-	}
+    this.addChild(this.settingsList);
+  }
 
-	handleInput(data: string): void {
-		this.settingsList.handleInput(data)
-	}
+  handleInput(data: string): void {
+    this.settingsList.handleInput(data);
+  }
 }

--- a/mastracode/src/tui/components/shell-output.ts
+++ b/mastracode/src/tui/components/shell-output.ts
@@ -2,45 +2,32 @@
  * Component that renders shell command output in the chat view.
  */
 
-import { Container, Spacer, Text } from "@mariozechner/pi-tui"
-import { fg, bold } from "../theme.js"
+import { Container, Spacer, Text } from '@mariozechner/pi-tui';
+import { fg, bold } from '../theme.js';
 
 export class ShellOutputComponent extends Container {
-	constructor(
-		command: string,
-		stdout: string,
-		stderr: string,
-		exitCode: number,
-	) {
-		super()
-		this.addChild(new Spacer(1))
+  constructor(command: string, stdout: string, stderr: string, exitCode: number) {
+    super();
+    this.addChild(new Spacer(1));
 
-		// Command header
-		const statusIcon = exitCode === 0 ? "✓" : "✗"
-		const statusColor = exitCode === 0 ? "success" : "error"
-		this.addChild(
-			new Text(
-				`${fg(statusColor, statusIcon)} ${bold(fg("muted", "$"))} ${fg("text", command)}`,
-				1,
-				0,
-			),
-		)
+    // Command header
+    const statusIcon = exitCode === 0 ? '✓' : '✗';
+    const statusColor = exitCode === 0 ? 'success' : 'error';
+    this.addChild(new Text(`${fg(statusColor, statusIcon)} ${bold(fg('muted', '$'))} ${fg('text', command)}`, 1, 0));
 
-		// Output
-		const output = (
-			stdout + (stderr ? (stdout ? "\n" : "") + stderr : "")
-		).trimEnd()
-		if (output) {
-			// Indent each line by 2 spaces
-			const lines = output.split("\n")
-			for (const line of lines) {
-				this.addChild(new Text(fg("toolOutput", `  ${line}`), 0, 0))
-			}
-		}
+    // Output
+    const output = (stdout + (stderr ? (stdout ? '\n' : '') + stderr : '')).trimEnd();
+    if (output) {
+      // Indent each line by 2 spaces
+      const lines = output.split('\n');
+      for (const line of lines) {
+        this.addChild(new Text(fg('toolOutput', `  ${line}`), 0, 0));
+      }
+    }
 
-		// Show exit code if non-zero
-		if (exitCode !== 0) {
-			this.addChild(new Text(fg("error", `  Exit code: ${exitCode}`), 0, 0))
-		}
-	}
+    // Show exit code if non-zero
+    if (exitCode !== 0) {
+      this.addChild(new Text(fg('error', `  Exit code: ${exitCode}`), 0, 0));
+    }
+  }
 }

--- a/mastracode/src/tui/components/simple-progress.ts
+++ b/mastracode/src/tui/components/simple-progress.ts
@@ -3,13 +3,13 @@
  * Shows a compact progress display with spinner and status text.
  */
 
-import { Container, Text } from "@mariozechner/pi-tui"
-import chalk from "chalk"
+import { Container, Text } from '@mariozechner/pi-tui';
+import chalk from 'chalk';
 
 export interface SimpleProgressOptions {
-	prefix?: string
-	showElapsed?: boolean
-	showPercentage?: boolean
+  prefix?: string;
+  showElapsed?: boolean;
+  showPercentage?: boolean;
 }
 
 /**
@@ -21,125 +21,125 @@ export interface SimpleProgressOptions {
  * - Optional percentage display
  */
 export class SimpleProgressComponent extends Container {
-	private status: string = ""
-	private progress?: number
-	private startTime: number
-	private spinnerFrame = 0
-	private lastRenderTime = 0
-	private isActive = false
-	private options: Required<SimpleProgressOptions>
+  private status: string = '';
+  private progress?: number;
+  private startTime: number;
+  private spinnerFrame = 0;
+  private lastRenderTime = 0;
+  private isActive = false;
+  private options: Required<SimpleProgressOptions>;
 
-	constructor(options: SimpleProgressOptions = {}) {
-		super()
-		this.options = {
-			prefix: "",
-			showElapsed: true,
-			showPercentage: true,
-			...options,
-		}
-		this.startTime = Date.now()
-	}
+  constructor(options: SimpleProgressOptions = {}) {
+    super();
+    this.options = {
+      prefix: '',
+      showElapsed: true,
+      showPercentage: true,
+      ...options,
+    };
+    this.startTime = Date.now();
+  }
 
-	/**
-	 * Start showing progress with initial status.
-	 */
-	start(status: string): void {
-		this.status = status
-		this.isActive = true
-		this.startTime = Date.now()
-		this.rebuild()
-	}
+  /**
+   * Start showing progress with initial status.
+   */
+  start(status: string): void {
+    this.status = status;
+    this.isActive = true;
+    this.startTime = Date.now();
+    this.rebuild();
+  }
 
-	/**
-	 * Update the status text.
-	 */
-	updateStatus(status: string): void {
-		this.status = status
-		this.rebuild()
-	}
+  /**
+   * Update the status text.
+   */
+  updateStatus(status: string): void {
+    this.status = status;
+    this.rebuild();
+  }
 
-	/**
-	 * Update the progress percentage (0-100).
-	 */
-	updateProgress(progress: number): void {
-		this.progress = Math.min(100, Math.max(0, progress))
-		this.rebuild()
-	}
+  /**
+   * Update the progress percentage (0-100).
+   */
+  updateProgress(progress: number): void {
+    this.progress = Math.min(100, Math.max(0, progress));
+    this.rebuild();
+  }
 
-	/**
-	 * Mark the operation as complete.
-	 */
-	complete(message?: string): void {
-		this.isActive = false
-		this.status = message || "Complete"
-		this.progress = 100
-		this.rebuild()
-	}
+  /**
+   * Mark the operation as complete.
+   */
+  complete(message?: string): void {
+    this.isActive = false;
+    this.status = message || 'Complete';
+    this.progress = 100;
+    this.rebuild();
+  }
 
-	/**
-	 * Mark the operation as failed.
-	 */
-	fail(error: string): void {
-		this.isActive = false
-		this.status = error
-		this.rebuild()
-	}
+  /**
+   * Mark the operation as failed.
+   */
+  fail(error: string): void {
+    this.isActive = false;
+    this.status = error;
+    this.rebuild();
+  }
 
-	private rebuild(): void {
-		this.clear()
+  private rebuild(): void {
+    this.clear();
 
-		if (!this.status) return
+    if (!this.status) return;
 
-		const now = Date.now()
+    const now = Date.now();
 
-		// Update spinner animation
-		if (this.isActive && now - this.lastRenderTime > 100) {
-			this.spinnerFrame = (this.spinnerFrame + 1) % 10
-			this.lastRenderTime = now
-		}
-
-		let text = ""
-
-		// Add prefix if provided
-		if (this.options.prefix) {
-			text += this.options.prefix + " "
-		}
-
-		// Add spinner or status icon
-		if (this.isActive) {
-			const spinner = this.getSpinner()
-			text += chalk.cyan(spinner) + " "
-		} else if (this.progress === 100) {
-			text += chalk.green("✓") + " "
-		} else {
-			text += chalk.red("✗") + " "
-		}
-
-		// Add status text
-		text += this.status
-
-		// Add progress percentage if enabled and available
-		if (this.options.showPercentage && this.progress !== undefined) {
-			text += chalk.dim(` (${this.progress}%)`)
-		}
-
-		// Add elapsed time if enabled
-		if (this.options.showElapsed && this.isActive) {
-			const elapsed = Math.floor((now - this.startTime) / 1000)
-			text += chalk.dim(` ${elapsed}s`)
-		}
-
-		this.addChild(new Text(text, 0, 0))
-	}
-    private getSpinner(): string {
-        const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
-        return frames[this.spinnerFrame]!
+    // Update spinner animation
+    if (this.isActive && now - this.lastRenderTime > 100) {
+      this.spinnerFrame = (this.spinnerFrame + 1) % 10;
+      this.lastRenderTime = now;
     }
 
-	render(maxWidth: number): string[] {
-		this.rebuild()
-		return super.render(maxWidth)
-	}
+    let text = '';
+
+    // Add prefix if provided
+    if (this.options.prefix) {
+      text += this.options.prefix + ' ';
+    }
+
+    // Add spinner or status icon
+    if (this.isActive) {
+      const spinner = this.getSpinner();
+      text += chalk.cyan(spinner) + ' ';
+    } else if (this.progress === 100) {
+      text += chalk.green('✓') + ' ';
+    } else {
+      text += chalk.red('✗') + ' ';
+    }
+
+    // Add status text
+    text += this.status;
+
+    // Add progress percentage if enabled and available
+    if (this.options.showPercentage && this.progress !== undefined) {
+      text += chalk.dim(` (${this.progress}%)`);
+    }
+
+    // Add elapsed time if enabled
+    if (this.options.showElapsed && this.isActive) {
+      const elapsed = Math.floor((now - this.startTime) / 1000);
+      text += chalk.dim(` ${elapsed}s`);
+    }
+
+    this.addChild(new Text(text, 0, 0));
+  }
+  private getSpinner(): string {
+    const frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+    return frames[this.spinnerFrame]!;
+  }
+
+  render(maxWidth: number): string[] {
+    this.rebuild();
+    return super.render(maxWidth);
+  }
 }
 
 /**
@@ -147,33 +147,33 @@ export class SimpleProgressComponent extends Container {
  * Useful for quick operations that need feedback.
  */
 export class TemporaryProgressComponent extends SimpleProgressComponent {
-	private hideTimeout?: NodeJS.Timeout
-	private hideDelay: number
+  private hideTimeout?: NodeJS.Timeout;
+  private hideDelay: number;
 
-	constructor(options: SimpleProgressOptions & { hideDelay?: number } = {}) {
-		super(options)
-		this.hideDelay = options.hideDelay || 2000
-	}
+  constructor(options: SimpleProgressOptions & { hideDelay?: number } = {}) {
+    super(options);
+    this.hideDelay = options.hideDelay || 2000;
+  }
 
-	complete(message?: string): void {
-		super.complete(message)
-		this.hideTimeout = setTimeout(() => {
-			this.clear()
-		}, this.hideDelay)
-	}
+  complete(message?: string): void {
+    super.complete(message);
+    this.hideTimeout = setTimeout(() => {
+      this.clear();
+    }, this.hideDelay);
+  }
 
-	fail(error: string): void {
-		super.fail(error)
-		this.hideTimeout = setTimeout(() => {
-			this.clear()
-		}, this.hideDelay * 2) // Show errors longer
-	}
+  fail(error: string): void {
+    super.fail(error);
+    this.hideTimeout = setTimeout(() => {
+      this.clear();
+    }, this.hideDelay * 2); // Show errors longer
+  }
 
-	override clear(): void {
-		if (this.hideTimeout) {
-			clearTimeout(this.hideTimeout)
-			this.hideTimeout = undefined
-		}
-		super.clear()
-	}
+  override clear(): void {
+    if (this.hideTimeout) {
+      clearTimeout(this.hideTimeout);
+      this.hideTimeout = undefined;
+    }
+    super.clear();
+  }
 }

--- a/mastracode/src/tui/components/simple-progress.ts
+++ b/mastracode/src/tui/components/simple-progress.ts
@@ -131,11 +131,10 @@ export class SimpleProgressComponent extends Container {
 
 		this.addChild(new Text(text, 0, 0))
 	}
-
-	private getSpinner(): string {
-		const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
-		return frames[this.spinnerFrame]
-	}
+    private getSpinner(): string {
+        const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+        return frames[this.spinnerFrame]!
+    }
 
 	render(maxWidth: number): string[] {
 		this.rebuild()

--- a/mastracode/src/tui/components/slash-command.ts
+++ b/mastracode/src/tui/components/slash-command.ts
@@ -4,89 +4,84 @@
  * expanded with ctrl+e. The full content is still sent to the assistant.
  */
 
-import { Container, Spacer, Text } from "@mariozechner/pi-tui"
-import chalk from "chalk"
-import { mastra } from "../theme.js"
+import { Container, Spacer, Text } from '@mariozechner/pi-tui';
+import chalk from 'chalk';
+import { mastra } from '../theme.js';
 
-const MAX_COLLAPSED_LINES = 3
-const BORDER_COLOR = mastra.purple
+const MAX_COLLAPSED_LINES = 3;
+const BORDER_COLOR = mastra.purple;
 
 export class SlashCommandComponent extends Container {
-	private commandName: string
-	private contentLines: string[]
-	private expanded = false
+  private commandName: string;
+  private contentLines: string[];
+  private expanded = false;
 
-	constructor(commandName: string, content?: string) {
-		super()
-		this.commandName = commandName
-		this.contentLines = content
-			? content.split("\n").filter((l) => l.trim())
-			: []
-		this.rebuild()
-	}
+  constructor(commandName: string, content?: string) {
+    super();
+    this.commandName = commandName;
+    this.contentLines = content ? content.split('\n').filter(l => l.trim()) : [];
+    this.rebuild();
+  }
 
-	setExpanded(expanded: boolean): void {
-		if (this.expanded === expanded) return
-		this.expanded = expanded
-		this.rebuild()
-	}
+  setExpanded(expanded: boolean): void {
+    if (this.expanded === expanded) return;
+    this.expanded = expanded;
+    this.rebuild();
+  }
 
-	private rebuild(): void {
-		this.clear()
-		this.addChild(new Spacer(1))
+  private rebuild(): void {
+    this.clear();
+    this.addChild(new Spacer(1));
 
-		const border = (char: string) => chalk.bold.hex(BORDER_COLOR)(char)
-		const termWidth = process.stdout.columns || 80
-		const maxLineWidth = termWidth - 6
+    const border = (char: string) => chalk.bold.hex(BORDER_COLOR)(char);
+    const termWidth = process.stdout.columns || 80;
+    const maxLineWidth = termWidth - 6;
 
-		// Top border with command name
-		const heading = chalk.hex(mastra.specialGray)(`/${this.commandName}`)
-		this.addChild(new Text(`${border("┌──")} ${heading}`, 0, 0))
+    // Top border with command name
+    const heading = chalk.hex(mastra.specialGray)(`/${this.commandName}`);
+    this.addChild(new Text(`${border('┌──')} ${heading}`, 0, 0));
 
-		if (this.contentLines.length === 0) {
-			this.addChild(new Text(`${border("└──")}`, 0, 0))
-			return
-		}
+    if (this.contentLines.length === 0) {
+      this.addChild(new Text(`${border('└──')}`, 0, 0));
+      return;
+    }
 
-		// Word-wrap content lines
-		const wrappedLines: string[] = []
-		for (const line of this.contentLines) {
-			if (line.length > maxLineWidth) {
-				let remaining = line
-				while (remaining.length > maxLineWidth) {
-					const breakAt = remaining.lastIndexOf(" ", maxLineWidth)
-					const splitAt = breakAt > 0 ? breakAt : maxLineWidth
-					wrappedLines.push(remaining.slice(0, splitAt))
-					remaining = remaining.slice(splitAt).trimStart()
-				}
-				if (remaining) wrappedLines.push(remaining)
-			} else {
-				wrappedLines.push(line)
-			}
-		}
+    // Word-wrap content lines
+    const wrappedLines: string[] = [];
+    for (const line of this.contentLines) {
+      if (line.length > maxLineWidth) {
+        let remaining = line;
+        while (remaining.length > maxLineWidth) {
+          const breakAt = remaining.lastIndexOf(' ', maxLineWidth);
+          const splitAt = breakAt > 0 ? breakAt : maxLineWidth;
+          wrappedLines.push(remaining.slice(0, splitAt));
+          remaining = remaining.slice(splitAt).trimStart();
+        }
+        if (remaining) wrappedLines.push(remaining);
+      } else {
+        wrappedLines.push(line);
+      }
+    }
 
-		const truncated =
-			!this.expanded && wrappedLines.length > MAX_COLLAPSED_LINES + 1
-		const displayLines = truncated
-			? wrappedLines.slice(0, MAX_COLLAPSED_LINES)
-			: wrappedLines
+    const truncated = !this.expanded && wrappedLines.length > MAX_COLLAPSED_LINES + 1;
+    const displayLines = truncated ? wrappedLines.slice(0, MAX_COLLAPSED_LINES) : wrappedLines;
 
-		const contentText = displayLines
-			.map(
-				(line) =>
-					`${border("│")} ${chalk.hex(mastra.mainGray)(line.length > maxLineWidth ? line.slice(0, maxLineWidth - 1) + "…" : line)}`,
-			)
-			.join("\n")
-		this.addChild(new Text(contentText, 0, 0))
+    const contentText = displayLines
+      .map(
+        line =>
+          `${border('│')} ${chalk.hex(mastra.mainGray)(line.length > maxLineWidth ? line.slice(0, maxLineWidth - 1) + '…' : line)}`,
+      )
+      .join('\n');
+    this.addChild(new Text(contentText, 0, 0));
 
-		if (truncated) {
-			const moreText = chalk.hex(mastra.darkGray)(
-				`... ${wrappedLines.length - MAX_COLLAPSED_LINES} more lines (ctrl+e to expand)`,
-			)
-			this.addChild(new Text(`${border("│")} ${moreText}`, 0, 0))
-		}
+    if (truncated) {
+      const moreText = chalk.hex(mastra.darkGray)(
+        `... ${wrappedLines.length - MAX_COLLAPSED_LINES} more lines (ctrl+e to expand)`,
+      );
+      this.addChild(new Text(`${border('│')} ${moreText}`, 0, 0));
+    }
 
-		// Bottom border
-		this.addChild(new Text(`${border("└──")}`, 0, 0))
-	}
+    // Bottom border
+    this.addChild(new Text(`${border('└──')}`, 0, 0));
+  }
 }

--- a/mastracode/src/tui/components/subagent-execution.ts
+++ b/mastracode/src/tui/components/subagent-execution.ts
@@ -8,252 +8,218 @@
  *  - Bottom border with agent type, model, status, duration
  */
 
-import { Container, Spacer, Text  } from "@mariozechner/pi-tui"
-import type {TUI} from "@mariozechner/pi-tui";
-import { theme } from "../theme.js"
-import type { IToolExecutionComponent } from "./tool-execution-interface.js"
+import { Container, Spacer, Text } from '@mariozechner/pi-tui';
+import type { TUI } from '@mariozechner/pi-tui';
+import { theme } from '../theme.js';
+import type { IToolExecutionComponent } from './tool-execution-interface.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
 // ─────────────────────────────────────────────────────────────────────────────
 
 export interface SubagentToolCall {
-	name: string
-	args: unknown
-	result?: string
-	isError?: boolean
-	done: boolean
+  name: string;
+  args: unknown;
+  result?: string;
+  isError?: boolean;
+  done: boolean;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Component
 // ─────────────────────────────────────────────────────────────────────────────
 
-const MAX_ACTIVITY_LINES = 15
-const COLLAPSED_LINES = 15
+const MAX_ACTIVITY_LINES = 15;
+const COLLAPSED_LINES = 15;
 
-export class SubagentExecutionComponent
-	extends Container
-	implements IToolExecutionComponent
-{
-	private ui: TUI
+export class SubagentExecutionComponent extends Container implements IToolExecutionComponent {
+  private ui: TUI;
 
-	// State
-	private agentType: string
-	private task: string
-	private modelId?: string
-	private toolCalls: SubagentToolCall[] = []
-	private done = false
-	private isError = false
-	private startTime = Date.now()
-	private durationMs = 0
-	private finalResult?: string
-	private expanded = false
+  // State
+  private agentType: string;
+  private task: string;
+  private modelId?: string;
+  private toolCalls: SubagentToolCall[] = [];
+  private done = false;
+  private isError = false;
+  private startTime = Date.now();
+  private durationMs = 0;
+  private finalResult?: string;
+  private expanded = false;
 
-	constructor(agentType: string, task: string, ui: TUI, modelId?: string) {
-		super()
-		this.agentType = agentType
-		this.task = task
-		this.modelId = modelId
-		this.ui = ui
+  constructor(agentType: string, task: string, ui: TUI, modelId?: string) {
+    super();
+    this.agentType = agentType;
+    this.task = task;
+    this.modelId = modelId;
+    this.ui = ui;
 
-		this.rebuild()
-	}
+    this.rebuild();
+  }
 
-	// ── Mutation API ──────────────────────────────────────────────────────
+  // ── Mutation API ──────────────────────────────────────────────────────
 
-	addToolStart(name: string, args: unknown): void {
-		this.toolCalls.push({ name, args, done: false })
-		this.rebuild()
-	}
-    addToolEnd(name: string, result: unknown, isError: boolean): void {
-        for (let i = this.toolCalls.length - 1; i >= 0; i--) {
-            const toolCall = this.toolCalls[i]!
-            if (toolCall.name === name && !toolCall.done) {
-                toolCall.done = true
-                toolCall.isError = isError
-                toolCall.result =
-                    typeof result === "string" ? result : JSON.stringify(result ?? "")
-                break
-            }
+  addToolStart(name: string, args: unknown): void {
+    this.toolCalls.push({ name, args, done: false });
+    this.rebuild();
+  }
+  addToolEnd(name: string, result: unknown, isError: boolean): void {
+    for (let i = this.toolCalls.length - 1; i >= 0; i--) {
+      const toolCall = this.toolCalls[i]!;
+      if (toolCall.name === name && !toolCall.done) {
+        toolCall.done = true;
+        toolCall.isError = isError;
+        toolCall.result = typeof result === 'string' ? result : JSON.stringify(result ?? '');
+        break;
+      }
+    }
+    this.rebuild();
+  }
+
+  finish(isError: boolean, durationMs: number, result?: string): void {
+    this.done = true;
+    this.isError = isError;
+    this.durationMs = durationMs;
+    this.finalResult = result;
+    this.rebuild();
+  }
+
+  setExpanded(expanded: boolean): void {
+    this.expanded = expanded;
+    this.rebuild();
+  }
+
+  toggleExpanded(): void {
+    this.expanded = !this.expanded;
+    this.rebuild();
+  }
+
+  // IToolExecutionComponent interface methods
+  updateArgs(_args: unknown): void {}
+  updateResult(_result: unknown, _isPartial: boolean): void {}
+
+  // ── Rendering ──────────────────────────────────────────────────────────
+
+  private rebuild(): void {
+    this.clear();
+    this.addChild(new Spacer(1));
+
+    const border = (char: string) => theme.bold(theme.fg('accent', char));
+    const termWidth = process.stdout.columns || 80;
+    const maxLineWidth = termWidth - 6;
+
+    // ── Top border ──
+    this.addChild(new Text(border('┌──'), 0, 0));
+
+    // ── Task description (capped when collapsed) ──
+    const taskLines = this.task.split('\n');
+    const wrappedTaskLines: string[] = [];
+    for (const line of taskLines) {
+      if (line.length > maxLineWidth) {
+        let remaining = line;
+        while (remaining.length > maxLineWidth) {
+          const breakAt = remaining.lastIndexOf(' ', maxLineWidth);
+          const splitAt = breakAt > 0 ? breakAt : maxLineWidth;
+          wrappedTaskLines.push(remaining.slice(0, splitAt));
+          remaining = remaining.slice(splitAt).trimStart();
         }
-        this.rebuild()
+        if (remaining) wrappedTaskLines.push(remaining);
+      } else {
+        wrappedTaskLines.push(line);
+      }
+    }
+    const maxTaskLines = 5;
+    const taskTruncated = !this.expanded && wrappedTaskLines.length > maxTaskLines + 1;
+    const displayTaskLines = taskTruncated ? wrappedTaskLines.slice(0, maxTaskLines) : wrappedTaskLines;
+
+    const taskContent = displayTaskLines.map(line => `${border('│')} ${line}`).join('\n');
+    this.addChild(new Text(taskContent, 0, 0));
+
+    if (taskTruncated) {
+      const moreText = theme.fg('muted', `... ${wrappedTaskLines.length - maxTaskLines} more lines (ctrl+e to expand)`);
+      this.addChild(new Text(`${border('│')} ${moreText}`, 0, 0));
     }
 
-	finish(isError: boolean, durationMs: number, result?: string): void {
-		this.done = true
-		this.isError = isError
-		this.durationMs = durationMs
-		this.finalResult = result
-		this.rebuild()
-	}
+    // ── Activity lines (tool calls — capped rolling window) ──
+    if (this.toolCalls.length > 0) {
+      // Separator between task and activity
+      this.addChild(new Text(`${border('│')} ${theme.fg('muted', '───')}`, 0, 0));
 
-	setExpanded(expanded: boolean): void {
-		this.expanded = expanded
-		this.rebuild()
-	}
+      const activityLines = this.toolCalls.map(tc => formatToolCallLine(tc, maxLineWidth));
 
-	toggleExpanded(): void {
-		this.expanded = !this.expanded
-		this.rebuild()
-	}
+      // While streaming: rolling window. When done: collapsible.
+      const cap = this.done ? COLLAPSED_LINES : MAX_ACTIVITY_LINES;
+      let displayLines = activityLines;
+      let hiddenCount = 0;
+      const minHidden = this.done ? 2 : 1;
+      if (!this.expanded && activityLines.length > cap + minHidden - 1) {
+        hiddenCount = activityLines.length - cap;
+        if (this.done) {
+          // Show first N lines when collapsed (completed)
+          displayLines = activityLines.slice(0, cap);
+        } else {
+          // Show last N lines while streaming
+          displayLines = activityLines.slice(-cap);
+        }
+      }
 
-	// IToolExecutionComponent interface methods
-	updateArgs(_args: unknown): void {}
-	updateResult(_result: unknown, _isPartial: boolean): void {}
+      if (!this.done && hiddenCount > 0) {
+        const hiddenText = theme.fg('muted', `  ... ${hiddenCount} more above`);
+        this.addChild(new Text(`${border('│')} ${hiddenText}`, 0, 0));
+      }
 
-	// ── Rendering ──────────────────────────────────────────────────────────
+      const activityContent = displayLines.map(line => `${border('│')} ${line}`).join('\n');
+      this.addChild(new Text(activityContent, 0, 0));
 
-	private rebuild(): void {
-		this.clear()
-		this.addChild(new Spacer(1))
+      if (this.done && hiddenCount > 0) {
+        const moreText = theme.fg('muted', `... ${hiddenCount} more (ctrl+e to expand)`);
+        this.addChild(new Text(`${border('│')} ${moreText}`, 0, 0));
+      }
+    }
 
-		const border = (char: string) => theme.bold(theme.fg("accent", char))
-		const termWidth = process.stdout.columns || 80
-		const maxLineWidth = termWidth - 6
+    // ── Final result (shown after completion) ──
+    // When tool calls exist: only show result when expanded
+    // When no tool calls: always show result (capped when collapsed)
+    const showResult = this.done && this.finalResult && (this.expanded || this.toolCalls.length === 0);
+    if (showResult) {
+      this.addChild(new Text(`${border('│')} ${theme.fg('muted', '───')}`, 0, 0));
+      const resultLines = this.finalResult!.split('\n');
+      const maxResultLines = this.expanded ? resultLines.length : 10;
+      const truncated = !this.expanded && resultLines.length > maxResultLines + 1;
+      const displayLines = truncated ? resultLines.slice(-maxResultLines) : resultLines;
 
-		// ── Top border ──
-		this.addChild(new Text(border("┌──"), 0, 0))
+      if (truncated) {
+        const hiddenLine = `${border('│')} ${theme.fg('muted', `  ... ${resultLines.length - maxResultLines} more lines (ctrl+e to expand)`)}`;
+        this.addChild(new Text(hiddenLine, 0, 0));
+      }
 
-		// ── Task description (capped when collapsed) ──
-		const taskLines = this.task.split("\n")
-		const wrappedTaskLines: string[] = []
-		for (const line of taskLines) {
-			if (line.length > maxLineWidth) {
-				let remaining = line
-				while (remaining.length > maxLineWidth) {
-					const breakAt = remaining.lastIndexOf(" ", maxLineWidth)
-					const splitAt = breakAt > 0 ? breakAt : maxLineWidth
-					wrappedTaskLines.push(remaining.slice(0, splitAt))
-					remaining = remaining.slice(splitAt).trimStart()
-				}
-				if (remaining) wrappedTaskLines.push(remaining)
-			} else {
-				wrappedTaskLines.push(line)
-			}
-		}
-		const maxTaskLines = 5
-		const taskTruncated =
-			!this.expanded && wrappedTaskLines.length > maxTaskLines + 1
-		const displayTaskLines = taskTruncated
-			? wrappedTaskLines.slice(0, maxTaskLines)
-			: wrappedTaskLines
+      const resultContent = displayLines
+        .map(line => {
+          const truncatedLine = line.length > maxLineWidth ? line.slice(0, maxLineWidth - 1) + '…' : line;
+          return `${border('│')} ${theme.fg('muted', truncatedLine)}`;
+        })
+        .join('\n');
+      if (resultContent.trim()) {
+        this.addChild(new Text(resultContent, 0, 0));
+      }
+    }
 
-		const taskContent = displayTaskLines
-			.map((line) => `${border("│")} ${line}`)
-			.join("\n")
-		this.addChild(new Text(taskContent, 0, 0))
+    // ── Bottom border with info ──
+    const typeLabel = theme.bold(theme.fg('accent', this.agentType));
+    const modelLabel = this.modelId ? theme.fg('muted', ` ${this.modelId}`) : '';
+    const statusIcon = this.done
+      ? this.isError
+        ? theme.fg('error', ' ✗')
+        : theme.fg('success', ' ✓')
+      : theme.fg('muted', ' ⋯');
+    const durationStr = this.done ? theme.fg('muted', ` ${formatDuration(this.durationMs)}`) : '';
 
-		if (taskTruncated) {
-			const moreText = theme.fg(
-				"muted",
-				`... ${wrappedTaskLines.length - maxTaskLines} more lines (ctrl+e to expand)`,
-			)
-			this.addChild(new Text(`${border("│")} ${moreText}`, 0, 0))
-		}
+    const footerText = `${theme.bold(theme.fg('toolTitle', 'subagent'))} ${typeLabel}${modelLabel}${durationStr}${statusIcon}`;
+    this.addChild(new Text(`${border('└──')} ${footerText}`, 0, 0));
 
-		// ── Activity lines (tool calls — capped rolling window) ──
-		if (this.toolCalls.length > 0) {
-			// Separator between task and activity
-			this.addChild(
-				new Text(`${border("│")} ${theme.fg("muted", "───")}`, 0, 0),
-			)
-
-			const activityLines = this.toolCalls.map((tc) =>
-				formatToolCallLine(tc, maxLineWidth),
-			)
-
-			// While streaming: rolling window. When done: collapsible.
-			const cap = this.done ? COLLAPSED_LINES : MAX_ACTIVITY_LINES
-			let displayLines = activityLines
-			let hiddenCount = 0
-			const minHidden = this.done ? 2 : 1
-			if (!this.expanded && activityLines.length > cap + minHidden - 1) {
-				hiddenCount = activityLines.length - cap
-				if (this.done) {
-					// Show first N lines when collapsed (completed)
-					displayLines = activityLines.slice(0, cap)
-				} else {
-					// Show last N lines while streaming
-					displayLines = activityLines.slice(-cap)
-				}
-			}
-
-			if (!this.done && hiddenCount > 0) {
-				const hiddenText = theme.fg("muted", `  ... ${hiddenCount} more above`)
-				this.addChild(new Text(`${border("│")} ${hiddenText}`, 0, 0))
-			}
-
-			const activityContent = displayLines
-				.map((line) => `${border("│")} ${line}`)
-				.join("\n")
-			this.addChild(new Text(activityContent, 0, 0))
-
-			if (this.done && hiddenCount > 0) {
-				const moreText = theme.fg(
-					"muted",
-					`... ${hiddenCount} more (ctrl+e to expand)`,
-				)
-				this.addChild(new Text(`${border("│")} ${moreText}`, 0, 0))
-			}
-		}
-
-		// ── Final result (shown after completion) ──
-		// When tool calls exist: only show result when expanded
-		// When no tool calls: always show result (capped when collapsed)
-		const showResult =
-			this.done &&
-			this.finalResult &&
-			(this.expanded || this.toolCalls.length === 0)
-		if (showResult) {
-			this.addChild(
-				new Text(`${border("│")} ${theme.fg("muted", "───")}`, 0, 0),
-			)
-			const resultLines = this.finalResult!.split("\n")
-			const maxResultLines = this.expanded ? resultLines.length : 10
-			const truncated =
-				!this.expanded && resultLines.length > maxResultLines + 1
-			const displayLines = truncated
-				? resultLines.slice(-maxResultLines)
-				: resultLines
-
-			if (truncated) {
-				const hiddenLine = `${border("│")} ${theme.fg("muted", `  ... ${resultLines.length - maxResultLines} more lines (ctrl+e to expand)`)}`
-				this.addChild(new Text(hiddenLine, 0, 0))
-			}
-
-			const resultContent = displayLines
-				.map((line) => {
-					const truncatedLine =
-						line.length > maxLineWidth
-							? line.slice(0, maxLineWidth - 1) + "…"
-							: line
-					return `${border("│")} ${theme.fg("muted", truncatedLine)}`
-				})
-				.join("\n")
-			if (resultContent.trim()) {
-				this.addChild(new Text(resultContent, 0, 0))
-			}
-		}
-
-		// ── Bottom border with info ──
-		const typeLabel = theme.bold(theme.fg("accent", this.agentType))
-		const modelLabel = this.modelId ? theme.fg("muted", ` ${this.modelId}`) : ""
-		const statusIcon = this.done
-			? this.isError
-				? theme.fg("error", " ✗")
-				: theme.fg("success", " ✓")
-			: theme.fg("muted", " ⋯")
-		const durationStr = this.done
-			? theme.fg("muted", ` ${formatDuration(this.durationMs)}`)
-			: ""
-
-		const footerText = `${theme.bold(theme.fg("toolTitle", "subagent"))} ${typeLabel}${modelLabel}${durationStr}${statusIcon}`
-		this.addChild(new Text(`${border("└──")} ${footerText}`, 0, 0))
-
-		this.invalidate()
-		this.ui.requestRender()
-	}
+    this.invalidate();
+    this.ui.requestRender();
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -261,52 +227,47 @@ export class SubagentExecutionComponent
 // ─────────────────────────────────────────────────────────────────────────────
 
 function formatToolCallLine(tc: SubagentToolCall, _maxWidth: number): string {
-	const icon = tc.done
-		? tc.isError
-			? theme.fg("error", "✗")
-			: theme.fg("success", "✓")
-		: theme.fg("muted", "⋯")
-	const name = theme.fg("toolTitle", tc.name)
-	const argsSummary = summarizeArgs(tc.args)
-	return `${icon} ${name} ${argsSummary}`
+  const icon = tc.done ? (tc.isError ? theme.fg('error', '✗') : theme.fg('success', '✓')) : theme.fg('muted', '⋯');
+  const name = theme.fg('toolTitle', tc.name);
+  const argsSummary = summarizeArgs(tc.args);
+  return `${icon} ${name} ${argsSummary}`;
 }
 
 function formatDuration(ms: number): string {
-	if (ms < 1000) return `${ms}ms`
-	const s = (ms / 1000).toFixed(1)
-	return `${s}s`
+  if (ms < 1000) return `${ms}ms`;
+  const s = (ms / 1000).toFixed(1);
+  return `${s}s`;
 }
 
 function summarizeArgs(args: unknown): string {
-	if (!args || typeof args !== "object") return ""
-	const obj = args as Record<string, unknown>
-	const parts: string[] = []
+  if (!args || typeof args !== 'object') return '';
+  const obj = args as Record<string, unknown>;
+  const parts: string[] = [];
 
-	// Special handling for todo_write tool
-	if (obj.todos && Array.isArray(obj.todos)) {
-		const todos = obj.todos as Array<{
-			content?: string
-			status?: string
-			activeForm?: string
-		}>
-		const taskSummaries = todos.map((t) => {
-			const icon =
-				t.status === "completed" ? "✓" : t.status === "in_progress" ? "→" : "○"
-			const content = t.content || t.activeForm || "task"
-			return `${icon} ${content}`
-		})
-		return theme.fg("muted", taskSummaries.join(", "))
-	}
+  // Special handling for todo_write tool
+  if (obj.todos && Array.isArray(obj.todos)) {
+    const todos = obj.todos as Array<{
+      content?: string;
+      status?: string;
+      activeForm?: string;
+    }>;
+    const taskSummaries = todos.map(t => {
+      const icon = t.status === 'completed' ? '✓' : t.status === 'in_progress' ? '→' : '○';
+      const content = t.content || t.activeForm || 'task';
+      return `${icon} ${content}`;
+    });
+    return theme.fg('muted', taskSummaries.join(', '));
+  }
 
-	for (const [_key, val] of Object.entries(obj)) {
-		if (typeof val === "string") {
-			const short = val.length > 40 ? val.slice(0, 40) + "…" : val
-			parts.push(theme.fg("muted", short))
-		} else if (Array.isArray(val)) {
-			parts.push(theme.fg("muted", `${val.length} items`))
-		} else if (typeof val === "object" && val !== null) {
-			parts.push(theme.fg("muted", "{...}"))
-		}
-	}
-	return parts.join(" ")
+  for (const [_key, val] of Object.entries(obj)) {
+    if (typeof val === 'string') {
+      const short = val.length > 40 ? val.slice(0, 40) + '…' : val;
+      parts.push(theme.fg('muted', short));
+    } else if (Array.isArray(val)) {
+      parts.push(theme.fg('muted', `${val.length} items`));
+    } else if (typeof val === 'object' && val !== null) {
+      parts.push(theme.fg('muted', '{...}'));
+    }
+  }
+  return parts.join(' ');
 }

--- a/mastracode/src/tui/components/subagent-execution.ts
+++ b/mastracode/src/tui/components/subagent-execution.ts
@@ -66,19 +66,19 @@ export class SubagentExecutionComponent
 		this.toolCalls.push({ name, args, done: false })
 		this.rebuild()
 	}
-
-	addToolEnd(name: string, result: unknown, isError: boolean): void {
-		for (let i = this.toolCalls.length - 1; i >= 0; i--) {
-			if (this.toolCalls[i].name === name && !this.toolCalls[i].done) {
-				this.toolCalls[i].done = true
-				this.toolCalls[i].isError = isError
-				this.toolCalls[i].result =
-					typeof result === "string" ? result : JSON.stringify(result ?? "")
-				break
-			}
-		}
-		this.rebuild()
-	}
+    addToolEnd(name: string, result: unknown, isError: boolean): void {
+        for (let i = this.toolCalls.length - 1; i >= 0; i--) {
+            const toolCall = this.toolCalls[i]!
+            if (toolCall.name === name && !toolCall.done) {
+                toolCall.done = true
+                toolCall.isError = isError
+                toolCall.result =
+                    typeof result === "string" ? result : JSON.stringify(result ?? "")
+                break
+            }
+        }
+        this.rebuild()
+    }
 
 	finish(isError: boolean, durationMs: number, result?: string): void {
 		this.done = true

--- a/mastracode/src/tui/components/system-reminder.ts
+++ b/mastracode/src/tui/components/system-reminder.ts
@@ -3,26 +3,26 @@
  * with a distinct orange/dim style to differentiate from user messages.
  */
 
-import { Container, Markdown } from "@mariozechner/pi-tui"
-import { getMarkdownTheme, theme } from "../theme.js"
+import { Container, Markdown } from '@mariozechner/pi-tui';
+import { getMarkdownTheme, theme } from '../theme.js';
 
 export interface SystemReminderOptions {
-	message: string
+  message: string;
 }
 
 export class SystemReminderComponent extends Container {
-	constructor(options: SystemReminderOptions) {
-		super()
+  constructor(options: SystemReminderOptions) {
+    super();
 
-		// Title and message combined with full-width background
-		const title = theme.fg("warning", "⚡ System Notice")
-		const content = `${title}\n${options.message.trim()}`
+    // Title and message combined with full-width background
+    const title = theme.fg('warning', '⚡ System Notice');
+    const content = `${title}\n${options.message.trim()}`;
 
-		this.addChild(
-			new Markdown(content, 1, 1, getMarkdownTheme(), {
-				bgColor: (text: string) => theme.bg("systemReminderBg", text),
-				color: (text: string) => theme.fg("muted", text),
-			}),
-		)
-	}
+    this.addChild(
+      new Markdown(content, 1, 1, getMarkdownTheme(), {
+        bgColor: (text: string) => theme.bg('systemReminderBg', text),
+        color: (text: string) => theme.fg('muted', text),
+      }),
+    );
+  }
 }

--- a/mastracode/src/tui/components/thinking-settings.ts
+++ b/mastracode/src/tui/components/thinking-settings.ts
@@ -5,24 +5,17 @@
  * Changes apply immediately — Esc closes the panel.
  */
 
-import {
-	Box,
-	SelectList,
-	
-	Spacer,
-	Text
-	
-} from "@mariozechner/pi-tui"
-import type {SelectItem, Focusable} from "@mariozechner/pi-tui";
-import { fg, bg, bold, getSelectListTheme } from "../theme.js"
+import { Box, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
+import type { SelectItem, Focusable } from '@mariozechner/pi-tui';
+import { fg, bg, bold, getSelectListTheme } from '../theme.js';
 
 // =============================================================================
 // Types
 // =============================================================================
 
 export interface ThinkingSettingsCallbacks {
-	onLevelChange: (level: string) => void
-	onClose: () => void
+  onLevelChange: (level: string) => void;
+  onClose: () => void;
 }
 
 // =============================================================================
@@ -30,66 +23,64 @@ export interface ThinkingSettingsCallbacks {
 // =============================================================================
 
 export const THINKING_LEVELS = [
-	{ id: "off", label: "Off", description: "No extended thinking" },
-	{ id: "minimal", label: "Minimal", description: "~1k budget tokens" },
-	{ id: "low", label: "Low", description: "~4k budget tokens" },
-	{ id: "medium", label: "Medium", description: "~10k budget tokens" },
-	{ id: "high", label: "High", description: "~32k budget tokens" },
-] as const
+  { id: 'off', label: 'Off', description: 'No extended thinking' },
+  { id: 'minimal', label: 'Minimal', description: '~1k budget tokens' },
+  { id: 'low', label: 'Low', description: '~4k budget tokens' },
+  { id: 'medium', label: 'Medium', description: '~10k budget tokens' },
+  { id: 'high', label: 'High', description: '~32k budget tokens' },
+] as const;
 
 // =============================================================================
 // Thinking Settings Component
 // =============================================================================
 
 export class ThinkingSettingsComponent extends Box implements Focusable {
-	private selectList: SelectList
+  private selectList: SelectList;
 
-	// Focusable implementation
-	private _focused = false
-	get focused(): boolean {
-		return this._focused
-	}
-	set focused(value: boolean) {
-		this._focused = value
-	}
+  // Focusable implementation
+  private _focused = false;
+  get focused(): boolean {
+    return this._focused;
+  }
+  set focused(value: boolean) {
+    this._focused = value;
+  }
 
-	constructor(currentLevel: string, callbacks: ThinkingSettingsCallbacks) {
-		super(2, 1, (text: string) => bg("overlayBg", text))
+  constructor(currentLevel: string, callbacks: ThinkingSettingsCallbacks) {
+    super(2, 1, (text: string) => bg('overlayBg', text));
 
-		// Title
-		this.addChild(new Text(bold(fg("accent", "Thinking Level")), 0, 0))
-		this.addChild(new Spacer(1))
-		this.addChild(
-			new Text(fg("muted", "Extended thinking for Anthropic models"), 0, 0),
-		)
-		this.addChild(new Spacer(1))
+    // Title
+    this.addChild(new Text(bold(fg('accent', 'Thinking Level')), 0, 0));
+    this.addChild(new Spacer(1));
+    this.addChild(new Text(fg('muted', 'Extended thinking for Anthropic models'), 0, 0));
+    this.addChild(new Spacer(1));
 
-		// Build items
-		const items: SelectItem[] = THINKING_LEVELS.map((level) => ({
-			value: level.id,
-			label: `  ${level.label}  ${fg("dim", level.description)}`,
-		}))
+    // Build items
+    const items: SelectItem[] = THINKING_LEVELS.map(level => ({
+      value: level.id,
+      label: `  ${level.label}  ${fg('dim', level.description)}`,
+    }));
 
-		this.selectList = new SelectList(items, items.length, getSelectListTheme())
+    this.selectList = new SelectList(items, items.length, getSelectListTheme());
 
-		// Pre-select current level
-		const currentIndex = THINKING_LEVELS.findIndex((l) => l.id === currentLevel)
-		if (currentIndex !== -1) {
-			this.selectList.setSelectedIndex(currentIndex)
-		}
+    // Pre-select current level
+    const currentIndex = THINKING_LEVELS.findIndex(l => l.id === currentLevel);
+    if (currentIndex !== -1) {
+      this.selectList.setSelectedIndex(currentIndex);
+    }
 
-		this.selectList.onSelect = (item: SelectItem) => {
-			callbacks.onLevelChange(item.value)
-			callbacks.onClose()
-		}
-		this.selectList.onCancel = callbacks.onClose
+    this.selectList.onSelect = (item: SelectItem) => {
+      callbacks.onLevelChange(item.value);
+      callbacks.onClose();
+    };
+    this.selectList.onCancel = callbacks.onClose;
 
-		this.addChild(this.selectList)
-		this.addChild(new Spacer(1))
-		this.addChild(new Text(fg("dim", "  Enter to select · Esc to close"), 0, 0))
-	}
+    this.addChild(this.selectList);
+    this.addChild(new Spacer(1));
+    this.addChild(new Text(fg('dim', '  Enter to select · Esc to close'), 0, 0));
+  }
 
-	handleInput(data: string): void {
-		this.selectList.handleInput(data)
-	}
+  handleInput(data: string): void {
+    this.selectList.handleInput(data);
+  }
 }

--- a/mastracode/src/tui/components/thread-selector.ts
+++ b/mastracode/src/tui/components/thread-selector.ts
@@ -3,35 +3,25 @@
  * Uses pi-tui overlay pattern with search and navigation.
  */
 
-import {
-	Box,
-	Container,
-	
-	fuzzyFilter,
-	getEditorKeybindings,
-	Input,
-	Spacer,
-	Text
-	
-} from "@mariozechner/pi-tui"
-import type {Focusable, TUI} from "@mariozechner/pi-tui";
-import type { HarnessThread } from "../../harness/types.js"
-import { bg, fg, bold } from "../theme.js"
+import { Box, Container, fuzzyFilter, getEditorKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
+import type { Focusable, TUI } from '@mariozechner/pi-tui';
+import type { HarnessThread } from '../../harness/types.js';
+import { bg, fg, bold } from '../theme.js';
 
 // =============================================================================
 // Types
 // =============================================================================
 
 export interface ThreadSelectorOptions {
-	tui: TUI
-	threads: HarnessThread[]
-	currentThreadId: string | null
-	/** Current resource ID — threads from this resource sort to the top */
-	currentResourceId?: string
-	onSelect: (thread: HarnessThread) => void
-	onCancel: () => void
-	/** Function to fetch message preview for a thread */
-	getMessagePreview?: (threadId: string) => Promise<string | null>
+  tui: TUI;
+  threads: HarnessThread[];
+  currentThreadId: string | null;
+  /** Current resource ID — threads from this resource sort to the top */
+  currentResourceId?: string;
+  onSelect: (thread: HarnessThread) => void;
+  onCancel: () => void;
+  /** Function to fetch message preview for a thread */
+  getMessagePreview?: (threadId: string) => Promise<string | null>;
 }
 
 // =============================================================================
@@ -39,245 +29,207 @@ export interface ThreadSelectorOptions {
 // =============================================================================
 
 export class ThreadSelectorComponent extends Box implements Focusable {
-	private searchInput!: Input
-	private listContainer!: Container
-	private allThreads: HarnessThread[]
-	private filteredThreads: HarnessThread[]
-	private selectedIndex = 0
-	private currentThreadId: string | null
-	private currentResourceId: string | undefined
-	private onSelectCallback: (thread: HarnessThread) => void
-	private onCancelCallback: () => void
-	private tui: TUI
-	private getMessagePreview:
-		| ((threadId: string) => Promise<string | null>)
-		| undefined
-	private messagePreviews: Map<string, string> = new Map()
+  private searchInput!: Input;
+  private listContainer!: Container;
+  private allThreads: HarnessThread[];
+  private filteredThreads: HarnessThread[];
+  private selectedIndex = 0;
+  private currentThreadId: string | null;
+  private currentResourceId: string | undefined;
+  private onSelectCallback: (thread: HarnessThread) => void;
+  private onCancelCallback: () => void;
+  private tui: TUI;
+  private getMessagePreview: ((threadId: string) => Promise<string | null>) | undefined;
+  private messagePreviews: Map<string, string> = new Map();
 
-	// Focusable implementation
-	private _focused = false
-	get focused(): boolean {
-		return this._focused
-	}
-	set focused(value: boolean) {
-		this._focused = value
-		this.searchInput.focused = value
-	}
+  // Focusable implementation
+  private _focused = false;
+  get focused(): boolean {
+    return this._focused;
+  }
+  set focused(value: boolean) {
+    this._focused = value;
+    this.searchInput.focused = value;
+  }
 
-	constructor(options: ThreadSelectorOptions) {
-		super(2, 1, (text) => bg("overlayBg", text))
+  constructor(options: ThreadSelectorOptions) {
+    super(2, 1, text => bg('overlayBg', text));
 
-		this.tui = options.tui
-		this.currentResourceId = options.currentResourceId
-		this.allThreads = this.sortThreads(options.threads, options.currentThreadId)
-		this.currentThreadId = options.currentThreadId
-		this.onSelectCallback = options.onSelect
-		this.onCancelCallback = options.onCancel
-		this.getMessagePreview = options.getMessagePreview
-		this.filteredThreads = this.allThreads
+    this.tui = options.tui;
+    this.currentResourceId = options.currentResourceId;
+    this.allThreads = this.sortThreads(options.threads, options.currentThreadId);
+    this.currentThreadId = options.currentThreadId;
+    this.onSelectCallback = options.onSelect;
+    this.onCancelCallback = options.onCancel;
+    this.getMessagePreview = options.getMessagePreview;
+    this.filteredThreads = this.allThreads;
 
-		this.buildUI()
-		this.loadMessagePreviews()
-	}
+    this.buildUI();
+    this.loadMessagePreviews();
+  }
 
-	private async loadMessagePreviews(): Promise<void> {
-		if (!this.getMessagePreview) return
+  private async loadMessagePreviews(): Promise<void> {
+    if (!this.getMessagePreview) return;
 
-		// Load previews for all threads
-		for (const thread of this.allThreads) {
-			try {
-				const preview = await this.getMessagePreview(thread.id)
-				if (preview) {
-					this.messagePreviews.set(thread.id, preview)
-				}
-			} catch {
-				// Ignore errors, preview will just be empty
-			}
-		}
-		this.updateList()
-		this.tui.requestRender()
-	}
+    // Load previews for all threads
+    for (const thread of this.allThreads) {
+      try {
+        const preview = await this.getMessagePreview(thread.id);
+        if (preview) {
+          this.messagePreviews.set(thread.id, preview);
+        }
+      } catch {
+        // Ignore errors, preview will just be empty
+      }
+    }
+    this.updateList();
+    this.tui.requestRender();
+  }
 
-	private buildUI(): void {
-		this.addChild(new Text(bold(fg("accent", "Select Thread")), 0, 0))
-		this.addChild(new Spacer(1))
-		this.addChild(
-			new Text(
-				fg("muted", "Type to search • ↑↓ navigate • Enter select • Esc cancel"),
-				0,
-				0,
-			),
-		)
-		this.addChild(new Spacer(1))
+  private buildUI(): void {
+    this.addChild(new Text(bold(fg('accent', 'Select Thread')), 0, 0));
+    this.addChild(new Spacer(1));
+    this.addChild(new Text(fg('muted', 'Type to search • ↑↓ navigate • Enter select • Esc cancel'), 0, 0));
+    this.addChild(new Spacer(1));
 
-		this.searchInput = new Input()
-		this.searchInput.onSubmit = () => {
-			const selected = this.filteredThreads[this.selectedIndex]
-			if (selected) {
-				this.onSelectCallback(selected)
-			}
-		}
-		this.addChild(this.searchInput)
-		this.addChild(new Spacer(1))
+    this.searchInput = new Input();
+    this.searchInput.onSubmit = () => {
+      const selected = this.filteredThreads[this.selectedIndex];
+      if (selected) {
+        this.onSelectCallback(selected);
+      }
+    };
+    this.addChild(this.searchInput);
+    this.addChild(new Spacer(1));
 
-		this.listContainer = new Container()
-		this.addChild(this.listContainer)
+    this.listContainer = new Container();
+    this.addChild(this.listContainer);
 
-		this.updateList()
-	}
+    this.updateList();
+  }
 
-	private sortThreads(
-		threads: HarnessThread[],
-		currentThreadId: string | null,
-	): HarnessThread[] {
-		const sorted = [...threads]
-		const resId = this.currentResourceId
-		sorted.sort((a, b) => {
-			// Current thread first
-			if (a.id === currentThreadId) return -1
-			if (b.id === currentThreadId) return 1
-			// Current resource threads before other resources
-			if (resId) {
-				const aLocal = a.resourceId === resId
-				const bLocal = b.resourceId === resId
-				if (aLocal && !bLocal) return -1
-				if (!aLocal && bLocal) return 1
-			}
-			// Then by most recently updated
-			return b.updatedAt.getTime() - a.updatedAt.getTime()
-		})
-		return sorted
-	}
+  private sortThreads(threads: HarnessThread[], currentThreadId: string | null): HarnessThread[] {
+    const sorted = [...threads];
+    const resId = this.currentResourceId;
+    sorted.sort((a, b) => {
+      // Current thread first
+      if (a.id === currentThreadId) return -1;
+      if (b.id === currentThreadId) return 1;
+      // Current resource threads before other resources
+      if (resId) {
+        const aLocal = a.resourceId === resId;
+        const bLocal = b.resourceId === resId;
+        if (aLocal && !bLocal) return -1;
+        if (!aLocal && bLocal) return 1;
+      }
+      // Then by most recently updated
+      return b.updatedAt.getTime() - a.updatedAt.getTime();
+    });
+    return sorted;
+  }
 
-	private filterThreads(query: string): void {
-		this.filteredThreads = query
-			? fuzzyFilter(
-					this.allThreads,
-					query,
-					(t) =>
-						`${t.title ?? ""} ${t.resourceId} ${t.id} ${(t.metadata?.projectPath as string) ?? ""}`,
-				)
-			: this.allThreads
+  private filterThreads(query: string): void {
+    this.filteredThreads = query
+      ? fuzzyFilter(
+          this.allThreads,
+          query,
+          t => `${t.title ?? ''} ${t.resourceId} ${t.id} ${(t.metadata?.projectPath as string) ?? ''}`,
+        )
+      : this.allThreads;
 
-		this.selectedIndex = Math.min(
-			this.selectedIndex,
-			Math.max(0, this.filteredThreads.length - 1),
-		)
-		this.updateList()
-	}
+    this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.filteredThreads.length - 1));
+    this.updateList();
+  }
 
-	private formatTimeAgo(date: Date): string {
-		const seconds = Math.floor((Date.now() - date.getTime()) / 1000)
-		if (seconds < 60) return "just now"
-		const minutes = Math.floor(seconds / 60)
-		if (minutes < 60) return `${minutes}m ago`
-		const hours = Math.floor(minutes / 60)
-		if (hours < 24) return `${hours}h ago`
-		const days = Math.floor(hours / 24)
-		return `${days}d ago`
-	}
+  private formatTimeAgo(date: Date): string {
+    const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+    if (seconds < 60) return 'just now';
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+  }
 
-	private updateList(): void {
-		this.listContainer.clear()
+  private updateList(): void {
+    this.listContainer.clear();
 
-		const maxVisible = 12
-		const startIndex = Math.max(
-			0,
-			Math.min(
-				this.selectedIndex - Math.floor(maxVisible / 2),
-				this.filteredThreads.length - maxVisible,
-			),
-		)
-		const endIndex = Math.min(
-			startIndex + maxVisible,
-			this.filteredThreads.length,
-		)
+    const maxVisible = 12;
+    const startIndex = Math.max(
+      0,
+      Math.min(this.selectedIndex - Math.floor(maxVisible / 2), this.filteredThreads.length - maxVisible),
+    );
+    const endIndex = Math.min(startIndex + maxVisible, this.filteredThreads.length);
 
-		for (let i = startIndex; i < endIndex; i++) {
-			const thread = this.filteredThreads[i]
-			if (!thread) continue
+    for (let i = startIndex; i < endIndex; i++) {
+      const thread = this.filteredThreads[i];
+      if (!thread) continue;
 
-			const isSelected = i === this.selectedIndex
-			const isCurrent = thread.id === this.currentThreadId
-			const checkmark = isCurrent ? fg("success", " ✓") : ""
-			const shortId = thread.id.slice(-6)
-			const threadPath = thread.metadata?.projectPath as string | undefined
-			const pathTag = threadPath
-				? fg("dim", ` [${threadPath.split("/").pop()}]`)
-				: ""
-			const displayId = `${thread.resourceId}/${shortId}`
-			const timeAgo = fg("muted", ` (${this.formatTimeAgo(thread.updatedAt)})`)
+      const isSelected = i === this.selectedIndex;
+      const isCurrent = thread.id === this.currentThreadId;
+      const checkmark = isCurrent ? fg('success', ' ✓') : '';
+      const shortId = thread.id.slice(-6);
+      const threadPath = thread.metadata?.projectPath as string | undefined;
+      const pathTag = threadPath ? fg('dim', ` [${threadPath.split('/').pop()}]`) : '';
+      const displayId = `${thread.resourceId}/${shortId}`;
+      const timeAgo = fg('muted', ` (${this.formatTimeAgo(thread.updatedAt)})`);
 
-			// Only show custom titles (not auto-generated "New Thread")
-			const hasCustomTitle = thread.title && thread.title !== "New Thread"
+      // Only show custom titles (not auto-generated "New Thread")
+      const hasCustomTitle = thread.title && thread.title !== 'New Thread';
 
-			let line = ""
-			if (isSelected) {
-				line = fg("accent", `→ ${displayId}`) + pathTag + timeAgo + checkmark
-			} else {
-				line = `  ${displayId}` + pathTag + timeAgo + checkmark
-			}
+      let line = '';
+      if (isSelected) {
+        line = fg('accent', `→ ${displayId}`) + pathTag + timeAgo + checkmark;
+      } else {
+        line = `  ${displayId}` + pathTag + timeAgo + checkmark;
+      }
 
-			this.listContainer.addChild(new Text(line, 0, 0))
+      this.listContainer.addChild(new Text(line, 0, 0));
 
-			// Show message preview or custom title on second line
-			const preview = this.messagePreviews.get(thread.id)
-			if (preview) {
-				this.listContainer.addChild(
-					new Text(`     ${fg("muted", `"${preview}"`)}`, 0, 0),
-				)
-			} else if (hasCustomTitle) {
-				this.listContainer.addChild(
-					new Text(`     ${fg("muted", `"${thread.title}"`)}`, 0, 0),
-				)
-			}
-		}
+      // Show message preview or custom title on second line
+      const preview = this.messagePreviews.get(thread.id);
+      if (preview) {
+        this.listContainer.addChild(new Text(`     ${fg('muted', `"${preview}"`)}`, 0, 0));
+      } else if (hasCustomTitle) {
+        this.listContainer.addChild(new Text(`     ${fg('muted', `"${thread.title}"`)}`, 0, 0));
+      }
+    }
 
-		if (startIndex > 0 || endIndex < this.filteredThreads.length) {
-			const scrollInfo = fg(
-				"muted",
-				`(${this.selectedIndex + 1}/${this.filteredThreads.length})`,
-			)
-			this.listContainer.addChild(new Text(scrollInfo, 0, 0))
-		}
+    if (startIndex > 0 || endIndex < this.filteredThreads.length) {
+      const scrollInfo = fg('muted', `(${this.selectedIndex + 1}/${this.filteredThreads.length})`);
+      this.listContainer.addChild(new Text(scrollInfo, 0, 0));
+    }
 
-		if (this.filteredThreads.length === 0) {
-			this.listContainer.addChild(
-				new Text(fg("muted", "No matching threads"), 0, 0),
-			)
-		}
-	}
+    if (this.filteredThreads.length === 0) {
+      this.listContainer.addChild(new Text(fg('muted', 'No matching threads'), 0, 0));
+    }
+  }
 
-	handleInput(keyData: string): void {
-		const kb = getEditorKeybindings()
+  handleInput(keyData: string): void {
+    const kb = getEditorKeybindings();
 
-		if (kb.matches(keyData, "selectUp")) {
-			if (this.filteredThreads.length === 0) return
-			this.selectedIndex =
-				this.selectedIndex === 0
-					? this.filteredThreads.length - 1
-					: this.selectedIndex - 1
-			this.updateList()
-			this.tui.requestRender()
-		} else if (kb.matches(keyData, "selectDown")) {
-			if (this.filteredThreads.length === 0) return
-			this.selectedIndex =
-				this.selectedIndex === this.filteredThreads.length - 1
-					? 0
-					: this.selectedIndex + 1
-			this.updateList()
-			this.tui.requestRender()
-		} else if (kb.matches(keyData, "selectConfirm")) {
-			const selected = this.filteredThreads[this.selectedIndex]
-			if (selected) {
-				this.onSelectCallback(selected)
-			}
-		} else if (kb.matches(keyData, "selectCancel")) {
-			this.onCancelCallback()
-		} else {
-			this.searchInput.handleInput(keyData)
-			this.filterThreads(this.searchInput.getValue())
-			this.tui.requestRender()
-		}
-	}
+    if (kb.matches(keyData, 'selectUp')) {
+      if (this.filteredThreads.length === 0) return;
+      this.selectedIndex = this.selectedIndex === 0 ? this.filteredThreads.length - 1 : this.selectedIndex - 1;
+      this.updateList();
+      this.tui.requestRender();
+    } else if (kb.matches(keyData, 'selectDown')) {
+      if (this.filteredThreads.length === 0) return;
+      this.selectedIndex = this.selectedIndex === this.filteredThreads.length - 1 ? 0 : this.selectedIndex + 1;
+      this.updateList();
+      this.tui.requestRender();
+    } else if (kb.matches(keyData, 'selectConfirm')) {
+      const selected = this.filteredThreads[this.selectedIndex];
+      if (selected) {
+        this.onSelectCallback(selected);
+      }
+    } else if (kb.matches(keyData, 'selectCancel')) {
+      this.onCancelCallback();
+    } else {
+      this.searchInput.handleInput(keyData);
+      this.filterThreads(this.searchInput.getValue());
+      this.tui.requestRender();
+    }
+  }
 }

--- a/mastracode/src/tui/components/todo-progress.ts
+++ b/mastracode/src/tui/components/todo-progress.ts
@@ -4,83 +4,80 @@
  * Hidden when no todos exist OR when all todos are completed.
  * Renders between status and editor.
  */
-import { Container, Text, Spacer } from "@mariozechner/pi-tui"
-import chalk from "chalk"
-import { fg, bold } from "../theme.js"
+import { Container, Text, Spacer } from '@mariozechner/pi-tui';
+import chalk from 'chalk';
+import { fg, bold } from '../theme.js';
 
 export interface TodoItem {
-	content: string
-	status: "pending" | "in_progress" | "completed"
-	activeForm: string
+  content: string;
+  status: 'pending' | 'in_progress' | 'completed';
+  activeForm: string;
 }
 
 export class TodoProgressComponent extends Container {
-	private todos: TodoItem[] = []
+  private todos: TodoItem[] = [];
 
-	constructor() {
-		super()
-	}
+  constructor() {
+    super();
+  }
 
-	/**
-	 * Replace the entire todo list and re-render.
-	 */
-	updateTodos(todos: TodoItem[]): void {
-		this.todos = todos
-		this.rebuildDisplay()
-	}
+  /**
+   * Replace the entire todo list and re-render.
+   */
+  updateTodos(todos: TodoItem[]): void {
+    this.todos = todos;
+    this.rebuildDisplay();
+  }
 
-	/**
-	 * Get the current todo list (read-only copy).
-	 */
-	getTodos(): TodoItem[] {
-		return [...this.todos]
-	}
+  /**
+   * Get the current todo list (read-only copy).
+   */
+  getTodos(): TodoItem[] {
+    return [...this.todos];
+  }
 
-	private rebuildDisplay(): void {
-		this.clear()
+  private rebuildDisplay(): void {
+    this.clear();
 
-		// No todos = no render (component takes zero vertical space)
-		if (this.todos.length === 0) return
+    // No todos = no render (component takes zero vertical space)
+    if (this.todos.length === 0) return;
 
-		// Progress header
-		const completed = this.todos.filter((t) => t.status === "completed").length
-		const total = this.todos.length
+    // Progress header
+    const completed = this.todos.filter(t => t.status === 'completed').length;
+    const total = this.todos.length;
 
-		// Hide the component when all todos are completed
-		if (completed === total) return
-		const headerText =
-			"  " +
-			bold(fg("accent", "Tasks")) +
-			fg("dim", ` [${completed}/${total} completed]`)
+    // Hide the component when all todos are completed
+    if (completed === total) return;
+    const headerText = '  ' + bold(fg('accent', 'Tasks')) + fg('dim', ` [${completed}/${total} completed]`);
 
-		this.addChild(new Spacer(1))
-		this.addChild(new Text(headerText, 0, 0))
+    this.addChild(new Spacer(1));
+    this.addChild(new Text(headerText, 0, 0));
 
-		// Render each todo
-		for (const todo of this.todos) {
-			this.addChild(new Text(this.formatTodoLine(todo), 0, 0))
-		}
-	}
+    // Render each todo
+    for (const todo of this.todos) {
+      this.addChild(new Text(this.formatTodoLine(todo), 0, 0));
+    }
+  }
 
-	private formatTodoLine(todo: TodoItem): string {
-		const indent = "    "
+  private formatTodoLine(todo: TodoItem): string {
+    const indent = '    ';
 
-		switch (todo.status) {
-			case "completed": {
-				const icon = chalk.green("\u2713")
-				const text = chalk.green.strikethrough(todo.content)
-				return `${indent}${icon} ${text}`
-			}
-			case "in_progress": {
-				const icon = chalk.yellow("\u25B6")
-				const text = chalk.yellow.bold(todo.activeForm)
-				return `${indent}${icon} ${text}`
-			}
-			case "pending": {
-				const icon = chalk.dim("\u25CB")
-				const text = chalk.dim(todo.content)
-				return `${indent}${icon} ${text}`
-			}
-		}
-	}
+    switch (todo.status) {
+      case 'completed': {
+        const icon = chalk.green('\u2713');
+        const text = chalk.green.strikethrough(todo.content);
+        return `${indent}${icon} ${text}`;
+      }
+      case 'in_progress': {
+        const icon = chalk.yellow('\u25B6');
+        const text = chalk.yellow.bold(todo.activeForm);
+        return `${indent}${icon} ${text}`;
+      }
+      case 'pending': {
+        const icon = chalk.dim('\u25CB');
+        const text = chalk.dim(todo.content);
+        return `${indent}${icon} ${text}`;
+      }
+    }
+  }
 }

--- a/mastracode/src/tui/components/tool-approval-dialog.ts
+++ b/mastracode/src/tui/components/tool-approval-dialog.ts
@@ -8,160 +8,145 @@
  *   a       — always allow this category for the session
  *   Y       — switch to YOLO mode (approve all)
  */
-import {
-	Box,
-	
-	getEditorKeybindings,
-	Spacer,
-	Text
-} from "@mariozechner/pi-tui"
-import type {Focusable} from "@mariozechner/pi-tui";
-import chalk from "chalk"
-import { bg, fg } from "../theme.js"
+import { Box, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
+import type { Focusable } from '@mariozechner/pi-tui';
+import chalk from 'chalk';
+import { bg, fg } from '../theme.js';
 
 export type ApprovalAction =
-	| { type: "approve" }
-	| { type: "decline" }
-	| { type: "always_allow_category" }
-	| { type: "yolo" }
+  | { type: 'approve' }
+  | { type: 'decline' }
+  | { type: 'always_allow_category' }
+  | { type: 'yolo' };
 
 export interface ToolApprovalDialogOptions {
-	toolCallId: string
-	toolName: string
-	args: unknown
-	/** Human-readable category label, e.g. "Edit" or "Execute" */
-	categoryLabel?: string
-	onAction: (action: ApprovalAction) => void
+  toolCallId: string;
+  toolName: string;
+  args: unknown;
+  /** Human-readable category label, e.g. "Edit" or "Execute" */
+  categoryLabel?: string;
+  onAction: (action: ApprovalAction) => void;
 }
 
 export class ToolApprovalDialogComponent extends Box implements Focusable {
-	private toolName: string
-	private args: unknown
-	private categoryLabel: string | undefined
-	private onAction: (action: ApprovalAction) => void
+  private toolName: string;
+  private args: unknown;
+  private categoryLabel: string | undefined;
+  private onAction: (action: ApprovalAction) => void;
 
-	// Focusable implementation
-	private _focused = false
-	get focused(): boolean {
-		return this._focused
-	}
-	set focused(value: boolean) {
-		this._focused = value
-	}
+  // Focusable implementation
+  private _focused = false;
+  get focused(): boolean {
+    return this._focused;
+  }
+  set focused(value: boolean) {
+    this._focused = value;
+  }
 
-	constructor(options: ToolApprovalDialogOptions) {
-		super(2, 1, (text) => bg("overlayBg", text))
+  constructor(options: ToolApprovalDialogOptions) {
+    super(2, 1, text => bg('overlayBg', text));
 
-		this.toolName = options.toolName
-		this.args = options.args
-		this.categoryLabel = options.categoryLabel
-		this.onAction = options.onAction
+    this.toolName = options.toolName;
+    this.args = options.args;
+    this.categoryLabel = options.categoryLabel;
+    this.onAction = options.onAction;
 
-		this.buildUI()
-	}
+    this.buildUI();
+  }
 
-	private buildUI(): void {
-		// Title
-		this.addChild(new Text(fg("warning", "⚠ Tool Approval Required"), 0, 0))
-		this.addChild(new Spacer(1))
+  private buildUI(): void {
+    // Title
+    this.addChild(new Text(fg('warning', '⚠ Tool Approval Required'), 0, 0));
+    this.addChild(new Spacer(1));
 
-		// Tool name
-		this.addChild(
-			new Text(fg("accent", `Tool: `) + fg("text", this.toolName), 0, 0),
-		)
-		if (this.categoryLabel) {
-			this.addChild(
-				new Text(
-					fg("accent", `Category: `) + fg("text", this.categoryLabel),
-					0,
-					0,
-				),
-			)
-		}
-		this.addChild(new Spacer(1))
+    // Tool name
+    this.addChild(new Text(fg('accent', `Tool: `) + fg('text', this.toolName), 0, 0));
+    if (this.categoryLabel) {
+      this.addChild(new Text(fg('accent', `Category: `) + fg('text', this.categoryLabel), 0, 0));
+    }
+    this.addChild(new Spacer(1));
 
-		// Arguments (formatted)
-		this.addChild(new Text(fg("muted", "Arguments:"), 0, 0))
-		const argsText = this.formatArgs(this.args)
-		for (const line of argsText.split("\n").slice(0, 10)) {
-			this.addChild(new Text(fg("text", "  " + line), 0, 0))
-		}
-		if (argsText.split("\n").length > 10) {
-			this.addChild(new Text(fg("muted", "  ... (truncated)"), 0, 0))
-		}
+    // Arguments (formatted)
+    this.addChild(new Text(fg('muted', 'Arguments:'), 0, 0));
+    const argsText = this.formatArgs(this.args);
+    for (const line of argsText.split('\n').slice(0, 10)) {
+      this.addChild(new Text(fg('text', '  ' + line), 0, 0));
+    }
+    if (argsText.split('\n').length > 10) {
+      this.addChild(new Text(fg('muted', '  ... (truncated)'), 0, 0));
+    }
 
-		this.addChild(new Spacer(1))
-		// Prompt text with keyboard shortcuts
-		const categoryHint = this.categoryLabel
-			? `lways allow ${this.categoryLabel.toLowerCase()}`
-			: "lways allow category"
-		const dim = chalk.hex("#555")
-		const key = chalk.white.bold
-		this.addChild(
-			new Text(
-				fg("accent", "Allow? ") +
-					key("y") +
-					dim("es  ") +
-					key("n") +
-					dim("o  ") +
-					key("a") +
-					dim(categoryHint + "  ") +
-					key("Y") +
-					dim("olo"),
-				0,
-				0,
-			),
-		)
-	}
+    this.addChild(new Spacer(1));
+    // Prompt text with keyboard shortcuts
+    const categoryHint = this.categoryLabel
+      ? `lways allow ${this.categoryLabel.toLowerCase()}`
+      : 'lways allow category';
+    const dim = chalk.hex('#555');
+    const key = chalk.white.bold;
+    this.addChild(
+      new Text(
+        fg('accent', 'Allow? ') +
+          key('y') +
+          dim('es  ') +
+          key('n') +
+          dim('o  ') +
+          key('a') +
+          dim(categoryHint + '  ') +
+          key('Y') +
+          dim('olo'),
+        0,
+        0,
+      ),
+    );
+  }
 
-	private formatArgs(args: unknown): string {
-		if (args === null || args === undefined) {
-			return "(none)"
-		}
+  private formatArgs(args: unknown): string {
+    if (args === null || args === undefined) {
+      return '(none)';
+    }
 
-		if (typeof args !== "object") {
-			return String(args)
-		}
+    if (typeof args !== 'object') {
+      return String(args);
+    }
 
-		const entries = Object.entries(args as Record<string, unknown>)
-		if (entries.length === 0) return "(none)"
+    const entries = Object.entries(args as Record<string, unknown>);
+    if (entries.length === 0) return '(none)';
 
-		const lines: string[] = []
-		for (const [key, value] of entries) {
-			const str = typeof value === "string" ? value : JSON.stringify(value)
-			const maxLen = 120
-			const firstLine = str.split("\n")[0] ?? ""
-			const lineCount = typeof value === "string" ? str.split("\n").length : 0
-			const suffix = lineCount > 1 ? ` (${lineCount} lines)` : ""
-			const display =
-				firstLine.length > maxLen ? firstLine.slice(0, maxLen) + "…" : firstLine
-			lines.push(`${key}: ${display}${suffix}`)
-		}
-		return lines.join("\n")
-	}
+    const lines: string[] = [];
+    for (const [key, value] of entries) {
+      const str = typeof value === 'string' ? value : JSON.stringify(value);
+      const maxLen = 120;
+      const firstLine = str.split('\n')[0] ?? '';
+      const lineCount = typeof value === 'string' ? str.split('\n').length : 0;
+      const suffix = lineCount > 1 ? ` (${lineCount} lines)` : '';
+      const display = firstLine.length > maxLen ? firstLine.slice(0, maxLen) + '…' : firstLine;
+      lines.push(`${key}: ${display}${suffix}`);
+    }
+    return lines.join('\n');
+  }
 
-	handleInput(data: string): void {
-		const kb = getEditorKeybindings()
+  handleInput(data: string): void {
+    const kb = getEditorKeybindings();
 
-		// Escape to decline
-		if (kb.matches(data, "selectCancel")) {
-			this.onAction({ type: "decline" })
-			return
-		}
+    // Escape to decline
+    if (kb.matches(data, 'selectCancel')) {
+      this.onAction({ type: 'decline' });
+      return;
+    }
 
-		// Single keypress shortcuts
-		if (data === "y") {
-			this.onAction({ type: "approve" })
-		} else if (data === "n") {
-			this.onAction({ type: "decline" })
-		} else if (data === "a") {
-			this.onAction({ type: "always_allow_category" })
-		} else if (data === "Y") {
-			this.onAction({ type: "yolo" })
-		}
-	}
+    // Single keypress shortcuts
+    if (data === 'y') {
+      this.onAction({ type: 'approve' });
+    } else if (data === 'n') {
+      this.onAction({ type: 'decline' });
+    } else if (data === 'a') {
+      this.onAction({ type: 'always_allow_category' });
+    } else if (data === 'Y') {
+      this.onAction({ type: 'yolo' });
+    }
+  }
 
-	render(maxWidth: number): string[] {
-		return super.render(maxWidth)
-	}
+  render(maxWidth: number): string[] {
+    return super.render(maxWidth);
+  }
 }

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -3,50 +3,44 @@
  * This will replace the existing tool-execution.ts
  */
 
-import * as os from "node:os"
-import { Box, Container, Spacer, Text  } from "@mariozechner/pi-tui"
-import type {TUI} from "@mariozechner/pi-tui";
-import chalk from "chalk"
-import { highlight } from "cli-highlight"
-import { theme, mastra } from "../theme.js"
-import { CollapsibleComponent } from "./collapsible.js"
-import { ErrorDisplayComponent } from "./error-display.js"
-import type {
-	IToolExecutionComponent,
-	ToolResult,
-} from "./tool-execution-interface.js"
-import {
-	ToolValidationErrorComponent,
-	parseValidationErrors,
-} from "./tool-validation-error.js"
+import * as os from 'node:os';
+import { Box, Container, Spacer, Text } from '@mariozechner/pi-tui';
+import type { TUI } from '@mariozechner/pi-tui';
+import chalk from 'chalk';
+import { highlight } from 'cli-highlight';
+import { theme, mastra } from '../theme.js';
+import { CollapsibleComponent } from './collapsible.js';
+import { ErrorDisplayComponent } from './error-display.js';
+import type { IToolExecutionComponent, ToolResult } from './tool-execution-interface.js';
+import { ToolValidationErrorComponent, parseValidationErrors } from './tool-validation-error.js';
 
-export type { ToolResult }
+export type { ToolResult };
 
 export interface ToolExecutionOptions {
-	showImages?: boolean
-	autoCollapse?: boolean
-	collapsedByDefault?: boolean
+  showImages?: boolean;
+  autoCollapse?: boolean;
+  collapsedByDefault?: boolean;
 }
 /**
  * Convert absolute path to tilde notation if it's in home directory
  */
 function shortenPath(path: string): string {
-	const home = os.homedir()
-	if (path.startsWith(home)) {
-		return `~${path.slice(home.length)}`
-	}
-	return path
+  const home = os.homedir();
+  if (path.startsWith(home)) {
+    return `~${path.slice(home.length)}`;
+  }
+  return path;
 }
 
 /**
  * Resolve a file path to an absolute path for use in file:// URLs.
  */
 function resolveAbsolutePath(filePath: string): string {
-	if (filePath.startsWith("/")) return filePath
-	if (filePath.startsWith("~")) {
-		return os.homedir() + filePath.slice(1)
-	}
-	return process.cwd() + "/" + filePath
+  if (filePath.startsWith('/')) return filePath;
+  if (filePath.startsWith('~')) {
+    return os.homedir() + filePath.slice(1);
+  }
+  return process.cwd() + '/' + filePath;
 }
 
 /**
@@ -55,1015 +49,917 @@ function resolveAbsolutePath(filePath: string): string {
  * render the text as a clickable link that opens the file.
  * Other terminals will just show the visible text.
  */
-function fileLink(
-	displayText: string,
-	filePath: string,
-	line?: number,
-): string {
-	const absPath = resolveAbsolutePath(filePath)
-	const lineFragment = line ? `#${line}` : ""
-	// OSC 8: \x1b]8;params;URI\x07 ... \x1b]8;;\x07
-	return `\x1b]8;;file://${absPath}${lineFragment}\x07${displayText}\x1b]8;;\x07`
+function fileLink(displayText: string, filePath: string, line?: number): string {
+  const absPath = resolveAbsolutePath(filePath);
+  const lineFragment = line ? `#${line}` : '';
+  // OSC 8: \x1b]8;params;URI\x07 ... \x1b]8;;\x07
+  return `\x1b]8;;file://${absPath}${lineFragment}\x07${displayText}\x1b]8;;\x07`;
 }
 
 /**
  * Extract the actual content from tool result text.
  */
 function extractContent(text: string): { content: string; isError: boolean } {
-	try {
-		const parsed = JSON.parse(text)
-		if (typeof parsed === "object" && parsed !== null) {
-			if ("content" in parsed) {
-				const content = parsed.content
-				let contentStr: string
+  try {
+    const parsed = JSON.parse(text);
+    if (typeof parsed === 'object' && parsed !== null) {
+      if ('content' in parsed) {
+        const content = parsed.content;
+        let contentStr: string;
 
-				if (typeof content === "string") {
-					contentStr = content
-				} else if (Array.isArray(content)) {
-					contentStr = content
-						.filter(
-							(part: unknown) =>
-								typeof part === "object" &&
-								part !== null &&
-								(part as Record<string, unknown>).type === "text",
-						)
-						.map(
-							(part: unknown) => (part as Record<string, unknown>).text || "",
-						)
-						.join("")
-				} else {
-					contentStr = JSON.stringify(content, null, 2)
-				}
+        if (typeof content === 'string') {
+          contentStr = content;
+        } else if (Array.isArray(content)) {
+          contentStr = content
+            .filter(
+              (part: unknown) =>
+                typeof part === 'object' && part !== null && (part as Record<string, unknown>).type === 'text',
+            )
+            .map((part: unknown) => (part as Record<string, unknown>).text || '')
+            .join('');
+        } else {
+          contentStr = JSON.stringify(content, null, 2);
+        }
 
-				return {
-					content: contentStr,
-					isError: Boolean(parsed.isError),
-				}
-			}
-			return { content: JSON.stringify(parsed, null, 2), isError: false }
-		}
-	} catch {
-		// Not JSON, use as-is
-	}
-	return { content: text, isError: false }
+        return {
+          content: contentStr,
+          isError: Boolean(parsed.isError),
+        };
+      }
+      return { content: JSON.stringify(parsed, null, 2), isError: false };
+    }
+  } catch {
+    // Not JSON, use as-is
+  }
+  return { content: text, isError: false };
 }
 
 /**
  * Enhanced tool execution component with collapsible sections
  */
-export class ToolExecutionComponentEnhanced
-	extends Container
-	implements IToolExecutionComponent
-{
-	private contentBox: Box
-	private toolName: string
-	private args: unknown
-	private expanded = false
-	private isPartial = true
-	private ui: TUI
-	private result?: ToolResult
-	private options: ToolExecutionOptions
-	private collapsible?: CollapsibleComponent
-	private startTime = Date.now()
-	private streamingOutput = "" // Buffer for streaming shell output
+export class ToolExecutionComponentEnhanced extends Container implements IToolExecutionComponent {
+  private contentBox: Box;
+  private toolName: string;
+  private args: unknown;
+  private expanded = false;
+  private isPartial = true;
+  private ui: TUI;
+  private result?: ToolResult;
+  private options: ToolExecutionOptions;
+  private collapsible?: CollapsibleComponent;
+  private startTime = Date.now();
+  private streamingOutput = ''; // Buffer for streaming shell output
 
-	constructor(
-		toolName: string,
-		args: unknown,
-		options: ToolExecutionOptions = {},
-		ui: TUI,
-	) {
-		super()
-		this.toolName = toolName
-		this.args = args
-		this.ui = ui
-		this.options = {
-			autoCollapse: true,
-			collapsedByDefault: true,
-			...options,
-		}
-		this.expanded = !this.options.collapsedByDefault
+  constructor(toolName: string, args: unknown, options: ToolExecutionOptions = {}, ui: TUI) {
+    super();
+    this.toolName = toolName;
+    this.args = args;
+    this.ui = ui;
+    this.options = {
+      autoCollapse: true,
+      collapsedByDefault: true,
+      ...options,
+    };
+    this.expanded = !this.options.collapsedByDefault;
 
-		this.addChild(new Spacer(1))
+    this.addChild(new Spacer(1));
 
-		// Content box with background
-		this.contentBox = new Box(1, 1, (text: string) =>
-			theme.bg("toolPendingBg", text),
-		)
-		this.addChild(this.contentBox)
+    // Content box with background
+    this.contentBox = new Box(1, 1, (text: string) => theme.bg('toolPendingBg', text));
+    this.addChild(this.contentBox);
 
-		this.rebuild()
-	}
+    this.rebuild();
+  }
 
-	updateArgs(args: unknown): void {
-		this.args = args
-		this.rebuild()
-	}
+  updateArgs(args: unknown): void {
+    this.args = args;
+    this.rebuild();
+  }
 
-	updateResult(result: ToolResult, isPartial = false): void {
-		this.result = result
-		this.isPartial = isPartial
-		// Keep streaming output for colored display in final result
-		this.rebuild()
-	}
+  updateResult(result: ToolResult, isPartial = false): void {
+    this.result = result;
+    this.isPartial = isPartial;
+    // Keep streaming output for colored display in final result
+    this.rebuild();
+  }
 
-	/**
-	 * Append streaming shell output.
-	 * Only for execute_command tool - shows live output while command runs.
-	 */
-	appendStreamingOutput(output: string): void {
-		if (
-			this.toolName !== "execute_command" &&
-			this.toolName !== "mastra_workspace_execute_command"
-		) {
-			return
-		}
-		this.streamingOutput += output
-		this.rebuild()
-	}
+  /**
+   * Append streaming shell output.
+   * Only for execute_command tool - shows live output while command runs.
+   */
+  appendStreamingOutput(output: string): void {
+    if (this.toolName !== 'execute_command' && this.toolName !== 'mastra_workspace_execute_command') {
+      return;
+    }
+    this.streamingOutput += output;
+    this.rebuild();
+  }
 
-	setExpanded(expanded: boolean): void {
-		this.expanded = expanded
-		if (this.collapsible) {
-			this.collapsible.setExpanded(expanded)
-			this.updateBgColor()
-			super.invalidate()
-			return
-		}
-		// No collapsible — need a full rebuild (e.g. write tool, header-only tools)
-		this.rebuild()
-	}
+  setExpanded(expanded: boolean): void {
+    this.expanded = expanded;
+    if (this.collapsible) {
+      this.collapsible.setExpanded(expanded);
+      this.updateBgColor();
+      super.invalidate();
+      return;
+    }
+    // No collapsible — need a full rebuild (e.g. write tool, header-only tools)
+    this.rebuild();
+  }
 
-	toggleExpanded(): void {
-		this.setExpanded(!this.expanded)
-	}
+  toggleExpanded(): void {
+    this.setExpanded(!this.expanded);
+  }
 
-	override invalidate(): void {
-		super.invalidate()
-		// invalidate is called by the layout system — only update bg, don't rebuild
-		this.updateBgColor()
-	}
+  override invalidate(): void {
+    super.invalidate();
+    // invalidate is called by the layout system — only update bg, don't rebuild
+    this.updateBgColor();
+  }
 
-	private updateBgColor(): void {
-		// For shell, view, and edit commands, skip background - we use bordered box style instead
-		const isShellCommand =
-			this.toolName === "execute_command" ||
-			this.toolName === "mastra_workspace_execute_command"
-		const isViewCommand =
-			this.toolName === "view" || this.toolName === "mastra_workspace_read_file"
-		const isEditCommand =
-			this.toolName === "string_replace_lsp" ||
-			this.toolName === "mastra_workspace_edit_file"
+  private updateBgColor(): void {
+    // For shell, view, and edit commands, skip background - we use bordered box style instead
+    const isShellCommand = this.toolName === 'execute_command' || this.toolName === 'mastra_workspace_execute_command';
+    const isViewCommand = this.toolName === 'view' || this.toolName === 'mastra_workspace_read_file';
+    const isEditCommand = this.toolName === 'string_replace_lsp' || this.toolName === 'mastra_workspace_edit_file';
 
-		if (isShellCommand || isViewCommand || isEditCommand) {
-			// No background - let terminal colors show through
-			this.contentBox.setBgFn((text: string) => text)
-			return
-		}
+    if (isShellCommand || isViewCommand || isEditCommand) {
+      // No background - let terminal colors show through
+      this.contentBox.setBgFn((text: string) => text);
+      return;
+    }
 
-		const bgColor = this.isPartial
-			? "toolPendingBg"
-			: this.result?.isError
-				? "toolErrorBg"
-				: "toolSuccessBg"
-		this.contentBox.setBgFn((text: string) => theme.bg(bgColor, text))
-	}
+    const bgColor = this.isPartial ? 'toolPendingBg' : this.result?.isError ? 'toolErrorBg' : 'toolSuccessBg';
+    this.contentBox.setBgFn((text: string) => theme.bg(bgColor, text));
+  }
 
-	/**
-	 * Full clear-and-rebuild. Called when:
-	 * - args change (updateArgs)
-	 * - result arrives or changes (updateResult)
-	 * - expand/collapse on a tool with no collapsible child
-	 * - initial construction
-	 */
-	private rebuild(): void {
-		this.updateBgColor()
-		this.contentBox.clear()
-		this.collapsible = undefined
+  /**
+   * Full clear-and-rebuild. Called when:
+   * - args change (updateArgs)
+   * - result arrives or changes (updateResult)
+   * - expand/collapse on a tool with no collapsible child
+   * - initial construction
+   */
+  private rebuild(): void {
+    this.updateBgColor();
+    this.contentBox.clear();
+    this.collapsible = undefined;
 
-		switch (this.toolName) {
-			case "view":
-			case "mastra_workspace_read_file":
-				this.renderViewToolEnhanced()
-				break
-			case "execute_command":
-			case "mastra_workspace_execute_command":
-				this.renderBashToolEnhanced()
-				break
-			case "string_replace_lsp":
-			case "mastra_workspace_edit_file":
-				this.renderEditToolEnhanced()
-				break
-			case "mastra_workspace_write_file":
-				this.renderWriteToolEnhanced()
-				break
-			case "mastra_workspace_list_files":
-				this.renderListFilesEnhanced()
-				break
-			default:
-				this.renderGenericToolEnhanced()
-		}
-	}
+    switch (this.toolName) {
+      case 'view':
+      case 'mastra_workspace_read_file':
+        this.renderViewToolEnhanced();
+        break;
+      case 'execute_command':
+      case 'mastra_workspace_execute_command':
+        this.renderBashToolEnhanced();
+        break;
+      case 'string_replace_lsp':
+      case 'mastra_workspace_edit_file':
+        this.renderEditToolEnhanced();
+        break;
+      case 'mastra_workspace_write_file':
+        this.renderWriteToolEnhanced();
+        break;
+      case 'mastra_workspace_list_files':
+        this.renderListFilesEnhanced();
+        break;
+      default:
+        this.renderGenericToolEnhanced();
+    }
+  }
 
-	private renderViewToolEnhanced(): void {
-		const argsObj = this.args as Record<string, unknown> | undefined
-		const fullPath = argsObj?.path ? String(argsObj.path) : ""
-		const viewRange = argsObj?.view_range as [number, number] | undefined
-		const startLine = viewRange?.[0] ?? 1
-		// Don't show border until we have a result
-		if (!this.result || this.isPartial) {
-			// Just show pending indicator
-			const path = argsObj?.path ? shortenPath(String(argsObj.path)) : "..."
-			const rangeDisplay = viewRange
-				? theme.fg("muted", `:${viewRange[0]},${viewRange[1]}`)
-				: ""
-			const status = this.getStatusIndicator()
-			const pathDisplay = fullPath
-				? fileLink(theme.fg("accent", path), fullPath, viewRange?.[0])
-				: theme.fg("accent", path)
-			const headerText = `${theme.bold(theme.fg("toolTitle", "view"))} ${pathDisplay}${rangeDisplay}${status}`
-			this.contentBox.addChild(new Text(headerText, 0, 0))
-			return
-		}
+  private renderViewToolEnhanced(): void {
+    const argsObj = this.args as Record<string, unknown> | undefined;
+    const fullPath = argsObj?.path ? String(argsObj.path) : '';
+    const viewRange = argsObj?.view_range as [number, number] | undefined;
+    const startLine = viewRange?.[0] ?? 1;
+    // Don't show border until we have a result
+    if (!this.result || this.isPartial) {
+      // Just show pending indicator
+      const path = argsObj?.path ? shortenPath(String(argsObj.path)) : '...';
+      const rangeDisplay = viewRange ? theme.fg('muted', `:${viewRange[0]},${viewRange[1]}`) : '';
+      const status = this.getStatusIndicator();
+      const pathDisplay = fullPath
+        ? fileLink(theme.fg('accent', path), fullPath, viewRange?.[0])
+        : theme.fg('accent', path);
+      const headerText = `${theme.bold(theme.fg('toolTitle', 'view'))} ${pathDisplay}${rangeDisplay}${status}`;
+      this.contentBox.addChild(new Text(headerText, 0, 0));
+      return;
+    }
 
-		const border = (char: string) => theme.bold(theme.fg("accent", char))
-		const status = this.getStatusIndicator()
-		const rangeDisplay = viewRange
-			? theme.fg("muted", `:${viewRange[0]},${viewRange[1]}`)
-			: ""
+    const border = (char: string) => theme.bold(theme.fg('accent', char));
+    const status = this.getStatusIndicator();
+    const rangeDisplay = viewRange ? theme.fg('muted', `:${viewRange[0]},${viewRange[1]}`) : '';
 
-		// Calculate available width for path and truncate from beginning if needed
-		const termWidth = process.stdout.columns || 80
-		const fixedParts = "└── view  " + (rangeDisplay ? `:XXX,XXX` : "") + " ✓" // approximate fixed width
-		const availableForPath = termWidth - fixedParts.length - 6 // buffer
-		let path = argsObj?.path ? shortenPath(String(argsObj.path)) : "..."
-		if (path.length > availableForPath && availableForPath > 10) {
-			path = "…" + path.slice(-(availableForPath - 1))
-		}
+    // Calculate available width for path and truncate from beginning if needed
+    const termWidth = process.stdout.columns || 80;
+    const fixedParts = '└── view  ' + (rangeDisplay ? `:XXX,XXX` : '') + ' ✓'; // approximate fixed width
+    const availableForPath = termWidth - fixedParts.length - 6; // buffer
+    let path = argsObj?.path ? shortenPath(String(argsObj.path)) : '...';
+    if (path.length > availableForPath && availableForPath > 10) {
+      path = '…' + path.slice(-(availableForPath - 1));
+    }
 
-		const pathDisplay = fullPath
-			? fileLink(theme.fg("accent", path), fullPath, viewRange?.[0])
-			: theme.fg("accent", path)
-		const footerText = `${theme.bold(theme.fg("toolTitle", "view"))} ${pathDisplay}${rangeDisplay}${status}`
+    const pathDisplay = fullPath
+      ? fileLink(theme.fg('accent', path), fullPath, viewRange?.[0])
+      : theme.fg('accent', path);
+    const footerText = `${theme.bold(theme.fg('toolTitle', 'view'))} ${pathDisplay}${rangeDisplay}${status}`;
 
-		// Empty line padding above
-		this.contentBox.addChild(new Text("", 0, 0))
+    // Empty line padding above
+    this.contentBox.addChild(new Text('', 0, 0));
 
-		// Top border
-		this.contentBox.addChild(new Text(border("┌──"), 0, 0))
+    // Top border
+    this.contentBox.addChild(new Text(border('┌──'), 0, 0));
 
-		// Syntax-highlighted content with left border, truncated to prevent soft wrap
-		const output = this.getFormattedOutput()
-		if (output) {
-			const termWidth = process.stdout.columns || 80
-			const maxLineWidth = termWidth - 6 // Account for border "│ " (2) + padding (2) + buffer (2)
-			const highlighted = highlightCode(output, fullPath, startLine)
-			let lines = highlighted.split("\n")
+    // Syntax-highlighted content with left border, truncated to prevent soft wrap
+    const output = this.getFormattedOutput();
+    if (output) {
+      const termWidth = process.stdout.columns || 80;
+      const maxLineWidth = termWidth - 6; // Account for border "│ " (2) + padding (2) + buffer (2)
+      const highlighted = highlightCode(output, fullPath, startLine);
+      let lines = highlighted.split('\n');
 
-			// Limit lines when collapsed
-			const collapsedLines = 20
-			const totalLines = lines.length
-			const hasMore = !this.expanded && totalLines > collapsedLines + 1
+      // Limit lines when collapsed
+      const collapsedLines = 20;
+      const totalLines = lines.length;
+      const hasMore = !this.expanded && totalLines > collapsedLines + 1;
 
-			if (hasMore) {
-				lines = lines.slice(0, collapsedLines)
-			}
+      if (hasMore) {
+        lines = lines.slice(0, collapsedLines);
+      }
 
-			const borderedLines = lines.map((line) => {
-				const truncated = truncateAnsi(line, maxLineWidth)
-				return border("│") + " " + truncated
-			})
-			this.contentBox.addChild(new Text(borderedLines.join("\n"), 0, 0))
+      const borderedLines = lines.map(line => {
+        const truncated = truncateAnsi(line, maxLineWidth);
+        return border('│') + ' ' + truncated;
+      });
+      this.contentBox.addChild(new Text(borderedLines.join('\n'), 0, 0));
 
-			// Show truncation indicator
-			if (hasMore) {
-				const remaining = totalLines - collapsedLines
-				this.contentBox.addChild(
-					new Text(
-						border("│") +
-							" " +
-							theme.fg(
-								"muted",
-								`... ${remaining} more lines (ctrl+e to expand)`,
-							),
-						0,
-						0,
-					),
-				)
-			}
-		}
+      // Show truncation indicator
+      if (hasMore) {
+        const remaining = totalLines - collapsedLines;
+        this.contentBox.addChild(
+          new Text(border('│') + ' ' + theme.fg('muted', `... ${remaining} more lines (ctrl+e to expand)`), 0, 0),
+        );
+      }
+    }
 
-		// Bottom border with tool info
-		this.contentBox.addChild(new Text(`${border("└──")} ${footerText}`, 0, 0))
-	}
+    // Bottom border with tool info
+    this.contentBox.addChild(new Text(`${border('└──')} ${footerText}`, 0, 0));
+  }
 
-	private renderBashToolEnhanced(): void {
-		const argsObj = this.args as Record<string, unknown> | undefined
-		let command = argsObj?.command ? String(argsObj.command) : "..."
-		const timeout = argsObj?.timeout as number | undefined
-		const cwd = argsObj?.cwd ? shortenPath(String(argsObj.cwd)) : ""
+  private renderBashToolEnhanced(): void {
+    const argsObj = this.args as Record<string, unknown> | undefined;
+    let command = argsObj?.command ? String(argsObj.command) : '...';
+    const timeout = argsObj?.timeout as number | undefined;
+    const cwd = argsObj?.cwd ? shortenPath(String(argsObj.cwd)) : '';
 
-		// Strip "cd $CWD && " from the start since we show cwd in the footer
-		const cdPattern = /^cd\s+[^\s]+\s+&&\s+/
-		command = command.replace(cdPattern, "")
+    // Strip "cd $CWD && " from the start since we show cwd in the footer
+    const cdPattern = /^cd\s+[^\s]+\s+&&\s+/;
+    command = command.replace(cdPattern, '');
 
-		// Extract tail value from command (e.g., "| tail -5" or "| tail -n 5")
-        let maxStreamLines: number | undefined
-        const tailMatch = command.match(/\|\s*tail\s+(?:-n\s+)?(-?\d+)\s*$/)
-        if (tailMatch) {
-            maxStreamLines = Math.abs(parseInt(tailMatch[1]!, 10))
+    // Extract tail value from command (e.g., "| tail -5" or "| tail -n 5")
+    let maxStreamLines: number | undefined;
+    const tailMatch = command.match(/\|\s*tail\s+(?:-n\s+)?(-?\d+)\s*$/);
+    if (tailMatch) {
+      maxStreamLines = Math.abs(parseInt(tailMatch[1]!, 10));
+    }
+
+    const timeoutSuffix = timeout ? theme.fg('muted', ` (timeout ${timeout}s)`) : '';
+    const cwdSuffix = cwd ? theme.fg('muted', ` in ${cwd}`) : '';
+    const timeSuffix = this.isPartial ? timeoutSuffix : this.getDurationSuffix();
+
+    // Helper to render shell command with bordered box
+    const renderBorderedShell = (status: string, outputLines: string[]) => {
+      const border = (char: string) => theme.bold(theme.fg('accent', char));
+      const footerText = `${theme.bold(theme.fg('toolTitle', '$'))} ${theme.fg('accent', command)}${cwdSuffix}${timeSuffix}${status}`;
+
+      // Top border
+      this.contentBox.addChild(new Text(border('┌──'), 0, 0));
+
+      // Output lines with left border, truncated to prevent soft wrap
+      const termWidth = process.stdout.columns || 80;
+      const maxLineWidth = termWidth - 6; // Account for border "│ " (2) + buffer (4)
+      const borderedLines = outputLines.map(line => {
+        const truncated = truncateAnsi(line, maxLineWidth);
+        return border('│') + ' ' + truncated;
+      });
+      const displayOutput = borderedLines.join('\n');
+      if (displayOutput.trim()) {
+        this.contentBox.addChild(new Text(displayOutput, 0, 0));
+      }
+
+      // Bottom border with command info
+      this.contentBox.addChild(new Text(`${border('└──')} ${footerText}`, 0, 0));
+    };
+
+    if (!this.result || this.isPartial) {
+      const status = this.getStatusIndicator();
+      let lines = this.streamingOutput ? this.streamingOutput.split('\n') : [];
+      // Remove leading empty lines during streaming
+      while (lines.length > 0 && lines[0] === '') {
+        lines.shift();
+      }
+      // Remove trailing empty lines during streaming (from trailing newline)
+      while (lines.length > 0 && lines[lines.length - 1] === '') {
+        lines.pop();
+      }
+      // Apply tail limit to streaming output to match final result
+      if (maxStreamLines && lines.length > maxStreamLines) {
+        lines = lines.slice(-maxStreamLines);
+      }
+      renderBorderedShell(status, lines);
+      return;
+    }
+
+    // Helper to apply tail limit and clean up lines
+    const prepareOutputLines = (output: string): string[] => {
+      let lines = output.split('\n');
+      // Remove leading/trailing empty lines
+      while (lines.length > 0 && lines[0] === '') {
+        lines.shift();
+      }
+      while (lines.length > 0 && lines[lines.length - 1] === '') {
+        lines.pop();
+      }
+      // Apply tail limit to match streaming display
+      if (maxStreamLines && lines.length > maxStreamLines) {
+        lines = lines.slice(-maxStreamLines);
+      }
+      return lines;
+    };
+
+    // For errors, use bordered box with error status
+    if (this.result.isError) {
+      const status = theme.fg('error', ' ✗');
+      const output = this.streamingOutput.trim() || this.getFormattedOutput();
+      renderBorderedShell(status, prepareOutputLines(output));
+      return;
+    }
+
+    // Also check if output contains common error patterns
+    const outputText = this.getFormattedOutput();
+    const looksLikeError = outputText.match(
+      /Error:|TypeError:|SyntaxError:|ReferenceError:|command not found|fatal:|error:/i,
+    );
+    if (looksLikeError) {
+      const status = theme.fg('error', ' ✗');
+      const output = this.streamingOutput.trim() || this.getFormattedOutput();
+      renderBorderedShell(status, prepareOutputLines(output));
+      return;
+    }
+
+    // Success - use bordered box with checkmark
+    const status = theme.fg('success', ' ✓');
+    const output = this.streamingOutput.trim() || this.getFormattedOutput();
+    renderBorderedShell(status, prepareOutputLines(output));
+  }
+  private renderEditToolEnhanced(): void {
+    const argsObj = this.args as Record<string, unknown> | undefined;
+    const fullPath = argsObj?.path ? String(argsObj.path) : '';
+    const startLineNum = argsObj?.start_line ? Number(argsObj.start_line) : undefined;
+    const startLine = startLineNum ? `:${String(startLineNum)}` : '';
+
+    // Don't show border until we have a result
+    if (!this.result || this.isPartial) {
+      const path = argsObj?.path ? shortenPath(String(argsObj.path)) : '...';
+      const status = this.getStatusIndicator();
+      const pathDisplay = fullPath
+        ? fileLink(theme.fg('accent', path), fullPath, startLineNum)
+        : theme.fg('accent', path);
+      const headerText = `${theme.bold(theme.fg('toolTitle', 'edit'))} ${pathDisplay}${theme.fg('muted', startLine)}${status}`;
+      this.contentBox.addChild(new Text(headerText, 0, 0));
+      return;
+    }
+
+    const border = (char: string) => theme.bold(theme.fg('accent', char));
+    const status = this.getStatusIndicator();
+
+    // Calculate available width for path and truncate from beginning if needed
+    const termWidth = process.stdout.columns || 80;
+    const fixedParts = '└── edit  ' + startLine + ' ✓'; // approximate fixed width
+    const availableForPath = termWidth - fixedParts.length - 6; // buffer
+    let path = argsObj?.path ? shortenPath(String(argsObj.path)) : '...';
+    if (path.length > availableForPath && availableForPath > 10) {
+      path = '…' + path.slice(-(availableForPath - 1));
+    }
+
+    const pathDisplay = fullPath
+      ? fileLink(theme.fg('accent', path), fullPath, startLineNum)
+      : theme.fg('accent', path);
+    const footerText = `${theme.bold(theme.fg('toolTitle', 'edit'))} ${pathDisplay}${theme.fg('muted', startLine)}${status}`;
+
+    // Empty line padding above
+    this.contentBox.addChild(new Text('', 0, 0));
+
+    // Top border
+    this.contentBox.addChild(new Text(border('┌──'), 0, 0));
+
+    // For edits, show the diff
+    if (argsObj?.old_str && argsObj?.new_str && !this.result.isError) {
+      const oldStr = String(argsObj.old_str);
+      const newStr = String(argsObj.new_str);
+      const { lines: diffLines, firstChangeIndex } = this.generateDiffLines(oldStr, newStr);
+
+      // Limit lines when collapsed, windowed around first change
+      const collapsedLines = 15;
+      const totalLines = diffLines.length;
+      const hasMore = !this.expanded && totalLines > collapsedLines + 1;
+
+      let linesToShow = diffLines;
+      let skippedBefore = 0;
+      if (hasMore) {
+        // Show 3 context lines before the first change, rest after
+        const contextBefore = 3;
+        const start = Math.max(0, firstChangeIndex - contextBefore);
+        linesToShow = diffLines.slice(start, start + collapsedLines);
+        skippedBefore = start;
+      }
+      // Render diff lines with border, truncated to prevent wrap
+      const maxLineWidth = termWidth - 6;
+
+      // Show "skipped above" indicator
+      if (skippedBefore > 0) {
+        this.contentBox.addChild(
+          new Text(border('│') + ' ' + theme.fg('muted', `... ${skippedBefore} lines above`), 0, 0),
+        );
+      }
+
+      const borderedLines = linesToShow.map(line => {
+        const truncated = truncateAnsi(line, maxLineWidth);
+        return border('│') + ' ' + truncated;
+      });
+      this.contentBox.addChild(new Text(borderedLines.join('\n'), 0, 0));
+
+      // Show truncation indicator
+      if (hasMore) {
+        const remaining = totalLines - (skippedBefore + linesToShow.length);
+        if (remaining > 0) {
+          this.contentBox.addChild(
+            new Text(border('│') + ' ' + theme.fg('muted', `... ${remaining} more lines (ctrl+e to expand)`), 0, 0),
+          );
         }
+      }
+    } else if (this.result.isError) {
+      // Show error output
+      const output = this.getFormattedOutput();
+      if (output) {
+        const maxLineWidth = termWidth - 6;
+        const lines = output.split('\n').map(line => {
+          const truncated = truncateAnsi(line, maxLineWidth);
+          return border('│') + ' ' + theme.fg('error', truncated);
+        });
+        this.contentBox.addChild(new Text(lines.join('\n'), 0, 0));
+      }
+    }
 
-		const timeoutSuffix = timeout
-			? theme.fg("muted", ` (timeout ${timeout}s)`)
-			: ""
-		const cwdSuffix = cwd ? theme.fg("muted", ` in ${cwd}`) : ""
-		const timeSuffix = this.isPartial ? timeoutSuffix : this.getDurationSuffix()
+    // Bottom border with tool info
+    this.contentBox.addChild(new Text(`${border('└──')} ${footerText}`, 0, 0));
 
-		// Helper to render shell command with bordered box
-		const renderBorderedShell = (status: string, outputLines: string[]) => {
-			const border = (char: string) => theme.bold(theme.fg("accent", char))
-			const footerText = `${theme.bold(theme.fg("toolTitle", "$"))} ${theme.fg("accent", command)}${cwdSuffix}${timeSuffix}${status}`
+    // LSP diagnostics below the box
+    const diagnostics = this.parseLSPDiagnostics();
+    if (diagnostics && diagnostics.hasIssues) {
+      const COLLAPSED_DIAG_LINES = 3;
+      const shouldCollapse = !this.expanded && diagnostics.entries.length > COLLAPSED_DIAG_LINES + 1;
+      const maxDiags = shouldCollapse ? COLLAPSED_DIAG_LINES : diagnostics.entries.length;
+      const entriesToShow = diagnostics.entries.slice(0, maxDiags);
+      for (const diag of entriesToShow) {
+        const color = diag.severity === 'error' ? '#e06c75' : diag.severity === 'warning' ? '#f59e0b' : '#71717a';
+        const icon = diag.severity === 'error' ? '✗' : diag.severity === 'warning' ? '⚠' : 'ℹ';
+        const location = diag.location ? chalk.hex(color)(diag.location) + ' ' : '';
+        const line = `  ${chalk.hex(color)(icon)} ${location}${chalk.hex('#a1a1aa')(diag.message)}`;
+        this.contentBox.addChild(new Text(line, 0, 0));
+      }
+      if (shouldCollapse) {
+        const remaining = diagnostics.entries.length - COLLAPSED_DIAG_LINES;
+        this.contentBox.addChild(
+          new Text(
+            chalk.hex('#71717a')(`  ... ${remaining} more diagnostic${remaining > 1 ? 's' : ''} (ctrl+e to expand)`),
+            0,
+            0,
+          ),
+        );
+      }
+    }
+  }
 
-			// Top border
-			this.contentBox.addChild(new Text(border("┌──"), 0, 0))
+  private parseLSPDiagnostics(): {
+    hasIssues: boolean;
+    entries: Array<{
+      severity: 'error' | 'warning' | 'info' | 'hint';
+      location: string;
+      message: string;
+    }>;
+  } | null {
+    const output = this.getFormattedOutput();
+    const lspIdx = output.indexOf('LSP Diagnostics:');
+    if (lspIdx === -1) return null;
 
-			// Output lines with left border, truncated to prevent soft wrap
-			const termWidth = process.stdout.columns || 80
-			const maxLineWidth = termWidth - 6 // Account for border "│ " (2) + buffer (4)
-			const borderedLines = outputLines.map((line) => {
-				const truncated = truncateAnsi(line, maxLineWidth)
-				return border("│") + " " + truncated
-			})
-			const displayOutput = borderedLines.join("\n")
-			if (displayOutput.trim()) {
-				this.contentBox.addChild(new Text(displayOutput, 0, 0))
-			}
+    const lspText = output.slice(lspIdx + 'LSP Diagnostics:'.length);
+    if (lspText.includes('No errors or warnings')) {
+      return { hasIssues: false, entries: [] };
+    }
 
-			// Bottom border with command info
-			this.contentBox.addChild(new Text(`${border("└──")} ${footerText}`, 0, 0))
-		}
+    const entries: Array<{
+      severity: 'error' | 'warning' | 'info' | 'hint';
+      location: string;
+      message: string;
+    }> = [];
+    let currentSeverity: 'error' | 'warning' | 'info' | 'hint' = 'error';
 
-		if (!this.result || this.isPartial) {
-			const status = this.getStatusIndicator()
-			let lines = this.streamingOutput ? this.streamingOutput.split("\n") : []
-			// Remove leading empty lines during streaming
-			while (lines.length > 0 && lines[0] === "") {
-				lines.shift()
-			}
-			// Remove trailing empty lines during streaming (from trailing newline)
-			while (lines.length > 0 && lines[lines.length - 1] === "") {
-				lines.pop()
-			}
-			// Apply tail limit to streaming output to match final result
-			if (maxStreamLines && lines.length > maxStreamLines) {
-				lines = lines.slice(-maxStreamLines)
-			}
-			renderBorderedShell(status, lines)
-			return
-		}
+    for (const line of lspText.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      if (trimmed === 'Errors:') {
+        currentSeverity = 'error';
+      } else if (trimmed === 'Warnings:') {
+        currentSeverity = 'warning';
+      } else if (trimmed === 'Info:') {
+        currentSeverity = 'info';
+      } else if (trimmed === 'Hints:') {
+        currentSeverity = 'hint';
+      } else {
+        const match = trimmed.match(/^((?:.*:)?\d+:\d+)\s*-\s*(.+)$/);
+        if (match) {
+          entries.push({
+            severity: currentSeverity,
+            location: match[1]!,
+            message: match[2]!,
+          });
+        }
+      }
+    }
 
-		// Helper to apply tail limit and clean up lines
-		const prepareOutputLines = (output: string): string[] => {
-			let lines = output.split("\n")
-			// Remove leading/trailing empty lines
-			while (lines.length > 0 && lines[0] === "") {
-				lines.shift()
-			}
-			while (lines.length > 0 && lines[lines.length - 1] === "") {
-				lines.pop()
-			}
-			// Apply tail limit to match streaming display
-			if (maxStreamLines && lines.length > maxStreamLines) {
-				lines = lines.slice(-maxStreamLines)
-			}
-			return lines
-		}
+    return { hasIssues: entries.length > 0, entries };
+  }
+  private generateDiffLines(oldStr: string, newStr: string): { lines: string[]; firstChangeIndex: number } {
+    const oldLines = oldStr.split('\n');
+    const newLines = newStr.split('\n');
+    const lines: string[] = [];
+    let firstChangeIndex = -1;
 
-		// For errors, use bordered box with error status
-		if (this.result.isError) {
-			const status = theme.fg("error", " ✗")
-			const output = this.streamingOutput.trim() || this.getFormattedOutput()
-			renderBorderedShell(status, prepareOutputLines(output))
-			return
-		}
+    // Use soft red for removed, green for added
+    const removedColor = chalk.hex(mastra.red); // soft red
+    const addedColor = chalk.hex('#5cb85c'); // soft green
 
-		// Also check if output contains common error patterns
-		const outputText = this.getFormattedOutput()
-		const looksLikeError = outputText.match(
-			/Error:|TypeError:|SyntaxError:|ReferenceError:|command not found|fatal:|error:/i,
-		)
-		if (looksLikeError) {
-			const status = theme.fg("error", " ✗")
-			const output = this.streamingOutput.trim() || this.getFormattedOutput()
-			renderBorderedShell(status, prepareOutputLines(output))
-			return
-		}
+    const maxLines = Math.max(oldLines.length, newLines.length);
 
-		// Success - use bordered box with checkmark
-		const status = theme.fg("success", " ✓")
-		const output = this.streamingOutput.trim() || this.getFormattedOutput()
-		renderBorderedShell(status, prepareOutputLines(output))
-	}
-	private renderEditToolEnhanced(): void {
-		const argsObj = this.args as Record<string, unknown> | undefined
-		const fullPath = argsObj?.path ? String(argsObj.path) : ""
-		const startLineNum = argsObj?.start_line
-			? Number(argsObj.start_line)
-			: undefined
-		const startLine = startLineNum ? `:${String(startLineNum)}` : ""
+    for (let i = 0; i < maxLines; i++) {
+      if (i >= oldLines.length) {
+        if (firstChangeIndex === -1) firstChangeIndex = lines.length;
+        lines.push(addedColor(newLines[i]));
+      } else if (i >= newLines.length) {
+        if (firstChangeIndex === -1) firstChangeIndex = lines.length;
+        lines.push(removedColor(oldLines[i]));
+      } else if (oldLines[i] !== newLines[i]) {
+        if (firstChangeIndex === -1) firstChangeIndex = lines.length;
+        lines.push(removedColor(oldLines[i]!));
+        lines.push(addedColor(newLines[i]!));
+      } else {
+        // Context line
+        lines.push(theme.fg('muted', oldLines[i]!));
+      }
+    }
 
-		// Don't show border until we have a result
-		if (!this.result || this.isPartial) {
-			const path = argsObj?.path ? shortenPath(String(argsObj.path)) : "..."
-			const status = this.getStatusIndicator()
-			const pathDisplay = fullPath
-				? fileLink(theme.fg("accent", path), fullPath, startLineNum)
-				: theme.fg("accent", path)
-			const headerText = `${theme.bold(theme.fg("toolTitle", "edit"))} ${pathDisplay}${theme.fg("muted", startLine)}${status}`
-			this.contentBox.addChild(new Text(headerText, 0, 0))
-			return
-		}
+    return {
+      lines,
+      firstChangeIndex: firstChangeIndex === -1 ? 0 : firstChangeIndex,
+    };
+  }
+  private renderWriteToolEnhanced(): void {
+    const argsObj = this.args as Record<string, unknown> | undefined;
+    const fullPath = argsObj?.path ? String(argsObj.path) : '';
+    const path = argsObj?.path ? shortenPath(String(argsObj.path)) : '...';
 
-		const border = (char: string) => theme.bold(theme.fg("accent", char))
-		const status = this.getStatusIndicator()
+    const status = this.getStatusIndicator();
+    const pathDisplay = fullPath ? fileLink(theme.fg('accent', path), fullPath) : theme.fg('accent', path);
+    const header = `${theme.bold(theme.fg('toolTitle', '💾 write'))} ${pathDisplay}${status}`;
 
-		// Calculate available width for path and truncate from beginning if needed
-		const termWidth = process.stdout.columns || 80
-		const fixedParts = "└── edit  " + startLine + " ✓" // approximate fixed width
-		const availableForPath = termWidth - fixedParts.length - 6 // buffer
-		let path = argsObj?.path ? shortenPath(String(argsObj.path)) : "..."
-		if (path.length > availableForPath && availableForPath > 10) {
-			path = "…" + path.slice(-(availableForPath - 1))
-		}
+    this.contentBox.addChild(new Text(header, 0, 0));
 
-		const pathDisplay = fullPath
-			? fileLink(theme.fg("accent", path), fullPath, startLineNum)
-			: theme.fg("accent", path)
-		const footerText = `${theme.bold(theme.fg("toolTitle", "edit"))} ${pathDisplay}${theme.fg("muted", startLine)}${status}`
+    if (this.result && !this.isPartial) {
+      const output = this.getFormattedOutput();
+      if (output && (this.result.isError || this.expanded)) {
+        this.contentBox.addChild(new Text('', 0, 0));
+        const color = this.result.isError ? 'error' : 'success';
+        this.contentBox.addChild(new Text(theme.fg(color, output), 0, 0));
+      }
+    }
+  }
+  private renderListFilesEnhanced(): void {
+    const argsObj = this.args as Record<string, unknown> | undefined;
+    const fullPath = argsObj?.path ? String(argsObj.path) : '';
+    const path = argsObj?.path ? shortenPath(String(argsObj.path)) : '/';
 
-		// Empty line padding above
-		this.contentBox.addChild(new Text("", 0, 0))
+    if (!this.result || this.isPartial) {
+      const status = this.getStatusIndicator();
+      const pathDisplay = fullPath ? fileLink(theme.fg('accent', path), fullPath) : theme.fg('accent', path);
+      const header = `${theme.bold(theme.fg('toolTitle', '📁 list'))} ${pathDisplay}${status}`;
+      this.contentBox.addChild(new Text(header, 0, 0));
+      return;
+    }
 
-		// Top border
-		this.contentBox.addChild(new Text(border("┌──"), 0, 0))
+    const output = this.getFormattedOutput();
+    if (output) {
+      const lines = output.split('\n');
+      const fileCount = lines.filter(l => l.trim() && !l.includes('└') && !l.includes('├') && !l.includes('│')).length;
+      const listStatus = this.getStatusIndicator();
 
-		// For edits, show the diff
-		if (argsObj?.old_str && argsObj?.new_str && !this.result.isError) {
-			const oldStr = String(argsObj.old_str)
-			const newStr = String(argsObj.new_str)
-			const { lines: diffLines, firstChangeIndex } = this.generateDiffLines(
-				oldStr,
-				newStr,
-			)
+      this.collapsible = new CollapsibleComponent(
+        {
+          header: `${theme.bold(theme.fg('toolTitle', '📁 list'))} ${theme.fg('accent', path)}${listStatus}`,
+          summary: `${fileCount} items`,
+          expanded: this.expanded,
+          collapsedLines: 15,
+          expandedLines: 100,
+          showLineCount: false,
+        },
+        this.ui,
+      );
 
-			// Limit lines when collapsed, windowed around first change
-			const collapsedLines = 15
-			const totalLines = diffLines.length
-			const hasMore = !this.expanded && totalLines > collapsedLines + 1
+      this.collapsible.setContent(output);
+      this.contentBox.addChild(this.collapsible);
+    }
+  }
 
-			let linesToShow = diffLines
-			let skippedBefore = 0
-			if (hasMore) {
-				// Show 3 context lines before the first change, rest after
-				const contextBefore = 3
-				const start = Math.max(0, firstChangeIndex - contextBefore)
-				linesToShow = diffLines.slice(start, start + collapsedLines)
-				skippedBefore = start
-			}
-			// Render diff lines with border, truncated to prevent wrap
-			const maxLineWidth = termWidth - 6
+  private renderGenericToolEnhanced(): void {
+    const status = this.getStatusIndicator();
 
-			// Show "skipped above" indicator
-			if (skippedBefore > 0) {
-				this.contentBox.addChild(
-					new Text(
-						border("│") +
-							" " +
-							theme.fg("muted", `... ${skippedBefore} lines above`),
-						0,
-						0,
-					),
-				)
-			}
+    let argsSummary = '';
+    if (this.args && typeof this.args === 'object') {
+      const argsObj = this.args as Record<string, unknown>;
+      const keys = Object.keys(argsObj);
+      if (keys.length > 0) {
+        argsSummary = theme.fg('muted', ` (${keys.length} args)`);
+      }
+    }
 
-			const borderedLines = linesToShow.map((line) => {
-				const truncated = truncateAnsi(line, maxLineWidth)
-				return border("│") + " " + truncated
-			})
-			this.contentBox.addChild(new Text(borderedLines.join("\n"), 0, 0))
+    const header = `${theme.bold(theme.fg('toolTitle', this.toolName))}${argsSummary}${status}`;
 
-			// Show truncation indicator
-			if (hasMore) {
-				const remaining = totalLines - (skippedBefore + linesToShow.length)
-				if (remaining > 0) {
-					this.contentBox.addChild(
-						new Text(
-							border("│") +
-								" " +
-								theme.fg(
-									"muted",
-									`... ${remaining} more lines (ctrl+e to expand)`,
-								),
-							0,
-							0,
-						),
-					)
-				}
-			}
-		} else if (this.result.isError) {
-			// Show error output
-			const output = this.getFormattedOutput()
-			if (output) {
-				const maxLineWidth = termWidth - 6
-				const lines = output.split("\n").map((line) => {
-					const truncated = truncateAnsi(line, maxLineWidth)
-					return border("│") + " " + theme.fg("error", truncated)
-				})
-				this.contentBox.addChild(new Text(lines.join("\n"), 0, 0))
-			}
-		}
+    if (!this.result || this.isPartial) {
+      this.contentBox.addChild(new Text(header, 0, 0));
+      return;
+    }
 
-		// Bottom border with tool info
-		this.contentBox.addChild(new Text(`${border("└──")} ${footerText}`, 0, 0))
+    // Use enhanced error display for errors
+    if (this.result.isError) {
+      this.renderErrorResult(header);
+      return;
+    }
 
-		// LSP diagnostics below the box
-		const diagnostics = this.parseLSPDiagnostics()
-		if (diagnostics && diagnostics.hasIssues) {
-			const COLLAPSED_DIAG_LINES = 3
-			const shouldCollapse =
-				!this.expanded && diagnostics.entries.length > COLLAPSED_DIAG_LINES + 1
-			const maxDiags = shouldCollapse
-				? COLLAPSED_DIAG_LINES
-				: diagnostics.entries.length
-			const entriesToShow = diagnostics.entries.slice(0, maxDiags)
-			for (const diag of entriesToShow) {
-				const color =
-					diag.severity === "error"
-						? "#e06c75"
-						: diag.severity === "warning"
-							? "#f59e0b"
-							: "#71717a"
-				const icon =
-					diag.severity === "error"
-						? "✗"
-						: diag.severity === "warning"
-							? "⚠"
-							: "ℹ"
-				const location = diag.location
-					? chalk.hex(color)(diag.location) + " "
-					: ""
-				const line = `  ${chalk.hex(color)(icon)} ${location}${chalk.hex("#a1a1aa")(diag.message)}`
-				this.contentBox.addChild(new Text(line, 0, 0))
-			}
-			if (shouldCollapse) {
-				const remaining = diagnostics.entries.length - COLLAPSED_DIAG_LINES
-				this.contentBox.addChild(
-					new Text(
-						chalk.hex("#71717a")(
-							`  ... ${remaining} more diagnostic${remaining > 1 ? "s" : ""} (ctrl+e to expand)`,
-						),
-						0,
-						0,
-					),
-				)
-			}
-		}
-	}
+    const output = this.getFormattedOutput();
+    if (output) {
+      this.collapsible = new CollapsibleComponent(
+        {
+          header,
+          expanded: this.expanded,
+          collapsedLines: 10,
+          expandedLines: 200,
+          showLineCount: true,
+        },
+        this.ui,
+      );
 
-	private parseLSPDiagnostics(): {
-		hasIssues: boolean
-		entries: Array<{
-			severity: "error" | "warning" | "info" | "hint"
-			location: string
-			message: string
-		}>
-	} | null {
-		const output = this.getFormattedOutput()
-		const lspIdx = output.indexOf("LSP Diagnostics:")
-		if (lspIdx === -1) return null
+      this.collapsible.setContent(output);
+      this.contentBox.addChild(this.collapsible);
+    }
+  }
 
-		const lspText = output.slice(lspIdx + "LSP Diagnostics:".length)
-		if (lspText.includes("No errors or warnings")) {
-			return { hasIssues: false, entries: [] }
-		}
+  private getStatusIndicator(): string {
+    return this.isPartial
+      ? theme.fg('muted', ' ⋯')
+      : this.result?.isError
+        ? theme.fg('error', ' ✗')
+        : theme.fg('success', ' ✓');
+  }
 
-		const entries: Array<{
-			severity: "error" | "warning" | "info" | "hint"
-			location: string
-			message: string
-		}> = []
-		let currentSeverity: "error" | "warning" | "info" | "hint" = "error"
+  private getDurationSuffix(): string {
+    if (this.isPartial) return '';
+    const ms = Date.now() - this.startTime;
+    if (ms < 1000) return theme.fg('muted', ` ${ms}ms`);
+    return theme.fg('muted', ` ${(ms / 1000).toFixed(1)}s`);
+  }
 
-		for (const line of lspText.split("\n")) {
-			const trimmed = line.trim()
-			if (!trimmed) continue
-			if (trimmed === "Errors:") {
-				currentSeverity = "error"
-			} else if (trimmed === "Warnings:") {
-				currentSeverity = "warning"
-			} else if (trimmed === "Info:") {
-				currentSeverity = "info"
-			} else if (trimmed === "Hints:") {
-				currentSeverity = "hint"
-			} else {
-                const match = trimmed.match(/^((?:.*:)?\d+:\d+)\s*-\s*(.+)$/)
-                if (match) {
-                    entries.push({
-                        severity: currentSeverity,
-                        location: match[1]!,
-                        message: match[2]!,
-                    })
-                }
-			}
-		}
+  private getFormattedOutput(): string {
+    if (!this.result) return '';
 
-		return { hasIssues: entries.length > 0, entries }
-	}
-	private generateDiffLines(
-		oldStr: string,
-		newStr: string,
-	): { lines: string[]; firstChangeIndex: number } {
-		const oldLines = oldStr.split("\n")
-		const newLines = newStr.split("\n")
-		const lines: string[] = []
-		let firstChangeIndex = -1
+    const textContent = this.result.content
+      .filter(c => c.type === 'text' && c.text)
+      .map(c => c.text!)
+      .join('\n');
 
-		// Use soft red for removed, green for added
-		const removedColor = chalk.hex(mastra.red) // soft red
-		const addedColor = chalk.hex("#5cb85c") // soft green
+    if (!textContent) return '';
 
-		const maxLines = Math.max(oldLines.length, newLines.length)
+    const { content } = extractContent(textContent);
+    // Remove excessive blank lines while preserving intentional formatting
+    return content.trim().replace(/\n\s*\n\s*\n/g, '\n\n');
+  }
 
-		for (let i = 0; i < maxLines; i++) {
-			if (i >= oldLines.length) {
-				if (firstChangeIndex === -1) firstChangeIndex = lines.length
-				lines.push(addedColor(newLines[i]))
-			} else if (i >= newLines.length) {
-				if (firstChangeIndex === -1) firstChangeIndex = lines.length
-				lines.push(removedColor(oldLines[i]))
-            } else if (oldLines[i] !== newLines[i]) {
-                if (firstChangeIndex === -1) firstChangeIndex = lines.length
-                lines.push(removedColor(oldLines[i]!))
-                lines.push(addedColor(newLines[i]!))
-            } else {
-                // Context line
-                lines.push(theme.fg("muted", oldLines[i]!))
-            }
-		}
+  /**
+   * Render an error result using the enhanced error display component
+   */
+  private renderErrorResult(header: string): void {
+    if (!this.result) return;
 
-		return {
-			lines,
-			firstChangeIndex: firstChangeIndex === -1 ? 0 : firstChangeIndex,
-		}
-	}
-	private renderWriteToolEnhanced(): void {
-		const argsObj = this.args as Record<string, unknown> | undefined
-		const fullPath = argsObj?.path ? String(argsObj.path) : ""
-		const path = argsObj?.path ? shortenPath(String(argsObj.path)) : "..."
+    // First add the header
+    this.contentBox.addChild(new Text(header, 0, 0));
 
-		const status = this.getStatusIndicator()
-		const pathDisplay = fullPath
-			? fileLink(theme.fg("accent", path), fullPath)
-			: theme.fg("accent", path)
-		const header = `${theme.bold(theme.fg("toolTitle", "💾 write"))} ${pathDisplay}${status}`
+    // Extract error text from result
+    const errorText = this.result.content
+      .filter(c => c.type === 'text' && c.text)
+      .map(c => c.text!)
+      .join('\n');
 
-		this.contentBox.addChild(new Text(header, 0, 0))
+    if (!errorText) return;
 
-		if (this.result && !this.isPartial) {
-			const output = this.getFormattedOutput()
-			if (output && (this.result.isError || this.expanded)) {
-				this.contentBox.addChild(new Text("", 0, 0))
-				const color = this.result.isError ? "error" : "success"
-				this.contentBox.addChild(new Text(theme.fg(color, output), 0, 0))
-			}
-		}
-	}
-	private renderListFilesEnhanced(): void {
-		const argsObj = this.args as Record<string, unknown> | undefined
-		const fullPath = argsObj?.path ? String(argsObj.path) : ""
-		const path = argsObj?.path ? shortenPath(String(argsObj.path)) : "/"
+    // Check if this is a validation error
+    const isValidationError =
+      errorText.toLowerCase().includes('validation') ||
+      errorText.toLowerCase().includes('required parameter') ||
+      errorText.toLowerCase().includes('missing required') ||
+      errorText.match(/at "\w+"/i) || // Zod-style errors
+      (errorText.includes('Expected') && errorText.includes('Received'));
 
-		if (!this.result || this.isPartial) {
-			const status = this.getStatusIndicator()
-			const pathDisplay = fullPath
-				? fileLink(theme.fg("accent", path), fullPath)
-				: theme.fg("accent", path)
-			const header = `${theme.bold(theme.fg("toolTitle", "📁 list"))} ${pathDisplay}${status}`
-			this.contentBox.addChild(new Text(header, 0, 0))
-			return
-		}
+    if (isValidationError) {
+      // Use specialized validation error component
+      const validationErrors = parseValidationErrors(errorText);
+      const validationDisplay = new ToolValidationErrorComponent(
+        {
+          toolName: this.toolName,
+          errors: validationErrors,
+          args: this.args,
+        },
+        this.ui,
+      );
+      this.contentBox.addChild(validationDisplay);
+      return;
+    }
 
-		const output = this.getFormattedOutput()
-		if (output) {
-			const lines = output.split("\n")
-			const fileCount = lines.filter(
-				(l) =>
-					l.trim() && !l.includes("└") && !l.includes("├") && !l.includes("│"),
-			).length
-			const listStatus = this.getStatusIndicator()
+    // Try to parse as an error object
+    let error: Error | string = errorText;
+    try {
+      const { content } = extractContent(errorText);
+      error = content;
 
-			this.collapsible = new CollapsibleComponent(
-				{
-					header: `${theme.bold(theme.fg("toolTitle", "📁 list"))} ${theme.fg("accent", path)}${listStatus}`,
-					summary: `${fileCount} items`,
-					expanded: this.expanded,
-					collapsedLines: 15,
-					expandedLines: 100,
-					showLineCount: false,
-				},
-				this.ui,
-			)
+      // Try to create an Error object with better structure
+      const errorMatch = content.match(/^([A-Z][a-zA-Z]*Error):\s*(.+)$/m);
+      if (errorMatch) {
+        const err = new Error(errorMatch[2]!);
+        err.name = errorMatch[1]!;
+        // Try to extract stack trace
+        const stackMatch = content.match(/\n\s+at\s+.+/g);
+        if (stackMatch) {
+          err.stack = `${err.name}: ${err.message}\n${stackMatch.join('\n')}`;
+        }
+        error = err;
+      }
+    } catch {
+      // Keep as string
+    }
 
-			this.collapsible.setContent(output)
-			this.contentBox.addChild(this.collapsible)
-		}
-	}
+    // Create error display component
+    const errorDisplay = new ErrorDisplayComponent(
+      error,
+      {
+        showStack: true,
+        showContext: true,
+        expanded: this.expanded,
+      },
+      this.ui,
+    );
 
-	private renderGenericToolEnhanced(): void {
-		const status = this.getStatusIndicator()
-
-		let argsSummary = ""
-		if (this.args && typeof this.args === "object") {
-			const argsObj = this.args as Record<string, unknown>
-			const keys = Object.keys(argsObj)
-			if (keys.length > 0) {
-				argsSummary = theme.fg("muted", ` (${keys.length} args)`)
-			}
-		}
-
-		const header = `${theme.bold(theme.fg("toolTitle", this.toolName))}${argsSummary}${status}`
-
-		if (!this.result || this.isPartial) {
-			this.contentBox.addChild(new Text(header, 0, 0))
-			return
-		}
-
-		// Use enhanced error display for errors
-		if (this.result.isError) {
-			this.renderErrorResult(header)
-			return
-		}
-
-		const output = this.getFormattedOutput()
-		if (output) {
-			this.collapsible = new CollapsibleComponent(
-				{
-					header,
-					expanded: this.expanded,
-					collapsedLines: 10,
-					expandedLines: 200,
-					showLineCount: true,
-				},
-				this.ui,
-			)
-
-			this.collapsible.setContent(output)
-			this.contentBox.addChild(this.collapsible)
-		}
-	}
-
-	private getStatusIndicator(): string {
-		return this.isPartial
-			? theme.fg("muted", " ⋯")
-			: this.result?.isError
-				? theme.fg("error", " ✗")
-				: theme.fg("success", " ✓")
-	}
-
-	private getDurationSuffix(): string {
-		if (this.isPartial) return ""
-		const ms = Date.now() - this.startTime
-		if (ms < 1000) return theme.fg("muted", ` ${ms}ms`)
-		return theme.fg("muted", ` ${(ms / 1000).toFixed(1)}s`)
-	}
-
-	private getFormattedOutput(): string {
-		if (!this.result) return ""
-
-		const textContent = this.result.content
-			.filter((c) => c.type === "text" && c.text)
-			.map((c) => c.text!)
-			.join("\n")
-
-		if (!textContent) return ""
-
-		const { content } = extractContent(textContent)
-		// Remove excessive blank lines while preserving intentional formatting
-		return content.trim().replace(/\n\s*\n\s*\n/g, "\n\n")
-	}
-
-	/**
-	 * Render an error result using the enhanced error display component
-	 */
-	private renderErrorResult(header: string): void {
-		if (!this.result) return
-
-		// First add the header
-		this.contentBox.addChild(new Text(header, 0, 0))
-
-		// Extract error text from result
-		const errorText = this.result.content
-			.filter((c) => c.type === "text" && c.text)
-			.map((c) => c.text!)
-			.join("\n")
-
-		if (!errorText) return
-
-		// Check if this is a validation error
-		const isValidationError =
-			errorText.toLowerCase().includes("validation") ||
-			errorText.toLowerCase().includes("required parameter") ||
-			errorText.toLowerCase().includes("missing required") ||
-			errorText.match(/at "\w+"/i) || // Zod-style errors
-			(errorText.includes("Expected") && errorText.includes("Received"))
-
-		if (isValidationError) {
-			// Use specialized validation error component
-			const validationErrors = parseValidationErrors(errorText)
-			const validationDisplay = new ToolValidationErrorComponent(
-				{
-					toolName: this.toolName,
-					errors: validationErrors,
-					args: this.args,
-				},
-				this.ui,
-			)
-			this.contentBox.addChild(validationDisplay)
-			return
-		}
-
-		// Try to parse as an error object
-		let error: Error | string = errorText
-		try {
-			const { content } = extractContent(errorText)
-			error = content
-
-			// Try to create an Error object with better structure
-            const errorMatch = content.match(/^([A-Z][a-zA-Z]*Error):\s*(.+)$/m)
-            if (errorMatch) {
-                const err = new Error(errorMatch[2]!)
-                err.name = errorMatch[1]!
-				// Try to extract stack trace
-				const stackMatch = content.match(/\n\s+at\s+.+/g)
-				if (stackMatch) {
-					err.stack = `${err.name}: ${err.message}\n${stackMatch.join("\n")}`
-				}
-				error = err
-			}
-		} catch {
-			// Keep as string
-		}
-
-		// Create error display component
-		const errorDisplay = new ErrorDisplayComponent(
-			error,
-			{
-				showStack: true,
-				showContext: true,
-				expanded: this.expanded,
-			},
-			this.ui,
-		)
-
-		this.contentBox.addChild(errorDisplay)
-	}
+    this.contentBox.addChild(errorDisplay);
+  }
 }
 
 /** Map file extensions to highlight.js language names */
 function getLanguageFromPath(path: string): string | undefined {
-	const ext = path.split(".").pop()?.toLowerCase()
-	const langMap: Record<string, string> = {
-		ts: "typescript",
-		tsx: "typescript",
-		js: "javascript",
-		jsx: "javascript",
-		mjs: "javascript",
-		cjs: "javascript",
-		json: "json",
-		md: "markdown",
-		py: "python",
-		rb: "ruby",
-		rs: "rust",
-		go: "go",
-		java: "java",
-		kt: "kotlin",
-		swift: "swift",
-		c: "c",
-		cpp: "cpp",
-		h: "c",
-		hpp: "cpp",
-		cs: "csharp",
-		php: "php",
-		sh: "bash",
-		bash: "bash",
-		zsh: "bash",
-		fish: "bash",
-		yml: "yaml",
-		yaml: "yaml",
-		toml: "ini",
-		ini: "ini",
-		xml: "xml",
-		html: "html",
-		htm: "html",
-		css: "css",
-		scss: "scss",
-		sass: "scss",
-		less: "less",
-		sql: "sql",
-		graphql: "graphql",
-		gql: "graphql",
-		dockerfile: "dockerfile",
-		makefile: "makefile",
-		cmake: "cmake",
-		vue: "vue",
-		svelte: "xml",
-	}
-	return ext ? langMap[ext] : undefined
+  const ext = path.split('.').pop()?.toLowerCase();
+  const langMap: Record<string, string> = {
+    ts: 'typescript',
+    tsx: 'typescript',
+    js: 'javascript',
+    jsx: 'javascript',
+    mjs: 'javascript',
+    cjs: 'javascript',
+    json: 'json',
+    md: 'markdown',
+    py: 'python',
+    rb: 'ruby',
+    rs: 'rust',
+    go: 'go',
+    java: 'java',
+    kt: 'kotlin',
+    swift: 'swift',
+    c: 'c',
+    cpp: 'cpp',
+    h: 'c',
+    hpp: 'cpp',
+    cs: 'csharp',
+    php: 'php',
+    sh: 'bash',
+    bash: 'bash',
+    zsh: 'bash',
+    fish: 'bash',
+    yml: 'yaml',
+    yaml: 'yaml',
+    toml: 'ini',
+    ini: 'ini',
+    xml: 'xml',
+    html: 'html',
+    htm: 'html',
+    css: 'css',
+    scss: 'scss',
+    sass: 'scss',
+    less: 'less',
+    sql: 'sql',
+    graphql: 'graphql',
+    gql: 'graphql',
+    dockerfile: 'dockerfile',
+    makefile: 'makefile',
+    cmake: 'cmake',
+    vue: 'vue',
+    svelte: 'xml',
+  };
+  return ext ? langMap[ext] : undefined;
 }
 
 /** Strip cat -n formatting and apply syntax highlighting */
-function highlightCode(
-	content: string,
-	path: string,
-	startLine?: number,
-): string {
-	let lines = content.split("\n").map((line) => line.trimEnd())
-    // Remove "[Truncated N tokens]" and "Here's the result of running `cat -n`..." headers
-    while (
-        lines.length > 0 &&
-        (lines[0]!.includes("Here's the result of running") ||
-            lines[0]!.match(/^\[Truncated \d+ tokens\]$/))
-    ) {
-        lines = lines.slice(1)
+function highlightCode(content: string, path: string, startLine?: number): string {
+  let lines = content.split('\n').map(line => line.trimEnd());
+  // Remove "[Truncated N tokens]" and "Here's the result of running `cat -n`..." headers
+  while (
+    lines.length > 0 &&
+    (lines[0]!.includes("Here's the result of running") || lines[0]!.match(/^\[Truncated \d+ tokens\]$/))
+  ) {
+    lines = lines.slice(1);
+  }
+
+  // Strip line numbers - we know they're sequential starting from startLine
+  let expectedLineNum = startLine ?? 1;
+  const codeLines = lines.map(line => {
+    const numStr = String(expectedLineNum);
+    // Line format is like "   123\tcode" or "   123" for blank lines
+    // Check if line starts with spaces + our expected number
+    const match = line.match(/^(\s*)(\d+)(\t?)(.*)$/);
+    if (match && match[2] === numStr) {
+      expectedLineNum++;
+      return match[4]; // Return just the code part after the tab
     }
+    return line;
+  });
 
-	// Strip line numbers - we know they're sequential starting from startLine
-	let expectedLineNum = startLine ?? 1
-	const codeLines = lines.map((line) => {
-		const numStr = String(expectedLineNum)
-		// Line format is like "   123\tcode" or "   123" for blank lines
-		// Check if line starts with spaces + our expected number
-		const match = line.match(/^(\s*)(\d+)(\t?)(.*)$/)
-		if (match && match[2] === numStr) {
-			expectedLineNum++
-			return match[4] // Return just the code part after the tab
-		}
-		return line
-	})
+  // Remove trailing empty lines
+  while (codeLines.length > 0 && codeLines[codeLines.length - 1] === '') {
+    codeLines.pop();
+  }
 
-	// Remove trailing empty lines
-	while (codeLines.length > 0 && codeLines[codeLines.length - 1] === "") {
-		codeLines.pop()
-	}
-
-	// Apply syntax highlighting
-	try {
-		return highlight(codeLines.join("\n"), {
-			language: getLanguageFromPath(path),
-			ignoreIllegals: true,
-		})
-	} catch {
-		return codeLines.join("\n")
-	}
+  // Apply syntax highlighting
+  try {
+    return highlight(codeLines.join('\n'), {
+      language: getLanguageFromPath(path),
+      ignoreIllegals: true,
+    });
+  } catch {
+    return codeLines.join('\n');
+  }
 }
 /** Truncate a string with ANSI codes to a visible width.
  *  Handles both SGR sequences (\x1b[...m) and OSC 8 hyperlinks (\x1b]8;...;\x07).
  */
 function truncateAnsi(str: string, maxWidth: number): string {
-	 
-	const ansiRegex = /\x1b\[[0-9;]*m|\x1b\]8;[^\x07]*\x07/g
-	let visibleLength = 0
-	let result = ""
-	let lastIndex = 0
-	let match: RegExpExecArray | null
+  const ansiRegex = /\x1b\[[0-9;]*m|\x1b\]8;[^\x07]*\x07/g;
+  let visibleLength = 0;
+  let result = '';
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
 
-	while ((match = ansiRegex.exec(str)) !== null) {
-		// Add text before this ANSI code
-		const textBefore = str.slice(lastIndex, match.index)
-		const remaining = maxWidth - visibleLength
-		if (textBefore.length <= remaining) {
-			result += textBefore
-			visibleLength += textBefore.length
-		} else {
-			result += textBefore.slice(0, remaining - 1) + "…"
-			result += "\x1b]8;;\x07\x1b[0m" // Close any open hyperlink + reset styles
-			return result
-		}
-		// Add the ANSI code (doesn't count toward visible length)
-		result += match[0]
-		lastIndex = match.index + match[0].length
-	}
+  while ((match = ansiRegex.exec(str)) !== null) {
+    // Add text before this ANSI code
+    const textBefore = str.slice(lastIndex, match.index);
+    const remaining = maxWidth - visibleLength;
+    if (textBefore.length <= remaining) {
+      result += textBefore;
+      visibleLength += textBefore.length;
+    } else {
+      result += textBefore.slice(0, remaining - 1) + '…';
+      result += '\x1b]8;;\x07\x1b[0m'; // Close any open hyperlink + reset styles
+      return result;
+    }
+    // Add the ANSI code (doesn't count toward visible length)
+    result += match[0];
+    lastIndex = match.index + match[0].length;
+  }
 
-	// Add remaining text after last ANSI code
-	const remaining = str.slice(lastIndex)
-	const spaceLeft = maxWidth - visibleLength
-	if (remaining.length <= spaceLeft) {
-		result += remaining
-	} else {
-		result += remaining.slice(0, spaceLeft - 1) + "…"
-		result += "\x1b]8;;\x07\x1b[0m" // Close hyperlink + reset
-	}
+  // Add remaining text after last ANSI code
+  const remaining = str.slice(lastIndex);
+  const spaceLeft = maxWidth - visibleLength;
+  if (remaining.length <= spaceLeft) {
+    result += remaining;
+  } else {
+    result += remaining.slice(0, spaceLeft - 1) + '…';
+    result += '\x1b]8;;\x07\x1b[0m'; // Close hyperlink + reset
+  }
 
-	return result
+  return result;
 }

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -368,11 +368,11 @@ export class ToolExecutionComponentEnhanced
 		command = command.replace(cdPattern, "")
 
 		// Extract tail value from command (e.g., "| tail -5" or "| tail -n 5")
-		let maxStreamLines: number | undefined
-		const tailMatch = command.match(/\|\s*tail\s+(?:-n\s+)?(-?\d+)\s*$/)
-		if (tailMatch) {
-			maxStreamLines = Math.abs(parseInt(tailMatch[1], 10))
-		}
+        let maxStreamLines: number | undefined
+        const tailMatch = command.match(/\|\s*tail\s+(?:-n\s+)?(-?\d+)\s*$/)
+        if (tailMatch) {
+            maxStreamLines = Math.abs(parseInt(tailMatch[1]!, 10))
+        }
 
 		const timeoutSuffix = timeout
 			? theme.fg("muted", ` (timeout ${timeout}s)`)
@@ -667,14 +667,14 @@ export class ToolExecutionComponentEnhanced
 			} else if (trimmed === "Hints:") {
 				currentSeverity = "hint"
 			} else {
-				const match = trimmed.match(/^((?:.*:)?\d+:\d+)\s*-\s*(.+)$/)
-				if (match) {
-					entries.push({
-						severity: currentSeverity,
-						location: match[1],
-						message: match[2],
-					})
-				}
+                const match = trimmed.match(/^((?:.*:)?\d+:\d+)\s*-\s*(.+)$/)
+                if (match) {
+                    entries.push({
+                        severity: currentSeverity,
+                        location: match[1]!,
+                        message: match[2]!,
+                    })
+                }
 			}
 		}
 
@@ -702,14 +702,14 @@ export class ToolExecutionComponentEnhanced
 			} else if (i >= newLines.length) {
 				if (firstChangeIndex === -1) firstChangeIndex = lines.length
 				lines.push(removedColor(oldLines[i]))
-			} else if (oldLines[i] !== newLines[i]) {
-				if (firstChangeIndex === -1) firstChangeIndex = lines.length
-				lines.push(removedColor(oldLines[i]))
-				lines.push(addedColor(newLines[i]))
-			} else {
-				// Context line
-				lines.push(theme.fg("muted", oldLines[i]))
-			}
+            } else if (oldLines[i] !== newLines[i]) {
+                if (firstChangeIndex === -1) firstChangeIndex = lines.length
+                lines.push(removedColor(oldLines[i]!))
+                lines.push(addedColor(newLines[i]!))
+            } else {
+                // Context line
+                lines.push(theme.fg("muted", oldLines[i]!))
+            }
 		}
 
 		return {
@@ -900,10 +900,10 @@ export class ToolExecutionComponentEnhanced
 			error = content
 
 			// Try to create an Error object with better structure
-			const errorMatch = content.match(/^([A-Z][a-zA-Z]*Error):\s*(.+)$/m)
-			if (errorMatch) {
-				const err = new Error(errorMatch[2])
-				err.name = errorMatch[1]
+            const errorMatch = content.match(/^([A-Z][a-zA-Z]*Error):\s*(.+)$/m)
+            if (errorMatch) {
+                const err = new Error(errorMatch[2]!)
+                err.name = errorMatch[1]!
 				// Try to extract stack trace
 				const stackMatch = content.match(/\n\s+at\s+.+/g)
 				if (stackMatch) {
@@ -989,15 +989,14 @@ function highlightCode(
 	startLine?: number,
 ): string {
 	let lines = content.split("\n").map((line) => line.trimEnd())
-
-	// Remove "[Truncated N tokens]" and "Here's the result of running `cat -n`..." headers
-	while (
-		lines.length > 0 &&
-		(lines[0].includes("Here's the result of running") ||
-			lines[0].match(/^\[Truncated \d+ tokens\]$/))
-	) {
-		lines = lines.slice(1)
-	}
+    // Remove "[Truncated N tokens]" and "Here's the result of running `cat -n`..." headers
+    while (
+        lines.length > 0 &&
+        (lines[0]!.includes("Here's the result of running") ||
+            lines[0]!.match(/^\[Truncated \d+ tokens\]$/))
+    ) {
+        lines = lines.slice(1)
+    }
 
 	// Strip line numbers - we know they're sequential starting from startLine
 	let expectedLineNum = startLine ?? 1

--- a/mastracode/src/tui/components/tool-execution-interface.ts
+++ b/mastracode/src/tui/components/tool-execution-interface.ts
@@ -3,19 +3,19 @@
  */
 
 export interface ToolResult {
-	content: Array<{
-		type: string
-		text?: string
-		data?: string
-		mimeType?: string
-	}>
-	isError: boolean
+  content: Array<{
+    type: string;
+    text?: string;
+    data?: string;
+    mimeType?: string;
+  }>;
+  isError: boolean;
 }
 
 export interface IToolExecutionComponent {
-	updateArgs(args: unknown): void
-	updateResult(result: ToolResult, isPartial?: boolean): void
-	setExpanded(expanded: boolean): void
-	/** Append streaming output for shell commands */
-	appendStreamingOutput?(output: string): void
+  updateArgs(args: unknown): void;
+  updateResult(result: ToolResult, isPartial?: boolean): void;
+  setExpanded(expanded: boolean): void;
+  /** Append streaming output for shell commands */
+  appendStreamingOutput?(output: string): void;
 }

--- a/mastracode/src/tui/components/tool-validation-error.ts
+++ b/mastracode/src/tui/components/tool-validation-error.ts
@@ -3,251 +3,214 @@
  * Provides clear, actionable feedback when tool inputs are invalid.
  */
 
-import { Container, Text  } from "@mariozechner/pi-tui"
-import type {TUI} from "@mariozechner/pi-tui";
-import { theme } from "../theme.js"
+import { Container, Text } from '@mariozechner/pi-tui';
+import type { TUI } from '@mariozechner/pi-tui';
+import { theme } from '../theme.js';
 
 export interface ValidationError {
-	field: string
-	message: string
-	expected?: string
-	received?: string
+  field: string;
+  message: string;
+  expected?: string;
+  received?: string;
 }
 
 export interface ToolValidationErrorOptions {
-	toolName: string
-	errors: ValidationError[]
-	args?: unknown
-	schema?: unknown
+  toolName: string;
+  errors: ValidationError[];
+  args?: unknown;
+  schema?: unknown;
 }
 
 /**
  * Parse validation errors from various error formats
  */
 export function parseValidationErrors(error: unknown): ValidationError[] {
-	const errors: ValidationError[] = []
+  const errors: ValidationError[] = [];
 
-	if (typeof error === "string") {
-		// Try to parse Zod-style errors
-		const zodMatch = error.match(/at "([^"]+)".*?: (.+?)(?:\n|$)/g)
-		if (zodMatch) {
-			zodMatch.forEach((match) => {
-				const [, field, message] =
-					match.match(/at "([^"]+)".*?: (.+?)(?:\n|$)/) || []
-				if (field && message) {
-					errors.push({ field, message })
-				}
-			})
-		}
-
-		// Try to parse "missing required parameter" errors
-        const missingMatch = error.match(/missing required.*?["`'](\w+)["`']/i)
-        if (missingMatch) {
-            errors.push({
-                field: missingMatch[1]!,
-                message: "Required parameter is missing",
-            })
+  if (typeof error === 'string') {
+    // Try to parse Zod-style errors
+    const zodMatch = error.match(/at "([^"]+)".*?: (.+?)(?:\n|$)/g);
+    if (zodMatch) {
+      zodMatch.forEach(match => {
+        const [, field, message] = match.match(/at "([^"]+)".*?: (.+?)(?:\n|$)/) || [];
+        if (field && message) {
+          errors.push({ field, message });
         }
+      });
+    }
 
-		// Generic fallback
-		if (errors.length === 0) {
-			errors.push({
-				field: "unknown",
-				message: error,
-			})
-		}
-	} else if (typeof error === "object" && error !== null) {
-		// Handle structured error objects
-		const err = error as any
+    // Try to parse "missing required parameter" errors
+    const missingMatch = error.match(/missing required.*?["`'](\w+)["`']/i);
+    if (missingMatch) {
+      errors.push({
+        field: missingMatch[1]!,
+        message: 'Required parameter is missing',
+      });
+    }
 
-		// Zod error format
-		if (err.issues && Array.isArray(err.issues)) {
-			err.issues.forEach((issue: any) => {
-				errors.push({
-					field: issue.path?.join(".") || "unknown",
-					message: issue.message,
-					expected: issue.expected,
-					received: issue.received,
-				})
-			})
-		}
-		// Generic error with message
-		else if (err.message) {
-			errors.push({
-				field: err.field || "unknown",
-				message: err.message,
-			})
-		}
-	}
+    // Generic fallback
+    if (errors.length === 0) {
+      errors.push({
+        field: 'unknown',
+        message: error,
+      });
+    }
+  } else if (typeof error === 'object' && error !== null) {
+    // Handle structured error objects
+    const err = error as any;
 
-	return errors.length > 0
-		? errors
-		: [{ field: "unknown", message: String(error) }]
+    // Zod error format
+    if (err.issues && Array.isArray(err.issues)) {
+      err.issues.forEach((issue: any) => {
+        errors.push({
+          field: issue.path?.join('.') || 'unknown',
+          message: issue.message,
+          expected: issue.expected,
+          received: issue.received,
+        });
+      });
+    }
+    // Generic error with message
+    else if (err.message) {
+      errors.push({
+        field: err.field || 'unknown',
+        message: err.message,
+      });
+    }
+  }
+
+  return errors.length > 0 ? errors : [{ field: 'unknown', message: String(error) }];
 }
 
 /**
  * Format tool arguments for display
  */
 function formatArgs(args: unknown): string[] {
-	if (!args || typeof args !== "object") return []
+  if (!args || typeof args !== 'object') return [];
 
-	const lines: string[] = []
-	const obj = args as Record<string, unknown>
+  const lines: string[] = [];
+  const obj = args as Record<string, unknown>;
 
-	for (const [key, value] of Object.entries(obj)) {
-		let valueStr: string
-		if (value === null || value === undefined) {
-			valueStr = theme.fg("muted", "undefined")
-		} else if (typeof value === "string") {
-			valueStr = value.length > 50 ? `"${value.slice(0, 47)}..."` : `"${value}"`
-		} else if (typeof value === "object") {
-			valueStr = JSON.stringify(value)
-			if (valueStr.length > 50) {
-				valueStr = valueStr.slice(0, 47) + "..."
-			}
-		} else {
-			valueStr = String(value)
-		}
+  for (const [key, value] of Object.entries(obj)) {
+    let valueStr: string;
+    if (value === null || value === undefined) {
+      valueStr = theme.fg('muted', 'undefined');
+    } else if (typeof value === 'string') {
+      valueStr = value.length > 50 ? `"${value.slice(0, 47)}..."` : `"${value}"`;
+    } else if (typeof value === 'object') {
+      valueStr = JSON.stringify(value);
+      if (valueStr.length > 50) {
+        valueStr = valueStr.slice(0, 47) + '...';
+      }
+    } else {
+      valueStr = String(value);
+    }
 
-		lines.push(`  ${theme.fg("accent", key)}: ${valueStr}`)
-	}
+    lines.push(`  ${theme.fg('accent', key)}: ${valueStr}`);
+  }
 
-	return lines
+  return lines;
 }
 
 /**
  * Enhanced tool validation error display component
  */
 export class ToolValidationErrorComponent extends Container {
-	constructor(options: ToolValidationErrorOptions, _ui: TUI) {
-		super()
+  constructor(options: ToolValidationErrorOptions, _ui: TUI) {
+    super();
 
-		const { toolName, errors, args } = options
+    const { toolName, errors, args } = options;
 
-		// Header
-		this.addChild(
-			new Text(
-				`${theme.fg("error", "✗ Tool validation failed: ")}${theme.bold(theme.fg("toolTitle", toolName))}`,
-				0,
-				0,
-			),
-		)
-		this.addChild(new Text("", 0, 0))
+    // Header
+    this.addChild(
+      new Text(
+        `${theme.fg('error', '✗ Tool validation failed: ')}${theme.bold(theme.fg('toolTitle', toolName))}`,
+        0,
+        0,
+      ),
+    );
+    this.addChild(new Text('', 0, 0));
 
-		// Error details
-		errors.forEach((error, index) => {
-			if (index > 0) {
-				this.addChild(new Text("", 0, 0))
-			}
+    // Error details
+    errors.forEach((error, index) => {
+      if (index > 0) {
+        this.addChild(new Text('', 0, 0));
+      }
 
-			if (error.field !== "unknown") {
-				this.addChild(
-					new Text(
-						`${theme.fg("muted", "  Parameter: ")}${theme.fg("accent", error.field)}`,
-						0,
-						0,
-					),
-				)
-			}
+      if (error.field !== 'unknown') {
+        this.addChild(new Text(`${theme.fg('muted', '  Parameter: ')}${theme.fg('accent', error.field)}`, 0, 0));
+      }
 
-			this.addChild(
-				new Text(
-					`${theme.fg("muted", "  Issue: ")}${theme.fg("error", error.message)}`,
-					0,
-					0,
-				),
-			)
+      this.addChild(new Text(`${theme.fg('muted', '  Issue: ')}${theme.fg('error', error.message)}`, 0, 0));
 
-			if (error.expected || error.received) {
-				let detail = ""
-				if (error.expected) {
-					detail += `${theme.fg("muted", "  Expected: ")}${theme.fg("success", error.expected)}`
-					if (error.received) detail += theme.fg("muted", ", ")
-				}
-				if (error.received) {
-					detail += `${theme.fg("muted", "Received: ")}${theme.fg("error", error.received)}`
-				}
-				this.addChild(new Text(detail, 0, 0))
-			}
-		})
+      if (error.expected || error.received) {
+        let detail = '';
+        if (error.expected) {
+          detail += `${theme.fg('muted', '  Expected: ')}${theme.fg('success', error.expected)}`;
+          if (error.received) detail += theme.fg('muted', ', ');
+        }
+        if (error.received) {
+          detail += `${theme.fg('muted', 'Received: ')}${theme.fg('error', error.received)}`;
+        }
+        this.addChild(new Text(detail, 0, 0));
+      }
+    });
 
-		// Show provided arguments if available
-		if (args && Object.keys(args as any).length > 0) {
-			this.addChild(new Text("", 0, 0))
-			this.addChild(new Text(theme.fg("muted", "Provided arguments:"), 0, 0))
-			const argsLines = formatArgs(args)
-			argsLines.forEach((line) => {
-				this.addChild(new Text(line, 0, 0))
-			})
-		}
+    // Show provided arguments if available
+    if (args && Object.keys(args as any).length > 0) {
+      this.addChild(new Text('', 0, 0));
+      this.addChild(new Text(theme.fg('muted', 'Provided arguments:'), 0, 0));
+      const argsLines = formatArgs(args);
+      argsLines.forEach(line => {
+        this.addChild(new Text(line, 0, 0));
+      });
+    }
 
-		// Suggestions
-		const suggestions = this.generateSuggestions(toolName, errors)
-		if (suggestions.length > 0) {
-			this.addChild(new Text("", 0, 0))
-			this.addChild(
-				new Text(theme.bold(theme.fg("accent", "Suggestions:")), 0, 0),
-			)
-			suggestions.forEach((suggestion) => {
-				this.addChild(new Text(`  • ${suggestion}`, 0, 0))
-			})
-		}
-	}
+    // Suggestions
+    const suggestions = this.generateSuggestions(toolName, errors);
+    if (suggestions.length > 0) {
+      this.addChild(new Text('', 0, 0));
+      this.addChild(new Text(theme.bold(theme.fg('accent', 'Suggestions:')), 0, 0));
+      suggestions.forEach(suggestion => {
+        this.addChild(new Text(`  • ${suggestion}`, 0, 0));
+      });
+    }
+  }
 
-	private generateSuggestions(
-		toolName: string,
-		errors: ValidationError[],
-	): string[] {
-		const suggestions: string[] = []
+  private generateSuggestions(toolName: string, errors: ValidationError[]): string[] {
+    const suggestions: string[] = [];
 
-		const missingParams = errors.filter(
-			(e) =>
-				e.message.toLowerCase().includes("required") ||
-				e.message.toLowerCase().includes("missing"),
-		)
+    const missingParams = errors.filter(
+      e => e.message.toLowerCase().includes('required') || e.message.toLowerCase().includes('missing'),
+    );
 
-		if (missingParams.length > 0) {
-			const params = missingParams
-				.map((e) => e.field)
-				.filter((f) => f !== "unknown")
-			if (params.length > 0) {
-				suggestions.push(
-					`Add the required parameter${params.length > 1 ? "s" : ""}: ${params.join(", ")}`,
-				)
-			}
-		}
+    if (missingParams.length > 0) {
+      const params = missingParams.map(e => e.field).filter(f => f !== 'unknown');
+      if (params.length > 0) {
+        suggestions.push(`Add the required parameter${params.length > 1 ? 's' : ''}: ${params.join(', ')}`);
+      }
+    }
 
-		const typeErrors = errors.filter(
-			(e) =>
-				e.message.toLowerCase().includes("type") ||
-				e.message.toLowerCase().includes("expected"),
-		)
+    const typeErrors = errors.filter(
+      e => e.message.toLowerCase().includes('type') || e.message.toLowerCase().includes('expected'),
+    );
 
-		if (typeErrors.length > 0) {
-			suggestions.push("Check that parameter types match the expected format")
-		}
+    if (typeErrors.length > 0) {
+      suggestions.push('Check that parameter types match the expected format');
+    }
 
-		if (toolName === "ask_user" && errors.some((e) => e.field === "question")) {
-			suggestions.push(
-				'Make sure to provide a "question" parameter with your question text',
-			)
-		}
+    if (toolName === 'ask_user' && errors.some(e => e.field === 'question')) {
+      suggestions.push('Make sure to provide a "question" parameter with your question text');
+    }
 
-		if (
-			toolName === "execute_command" &&
-			errors.some((e) => e.field === "command")
-		) {
-			suggestions.push(
-				'Provide a "command" parameter with the command to execute',
-			)
-		}
+    if (toolName === 'execute_command' && errors.some(e => e.field === 'command')) {
+      suggestions.push('Provide a "command" parameter with the command to execute');
+    }
 
-		if (toolName === "view" && errors.some((e) => e.field === "path")) {
-			suggestions.push(
-				'Provide a "path" parameter with the file or directory path',
-			)
-		}
+    if (toolName === 'view' && errors.some(e => e.field === 'path')) {
+      suggestions.push('Provide a "path" parameter with the file or directory path');
+    }
 
-		return suggestions
-	}
+    return suggestions;
+  }
 }

--- a/mastracode/src/tui/components/tool-validation-error.ts
+++ b/mastracode/src/tui/components/tool-validation-error.ts
@@ -41,13 +41,13 @@ export function parseValidationErrors(error: unknown): ValidationError[] {
 		}
 
 		// Try to parse "missing required parameter" errors
-		const missingMatch = error.match(/missing required.*?["`'](\w+)["`']/i)
-		if (missingMatch) {
-			errors.push({
-				field: missingMatch[1],
-				message: "Required parameter is missing",
-			})
-		}
+        const missingMatch = error.match(/missing required.*?["`'](\w+)["`']/i)
+        if (missingMatch) {
+            errors.push({
+                field: missingMatch[1]!,
+                message: "Required parameter is missing",
+            })
+        }
 
 		// Generic fallback
 		if (errors.length === 0) {

--- a/mastracode/src/tui/components/user-message.ts
+++ b/mastracode/src/tui/components/user-message.ts
@@ -2,24 +2,19 @@
  * Component that renders a user message.
  */
 
-import {
-	Container,
-	Markdown,
-	
-	Spacer
-} from "@mariozechner/pi-tui"
-import type {MarkdownTheme} from "@mariozechner/pi-tui";
-import { getMarkdownTheme, theme } from "../theme.js"
+import { Container, Markdown, Spacer } from '@mariozechner/pi-tui';
+import type { MarkdownTheme } from '@mariozechner/pi-tui';
+import { getMarkdownTheme, theme } from '../theme.js';
 
 export class UserMessageComponent extends Container {
-	constructor(text: string, markdownTheme: MarkdownTheme = getMarkdownTheme()) {
-		super()
-		this.addChild(new Spacer(1))
-		this.addChild(
-			new Markdown(text, 1, 1, markdownTheme, {
-				bgColor: (text: string) => theme.bg("userMessageBg", text),
-				color: (text: string) => theme.fg("userMessageText", text),
-			}),
-		)
-	}
+  constructor(text: string, markdownTheme: MarkdownTheme = getMarkdownTheme()) {
+    super();
+    this.addChild(new Spacer(1));
+    this.addChild(
+      new Markdown(text, 1, 1, markdownTheme, {
+        bgColor: (text: string) => theme.bg('userMessageBg', text),
+        color: (text: string) => theme.fg('userMessageText', text),
+      }),
+    );
+  }
 }

--- a/mastracode/src/tui/index.ts
+++ b/mastracode/src/tui/index.ts
@@ -2,33 +2,18 @@
  * TUI exports for Mastra Code.
  */
 
-export { MastraTUI, type MastraTUIOptions } from "./mastra-tui.js"
-export { AssistantMessageComponent } from "./components/assistant-message.js"
+export { MastraTUI, type MastraTUIOptions } from './mastra-tui.js';
+export { AssistantMessageComponent } from './components/assistant-message.js';
+export { OMProgressComponent, type OMProgressState, type OMStatus, formatOMStatus } from './components/om-progress.js';
 export {
-	OMProgressComponent,
-	type OMProgressState,
-	type OMStatus,
-	formatOMStatus,
-} from "./components/om-progress.js"
-export {
-	ToolExecutionComponentEnhanced,
-	type ToolExecutionOptions,
-	type ToolResult,
-} from "./components/tool-execution-enhanced.js"
-export type { IToolExecutionComponent } from "./components/tool-execution-interface.js"
-export { UserMessageComponent } from "./components/user-message.js"
-export {
-	ModelSelectorComponent,
-	type ModelItem,
-	type ModelSelectorOptions,
-} from "./components/model-selector.js"
-export { LoginSelectorComponent } from "./components/login-selector.js"
-export { LoginDialogComponent } from "./components/login-dialog.js"
-export {
-	theme,
-	getTheme,
-	setTheme,
-	getMarkdownTheme,
-	getEditorTheme,
-} from "./theme.js"
-export type { ThemeColor, ThemeBg, ThemeColors } from "./theme.js"
+  ToolExecutionComponentEnhanced,
+  type ToolExecutionOptions,
+  type ToolResult,
+} from './components/tool-execution-enhanced.js';
+export type { IToolExecutionComponent } from './components/tool-execution-interface.js';
+export { UserMessageComponent } from './components/user-message.js';
+export { ModelSelectorComponent, type ModelItem, type ModelSelectorOptions } from './components/model-selector.js';
+export { LoginSelectorComponent } from './components/login-selector.js';
+export { LoginDialogComponent } from './components/login-dialog.js';
+export { theme, getTheme, setTheme, getMarkdownTheme, getEditorTheme } from './theme.js';
+export type { ThemeColor, ThemeBg, ThemeColors } from './theme.js';

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -2,144 +2,102 @@
  * Main TUI class for Mastra Code.
  * Wires the Harness to pi-tui components for a full interactive experience.
  */
-import fs from "node:fs"
-import path from "node:path"
+import fs from 'node:fs';
+import path from 'node:path';
 import {
-	CombinedAutocompleteProvider,
-	
-	Container,
-	Spacer,
-	Text,
-	TUI,
-	ProcessTerminal,
-	visibleWidth
-	
-	
-} from "@mariozechner/pi-tui"
-import type {Component, SlashCommand} from "@mariozechner/pi-tui";
-import type { Workspace } from "@mastra/core/workspace"
-import chalk from "chalk"
-import type { Harness } from "../harness/harness.js"
+  CombinedAutocompleteProvider,
+  Container,
+  Spacer,
+  Text,
+  TUI,
+  ProcessTerminal,
+  visibleWidth,
+} from '@mariozechner/pi-tui';
+import type { Component, SlashCommand } from '@mariozechner/pi-tui';
+import type { Workspace } from '@mastra/core/workspace';
+import chalk from 'chalk';
+import type { Harness } from '../harness/harness.js';
 import type {
-	HarnessEvent,
-	HarnessMessage,
-	HarnessMessageContent,
-	HarnessEventListener,
-	TokenUsage,
-} from "../harness/types.js"
-import { getToolCategory, TOOL_CATEGORIES } from "../permissions.js"
-import { parseSubagentMeta } from "../tools/subagent.js"
-import { parseError } from "../utils/errors.js"
-import { detectProject  } from "../utils/project.js"
-import type {ProjectInfo} from "../utils/project.js";
-import {
-	loadCustomCommands
-	
-} from "../utils/slash-command-loader.js"
-import type {SlashCommandMetadata} from "../utils/slash-command-loader.js";
-import { processSlashCommand } from "../utils/slash-command-processor.js"
-import { ThreadLockError } from "../utils/thread-lock.js"
-import { AskQuestionDialogComponent } from "./components/ask-question-dialog.js"
-import { AskQuestionInlineComponent } from "./components/ask-question-inline.js"
-import { AssistantMessageComponent } from "./components/assistant-message.js"
-import { CustomEditor } from "./components/custom-editor.js"
-import { DiffOutputComponent } from "./components/diff-output.js"
-import { LoginDialogComponent } from "./components/login-dialog.js"
-import {
-	ModelSelectorComponent
-	
-} from "./components/model-selector.js"
-import type {ModelItem} from "./components/model-selector.js";
-import {
-	GradientAnimator,
-	applyGradientSweep,
-} from "./components/obi-loader.js"
+  HarnessEvent,
+  HarnessMessage,
+  HarnessMessageContent,
+  HarnessEventListener,
+  TokenUsage,
+} from '../harness/types.js';
+import { getToolCategory, TOOL_CATEGORIES } from '../permissions.js';
+import { parseSubagentMeta } from '../tools/subagent.js';
+import { parseError } from '../utils/errors.js';
+import { detectProject } from '../utils/project.js';
+import type { ProjectInfo } from '../utils/project.js';
+import { loadCustomCommands } from '../utils/slash-command-loader.js';
+import type { SlashCommandMetadata } from '../utils/slash-command-loader.js';
+import { processSlashCommand } from '../utils/slash-command-processor.js';
+import { ThreadLockError } from '../utils/thread-lock.js';
+import { AskQuestionDialogComponent } from './components/ask-question-dialog.js';
+import { AskQuestionInlineComponent } from './components/ask-question-inline.js';
+import { AssistantMessageComponent } from './components/assistant-message.js';
+import { CustomEditor } from './components/custom-editor.js';
+import { DiffOutputComponent } from './components/diff-output.js';
+import { LoginDialogComponent } from './components/login-dialog.js';
+import { ModelSelectorComponent } from './components/model-selector.js';
+import type { ModelItem } from './components/model-selector.js';
+import { GradientAnimator, applyGradientSweep } from './components/obi-loader.js';
 
-import { OMMarkerComponent  } from "./components/om-marker.js"
-import type {OMMarkerData} from "./components/om-marker.js";
-import { OMOutputComponent } from "./components/om-output.js"
-import type {
-	OMProgressComponent,OMProgressState} from "./components/om-progress.js";
-import {
-	
-	defaultOMProgressState,
-	formatObservationStatus,
-	formatReflectionStatus
-} from "./components/om-progress.js"
-import { OMSettingsComponent } from "./components/om-settings.js"
-import {
-	PlanApprovalInlineComponent,
-	PlanResultComponent,
-} from "./components/plan-approval-inline.js"
-import { SettingsComponent } from "./components/settings.js"
-import { ShellOutputComponent } from "./components/shell-output.js"
-import { SlashCommandComponent } from "./components/slash-command.js"
-import { SubagentExecutionComponent } from "./components/subagent-execution.js"
-import { SystemReminderComponent } from "./components/system-reminder.js"
-import { ThreadSelectorComponent } from "./components/thread-selector.js"
+import { OMMarkerComponent } from './components/om-marker.js';
+import type { OMMarkerData } from './components/om-marker.js';
+import { OMOutputComponent } from './components/om-output.js';
+import type { OMProgressComponent, OMProgressState } from './components/om-progress.js';
+import { defaultOMProgressState, formatObservationStatus, formatReflectionStatus } from './components/om-progress.js';
+import { OMSettingsComponent } from './components/om-settings.js';
+import { PlanApprovalInlineComponent, PlanResultComponent } from './components/plan-approval-inline.js';
+import { SettingsComponent } from './components/settings.js';
+import { ShellOutputComponent } from './components/shell-output.js';
+import { SlashCommandComponent } from './components/slash-command.js';
+import { SubagentExecutionComponent } from './components/subagent-execution.js';
+import { SystemReminderComponent } from './components/system-reminder.js';
+import { ThreadSelectorComponent } from './components/thread-selector.js';
 
-import {
-	TodoProgressComponent
-	
-} from "./components/todo-progress.js"
-import type {TodoItem} from "./components/todo-progress.js";
-import {
-	ToolApprovalDialogComponent
-	
-} from "./components/tool-approval-dialog.js"
-import type {ApprovalAction} from "./components/tool-approval-dialog.js";
-import {
-	ToolExecutionComponentEnhanced
-	
-} from "./components/tool-execution-enhanced.js"
-import type {ToolResult} from "./components/tool-execution-enhanced.js";
-import type { IToolExecutionComponent } from "./components/tool-execution-interface.js"
-import { UserMessageComponent } from "./components/user-message.js"
-import {
-	sendNotification
-	
-	
-} from "./notify.js"
-import type {NotificationMode, NotificationReason} from "./notify.js";
-import {
-	getEditorTheme,
-	getMarkdownTheme,
-	fg,
-	bold,
-	theme,
-	mastra,
-	tintHex,
-} from "./theme.js"
+import { TodoProgressComponent } from './components/todo-progress.js';
+import type { TodoItem } from './components/todo-progress.js';
+import { ToolApprovalDialogComponent } from './components/tool-approval-dialog.js';
+import type { ApprovalAction } from './components/tool-approval-dialog.js';
+import { ToolExecutionComponentEnhanced } from './components/tool-execution-enhanced.js';
+import type { ToolResult } from './components/tool-execution-enhanced.js';
+import type { IToolExecutionComponent } from './components/tool-execution-interface.js';
+import { UserMessageComponent } from './components/user-message.js';
+import { sendNotification } from './notify.js';
+import type { NotificationMode, NotificationReason } from './notify.js';
+import { getEditorTheme, getMarkdownTheme, fg, bold, theme, mastra, tintHex } from './theme.js';
 
 // =============================================================================
 // Types
 // =============================================================================
 
 export interface MastraTUIOptions {
-	/** The harness instance to control */
-	harness: Harness<any>
+  /** The harness instance to control */
+  harness: Harness<any>;
 
-	/**
-	 * @deprecated Workspace is now obtained from the Harness.
-	 * Configure workspace via HarnessConfig.workspace instead.
-	 * Kept as fallback for backward compatibility.
-	 */
-	workspace?: Workspace
+  /**
+   * @deprecated Workspace is now obtained from the Harness.
+   * Configure workspace via HarnessConfig.workspace instead.
+   * Kept as fallback for backward compatibility.
+   */
+  workspace?: Workspace;
 
-	/** Initial message to send on startup */
-	initialMessage?: string
+  /** Initial message to send on startup */
+  initialMessage?: string;
 
-	/** Whether to show verbose startup info */
-	verbose?: boolean
+  /** Whether to show verbose startup info */
+  verbose?: boolean;
 
-	/** App name for header */
-	appName?: string
+  /** App name for header */
+  appName?: string;
 
-	/** App version for header */
-	version?: string
+  /** App version for header */
+  version?: string;
 
-	/** Use inline questions instead of dialog overlays */
-	inlineQuestions?: boolean
+  /** Use inline questions instead of dialog overlays */
+  inlineQuestions?: boolean;
 }
 
 // =============================================================================
@@ -147,3935 +105,3608 @@ export interface MastraTUIOptions {
 // =============================================================================
 
 export class MastraTUI {
-	private harness: Harness<any>
-	private options: MastraTUIOptions
-
-	// TUI components
-	private ui: TUI
-	private chatContainer: Container
-	private editorContainer: Container
-	private editor: CustomEditor
-	private footer: Container
-
-	// State tracking
-	private isInitialized = false
-	private gradientAnimator?: GradientAnimator
-	private isAgentActive = false
-	private streamingComponent?: AssistantMessageComponent
-	private streamingMessage?: HarnessMessage
-	private pendingTools = new Map<string, IToolExecutionComponent>()
-	private seenToolCallIds = new Set<string>() // Track all tool IDs seen during current stream (prevents duplicates)
-	private subagentToolCallIds = new Set<string>() // Track subagent tool call IDs to skip in trailing content logic
-	private allToolComponents: IToolExecutionComponent[] = [] // Track all tools for expand/collapse
-	private allSlashCommandComponents: SlashCommandComponent[] = [] // Track slash command boxes for expand/collapse
-	private pendingSubagents = new Map<string, SubagentExecutionComponent>() // Track active subagent tasks
-	private toolOutputExpanded = false
-	private hideThinkingBlock = true
-	private pendingNewThread = false // True when we want a new thread but haven't created it yet
-	private pendingLockConflict: {
-		threadTitle: string
-		ownerPid: number
-	} | null = null
-	private lastAskUserComponent?: IToolExecutionComponent // Track the most recent ask_user tool for inline question placement
-	private lastClearedText = "" // Saved editor text for Ctrl+Z undo
-
-	// Status line state
-	private projectInfo: ProjectInfo
-	private tokenUsage: TokenUsage = {
-		promptTokens: 0,
-		completionTokens: 0,
-		totalTokens: 0,
-	}
-	private statusLine?: Text
-	private memoryStatusLine?: Text
-	private modelAuthStatus: { hasAuth: boolean; apiKeyEnvVar?: string } = {
-		hasAuth: true,
-	}
-	// Observational Memory state
-	private omProgress: OMProgressState = defaultOMProgressState()
-	private omProgressComponent?: OMProgressComponent
-	private activeOMMarker?: OMMarkerComponent
-	private activeBufferingMarker?: OMMarkerComponent
-	private activeActivationMarker?: OMMarkerComponent
-	// Buffering state — drives statusline label animation
-	private bufferingMessages = false
-	private bufferingObservations = false
-	private todoProgress?: TodoProgressComponent
-	private previousTodos: TodoItem[] = [] // Track previous state for diff
-
-	// Autocomplete
-	private autocompleteProvider?: CombinedAutocompleteProvider
-
-	// Custom slash commands
-	private customSlashCommands: SlashCommandMetadata[] = []
-
-	// Pending images from clipboard paste
-	private pendingImages: Array<{ data: string; mimeType: string }> = []
-
-	// Workspace (for skills)
-	private workspace?: Workspace
-
-	// Active inline question component
-	private activeInlineQuestion?: AskQuestionInlineComponent
-
-	// Active inline plan approval component
-	private activeInlinePlanApproval?: PlanApprovalInlineComponent
-	private lastSubmitPlanComponent?: IToolExecutionComponent
-	// Follow-up messages sent via Ctrl+F while streaming
-	// These must stay anchored at the bottom of the chat stream
-	private followUpComponents: UserMessageComponent[] = []
-
-	// Active approval dialog dismiss callback — called on Ctrl+C to unblock the dialog
-	private pendingApprovalDismiss: (() => void) | null = null
-
-	// Ctrl+C double-tap tracking
-	private lastCtrlCTime = 0
-	private static readonly DOUBLE_CTRL_C_MS = 500
-	// Track user-initiated aborts (Ctrl+C/Esc) vs system aborts (mode switch, etc.)
-	private userInitiatedAbort = false
-
-	// Track files modified during this session (for /diff command)
-	private modifiedFiles = new Map<
-		string,
-		{ operations: string[]; firstModified: Date }
-	>()
-	// Map toolCallId -> { toolName, filePath } for pending tool calls that modify files
-	private pendingFileTools = new Map<
-		string,
-		{ toolName: string; filePath: string }
-	>()
-
-	// Event handling
-	private unsubscribe?: () => void
-
-	private terminal: ProcessTerminal
-
-	constructor(options: MastraTUIOptions) {
-		this.harness = options.harness
-		this.options = options
-		this.workspace = options.workspace
-
-		// Detect project info for status line
-		this.projectInfo = detectProject(process.cwd())
-
-		// Create terminal and TUI instance
-		this.terminal = new ProcessTerminal()
-		this.ui = new TUI(this.terminal)
-
-		// Create containers
-		this.chatContainer = new Container()
-		this.editorContainer = new Container()
-		this.footer = new Container()
-
-		// Create editor with custom keybindings
-		this.editor = new CustomEditor(this.ui, getEditorTheme())
-
-		// Override editor input handling to check for active inline components
-		const originalHandleInput = this.editor.handleInput.bind(this.editor)
-		this.editor.handleInput = (data: string) => {
-			// If there's an active plan approval, route input to it
-			if (this.activeInlinePlanApproval) {
-				this.activeInlinePlanApproval.handleInput(data)
-				return
-			}
-			// If there's an active inline question, route input to it
-			if (this.activeInlineQuestion) {
-				this.activeInlineQuestion.handleInput(data)
-				return
-			}
-			// Otherwise, handle normally
-			originalHandleInput(data)
-		}
-
-		// Wire clipboard image paste
-		this.editor.onImagePaste = (image) => {
-			this.pendingImages.push(image)
-			this.editor.insertTextAtCursor?.("[image] ")
-			this.ui.requestRender()
-		}
-
-		this.setupKeyboardShortcuts()
-	}
-
-	/**
-	 * Setup keyboard shortcuts for the custom editor.
-	 */
-	private setupKeyboardShortcuts(): void {
-		// Ctrl+C / Escape - abort if running, clear input if idle, double-tap always exits
-		this.editor.onAction("clear", () => {
-			const now = Date.now()
-			if (now - this.lastCtrlCTime < MastraTUI.DOUBLE_CTRL_C_MS) {
-				// Double Ctrl+C → exit
-				this.stop()
-				process.exit(0)
-			}
-			this.lastCtrlCTime = now
-
-			if (this.pendingApprovalDismiss) {
-				// Dismiss active approval dialog and abort
-				this.pendingApprovalDismiss()
-				this.activeInlinePlanApproval = undefined
-				this.activeInlineQuestion = undefined
-				this.userInitiatedAbort = true
-				this.harness.abort()
-			} else if (this.harness.isRunning()) {
-				// Clean up active inline components on abort
-				this.activeInlinePlanApproval = undefined
-				this.activeInlineQuestion = undefined
-				this.userInitiatedAbort = true
-				this.harness.abort()
-			} else {
-				const current = this.editor.getText()
-				if (current.length > 0) {
-					this.lastClearedText = current
-				}
-				this.editor.setText("")
-				this.ui.requestRender()
-			}
-		})
-
-		// Ctrl+Z - undo last clear (restore editor text)
-		this.editor.onAction("undo", () => {
-			if (this.lastClearedText && this.editor.getText().length === 0) {
-				this.editor.setText(this.lastClearedText)
-				this.lastClearedText = ""
-				this.ui.requestRender()
-			}
-		})
-
-		// Ctrl+D - exit when editor is empty
-		this.editor.onCtrlD = () => {
-			this.stop()
-			process.exit(0)
-		}
-
-		// Ctrl+T - toggle thinking blocks visibility
-		this.editor.onAction("toggleThinking", () => {
-			this.hideThinkingBlock = !this.hideThinkingBlock
-			this.ui.requestRender()
-		})
-		// Ctrl+E - expand/collapse tool outputs
-		this.editor.onAction("expandTools", () => {
-			this.toolOutputExpanded = !this.toolOutputExpanded
-			for (const tool of this.allToolComponents) {
-				tool.setExpanded(this.toolOutputExpanded)
-			}
-			for (const sc of this.allSlashCommandComponents) {
-				sc.setExpanded(this.toolOutputExpanded)
-			}
-			this.ui.requestRender()
-		})
-
-		// Shift+Tab - cycle harness modes
-		this.editor.onAction("cycleMode", async () => {
-			// Block mode switching while plan approval is active
-			if (this.activeInlinePlanApproval) {
-				this.showInfo("Resolve the plan approval first")
-				return
-			}
-
-			const modes = this.harness.getModes()
-			if (modes.length <= 1) return
-            const currentId = this.harness.getCurrentModeId()
-            const currentIndex = modes.findIndex((m) => m.id === currentId)
-            const nextIndex = (currentIndex + 1) % modes.length
-            const nextMode = modes[nextIndex]!
-            await this.harness.switchMode(nextMode.id)
-			// The mode_changed event handler will show the info message
-			this.updateStatusLine()
-		})
-		// Ctrl+Y - toggle YOLO mode
-		this.editor.onAction("toggleYolo", () => {
-			const current = this.harness.getYoloMode()
-			this.harness.setYoloMode(!current)
-			this.updateStatusLine()
-			this.showInfo(current ? "YOLO mode off" : "YOLO mode on")
-		})
-
-		// Ctrl+F - queue follow-up message while streaming
-		this.editor.onAction("followUp", () => {
-			const text = this.editor.getText().trim()
-			if (!text) return
-			if (!this.harness.isRunning()) return // Only relevant while streaming
-
-			// Clear editor and add user message to chat
-			this.editor.setText("")
-			this.addUserMessage({
-				id: `user-${Date.now()}`,
-				role: "user",
-				content: [{ type: "text", text }],
-				createdAt: new Date(),
-			})
-			this.ui.requestRender()
-
-			// Queue the follow-up
-			this.harness.followUp(text).catch((error) => {
-				this.showError(
-					error instanceof Error ? error.message : "Follow-up failed",
-				)
-			})
-		})
-	}
-
-	// ===========================================================================
-	// Public API
-	// ===========================================================================
-
-	/**
-	 * Run the TUI. This is the main entry point.
-	 */
-	async run(): Promise<void> {
-		await this.init()
-
-		// Run SessionStart hooks (fire and forget)
-		const hookMgr = this.harness.getHookManager?.()
-		if (hookMgr) {
-			hookMgr.runSessionStart().catch(() => {})
-		}
-
-		// Process initial message if provided
-		if (this.options.initialMessage) {
-			this.fireMessage(this.options.initialMessage)
-		}
-
-		// Main interactive loop — never blocks on streaming,
-		// so the editor stays responsive for steer / follow-up.
-		while (true) {
-			const userInput = await this.getUserInput()
-			if (!userInput.trim()) continue
-
-			try {
-				// Handle slash commands
-				if (userInput.startsWith("/")) {
-					const handled = await this.handleSlashCommand(userInput)
-					if (handled) continue
-				}
-
-				// Handle shell passthrough (! prefix)
-				if (userInput.startsWith("!")) {
-					await this.handleShellPassthrough(userInput.slice(1).trim())
-					continue
-				}
-
-				// Create thread lazily on first message (may load last-used model)
-				if (this.pendingNewThread) {
-					await this.harness.createThread()
-					this.pendingNewThread = false
-					this.updateStatusLine()
-				}
-
-				// Check if a model is selected
-				if (!this.harness.hasModelSelected()) {
-					this.showInfo(
-						"No model selected. Use /models to select a model, or /login to authenticate.",
-					)
-					continue
-				}
-
-				// Collect any pending images from clipboard paste
-				const images =
-					this.pendingImages.length > 0 ? [...this.pendingImages] : undefined
-				this.pendingImages = []
-
-				// Add user message to chat immediately
-				this.addUserMessage({
-					id: `user-${Date.now()}`,
-					role: "user",
-					content: [
-						{ type: "text", text: userInput },
-						...(images?.map((img) => ({
-							type: "image" as const,
-							data: img.data,
-							mimeType: img.mimeType,
-						})) ?? []),
-					],
-					createdAt: new Date(),
-				})
-				this.ui.requestRender()
-
-				if (this.harness.isRunning()) {
-					// Agent is streaming → steer (abort + resend)
-					// Clear follow-up tracking since steer replaces the current response
-					this.followUpComponents = []
-					this.harness.steer(userInput).catch((error) => {
-						this.showError(
-							error instanceof Error ? error.message : "Steer failed",
-						)
-					})
-				} else {
-					// Normal send — fire and forget; events handle the rest
-					this.fireMessage(userInput, images)
-				}
-            } catch (error) {
-                this.showError(error instanceof Error ? error.message : "Unknown error")
-			}
-		}
-	}
-
-	/**
-	 * Fire off a message without blocking the main loop.
-	 * Errors are handled via harness events.
-	 */
-	private fireMessage(
-		content: string,
-		images?: Array<{ data: string; mimeType: string }>,
-	): void {
-		this.harness
-			.sendMessage(content, images ? { images } : undefined)
-			.catch((error) => {
-				this.showError(error instanceof Error ? error.message : "Unknown error")
-			})
-	}
-
-	/**
-	 * Stop the TUI and clean up.
-	 */
-	stop(): void {
-		// Run SessionEnd hooks (best-effort, don't await)
-		const hookMgr = this.harness.getHookManager?.()
-		if (hookMgr) {
-			hookMgr.runSessionEnd().catch(() => {})
-		}
-
-		if (this.unsubscribe) {
-			this.unsubscribe()
-		}
-		this.ui.stop()
-	}
-
-	// ===========================================================================
-	// Initialization
-	// ===========================================================================
-
-	private async init(): Promise<void> {
-		if (this.isInitialized) return
-
-		// Initialize harness (but don't select thread yet)
-		await this.harness.init()
-
-		// Check for existing threads and prompt for resume
-		await this.promptForThreadSelection()
-
-		// Load initial token usage from harness (persisted from previous session)
-		this.tokenUsage = this.harness.getTokenUsage()
-
-		// Load custom slash commands
-		await this.loadCustomSlashCommands()
-
-		// Setup autocomplete
-		this.setupAutocomplete()
-
-		// Build UI layout
-		this.buildLayout()
-
-		// Setup key handlers
-		this.setupKeyHandlers()
-
-		// Setup editor submit handler
-		this.setupEditorSubmitHandler()
-
-		// Subscribe to harness events
-		this.subscribeToHarness()
-		// Restore escape-as-cancel setting from persisted state
-		const escState = this.harness.getState() as any
-		if (escState?.escapeAsCancel === false) {
-			this.editor.escapeEnabled = false
-		}
-
-		// Load OM progress now that we're subscribed (the event during
-		// thread selection fired before we were listening)
-		await this.harness.loadOMProgress()
-
-		// Sync OM thresholds from thread metadata (may differ from OM defaults)
-		this.syncOMThresholdsFromHarness()
-
-		// Start the UI
-		this.ui.start()
-		this.isInitialized = true
-
-		// Set terminal title
-		this.updateTerminalTitle()
-		// Render existing messages
-		await this.renderExistingMessages()
-		// Render existing todos if any
-		await this.renderExistingTodos()
-
-		// Show deferred thread lock prompt (must happen after TUI is started)
-		if (this.pendingLockConflict) {
-			this.showThreadLockPrompt(
-				this.pendingLockConflict.threadTitle,
-				this.pendingLockConflict.ownerPid,
-			)
-			this.pendingLockConflict = null
-		}
-	}
-
-	/**
-	 * Render existing todos from the harness state on startup
-	 */
-	private async renderExistingTodos(): Promise<void> {
-		try {
-			// Access the harness state using the public method
-			const state = this.harness.getState() as { todos?: TodoItem[] }
-			const todos = state.todos || []
-
-			if (todos.length > 0 && this.todoProgress) {
-				// Update the existing todo progress component
-				this.todoProgress.updateTodos(todos)
-				this.ui.requestRender()
-			}
-		} catch {
-			// Silently ignore todo rendering errors
-		}
-	}
-	/**
-	 * Prompt user to continue existing thread or start new one.
-	 * This runs before the TUI is fully initialized.
-	 * Threads are already scoped to the current project path by listThreads().
-	 */
-	private async promptForThreadSelection(): Promise<void> {
-		const threads = await this.harness.listThreads()
-
-		if (threads.length === 0) {
-			// No existing threads for this path - defer creation until first message
-			this.pendingNewThread = true
-			return
-		}
-
-		// Sort by most recent
-		const sortedThreads = [...threads].sort(
-			(a, b) => b.updatedAt.getTime() - a.updatedAt.getTime(),
-		)
-        const mostRecent = sortedThreads[0]!
-        // Auto-resume the most recent thread for this directory
-        try {
-            await this.harness.switchThread(mostRecent.id)
-        } catch (error) {
-            if (error instanceof ThreadLockError) {
-                // Defer the lock conflict prompt until after the TUI is started
-                this.pendingNewThread = true
-                this.pendingLockConflict = {
-                    threadTitle: mostRecent.title || mostRecent.id,
-                    ownerPid: error.ownerPid,
-                }
-                return
-            }
-            throw error
+  private harness: Harness<any>;
+  private options: MastraTUIOptions;
+
+  // TUI components
+  private ui: TUI;
+  private chatContainer: Container;
+  private editorContainer: Container;
+  private editor: CustomEditor;
+  private footer: Container;
+
+  // State tracking
+  private isInitialized = false;
+  private gradientAnimator?: GradientAnimator;
+  private isAgentActive = false;
+  private streamingComponent?: AssistantMessageComponent;
+  private streamingMessage?: HarnessMessage;
+  private pendingTools = new Map<string, IToolExecutionComponent>();
+  private seenToolCallIds = new Set<string>(); // Track all tool IDs seen during current stream (prevents duplicates)
+  private subagentToolCallIds = new Set<string>(); // Track subagent tool call IDs to skip in trailing content logic
+  private allToolComponents: IToolExecutionComponent[] = []; // Track all tools for expand/collapse
+  private allSlashCommandComponents: SlashCommandComponent[] = []; // Track slash command boxes for expand/collapse
+  private pendingSubagents = new Map<string, SubagentExecutionComponent>(); // Track active subagent tasks
+  private toolOutputExpanded = false;
+  private hideThinkingBlock = true;
+  private pendingNewThread = false; // True when we want a new thread but haven't created it yet
+  private pendingLockConflict: {
+    threadTitle: string;
+    ownerPid: number;
+  } | null = null;
+  private lastAskUserComponent?: IToolExecutionComponent; // Track the most recent ask_user tool for inline question placement
+  private lastClearedText = ''; // Saved editor text for Ctrl+Z undo
+
+  // Status line state
+  private projectInfo: ProjectInfo;
+  private tokenUsage: TokenUsage = {
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+  };
+  private statusLine?: Text;
+  private memoryStatusLine?: Text;
+  private modelAuthStatus: { hasAuth: boolean; apiKeyEnvVar?: string } = {
+    hasAuth: true,
+  };
+  // Observational Memory state
+  private omProgress: OMProgressState = defaultOMProgressState();
+  private omProgressComponent?: OMProgressComponent;
+  private activeOMMarker?: OMMarkerComponent;
+  private activeBufferingMarker?: OMMarkerComponent;
+  private activeActivationMarker?: OMMarkerComponent;
+  // Buffering state — drives statusline label animation
+  private bufferingMessages = false;
+  private bufferingObservations = false;
+  private todoProgress?: TodoProgressComponent;
+  private previousTodos: TodoItem[] = []; // Track previous state for diff
+
+  // Autocomplete
+  private autocompleteProvider?: CombinedAutocompleteProvider;
+
+  // Custom slash commands
+  private customSlashCommands: SlashCommandMetadata[] = [];
+
+  // Pending images from clipboard paste
+  private pendingImages: Array<{ data: string; mimeType: string }> = [];
+
+  // Workspace (for skills)
+  private workspace?: Workspace;
+
+  // Active inline question component
+  private activeInlineQuestion?: AskQuestionInlineComponent;
+
+  // Active inline plan approval component
+  private activeInlinePlanApproval?: PlanApprovalInlineComponent;
+  private lastSubmitPlanComponent?: IToolExecutionComponent;
+  // Follow-up messages sent via Ctrl+F while streaming
+  // These must stay anchored at the bottom of the chat stream
+  private followUpComponents: UserMessageComponent[] = [];
+
+  // Active approval dialog dismiss callback — called on Ctrl+C to unblock the dialog
+  private pendingApprovalDismiss: (() => void) | null = null;
+
+  // Ctrl+C double-tap tracking
+  private lastCtrlCTime = 0;
+  private static readonly DOUBLE_CTRL_C_MS = 500;
+  // Track user-initiated aborts (Ctrl+C/Esc) vs system aborts (mode switch, etc.)
+  private userInitiatedAbort = false;
+
+  // Track files modified during this session (for /diff command)
+  private modifiedFiles = new Map<string, { operations: string[]; firstModified: Date }>();
+  // Map toolCallId -> { toolName, filePath } for pending tool calls that modify files
+  private pendingFileTools = new Map<string, { toolName: string; filePath: string }>();
+
+  // Event handling
+  private unsubscribe?: () => void;
+
+  private terminal: ProcessTerminal;
+
+  constructor(options: MastraTUIOptions) {
+    this.harness = options.harness;
+    this.options = options;
+    this.workspace = options.workspace;
+
+    // Detect project info for status line
+    this.projectInfo = detectProject(process.cwd());
+
+    // Create terminal and TUI instance
+    this.terminal = new ProcessTerminal();
+    this.ui = new TUI(this.terminal);
+
+    // Create containers
+    this.chatContainer = new Container();
+    this.editorContainer = new Container();
+    this.footer = new Container();
+
+    // Create editor with custom keybindings
+    this.editor = new CustomEditor(this.ui, getEditorTheme());
+
+    // Override editor input handling to check for active inline components
+    const originalHandleInput = this.editor.handleInput.bind(this.editor);
+    this.editor.handleInput = (data: string) => {
+      // If there's an active plan approval, route input to it
+      if (this.activeInlinePlanApproval) {
+        this.activeInlinePlanApproval.handleInput(data);
+        return;
+      }
+      // If there's an active inline question, route input to it
+      if (this.activeInlineQuestion) {
+        this.activeInlineQuestion.handleInput(data);
+        return;
+      }
+      // Otherwise, handle normally
+      originalHandleInput(data);
+    };
+
+    // Wire clipboard image paste
+    this.editor.onImagePaste = image => {
+      this.pendingImages.push(image);
+      this.editor.insertTextAtCursor?.('[image] ');
+      this.ui.requestRender();
+    };
+
+    this.setupKeyboardShortcuts();
+  }
+
+  /**
+   * Setup keyboard shortcuts for the custom editor.
+   */
+  private setupKeyboardShortcuts(): void {
+    // Ctrl+C / Escape - abort if running, clear input if idle, double-tap always exits
+    this.editor.onAction('clear', () => {
+      const now = Date.now();
+      if (now - this.lastCtrlCTime < MastraTUI.DOUBLE_CTRL_C_MS) {
+        // Double Ctrl+C → exit
+        this.stop();
+        process.exit(0);
+      }
+      this.lastCtrlCTime = now;
+
+      if (this.pendingApprovalDismiss) {
+        // Dismiss active approval dialog and abort
+        this.pendingApprovalDismiss();
+        this.activeInlinePlanApproval = undefined;
+        this.activeInlineQuestion = undefined;
+        this.userInitiatedAbort = true;
+        this.harness.abort();
+      } else if (this.harness.isRunning()) {
+        // Clean up active inline components on abort
+        this.activeInlinePlanApproval = undefined;
+        this.activeInlineQuestion = undefined;
+        this.userInitiatedAbort = true;
+        this.harness.abort();
+      } else {
+        const current = this.editor.getText();
+        if (current.length > 0) {
+          this.lastClearedText = current;
         }
-	}
-	/**
-	 * Extract text content from a harness message.
-	 */
-	private extractTextContent(message: HarnessMessage): string {
-		return message.content
-			.filter((c): c is { type: "text"; text: string } => c.type === "text")
-			.map((c) => c.text)
-			.join(" ")
-			.trim()
-	}
+        this.editor.setText('');
+        this.ui.requestRender();
+      }
+    });
 
-	/**
-	 * Truncate text for preview display.
-	 */
-	private truncatePreview(text: string, maxLength = 50): string {
-		if (text.length <= maxLength) return text
-		return text.slice(0, maxLength - 3) + "..."
-	}
+    // Ctrl+Z - undo last clear (restore editor text)
+    this.editor.onAction('undo', () => {
+      if (this.lastClearedText && this.editor.getText().length === 0) {
+        this.editor.setText(this.lastClearedText);
+        this.lastClearedText = '';
+        this.ui.requestRender();
+      }
+    });
 
-	private buildLayout(): void {
-		// Add header
-		const appName = this.options.appName || "Mastra Code"
-		const version = this.options.version || "0.1.0"
+    // Ctrl+D - exit when editor is empty
+    this.editor.onCtrlD = () => {
+      this.stop();
+      process.exit(0);
+    };
 
-		const logo =
-			fg("accent", "◆") +
-			" " +
-			bold(fg("accent", appName)) +
-			fg("dim", ` v${version}`)
+    // Ctrl+T - toggle thinking blocks visibility
+    this.editor.onAction('toggleThinking', () => {
+      this.hideThinkingBlock = !this.hideThinkingBlock;
+      this.ui.requestRender();
+    });
+    // Ctrl+E - expand/collapse tool outputs
+    this.editor.onAction('expandTools', () => {
+      this.toolOutputExpanded = !this.toolOutputExpanded;
+      for (const tool of this.allToolComponents) {
+        tool.setExpanded(this.toolOutputExpanded);
+      }
+      for (const sc of this.allSlashCommandComponents) {
+        sc.setExpanded(this.toolOutputExpanded);
+      }
+      this.ui.requestRender();
+    });
 
-		const keyStyle = (k: string) => fg("accent", k)
-		const sep = fg("dim", " · ")
-		const instructions = [
-			`  ${keyStyle("Ctrl+C")} ${fg("muted", "interrupt/clear")}${sep}${keyStyle("Ctrl+C×2")} ${fg("muted", "exit")}`,
-			`  ${keyStyle("Enter")} ${fg("muted", "while working → steer")}${sep}${keyStyle("Ctrl+F")} ${fg("muted", "→ queue follow-up")}`,
-			`  ${keyStyle("/")} ${fg("muted", "commands")}${sep}${keyStyle("!")} ${fg("muted", "shell")}${sep}${keyStyle("Ctrl+T")} ${fg("muted", "thinking")}${sep}${keyStyle("Ctrl+E")} ${fg("muted", "tools")}${this.harness.getModes().length > 1 ? `${sep}${keyStyle("⇧Tab")} ${fg("muted", "mode")}` : ""}`,
-		].join("\n")
+    // Shift+Tab - cycle harness modes
+    this.editor.onAction('cycleMode', async () => {
+      // Block mode switching while plan approval is active
+      if (this.activeInlinePlanApproval) {
+        this.showInfo('Resolve the plan approval first');
+        return;
+      }
 
-		this.ui.addChild(new Spacer(1))
-		this.ui.addChild(
-			new Text(
-				`${logo}
+      const modes = this.harness.getModes();
+      if (modes.length <= 1) return;
+      const currentId = this.harness.getCurrentModeId();
+      const currentIndex = modes.findIndex(m => m.id === currentId);
+      const nextIndex = (currentIndex + 1) % modes.length;
+      const nextMode = modes[nextIndex]!;
+      await this.harness.switchMode(nextMode.id);
+      // The mode_changed event handler will show the info message
+      this.updateStatusLine();
+    });
+    // Ctrl+Y - toggle YOLO mode
+    this.editor.onAction('toggleYolo', () => {
+      const current = this.harness.getYoloMode();
+      this.harness.setYoloMode(!current);
+      this.updateStatusLine();
+      this.showInfo(current ? 'YOLO mode off' : 'YOLO mode on');
+    });
+
+    // Ctrl+F - queue follow-up message while streaming
+    this.editor.onAction('followUp', () => {
+      const text = this.editor.getText().trim();
+      if (!text) return;
+      if (!this.harness.isRunning()) return; // Only relevant while streaming
+
+      // Clear editor and add user message to chat
+      this.editor.setText('');
+      this.addUserMessage({
+        id: `user-${Date.now()}`,
+        role: 'user',
+        content: [{ type: 'text', text }],
+        createdAt: new Date(),
+      });
+      this.ui.requestRender();
+
+      // Queue the follow-up
+      this.harness.followUp(text).catch(error => {
+        this.showError(error instanceof Error ? error.message : 'Follow-up failed');
+      });
+    });
+  }
+
+  // ===========================================================================
+  // Public API
+  // ===========================================================================
+
+  /**
+   * Run the TUI. This is the main entry point.
+   */
+  async run(): Promise<void> {
+    await this.init();
+
+    // Run SessionStart hooks (fire and forget)
+    const hookMgr = this.harness.getHookManager?.();
+    if (hookMgr) {
+      hookMgr.runSessionStart().catch(() => {});
+    }
+
+    // Process initial message if provided
+    if (this.options.initialMessage) {
+      this.fireMessage(this.options.initialMessage);
+    }
+
+    // Main interactive loop — never blocks on streaming,
+    // so the editor stays responsive for steer / follow-up.
+    while (true) {
+      const userInput = await this.getUserInput();
+      if (!userInput.trim()) continue;
+
+      try {
+        // Handle slash commands
+        if (userInput.startsWith('/')) {
+          const handled = await this.handleSlashCommand(userInput);
+          if (handled) continue;
+        }
+
+        // Handle shell passthrough (! prefix)
+        if (userInput.startsWith('!')) {
+          await this.handleShellPassthrough(userInput.slice(1).trim());
+          continue;
+        }
+
+        // Create thread lazily on first message (may load last-used model)
+        if (this.pendingNewThread) {
+          await this.harness.createThread();
+          this.pendingNewThread = false;
+          this.updateStatusLine();
+        }
+
+        // Check if a model is selected
+        if (!this.harness.hasModelSelected()) {
+          this.showInfo('No model selected. Use /models to select a model, or /login to authenticate.');
+          continue;
+        }
+
+        // Collect any pending images from clipboard paste
+        const images = this.pendingImages.length > 0 ? [...this.pendingImages] : undefined;
+        this.pendingImages = [];
+
+        // Add user message to chat immediately
+        this.addUserMessage({
+          id: `user-${Date.now()}`,
+          role: 'user',
+          content: [
+            { type: 'text', text: userInput },
+            ...(images?.map(img => ({
+              type: 'image' as const,
+              data: img.data,
+              mimeType: img.mimeType,
+            })) ?? []),
+          ],
+          createdAt: new Date(),
+        });
+        this.ui.requestRender();
+
+        if (this.harness.isRunning()) {
+          // Agent is streaming → steer (abort + resend)
+          // Clear follow-up tracking since steer replaces the current response
+          this.followUpComponents = [];
+          this.harness.steer(userInput).catch(error => {
+            this.showError(error instanceof Error ? error.message : 'Steer failed');
+          });
+        } else {
+          // Normal send — fire and forget; events handle the rest
+          this.fireMessage(userInput, images);
+        }
+      } catch (error) {
+        this.showError(error instanceof Error ? error.message : 'Unknown error');
+      }
+    }
+  }
+
+  /**
+   * Fire off a message without blocking the main loop.
+   * Errors are handled via harness events.
+   */
+  private fireMessage(content: string, images?: Array<{ data: string; mimeType: string }>): void {
+    this.harness.sendMessage(content, images ? { images } : undefined).catch(error => {
+      this.showError(error instanceof Error ? error.message : 'Unknown error');
+    });
+  }
+
+  /**
+   * Stop the TUI and clean up.
+   */
+  stop(): void {
+    // Run SessionEnd hooks (best-effort, don't await)
+    const hookMgr = this.harness.getHookManager?.();
+    if (hookMgr) {
+      hookMgr.runSessionEnd().catch(() => {});
+    }
+
+    if (this.unsubscribe) {
+      this.unsubscribe();
+    }
+    this.ui.stop();
+  }
+
+  // ===========================================================================
+  // Initialization
+  // ===========================================================================
+
+  private async init(): Promise<void> {
+    if (this.isInitialized) return;
+
+    // Initialize harness (but don't select thread yet)
+    await this.harness.init();
+
+    // Check for existing threads and prompt for resume
+    await this.promptForThreadSelection();
+
+    // Load initial token usage from harness (persisted from previous session)
+    this.tokenUsage = this.harness.getTokenUsage();
+
+    // Load custom slash commands
+    await this.loadCustomSlashCommands();
+
+    // Setup autocomplete
+    this.setupAutocomplete();
+
+    // Build UI layout
+    this.buildLayout();
+
+    // Setup key handlers
+    this.setupKeyHandlers();
+
+    // Setup editor submit handler
+    this.setupEditorSubmitHandler();
+
+    // Subscribe to harness events
+    this.subscribeToHarness();
+    // Restore escape-as-cancel setting from persisted state
+    const escState = this.harness.getState() as any;
+    if (escState?.escapeAsCancel === false) {
+      this.editor.escapeEnabled = false;
+    }
+
+    // Load OM progress now that we're subscribed (the event during
+    // thread selection fired before we were listening)
+    await this.harness.loadOMProgress();
+
+    // Sync OM thresholds from thread metadata (may differ from OM defaults)
+    this.syncOMThresholdsFromHarness();
+
+    // Start the UI
+    this.ui.start();
+    this.isInitialized = true;
+
+    // Set terminal title
+    this.updateTerminalTitle();
+    // Render existing messages
+    await this.renderExistingMessages();
+    // Render existing todos if any
+    await this.renderExistingTodos();
+
+    // Show deferred thread lock prompt (must happen after TUI is started)
+    if (this.pendingLockConflict) {
+      this.showThreadLockPrompt(this.pendingLockConflict.threadTitle, this.pendingLockConflict.ownerPid);
+      this.pendingLockConflict = null;
+    }
+  }
+
+  /**
+   * Render existing todos from the harness state on startup
+   */
+  private async renderExistingTodos(): Promise<void> {
+    try {
+      // Access the harness state using the public method
+      const state = this.harness.getState() as { todos?: TodoItem[] };
+      const todos = state.todos || [];
+
+      if (todos.length > 0 && this.todoProgress) {
+        // Update the existing todo progress component
+        this.todoProgress.updateTodos(todos);
+        this.ui.requestRender();
+      }
+    } catch {
+      // Silently ignore todo rendering errors
+    }
+  }
+  /**
+   * Prompt user to continue existing thread or start new one.
+   * This runs before the TUI is fully initialized.
+   * Threads are already scoped to the current project path by listThreads().
+   */
+  private async promptForThreadSelection(): Promise<void> {
+    const threads = await this.harness.listThreads();
+
+    if (threads.length === 0) {
+      // No existing threads for this path - defer creation until first message
+      this.pendingNewThread = true;
+      return;
+    }
+
+    // Sort by most recent
+    const sortedThreads = [...threads].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+    const mostRecent = sortedThreads[0]!;
+    // Auto-resume the most recent thread for this directory
+    try {
+      await this.harness.switchThread(mostRecent.id);
+    } catch (error) {
+      if (error instanceof ThreadLockError) {
+        // Defer the lock conflict prompt until after the TUI is started
+        this.pendingNewThread = true;
+        this.pendingLockConflict = {
+          threadTitle: mostRecent.title || mostRecent.id,
+          ownerPid: error.ownerPid,
+        };
+        return;
+      }
+      throw error;
+    }
+  }
+  /**
+   * Extract text content from a harness message.
+   */
+  private extractTextContent(message: HarnessMessage): string {
+    return message.content
+      .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
+      .map(c => c.text)
+      .join(' ')
+      .trim();
+  }
+
+  /**
+   * Truncate text for preview display.
+   */
+  private truncatePreview(text: string, maxLength = 50): string {
+    if (text.length <= maxLength) return text;
+    return text.slice(0, maxLength - 3) + '...';
+  }
+
+  private buildLayout(): void {
+    // Add header
+    const appName = this.options.appName || 'Mastra Code';
+    const version = this.options.version || '0.1.0';
+
+    const logo = fg('accent', '◆') + ' ' + bold(fg('accent', appName)) + fg('dim', ` v${version}`);
+
+    const keyStyle = (k: string) => fg('accent', k);
+    const sep = fg('dim', ' · ');
+    const instructions = [
+      `  ${keyStyle('Ctrl+C')} ${fg('muted', 'interrupt/clear')}${sep}${keyStyle('Ctrl+C×2')} ${fg('muted', 'exit')}`,
+      `  ${keyStyle('Enter')} ${fg('muted', 'while working → steer')}${sep}${keyStyle('Ctrl+F')} ${fg('muted', '→ queue follow-up')}`,
+      `  ${keyStyle('/')} ${fg('muted', 'commands')}${sep}${keyStyle('!')} ${fg('muted', 'shell')}${sep}${keyStyle('Ctrl+T')} ${fg('muted', 'thinking')}${sep}${keyStyle('Ctrl+E')} ${fg('muted', 'tools')}${this.harness.getModes().length > 1 ? `${sep}${keyStyle('⇧Tab')} ${fg('muted', 'mode')}` : ''}`,
+    ].join('\n');
+
+    this.ui.addChild(new Spacer(1));
+    this.ui.addChild(
+      new Text(
+        `${logo}
 ${instructions}`,
-				1,
-				0,
-			),
-		)
-		this.ui.addChild(new Spacer(1))
-
-		// Add main containers
-		this.ui.addChild(this.chatContainer)
-		// Todo progress (between chat and editor, visible only when todos exist)
-		this.todoProgress = new TodoProgressComponent()
-		this.ui.addChild(this.todoProgress)
-		this.ui.addChild(this.editorContainer)
-		this.editorContainer.addChild(this.editor)
-
-		// Add footer with two-line status
-		this.statusLine = new Text("", 0, 0)
-		this.memoryStatusLine = new Text("", 0, 0)
-		this.footer.addChild(this.statusLine)
-		this.footer.addChild(this.memoryStatusLine)
-		this.ui.addChild(this.footer)
-		this.updateStatusLine()
-		this.refreshModelAuthStatus()
-
-		// Set focus to editor
-		this.ui.setFocus(this.editor)
-	}
-
-	/**
-	 * Update the two-line status bar.
-	 * Line 1: [MODE] provider/model  memory  tokens  think:level
-	 * Line 2:        ~/path/to/project (branch)
-	 */
-	private updateStatusLine(): void {
-		if (!this.statusLine) return
-		const termWidth = (process.stdout.columns || 80) - 1 // buffer to prevent jitter
-		const SEP = "  " // double-space separator between parts
-
-		// --- Determine if we're showing observer/reflector instead of main mode ---
-		const omStatus = this.omProgress.status
-		const isObserving = omStatus === "observing"
-		const isReflecting = omStatus === "reflecting"
-		const showOMMode = isObserving || isReflecting
-
-		// Colors for OM modes
-		const OBSERVER_COLOR = mastra.orange // Mastra orange
-		const REFLECTOR_COLOR = mastra.pink // Mastra pink
-
-		// --- Mode badge ---
-		let modeBadge = ""
-		let modeBadgeWidth = 0
-		const modes = this.harness.getModes()
-		const currentMode =
-			modes.length > 1 ? this.harness.getCurrentMode() : undefined
-		// Use OM color when observing/reflecting, otherwise mode color
-		const mainModeColor = currentMode?.color
-		const modeColor = showOMMode
-			? isObserving
-				? OBSERVER_COLOR
-				: REFLECTOR_COLOR
-			: mainModeColor
-		// Badge name: use OM mode name when observing/reflecting, otherwise main mode name
-		const badgeName = showOMMode
-			? isObserving
-				? "observe"
-				: "reflect"
-			: currentMode
-				? currentMode.name || currentMode.id || "unknown"
-				: undefined
-		if (badgeName && modeColor) {
-			const [mcr, mcg, mcb] = [
-				parseInt(modeColor.slice(1, 3), 16),
-				parseInt(modeColor.slice(3, 5), 16),
-				parseInt(modeColor.slice(5, 7), 16),
-			]
-			// Pulse the badge bg brightness opposite to the gradient sweep
-			let badgeBrightness = 0.9
-			if (this.gradientAnimator?.isRunning()) {
-				const fade = this.gradientAnimator.getFadeProgress()
-				if (fade < 1) {
-					const offset = this.gradientAnimator.getOffset() % 1
-					// Inverted phase (+ PI), range 0.65-0.95
-					const animBrightness =
-						0.65 + 0.3 * (0.5 + 0.5 * Math.sin(offset * Math.PI * 2 + Math.PI))
-					// Interpolate toward idle (0.9) as fade progresses
-					badgeBrightness = animBrightness + (0.9 - animBrightness) * fade
-				}
-			}
-			const [mr, mg, mb] = [
-				Math.floor(mcr * badgeBrightness),
-				Math.floor(mcg * badgeBrightness),
-				Math.floor(mcb * badgeBrightness),
-			]
-			modeBadge = chalk
-				.bgRgb(mr, mg, mb)
-				.hex(mastra.bg)
-				.bold(` ${badgeName.toLowerCase()} `)
-			modeBadgeWidth = badgeName.length + 2
-		} else if (badgeName) {
-			modeBadge = fg("dim", badgeName) + " "
-			modeBadgeWidth = badgeName.length + 1
-		}
-
-		// --- Update editor border to match mode color (not OM color) ---
-		if (mainModeColor) {
-			const [br, bg, bb] = [
-				parseInt(mainModeColor.slice(1, 3), 16),
-				parseInt(mainModeColor.slice(3, 5), 16),
-				parseInt(mainModeColor.slice(5, 7), 16),
-			]
-			const dim = 0.35
-			this.editor.borderColor = (text: string) =>
-				chalk.rgb(
-					Math.floor(br * dim),
-					Math.floor(bg * dim),
-					Math.floor(bb * dim),
-				)(text)
-		}
-
-		// --- Collect raw data ---
-		// Show OM model when observing/reflecting, otherwise main model
-		const fullModelId = showOMMode
-			? isObserving
-				? this.harness.getObserverModelId()
-				: this.harness.getReflectorModelId()
-			: this.harness.getFullModelId()
-		// e.g. "anthropic/claude-sonnet-4-20250514" → "claude-sonnet-4-20250514"
-		const shortModelId = fullModelId.includes("/")
-			? fullModelId.slice(fullModelId.indexOf("/") + 1)
-			: fullModelId
-		// e.g. "claude-opus-4-6" → "opus 4.6", "claude-sonnet-4-20250514" → "sonnet-4-20250514"
-		const tinyModelId = shortModelId
-			.replace(/^claude-/, "")
-			.replace(/^(\w+)-(\d+)-(\d{1,2})$/, "$1 $2.$3")
-
-		const homedir = process.env.HOME || process.env.USERPROFILE || ""
-		let displayPath = this.projectInfo.rootPath
-		if (homedir && displayPath.startsWith(homedir)) {
-			displayPath = "~" + displayPath.slice(homedir.length)
-		}
-		if (this.projectInfo.gitBranch) {
-			displayPath = `${displayPath} (${this.projectInfo.gitBranch})`
-		}
-
-		// --- Helper to style the model ID ---
-		const isYolo = this.harness.getYoloMode()
-		const styleModelId = (id: string): string => {
-			if (!this.modelAuthStatus.hasAuth) {
-				const envVar = this.modelAuthStatus.apiKeyEnvVar
-				return (
-					fg("dim", id) +
-					fg("error", " ✗") +
-					fg("muted", envVar ? ` (${envVar})` : " (no key)")
-				)
-			}
-			// Tinted near-black background from mode color
-			const tintBg = modeColor ? tintHex(modeColor, 0.15) : undefined
-			const padded = ` ${id} `
-
-			if (this.gradientAnimator?.isRunning() && modeColor) {
-				const fade = this.gradientAnimator.getFadeProgress()
-				if (fade < 1) {
-					// During active or fade-out: interpolate gradient toward idle color
-					const text = applyGradientSweep(
-						padded,
-						this.gradientAnimator.getOffset(),
-						modeColor,
-						fade, // pass fade progress to flatten the gradient
-					)
-					return tintBg ? chalk.bgHex(tintBg)(text) : text
-				}
-			}
-			if (modeColor) {
-				// Idle state
-				const [r, g, b] = [
-					parseInt(modeColor.slice(1, 3), 16),
-					parseInt(modeColor.slice(3, 5), 16),
-					parseInt(modeColor.slice(5, 7), 16),
-				]
-				const dim = 0.8
-				const fg = chalk
-					.rgb(Math.floor(r * dim), Math.floor(g * dim), Math.floor(b * dim))
-					.bold(padded)
-				return tintBg ? chalk.bgHex(tintBg)(fg) : fg
-			}
-			return chalk.hex(mastra.specialGray).bold(id)
-		}
-		// --- Build line with progressive reduction ---
-		// Strategy: progressively drop less-important elements to fit terminal width.
-		// Each attempt assembles plain-text parts, measures, and if it fits, styles and renders.
-
-		// Short badge: first letter only (e.g., "build" → "b", "observe" → "o")
-		let shortModeBadge = ""
-		let shortModeBadgeWidth = 0
-		if (badgeName && modeColor) {
-			const shortName = badgeName.toLowerCase().charAt(0)
-			const [mcr, mcg, mcb] = [
-				parseInt(modeColor.slice(1, 3), 16),
-				parseInt(modeColor.slice(3, 5), 16),
-				parseInt(modeColor.slice(5, 7), 16),
-			]
-			let sBadgeBrightness = 0.9
-			if (this.gradientAnimator?.isRunning()) {
-				const fade = this.gradientAnimator.getFadeProgress()
-				if (fade < 1) {
-					const offset = this.gradientAnimator.getOffset() % 1
-					const animBrightness =
-						0.65 + 0.3 * (0.5 + 0.5 * Math.sin(offset * Math.PI * 2 + Math.PI))
-					sBadgeBrightness = animBrightness + (0.9 - animBrightness) * fade
-				}
-			}
-			const [sr, sg, sb] = [
-				Math.floor(mcr * sBadgeBrightness),
-				Math.floor(mcg * sBadgeBrightness),
-				Math.floor(mcb * sBadgeBrightness),
-			]
-			shortModeBadge = chalk
-				.bgRgb(sr, sg, sb)
-				.hex(mastra.bg)
-				.bold(` ${shortName} `)
-			shortModeBadgeWidth = shortName.length + 2
-		} else if (badgeName) {
-			const shortName = badgeName.toLowerCase().charAt(0)
-			shortModeBadge = fg("dim", shortName) + " "
-			shortModeBadgeWidth = shortName.length + 1
-		}
-
-		const buildLine = (opts: {
-			modelId: string
-			memCompact?: "percentOnly" | "noBuffer" | "full"
-			showDir: boolean
-			badge?: "full" | "short"
-		}): { plain: string; styled: string } | null => {
-			const parts: Array<{ plain: string; styled: string }> = []
-			// Model ID (always present) — styleModelId adds padding spaces
-			// When YOLO, append ⚒ box flush (no SEP gap)
-			if (isYolo && modeColor) {
-				const yBox = chalk
-					.bgHex(tintHex(modeColor, 0.25))
-					.hex(tintHex(modeColor, 0.9))
-					.bold(" ⚒ ")
-				parts.push({
-					plain: ` ${opts.modelId}  ⚒ `,
-					styled: styleModelId(opts.modelId) + yBox,
-				})
-			} else {
-				parts.push({
-					plain: ` ${opts.modelId} `,
-					styled: styleModelId(opts.modelId),
-				})
-			}
-			const useBadge = opts.badge === "short" ? shortModeBadge : modeBadge
-			const useBadgeWidth =
-				opts.badge === "short" ? shortModeBadgeWidth : modeBadgeWidth
-			// Memory info — animate label text when buffering is active
-			const msgLabelStyler =
-				this.bufferingMessages && this.gradientAnimator?.isRunning()
-					? (label: string) =>
-							applyGradientSweep(
-								label,
-								this.gradientAnimator!.getOffset(),
-								OBSERVER_COLOR,
-								this.gradientAnimator!.getFadeProgress(),
-							)
-					: undefined
-			const obsLabelStyler =
-				this.bufferingObservations && this.gradientAnimator?.isRunning()
-					? (label: string) =>
-							applyGradientSweep(
-								label,
-								this.gradientAnimator!.getOffset(),
-								REFLECTOR_COLOR,
-								this.gradientAnimator!.getFadeProgress(),
-							)
-					: undefined
-			const obs = formatObservationStatus(
-				this.omProgress,
-				opts.memCompact,
-				msgLabelStyler,
-			)
-			const ref = formatReflectionStatus(
-				this.omProgress,
-				opts.memCompact,
-				obsLabelStyler,
-			)
-			if (obs) {
-				parts.push({ plain: obs, styled: obs })
-			}
-			if (ref) {
-				parts.push({ plain: ref, styled: ref })
-			}
-			// Directory (lowest priority on line 1)
-			if (opts.showDir) {
-				parts.push({
-					plain: displayPath,
-					styled: fg("dim", displayPath),
-				})
-			}
-			const totalPlain =
-				useBadgeWidth +
-				parts.reduce(
-					(sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0),
-					0,
-				)
-
-			if (totalPlain > termWidth) return null
-
-			let styledLine: string
-			if (opts.showDir && parts.length >= 3) {
-				// Three groups: left (model), center (mem/tokens/thinking), right (dir)
-				const leftPart = parts[0]! // model
-				const centerParts = parts.slice(1, -1) // mem, tokens, thinking
-				const dirPart = parts[parts.length - 1]! // dir
-
-				const leftWidth = useBadgeWidth + visibleWidth(leftPart.plain)
-				const centerWidth = centerParts.reduce(
-					(sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0),
-					0,
-				)
-				const rightWidth = visibleWidth(dirPart.plain)
-				const totalContent = leftWidth + centerWidth + rightWidth
-				const freeSpace = termWidth - totalContent
-				const gapLeft = Math.floor(freeSpace / 2)
-				const gapRight = freeSpace - gapLeft
-
-				styledLine =
-					useBadge +
-					leftPart.styled +
-					" ".repeat(Math.max(gapLeft, 1)) +
-					centerParts.map((p) => p.styled).join(SEP) +
-					" ".repeat(Math.max(gapRight, 1)) +
-					dirPart.styled
-			} else if (opts.showDir && parts.length === 2) {
-				// Just model + dir, right-align dir
-				const mainStr = useBadge + parts[0]!.styled
-				const dirPart = parts[parts.length - 1]!
-				const gap = termWidth - totalPlain
-				styledLine = mainStr + " ".repeat(gap + SEP.length) + dirPart.styled
-			} else {
-				styledLine = useBadge + parts.map((p) => p.styled).join(SEP)
-			}
-			return { plain: "", styled: styledLine }
-		}
-		// Try progressively more compact layouts.
-		// Priority: token fractions + buffer > labels > provider > badge > buffer > fractions
-		const result =
-			// 1. Full badge + full model + long labels + fractions + buffer + dir
-			buildLine({ modelId: fullModelId, memCompact: "full", showDir: true }) ??
-			// 2. Drop directory
-			buildLine({ modelId: fullModelId, memCompact: "full", showDir: false }) ??
-			// 3. Drop provider + "claude-" prefix, keep full labels + fractions + buffer
-			buildLine({ modelId: tinyModelId, memCompact: "full", showDir: false }) ??
-			// 4. Short labels (msg/mem) + fractions + buffer
-			buildLine({ modelId: tinyModelId, showDir: false }) ??
-			// 5. Short badge + short labels + fractions + buffer
-			buildLine({ modelId: tinyModelId, showDir: false, badge: "short" }) ??
-			// 6. Short badge + fractions (drop buffer indicator)
-			buildLine({
-				modelId: tinyModelId,
-				memCompact: "noBuffer",
-				showDir: false,
-				badge: "short",
-			}) ??
-			// 7. Full badge + percent only
-			buildLine({
-				modelId: tinyModelId,
-				memCompact: "percentOnly",
-				showDir: false,
-			}) ??
-			// 8. Short badge + percent only
-			buildLine({
-				modelId: tinyModelId,
-				memCompact: "percentOnly",
-				showDir: false,
-				badge: "short",
-			})
-
-		this.statusLine.setText(
-			result?.styled ??
-				shortModeBadge +
-					styleModelId(tinyModelId) +
-					(isYolo && modeColor
-						? chalk
-								.bgHex(tintHex(modeColor, 0.25))
-								.hex(tintHex(modeColor, 0.9))
-								.bold(" ⚒ ")
-						: ""),
-		)
-
-		// Line 2: hidden — dir only shows on line 1 when it fits
-		if (this.memoryStatusLine) {
-			this.memoryStatusLine.setText("")
-		}
-
-		this.ui.requestRender()
-	}
-
-	private async refreshModelAuthStatus(): Promise<void> {
-		this.modelAuthStatus = await this.harness.getCurrentModelAuthStatus()
-		this.updateStatusLine()
-	}
-
-	private setupAutocomplete(): void {
-		const slashCommands: SlashCommand[] = [
-			{ name: "new", description: "Start a new thread" },
-			{ name: "threads", description: "Switch between threads" },
-			{ name: "models", description: "Configure model (global/thread/mode)" },
-			{ name: "subagents", description: "Configure subagent model defaults" },
-			{ name: "om", description: "Configure Observational Memory models" },
-			{ name: "think", description: "Set thinking level (Anthropic)" },
-			{ name: "login", description: "Login with OAuth provider" },
-			{ name: "skills", description: "List available skills" },
-			{ name: "cost", description: "Show token usage and estimated costs" },
-			{ name: "diff", description: "Show modified files or git diff" },
-			{ name: "name", description: "Rename current thread" },
-			{
-				name: "resource",
-				description: "Show/switch resource ID (tag for sharing)",
-			},
-			{ name: "logout", description: "Logout from OAuth provider" },
-			{ name: "hooks", description: "Show/reload configured hooks" },
-			{ name: "mcp", description: "Show/reload MCP server connections" },
-			{
-				name: "thread:tag-dir",
-				description: "Tag current thread with this directory",
-			},
-			{
-				name: "sandbox",
-				description: "Manage allowed paths (add/remove directories)",
-			},
-			{
-				name: "permissions",
-				description: "View/manage tool approval permissions",
-			},
-			{
-				name: "settings",
-				description: "General settings (notifications, YOLO, thinking)",
-			},
-			{
-				name: "yolo",
-				description: "Toggle YOLO mode (auto-approve all tools)",
-			},
-			{ name: "review", description: "Review a GitHub pull request" },
-			{ name: "exit", description: "Exit the TUI" },
-			{ name: "help", description: "Show available commands" },
-		]
-
-		// Only show /mode if there's more than one mode
-		const modes = this.harness.getModes()
-		if (modes.length > 1) {
-			slashCommands.push({ name: "mode", description: "Switch agent mode" })
-		}
-
-		// Add custom slash commands to the list
-		for (const customCmd of this.customSlashCommands) {
-			// Prefix with extra / to distinguish from built-in commands (//command-name)
-			slashCommands.push({
-				name: `/${customCmd.name}`,
-				description: customCmd.description || `Custom: ${customCmd.name}`,
-			})
-		}
-
-		this.autocompleteProvider = new CombinedAutocompleteProvider(
-			slashCommands,
-			process.cwd(),
-		)
-		this.editor.setAutocompleteProvider(this.autocompleteProvider)
-	}
-	/**
-	 * Load custom slash commands from all sources:
-	 * - Global: ~/.opencode/command, ~/.claude/commands, and ~/.mastracode/commands
-	 * - Local: .opencode/command, .claude/commands, and .mastracode/commands
-	 */
-	private async loadCustomSlashCommands(): Promise<void> {
-		try {
-			// Load from all sources (global and local)
-			const globalCommands = await loadCustomCommands()
-			const localCommands = await loadCustomCommands(process.cwd())
-
-			// Merge commands, with local taking precedence over global for same names
-			const commandMap = new Map<string, SlashCommandMetadata>()
-
-			// Add global commands first
-			for (const cmd of globalCommands) {
-				commandMap.set(cmd.name, cmd)
-			}
-
-			// Add local commands (will override global if same name)
-			for (const cmd of localCommands) {
-				commandMap.set(cmd.name, cmd)
-			}
-
-			this.customSlashCommands = Array.from(commandMap.values())
-		} catch {
-			this.customSlashCommands = []
-		}
-	}
-
-	private setupKeyHandlers(): void {
-		// Handle Ctrl+C via process signal (backup for when editor doesn't capture it)
-		process.on("SIGINT", () => {
-			const now = Date.now()
-			if (now - this.lastCtrlCTime < MastraTUI.DOUBLE_CTRL_C_MS) {
-				this.stop()
-				process.exit(0)
-			}
-			this.lastCtrlCTime = now
-			if (this.pendingApprovalDismiss) {
-				this.pendingApprovalDismiss()
-			}
-			this.userInitiatedAbort = true
-			this.harness.abort()
-		})
-
-		// Use onDebug callback for Shift+Ctrl+D
-		this.ui.onDebug = () => {
-			// Toggle debug mode or show debug info
-			// Currently unused - could add debug panel in future
-		}
-	}
-
-	private setupEditorSubmitHandler(): void {
-		// The editor's onSubmit is handled via getUserInput promise
-	}
-
-	private subscribeToHarness(): void {
-		const listener: HarnessEventListener = async (event) => {
-			await this.handleEvent(event)
-		}
-		this.unsubscribe = this.harness.subscribe(listener)
-	}
-
-	private updateTerminalTitle(): void {
-		const appName = this.options.appName || "Mastra Code"
-		const cwd = process.cwd().split("/").pop() || ""
-		this.ui.terminal.setTitle(`${appName} - ${cwd}`)
-	}
-
-	// ===========================================================================
-	// Event Handling
-	// ===========================================================================
-
-	private async handleEvent(event: HarnessEvent): Promise<void> {
-		switch (event.type) {
-			case "agent_start":
-				this.handleAgentStart()
-				break
-
-			case "agent_end":
-				if (event.reason === "aborted") {
-					this.handleAgentAborted()
-				} else if (event.reason === "error") {
-					this.handleAgentError()
-				} else {
-					this.handleAgentEnd()
-				}
-				break
-
-			case "message_start":
-				this.handleMessageStart(event.message)
-				break
-
-			case "message_update":
-				this.handleMessageUpdate(event.message)
-				break
-
-			case "message_end":
-				this.handleMessageEnd(event.message)
-				break
-			case "tool_start":
-				this.handleToolStart(event.toolCallId, event.toolName, event.args)
-				break
-
-			case "tool_approval_required":
-				this.handleToolApprovalRequired(
-					event.toolCallId,
-					event.toolName,
-					event.args,
-				)
-				break
-
-			case "tool_update":
-				this.handleToolUpdate(event.toolCallId, event.partialResult)
-				break
-
-			case "shell_output":
-				this.handleShellOutput(event.toolCallId, event.output, event.stream)
-				break
-
-			case "tool_end":
-				this.handleToolEnd(event.toolCallId, event.result, event.isError)
-				break
-			case "info":
-				this.showInfo(event.message)
-				break
-
-			case "error":
-				this.showFormattedError(event)
-				break
-
-			case "mode_changed": {
-				// Mode is already visible in status line, no need to log it
-				await this.refreshModelAuthStatus()
-				break
-			}
-
-			case "model_changed":
-				// Update status line to reflect new model and auth status
-				await this.refreshModelAuthStatus()
-				break
-
-			case "thread_changed": {
-				this.showInfo(`Switched to thread: ${event.threadId}`)
-				this.resetStatusLineState()
-				await this.renderExistingMessages()
-				await this.harness.loadOMProgress()
-				this.syncOMThresholdsFromHarness()
-				this.tokenUsage = this.harness.getTokenUsage()
-				this.updateStatusLine()
-				// Restore todos from thread state
-				const threadState = this.harness.getState() as {
-					todos?: TodoItem[]
-				}
-				if (this.todoProgress) {
-					this.todoProgress.updateTodos(threadState.todos ?? [])
-					this.ui.requestRender()
-				}
-				break
-			}
-			case "thread_created": {
-				this.showInfo(`Created thread: ${event.thread.id}`)
-				// Sync inherited resource-level settings
-				const tState = this.harness.getState() as any
-				if (typeof tState?.escapeAsCancel === "boolean") {
-					this.editor.escapeEnabled = tState.escapeAsCancel
-				}
-				this.updateStatusLine()
-				break
-			}
-
-			case "usage_update":
-				this.handleUsageUpdate(event.usage)
-				break
-			// Observational Memory events
-			case "om_status":
-				this.handleOMStatus(event)
-				break
-
-			case "om_observation_start":
-				this.handleOMObservationStart(event.cycleId, event.tokensToObserve)
-				break
-			case "om_observation_end":
-				this.handleOMObservationEnd(
-					event.cycleId,
-					event.durationMs,
-					event.tokensObserved,
-					event.observationTokens,
-					event.observations,
-					event.currentTask,
-					event.suggestedResponse,
-				)
-				break
-
-			case "om_observation_failed":
-				this.handleOMFailed(event.cycleId, event.error, "observation")
-				break
-
-			case "om_reflection_start":
-				this.handleOMReflectionStart(event.cycleId, event.tokensToReflect)
-				break
-			case "om_reflection_end":
-				this.handleOMReflectionEnd(
-					event.cycleId,
-					event.durationMs,
-					event.compressedTokens,
-					event.observations,
-				)
-				break
-			case "om_reflection_failed":
-				this.handleOMFailed(event.cycleId, event.error, "reflection")
-				break
-			// Buffering lifecycle
-			case "om_buffering_start":
-				if (event.operationType === "observation") {
-					this.bufferingMessages = true
-				} else {
-					this.bufferingObservations = true
-				}
-				this.activeActivationMarker = undefined
-				this.activeBufferingMarker = new OMMarkerComponent({
-					type: "om_buffering_start",
-					operationType: event.operationType,
-					tokensToBuffer: event.tokensToBuffer,
-				})
-				this.addOMMarkerToChat(this.activeBufferingMarker)
-				this.updateStatusLine()
-				this.ui.requestRender()
-				break
-			case "om_buffering_end":
-				if (event.operationType === "observation") {
-					this.bufferingMessages = false
-				} else {
-					this.bufferingObservations = false
-				}
-				if (this.activeBufferingMarker) {
-					this.activeBufferingMarker.update({
-						type: "om_buffering_end",
-						operationType: event.operationType,
-						tokensBuffered: event.tokensBuffered,
-						bufferedTokens: event.bufferedTokens,
-						observations: event.observations,
-					})
-				}
-				this.activeBufferingMarker = undefined
-				this.updateStatusLine()
-				this.ui.requestRender()
-				break
-
-			case "om_buffering_failed":
-				if (event.operationType === "observation") {
-					this.bufferingMessages = false
-				} else {
-					this.bufferingObservations = false
-				}
-				if (this.activeBufferingMarker) {
-					this.activeBufferingMarker.update({
-						type: "om_buffering_failed",
-						operationType: event.operationType,
-						error: event.error,
-					})
-				}
-				this.activeBufferingMarker = undefined
-				this.updateStatusLine()
-				this.ui.requestRender()
-				break
-			case "om_activation":
-				if (event.operationType === "observation") {
-					this.bufferingMessages = false
-				} else {
-					this.bufferingObservations = false
-				}
-				const activationData: OMMarkerData = {
-					type: "om_activation",
-					operationType: event.operationType,
-					tokensActivated: event.tokensActivated,
-					observationTokens: event.observationTokens,
-				}
-				this.activeActivationMarker = new OMMarkerComponent(activationData)
-				this.addOMMarkerToChat(this.activeActivationMarker)
-				this.activeBufferingMarker = undefined
-				this.updateStatusLine()
-				this.ui.requestRender()
-				break
-
-			case "follow_up_queued":
-				this.showInfo(`Follow-up queued (${event.count} pending)`)
-				break
-
-			case "workspace_ready":
-				// Workspace initialized successfully - silent unless verbose
-				break
-
-			case "workspace_error":
-				this.showError(`Workspace: ${event.error.message}`)
-				break
-
-			case "workspace_status_changed":
-				if (event.status === "error" && event.error) {
-					this.showError(`Workspace: ${event.error.message}`)
-				}
-				break
-
-			// Subagent / Task delegation events
-			case "subagent_start":
-				this.handleSubagentStart(
-					event.toolCallId,
-					event.agentType,
-					event.task,
-					event.modelId,
-				)
-				break
-
-			case "subagent_tool_start":
-				this.handleSubagentToolStart(
-					event.toolCallId,
-					event.subToolName,
-					event.subToolArgs,
-				)
-				break
-
-			case "subagent_tool_end":
-				this.handleSubagentToolEnd(
-					event.toolCallId,
-					event.subToolName,
-					event.subToolResult,
-					event.isError,
-				)
-				break
-
-			case "subagent_text_delta":
-				// Text deltas are streamed but we don't render them incrementally
-				// (the final result is shown via tool_end for the parent tool call)
-				break
-
-			case "subagent_end":
-				this.handleSubagentEnd(
-					event.toolCallId,
-					event.isError,
-					event.durationMs,
-					event.result,
-				)
-				break
-
-			case "todo_updated": {
-				const todos = event.todos as TodoItem[]
-				if (this.todoProgress) {
-					this.todoProgress.updateTodos(todos ?? [])
-
-					// Find the most recent todo_write tool component and get its position
-					let insertIndex = -1
-					for (let i = this.allToolComponents.length - 1; i >= 0; i--) {
-						const comp = this.allToolComponents[i]
-						if ((comp as any).toolName === "todo_write") {
-							insertIndex = this.chatContainer.children.indexOf(comp as any)
-							this.chatContainer.removeChild(comp as any)
-							this.allToolComponents.splice(i, 1)
-							break
-						}
-					}
-
-					// Check if all todos are completed
-					const allCompleted =
-						todos &&
-						todos.length > 0 &&
-						todos.every((t) => t.status === "completed")
-					if (allCompleted) {
-						// Show collapsed completed list (pinned/live)
-						this.renderCompletedTodosInline(todos, insertIndex, true)
-					} else if (
-						this.previousTodos.length > 0 &&
-						(!todos || todos.length === 0)
-					) {
-						// Tasks were cleared
-						this.renderClearedTodosInline(this.previousTodos, insertIndex)
-					}
-
-					// Track for next diff
-					this.previousTodos = todos ? [...todos] : []
-
-					this.ui.requestRender()
-				}
-				break
-			}
-
-			case "ask_question":
-				await this.handleAskQuestion(
-					event.questionId,
-					event.question,
-					event.options,
-				)
-				break
-
-			case "sandbox_access_request":
-				await this.handleSandboxAccessRequest(
-					event.questionId,
-					event.path,
-					event.reason,
-				)
-				break
-
-			case "plan_approval_required":
-				await this.handlePlanApproval(event.planId, event.title, event.plan)
-				break
-
-			case "plan_approved":
-				// Handled directly in onApprove callback to ensure proper sequencing
-				break
-		}
-	}
-
-	private handleUsageUpdate(usage: TokenUsage): void {
-		// Accumulate token usage
-		this.tokenUsage.promptTokens += usage.promptTokens
-		this.tokenUsage.completionTokens += usage.completionTokens
-		this.tokenUsage.totalTokens += usage.totalTokens
-		this.updateStatusLine()
-	}
-
-	// ===========================================================================
-	// Status Line Reset
-	// ===========================================================================
-
-	/**
-	 * Sync omProgress thresholds from harness state (thread metadata).
-	 * Called after thread load to pick up per-thread threshold overrides.
-	 */
-	private syncOMThresholdsFromHarness(): void {
-		const obsThreshold = this.harness.getObservationThreshold()
-		const refThreshold = this.harness.getReflectionThreshold()
-		this.omProgress.threshold = obsThreshold
-		this.omProgress.thresholdPercent =
-			obsThreshold > 0
-				? (this.omProgress.pendingTokens / obsThreshold) * 100
-				: 0
-		this.omProgress.reflectionThreshold = refThreshold
-		this.omProgress.reflectionThresholdPercent =
-			refThreshold > 0
-				? (this.omProgress.observationTokens / refThreshold) * 100
-				: 0
-		this.updateStatusLine()
-	}
-	private resetStatusLineState(): void {
-		const prev = this.omProgress
-		this.omProgress = {
-			...defaultOMProgressState(),
-			// Preserve thresholds across resets
-			threshold: prev.threshold,
-			reflectionThreshold: prev.reflectionThreshold,
-		}
-		this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
-		this.bufferingMessages = false
-		this.bufferingObservations = false
-		this.updateStatusLine()
-	}
-
-	// ===========================================================================
-	// Observational Memory Event Handlers
-	// ===========================================================================
-
-	/**
-	 * Add an OM marker to the chat container, inserting it *before* the
-	 * current streaming component so it doesn't get pushed down as text
-	 * streams in.  Falls back to a normal append when nothing is streaming.
-	 */
-	private addOMMarkerToChat(marker: OMMarkerComponent): void {
-		if (this.streamingComponent) {
-			const idx = this.chatContainer.children.indexOf(this.streamingComponent)
-			if (idx >= 0) {
-				this.chatContainer.children.splice(idx, 0, marker)
-				this.chatContainer.invalidate()
-				return
-			}
-		}
-		this.chatContainer.addChild(marker)
-	}
-
-	private addOMOutputToChat(output: OMOutputComponent): void {
-		if (this.streamingComponent) {
-			const idx = this.chatContainer.children.indexOf(this.streamingComponent)
-			if (idx >= 0) {
-				this.chatContainer.children.splice(idx, 0, output)
-				this.chatContainer.invalidate()
-				return
-			}
-		}
-		this.chatContainer.addChild(output)
-	}
-	private handleOMStatus(
-		event: Extract<HarnessEvent, { type: "om_status" }>,
-	): void {
-		const { windows, generationCount, stepNumber } = event
-		const { active, buffered } = windows
-
-		// Update active window state
-		this.omProgress.pendingTokens = active.messages.tokens
-		this.omProgress.threshold = active.messages.threshold
-		this.omProgress.thresholdPercent =
-			active.messages.threshold > 0
-				? (active.messages.tokens / active.messages.threshold) * 100
-				: 0
-		this.omProgress.observationTokens = active.observations.tokens
-		this.omProgress.reflectionThreshold = active.observations.threshold
-		this.omProgress.reflectionThresholdPercent =
-			active.observations.threshold > 0
-				? (active.observations.tokens / active.observations.threshold) * 100
-				: 0
-
-		// Update buffered state
-		this.omProgress.buffered = {
-			observations: { ...buffered.observations },
-			reflection: { ...buffered.reflection },
-		}
-		this.omProgress.generationCount = generationCount
-		this.omProgress.stepNumber = stepNumber
-
-		// Drive buffering animation from status fields
-		this.bufferingMessages = buffered.observations.status === "running"
-		this.bufferingObservations = buffered.reflection.status === "running"
-
-		this.updateStatusLine()
-	}
-
-	private handleOMObservationStart(
-		cycleId: string,
-		tokensToObserve: number,
-	): void {
-		this.omProgress.status = "observing"
-		this.omProgress.cycleId = cycleId
-		this.omProgress.startTime = Date.now()
-		// Show in-progress marker in chat
-		this.activeOMMarker = new OMMarkerComponent({
-			type: "om_observation_start",
-			tokensToObserve,
-			operationType: "observation",
-		})
-		this.addOMMarkerToChat(this.activeOMMarker)
-		this.updateStatusLine()
-		this.ui.requestRender()
-	}
-	private handleOMObservationEnd(
-		_cycleId: string,
-		durationMs: number,
-		tokensObserved: number,
-		observationTokens: number,
-		observations?: string,
-		currentTask?: string,
-		suggestedResponse?: string,
-	): void {
-		this.omProgress.status = "idle"
-		this.omProgress.cycleId = undefined
-		this.omProgress.startTime = undefined
-		this.omProgress.observationTokens = observationTokens
-		// Messages have been observed — reset pending tokens
-		this.omProgress.pendingTokens = 0
-		this.omProgress.thresholdPercent = 0
-		// Remove in-progress marker — the output box replaces it
-		if (this.activeOMMarker) {
-			const idx = this.chatContainer.children.indexOf(this.activeOMMarker)
-			if (idx >= 0) {
-				this.chatContainer.children.splice(idx, 1)
-				this.chatContainer.invalidate()
-			}
-			this.activeOMMarker = undefined
-		}
-		// Show observation output in a bordered box (includes marker info in footer)
-		const outputComponent = new OMOutputComponent({
-			type: "observation",
-			observations: observations ?? "",
-			currentTask,
-			suggestedResponse,
-			durationMs,
-			tokensObserved,
-			observationTokens,
-		})
-		this.addOMOutputToChat(outputComponent)
-		this.updateStatusLine()
-		this.ui.requestRender()
-	}
-
-	private handleOMReflectionStart(
-		cycleId: string,
-		tokensToReflect: number,
-	): void {
-		this.omProgress.status = "reflecting"
-		this.omProgress.cycleId = cycleId
-		this.omProgress.startTime = Date.now()
-		// Update observation tokens to show the total being reflected
-		this.omProgress.observationTokens = tokensToReflect
-		this.omProgress.reflectionThresholdPercent =
-			this.omProgress.reflectionThreshold > 0
-				? (tokensToReflect / this.omProgress.reflectionThreshold) * 100
-				: 0
-		// Show in-progress marker in chat
-		this.activeOMMarker = new OMMarkerComponent({
-			type: "om_observation_start",
-			tokensToObserve: tokensToReflect,
-			operationType: "reflection",
-		})
-		this.addOMMarkerToChat(this.activeOMMarker)
-		this.updateStatusLine()
-		this.ui.requestRender()
-	}
-	private handleOMReflectionEnd(
-		_cycleId: string,
-		durationMs: number,
-		compressedTokens: number,
-		observations?: string,
-	): void {
-		// Capture the pre-compression observation tokens for the marker display
-		const preCompressionTokens = this.omProgress.observationTokens
-		this.omProgress.status = "idle"
-		this.omProgress.cycleId = undefined
-		this.omProgress.startTime = undefined
-		// Observations were compressed — update token count
-		this.omProgress.observationTokens = compressedTokens
-		this.omProgress.reflectionThresholdPercent =
-			this.omProgress.reflectionThreshold > 0
-				? (compressedTokens / this.omProgress.reflectionThreshold) * 100
-				: 0
-		// Remove in-progress marker — the output box replaces it
-		if (this.activeOMMarker) {
-			const idx = this.chatContainer.children.indexOf(this.activeOMMarker)
-			if (idx >= 0) {
-				this.chatContainer.children.splice(idx, 1)
-				this.chatContainer.invalidate()
-			}
-			this.activeOMMarker = undefined
-		}
-		// Show reflection output in a bordered box (includes marker info in footer)
-		const outputComponent = new OMOutputComponent({
-			type: "reflection",
-			observations: observations ?? "",
-			durationMs,
-			compressedTokens,
-			tokensObserved: preCompressionTokens,
-		})
-		this.addOMOutputToChat(outputComponent)
-		// Revert spinner to "Working..."
-		this.updateLoaderText("Working...")
-		this.ui.requestRender()
-		this.updateStatusLine()
-	}
-
-	private handleOMFailed(
-		_cycleId: string,
-		error: string,
-		operation: "observation" | "reflection",
-	): void {
-		this.omProgress.status = "idle"
-		this.omProgress.cycleId = undefined
-		this.omProgress.startTime = undefined
-		// Update existing marker in-place, or create new one
-		const failData: OMMarkerData = {
-			type: "om_observation_failed",
-			error,
-			operationType: operation,
-		}
-		if (this.activeOMMarker) {
-			this.activeOMMarker.update(failData)
-			this.activeOMMarker = undefined
-		} else {
-			this.addOMMarkerToChat(new OMMarkerComponent(failData))
-		}
-		this.updateStatusLine()
-		this.ui.requestRender()
-	}
-
-	/** Update the loading animation text (e.g., "Working..." → "Observing...") */
-	private updateLoaderText(_text: string): void {
-		// Status text changes are now reflected via updateStatusLine gradient
-		this.updateStatusLine()
-	}
-
-	private handleAgentStart(): void {
-		this.isAgentActive = true
-		if (!this.gradientAnimator) {
-			this.gradientAnimator = new GradientAnimator(() => {
-				this.updateStatusLine()
-			})
-		}
-		this.gradientAnimator.start()
-		this.updateStatusLine()
-	}
-	private handleAgentEnd(): void {
-		this.isAgentActive = false
-		if (this.gradientAnimator) {
-			this.gradientAnimator.fadeOut()
-		}
-		this.updateStatusLine()
-
-		if (this.streamingComponent) {
-			this.streamingComponent = undefined
-			this.streamingMessage = undefined
-		}
-		this.followUpComponents = []
-		this.pendingTools.clear()
-		// Keep allToolComponents so Ctrl+E continues to work after agent completes
-
-		this.notify("agent_done")
-	}
-
-	private handleAgentAborted(): void {
-		this.isAgentActive = false
-		if (this.gradientAnimator) {
-			this.gradientAnimator.fadeOut()
-		}
-		this.updateStatusLine()
-
-		// Update streaming message to show it was interrupted
-		if (this.streamingComponent && this.streamingMessage) {
-			this.streamingMessage.stopReason = "aborted"
-			this.streamingMessage.errorMessage = "Interrupted"
-			this.streamingComponent.updateContent(this.streamingMessage)
-			this.streamingComponent = undefined
-			this.streamingMessage = undefined
-		} else if (this.userInitiatedAbort) {
-			// Show standalone "Interrupted" if user pressed Ctrl+C but no streaming component
-			this.chatContainer.addChild(new Spacer(1))
-			this.chatContainer.addChild(
-				new Text(theme.fg("error", "Interrupted"), 1, 0),
-			)
-		}
-		this.userInitiatedAbort = false
-
-		this.followUpComponents = []
-		this.pendingTools.clear()
-		// Keep allToolComponents so Ctrl+E continues to work after interruption
-		this.ui.requestRender()
-	}
-
-	private handleAgentError(): void {
-		this.isAgentActive = false
-		if (this.gradientAnimator) {
-			this.gradientAnimator.fadeOut()
-		}
-		this.updateStatusLine()
-
-		if (this.streamingComponent) {
-			this.streamingComponent = undefined
-			this.streamingMessage = undefined
-		}
-
-		this.followUpComponents = []
-		this.pendingTools.clear()
-		// Keep allToolComponents so Ctrl+E continues to work after errors
-	}
-
-	private handleMessageStart(message: HarnessMessage): void {
-		if (message.role === "user") {
-			this.addUserMessage(message)
-		} else if (message.role === "assistant") {
-			// Clear tool component references when starting a new assistant message
-			this.lastAskUserComponent = undefined
-			this.lastSubmitPlanComponent = undefined
-			if (!this.streamingComponent) {
-				this.streamingComponent = new AssistantMessageComponent(
-					undefined,
-					this.hideThinkingBlock,
-					getMarkdownTheme(),
-				)
-				this.addChildBeforeFollowUps(this.streamingComponent)
-				this.streamingMessage = message
-				const trailingParts = this.getTrailingContentParts(message)
-				this.streamingComponent.updateContent({
-					...message,
-					content: trailingParts,
-				})
-			}
-			this.ui.requestRender()
-		}
-	}
-
-	private handleMessageUpdate(message: HarnessMessage): void {
-		if (!this.streamingComponent || message.role !== "assistant") return
-
-		this.streamingMessage = message
-		// Check for new tool calls
-		for (const content of message.content) {
-			if (content.type === "tool_call") {
-				// For subagent calls, freeze the current streaming component
-				// with content before the tool call, then create a new one.
-				// SubagentExecutionComponent handles the visual rendering.
-				// Check subagentToolCallIds separately since handleToolStart
-				// may have already added the ID to seenToolCallIds.
-				if (
-					content.name === "subagent" &&
-					!this.subagentToolCallIds.has(content.id)
-				) {
-					this.seenToolCallIds.add(content.id)
-					this.subagentToolCallIds.add(content.id)
-					// Freeze current component with pre-subagent content
-					const preContent = this.getContentBeforeToolCall(message, content.id)
-					this.streamingComponent.updateContent({
-						...message,
-						content: preContent,
-					})
-					this.streamingComponent = new AssistantMessageComponent(
-						undefined,
-						this.hideThinkingBlock,
-						getMarkdownTheme(),
-					)
-					this.addChildBeforeFollowUps(this.streamingComponent)
-					continue
-				}
-
-				if (!this.seenToolCallIds.has(content.id)) {
-					this.seenToolCallIds.add(content.id)
-
-					this.addChildBeforeFollowUps(new Text("", 0, 0))
-					const component = new ToolExecutionComponentEnhanced(
-						content.name,
-						content.args,
-						{ showImages: false, collapsedByDefault: !this.toolOutputExpanded },
-						this.ui,
-					)
-					component.setExpanded(this.toolOutputExpanded)
-					this.addChildBeforeFollowUps(component)
-					this.pendingTools.set(content.id, component)
-					this.allToolComponents.push(component)
-
-					this.streamingComponent = new AssistantMessageComponent(
-						undefined,
-						this.hideThinkingBlock,
-						getMarkdownTheme(),
-					)
-					this.addChildBeforeFollowUps(this.streamingComponent)
-				} else {
-					const component = this.pendingTools.get(content.id)
-					if (component) {
-						component.updateArgs(content.args)
-					}
-				}
-			}
-		}
-
-		const trailingParts = this.getTrailingContentParts(message)
-		this.streamingComponent.updateContent({
-			...message,
-			content: trailingParts,
-		})
-
-		this.ui.requestRender()
-	}
-
-	/**
-	 * Get content parts after the last tool_call/tool_result in the message.
-	 * These are the parts that should be rendered in the current streaming component.
-	 */
-	private getTrailingContentParts(
-		message: HarnessMessage,
-	): HarnessMessage["content"] {
-        let lastToolIndex = -1
-        for (let i = message.content.length - 1; i >= 0; i--) {
-            const c = message.content[i]!
-            if (c.type === "tool_call" || c.type === "tool_result") {
-                lastToolIndex = i
-                break
+        1,
+        0,
+      ),
+    );
+    this.ui.addChild(new Spacer(1));
+
+    // Add main containers
+    this.ui.addChild(this.chatContainer);
+    // Todo progress (between chat and editor, visible only when todos exist)
+    this.todoProgress = new TodoProgressComponent();
+    this.ui.addChild(this.todoProgress);
+    this.ui.addChild(this.editorContainer);
+    this.editorContainer.addChild(this.editor);
+
+    // Add footer with two-line status
+    this.statusLine = new Text('', 0, 0);
+    this.memoryStatusLine = new Text('', 0, 0);
+    this.footer.addChild(this.statusLine);
+    this.footer.addChild(this.memoryStatusLine);
+    this.ui.addChild(this.footer);
+    this.updateStatusLine();
+    this.refreshModelAuthStatus();
+
+    // Set focus to editor
+    this.ui.setFocus(this.editor);
+  }
+
+  /**
+   * Update the two-line status bar.
+   * Line 1: [MODE] provider/model  memory  tokens  think:level
+   * Line 2:        ~/path/to/project (branch)
+   */
+  private updateStatusLine(): void {
+    if (!this.statusLine) return;
+    const termWidth = (process.stdout.columns || 80) - 1; // buffer to prevent jitter
+    const SEP = '  '; // double-space separator between parts
+
+    // --- Determine if we're showing observer/reflector instead of main mode ---
+    const omStatus = this.omProgress.status;
+    const isObserving = omStatus === 'observing';
+    const isReflecting = omStatus === 'reflecting';
+    const showOMMode = isObserving || isReflecting;
+
+    // Colors for OM modes
+    const OBSERVER_COLOR = mastra.orange; // Mastra orange
+    const REFLECTOR_COLOR = mastra.pink; // Mastra pink
+
+    // --- Mode badge ---
+    let modeBadge = '';
+    let modeBadgeWidth = 0;
+    const modes = this.harness.getModes();
+    const currentMode = modes.length > 1 ? this.harness.getCurrentMode() : undefined;
+    // Use OM color when observing/reflecting, otherwise mode color
+    const mainModeColor = currentMode?.color;
+    const modeColor = showOMMode ? (isObserving ? OBSERVER_COLOR : REFLECTOR_COLOR) : mainModeColor;
+    // Badge name: use OM mode name when observing/reflecting, otherwise main mode name
+    const badgeName = showOMMode
+      ? isObserving
+        ? 'observe'
+        : 'reflect'
+      : currentMode
+        ? currentMode.name || currentMode.id || 'unknown'
+        : undefined;
+    if (badgeName && modeColor) {
+      const [mcr, mcg, mcb] = [
+        parseInt(modeColor.slice(1, 3), 16),
+        parseInt(modeColor.slice(3, 5), 16),
+        parseInt(modeColor.slice(5, 7), 16),
+      ];
+      // Pulse the badge bg brightness opposite to the gradient sweep
+      let badgeBrightness = 0.9;
+      if (this.gradientAnimator?.isRunning()) {
+        const fade = this.gradientAnimator.getFadeProgress();
+        if (fade < 1) {
+          const offset = this.gradientAnimator.getOffset() % 1;
+          // Inverted phase (+ PI), range 0.65-0.95
+          const animBrightness = 0.65 + 0.3 * (0.5 + 0.5 * Math.sin(offset * Math.PI * 2 + Math.PI));
+          // Interpolate toward idle (0.9) as fade progresses
+          badgeBrightness = animBrightness + (0.9 - animBrightness) * fade;
+        }
+      }
+      const [mr, mg, mb] = [
+        Math.floor(mcr * badgeBrightness),
+        Math.floor(mcg * badgeBrightness),
+        Math.floor(mcb * badgeBrightness),
+      ];
+      modeBadge = chalk.bgRgb(mr, mg, mb).hex(mastra.bg).bold(` ${badgeName.toLowerCase()} `);
+      modeBadgeWidth = badgeName.length + 2;
+    } else if (badgeName) {
+      modeBadge = fg('dim', badgeName) + ' ';
+      modeBadgeWidth = badgeName.length + 1;
+    }
+
+    // --- Update editor border to match mode color (not OM color) ---
+    if (mainModeColor) {
+      const [br, bg, bb] = [
+        parseInt(mainModeColor.slice(1, 3), 16),
+        parseInt(mainModeColor.slice(3, 5), 16),
+        parseInt(mainModeColor.slice(5, 7), 16),
+      ];
+      const dim = 0.35;
+      this.editor.borderColor = (text: string) =>
+        chalk.rgb(Math.floor(br * dim), Math.floor(bg * dim), Math.floor(bb * dim))(text);
+    }
+
+    // --- Collect raw data ---
+    // Show OM model when observing/reflecting, otherwise main model
+    const fullModelId = showOMMode
+      ? isObserving
+        ? this.harness.getObserverModelId()
+        : this.harness.getReflectorModelId()
+      : this.harness.getFullModelId();
+    // e.g. "anthropic/claude-sonnet-4-20250514" → "claude-sonnet-4-20250514"
+    const shortModelId = fullModelId.includes('/') ? fullModelId.slice(fullModelId.indexOf('/') + 1) : fullModelId;
+    // e.g. "claude-opus-4-6" → "opus 4.6", "claude-sonnet-4-20250514" → "sonnet-4-20250514"
+    const tinyModelId = shortModelId.replace(/^claude-/, '').replace(/^(\w+)-(\d+)-(\d{1,2})$/, '$1 $2.$3');
+
+    const homedir = process.env.HOME || process.env.USERPROFILE || '';
+    let displayPath = this.projectInfo.rootPath;
+    if (homedir && displayPath.startsWith(homedir)) {
+      displayPath = '~' + displayPath.slice(homedir.length);
+    }
+    if (this.projectInfo.gitBranch) {
+      displayPath = `${displayPath} (${this.projectInfo.gitBranch})`;
+    }
+
+    // --- Helper to style the model ID ---
+    const isYolo = this.harness.getYoloMode();
+    const styleModelId = (id: string): string => {
+      if (!this.modelAuthStatus.hasAuth) {
+        const envVar = this.modelAuthStatus.apiKeyEnvVar;
+        return fg('dim', id) + fg('error', ' ✗') + fg('muted', envVar ? ` (${envVar})` : ' (no key)');
+      }
+      // Tinted near-black background from mode color
+      const tintBg = modeColor ? tintHex(modeColor, 0.15) : undefined;
+      const padded = ` ${id} `;
+
+      if (this.gradientAnimator?.isRunning() && modeColor) {
+        const fade = this.gradientAnimator.getFadeProgress();
+        if (fade < 1) {
+          // During active or fade-out: interpolate gradient toward idle color
+          const text = applyGradientSweep(
+            padded,
+            this.gradientAnimator.getOffset(),
+            modeColor,
+            fade, // pass fade progress to flatten the gradient
+          );
+          return tintBg ? chalk.bgHex(tintBg)(text) : text;
+        }
+      }
+      if (modeColor) {
+        // Idle state
+        const [r, g, b] = [
+          parseInt(modeColor.slice(1, 3), 16),
+          parseInt(modeColor.slice(3, 5), 16),
+          parseInt(modeColor.slice(5, 7), 16),
+        ];
+        const dim = 0.8;
+        const fg = chalk.rgb(Math.floor(r * dim), Math.floor(g * dim), Math.floor(b * dim)).bold(padded);
+        return tintBg ? chalk.bgHex(tintBg)(fg) : fg;
+      }
+      return chalk.hex(mastra.specialGray).bold(id);
+    };
+    // --- Build line with progressive reduction ---
+    // Strategy: progressively drop less-important elements to fit terminal width.
+    // Each attempt assembles plain-text parts, measures, and if it fits, styles and renders.
+
+    // Short badge: first letter only (e.g., "build" → "b", "observe" → "o")
+    let shortModeBadge = '';
+    let shortModeBadgeWidth = 0;
+    if (badgeName && modeColor) {
+      const shortName = badgeName.toLowerCase().charAt(0);
+      const [mcr, mcg, mcb] = [
+        parseInt(modeColor.slice(1, 3), 16),
+        parseInt(modeColor.slice(3, 5), 16),
+        parseInt(modeColor.slice(5, 7), 16),
+      ];
+      let sBadgeBrightness = 0.9;
+      if (this.gradientAnimator?.isRunning()) {
+        const fade = this.gradientAnimator.getFadeProgress();
+        if (fade < 1) {
+          const offset = this.gradientAnimator.getOffset() % 1;
+          const animBrightness = 0.65 + 0.3 * (0.5 + 0.5 * Math.sin(offset * Math.PI * 2 + Math.PI));
+          sBadgeBrightness = animBrightness + (0.9 - animBrightness) * fade;
+        }
+      }
+      const [sr, sg, sb] = [
+        Math.floor(mcr * sBadgeBrightness),
+        Math.floor(mcg * sBadgeBrightness),
+        Math.floor(mcb * sBadgeBrightness),
+      ];
+      shortModeBadge = chalk.bgRgb(sr, sg, sb).hex(mastra.bg).bold(` ${shortName} `);
+      shortModeBadgeWidth = shortName.length + 2;
+    } else if (badgeName) {
+      const shortName = badgeName.toLowerCase().charAt(0);
+      shortModeBadge = fg('dim', shortName) + ' ';
+      shortModeBadgeWidth = shortName.length + 1;
+    }
+
+    const buildLine = (opts: {
+      modelId: string;
+      memCompact?: 'percentOnly' | 'noBuffer' | 'full';
+      showDir: boolean;
+      badge?: 'full' | 'short';
+    }): { plain: string; styled: string } | null => {
+      const parts: Array<{ plain: string; styled: string }> = [];
+      // Model ID (always present) — styleModelId adds padding spaces
+      // When YOLO, append ⚒ box flush (no SEP gap)
+      if (isYolo && modeColor) {
+        const yBox = chalk.bgHex(tintHex(modeColor, 0.25)).hex(tintHex(modeColor, 0.9)).bold(' ⚒ ');
+        parts.push({
+          plain: ` ${opts.modelId}  ⚒ `,
+          styled: styleModelId(opts.modelId) + yBox,
+        });
+      } else {
+        parts.push({
+          plain: ` ${opts.modelId} `,
+          styled: styleModelId(opts.modelId),
+        });
+      }
+      const useBadge = opts.badge === 'short' ? shortModeBadge : modeBadge;
+      const useBadgeWidth = opts.badge === 'short' ? shortModeBadgeWidth : modeBadgeWidth;
+      // Memory info — animate label text when buffering is active
+      const msgLabelStyler =
+        this.bufferingMessages && this.gradientAnimator?.isRunning()
+          ? (label: string) =>
+              applyGradientSweep(
+                label,
+                this.gradientAnimator!.getOffset(),
+                OBSERVER_COLOR,
+                this.gradientAnimator!.getFadeProgress(),
+              )
+          : undefined;
+      const obsLabelStyler =
+        this.bufferingObservations && this.gradientAnimator?.isRunning()
+          ? (label: string) =>
+              applyGradientSweep(
+                label,
+                this.gradientAnimator!.getOffset(),
+                REFLECTOR_COLOR,
+                this.gradientAnimator!.getFadeProgress(),
+              )
+          : undefined;
+      const obs = formatObservationStatus(this.omProgress, opts.memCompact, msgLabelStyler);
+      const ref = formatReflectionStatus(this.omProgress, opts.memCompact, obsLabelStyler);
+      if (obs) {
+        parts.push({ plain: obs, styled: obs });
+      }
+      if (ref) {
+        parts.push({ plain: ref, styled: ref });
+      }
+      // Directory (lowest priority on line 1)
+      if (opts.showDir) {
+        parts.push({
+          plain: displayPath,
+          styled: fg('dim', displayPath),
+        });
+      }
+      const totalPlain =
+        useBadgeWidth + parts.reduce((sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0), 0);
+
+      if (totalPlain > termWidth) return null;
+
+      let styledLine: string;
+      if (opts.showDir && parts.length >= 3) {
+        // Three groups: left (model), center (mem/tokens/thinking), right (dir)
+        const leftPart = parts[0]!; // model
+        const centerParts = parts.slice(1, -1); // mem, tokens, thinking
+        const dirPart = parts[parts.length - 1]!; // dir
+
+        const leftWidth = useBadgeWidth + visibleWidth(leftPart.plain);
+        const centerWidth = centerParts.reduce(
+          (sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0),
+          0,
+        );
+        const rightWidth = visibleWidth(dirPart.plain);
+        const totalContent = leftWidth + centerWidth + rightWidth;
+        const freeSpace = termWidth - totalContent;
+        const gapLeft = Math.floor(freeSpace / 2);
+        const gapRight = freeSpace - gapLeft;
+
+        styledLine =
+          useBadge +
+          leftPart.styled +
+          ' '.repeat(Math.max(gapLeft, 1)) +
+          centerParts.map(p => p.styled).join(SEP) +
+          ' '.repeat(Math.max(gapRight, 1)) +
+          dirPart.styled;
+      } else if (opts.showDir && parts.length === 2) {
+        // Just model + dir, right-align dir
+        const mainStr = useBadge + parts[0]!.styled;
+        const dirPart = parts[parts.length - 1]!;
+        const gap = termWidth - totalPlain;
+        styledLine = mainStr + ' '.repeat(gap + SEP.length) + dirPart.styled;
+      } else {
+        styledLine = useBadge + parts.map(p => p.styled).join(SEP);
+      }
+      return { plain: '', styled: styledLine };
+    };
+    // Try progressively more compact layouts.
+    // Priority: token fractions + buffer > labels > provider > badge > buffer > fractions
+    const result =
+      // 1. Full badge + full model + long labels + fractions + buffer + dir
+      buildLine({ modelId: fullModelId, memCompact: 'full', showDir: true }) ??
+      // 2. Drop directory
+      buildLine({ modelId: fullModelId, memCompact: 'full', showDir: false }) ??
+      // 3. Drop provider + "claude-" prefix, keep full labels + fractions + buffer
+      buildLine({ modelId: tinyModelId, memCompact: 'full', showDir: false }) ??
+      // 4. Short labels (msg/mem) + fractions + buffer
+      buildLine({ modelId: tinyModelId, showDir: false }) ??
+      // 5. Short badge + short labels + fractions + buffer
+      buildLine({ modelId: tinyModelId, showDir: false, badge: 'short' }) ??
+      // 6. Short badge + fractions (drop buffer indicator)
+      buildLine({
+        modelId: tinyModelId,
+        memCompact: 'noBuffer',
+        showDir: false,
+        badge: 'short',
+      }) ??
+      // 7. Full badge + percent only
+      buildLine({
+        modelId: tinyModelId,
+        memCompact: 'percentOnly',
+        showDir: false,
+      }) ??
+      // 8. Short badge + percent only
+      buildLine({
+        modelId: tinyModelId,
+        memCompact: 'percentOnly',
+        showDir: false,
+        badge: 'short',
+      });
+
+    this.statusLine.setText(
+      result?.styled ??
+        shortModeBadge +
+          styleModelId(tinyModelId) +
+          (isYolo && modeColor ? chalk.bgHex(tintHex(modeColor, 0.25)).hex(tintHex(modeColor, 0.9)).bold(' ⚒ ') : ''),
+    );
+
+    // Line 2: hidden — dir only shows on line 1 when it fits
+    if (this.memoryStatusLine) {
+      this.memoryStatusLine.setText('');
+    }
+
+    this.ui.requestRender();
+  }
+
+  private async refreshModelAuthStatus(): Promise<void> {
+    this.modelAuthStatus = await this.harness.getCurrentModelAuthStatus();
+    this.updateStatusLine();
+  }
+
+  private setupAutocomplete(): void {
+    const slashCommands: SlashCommand[] = [
+      { name: 'new', description: 'Start a new thread' },
+      { name: 'threads', description: 'Switch between threads' },
+      { name: 'models', description: 'Configure model (global/thread/mode)' },
+      { name: 'subagents', description: 'Configure subagent model defaults' },
+      { name: 'om', description: 'Configure Observational Memory models' },
+      { name: 'think', description: 'Set thinking level (Anthropic)' },
+      { name: 'login', description: 'Login with OAuth provider' },
+      { name: 'skills', description: 'List available skills' },
+      { name: 'cost', description: 'Show token usage and estimated costs' },
+      { name: 'diff', description: 'Show modified files or git diff' },
+      { name: 'name', description: 'Rename current thread' },
+      {
+        name: 'resource',
+        description: 'Show/switch resource ID (tag for sharing)',
+      },
+      { name: 'logout', description: 'Logout from OAuth provider' },
+      { name: 'hooks', description: 'Show/reload configured hooks' },
+      { name: 'mcp', description: 'Show/reload MCP server connections' },
+      {
+        name: 'thread:tag-dir',
+        description: 'Tag current thread with this directory',
+      },
+      {
+        name: 'sandbox',
+        description: 'Manage allowed paths (add/remove directories)',
+      },
+      {
+        name: 'permissions',
+        description: 'View/manage tool approval permissions',
+      },
+      {
+        name: 'settings',
+        description: 'General settings (notifications, YOLO, thinking)',
+      },
+      {
+        name: 'yolo',
+        description: 'Toggle YOLO mode (auto-approve all tools)',
+      },
+      { name: 'review', description: 'Review a GitHub pull request' },
+      { name: 'exit', description: 'Exit the TUI' },
+      { name: 'help', description: 'Show available commands' },
+    ];
+
+    // Only show /mode if there's more than one mode
+    const modes = this.harness.getModes();
+    if (modes.length > 1) {
+      slashCommands.push({ name: 'mode', description: 'Switch agent mode' });
+    }
+
+    // Add custom slash commands to the list
+    for (const customCmd of this.customSlashCommands) {
+      // Prefix with extra / to distinguish from built-in commands (//command-name)
+      slashCommands.push({
+        name: `/${customCmd.name}`,
+        description: customCmd.description || `Custom: ${customCmd.name}`,
+      });
+    }
+
+    this.autocompleteProvider = new CombinedAutocompleteProvider(slashCommands, process.cwd());
+    this.editor.setAutocompleteProvider(this.autocompleteProvider);
+  }
+  /**
+   * Load custom slash commands from all sources:
+   * - Global: ~/.opencode/command, ~/.claude/commands, and ~/.mastracode/commands
+   * - Local: .opencode/command, .claude/commands, and .mastracode/commands
+   */
+  private async loadCustomSlashCommands(): Promise<void> {
+    try {
+      // Load from all sources (global and local)
+      const globalCommands = await loadCustomCommands();
+      const localCommands = await loadCustomCommands(process.cwd());
+
+      // Merge commands, with local taking precedence over global for same names
+      const commandMap = new Map<string, SlashCommandMetadata>();
+
+      // Add global commands first
+      for (const cmd of globalCommands) {
+        commandMap.set(cmd.name, cmd);
+      }
+
+      // Add local commands (will override global if same name)
+      for (const cmd of localCommands) {
+        commandMap.set(cmd.name, cmd);
+      }
+
+      this.customSlashCommands = Array.from(commandMap.values());
+    } catch {
+      this.customSlashCommands = [];
+    }
+  }
+
+  private setupKeyHandlers(): void {
+    // Handle Ctrl+C via process signal (backup for when editor doesn't capture it)
+    process.on('SIGINT', () => {
+      const now = Date.now();
+      if (now - this.lastCtrlCTime < MastraTUI.DOUBLE_CTRL_C_MS) {
+        this.stop();
+        process.exit(0);
+      }
+      this.lastCtrlCTime = now;
+      if (this.pendingApprovalDismiss) {
+        this.pendingApprovalDismiss();
+      }
+      this.userInitiatedAbort = true;
+      this.harness.abort();
+    });
+
+    // Use onDebug callback for Shift+Ctrl+D
+    this.ui.onDebug = () => {
+      // Toggle debug mode or show debug info
+      // Currently unused - could add debug panel in future
+    };
+  }
+
+  private setupEditorSubmitHandler(): void {
+    // The editor's onSubmit is handled via getUserInput promise
+  }
+
+  private subscribeToHarness(): void {
+    const listener: HarnessEventListener = async event => {
+      await this.handleEvent(event);
+    };
+    this.unsubscribe = this.harness.subscribe(listener);
+  }
+
+  private updateTerminalTitle(): void {
+    const appName = this.options.appName || 'Mastra Code';
+    const cwd = process.cwd().split('/').pop() || '';
+    this.ui.terminal.setTitle(`${appName} - ${cwd}`);
+  }
+
+  // ===========================================================================
+  // Event Handling
+  // ===========================================================================
+
+  private async handleEvent(event: HarnessEvent): Promise<void> {
+    switch (event.type) {
+      case 'agent_start':
+        this.handleAgentStart();
+        break;
+
+      case 'agent_end':
+        if (event.reason === 'aborted') {
+          this.handleAgentAborted();
+        } else if (event.reason === 'error') {
+          this.handleAgentError();
+        } else {
+          this.handleAgentEnd();
+        }
+        break;
+
+      case 'message_start':
+        this.handleMessageStart(event.message);
+        break;
+
+      case 'message_update':
+        this.handleMessageUpdate(event.message);
+        break;
+
+      case 'message_end':
+        this.handleMessageEnd(event.message);
+        break;
+      case 'tool_start':
+        this.handleToolStart(event.toolCallId, event.toolName, event.args);
+        break;
+
+      case 'tool_approval_required':
+        this.handleToolApprovalRequired(event.toolCallId, event.toolName, event.args);
+        break;
+
+      case 'tool_update':
+        this.handleToolUpdate(event.toolCallId, event.partialResult);
+        break;
+
+      case 'shell_output':
+        this.handleShellOutput(event.toolCallId, event.output, event.stream);
+        break;
+
+      case 'tool_end':
+        this.handleToolEnd(event.toolCallId, event.result, event.isError);
+        break;
+      case 'info':
+        this.showInfo(event.message);
+        break;
+
+      case 'error':
+        this.showFormattedError(event);
+        break;
+
+      case 'mode_changed': {
+        // Mode is already visible in status line, no need to log it
+        await this.refreshModelAuthStatus();
+        break;
+      }
+
+      case 'model_changed':
+        // Update status line to reflect new model and auth status
+        await this.refreshModelAuthStatus();
+        break;
+
+      case 'thread_changed': {
+        this.showInfo(`Switched to thread: ${event.threadId}`);
+        this.resetStatusLineState();
+        await this.renderExistingMessages();
+        await this.harness.loadOMProgress();
+        this.syncOMThresholdsFromHarness();
+        this.tokenUsage = this.harness.getTokenUsage();
+        this.updateStatusLine();
+        // Restore todos from thread state
+        const threadState = this.harness.getState() as {
+          todos?: TodoItem[];
+        };
+        if (this.todoProgress) {
+          this.todoProgress.updateTodos(threadState.todos ?? []);
+          this.ui.requestRender();
+        }
+        break;
+      }
+      case 'thread_created': {
+        this.showInfo(`Created thread: ${event.thread.id}`);
+        // Sync inherited resource-level settings
+        const tState = this.harness.getState() as any;
+        if (typeof tState?.escapeAsCancel === 'boolean') {
+          this.editor.escapeEnabled = tState.escapeAsCancel;
+        }
+        this.updateStatusLine();
+        break;
+      }
+
+      case 'usage_update':
+        this.handleUsageUpdate(event.usage);
+        break;
+      // Observational Memory events
+      case 'om_status':
+        this.handleOMStatus(event);
+        break;
+
+      case 'om_observation_start':
+        this.handleOMObservationStart(event.cycleId, event.tokensToObserve);
+        break;
+      case 'om_observation_end':
+        this.handleOMObservationEnd(
+          event.cycleId,
+          event.durationMs,
+          event.tokensObserved,
+          event.observationTokens,
+          event.observations,
+          event.currentTask,
+          event.suggestedResponse,
+        );
+        break;
+
+      case 'om_observation_failed':
+        this.handleOMFailed(event.cycleId, event.error, 'observation');
+        break;
+
+      case 'om_reflection_start':
+        this.handleOMReflectionStart(event.cycleId, event.tokensToReflect);
+        break;
+      case 'om_reflection_end':
+        this.handleOMReflectionEnd(event.cycleId, event.durationMs, event.compressedTokens, event.observations);
+        break;
+      case 'om_reflection_failed':
+        this.handleOMFailed(event.cycleId, event.error, 'reflection');
+        break;
+      // Buffering lifecycle
+      case 'om_buffering_start':
+        if (event.operationType === 'observation') {
+          this.bufferingMessages = true;
+        } else {
+          this.bufferingObservations = true;
+        }
+        this.activeActivationMarker = undefined;
+        this.activeBufferingMarker = new OMMarkerComponent({
+          type: 'om_buffering_start',
+          operationType: event.operationType,
+          tokensToBuffer: event.tokensToBuffer,
+        });
+        this.addOMMarkerToChat(this.activeBufferingMarker);
+        this.updateStatusLine();
+        this.ui.requestRender();
+        break;
+      case 'om_buffering_end':
+        if (event.operationType === 'observation') {
+          this.bufferingMessages = false;
+        } else {
+          this.bufferingObservations = false;
+        }
+        if (this.activeBufferingMarker) {
+          this.activeBufferingMarker.update({
+            type: 'om_buffering_end',
+            operationType: event.operationType,
+            tokensBuffered: event.tokensBuffered,
+            bufferedTokens: event.bufferedTokens,
+            observations: event.observations,
+          });
+        }
+        this.activeBufferingMarker = undefined;
+        this.updateStatusLine();
+        this.ui.requestRender();
+        break;
+
+      case 'om_buffering_failed':
+        if (event.operationType === 'observation') {
+          this.bufferingMessages = false;
+        } else {
+          this.bufferingObservations = false;
+        }
+        if (this.activeBufferingMarker) {
+          this.activeBufferingMarker.update({
+            type: 'om_buffering_failed',
+            operationType: event.operationType,
+            error: event.error,
+          });
+        }
+        this.activeBufferingMarker = undefined;
+        this.updateStatusLine();
+        this.ui.requestRender();
+        break;
+      case 'om_activation':
+        if (event.operationType === 'observation') {
+          this.bufferingMessages = false;
+        } else {
+          this.bufferingObservations = false;
+        }
+        const activationData: OMMarkerData = {
+          type: 'om_activation',
+          operationType: event.operationType,
+          tokensActivated: event.tokensActivated,
+          observationTokens: event.observationTokens,
+        };
+        this.activeActivationMarker = new OMMarkerComponent(activationData);
+        this.addOMMarkerToChat(this.activeActivationMarker);
+        this.activeBufferingMarker = undefined;
+        this.updateStatusLine();
+        this.ui.requestRender();
+        break;
+
+      case 'follow_up_queued':
+        this.showInfo(`Follow-up queued (${event.count} pending)`);
+        break;
+
+      case 'workspace_ready':
+        // Workspace initialized successfully - silent unless verbose
+        break;
+
+      case 'workspace_error':
+        this.showError(`Workspace: ${event.error.message}`);
+        break;
+
+      case 'workspace_status_changed':
+        if (event.status === 'error' && event.error) {
+          this.showError(`Workspace: ${event.error.message}`);
+        }
+        break;
+
+      // Subagent / Task delegation events
+      case 'subagent_start':
+        this.handleSubagentStart(event.toolCallId, event.agentType, event.task, event.modelId);
+        break;
+
+      case 'subagent_tool_start':
+        this.handleSubagentToolStart(event.toolCallId, event.subToolName, event.subToolArgs);
+        break;
+
+      case 'subagent_tool_end':
+        this.handleSubagentToolEnd(event.toolCallId, event.subToolName, event.subToolResult, event.isError);
+        break;
+
+      case 'subagent_text_delta':
+        // Text deltas are streamed but we don't render them incrementally
+        // (the final result is shown via tool_end for the parent tool call)
+        break;
+
+      case 'subagent_end':
+        this.handleSubagentEnd(event.toolCallId, event.isError, event.durationMs, event.result);
+        break;
+
+      case 'todo_updated': {
+        const todos = event.todos as TodoItem[];
+        if (this.todoProgress) {
+          this.todoProgress.updateTodos(todos ?? []);
+
+          // Find the most recent todo_write tool component and get its position
+          let insertIndex = -1;
+          for (let i = this.allToolComponents.length - 1; i >= 0; i--) {
+            const comp = this.allToolComponents[i];
+            if ((comp as any).toolName === 'todo_write') {
+              insertIndex = this.chatContainer.children.indexOf(comp as any);
+              this.chatContainer.removeChild(comp as any);
+              this.allToolComponents.splice(i, 1);
+              break;
             }
+          }
+
+          // Check if all todos are completed
+          const allCompleted = todos && todos.length > 0 && todos.every(t => t.status === 'completed');
+          if (allCompleted) {
+            // Show collapsed completed list (pinned/live)
+            this.renderCompletedTodosInline(todos, insertIndex, true);
+          } else if (this.previousTodos.length > 0 && (!todos || todos.length === 0)) {
+            // Tasks were cleared
+            this.renderClearedTodosInline(this.previousTodos, insertIndex);
+          }
+
+          // Track for next diff
+          this.previousTodos = todos ? [...todos] : [];
+
+          this.ui.requestRender();
         }
-		if (lastToolIndex === -1) {
-			// No tool calls — return all content
-			return message.content
-		}
-		// Return everything after the last tool-related part
-		return message.content.slice(lastToolIndex + 1)
-	}
-	/**
-	 * Get content parts between the last processed tool call and this one (text/thinking only).
-	 */
-	private getContentBeforeToolCall(
-		message: HarnessMessage,
-		toolCallId: string,
-	): HarnessMessage["content"] {
-		const idx = message.content.findIndex(
-			(c) => c.type === "tool_call" && c.id === toolCallId,
-		)
-		if (idx === -1) return message.content
-        // Find the start: after the last tool_call/tool_result that we've already seen
-        let startIdx = 0
-        for (let i = idx - 1; i >= 0; i--) {
-            const c = message.content[i]!
-            if (
-                (c.type === "tool_call" && "id" in c && this.seenToolCallIds.has(c.id)) ||
-                (c.type === "tool_result" && "id" in c && this.seenToolCallIds.has(c.id))
-            ) {
-                startIdx = i + 1
-                break
+        break;
+      }
+
+      case 'ask_question':
+        await this.handleAskQuestion(event.questionId, event.question, event.options);
+        break;
+
+      case 'sandbox_access_request':
+        await this.handleSandboxAccessRequest(event.questionId, event.path, event.reason);
+        break;
+
+      case 'plan_approval_required':
+        await this.handlePlanApproval(event.planId, event.title, event.plan);
+        break;
+
+      case 'plan_approved':
+        // Handled directly in onApprove callback to ensure proper sequencing
+        break;
+    }
+  }
+
+  private handleUsageUpdate(usage: TokenUsage): void {
+    // Accumulate token usage
+    this.tokenUsage.promptTokens += usage.promptTokens;
+    this.tokenUsage.completionTokens += usage.completionTokens;
+    this.tokenUsage.totalTokens += usage.totalTokens;
+    this.updateStatusLine();
+  }
+
+  // ===========================================================================
+  // Status Line Reset
+  // ===========================================================================
+
+  /**
+   * Sync omProgress thresholds from harness state (thread metadata).
+   * Called after thread load to pick up per-thread threshold overrides.
+   */
+  private syncOMThresholdsFromHarness(): void {
+    const obsThreshold = this.harness.getObservationThreshold();
+    const refThreshold = this.harness.getReflectionThreshold();
+    this.omProgress.threshold = obsThreshold;
+    this.omProgress.thresholdPercent = obsThreshold > 0 ? (this.omProgress.pendingTokens / obsThreshold) * 100 : 0;
+    this.omProgress.reflectionThreshold = refThreshold;
+    this.omProgress.reflectionThresholdPercent =
+      refThreshold > 0 ? (this.omProgress.observationTokens / refThreshold) * 100 : 0;
+    this.updateStatusLine();
+  }
+  private resetStatusLineState(): void {
+    const prev = this.omProgress;
+    this.omProgress = {
+      ...defaultOMProgressState(),
+      // Preserve thresholds across resets
+      threshold: prev.threshold,
+      reflectionThreshold: prev.reflectionThreshold,
+    };
+    this.tokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+    this.bufferingMessages = false;
+    this.bufferingObservations = false;
+    this.updateStatusLine();
+  }
+
+  // ===========================================================================
+  // Observational Memory Event Handlers
+  // ===========================================================================
+
+  /**
+   * Add an OM marker to the chat container, inserting it *before* the
+   * current streaming component so it doesn't get pushed down as text
+   * streams in.  Falls back to a normal append when nothing is streaming.
+   */
+  private addOMMarkerToChat(marker: OMMarkerComponent): void {
+    if (this.streamingComponent) {
+      const idx = this.chatContainer.children.indexOf(this.streamingComponent);
+      if (idx >= 0) {
+        this.chatContainer.children.splice(idx, 0, marker);
+        this.chatContainer.invalidate();
+        return;
+      }
+    }
+    this.chatContainer.addChild(marker);
+  }
+
+  private addOMOutputToChat(output: OMOutputComponent): void {
+    if (this.streamingComponent) {
+      const idx = this.chatContainer.children.indexOf(this.streamingComponent);
+      if (idx >= 0) {
+        this.chatContainer.children.splice(idx, 0, output);
+        this.chatContainer.invalidate();
+        return;
+      }
+    }
+    this.chatContainer.addChild(output);
+  }
+  private handleOMStatus(event: Extract<HarnessEvent, { type: 'om_status' }>): void {
+    const { windows, generationCount, stepNumber } = event;
+    const { active, buffered } = windows;
+
+    // Update active window state
+    this.omProgress.pendingTokens = active.messages.tokens;
+    this.omProgress.threshold = active.messages.threshold;
+    this.omProgress.thresholdPercent =
+      active.messages.threshold > 0 ? (active.messages.tokens / active.messages.threshold) * 100 : 0;
+    this.omProgress.observationTokens = active.observations.tokens;
+    this.omProgress.reflectionThreshold = active.observations.threshold;
+    this.omProgress.reflectionThresholdPercent =
+      active.observations.threshold > 0 ? (active.observations.tokens / active.observations.threshold) * 100 : 0;
+
+    // Update buffered state
+    this.omProgress.buffered = {
+      observations: { ...buffered.observations },
+      reflection: { ...buffered.reflection },
+    };
+    this.omProgress.generationCount = generationCount;
+    this.omProgress.stepNumber = stepNumber;
+
+    // Drive buffering animation from status fields
+    this.bufferingMessages = buffered.observations.status === 'running';
+    this.bufferingObservations = buffered.reflection.status === 'running';
+
+    this.updateStatusLine();
+  }
+
+  private handleOMObservationStart(cycleId: string, tokensToObserve: number): void {
+    this.omProgress.status = 'observing';
+    this.omProgress.cycleId = cycleId;
+    this.omProgress.startTime = Date.now();
+    // Show in-progress marker in chat
+    this.activeOMMarker = new OMMarkerComponent({
+      type: 'om_observation_start',
+      tokensToObserve,
+      operationType: 'observation',
+    });
+    this.addOMMarkerToChat(this.activeOMMarker);
+    this.updateStatusLine();
+    this.ui.requestRender();
+  }
+  private handleOMObservationEnd(
+    _cycleId: string,
+    durationMs: number,
+    tokensObserved: number,
+    observationTokens: number,
+    observations?: string,
+    currentTask?: string,
+    suggestedResponse?: string,
+  ): void {
+    this.omProgress.status = 'idle';
+    this.omProgress.cycleId = undefined;
+    this.omProgress.startTime = undefined;
+    this.omProgress.observationTokens = observationTokens;
+    // Messages have been observed — reset pending tokens
+    this.omProgress.pendingTokens = 0;
+    this.omProgress.thresholdPercent = 0;
+    // Remove in-progress marker — the output box replaces it
+    if (this.activeOMMarker) {
+      const idx = this.chatContainer.children.indexOf(this.activeOMMarker);
+      if (idx >= 0) {
+        this.chatContainer.children.splice(idx, 1);
+        this.chatContainer.invalidate();
+      }
+      this.activeOMMarker = undefined;
+    }
+    // Show observation output in a bordered box (includes marker info in footer)
+    const outputComponent = new OMOutputComponent({
+      type: 'observation',
+      observations: observations ?? '',
+      currentTask,
+      suggestedResponse,
+      durationMs,
+      tokensObserved,
+      observationTokens,
+    });
+    this.addOMOutputToChat(outputComponent);
+    this.updateStatusLine();
+    this.ui.requestRender();
+  }
+
+  private handleOMReflectionStart(cycleId: string, tokensToReflect: number): void {
+    this.omProgress.status = 'reflecting';
+    this.omProgress.cycleId = cycleId;
+    this.omProgress.startTime = Date.now();
+    // Update observation tokens to show the total being reflected
+    this.omProgress.observationTokens = tokensToReflect;
+    this.omProgress.reflectionThresholdPercent =
+      this.omProgress.reflectionThreshold > 0 ? (tokensToReflect / this.omProgress.reflectionThreshold) * 100 : 0;
+    // Show in-progress marker in chat
+    this.activeOMMarker = new OMMarkerComponent({
+      type: 'om_observation_start',
+      tokensToObserve: tokensToReflect,
+      operationType: 'reflection',
+    });
+    this.addOMMarkerToChat(this.activeOMMarker);
+    this.updateStatusLine();
+    this.ui.requestRender();
+  }
+  private handleOMReflectionEnd(
+    _cycleId: string,
+    durationMs: number,
+    compressedTokens: number,
+    observations?: string,
+  ): void {
+    // Capture the pre-compression observation tokens for the marker display
+    const preCompressionTokens = this.omProgress.observationTokens;
+    this.omProgress.status = 'idle';
+    this.omProgress.cycleId = undefined;
+    this.omProgress.startTime = undefined;
+    // Observations were compressed — update token count
+    this.omProgress.observationTokens = compressedTokens;
+    this.omProgress.reflectionThresholdPercent =
+      this.omProgress.reflectionThreshold > 0 ? (compressedTokens / this.omProgress.reflectionThreshold) * 100 : 0;
+    // Remove in-progress marker — the output box replaces it
+    if (this.activeOMMarker) {
+      const idx = this.chatContainer.children.indexOf(this.activeOMMarker);
+      if (idx >= 0) {
+        this.chatContainer.children.splice(idx, 1);
+        this.chatContainer.invalidate();
+      }
+      this.activeOMMarker = undefined;
+    }
+    // Show reflection output in a bordered box (includes marker info in footer)
+    const outputComponent = new OMOutputComponent({
+      type: 'reflection',
+      observations: observations ?? '',
+      durationMs,
+      compressedTokens,
+      tokensObserved: preCompressionTokens,
+    });
+    this.addOMOutputToChat(outputComponent);
+    // Revert spinner to "Working..."
+    this.updateLoaderText('Working...');
+    this.ui.requestRender();
+    this.updateStatusLine();
+  }
+
+  private handleOMFailed(_cycleId: string, error: string, operation: 'observation' | 'reflection'): void {
+    this.omProgress.status = 'idle';
+    this.omProgress.cycleId = undefined;
+    this.omProgress.startTime = undefined;
+    // Update existing marker in-place, or create new one
+    const failData: OMMarkerData = {
+      type: 'om_observation_failed',
+      error,
+      operationType: operation,
+    };
+    if (this.activeOMMarker) {
+      this.activeOMMarker.update(failData);
+      this.activeOMMarker = undefined;
+    } else {
+      this.addOMMarkerToChat(new OMMarkerComponent(failData));
+    }
+    this.updateStatusLine();
+    this.ui.requestRender();
+  }
+
+  /** Update the loading animation text (e.g., "Working..." → "Observing...") */
+  private updateLoaderText(_text: string): void {
+    // Status text changes are now reflected via updateStatusLine gradient
+    this.updateStatusLine();
+  }
+
+  private handleAgentStart(): void {
+    this.isAgentActive = true;
+    if (!this.gradientAnimator) {
+      this.gradientAnimator = new GradientAnimator(() => {
+        this.updateStatusLine();
+      });
+    }
+    this.gradientAnimator.start();
+    this.updateStatusLine();
+  }
+  private handleAgentEnd(): void {
+    this.isAgentActive = false;
+    if (this.gradientAnimator) {
+      this.gradientAnimator.fadeOut();
+    }
+    this.updateStatusLine();
+
+    if (this.streamingComponent) {
+      this.streamingComponent = undefined;
+      this.streamingMessage = undefined;
+    }
+    this.followUpComponents = [];
+    this.pendingTools.clear();
+    // Keep allToolComponents so Ctrl+E continues to work after agent completes
+
+    this.notify('agent_done');
+  }
+
+  private handleAgentAborted(): void {
+    this.isAgentActive = false;
+    if (this.gradientAnimator) {
+      this.gradientAnimator.fadeOut();
+    }
+    this.updateStatusLine();
+
+    // Update streaming message to show it was interrupted
+    if (this.streamingComponent && this.streamingMessage) {
+      this.streamingMessage.stopReason = 'aborted';
+      this.streamingMessage.errorMessage = 'Interrupted';
+      this.streamingComponent.updateContent(this.streamingMessage);
+      this.streamingComponent = undefined;
+      this.streamingMessage = undefined;
+    } else if (this.userInitiatedAbort) {
+      // Show standalone "Interrupted" if user pressed Ctrl+C but no streaming component
+      this.chatContainer.addChild(new Spacer(1));
+      this.chatContainer.addChild(new Text(theme.fg('error', 'Interrupted'), 1, 0));
+    }
+    this.userInitiatedAbort = false;
+
+    this.followUpComponents = [];
+    this.pendingTools.clear();
+    // Keep allToolComponents so Ctrl+E continues to work after interruption
+    this.ui.requestRender();
+  }
+
+  private handleAgentError(): void {
+    this.isAgentActive = false;
+    if (this.gradientAnimator) {
+      this.gradientAnimator.fadeOut();
+    }
+    this.updateStatusLine();
+
+    if (this.streamingComponent) {
+      this.streamingComponent = undefined;
+      this.streamingMessage = undefined;
+    }
+
+    this.followUpComponents = [];
+    this.pendingTools.clear();
+    // Keep allToolComponents so Ctrl+E continues to work after errors
+  }
+
+  private handleMessageStart(message: HarnessMessage): void {
+    if (message.role === 'user') {
+      this.addUserMessage(message);
+    } else if (message.role === 'assistant') {
+      // Clear tool component references when starting a new assistant message
+      this.lastAskUserComponent = undefined;
+      this.lastSubmitPlanComponent = undefined;
+      if (!this.streamingComponent) {
+        this.streamingComponent = new AssistantMessageComponent(undefined, this.hideThinkingBlock, getMarkdownTheme());
+        this.addChildBeforeFollowUps(this.streamingComponent);
+        this.streamingMessage = message;
+        const trailingParts = this.getTrailingContentParts(message);
+        this.streamingComponent.updateContent({
+          ...message,
+          content: trailingParts,
+        });
+      }
+      this.ui.requestRender();
+    }
+  }
+
+  private handleMessageUpdate(message: HarnessMessage): void {
+    if (!this.streamingComponent || message.role !== 'assistant') return;
+
+    this.streamingMessage = message;
+    // Check for new tool calls
+    for (const content of message.content) {
+      if (content.type === 'tool_call') {
+        // For subagent calls, freeze the current streaming component
+        // with content before the tool call, then create a new one.
+        // SubagentExecutionComponent handles the visual rendering.
+        // Check subagentToolCallIds separately since handleToolStart
+        // may have already added the ID to seenToolCallIds.
+        if (content.name === 'subagent' && !this.subagentToolCallIds.has(content.id)) {
+          this.seenToolCallIds.add(content.id);
+          this.subagentToolCallIds.add(content.id);
+          // Freeze current component with pre-subagent content
+          const preContent = this.getContentBeforeToolCall(message, content.id);
+          this.streamingComponent.updateContent({
+            ...message,
+            content: preContent,
+          });
+          this.streamingComponent = new AssistantMessageComponent(
+            undefined,
+            this.hideThinkingBlock,
+            getMarkdownTheme(),
+          );
+          this.addChildBeforeFollowUps(this.streamingComponent);
+          continue;
+        }
+
+        if (!this.seenToolCallIds.has(content.id)) {
+          this.seenToolCallIds.add(content.id);
+
+          this.addChildBeforeFollowUps(new Text('', 0, 0));
+          const component = new ToolExecutionComponentEnhanced(
+            content.name,
+            content.args,
+            { showImages: false, collapsedByDefault: !this.toolOutputExpanded },
+            this.ui,
+          );
+          component.setExpanded(this.toolOutputExpanded);
+          this.addChildBeforeFollowUps(component);
+          this.pendingTools.set(content.id, component);
+          this.allToolComponents.push(component);
+
+          this.streamingComponent = new AssistantMessageComponent(
+            undefined,
+            this.hideThinkingBlock,
+            getMarkdownTheme(),
+          );
+          this.addChildBeforeFollowUps(this.streamingComponent);
+        } else {
+          const component = this.pendingTools.get(content.id);
+          if (component) {
+            component.updateArgs(content.args);
+          }
+        }
+      }
+    }
+
+    const trailingParts = this.getTrailingContentParts(message);
+    this.streamingComponent.updateContent({
+      ...message,
+      content: trailingParts,
+    });
+
+    this.ui.requestRender();
+  }
+
+  /**
+   * Get content parts after the last tool_call/tool_result in the message.
+   * These are the parts that should be rendered in the current streaming component.
+   */
+  private getTrailingContentParts(message: HarnessMessage): HarnessMessage['content'] {
+    let lastToolIndex = -1;
+    for (let i = message.content.length - 1; i >= 0; i--) {
+      const c = message.content[i]!;
+      if (c.type === 'tool_call' || c.type === 'tool_result') {
+        lastToolIndex = i;
+        break;
+      }
+    }
+    if (lastToolIndex === -1) {
+      // No tool calls — return all content
+      return message.content;
+    }
+    // Return everything after the last tool-related part
+    return message.content.slice(lastToolIndex + 1);
+  }
+  /**
+   * Get content parts between the last processed tool call and this one (text/thinking only).
+   */
+  private getContentBeforeToolCall(message: HarnessMessage, toolCallId: string): HarnessMessage['content'] {
+    const idx = message.content.findIndex(c => c.type === 'tool_call' && c.id === toolCallId);
+    if (idx === -1) return message.content;
+    // Find the start: after the last tool_call/tool_result that we've already seen
+    let startIdx = 0;
+    for (let i = idx - 1; i >= 0; i--) {
+      const c = message.content[i]!;
+      if (
+        (c.type === 'tool_call' && 'id' in c && this.seenToolCallIds.has(c.id)) ||
+        (c.type === 'tool_result' && 'id' in c && this.seenToolCallIds.has(c.id))
+      ) {
+        startIdx = i + 1;
+        break;
+      }
+    }
+
+    return message.content.slice(startIdx, idx).filter(c => c.type === 'text' || c.type === 'thinking');
+  }
+
+  private handleMessageEnd(message: HarnessMessage): void {
+    if (message.role === 'user') return;
+
+    if (this.streamingComponent && message.role === 'assistant') {
+      this.streamingMessage = message;
+      const trailingParts = this.getTrailingContentParts(message);
+      this.streamingComponent.updateContent({
+        ...message,
+        content: trailingParts,
+      });
+
+      if (message.stopReason === 'aborted' || message.stopReason === 'error') {
+        const errorMessage = message.errorMessage || 'Operation aborted';
+        for (const [, component] of this.pendingTools) {
+          component.updateResult({
+            content: [{ type: 'text', text: errorMessage }],
+            isError: true,
+          });
+        }
+        this.pendingTools.clear();
+      }
+
+      this.streamingComponent = undefined;
+      this.streamingMessage = undefined;
+      this.seenToolCallIds.clear();
+      this.subagentToolCallIds.clear();
+    }
+    this.ui.requestRender();
+  }
+  /**
+   * Insert a child into the chat container before any follow-up user messages.
+   * If no follow-ups are pending, appends to end.
+   */
+  private addChildBeforeFollowUps(child: Component): void {
+    if (this.followUpComponents.length > 0) {
+      const firstFollowUp = this.followUpComponents[0];
+      const idx = this.chatContainer.children.indexOf(firstFollowUp as any);
+      if (idx >= 0) {
+        (this.chatContainer.children as unknown[]).splice(idx, 0, child);
+        this.chatContainer.invalidate();
+        return;
+      }
+    }
+    this.chatContainer.addChild(child);
+  }
+  private handleToolApprovalRequired(toolCallId: string, toolName: string, args: unknown): void {
+    // Compute category label for the dialog
+    const category = getToolCategory(toolName);
+    const categoryLabel = category ? TOOL_CATEGORIES[category]?.label : undefined;
+
+    // Send notification to alert the user
+    this.notify('tool_approval', `Approve ${toolName}?`);
+
+    const dialog = new ToolApprovalDialogComponent({
+      toolCallId,
+      toolName,
+      args,
+      categoryLabel,
+      onAction: (action: ApprovalAction) => {
+        this.ui.hideOverlay();
+        this.pendingApprovalDismiss = null;
+        if (action.type === 'approve') {
+          this.harness.resolveToolApprovalDecision('approve');
+        } else if (action.type === 'always_allow_category') {
+          this.harness.resolveToolApprovalDecision('always_allow_category');
+        } else if (action.type === 'yolo') {
+          this.harness.setYoloMode(true);
+          this.harness.resolveToolApprovalDecision('approve');
+          this.updateStatusLine();
+        } else {
+          this.harness.resolveToolApprovalDecision('decline');
+        }
+      },
+    });
+
+    // Set up Ctrl+C dismiss to decline
+    this.pendingApprovalDismiss = () => {
+      this.ui.hideOverlay();
+      this.pendingApprovalDismiss = null;
+      this.harness.resolveToolApprovalDecision('decline');
+    };
+
+    // Show the dialog as an overlay
+    this.ui.showOverlay(dialog, {
+      width: '70%',
+      anchor: 'center',
+    });
+    dialog.focused = true;
+    this.ui.requestRender();
+  }
+
+  private handleToolStart(toolCallId: string, toolName: string, args: unknown): void {
+    if (!this.seenToolCallIds.has(toolCallId)) {
+      this.seenToolCallIds.add(toolCallId);
+
+      // Skip creating the regular tool component for subagent calls
+      // The SubagentExecutionComponent will handle all the rendering
+      if (toolName === 'subagent') {
+        return;
+      }
+
+      this.addChildBeforeFollowUps(new Text('', 0, 0));
+      const component = new ToolExecutionComponentEnhanced(
+        toolName,
+        args,
+        { showImages: false, collapsedByDefault: !this.toolOutputExpanded },
+        this.ui,
+      );
+      component.setExpanded(this.toolOutputExpanded);
+      this.addChildBeforeFollowUps(component);
+      this.pendingTools.set(toolCallId, component);
+      this.allToolComponents.push(component);
+
+      // Track ask_user tool components for inline question placement
+      if (toolName === 'ask_user') {
+        this.lastAskUserComponent = component;
+      }
+      // Track submit_plan tool components for inline plan approval placement
+      if (toolName === 'submit_plan') {
+        this.lastSubmitPlanComponent = component;
+      }
+
+      // Track file-modifying tools for /diff command
+      const FILE_TOOLS = ['string_replace_lsp', 'write_file', 'ast_smart_edit'];
+      if (FILE_TOOLS.includes(toolName)) {
+        const toolArgs = args as Record<string, unknown>;
+        const filePath = toolArgs?.path as string;
+        if (filePath) {
+          this.pendingFileTools.set(toolCallId, { toolName, filePath });
+        }
+      }
+
+      // Create a new post-tool AssistantMessageComponent so pre-tool text is preserved
+      this.streamingComponent = new AssistantMessageComponent(undefined, this.hideThinkingBlock, getMarkdownTheme());
+      this.addChildBeforeFollowUps(this.streamingComponent);
+
+      this.ui.requestRender();
+    }
+  }
+
+  private handleToolUpdate(toolCallId: string, partialResult: unknown): void {
+    const component = this.pendingTools.get(toolCallId);
+    if (component) {
+      const result: ToolResult = {
+        content: [{ type: 'text', text: this.formatToolResult(partialResult) }],
+        isError: false,
+      };
+      component.updateResult(result, true);
+      this.ui.requestRender();
+    }
+  }
+
+  /**
+   * Handle streaming shell output from execute_command tool.
+   */
+  private handleShellOutput(toolCallId: string, output: string, _stream: 'stdout' | 'stderr'): void {
+    const component = this.pendingTools.get(toolCallId);
+    if (component?.appendStreamingOutput) {
+      component.appendStreamingOutput(output);
+      this.ui.requestRender();
+    }
+  }
+
+  /**
+   * Handle an ask_question event from the ask_user tool.
+   * Shows a dialog overlay and resolves the tool's pending promise.
+   */
+  private async handleAskQuestion(
+    questionId: string,
+    question: string,
+    options?: Array<{ label: string; description?: string }>,
+  ): Promise<void> {
+    return new Promise(resolve => {
+      if (this.options.inlineQuestions) {
+        // Inline mode: Add question component to chat
+        const questionComponent = new AskQuestionInlineComponent(
+          {
+            question,
+            options,
+            onSubmit: answer => {
+              this.activeInlineQuestion = undefined;
+              this.harness.respondToQuestion(questionId, answer);
+              resolve();
+            },
+            onCancel: () => {
+              this.activeInlineQuestion = undefined;
+              this.harness.respondToQuestion(questionId, '(skipped)');
+              resolve();
+            },
+          },
+          this.ui,
+        );
+
+        // Store as active question
+        this.activeInlineQuestion = questionComponent;
+
+        // Insert the question right after the ask_user tool component
+        if (this.lastAskUserComponent) {
+          // Find the position of the ask_user component
+          const children = [...this.chatContainer.children];
+          // Since lastAskUserComponent extends Container, it should be in children
+          const askUserIndex = children.indexOf(this.lastAskUserComponent as any);
+
+          if (askUserIndex >= 0) {
+            // Debug: Log the positioning
+
+            // Clear and rebuild with question in the right place
+            this.chatContainer.clear();
+            // Add all children up to and including the ask_user tool
+            for (let i = 0; i <= askUserIndex; i++) {
+              this.chatContainer.addChild(children[i]!);
             }
+
+            // Add the question component with spacing
+            this.chatContainer.addChild(new Spacer(1));
+            this.chatContainer.addChild(questionComponent);
+            this.chatContainer.addChild(new Spacer(1));
+
+            // Add remaining children
+            for (let i = askUserIndex + 1; i < children.length; i++) {
+              this.chatContainer.addChild(children[i]!);
+            }
+          } else {
+            // Fallback: add at the end
+            this.chatContainer.addChild(new Spacer(1));
+            this.chatContainer.addChild(questionComponent);
+            this.chatContainer.addChild(new Spacer(1));
+          }
+        } else {
+          // Fallback: add at the end if no ask_user component tracked
+          this.chatContainer.addChild(new Spacer(1));
+          this.chatContainer.addChild(questionComponent);
+          this.chatContainer.addChild(new Spacer(1));
         }
 
-		return message.content
-			.slice(startIdx, idx)
-			.filter((c) => c.type === "text" || c.type === "thinking")
-	}
-
-	private handleMessageEnd(message: HarnessMessage): void {
-		if (message.role === "user") return
-
-		if (this.streamingComponent && message.role === "assistant") {
-			this.streamingMessage = message
-			const trailingParts = this.getTrailingContentParts(message)
-			this.streamingComponent.updateContent({
-				...message,
-				content: trailingParts,
-			})
-
-			if (message.stopReason === "aborted" || message.stopReason === "error") {
-				const errorMessage = message.errorMessage || "Operation aborted"
-				for (const [, component] of this.pendingTools) {
-					component.updateResult({
-						content: [{ type: "text", text: errorMessage }],
-						isError: true,
-					})
-				}
-				this.pendingTools.clear()
-			}
-
-			this.streamingComponent = undefined
-			this.streamingMessage = undefined
-			this.seenToolCallIds.clear()
-			this.subagentToolCallIds.clear()
-		}
-		this.ui.requestRender()
-	}
-	/**
-	 * Insert a child into the chat container before any follow-up user messages.
-	 * If no follow-ups are pending, appends to end.
-	 */
-	private addChildBeforeFollowUps(child: Component): void {
-		if (this.followUpComponents.length > 0) {
-			const firstFollowUp = this.followUpComponents[0]
-			const idx = this.chatContainer.children.indexOf(firstFollowUp as any)
-			if (idx >= 0) {
-				;(this.chatContainer.children as unknown[]).splice(idx, 0, child)
-				this.chatContainer.invalidate()
-				return
-			}
-		}
-		this.chatContainer.addChild(child)
-	}
-	private handleToolApprovalRequired(
-		toolCallId: string,
-		toolName: string,
-		args: unknown,
-	): void {
-		// Compute category label for the dialog
-		const category = getToolCategory(toolName)
-		const categoryLabel = category
-			? TOOL_CATEGORIES[category]?.label
-			: undefined
-
-		// Send notification to alert the user
-		this.notify("tool_approval", `Approve ${toolName}?`)
-
-		const dialog = new ToolApprovalDialogComponent({
-			toolCallId,
-			toolName,
-			args,
-			categoryLabel,
-			onAction: (action: ApprovalAction) => {
-				this.ui.hideOverlay()
-				this.pendingApprovalDismiss = null
-				if (action.type === "approve") {
-					this.harness.resolveToolApprovalDecision("approve")
-				} else if (action.type === "always_allow_category") {
-					this.harness.resolveToolApprovalDecision("always_allow_category")
-				} else if (action.type === "yolo") {
-					this.harness.setYoloMode(true)
-					this.harness.resolveToolApprovalDecision("approve")
-					this.updateStatusLine()
-				} else {
-					this.harness.resolveToolApprovalDecision("decline")
-				}
-			},
-		})
-
-		// Set up Ctrl+C dismiss to decline
-		this.pendingApprovalDismiss = () => {
-			this.ui.hideOverlay()
-			this.pendingApprovalDismiss = null
-			this.harness.resolveToolApprovalDecision("decline")
-		}
-
-		// Show the dialog as an overlay
-		this.ui.showOverlay(dialog, {
-			width: "70%",
-			anchor: "center",
-		})
-		dialog.focused = true
-		this.ui.requestRender()
-	}
-
-	private handleToolStart(
-		toolCallId: string,
-		toolName: string,
-		args: unknown,
-	): void {
-		if (!this.seenToolCallIds.has(toolCallId)) {
-			this.seenToolCallIds.add(toolCallId)
-
-			// Skip creating the regular tool component for subagent calls
-			// The SubagentExecutionComponent will handle all the rendering
-			if (toolName === "subagent") {
-				return
-			}
-
-			this.addChildBeforeFollowUps(new Text("", 0, 0))
-			const component = new ToolExecutionComponentEnhanced(
-				toolName,
-				args,
-				{ showImages: false, collapsedByDefault: !this.toolOutputExpanded },
-				this.ui,
-			)
-			component.setExpanded(this.toolOutputExpanded)
-			this.addChildBeforeFollowUps(component)
-			this.pendingTools.set(toolCallId, component)
-			this.allToolComponents.push(component)
-
-			// Track ask_user tool components for inline question placement
-			if (toolName === "ask_user") {
-				this.lastAskUserComponent = component
-			}
-			// Track submit_plan tool components for inline plan approval placement
-			if (toolName === "submit_plan") {
-				this.lastSubmitPlanComponent = component
-			}
-
-			// Track file-modifying tools for /diff command
-			const FILE_TOOLS = ["string_replace_lsp", "write_file", "ast_smart_edit"]
-			if (FILE_TOOLS.includes(toolName)) {
-				const toolArgs = args as Record<string, unknown>
-				const filePath = toolArgs?.path as string
-				if (filePath) {
-					this.pendingFileTools.set(toolCallId, { toolName, filePath })
-				}
-			}
-
-			// Create a new post-tool AssistantMessageComponent so pre-tool text is preserved
-			this.streamingComponent = new AssistantMessageComponent(
-				undefined,
-				this.hideThinkingBlock,
-				getMarkdownTheme(),
-			)
-			this.addChildBeforeFollowUps(this.streamingComponent)
-
-			this.ui.requestRender()
-		}
-	}
-
-	private handleToolUpdate(toolCallId: string, partialResult: unknown): void {
-		const component = this.pendingTools.get(toolCallId)
-		if (component) {
-			const result: ToolResult = {
-				content: [{ type: "text", text: this.formatToolResult(partialResult) }],
-				isError: false,
-			}
-			component.updateResult(result, true)
-			this.ui.requestRender()
-		}
-	}
-
-	/**
-	 * Handle streaming shell output from execute_command tool.
-	 */
-	private handleShellOutput(
-		toolCallId: string,
-		output: string,
-		_stream: "stdout" | "stderr",
-	): void {
-		const component = this.pendingTools.get(toolCallId)
-		if (component?.appendStreamingOutput) {
-			component.appendStreamingOutput(output)
-			this.ui.requestRender()
-		}
-	}
-
-	/**
-	 * Handle an ask_question event from the ask_user tool.
-	 * Shows a dialog overlay and resolves the tool's pending promise.
-	 */
-	private async handleAskQuestion(
-		questionId: string,
-		question: string,
-		options?: Array<{ label: string; description?: string }>,
-	): Promise<void> {
-		return new Promise((resolve) => {
-			if (this.options.inlineQuestions) {
-				// Inline mode: Add question component to chat
-				const questionComponent = new AskQuestionInlineComponent(
-					{
-						question,
-						options,
-						onSubmit: (answer) => {
-							this.activeInlineQuestion = undefined
-							this.harness.respondToQuestion(questionId, answer)
-							resolve()
-						},
-						onCancel: () => {
-							this.activeInlineQuestion = undefined
-							this.harness.respondToQuestion(questionId, "(skipped)")
-							resolve()
-						},
-					},
-					this.ui,
-				)
-
-				// Store as active question
-				this.activeInlineQuestion = questionComponent
-
-				// Insert the question right after the ask_user tool component
-				if (this.lastAskUserComponent) {
-					// Find the position of the ask_user component
-					const children = [...this.chatContainer.children]
-					// Since lastAskUserComponent extends Container, it should be in children
-					const askUserIndex = children.indexOf(
-						this.lastAskUserComponent as any,
-					)
-
-					if (askUserIndex >= 0) {
-						// Debug: Log the positioning
-
-						// Clear and rebuild with question in the right place
-						this.chatContainer.clear()
-                        // Add all children up to and including the ask_user tool
-                        for (let i = 0; i <= askUserIndex; i++) {
-                            this.chatContainer.addChild(children[i]!)
-                        }
-
-                        // Add the question component with spacing
-                        this.chatContainer.addChild(new Spacer(1))
-                        this.chatContainer.addChild(questionComponent)
-                        this.chatContainer.addChild(new Spacer(1))
-
-                        // Add remaining children
-                        for (let i = askUserIndex + 1; i < children.length; i++) {
-                            this.chatContainer.addChild(children[i]!)
-                        }
-					} else {
-						// Fallback: add at the end
-						this.chatContainer.addChild(new Spacer(1))
-						this.chatContainer.addChild(questionComponent)
-						this.chatContainer.addChild(new Spacer(1))
-					}
-				} else {
-					// Fallback: add at the end if no ask_user component tracked
-					this.chatContainer.addChild(new Spacer(1))
-					this.chatContainer.addChild(questionComponent)
-					this.chatContainer.addChild(new Spacer(1))
-				}
-
-				this.ui.requestRender()
-
-				// Ensure the chat scrolls to show the question
-				this.chatContainer.invalidate()
-
-				// Focus the question component
-				questionComponent.focused = true
-			} else {
-				// Dialog mode: Show overlay
-				const dialog = new AskQuestionDialogComponent({
-					question,
-					options,
-					onSubmit: (answer) => {
-						this.ui.hideOverlay()
-						this.harness.respondToQuestion(questionId, answer)
-						resolve()
-					},
-					onCancel: () => {
-						this.ui.hideOverlay()
-						this.harness.respondToQuestion(questionId, "(skipped)")
-						resolve()
-					},
-				})
-				this.ui.showOverlay(dialog, { width: "70%", anchor: "center" })
-				dialog.focused = true
-			}
-
-			this.notify("ask_question", question)
-		})
-	}
-
-	/**
-	 * Handle a sandbox_access_request event from the request_sandbox_access tool.
-	 * Shows an inline prompt for the user to approve or deny directory access.
-	 */
-	private async handleSandboxAccessRequest(
-		questionId: string,
-		requestedPath: string,
-		reason: string,
-	): Promise<void> {
-		return new Promise((resolve) => {
-			const questionComponent = new AskQuestionInlineComponent(
-				{
-					question: `Grant sandbox access to "${requestedPath}"?\n${fg("dim", `Reason: ${reason}`)}`,
-					options: [
-						{ label: "Yes", description: "Allow access to this directory" },
-						{ label: "No", description: "Deny access" },
-					],
-					onSubmit: (answer) => {
-						this.activeInlineQuestion = undefined
-						this.harness.respondToQuestion(questionId, answer)
-						resolve()
-					},
-					onCancel: () => {
-						this.activeInlineQuestion = undefined
-						this.harness.respondToQuestion(questionId, "No")
-						resolve()
-					},
-					formatResult: (answer) => {
-						const approved = answer.toLowerCase().startsWith("y")
-						return approved
-							? `Granted access to ${requestedPath}`
-							: `Denied access to ${requestedPath}`
-					},
-					isNegativeAnswer: (answer) => !answer.toLowerCase().startsWith("y"),
-				},
-				this.ui,
-			)
-
-			// Store as active question so input routing works
-			this.activeInlineQuestion = questionComponent
-
-			// Add to chat
-			this.chatContainer.addChild(new Spacer(1))
-			this.chatContainer.addChild(questionComponent)
-			this.chatContainer.addChild(new Spacer(1))
-			this.ui.requestRender()
-			this.chatContainer.invalidate()
-
-			this.notify(
-				"sandbox_access",
-				`Sandbox access requested: ${requestedPath}`,
-			)
-		})
-	}
-
-	/**
-	 * Handle a plan_approval_required event from the submit_plan tool.
-	 * Shows the plan inline with Approve/Reject/Request Changes options.
-	 */
-	private async handlePlanApproval(
-		planId: string,
-		title: string,
-		plan: string,
-	): Promise<void> {
-		return new Promise((resolve) => {
-			const approvalComponent = new PlanApprovalInlineComponent(
-				{
-					planId,
-					title,
-					plan,
-					onApprove: async () => {
-						this.activeInlinePlanApproval = undefined
-						// Store the approved plan in harness state
-						await this.harness.setState({
-							activePlan: {
-								title,
-								plan,
-								approvedAt: new Date().toISOString(),
-							},
-						})
-						// Wait for plan approval to complete (switches mode, aborts stream)
-						await this.harness.respondToPlanApproval(planId, {
-							action: "approved",
-						})
-						this.updateStatusLine()
-
-						// Now that mode switch is complete, add system reminder and trigger build agent
-						// Use setTimeout to ensure the plan approval component has fully rendered
-						setTimeout(() => {
-							const reminderText =
-								"<system-reminder>The user has approved the plan, begin executing.</system-reminder>"
-							this.addUserMessage({
-								id: `system-${Date.now()}`,
-								role: "user",
-								content: [{ type: "text", text: reminderText }],
-								createdAt: new Date(),
-							})
-							this.fireMessage(reminderText)
-						}, 50)
-
-						resolve()
-					},
-					onReject: async (feedback?: string) => {
-						this.activeInlinePlanApproval = undefined
-						this.harness.respondToPlanApproval(planId, {
-							action: "rejected",
-							feedback,
-						})
-						resolve()
-					},
-				},
-				this.ui,
-			)
-
-			// Store as active plan approval
-			this.activeInlinePlanApproval = approvalComponent
-
-			// Insert after the submit_plan tool component (same pattern as ask_user)
-			if (this.lastSubmitPlanComponent) {
-				const children = [...this.chatContainer.children]
-				const submitPlanIndex = children.indexOf(
-					this.lastSubmitPlanComponent as any,
-				)
-                if (submitPlanIndex >= 0) {
-                    this.chatContainer.clear()
-                    for (let i = 0; i <= submitPlanIndex; i++) {
-                        this.chatContainer.addChild(children[i]!)
-                    }
-                    this.chatContainer.addChild(new Spacer(1))
-                    this.chatContainer.addChild(approvalComponent)
-                    this.chatContainer.addChild(new Spacer(1))
-                    for (let i = submitPlanIndex + 1; i < children.length; i++) {
-                        this.chatContainer.addChild(children[i]!)
-                    }
-				} else {
-					this.chatContainer.addChild(new Spacer(1))
-					this.chatContainer.addChild(approvalComponent)
-					this.chatContainer.addChild(new Spacer(1))
-				}
-			} else {
-				this.chatContainer.addChild(new Spacer(1))
-				this.chatContainer.addChild(approvalComponent)
-				this.chatContainer.addChild(new Spacer(1))
-			}
-			this.ui.requestRender()
-			this.chatContainer.invalidate()
-			approvalComponent.focused = true
-
-			this.notify("plan_approval", `Plan "${title}" requires approval`)
-		})
-	}
-	private handleToolEnd(
-		toolCallId: string,
-		result: unknown,
-		isError: boolean,
-	): void {
-		// If this is a subagent tool, store the result in the SubagentExecutionComponent
-		const subagentComponent = this.pendingSubagents.get(toolCallId)
-		if (subagentComponent) {
-			// The final result is available here
-			const resultText = this.formatToolResult(result)
-			// We'll need to wait for subagent_end to set this
-			// Store it temporarily
-			;(subagentComponent as any)._pendingResult = resultText
-		}
-
-		// Track successful file modifications for /diff command
-		const pendingFile = this.pendingFileTools.get(toolCallId)
-		if (pendingFile && !isError) {
-			const existing = this.modifiedFiles.get(pendingFile.filePath)
-			if (existing) {
-				existing.operations.push(pendingFile.toolName)
-			} else {
-				this.modifiedFiles.set(pendingFile.filePath, {
-					operations: [pendingFile.toolName],
-					firstModified: new Date(),
-				})
-			}
-		}
-		this.pendingFileTools.delete(toolCallId)
-
-		const component = this.pendingTools.get(toolCallId)
-		if (component) {
-			const toolResult: ToolResult = {
-				content: [{ type: "text", text: this.formatToolResult(result) }],
-				isError,
-			}
-			component.updateResult(toolResult, false)
-
-			this.pendingTools.delete(toolCallId)
-			this.ui.requestRender()
-		}
-	}
-
-	/**
-	 * Format a tool result for display.
-	 * Handles objects, strings, and other types.
-	 * Extracts content from common tool return structures like { content: "...", isError: false }
-	 */
-	private formatToolResult(result: unknown): string {
-		if (result === null || result === undefined) {
-			return ""
-		}
-		if (typeof result === "string") {
-			return result
-		}
-		if (typeof result === "object") {
-			const obj = result as Record<string, unknown>
-			// Handle common tool return format: { content: "...", isError: boolean }
-			if ("content" in obj && typeof obj.content === "string") {
-				return obj.content
-			}
-			// Handle content array format: { content: [{ type: "text", text: "..." }] }
-			if ("content" in obj && Array.isArray(obj.content)) {
-				const textParts = obj.content
-					.filter(
-						(part: unknown) =>
-							typeof part === "object" &&
-							part !== null &&
-							(part as Record<string, unknown>).type === "text",
-					)
-					.map((part: unknown) => (part as Record<string, unknown>).text || "")
-				if (textParts.length > 0) {
-					return textParts.join("\n")
-				}
-			}
-			try {
-				return JSON.stringify(result, null, 2)
-			} catch {
-				return String(result)
-			}
-		}
-		return String(result)
-	}
-
-	/**
-	 * Render a completed todo list inline in the chat history.
-	 * This mirrors the pinned TodoProgressComponent format but shows
-	 * all items as completed, since the pinned component hides itself
-	 * when everything is done.
-	 * @param todos The completed todo items
-	 * @param insertIndex Optional index to insert at (replaces tool component position)
-	 */
-	private renderCompletedTodosInline(
-		todos: TodoItem[],
-		insertIndex = -1,
-		collapsed = false,
-	): void {
-		const headerText =
-			bold(fg("accent", "Tasks")) +
-			fg("dim", ` [${todos.length}/${todos.length} completed]`)
-
-		const container = new Container()
-		container.addChild(new Spacer(1))
-		container.addChild(new Text(headerText, 0, 0))
-		const MAX_VISIBLE = 4
-		const shouldCollapse = collapsed && todos.length > MAX_VISIBLE + 1
-		const visible = shouldCollapse ? todos.slice(0, MAX_VISIBLE) : todos
-		const remaining = shouldCollapse ? todos.length - MAX_VISIBLE : 0
-
-		for (const todo of visible) {
-			const icon = chalk.hex(mastra.green)("✓")
-			const text = chalk.hex(mastra.green)(todo.content)
-			container.addChild(new Text(`  ${icon} ${text}`, 0, 0))
-		}
-		if (remaining > 0) {
-			container.addChild(
-				new Text(
-					fg(
-						"dim",
-						`  ... ${remaining} more completed task${remaining > 1 ? "s" : ""} (ctrl+e to expand)`,
-					),
-					0,
-					0,
-				),
-			)
-		}
-
-		if (insertIndex >= 0) {
-			// Insert at the position where the todo_write tool was
-			this.chatContainer.children.splice(insertIndex, 0, container)
-			this.chatContainer.invalidate()
-		} else {
-			// Fallback: append at end
-			this.chatContainer.addChild(container)
-		}
-	}
-
-	/**
-	 * Render inline display when tasks are cleared.
-	 * Shows what was cleared with strikethrough.
-	 */
-	private renderClearedTodosInline(
-		clearedTodos: TodoItem[],
-		insertIndex = -1,
-	): void {
-		const container = new Container()
-		container.addChild(new Spacer(1))
-		const count = clearedTodos.length
-		const label = count === 1 ? "Task" : "Tasks"
-		container.addChild(new Text(fg("accent", `${label} cleared`), 0, 0))
-		for (const todo of clearedTodos) {
-			const icon =
-				todo.status === "completed"
-					? chalk.hex(mastra.green)("✓")
-					: chalk.hex(mastra.darkGray)("○")
-			const text = chalk.dim.strikethrough(todo.content)
-			container.addChild(new Text(`  ${icon} ${text}`, 0, 0))
-		}
-		if (insertIndex >= 0) {
-			this.chatContainer.children.splice(insertIndex, 0, container)
-			this.chatContainer.invalidate()
-		} else {
-			this.chatContainer.addChild(container)
-		}
-	}
-	// ===========================================================================
-	// Subagent Events
-	// ===========================================================================
-
-	private handleSubagentStart(
-		toolCallId: string,
-		agentType: string,
-		task: string,
-		modelId?: string,
-	): void {
-		// Create a dedicated rendering component for this subagent run
-		const component = new SubagentExecutionComponent(
-			agentType,
-			task,
-			this.ui,
-			modelId,
-		)
-		this.pendingSubagents.set(toolCallId, component)
-		this.allToolComponents.push(component as any)
-
-		// Insert before the current streamingComponent so subagent box
-		// appears between pre-subagent text and post-subagent text
-		if (this.streamingComponent) {
-			const idx = this.chatContainer.children.indexOf(
-				this.streamingComponent as any,
-			)
-			if (idx >= 0) {
-				;(this.chatContainer.children as unknown[]).splice(idx, 0, component)
-				this.chatContainer.invalidate()
-			} else {
-				this.chatContainer.addChild(component)
-			}
-		} else {
-			this.chatContainer.addChild(component)
-		}
-
-		this.ui.requestRender()
-	}
-
-	private handleSubagentToolStart(
-		toolCallId: string,
-		subToolName: string,
-		subToolArgs: unknown,
-	): void {
-		const component = this.pendingSubagents.get(toolCallId)
-		if (component) {
-			component.addToolStart(subToolName, subToolArgs)
-			this.ui.requestRender()
-		}
-	}
-
-	private handleSubagentToolEnd(
-		toolCallId: string,
-		subToolName: string,
-		subToolResult: unknown,
-		isError: boolean,
-	): void {
-		const component = this.pendingSubagents.get(toolCallId)
-		if (component) {
-			component.addToolEnd(subToolName, subToolResult, isError)
-			this.ui.requestRender()
-		}
-	}
-
-	private handleSubagentEnd(
-		toolCallId: string,
-		isError: boolean,
-		durationMs: number,
-		result?: string,
-	): void {
-		const component = this.pendingSubagents.get(toolCallId)
-		if (component) {
-			component.finish(isError, durationMs, result)
-			this.pendingSubagents.delete(toolCallId)
-			this.ui.requestRender()
-		}
-	}
-
-	// ===========================================================================
-	// User Input
-	// ===========================================================================
-
-	private getUserInput(): Promise<string> {
-		return new Promise((resolve) => {
-			this.editor.onSubmit = (text: string) => {
-				// Add to history for arrow up/down navigation (skip empty)
-				if (text.trim()) {
-					this.editor.addToHistory(text)
-				}
-				this.editor.setText("")
-				resolve(text)
-			}
-		})
-	}
-
-	// ===========================================================================
-	// Thread Selector
-	// ===========================================================================
-
-	private async showThreadSelector(): Promise<void> {
-		const threads = await this.harness.listThreads({ allResources: true })
-		const currentId = this.pendingNewThread
-			? null
-			: this.harness.getCurrentThreadId()
-		const currentResourceId = this.harness.getResourceId()
-
-		if (threads.length === 0) {
-			this.showInfo("No threads yet. Send a message to create one.")
-			return
-		}
-
-		return new Promise((resolve) => {
-			const selector = new ThreadSelectorComponent({
-				tui: this.ui,
-				threads,
-				currentThreadId: currentId,
-				currentResourceId,
-				getMessagePreview: async (threadId: string) => {
-					const firstUserMessage =
-						await this.harness.getFirstUserMessageForThread(threadId)
-					if (firstUserMessage) {
-						const text = this.extractTextContent(firstUserMessage)
-						return this.truncatePreview(text)
-					}
-					return null
-				},
-				onSelect: async (thread) => {
-					this.ui.hideOverlay()
-
-					if (thread.id === currentId) {
-						resolve()
-						return
-					}
-
-					// If thread is from a different resource, switch resource first
-					if (thread.resourceId !== currentResourceId) {
-						this.harness.setResourceId(thread.resourceId)
-					}
-					try {
-						await this.harness.switchThread(thread.id)
-                    } catch (error) {
-                        if (error instanceof ThreadLockError) {
-                            this.showThreadLockPrompt(
-                                thread.title || thread.id,
-                                error.ownerPid,
-                            )
-                            resolve()
-                            return
-                        }
-                        throw error
-                    }
-					this.pendingNewThread = false
-
-					// Clear chat and render existing messages
-					this.chatContainer.clear()
-					this.allToolComponents = []
-					this.pendingTools.clear()
-					await this.renderExistingMessages()
-					this.updateStatusLine()
-
-					this.showInfo(`Switched to: ${thread.title || thread.id}`)
-					resolve()
-				},
-				onCancel: () => {
-					this.ui.hideOverlay()
-					resolve()
-				},
-			})
-
-			this.ui.showOverlay(selector, {
-				width: "80%",
-				maxHeight: "60%",
-				anchor: "center",
-			})
-			selector.focused = true
-		})
-	}
-
-	// ===========================================================================
-	// Thread Tagging
-	// ===========================================================================
-
-	private async tagThreadWithDir(): Promise<void> {
-		const threadId = this.harness.getCurrentThreadId()
-		if (!threadId && this.pendingNewThread) {
-			this.showInfo("No active thread yet — send a message first.")
-			return
-		}
-		if (!threadId) {
-			this.showInfo("No active thread.")
-			return
-		}
-
-		const projectPath = (this.harness.getState() as any)?.projectPath as
-			| string
-			| undefined
-		if (!projectPath) {
-			this.showInfo("Could not detect current project path.")
-			return
-		}
-
-		const dirName = projectPath.split("/").pop() || projectPath
-
-		return new Promise<void>((resolve) => {
-			const questionComponent = new AskQuestionInlineComponent(
-				{
-					question: `Tag this thread with directory "${dirName}"?\n  ${fg("dim", projectPath)}`,
-					options: [{ label: "Yes" }, { label: "No" }],
-					formatResult: (answer) =>
-						answer === "Yes"
-							? `Tagged thread with: ${dirName}`
-							: `Thread not tagged`,
-					onSubmit: async (answer) => {
-						this.activeInlineQuestion = undefined
-						if (answer.toLowerCase().startsWith("y")) {
-							await this.harness.persistThreadSetting(
-								"projectPath",
-								projectPath,
-							)
-						}
-						resolve()
-					},
-					onCancel: () => {
-						this.activeInlineQuestion = undefined
-						resolve()
-					},
-				},
-				this.ui,
-			)
-
-			this.activeInlineQuestion = questionComponent
-			this.chatContainer.addChild(new Spacer(1))
-			this.chatContainer.addChild(questionComponent)
-			this.chatContainer.addChild(new Spacer(1))
-			this.ui.requestRender()
-			this.chatContainer.invalidate()
-		})
-	}
-	/**
-	 * Show an inline prompt when a thread is locked by another process.
-	 * User can create a new thread (y) or exit (n).
-	 */
-	private showThreadLockPrompt(threadTitle: string, ownerPid: number): void {
-		const questionComponent = new AskQuestionInlineComponent(
-			{
-				question: `Thread "${threadTitle}" is locked by pid ${ownerPid}. Create a new thread?`,
-				options: [
-					{ label: "Yes", description: "Start a new thread" },
-					{ label: "No", description: "Exit" },
-				],
-				formatResult: (answer) =>
-					answer === "Yes" ? "Thread created" : "Exiting.",
-				onSubmit: async (answer) => {
-					this.activeInlineQuestion = undefined
-					if (answer.toLowerCase().startsWith("y")) {
-						// pendingNewThread is already true — thread will be
-						// created lazily on first message
-					} else {
-						process.exit(0)
-					}
-				},
-				onCancel: () => {
-					this.activeInlineQuestion = undefined
-					process.exit(0)
-				},
-			},
-			this.ui,
-		)
-
-		this.activeInlineQuestion = questionComponent
-		this.chatContainer.addChild(questionComponent)
-		this.chatContainer.addChild(new Spacer(1))
-		this.ui.requestRender()
-		this.chatContainer.invalidate()
-	}
-
-	// ===========================================================================
-	// Sandbox Management
-	// ===========================================================================
-
-	private async handleSandboxCommand(args: string[]): Promise<void> {
-		const state = this.harness.getState() as {
-			sandboxAllowedPaths?: string[]
-		}
-		const currentPaths = state.sandboxAllowedPaths ?? []
-
-		// If called with args, handle directly (e.g. /sandbox add /some/path)
-		const subcommand = args[0]?.toLowerCase()
-		if (subcommand === "add" && args.length > 1) {
-			await this.sandboxAddPath(args.slice(1).join(" ").trim())
-			return
-		}
-		if (subcommand === "remove" && args.length > 1) {
-			await this.sandboxRemovePath(args.slice(1).join(" ").trim(), currentPaths)
-			return
-		}
-
-		// Interactive mode — show inline selector
-		const options: Array<{ label: string; description?: string }> = [
-			{ label: "Add path", description: "Allow access to another directory" },
-		]
-
-		for (const p of currentPaths) {
-			const short = p.split("/").pop() || p
-			options.push({
-				label: `Remove: ${short}`,
-				description: p,
-			})
-		}
-
-		const pathsSummary = currentPaths.length
-			? `${currentPaths.length} allowed path${currentPaths.length > 1 ? "s" : ""}`
-			: "no extra paths"
-
-		return new Promise<void>((resolve) => {
-			const questionComponent = new AskQuestionInlineComponent(
-				{
-					question: `Sandbox settings (${pathsSummary})`,
-					options,
-					formatResult: (answer) => {
-						if (answer === "Add path") return "Adding sandbox path…"
-						if (answer.startsWith("Remove: ")) {
-							const short = answer.replace("Remove: ", "")
-							return `Removed: ${short}`
-						}
-						return answer
-					},
-					onSubmit: async (answer) => {
-						this.activeInlineQuestion = undefined
-						if (answer === "Add path") {
-							resolve()
-							await this.showSandboxAddPrompt()
-						} else if (answer.startsWith("Remove: ")) {
-							const short = answer.replace("Remove: ", "")
-							const fullPath = currentPaths.find(
-								(p) => (p.split("/").pop() || p) === short,
-							)
-							if (fullPath) {
-								await this.sandboxRemovePath(fullPath, currentPaths)
-							}
-							resolve()
-						} else {
-							resolve()
-						}
-					},
-					onCancel: () => {
-						this.activeInlineQuestion = undefined
-						resolve()
-					},
-				},
-				this.ui,
-			)
-
-			this.activeInlineQuestion = questionComponent
-			this.chatContainer.addChild(new Spacer(1))
-			this.chatContainer.addChild(questionComponent)
-			this.chatContainer.addChild(new Spacer(1))
-			this.ui.requestRender()
-			this.chatContainer.invalidate()
-		})
-	}
-
-	private async showSandboxAddPrompt(): Promise<void> {
-		return new Promise<void>((resolve) => {
-			const questionComponent = new AskQuestionInlineComponent(
-				{
-					question: "Enter path to allow",
-					formatResult: (answer) => {
-						const resolved = path.resolve(answer)
-						return `Added: ${resolved}`
-					},
-					onSubmit: async (answer) => {
-						this.activeInlineQuestion = undefined
-						await this.sandboxAddPath(answer)
-						resolve()
-					},
-					onCancel: () => {
-						this.activeInlineQuestion = undefined
-						resolve()
-					},
-				},
-				this.ui,
-			)
-
-			this.activeInlineQuestion = questionComponent
-			this.chatContainer.addChild(new Spacer(1))
-			this.chatContainer.addChild(questionComponent)
-			this.chatContainer.addChild(new Spacer(1))
-			this.ui.requestRender()
-			this.chatContainer.invalidate()
-		})
-	}
-
-	private async sandboxAddPath(rawPath: string): Promise<void> {
-		const state = this.harness.getState() as {
-			sandboxAllowedPaths?: string[]
-		}
-		const currentPaths = state.sandboxAllowedPaths ?? []
-		const resolved = path.resolve(rawPath)
-
-		if (currentPaths.includes(resolved)) {
-			this.showInfo(`Path already allowed: ${resolved}`)
-			return
-		}
-		try {
-			await fs.promises.access(resolved)
-		} catch {
-			this.showError(`Path does not exist: ${resolved}`)
-			return
-		}
-		const updated = [...currentPaths, resolved]
-		this.harness.setState({ sandboxAllowedPaths: updated } as any)
-		await this.harness.persistThreadSetting("sandboxAllowedPaths", updated)
-		this.showInfo(`Added to sandbox: ${resolved}`)
-	}
-
-	private async sandboxRemovePath(
-		rawPath: string,
-		currentPaths: string[],
-	): Promise<void> {
-		const resolved = path.resolve(rawPath)
-		const match = currentPaths.find((p) => p === resolved || p === rawPath)
-		if (!match) {
-			this.showError(`Path not in allowed list: ${resolved}`)
-			return
-		}
-		const updated = currentPaths.filter((p) => p !== match)
-		this.harness.setState({ sandboxAllowedPaths: updated } as any)
-		await this.harness.persistThreadSetting("sandboxAllowedPaths", updated)
-		this.showInfo(`Removed from sandbox: ${match}`)
-	}
-
-	// ===========================================================================
-	// Skills List
-	// ===========================================================================
-
-	/**
-	 * Get the workspace, preferring harness-owned workspace over the direct option.
-	 */
-	private getResolvedWorkspace(): Workspace | undefined {
-		return this.harness.getWorkspace() ?? this.workspace
-	}
-
-	private async showSkillsList(): Promise<void> {
-		const workspace = this.getResolvedWorkspace()
-		if (!workspace?.skills) {
-			this.showInfo(
-				"No skills configured.\n\n" +
-					"Add skills to any of these locations:\n" +
-					"  .mastracode/skills/   (project-local)\n" +
-					"  .claude/skills/       (project-local)\n" +
-					"  ~/.mastracode/skills/ (global)\n" +
-					"  ~/.claude/skills/     (global)\n\n" +
-					"Each skill is a folder with a SKILL.md file.\n" +
-					"Install skills: npx add-skill <github-url>",
-			)
-			return
-		}
-
-		try {
-			const skills = await workspace.skills!.list()
-
-			if (skills.length === 0) {
-				this.showInfo(
-					"No skills found in configured directories.\n\n" +
-						"Each skill needs a SKILL.md file with YAML frontmatter.\n" +
-						"Install skills: npx add-skill <github-url>",
-				)
-				return
-			}
-
-			const skillLines = skills.map((skill) => {
-				const desc = skill.description
-					? ` - ${skill.description.length > 60 ? skill.description.slice(0, 57) + "..." : skill.description}`
-					: ""
-				return `  ${skill.name}${desc}`
-			})
-
-			this.showInfo(
-				`Skills (${skills.length}):\n${skillLines.join("\n")}\n\n` +
-					"Skills are automatically activated by the agent when relevant.",
-			)
-        } catch (error) {
-            this.showError(
-                `Failed to list skills: ${error instanceof Error ? error.message : String(error)}`,
-            )
+        this.ui.requestRender();
+
+        // Ensure the chat scrolls to show the question
+        this.chatContainer.invalidate();
+
+        // Focus the question component
+        questionComponent.focused = true;
+      } else {
+        // Dialog mode: Show overlay
+        const dialog = new AskQuestionDialogComponent({
+          question,
+          options,
+          onSubmit: answer => {
+            this.ui.hideOverlay();
+            this.harness.respondToQuestion(questionId, answer);
+            resolve();
+          },
+          onCancel: () => {
+            this.ui.hideOverlay();
+            this.harness.respondToQuestion(questionId, '(skipped)');
+            resolve();
+          },
+        });
+        this.ui.showOverlay(dialog, { width: '70%', anchor: 'center' });
+        dialog.focused = true;
+      }
+
+      this.notify('ask_question', question);
+    });
+  }
+
+  /**
+   * Handle a sandbox_access_request event from the request_sandbox_access tool.
+   * Shows an inline prompt for the user to approve or deny directory access.
+   */
+  private async handleSandboxAccessRequest(questionId: string, requestedPath: string, reason: string): Promise<void> {
+    return new Promise(resolve => {
+      const questionComponent = new AskQuestionInlineComponent(
+        {
+          question: `Grant sandbox access to "${requestedPath}"?\n${fg('dim', `Reason: ${reason}`)}`,
+          options: [
+            { label: 'Yes', description: 'Allow access to this directory' },
+            { label: 'No', description: 'Deny access' },
+          ],
+          onSubmit: answer => {
+            this.activeInlineQuestion = undefined;
+            this.harness.respondToQuestion(questionId, answer);
+            resolve();
+          },
+          onCancel: () => {
+            this.activeInlineQuestion = undefined;
+            this.harness.respondToQuestion(questionId, 'No');
+            resolve();
+          },
+          formatResult: answer => {
+            const approved = answer.toLowerCase().startsWith('y');
+            return approved ? `Granted access to ${requestedPath}` : `Denied access to ${requestedPath}`;
+          },
+          isNegativeAnswer: answer => !answer.toLowerCase().startsWith('y'),
+        },
+        this.ui,
+      );
+
+      // Store as active question so input routing works
+      this.activeInlineQuestion = questionComponent;
+
+      // Add to chat
+      this.chatContainer.addChild(new Spacer(1));
+      this.chatContainer.addChild(questionComponent);
+      this.chatContainer.addChild(new Spacer(1));
+      this.ui.requestRender();
+      this.chatContainer.invalidate();
+
+      this.notify('sandbox_access', `Sandbox access requested: ${requestedPath}`);
+    });
+  }
+
+  /**
+   * Handle a plan_approval_required event from the submit_plan tool.
+   * Shows the plan inline with Approve/Reject/Request Changes options.
+   */
+  private async handlePlanApproval(planId: string, title: string, plan: string): Promise<void> {
+    return new Promise(resolve => {
+      const approvalComponent = new PlanApprovalInlineComponent(
+        {
+          planId,
+          title,
+          plan,
+          onApprove: async () => {
+            this.activeInlinePlanApproval = undefined;
+            // Store the approved plan in harness state
+            await this.harness.setState({
+              activePlan: {
+                title,
+                plan,
+                approvedAt: new Date().toISOString(),
+              },
+            });
+            // Wait for plan approval to complete (switches mode, aborts stream)
+            await this.harness.respondToPlanApproval(planId, {
+              action: 'approved',
+            });
+            this.updateStatusLine();
+
+            // Now that mode switch is complete, add system reminder and trigger build agent
+            // Use setTimeout to ensure the plan approval component has fully rendered
+            setTimeout(() => {
+              const reminderText =
+                '<system-reminder>The user has approved the plan, begin executing.</system-reminder>';
+              this.addUserMessage({
+                id: `system-${Date.now()}`,
+                role: 'user',
+                content: [{ type: 'text', text: reminderText }],
+                createdAt: new Date(),
+              });
+              this.fireMessage(reminderText);
+            }, 50);
+
+            resolve();
+          },
+          onReject: async (feedback?: string) => {
+            this.activeInlinePlanApproval = undefined;
+            this.harness.respondToPlanApproval(planId, {
+              action: 'rejected',
+              feedback,
+            });
+            resolve();
+          },
+        },
+        this.ui,
+      );
+
+      // Store as active plan approval
+      this.activeInlinePlanApproval = approvalComponent;
+
+      // Insert after the submit_plan tool component (same pattern as ask_user)
+      if (this.lastSubmitPlanComponent) {
+        const children = [...this.chatContainer.children];
+        const submitPlanIndex = children.indexOf(this.lastSubmitPlanComponent as any);
+        if (submitPlanIndex >= 0) {
+          this.chatContainer.clear();
+          for (let i = 0; i <= submitPlanIndex; i++) {
+            this.chatContainer.addChild(children[i]!);
+          }
+          this.chatContainer.addChild(new Spacer(1));
+          this.chatContainer.addChild(approvalComponent);
+          this.chatContainer.addChild(new Spacer(1));
+          for (let i = submitPlanIndex + 1; i < children.length; i++) {
+            this.chatContainer.addChild(children[i]!);
+          }
+        } else {
+          this.chatContainer.addChild(new Spacer(1));
+          this.chatContainer.addChild(approvalComponent);
+          this.chatContainer.addChild(new Spacer(1));
         }
-	}
+      } else {
+        this.chatContainer.addChild(new Spacer(1));
+        this.chatContainer.addChild(approvalComponent);
+        this.chatContainer.addChild(new Spacer(1));
+      }
+      this.ui.requestRender();
+      this.chatContainer.invalidate();
+      approvalComponent.focused = true;
 
-	// ===========================================================================
-	// Model Selector
-	// ===========================================================================
+      this.notify('plan_approval', `Plan "${title}" requires approval`);
+    });
+  }
+  private handleToolEnd(toolCallId: string, result: unknown, isError: boolean): void {
+    // If this is a subagent tool, store the result in the SubagentExecutionComponent
+    const subagentComponent = this.pendingSubagents.get(toolCallId);
+    if (subagentComponent) {
+      // The final result is available here
+      const resultText = this.formatToolResult(result);
+      // We'll need to wait for subagent_end to set this
+      // Store it temporarily
+      (subagentComponent as any)._pendingResult = resultText;
+    }
 
-	/**
-	 * Show mode selector first, then scope (global/thread), then model list.
-	 * Flow: Mode → Scope → Model
-	 */
-	private async showModelScopeSelector(): Promise<void> {
-		const modes = this.harness.getModes()
-		const currentMode = this.harness.getCurrentMode()
+    // Track successful file modifications for /diff command
+    const pendingFile = this.pendingFileTools.get(toolCallId);
+    if (pendingFile && !isError) {
+      const existing = this.modifiedFiles.get(pendingFile.filePath);
+      if (existing) {
+        existing.operations.push(pendingFile.toolName);
+      } else {
+        this.modifiedFiles.set(pendingFile.filePath, {
+          operations: [pendingFile.toolName],
+          firstModified: new Date(),
+        });
+      }
+    }
+    this.pendingFileTools.delete(toolCallId);
 
-		// Sort modes with active mode first
-		const sortedModes = [...modes].sort((a, b) => {
-			if (a.id === currentMode?.id) return -1
-			if (b.id === currentMode?.id) return 1
-			return 0
-		})
+    const component = this.pendingTools.get(toolCallId);
+    if (component) {
+      const toolResult: ToolResult = {
+        content: [{ type: 'text', text: this.formatToolResult(result) }],
+        isError,
+      };
+      component.updateResult(toolResult, false);
 
-		const modeOptions = sortedModes.map((mode) => ({
-			label: mode.name + (mode.id === currentMode?.id ? " (active)" : ""),
-			modeId: mode.id,
-			modeName: mode.name,
-		}))
+      this.pendingTools.delete(toolCallId);
+      this.ui.requestRender();
+    }
+  }
 
-		return new Promise<void>((resolve) => {
-			const questionComponent = new AskQuestionInlineComponent(
-				{
-					question: "Select mode",
-					options: modeOptions.map((m) => ({ label: m.label })),
-					formatResult: (answer) => {
-						const mode = modeOptions.find((m) => m.label === answer)
-						return `Mode: ${mode?.modeName ?? answer}`
-					},
-					onSubmit: async (answer) => {
-						this.activeInlineQuestion = undefined
-						const selected = modeOptions.find((m) => m.label === answer)
-						if (selected?.modeId && selected?.modeName) {
-							await this.showModelScopeThenList(
-								selected.modeId,
-								selected.modeName,
-							)
-						}
-						resolve()
-					},
-					onCancel: () => {
-						this.activeInlineQuestion = undefined
-						resolve()
-					},
-				},
-				this.ui,
-			)
+  /**
+   * Format a tool result for display.
+   * Handles objects, strings, and other types.
+   * Extracts content from common tool return structures like { content: "...", isError: false }
+   */
+  private formatToolResult(result: unknown): string {
+    if (result === null || result === undefined) {
+      return '';
+    }
+    if (typeof result === 'string') {
+      return result;
+    }
+    if (typeof result === 'object') {
+      const obj = result as Record<string, unknown>;
+      // Handle common tool return format: { content: "...", isError: boolean }
+      if ('content' in obj && typeof obj.content === 'string') {
+        return obj.content;
+      }
+      // Handle content array format: { content: [{ type: "text", text: "..." }] }
+      if ('content' in obj && Array.isArray(obj.content)) {
+        const textParts = obj.content
+          .filter(
+            (part: unknown) =>
+              typeof part === 'object' && part !== null && (part as Record<string, unknown>).type === 'text',
+          )
+          .map((part: unknown) => (part as Record<string, unknown>).text || '');
+        if (textParts.length > 0) {
+          return textParts.join('\n');
+        }
+      }
+      try {
+        return JSON.stringify(result, null, 2);
+      } catch {
+        return String(result);
+      }
+    }
+    return String(result);
+  }
 
-			this.activeInlineQuestion = questionComponent
-			this.chatContainer.addChild(new Spacer(1))
-			this.chatContainer.addChild(questionComponent)
-			this.chatContainer.addChild(new Spacer(1))
-			this.ui.requestRender()
-			this.chatContainer.invalidate()
-		})
-	}
+  /**
+   * Render a completed todo list inline in the chat history.
+   * This mirrors the pinned TodoProgressComponent format but shows
+   * all items as completed, since the pinned component hides itself
+   * when everything is done.
+   * @param todos The completed todo items
+   * @param insertIndex Optional index to insert at (replaces tool component position)
+   */
+  private renderCompletedTodosInline(todos: TodoItem[], insertIndex = -1, collapsed = false): void {
+    const headerText = bold(fg('accent', 'Tasks')) + fg('dim', ` [${todos.length}/${todos.length} completed]`);
 
-	/**
-	 * Show scope selector (global/thread) for a specific mode, then model list.
-	 */
-	private async showModelScopeThenList(
-		modeId: string,
-		modeName: string,
-	): Promise<void> {
-		const scopes = [
-			{
-				label: "Thread default",
-				description: `Default for ${modeName} mode in this thread`,
-				scope: "thread" as const,
-			},
-			{
-				label: "Global default",
-				description: `Default for ${modeName} mode in all threads`,
-				scope: "global" as const,
-			},
-		]
+    const container = new Container();
+    container.addChild(new Spacer(1));
+    container.addChild(new Text(headerText, 0, 0));
+    const MAX_VISIBLE = 4;
+    const shouldCollapse = collapsed && todos.length > MAX_VISIBLE + 1;
+    const visible = shouldCollapse ? todos.slice(0, MAX_VISIBLE) : todos;
+    const remaining = shouldCollapse ? todos.length - MAX_VISIBLE : 0;
 
-		return new Promise<void>((resolve) => {
-			const questionComponent = new AskQuestionInlineComponent(
-				{
-					question: `Select scope for ${modeName}`,
-					options: scopes.map((s) => ({
-						label: s.label,
-						description: s.description,
-					})),
-					formatResult: (answer) => `${modeName} · ${answer}`,
-					onSubmit: async (answer) => {
-						this.activeInlineQuestion = undefined
-						const selected = scopes.find((s) => s.label === answer)
-						if (selected) {
-							await this.showModelListForScope(selected.scope, modeId, modeName)
-						}
-						resolve()
-					},
-					onCancel: () => {
-						this.activeInlineQuestion = undefined
-						resolve()
-					},
-				},
-				this.ui,
-			)
+    for (const todo of visible) {
+      const icon = chalk.hex(mastra.green)('✓');
+      const text = chalk.hex(mastra.green)(todo.content);
+      container.addChild(new Text(`  ${icon} ${text}`, 0, 0));
+    }
+    if (remaining > 0) {
+      container.addChild(
+        new Text(
+          fg('dim', `  ... ${remaining} more completed task${remaining > 1 ? 's' : ''} (ctrl+e to expand)`),
+          0,
+          0,
+        ),
+      );
+    }
 
-			this.activeInlineQuestion = questionComponent
-			this.chatContainer.addChild(new Spacer(1))
-			this.chatContainer.addChild(questionComponent)
-			this.chatContainer.addChild(new Spacer(1))
-			this.ui.requestRender()
-			this.chatContainer.invalidate()
-		})
-	}
+    if (insertIndex >= 0) {
+      // Insert at the position where the todo_write tool was
+      this.chatContainer.children.splice(insertIndex, 0, container);
+      this.chatContainer.invalidate();
+    } else {
+      // Fallback: append at end
+      this.chatContainer.addChild(container);
+    }
+  }
 
-	/**
-	 * Show the model list for a specific mode and scope.
-	 */
-	private async showModelListForScope(
-		scope: "global" | "thread",
-		modeId: string,
-		modeName: string,
-	): Promise<void> {
-		const availableModels = await this.harness.getAvailableModels()
+  /**
+   * Render inline display when tasks are cleared.
+   * Shows what was cleared with strikethrough.
+   */
+  private renderClearedTodosInline(clearedTodos: TodoItem[], insertIndex = -1): void {
+    const container = new Container();
+    container.addChild(new Spacer(1));
+    const count = clearedTodos.length;
+    const label = count === 1 ? 'Task' : 'Tasks';
+    container.addChild(new Text(fg('accent', `${label} cleared`), 0, 0));
+    for (const todo of clearedTodos) {
+      const icon = todo.status === 'completed' ? chalk.hex(mastra.green)('✓') : chalk.hex(mastra.darkGray)('○');
+      const text = chalk.dim.strikethrough(todo.content);
+      container.addChild(new Text(`  ${icon} ${text}`, 0, 0));
+    }
+    if (insertIndex >= 0) {
+      this.chatContainer.children.splice(insertIndex, 0, container);
+      this.chatContainer.invalidate();
+    } else {
+      this.chatContainer.addChild(container);
+    }
+  }
+  // ===========================================================================
+  // Subagent Events
+  // ===========================================================================
 
-		if (availableModels.length === 0) {
-			this.showInfo("No models available. Check your Mastra configuration.")
-			return
-		}
+  private handleSubagentStart(toolCallId: string, agentType: string, task: string, modelId?: string): void {
+    // Create a dedicated rendering component for this subagent run
+    const component = new SubagentExecutionComponent(agentType, task, this.ui, modelId);
+    this.pendingSubagents.set(toolCallId, component);
+    this.allToolComponents.push(component as any);
 
-		const currentModelId = this.harness.getCurrentModelId()
-		const scopeLabel =
-			scope === "global" ? `${modeName} · Global` : `${modeName} · Thread`
+    // Insert before the current streamingComponent so subagent box
+    // appears between pre-subagent text and post-subagent text
+    if (this.streamingComponent) {
+      const idx = this.chatContainer.children.indexOf(this.streamingComponent as any);
+      if (idx >= 0) {
+        (this.chatContainer.children as unknown[]).splice(idx, 0, component);
+        this.chatContainer.invalidate();
+      } else {
+        this.chatContainer.addChild(component);
+      }
+    } else {
+      this.chatContainer.addChild(component);
+    }
 
-		return new Promise((resolve) => {
-			const selector = new ModelSelectorComponent({
-				tui: this.ui,
-				models: availableModels,
-				currentModelId,
-				title: `Select model (${scopeLabel})`,
-				onSelect: async (model: ModelItem) => {
-					this.ui.hideOverlay()
-					await this.harness.switchModel(model.id, scope, modeId)
-					this.showInfo(`Model set for ${scopeLabel}: ${model.id}`)
-					this.updateStatusLine()
-					resolve()
-				},
-				onCancel: () => {
-					this.ui.hideOverlay()
-					resolve()
-				},
-			})
+    this.ui.requestRender();
+  }
 
-			this.ui.showOverlay(selector, {
-				width: "80%",
-				maxHeight: "60%",
-				anchor: "center",
-			})
-			selector.focused = true
-		})
-	}
+  private handleSubagentToolStart(toolCallId: string, subToolName: string, subToolArgs: unknown): void {
+    const component = this.pendingSubagents.get(toolCallId);
+    if (component) {
+      component.addToolStart(subToolName, subToolArgs);
+      this.ui.requestRender();
+    }
+  }
 
-	/**
-	 * Show agent type selector first, then scope (global/thread), then model list.
-	 * Flow: Agent Type → Scope → Model
-	 */
-	private async showSubagentModelSelector(): Promise<void> {
-		const agentTypes = [
-			{
-				id: "explore",
-				label: "Explore",
-				description: "Read-only codebase exploration",
-			},
-			{
-				id: "plan",
-				label: "Plan",
-				description: "Read-only analysis and planning",
-			},
-			{
-				id: "execute",
-				label: "Execute",
-				description: "Task execution with write access",
-			},
-		]
+  private handleSubagentToolEnd(
+    toolCallId: string,
+    subToolName: string,
+    subToolResult: unknown,
+    isError: boolean,
+  ): void {
+    const component = this.pendingSubagents.get(toolCallId);
+    if (component) {
+      component.addToolEnd(subToolName, subToolResult, isError);
+      this.ui.requestRender();
+    }
+  }
 
-		return new Promise<void>((resolve) => {
-			const questionComponent = new AskQuestionInlineComponent(
-				{
-					question: "Select subagent type",
-					options: agentTypes.map((t) => ({
-						label: t.label,
-						description: t.description,
-					})),
-					formatResult: (answer) => `Subagent: ${answer}`,
-					onSubmit: async (answer) => {
-						this.activeInlineQuestion = undefined
-						const selected = agentTypes.find((t) => t.label === answer)
-						if (selected) {
-							await this.showSubagentScopeThenList(selected.id, selected.label)
-						}
-						resolve()
-					},
-					onCancel: () => {
-						this.activeInlineQuestion = undefined
-						resolve()
-					},
-				},
-				this.ui,
-			)
+  private handleSubagentEnd(toolCallId: string, isError: boolean, durationMs: number, result?: string): void {
+    const component = this.pendingSubagents.get(toolCallId);
+    if (component) {
+      component.finish(isError, durationMs, result);
+      this.pendingSubagents.delete(toolCallId);
+      this.ui.requestRender();
+    }
+  }
 
-			this.activeInlineQuestion = questionComponent
-			this.chatContainer.addChild(new Spacer(1))
-			this.chatContainer.addChild(questionComponent)
-			this.chatContainer.addChild(new Spacer(1))
-			this.ui.requestRender()
-			this.chatContainer.invalidate()
-		})
-	}
+  // ===========================================================================
+  // User Input
+  // ===========================================================================
 
-	/**
-	 * Show scope selector (global/thread) for a specific agent type, then model list.
-	 */
-	private async showSubagentScopeThenList(
-		agentType: string,
-		agentTypeLabel: string,
-	): Promise<void> {
-		const scopes = [
-			{
-				label: "Thread default",
-				description: `Default for ${agentTypeLabel} subagents in this thread`,
-				scope: "thread" as const,
-			},
-			{
-				label: "Global default",
-				description: `Default for ${agentTypeLabel} subagents in all threads`,
-				scope: "global" as const,
-			},
-		]
+  private getUserInput(): Promise<string> {
+    return new Promise(resolve => {
+      this.editor.onSubmit = (text: string) => {
+        // Add to history for arrow up/down navigation (skip empty)
+        if (text.trim()) {
+          this.editor.addToHistory(text);
+        }
+        this.editor.setText('');
+        resolve(text);
+      };
+    });
+  }
 
-		return new Promise<void>((resolve) => {
-			const questionComponent = new AskQuestionInlineComponent(
-				{
-					question: `Select scope for ${agentTypeLabel} subagents`,
-					options: scopes.map((s) => ({
-						label: s.label,
-						description: s.description,
-					})),
-					formatResult: (answer) => `${agentTypeLabel} · ${answer}`,
-					onSubmit: async (answer) => {
-						this.activeInlineQuestion = undefined
-						const selected = scopes.find((s) => s.label === answer)
-						if (selected) {
-							await this.showSubagentModelListForScope(
-								selected.scope,
-								agentType,
-								agentTypeLabel,
-							)
-						}
-						resolve()
-					},
-					onCancel: () => {
-						this.activeInlineQuestion = undefined
-						resolve()
-					},
-				},
-				this.ui,
-			)
+  // ===========================================================================
+  // Thread Selector
+  // ===========================================================================
 
-			this.activeInlineQuestion = questionComponent
-			this.chatContainer.addChild(new Spacer(1))
-			this.chatContainer.addChild(questionComponent)
-			this.chatContainer.addChild(new Spacer(1))
-			this.ui.requestRender()
-			this.chatContainer.invalidate()
-		})
-	}
+  private async showThreadSelector(): Promise<void> {
+    const threads = await this.harness.listThreads({ allResources: true });
+    const currentId = this.pendingNewThread ? null : this.harness.getCurrentThreadId();
+    const currentResourceId = this.harness.getResourceId();
 
-	/**
-	 * Show the model list for subagent type and scope selection.
-	 */
-	private async showSubagentModelListForScope(
-		scope: "global" | "thread",
-		agentType: string,
-		agentTypeLabel: string,
-	): Promise<void> {
-		const availableModels = await this.harness.getAvailableModels()
+    if (threads.length === 0) {
+      this.showInfo('No threads yet. Send a message to create one.');
+      return;
+    }
 
-		if (availableModels.length === 0) {
-			this.showInfo("No models available. Check your Mastra configuration.")
-			return
-		}
+    return new Promise(resolve => {
+      const selector = new ThreadSelectorComponent({
+        tui: this.ui,
+        threads,
+        currentThreadId: currentId,
+        currentResourceId,
+        getMessagePreview: async (threadId: string) => {
+          const firstUserMessage = await this.harness.getFirstUserMessageForThread(threadId);
+          if (firstUserMessage) {
+            const text = this.extractTextContent(firstUserMessage);
+            return this.truncatePreview(text);
+          }
+          return null;
+        },
+        onSelect: async thread => {
+          this.ui.hideOverlay();
 
-		// Get current subagent model if set
-		const currentSubagentModel =
-			await this.harness.getSubagentModelId(agentType)
-		const scopeLabel =
-			scope === "global"
-				? `${agentTypeLabel} · Global`
-				: `${agentTypeLabel} · Thread`
+          if (thread.id === currentId) {
+            resolve();
+            return;
+          }
 
-		return new Promise((resolve) => {
-			const selector = new ModelSelectorComponent({
-				tui: this.ui,
-				models: availableModels,
-				currentModelId: currentSubagentModel ?? undefined,
-				title: `Select subagent model (${scopeLabel})`,
-				onSelect: async (model: ModelItem) => {
-					this.ui.hideOverlay()
-					await this.harness.setSubagentModelId(model.id, scope, agentType)
-					this.showInfo(`Subagent model set for ${scopeLabel}: ${model.id}`)
-					resolve()
-				},
-				onCancel: () => {
-					this.ui.hideOverlay()
-					resolve()
-				},
-			})
+          // If thread is from a different resource, switch resource first
+          if (thread.resourceId !== currentResourceId) {
+            this.harness.setResourceId(thread.resourceId);
+          }
+          try {
+            await this.harness.switchThread(thread.id);
+          } catch (error) {
+            if (error instanceof ThreadLockError) {
+              this.showThreadLockPrompt(thread.title || thread.id, error.ownerPid);
+              resolve();
+              return;
+            }
+            throw error;
+          }
+          this.pendingNewThread = false;
 
-			this.ui.showOverlay(selector, {
-				width: "80%",
-				maxHeight: "60%",
-				anchor: "center",
-			})
-			selector.focused = true
-		})
-	}
+          // Clear chat and render existing messages
+          this.chatContainer.clear();
+          this.allToolComponents = [];
+          this.pendingTools.clear();
+          await this.renderExistingMessages();
+          this.updateStatusLine();
 
-	// ===========================================================================
-	// Observational Memory Settings
-	// ===========================================================================
+          this.showInfo(`Switched to: ${thread.title || thread.id}`);
+          resolve();
+        },
+        onCancel: () => {
+          this.ui.hideOverlay();
+          resolve();
+        },
+      });
 
-	private async showOMSettings(): Promise<void> {
-		// Get available models for the model submenus
-		const availableModels = await this.harness.getAvailableModels()
-		const modelOptions = availableModels.map((m) => ({
-			id: m.id,
-			label: m.id,
-		}))
+      this.ui.showOverlay(selector, {
+        width: '80%',
+        maxHeight: '60%',
+        anchor: 'center',
+      });
+      selector.focused = true;
+    });
+  }
 
-		const config = {
-			observerModelId: this.harness.getObserverModelId(),
-			reflectorModelId: this.harness.getReflectorModelId(),
-			observationThreshold: this.harness.getObservationThreshold(),
-			reflectionThreshold: this.harness.getReflectionThreshold(),
-		}
+  // ===========================================================================
+  // Thread Tagging
+  // ===========================================================================
 
-		return new Promise<void>((resolve) => {
-			const settings = new OMSettingsComponent(
-				config,
-				{
-					onObserverModelChange: async (modelId) => {
-						await this.harness.switchObserverModel(modelId)
-						this.showInfo(`Observer model → ${modelId}`)
-					},
-					onReflectorModelChange: async (modelId) => {
-						await this.harness.switchReflectorModel(modelId)
-						this.showInfo(`Reflector model → ${modelId}`)
-					},
-					onObservationThresholdChange: (value) => {
-						this.harness.setObservationThreshold(value)
-						this.omProgress.threshold = value
-						this.omProgress.thresholdPercent =
-							value > 0 ? (this.omProgress.pendingTokens / value) * 100 : 0
-						this.updateStatusLine()
-					},
-					onReflectionThresholdChange: (value) => {
-						this.harness.setReflectionThreshold(value)
-						this.omProgress.reflectionThreshold = value
-						this.omProgress.reflectionThresholdPercent =
-							value > 0 ? (this.omProgress.observationTokens / value) * 100 : 0
-						this.updateStatusLine()
-					},
-					onClose: () => {
-						this.ui.hideOverlay()
-						this.updateStatusLine()
-						resolve()
-					},
-				},
-				modelOptions,
-				this.ui,
-			)
+  private async tagThreadWithDir(): Promise<void> {
+    const threadId = this.harness.getCurrentThreadId();
+    if (!threadId && this.pendingNewThread) {
+      this.showInfo('No active thread yet — send a message first.');
+      return;
+    }
+    if (!threadId) {
+      this.showInfo('No active thread.');
+      return;
+    }
 
-			this.ui.showOverlay(settings, {
-				width: "80%",
-				maxHeight: "70%",
-				anchor: "center",
-			})
-			settings.focused = true
-		})
-	}
-	// ===========================================================================
-	// General Settings
-	// ===========================================================================
-	private async showPermissions(): Promise<void> {
-		const { TOOL_CATEGORIES, getToolsForCategory } =
-			await import("../permissions.js")
-		const rules = this.harness.getPermissionRules_public()
-		const grants = this.harness.getSessionGrants()
-		const isYolo = this.harness.getYoloMode()
+    const projectPath = (this.harness.getState() as any)?.projectPath as string | undefined;
+    if (!projectPath) {
+      this.showInfo('Could not detect current project path.');
+      return;
+    }
 
-		const lines: string[] = []
-		lines.push("Tool Approval Permissions")
-		lines.push("─".repeat(40))
+    const dirName = projectPath.split('/').pop() || projectPath;
 
-		if (isYolo) {
-			lines.push("")
-			lines.push("⚡ YOLO mode is ON — all tools are auto-approved")
-			lines.push("  Use /yolo to toggle off")
-		}
+    return new Promise<void>(resolve => {
+      const questionComponent = new AskQuestionInlineComponent(
+        {
+          question: `Tag this thread with directory "${dirName}"?\n  ${fg('dim', projectPath)}`,
+          options: [{ label: 'Yes' }, { label: 'No' }],
+          formatResult: answer => (answer === 'Yes' ? `Tagged thread with: ${dirName}` : `Thread not tagged`),
+          onSubmit: async answer => {
+            this.activeInlineQuestion = undefined;
+            if (answer.toLowerCase().startsWith('y')) {
+              await this.harness.persistThreadSetting('projectPath', projectPath);
+            }
+            resolve();
+          },
+          onCancel: () => {
+            this.activeInlineQuestion = undefined;
+            resolve();
+          },
+        },
+        this.ui,
+      );
 
-		lines.push("")
-		lines.push("Category Policies:")
-		for (const [cat, meta] of Object.entries(TOOL_CATEGORIES)) {
-			const policy =
-				rules.categories[cat as keyof typeof rules.categories] || "ask"
-			const sessionGranted = grants.categories.includes(cat as any)
-			const tools = getToolsForCategory(cat as any)
-			const status = sessionGranted
-				? `${policy} (session: always allow)`
-				: policy
-			lines.push(
-				`  ${meta.label.padEnd(12)} ${status.padEnd(16)} tools: ${tools.join(", ")}`,
-			)
-		}
+      this.activeInlineQuestion = questionComponent;
+      this.chatContainer.addChild(new Spacer(1));
+      this.chatContainer.addChild(questionComponent);
+      this.chatContainer.addChild(new Spacer(1));
+      this.ui.requestRender();
+      this.chatContainer.invalidate();
+    });
+  }
+  /**
+   * Show an inline prompt when a thread is locked by another process.
+   * User can create a new thread (y) or exit (n).
+   */
+  private showThreadLockPrompt(threadTitle: string, ownerPid: number): void {
+    const questionComponent = new AskQuestionInlineComponent(
+      {
+        question: `Thread "${threadTitle}" is locked by pid ${ownerPid}. Create a new thread?`,
+        options: [
+          { label: 'Yes', description: 'Start a new thread' },
+          { label: 'No', description: 'Exit' },
+        ],
+        formatResult: answer => (answer === 'Yes' ? 'Thread created' : 'Exiting.'),
+        onSubmit: async answer => {
+          this.activeInlineQuestion = undefined;
+          if (answer.toLowerCase().startsWith('y')) {
+            // pendingNewThread is already true — thread will be
+            // created lazily on first message
+          } else {
+            process.exit(0);
+          }
+        },
+        onCancel: () => {
+          this.activeInlineQuestion = undefined;
+          process.exit(0);
+        },
+      },
+      this.ui,
+    );
 
-		if (Object.keys(rules.tools).length > 0) {
-			lines.push("")
-			lines.push("Per-tool Overrides:")
-			for (const [tool, policy] of Object.entries(rules.tools)) {
-				lines.push(`  ${tool.padEnd(24)} ${policy}`)
-			}
-		}
+    this.activeInlineQuestion = questionComponent;
+    this.chatContainer.addChild(questionComponent);
+    this.chatContainer.addChild(new Spacer(1));
+    this.ui.requestRender();
+    this.chatContainer.invalidate();
+  }
 
-		if (grants.categories.length > 0 || grants.tools.length > 0) {
-			lines.push("")
-			lines.push("Session Grants (reset on restart):")
-			if (grants.categories.length > 0) {
-				lines.push(`  Categories: ${grants.categories.join(", ")}`)
-			}
-			if (grants.tools.length > 0) {
-				lines.push(`  Tools: ${grants.tools.join(", ")}`)
-			}
-		}
+  // ===========================================================================
+  // Sandbox Management
+  // ===========================================================================
 
-		lines.push("")
-		lines.push("Commands:")
-		lines.push("  /permissions set <category> <allow|ask|deny>")
-		lines.push("  /yolo — toggle auto-approve all tools")
+  private async handleSandboxCommand(args: string[]): Promise<void> {
+    const state = this.harness.getState() as {
+      sandboxAllowedPaths?: string[];
+    };
+    const currentPaths = state.sandboxAllowedPaths ?? [];
 
-		this.showInfo(lines.join("\n"))
-	}
+    // If called with args, handle directly (e.g. /sandbox add /some/path)
+    const subcommand = args[0]?.toLowerCase();
+    if (subcommand === 'add' && args.length > 1) {
+      await this.sandboxAddPath(args.slice(1).join(' ').trim());
+      return;
+    }
+    if (subcommand === 'remove' && args.length > 1) {
+      await this.sandboxRemovePath(args.slice(1).join(' ').trim(), currentPaths);
+      return;
+    }
 
-	private async showSettings(): Promise<void> {
-		const state = this.harness.getState() as any
-		const config = {
-			notifications: (state?.notifications ?? "off") as NotificationMode,
-			yolo: this.harness.getYoloMode(),
-			thinkingLevel: this.harness.getThinkingLevel(),
-			escapeAsCancel: this.editor.escapeEnabled,
-		}
+    // Interactive mode — show inline selector
+    const options: Array<{ label: string; description?: string }> = [
+      { label: 'Add path', description: 'Allow access to another directory' },
+    ];
 
-		return new Promise<void>((resolve) => {
-			const settings = new SettingsComponent(config, {
-				onNotificationsChange: async (mode) => {
-					await this.harness.setState({ notifications: mode })
-					this.showInfo(`Notifications: ${mode}`)
-				},
-				onYoloChange: (enabled) => {
-					this.harness.setYoloMode(enabled)
-					this.updateStatusLine()
-				},
-				onThinkingLevelChange: async (level) => {
-					await this.harness.setThinkingLevel(level)
-					this.updateStatusLine()
-				},
-				onEscapeAsCancelChange: async (enabled) => {
-					this.editor.escapeEnabled = enabled
-					await this.harness.setState({ escapeAsCancel: enabled })
-					await this.harness.persistThreadSetting("escapeAsCancel", enabled)
-				},
-				onClose: () => {
-					this.ui.hideOverlay()
-					resolve()
-				},
-			})
+    for (const p of currentPaths) {
+      const short = p.split('/').pop() || p;
+      options.push({
+        label: `Remove: ${short}`,
+        description: p,
+      });
+    }
 
-			this.ui.showOverlay(settings, {
-				width: "60%",
-				maxHeight: "50%",
-				anchor: "center",
-			})
-			settings.focused = true
-		})
-	}
-	// ===========================================================================
-	// Login Selector
-	// ===========================================================================
+    const pathsSummary = currentPaths.length
+      ? `${currentPaths.length} allowed path${currentPaths.length > 1 ? 's' : ''}`
+      : 'no extra paths';
 
-	private async showLoginSelector(mode: "login" | "logout"): Promise<void> {
-		const allProviders = this.harness.getOAuthProviders()
-		const loggedInIds = this.harness.getLoggedInProviders()
+    return new Promise<void>(resolve => {
+      const questionComponent = new AskQuestionInlineComponent(
+        {
+          question: `Sandbox settings (${pathsSummary})`,
+          options,
+          formatResult: answer => {
+            if (answer === 'Add path') return 'Adding sandbox path…';
+            if (answer.startsWith('Remove: ')) {
+              const short = answer.replace('Remove: ', '');
+              return `Removed: ${short}`;
+            }
+            return answer;
+          },
+          onSubmit: async answer => {
+            this.activeInlineQuestion = undefined;
+            if (answer === 'Add path') {
+              resolve();
+              await this.showSandboxAddPrompt();
+            } else if (answer.startsWith('Remove: ')) {
+              const short = answer.replace('Remove: ', '');
+              const fullPath = currentPaths.find(p => (p.split('/').pop() || p) === short);
+              if (fullPath) {
+                await this.sandboxRemovePath(fullPath, currentPaths);
+              }
+              resolve();
+            } else {
+              resolve();
+            }
+          },
+          onCancel: () => {
+            this.activeInlineQuestion = undefined;
+            resolve();
+          },
+        },
+        this.ui,
+      );
 
-		if (mode === "logout") {
-			if (loggedInIds.length === 0) {
-				this.showInfo("No OAuth providers logged in. Use /login first.")
-				return
-			}
-		}
+      this.activeInlineQuestion = questionComponent;
+      this.chatContainer.addChild(new Spacer(1));
+      this.chatContainer.addChild(questionComponent);
+      this.chatContainer.addChild(new Spacer(1));
+      this.ui.requestRender();
+      this.chatContainer.invalidate();
+    });
+  }
 
-		const providers =
-			mode === "logout"
-				? allProviders.filter((p) => loggedInIds.includes(p.id))
-				: allProviders
+  private async showSandboxAddPrompt(): Promise<void> {
+    return new Promise<void>(resolve => {
+      const questionComponent = new AskQuestionInlineComponent(
+        {
+          question: 'Enter path to allow',
+          formatResult: answer => {
+            const resolved = path.resolve(answer);
+            return `Added: ${resolved}`;
+          },
+          onSubmit: async answer => {
+            this.activeInlineQuestion = undefined;
+            await this.sandboxAddPath(answer);
+            resolve();
+          },
+          onCancel: () => {
+            this.activeInlineQuestion = undefined;
+            resolve();
+          },
+        },
+        this.ui,
+      );
 
-		if (providers.length === 0) {
-			this.showInfo("No OAuth providers available.")
-			return
-		}
+      this.activeInlineQuestion = questionComponent;
+      this.chatContainer.addChild(new Spacer(1));
+      this.chatContainer.addChild(questionComponent);
+      this.chatContainer.addChild(new Spacer(1));
+      this.ui.requestRender();
+      this.chatContainer.invalidate();
+    });
+  }
 
-		const action = mode === "login" ? "Log in to" : "Log out from"
+  private async sandboxAddPath(rawPath: string): Promise<void> {
+    const state = this.harness.getState() as {
+      sandboxAllowedPaths?: string[];
+    };
+    const currentPaths = state.sandboxAllowedPaths ?? [];
+    const resolved = path.resolve(rawPath);
 
-		return new Promise<void>((resolve) => {
-			const questionComponent = new AskQuestionInlineComponent(
-				{
-					question: `${action} which provider?`,
-					options: providers.map((p) => ({
-						label: p.name,
-						description: loggedInIds.includes(p.id) ? "(logged in)" : "",
-					})),
-					formatResult: (answer) =>
-						mode === "login"
-							? `Logging in to ${answer}…`
-							: `Logged out from ${answer}`,
-					onSubmit: async (answer) => {
-						this.activeInlineQuestion = undefined
-						const provider = providers.find((p) => p.name === answer)
-						if (provider) {
-							if (mode === "login") {
-								await this.performLogin(provider.id)
-							} else {
-								this.harness.logout(provider.id)
-								this.showInfo(`Logged out from ${provider.name}`)
-							}
-						}
-						resolve()
-					},
-					onCancel: () => {
-						this.activeInlineQuestion = undefined
-						resolve()
-					},
-				},
-				this.ui,
-			)
+    if (currentPaths.includes(resolved)) {
+      this.showInfo(`Path already allowed: ${resolved}`);
+      return;
+    }
+    try {
+      await fs.promises.access(resolved);
+    } catch {
+      this.showError(`Path does not exist: ${resolved}`);
+      return;
+    }
+    const updated = [...currentPaths, resolved];
+    this.harness.setState({ sandboxAllowedPaths: updated } as any);
+    await this.harness.persistThreadSetting('sandboxAllowedPaths', updated);
+    this.showInfo(`Added to sandbox: ${resolved}`);
+  }
 
-			this.activeInlineQuestion = questionComponent
-			this.chatContainer.addChild(new Spacer(1))
-			this.chatContainer.addChild(questionComponent)
-			this.chatContainer.addChild(new Spacer(1))
-			this.ui.requestRender()
-			this.chatContainer.invalidate()
-		})
-	}
+  private async sandboxRemovePath(rawPath: string, currentPaths: string[]): Promise<void> {
+    const resolved = path.resolve(rawPath);
+    const match = currentPaths.find(p => p === resolved || p === rawPath);
+    if (!match) {
+      this.showError(`Path not in allowed list: ${resolved}`);
+      return;
+    }
+    const updated = currentPaths.filter(p => p !== match);
+    this.harness.setState({ sandboxAllowedPaths: updated } as any);
+    await this.harness.persistThreadSetting('sandboxAllowedPaths', updated);
+    this.showInfo(`Removed from sandbox: ${match}`);
+  }
 
-	private async performLogin(providerId: string): Promise<void> {
-		const provider = this.harness
-			.getOAuthProviders()
-			.find((p) => p.id === providerId)
-		const providerName = provider?.name || providerId
+  // ===========================================================================
+  // Skills List
+  // ===========================================================================
 
-		return new Promise((resolve) => {
-			const dialog = new LoginDialogComponent(
-				this.ui,
-				providerId,
-				(success, message) => {
-					this.ui.hideOverlay()
-					if (success) {
-						this.showInfo(`Successfully logged in to ${providerName}`)
-					} else if (message) {
-						this.showInfo(message)
-					}
-					resolve()
-				},
-			)
+  /**
+   * Get the workspace, preferring harness-owned workspace over the direct option.
+   */
+  private getResolvedWorkspace(): Workspace | undefined {
+    return this.harness.getWorkspace() ?? this.workspace;
+  }
 
-			// Show as overlay - same size as model selector
-			this.ui.showOverlay(dialog, {
-				width: "80%",
-				maxHeight: "60%",
-				anchor: "center",
-			})
-			dialog.focused = true
+  private async showSkillsList(): Promise<void> {
+    const workspace = this.getResolvedWorkspace();
+    if (!workspace?.skills) {
+      this.showInfo(
+        'No skills configured.\n\n' +
+          'Add skills to any of these locations:\n' +
+          '  .mastracode/skills/   (project-local)\n' +
+          '  .claude/skills/       (project-local)\n' +
+          '  ~/.mastracode/skills/ (global)\n' +
+          '  ~/.claude/skills/     (global)\n\n' +
+          'Each skill is a folder with a SKILL.md file.\n' +
+          'Install skills: npx add-skill <github-url>',
+      );
+      return;
+    }
 
-			// Start the login flow via harness
-			this.harness
-				.login(providerId, {
-					onAuth: (info: { url: string; instructions?: string }) => {
-						dialog.showAuth(info.url, info.instructions)
-					},
-					onPrompt: async (prompt: {
-						message: string
-						placeholder?: string
-					}) => {
-						return dialog.showPrompt(prompt.message, prompt.placeholder)
-					},
-					onProgress: (message: string) => {
-						dialog.showProgress(message)
-					},
-					signal: dialog.signal,
-				})
-				.then(async () => {
-					this.ui.hideOverlay()
+    try {
+      const skills = await workspace.skills!.list();
 
-					// Auto-switch to the provider's default model
-					const defaultModel = this.harness
-						.getAuthStorage()
-						.getDefaultModelForProvider(providerId as any)
-					if (defaultModel) {
-						await this.harness.switchModel(defaultModel)
-						this.updateStatusLine()
-						this.showInfo(
-							`Logged in to ${providerName} - switched to ${defaultModel}`,
-						)
-					} else {
-						this.showInfo(`Successfully logged in to ${providerName}`)
-					}
+      if (skills.length === 0) {
+        this.showInfo(
+          'No skills found in configured directories.\n\n' +
+            'Each skill needs a SKILL.md file with YAML frontmatter.\n' +
+            'Install skills: npx add-skill <github-url>',
+        );
+        return;
+      }
 
-					resolve()
-				})
-				.catch((error: Error) => {
-					this.ui.hideOverlay()
-					if (error.message !== "Login cancelled") {
-						this.showError(`Failed to login: ${error.message}`)
-					}
-					resolve()
-				})
-		})
-	}
+      const skillLines = skills.map(skill => {
+        const desc = skill.description
+          ? ` - ${skill.description.length > 60 ? skill.description.slice(0, 57) + '...' : skill.description}`
+          : '';
+        return `  ${skill.name}${desc}`;
+      });
 
-	// ===========================================================================
-	// Cost Tracking
-	// ===========================================================================
+      this.showInfo(
+        `Skills (${skills.length}):\n${skillLines.join('\n')}\n\n` +
+          'Skills are automatically activated by the agent when relevant.',
+      );
+    } catch (error) {
+      this.showError(`Failed to list skills: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
 
-	private async showCostBreakdown(): Promise<void> {
-		// Format the breakdown
-		const formatNumber = (n: number) => n.toLocaleString()
+  // ===========================================================================
+  // Model Selector
+  // ===========================================================================
 
-		// Get OM token usage if available
-		let omTokensText = ""
-		if (this.omProgress.observationTokens > 0) {
-			omTokensText = `
-  Memory:     ${formatNumber(this.omProgress.observationTokens)} tokens`
-		}
+  /**
+   * Show mode selector first, then scope (global/thread), then model list.
+   * Flow: Mode → Scope → Model
+   */
+  private async showModelScopeSelector(): Promise<void> {
+    const modes = this.harness.getModes();
+    const currentMode = this.harness.getCurrentMode();
 
-		this.showInfo(`Token Usage (Current Thread):
+    // Sort modes with active mode first
+    const sortedModes = [...modes].sort((a, b) => {
+      if (a.id === currentMode?.id) return -1;
+      if (b.id === currentMode?.id) return 1;
+      return 0;
+    });
+
+    const modeOptions = sortedModes.map(mode => ({
+      label: mode.name + (mode.id === currentMode?.id ? ' (active)' : ''),
+      modeId: mode.id,
+      modeName: mode.name,
+    }));
+
+    return new Promise<void>(resolve => {
+      const questionComponent = new AskQuestionInlineComponent(
+        {
+          question: 'Select mode',
+          options: modeOptions.map(m => ({ label: m.label })),
+          formatResult: answer => {
+            const mode = modeOptions.find(m => m.label === answer);
+            return `Mode: ${mode?.modeName ?? answer}`;
+          },
+          onSubmit: async answer => {
+            this.activeInlineQuestion = undefined;
+            const selected = modeOptions.find(m => m.label === answer);
+            if (selected?.modeId && selected?.modeName) {
+              await this.showModelScopeThenList(selected.modeId, selected.modeName);
+            }
+            resolve();
+          },
+          onCancel: () => {
+            this.activeInlineQuestion = undefined;
+            resolve();
+          },
+        },
+        this.ui,
+      );
+
+      this.activeInlineQuestion = questionComponent;
+      this.chatContainer.addChild(new Spacer(1));
+      this.chatContainer.addChild(questionComponent);
+      this.chatContainer.addChild(new Spacer(1));
+      this.ui.requestRender();
+      this.chatContainer.invalidate();
+    });
+  }
+
+  /**
+   * Show scope selector (global/thread) for a specific mode, then model list.
+   */
+  private async showModelScopeThenList(modeId: string, modeName: string): Promise<void> {
+    const scopes = [
+      {
+        label: 'Thread default',
+        description: `Default for ${modeName} mode in this thread`,
+        scope: 'thread' as const,
+      },
+      {
+        label: 'Global default',
+        description: `Default for ${modeName} mode in all threads`,
+        scope: 'global' as const,
+      },
+    ];
+
+    return new Promise<void>(resolve => {
+      const questionComponent = new AskQuestionInlineComponent(
+        {
+          question: `Select scope for ${modeName}`,
+          options: scopes.map(s => ({
+            label: s.label,
+            description: s.description,
+          })),
+          formatResult: answer => `${modeName} · ${answer}`,
+          onSubmit: async answer => {
+            this.activeInlineQuestion = undefined;
+            const selected = scopes.find(s => s.label === answer);
+            if (selected) {
+              await this.showModelListForScope(selected.scope, modeId, modeName);
+            }
+            resolve();
+          },
+          onCancel: () => {
+            this.activeInlineQuestion = undefined;
+            resolve();
+          },
+        },
+        this.ui,
+      );
+
+      this.activeInlineQuestion = questionComponent;
+      this.chatContainer.addChild(new Spacer(1));
+      this.chatContainer.addChild(questionComponent);
+      this.chatContainer.addChild(new Spacer(1));
+      this.ui.requestRender();
+      this.chatContainer.invalidate();
+    });
+  }
+
+  /**
+   * Show the model list for a specific mode and scope.
+   */
+  private async showModelListForScope(scope: 'global' | 'thread', modeId: string, modeName: string): Promise<void> {
+    const availableModels = await this.harness.getAvailableModels();
+
+    if (availableModels.length === 0) {
+      this.showInfo('No models available. Check your Mastra configuration.');
+      return;
+    }
+
+    const currentModelId = this.harness.getCurrentModelId();
+    const scopeLabel = scope === 'global' ? `${modeName} · Global` : `${modeName} · Thread`;
+
+    return new Promise(resolve => {
+      const selector = new ModelSelectorComponent({
+        tui: this.ui,
+        models: availableModels,
+        currentModelId,
+        title: `Select model (${scopeLabel})`,
+        onSelect: async (model: ModelItem) => {
+          this.ui.hideOverlay();
+          await this.harness.switchModel(model.id, scope, modeId);
+          this.showInfo(`Model set for ${scopeLabel}: ${model.id}`);
+          this.updateStatusLine();
+          resolve();
+        },
+        onCancel: () => {
+          this.ui.hideOverlay();
+          resolve();
+        },
+      });
+
+      this.ui.showOverlay(selector, {
+        width: '80%',
+        maxHeight: '60%',
+        anchor: 'center',
+      });
+      selector.focused = true;
+    });
+  }
+
+  /**
+   * Show agent type selector first, then scope (global/thread), then model list.
+   * Flow: Agent Type → Scope → Model
+   */
+  private async showSubagentModelSelector(): Promise<void> {
+    const agentTypes = [
+      {
+        id: 'explore',
+        label: 'Explore',
+        description: 'Read-only codebase exploration',
+      },
+      {
+        id: 'plan',
+        label: 'Plan',
+        description: 'Read-only analysis and planning',
+      },
+      {
+        id: 'execute',
+        label: 'Execute',
+        description: 'Task execution with write access',
+      },
+    ];
+
+    return new Promise<void>(resolve => {
+      const questionComponent = new AskQuestionInlineComponent(
+        {
+          question: 'Select subagent type',
+          options: agentTypes.map(t => ({
+            label: t.label,
+            description: t.description,
+          })),
+          formatResult: answer => `Subagent: ${answer}`,
+          onSubmit: async answer => {
+            this.activeInlineQuestion = undefined;
+            const selected = agentTypes.find(t => t.label === answer);
+            if (selected) {
+              await this.showSubagentScopeThenList(selected.id, selected.label);
+            }
+            resolve();
+          },
+          onCancel: () => {
+            this.activeInlineQuestion = undefined;
+            resolve();
+          },
+        },
+        this.ui,
+      );
+
+      this.activeInlineQuestion = questionComponent;
+      this.chatContainer.addChild(new Spacer(1));
+      this.chatContainer.addChild(questionComponent);
+      this.chatContainer.addChild(new Spacer(1));
+      this.ui.requestRender();
+      this.chatContainer.invalidate();
+    });
+  }
+
+  /**
+   * Show scope selector (global/thread) for a specific agent type, then model list.
+   */
+  private async showSubagentScopeThenList(agentType: string, agentTypeLabel: string): Promise<void> {
+    const scopes = [
+      {
+        label: 'Thread default',
+        description: `Default for ${agentTypeLabel} subagents in this thread`,
+        scope: 'thread' as const,
+      },
+      {
+        label: 'Global default',
+        description: `Default for ${agentTypeLabel} subagents in all threads`,
+        scope: 'global' as const,
+      },
+    ];
+
+    return new Promise<void>(resolve => {
+      const questionComponent = new AskQuestionInlineComponent(
+        {
+          question: `Select scope for ${agentTypeLabel} subagents`,
+          options: scopes.map(s => ({
+            label: s.label,
+            description: s.description,
+          })),
+          formatResult: answer => `${agentTypeLabel} · ${answer}`,
+          onSubmit: async answer => {
+            this.activeInlineQuestion = undefined;
+            const selected = scopes.find(s => s.label === answer);
+            if (selected) {
+              await this.showSubagentModelListForScope(selected.scope, agentType, agentTypeLabel);
+            }
+            resolve();
+          },
+          onCancel: () => {
+            this.activeInlineQuestion = undefined;
+            resolve();
+          },
+        },
+        this.ui,
+      );
+
+      this.activeInlineQuestion = questionComponent;
+      this.chatContainer.addChild(new Spacer(1));
+      this.chatContainer.addChild(questionComponent);
+      this.chatContainer.addChild(new Spacer(1));
+      this.ui.requestRender();
+      this.chatContainer.invalidate();
+    });
+  }
+
+  /**
+   * Show the model list for subagent type and scope selection.
+   */
+  private async showSubagentModelListForScope(
+    scope: 'global' | 'thread',
+    agentType: string,
+    agentTypeLabel: string,
+  ): Promise<void> {
+    const availableModels = await this.harness.getAvailableModels();
+
+    if (availableModels.length === 0) {
+      this.showInfo('No models available. Check your Mastra configuration.');
+      return;
+    }
+
+    // Get current subagent model if set
+    const currentSubagentModel = await this.harness.getSubagentModelId(agentType);
+    const scopeLabel = scope === 'global' ? `${agentTypeLabel} · Global` : `${agentTypeLabel} · Thread`;
+
+    return new Promise(resolve => {
+      const selector = new ModelSelectorComponent({
+        tui: this.ui,
+        models: availableModels,
+        currentModelId: currentSubagentModel ?? undefined,
+        title: `Select subagent model (${scopeLabel})`,
+        onSelect: async (model: ModelItem) => {
+          this.ui.hideOverlay();
+          await this.harness.setSubagentModelId(model.id, scope, agentType);
+          this.showInfo(`Subagent model set for ${scopeLabel}: ${model.id}`);
+          resolve();
+        },
+        onCancel: () => {
+          this.ui.hideOverlay();
+          resolve();
+        },
+      });
+
+      this.ui.showOverlay(selector, {
+        width: '80%',
+        maxHeight: '60%',
+        anchor: 'center',
+      });
+      selector.focused = true;
+    });
+  }
+
+  // ===========================================================================
+  // Observational Memory Settings
+  // ===========================================================================
+
+  private async showOMSettings(): Promise<void> {
+    // Get available models for the model submenus
+    const availableModels = await this.harness.getAvailableModels();
+    const modelOptions = availableModels.map(m => ({
+      id: m.id,
+      label: m.id,
+    }));
+
+    const config = {
+      observerModelId: this.harness.getObserverModelId(),
+      reflectorModelId: this.harness.getReflectorModelId(),
+      observationThreshold: this.harness.getObservationThreshold(),
+      reflectionThreshold: this.harness.getReflectionThreshold(),
+    };
+
+    return new Promise<void>(resolve => {
+      const settings = new OMSettingsComponent(
+        config,
+        {
+          onObserverModelChange: async modelId => {
+            await this.harness.switchObserverModel(modelId);
+            this.showInfo(`Observer model → ${modelId}`);
+          },
+          onReflectorModelChange: async modelId => {
+            await this.harness.switchReflectorModel(modelId);
+            this.showInfo(`Reflector model → ${modelId}`);
+          },
+          onObservationThresholdChange: value => {
+            this.harness.setObservationThreshold(value);
+            this.omProgress.threshold = value;
+            this.omProgress.thresholdPercent = value > 0 ? (this.omProgress.pendingTokens / value) * 100 : 0;
+            this.updateStatusLine();
+          },
+          onReflectionThresholdChange: value => {
+            this.harness.setReflectionThreshold(value);
+            this.omProgress.reflectionThreshold = value;
+            this.omProgress.reflectionThresholdPercent =
+              value > 0 ? (this.omProgress.observationTokens / value) * 100 : 0;
+            this.updateStatusLine();
+          },
+          onClose: () => {
+            this.ui.hideOverlay();
+            this.updateStatusLine();
+            resolve();
+          },
+        },
+        modelOptions,
+        this.ui,
+      );
+
+      this.ui.showOverlay(settings, {
+        width: '80%',
+        maxHeight: '70%',
+        anchor: 'center',
+      });
+      settings.focused = true;
+    });
+  }
+  // ===========================================================================
+  // General Settings
+  // ===========================================================================
+  private async showPermissions(): Promise<void> {
+    const { TOOL_CATEGORIES, getToolsForCategory } = await import('../permissions.js');
+    const rules = this.harness.getPermissionRules_public();
+    const grants = this.harness.getSessionGrants();
+    const isYolo = this.harness.getYoloMode();
+
+    const lines: string[] = [];
+    lines.push('Tool Approval Permissions');
+    lines.push('─'.repeat(40));
+
+    if (isYolo) {
+      lines.push('');
+      lines.push('⚡ YOLO mode is ON — all tools are auto-approved');
+      lines.push('  Use /yolo to toggle off');
+    }
+
+    lines.push('');
+    lines.push('Category Policies:');
+    for (const [cat, meta] of Object.entries(TOOL_CATEGORIES)) {
+      const policy = rules.categories[cat as keyof typeof rules.categories] || 'ask';
+      const sessionGranted = grants.categories.includes(cat as any);
+      const tools = getToolsForCategory(cat as any);
+      const status = sessionGranted ? `${policy} (session: always allow)` : policy;
+      lines.push(`  ${meta.label.padEnd(12)} ${status.padEnd(16)} tools: ${tools.join(', ')}`);
+    }
+
+    if (Object.keys(rules.tools).length > 0) {
+      lines.push('');
+      lines.push('Per-tool Overrides:');
+      for (const [tool, policy] of Object.entries(rules.tools)) {
+        lines.push(`  ${tool.padEnd(24)} ${policy}`);
+      }
+    }
+
+    if (grants.categories.length > 0 || grants.tools.length > 0) {
+      lines.push('');
+      lines.push('Session Grants (reset on restart):');
+      if (grants.categories.length > 0) {
+        lines.push(`  Categories: ${grants.categories.join(', ')}`);
+      }
+      if (grants.tools.length > 0) {
+        lines.push(`  Tools: ${grants.tools.join(', ')}`);
+      }
+    }
+
+    lines.push('');
+    lines.push('Commands:');
+    lines.push('  /permissions set <category> <allow|ask|deny>');
+    lines.push('  /yolo — toggle auto-approve all tools');
+
+    this.showInfo(lines.join('\n'));
+  }
+
+  private async showSettings(): Promise<void> {
+    const state = this.harness.getState() as any;
+    const config = {
+      notifications: (state?.notifications ?? 'off') as NotificationMode,
+      yolo: this.harness.getYoloMode(),
+      thinkingLevel: this.harness.getThinkingLevel(),
+      escapeAsCancel: this.editor.escapeEnabled,
+    };
+
+    return new Promise<void>(resolve => {
+      const settings = new SettingsComponent(config, {
+        onNotificationsChange: async mode => {
+          await this.harness.setState({ notifications: mode });
+          this.showInfo(`Notifications: ${mode}`);
+        },
+        onYoloChange: enabled => {
+          this.harness.setYoloMode(enabled);
+          this.updateStatusLine();
+        },
+        onThinkingLevelChange: async level => {
+          await this.harness.setThinkingLevel(level);
+          this.updateStatusLine();
+        },
+        onEscapeAsCancelChange: async enabled => {
+          this.editor.escapeEnabled = enabled;
+          await this.harness.setState({ escapeAsCancel: enabled });
+          await this.harness.persistThreadSetting('escapeAsCancel', enabled);
+        },
+        onClose: () => {
+          this.ui.hideOverlay();
+          resolve();
+        },
+      });
+
+      this.ui.showOverlay(settings, {
+        width: '60%',
+        maxHeight: '50%',
+        anchor: 'center',
+      });
+      settings.focused = true;
+    });
+  }
+  // ===========================================================================
+  // Login Selector
+  // ===========================================================================
+
+  private async showLoginSelector(mode: 'login' | 'logout'): Promise<void> {
+    const allProviders = this.harness.getOAuthProviders();
+    const loggedInIds = this.harness.getLoggedInProviders();
+
+    if (mode === 'logout') {
+      if (loggedInIds.length === 0) {
+        this.showInfo('No OAuth providers logged in. Use /login first.');
+        return;
+      }
+    }
+
+    const providers = mode === 'logout' ? allProviders.filter(p => loggedInIds.includes(p.id)) : allProviders;
+
+    if (providers.length === 0) {
+      this.showInfo('No OAuth providers available.');
+      return;
+    }
+
+    const action = mode === 'login' ? 'Log in to' : 'Log out from';
+
+    return new Promise<void>(resolve => {
+      const questionComponent = new AskQuestionInlineComponent(
+        {
+          question: `${action} which provider?`,
+          options: providers.map(p => ({
+            label: p.name,
+            description: loggedInIds.includes(p.id) ? '(logged in)' : '',
+          })),
+          formatResult: answer => (mode === 'login' ? `Logging in to ${answer}…` : `Logged out from ${answer}`),
+          onSubmit: async answer => {
+            this.activeInlineQuestion = undefined;
+            const provider = providers.find(p => p.name === answer);
+            if (provider) {
+              if (mode === 'login') {
+                await this.performLogin(provider.id);
+              } else {
+                this.harness.logout(provider.id);
+                this.showInfo(`Logged out from ${provider.name}`);
+              }
+            }
+            resolve();
+          },
+          onCancel: () => {
+            this.activeInlineQuestion = undefined;
+            resolve();
+          },
+        },
+        this.ui,
+      );
+
+      this.activeInlineQuestion = questionComponent;
+      this.chatContainer.addChild(new Spacer(1));
+      this.chatContainer.addChild(questionComponent);
+      this.chatContainer.addChild(new Spacer(1));
+      this.ui.requestRender();
+      this.chatContainer.invalidate();
+    });
+  }
+
+  private async performLogin(providerId: string): Promise<void> {
+    const provider = this.harness.getOAuthProviders().find(p => p.id === providerId);
+    const providerName = provider?.name || providerId;
+
+    return new Promise(resolve => {
+      const dialog = new LoginDialogComponent(this.ui, providerId, (success, message) => {
+        this.ui.hideOverlay();
+        if (success) {
+          this.showInfo(`Successfully logged in to ${providerName}`);
+        } else if (message) {
+          this.showInfo(message);
+        }
+        resolve();
+      });
+
+      // Show as overlay - same size as model selector
+      this.ui.showOverlay(dialog, {
+        width: '80%',
+        maxHeight: '60%',
+        anchor: 'center',
+      });
+      dialog.focused = true;
+
+      // Start the login flow via harness
+      this.harness
+        .login(providerId, {
+          onAuth: (info: { url: string; instructions?: string }) => {
+            dialog.showAuth(info.url, info.instructions);
+          },
+          onPrompt: async (prompt: { message: string; placeholder?: string }) => {
+            return dialog.showPrompt(prompt.message, prompt.placeholder);
+          },
+          onProgress: (message: string) => {
+            dialog.showProgress(message);
+          },
+          signal: dialog.signal,
+        })
+        .then(async () => {
+          this.ui.hideOverlay();
+
+          // Auto-switch to the provider's default model
+          const defaultModel = this.harness.getAuthStorage().getDefaultModelForProvider(providerId as any);
+          if (defaultModel) {
+            await this.harness.switchModel(defaultModel);
+            this.updateStatusLine();
+            this.showInfo(`Logged in to ${providerName} - switched to ${defaultModel}`);
+          } else {
+            this.showInfo(`Successfully logged in to ${providerName}`);
+          }
+
+          resolve();
+        })
+        .catch((error: Error) => {
+          this.ui.hideOverlay();
+          if (error.message !== 'Login cancelled') {
+            this.showError(`Failed to login: ${error.message}`);
+          }
+          resolve();
+        });
+    });
+  }
+
+  // ===========================================================================
+  // Cost Tracking
+  // ===========================================================================
+
+  private async showCostBreakdown(): Promise<void> {
+    // Format the breakdown
+    const formatNumber = (n: number) => n.toLocaleString();
+
+    // Get OM token usage if available
+    let omTokensText = '';
+    if (this.omProgress.observationTokens > 0) {
+      omTokensText = `
+  Memory:     ${formatNumber(this.omProgress.observationTokens)} tokens`;
+    }
+
+    this.showInfo(`Token Usage (Current Thread):
   Input:      ${formatNumber(this.tokenUsage.promptTokens)} tokens
   Output:     ${formatNumber(this.tokenUsage.completionTokens)} tokens${omTokensText}
   ─────────────────────────────────────────
   Total:      ${formatNumber(this.tokenUsage.totalTokens)} tokens
   
-  Note: For cost estimates, check your provider's pricing page.`)
-	}
+  Note: For cost estimates, check your provider's pricing page.`);
+  }
 
-	// ===========================================================================
-	// Slash Commands
-	// ===========================================================================
+  // ===========================================================================
+  // Slash Commands
+  // ===========================================================================
 
-	private async handleSlashCommand(input: string): Promise<boolean> {
-		const trimmedInput = input.trim()
+  private async handleSlashCommand(input: string): Promise<boolean> {
+    const trimmedInput = input.trim();
 
-		// Strip leading slashes — pi-tui may pass /command or command depending
-		// on how the user invoked it.  Try custom commands first, then built-in.
-		const withoutSlashes = trimmedInput.replace(/^\/+/, "")
-		if (trimmedInput.startsWith("/")) {
-			const [cmdName, ...cmdArgs] = withoutSlashes.split(" ")
-			const customCommand = this.customSlashCommands.find(
-				(cmd) => cmd.name === cmdName,
-			)
-			if (customCommand) {
-				await this.handleCustomSlashCommand(customCommand, cmdArgs)
-				return true
-			}
-			// Not a custom command — fall through to built-in routing
-		}
+    // Strip leading slashes — pi-tui may pass /command or command depending
+    // on how the user invoked it.  Try custom commands first, then built-in.
+    const withoutSlashes = trimmedInput.replace(/^\/+/, '');
+    if (trimmedInput.startsWith('/')) {
+      const [cmdName, ...cmdArgs] = withoutSlashes.split(' ');
+      const customCommand = this.customSlashCommands.find(cmd => cmd.name === cmdName);
+      if (customCommand) {
+        await this.handleCustomSlashCommand(customCommand, cmdArgs);
+        return true;
+      }
+      // Not a custom command — fall through to built-in routing
+    }
 
-		const [command, ...args] = withoutSlashes.split(" ")
+    const [command, ...args] = withoutSlashes.split(' ');
 
-		switch (command) {
-			case "new": {
-				// Defer thread creation until first message
-				this.pendingNewThread = true
-				this.chatContainer.clear()
-				this.pendingTools.clear()
-				this.allToolComponents = []
-				this.modifiedFiles.clear()
-				this.pendingFileTools.clear()
-				this.resetStatusLineState()
-				this.ui.requestRender()
-				this.showInfo("Ready for new conversation")
-				return true
-			}
+    switch (command) {
+      case 'new': {
+        // Defer thread creation until first message
+        this.pendingNewThread = true;
+        this.chatContainer.clear();
+        this.pendingTools.clear();
+        this.allToolComponents = [];
+        this.modifiedFiles.clear();
+        this.pendingFileTools.clear();
+        this.resetStatusLineState();
+        this.ui.requestRender();
+        this.showInfo('Ready for new conversation');
+        return true;
+      }
 
-			case "threads": {
-				await this.showThreadSelector()
-				return true
-			}
+      case 'threads': {
+        await this.showThreadSelector();
+        return true;
+      }
 
-			case "skills": {
-				await this.showSkillsList()
-				return true
-			}
+      case 'skills': {
+        await this.showSkillsList();
+        return true;
+      }
 
-			case "thread:tag-dir": {
-				await this.tagThreadWithDir()
-				return true
-			}
+      case 'thread:tag-dir': {
+        await this.tagThreadWithDir();
+        return true;
+      }
 
-			case "sandbox": {
-				await this.handleSandboxCommand(args)
-				return true
-			}
+      case 'sandbox': {
+        await this.handleSandboxCommand(args);
+        return true;
+      }
 
-			case "mode": {
-				const modes = this.harness.getModes()
-				if (modes.length <= 1) {
-					this.showInfo("Only one mode available")
-					return true
-				}
-				if (args[0]) {
-					await this.harness.switchMode(args[0])
-				} else {
-					const currentMode = this.harness.getCurrentMode()
-					const modeList = modes
-						.map(
-							(m) =>
-								`  ${m.id === currentMode?.id ? "* " : "  "}${m.id}${m.name ? ` - ${m.name}` : ""}`,
-						)
-						.join("\n")
-					this.showInfo(`Modes:
-${modeList}`)
-				}
-				return true
-			}
+      case 'mode': {
+        const modes = this.harness.getModes();
+        if (modes.length <= 1) {
+          this.showInfo('Only one mode available');
+          return true;
+        }
+        if (args[0]) {
+          await this.harness.switchMode(args[0]);
+        } else {
+          const currentMode = this.harness.getCurrentMode();
+          const modeList = modes
+            .map(m => `  ${m.id === currentMode?.id ? '* ' : '  '}${m.id}${m.name ? ` - ${m.name}` : ''}`)
+            .join('\n');
+          this.showInfo(`Modes:
+${modeList}`);
+        }
+        return true;
+      }
 
-			case "models": {
-				await this.showModelScopeSelector()
-				return true
-			}
+      case 'models': {
+        await this.showModelScopeSelector();
+        return true;
+      }
 
-			case "subagents": {
-				await this.showSubagentModelSelector()
-				return true
-			}
+      case 'subagents': {
+        await this.showSubagentModelSelector();
+        return true;
+      }
 
-			case "om": {
-				await this.showOMSettings()
-				return true
-			}
-			case "think": {
-				const currentLevel = this.harness.getThinkingLevel()
-				const levels = [
-					{ label: "Off", id: "off" },
-					{ label: "Minimal", id: "minimal" },
-					{ label: "Low", id: "low" },
-					{ label: "Medium", id: "medium" },
-					{ label: "High", id: "high" },
-				]
-                const currentIdx = levels.findIndex((l) => l.id === currentLevel)
-                const nextIdx = (currentIdx + 1) % levels.length
-                const next = levels[nextIdx]!
-                await this.harness.setThinkingLevel(next.id)
-                this.showInfo(`Thinking: ${next.label}`)
-				this.updateStatusLine()
-				return true
-			}
-			case "permissions": {
-				if (args[0] === "set" && args.length >= 3) {
-					const category = args[1] as any
-					const policy = args[2] as any
-					const validCategories = ["read", "edit", "execute", "mcp"]
-					const validPolicies = ["allow", "ask", "deny"]
-					if (!validCategories.includes(category)) {
-						this.showInfo(
-							`Invalid category: ${category}. Must be one of: ${validCategories.join(", ")}`,
-						)
-						return true
-					}
-					if (!validPolicies.includes(policy)) {
-						this.showInfo(
-							`Invalid policy: ${policy}. Must be one of: ${validPolicies.join(", ")}`,
-						)
-						return true
-					}
-					this.harness.setPermissionCategory(category, policy)
-					this.showInfo(`Set ${category} policy to: ${policy}`)
-					return true
-				}
-				await this.showPermissions()
-				return true
-			}
-			case "yolo": {
-				const current = this.harness.getYoloMode()
-				this.harness.setYoloMode(!current)
-				this.showInfo(
-					!current
-						? "YOLO mode ON — tools auto-approved"
-						: "YOLO mode OFF — tools require approval",
-				)
-				this.updateStatusLine()
-				return true
-			}
-			case "settings": {
-				await this.showSettings()
-				return true
-			}
+      case 'om': {
+        await this.showOMSettings();
+        return true;
+      }
+      case 'think': {
+        const currentLevel = this.harness.getThinkingLevel();
+        const levels = [
+          { label: 'Off', id: 'off' },
+          { label: 'Minimal', id: 'minimal' },
+          { label: 'Low', id: 'low' },
+          { label: 'Medium', id: 'medium' },
+          { label: 'High', id: 'high' },
+        ];
+        const currentIdx = levels.findIndex(l => l.id === currentLevel);
+        const nextIdx = (currentIdx + 1) % levels.length;
+        const next = levels[nextIdx]!;
+        await this.harness.setThinkingLevel(next.id);
+        this.showInfo(`Thinking: ${next.label}`);
+        this.updateStatusLine();
+        return true;
+      }
+      case 'permissions': {
+        if (args[0] === 'set' && args.length >= 3) {
+          const category = args[1] as any;
+          const policy = args[2] as any;
+          const validCategories = ['read', 'edit', 'execute', 'mcp'];
+          const validPolicies = ['allow', 'ask', 'deny'];
+          if (!validCategories.includes(category)) {
+            this.showInfo(`Invalid category: ${category}. Must be one of: ${validCategories.join(', ')}`);
+            return true;
+          }
+          if (!validPolicies.includes(policy)) {
+            this.showInfo(`Invalid policy: ${policy}. Must be one of: ${validPolicies.join(', ')}`);
+            return true;
+          }
+          this.harness.setPermissionCategory(category, policy);
+          this.showInfo(`Set ${category} policy to: ${policy}`);
+          return true;
+        }
+        await this.showPermissions();
+        return true;
+      }
+      case 'yolo': {
+        const current = this.harness.getYoloMode();
+        this.harness.setYoloMode(!current);
+        this.showInfo(!current ? 'YOLO mode ON — tools auto-approved' : 'YOLO mode OFF — tools require approval');
+        this.updateStatusLine();
+        return true;
+      }
+      case 'settings': {
+        await this.showSettings();
+        return true;
+      }
 
-			case "login": {
-				await this.showLoginSelector("login")
-				return true
-			}
+      case 'login': {
+        await this.showLoginSelector('login');
+        return true;
+      }
 
-			case "logout": {
-				await this.showLoginSelector("logout")
-				return true
-			}
-			case "cost": {
-				await this.showCostBreakdown()
-				return true
-			}
+      case 'logout': {
+        await this.showLoginSelector('logout');
+        return true;
+      }
+      case 'cost': {
+        await this.showCostBreakdown();
+        return true;
+      }
 
-			case "diff": {
-				await this.showDiff(args[0])
-				return true
-			}
+      case 'diff': {
+        await this.showDiff(args[0]);
+        return true;
+      }
 
-			case "name": {
-				const title = args.join(" ").trim()
-				if (!title) {
-					this.showInfo("Usage: /name <title>")
-					return true
-				}
-				if (!this.harness.getCurrentThreadId()) {
-					this.showInfo("No active thread. Send a message first.")
-					return true
-				}
-				await this.harness.renameThread(title)
-				this.showInfo(`Thread renamed to: ${title}`)
-				return true
-			}
-			case "resource": {
-				const sub = args[0]?.trim()
-				const current = this.harness.getResourceId()
-				const defaultId = this.harness.getDefaultResourceId()
+      case 'name': {
+        const title = args.join(' ').trim();
+        if (!title) {
+          this.showInfo('Usage: /name <title>');
+          return true;
+        }
+        if (!this.harness.getCurrentThreadId()) {
+          this.showInfo('No active thread. Send a message first.');
+          return true;
+        }
+        await this.harness.renameThread(title);
+        this.showInfo(`Thread renamed to: ${title}`);
+        return true;
+      }
+      case 'resource': {
+        const sub = args[0]?.trim();
+        const current = this.harness.getResourceId();
+        const defaultId = this.harness.getDefaultResourceId();
 
-				if (!sub) {
-					// Show current resource ID and list known ones
-					const knownIds = await this.harness.getKnownResourceIds()
-					const isOverridden = current !== defaultId
-					const lines = [
-						`Current: ${current}${isOverridden ? ` (auto-detected: ${defaultId})` : ""}`,
-						"",
-						"Known resource IDs:",
-						...knownIds.map((id) => `  ${id === current ? "* " : "  "}${id}`),
-						"",
-						"Usage:",
-						"  /resource <id>    - Switch to a resource ID",
-						"  /resource reset   - Reset to auto-detected ID",
-					]
-					this.showInfo(lines.join("\n"))
-				} else if (sub === "reset") {
-					this.harness.setResourceId(defaultId)
-					this.pendingNewThread = true
-					this.chatContainer.clear()
-					this.pendingTools.clear()
-					this.allToolComponents = []
-					this.resetStatusLineState()
-					this.ui.requestRender()
-					this.showInfo(`Resource ID reset to: ${defaultId}`)
-				} else {
-					const newId = args.join(" ").trim()
-					this.harness.setResourceId(newId)
-					this.pendingNewThread = true
-					this.chatContainer.clear()
-					this.pendingTools.clear()
-					this.allToolComponents = []
-					this.resetStatusLineState()
-					this.ui.requestRender()
-					this.showInfo(`Switched to resource: ${newId}`)
-				}
-				return true
-			}
+        if (!sub) {
+          // Show current resource ID and list known ones
+          const knownIds = await this.harness.getKnownResourceIds();
+          const isOverridden = current !== defaultId;
+          const lines = [
+            `Current: ${current}${isOverridden ? ` (auto-detected: ${defaultId})` : ''}`,
+            '',
+            'Known resource IDs:',
+            ...knownIds.map(id => `  ${id === current ? '* ' : '  '}${id}`),
+            '',
+            'Usage:',
+            '  /resource <id>    - Switch to a resource ID',
+            '  /resource reset   - Reset to auto-detected ID',
+          ];
+          this.showInfo(lines.join('\n'));
+        } else if (sub === 'reset') {
+          this.harness.setResourceId(defaultId);
+          this.pendingNewThread = true;
+          this.chatContainer.clear();
+          this.pendingTools.clear();
+          this.allToolComponents = [];
+          this.resetStatusLineState();
+          this.ui.requestRender();
+          this.showInfo(`Resource ID reset to: ${defaultId}`);
+        } else {
+          const newId = args.join(' ').trim();
+          this.harness.setResourceId(newId);
+          this.pendingNewThread = true;
+          this.chatContainer.clear();
+          this.pendingTools.clear();
+          this.allToolComponents = [];
+          this.resetStatusLineState();
+          this.ui.requestRender();
+          this.showInfo(`Switched to resource: ${newId}`);
+        }
+        return true;
+      }
 
-			case "exit":
-				this.stop()
-				process.exit(0)
+      case 'exit':
+        this.stop();
+        process.exit(0);
 
-			case "help": {
-				const modes = this.harness.getModes()
-				const modeHelp =
-					modes.length > 1 ? "\n/mode     - Switch or list modes" : ""
+      case 'help': {
+        const modes = this.harness.getModes();
+        const modeHelp = modes.length > 1 ? '\n/mode     - Switch or list modes' : '';
 
-				// Build custom commands help
-				let customCommandsHelp = ""
-				if (this.customSlashCommands.length > 0) {
-					customCommandsHelp =
-						"\n\nCustom commands (use // prefix):\n" +
-						this.customSlashCommands
-							.map(
-								(cmd) =>
-									`  //${cmd.name.padEnd(8)} - ${cmd.description || "No description"}`,
-							)
-							.join("\n")
-				}
+        // Build custom commands help
+        let customCommandsHelp = '';
+        if (this.customSlashCommands.length > 0) {
+          customCommandsHelp =
+            '\n\nCustom commands (use // prefix):\n' +
+            this.customSlashCommands
+              .map(cmd => `  //${cmd.name.padEnd(8)} - ${cmd.description || 'No description'}`)
+              .join('\n');
+        }
 
-				this.showInfo(`Available commands:
+        this.showInfo(`Available commands:
   /new       - Start a new thread
   /threads       - Switch between threads
   /thread:tag-dir - Tag thread with current directory
@@ -4109,855 +3740,760 @@ Keyboard shortcuts:
   Ctrl+F    - While working: queue follow-up message
   Shift+Tab - Cycle agent modes
   Ctrl+T    - Toggle thinking blocks
-  Ctrl+E    - Expand/collapse tool outputs`)
-				return true
-			}
-
-			case "hooks": {
-				const hm = this.harness.getHookManager?.()
-				if (!hm) {
-					this.showInfo("Hooks system not initialized.")
-					return true
-				}
-
-				const subcommand = args[0]
-				if (subcommand === "reload") {
-					hm.reload()
-					this.showInfo("Hooks config reloaded.")
-					return true
-				}
-
-				const paths = hm.getConfigPaths()
-
-				if (!hm.hasHooks()) {
-					this.showInfo(
-						`No hooks configured.\n\n` +
-							`Add hooks to:\n` +
-							`  ${paths.project} (project)\n` +
-							`  ${paths.global} (global)\n\n` +
-							`Example hooks.json:\n` +
-							`  {\n` +
-							`    "PreToolUse": [{\n` +
-							`      "type": "command",\n` +
-							`      "command": "echo 'tool called'",\n` +
-							`      "matcher": { "tool_name": "execute_command" }\n` +
-							`    }]\n` +
-							`  }`,
-					)
-					return true
-				}
-
-				const hookConfig = hm.getConfig()
-				const lines: string[] = [`Hooks Configuration:`]
-				lines.push(`  Project: ${paths.project}`)
-				lines.push(`  Global:  ${paths.global}`)
-				lines.push("")
-
-				const eventNames = [
-					"PreToolUse",
-					"PostToolUse",
-					"Stop",
-					"UserPromptSubmit",
-					"SessionStart",
-					"SessionEnd",
-				] as const
-
-				for (const event of eventNames) {
-					const hooks = hookConfig[event]
-					if (hooks && hooks.length > 0) {
-						lines.push(
-							`  ${event} (${hooks.length} hook${hooks.length > 1 ? "s" : ""}):`,
-						)
-						for (const hook of hooks) {
-							const matcherStr = hook.matcher?.tool_name
-								? ` [tool: ${hook.matcher.tool_name}]`
-								: ""
-							const desc = hook.description ? ` - ${hook.description}` : ""
-							lines.push(`    ${hook.command}${matcherStr}${desc}`)
-						}
-					}
-				}
-
-				lines.push("")
-				lines.push(`  /hooks reload - Reload config from disk`)
-
-				this.showInfo(lines.join("\n"))
-				return true
-			}
-
-			case "mcp": {
-				const mm = this.harness.getMcpManager?.()
-				if (!mm) {
-					this.showInfo("MCP system not initialized.")
-					return true
-				}
-
-				const subcommand = args[0]
-				if (subcommand === "reload") {
-					this.showInfo("MCP: Reconnecting to servers...")
-					try {
-						await mm.reload()
-						const statuses = mm.getServerStatuses()
-						const connected = statuses.filter((s) => s.connected)
-						const totalTools = connected.reduce(
-							(sum, s) => sum + s.toolCount,
-							0,
-						)
-						this.showInfo(
-							`MCP: Reloaded. ${connected.length} server(s) connected, ${totalTools} tool(s).`,
-						)
-                    } catch (error) {
-                        this.showError(
-                            `MCP reload failed: ${error instanceof Error ? error.message : String(error)}`,
-                        )
-					}
-					return true
-				}
-
-				const paths = mm.getConfigPaths()
-
-				if (!mm.hasServers()) {
-					this.showInfo(
-						`No MCP servers configured.\n\n` +
-							`Add servers to:\n` +
-							`  ${paths.project} (project)\n` +
-							`  ${paths.global} (global)\n` +
-							`  ${paths.claude} (Claude Code compat)\n\n` +
-							`Example mcp.json:\n` +
-							`  {\n` +
-							`    "mcpServers": {\n` +
-							`      "filesystem": {\n` +
-							`        "command": "npx",\n` +
-							`        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path"],\n` +
-							`        "env": {}\n` +
-							`      }\n` +
-							`    }\n` +
-							`  }`,
-					)
-					return true
-				}
-
-				const statuses = mm.getServerStatuses()
-				const lines: string[] = [`MCP Servers:`]
-				lines.push(`  Project: ${paths.project}`)
-				lines.push(`  Global:  ${paths.global}`)
-				lines.push(`  Claude:  ${paths.claude}`)
-				lines.push("")
-
-				for (const status of statuses) {
-					const icon = status.connected ? "\u2713" : "\u2717"
-					const state = status.connected
-						? "connected"
-						: `error: ${status.error}`
-					lines.push(`  ${icon} ${status.name} (${state})`)
-					if (status.toolNames.length > 0) {
-						for (const toolName of status.toolNames) {
-							lines.push(`      - ${toolName}`)
-						}
-					}
-				}
-
-				lines.push("")
-				lines.push(`  /mcp reload - Disconnect and reconnect all servers`)
-
-				this.showInfo(lines.join("\n"))
-				return true
-			}
-			case "review": {
-				await this.handleReviewCommand(args)
-				return true
-			}
-
-			default: {
-				// Fall back to custom commands for single-slash input
-				const customCommand = this.customSlashCommands.find(
-					(cmd) => cmd.name === command,
-				)
-				if (customCommand) {
-					await this.handleCustomSlashCommand(customCommand, args)
-					return true
-				}
-				this.showError(`Unknown command: ${command}`)
-				return true
-			}
-		}
-	}
-	/**
-	 * Handle the /review command — send a PR review prompt to the agent.
-	 * With no args: lists open PRs. With a PR number: reviews that PR.
-	 */
-	private async handleReviewCommand(args: string[]): Promise<void> {
-		if (!this.harness.hasModelSelected()) {
-			this.showInfo(
-				"No model selected. Use /models to select a model, or /login to authenticate.",
-			)
-			return
-		}
-
-		// Ensure thread exists
-		if (this.pendingNewThread) {
-			await this.harness.createThread()
-			this.pendingNewThread = false
-			this.updateStatusLine()
-		}
-
-		const prNumber = args[0]
-		const focusArea = args.slice(1).join(" ")
-
-		let prompt: string
-
-		if (!prNumber) {
-			// No PR specified — list open PRs and ask
-			prompt =
-				`List the open pull requests for this repository using \`gh pr list --limit 20\`. ` +
-				`Present them in a clear table with PR number, title, and author. ` +
-				`Then ask me which PR I'd like you to review.`
-		} else {
-			// PR number given — do a thorough review
-			prompt =
-				`Do a thorough code review of PR #${prNumber}. Follow these steps:\n\n` +
-				`1. Run \`gh pr view ${prNumber}\` to get the PR description and metadata.\n` +
-				`2. Run \`gh pr diff ${prNumber}\` to get the full diff.\n` +
-				`3. Run \`gh pr checks ${prNumber}\` to check CI status.\n` +
-				`4. Read any relevant source files for full context on the changes.\n` +
-				`5. Provide a detailed code review covering:\n` +
-				`   - Overview of what the PR does\n` +
-				`   - Root cause analysis (if it's a fix)\n` +
-				`   - Code quality assessment\n` +
-				`   - Potential concerns or edge cases\n` +
-				`   - CI status\n` +
-				`   - Suggestions for improvement\n` +
-				`   - Final verdict (approve/request changes/comment)\n`
-
-			if (focusArea) {
-				prompt += `\nPay special attention to: ${focusArea}\n`
-			}
-		}
-
-		// Show what's happening
-		this.addUserMessage({
-			id: `user-${Date.now()}`,
-			role: "user",
-			content: [
-				{
-					type: "text",
-					text: prNumber ? `/review ${args.join(" ")}` : "/review",
-				},
-			],
-			createdAt: new Date(),
-		})
-		this.ui.requestRender()
-
-		// Send to the agent
-		this.harness.sendMessage(prompt).catch((error) => {
-			this.showError(error instanceof Error ? error.message : "Review failed")
-		})
-	}
-
-	/**
-	 * Handle a custom slash command by processing its template and adding to context
-	 */
-	private async handleCustomSlashCommand(
-		command: SlashCommandMetadata,
-		args: string[],
-	): Promise<void> {
-		try {
-			// Process the command template
-			const processedContent = await processSlashCommand(
-				command,
-				args,
-				process.cwd(),
-			)
-			// Add the processed content as a system message / context
-			if (processedContent.trim()) {
-				// Show bordered indicator immediately with content
-				const slashComp = new SlashCommandComponent(
-					command.name,
-					processedContent.trim(),
-				)
-				this.allSlashCommandComponents.push(slashComp)
-				this.chatContainer.addChild(slashComp)
-				this.ui.requestRender()
-
-				// Wrap in <slash-command> tags so the assistant sees the full
-				// content but addUserMessage won't double-render it.
-				const wrapped = `<slash-command name="${command.name}">\n${processedContent.trim()}\n</slash-command>`
-				await this.harness.sendMessage(wrapped)
-			} else {
-				this.showInfo(`Executed //${command.name} (no output)`)
-			}
-        } catch (error) {
-            this.showError(
-                `Error executing //${command.name}: ${error instanceof Error ? error.message : String(error)}`,
-            )
-		}
-	}
-
-	// ===========================================================================
-	// Message Rendering
-	// ===========================================================================
-
-	private addUserMessage(message: HarnessMessage): void {
-		const textContent = message.content
-			.filter((c) => c.type === "text")
-			.map((c) => (c as { type: "text"; text: string }).text)
-			.join("\n")
-
-		const imageCount = message.content.filter((c) => c.type === "image").length
-
-		// Strip [image] markers from text since we show count separately
-		const displayText =
-			imageCount > 0
-				? textContent.replace(/\[image\]\s*/g, "").trim()
-				: textContent.trim()
-		// Check for system reminder tags
-		const systemReminderMatch = displayText.match(
-			/<system-reminder>([\s\S]*?)<\/system-reminder>/,
-		)
-        if (systemReminderMatch) {
-            const reminderText = systemReminderMatch[1]!.trim()
-            const reminderComponent = new SystemReminderComponent({
-                message: reminderText,
-            })
-
-			// System reminders always go at the end (after plan approval)
-			this.chatContainer.addChild(new Spacer(1))
-			this.chatContainer.addChild(reminderComponent)
-			this.ui.requestRender()
-			return
-		}
-
-		// Check for slash command tags
-		const slashCommandMatch = displayText.match(
-			/<slash-command\s+name="([^"]*)">([\s\S]*?)<\/slash-command>/,
-		)
-        if (slashCommandMatch) {
-            const commandName = slashCommandMatch[1]!
-            const commandContent = slashCommandMatch[2]!.trim()
-            const slashComp = new SlashCommandComponent(commandName, commandContent)
-			this.allSlashCommandComponents.push(slashComp)
-			this.chatContainer.addChild(slashComp)
-			this.ui.requestRender()
-			return
-		}
-
-		const prefix =
-			imageCount > 0 ? `[${imageCount} image${imageCount > 1 ? "s" : ""}] ` : ""
-		if (displayText || prefix) {
-			const userComponent = new UserMessageComponent(prefix + displayText)
-
-			// Always append to end — follow-ups should stay at the bottom
-			this.chatContainer.addChild(userComponent)
-
-			// Track follow-up components sent while streaming so tool calls
-			// can be inserted before them (keeping them anchored at bottom).
-			// Only track if the agent is already streaming a response — otherwise
-			// this is the initial message that triggers the response, not a follow-up.
-			if (this.isAgentActive && this.streamingComponent) {
-				this.followUpComponents.push(userComponent)
-			}
-		}
-	}
-
-	private async renderExistingMessages(): Promise<void> {
-		this.chatContainer.clear()
-		this.pendingTools.clear()
-		this.allToolComponents = []
-
-		const messages = await this.harness.getMessages({ limit: 40 })
-
-		for (const message of messages) {
-			if (message.role === "user") {
-				this.addUserMessage(message)
-			} else if (message.role === "assistant") {
-				// Render content in order - interleaving text and tool calls
-				// Accumulate text/thinking until we hit a tool call, then render both
-				let accumulatedContent: HarnessMessageContent[] = []
-
-				for (const content of message.content) {
-					if (content.type === "text" || content.type === "thinking") {
-						accumulatedContent.push(content)
-					} else if (content.type === "tool_call") {
-						// Render accumulated text first if any
-						if (accumulatedContent.length > 0) {
-							const textMessage: HarnessMessage = {
-								...message,
-								content: accumulatedContent,
-							}
-							const textComponent = new AssistantMessageComponent(
-								textMessage,
-								this.hideThinkingBlock,
-								getMarkdownTheme(),
-							)
-							this.chatContainer.addChild(textComponent)
-							accumulatedContent = []
-						}
-
-						// Find matching tool result
-						const toolResult = message.content.find(
-							(c) => c.type === "tool_result" && c.id === content.id,
-						)
-
-						// Render subagent tool calls with dedicated component
-						if (content.name === "subagent") {
-							const subArgs = content.args as
-								| {
-										agentType?: string
-										task?: string
-										modelId?: string
-								  }
-								| undefined
-							const rawResult =
-								toolResult?.type === "tool_result"
-									? this.formatToolResult(toolResult.result)
-									: undefined
-							const isErr =
-								toolResult?.type === "tool_result" && toolResult.isError
-
-							// Parse embedded metadata for model ID, duration, tool calls
-							const meta = rawResult ? parseSubagentMeta(rawResult) : null
-							const resultText = meta?.text ?? rawResult
-							const modelId = meta?.modelId ?? subArgs?.modelId
-							const durationMs = meta?.durationMs ?? 0
-
-							const subComponent = new SubagentExecutionComponent(
-								subArgs?.agentType ?? "unknown",
-								subArgs?.task ?? "",
-								this.ui,
-								modelId,
-							)
-							// Populate tool calls from metadata
-							if (meta?.toolCalls) {
-								for (const tc of meta.toolCalls) {
-									subComponent.addToolStart(tc.name, {})
-									subComponent.addToolEnd(tc.name, "", tc.isError)
-								}
-							}
-							// Mark as finished with result
-							subComponent.finish(isErr ?? false, durationMs, resultText)
-							this.chatContainer.addChild(subComponent)
-							this.allToolComponents.push(subComponent as any)
-							continue
-						}
-
-						// Render the tool call
-						const toolComponent = new ToolExecutionComponentEnhanced(
-							content.name,
-							content.args,
-							{
-								showImages: false,
-								collapsedByDefault: !this.toolOutputExpanded,
-							},
-							this.ui,
-						)
-
-						if (toolResult && toolResult.type === "tool_result") {
-							toolComponent.updateResult(
-								{
-									content: [
-										{
-											type: "text",
-											text: this.formatToolResult(toolResult.result),
-										},
-									],
-									isError: toolResult.isError,
-								},
-								false,
-							)
-						}
-
-						// If this was todo_write with all completed or cleared, show inline instead of tool component
-						let replacedWithInline = false
-						if (
-							content.name === "todo_write" &&
-							toolResult?.type === "tool_result" &&
-							!toolResult.isError
-						) {
-							const args = content.args as { todos?: TodoItem[] } | undefined
-							const todos = args?.todos
-							if (
-								todos &&
-								todos.length > 0 &&
-								todos.every((t) => t.status === "completed")
-							) {
-								this.renderCompletedTodosInline(todos)
-								replacedWithInline = true
-							} else if (!todos || todos.length === 0) {
-								// Tasks were cleared - show with previous todos if we have them
-								if (this.previousTodos.length > 0) {
-									this.renderClearedTodosInline(this.previousTodos)
-									this.previousTodos = []
-									replacedWithInline = true
-								}
-							} else {
-								// Track for detecting clears
-								this.previousTodos = [...todos]
-							}
-						}
-
-						// If this was submit_plan, show the plan with approval status
-						if (
-							content.name === "submit_plan" &&
-							toolResult?.type === "tool_result"
-						) {
-							const args = content.args as
-								| { title?: string; plan?: string }
-								| undefined
-							// Result could be a string or an object with content property
-							let resultText = ""
-							if (typeof toolResult.result === "string") {
-								resultText = toolResult.result
-							} else if (
-								typeof toolResult.result === "object" &&
-								toolResult.result !== null &&
-								"content" in toolResult.result &&
-								typeof (toolResult.result as any).content === "string"
-							) {
-								resultText = (toolResult.result as any).content
-							}
-							const isApproved = resultText.toLowerCase().includes("approved")
-							// Extract feedback if rejected with feedback
-							let feedback: string | undefined
-							if (!isApproved && resultText.includes("Feedback:")) {
-								const feedbackMatch = resultText.match(/Feedback:\s*(.+)/)
-								feedback = feedbackMatch?.[1]
-							}
-
-							if (args?.title && args?.plan) {
-								const planResult = new PlanResultComponent({
-									title: args.title,
-									plan: args.plan,
-									isApproved,
-									feedback,
-								})
-								this.chatContainer.addChild(planResult)
-								replacedWithInline = true
-							}
-						}
-
-						if (!replacedWithInline) {
-							this.chatContainer.addChild(toolComponent)
-							this.allToolComponents.push(toolComponent)
-						}
-					} else if (
-						content.type === "om_observation_start" ||
-						content.type === "om_observation_end" ||
-						content.type === "om_observation_failed"
-					) {
-						// Skip start markers in history — only show completed/failed results
-						if (content.type === "om_observation_start") continue
-
-						// Render accumulated text first if any
-						if (accumulatedContent.length > 0) {
-							const textMessage: HarnessMessage = {
-								...message,
-								content: accumulatedContent,
-							}
-							const textComponent = new AssistantMessageComponent(
-								textMessage,
-								this.hideThinkingBlock,
-								getMarkdownTheme(),
-							)
-							this.chatContainer.addChild(textComponent)
-							accumulatedContent = []
-						}
-
-						if (content.type === "om_observation_end") {
-							// Render bordered output box with marker info in footer
-							const isReflection = content.operationType === "reflection"
-							const outputComponent = new OMOutputComponent({
-								type: isReflection ? "reflection" : "observation",
-								observations: content.observations ?? "",
-								currentTask: content.currentTask,
-								suggestedResponse: content.suggestedResponse,
-								durationMs: content.durationMs,
-								tokensObserved: content.tokensObserved,
-								observationTokens: content.observationTokens,
-								compressedTokens: isReflection
-									? content.observationTokens
-									: undefined,
-							})
-							this.chatContainer.addChild(outputComponent)
-						} else {
-							// Failed marker
-							this.chatContainer.addChild(new OMMarkerComponent(content))
-						}
-					}
-					// Skip tool_result - it's handled with tool_call above
-				}
-
-				// Render any remaining text after the last tool call
-				if (accumulatedContent.length > 0) {
-					const textMessage: HarnessMessage = {
-						...message,
-						content: accumulatedContent,
-					}
-					const textComponent = new AssistantMessageComponent(
-						textMessage,
-						this.hideThinkingBlock,
-						getMarkdownTheme(),
-					)
-					this.chatContainer.addChild(textComponent)
-				}
-			}
-		}
-
-		this.ui.requestRender()
-	}
-
-	// ===========================================================================
-	// UI Helpers
-	// ===========================================================================
-
-	private showError(message: string): void {
-		this.chatContainer.addChild(new Spacer(1))
-		this.chatContainer.addChild(
-			new Text(fg("error", `Error: ${message}`), 1, 0),
-		)
-		this.ui.requestRender()
-	}
-
-	/**
-	 * Show a formatted error with helpful context based on error type.
-	 */
-	showFormattedError(
-		event:
-			| {
-					error: Error
-					errorType?: string
-					retryable?: boolean
-					retryDelay?: number
-			  }
-			| Error,
-	): void {
-		const error = "error" in event ? event.error : event
-		const parsed = parseError(error)
-
-		this.chatContainer.addChild(new Spacer(1))
-
-		// Check if this is a tool validation error
-		const errorMessage = error.message || String(error)
-		const isValidationError =
-			errorMessage.toLowerCase().includes("validation failed") ||
-			errorMessage.toLowerCase().includes("required parameter") ||
-			errorMessage.includes("Required")
-
-		if (isValidationError) {
-			// Show a simplified message for validation errors
-			this.chatContainer.addChild(
-				new Text(
-					fg("error", "Tool validation error - see details above"),
-					1,
-					0,
-				),
-			)
-			this.chatContainer.addChild(
-				new Text(
-					fg(
-						"muted",
-						"  Check the tool execution box for specific parameter requirements",
-					),
-					1,
-					0,
-				),
-			)
-		} else {
-			// Show the main error message
-			let errorText = `Error: ${parsed.message}`
-
-			// Add retry info if applicable
-			const retryable =
-				"retryable" in event ? event.retryable : parsed.retryable
-			const retryDelay =
-				"retryDelay" in event ? event.retryDelay : parsed.retryDelay
-			if (retryable && retryDelay) {
-				const seconds = Math.ceil(retryDelay / 1000)
-				errorText += fg("muted", ` (retry in ${seconds}s)`)
-			}
-
-			this.chatContainer.addChild(new Text(fg("error", errorText), 1, 0))
-
-			// Add helpful hints based on error type
-			const hint = this.getErrorHint(parsed.type)
-			if (hint) {
-				this.chatContainer.addChild(
-					new Text(fg("muted", `  Hint: ${hint}`), 1, 0),
-				)
-			}
-		}
-
-		this.ui.requestRender()
-	}
-
-	/**
-	 * Get a helpful hint based on error type.
-	 */
-	private getErrorHint(errorType: string): string | null {
-		switch (errorType) {
-			case "auth":
-				return "Use /login to authenticate with a provider"
-			case "model_not_found":
-				return "Use /models to select a different model"
-			case "context_length":
-				return "Use /new to start a fresh conversation"
-			case "rate_limit":
-				return "Wait a moment and try again"
-			case "network":
-				return "Check your internet connection"
-			default:
-				return null
-		}
-	}
-	/**
-	 * Show file changes tracked during this session.
-	 * With no args: shows summary of all modified files.
-	 * With a path: shows git diff for that specific file.
-	 */
-	private async showDiff(filePath?: string): Promise<void> {
-		if (filePath) {
-			// Show git diff for a specific file
-			try {
-				const { execa } = await import("execa")
-				const result = await execa("git", ["diff", filePath], {
-					cwd: process.cwd(),
-					reject: false,
-				})
-
-				if (!result.stdout.trim()) {
-					// Try staged diff
-					const staged = await execa("git", ["diff", "--cached", filePath], {
-						cwd: process.cwd(),
-						reject: false,
-					})
-					if (!staged.stdout.trim()) {
-						this.showInfo(`No changes detected for: ${filePath}`)
-						return
-					}
-					const component = new DiffOutputComponent(
-						`git diff --cached ${filePath}`,
-						staged.stdout,
-					)
-					this.chatContainer.addChild(component)
-					this.ui.requestRender()
-					return
-				}
-
-				const component = new DiffOutputComponent(
-					`git diff ${filePath}`,
-					result.stdout,
-				)
-				this.chatContainer.addChild(component)
-				this.ui.requestRender()
-            } catch (error) {
-                this.showError(
-                    error instanceof Error ? error.message : "Failed to get diff",
-                )
-			}
-			return
-		}
-
-		// No path specified — show summary of all tracked modified files
-		if (this.modifiedFiles.size === 0) {
-			// Fall back to git diff --stat
-			try {
-				const { execa } = await import("execa")
-				const result = await execa("git", ["diff", "--stat"], {
-					cwd: process.cwd(),
-					reject: false,
-				})
-				const staged = await execa("git", ["diff", "--cached", "--stat"], {
-					cwd: process.cwd(),
-					reject: false,
-				})
-
-				const output = [result.stdout, staged.stdout].filter(Boolean).join("\n")
-				if (output.trim()) {
-					const component = new DiffOutputComponent("git diff --stat", output)
-					this.chatContainer.addChild(component)
-					this.ui.requestRender()
-				} else {
-					this.showInfo(
-						"No file changes detected in this session or working tree.",
-					)
-				}
-			} catch {
-				this.showInfo("No file changes tracked in this session.")
-			}
-			return
-		}
-
-		const lines: string[] = [`Modified files (${this.modifiedFiles.size}):`]
-		for (const [filePath, info] of this.modifiedFiles) {
-			const opCounts = new Map<string, number>()
-			for (const op of info.operations) {
-				opCounts.set(op, (opCounts.get(op) || 0) + 1)
-			}
-			const ops = Array.from(opCounts.entries())
-				.map(([op, count]) => (count > 1 ? `${op}×${count}` : op))
-				.join(", ")
-			lines.push(`  ${fg("path", filePath)} ${fg("muted", `(${ops})`)}`)
-		}
-		lines.push("")
-		lines.push(
-			fg("muted", "Use /diff <path> to see the git diff for a specific file."),
-		)
-
-		this.showInfo(lines.join("\n"))
-	}
-
-	/**
-	 * Run a shell command directly and display the output in the chat.
-	 * Triggered by the `!` prefix (e.g., `!ls -la`).
-	 */
-	private async handleShellPassthrough(command: string): Promise<void> {
-		if (!command) {
-			this.showInfo("Usage: !<command> (e.g., !ls -la)")
-			return
-		}
-
-		try {
-			const { execa } = await import("execa")
-			const result = await execa(command, {
-				shell: true,
-				cwd: process.cwd(),
-				reject: false,
-				timeout: 30_000,
-				env: {
-					...process.env,
-					FORCE_COLOR: "1",
-				},
-			})
-
-			const component = new ShellOutputComponent(
-				command,
-				result.stdout ?? "",
-				result.stderr ?? "",
-				result.exitCode ?? 0,
-			)
-			this.chatContainer.addChild(component)
-			this.ui.requestRender()
-        } catch (error) {
-            this.showError(
-                error instanceof Error ? error.message : "Shell command failed",
-            )
-		}
-	}
-	/**
-	 * Send a notification alert (bell / system / hooks) based on user settings.
-	 */
-	private notify(reason: NotificationReason, message?: string): void {
-		const mode = ((this.harness.getState() as any)?.notifications ??
-			"off") as NotificationMode
-		sendNotification(reason, {
-			mode,
-			message,
-			hookManager: this.harness.getHookManager?.(),
-		})
-	}
-
-	private showInfo(message: string): void {
-		this.chatContainer.addChild(new Spacer(1))
-		this.chatContainer.addChild(new Text(fg("muted", message), 1, 0))
-		this.ui.requestRender()
-	}
+  Ctrl+E    - Expand/collapse tool outputs`);
+        return true;
+      }
+
+      case 'hooks': {
+        const hm = this.harness.getHookManager?.();
+        if (!hm) {
+          this.showInfo('Hooks system not initialized.');
+          return true;
+        }
+
+        const subcommand = args[0];
+        if (subcommand === 'reload') {
+          hm.reload();
+          this.showInfo('Hooks config reloaded.');
+          return true;
+        }
+
+        const paths = hm.getConfigPaths();
+
+        if (!hm.hasHooks()) {
+          this.showInfo(
+            `No hooks configured.\n\n` +
+              `Add hooks to:\n` +
+              `  ${paths.project} (project)\n` +
+              `  ${paths.global} (global)\n\n` +
+              `Example hooks.json:\n` +
+              `  {\n` +
+              `    "PreToolUse": [{\n` +
+              `      "type": "command",\n` +
+              `      "command": "echo 'tool called'",\n` +
+              `      "matcher": { "tool_name": "execute_command" }\n` +
+              `    }]\n` +
+              `  }`,
+          );
+          return true;
+        }
+
+        const hookConfig = hm.getConfig();
+        const lines: string[] = [`Hooks Configuration:`];
+        lines.push(`  Project: ${paths.project}`);
+        lines.push(`  Global:  ${paths.global}`);
+        lines.push('');
+
+        const eventNames = [
+          'PreToolUse',
+          'PostToolUse',
+          'Stop',
+          'UserPromptSubmit',
+          'SessionStart',
+          'SessionEnd',
+        ] as const;
+
+        for (const event of eventNames) {
+          const hooks = hookConfig[event];
+          if (hooks && hooks.length > 0) {
+            lines.push(`  ${event} (${hooks.length} hook${hooks.length > 1 ? 's' : ''}):`);
+            for (const hook of hooks) {
+              const matcherStr = hook.matcher?.tool_name ? ` [tool: ${hook.matcher.tool_name}]` : '';
+              const desc = hook.description ? ` - ${hook.description}` : '';
+              lines.push(`    ${hook.command}${matcherStr}${desc}`);
+            }
+          }
+        }
+
+        lines.push('');
+        lines.push(`  /hooks reload - Reload config from disk`);
+
+        this.showInfo(lines.join('\n'));
+        return true;
+      }
+
+      case 'mcp': {
+        const mm = this.harness.getMcpManager?.();
+        if (!mm) {
+          this.showInfo('MCP system not initialized.');
+          return true;
+        }
+
+        const subcommand = args[0];
+        if (subcommand === 'reload') {
+          this.showInfo('MCP: Reconnecting to servers...');
+          try {
+            await mm.reload();
+            const statuses = mm.getServerStatuses();
+            const connected = statuses.filter(s => s.connected);
+            const totalTools = connected.reduce((sum, s) => sum + s.toolCount, 0);
+            this.showInfo(`MCP: Reloaded. ${connected.length} server(s) connected, ${totalTools} tool(s).`);
+          } catch (error) {
+            this.showError(`MCP reload failed: ${error instanceof Error ? error.message : String(error)}`);
+          }
+          return true;
+        }
+
+        const paths = mm.getConfigPaths();
+
+        if (!mm.hasServers()) {
+          this.showInfo(
+            `No MCP servers configured.\n\n` +
+              `Add servers to:\n` +
+              `  ${paths.project} (project)\n` +
+              `  ${paths.global} (global)\n` +
+              `  ${paths.claude} (Claude Code compat)\n\n` +
+              `Example mcp.json:\n` +
+              `  {\n` +
+              `    "mcpServers": {\n` +
+              `      "filesystem": {\n` +
+              `        "command": "npx",\n` +
+              `        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path"],\n` +
+              `        "env": {}\n` +
+              `      }\n` +
+              `    }\n` +
+              `  }`,
+          );
+          return true;
+        }
+
+        const statuses = mm.getServerStatuses();
+        const lines: string[] = [`MCP Servers:`];
+        lines.push(`  Project: ${paths.project}`);
+        lines.push(`  Global:  ${paths.global}`);
+        lines.push(`  Claude:  ${paths.claude}`);
+        lines.push('');
+
+        for (const status of statuses) {
+          const icon = status.connected ? '\u2713' : '\u2717';
+          const state = status.connected ? 'connected' : `error: ${status.error}`;
+          lines.push(`  ${icon} ${status.name} (${state})`);
+          if (status.toolNames.length > 0) {
+            for (const toolName of status.toolNames) {
+              lines.push(`      - ${toolName}`);
+            }
+          }
+        }
+
+        lines.push('');
+        lines.push(`  /mcp reload - Disconnect and reconnect all servers`);
+
+        this.showInfo(lines.join('\n'));
+        return true;
+      }
+      case 'review': {
+        await this.handleReviewCommand(args);
+        return true;
+      }
+
+      default: {
+        // Fall back to custom commands for single-slash input
+        const customCommand = this.customSlashCommands.find(cmd => cmd.name === command);
+        if (customCommand) {
+          await this.handleCustomSlashCommand(customCommand, args);
+          return true;
+        }
+        this.showError(`Unknown command: ${command}`);
+        return true;
+      }
+    }
+  }
+  /**
+   * Handle the /review command — send a PR review prompt to the agent.
+   * With no args: lists open PRs. With a PR number: reviews that PR.
+   */
+  private async handleReviewCommand(args: string[]): Promise<void> {
+    if (!this.harness.hasModelSelected()) {
+      this.showInfo('No model selected. Use /models to select a model, or /login to authenticate.');
+      return;
+    }
+
+    // Ensure thread exists
+    if (this.pendingNewThread) {
+      await this.harness.createThread();
+      this.pendingNewThread = false;
+      this.updateStatusLine();
+    }
+
+    const prNumber = args[0];
+    const focusArea = args.slice(1).join(' ');
+
+    let prompt: string;
+
+    if (!prNumber) {
+      // No PR specified — list open PRs and ask
+      prompt =
+        `List the open pull requests for this repository using \`gh pr list --limit 20\`. ` +
+        `Present them in a clear table with PR number, title, and author. ` +
+        `Then ask me which PR I'd like you to review.`;
+    } else {
+      // PR number given — do a thorough review
+      prompt =
+        `Do a thorough code review of PR #${prNumber}. Follow these steps:\n\n` +
+        `1. Run \`gh pr view ${prNumber}\` to get the PR description and metadata.\n` +
+        `2. Run \`gh pr diff ${prNumber}\` to get the full diff.\n` +
+        `3. Run \`gh pr checks ${prNumber}\` to check CI status.\n` +
+        `4. Read any relevant source files for full context on the changes.\n` +
+        `5. Provide a detailed code review covering:\n` +
+        `   - Overview of what the PR does\n` +
+        `   - Root cause analysis (if it's a fix)\n` +
+        `   - Code quality assessment\n` +
+        `   - Potential concerns or edge cases\n` +
+        `   - CI status\n` +
+        `   - Suggestions for improvement\n` +
+        `   - Final verdict (approve/request changes/comment)\n`;
+
+      if (focusArea) {
+        prompt += `\nPay special attention to: ${focusArea}\n`;
+      }
+    }
+
+    // Show what's happening
+    this.addUserMessage({
+      id: `user-${Date.now()}`,
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: prNumber ? `/review ${args.join(' ')}` : '/review',
+        },
+      ],
+      createdAt: new Date(),
+    });
+    this.ui.requestRender();
+
+    // Send to the agent
+    this.harness.sendMessage(prompt).catch(error => {
+      this.showError(error instanceof Error ? error.message : 'Review failed');
+    });
+  }
+
+  /**
+   * Handle a custom slash command by processing its template and adding to context
+   */
+  private async handleCustomSlashCommand(command: SlashCommandMetadata, args: string[]): Promise<void> {
+    try {
+      // Process the command template
+      const processedContent = await processSlashCommand(command, args, process.cwd());
+      // Add the processed content as a system message / context
+      if (processedContent.trim()) {
+        // Show bordered indicator immediately with content
+        const slashComp = new SlashCommandComponent(command.name, processedContent.trim());
+        this.allSlashCommandComponents.push(slashComp);
+        this.chatContainer.addChild(slashComp);
+        this.ui.requestRender();
+
+        // Wrap in <slash-command> tags so the assistant sees the full
+        // content but addUserMessage won't double-render it.
+        const wrapped = `<slash-command name="${command.name}">\n${processedContent.trim()}\n</slash-command>`;
+        await this.harness.sendMessage(wrapped);
+      } else {
+        this.showInfo(`Executed //${command.name} (no output)`);
+      }
+    } catch (error) {
+      this.showError(`Error executing //${command.name}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  // ===========================================================================
+  // Message Rendering
+  // ===========================================================================
+
+  private addUserMessage(message: HarnessMessage): void {
+    const textContent = message.content
+      .filter(c => c.type === 'text')
+      .map(c => (c as { type: 'text'; text: string }).text)
+      .join('\n');
+
+    const imageCount = message.content.filter(c => c.type === 'image').length;
+
+    // Strip [image] markers from text since we show count separately
+    const displayText = imageCount > 0 ? textContent.replace(/\[image\]\s*/g, '').trim() : textContent.trim();
+    // Check for system reminder tags
+    const systemReminderMatch = displayText.match(/<system-reminder>([\s\S]*?)<\/system-reminder>/);
+    if (systemReminderMatch) {
+      const reminderText = systemReminderMatch[1]!.trim();
+      const reminderComponent = new SystemReminderComponent({
+        message: reminderText,
+      });
+
+      // System reminders always go at the end (after plan approval)
+      this.chatContainer.addChild(new Spacer(1));
+      this.chatContainer.addChild(reminderComponent);
+      this.ui.requestRender();
+      return;
+    }
+
+    // Check for slash command tags
+    const slashCommandMatch = displayText.match(/<slash-command\s+name="([^"]*)">([\s\S]*?)<\/slash-command>/);
+    if (slashCommandMatch) {
+      const commandName = slashCommandMatch[1]!;
+      const commandContent = slashCommandMatch[2]!.trim();
+      const slashComp = new SlashCommandComponent(commandName, commandContent);
+      this.allSlashCommandComponents.push(slashComp);
+      this.chatContainer.addChild(slashComp);
+      this.ui.requestRender();
+      return;
+    }
+
+    const prefix = imageCount > 0 ? `[${imageCount} image${imageCount > 1 ? 's' : ''}] ` : '';
+    if (displayText || prefix) {
+      const userComponent = new UserMessageComponent(prefix + displayText);
+
+      // Always append to end — follow-ups should stay at the bottom
+      this.chatContainer.addChild(userComponent);
+
+      // Track follow-up components sent while streaming so tool calls
+      // can be inserted before them (keeping them anchored at bottom).
+      // Only track if the agent is already streaming a response — otherwise
+      // this is the initial message that triggers the response, not a follow-up.
+      if (this.isAgentActive && this.streamingComponent) {
+        this.followUpComponents.push(userComponent);
+      }
+    }
+  }
+
+  private async renderExistingMessages(): Promise<void> {
+    this.chatContainer.clear();
+    this.pendingTools.clear();
+    this.allToolComponents = [];
+
+    const messages = await this.harness.getMessages({ limit: 40 });
+
+    for (const message of messages) {
+      if (message.role === 'user') {
+        this.addUserMessage(message);
+      } else if (message.role === 'assistant') {
+        // Render content in order - interleaving text and tool calls
+        // Accumulate text/thinking until we hit a tool call, then render both
+        let accumulatedContent: HarnessMessageContent[] = [];
+
+        for (const content of message.content) {
+          if (content.type === 'text' || content.type === 'thinking') {
+            accumulatedContent.push(content);
+          } else if (content.type === 'tool_call') {
+            // Render accumulated text first if any
+            if (accumulatedContent.length > 0) {
+              const textMessage: HarnessMessage = {
+                ...message,
+                content: accumulatedContent,
+              };
+              const textComponent = new AssistantMessageComponent(
+                textMessage,
+                this.hideThinkingBlock,
+                getMarkdownTheme(),
+              );
+              this.chatContainer.addChild(textComponent);
+              accumulatedContent = [];
+            }
+
+            // Find matching tool result
+            const toolResult = message.content.find(c => c.type === 'tool_result' && c.id === content.id);
+
+            // Render subagent tool calls with dedicated component
+            if (content.name === 'subagent') {
+              const subArgs = content.args as
+                | {
+                    agentType?: string;
+                    task?: string;
+                    modelId?: string;
+                  }
+                | undefined;
+              const rawResult =
+                toolResult?.type === 'tool_result' ? this.formatToolResult(toolResult.result) : undefined;
+              const isErr = toolResult?.type === 'tool_result' && toolResult.isError;
+
+              // Parse embedded metadata for model ID, duration, tool calls
+              const meta = rawResult ? parseSubagentMeta(rawResult) : null;
+              const resultText = meta?.text ?? rawResult;
+              const modelId = meta?.modelId ?? subArgs?.modelId;
+              const durationMs = meta?.durationMs ?? 0;
+
+              const subComponent = new SubagentExecutionComponent(
+                subArgs?.agentType ?? 'unknown',
+                subArgs?.task ?? '',
+                this.ui,
+                modelId,
+              );
+              // Populate tool calls from metadata
+              if (meta?.toolCalls) {
+                for (const tc of meta.toolCalls) {
+                  subComponent.addToolStart(tc.name, {});
+                  subComponent.addToolEnd(tc.name, '', tc.isError);
+                }
+              }
+              // Mark as finished with result
+              subComponent.finish(isErr ?? false, durationMs, resultText);
+              this.chatContainer.addChild(subComponent);
+              this.allToolComponents.push(subComponent as any);
+              continue;
+            }
+
+            // Render the tool call
+            const toolComponent = new ToolExecutionComponentEnhanced(
+              content.name,
+              content.args,
+              {
+                showImages: false,
+                collapsedByDefault: !this.toolOutputExpanded,
+              },
+              this.ui,
+            );
+
+            if (toolResult && toolResult.type === 'tool_result') {
+              toolComponent.updateResult(
+                {
+                  content: [
+                    {
+                      type: 'text',
+                      text: this.formatToolResult(toolResult.result),
+                    },
+                  ],
+                  isError: toolResult.isError,
+                },
+                false,
+              );
+            }
+
+            // If this was todo_write with all completed or cleared, show inline instead of tool component
+            let replacedWithInline = false;
+            if (content.name === 'todo_write' && toolResult?.type === 'tool_result' && !toolResult.isError) {
+              const args = content.args as { todos?: TodoItem[] } | undefined;
+              const todos = args?.todos;
+              if (todos && todos.length > 0 && todos.every(t => t.status === 'completed')) {
+                this.renderCompletedTodosInline(todos);
+                replacedWithInline = true;
+              } else if (!todos || todos.length === 0) {
+                // Tasks were cleared - show with previous todos if we have them
+                if (this.previousTodos.length > 0) {
+                  this.renderClearedTodosInline(this.previousTodos);
+                  this.previousTodos = [];
+                  replacedWithInline = true;
+                }
+              } else {
+                // Track for detecting clears
+                this.previousTodos = [...todos];
+              }
+            }
+
+            // If this was submit_plan, show the plan with approval status
+            if (content.name === 'submit_plan' && toolResult?.type === 'tool_result') {
+              const args = content.args as { title?: string; plan?: string } | undefined;
+              // Result could be a string or an object with content property
+              let resultText = '';
+              if (typeof toolResult.result === 'string') {
+                resultText = toolResult.result;
+              } else if (
+                typeof toolResult.result === 'object' &&
+                toolResult.result !== null &&
+                'content' in toolResult.result &&
+                typeof (toolResult.result as any).content === 'string'
+              ) {
+                resultText = (toolResult.result as any).content;
+              }
+              const isApproved = resultText.toLowerCase().includes('approved');
+              // Extract feedback if rejected with feedback
+              let feedback: string | undefined;
+              if (!isApproved && resultText.includes('Feedback:')) {
+                const feedbackMatch = resultText.match(/Feedback:\s*(.+)/);
+                feedback = feedbackMatch?.[1];
+              }
+
+              if (args?.title && args?.plan) {
+                const planResult = new PlanResultComponent({
+                  title: args.title,
+                  plan: args.plan,
+                  isApproved,
+                  feedback,
+                });
+                this.chatContainer.addChild(planResult);
+                replacedWithInline = true;
+              }
+            }
+
+            if (!replacedWithInline) {
+              this.chatContainer.addChild(toolComponent);
+              this.allToolComponents.push(toolComponent);
+            }
+          } else if (
+            content.type === 'om_observation_start' ||
+            content.type === 'om_observation_end' ||
+            content.type === 'om_observation_failed'
+          ) {
+            // Skip start markers in history — only show completed/failed results
+            if (content.type === 'om_observation_start') continue;
+
+            // Render accumulated text first if any
+            if (accumulatedContent.length > 0) {
+              const textMessage: HarnessMessage = {
+                ...message,
+                content: accumulatedContent,
+              };
+              const textComponent = new AssistantMessageComponent(
+                textMessage,
+                this.hideThinkingBlock,
+                getMarkdownTheme(),
+              );
+              this.chatContainer.addChild(textComponent);
+              accumulatedContent = [];
+            }
+
+            if (content.type === 'om_observation_end') {
+              // Render bordered output box with marker info in footer
+              const isReflection = content.operationType === 'reflection';
+              const outputComponent = new OMOutputComponent({
+                type: isReflection ? 'reflection' : 'observation',
+                observations: content.observations ?? '',
+                currentTask: content.currentTask,
+                suggestedResponse: content.suggestedResponse,
+                durationMs: content.durationMs,
+                tokensObserved: content.tokensObserved,
+                observationTokens: content.observationTokens,
+                compressedTokens: isReflection ? content.observationTokens : undefined,
+              });
+              this.chatContainer.addChild(outputComponent);
+            } else {
+              // Failed marker
+              this.chatContainer.addChild(new OMMarkerComponent(content));
+            }
+          }
+          // Skip tool_result - it's handled with tool_call above
+        }
+
+        // Render any remaining text after the last tool call
+        if (accumulatedContent.length > 0) {
+          const textMessage: HarnessMessage = {
+            ...message,
+            content: accumulatedContent,
+          };
+          const textComponent = new AssistantMessageComponent(textMessage, this.hideThinkingBlock, getMarkdownTheme());
+          this.chatContainer.addChild(textComponent);
+        }
+      }
+    }
+
+    this.ui.requestRender();
+  }
+
+  // ===========================================================================
+  // UI Helpers
+  // ===========================================================================
+
+  private showError(message: string): void {
+    this.chatContainer.addChild(new Spacer(1));
+    this.chatContainer.addChild(new Text(fg('error', `Error: ${message}`), 1, 0));
+    this.ui.requestRender();
+  }
+
+  /**
+   * Show a formatted error with helpful context based on error type.
+   */
+  showFormattedError(
+    event:
+      | {
+          error: Error;
+          errorType?: string;
+          retryable?: boolean;
+          retryDelay?: number;
+        }
+      | Error,
+  ): void {
+    const error = 'error' in event ? event.error : event;
+    const parsed = parseError(error);
+
+    this.chatContainer.addChild(new Spacer(1));
+
+    // Check if this is a tool validation error
+    const errorMessage = error.message || String(error);
+    const isValidationError =
+      errorMessage.toLowerCase().includes('validation failed') ||
+      errorMessage.toLowerCase().includes('required parameter') ||
+      errorMessage.includes('Required');
+
+    if (isValidationError) {
+      // Show a simplified message for validation errors
+      this.chatContainer.addChild(new Text(fg('error', 'Tool validation error - see details above'), 1, 0));
+      this.chatContainer.addChild(
+        new Text(fg('muted', '  Check the tool execution box for specific parameter requirements'), 1, 0),
+      );
+    } else {
+      // Show the main error message
+      let errorText = `Error: ${parsed.message}`;
+
+      // Add retry info if applicable
+      const retryable = 'retryable' in event ? event.retryable : parsed.retryable;
+      const retryDelay = 'retryDelay' in event ? event.retryDelay : parsed.retryDelay;
+      if (retryable && retryDelay) {
+        const seconds = Math.ceil(retryDelay / 1000);
+        errorText += fg('muted', ` (retry in ${seconds}s)`);
+      }
+
+      this.chatContainer.addChild(new Text(fg('error', errorText), 1, 0));
+
+      // Add helpful hints based on error type
+      const hint = this.getErrorHint(parsed.type);
+      if (hint) {
+        this.chatContainer.addChild(new Text(fg('muted', `  Hint: ${hint}`), 1, 0));
+      }
+    }
+
+    this.ui.requestRender();
+  }
+
+  /**
+   * Get a helpful hint based on error type.
+   */
+  private getErrorHint(errorType: string): string | null {
+    switch (errorType) {
+      case 'auth':
+        return 'Use /login to authenticate with a provider';
+      case 'model_not_found':
+        return 'Use /models to select a different model';
+      case 'context_length':
+        return 'Use /new to start a fresh conversation';
+      case 'rate_limit':
+        return 'Wait a moment and try again';
+      case 'network':
+        return 'Check your internet connection';
+      default:
+        return null;
+    }
+  }
+  /**
+   * Show file changes tracked during this session.
+   * With no args: shows summary of all modified files.
+   * With a path: shows git diff for that specific file.
+   */
+  private async showDiff(filePath?: string): Promise<void> {
+    if (filePath) {
+      // Show git diff for a specific file
+      try {
+        const { execa } = await import('execa');
+        const result = await execa('git', ['diff', filePath], {
+          cwd: process.cwd(),
+          reject: false,
+        });
+
+        if (!result.stdout.trim()) {
+          // Try staged diff
+          const staged = await execa('git', ['diff', '--cached', filePath], {
+            cwd: process.cwd(),
+            reject: false,
+          });
+          if (!staged.stdout.trim()) {
+            this.showInfo(`No changes detected for: ${filePath}`);
+            return;
+          }
+          const component = new DiffOutputComponent(`git diff --cached ${filePath}`, staged.stdout);
+          this.chatContainer.addChild(component);
+          this.ui.requestRender();
+          return;
+        }
+
+        const component = new DiffOutputComponent(`git diff ${filePath}`, result.stdout);
+        this.chatContainer.addChild(component);
+        this.ui.requestRender();
+      } catch (error) {
+        this.showError(error instanceof Error ? error.message : 'Failed to get diff');
+      }
+      return;
+    }
+
+    // No path specified — show summary of all tracked modified files
+    if (this.modifiedFiles.size === 0) {
+      // Fall back to git diff --stat
+      try {
+        const { execa } = await import('execa');
+        const result = await execa('git', ['diff', '--stat'], {
+          cwd: process.cwd(),
+          reject: false,
+        });
+        const staged = await execa('git', ['diff', '--cached', '--stat'], {
+          cwd: process.cwd(),
+          reject: false,
+        });
+
+        const output = [result.stdout, staged.stdout].filter(Boolean).join('\n');
+        if (output.trim()) {
+          const component = new DiffOutputComponent('git diff --stat', output);
+          this.chatContainer.addChild(component);
+          this.ui.requestRender();
+        } else {
+          this.showInfo('No file changes detected in this session or working tree.');
+        }
+      } catch {
+        this.showInfo('No file changes tracked in this session.');
+      }
+      return;
+    }
+
+    const lines: string[] = [`Modified files (${this.modifiedFiles.size}):`];
+    for (const [filePath, info] of this.modifiedFiles) {
+      const opCounts = new Map<string, number>();
+      for (const op of info.operations) {
+        opCounts.set(op, (opCounts.get(op) || 0) + 1);
+      }
+      const ops = Array.from(opCounts.entries())
+        .map(([op, count]) => (count > 1 ? `${op}×${count}` : op))
+        .join(', ');
+      lines.push(`  ${fg('path', filePath)} ${fg('muted', `(${ops})`)}`);
+    }
+    lines.push('');
+    lines.push(fg('muted', 'Use /diff <path> to see the git diff for a specific file.'));
+
+    this.showInfo(lines.join('\n'));
+  }
+
+  /**
+   * Run a shell command directly and display the output in the chat.
+   * Triggered by the `!` prefix (e.g., `!ls -la`).
+   */
+  private async handleShellPassthrough(command: string): Promise<void> {
+    if (!command) {
+      this.showInfo('Usage: !<command> (e.g., !ls -la)');
+      return;
+    }
+
+    try {
+      const { execa } = await import('execa');
+      const result = await execa(command, {
+        shell: true,
+        cwd: process.cwd(),
+        reject: false,
+        timeout: 30_000,
+        env: {
+          ...process.env,
+          FORCE_COLOR: '1',
+        },
+      });
+
+      const component = new ShellOutputComponent(
+        command,
+        result.stdout ?? '',
+        result.stderr ?? '',
+        result.exitCode ?? 0,
+      );
+      this.chatContainer.addChild(component);
+      this.ui.requestRender();
+    } catch (error) {
+      this.showError(error instanceof Error ? error.message : 'Shell command failed');
+    }
+  }
+  /**
+   * Send a notification alert (bell / system / hooks) based on user settings.
+   */
+  private notify(reason: NotificationReason, message?: string): void {
+    const mode = ((this.harness.getState() as any)?.notifications ?? 'off') as NotificationMode;
+    sendNotification(reason, {
+      mode,
+      message,
+      hookManager: this.harness.getHookManager?.(),
+    });
+  }
+
+  private showInfo(message: string): void {
+    this.chatContainer.addChild(new Spacer(1));
+    this.chatContainer.addChild(new Text(fg('muted', message), 1, 0));
+    this.ui.requestRender();
+  }
 }

--- a/mastracode/src/tui/notify.ts
+++ b/mastracode/src/tui/notify.ts
@@ -3,17 +3,12 @@
  * Sends a terminal bell and optionally a native OS notification.
  */
 
-import { exec } from "node:child_process"
-import type { HookManager } from "../hooks/manager.js"
+import { exec } from 'node:child_process';
+import type { HookManager } from '../hooks/manager.js';
 
-export type NotificationMode = "bell" | "system" | "both" | "off"
+export type NotificationMode = 'bell' | 'system' | 'both' | 'off';
 
-export type NotificationReason =
-	| "agent_done"
-	| "ask_question"
-	| "tool_approval"
-	| "plan_approval"
-	| "sandbox_access"
+export type NotificationReason = 'agent_done' | 'ask_question' | 'tool_approval' | 'plan_approval' | 'sandbox_access';
 
 /**
  * Send a notification to the user.
@@ -25,58 +20,53 @@ export type NotificationReason =
  * Also fires Notification hooks if a hookManager is provided.
  */
 export function sendNotification(
-	reason: NotificationReason,
-	opts: {
-		mode: NotificationMode
-		message?: string
-		hookManager?: HookManager
-	},
+  reason: NotificationReason,
+  opts: {
+    mode: NotificationMode;
+    message?: string;
+    hookManager?: HookManager;
+  },
 ): void {
-	const { mode, message, hookManager } = opts
+  const { mode, message, hookManager } = opts;
 
-	if (mode === "off") {
-		// Still fire hooks even when built-in notifications are off
-		hookManager?.runNotification(reason, message)
-		return
-	}
+  if (mode === 'off') {
+    // Still fire hooks even when built-in notifications are off
+    hookManager?.runNotification(reason, message);
+    return;
+  }
 
-	if (mode === "bell" || mode === "both") {
-		process.stdout.write("\x07")
-	}
+  if (mode === 'bell' || mode === 'both') {
+    process.stdout.write('\x07');
+  }
 
-	if (mode === "system" || mode === "both") {
-		sendSystemNotification(reason, message)
-	}
+  if (mode === 'system' || mode === 'both') {
+    sendSystemNotification(reason, message);
+  }
 
-	hookManager?.runNotification(reason, message)
+  hookManager?.runNotification(reason, message);
 }
 
-function sendSystemNotification(
-	reason: NotificationReason,
-	message?: string,
-): void {
-	if (process.platform === "darwin") {
-		const title = "Mastra Code"
-		const body = message || reasonToMessage(reason)
-		const escaped = body.replace(/"/g, '\\"')
-		exec(
-			`osascript -e 'display notification "${escaped}" with title "${title}"'`,
-		)
-	}
-	// Linux/Windows: could add notify-send / powershell in the future
+function sendSystemNotification(reason: NotificationReason, message?: string): void {
+  if (process.platform === 'darwin') {
+    const title = 'Mastra Code';
+    const body = message || reasonToMessage(reason);
+    const escaped = body.replace(/"/g, '\\"');
+    exec(`osascript -e 'display notification "${escaped}" with title "${title}"'`);
+  }
+  // Linux/Windows: could add notify-send / powershell in the future
 }
 
 function reasonToMessage(reason: NotificationReason): string {
-	switch (reason) {
-		case "agent_done":
-			return "Agent finished — waiting for your input"
-		case "ask_question":
-			return "Agent has a question for you"
-		case "tool_approval":
-			return "Tool requires your approval"
-		case "plan_approval":
-			return "Plan requires your approval"
-		case "sandbox_access":
-			return "Sandbox access requested"
-	}
+  switch (reason) {
+    case 'agent_done':
+      return 'Agent finished — waiting for your input';
+    case 'ask_question':
+      return 'Agent has a question for you';
+    case 'tool_approval':
+      return 'Tool requires your approval';
+    case 'plan_approval':
+      return 'Plan requires your approval';
+    case 'sandbox_access':
+      return 'Sandbox access requested';
+  }
 }

--- a/mastracode/src/tui/theme.ts
+++ b/mastracode/src/tui/theme.ts
@@ -3,8 +3,8 @@
  * Simplified from pi-mono's theme system.
  */
 
-import type { MarkdownTheme, EditorTheme, SettingsListTheme, SelectListTheme } from "@mariozechner/pi-tui"
-import chalk from "chalk"
+import type { MarkdownTheme, EditorTheme, SettingsListTheme, SelectListTheme } from '@mariozechner/pi-tui';
+import chalk from 'chalk';
 
 // =============================================================================
 // Mastra Brand Palette
@@ -12,35 +12,35 @@ import chalk from "chalk"
 
 /** Mastra brand colors — single source of truth for all hex values. */
 export const mastra = {
-	purple: "#7f45e0", // #b588fe brand is too washed out for terminal
-	green: "#059669", // #7aff78 too vibrant
-	orange: "#fdac53",
-	pink: "#ff69cc",
-	blue: "#2563eb", // #6ccdfb brand is to washed out
-	red: "#DC5663", // #ff4758 too intense
-	yellow: "#e7e67b",
-	// Surface colors
-	bg: "#020202",
-	antiGrid: "#0d0d0d",
-	elevationSm: "#1a1a1a",
-	elevationLg: "#141414",
-	hover: "#262626",
-	// Text colors
-	white: "#f0f0f0",
-	specialGray: "#cccccc",
-	mainGray: "#939393",
-	darkGray: "#424242",
-	// Border colors
-	borderAntiGrid: "#141414",
-	borderElevation: "#1a1a1a",
-} as const
+  purple: '#7f45e0', // #b588fe brand is too washed out for terminal
+  green: '#059669', // #7aff78 too vibrant
+  orange: '#fdac53',
+  pink: '#ff69cc',
+  blue: '#2563eb', // #6ccdfb brand is to washed out
+  red: '#DC5663', // #ff4758 too intense
+  yellow: '#e7e67b',
+  // Surface colors
+  bg: '#020202',
+  antiGrid: '#0d0d0d',
+  elevationSm: '#1a1a1a',
+  elevationLg: '#141414',
+  hover: '#262626',
+  // Text colors
+  white: '#f0f0f0',
+  specialGray: '#cccccc',
+  mainGray: '#939393',
+  darkGray: '#424242',
+  // Border colors
+  borderAntiGrid: '#141414',
+  borderElevation: '#1a1a1a',
+} as const;
 
 /** Tint a hex color by a brightness factor (0–1). e.g. tintHex("#ff8800", 0.15) → near-black orange */
 export function tintHex(hex: string, factor: number): string {
-	const r = Math.floor(parseInt(hex.slice(1, 3), 16) * factor)
-	const g = Math.floor(parseInt(hex.slice(3, 5), 16) * factor)
-	const b = Math.floor(parseInt(hex.slice(5, 7), 16) * factor)
-	return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`
+  const r = Math.floor(parseInt(hex.slice(1, 3), 16) * factor);
+  const g = Math.floor(parseInt(hex.slice(3, 5), 16) * factor);
+  const b = Math.floor(parseInt(hex.slice(5, 7), 16) * factor);
+  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
 }
 
 // =============================================================================
@@ -48,73 +48,73 @@ export function tintHex(hex: string, factor: number): string {
 // =============================================================================
 
 export type ThemeColor =
-	| "accent"
-	| "border"
-	| "borderAccent"
-	| "borderMuted"
-	| "success"
-	| "error"
-	| "warning"
-	| "muted"
-	| "dim"
-	| "text"
-	| "thinkingText"
-	| "userMessageText"
-	| "toolTitle"
-	| "toolOutput"
-	| "toolBorderPending"
-	| "toolBorderSuccess"
-	| "toolBorderError"
-	| "function"
-	| "path"
-	| "number"
+  | 'accent'
+  | 'border'
+  | 'borderAccent'
+  | 'borderMuted'
+  | 'success'
+  | 'error'
+  | 'warning'
+  | 'muted'
+  | 'dim'
+  | 'text'
+  | 'thinkingText'
+  | 'userMessageText'
+  | 'toolTitle'
+  | 'toolOutput'
+  | 'toolBorderPending'
+  | 'toolBorderSuccess'
+  | 'toolBorderError'
+  | 'function'
+  | 'path'
+  | 'number';
 
 export type ThemeBg =
-	| "selectedBg"
-	| "userMessageBg"
-	| "systemReminderBg"
-	| "toolPendingBg"
-	| "toolSuccessBg"
-	| "toolErrorBg"
-	| "overlayBg"
-	| "errorBg"
+  | 'selectedBg'
+  | 'userMessageBg'
+  | 'systemReminderBg'
+  | 'toolPendingBg'
+  | 'toolSuccessBg'
+  | 'toolErrorBg'
+  | 'overlayBg'
+  | 'errorBg';
 
 export interface ThemeColors {
-	// Core UI
-	accent: string
-	border: string
-	borderAccent: string
-	borderMuted: string
-	success: string
-	error: string
-	warning: string
-	muted: string
-	dim: string
-	text: string
-	thinkingText: string
-	// User messages
-	userMessageBg: string
-	userMessageText: string
-	// System reminders
-	systemReminderBg: string
-	// Tool execution
-	toolPendingBg: string
-	toolSuccessBg: string
-	toolErrorBg: string
-	toolBorderPending: string
-	toolBorderSuccess: string
-	toolBorderError: string
-	toolTitle: string
-	toolOutput: string
-	// Selection
-	selectedBg: string
-	// Overlays
-	overlayBg: string
-	// Error display
-	errorBg: string
-	path: string
-	number: string
-	function: string
+  // Core UI
+  accent: string;
+  border: string;
+  borderAccent: string;
+  borderMuted: string;
+  success: string;
+  error: string;
+  warning: string;
+  muted: string;
+  dim: string;
+  text: string;
+  thinkingText: string;
+  // User messages
+  userMessageBg: string;
+  userMessageText: string;
+  // System reminders
+  systemReminderBg: string;
+  // Tool execution
+  toolPendingBg: string;
+  toolSuccessBg: string;
+  toolErrorBg: string;
+  toolBorderPending: string;
+  toolBorderSuccess: string;
+  toolBorderError: string;
+  toolTitle: string;
+  toolOutput: string;
+  // Selection
+  selectedBg: string;
+  // Overlays
+  overlayBg: string;
+  // Error display
+  errorBg: string;
+  path: string;
+  number: string;
+  function: string;
 }
 
 // =============================================================================
@@ -122,61 +122,61 @@ export interface ThemeColors {
 // =============================================================================
 
 const darkTheme: ThemeColors = {
-	// Core UI
-	accent: "#7c3aed", // Purple
-	border: "#3f3f46",
-	borderAccent: "#7c3aed",
-	borderMuted: "#27272a",
-	success: "#22c55e",
-	error: "#ef4444",
-	warning: "#f59e0b",
-	muted: "#71717a",
-	dim: "#52525b",
-	text: "#fafafa",
-	thinkingText: "#a1a1aa",
-	// User messages
-	userMessageBg: "#0f172a", // Slate blue
-	userMessageText: "#fafafa",
-	// System reminders
-	systemReminderBg: "#1a1400", // Dark orange tint
-	// Tool execution
-	toolPendingBg: "#18152a", // Dark purple (matches tool title accent)
-	toolSuccessBg: "#18152a", // Dark purple (same as pending)
-	toolErrorBg: "#1f0a0a", // Dark red tint
-	toolBorderPending: "#6366f1", // Indigo for pending
-	toolBorderSuccess: "#22c55e", // Green for success
-	toolBorderError: "#ef4444", // Red for error
-	toolTitle: "#a78bfa",
-	toolOutput: "#d4d4d8",
-	// Error display
-	errorBg: "#291415", // Slightly lighter than toolErrorBg for contrast
-	path: "#9ca3af", // Gray for file paths
-	number: "#fbbf24", // Yellow for line numbers
-	function: "#60a5fa", // Light blue for function names
-	// Selection
-	selectedBg: mastra.hover,
-	// Overlays
-	overlayBg: mastra.antiGrid,
-}
+  // Core UI
+  accent: '#7c3aed', // Purple
+  border: '#3f3f46',
+  borderAccent: '#7c3aed',
+  borderMuted: '#27272a',
+  success: '#22c55e',
+  error: '#ef4444',
+  warning: '#f59e0b',
+  muted: '#71717a',
+  dim: '#52525b',
+  text: '#fafafa',
+  thinkingText: '#a1a1aa',
+  // User messages
+  userMessageBg: '#0f172a', // Slate blue
+  userMessageText: '#fafafa',
+  // System reminders
+  systemReminderBg: '#1a1400', // Dark orange tint
+  // Tool execution
+  toolPendingBg: '#18152a', // Dark purple (matches tool title accent)
+  toolSuccessBg: '#18152a', // Dark purple (same as pending)
+  toolErrorBg: '#1f0a0a', // Dark red tint
+  toolBorderPending: '#6366f1', // Indigo for pending
+  toolBorderSuccess: '#22c55e', // Green for success
+  toolBorderError: '#ef4444', // Red for error
+  toolTitle: '#a78bfa',
+  toolOutput: '#d4d4d8',
+  // Error display
+  errorBg: '#291415', // Slightly lighter than toolErrorBg for contrast
+  path: '#9ca3af', // Gray for file paths
+  number: '#fbbf24', // Yellow for line numbers
+  function: '#60a5fa', // Light blue for function names
+  // Selection
+  selectedBg: mastra.hover,
+  // Overlays
+  overlayBg: mastra.antiGrid,
+};
 
 // =============================================================================
 // Theme Instance
 // =============================================================================
 
-let currentTheme: ThemeColors = darkTheme
+let currentTheme: ThemeColors = darkTheme;
 
 /**
  * Get the current theme colors.
  */
 export function getTheme(): ThemeColors {
-	return currentTheme
+  return currentTheme;
 }
 
 /**
  * Set the current theme.
  */
 export function setTheme(colors: ThemeColors): void {
-	currentTheme = colors
+  currentTheme = colors;
 }
 
 // =============================================================================
@@ -187,39 +187,39 @@ export function setTheme(colors: ThemeColors): void {
  * Apply foreground color from theme.
  */
 export function fg(color: ThemeColor, text: string): string {
-	const hex = currentTheme[color]
-	if (!hex) return text
-	return chalk.hex(hex)(text)
+  const hex = currentTheme[color];
+  if (!hex) return text;
+  return chalk.hex(hex)(text);
 }
 
 /**
  * Apply background color from theme.
  */
 export function bg(color: ThemeBg, text: string): string {
-	const hex = currentTheme[color]
-	if (!hex) return text
-	return chalk.bgHex(hex)(text)
+  const hex = currentTheme[color];
+  if (!hex) return text;
+  return chalk.bgHex(hex)(text);
 }
 
 /**
  * Apply bold styling.
  */
 export function bold(text: string): string {
-	return chalk.bold(text)
+  return chalk.bold(text);
 }
 
 /**
  * Apply italic styling.
  */
 export function italic(text: string): string {
-	return chalk.italic(text)
+  return chalk.italic(text);
 }
 
 /**
  * Apply dim styling.
  */
 export function dim(text: string): string {
-	return chalk.dim(text)
+  return chalk.dim(text);
 }
 
 /**
@@ -227,15 +227,13 @@ export function dim(text: string): string {
  * against the given hex background color (WCAG relative luminance).
  */
 export function getContrastText(hexBg: string): string {
-	const hex = hexBg.replace("#", "")
-	const r = parseInt(hex.slice(0, 2), 16) / 255
-	const g = parseInt(hex.slice(2, 4), 16) / 255
-	const b = parseInt(hex.slice(4, 6), 16) / 255
-	const toLinear = (c: number) =>
-		c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
-	const luminance =
-		0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b)
-	return luminance > 0.179 ? "#000000" : "#ffffff"
+  const hex = hexBg.replace('#', '');
+  const r = parseInt(hex.slice(0, 2), 16) / 255;
+  const g = parseInt(hex.slice(2, 4), 16) / 255;
+  const b = parseInt(hex.slice(4, 6), 16) / 255;
+  const toLinear = (c: number) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+  const luminance = 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+  return luminance > 0.179 ? '#000000' : '#ffffff';
 }
 
 // =============================================================================
@@ -243,39 +241,38 @@ export function getContrastText(hexBg: string): string {
 // =============================================================================
 
 export const theme = {
-	fg,
-	bg,
-	bold,
-	italic,
-	dim,
-	getTheme,
-	setTheme,
-}
+  fg,
+  bg,
+  bold,
+  italic,
+  dim,
+  getTheme,
+  setTheme,
+};
 
 // =============================================================================
 // Markdown Theme (for pi-tui Markdown component)
 // =============================================================================
 
-
 export function getMarkdownTheme(): MarkdownTheme {
-	const t = getTheme()
-	return {
-		heading: (text: string) => chalk.hex(t.accent).bold(text),
-		link: (text: string) => chalk.hex(t.accent)(text),
-		linkUrl: (text: string) => chalk.hex(t.muted)(text),
-		code: (text: string) => chalk.hex(t.accent)(text),
-		codeBlock: (text: string) => text,
-		codeBlockBorder: (text: string) => chalk.hex(t.borderMuted)(text),
-		quote: (text: string) => chalk.hex(t.muted).italic(text),
-		quoteBorder: (text: string) => chalk.hex(t.borderMuted)(text),
-		hr: (text: string) => chalk.hex(t.borderMuted)(text),
-		listBullet: (text: string) => chalk.hex(t.accent)(text),
-		// Required by MarkdownTheme interface
-		bold: (text: string) => chalk.bold(text),
-		italic: (text: string) => chalk.italic(text),
-		strikethrough: (text: string) => chalk.strikethrough(text),
-		underline: (text: string) => chalk.underline(text),
-	}
+  const t = getTheme();
+  return {
+    heading: (text: string) => chalk.hex(t.accent).bold(text),
+    link: (text: string) => chalk.hex(t.accent)(text),
+    linkUrl: (text: string) => chalk.hex(t.muted)(text),
+    code: (text: string) => chalk.hex(t.accent)(text),
+    codeBlock: (text: string) => text,
+    codeBlockBorder: (text: string) => chalk.hex(t.borderMuted)(text),
+    quote: (text: string) => chalk.hex(t.muted).italic(text),
+    quoteBorder: (text: string) => chalk.hex(t.borderMuted)(text),
+    hr: (text: string) => chalk.hex(t.borderMuted)(text),
+    listBullet: (text: string) => chalk.hex(t.accent)(text),
+    // Required by MarkdownTheme interface
+    bold: (text: string) => chalk.bold(text),
+    italic: (text: string) => chalk.italic(text),
+    strikethrough: (text: string) => chalk.strikethrough(text),
+    underline: (text: string) => chalk.underline(text),
+  };
 }
 
 // =============================================================================
@@ -283,44 +280,41 @@ export function getMarkdownTheme(): MarkdownTheme {
 // =============================================================================
 
 export function getEditorTheme(): EditorTheme {
-	const t = getTheme()
-	return {
-		borderColor: (text: string) => chalk.hex(t.border)(text),
-		selectList: {
-			selectedPrefix: (text: string) => chalk.hex(t.accent)(text),
-			selectedText: (text: string) => chalk.bgHex(t.selectedBg)(text),
-			description: (text: string) => chalk.hex(t.muted)(text),
-			scrollInfo: (text: string) => chalk.hex(t.dim)(text),
-			noMatch: (text: string) => chalk.hex(t.muted)(text),
-		},
-	}
+  const t = getTheme();
+  return {
+    borderColor: (text: string) => chalk.hex(t.border)(text),
+    selectList: {
+      selectedPrefix: (text: string) => chalk.hex(t.accent)(text),
+      selectedText: (text: string) => chalk.bgHex(t.selectedBg)(text),
+      description: (text: string) => chalk.hex(t.muted)(text),
+      scrollInfo: (text: string) => chalk.hex(t.dim)(text),
+      noMatch: (text: string) => chalk.hex(t.muted)(text),
+    },
+  };
 }
 
 // =============================================================================
 // Settings List Theme (for pi-tui SettingsList component)
 // =============================================================================
 
-
 export function getSettingsListTheme(): SettingsListTheme {
-	const t = getTheme()
-	return {
-		label: (text: string, selected: boolean) =>
-			selected ? chalk.hex(t.text).bold(text) : chalk.hex(t.muted)(text),
-		value: (text: string, selected: boolean) =>
-			selected ? chalk.hex(t.accent)(text) : chalk.hex(t.dim)(text),
-		description: (text: string) => chalk.hex(t.muted).italic(text),
-		cursor: chalk.hex(t.accent)("→ "),
-		hint: (text: string) => chalk.hex(t.dim)(text),
-	}
+  const t = getTheme();
+  return {
+    label: (text: string, selected: boolean) => (selected ? chalk.hex(t.text).bold(text) : chalk.hex(t.muted)(text)),
+    value: (text: string, selected: boolean) => (selected ? chalk.hex(t.accent)(text) : chalk.hex(t.dim)(text)),
+    description: (text: string) => chalk.hex(t.muted).italic(text),
+    cursor: chalk.hex(t.accent)('→ '),
+    hint: (text: string) => chalk.hex(t.dim)(text),
+  };
 }
 
 export function getSelectListTheme(): SelectListTheme {
-	const t = getTheme()
-	return {
-		selectedPrefix: (text: string) => chalk.hex(t.accent)(text),
-		selectedText: (text: string) => chalk.bgHex(t.selectedBg)(text),
-		description: (text: string) => chalk.hex(t.muted)(text),
-		scrollInfo: (text: string) => chalk.hex(t.dim)(text),
-		noMatch: (text: string) => chalk.hex(t.muted)(text),
-	}
+  const t = getTheme();
+  return {
+    selectedPrefix: (text: string) => chalk.hex(t.accent)(text),
+    selectedText: (text: string) => chalk.bgHex(t.selectedBg)(text),
+    description: (text: string) => chalk.hex(t.muted)(text),
+    scrollInfo: (text: string) => chalk.hex(t.dim)(text),
+    noMatch: (text: string) => chalk.hex(t.muted)(text),
+  };
 }

--- a/mastracode/src/utils/errors.ts
+++ b/mastracode/src/utils/errors.ts
@@ -4,309 +4,296 @@
  */
 
 export interface ParsedError {
-	/** User-friendly error message */
-	message: string
-	/** Error type for categorization */
-	type: ErrorType
-	/** Whether this error is retryable */
-	retryable: boolean
-	/** Suggested retry delay in ms (if retryable) */
-	retryDelay?: number
-	/** Original error for debugging */
-	originalError: Error
+  /** User-friendly error message */
+  message: string;
+  /** Error type for categorization */
+  type: ErrorType;
+  /** Whether this error is retryable */
+  retryable: boolean;
+  /** Suggested retry delay in ms (if retryable) */
+  retryDelay?: number;
+  /** Original error for debugging */
+  originalError: Error;
 }
 
 export type ErrorType =
-	| "rate_limit"
-	| "auth"
-	| "network"
-	| "timeout"
-	| "invalid_request"
-	| "server_error"
-	| "model_not_found"
-	| "context_length"
-	| "content_filter"
-	| "unknown"
+  | 'rate_limit'
+  | 'auth'
+  | 'network'
+  | 'timeout'
+  | 'invalid_request'
+  | 'server_error'
+  | 'model_not_found'
+  | 'context_length'
+  | 'content_filter'
+  | 'unknown';
 
 /**
  * Parse an error and return a user-friendly representation.
  */
 export function parseError(error: unknown): ParsedError {
-	const err = error instanceof Error ? error : new Error(String(error))
-	const message = err.message.toLowerCase()
-	const errorObj = error as Record<string, unknown>
+  const err = error instanceof Error ? error : new Error(String(error));
+  const message = err.message.toLowerCase();
+  const errorObj = error as Record<string, unknown>;
 
-	// Check for rate limiting
-	if (
-		message.includes("rate limit") ||
-		message.includes("rate_limit") ||
-		message.includes("429") ||
-		errorObj.statusCode === 429 ||
-		errorObj.status === 429
-	) {
-		const retryAfter = extractRetryAfter(errorObj)
-		return {
-			message: "Rate limited. Please wait a moment before trying again.",
-			type: "rate_limit",
-			retryable: true,
-			retryDelay: retryAfter || 5000,
-			originalError: err,
-		}
-	}
+  // Check for rate limiting
+  if (
+    message.includes('rate limit') ||
+    message.includes('rate_limit') ||
+    message.includes('429') ||
+    errorObj.statusCode === 429 ||
+    errorObj.status === 429
+  ) {
+    const retryAfter = extractRetryAfter(errorObj);
+    return {
+      message: 'Rate limited. Please wait a moment before trying again.',
+      type: 'rate_limit',
+      retryable: true,
+      retryDelay: retryAfter || 5000,
+      originalError: err,
+    };
+  }
 
-	// Check for authentication errors
-	if (
-		message.includes("unauthorized") ||
-		message.includes("authentication") ||
-		message.includes("invalid api key") ||
-		message.includes("invalid_api_key") ||
-		message.includes("api key") ||
-		errorObj.statusCode === 401 ||
-		errorObj.status === 401
-	) {
-		return {
-			message:
-				"Authentication failed. Please check your API key or login with /login.",
-			type: "auth",
-			retryable: false,
-			originalError: err,
-		}
-	}
+  // Check for authentication errors
+  if (
+    message.includes('unauthorized') ||
+    message.includes('authentication') ||
+    message.includes('invalid api key') ||
+    message.includes('invalid_api_key') ||
+    message.includes('api key') ||
+    errorObj.statusCode === 401 ||
+    errorObj.status === 401
+  ) {
+    return {
+      message: 'Authentication failed. Please check your API key or login with /login.',
+      type: 'auth',
+      retryable: false,
+      originalError: err,
+    };
+  }
 
-	// Check for forbidden/permission errors
-	if (errorObj.statusCode === 403 || errorObj.status === 403) {
-		return {
-			message: "Access denied. You may not have permission to use this model.",
-			type: "auth",
-			retryable: false,
-			originalError: err,
-		}
-	}
+  // Check for forbidden/permission errors
+  if (errorObj.statusCode === 403 || errorObj.status === 403) {
+    return {
+      message: 'Access denied. You may not have permission to use this model.',
+      type: 'auth',
+      retryable: false,
+      originalError: err,
+    };
+  }
 
-	// Check for network errors
-	if (
-		message.includes("network") ||
-		message.includes("econnrefused") ||
-		message.includes("enotfound") ||
-		message.includes("fetch failed") ||
-		message.includes("connection")
-	) {
-		return {
-			message: "Network error. Please check your internet connection.",
-			type: "network",
-			retryable: true,
-			retryDelay: 2000,
-			originalError: err,
-		}
-	}
+  // Check for network errors
+  if (
+    message.includes('network') ||
+    message.includes('econnrefused') ||
+    message.includes('enotfound') ||
+    message.includes('fetch failed') ||
+    message.includes('connection')
+  ) {
+    return {
+      message: 'Network error. Please check your internet connection.',
+      type: 'network',
+      retryable: true,
+      retryDelay: 2000,
+      originalError: err,
+    };
+  }
 
-	// Check for timeout errors
-	if (
-		message.includes("timeout") ||
-		message.includes("timed out") ||
-		message.includes("etimedout")
-	) {
-		return {
-			message: "Request timed out. The server may be overloaded.",
-			type: "timeout",
-			retryable: true,
-			retryDelay: 3000,
-			originalError: err,
-		}
-	}
+  // Check for timeout errors
+  if (message.includes('timeout') || message.includes('timed out') || message.includes('etimedout')) {
+    return {
+      message: 'Request timed out. The server may be overloaded.',
+      type: 'timeout',
+      retryable: true,
+      retryDelay: 3000,
+      originalError: err,
+    };
+  }
 
-	// Check for model not found
-	if (
-		message.includes("model not found") ||
-		message.includes("model_not_found") ||
-		message.includes("does not exist") ||
-		message.includes("invalid model")
-	) {
-		return {
-			message: "Model not found. Please select a different model with /models.",
-			type: "model_not_found",
-			retryable: false,
-			originalError: err,
-		}
-	}
+  // Check for model not found
+  if (
+    message.includes('model not found') ||
+    message.includes('model_not_found') ||
+    message.includes('does not exist') ||
+    message.includes('invalid model')
+  ) {
+    return {
+      message: 'Model not found. Please select a different model with /models.',
+      type: 'model_not_found',
+      retryable: false,
+      originalError: err,
+    };
+  }
 
-	// Check for context length errors
-	if (
-		message.includes("context length") ||
-		message.includes("context_length") ||
-		message.includes("too many tokens") ||
-		message.includes("maximum context") ||
-		message.includes("token limit")
-	) {
-		return {
-			message: "Message too long. Try starting a new thread with /new.",
-			type: "context_length",
-			retryable: false,
-			originalError: err,
-		}
-	}
+  // Check for context length errors
+  if (
+    message.includes('context length') ||
+    message.includes('context_length') ||
+    message.includes('too many tokens') ||
+    message.includes('maximum context') ||
+    message.includes('token limit')
+  ) {
+    return {
+      message: 'Message too long. Try starting a new thread with /new.',
+      type: 'context_length',
+      retryable: false,
+      originalError: err,
+    };
+  }
 
-	// Check for content filter errors
-	if (
-		message.includes("content filter") ||
-		message.includes("content_filter") ||
-		message.includes("content policy") ||
-		message.includes("safety") ||
-		message.includes("prohibited")
-	) {
-		return {
-			message: "Content was filtered by the model's safety system.",
-			type: "content_filter",
-			retryable: false,
-			originalError: err,
-		}
-	}
+  // Check for content filter errors
+  if (
+    message.includes('content filter') ||
+    message.includes('content_filter') ||
+    message.includes('content policy') ||
+    message.includes('safety') ||
+    message.includes('prohibited')
+  ) {
+    return {
+      message: "Content was filtered by the model's safety system.",
+      type: 'content_filter',
+      retryable: false,
+      originalError: err,
+    };
+  }
 
-	// Check for server errors
-	if (
-		message.includes("internal server") ||
-		message.includes("server error") ||
-		errorObj.statusCode === 500 ||
-		errorObj.status === 500 ||
-		errorObj.statusCode === 502 ||
-		errorObj.status === 502 ||
-		errorObj.statusCode === 503 ||
-		errorObj.status === 503
-	) {
-		return {
-			message: "Server error. The API may be experiencing issues.",
-			type: "server_error",
-			retryable: true,
-			retryDelay: 5000,
-			originalError: err,
-		}
-	}
+  // Check for server errors
+  if (
+    message.includes('internal server') ||
+    message.includes('server error') ||
+    errorObj.statusCode === 500 ||
+    errorObj.status === 500 ||
+    errorObj.statusCode === 502 ||
+    errorObj.status === 502 ||
+    errorObj.statusCode === 503 ||
+    errorObj.status === 503
+  ) {
+    return {
+      message: 'Server error. The API may be experiencing issues.',
+      type: 'server_error',
+      retryable: true,
+      retryDelay: 5000,
+      originalError: err,
+    };
+  }
 
-	// Check for invalid request errors
-	if (
-		message.includes("invalid request") ||
-		message.includes("bad request") ||
-		errorObj.statusCode === 400 ||
-		errorObj.status === 400
-	) {
-		return {
-			message: `Invalid request: ${extractErrorDetail(err)}`,
-			type: "invalid_request",
-			retryable: false,
-			originalError: err,
-		}
-	}
+  // Check for invalid request errors
+  if (
+    message.includes('invalid request') ||
+    message.includes('bad request') ||
+    errorObj.statusCode === 400 ||
+    errorObj.status === 400
+  ) {
+    return {
+      message: `Invalid request: ${extractErrorDetail(err)}`,
+      type: 'invalid_request',
+      retryable: false,
+      originalError: err,
+    };
+  }
 
-	// Unknown error - try to extract useful info
-	return {
-		message: extractErrorDetail(err),
-		type: "unknown",
-		retryable: false,
-		originalError: err,
-	}
+  // Unknown error - try to extract useful info
+  return {
+    message: extractErrorDetail(err),
+    type: 'unknown',
+    retryable: false,
+    originalError: err,
+  };
 }
 
 /**
  * Extract retry-after header value from error.
  */
 function extractRetryAfter(error: Record<string, unknown>): number | undefined {
-	const headers = error.headers as Record<string, unknown> | undefined
-	const retryAfter = error.retryAfter || headers?.["retry-after"]
-	if (typeof retryAfter === "number") {
-		return retryAfter * 1000 // Convert seconds to ms
-	}
-	if (typeof retryAfter === "string") {
-		const seconds = parseInt(retryAfter, 10)
-		if (!isNaN(seconds)) {
-			return seconds * 1000
-		}
-	}
-	return undefined
+  const headers = error.headers as Record<string, unknown> | undefined;
+  const retryAfter = error.retryAfter || headers?.['retry-after'];
+  if (typeof retryAfter === 'number') {
+    return retryAfter * 1000; // Convert seconds to ms
+  }
+  if (typeof retryAfter === 'string') {
+    const seconds = parseInt(retryAfter, 10);
+    if (!isNaN(seconds)) {
+      return seconds * 1000;
+    }
+  }
+  return undefined;
 }
 
 /**
  * Extract a useful error detail from an error object.
  */
 function extractErrorDetail(error: Error): string {
-	const errorObj = error as unknown as Record<string, unknown>
+  const errorObj = error as unknown as Record<string, unknown>;
 
-	// Try to get a specific error message from common API error formats
-	if (errorObj.error && typeof errorObj.error === "object") {
-		const apiError = errorObj.error as Record<string, unknown>
-		if (apiError.message) return String(apiError.message)
-	}
+  // Try to get a specific error message from common API error formats
+  if (errorObj.error && typeof errorObj.error === 'object') {
+    const apiError = errorObj.error as Record<string, unknown>;
+    if (apiError.message) return String(apiError.message);
+  }
 
-	if (errorObj.message) return String(errorObj.message)
-	if (errorObj.detail) return String(errorObj.detail)
-	if (errorObj.reason) return String(errorObj.reason)
+  if (errorObj.message) return String(errorObj.message);
+  if (errorObj.detail) return String(errorObj.detail);
+  if (errorObj.reason) return String(errorObj.reason);
 
-	// Clean up the error message
-	let message = error.message
+  // Clean up the error message
+  let message = error.message;
 
-	// Remove common prefixes
-	message = message.replace(/^(error|exception|failed):\s*/i, "")
+  // Remove common prefixes
+  message = message.replace(/^(error|exception|failed):\s*/i, '');
 
-	// Truncate very long messages
-	if (message.length > 200) {
-		message = message.substring(0, 200) + "..."
-	}
+  // Truncate very long messages
+  if (message.length > 200) {
+    message = message.substring(0, 200) + '...';
+  }
 
-	return message || "An unknown error occurred"
+  return message || 'An unknown error occurred';
 }
 
 /**
  * Sleep for a given number of milliseconds.
  */
 export function sleep(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms))
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 /**
  * Retry a function with exponential backoff.
  */
 export async function withRetry<T>(
-	fn: () => Promise<T>,
-	options: {
-		maxRetries?: number
-		initialDelay?: number
-		maxDelay?: number
-		onRetry?: (error: ParsedError, attempt: number) => void
-	} = {},
+  fn: () => Promise<T>,
+  options: {
+    maxRetries?: number;
+    initialDelay?: number;
+    maxDelay?: number;
+    onRetry?: (error: ParsedError, attempt: number) => void;
+  } = {},
 ): Promise<T> {
-	const {
-		maxRetries = 3,
-		initialDelay = 1000,
-		maxDelay = 30000,
-		onRetry,
-	} = options
+  const { maxRetries = 3, initialDelay = 1000, maxDelay = 30000, onRetry } = options;
 
-	let lastError: ParsedError | undefined
+  let lastError: ParsedError | undefined;
 
-	for (let attempt = 0; attempt <= maxRetries; attempt++) {
-		try {
-			return await fn()
-		} catch (error) {
-			lastError = parseError(error)
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = parseError(error);
 
-			// Don't retry non-retryable errors
-			if (!lastError.retryable || attempt === maxRetries) {
-				throw lastError.originalError
-			}
+      // Don't retry non-retryable errors
+      if (!lastError.retryable || attempt === maxRetries) {
+        throw lastError.originalError;
+      }
 
-			// Calculate delay with exponential backoff
-			const delay = Math.min(
-				lastError.retryDelay || initialDelay * Math.pow(2, attempt),
-				maxDelay,
-			)
+      // Calculate delay with exponential backoff
+      const delay = Math.min(lastError.retryDelay || initialDelay * Math.pow(2, attempt), maxDelay);
 
-			if (onRetry) {
-				onRetry(lastError, attempt + 1)
-			}
+      if (onRetry) {
+        onRetry(lastError, attempt + 1);
+      }
 
-			await sleep(delay)
-		}
-	}
+      await sleep(delay);
+    }
+  }
 
-	// Should never reach here, but TypeScript needs this
-	throw lastError?.originalError || new Error("Retry failed")
+  // Should never reach here, but TypeScript needs this
+  throw lastError?.originalError || new Error('Retry failed');
 }

--- a/mastracode/src/utils/gateway-sync.ts
+++ b/mastracode/src/utils/gateway-sync.ts
@@ -3,112 +3,103 @@
  * Periodically fetches provider data from gateways and updates the global cache.
  */
 
-import fs from "node:fs"
-import os from "node:os"
-import path from "node:path"
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
-import { ModelsDevGateway, NetlifyGateway } from "@mastra/core/llm"
-import type { ProviderConfig } from "@mastra/core/llm"
+import { ModelsDevGateway, NetlifyGateway } from '@mastra/core/llm';
+import type { ProviderConfig } from '@mastra/core/llm';
 
 // Cache paths (same as Mastra uses)
-const CACHE_DIR = path.join(os.homedir(), ".cache", "mastra")
-const CACHE_FILE = path.join(CACHE_DIR, "gateway-refresh-time")
-const GLOBAL_PROVIDER_REGISTRY_JSON = path.join(
-	CACHE_DIR,
-	"provider-registry.json",
-)
-const GLOBAL_PROVIDER_TYPES_DTS = path.join(
-	CACHE_DIR,
-	"provider-types.generated.d.ts",
-)
+const CACHE_DIR = path.join(os.homedir(), '.cache', 'mastra');
+const CACHE_FILE = path.join(CACHE_DIR, 'gateway-refresh-time');
+const GLOBAL_PROVIDER_REGISTRY_JSON = path.join(CACHE_DIR, 'provider-registry.json');
+const GLOBAL_PROVIDER_TYPES_DTS = path.join(CACHE_DIR, 'provider-types.generated.d.ts');
 
 // Default sync interval: 5 minutes
-const DEFAULT_SYNC_INTERVAL_MS = 5 * 60 * 1000
+const DEFAULT_SYNC_INTERVAL_MS = 5 * 60 * 1000;
 
-let syncInterval: NodeJS.Timeout | null = null
-let isSyncing = false
+let syncInterval: NodeJS.Timeout | null = null;
+let isSyncing = false;
 
 /**
  * Atomic file write to prevent corruption from concurrent writes
  */
-async function atomicWriteFile(
-	filePath: string,
-	content: string,
-): Promise<void> {
-	const randomSuffix = Math.random().toString(36).substring(2, 15)
-	const tempPath = `${filePath}.${process.pid}.${Date.now()}.${randomSuffix}.tmp`
+async function atomicWriteFile(filePath: string, content: string): Promise<void> {
+  const randomSuffix = Math.random().toString(36).substring(2, 15);
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.${randomSuffix}.tmp`;
 
-	try {
-		await fs.promises.writeFile(tempPath, content, "utf-8")
-		await fs.promises.rename(tempPath, filePath)
-	} catch (error) {
-		try {
-			await fs.promises.unlink(tempPath)
-		} catch {
-			// Ignore cleanup errors
-		}
-		throw error
-	}
+  try {
+    await fs.promises.writeFile(tempPath, content, 'utf-8');
+    await fs.promises.rename(tempPath, filePath);
+  } catch (error) {
+    try {
+      await fs.promises.unlink(tempPath);
+    } catch {
+      // Ignore cleanup errors
+    }
+    throw error;
+  }
 }
 
 /**
  * Fetch providers from all gateways
  */
 async function fetchProvidersFromGateways(): Promise<{
-	providers: Record<string, ProviderConfig>
-	models: Record<string, string[]>
+  providers: Record<string, ProviderConfig>;
+  models: Record<string, string[]>;
 }> {
-	const allProviders: Record<string, ProviderConfig> = {}
-	const allModels: Record<string, string[]> = {}
+  const allProviders: Record<string, ProviderConfig> = {};
+  const allModels: Record<string, string[]> = {};
 
-	const gateways = [new ModelsDevGateway({}), new NetlifyGateway()]
+  const gateways = [new ModelsDevGateway({}), new NetlifyGateway()];
 
-	for (const gateway of gateways) {
-		try {
-			const providers = await gateway.fetchProviders()
+  for (const gateway of gateways) {
+    try {
+      const providers = await gateway.fetchProviders();
 
-			// models.dev is a provider registry, not a true gateway - don't prefix its providers
-			const isProviderRegistry = gateway.id === "models.dev"
+      // models.dev is a provider registry, not a true gateway - don't prefix its providers
+      const isProviderRegistry = gateway.id === 'models.dev';
 
-			for (const [providerId, config] of Object.entries(providers)) {
-				const typeProviderId = isProviderRegistry
-					? providerId
-					: providerId === gateway.id
-						? gateway.id
-						: `${gateway.id}/${providerId}`
+      for (const [providerId, config] of Object.entries(providers)) {
+        const typeProviderId = isProviderRegistry
+          ? providerId
+          : providerId === gateway.id
+            ? gateway.id
+            : `${gateway.id}/${providerId}`;
 
-				allProviders[typeProviderId] = config
-				allModels[typeProviderId] = config.models.sort()
-			}
-		} catch (error) {
-			console.warn(`[GatewaySync] Failed to fetch from ${gateway.id}:`, error)
-		}
-	}
+        allProviders[typeProviderId] = config;
+        allModels[typeProviderId] = config.models.sort();
+      }
+    } catch (error) {
+      console.warn(`[GatewaySync] Failed to fetch from ${gateway.id}:`, error);
+    }
+  }
 
-	return { providers: allProviders, models: allModels }
+  return { providers: allProviders, models: allModels };
 }
 
 /**
  * Generate TypeScript type definitions content
  */
 function generateTypesContent(models: Record<string, string[]>): string {
-	const providerModelsEntries = Object.entries(models)
-		.map(([provider, modelList]) => {
-			const modelsList = modelList.map((m) => `'${m}'`)
-			const needsQuotes = /[^a-zA-Z0-9_$]/.test(provider)
-			const providerKey = needsQuotes ? `'${provider}'` : provider
-			const singleLine = `  readonly ${providerKey}: readonly [${modelsList.join(", ")}];`
+  const providerModelsEntries = Object.entries(models)
+    .map(([provider, modelList]) => {
+      const modelsList = modelList.map(m => `'${m}'`);
+      const needsQuotes = /[^a-zA-Z0-9_$]/.test(provider);
+      const providerKey = needsQuotes ? `'${provider}'` : provider;
+      const singleLine = `  readonly ${providerKey}: readonly [${modelsList.join(', ')}];`;
 
-			if (singleLine.length > 120) {
-				const formattedModels = modelList.map((m) => `    '${m}',`).join("\n")
-				return `  readonly ${providerKey}: readonly [\n${formattedModels}\n  ];`
-			}
+      if (singleLine.length > 120) {
+        const formattedModels = modelList.map(m => `    '${m}',`).join('\n');
+        return `  readonly ${providerKey}: readonly [\n${formattedModels}\n  ];`;
+      }
 
-			return singleLine
-		})
-		.join("\n")
+      return singleLine;
+    })
+    .join('\n');
 
-	return `/**
+  return `/**
  * THIS FILE IS AUTO-GENERATED - DO NOT EDIT
  * Generated from model gateway providers
  */
@@ -130,93 +121,90 @@ export type ModelRouterModelId =
   | (string & {});
 
 export type ModelForProvider<P extends Provider> = ProviderModelsMap[P][number];
-`
+`;
 }
 
 /**
  * Get the last sync time from disk
  */
 function getLastSyncTime(): Date | null {
-	try {
-		if (!fs.existsSync(CACHE_FILE)) {
-			return null
-		}
-		const timestamp = fs.readFileSync(CACHE_FILE, "utf-8").trim()
-		return new Date(parseInt(timestamp, 10))
-	} catch {
-		return null
-	}
+  try {
+    if (!fs.existsSync(CACHE_FILE)) {
+      return null;
+    }
+    const timestamp = fs.readFileSync(CACHE_FILE, 'utf-8').trim();
+    return new Date(parseInt(timestamp, 10));
+  } catch {
+    return null;
+  }
 }
 
 /**
  * Save the last sync time to disk
  */
 function saveLastSyncTime(date: Date): void {
-	try {
-		if (!fs.existsSync(CACHE_DIR)) {
-			fs.mkdirSync(CACHE_DIR, { recursive: true })
-		}
-		fs.writeFileSync(CACHE_FILE, date.getTime().toString(), "utf-8")
-	} catch (error) {
-		console.warn("[GatewaySync] Failed to save sync time:", error)
-	}
+  try {
+    if (!fs.existsSync(CACHE_DIR)) {
+      fs.mkdirSync(CACHE_DIR, { recursive: true });
+    }
+    fs.writeFileSync(CACHE_FILE, date.getTime().toString(), 'utf-8');
+  } catch (error) {
+    console.warn('[GatewaySync] Failed to save sync time:', error);
+  }
 }
 
 /**
  * Sync gateways and update the global cache
  */
 export async function syncGateways(force = false): Promise<void> {
-	if (isSyncing && !force) {
-		return
-	}
+  if (isSyncing && !force) {
+    return;
+  }
 
-	// Check if we synced recently (within the last 5 minutes)
-	if (!force) {
-		const lastSync = getLastSyncTime()
-		if (lastSync) {
-			const timeSinceSync = Date.now() - lastSync.getTime()
-			if (timeSinceSync < DEFAULT_SYNC_INTERVAL_MS) {
-				// console.debug(`[GatewaySync] Skipping sync, last sync was ${Math.round(timeSinceSync / 1000)}s ago`)
-				return
-			}
-		}
-	}
+  // Check if we synced recently (within the last 5 minutes)
+  if (!force) {
+    const lastSync = getLastSyncTime();
+    if (lastSync) {
+      const timeSinceSync = Date.now() - lastSync.getTime();
+      if (timeSinceSync < DEFAULT_SYNC_INTERVAL_MS) {
+        // console.debug(`[GatewaySync] Skipping sync, last sync was ${Math.round(timeSinceSync / 1000)}s ago`)
+        return;
+      }
+    }
+  }
 
-	isSyncing = true
+  isSyncing = true;
 
-	try {
-		// console.debug("[GatewaySync] Starting gateway sync...")
+  try {
+    // console.debug("[GatewaySync] Starting gateway sync...")
 
-		const { providers, models } = await fetchProvidersFromGateways()
+    const { providers, models } = await fetchProvidersFromGateways();
 
-		// Ensure cache directory exists
-		await fs.promises.mkdir(CACHE_DIR, { recursive: true })
+    // Ensure cache directory exists
+    await fs.promises.mkdir(CACHE_DIR, { recursive: true });
 
-		// Write registry JSON
-		const registryData = {
-			providers,
-			models,
-			version: "1.0.0",
-		}
-		await atomicWriteFile(
-			GLOBAL_PROVIDER_REGISTRY_JSON,
-			JSON.stringify(registryData, null, 2),
-		)
+    // Write registry JSON
+    const registryData = {
+      providers,
+      models,
+      version: '1.0.0',
+    };
+    await atomicWriteFile(GLOBAL_PROVIDER_REGISTRY_JSON, JSON.stringify(registryData, null, 2));
 
-		// Write types file
-		const typesContent = generateTypesContent(models)
-		await atomicWriteFile(GLOBAL_PROVIDER_TYPES_DTS, typesContent)
+    // Write types file
+    const typesContent = generateTypesContent(models);
+    await atomicWriteFile(GLOBAL_PROVIDER_TYPES_DTS, typesContent);
 
-		// Save sync time
-		const now = new Date()
-		saveLastSyncTime(now)
+    // Save sync time
+    const now = new Date();
+    saveLastSyncTime(now);
 
-		// console.debug(`[GatewaySync] ✅ Sync completed at ${now.toISOString()}`)
-	} catch (error) {
-		console.error("[GatewaySync] ❌ Sync failed:", error)
-	} finally {
-		isSyncing = false
-	}
+    // console.debug(`[GatewaySync] ✅ Sync completed at ${now.toISOString()}`)
+  } catch (error) {
+    console.error('[GatewaySync] ❌ Sync failed:', error);
+  } finally {
+    isSyncing = false;
+  }
 }
 
 /**
@@ -224,28 +212,28 @@ export async function syncGateways(force = false): Promise<void> {
  * @param intervalMs Sync interval in milliseconds (default: 5 minutes)
  */
 export function startGatewaySync(intervalMs = DEFAULT_SYNC_INTERVAL_MS): void {
-	if (syncInterval) {
-		return
-	}
+  if (syncInterval) {
+    return;
+  }
 
-	// Do an initial sync
-	syncGateways().catch(console.error)
+  // Do an initial sync
+  syncGateways().catch(console.error);
 
-	// Set up periodic sync
-	syncInterval = setInterval(() => {
-		syncGateways().catch(console.error)
-	}, intervalMs)
+  // Set up periodic sync
+  syncInterval = setInterval(() => {
+    syncGateways().catch(console.error);
+  }, intervalMs);
 
-	// Don't prevent process exit
-	syncInterval.unref()
+  // Don't prevent process exit
+  syncInterval.unref();
 }
 
 /**
  * Stop periodic gateway sync
  */
 export function stopGatewaySync(): void {
-	if (syncInterval) {
-		clearInterval(syncInterval)
-		syncInterval = null
-	}
+  if (syncInterval) {
+    clearInterval(syncInterval);
+    syncInterval = null;
+  }
 }

--- a/mastracode/src/utils/project.ts
+++ b/mastracode/src/utils/project.ts
@@ -5,60 +5,60 @@
  * Handles git worktrees by finding the main repository.
  */
 
-import { execSync } from "node:child_process"
-import { createHash } from "node:crypto"
-import fs from "node:fs"
-import os from "node:os"
-import path from "node:path"
+import { execSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 export interface ProjectInfo {
-	/** Unique resource ID for this project (used for thread grouping) */
-	resourceId: string
-	/** Human-readable project name */
-	name: string
-	/** Absolute path to the project root */
-	rootPath: string
-	/** Git remote URL if available */
-	gitUrl?: string
-	/** Current git branch */
-	gitBranch?: string
-	/** Whether this is a git worktree */
-	isWorktree: boolean
-	/** Path to main git repo (different from rootPath if worktree) */
-	mainRepoPath?: string
-	/** Whether the resourceId was explicitly overridden (env var or config) */
-	resourceIdOverride?: boolean
+  /** Unique resource ID for this project (used for thread grouping) */
+  resourceId: string;
+  /** Human-readable project name */
+  name: string;
+  /** Absolute path to the project root */
+  rootPath: string;
+  /** Git remote URL if available */
+  gitUrl?: string;
+  /** Current git branch */
+  gitBranch?: string;
+  /** Whether this is a git worktree */
+  isWorktree: boolean;
+  /** Path to main git repo (different from rootPath if worktree) */
+  mainRepoPath?: string;
+  /** Whether the resourceId was explicitly overridden (env var or config) */
+  resourceIdOverride?: boolean;
 }
 
 /**
  * Run a git command and return stdout, or undefined if it fails
  */
 function git(args: string, cwd: string): string | undefined {
-	try {
-		return execSync(`git ${args}`, {
-			cwd,
-			encoding: "utf-8",
-			stdio: ["pipe", "pipe", "pipe"],
-		}).trim()
-	} catch {
-		return undefined
-	}
+  try {
+    return execSync(`git ${args}`, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return undefined;
+  }
 }
 
 /**
  * Slugify a string for use in IDs
  */
 function slugify(str: string): string {
-	return str
-		.toLowerCase()
-		.replace(/[^a-z0-9]+/g, "-")
-		.replace(/^-|-$/g, "")
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
 }
 
 /**
  * Create a short hash of a string
  */
 function shortHash(str: string): string {
-	return createHash("sha256").update(str).digest("hex").slice(0, 12)
+  return createHash('sha256').update(str).digest('hex').slice(0, 12);
 }
 
 /**
@@ -68,88 +68,88 @@ function shortHash(str: string): string {
  * - Lowercases
  */
 function normalizeGitUrl(url: string): string {
-	return url
-		.replace(/\.git$/, "")
-		.replace(/^git@([^:]+):/, "https://$1/")
-		.replace(/^ssh:\/\/git@/, "https://")
-		.toLowerCase()
+  return url
+    .replace(/\.git$/, '')
+    .replace(/^git@([^:]+):/, 'https://$1/')
+    .replace(/^ssh:\/\/git@/, 'https://')
+    .toLowerCase();
 }
 
 /**
  * Detect project info from a directory path
  */
 export function detectProject(projectPath: string): ProjectInfo {
-	const absolutePath = path.resolve(projectPath)
+  const absolutePath = path.resolve(projectPath);
 
-	// Check if this is a git repo
-	const gitDir = git("rev-parse --git-dir", absolutePath)
-	const isGitRepo = gitDir !== undefined
+  // Check if this is a git repo
+  const gitDir = git('rev-parse --git-dir', absolutePath);
+  const isGitRepo = gitDir !== undefined;
 
-	let rootPath = absolutePath
-	let gitUrl: string | undefined
-	let gitBranch: string | undefined
-	let isWorktree = false
-	let mainRepoPath: string | undefined
+  let rootPath = absolutePath;
+  let gitUrl: string | undefined;
+  let gitBranch: string | undefined;
+  let isWorktree = false;
+  let mainRepoPath: string | undefined;
 
-	if (isGitRepo) {
-		// Get the repo root (handles being in a subdirectory)
-		rootPath = git("rev-parse --show-toplevel", absolutePath) || absolutePath
+  if (isGitRepo) {
+    // Get the repo root (handles being in a subdirectory)
+    rootPath = git('rev-parse --show-toplevel', absolutePath) || absolutePath;
 
-		// Check for worktree - git-common-dir differs from git-dir in worktrees
-		const commonDir = git("rev-parse --git-common-dir", absolutePath)
-		if (commonDir && commonDir !== ".git" && commonDir !== gitDir) {
-			isWorktree = true
-			// The common dir is inside the main repo's .git folder
-			mainRepoPath = path.dirname(path.resolve(rootPath, commonDir))
-		}
+    // Check for worktree - git-common-dir differs from git-dir in worktrees
+    const commonDir = git('rev-parse --git-common-dir', absolutePath);
+    if (commonDir && commonDir !== '.git' && commonDir !== gitDir) {
+      isWorktree = true;
+      // The common dir is inside the main repo's .git folder
+      mainRepoPath = path.dirname(path.resolve(rootPath, commonDir));
+    }
 
-		// Get remote URL (prefer origin, fall back to first remote)
-		gitUrl = git("remote get-url origin", absolutePath)
-		if (!gitUrl) {
-			const remotes = git("remote", absolutePath)
-			if (remotes) {
-				const firstRemote = remotes.split("\n")[0]
-				if (firstRemote) {
-					gitUrl = git(`remote get-url ${firstRemote}`, absolutePath)
-				}
-			}
-		}
+    // Get remote URL (prefer origin, fall back to first remote)
+    gitUrl = git('remote get-url origin', absolutePath);
+    if (!gitUrl) {
+      const remotes = git('remote', absolutePath);
+      if (remotes) {
+        const firstRemote = remotes.split('\n')[0];
+        if (firstRemote) {
+          gitUrl = git(`remote get-url ${firstRemote}`, absolutePath);
+        }
+      }
+    }
 
-		// Get current branch
-		gitBranch = git("rev-parse --abbrev-ref HEAD", absolutePath)
-	}
+    // Get current branch
+    gitBranch = git('rev-parse --abbrev-ref HEAD', absolutePath);
+  }
 
-	// Generate resource ID
-	// Priority: normalized git URL > main repo path (for worktrees) > absolute path
-	let resourceIdSource: string
-	if (gitUrl) {
-		resourceIdSource = normalizeGitUrl(gitUrl)
-	} else if (mainRepoPath) {
-		resourceIdSource = mainRepoPath
-	} else {
-		resourceIdSource = rootPath
-	}
+  // Generate resource ID
+  // Priority: normalized git URL > main repo path (for worktrees) > absolute path
+  let resourceIdSource: string;
+  if (gitUrl) {
+    resourceIdSource = normalizeGitUrl(gitUrl);
+  } else if (mainRepoPath) {
+    resourceIdSource = mainRepoPath;
+  } else {
+    resourceIdSource = rootPath;
+  }
 
-	// Create a readable but unique resource ID
-	// Format: slugified-name-shorthash
-	const baseName = gitUrl
-		? gitUrl
-			.split("/")
-			.pop()
-			?.replace(/\.git$/, "") || "project"
-		: path.basename(rootPath)
+  // Create a readable but unique resource ID
+  // Format: slugified-name-shorthash
+  const baseName = gitUrl
+    ? gitUrl
+        .split('/')
+        .pop()
+        ?.replace(/\.git$/, '') || 'project'
+    : path.basename(rootPath);
 
-	const resourceId = `${slugify(baseName)}-${shortHash(resourceIdSource)}`
+  const resourceId = `${slugify(baseName)}-${shortHash(resourceIdSource)}`;
 
-	return {
-		resourceId,
-		name: baseName,
-		rootPath,
-		gitUrl,
-		gitBranch,
-		isWorktree,
-		mainRepoPath,
-	}
+  return {
+    resourceId,
+    name: baseName,
+    rootPath,
+    gitUrl,
+    gitBranch,
+    isWorktree,
+    mainRepoPath,
+  };
 }
 
 /**
@@ -159,38 +159,36 @@ export function detectProject(projectPath: string): ProjectInfo {
  * - Windows: %APPDATA%/mastracode
  */
 export function getAppDataDir(): string {
-	const platform = os.platform()
-	let baseDir: string
+  const platform = os.platform();
+  let baseDir: string;
 
-	if (platform === "darwin") {
-		baseDir = path.join(os.homedir(), "Library", "Application Support")
-	} else if (platform === "win32") {
-		baseDir =
-			process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming")
-	} else {
-		// Linux and others - follow XDG spec
-		baseDir =
-			process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share")
-	}
+  if (platform === 'darwin') {
+    baseDir = path.join(os.homedir(), 'Library', 'Application Support');
+  } else if (platform === 'win32') {
+    baseDir = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
+  } else {
+    // Linux and others - follow XDG spec
+    baseDir = process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
+  }
 
-	const appDir = path.join(baseDir, "mastracode")
+  const appDir = path.join(baseDir, 'mastracode');
 
-	// Ensure directory exists
-	if (!fs.existsSync(appDir)) {
-		fs.mkdirSync(appDir, { recursive: true })
-	}
+  // Ensure directory exists
+  if (!fs.existsSync(appDir)) {
+    fs.mkdirSync(appDir, { recursive: true });
+  }
 
-	return appDir
+  return appDir;
 }
 /**
  * Get the database path for mastracode
  * Can be overridden with the MASTRA_DB_PATH environment variable for debugging.
  */
 export function getDatabasePath(): string {
-	if (process.env.MASTRA_DB_PATH) {
-		return process.env.MASTRA_DB_PATH
-	}
-	return path.join(getAppDataDir(), "mastra.db")
+  if (process.env.MASTRA_DB_PATH) {
+    return process.env.MASTRA_DB_PATH;
+  }
+  return path.join(getAppDataDir(), 'mastra.db');
 }
 
 /**
@@ -198,9 +196,9 @@ export function getDatabasePath(): string {
  * Either a local file URL or a remote Turso URL with auth token.
  */
 export interface StorageConfig {
-	url: string
-	authToken?: string
-	isRemote: boolean
+  url: string;
+  authToken?: string;
+  isRemote: boolean;
 }
 
 /**
@@ -213,34 +211,30 @@ export interface StorageConfig {
  *   4. Local file database (default)
  */
 export function getStorageConfig(projectDir?: string): StorageConfig {
-	// 1. Environment variables
-	if (process.env.MASTRA_DB_URL) {
-		return {
-			url: process.env.MASTRA_DB_URL,
-			authToken: process.env.MASTRA_DB_AUTH_TOKEN,
-			isRemote: !process.env.MASTRA_DB_URL.startsWith("file:"),
-		}
-	}
+  // 1. Environment variables
+  if (process.env.MASTRA_DB_URL) {
+    return {
+      url: process.env.MASTRA_DB_URL,
+      authToken: process.env.MASTRA_DB_AUTH_TOKEN,
+      isRemote: !process.env.MASTRA_DB_URL.startsWith('file:'),
+    };
+  }
 
-	// 2. Project-level config
-	if (projectDir) {
-		const projectConfig = loadDatabaseConfig(
-			path.join(projectDir, ".mastracode", "database.json"),
-		)
-		if (projectConfig) return projectConfig
-	}
+  // 2. Project-level config
+  if (projectDir) {
+    const projectConfig = loadDatabaseConfig(path.join(projectDir, '.mastracode', 'database.json'));
+    if (projectConfig) return projectConfig;
+  }
 
-	// 3. Global config
-	const globalConfig = loadDatabaseConfig(
-		path.join(os.homedir(), ".mastracode", "database.json"),
-	)
-	if (globalConfig) return globalConfig
+  // 3. Global config
+  const globalConfig = loadDatabaseConfig(path.join(os.homedir(), '.mastracode', 'database.json'));
+  if (globalConfig) return globalConfig;
 
-	// 4. Default: local file database
-	return {
-		url: `file:${getDatabasePath()}`,
-		isRemote: false,
-	}
+  // 4. Default: local file database
+  return {
+    url: `file:${getDatabasePath()}`,
+    isRemote: false,
+  };
 }
 
 /**
@@ -248,22 +242,21 @@ export function getStorageConfig(projectDir?: string): StorageConfig {
  * Expected format: { "url": "libsql://...", "authToken": "..." }
  */
 function loadDatabaseConfig(filePath: string): StorageConfig | null {
-	try {
-		if (!fs.existsSync(filePath)) return null
-		const raw = fs.readFileSync(filePath, "utf-8")
-		const parsed = JSON.parse(raw)
-		if (typeof parsed?.url === "string" && parsed.url) {
-			return {
-				url: parsed.url,
-				authToken:
-					typeof parsed.authToken === "string" ? parsed.authToken : undefined,
-				isRemote: !parsed.url.startsWith("file:"),
-			}
-		}
-		return null
-	} catch {
-		return null
-	}
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.url === 'string' && parsed.url) {
+      return {
+        url: parsed.url,
+        authToken: typeof parsed.authToken === 'string' ? parsed.authToken : undefined,
+        isRemote: !parsed.url.startsWith('file:'),
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -275,26 +268,26 @@ function loadDatabaseConfig(filePath: string): StorageConfig | null {
  *   3. OS username as fallback
  */
 export function getUserId(projectDir?: string): string {
-	// 1. Environment variable override
-	if (process.env.MASTRA_USER_ID) {
-		return process.env.MASTRA_USER_ID
-	}
+  // 1. Environment variable override
+  if (process.env.MASTRA_USER_ID) {
+    return process.env.MASTRA_USER_ID;
+  }
 
-	// 2. git user.email
-	const cwd = projectDir || process.cwd()
-	const email = git("config user.email", cwd)
-	if (email) {
-		return email
-	}
+  // 2. git user.email
+  const cwd = projectDir || process.cwd();
+  const email = git('config user.email', cwd);
+  if (email) {
+    return email;
+  }
 
-	// 3. OS username fallback
-	return os.userInfo().username || "unknown"
+  // 3. OS username fallback
+  return os.userInfo().username || 'unknown';
 }
 
 /**
  * Observational memory scope: "thread" (per-conversation) or "resource" (shared across threads).
  */
-export type OmScope = "thread" | "resource"
+export type OmScope = 'thread' | 'resource';
 
 /**
  * Get the configured observational memory scope.
@@ -306,42 +299,38 @@ export type OmScope = "thread" | "resource"
  *   4. Default: "thread"
  */
 export function getOmScope(projectDir?: string): OmScope {
-	// 1. Environment variable
-	const envScope = process.env.MASTRA_OM_SCOPE
-	if (envScope === "thread" || envScope === "resource") {
-		return envScope
-	}
+  // 1. Environment variable
+  const envScope = process.env.MASTRA_OM_SCOPE;
+  if (envScope === 'thread' || envScope === 'resource') {
+    return envScope;
+  }
 
-	// 2. Project-level config
-	if (projectDir) {
-		const scope = loadOmScopeFromConfig(
-			path.join(projectDir, ".mastracode", "database.json"),
-		)
-		if (scope) return scope
-	}
+  // 2. Project-level config
+  if (projectDir) {
+    const scope = loadOmScopeFromConfig(path.join(projectDir, '.mastracode', 'database.json'));
+    if (scope) return scope;
+  }
 
-	// 3. Global config
-	const scope = loadOmScopeFromConfig(
-		path.join(os.homedir(), ".mastracode", "database.json"),
-	)
-	if (scope) return scope
+  // 3. Global config
+  const scope = loadOmScopeFromConfig(path.join(os.homedir(), '.mastracode', 'database.json'));
+  if (scope) return scope;
 
-	// 4. Default
-	return "thread"
+  // 4. Default
+  return 'thread';
 }
 
 function loadOmScopeFromConfig(filePath: string): OmScope | null {
-	try {
-		if (!fs.existsSync(filePath)) return null
-		const raw = fs.readFileSync(filePath, "utf-8")
-		const parsed = JSON.parse(raw)
-		if (parsed?.omScope === "thread" || parsed?.omScope === "resource") {
-			return parsed.omScope
-		}
-		return null
-	} catch {
-		return null
-	}
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (parsed?.omScope === 'thread' || parsed?.omScope === 'resource') {
+      return parsed.omScope;
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -357,41 +346,35 @@ function loadOmScopeFromConfig(filePath: string): OmScope | null {
  *   4. null (use auto-detected value)
  */
 export function getResourceIdOverride(projectDir?: string): string | null {
-	// 1. Environment variable
-	if (process.env.MASTRA_RESOURCE_ID) {
-		return process.env.MASTRA_RESOURCE_ID
-	}
+  // 1. Environment variable
+  if (process.env.MASTRA_RESOURCE_ID) {
+    return process.env.MASTRA_RESOURCE_ID;
+  }
 
-	// 2. Project-level config
-	if (projectDir) {
-		const rid = loadStringField(
-			path.join(projectDir, ".mastracode", "database.json"),
-			"resourceId",
-		)
-		if (rid) return rid
-	}
+  // 2. Project-level config
+  if (projectDir) {
+    const rid = loadStringField(path.join(projectDir, '.mastracode', 'database.json'), 'resourceId');
+    if (rid) return rid;
+  }
 
-	// 3. Global config
-	const rid = loadStringField(
-		path.join(os.homedir(), ".mastracode", "database.json"),
-		"resourceId",
-	)
-	if (rid) return rid
+  // 3. Global config
+  const rid = loadStringField(path.join(os.homedir(), '.mastracode', 'database.json'), 'resourceId');
+  if (rid) return rid;
 
-	return null
+  return null;
 }
 
 function loadStringField(filePath: string, field: string): string | null {
-	try {
-		if (!fs.existsSync(filePath)) return null
-		const raw = fs.readFileSync(filePath, "utf-8")
-		const parsed = JSON.parse(raw)
-		const value = parsed?.[field]
-		if (typeof value === "string" && value) {
-			return value
-		}
-		return null
-	} catch {
-		return null
-	}
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    const value = parsed?.[field];
+    if (typeof value === 'string' && value) {
+      return value;
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }

--- a/mastracode/src/utils/slash-command-loader.ts
+++ b/mastracode/src/utils/slash-command-loader.ts
@@ -47,12 +47,12 @@ export async function parseCommandFile(
 		}
 
 		// Split frontmatter and template
-		const parts = content.split("---")
-		if (parts.length < 3) {
-			return null
-		}
+        const parts = content.split("---")
+        if (parts.length < 3) {
+            return null
+        }
 
-		const frontmatter = parts[1].trim()
+        const frontmatter = parts[1]!.trim()
 		const template = parts.slice(2).join("---").trim()
 
 		// Parse YAML frontmatter

--- a/mastracode/src/utils/slash-command-loader.ts
+++ b/mastracode/src/utils/slash-command-loader.ts
@@ -1,84 +1,79 @@
-import { promises as fs } from "node:fs"
-import * as path from "node:path"
-import * as yaml from "js-yaml"
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as yaml from 'js-yaml';
 
 /**
  * Metadata for a slash command
  */
 export interface SlashCommandMetadata {
-	/** Command name (e.g., "git:commit") */
-	name: string
-	/** Human-readable description */
-	description: string
-	/** The command template with variables */
-	template: string
-	/** Source file path */
-	sourcePath: string
-	/** Namespace derived from directory structure */
-	namespace?: string
+  /** Command name (e.g., "git:commit") */
+  name: string;
+  /** Human-readable description */
+  description: string;
+  /** The command template with variables */
+  template: string;
+  /** Source file path */
+  sourcePath: string;
+  /** Namespace derived from directory structure */
+  namespace?: string;
 }
 
 /**
  * Parse a command file and extract metadata and template
  * Supports both frontmatter-based and plain markdown files
  */
-export async function parseCommandFile(
-	filePath: string,
-	baseDir?: string,
-): Promise<SlashCommandMetadata | null> {
-	try {
-		const content = await fs.readFile(filePath, "utf-8")
-		const trimmedContent = content.trim()
+export async function parseCommandFile(filePath: string, baseDir?: string): Promise<SlashCommandMetadata | null> {
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    const trimmedContent = content.trim();
 
-		// Check if file has frontmatter (starts with ---)
-		if (!trimmedContent.startsWith("---")) {
-			// No frontmatter - treat entire file as template
-			// Derive name from file path
-			const name = baseDir
-				? extractCommandName(filePath, baseDir)
-				: path.basename(filePath, ".md")
+    // Check if file has frontmatter (starts with ---)
+    if (!trimmedContent.startsWith('---')) {
+      // No frontmatter - treat entire file as template
+      // Derive name from file path
+      const name = baseDir ? extractCommandName(filePath, baseDir) : path.basename(filePath, '.md');
 
-			return {
-				name,
-				description: "",
-				template: content,
-				sourcePath: filePath,
-			}
-		}
+      return {
+        name,
+        description: '',
+        template: content,
+        sourcePath: filePath,
+      };
+    }
 
-		// Split frontmatter and template
-        const parts = content.split("---")
-        if (parts.length < 3) {
-            return null
-        }
+    // Split frontmatter and template
+    const parts = content.split('---');
+    if (parts.length < 3) {
+      return null;
+    }
 
-        const frontmatter = parts[1]!.trim()
-		const template = parts.slice(2).join("---").trim()
+    const frontmatter = parts[1]!.trim();
+    const template = parts.slice(2).join('---').trim();
 
-		// Parse YAML frontmatter
-		const metadata = yaml.load(frontmatter) as Record<string, string>
+    // Parse YAML frontmatter
+    const metadata = yaml.load(frontmatter) as Record<string, string>;
 
-		// Derive name from file path if not specified in frontmatter
-		let name: string
-		if (metadata?.name) {
-			name = metadata.name
-		} else if (baseDir) {
-			name = extractCommandName(filePath, baseDir)
-		} else {
-			name = path.basename(filePath, ".md")
-		}
+    // Derive name from file path if not specified in frontmatter
+    let name: string;
+    if (metadata?.name) {
+      name = metadata.name;
+    } else if (baseDir) {
+      name = extractCommandName(filePath, baseDir);
+    } else {
+      name = path.basename(filePath, '.md');
+    }
 
-		return {
-			name,
-			description: metadata?.description || "",
-			template,
-			sourcePath: filePath,
-			namespace: metadata?.namespace,
-		}
-	} catch (error) {
-		console.error(`Error parsing command file ${filePath}:`, error)
-		return null
-	}
+    return {
+      name,
+      description: metadata?.description || '',
+      template,
+      sourcePath: filePath,
+      namespace: metadata?.namespace,
+    };
+  } catch (error) {
+    console.error(`Error parsing command file ${filePath}:`, error);
+    return null;
+  }
 }
 
 /**
@@ -86,138 +81,133 @@ export async function parseCommandFile(
  * Converts path like "git/commit.md" to "git:commit"
  */
 export function extractCommandName(filePath: string, baseDir: string): string {
-	const relativePath = path.relative(baseDir, filePath)
-	const dirName = path.dirname(relativePath)
-	const baseName = path.basename(relativePath, ".md")
+  const relativePath = path.relative(baseDir, filePath);
+  const dirName = path.dirname(relativePath);
+  const baseName = path.basename(relativePath, '.md');
 
-	if (dirName === "." || dirName === "") {
-		return baseName
-	}
+  if (dirName === '.' || dirName === '') {
+    return baseName;
+  }
 
-	// Replace path separators with colons for namespacing
-	const namespace = dirName.replace(/[\\/]/g, ":")
-	return `${namespace}:${baseName}`
+  // Replace path separators with colons for namespacing
+  const namespace = dirName.replace(/[\\/]/g, ':');
+  return `${namespace}:${baseName}`;
 }
 
 /**
  * Recursively scan a directory for command files
  */
-export async function scanCommandDirectory(
-	dirPath: string,
-): Promise<SlashCommandMetadata[]> {
-	const commands: SlashCommandMetadata[] = []
+export async function scanCommandDirectory(dirPath: string): Promise<SlashCommandMetadata[]> {
+  const commands: SlashCommandMetadata[] = [];
 
-	try {
-		const entries = await fs.readdir(dirPath, { withFileTypes: true })
+  try {
+    const entries = await fs.readdir(dirPath, { withFileTypes: true });
 
-		for (const entry of entries) {
-			const fullPath = path.join(dirPath, entry.name)
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry.name);
 
-			if (entry.isDirectory()) {
-				// Recursively scan subdirectories
-				const subCommands = await scanCommandDirectory(fullPath)
-				commands.push(...subCommands)
-			} else if (entry.isFile() && entry.name.endsWith(".md")) {
-				// Parse markdown command files, passing dirPath as baseDir for name derivation
-				const command = await parseCommandFile(fullPath, dirPath)
-				if (command) {
-					commands.push(command)
-				}
-			}
-		}
-	} catch {
-		// Directory doesn't exist or can't be read - silently skip
-	}
+      if (entry.isDirectory()) {
+        // Recursively scan subdirectories
+        const subCommands = await scanCommandDirectory(fullPath);
+        commands.push(...subCommands);
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        // Parse markdown command files, passing dirPath as baseDir for name derivation
+        const command = await parseCommandFile(fullPath, dirPath);
+        if (command) {
+          commands.push(command);
+        }
+      }
+    }
+  } catch {
+    // Directory doesn't exist or can't be read - silently skip
+  }
 
-	return commands
+  return commands;
 }
 /**
  * Load custom slash commands from all configured directories
  * Priority: mastra project > claude project > opencode project > mastra user > claude user > opencode user
  */
-export async function loadCustomCommands(
-	projectDir?: string,
-): Promise<SlashCommandMetadata[]> {
-	const commands: SlashCommandMetadata[] = []
-	const seenNames = new Set<string>()
+export async function loadCustomCommands(projectDir?: string): Promise<SlashCommandMetadata[]> {
+  const commands: SlashCommandMetadata[] = [];
+  const seenNames = new Set<string>();
 
-	// Helper to add commands without duplicates (later commands override earlier ones)
-	const addCommands = (newCommands: SlashCommandMetadata[]) => {
-		for (const cmd of newCommands) {
-			if (!seenNames.has(cmd.name)) {
-				seenNames.add(cmd.name)
-				commands.push(cmd)
-			}
-		}
-	}
+  // Helper to add commands without duplicates (later commands override earlier ones)
+  const addCommands = (newCommands: SlashCommandMetadata[]) => {
+    for (const cmd of newCommands) {
+      if (!seenNames.has(cmd.name)) {
+        seenNames.add(cmd.name);
+        commands.push(cmd);
+      }
+    }
+  };
 
-	const homeDir = process.env.HOME || process.env.USERPROFILE
+  const homeDir = process.env.HOME || process.env.USERPROFILE;
 
-	// 1. Load from opencode user directory ~/.opencode/command (lowest priority)
-	if (homeDir) {
-		const opencodeUserDir = path.join(homeDir, ".opencode", "command")
-		const opencodeUserCommands = await scanCommandDirectory(opencodeUserDir)
-		addCommands(opencodeUserCommands)
-	}
+  // 1. Load from opencode user directory ~/.opencode/command (lowest priority)
+  if (homeDir) {
+    const opencodeUserDir = path.join(homeDir, '.opencode', 'command');
+    const opencodeUserCommands = await scanCommandDirectory(opencodeUserDir);
+    addCommands(opencodeUserCommands);
+  }
 
-	// 2. Load from claude user directory ~/.claude/commands (Claude Code compat)
-	if (homeDir) {
-		const claudeUserDir = path.join(homeDir, ".claude", "commands")
-		const claudeUserCommands = await scanCommandDirectory(claudeUserDir)
-		addCommands(claudeUserCommands)
-	}
+  // 2. Load from claude user directory ~/.claude/commands (Claude Code compat)
+  if (homeDir) {
+    const claudeUserDir = path.join(homeDir, '.claude', 'commands');
+    const claudeUserCommands = await scanCommandDirectory(claudeUserDir);
+    addCommands(claudeUserCommands);
+  }
 
-	// 3. Load from mastra user directory ~/.mastracode/commands
-	if (homeDir) {
-		const mastraUserDir = path.join(homeDir, ".mastracode", "commands")
-		const mastraUserCommands = await scanCommandDirectory(mastraUserDir)
-		addCommands(mastraUserCommands)
-	}
+  // 3. Load from mastra user directory ~/.mastracode/commands
+  if (homeDir) {
+    const mastraUserDir = path.join(homeDir, '.mastracode', 'commands');
+    const mastraUserCommands = await scanCommandDirectory(mastraUserDir);
+    addCommands(mastraUserCommands);
+  }
 
-	// 4. Load from opencode project directory .opencode/command
-	if (projectDir) {
-		const opencodeProjectDir = path.join(projectDir, ".opencode", "command")
-		const opencodeProjectCommands =
-			await scanCommandDirectory(opencodeProjectDir)
-		addCommands(opencodeProjectCommands)
-	}
+  // 4. Load from opencode project directory .opencode/command
+  if (projectDir) {
+    const opencodeProjectDir = path.join(projectDir, '.opencode', 'command');
+    const opencodeProjectCommands = await scanCommandDirectory(opencodeProjectDir);
+    addCommands(opencodeProjectCommands);
+  }
 
-	// 5. Load from claude project directory .claude/commands (Claude Code compat)
-	if (projectDir) {
-		const claudeProjectDir = path.join(projectDir, ".claude", "commands")
-		const claudeProjectCommands = await scanCommandDirectory(claudeProjectDir)
-		addCommands(claudeProjectCommands)
-	}
+  // 5. Load from claude project directory .claude/commands (Claude Code compat)
+  if (projectDir) {
+    const claudeProjectDir = path.join(projectDir, '.claude', 'commands');
+    const claudeProjectCommands = await scanCommandDirectory(claudeProjectDir);
+    addCommands(claudeProjectCommands);
+  }
 
-	// 6. Load from mastra project directory .mastracode/commands (highest priority)
-	if (projectDir) {
-		const mastraProjectDir = path.join(projectDir, ".mastracode", "commands")
-		const mastraProjectCommands = await scanCommandDirectory(mastraProjectDir)
-		addCommands(mastraProjectCommands)
-	}
+  // 6. Load from mastra project directory .mastracode/commands (highest priority)
+  if (projectDir) {
+    const mastraProjectDir = path.join(projectDir, '.mastracode', 'commands');
+    const mastraProjectCommands = await scanCommandDirectory(mastraProjectDir);
+    addCommands(mastraProjectCommands);
+  }
 
-	return commands
+  return commands;
 }
 
 /**
  * Get the commands directory path for a project
  */
 export function getProjectCommandsDir(projectDir: string): string {
-	return path.join(projectDir, ".mastracode", "commands")
+  return path.join(projectDir, '.mastracode', 'commands');
 }
 
 /**
  * Initialize a commands directory with an example command
  */
 export async function initCommandsDirectory(projectDir: string): Promise<void> {
-	const commandsDir = getProjectCommandsDir(projectDir)
+  const commandsDir = getProjectCommandsDir(projectDir);
 
-	try {
-		await fs.mkdir(commandsDir, { recursive: true })
+  try {
+    await fs.mkdir(commandsDir, { recursive: true });
 
-		// Create an example command
-		const examplePath = path.join(commandsDir, "example.md")
-		const exampleContent = `---
+    // Create an example command
+    const examplePath = path.join(commandsDir, 'example.md');
+    const exampleContent = `---
 name: example
 description: An example slash command
 ---
@@ -226,15 +216,15 @@ This is an example slash command template.
 You can use variables like \$ARGUMENTS or \$1, \$2 for positional args.
 You can also include file content with @filename.
 Shell commands with !command will be executed and output included.
-`
+`;
 
-		try {
-			await fs.access(examplePath)
-			// File already exists, don't overwrite
-		} catch {
-			await fs.writeFile(examplePath, exampleContent, "utf-8")
-		}
-	} catch (error) {
-		console.error("Error initializing commands directory:", error)
-	}
+    try {
+      await fs.access(examplePath);
+      // File already exists, don't overwrite
+    } catch {
+      await fs.writeFile(examplePath, exampleContent, 'utf-8');
+    }
+  } catch (error) {
+    console.error('Error initializing commands directory:', error);
+  }
 }

--- a/mastracode/src/utils/slash-command-processor.ts
+++ b/mastracode/src/utils/slash-command-processor.ts
@@ -60,16 +60,15 @@ async function replaceShellOutput(
 	const matches = [...template.matchAll(shellPattern)]
 
 	let result = template
-
-	for (const match of matches) {
-		const [fullMatch, command] = match
-		try {
-			const output = execSync(command, {
-				cwd: workingDir,
-				encoding: "utf-8",
-				timeout: 30000,
-				maxBuffer: 1024 * 1024, // 1MB buffer
-			})
+    for (const match of matches) {
+        const [fullMatch, command] = match
+        try {
+            const output = execSync(command!, {
+                cwd: workingDir,
+                encoding: "utf-8",
+                timeout: 30000,
+                maxBuffer: 1024 * 1024, // 1MB buffer
+            })
 			result = result.replace(fullMatch, output.trim())
 		} catch (error) {
 			console.error(`Error executing shell command "${command}":`, error)
@@ -95,11 +94,10 @@ async function replaceFileReferences(
 	const matches = [...template.matchAll(filePattern)]
 
 	let result = template
-
-	for (const match of matches) {
-		const [fullMatch, filePath] = match
-		try {
-			const fullPath = path.resolve(workingDir, filePath)
+    for (const match of matches) {
+        const [fullMatch, filePath] = match
+        try {
+            const fullPath = path.resolve(workingDir, filePath!)
 			const content = await fs.readFile(fullPath, "utf-8")
 			result = result.replace(fullMatch, content)
 		} catch (error) {

--- a/mastracode/src/utils/slash-command-processor.ts
+++ b/mastracode/src/utils/slash-command-processor.ts
@@ -1,28 +1,28 @@
-import { execSync } from "node:child_process"
-import { promises as fs } from "node:fs"
-import * as path from "node:path"
-import type { SlashCommandMetadata } from "./slash-command-loader.js"
+import { execSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import type { SlashCommandMetadata } from './slash-command-loader.js';
 
 /**
  * Process a slash command by replacing variables and executing shell commands
  */
 export async function processSlashCommand(
-	command: SlashCommandMetadata,
-	args: string[],
-	workingDir: string,
+  command: SlashCommandMetadata,
+  args: string[],
+  workingDir: string,
 ): Promise<string> {
-	let result = command.template
+  let result = command.template;
 
-	// Replace arguments
-	result = replaceArguments(result, args)
+  // Replace arguments
+  result = replaceArguments(result, args);
 
-	// Replace shell commands
-	result = await replaceShellOutput(result, workingDir)
+  // Replace shell commands
+  result = await replaceShellOutput(result, workingDir);
 
-	// Replace file references
-	result = await replaceFileReferences(result, workingDir)
+  // Replace file references
+  result = await replaceFileReferences(result, workingDir);
 
-	return result
+  return result;
 }
 
 /**
@@ -31,118 +31,103 @@ export async function processSlashCommand(
  * $1, $2, etc. - positional arguments
  */
 function replaceArguments(template: string, args: string[]): string {
-	let result = template
+  let result = template;
 
-	// Replace $ARGUMENTS with all args joined
-	result = result.replace(/\$ARGUMENTS/g, args.join(" "))
+  // Replace $ARGUMENTS with all args joined
+  result = result.replace(/\$ARGUMENTS/g, args.join(' '));
 
-	// Replace positional arguments $1, $2, etc.
-	args.forEach((arg, index) => {
-		const pattern = new RegExp(`\\\$${index + 1}`, "g")
-		result = result.replace(pattern, arg)
-	})
+  // Replace positional arguments $1, $2, etc.
+  args.forEach((arg, index) => {
+    const pattern = new RegExp(`\\\$${index + 1}`, 'g');
+    result = result.replace(pattern, arg);
+  });
 
-	// Clear unused positional arguments
-	result = result.replace(/\$\d+/g, "")
+  // Clear unused positional arguments
+  result = result.replace(/\$\d+/g, '');
 
-	return result
+  return result;
 }
 
 /**
  * Replace shell command references with their output
  * Format: !`command`
  */
-async function replaceShellOutput(
-	template: string,
-	workingDir: string,
-): Promise<string> {
-	const shellPattern = /!`([^`]+)`/g
-	const matches = [...template.matchAll(shellPattern)]
+async function replaceShellOutput(template: string, workingDir: string): Promise<string> {
+  const shellPattern = /!`([^`]+)`/g;
+  const matches = [...template.matchAll(shellPattern)];
 
-	let result = template
-    for (const match of matches) {
-        const [fullMatch, command] = match
-        try {
-            const output = execSync(command!, {
-                cwd: workingDir,
-                encoding: "utf-8",
-                timeout: 30000,
-                maxBuffer: 1024 * 1024, // 1MB buffer
-            })
-			result = result.replace(fullMatch, output.trim())
-		} catch (error) {
-			console.error(`Error executing shell command "${command}":`, error)
-			result = result.replace(
-				fullMatch,
-				`[Error: Failed to execute "${command}"]`,
-			)
-		}
-	}
+  let result = template;
+  for (const match of matches) {
+    const [fullMatch, command] = match;
+    try {
+      const output = execSync(command!, {
+        cwd: workingDir,
+        encoding: 'utf-8',
+        timeout: 30000,
+        maxBuffer: 1024 * 1024, // 1MB buffer
+      });
+      result = result.replace(fullMatch, output.trim());
+    } catch (error) {
+      console.error(`Error executing shell command "${command}":`, error);
+      result = result.replace(fullMatch, `[Error: Failed to execute "${command}"]`);
+    }
+  }
 
-	return result
+  return result;
 }
 
 /**
  * Replace file references with file content
  * Format: @filename or @path/to/file
  */
-async function replaceFileReferences(
-	template: string,
-	workingDir: string,
-): Promise<string> {
-	const filePattern = /@([\w./-]+)/g
-	const matches = [...template.matchAll(filePattern)]
+async function replaceFileReferences(template: string, workingDir: string): Promise<string> {
+  const filePattern = /@([\w./-]+)/g;
+  const matches = [...template.matchAll(filePattern)];
 
-	let result = template
-    for (const match of matches) {
-        const [fullMatch, filePath] = match
-        try {
-            const fullPath = path.resolve(workingDir, filePath!)
-			const content = await fs.readFile(fullPath, "utf-8")
-			result = result.replace(fullMatch, content)
-		} catch (error) {
-			console.error(`Error reading file "${filePath}":`, error)
-			result = result.replace(
-				fullMatch,
-				`[Error: Could not read "${filePath}"]`,
-			)
-		}
-	}
+  let result = template;
+  for (const match of matches) {
+    const [fullMatch, filePath] = match;
+    try {
+      const fullPath = path.resolve(workingDir, filePath!);
+      const content = await fs.readFile(fullPath, 'utf-8');
+      result = result.replace(fullMatch, content);
+    } catch (error) {
+      console.error(`Error reading file "${filePath}":`, error);
+      result = result.replace(fullMatch, `[Error: Could not read "${filePath}"]`);
+    }
+  }
 
-	return result
+  return result;
 }
 
 /**
  * Format a command for display in help/autocomplete
  */
 export function formatCommandForDisplay(command: SlashCommandMetadata): string {
-	const parts = [command.name]
+  const parts = [command.name];
 
-	if (command.description) {
-		parts.push(`- ${command.description}`)
-	}
+  if (command.description) {
+    parts.push(`- ${command.description}`);
+  }
 
-	return parts.join(" ")
+  return parts.join(' ');
 }
 
 /**
  * Group commands by namespace for display
  */
-export function groupCommandsByNamespace(
-	commands: SlashCommandMetadata[],
-): Map<string, SlashCommandMetadata[]> {
-	const groups = new Map<string, SlashCommandMetadata[]>()
+export function groupCommandsByNamespace(commands: SlashCommandMetadata[]): Map<string, SlashCommandMetadata[]> {
+  const groups = new Map<string, SlashCommandMetadata[]>();
 
-	for (const command of commands) {
-		const namespace =
-			command.namespace || command.name.split(":")[0] || "general"
+  for (const command of commands) {
+    const namespace = command.namespace || command.name.split(':')[0] || 'general';
 
-		if (!groups.has(namespace)) {
-			groups.set(namespace, [])
-		}
+    if (!groups.has(namespace)) {
+      groups.set(namespace, []);
+    }
 
-		groups.get(namespace)!.push(command)
-	}
+    groups.get(namespace)!.push(command);
+  }
 
-	return groups
+  return groups;
 }

--- a/mastracode/src/utils/thread-lock.ts
+++ b/mastracode/src/utils/thread-lock.ts
@@ -5,41 +5,41 @@
  * Each lock file contains the PID of the owning process.
  * Stale locks (from crashed processes) are detected and reclaimed.
  */
-import * as fs from "node:fs"
-import * as path from "node:path"
-import { getAppDataDir } from "./project.js"
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { getAppDataDir } from './project.js';
 
 export class ThreadLockError extends Error {
-	constructor(
-		public readonly threadId: string,
-		public readonly ownerPid: number,
-	) {
-		super(`Thread ${threadId} is locked by another process (PID ${ownerPid})`)
-		this.name = "ThreadLockError"
-	}
+  constructor(
+    public readonly threadId: string,
+    public readonly ownerPid: number,
+  ) {
+    super(`Thread ${threadId} is locked by another process (PID ${ownerPid})`);
+    this.name = 'ThreadLockError';
+  }
 }
 
 function getLocksDir(): string {
-	const dir = path.join(getAppDataDir(), "locks")
-	if (!fs.existsSync(dir)) {
-		fs.mkdirSync(dir, { recursive: true })
-	}
-	return dir
+  const dir = path.join(getAppDataDir(), 'locks');
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  return dir;
 }
 
 function getLockPath(threadId: string): string {
-	// Sanitize thread ID for filesystem safety
-	const safeId = threadId.replace(/[^a-zA-Z0-9_-]/g, "_")
-	return path.join(getLocksDir(), `${safeId}.lock`)
+  // Sanitize thread ID for filesystem safety
+  const safeId = threadId.replace(/[^a-zA-Z0-9_-]/g, '_');
+  return path.join(getLocksDir(), `${safeId}.lock`);
 }
 
 function isProcessAlive(pid: number): boolean {
-	try {
-		process.kill(pid, 0)
-		return true
-	} catch {
-		return false
-	}
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -48,49 +48,49 @@ function isProcessAlive(pid: number): boolean {
  * Reclaims stale locks from dead processes.
  */
 export function acquireThreadLock(threadId: string): void {
-	const lockPath = getLockPath(threadId)
-	const myPid = process.pid
+  const lockPath = getLockPath(threadId);
+  const myPid = process.pid;
 
-	// Check for existing lock
-	if (fs.existsSync(lockPath)) {
-		try {
-			const content = fs.readFileSync(lockPath, "utf-8").trim()
-			const ownerPid = parseInt(content, 10)
+  // Check for existing lock
+  if (fs.existsSync(lockPath)) {
+    try {
+      const content = fs.readFileSync(lockPath, 'utf-8').trim();
+      const ownerPid = parseInt(content, 10);
 
-			if (!isNaN(ownerPid) && ownerPid !== myPid && isProcessAlive(ownerPid)) {
-				throw new ThreadLockError(threadId, ownerPid)
-			}
-			// Stale lock (dead process) or our own lock — reclaim it
-		} catch (error) {
-			if (error instanceof ThreadLockError) throw error
-			// File read error — try to overwrite
-		}
-	}
+      if (!isNaN(ownerPid) && ownerPid !== myPid && isProcessAlive(ownerPid)) {
+        throw new ThreadLockError(threadId, ownerPid);
+      }
+      // Stale lock (dead process) or our own lock — reclaim it
+    } catch (error) {
+      if (error instanceof ThreadLockError) throw error;
+      // File read error — try to overwrite
+    }
+  }
 
-	// Write our PID to the lock file
-	fs.writeFileSync(lockPath, String(myPid), { mode: 0o644 })
+  // Write our PID to the lock file
+  fs.writeFileSync(lockPath, String(myPid), { mode: 0o644 });
 }
 
 /**
  * Release the lock for the given thread (only if we own it).
  */
 export function releaseThreadLock(threadId: string): void {
-	const lockPath = getLockPath(threadId)
-	const myPid = process.pid
+  const lockPath = getLockPath(threadId);
+  const myPid = process.pid;
 
-	try {
-		if (!fs.existsSync(lockPath)) return
+  try {
+    if (!fs.existsSync(lockPath)) return;
 
-		const content = fs.readFileSync(lockPath, "utf-8").trim()
-		const ownerPid = parseInt(content, 10)
+    const content = fs.readFileSync(lockPath, 'utf-8').trim();
+    const ownerPid = parseInt(content, 10);
 
-		// Only remove if we own it
-		if (ownerPid === myPid) {
-			fs.unlinkSync(lockPath)
-		}
-	} catch {
-		// Best-effort cleanup — ignore errors
-	}
+    // Only remove if we own it
+    if (ownerPid === myPid) {
+      fs.unlinkSync(lockPath);
+    }
+  } catch {
+    // Best-effort cleanup — ignore errors
+  }
 }
 
 /**
@@ -98,28 +98,28 @@ export function releaseThreadLock(threadId: string): void {
  * Returns the PID of the owner if locked, null otherwise.
  */
 export function getThreadLockOwner(threadId: string): number | null {
-	const lockPath = getLockPath(threadId)
+  const lockPath = getLockPath(threadId);
 
-	try {
-		if (!fs.existsSync(lockPath)) return null
+  try {
+    if (!fs.existsSync(lockPath)) return null;
 
-		const content = fs.readFileSync(lockPath, "utf-8").trim()
-		const ownerPid = parseInt(content, 10)
+    const content = fs.readFileSync(lockPath, 'utf-8').trim();
+    const ownerPid = parseInt(content, 10);
 
-		if (isNaN(ownerPid)) return null
-		if (ownerPid === process.pid) return null // Our own lock
-		if (!isProcessAlive(ownerPid)) {
-			// Stale lock — clean it up
-			try {
-				fs.unlinkSync(lockPath)
-			} catch {}
-			return null
-		}
+    if (isNaN(ownerPid)) return null;
+    if (ownerPid === process.pid) return null; // Our own lock
+    if (!isProcessAlive(ownerPid)) {
+      // Stale lock — clean it up
+      try {
+        fs.unlinkSync(lockPath);
+      } catch {}
+      return null;
+    }
 
-		return ownerPid
-	} catch {
-		return null
-	}
+    return ownerPid;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -127,24 +127,24 @@ export function getThreadLockOwner(threadId: string): number | null {
  * Call this on process exit.
  */
 export function releaseAllThreadLocks(): void {
-	try {
-		const locksDir = getLocksDir()
-		const files = fs.readdirSync(locksDir)
-		const myPid = String(process.pid)
+  try {
+    const locksDir = getLocksDir();
+    const files = fs.readdirSync(locksDir);
+    const myPid = String(process.pid);
 
-		for (const file of files) {
-			if (!file.endsWith(".lock")) continue
-			const lockPath = path.join(locksDir, file)
-			try {
-				const content = fs.readFileSync(lockPath, "utf-8").trim()
-				if (content === myPid) {
-					fs.unlinkSync(lockPath)
-				}
-			} catch {
-				// Best-effort
-			}
-		}
-	} catch {
-		// Best-effort
-	}
+    for (const file of files) {
+      if (!file.endsWith('.lock')) continue;
+      const lockPath = path.join(locksDir, file);
+      try {
+        const content = fs.readFileSync(lockPath, 'utf-8').trim();
+        if (content === myPid) {
+          fs.unlinkSync(lockPath);
+        }
+      } catch {
+        // Best-effort
+      }
+    }
+  } catch {
+    // Best-effort
+  }
 }

--- a/mastracode/src/utils/token-estimator.ts
+++ b/mastracode/src/utils/token-estimator.ts
@@ -1,27 +1,23 @@
-import { Tiktoken } from "js-tiktoken/lite"
-import o200k_base from "js-tiktoken/ranks/o200k_base"
+import { Tiktoken } from 'js-tiktoken/lite';
+import o200k_base from 'js-tiktoken/ranks/o200k_base';
 
-const enc = new Tiktoken(o200k_base)
+const enc = new Tiktoken(o200k_base);
 
 function sanitizeInput(text: string | object) {
-	if (!text) return ""
-	return (typeof text === `string` ? text : JSON.stringify(text))
-		.replaceAll(`<|endoftext|>`, ``)
-		.replaceAll(`<|endofprompt|>`, ``)
+  if (!text) return '';
+  return (typeof text === `string` ? text : JSON.stringify(text))
+    .replaceAll(`<|endoftext|>`, ``)
+    .replaceAll(`<|endofprompt|>`, ``);
 }
 export function tokenEstimate(text: string | object): number {
-	return enc.encode(sanitizeInput(text), `all`).length
+  return enc.encode(sanitizeInput(text), `all`).length;
 }
 
-export function truncateStringForTokenEstimate(
-	text: string,
-	desiredTokenCount: number,
-	fromEnd = true,
-) {
-	const tokens = enc.encode(sanitizeInput(text))
+export function truncateStringForTokenEstimate(text: string, desiredTokenCount: number, fromEnd = true) {
+  const tokens = enc.encode(sanitizeInput(text));
 
-	if (tokens.length <= desiredTokenCount) return text
+  if (tokens.length <= desiredTokenCount) return text;
 
-	return `[Truncated ${tokens.length - desiredTokenCount} tokens]
-${enc.decode(tokens.slice(fromEnd ? -desiredTokenCount : 0, fromEnd ? undefined : desiredTokenCount))}`
+  return `[Truncated ${tokens.length - desiredTokenCount} tokens]
+${enc.decode(tokens.slice(fromEnd ? -desiredTokenCount : 0, fromEnd ? undefined : desiredTokenCount))}`;
 }

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -505,7 +505,7 @@ export class Agent<
         // @ts-expect-error - processorIndex is set at runtime for span attributes
         processor.processorIndex = index;
         // Cast needed because TypeScript can't narrow after isProcessorWorkflow check
-        step = createStep(processor as Parameters<typeof createStep>[0]);
+        step = createStep(processor as unknown as Parameters<typeof createStep>[0]);
       }
       workflow = workflow.then(step);
     }

--- a/packages/core/src/types/zod-compat.ts
+++ b/packages/core/src/types/zod-compat.ts
@@ -14,14 +14,15 @@ export type ZodLikeSchema<T = any> = {
   parse(data: unknown): T;
   safeParse(
     data: unknown,
-  ): { success: true; data: T } | { success: false; error: { issues: Array<{ path?: any; message: string }>; format(...args: any[]): any } };
+  ):
+    | { success: true; data: T }
+    | { success: false; error: { issues: Array<{ path?: any; message: string }>; format(...args: any[]): any } };
 };
 
 /**
  * Helper type for extracting the inferred type from a Zod-like schema after parsing
  */
-export type InferZodLikeSchema<T extends ZodLikeSchema<any>> =
-  T extends ZodLikeSchema<infer V> ? V : never;
+export type InferZodLikeSchema<T extends ZodLikeSchema<any>> = T extends ZodLikeSchema<infer V> ? V : never;
 
 /**
  * Helper type for extracting the input type from a Zod-like schema.

--- a/packages/server/src/server/utils.ts
+++ b/packages/server/src/server/utils.ts
@@ -40,7 +40,9 @@ export function normalizeRoutePath(path: string): string {
  * Check if a schema looks like a processor step schema.
  * Processor step schemas are discriminated unions on 'phase' with specific values.
  */
-function looksLikeProcessorStepSchema(schema: ZodType | zv4.ZodType<any, any> | undefined): boolean {
+function looksLikeProcessorStepSchema(
+  schema: ZodType | zv4.ZodType<any, any> | { parse(data: unknown): unknown } | undefined,
+): boolean {
   if (!schema) return false;
 
   try {


### PR DESCRIPTION
ZodLikeSchema was a nominal union of `z.ZodType<T> | zv4.ZodType<T>`, which caused tsc to perform deep comparison of both zod type trees during generic inference (e.g. in `createTool`). This led to combinatorial explosion — tsc would hang or OOM when generating types for packages that depend on `@mastra/core` tool types.

Replaced with a structural type:

```ts
// before
export type ZodLikeSchema<T = any> = z.ZodType<T, z.ZodTypeDef, any> | zv4.ZodType<T, any>;

// after
export type ZodLikeSchema<T = any> = {
  parse(data: unknown): T;
  safeParse(data: unknown): { success: true; data: T } | { success: false; error: { issues: Array<{ path?: any; message: string }>; format(...args: any[]): any } };
};
```

This is a backward-compatible widening — all zod v3/v4 schemas satisfy the structural constraint. No usages of these types exist outside `packages/core`. Zod compat tests (9/9) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full AST-based smart-edit tool for advanced code refactors.
  * Codex provider now uses an OAuth-backed request flow with automatic token refresh.

* **Bug Fixes**
  * Resolved a TypeScript type-generation issue that could hang or exhaust memory.
  * Improved LSP robustness when server info is absent.

* **Chores**
  * Permission defaults tightened to { categories: {}, tools: {} } by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->