### PR TITLE
fix(docs): Cookie banner

### DIFF
--- a/docs/src/components/cookie/cookie-banner.tsx
+++ b/docs/src/components/cookie/cookie-banner.tsx
@@ -33,6 +33,27 @@ export function CookieBanner({ onConsentChange }: { onConsentChange: (consent: b
         ad_personalization: 'granted',
       })
       return
+    }
+
+    const existingConsent = localStorage.getItem('cookie-consent')
+    if (existingConsent === 'true') {
+      setShowBanner(false)
+      onConsentChange(true)
+      window.gtag?.('consent', 'update', {
+        analytics_storage: 'granted',
+        ad_storage: 'granted',
+        ad_user_data: 'granted',
+        ad_personalization: 'granted',
+      })
+    } else if (existingConsent === 'false') {
+      setShowBanner(false)
+      onConsentChange(false)
+      window.gtag?.('consent', 'update', {
+        analytics_storage: 'denied',
+        ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
+      })
     } else {
       setShowBanner(true)
     }


### PR DESCRIPTION
## Description

Fix a bug where the cookie banner was always shown in the docs, even after dismissing it

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Cookie consent preferences are now persisted and automatically restored on return visits. The consent banner displays only when users are making their initial consent choice, eliminating redundant prompts for returning users. Existing preferences are automatically detected and applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->