### PR TITLE
feat(playground-ui): add Tree.Input component for inline creation

### DIFF
--- a/.changeset/free-groups-sip.md
+++ b/.changeset/free-groups-sip.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added Tree.Input component for inline file and folder creation within the Tree, with auto-focus, Enter/Escape/blur handling, and correct depth indentation

--- a/packages/playground-ui/src/ds/components/Tree/tree-input.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree-input.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+import { transitions } from '@/ds/primitives/transitions';
+import { useTreeDepth } from './tree-context';
+import { File, Folder } from 'lucide-react';
+
+export interface TreeInputProps {
+  type: 'file' | 'folder';
+  onSubmit: (name: string) => void;
+  onCancel?: () => void;
+  defaultValue?: string;
+  placeholder?: string;
+  autoFocus?: boolean;
+  className?: string;
+}
+
+export const TreeInput = React.forwardRef<HTMLLIElement, TreeInputProps>(
+  ({ type, onSubmit, onCancel, defaultValue = '', placeholder, autoFocus = true, className }, ref) => {
+    const depth = useTreeDepth();
+    const inputRef = React.useRef<HTMLInputElement>(null);
+    const submittedRef = React.useRef(false);
+
+    const handleSubmit = React.useCallback(
+      (value: string) => {
+        if (submittedRef.current) return;
+        const trimmed = value.trim();
+        if (trimmed) {
+          submittedRef.current = true;
+          onSubmit(trimmed);
+        } else {
+          onCancel?.();
+        }
+      },
+      [onSubmit, onCancel],
+    );
+
+    const handleKeyDown = React.useCallback(
+      (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          handleSubmit(e.currentTarget.value);
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          onCancel?.();
+        }
+      },
+      [handleSubmit, onCancel],
+    );
+
+    const handleBlur = React.useCallback(
+      (e: React.FocusEvent<HTMLInputElement>) => {
+        handleSubmit(e.currentTarget.value);
+      },
+      [handleSubmit],
+    );
+
+    const handleFocus = React.useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+      e.currentTarget.select();
+    }, []);
+
+    const Icon = type === 'folder' ? Folder : File;
+
+    return (
+      <li
+        ref={ref}
+        role="treeitem"
+        className={cn(
+          'group flex items-center gap-1.5 rounded-sm px-1 py-0.5',
+          transitions.colors,
+          'focus-within:outline-none focus-within:ring-1 focus-within:ring-accent1 focus-within:shadow-focus-ring',
+          className,
+        )}
+        style={{ paddingLeft: depth * 12 + 18 }}
+      >
+        <span className="flex shrink-0 items-center [&>svg]:size-3.5">
+          <Icon className="text-neutral3" />
+        </span>
+        <input
+          ref={inputRef}
+          type="text"
+          defaultValue={defaultValue}
+          placeholder={placeholder}
+          autoFocus={autoFocus}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          onFocus={handleFocus}
+          className="min-w-0 flex-1 border-none bg-transparent text-xs text-neutral5 outline-none placeholder:text-neutral3"
+        />
+      </li>
+    );
+  },
+);
+TreeInput.displayName = 'Tree.Input';

--- a/packages/playground-ui/src/ds/components/Tree/tree.stories.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { File, FileCode, FileJson, FileText, Folder, FolderGit2, FolderPlus, Plus, Trash2 } from 'lucide-react';
 import { Tree } from './tree';
 import { IconButton } from '../IconButton';
@@ -215,4 +215,106 @@ export const CustomContent: Story = {
       </Tree>
     </div>
   ),
+};
+
+interface FileItem {
+  id: string;
+  name: string;
+  type: 'file' | 'folder';
+}
+
+function WithInlineCreationExample() {
+  const [files, setFiles] = useState<FileItem[]>([
+    { id: 'src/index.ts', name: 'index.ts', type: 'file' },
+    { id: 'src/utils.ts', name: 'utils.ts', type: 'file' },
+  ]);
+  const [creating, setCreating] = useState<'file' | 'folder' | null>(null);
+
+  const handleSubmit = useCallback(
+    (name: string) => {
+      const type = creating ?? 'file';
+      setFiles(prev => [...prev, { id: `src/${name}`, name, type }]);
+      setCreating(null);
+    },
+    [creating],
+  );
+
+  const handleCancel = useCallback(() => {
+    setCreating(null);
+  }, []);
+
+  return (
+    <TooltipProvider>
+      <div className="w-[300px]">
+        <Tree>
+          <Tree.Folder defaultOpen>
+            <Tree.FolderTrigger>
+              <Tree.Icon className="text-accent6">
+                <Folder />
+              </Tree.Icon>
+              <Tree.Label>src</Tree.Label>
+              <span className="ml-auto flex shrink-0 gap-0.5 opacity-0 group-hover:opacity-100">
+                <IconButton
+                  size="sm"
+                  variant="ghost"
+                  tooltip="New file"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setCreating('file');
+                  }}
+                >
+                  <Plus />
+                </IconButton>
+                <IconButton
+                  size="sm"
+                  variant="ghost"
+                  tooltip="New folder"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setCreating('folder');
+                  }}
+                >
+                  <FolderPlus />
+                </IconButton>
+              </span>
+            </Tree.FolderTrigger>
+            <Tree.FolderContent>
+              {creating && (
+                <Tree.Input
+                  type={creating}
+                  placeholder={creating === 'folder' ? 'Folder name…' : 'File name…'}
+                  onSubmit={handleSubmit}
+                  onCancel={handleCancel}
+                />
+              )}
+              {files.map(file =>
+                file.type === 'folder' ? (
+                  <Tree.Folder key={file.id}>
+                    <Tree.FolderTrigger>
+                      <Tree.Icon className="text-accent6">
+                        <Folder />
+                      </Tree.Icon>
+                      <Tree.Label>{file.name}</Tree.Label>
+                    </Tree.FolderTrigger>
+                    <Tree.FolderContent>{null}</Tree.FolderContent>
+                  </Tree.Folder>
+                ) : (
+                  <Tree.File key={file.id} id={file.id}>
+                    <Tree.Icon className="text-accent3">
+                      <FileCode />
+                    </Tree.Icon>
+                    <Tree.Label>{file.name}</Tree.Label>
+                  </Tree.File>
+                ),
+              )}
+            </Tree.FolderContent>
+          </Tree.Folder>
+        </Tree>
+      </div>
+    </TooltipProvider>
+  );
+}
+
+export const WithInlineCreation: Story = {
+  render: () => <WithInlineCreationExample />,
 };

--- a/packages/playground-ui/src/ds/components/Tree/tree.tsx
+++ b/packages/playground-ui/src/ds/components/Tree/tree.tsx
@@ -5,6 +5,7 @@ import { TreeFolderContent } from './tree-folder-content';
 import { TreeFile } from './tree-file';
 import { TreeIcon } from './tree-icon';
 import { TreeLabel } from './tree-label';
+import { TreeInput } from './tree-input';
 
 export const Tree = Object.assign(TreeRoot, {
   Folder: TreeFolder,
@@ -13,4 +14,5 @@ export const Tree = Object.assign(TreeRoot, {
   File: TreeFile,
   Icon: TreeIcon,
   Label: TreeLabel,
+  Input: TreeInput,
 });


### PR DESCRIPTION
Adds a `Tree.Input` compound component for inline file/folder creation within the Tree, similar to VSCode's behavior.

Usage:

```tsx
<Tree.FolderContent>
  <Tree.Input
    type="file"
    placeholder="File name…"
    onSubmit={(name) => addFile(name)}
    onCancel={() => setCreating(false)}
  />
</Tree.FolderContent>
```

Enter submits, Escape cancels, blur submits if non-empty. Auto-focuses on mount and selects existing text for rename scenarios. Includes a `WithInlineCreation` story showing the full integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Tree.Input` component for inline file and folder creation within Tree structures, featuring auto-focus, keyboard shortcuts (Enter to submit, Escape to cancel), and automatic depth-aware indentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->