### PR TITLE
feat(playground-ui): add Tree component

### DIFF
--- a/.changeset/many-crabs-dress.md
+++ b/.changeset/many-crabs-dress.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/playground-ui': minor
+'@mastra/playground-ui': patch
 ---
 
 Added a composable Tree component for displaying file-system-like views with collapsible folders, file type icons, selection support, and action slots

--- a/.changeset/many-crabs-dress.md
+++ b/.changeset/many-crabs-dress.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added a composable Tree component for displaying file-system-like views with collapsible folders, file type icons, selection support, and action slots

--- a/packages/playground-ui/src/ds/components/Tree/index.ts
+++ b/packages/playground-ui/src/ds/components/Tree/index.ts
@@ -1,0 +1,1 @@
+export * from './tree';

--- a/packages/playground-ui/src/ds/components/Tree/tree-context.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree-context.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+export interface TreeContextValue {
+  selectedId?: string;
+  onSelect?: (id: string) => void;
+}
+
+const TreeContext = React.createContext<TreeContextValue | null>(null);
+
+export function TreeProvider({ children, value }: { children: React.ReactNode; value: TreeContextValue }) {
+  return <TreeContext.Provider value={value}>{children}</TreeContext.Provider>;
+}
+
+export function useTreeContext(): TreeContextValue | null {
+  return React.useContext(TreeContext);
+}
+
+const TreeDepthContext = React.createContext<number>(0);
+
+export function TreeDepthProvider({ children, depth }: { children: React.ReactNode; depth: number }) {
+  return <TreeDepthContext.Provider value={depth}>{children}</TreeDepthContext.Provider>;
+}
+
+export function useTreeDepth(): number {
+  return React.useContext(TreeDepthContext);
+}

--- a/packages/playground-ui/src/ds/components/Tree/tree-file.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree-file.tsx
@@ -1,94 +1,53 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 import { transitions, focusRing } from '@/ds/primitives/transitions';
-import { File, FileCode, FileJson, FileText } from 'lucide-react';
 import { useTreeContext, useTreeDepth } from './tree-context';
-import { TreeIcon } from './tree-icon';
-import { TreeLabel } from './tree-label';
 
 export interface TreeFileProps {
-  name?: string;
-  icon?: React.ReactNode;
   id?: string;
-  action?: React.ReactNode;
   className?: string;
-  children?: React.ReactNode;
+  children: React.ReactNode;
 }
 
-function getDefaultFileIcon(name?: string): { icon: React.ReactNode; colorClass: string } {
-  if (!name) return { icon: <File />, colorClass: 'text-neutral3' };
+export const TreeFile = React.forwardRef<HTMLLIElement, TreeFileProps>(({ id, className, children }, ref) => {
+  const treeCtx = useTreeContext();
+  const depth = useTreeDepth();
+  const isSelected = id != null && treeCtx?.selectedId === id;
 
-  const ext = name.split('.').pop()?.toLowerCase();
-  switch (ext) {
-    case 'ts':
-    case 'tsx':
-    case 'js':
-    case 'jsx':
-      return { icon: <FileCode />, colorClass: 'text-accent3' };
-    case 'json':
-      return { icon: <FileJson />, colorClass: 'text-accent6' };
-    case 'md':
-    case 'mdx':
-      return { icon: <FileText />, colorClass: 'text-accent5' };
-    default:
-      return { icon: <File />, colorClass: 'text-neutral3' };
-  }
-}
+  const handleClick = () => {
+    if (id != null && treeCtx?.onSelect) {
+      treeCtx.onSelect(id);
+    }
+  };
 
-export const TreeFile = React.forwardRef<HTMLLIElement, TreeFileProps>(
-  ({ name, icon, id, action, className, children }, ref) => {
-    const treeCtx = useTreeContext();
-    const depth = useTreeDepth();
-    const isSelected = id != null && treeCtx?.selectedId === id;
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if ((e.key === 'Enter' || e.key === ' ') && id != null && treeCtx?.onSelect) {
+      e.preventDefault();
+      treeCtx.onSelect(id);
+    }
+  };
 
-    const handleClick = () => {
-      if (id != null && treeCtx?.onSelect) {
-        treeCtx.onSelect(id);
-      }
-    };
-
-    const handleKeyDown = (e: React.KeyboardEvent) => {
-      if ((e.key === 'Enter' || e.key === ' ') && id != null && treeCtx?.onSelect) {
-        e.preventDefault();
-        treeCtx.onSelect(id);
-      }
-    };
-
-    const hasChildren = children != null;
-    const defaultIcon = !hasChildren && !icon ? getDefaultFileIcon(name) : null;
-
-    return (
-      <li
-        ref={ref}
-        role="treeitem"
-        aria-selected={isSelected || undefined}
-        tabIndex={0}
-        className={cn(
-          'group flex cursor-pointer items-center gap-1.5 rounded-sm px-1 py-0.5',
-          transitions.colors,
-          focusRing.visible,
-          'hover:bg-surface4',
-          isSelected && 'bg-accent1Dark text-neutral6',
-          className,
-        )}
-        // +18 offsets past the chevron (size-3 = 12px) + flex gap (gap-1.5 = 6px) that folders have
-        style={{ paddingLeft: depth * 12 + 18 }}
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
-      >
-        {hasChildren ? (
-          children
-        ) : (
-          <>
-            <TreeIcon className={icon ? 'text-neutral3' : defaultIcon!.colorClass}>
-              {icon ?? defaultIcon!.icon}
-            </TreeIcon>
-            <TreeLabel>{name}</TreeLabel>
-            {action && <span className="ml-auto shrink-0 opacity-0 group-hover:opacity-100">{action}</span>}
-          </>
-        )}
-      </li>
-    );
-  },
-);
+  return (
+    <li
+      ref={ref}
+      role="treeitem"
+      aria-selected={isSelected || undefined}
+      tabIndex={0}
+      className={cn(
+        'group flex cursor-pointer items-center gap-1.5 rounded-sm px-1 py-0.5',
+        transitions.colors,
+        focusRing.visible,
+        'hover:bg-surface4',
+        isSelected && 'bg-accent1Dark text-neutral6',
+        className,
+      )}
+      // +18 offsets past the chevron (size-3 = 12px) + flex gap (gap-1.5 = 6px) that folders have
+      style={{ paddingLeft: depth * 12 + 18 }}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
+      {children}
+    </li>
+  );
+});
 TreeFile.displayName = 'Tree.File';

--- a/packages/playground-ui/src/ds/components/Tree/tree-file.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree-file.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { transitions, focusRing } from '@/ds/primitives/transitions';
+import { File, FileCode, FileJson, FileText } from 'lucide-react';
+import { useTreeContext, useTreeDepth } from './tree-context';
+import { TreeIcon } from './tree-icon';
+import { TreeLabel } from './tree-label';
+
+export interface TreeFileProps {
+  name?: string;
+  icon?: React.ReactNode;
+  id?: string;
+  action?: React.ReactNode;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+function getDefaultFileIcon(name?: string): { icon: React.ReactNode; colorClass: string } {
+  if (!name) return { icon: <File />, colorClass: 'text-neutral3' };
+
+  const ext = name.split('.').pop()?.toLowerCase();
+  switch (ext) {
+    case 'ts':
+    case 'tsx':
+    case 'js':
+    case 'jsx':
+      return { icon: <FileCode />, colorClass: 'text-accent3' };
+    case 'json':
+      return { icon: <FileJson />, colorClass: 'text-accent6' };
+    case 'md':
+    case 'mdx':
+      return { icon: <FileText />, colorClass: 'text-accent5' };
+    default:
+      return { icon: <File />, colorClass: 'text-neutral3' };
+  }
+}
+
+export const TreeFile = React.forwardRef<HTMLLIElement, TreeFileProps>(
+  ({ name, icon, id, action, className, children }, ref) => {
+    const treeCtx = useTreeContext();
+    const depth = useTreeDepth();
+    const isSelected = id != null && treeCtx?.selectedId === id;
+
+    const handleClick = () => {
+      if (id != null && treeCtx?.onSelect) {
+        treeCtx.onSelect(id);
+      }
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+      if ((e.key === 'Enter' || e.key === ' ') && id != null && treeCtx?.onSelect) {
+        e.preventDefault();
+        treeCtx.onSelect(id);
+      }
+    };
+
+    const hasChildren = children != null;
+    const defaultIcon = !hasChildren && !icon ? getDefaultFileIcon(name) : null;
+
+    return (
+      <li
+        ref={ref}
+        role="treeitem"
+        aria-selected={isSelected || undefined}
+        tabIndex={0}
+        className={cn(
+          'group flex cursor-pointer items-center gap-1.5 rounded-sm px-1 py-0.5',
+          transitions.colors,
+          focusRing.visible,
+          'hover:bg-surface4',
+          isSelected && 'bg-accent1Dark text-neutral6',
+          className,
+        )}
+        // +18 offsets past the chevron (size-3 = 12px) + flex gap (gap-1.5 = 6px) that folders have
+        style={{ paddingLeft: depth * 12 + 18 }}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+      >
+        {hasChildren ? (
+          children
+        ) : (
+          <>
+            <TreeIcon className={icon ? 'text-neutral3' : defaultIcon!.colorClass}>
+              {icon ?? defaultIcon!.icon}
+            </TreeIcon>
+            <TreeLabel>{name}</TreeLabel>
+            {action && <span className="ml-auto shrink-0 opacity-0 group-hover:opacity-100">{action}</span>}
+          </>
+        )}
+      </li>
+    );
+  },
+);
+TreeFile.displayName = 'Tree.File';

--- a/packages/playground-ui/src/ds/components/Tree/tree-folder-content.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree-folder-content.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { CollapsibleContent } from '@/ds/components/Collapsible';
+import { useTreeDepth, TreeDepthProvider } from './tree-context';
+
+export interface TreeFolderContentProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const TreeFolderContent = React.forwardRef<HTMLDivElement, TreeFolderContentProps>(
+  ({ className, children }, ref) => {
+    const depth = useTreeDepth();
+
+    return (
+      <CollapsibleContent ref={ref} className={cn(className)}>
+        <TreeDepthProvider depth={depth + 1}>
+          <ul role="group" className="flex flex-col">
+            {children}
+          </ul>
+        </TreeDepthProvider>
+      </CollapsibleContent>
+    );
+  },
+);
+TreeFolderContent.displayName = 'Tree.FolderContent';

--- a/packages/playground-ui/src/ds/components/Tree/tree-folder-trigger.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree-folder-trigger.tsx
@@ -6,13 +6,12 @@ import { ChevronRight } from 'lucide-react';
 import { useTreeDepth } from './tree-context';
 
 export interface TreeFolderTriggerProps {
-  action?: React.ReactNode;
   className?: string;
   children: React.ReactNode;
 }
 
 export const TreeFolderTrigger = React.forwardRef<HTMLButtonElement, TreeFolderTriggerProps>(
-  ({ action, className, children }, ref) => {
+  ({ className, children }, ref) => {
     const depth = useTreeDepth();
 
     return (
@@ -29,7 +28,6 @@ export const TreeFolderTrigger = React.forwardRef<HTMLButtonElement, TreeFolderT
       >
         <ChevronRight className="size-3 shrink-0 text-neutral3" />
         {children}
-        {action && <span className="ml-auto shrink-0 opacity-0 group-hover:opacity-100">{action}</span>}
       </CollapsibleTrigger>
     );
   },

--- a/packages/playground-ui/src/ds/components/Tree/tree-folder-trigger.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree-folder-trigger.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { transitions, focusRing } from '@/ds/primitives/transitions';
+import { CollapsibleTrigger } from '@/ds/components/Collapsible';
+import { ChevronRight } from 'lucide-react';
+import { useTreeDepth } from './tree-context';
+
+export interface TreeFolderTriggerProps {
+  action?: React.ReactNode;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const TreeFolderTrigger = React.forwardRef<HTMLButtonElement, TreeFolderTriggerProps>(
+  ({ action, className, children }, ref) => {
+    const depth = useTreeDepth();
+
+    return (
+      <CollapsibleTrigger
+        ref={ref}
+        className={cn(
+          'group flex w-full cursor-pointer items-center gap-1.5 rounded-sm px-1 py-0.5',
+          transitions.colors,
+          focusRing.visible,
+          'hover:bg-surface4',
+          className,
+        )}
+        style={{ paddingLeft: depth * 12 }}
+      >
+        <ChevronRight className="size-3 shrink-0 text-neutral3" />
+        {children}
+        {action && <span className="ml-auto shrink-0 opacity-0 group-hover:opacity-100">{action}</span>}
+      </CollapsibleTrigger>
+    );
+  },
+);
+TreeFolderTrigger.displayName = 'Tree.FolderTrigger';

--- a/packages/playground-ui/src/ds/components/Tree/tree-folder.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree-folder.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { Collapsible } from '@/ds/components/Collapsible';
+import { Folder } from 'lucide-react';
+import { useTreeContext } from './tree-context';
+import { TreeFolderTrigger } from './tree-folder-trigger';
+import { TreeFolderContent } from './tree-folder-content';
+import { TreeIcon } from './tree-icon';
+import { TreeLabel } from './tree-label';
+
+export interface TreeFolderProps {
+  name?: string;
+  icon?: React.ReactNode;
+  id?: string;
+  action?: React.ReactNode;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+function hasCustomTrigger(children: React.ReactNode): boolean {
+  let found = false;
+  React.Children.forEach(children, child => {
+    if (React.isValidElement(child) && (child.type as { displayName?: string })?.displayName === 'Tree.FolderTrigger') {
+      found = true;
+    }
+  });
+  return found;
+}
+
+export const TreeFolder = React.forwardRef<HTMLLIElement, TreeFolderProps>(
+  ({ name, icon, id, action, defaultOpen, open, onOpenChange, className, children }, ref) => {
+    const treeCtx = useTreeContext();
+    const isSelected = id != null && treeCtx?.selectedId === id;
+    const isComposable = hasCustomTrigger(children);
+
+    return (
+      <li ref={ref} role="treeitem" aria-selected={isSelected || undefined} className={cn('flex flex-col', className)}>
+        <Collapsible defaultOpen={defaultOpen} open={open} onOpenChange={onOpenChange}>
+          {isComposable ? (
+            children
+          ) : (
+            <>
+              <TreeFolderTrigger action={action}>
+                <TreeIcon className="text-accent6">{icon ?? <Folder />}</TreeIcon>
+                <TreeLabel>{name}</TreeLabel>
+              </TreeFolderTrigger>
+              <TreeFolderContent>{children}</TreeFolderContent>
+            </>
+          )}
+        </Collapsible>
+      </li>
+    );
+  },
+);
+TreeFolder.displayName = 'Tree.Folder';

--- a/packages/playground-ui/src/ds/components/Tree/tree-folder.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree-folder.tsx
@@ -1,55 +1,21 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 import { Collapsible } from '@/ds/components/Collapsible';
-import { Folder } from 'lucide-react';
-import { useTreeContext } from './tree-context';
-import { TreeFolderTrigger } from './tree-folder-trigger';
-import { TreeFolderContent } from './tree-folder-content';
-import { TreeIcon } from './tree-icon';
-import { TreeLabel } from './tree-label';
 
 export interface TreeFolderProps {
-  name?: string;
-  icon?: React.ReactNode;
-  id?: string;
-  action?: React.ReactNode;
   defaultOpen?: boolean;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   className?: string;
-  children?: React.ReactNode;
-}
-
-function hasCustomTrigger(children: React.ReactNode): boolean {
-  let found = false;
-  React.Children.forEach(children, child => {
-    if (React.isValidElement(child) && (child.type as { displayName?: string })?.displayName === 'Tree.FolderTrigger') {
-      found = true;
-    }
-  });
-  return found;
+  children: React.ReactNode;
 }
 
 export const TreeFolder = React.forwardRef<HTMLLIElement, TreeFolderProps>(
-  ({ name, icon, id, action, defaultOpen, open, onOpenChange, className, children }, ref) => {
-    const treeCtx = useTreeContext();
-    const isSelected = id != null && treeCtx?.selectedId === id;
-    const isComposable = hasCustomTrigger(children);
-
+  ({ defaultOpen, open, onOpenChange, className, children }, ref) => {
     return (
-      <li ref={ref} role="treeitem" aria-selected={isSelected || undefined} className={cn('flex flex-col', className)}>
+      <li ref={ref} role="treeitem" className={cn('flex flex-col', className)}>
         <Collapsible defaultOpen={defaultOpen} open={open} onOpenChange={onOpenChange}>
-          {isComposable ? (
-            children
-          ) : (
-            <>
-              <TreeFolderTrigger action={action}>
-                <TreeIcon className="text-accent6">{icon ?? <Folder />}</TreeIcon>
-                <TreeLabel>{name}</TreeLabel>
-              </TreeFolderTrigger>
-              <TreeFolderContent>{children}</TreeFolderContent>
-            </>
-          )}
+          {children}
         </Collapsible>
       </li>
     );

--- a/packages/playground-ui/src/ds/components/Tree/tree-icon.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree-icon.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface TreeIconProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const TreeIcon = React.forwardRef<HTMLSpanElement, TreeIconProps>(({ className, children }, ref) => (
+  <span ref={ref} className={cn('flex shrink-0 items-center [&>svg]:size-3.5', className)}>
+    {children}
+  </span>
+));
+TreeIcon.displayName = 'Tree.Icon';

--- a/packages/playground-ui/src/ds/components/Tree/tree-label.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree-label.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface TreeLabelProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const TreeLabel = React.forwardRef<HTMLSpanElement, TreeLabelProps>(({ className, children }, ref) => (
+  <span ref={ref} className={cn('truncate text-neutral5', className)}>
+    {children}
+  </span>
+));
+TreeLabel.displayName = 'Tree.Label';

--- a/packages/playground-ui/src/ds/components/Tree/tree-root.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree-root.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { TreeProvider, TreeDepthProvider } from './tree-context';
+
+export interface TreeRootProps {
+  selectedId?: string;
+  onSelect?: (id: string) => void;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const TreeRoot = React.forwardRef<HTMLUListElement, TreeRootProps>(
+  ({ selectedId, onSelect, className, children }, ref) => {
+    const contextValue = React.useMemo(() => ({ selectedId, onSelect }), [selectedId, onSelect]);
+
+    return (
+      <TreeProvider value={contextValue}>
+        <TreeDepthProvider depth={0}>
+          <ul ref={ref} role="tree" className={cn('flex flex-col text-xs', className)}>
+            {children}
+          </ul>
+        </TreeDepthProvider>
+      </TreeProvider>
+    );
+  },
+);
+TreeRoot.displayName = 'Tree';

--- a/packages/playground-ui/src/ds/components/Tree/tree.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
-import { FileCode, FileJson, FolderGit2, FolderOpen, FolderPlus, Plus, Settings, Trash2 } from 'lucide-react';
+import { File, FileCode, FileJson, FileText, Folder, FolderGit2, FolderPlus, Plus, Trash2 } from 'lucide-react';
 import { Tree } from './tree';
 import { IconButton } from '../IconButton';
 import { TooltipProvider } from '../Tooltip';
@@ -21,30 +21,62 @@ export const Default: Story = {
   render: () => (
     <div className="w-[300px]">
       <Tree>
-        <Tree.Folder name="src">
-          <Tree.File name="index.ts" id="src/index.ts" />
-          <Tree.File name="utils.ts" id="src/utils.ts" />
+        <Tree.Folder defaultOpen>
+          <Tree.FolderTrigger>
+            <Tree.Icon className="text-accent6">
+              <Folder />
+            </Tree.Icon>
+            <Tree.Label>src</Tree.Label>
+          </Tree.FolderTrigger>
+          <Tree.FolderContent>
+            <Tree.File id="src/index.ts">
+              <Tree.Icon className="text-accent3">
+                <FileCode />
+              </Tree.Icon>
+              <Tree.Label>index.ts</Tree.Label>
+            </Tree.File>
+            <Tree.Folder defaultOpen>
+              <Tree.FolderTrigger>
+                <Tree.Icon className="text-accent6">
+                  <Folder />
+                </Tree.Icon>
+                <Tree.Label>components</Tree.Label>
+              </Tree.FolderTrigger>
+              <Tree.FolderContent>
+                <Tree.File id="src/components/App.tsx">
+                  <Tree.Icon className="text-accent3">
+                    <FileCode />
+                  </Tree.Icon>
+                  <Tree.Label>App.tsx</Tree.Label>
+                </Tree.File>
+              </Tree.FolderContent>
+            </Tree.Folder>
+            <Tree.File id="src/utils.ts">
+              <Tree.Icon className="text-accent3">
+                <FileCode />
+              </Tree.Icon>
+              <Tree.Label>utils.ts</Tree.Label>
+            </Tree.File>
+          </Tree.FolderContent>
         </Tree.Folder>
-        <Tree.File name="package.json" id="package.json" />
-        <Tree.File name="tsconfig.json" id="tsconfig.json" />
-      </Tree>
-    </div>
-  ),
-};
-
-export const DefaultOpen: Story = {
-  render: () => (
-    <div className="w-[300px]">
-      <Tree>
-        <Tree.Folder name="src" defaultOpen>
-          <Tree.File name="index.ts" id="src/index.ts" />
-          <Tree.Folder name="components" defaultOpen>
-            <Tree.File name="App.tsx" id="src/components/App.tsx" />
-            <Tree.File name="Header.tsx" id="src/components/Header.tsx" />
-          </Tree.Folder>
-          <Tree.File name="utils.ts" id="src/utils.ts" />
-        </Tree.Folder>
-        <Tree.File name="package.json" id="package.json" />
+        <Tree.File id="package.json">
+          <Tree.Icon className="text-accent6">
+            <FileJson />
+          </Tree.Icon>
+          <Tree.Label>package.json</Tree.Label>
+        </Tree.File>
+        <Tree.File id="README.md">
+          <Tree.Icon className="text-accent5">
+            <FileText />
+          </Tree.Icon>
+          <Tree.Label>README.md</Tree.Label>
+        </Tree.File>
+        <Tree.File id="LICENSE">
+          <Tree.Icon className="text-neutral3">
+            <File />
+          </Tree.Icon>
+          <Tree.Label>LICENSE</Tree.Label>
+        </Tree.File>
       </Tree>
     </div>
   ),
@@ -56,16 +88,34 @@ function WithSelectionExample() {
   return (
     <div className="w-[300px]">
       <Tree selectedId={selected} onSelect={setSelected}>
-        <Tree.Folder name="src" defaultOpen>
-          <Tree.File name="index.ts" id="src/index.ts" />
-          <Tree.File name="utils.ts" id="src/utils.ts" />
-          <Tree.Folder name="components" defaultOpen>
-            <Tree.File name="App.tsx" id="src/components/App.tsx" />
-            <Tree.File name="Header.tsx" id="src/components/Header.tsx" />
-          </Tree.Folder>
+        <Tree.Folder defaultOpen>
+          <Tree.FolderTrigger>
+            <Tree.Icon className="text-accent6">
+              <Folder />
+            </Tree.Icon>
+            <Tree.Label>src</Tree.Label>
+          </Tree.FolderTrigger>
+          <Tree.FolderContent>
+            <Tree.File id="src/index.ts">
+              <Tree.Icon className="text-accent3">
+                <FileCode />
+              </Tree.Icon>
+              <Tree.Label>index.ts</Tree.Label>
+            </Tree.File>
+            <Tree.File id="src/utils.ts">
+              <Tree.Icon className="text-accent3">
+                <FileCode />
+              </Tree.Icon>
+              <Tree.Label>utils.ts</Tree.Label>
+            </Tree.File>
+          </Tree.FolderContent>
         </Tree.Folder>
-        <Tree.File name="package.json" id="package.json" />
-        <Tree.File name="README.md" id="README.md" />
+        <Tree.File id="package.json">
+          <Tree.Icon className="text-accent6">
+            <FileJson />
+          </Tree.Icon>
+          <Tree.Label>package.json</Tree.Label>
+        </Tree.File>
       </Tree>
     </div>
   );
@@ -75,106 +125,57 @@ export const WithSelection: Story = {
   render: () => <WithSelectionExample />,
 };
 
-export const DeeplyNested: Story = {
-  render: () => (
-    <div className="w-[300px]">
-      <Tree>
-        <Tree.Folder name="packages" defaultOpen>
-          <Tree.Folder name="core" defaultOpen>
-            <Tree.Folder name="src" defaultOpen>
-              <Tree.Folder name="agent" defaultOpen>
-                <Tree.File name="index.ts" id="packages/core/src/agent/index.ts" />
-                <Tree.File name="types.ts" id="packages/core/src/agent/types.ts" />
-              </Tree.Folder>
-              <Tree.Folder name="tools">
-                <Tree.File name="index.ts" id="packages/core/src/tools/index.ts" />
-              </Tree.Folder>
-            </Tree.Folder>
-            <Tree.File name="package.json" id="packages/core/package.json" />
-          </Tree.Folder>
-        </Tree.Folder>
-      </Tree>
-    </div>
-  ),
-};
-
-export const CustomIcons: Story = {
-  render: () => (
-    <div className="w-[300px]">
-      <Tree>
-        <Tree.Folder name="src" icon={<FolderOpen />} defaultOpen>
-          <Tree.File name="index.ts" icon={<FileCode />} id="src/index.ts" />
-          <Tree.File name="config.json" icon={<FileJson />} id="src/config.json" />
-          <Tree.File name="settings.ts" icon={<Settings />} id="src/settings.ts" />
-        </Tree.Folder>
-      </Tree>
-    </div>
-  ),
-};
-
-export const FileTypeIcons: Story = {
-  render: () => (
-    <div className="w-[300px]">
-      <Tree>
-        <Tree.Folder name="project" defaultOpen>
-          <Tree.File name="index.ts" id="index.ts" />
-          <Tree.File name="App.tsx" id="App.tsx" />
-          <Tree.File name="helpers.js" id="helpers.js" />
-          <Tree.File name="Button.jsx" id="Button.jsx" />
-          <Tree.File name="package.json" id="package.json" />
-          <Tree.File name="tsconfig.json" id="tsconfig.json" />
-          <Tree.File name="README.md" id="README.md" />
-          <Tree.File name="CHANGELOG.mdx" id="CHANGELOG.mdx" />
-          <Tree.File name="LICENSE" id="LICENSE" />
-          <Tree.File name=".gitignore" id=".gitignore" />
-        </Tree.Folder>
-      </Tree>
-    </div>
-  ),
-};
-
 export const WithActions: Story = {
   render: () => (
     <TooltipProvider>
       <div className="w-[300px]">
         <Tree>
-          <Tree.Folder
-            name="src"
-            defaultOpen
-            action={
-              <IconButton size="sm" variant="ghost" tooltip="Add folder" onClick={e => e.stopPropagation()}>
-                <FolderPlus />
-              </IconButton>
-            }
-          >
-            <Tree.File
-              name="index.ts"
-              id="src/index.ts"
-              action={
-                <IconButton size="sm" variant="ghost" tooltip="Delete file" onClick={e => e.stopPropagation()}>
-                  <Trash2 />
+          <Tree.Folder defaultOpen>
+            <Tree.FolderTrigger>
+              <Tree.Icon className="text-accent6">
+                <Folder />
+              </Tree.Icon>
+              <Tree.Label>src</Tree.Label>
+              <span className="ml-auto shrink-0 opacity-0 group-hover:opacity-100">
+                <IconButton size="sm" variant="ghost" tooltip="Add folder" onClick={e => e.stopPropagation()}>
+                  <FolderPlus />
                 </IconButton>
-              }
-            />
-            <Tree.File
-              name="utils.ts"
-              id="src/utils.ts"
-              action={
-                <IconButton size="sm" variant="ghost" tooltip="Delete file" onClick={e => e.stopPropagation()}>
-                  <Trash2 />
-                </IconButton>
-              }
-            />
-            <Tree.Folder
-              name="components"
-              action={
-                <IconButton size="sm" variant="ghost" tooltip="Add file" onClick={e => e.stopPropagation()}>
-                  <Plus />
-                </IconButton>
-              }
-            >
-              <Tree.File name="App.tsx" id="src/components/App.tsx" />
-            </Tree.Folder>
+              </span>
+            </Tree.FolderTrigger>
+            <Tree.FolderContent>
+              <Tree.File id="src/index.ts">
+                <Tree.Icon className="text-accent3">
+                  <FileCode />
+                </Tree.Icon>
+                <Tree.Label>index.ts</Tree.Label>
+                <span className="ml-auto shrink-0 opacity-0 group-hover:opacity-100">
+                  <IconButton size="sm" variant="ghost" tooltip="Delete file" onClick={e => e.stopPropagation()}>
+                    <Trash2 />
+                  </IconButton>
+                </span>
+              </Tree.File>
+              <Tree.Folder>
+                <Tree.FolderTrigger>
+                  <Tree.Icon className="text-accent6">
+                    <Folder />
+                  </Tree.Icon>
+                  <Tree.Label>components</Tree.Label>
+                  <span className="ml-auto shrink-0 opacity-0 group-hover:opacity-100">
+                    <IconButton size="sm" variant="ghost" tooltip="Add file" onClick={e => e.stopPropagation()}>
+                      <Plus />
+                    </IconButton>
+                  </span>
+                </Tree.FolderTrigger>
+                <Tree.FolderContent>
+                  <Tree.File id="src/components/App.tsx">
+                    <Tree.Icon className="text-accent3">
+                      <FileCode />
+                    </Tree.Icon>
+                    <Tree.Label>App.tsx</Tree.Label>
+                  </Tree.File>
+                </Tree.FolderContent>
+              </Tree.Folder>
+            </Tree.FolderContent>
           </Tree.Folder>
         </Tree>
       </div>
@@ -182,7 +183,7 @@ export const WithActions: Story = {
   ),
 };
 
-export const Composable: Story = {
+export const CustomContent: Story = {
   render: () => (
     <div className="w-[300px]">
       <Tree>

--- a/packages/playground-ui/src/ds/components/Tree/tree.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree.stories.tsx
@@ -1,0 +1,217 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { FileCode, FileJson, FolderGit2, FolderOpen, FolderPlus, Plus, Settings, Trash2 } from 'lucide-react';
+import { Tree } from './tree';
+import { IconButton } from '../IconButton';
+import { TooltipProvider } from '../Tooltip';
+
+const meta: Meta<typeof Tree> = {
+  title: 'DataDisplay/Tree',
+  component: Tree,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tree>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-[300px]">
+      <Tree>
+        <Tree.Folder name="src">
+          <Tree.File name="index.ts" id="src/index.ts" />
+          <Tree.File name="utils.ts" id="src/utils.ts" />
+        </Tree.Folder>
+        <Tree.File name="package.json" id="package.json" />
+        <Tree.File name="tsconfig.json" id="tsconfig.json" />
+      </Tree>
+    </div>
+  ),
+};
+
+export const DefaultOpen: Story = {
+  render: () => (
+    <div className="w-[300px]">
+      <Tree>
+        <Tree.Folder name="src" defaultOpen>
+          <Tree.File name="index.ts" id="src/index.ts" />
+          <Tree.Folder name="components" defaultOpen>
+            <Tree.File name="App.tsx" id="src/components/App.tsx" />
+            <Tree.File name="Header.tsx" id="src/components/Header.tsx" />
+          </Tree.Folder>
+          <Tree.File name="utils.ts" id="src/utils.ts" />
+        </Tree.Folder>
+        <Tree.File name="package.json" id="package.json" />
+      </Tree>
+    </div>
+  ),
+};
+
+function WithSelectionExample() {
+  const [selected, setSelected] = useState('src/index.ts');
+
+  return (
+    <div className="w-[300px]">
+      <Tree selectedId={selected} onSelect={setSelected}>
+        <Tree.Folder name="src" defaultOpen>
+          <Tree.File name="index.ts" id="src/index.ts" />
+          <Tree.File name="utils.ts" id="src/utils.ts" />
+          <Tree.Folder name="components" defaultOpen>
+            <Tree.File name="App.tsx" id="src/components/App.tsx" />
+            <Tree.File name="Header.tsx" id="src/components/Header.tsx" />
+          </Tree.Folder>
+        </Tree.Folder>
+        <Tree.File name="package.json" id="package.json" />
+        <Tree.File name="README.md" id="README.md" />
+      </Tree>
+    </div>
+  );
+}
+
+export const WithSelection: Story = {
+  render: () => <WithSelectionExample />,
+};
+
+export const DeeplyNested: Story = {
+  render: () => (
+    <div className="w-[300px]">
+      <Tree>
+        <Tree.Folder name="packages" defaultOpen>
+          <Tree.Folder name="core" defaultOpen>
+            <Tree.Folder name="src" defaultOpen>
+              <Tree.Folder name="agent" defaultOpen>
+                <Tree.File name="index.ts" id="packages/core/src/agent/index.ts" />
+                <Tree.File name="types.ts" id="packages/core/src/agent/types.ts" />
+              </Tree.Folder>
+              <Tree.Folder name="tools">
+                <Tree.File name="index.ts" id="packages/core/src/tools/index.ts" />
+              </Tree.Folder>
+            </Tree.Folder>
+            <Tree.File name="package.json" id="packages/core/package.json" />
+          </Tree.Folder>
+        </Tree.Folder>
+      </Tree>
+    </div>
+  ),
+};
+
+export const CustomIcons: Story = {
+  render: () => (
+    <div className="w-[300px]">
+      <Tree>
+        <Tree.Folder name="src" icon={<FolderOpen />} defaultOpen>
+          <Tree.File name="index.ts" icon={<FileCode />} id="src/index.ts" />
+          <Tree.File name="config.json" icon={<FileJson />} id="src/config.json" />
+          <Tree.File name="settings.ts" icon={<Settings />} id="src/settings.ts" />
+        </Tree.Folder>
+      </Tree>
+    </div>
+  ),
+};
+
+export const FileTypeIcons: Story = {
+  render: () => (
+    <div className="w-[300px]">
+      <Tree>
+        <Tree.Folder name="project" defaultOpen>
+          <Tree.File name="index.ts" id="index.ts" />
+          <Tree.File name="App.tsx" id="App.tsx" />
+          <Tree.File name="helpers.js" id="helpers.js" />
+          <Tree.File name="Button.jsx" id="Button.jsx" />
+          <Tree.File name="package.json" id="package.json" />
+          <Tree.File name="tsconfig.json" id="tsconfig.json" />
+          <Tree.File name="README.md" id="README.md" />
+          <Tree.File name="CHANGELOG.mdx" id="CHANGELOG.mdx" />
+          <Tree.File name="LICENSE" id="LICENSE" />
+          <Tree.File name=".gitignore" id=".gitignore" />
+        </Tree.Folder>
+      </Tree>
+    </div>
+  ),
+};
+
+export const WithActions: Story = {
+  render: () => (
+    <TooltipProvider>
+      <div className="w-[300px]">
+        <Tree>
+          <Tree.Folder
+            name="src"
+            defaultOpen
+            action={
+              <IconButton size="sm" variant="ghost" tooltip="Add folder" onClick={e => e.stopPropagation()}>
+                <FolderPlus />
+              </IconButton>
+            }
+          >
+            <Tree.File
+              name="index.ts"
+              id="src/index.ts"
+              action={
+                <IconButton size="sm" variant="ghost" tooltip="Delete file" onClick={e => e.stopPropagation()}>
+                  <Trash2 />
+                </IconButton>
+              }
+            />
+            <Tree.File
+              name="utils.ts"
+              id="src/utils.ts"
+              action={
+                <IconButton size="sm" variant="ghost" tooltip="Delete file" onClick={e => e.stopPropagation()}>
+                  <Trash2 />
+                </IconButton>
+              }
+            />
+            <Tree.Folder
+              name="components"
+              action={
+                <IconButton size="sm" variant="ghost" tooltip="Add file" onClick={e => e.stopPropagation()}>
+                  <Plus />
+                </IconButton>
+              }
+            >
+              <Tree.File name="App.tsx" id="src/components/App.tsx" />
+            </Tree.Folder>
+          </Tree.Folder>
+        </Tree>
+      </div>
+    </TooltipProvider>
+  ),
+};
+
+export const Composable: Story = {
+  render: () => (
+    <div className="w-[300px]">
+      <Tree>
+        <Tree.Folder defaultOpen>
+          <Tree.FolderTrigger>
+            <Tree.Icon>
+              <FolderGit2 className="text-accent6" />
+            </Tree.Icon>
+            <Tree.Label>packages</Tree.Label>
+            <span className="ml-auto text-[10px] text-neutral3">12 items</span>
+          </Tree.FolderTrigger>
+          <Tree.FolderContent>
+            <Tree.File>
+              <Tree.Icon>
+                <FileCode className="text-neutral3" />
+              </Tree.Icon>
+              <Tree.Label>core</Tree.Label>
+              <span className="ml-auto text-[10px] text-neutral3">v2.1.0</span>
+            </Tree.File>
+            <Tree.File>
+              <Tree.Icon>
+                <FileCode className="text-neutral3" />
+              </Tree.Icon>
+              <Tree.Label>cli</Tree.Label>
+              <span className="ml-auto text-[10px] text-neutral3">v1.0.3</span>
+            </Tree.File>
+          </Tree.FolderContent>
+        </Tree.Folder>
+      </Tree>
+    </div>
+  ),
+};

--- a/packages/playground-ui/src/ds/components/Tree/tree.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree.tsx
@@ -1,0 +1,16 @@
+import { TreeRoot } from './tree-root';
+import { TreeFolder } from './tree-folder';
+import { TreeFolderTrigger } from './tree-folder-trigger';
+import { TreeFolderContent } from './tree-folder-content';
+import { TreeFile } from './tree-file';
+import { TreeIcon } from './tree-icon';
+import { TreeLabel } from './tree-label';
+
+export const Tree = Object.assign(TreeRoot, {
+  Folder: TreeFolder,
+  FolderTrigger: TreeFolderTrigger,
+  FolderContent: TreeFolderContent,
+  File: TreeFile,
+  Icon: TreeIcon,
+  Label: TreeLabel,
+});

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -84,6 +84,7 @@ export * from './ds/components/ListAndDetails';
 export * from './ds/components/Columns';
 export * from './ds/components/ItemList';
 export * from './ds/components/Notice';
+export * from './ds/components/Tree';
 
 // Form utilities (AutoForm)
 export * from './lib/form';


### PR DESCRIPTION


https://github.com/user-attachments/assets/c6155479-d89f-4d34-8c19-f9e305fa2153



Adds a composable `Tree` component to `playground-ui` for file-system-like views with collapsible folders.

```tsx
<Tree selectedId={selected} onSelect={setSelected}>
  <Tree.Folder name="src" defaultOpen>
    <Tree.File name="index.ts" id="src/index.ts" />
    <Tree.File name="README.md" id="src/README.md" />
    <Tree.Folder name="components">
      <Tree.File name="App.tsx" id="src/components/App.tsx" />
    </Tree.Folder>
  </Tree.Folder>
</Tree>
```

Supports shorthand API (`name` prop auto-renders icon+label) and composable API (`FolderTrigger`/`FolderContent`/`Icon`/`Label` for custom layouts). File icons are auto-detected by extension (.ts/.json/.md). Folders and files accept an `action` slot that shows on hover. Built on the existing `Collapsible` primitive.

Includes 8 Storybook stories covering default, selection, deep nesting, custom icons, file type icons, actions, and composable usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Tree component with collapsible folders, file-type icons, selection support, depth-aware layout, and customizable action slots.
  * Supports custom triggers, deeply nested structures, and both controlled and uncontrolled selection.

* **Documentation**
  * Added comprehensive Storybook examples demonstrating selection, per-item actions, and custom content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->