### PR TITLE
fix: add hasDraft to create-mastra e2e snapshot

### DIFF
--- a/e2e-tests/create-mastra/create-mastra.test.ts
+++ b/e2e-tests/create-mastra/create-mastra.test.ts
@@ -109,6 +109,7 @@ describe('create mastra', () => {
               "defaultOptions": {},
               "defaultStreamOptionsLegacy": {},
               "description": "",
+              "hasDraft": false,
               "id": "weather-agent",
               "inputProcessors": [],
               "instructions": "


### PR DESCRIPTION
## Summary
- Add missing `hasDraft: false` to the agent response inline snapshot in `e2e-tests/create-mastra/create-mastra.test.ts`

## Context
PR #13194 added the `hasDraft` field to the agent serialization in the server handlers but didn't update the create-mastra e2e snapshot, causing the `should fetch agents` test to fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents now expose metadata indicating whether they have a draft version available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->