### PR TITLE
fix(mastracode): ESM module resolution error on startup

### DIFF
--- a/.changeset/ten-places-deny.md
+++ b/.changeset/ten-places-deny.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed mastracode crashing on startup with ERR_MODULE_NOT_FOUND for vscode-jsonrpc/node. Node.js ESM requires explicit .js extensions on subpath imports.

--- a/mastracode/src/lsp/client.ts
+++ b/mastracode/src/lsp/client.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from 'node:child_process';
-import { StreamMessageReader, StreamMessageWriter, createMessageConnection } from 'vscode-jsonrpc/node';
-import type { MessageConnection } from 'vscode-jsonrpc/node';
+import { StreamMessageReader, StreamMessageWriter, createMessageConnection } from 'vscode-jsonrpc/node.js';
+import type { MessageConnection } from 'vscode-jsonrpc/node.js';
 import { TextDocumentIdentifier, Position } from 'vscode-languageserver-protocol';
 import type { Diagnostic } from 'vscode-languageserver-protocol';
 import type { LSPServerInfo } from './server';


### PR DESCRIPTION
When running `mastracode` after a global install, it crashes immediately with:

```
ERR_MODULE_NOT_FOUND: Cannot find module 'vscode-jsonrpc/node'
Did you mean to import "vscode-jsonrpc/node.js"?
```

Node.js ESM requires explicit `.js` extensions on subpath imports. The fix adds the missing `.js` extension to the `vscode-jsonrpc/node` imports in the LSP client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical startup crash in mastracode when using Node.js ESM, resolving module resolution errors that prevented application initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->