### PR TITLE
Add Header with Combobox to Dataset page

### DIFF
--- a/.changeset/fancy-wasps-scream.md
+++ b/.changeset/fancy-wasps-scream.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+'create-mastra': patch
+---
+
+Added Header with Combobox to Dataset page

--- a/packages/playground-ui/src/domains/datasets/components/dataset-combobox.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/dataset-combobox.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect } from 'react';
+import { toast } from '@/lib/toast';
+import { Combobox } from '@/ds/components/Combobox';
+import { useDatasets } from '../hooks/use-datasets';
+import { useLinkComponent } from '@/lib/framework';
+
+export interface DatasetComboboxProps {
+  value?: string;
+  onValueChange?: (value: string) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  className?: string;
+  disabled?: boolean;
+  variant?: 'default' | 'light' | 'outline' | 'ghost';
+}
+
+export function DatasetCombobox({
+  value,
+  onValueChange,
+  placeholder = 'Select a dataset...',
+  searchPlaceholder = 'Search datasets...',
+  emptyText = 'No datasets found.',
+  className,
+  disabled = false,
+  variant = 'default',
+}: DatasetComboboxProps) {
+  const { data, isLoading, isError, error } = useDatasets();
+  const { navigate, paths } = useLinkComponent();
+
+  useEffect(() => {
+    if (isError) {
+      const errorMessage = error instanceof Error ? error.message : 'Failed to load datasets';
+      toast.error(`Error loading datasets: ${errorMessage}`);
+    }
+  }, [isError, error]);
+
+  const datasets = data?.datasets ?? [];
+  const datasetOptions = datasets.map(d => ({
+    label: d.name,
+    value: d.id,
+  }));
+
+  const handleValueChange = (newDatasetId: string) => {
+    if (onValueChange) {
+      onValueChange(newDatasetId);
+    } else if (newDatasetId && newDatasetId !== value) {
+      navigate(paths.datasetLink(newDatasetId));
+    }
+  };
+
+  return (
+    <Combobox
+      options={datasetOptions}
+      value={value}
+      onValueChange={handleValueChange}
+      placeholder={isLoading ? 'Loading datasets...' : placeholder}
+      searchPlaceholder={searchPlaceholder}
+      emptyText={emptyText}
+      className={className}
+      disabled={disabled || isLoading || isError}
+      variant={variant}
+    />
+  );
+}

--- a/packages/playground-ui/src/domains/datasets/components/dataset-detail/item-detail-toolbar.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/dataset-detail/item-detail-toolbar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '@/ds/components/Button';
-import { Pencil, Trash2, Copy, ChevronDownIcon, XIcon, History } from 'lucide-react';
+import { Pencil, Trash2, Copy, ChevronDownIcon, XIcon, History, EllipsisVerticalIcon } from 'lucide-react';
 import { DropdownMenu } from '@/ds/components/DropdownMenu';
 import { useLinkComponent } from '@/lib/framework';
 import { Column } from '@/ds/components/Columns';
@@ -43,33 +43,26 @@ export function ItemDetailToolbar({
           <>
             <Button variant="standard" size="default" href={`/datasets/${datasetId}/items/${itemId}`} as={Link}>
               <History />
-              History
+              Versions
             </Button>
 
-            <ButtonsGroup spacing="close">
-              <Button variant="standard" size="default" onClick={onEdit}>
-                <Pencil />
-                Edit
-              </Button>
-
-              <DropdownMenu>
-                <DropdownMenu.Trigger asChild>
-                  <Button variant="standard" size="default" aria-label="Actions menu">
-                    <ChevronDownIcon />
-                  </Button>
-                </DropdownMenu.Trigger>
-                <DropdownMenu.Content align="end" className="w-48">
-                  <DropdownMenu.Item onSelect={onDelete} className="text-red-500 focus:text-red-400">
-                    <Trash2 />
-                    <span>Delete Item</span>
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item disabled>
-                    <Copy />
-                    <span>Duplicate Item (Coming Soon)</span>
-                  </DropdownMenu.Item>
-                </DropdownMenu.Content>
-              </DropdownMenu>
-            </ButtonsGroup>
+            <DropdownMenu>
+              <DropdownMenu.Trigger asChild>
+                <Button variant="standard" size="default" aria-label="Actions menu">
+                  <EllipsisVerticalIcon />
+                </Button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content align="end" className="w-48">
+                <DropdownMenu.Item onSelect={onEdit}>
+                  <Pencil />
+                  Edit
+                </DropdownMenu.Item>
+                <DropdownMenu.Item onSelect={onDelete} className="text-red-500 focus:text-red-400">
+                  <Trash2 />
+                  Delete Item
+                </DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu>
           </>
         )}
 

--- a/packages/playground-ui/src/domains/datasets/index.ts
+++ b/packages/playground-ui/src/domains/datasets/index.ts
@@ -32,6 +32,8 @@ export { DuplicateDatasetDialog } from './components/duplicate-dataset-dialog';
 export { EditDatasetDialog } from './components/edit-dataset-dialog';
 export { DeleteDatasetDialog } from './components/delete-dataset-dialog';
 export { EmptyDatasetsTable } from './components/empty-datasets-table';
+export { DatasetCombobox } from './components/dataset-combobox';
+export type { DatasetComboboxProps } from './components/dataset-combobox';
 
 // Dataset detail components
 export { DatasetPageContent } from './components/dataset-detail/dataset-page-content';

--- a/packages/playground/src/pages/datasets/dataset/experiment/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/experiment/index.tsx
@@ -1,5 +1,5 @@
 import { useParams, Link } from 'react-router';
-import { Database, PlayCircle } from 'lucide-react';
+import { Database } from 'lucide-react';
 import {
   Header,
   MainContentLayout,
@@ -62,12 +62,9 @@ function DatasetExperimentPage() {
             Datasets
           </Crumb>
           <Crumb as={Link} to={`/datasets/${datasetId}`}>
-            {dataset?.name || datasetId}
+            {dataset?.name}
           </Crumb>
-          <Crumb isCurrent>
-            <Icon>
-              <PlayCircle />
-            </Icon>
+          <Crumb isCurrent as="span">
             Experiment
           </Crumb>
         </Breadcrumb>

--- a/packages/playground/src/pages/datasets/dataset/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/index.tsx
@@ -10,9 +10,15 @@ import {
   DeleteDatasetDialog,
   useDataset,
   Button,
+  Header,
+  Breadcrumb,
+  Crumb,
+  Icon,
+  DatasetCombobox,
 } from '@mastra/playground-ui';
 import type { DatasetVersion } from '@mastra/playground-ui';
-import { Play } from 'lucide-react';
+import { Link } from 'react-router';
+import { Database, Play } from 'lucide-react';
 
 function DatasetPage() {
   const { datasetId } = useParams<{ datasetId: string }>();
@@ -55,7 +61,20 @@ function DatasetPage() {
   };
 
   return (
-    <MainContentLayout className="grid-rows-1">
+    <MainContentLayout>
+      <Header>
+        <Breadcrumb>
+          <Crumb as={Link} to="/datasets">
+            <Icon>
+              <Database />
+            </Icon>
+            Datasets
+          </Crumb>
+          <Crumb as="span" to="" isCurrent>
+            <DatasetCombobox value={datasetId} variant="ghost" />
+          </Crumb>
+        </Breadcrumb>
+      </Header>
       <MainContentContent className="content-stretch">
         <DatasetPageContent
           datasetId={datasetId}

--- a/packages/playground/src/pages/datasets/dataset/item/compare/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/compare/index.tsx
@@ -1,15 +1,6 @@
 import { Fragment, useState } from 'react';
 import { useParams, useSearchParams, Link } from 'react-router';
-import {
-  Database,
-  ScaleIcon,
-  ArrowLeft,
-  GitCompareIcon,
-  History,
-  ArrowLeftIcon,
-  DiffIcon,
-  ColumnsIcon,
-} from 'lucide-react';
+import { Database, ArrowLeft, GitCompareIcon, History, ArrowLeftIcon, DiffIcon, ColumnsIcon } from 'lucide-react';
 import {
   Header,
   MainContentLayout,
@@ -71,9 +62,6 @@ function DatasetItemsComparePage() {
               Datasets
             </Crumb>
             <Crumb isCurrent as="span">
-              <Icon>
-                <ScaleIcon />
-              </Icon>
               Compare Items
             </Crumb>
           </Breadcrumb>
@@ -101,9 +89,6 @@ function DatasetItemsComparePage() {
             {dataset?.name || datasetId?.slice(0, 8)}
           </Crumb>
           <Crumb isCurrent as="span">
-            <Icon>
-              <ScaleIcon />
-            </Icon>
             Compare Items
           </Crumb>
         </Breadcrumb>

--- a/packages/playground/src/pages/datasets/dataset/item/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/index.tsx
@@ -231,12 +231,9 @@ function DatasetItemPage() {
               Datasets
             </Crumb>
             <Crumb as={Link} to={`/datasets/${datasetId}`}>
-              {dataset?.name || datasetId}
+              {dataset?.name}
             </Crumb>
             <Crumb isCurrent as="span">
-              <Icon>
-                <FileCodeIcon />
-              </Icon>
               Item
             </Crumb>
           </Breadcrumb>

--- a/packages/playground/src/pages/datasets/dataset/item/versions/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/versions/index.tsx
@@ -2,9 +2,7 @@ import { Fragment, useState } from 'react';
 import { useParams, useSearchParams, Link } from 'react-router';
 import {
   Database,
-  ScaleIcon,
   ArrowLeft,
-  FileCodeIcon,
   HistoryIcon,
   GitCompareIcon,
   ArrowLeftIcon,
@@ -91,9 +89,6 @@ function DatasetItemVersionsComparePage() {
               Datasets
             </Crumb>
             <Crumb isCurrent as="span">
-              <Icon>
-                <ScaleIcon />
-              </Icon>
               Compare Versions
             </Crumb>
           </Breadcrumb>
@@ -118,18 +113,12 @@ function DatasetItemVersionsComparePage() {
             Datasets
           </Crumb>
           <Crumb as={Link} to={`/datasets/${datasetId}`}>
-            {dataset?.name || datasetId?.slice(0, 8)}
+            {dataset?.name}
           </Crumb>
           <Crumb as={Link} to={`/datasets/${datasetId}/items/${itemId}`}>
-            <Icon>
-              <FileCodeIcon />
-            </Icon>
             Item
           </Crumb>
           <Crumb isCurrent as="span">
-            <Icon>
-              <ScaleIcon />
-            </Icon>
             Compare Versions
           </Crumb>
         </Breadcrumb>

--- a/packages/playground/src/pages/datasets/dataset/versions/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/versions/index.tsx
@@ -62,10 +62,7 @@ function DatasetCompareVersionsPage() {
               </Icon>
               Datasets
             </Crumb>
-            <Crumb isCurrent>
-              <Icon>
-                <ScaleIcon />
-              </Icon>
+            <Crumb isCurrent as="span">
               Compare Versions
             </Crumb>
           </Breadcrumb>
@@ -104,7 +101,7 @@ function DatasetCompareVersionsPage() {
           <Crumb as={Link} to={`/datasets/${datasetId}`}>
             {dataset?.name || datasetId?.slice(0, 8)}
           </Crumb>
-          <Crumb isCurrent>
+          <Crumb isCurrent as="span">
             <Icon>
               <ScaleIcon />
             </Icon>


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

- add missing Header with Combobox to Dataset page|
- update ItemDetailToolbar
- create DatasetsCombobox
- clean up breadcrumbs on Datasets inner pages (etc, remove unnecessary icons)

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dataset selection dropdown component for easier dataset navigation
  * Introduced breadcrumb header navigation on dataset pages

* **UI/UX Improvements**
  * Consolidated dataset item actions (edit/delete) into a single dropdown menu for a cleaner interface
  * Streamlined breadcrumb navigation with simplified labeling and refined icon usage
  * Enhanced navigation clarity with updated action labels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->