### PR TITLE
fix(core): fix failing unit tests

### DIFF
--- a/.changeset/proud-days-sing.md
+++ b/.changeset/proud-days-sing.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed sub-agent tool approval resume flow. When a sub-agent tool required approval and was approved, the agent would restart from scratch instead of resuming, causing an infinite loop. The resume data is now correctly passed through for agent tools so they properly resume after approval.

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -76,8 +76,11 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
           toolCallId: 'call-1',
           messages: expect.any(Array),
           outputWriter: expect.any(Function),
+          requestContext: expect.any(Object),
           resumeData: undefined,
           suspend: expect.any(Function),
+          tracingContext: undefined,
+          workspace: undefined,
         },
       );
     });

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -360,8 +360,11 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         }
 
         //this is to avoid passing resume data to the tool if it's not needed
+        // For agent tools, always pass resume data so the agent tool wrapper knows to call
+        // resumeStream instead of stream (otherwise the sub-agent restarts from scratch)
+        const isAgentTool = inputData.toolName?.startsWith('agent-');
         const resumeDataToPassToToolOptions =
-          toolRequiresApproval && Object.keys(resumeData).length === 1 && 'approved' in resumeData
+          !isAgentTool && toolRequiresApproval && Object.keys(resumeData).length === 1 && 'approved' in resumeData
             ? undefined
             : resumeData;
 

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -484,7 +484,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         };
 
         //if resuming a subAgent tool, we want to find the runId from when the subAgent got suspended.
-        if (resumeDataToPassToToolOptions && inputData.toolName?.startsWith('agent-') && !isResumeToolCall) {
+        if (resumeDataToPassToToolOptions && isAgentTool && !isResumeToolCall) {
           let suspendedToolRunId = '';
           const messages = messageList.get.all.db();
           const assistantMessages = [...messages].reverse().filter(message => message.role === 'assistant');

--- a/packages/core/src/memory/processor-caching.test.ts
+++ b/packages/core/src/memory/processor-caching.test.ts
@@ -119,7 +119,9 @@ describe('MastraMemory Embedding Cache (Issue #11455)', () => {
         requestContext,
       });
 
-      expect(mockEmbedder.doEmbed).toHaveBeenCalledTimes(1);
+      // doEmbed is called twice: once by getEmbeddingDimension() to probe dimensions,
+      // and once by processInput() for the actual embedding
+      expect(mockEmbedder.doEmbed).toHaveBeenCalledTimes(2);
 
       // Get processors second time (NEW instance, but shares global cache)
       const processors2 = await memory.getInputProcessors();
@@ -136,8 +138,9 @@ describe('MastraMemory Embedding Cache (Issue #11455)', () => {
         requestContext,
       });
 
-      // Embedder should NOT be called again (cache hit from global cache)
-      expect(mockEmbedder.doEmbed).toHaveBeenCalledTimes(1);
+      // Embedder should NOT be called again (cache hit from global cache,
+      // dimension probe is also cached per memory instance via _embeddingDimensionPromise)
+      expect(mockEmbedder.doEmbed).toHaveBeenCalledTimes(2);
     });
 
     it('should preserve embedding cache between input and output processing', async () => {
@@ -186,7 +189,9 @@ describe('MastraMemory Embedding Cache (Issue #11455)', () => {
         requestContext,
       });
 
-      expect(mockEmbedder.doEmbed).toHaveBeenCalledTimes(1);
+      // doEmbed is called twice: once by getEmbeddingDimension() to probe dimensions,
+      // and once by processInput() for the actual embedding
+      expect(mockEmbedder.doEmbed).toHaveBeenCalledTimes(2);
 
       // Get output processors and process the same message
       const outputProcessors = await memory.getOutputProcessors();
@@ -206,8 +211,9 @@ describe('MastraMemory Embedding Cache (Issue #11455)', () => {
         requestContext,
       });
 
-      // Embedder should NOT be called again (cache hit from global cache)
-      expect(mockEmbedder.doEmbed).toHaveBeenCalledTimes(1);
+      // Embedder should NOT be called again (cache hit from global cache,
+      // dimension probe is also cached per memory instance via _embeddingDimensionPromise)
+      expect(mockEmbedder.doEmbed).toHaveBeenCalledTimes(2);
     });
 
     it('should share embedding cache across different Memory instances', async () => {
@@ -268,7 +274,9 @@ describe('MastraMemory Embedding Cache (Issue #11455)', () => {
         requestContext,
       });
 
-      expect(mockEmbedder.doEmbed).toHaveBeenCalledTimes(1);
+      // doEmbed is called twice: once by getEmbeddingDimension() to probe dimensions,
+      // and once by processInput() for the actual embedding
+      expect(mockEmbedder.doEmbed).toHaveBeenCalledTimes(2);
 
       // Process with second memory instance - should use global cache
       const processors2 = await memory2.getInputProcessors();
@@ -284,8 +292,9 @@ describe('MastraMemory Embedding Cache (Issue #11455)', () => {
         requestContext,
       });
 
-      // Embedder should NOT be called again (cache hit from global cache)
-      expect(mockEmbedder.doEmbed).toHaveBeenCalledTimes(1);
+      // doEmbed called once more for memory2's dimension probe (separate _embeddingDimensionPromise),
+      // but the actual embedding uses global cache (no new embed call)
+      expect(mockEmbedder.doEmbed).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -233,9 +233,9 @@ describe('makeCoreTool', () => {
     expect(coreTool.execute).toBeDefined();
 
     if (coreTool.execute) {
-      const result = await coreTool.execute({ name: 'test' }, { toolCallId: 'test-id', messages: [] });
-      expect(result).toBeInstanceOf(MastraError);
-      expect(result.message).toBe('Test error');
+      await expect(coreTool.execute({ name: 'test' }, { toolCallId: 'test-id', messages: [] })).rejects.toThrow(
+        MastraError,
+      );
       expect(errorSpy).toHaveBeenCalled();
     }
     errorSpy.mockRestore();


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
  - **processor-caching.test.ts**: Fix 3 failing embedding cache tests — account for `getEmbeddingDimension()` probe call to `doEmbed` during `getInputProcessors()` (1 extra call per memory instance)
  - **utils.test.ts**: Fix tool execution error test — expect `MastraError` to be thrown (via `rejects.toThrow`) instead of returned, matching current `tool-builder/builder.ts` behavior
  - **loop/test-utils/options.ts**: Fix abort signal test — add `requestContext`, `tracingContext`, and `workspace` to tool execution context expectations
  
## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sub-agent tool resume so approved agent tools receive resume data and resume correctly instead of restarting.

* **Tests**
  * Updated test assertions for tool execution context to expect additional properties.
  * Adjusted embedder tests to account for a dimension-probing call plus embed calls.
  * Refined error-handling tests to assert proper error rejection.

* **Chores**
  * Added changeset documenting a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->