### PR TITLE
fix(schema-compat): fix zodToJsonSchema routing for v3/v4 schemas

### DIFF
--- a/.changeset/fix-schema-compat-zod-v3-v4.md
+++ b/.changeset/fix-schema-compat-zod-v3-v4.md
@@ -1,0 +1,12 @@
+---
+'@mastra/schema-compat': patch
+'mastracode': patch
+---
+
+fix(schema-compat): fix zodToJsonSchema routing for v3/v4 Zod schemas
+
+The `zodToJsonSchema` function now reliably detects and routes Zod v3 vs v4 schemas regardless of which version the ambient `zod` import resolves to. Previously, the detection relied on checking `'toJSONSchema' in z` against the ambient `z` import, which could resolve to either v3 or v4 depending on the environment (monorepo vs global install). This caused v3 schemas to be passed to v4's `toJSONSchema()` (crashing with "Cannot read properties of undefined (reading 'def')") or v4 schemas to be passed to the v3 converter (producing schemas missing the `type` field).
+
+The fix explicitly imports `z as zV4` from `zod/v4` and routes based on the schema's own `_zod` property, making the behavior environment-independent.
+
+Also migrates all mastracode tool files from `zod/v3` to `zod` imports now that the schema-compat fix supports both versions correctly.

--- a/mastracode/src/tools/ast-smart-edit.ts
+++ b/mastracode/src/tools/ast-smart-edit.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parse, Lang } from '@ast-grep/napi';
 import { createTool } from '@mastra/core/tools';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 import { assertPathAllowed, getAllowedPathsFromContext } from './utils.js';
 
 // Get the project root from the working directory

--- a/mastracode/src/tools/file-view.ts
+++ b/mastracode/src/tools/file-view.ts
@@ -4,7 +4,7 @@ import { homedir } from 'node:os';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
 import { createTool } from '@mastra/core/tools';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 import { truncateStringForTokenEstimate } from '../utils/token-estimator';
 import { assertPathAllowed, getAllowedPathsFromContext } from './utils.js';
 

--- a/mastracode/src/tools/glob.ts
+++ b/mastracode/src/tools/glob.ts
@@ -5,7 +5,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createTool } from '@mastra/core/tools';
 import { execa } from 'execa';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 import { truncateStringForTokenEstimate } from '../utils/token-estimator.js';
 import { assertPathAllowed, getAllowedPathsFromContext } from './utils.js';
 

--- a/mastracode/src/tools/grep.ts
+++ b/mastracode/src/tools/grep.ts
@@ -4,7 +4,7 @@
 import * as path from 'node:path';
 import { createTool } from '@mastra/core/tools';
 import { execa } from 'execa';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 import { truncateStringForTokenEstimate } from '../utils/token-estimator.js';
 import { assertPathAllowed, getAllowedPathsFromContext } from './utils.js';
 

--- a/mastracode/src/tools/request-sandbox-access.ts
+++ b/mastracode/src/tools/request-sandbox-access.ts
@@ -6,7 +6,7 @@
 import * as path from 'node:path';
 import type { HarnessRequestContext } from '@mastra/core/harness';
 import { createTool } from '@mastra/core/tools';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 import { isPathAllowed, getAllowedPathsFromContext } from './utils.js';
 
 let requestCounter = 0;

--- a/mastracode/src/tools/shell.ts
+++ b/mastracode/src/tools/shell.ts
@@ -3,7 +3,7 @@ import { createTool } from '@mastra/core/tools';
 import { execa, ExecaError } from 'execa';
 import stripAnsi from 'strip-ansi';
 import treeKill from 'tree-kill';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 import { ipcReporter } from '../ipc/ipc-reporter.js';
 import { truncateStringForTokenEstimate } from '../utils/token-estimator';
 import { isPathAllowed, getAllowedPathsFromContext } from './utils.js';
@@ -254,7 +254,7 @@ Usage notes:
           try {
             process.kill(-subprocess.pid, 'SIGKILL');
           } catch {
-            treeKill(subprocess.pid, 'SIGKILL', () => {});
+            treeKill(subprocess.pid, 'SIGKILL', () => { });
           }
         }
       };

--- a/mastracode/src/tools/shell.ts
+++ b/mastracode/src/tools/shell.ts
@@ -254,7 +254,7 @@ Usage notes:
           try {
             process.kill(-subprocess.pid, 'SIGKILL');
           } catch {
-            treeKill(subprocess.pid, 'SIGKILL', () => { });
+            treeKill(subprocess.pid, 'SIGKILL', () => {});
           }
         }
       };

--- a/mastracode/src/tools/string-replace-lsp.ts
+++ b/mastracode/src/tools/string-replace-lsp.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createTool } from '@mastra/core/tools';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 import { lspManager } from '../lsp/manager.js';
 import { findWorkspaceRoot } from '../lsp/workspace.js';
 import { truncateStringForTokenEstimate } from '../utils/token-estimator.js';

--- a/mastracode/src/tools/subagent.ts
+++ b/mastracode/src/tools/subagent.ts
@@ -330,12 +330,12 @@ export function parseSubagentMeta(content: string): {
   const durationMs = parseInt(match[2]!, 10);
   const toolCalls = match[3]
     ? match[3]
-      .split(',')
-      .filter(Boolean)
-      .map(entry => {
-        const [name, status] = entry.split(':');
-        return { name: name!, isError: status === 'err' };
-      })
+        .split(',')
+        .filter(Boolean)
+        .map(entry => {
+          const [name, status] = entry.split(':');
+          return { name: name!, isError: status === 'err' };
+        })
     : [];
 
   return { text, modelId, durationMs, toolCalls };

--- a/mastracode/src/tools/subagent.ts
+++ b/mastracode/src/tools/subagent.ts
@@ -11,7 +11,7 @@
 import { Agent } from '@mastra/core/agent';
 import type { HarnessRequestContext } from '@mastra/core/harness';
 import { createTool } from '@mastra/core/tools';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 import { getSubagentDefinition, getSubagentIds } from '../agents/subagents/index.js';
 
 export interface SubagentToolDeps {
@@ -330,12 +330,12 @@ export function parseSubagentMeta(content: string): {
   const durationMs = parseInt(match[2]!, 10);
   const toolCalls = match[3]
     ? match[3]
-        .split(',')
-        .filter(Boolean)
-        .map(entry => {
-          const [name, status] = entry.split(':');
-          return { name: name!, isError: status === 'err' };
-        })
+      .split(',')
+      .filter(Boolean)
+      .map(entry => {
+        const [name, status] = entry.split(':');
+        return { name: name!, isError: status === 'err' };
+      })
     : [];
 
   return { text, modelId, durationMs, toolCalls };

--- a/mastracode/src/tools/todo-check.ts
+++ b/mastracode/src/tools/todo-check.ts
@@ -16,7 +16,7 @@ Returns:
 - List of incomplete tasks (if any)
 - Boolean indicating if all tasks are done`,
   inputSchema: z.object({}), // No input needed
-  execute: async ({ }, context) => {
+  execute: async ({}, context) => {
     try {
       const harnessCtx = context?.requestContext?.get('harness') as HarnessRequestContext | undefined;
 

--- a/mastracode/src/tools/todo-check.ts
+++ b/mastracode/src/tools/todo-check.ts
@@ -4,7 +4,7 @@
  */
 import type { HarnessRequestContext } from '@mastra/core/harness';
 import { createTool } from '@mastra/core/tools';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 export const todoCheckTool = createTool({
   id: 'todo_check',
@@ -16,7 +16,7 @@ Returns:
 - List of incomplete tasks (if any)
 - Boolean indicating if all tasks are done`,
   inputSchema: z.object({}), // No input needed
-  execute: async ({}, context) => {
+  execute: async ({ }, context) => {
     try {
       const harnessCtx = context?.requestContext?.get('harness') as HarnessRequestContext | undefined;
 

--- a/mastracode/src/tools/todo.ts
+++ b/mastracode/src/tools/todo.ts
@@ -4,7 +4,7 @@
  */
 import type { HarnessRequestContext } from '@mastra/core/harness';
 import { createTool } from '@mastra/core/tools';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 const todoItemSchema = z.object({
   content: z.string().min(1).describe("Task description in imperative form (e.g., 'Fix authentication bug')"),

--- a/mastracode/src/tools/write.ts
+++ b/mastracode/src/tools/write.ts
@@ -4,7 +4,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createTool } from '@mastra/core/tools';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 import { assertPathAllowed, getAllowedPathsFromContext } from './utils.js';
 
 /**


### PR DESCRIPTION
## Summary
- Fixes `zodToJsonSchema` to reliably detect Zod v3 vs v4 schemas regardless of which version the ambient `zod` import resolves to
- Explicitly imports `z as zV4` from `zod/v4` and routes based on the schema's `_zod` property instead of checking `'toJSONSchema' in z`
- Migrates all mastracode tool files from `zod/v3` to `zod` imports now that schema-compat handles both correctly

## Problem
The previous implementation relied on `'toJSONSchema' in z` where `z` came from `import { z } from 'zod'`. This import resolves to v3 (3.25.76) in the monorepo but v4 (4.3.6) when installed globally via npm, causing environment-dependent failures:
- **Global install**: v3 schemas routed to v4's `toJSONSchema()` → crash: "Cannot read properties of undefined (reading 'def')"
- **Monorepo**: v4 schemas routed to v3's converter → schemas missing the `type` field, rejected by providers

## Fix
- Import `z as zV4` from `zod/v4` explicitly to guarantee access to `toJSONSchema`
- Route based on `zodSchema._zod` (present only on v4 schemas) instead of ambient import detection
- All 709 schema-compat tests pass

## Test plan
- [x] Build `@mastra/schema-compat` and run test suite (709 tests pass)
- [x] Test mastracode locally with v3 tool schemas — works
- [x] Test mastracode locally with v4 tool schemas (all tools migrated) — works
- [x] Verify tool calls succeed end-to-end (file operations, search, shell, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Zod v3/v4 schema routing so schemas are reliably detected and processed by the correct converter, preventing misrouting and improving compatibility and stability.

* **Chores**
  * Updated internal tooling imports to align with the fix and added a changeset documenting the patch releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->