### PR TITLE
feat(playground): Add Diff view to Item and Item Versions Compare

### DIFF
--- a/.changeset/cute-donuts-look.md
+++ b/.changeset/cute-donuts-look.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'create-mastra': patch
+'mastra': patch
+---
+
+Added Diff view to Compare Dataset Items and Compare Dataset Item Versions pages

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -78,6 +78,7 @@
     "@codemirror/autocomplete": "^6.20.0",
     "@codemirror/lang-javascript": "^6.2.4",
     "@codemirror/lang-json": "^6.0.2",
+    "@codemirror/merge": "^6.10.2",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language-data": "^6.5.2",
     "@codemirror/state": "^6.5.4",

--- a/packages/playground-ui/src/domains/datasets/components/versions/dataset-item-versions-panel.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/versions/dataset-item-versions-panel.tsx
@@ -2,12 +2,11 @@
 
 import { useState } from 'react';
 import { format } from 'date-fns';
-import { ScaleIcon, MoveRightIcon, XIcon } from 'lucide-react';
+import { GitCompareIcon } from 'lucide-react';
 import { Button, ButtonWithTooltip } from '@/ds/components/Button';
 import { ItemList } from '@/ds/components/ItemList';
 import { Checkbox } from '@/ds/components/Checkbox';
 import { useDatasetItemVersions, type DatasetItemVersion } from '../../hooks/use-dataset-item-versions';
-import { Badge } from '@/ds/components/Badge';
 import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
 import { Column } from '@/ds/components/Columns';
 
@@ -77,33 +76,29 @@ export function DatasetItemVersionsPanel({
   const columnsToRender = isSelectionActive ? versionsListColumnsWithCheckbox : versionsListColumns;
 
   return (
-    <Column className="min-w-[20rem]">
+    <Column className="min-w-[17rem]">
       {isSelectionActive ? (
         <Column.Toolbar className="grid justify-stretch gap-3 w-full">
-          {/* <div className="text-sm text-neutral3 flex items-center gap-2">
-            <Badge className="text-ui-md">{selectedIds.size}</Badge>
-            <span>selected</span>
-            <MoveRightIcon />
-          </div> */}
           <ButtonsGroup>
+            <Button variant="standard" size="default" onClick={handleCancelSelection}>
+              Cancel
+            </Button>
             <ButtonWithTooltip
               variant="cta"
               size="default"
               disabled={selectedIds.size !== 2}
               onClick={handleExecuteCompare}
-              tooltipContent={selectedIds.size !== 2 ? 'Select exactly 2 versions to compare' : undefined}
+              tooltipContent={selectedIds.size !== 2 ? 'Check 2 versions to compare' : undefined}
+              className="grow"
             >
-              Compare Versions
+              Compare Selected
             </ButtonWithTooltip>
-            <Button variant="standard" size="default" onClick={handleCancelSelection}>
-              Cancel
-            </Button>
           </ButtonsGroup>
         </Column.Toolbar>
       ) : (
         <Column.Toolbar>
-          <Button variant="standard" size="default" onClick={handleCompareClick}>
-            <ScaleIcon /> Compare
+          <Button variant="standard" size="default" onClick={handleCompareClick} className="w-full">
+            <GitCompareIcon /> Compare Versions
           </Button>
         </Column.Toolbar>
       )}
@@ -128,13 +123,7 @@ export function DatasetItemVersionsPanel({
             <ItemList.Items>
               {versions?.map((item, index) => {
                 const versionKey = String(item.datasetVersion);
-                const createdAtDate = typeof item.createdAt === 'string' ? new Date(item.createdAt) : item.createdAt;
-
-                // const entry = {
-                //   id: `version-${index}`,
-                //   version: `v${item.datasetVersion} — ${format(versionDate, 'MMM d, yyyy HH:mm')}`,
-                //   status: item.isLatest ? 'current' : '',
-                // };
+                const versionDate = typeof item.updatedAt === 'string' ? new Date(item.updatedAt) : item.updatedAt;
 
                 return (
                   <ItemList.Row
@@ -145,10 +134,13 @@ export function DatasetItemVersionsPanel({
                       <ItemList.FlexCell className="w-12 pl-4">
                         <Checkbox
                           checked={selectedIds.has(versionKey)}
+                          disabled={item.isDeleted}
                           onCheckedChange={() => {}}
                           onClick={e => {
                             e.stopPropagation();
-                            handleToggleSelection(versionKey);
+                            if (!item.isDeleted) {
+                              handleToggleSelection(versionKey);
+                            }
                           }}
                           aria-label={`Select version ${item.datasetVersion}`}
                         />
@@ -161,31 +153,26 @@ export function DatasetItemVersionsPanel({
                       onClick={() => handleVersionClick(item)}
                       className="py-3"
                     >
-                      <ItemList.FlexCell className="w-full text-neutral flex gap-4 items-baseline text-neutral3">
-                        <strong className="min-w-8">v{item.datasetVersion}</strong>
-                        <em>{createdAtDate ? format(createdAtDate, 'MMM d, yyyy HH:mm') : null}</em>
-                        {item.isLatest && (
-                          <span className="ml-auto inline-block text-neutral4 text-xs p-1 px-2 leading-none rounded-sm bg-cyan-800">
-                            Latest
-                          </span>
-                        )}
-                        {/* <em>{createdAtDate ? format(createdAtDate, 'MMM d, yyyy HH:mm') : null}</em>
-                        {item.isCurrent && (
-                          <span className="ml-auto inline-block text-neutral4 text-xs p-1 px-2 leading-none rounded-sm bg-cyan-800">
-                            Latest
-                          </span>
-                        )} */}
-                      </ItemList.FlexCell>
-                      {/* <ItemList.TextCell>
-                        <div className="flex gap-2 items-center justify-between w-full text-ui-sm">
-                          {entry.version}
-                          {item.isDeleted ? (
-                            <Badge variant="error">deleted</Badge>
-                          ) : (
-                            item.isLatest && <Badge>latest</Badge>
-                          )}
+                      <ItemList.FlexCell className="w-full text-neutral grid text-neutral3">
+                        <div className="flex">
+                          <strong className="min-w-11">v{item.datasetVersion}</strong>
+                          <em>{versionDate ? format(versionDate, 'MMM d, yyyy HH:mm') : null}</em>
                         </div>
-                      </ItemList.TextCell> */}
+                        {(item.isLatest || item.isDeleted) && (
+                          <div className="flex gap-2 pl-11  ">
+                            {item.isLatest && (
+                              <span className="inline-block text-neutral4 text-xs p-1 px-2 leading-none rounded-sm bg-cyan-900">
+                                Latest
+                              </span>
+                            )}
+                            {item.isDeleted && (
+                              <span className="inline-block text-neutral4 text-xs p-1 px-2 leading-none rounded-sm bg-red-900">
+                                Deleted
+                              </span>
+                            )}
+                          </div>
+                        )}
+                      </ItemList.FlexCell>
                     </ItemList.RowButton>
                   </ItemList.Row>
                 );

--- a/packages/playground-ui/src/domains/datasets/hooks/use-dataset-item-versions.ts
+++ b/packages/playground-ui/src/domains/datasets/hooks/use-dataset-item-versions.ts
@@ -25,6 +25,7 @@ export const useDatasetItemVersions = (datasetId: string, itemId: string) => {
     queryKey: ['dataset-item-versions', datasetId, itemId],
     queryFn: async () => {
       const res = await client.getItemHistory(datasetId, itemId);
+
       return (res?.history ?? []).map((v, index) => ({
         id: v.id,
         datasetId: v.datasetId,
@@ -46,13 +47,19 @@ export const useDatasetItemVersions = (datasetId: string, itemId: string) => {
 /**
  * Hook to fetch a specific version of a dataset item.
  */
-export const useDatasetItemVersion = (datasetId: string, itemId: string, datasetVersion: number) => {
+export const useDatasetItemVersion = (
+  datasetId: string,
+  itemId: string,
+  datasetVersion: number,
+  latestVersion?: number,
+) => {
   const client = useMastraClient();
 
   return useQuery({
     queryKey: ['dataset-item-version', datasetId, itemId, datasetVersion],
     queryFn: async (): Promise<DatasetItemVersion> => {
       const v = await client.getDatasetItemVersion(datasetId, itemId, datasetVersion);
+
       return {
         id: v.id,
         datasetId: v.datasetId,
@@ -60,11 +67,11 @@ export const useDatasetItemVersion = (datasetId: string, itemId: string, dataset
         input: v.input,
         groundTruth: v.groundTruth,
         metadata: v.metadata,
-        validTo: v.validTo,
-        isDeleted: v.isDeleted,
+        validTo: v.validTo ?? null,
+        isDeleted: v.isDeleted ?? false,
         createdAt: v.createdAt,
         updatedAt: v.updatedAt,
-        isLatest: false,
+        isLatest: latestVersion != null ? datasetVersion === latestVersion : false,
       };
     },
     enabled: Boolean(datasetId) && Boolean(itemId) && datasetVersion > 0,

--- a/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/playground-ui/src/ds/components/Breadcrumb/Breadcrumb.tsx
@@ -22,7 +22,7 @@ export interface CrumbProps {
   isCurrent?: boolean;
   as: React.ElementType;
   className?: string;
-  to: string;
+  to?: string;
   prefetch?: boolean | null;
   children: React.ReactNode;
   action?: React.ReactNode;

--- a/packages/playground-ui/src/ds/components/CodeDiff/code-diff.stories.tsx
+++ b/packages/playground-ui/src/ds/components/CodeDiff/code-diff.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { CodeDiff } from './code-diff';
+
+const meta: Meta<typeof CodeDiff> = {
+  title: 'Elements/CodeDiff',
+  component: CodeDiff,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof CodeDiff>;
+
+const sampleA = JSON.stringify(
+  {
+    input: { query: 'What is the capital of France?' },
+    groundTruth: { answer: 'Paris' },
+    metadata: { category: 'geography', difficulty: 'easy' },
+  },
+  null,
+  2,
+);
+
+const sampleB = JSON.stringify(
+  {
+    input: { query: 'What is the capital of France?' },
+    groundTruth: { answer: 'Paris, France' },
+    metadata: { category: 'geography', difficulty: 'medium', source: 'trivia-db' },
+  },
+  null,
+  2,
+);
+
+export const Default: Story = {
+  args: {
+    codeA: sampleA,
+    codeB: sampleB,
+  },
+};
+
+export const Identical: Story = {
+  args: {
+    codeA: sampleA,
+    codeB: sampleA,
+  },
+};
+
+export const CompletelyDifferent: Story = {
+  args: {
+    codeA: JSON.stringify({ input: { prompt: 'Hello' }, groundTruth: null }, null, 2),
+    codeB: JSON.stringify({ input: { prompt: 'Goodbye' }, groundTruth: { response: 'See you later' } }, null, 2),
+  },
+};
+
+export const LargeDocument: Story = {
+  args: {
+    codeA: JSON.stringify(
+      {
+        input: {
+          messages: [
+            { role: 'system', content: 'You are a helpful assistant.' },
+            { role: 'user', content: 'Explain quantum computing in simple terms.' },
+          ],
+          temperature: 0.7,
+          maxTokens: 500,
+        },
+        groundTruth: {
+          response:
+            'Quantum computing uses quantum bits (qubits) that can exist in multiple states simultaneously, unlike classical bits which are either 0 or 1.',
+        },
+        metadata: {
+          model: 'gpt-4',
+          latency: 1200,
+          tokens: { prompt: 45, completion: 120 },
+        },
+      },
+      null,
+      2,
+    ),
+    codeB: JSON.stringify(
+      {
+        input: {
+          messages: [
+            { role: 'system', content: 'You are a helpful and concise assistant.' },
+            { role: 'user', content: 'Explain quantum computing in simple terms.' },
+            { role: 'assistant', content: 'Sure! Let me break it down.' },
+          ],
+          temperature: 0.5,
+          maxTokens: 1000,
+        },
+        groundTruth: {
+          response:
+            'Quantum computing leverages quantum mechanics principles like superposition and entanglement to process information in fundamentally different ways than classical computers.',
+        },
+        metadata: {
+          model: 'gpt-4-turbo',
+          latency: 800,
+          tokens: { prompt: 60, completion: 150 },
+          version: 2,
+        },
+      },
+      null,
+      2,
+    ),
+  },
+};

--- a/packages/playground-ui/src/ds/components/CodeDiff/code-diff.tsx
+++ b/packages/playground-ui/src/ds/components/CodeDiff/code-diff.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { EditorView } from '@codemirror/view';
+import { EditorState } from '@codemirror/state';
+import { json } from '@codemirror/lang-json';
+import { MergeView } from '@codemirror/merge';
+import { draculaInit } from '@uiw/codemirror-theme-dracula';
+import { tags as t } from '@lezer/highlight';
+
+const diffOverrides = EditorView.theme({
+  '&.cm-editor .cm-changedLine': {
+    backgroundColor: 'transparent',
+    backgroundImage: 'none',
+    borderLeft: 'none',
+  },
+  '&.cm-editor .cm-changedText': {
+    backgroundImage: 'none',
+    backgroundColor: '#880000',
+    padding: '1px 5px',
+    display: 'inline-block',
+    borderRadius: '4px',
+  },
+  '&.cm-editor .cm-changedText, &.cm-editor .cm-changedText *': {
+    color: 'white',
+  },
+  '&.cm-editor .cm-line': {
+    lineHeight: '1.5',
+    opacity: '0.5',
+  },
+  '&.cm-editor .cm-line.cm-changedLine': {
+    opacity: '1',
+  },
+  '&.cm-editor .cm-gutters': {
+    display: 'none',
+  },
+});
+
+const theme = draculaInit({
+  settings: {
+    fontFamily: 'var(--geist-mono)',
+    fontSize: '0.8125rem',
+    lineHighlight: 'transparent',
+    gutterBackground: 'transparent',
+    gutterForeground: '#939393',
+    background: 'transparent',
+  },
+  styles: [{ tag: [t.className, t.propertyName] }],
+});
+
+export interface CodeDiffProps {
+  codeA: string;
+  codeB: string;
+}
+
+export function CodeDiff({ codeA, codeB }: CodeDiffProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<MergeView | null>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    // Clean up previous instance
+    if (viewRef.current) {
+      viewRef.current.destroy();
+    }
+
+    const extensions = [json(), theme, diffOverrides, EditorView.lineWrapping, EditorState.readOnly.of(true)];
+
+    const mergeView = new MergeView({
+      parent: containerRef.current,
+      a: {
+        doc: codeA,
+        extensions,
+      },
+      b: {
+        doc: codeB,
+        extensions,
+      },
+      collapseUnchanged: { margin: 3, minSize: 4 },
+    });
+
+    viewRef.current = mergeView;
+
+    return () => {
+      mergeView.destroy();
+      viewRef.current = null;
+    };
+  }, [codeA, codeB]);
+
+  return (
+    <div className="relative overflow-auto rounded-xl border border-white/10 bg-black/20">
+      <div className="absolute left-1/2 top-0 h-full w-px bg-white/10 z-10" />
+      <div
+        ref={containerRef}
+        className="[&_.cm-mergeViewEditor]:flex-1 [&_.cm-editor]:bg-transparent [&_.cm-editor]:p-6 [&_.cm-gutters]:bg-transparent"
+      />
+    </div>
+  );
+}

--- a/packages/playground-ui/src/ds/components/CodeDiff/index.ts
+++ b/packages/playground-ui/src/ds/components/CodeDiff/index.ts
@@ -1,0 +1,2 @@
+export { CodeDiff } from './code-diff';
+export type { CodeDiffProps } from './code-diff';

--- a/packages/playground-ui/src/ds/components/FormFields/select-field.tsx
+++ b/packages/playground-ui/src/ds/components/FormFields/select-field.tsx
@@ -21,7 +21,7 @@ export type SelectFieldProps = Omit<React.SelectHTMLAttributes<HTMLSelectElement
   value?: string;
   helpMsg?: string;
   errorMsg?: string;
-  options: { value: string; label: string; icon?: React.ReactNode }[];
+  options: { value: string; label: string; icon?: React.ReactNode; disabled?: boolean }[];
   placeholder?: string;
   onValueChange: (value: string) => void;
   size?: FormElementSize | 'default';
@@ -65,12 +65,17 @@ export function SelectField({
         </label>
       </LabelWrapper>
       <Select name={name} value={value} onValueChange={onValueChange} disabled={disabled}>
-        <SelectTrigger id={`select-${name}`} size={size} variant={variant}>
+        <SelectTrigger
+          id={`select-${name}`}
+          size={size}
+          variant={variant}
+          className="grid grid-cols-[1fr_auto] [&>span]:truncate"
+        >
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
         <SelectContent>
           {options.map(option => (
-            <SelectItem key={option.label} value={option.value}>
+            <SelectItem key={option.label} value={option.value} disabled={option.disabled}>
               <span className="whitespace-nowrap truncate flex items-center gap-2">
                 {option.icon}
                 {option.label}

--- a/packages/playground-ui/src/index.ts
+++ b/packages/playground-ui/src/index.ts
@@ -82,6 +82,7 @@ export * from './lib/rule-engine';
 // DS Components - New
 export * from './ds/components/ListAndDetails';
 export * from './ds/components/Columns';
+export * from './ds/components/CodeDiff';
 export * from './ds/components/ItemList';
 export * from './ds/components/Notice';
 export * from './ds/components/Tree';

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -73,8 +73,8 @@ import DatasetPage from './pages/datasets/dataset';
 import DatasetItemPage from './pages/datasets/dataset/item';
 import DatasetExperiment from './pages/datasets/dataset/experiment';
 import DatasetCompare from './pages/datasets/dataset/compare';
-import DatasetCompareItems from './pages/datasets/dataset/item/compare';
-import DatasetCompareVersions from './pages/datasets/dataset/item/versions';
+import DatasetItemsComparePage from './pages/datasets/dataset/item/compare';
+import DatasetItemVersionsComparePage from './pages/datasets/dataset/item/versions';
 import DatasetCompareDatasetVersions from './pages/datasets/dataset/versions';
 
 const paths: LinkComponentProviderProps['paths'] = {
@@ -229,10 +229,10 @@ const routes = [
             { path: '/datasets', element: <Datasets /> },
             { path: '/datasets/:datasetId', element: <DatasetPage /> },
             { path: '/datasets/:datasetId/items/:itemId', element: <DatasetItemPage /> },
-            { path: '/datasets/:datasetId/items/:itemId/versions', element: <DatasetCompareVersions /> },
+            { path: '/datasets/:datasetId/items/:itemId/versions', element: <DatasetItemVersionsComparePage /> },
             { path: '/datasets/:datasetId/experiments/:experimentId', element: <DatasetExperiment /> },
             { path: '/datasets/:datasetId/compare', element: <DatasetCompare /> },
-            { path: '/datasets/:datasetId/items', element: <DatasetCompareItems /> },
+            { path: '/datasets/:datasetId/items', element: <DatasetItemsComparePage /> },
             { path: '/datasets/:datasetId/versions', element: <DatasetCompareDatasetVersions /> },
           ]
         : []),

--- a/packages/playground/src/pages/datasets/dataset/item/compare/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/compare/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import { useParams, useSearchParams, Link } from 'react-router';
 import {
   Database,
@@ -70,7 +70,7 @@ function DatasetItemsComparePage() {
               </Icon>
               Datasets
             </Crumb>
-            <Crumb isCurrent>
+            <Crumb isCurrent as="span">
               <Icon>
                 <ScaleIcon />
               </Icon>
@@ -100,7 +100,7 @@ function DatasetItemsComparePage() {
           <Crumb as={Link} to={`/datasets/${datasetId}`}>
             {dataset?.name || datasetId?.slice(0, 8)}
           </Crumb>
-          <Crumb isCurrent>
+          <Crumb isCurrent as="span">
             <Icon>
               <ScaleIcon />
             </Icon>
@@ -161,9 +161,8 @@ function DatasetItemsComparePage() {
 
           <Columns className="grid-cols-[1fr_3vw_1fr]">
             {itemIds.map((itemId, idx) => (
-              <>
+              <Fragment key={itemId}>
                 <CompareItemColumn
-                  key={idx}
                   datasetId={datasetId}
                   itemId={itemId}
                   Link={FrameworkLink}
@@ -177,7 +176,7 @@ function DatasetItemsComparePage() {
                   }}
                 />
                 {idx == 0 && <div className={cn('bg-surface5 w-[3px] shrink-0 mx-[1.5vw]')}></div>}
-              </>
+              </Fragment>
             ))}
           </Columns>
           {isDiffView && itemA && itemB && <CodeDiff codeA={itemToText(itemA)} codeB={itemToText(itemB)} />}

--- a/packages/playground/src/pages/datasets/dataset/item/compare/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/compare/index.tsx
@@ -1,5 +1,15 @@
+import { useState } from 'react';
 import { useParams, useSearchParams, Link } from 'react-router';
-import { Database, ScaleIcon, ArrowLeft } from 'lucide-react';
+import {
+  Database,
+  ScaleIcon,
+  ArrowLeft,
+  GitCompareIcon,
+  History,
+  ArrowLeftIcon,
+  DiffIcon,
+  ColumnsIcon,
+} from 'lucide-react';
 import {
   Header,
   MainContentLayout,
@@ -13,19 +23,41 @@ import {
   TextAndIcon,
   useDataset,
   useDatasetItem,
+  useDatasetItems,
+  SelectField,
   DatasetItemHeader,
   DatasetItemContent,
+  CodeDiff,
   useLinkComponent,
   Columns,
   Column,
+  ButtonsGroup,
 } from '@mastra/playground-ui';
+import type { DatasetItem } from '@mastra/client-js';
+import { cn } from '@/lib/utils';
 
-function DatasetCompareItems() {
+function itemToText(item: DatasetItem): string {
+  return JSON.stringify(
+    {
+      input: item.input ?? null,
+      groundTruth: item.groundTruth ?? null,
+      metadata: item.metadata ?? null,
+    },
+    null,
+    2,
+  );
+}
+
+function DatasetItemsComparePage() {
   const { datasetId } = useParams<{ datasetId: string }>();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const itemIds = searchParams.get('items')?.split(',').filter(Boolean) ?? [];
   const { data: dataset } = useDataset(datasetId ?? '');
   const { Link: FrameworkLink } = useLinkComponent();
+  const [isDiffView, setIsDiffView] = useState<boolean>(false);
+
+  const { data: itemA } = useDatasetItem(datasetId ?? '', itemIds[0] ?? '');
+  const { data: itemB } = useDatasetItem(datasetId ?? '', itemIds[1] ?? '');
 
   if (!datasetId || itemIds.length < 2) {
     return (
@@ -86,24 +118,69 @@ function DatasetCompareItems() {
       </Header>
 
       <div className="h-full overflow-hidden px-[3vw] pb-4">
-        <div className="grid gap-6 max-w-[140rem] mx-auto grid-rows-[auto_1fr] h-full">
+        <div
+          className={cn('grid gap-6 max-w-[140rem] mx-auto grid-rows-[auto_1fr] h-full', {
+            'grid-rows-[auto_auto_1fr]': isDiffView,
+          })}
+        >
           <MainHeader>
             <MainHeader.Column>
               <MainHeader.Title>
-                <ScaleIcon />
-                Compare Items
+                <GitCompareIcon />
+                Compare Dataset Items
               </MainHeader.Title>
               <MainHeader.Description>
-                <TextAndIcon>Comparing {itemIds.length} items</TextAndIcon>
+                <TextAndIcon>
+                  Comparing {itemIds.length} items of{' '}
+                  <Link to={`/datasets/${datasetId}`} className="text-info1 hover:underline">
+                    {dataset?.name || datasetId?.slice(0, 8)}
+                  </Link>
+                </TextAndIcon>
               </MainHeader.Description>
+            </MainHeader.Column>
+            <MainHeader.Column>
+              <ButtonsGroup>
+                <Button as={Link} to={`/datasets/${datasetId}`} variant="standard" size="default">
+                  <ArrowLeftIcon />
+                  Back to Dataset
+                </Button>
+                <Button variant="cta" size="default" onClick={() => setIsDiffView(v => !v)}>
+                  {isDiffView ? (
+                    <>
+                      <ColumnsIcon /> Default View
+                    </>
+                  ) : (
+                    <>
+                      <DiffIcon /> Diff View
+                    </>
+                  )}
+                </Button>
+              </ButtonsGroup>
             </MainHeader.Column>
           </MainHeader>
 
-          <Columns className="grid-cols-2">
+          <Columns className="grid-cols-[1fr_3vw_1fr]">
             {itemIds.map((itemId, idx) => (
-              <CompareItemColumn key={itemId} datasetId={datasetId} itemId={itemId} Link={FrameworkLink} idx={idx} />
+              <>
+                <CompareItemColumn
+                  key={idx}
+                  datasetId={datasetId}
+                  itemId={itemId}
+                  Link={FrameworkLink}
+                  idx={idx}
+                  itemIds={itemIds}
+                  showContent={!isDiffView}
+                  onItemChange={(newItemId: string) => {
+                    const newIds = [...itemIds];
+                    newIds[idx] = newItemId;
+                    setSearchParams({ items: newIds.join(',') });
+                  }}
+                />
+                {idx == 0 && <div className={cn('bg-surface5 w-[3px] shrink-0 mx-[1.5vw]')}></div>}
+              </>
             ))}
           </Columns>
+          {isDiffView && itemA && itemB && <CodeDiff codeA={itemToText(itemA)} codeB={itemToText(itemB)} />}
         </div>
       </div>
     </MainContentLayout>
@@ -115,29 +192,65 @@ function CompareItemColumn({
   itemId,
   Link,
   idx,
+  itemIds,
+  onItemChange,
+  showContent = true,
 }: {
   datasetId: string;
   itemId: string;
   Link: ReturnType<typeof useLinkComponent>['Link'];
   idx: number;
+  itemIds: string[];
+  showContent?: boolean;
+  onItemChange: (newItemId: string) => void;
 }) {
   const { data: item, isLoading } = useDatasetItem(datasetId, itemId);
+  const { data: allItems } = useDatasetItems(datasetId);
 
-  if (isLoading) {
-    return <div className="text-neutral4 text-sm">Loading...</div>;
-  }
-
-  if (!item) {
-    return <div className="text-neutral4 text-sm">Item {itemId.slice(0, 8)} not found</div>;
-  }
+  const otherItemIds = new Set(itemIds.filter((_, i) => i !== idx));
+  const options = (allItems ?? []).map((i: { id: string }) => ({
+    value: i.id,
+    label: i.id,
+    disabled: otherItemIds.has(i.id),
+  }));
 
   return (
-    <Column withLeftSeparator={idx > 0}>
-      <DatasetItemHeader item={item} />
-      <DatasetItemContent item={item} Link={Link} />
+    <Column>
+      <Column.Toolbar className="flex gap-4">
+        <SelectField
+          label="Item"
+          name={`compare-item-${idx}`}
+          value={itemId}
+          onValueChange={onItemChange}
+          options={options}
+          placeholder="Select item"
+          variant="experimental"
+          size="default"
+          labelIsHidden={true}
+        />
+        <Button as={Link} to={`/datasets/${datasetId}/items/${itemId}`} variant="standard" size="default">
+          <History />
+          Versions
+        </Button>
+      </Column.Toolbar>
+
+      {showContent && (
+        <Column.Content>
+          {isLoading ? (
+            <div className="text-neutral4 text-sm">Loading...</div>
+          ) : !item ? (
+            <div className="text-neutral4 text-sm">Item {itemId.slice(0, 8)} not found</div>
+          ) : (
+            <>
+              <DatasetItemHeader item={item} />
+              <DatasetItemContent item={item} Link={Link} />
+            </>
+          )}
+        </Column.Content>
+      )}
     </Column>
   );
 }
 
-export { DatasetCompareItems };
-export default DatasetCompareItems;
+export { DatasetItemsComparePage };
+export default DatasetItemsComparePage;

--- a/packages/playground/src/pages/datasets/dataset/item/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/index.tsx
@@ -20,8 +20,6 @@ import {
   DatasetItemContent,
   DatasetItemVersionsPanel,
   EditModeContent,
-  Alert,
-  AlertTitle,
   AlertDialog,
   Button,
   Icon,
@@ -235,7 +233,7 @@ function DatasetItemPage() {
             <Crumb as={Link} to={`/datasets/${datasetId}`}>
               {dataset?.name || datasetId}
             </Crumb>
-            <Crumb isCurrent>
+            <Crumb isCurrent as="span">
               <Icon>
                 <FileCodeIcon />
               </Icon>
@@ -295,9 +293,10 @@ function DatasetItemPage() {
             <Columns className={isEditing ? 'grid-cols-1' : 'grid-cols-[1fr_auto]'}>
               <Column withRightSeparator={!isEditing}>
                 {isDeleted && latestVersion && (
-                  <Alert variant="destructive">
-                    <AlertTitle>This item was deleted at version v{latestVersion.datasetVersion}</AlertTitle>
-                  </Alert>
+                  <Notice variant="destructive">
+                    <AlertTriangleIcon />
+                    <Notice.Message>This item was deleted at version v{latestVersion.datasetVersion}</Notice.Message>
+                  </Notice>
                 )}
 
                 {!isDeleted && isViewingOldVersion && selectedVersion && (
@@ -325,12 +324,10 @@ function DatasetItemPage() {
                     onCancel={handleCancel}
                     isSaving={updateItem.isPending}
                   />
+                ) : displayItem ? (
+                  <DatasetItemContent item={displayItem} Link={FrameworkLink} />
                 ) : (
-                  displayItem && (
-                    <div className="grid content-start">
-                      <DatasetItemContent item={displayItem} Link={FrameworkLink} />
-                    </div>
-                  )
+                  <div className="text-neutral4 text-sm">Item data not available</div>
                 )}
               </Column>
               {!isEditing && (
@@ -375,60 +372,3 @@ function DatasetItemPage() {
 
 export { DatasetItemPage };
 export default DatasetItemPage;
-
-/*
-
-
-            <ListAndDetails isDetailsActive={true}>
-              <ListAndDetails.Column isTopFixed={isViewingOldVersion || isDeleted}>
-                {isDeleted && latestVersion && (
-                  <Alert variant="destructive">
-                    <AlertTitle>
-                      This item was deleted at version v{latestVersion.datasetVersion}
-                    </AlertTitle>
-                  </Alert>
-                )}
-                {!isDeleted && isViewingOldVersion && selectedVersion && (
-                  <Alert variant="warning">
-                    <AlertTitle>Viewing version v{selectedVersion.datasetVersion}</AlertTitle>
-                    <Button variant="standard" size="tiny" className="mt-2 mb-1" onClick={handleReturnToLatest}>
-                      <ArrowRightToLineIcon className="inline-block mr-2" /> Return to the latest version
-                    </Button>
-                  </Alert>
-                )}
-
-                {isEditing ? (
-                  <EditModeContent
-                    inputValue={inputValue}
-                    setInputValue={setInputValue}
-                    groundTruthValue={groundTruthValue}
-                    setGroundTruthValue={setGroundTruthValue}
-                    metadataValue={metadataValue}
-                    setMetadataValue={setMetadataValue}
-                    validationErrors={null}
-                    onSave={handleSave}
-                    onCancel={handleCancel}
-                    isSaving={updateItem.isPending}
-                  />
-                ) : (
-                  displayItem && (
-                    <div className="grid content-start">
-                      <DatasetItemContent item={displayItem} Link={FrameworkLink} />
-                    </div>
-                  )
-                )}
-              </ListAndDetails.Column>
-
-              <ListAndDetails.Separator />
-
-              <ListAndDetails.Column>
-                <DatasetItemVersionsPanel
-                  datasetId={datasetId}
-                  itemId={itemId}
-                  onClose={() => {}}
-                  onVersionSelect={handleVersionSelect}
-                  activeVersion={selectedVersion?.datasetVersion ?? null}
-                />
-              </ListAndDetails.Column>
-            </ListAndDetails>
-            */

--- a/packages/playground/src/pages/datasets/dataset/item/versions/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/versions/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import { useParams, useSearchParams, Link } from 'react-router';
 import {
   Database,
@@ -187,9 +187,8 @@ function DatasetItemVersionsComparePage() {
 
           <Columns className="grid-cols-[1fr_3vw_1fr]">
             {versionNumbers.map((datasetVersion, idx) => (
-              <>
+              <Fragment key={datasetVersion}>
                 <CompareVersionColumn
-                  key={datasetVersion}
                   datasetId={datasetId}
                   itemId={itemId}
                   datasetVersion={datasetVersion}
@@ -206,7 +205,7 @@ function DatasetItemVersionsComparePage() {
                   }}
                 />
                 {idx === 0 && <div className={cn('bg-surface5 w-[3px] shrink-0 mx-[1.5vw]')} />}
-              </>
+              </Fragment>
             ))}
           </Columns>
           {isDiffView && versionA && versionB && (

--- a/packages/playground/src/pages/datasets/dataset/item/versions/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/versions/index.tsx
@@ -1,5 +1,16 @@
+import { useState } from 'react';
 import { useParams, useSearchParams, Link } from 'react-router';
-import { Database, ScaleIcon, ArrowLeft, FileCodeIcon, HistoryIcon } from 'lucide-react';
+import {
+  Database,
+  ScaleIcon,
+  ArrowLeft,
+  FileCodeIcon,
+  HistoryIcon,
+  GitCompareIcon,
+  ArrowLeftIcon,
+  ColumnsIcon,
+  GitCompareArrowsIcon,
+} from 'lucide-react';
 import { format } from 'date-fns';
 import {
   Header,
@@ -14,16 +25,34 @@ import {
   TextAndIcon,
   useDataset,
   useDatasetItemVersion,
+  useDatasetItemVersions,
   DatasetItemContent,
+  CodeDiff,
+  SelectField,
   useLinkComponent,
   Columns,
   Column,
+  ButtonsGroup,
   type DatasetItemVersion,
 } from '@mastra/playground-ui';
+import { cn } from '@/lib/utils';
 
-function DatasetCompareVersions() {
+function versionToText(version: DatasetItemVersion): string {
+  return JSON.stringify(
+    {
+      input: version.input ?? null,
+      groundTruth: version.groundTruth ?? null,
+      metadata: version.metadata ?? null,
+    },
+    null,
+    2,
+  );
+}
+
+function DatasetItemVersionsComparePage() {
   const { datasetId, itemId } = useParams<{ datasetId: string; itemId: string }>();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [isDiffView, setIsDiffView] = useState<boolean>(false);
 
   // ?ids=2,5 — direct dataset version numbers
   const versionNumbers =
@@ -35,6 +64,20 @@ function DatasetCompareVersions() {
 
   const { data: dataset } = useDataset(datasetId ?? '');
   const { Link: FrameworkLink } = useLinkComponent();
+  const { data: allVersions } = useDatasetItemVersions(datasetId ?? '', itemId ?? '');
+
+  const { data: versionA } = useDatasetItemVersion(
+    datasetId ?? '',
+    itemId ?? '',
+    versionNumbers[0] ?? 0,
+    dataset?.version,
+  );
+  const { data: versionB } = useDatasetItemVersion(
+    datasetId ?? '',
+    itemId ?? '',
+    versionNumbers[1] ?? 0,
+    dataset?.version,
+  );
 
   if (!datasetId || !itemId || versionNumbers.length < 2) {
     return (
@@ -47,7 +90,7 @@ function DatasetCompareVersions() {
               </Icon>
               Datasets
             </Crumb>
-            <Crumb isCurrent>
+            <Crumb isCurrent as="span">
               <Icon>
                 <ScaleIcon />
               </Icon>
@@ -83,7 +126,7 @@ function DatasetCompareVersions() {
             </Icon>
             Item
           </Crumb>
-          <Crumb isCurrent>
+          <Crumb isCurrent as="span">
             <Icon>
               <ScaleIcon />
             </Icon>
@@ -101,33 +144,74 @@ function DatasetCompareVersions() {
       </Header>
 
       <div className="h-full overflow-hidden px-[3vw] pb-4">
-        <div className="grid gap-6 max-w-[140rem] mx-auto grid-rows-[auto_1fr] h-full">
+        <div
+          className={cn('grid gap-6 max-w-[140rem] mx-auto grid-rows-[auto_1fr] h-full', {
+            'grid-rows-[auto_auto_1fr]': isDiffView,
+          })}
+        >
           <MainHeader>
             <MainHeader.Column>
               <MainHeader.Title>
-                <ScaleIcon />
-                Compare Versions
+                <GitCompareIcon />
+                Compare Dataset Item Versions
               </MainHeader.Title>
               <MainHeader.Description>
                 <TextAndIcon>
-                  <HistoryIcon /> Comparing {versionNumbers.length} versions of item {itemId?.slice(0, 8)}
+                  Comparing {versionNumbers.length} versions of{' '}
+                  <Link to={`/datasets/${datasetId}/items/${itemId}`} className="text-info1 hover:underline">
+                    {itemId}
+                  </Link>
                 </TextAndIcon>
               </MainHeader.Description>
             </MainHeader.Column>
+            <MainHeader.Column>
+              <ButtonsGroup>
+                <Button as={Link} to={`/datasets/${datasetId}/items/${itemId}`} variant="standard" size="default">
+                  <ArrowLeftIcon />
+                  Back to Item
+                </Button>
+                <Button variant="cta" size="default" onClick={() => setIsDiffView(v => !v)}>
+                  {isDiffView ? (
+                    <>
+                      <ColumnsIcon /> Default View
+                    </>
+                  ) : (
+                    <>
+                      <GitCompareArrowsIcon /> Diff View
+                    </>
+                  )}
+                </Button>
+              </ButtonsGroup>
+            </MainHeader.Column>
           </MainHeader>
 
-          <Columns className="grid-cols-2">
+          <Columns className="grid-cols-[1fr_3vw_1fr]">
             {versionNumbers.map((datasetVersion, idx) => (
-              <CompareVersionColumn
-                key={datasetVersion}
-                datasetId={datasetId}
-                itemId={itemId}
-                datasetVersion={datasetVersion}
-                Link={FrameworkLink}
-                idx={idx}
-              />
+              <>
+                <CompareVersionColumn
+                  key={datasetVersion}
+                  datasetId={datasetId}
+                  itemId={itemId}
+                  datasetVersion={datasetVersion}
+                  latestVersion={dataset?.version}
+                  allVersions={allVersions ?? []}
+                  versionNumbers={versionNumbers}
+                  Link={FrameworkLink}
+                  idx={idx}
+                  showContent={!isDiffView}
+                  onVersionChange={(newVersion: number) => {
+                    const newVersions = [...versionNumbers];
+                    newVersions[idx] = newVersion;
+                    setSearchParams({ ids: newVersions.join(',') });
+                  }}
+                />
+                {idx === 0 && <div className={cn('bg-surface5 w-[3px] shrink-0 mx-[1.5vw]')} />}
+              </>
             ))}
           </Columns>
+          {isDiffView && versionA && versionB && (
+            <CodeDiff codeA={versionToText(versionA)} codeB={versionToText(versionB)} />
+          )}
         </div>
       </div>
     </MainContentLayout>
@@ -138,58 +222,84 @@ function CompareVersionColumn({
   datasetId,
   itemId,
   datasetVersion,
+  latestVersion,
+  allVersions,
+  versionNumbers,
   Link,
   idx,
+  showContent = true,
+  onVersionChange,
 }: {
   datasetId: string;
   itemId: string;
   datasetVersion: number;
+  latestVersion?: number;
+  allVersions: DatasetItemVersion[];
+  versionNumbers: number[];
   Link: ReturnType<typeof useLinkComponent>['Link'];
   idx: number;
+  showContent?: boolean;
+  onVersionChange: (newVersion: number) => void;
 }) {
-  const { data: version, isLoading } = useDatasetItemVersion(datasetId, itemId, datasetVersion);
+  const { data: version, isLoading } = useDatasetItemVersion(datasetId, itemId, datasetVersion, latestVersion);
 
-  if (isLoading) {
-    return <div className="text-neutral4 text-sm">Loading...</div>;
-  }
+  const otherVersionNumbers = new Set(versionNumbers.filter((_, i) => i !== idx));
+  const options = allVersions.map(v => {
+    const date = typeof v.updatedAt === 'string' ? new Date(v.updatedAt) : v.updatedAt;
+    return {
+      value: String(v.datasetVersion),
+      label: `v${v.datasetVersion} — ${format(date, 'MMM d, yyyy h:mm a')}${v.isLatest ? ' (latest)' : ''}`,
+      disabled: otherVersionNumbers.has(v.datasetVersion),
+    };
+  });
 
-  if (!version) {
-    return <div className="text-neutral4 text-sm">Version {datasetVersion} not found</div>;
-  }
-
-  const displayItem = {
-    id: version.id,
-    datasetId,
-    datasetVersion: version.datasetVersion,
-    input: version.input,
-    groundTruth: version.groundTruth,
-    metadata: version.metadata,
-    createdAt: version.createdAt,
-    updatedAt: version.updatedAt,
-  };
+  const displayItem = version
+    ? {
+        id: version.id,
+        datasetId,
+        datasetVersion: version.datasetVersion,
+        input: version.input,
+        groundTruth: version.groundTruth,
+        metadata: version.metadata,
+        createdAt: version.createdAt,
+        updatedAt: version.updatedAt,
+      }
+    : null;
 
   return (
-    <Column withLeftSeparator={idx > 0}>
-      <VersionHeader version={version} />
-      <DatasetItemContent item={displayItem} Link={Link} />
+    <Column>
+      <Column.Toolbar className="flex gap-4">
+        <HistoryIcon className="w-6 h-6 opacity-50" />
+        <SelectField
+          label="Version"
+          name={`compare-version-${idx}`}
+          value={String(datasetVersion)}
+          onValueChange={(val: string) => onVersionChange(Number(val))}
+          options={options}
+          placeholder="Select version"
+          variant="experimental"
+          size="default"
+          labelIsHidden={true}
+          className="w-full"
+        />
+      </Column.Toolbar>
+
+      {showContent && (
+        <Column.Content>
+          {isLoading ? (
+            <div className="text-neutral4 text-sm">Loading...</div>
+          ) : !version || !displayItem ? (
+            <div className="text-neutral4 text-sm">Version {datasetVersion} not found</div>
+          ) : (
+            <>
+              <DatasetItemContent item={displayItem} Link={Link} />
+            </>
+          )}
+        </Column.Content>
+      )}
     </Column>
   );
 }
 
-function VersionHeader({ version }: { version: DatasetItemVersion }) {
-  const versionDate = typeof version.createdAt === 'string' ? new Date(version.createdAt) : version.createdAt;
-
-  return (
-    <div className="flex items-center gap-3 py-3 px-4 border-b border-border1">
-      <div className="flex items-center gap-2 text-ui-md text-neutral1">
-        <HistoryIcon className="w-4 h-4 text-neutral4" />v{version.datasetVersion}
-      </div>
-      <span className="text-ui-sm text-neutral4">{format(versionDate, "MMM d, yyyy 'at' h:mm a")}</span>
-      {version.isLatest && <span className="text-ui-xs bg-neutral6 text-neutral2 px-2 py-0.5 rounded">latest</span>}
-      {version.isDeleted && <span className="text-ui-xs bg-red-100 text-red-600 px-2 py-0.5 rounded">deleted</span>}
-    </div>
-  );
-}
-
-export { DatasetCompareVersions };
-export default DatasetCompareVersions;
+export { DatasetItemVersionsComparePage };
+export default DatasetItemVersionsComparePage;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,7 +235,7 @@ importers:
     dependencies:
       firebase-admin:
         specifier: ^13.4.0
-        version: 13.5.0(encoding@0.1.13)
+        version: 13.5.0
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -3490,6 +3490,9 @@ importers:
       '@codemirror/language-data':
         specifier: ^6.5.2
         version: 6.5.2
+      '@codemirror/merge':
+        specifier: ^6.10.2
+        version: 6.12.0
       '@codemirror/state':
         specifier: ^6.5.4
         version: 6.5.4
@@ -7902,6 +7905,9 @@ packages:
 
   '@codemirror/lint@6.9.0':
     resolution: {integrity: sha512-wZxW+9XDytH3SKvS8cQzMyQCaaazH8XL1EMHleHe00wVzsv7NBQKVW2yzEHrRhmM7ZOhVdItPbvlRBvMp9ej7A==}
+
+  '@codemirror/merge@6.12.0':
+    resolution: {integrity: sha512-o+36bbapcEHf4Ux75pZ4CKjMBUd14parA0uozvWVlacaT+uxaA3DDefEvWYjngsKU+qsrDe/HOOfsw0Q72pLjA==}
 
   '@codemirror/search@6.5.11':
     resolution: {integrity: sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==}
@@ -25878,6 +25884,14 @@ snapshots:
       '@codemirror/view': 6.39.14
       crelt: 1.0.6
 
+  '@codemirror/merge@6.12.0':
+    dependencies:
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.14
+      '@lezer/highlight': 1.2.3
+      style-mod: 4.1.3
+
   '@codemirror/search@6.5.11':
     dependencies:
       '@codemirror/state': 6.5.4
@@ -27867,7 +27881,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google-cloud/firestore@7.11.6(encoding@0.1.13)':
+  '@google-cloud/firestore@7.11.6':
     dependencies:
       '@opentelemetry/api': 1.9.0
       fast-deep-equal: 3.1.3
@@ -36831,7 +36845,7 @@ snapshots:
       pkg-types: 1.3.1
       yaml: 2.8.1
 
-  firebase-admin@13.5.0(encoding@0.1.13):
+  firebase-admin@13.5.0:
     dependencies:
       '@fastify/busboy': 3.2.0
       '@firebase/database-compat': 2.1.0
@@ -36845,7 +36859,7 @@ snapshots:
       node-forge: 1.3.3
       uuid: 11.1.0
     optionalDependencies:
-      '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
+      '@google-cloud/firestore': 7.11.6
       '@google-cloud/storage': 7.19.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

- add Diff view for Items Compare and Item Versions Compare pages
- rename page components
- add Select element on Compare pages to change compared Items/Versions
- prevent comparing deleted Item version

https://github.com/user-attachments/assets/a18b1ec1-061f-4d44-931a-1ac57246d85a


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New code-diff view and UI to compare dataset items and versions side-by-side (with Storybook examples).
  * Toggleable Diff/View mode in item and version compare pages; inline controls to swap compared items/versions.

* **Improvements**
  * Clearer badges and deleted-item notices; layout and toolbar refinements for comparison panels.
  * Select fields now support per-option disabling; improved breadcrumb behavior and streamlined item content display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->