### PR TITLE
feat(mastracode): add separate export path for MastraTUI

### DIFF
--- a/.changeset/khaki-onions-stand.md
+++ b/.changeset/khaki-onions-stand.md
@@ -1,0 +1,10 @@
+---
+'mastracode': minor
+---
+
+Added a separate export path for the TUI at `mastracode/tui`, so consumers can cleanly import MastraTUI and related components without reaching into internals.
+
+```ts
+import { MastraTUI, type MastraTUIOptions } from 'mastracode/tui';
+import { theme, setTheme, ModelSelectorComponent } from 'mastracode/tui';
+```

--- a/mastracode/package.json
+++ b/mastracode/package.json
@@ -32,6 +32,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./tui": {
+      "import": {
+        "types": "./dist/tui/index.d.ts",
+        "default": "./dist/tui.js"
+      },
+      "require": {
+        "types": "./dist/tui/index.d.ts",
+        "default": "./dist/tui.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/mastracode/tsup.config.ts
+++ b/mastracode/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
     cli: 'src/main.ts',
+    tui: 'src/tui/index.ts',
   },
   format: ['esm', 'cjs'],
   clean: true,


### PR DESCRIPTION
Adds `mastracode/tui` as a public export path so consumers can import `MastraTUI` and related TUI components cleanly instead of reaching into internal paths.

```ts
import { createMastraCode } from 'mastracode';
import { MastraTUI } from 'mastracode/tui';

const { harness, hookManager, authStorage } = createMastraCode();
const tui = new MastraTUI({ harness, hookManager, authStorage });
```

Two files changed: added `tui` entry in `tsup.config.ts` and the `./tui` export map in `package.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated import path for TUI components. Users can now import MastraTUI, theme utilities, and ModelSelectorComponent directly from `mastracode/tui` for cleaner and more convenient imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->