### PR TITLE
feat(memory): add instruction property to observational memory configs

### DIFF
--- a/.changeset/observational-memory-instruction-core.md
+++ b/.changeset/observational-memory-instruction-core.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': minor
+---
+
+Add optional `instruction` field to ObservationalMemory config types
+
+Adds `instruction?: string` to `ObservationalMemoryObservationConfig` and `ObservationalMemoryReflectionConfig` interfaces, allowing external consumers to pass custom instructions to observational memory.

--- a/.changeset/observational-memory-instruction.md
+++ b/.changeset/observational-memory-instruction.md
@@ -1,0 +1,20 @@
+---
+'@mastra/memory': minor
+---
+
+Add `instruction` property to observational memory configs
+
+Adds optional `instruction` field to `ObservationConfig` and `ReflectionConfig` that allows users to extend the built-in observer/reflector system prompts with custom guidance.
+
+Example:
+```typescript
+const memory = new ObservationalMemory({
+  model: openai('gpt-4'),
+  observation: {
+    instruction: 'Focus on user preferences about food and dietary restrictions.',
+  },
+  reflection: {
+    instruction: 'Prioritize consolidating health-related observations together.',
+  },
+});
+```

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -97,6 +97,13 @@ The `observationalMemory` option accepts `true`, a configuration object, or `fal
       isOptional: true,
     },
     {
+      name: "instruction",
+      type: "string",
+      description:
+        "Custom instruction appended to the Observer's system prompt. Use this to customize what the Observer focuses on, such as domain-specific preferences or priorities.",
+      isOptional: true,
+    },
+    {
       name: "messageTokens",
       type: "number",
       description:
@@ -156,6 +163,13 @@ The `observationalMemory` option accepts `true`, a configuration object, or `fal
       type: "string | LanguageModel | DynamicModel | ModelWithRetries[]",
       description:
         "Model for the Reflector agent. Cannot be set if a top-level `model` is also provided. If neither this nor the top-level `model` is set, falls back to `observation.model`.",
+      isOptional: true,
+    },
+    {
+      name: "instruction",
+      type: "string",
+      description:
+        "Custom instruction appended to the Reflector's system prompt. Use this to customize how the Reflector consolidates observations, such as prioritizing certain types of information.",
       isOptional: true,
     },
     {
@@ -312,6 +326,38 @@ export const agent = new Agent({
         },
         reflection: {
           model: "openai/gpt-4o-mini",
+        },
+      },
+    },
+  }),
+});
+```
+
+### Custom instructions
+
+Customize what the Observer and Reflector focus on by providing custom instructions:
+
+```typescript title="src/mastra/agents/agent.ts"
+import { Memory } from "@mastra/memory";
+import { Agent } from "@mastra/core/agent";
+
+export const agent = new Agent({
+  name: "health-assistant",
+  instructions: "You are a health and wellness assistant.",
+  model: "openai/gpt-5-mini",
+  memory: new Memory({
+    options: {
+      observationalMemory: {
+        model: "google/gemini-2.5-flash",
+        observation: {
+          // Focus observations on health-related preferences and goals
+          instruction:
+            "Prioritize capturing user health goals, dietary restrictions, exercise preferences, and medical considerations. Avoid capturing general chit-chat.",
+        },
+        reflection: {
+          // Guide reflection to consolidate health patterns
+          instruction:
+            "When consolidating, group related health information together. Preserve specific metrics, dates, and medical details.",
         },
       },
     },

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -522,6 +522,19 @@ export interface ObservationalMemoryObservationConfig {
    * ```
    */
   blockAfter?: number;
+
+  /**
+   * Custom instructions appended to the Observer agent's system prompt.
+   * Use this to customize what the Observer focuses on or how it formats observations.
+   *
+   * @example
+   * ```ts
+   * observation: {
+   *   instruction: 'Focus on user dietary preferences and allergies.',
+   * }
+   * ```
+   */
+  instruction?: string;
 }
 
 /**
@@ -611,6 +624,19 @@ export interface ObservationalMemoryReflectionConfig {
    * ```
    */
   bufferActivation?: number;
+
+  /**
+   * Custom instructions appended to the Reflector agent's system prompt.
+   * Use this to customize how the Reflector consolidates observations.
+   *
+   * @example
+   * ```ts
+   * reflection: {
+   *   instruction: 'Consolidate observations and remove duplicates.',
+   * }
+   * ```
+   */
+  instruction?: string;
 }
 
 /**

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1715,6 +1715,7 @@ Notes:
             bufferTokens: omConfig.observation.bufferTokens,
             bufferActivation: omConfig.observation.bufferActivation,
             blockAfter: omConfig.observation.blockAfter,
+            instruction: omConfig.observation.instruction,
           }
         : undefined,
       reflection: omConfig.reflection
@@ -1725,6 +1726,7 @@ Notes:
             providerOptions: omConfig.reflection.providerOptions,
             bufferActivation: omConfig.reflection.bufferActivation,
             blockAfter: omConfig.reflection.blockAfter,
+            instruction: omConfig.reflection.instruction,
           }
         : undefined,
     });

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -13,7 +13,12 @@ import {
   hasCurrentTaskSection,
   extractCurrentTask,
 } from '../observer-agent';
-import { buildReflectorPrompt, parseReflectorOutput, validateCompression } from '../reflector-agent';
+import {
+  buildReflectorPrompt,
+  parseReflectorOutput,
+  validateCompression,
+  buildReflectorSystemPrompt,
+} from '../reflector-agent';
 import { TokenCounter } from '../token-counter';
 
 // =============================================================================
@@ -887,6 +892,31 @@ Line 2`;
 // =============================================================================
 
 describe('Reflector Agent Helpers', () => {
+  describe('buildReflectorSystemPrompt', () => {
+    it('should include base reflector instructions', () => {
+      const systemPrompt = buildReflectorSystemPrompt();
+
+      expect(systemPrompt).toContain('observational-memory-instruction');
+      expect(systemPrompt).toContain('observation reflector');
+    });
+
+    it('should include custom instruction when provided', () => {
+      const customInstruction = 'Prioritize consolidating health-related observations together.';
+      const systemPrompt = buildReflectorSystemPrompt(customInstruction);
+
+      expect(systemPrompt).toContain(customInstruction);
+      expect(systemPrompt).toContain('observational-memory-instruction');
+    });
+
+    it('should work without custom instruction', () => {
+      const systemPrompt = buildReflectorSystemPrompt();
+      const systemPromptWithUndefined = buildReflectorSystemPrompt(undefined);
+
+      expect(systemPrompt).toBe(systemPromptWithUndefined);
+      expect(systemPrompt).toContain('observational-memory-instruction');
+    });
+  });
+
   describe('buildReflectorPrompt', () => {
     it('should include observations to reflect on', () => {
       const observations = '- 🔴 User is building a React app';
@@ -2071,6 +2101,32 @@ describe('Scenario: Information should be preserved through observation cycle', 
     // Check for XML-based current task requirement in the system prompt
     expect(systemPrompt).toContain('<current-task>');
     expect(systemPrompt).toContain('MUST use XML tags');
+  });
+
+  it('observer system prompt should include custom instruction when provided', () => {
+    const customInstruction = 'Focus on capturing user dietary preferences and allergies.';
+    const systemPrompt = buildObserverSystemPrompt(false, customInstruction);
+
+    // Should include the custom instruction at the end
+    expect(systemPrompt).toContain(customInstruction);
+    expect(systemPrompt).toContain('<current-task>');
+  });
+
+  it('observer system prompt should work without custom instruction', () => {
+    const systemPrompt = buildObserverSystemPrompt(false);
+    const systemPromptWithUndefined = buildObserverSystemPrompt(false, undefined);
+
+    // Both should be identical
+    expect(systemPrompt).toBe(systemPromptWithUndefined);
+    expect(systemPrompt).toContain('<current-task>');
+  });
+
+  it('multi-thread observer system prompt should include custom instruction', () => {
+    const customInstruction = 'Prioritize cross-thread patterns and recurring topics.';
+    const systemPrompt = buildObserverSystemPrompt(true, customInstruction);
+
+    expect(systemPrompt).toContain(customInstruction);
+    expect(systemPrompt).toContain('<thread id=');
   });
 });
 

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -2130,6 +2130,183 @@ describe('Scenario: Information should be preserved through observation cycle', 
   });
 });
 
+describe('Instruction property integration', () => {
+  it('should pass observation instruction to observer agent during synchronous observation', async () => {
+    const storage = createInMemoryStorage();
+    const customInstruction = 'Focus on capturing user dietary preferences and allergies.';
+
+    let capturedPrompt: any = null;
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async options => {
+        capturedPrompt = options.prompt;
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+          content: [
+            {
+              type: 'text' as const,
+              text: `<observations>
+- User mentioned they are vegetarian
+</observations>
+<current-task>
+- Primary: Discussing dietary preferences
+</current-task>
+<suggested-response>
+Ask about favorite vegetarian dishes
+</suggested-response>`,
+            },
+          ],
+          warnings: [],
+        };
+      },
+    });
+
+    const om = new ObservationalMemory({
+      storage,
+      observation: {
+        messageTokens: 10, // Low threshold to trigger observation
+        model: mockModel as any,
+        instruction: customInstruction,
+      },
+      reflection: { observationTokens: 10000 },
+      scope: 'thread',
+    });
+
+    // Initialize record
+    await storage.initializeObservationalMemory({
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      scope: 'thread',
+      config: {},
+    });
+
+    // Simulate observation
+    const messages = [
+      createTestMessage('I am vegetarian', 'user', 'msg-1'),
+      createTestMessage('That is great to know!', 'assistant', 'msg-2'),
+    ];
+
+    await (om as any).doSynchronousObservation({
+      record: await storage.getObservationalMemory('thread-1', 'resource-1'),
+      threadId: 'thread-1',
+      unobservedMessages: messages,
+    });
+
+    // Verify the custom instruction was passed to the observer agent
+    expect(capturedPrompt).not.toBeNull();
+    const systemMessage = capturedPrompt.find((msg: any) => msg.role === 'system');
+    expect(systemMessage).toBeDefined();
+    expect(systemMessage.content).toContain(customInstruction);
+    expect(systemMessage.content).toContain('<current-task>');
+  });
+
+  it('should pass reflection instruction to reflector agent during synchronous reflection', async () => {
+    const storage = createInMemoryStorage();
+    const customInstruction = 'Consolidate observations about user preferences and remove duplicates.';
+
+    let capturedPrompt: any = null;
+    const mockObserverModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+        content: [
+          {
+            type: 'text' as const,
+            text: `<observations>
+- User likes pizza
+</observations>
+<current-task>
+- Primary: Discussing food preferences
+</current-task>
+<suggested-response>
+Ask about favorite pizza toppings
+</suggested-response>`,
+          },
+        ],
+        warnings: [],
+      }),
+    });
+
+    const mockReflectorModel = new MockLanguageModelV2({
+      doGenerate: async options => {
+        capturedPrompt = options.prompt;
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+          content: [
+            {
+              type: 'text' as const,
+              text: `<observations>
+- User enjoys pizza and Italian food
+</observations>
+<current-task>
+- Primary: Discussing food preferences
+</current-task>
+<suggested-response>
+Ask about favorite Italian dishes
+</suggested-response>`,
+            },
+          ],
+          warnings: [],
+        };
+      },
+    });
+
+    const om = new ObservationalMemory({
+      storage,
+      observation: {
+        messageTokens: 10, // Low threshold to trigger observation
+        model: mockObserverModel as any,
+      },
+      reflection: {
+        observationTokens: 10, // Low threshold to trigger reflection
+        model: mockReflectorModel as any,
+        instruction: customInstruction,
+      },
+      scope: 'thread',
+    });
+
+    // Initialize record with some existing observations to trigger reflection
+    const record = await storage.initializeObservationalMemory({
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      scope: 'thread',
+      config: {},
+    });
+
+    // Add existing observations to meet reflection threshold
+    await storage.updateActiveObservations({
+      id: record.id,
+      observations: `- Existing observation 1
+- Existing observation 2
+- Existing observation 3`,
+      tokenCount: 50000, // High count to trigger reflection
+      lastObservedAt: new Date(),
+    });
+
+    // Simulate observation which should then trigger reflection
+    const messages = [
+      createTestMessage('I like pizza', 'user', 'msg-1'),
+      createTestMessage('Nice!', 'assistant', 'msg-2'),
+    ];
+
+    await (om as any).doSynchronousObservation({
+      record: await storage.getObservationalMemory('thread-1', 'resource-1'),
+      threadId: 'thread-1',
+      unobservedMessages: messages,
+    });
+
+    // Verify the custom instruction was passed to the reflector agent
+    expect(capturedPrompt).not.toBeNull();
+    const systemMessage = capturedPrompt.find((msg: any) => msg.role === 'system');
+    expect(systemMessage).toBeDefined();
+    expect(systemMessage.content).toContain(customInstruction);
+  });
+});
+
 describe('Scenario: Cross-session memory (resource scope)', () => {
   it('should track observations across multiple threads with same resource', async () => {
     const storage = createInMemoryStorage();

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -464,6 +464,8 @@ interface ResolvedObservationConfig {
   bufferActivation?: number;
   /** Token threshold above which synchronous observation is forced */
   blockAfter?: number;
+  /** Custom instructions to append to the Observer's system prompt */
+  instruction?: string;
 }
 
 interface ResolvedReflectionConfig {
@@ -479,6 +481,8 @@ interface ResolvedReflectionConfig {
   bufferActivation?: number;
   /** Token threshold above which synchronous reflection is forced */
   blockAfter?: number;
+  /** Custom instructions to append to the Reflector's system prompt */
+  instruction?: string;
 }
 
 /**
@@ -1099,6 +1103,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
                 : undefined),
             config.observation?.messageTokens ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.messageTokens,
           ),
+      instruction: config.observation?.instruction,
     };
 
     // Resolve reflection config with defaults
@@ -1127,6 +1132,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
                 : undefined),
             config.reflection?.observationTokens ?? OBSERVATIONAL_MEMORY_DEFAULTS.reflection.observationTokens,
           ),
+      instruction: config.reflection?.instruction,
     };
 
     this.tokenCounter = new TokenCounter();
@@ -1430,7 +1436,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
    */
   private getObserverAgent(): Agent {
     if (!this.observerAgent) {
-      const systemPrompt = buildObserverSystemPrompt();
+      const systemPrompt = buildObserverSystemPrompt(false, this.observationConfig.instruction);
 
       this.observerAgent = new Agent({
         id: 'observational-memory-observer',
@@ -1447,7 +1453,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
    */
   private getReflectorAgent(): Agent {
     if (!this.reflectorAgent) {
-      const systemPrompt = buildReflectorSystemPrompt();
+      const systemPrompt = buildReflectorSystemPrompt(this.reflectionConfig.instruction);
 
       this.reflectorAgent = new Agent({
         id: 'observational-memory-reflector',
@@ -2159,7 +2165,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
       id: 'multi-thread-observer',
       name: 'multi-thread-observer',
       model: this.observationConfig.model,
-      instructions: buildObserverSystemPrompt(true),
+      instructions: buildObserverSystemPrompt(true, this.observationConfig.instruction),
     });
 
     const prompt = buildMultiThreadObserverPrompt(existingObservations, messagesByThread, threadOrder);

--- a/packages/memory/src/processors/observational-memory/reflector-agent.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-agent.ts
@@ -19,8 +19,10 @@ export interface ReflectorResult extends BaseReflectorResult {
  * - Drawing connections and conclusions between observations
  * - Identifying if the agent got off track and how to get back on track
  * - Preserving ALL important information (reflections become the ENTIRE memory)
+ *
+ * @param instruction - Optional custom instructions to append to the prompt
  */
-export function buildReflectorSystemPrompt(): string {
+export function buildReflectorSystemPrompt(instruction?: string): string {
   return `You are the memory consciousness of an AI assistant. Your memory observation reflections will be the ONLY information the assistant has about past interactions with this user.
 
 The following instructions were given to another part of your psyche (the observer) to create memories.
@@ -113,7 +115,7 @@ Hint for the agent's immediate next message. Examples:
 - Call the view tool on src/example.ts to continue debugging.
 </suggested-response>
 
-User messages are extremely important. If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority. If the assistant needs to respond to the user, indicate in <suggested-response> that it should pause for user reply before continuing other tasks.`;
+User messages are extremely important. If the user asks a question or gives a new task, make it clear in <current-task> that this is the priority. If the assistant needs to respond to the user, indicate in <suggested-response> that it should pause for user reply before continuing other tasks.${instruction ? `\n\n=== CUSTOM INSTRUCTIONS ===\n\n${instruction}` : ''}`;
 }
 
 /**

--- a/packages/memory/src/processors/observational-memory/types.ts
+++ b/packages/memory/src/processors/observational-memory/types.ts
@@ -134,6 +134,12 @@ export interface ObservationConfig {
    * If not set, synchronous observation is never used when async buffering is enabled.
    */
   blockAfter?: number;
+
+  /**
+   * Custom instructions to append to the Observer's system prompt.
+   * Use this to customize observation behavior for specific use cases.
+   */
+  instruction?: string;
 }
 
 /**
@@ -197,6 +203,12 @@ export interface ReflectionConfig {
    * Requires `observation.bufferTokens` to also be set.
    */
   bufferActivation?: number;
+
+  /**
+   * Custom instructions to append to the Reflector's system prompt.
+   * Use this to customize reflection behavior for specific use cases.
+   */
+  instruction?: string;
 }
 
 /**


### PR DESCRIPTION
Adds an `instruction` property to observation and reflection configs that appends custom instructions to the built-in system prompts.

```typescript
const memory = new Memory({
  options: {
    observationalMemory: {
      model: 'google/gemini-2.5-flash',
      observation: {
        instruction: 'Focus on user dietary preferences and allergies.',
      },
      reflection: {
        instruction: 'Consolidate observations and remove duplicates.',
      },
    },
  },
});
```

Also removes the legacy prompt variant (`LEGACY_OBSERVER_EXTRACTION_INSTRUCTIONS`) and `OM_USE_LEGACY_PROMPT` env var since they were only used for A/B testing.

<img width="1035" height="257" alt="Screenshot 2026-02-18 at 5 22 21 PM" src="https://github.com/user-attachments/assets/0d2e6e10-415b-40a6-ba52-1380b9fda218" />
<img width="689" height="369" alt="Screenshot 2026-02-18 at 5 22 07 PM" src="https://github.com/user-attachments/assets/3c2458c5-0e69-4cf2-b422-03180ed830bc" />

<img width="718" height="423" alt="Screenshot 2026-02-18 at 5 22 15 PM" src="https://github.com/user-attachments/assets/2d2a9ba7-44f2-4e99-a46b-41611fcc7d9b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional instruction fields to observational memory so custom guidance can be appended to observer and reflector system prompts.

* **Documentation**
  * Added docs and examples showing how to configure observation and reflection instructions.

* **Tests**
  * Expanded tests to verify custom instructions propagate into observer and reflector prompts and behave correctly across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->