### PR TITLE
feat: mcp tool tracing

### DIFF
--- a/.changeset/mcp-tool-icon.md
+++ b/.changeset/mcp-tool-icon.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Added MCP-specific icon and color in trace timeline for `mcp_tool_call` spans.

--- a/.changeset/mcp-tool-metadata.md
+++ b/.changeset/mcp-tool-metadata.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': minor
+---
+
+MCP client now attaches `mcpMetadata` (server name and version) to every tool it creates, enabling automatic `MCP_TOOL_CALL` span tracing without user code changes.

--- a/.changeset/mcp-tool-tracing.md
+++ b/.changeset/mcp-tool-tracing.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': minor
+'@mastra/mcp': minor
+'@mastra/playground-ui': patch
+---
+
+MCP tool calls now use `MCP_TOOL_CALL` span type instead of `TOOL_CALL` in traces. When an agent calls a tool from an MCP server, the trace span shows `mcp_tool_call` with MCP server name and version attributes. The playground displays an MCP-specific icon for these spans. No user code changes needed — metadata is automatically injected by the MCP client.

--- a/.changeset/mcp-tool-tracing.md
+++ b/.changeset/mcp-tool-tracing.md
@@ -1,7 +1,5 @@
 ---
 '@mastra/core': minor
-'@mastra/mcp': minor
-'@mastra/playground-ui': patch
 ---
 
-MCP tool calls now use `MCP_TOOL_CALL` span type instead of `TOOL_CALL` in traces. When an agent calls a tool from an MCP server, the trace span shows `mcp_tool_call` with MCP server name and version attributes. The playground displays an MCP-specific icon for these spans. No user code changes needed — metadata is automatically injected by the MCP client.
+MCP tool calls now use `MCP_TOOL_CALL` span type instead of `TOOL_CALL` in traces. `CoreToolBuilder` detects `mcpMetadata` on tools and creates spans with MCP server name, version, and tool description attributes.

--- a/docs/src/content/en/reference/observability/tracing/interfaces.mdx
+++ b/docs/src/content/en/reference/observability/tracing/interfaces.mdx
@@ -381,6 +381,9 @@ interface MCPToolCallAttributes {
   /** MCP server version */
   serverVersion?: string
 
+  /** Tool description */
+  toolDescription?: string
+
   /** Whether tool execution was successful */
   success?: boolean
 }

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -235,6 +235,8 @@ export interface MCPToolCallAttributes extends AIBaseAttributes {
   mcpServer: string;
   /** MCP server version */
   serverVersion?: string;
+  /** Tool description */
+  toolDescription?: string;
   /** Whether tool execution was successful */
   success?: boolean;
 }

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -55,6 +55,7 @@ describe('MCP Tool Tracing', () => {
         attributes: {
           mcpServer: 'filesystem-server',
           serverVersion: '1.2.0',
+          toolDescription: 'List files in a directory',
         },
       }),
     );
@@ -155,6 +156,7 @@ describe('MCP Tool Tracing', () => {
     expect(spanArgs.attributes).toEqual({
       mcpServer: 'my-mcp-server',
       serverVersion: undefined,
+      toolDescription: 'Read a resource',
     });
     expect(spanArgs.name).toBe("mcp_tool: 'mcp_read-resource' on 'my-mcp-server'");
   });

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { SpanType } from '../../observability';
+import type { AnySpan } from '../../observability';
+import { RequestContext } from '../../request-context';
+import { createTool } from '../../tools';
+import { CoreToolBuilder } from './builder';
+
+describe('MCP Tool Tracing', () => {
+  it('should use MCP_TOOL_CALL span type when tool has mcpMetadata', async () => {
+    const testTool = createTool({
+      id: 'mcp-server_list-files',
+      description: 'List files in a directory',
+      inputSchema: z.object({ path: z.string() }),
+      mcpMetadata: {
+        serverName: 'filesystem-server',
+        serverVersion: '1.2.0',
+      },
+      execute: async inputData => ({ files: [inputData.path] }),
+    });
+
+    const mockToolSpan = {
+      end: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const mockAgentSpan = {
+      createChildSpan: vi.fn().mockReturnValue(mockToolSpan),
+    } as unknown as AnySpan;
+
+    const builder = new CoreToolBuilder({
+      originalTool: testTool,
+      options: {
+        name: 'mcp-server_list-files',
+        logger: {
+          debug: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          trackException: vi.fn(),
+        } as any,
+        description: 'List files in a directory',
+        requestContext: new RequestContext(),
+        tracingContext: { currentSpan: mockAgentSpan },
+      },
+    });
+
+    const builtTool = builder.build();
+    await builtTool.execute!({ path: '/tmp' }, { toolCallId: 'test-call-id', messages: [] });
+
+    expect(mockAgentSpan.createChildSpan).toHaveBeenCalledWith({
+      type: SpanType.MCP_TOOL_CALL,
+      name: "mcp_tool: 'mcp-server_list-files' on 'filesystem-server'",
+      input: { path: '/tmp' },
+      entityType: 'tool',
+      entityId: 'mcp-server_list-files',
+      entityName: 'mcp-server_list-files',
+      attributes: {
+        mcpServer: 'filesystem-server',
+        serverVersion: '1.2.0',
+      },
+      tracingPolicy: undefined,
+    });
+
+    expect(mockToolSpan.end).toHaveBeenCalledWith({ attributes: { success: true }, output: { files: ['/tmp'] } });
+  });
+
+  it('should use TOOL_CALL span type for tools without mcpMetadata', async () => {
+    const testTool = createTool({
+      id: 'regular-tool',
+      description: 'A regular tool',
+      inputSchema: z.object({ value: z.string() }),
+      execute: async inputData => ({ result: inputData.value }),
+    });
+
+    const mockToolSpan = {
+      end: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const mockAgentSpan = {
+      createChildSpan: vi.fn().mockReturnValue(mockToolSpan),
+    } as unknown as AnySpan;
+
+    const builder = new CoreToolBuilder({
+      originalTool: testTool,
+      options: {
+        name: 'regular-tool',
+        logger: {
+          debug: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          trackException: vi.fn(),
+        } as any,
+        description: 'A regular tool',
+        requestContext: new RequestContext(),
+        tracingContext: { currentSpan: mockAgentSpan },
+      },
+    });
+
+    const builtTool = builder.build();
+    await builtTool.execute!({ value: 'test' }, { toolCallId: 'test-call-id', messages: [] });
+
+    expect(mockAgentSpan.createChildSpan).toHaveBeenCalledWith({
+      type: SpanType.TOOL_CALL,
+      name: "tool: 'regular-tool'",
+      input: { value: 'test' },
+      entityType: 'tool',
+      entityId: 'regular-tool',
+      entityName: 'regular-tool',
+      attributes: {
+        toolDescription: 'A regular tool',
+        toolType: 'tool',
+      },
+      tracingPolicy: undefined,
+    });
+  });
+
+  it('should handle mcpMetadata with missing serverVersion', async () => {
+    const testTool = createTool({
+      id: 'mcp_read-resource',
+      description: 'Read a resource',
+      inputSchema: z.object({ uri: z.string() }),
+      mcpMetadata: {
+        serverName: 'my-mcp-server',
+      },
+      execute: async inputData => ({ data: inputData.uri }),
+    });
+
+    const mockToolSpan = {
+      end: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const mockAgentSpan = {
+      createChildSpan: vi.fn().mockReturnValue(mockToolSpan),
+    } as unknown as AnySpan;
+
+    const builder = new CoreToolBuilder({
+      originalTool: testTool,
+      options: {
+        name: 'mcp_read-resource',
+        logger: {
+          debug: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          trackException: vi.fn(),
+        } as any,
+        description: 'Read a resource',
+        requestContext: new RequestContext(),
+        tracingContext: { currentSpan: mockAgentSpan },
+      },
+    });
+
+    const builtTool = builder.build();
+    await builtTool.execute!({ uri: 'file:///test' }, { toolCallId: 'test-call-id', messages: [] });
+
+    const spanArgs = (mockAgentSpan.createChildSpan as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(spanArgs.type).toBe(SpanType.MCP_TOOL_CALL);
+    expect(spanArgs.attributes).toEqual({
+      mcpServer: 'my-mcp-server',
+      serverVersion: undefined,
+    });
+    expect(spanArgs.name).toBe("mcp_tool: 'mcp_read-resource' on 'my-mcp-server'");
+  });
+
+  it('should not use MCP_TOOL_CALL for Vercel tools even with mcpMetadata-like properties', async () => {
+    const vercelTool = {
+      description: 'A vercel tool',
+      parameters: z.object({ input: z.string() }),
+      mcpMetadata: { serverName: 'fake' },
+      execute: async (args: any) => ({ output: args.input }),
+    };
+
+    const mockToolSpan = {
+      end: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const mockAgentSpan = {
+      createChildSpan: vi.fn().mockReturnValue(mockToolSpan),
+    } as unknown as AnySpan;
+
+    const builder = new CoreToolBuilder({
+      originalTool: vercelTool as any,
+      options: {
+        name: 'vercel-tool',
+        logger: {
+          debug: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          trackException: vi.fn(),
+        } as any,
+        description: 'A vercel tool',
+        requestContext: new RequestContext(),
+        tracingContext: { currentSpan: mockAgentSpan },
+      },
+    });
+
+    const builtTool = builder.build();
+    await builtTool.execute!({ input: 'test' }, { toolCallId: 'test-call-id', messages: [] });
+
+    expect(mockAgentSpan.createChildSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: SpanType.TOOL_CALL,
+        name: "tool: 'vercel-tool'",
+      }),
+    );
+  });
+});

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -59,6 +59,7 @@ describe('MCP Tool Tracing', () => {
         serverVersion: '1.2.0',
       },
       tracingPolicy: undefined,
+      requestContext: expect.any(RequestContext),
     });
 
     expect(mockToolSpan.end).toHaveBeenCalledWith({ attributes: { success: true }, output: { files: ['/tmp'] } });
@@ -112,6 +113,7 @@ describe('MCP Tool Tracing', () => {
         toolType: 'tool',
       },
       tracingPolicy: undefined,
+      requestContext: expect.any(RequestContext),
     });
   });
 

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -47,20 +47,17 @@ describe('MCP Tool Tracing', () => {
     const builtTool = builder.build();
     await builtTool.execute!({ path: '/tmp' }, { toolCallId: 'test-call-id', messages: [] });
 
-    expect(mockAgentSpan.createChildSpan).toHaveBeenCalledWith({
-      type: SpanType.MCP_TOOL_CALL,
-      name: "mcp_tool: 'mcp-server_list-files' on 'filesystem-server'",
-      input: { path: '/tmp' },
-      entityType: 'tool',
-      entityId: 'mcp-server_list-files',
-      entityName: 'mcp-server_list-files',
-      attributes: {
-        mcpServer: 'filesystem-server',
-        serverVersion: '1.2.0',
-      },
-      tracingPolicy: undefined,
-      requestContext: expect.any(RequestContext),
-    });
+    expect(mockAgentSpan.createChildSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: SpanType.MCP_TOOL_CALL,
+        name: "mcp_tool: 'mcp-server_list-files' on 'filesystem-server'",
+        input: { path: '/tmp' },
+        attributes: {
+          mcpServer: 'filesystem-server',
+          serverVersion: '1.2.0',
+        },
+      }),
+    );
 
     expect(mockToolSpan.end).toHaveBeenCalledWith({ attributes: { success: true }, output: { files: ['/tmp'] } });
   });
@@ -101,20 +98,17 @@ describe('MCP Tool Tracing', () => {
     const builtTool = builder.build();
     await builtTool.execute!({ value: 'test' }, { toolCallId: 'test-call-id', messages: [] });
 
-    expect(mockAgentSpan.createChildSpan).toHaveBeenCalledWith({
-      type: SpanType.TOOL_CALL,
-      name: "tool: 'regular-tool'",
-      input: { value: 'test' },
-      entityType: 'tool',
-      entityId: 'regular-tool',
-      entityName: 'regular-tool',
-      attributes: {
-        toolDescription: 'A regular tool',
-        toolType: 'tool',
-      },
-      tracingPolicy: undefined,
-      requestContext: expect.any(RequestContext),
-    });
+    expect(mockAgentSpan.createChildSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: SpanType.TOOL_CALL,
+        name: "tool: 'regular-tool'",
+        input: { value: 'test' },
+        attributes: {
+          toolDescription: 'A regular tool',
+          toolType: 'tool',
+        },
+      }),
+    );
   });
 
   it('should handle mcpMetadata with missing serverVersion', async () => {
@@ -207,5 +201,9 @@ describe('MCP Tool Tracing', () => {
         name: "tool: 'vercel-tool'",
       }),
     );
+
+    const spanArgs = (mockAgentSpan.createChildSpan as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(spanArgs.attributes).not.toHaveProperty('mcpServer');
+    expect(spanArgs.attributes).not.toHaveProperty('serverVersion');
   });
 });

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -30,7 +30,14 @@ import { isZodObject } from '../../utils/zod-utils';
 
 import type { SuspendOptions } from '../../workflows';
 import { ToolStream } from '../stream';
-import type { CoreTool, McpMetadata, MastraToolInvocationOptions, ToolAction, VercelTool, VercelToolV5 } from '../types';
+import type {
+  CoreTool,
+  McpMetadata,
+  MastraToolInvocationOptions,
+  ToolAction,
+  VercelTool,
+  VercelToolV5,
+} from '../types';
 import { validateToolInput, validateToolOutput, validateToolSuspendData } from '../validation';
 
 /**
@@ -331,17 +338,13 @@ export class CoreToolBuilder extends MastraBase {
 
       // Extract MCP metadata once with proper typing to avoid repeated unsafe casts
       const mcpMeta =
-        !isVercelTool(tool) && 'mcpMetadata' in tool
-          ? (tool as { mcpMetadata?: McpMetadata }).mcpMetadata
-          : undefined;
+        !isVercelTool(tool) && 'mcpMetadata' in tool ? (tool as { mcpMetadata?: McpMetadata }).mcpMetadata : undefined;
 
       // Create tool span - either as child of existing span or as new root span (e.g. MCP tools)
       const toolRequestContext = execOptions.requestContext ?? options.requestContext;
       const toolSpan = getOrCreateSpan({
         type: mcpMeta ? SpanType.MCP_TOOL_CALL : SpanType.TOOL_CALL,
-        name: mcpMeta
-          ? `mcp_tool: '${options.name}' on '${mcpMeta.serverName}'`
-          : `tool: '${options.name}'`,
+        name: mcpMeta ? `mcp_tool: '${options.name}' on '${mcpMeta.serverName}'` : `tool: '${options.name}'`,
         input: args,
         entityType: EntityType.TOOL,
         entityId: options.name,

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -30,7 +30,7 @@ import { isZodObject } from '../../utils/zod-utils';
 
 import type { SuspendOptions } from '../../workflows';
 import { ToolStream } from '../stream';
-import type { CoreTool, MastraToolInvocationOptions, ToolAction, VercelTool, VercelToolV5 } from '../types';
+import type { CoreTool, McpMetadata, MastraToolInvocationOptions, ToolAction, VercelTool, VercelToolV5 } from '../types';
 import { validateToolInput, validateToolOutput, validateToolSuspendData } from '../validation';
 
 /**
@@ -329,19 +329,33 @@ export class CoreToolBuilder extends MastraBase {
       // Fall back to build-time context for Legacy methods (AI SDK v4 doesn't support passing custom options)
       const tracingContext = execOptions.tracingContext || options.tracingContext;
 
+      // Extract MCP metadata once with proper typing to avoid repeated unsafe casts
+      const mcpMeta =
+        !isVercelTool(tool) && 'mcpMetadata' in tool
+          ? (tool as { mcpMetadata?: McpMetadata }).mcpMetadata
+          : undefined;
+
       // Create tool span - either as child of existing span or as new root span (e.g. MCP tools)
       const toolRequestContext = execOptions.requestContext ?? options.requestContext;
       const toolSpan = getOrCreateSpan({
-        type: SpanType.TOOL_CALL,
-        name: `tool: '${options.name}'`,
+        type: mcpMeta ? SpanType.MCP_TOOL_CALL : SpanType.TOOL_CALL,
+        name: mcpMeta
+          ? `mcp_tool: '${options.name}' on '${mcpMeta.serverName}'`
+          : `tool: '${options.name}'`,
         input: args,
         entityType: EntityType.TOOL,
         entityId: options.name,
         entityName: options.name,
-        attributes: {
-          toolDescription: options.description,
-          toolType: logType || 'tool',
-        },
+        attributes: mcpMeta
+          ? {
+              mcpServer: mcpMeta.serverName,
+              serverVersion: mcpMeta.serverVersion,
+              toolDescription: options.description,
+            }
+          : {
+              toolDescription: options.description,
+              toolType: logType || 'tool',
+            },
         tracingPolicy: options.tracingPolicy,
         tracingContext: tracingContext,
         requestContext: toolRequestContext,

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -3,7 +3,7 @@ import { RequestContext } from '../request-context';
 import { toStandardSchema } from '../schema';
 import type { PublicSchema, StandardSchemaWithJSON, InferPublicSchema } from '../schema';
 import type { SuspendOptions } from '../workflows';
-import type { MCPToolProperties, ToolAction, ToolExecutionContext } from './types';
+import type { McpMetadata, MCPToolProperties, ToolAction, ToolExecutionContext } from './types';
 import { validateToolInput, validateToolOutput, validateToolSuspendData, validateRequestContext } from './validation';
 
 /**
@@ -210,10 +210,7 @@ export class Tool<
    * Metadata identifying this tool as originating from an MCP server.
    * Set automatically by the MCP client when creating tools.
    */
-  mcpMetadata?: {
-    serverName: string;
-    serverVersion?: string;
-  };
+  mcpMetadata?: McpMetadata;
 
   /**
    * Creates a new Tool instance with input validation wrapper.

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -207,6 +207,15 @@ export class Tool<
   inputExamples?: Array<{ input: Record<string, unknown> }>;
 
   /**
+   * Metadata identifying this tool as originating from an MCP server.
+   * Set automatically by the MCP client when creating tools.
+   */
+  mcpMetadata?: {
+    serverName: string;
+    serverVersion?: string;
+  };
+
+  /**
    * Creates a new Tool instance with input validation wrapper.
    *
    * @param opts - Tool configuration and execute function
@@ -235,6 +244,7 @@ export class Tool<
     this.toModelOutput = opts.toModelOutput;
     this.inputExamples = opts.inputExamples;
     this.mcp = opts.mcp;
+    this.mcpMetadata = opts.mcpMetadata;
     this.onInputStart = opts.onInputStart;
     this.onInputDelta = opts.onInputDelta;
     this.onInputAvailable = opts.onInputAvailable;

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -112,6 +112,16 @@ export type MastraToolInvocationOptions = ToolInvocationOptions &
 export type MCPToolType = 'agent' | 'workflow';
 
 /**
+ * Metadata identifying a tool as originating from an MCP server.
+ * Set automatically by the MCP client when creating tools.
+ * Used by CoreToolBuilder to create MCP_TOOL_CALL spans instead of TOOL_CALL spans.
+ */
+export interface McpMetadata {
+  serverName: string;
+  serverVersion?: string;
+}
+
+/**
  * MCP Tool Annotations for describing tool behavior and UI presentation.
  * These annotations are part of the MCP protocol and are used by clients
  * like OpenAI Apps SDK to control tool card display and permission hints.
@@ -379,10 +389,7 @@ export interface ToolAction<
    * Set automatically by the MCP client when creating tools.
    * Used by CoreToolBuilder to create MCP_TOOL_CALL spans instead of TOOL_CALL spans.
    */
-  mcpMetadata?: {
-    serverName: string;
-    serverVersion?: string;
-  };
+  mcpMetadata?: McpMetadata;
   /**
    * Examples of valid tool inputs. Each example contains an `input` object
    * showing what valid arguments look like.

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -375,6 +375,15 @@ export interface ToolAction<
    */
   providerOptions?: Record<string, Record<string, unknown>>;
   /**
+   * Metadata identifying this tool as originating from an MCP server.
+   * Set automatically by the MCP client when creating tools.
+   * Used by CoreToolBuilder to create MCP_TOOL_CALL spans instead of TOOL_CALL spans.
+   */
+  mcpMetadata?: {
+    serverName: string;
+    serverVersion?: string;
+  };
+  /**
    * Examples of valid tool inputs. Each example contains an `input` object
    * showing what valid arguments look like.
    * Passed through to the AI SDK which forwards them to model providers

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -1794,3 +1794,46 @@ describe('MastraMCPClient - Filesystem Server Integration (Issue #8660)', () => 
     await client.disconnect();
   }, 30000);
 });
+
+describe('MastraMCPClient - mcpMetadata on tools', () => {
+  let testServer: {
+    httpServer: HttpServer;
+    mcpServer: McpServer;
+    serverTransport: StreamableHTTPServerTransport;
+    baseUrl: URL;
+  };
+  let client: InternalMastraMCPClient;
+
+  beforeEach(async () => {
+    testServer = await setupTestServer(false);
+    client = new InternalMastraMCPClient({
+      name: 'metadata-test-client',
+      server: {
+        url: testServer.baseUrl,
+      },
+    });
+    await client.connect();
+  });
+
+  afterEach(async () => {
+    await client?.disconnect().catch(() => {});
+    await testServer?.mcpServer.close().catch(() => {});
+    await testServer?.serverTransport.close().catch(() => {});
+    testServer?.httpServer.close();
+  });
+
+  it('should set mcpMetadata.serverName on created tools', async () => {
+    const tools = await client.tools();
+    const greetTool = tools.greet;
+    expect(greetTool).toBeDefined();
+    expect((greetTool as any).mcpMetadata).toBeDefined();
+    expect((greetTool as any).mcpMetadata.serverName).toBe('metadata-test-client');
+  });
+
+  it('should set mcpMetadata.serverVersion after connection', async () => {
+    const tools = await client.tools();
+    const greetTool = tools.greet;
+    expect((greetTool as any).mcpMetadata).toBeDefined();
+    expect((greetTool as any).mcpMetadata.serverVersion).toBe('1.0.0');
+  });
+});

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -1826,14 +1826,14 @@ describe('MastraMCPClient - mcpMetadata on tools', () => {
     const tools = await client.tools();
     const greetTool = tools.greet;
     expect(greetTool).toBeDefined();
-    expect((greetTool as any).mcpMetadata).toBeDefined();
-    expect((greetTool as any).mcpMetadata.serverName).toBe('metadata-test-client');
+    expect(greetTool.mcpMetadata).toBeDefined();
+    expect(greetTool.mcpMetadata!.serverName).toBe('metadata-test-client');
   });
 
   it('should set mcpMetadata.serverVersion after connection', async () => {
     const tools = await client.tools();
     const greetTool = tools.greet;
-    expect((greetTool as any).mcpMetadata).toBeDefined();
-    expect((greetTool as any).mcpMetadata.serverVersion).toBe('1.0.0');
+    expect(greetTool.mcpMetadata).toBeDefined();
+    expect(greetTool.mcpMetadata!.serverVersion).toBe('1.0.0');
   });
 });

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -725,6 +725,10 @@ export class InternalMastraMCPClient extends MastraBase {
           description: tool.description || '',
           inputSchema: await this.convertInputSchema(tool.inputSchema),
           outputSchema: await this.convertOutputSchema(tool.outputSchema),
+          mcpMetadata: {
+            serverName: this.name,
+            serverVersion: this.client.getServerVersion()?.version,
+          },
           execute: async (
             input: any,
             context?: { requestContext?: RequestContext | null; runId?: string; abortSignal?: AbortSignal },

--- a/packages/playground-ui/src/domains/experiments/components/experiment-trace-shared.tsx
+++ b/packages/playground-ui/src/domains/experiments/components/experiment-trace-shared.tsx
@@ -1,8 +1,8 @@
-import { AgentIcon, ToolsIcon, WorkflowIcon } from '@/ds/icons';
+import { AgentIcon, McpServerIcon, ToolsIcon, WorkflowIcon } from '@/ds/icons';
 import { BrainIcon } from 'lucide-react';
 import { type ExperimentUISpanStyle } from '../types';
 
-export const spanTypePrefixes = ['agent', 'workflow', 'model', 'tool', 'other'];
+export const spanTypePrefixes = ['agent', 'workflow', 'model', 'mcp', 'tool', 'other'];
 
 export function getExperimentSpanTypeUi(type: string): ExperimentUISpanStyle | null {
   const typePrefix = type?.toLowerCase().split('_')[0];
@@ -28,6 +28,13 @@ export function getExperimentSpanTypeUi(type: string): ExperimentUISpanStyle | n
       label: 'Model',
       bgColor: 'bg-oklch(0.75 0.15 320 / 0.1)',
       typePrefix: 'model',
+    },
+    mcp: {
+      icon: <McpServerIcon />,
+      color: 'oklch(0.75 0.15 160)',
+      label: 'MCP',
+      bgColor: 'bg-oklch(0.75 0.15 160 / 0.1)',
+      typePrefix: 'mcp',
     },
     tool: {
       icon: <ToolsIcon />,

--- a/packages/playground-ui/src/domains/observability/components/shared.tsx
+++ b/packages/playground-ui/src/domains/observability/components/shared.tsx
@@ -1,13 +1,13 @@
-import { AgentIcon, ToolsIcon, WorkflowIcon } from '@/ds/icons';
+import { AgentIcon, McpServerIcon, ToolsIcon, WorkflowIcon } from '@/ds/icons';
 import { BrainIcon } from 'lucide-react';
 import { type UISpanStyle } from '../types';
 
-export const spanTypePrefixes = ['agent', 'workflow', 'model', 'tool', 'other'];
+export const spanTypePrefixes = ['agent', 'workflow', 'model', 'mcp', 'tool', 'other'];
 
 export function getSpanTypeUi(type: string) {
   const typePrefix = type?.toLowerCase().split('_')[0];
 
-  const spanTypeToUiElements: Record<(typeof spanTypePrefixes)[number], UISpanStyle> = {
+  const spanTypeToUiElements: Record<string, UISpanStyle> = {
     agent: {
       icon: <AgentIcon />,
       color: 'oklch(0.75 0.15 250)',
@@ -29,6 +29,13 @@ export function getSpanTypeUi(type: string) {
       bgColor: 'bg-oklch(0.75 0.15 320 / 0.1)',
       typePrefix: 'model',
     },
+    mcp: {
+      icon: <McpServerIcon />,
+      color: 'oklch(0.75 0.15 160)',
+      label: 'MCP',
+      bgColor: 'bg-oklch(0.75 0.15 160 / 0.1)',
+      typePrefix: 'mcp',
+    },
     tool: {
       icon: <ToolsIcon />,
       color: 'oklch(0.75 0.15 100)',
@@ -40,11 +47,9 @@ export function getSpanTypeUi(type: string) {
 
   if (typePrefix in spanTypeToUiElements) {
     return spanTypeToUiElements[typePrefix];
-  } else {
-    return {
-      typePrefix: 'other',
-    };
   }
 
-  return null;
+  return {
+    typePrefix: 'other',
+  };
 }


### PR DESCRIPTION
 ## Description

MCP tool calls now produce **`MCP_TOOL_CALL`** spans instead of generic `TOOL_CALL` spans in traces. When an agent invokes a tool from an MCP server, the trace automatically distinguishes it with a dedicated span type, MCP server name, and server version — no user code changes required.

### What changed

- **`@mastra/mcp`** — MCP client attaches `mcpMetadata` (`serverName`, `serverVersion`) to every tool it
creates
- **`@mastra/core`** — `CoreToolBuilder` detects `mcpMetadata` and creates an `MCP_TOOL_CALL` span
(replacing the `TOOL_CALL` span) with MCP-specific attributes
- **`@mastra/playground-ui`** — Trace timeline renders a distinct MCP icon and color for `mcp_tool_call`
spans

### How it works

Agent span
└─ MCP_TOOL_CALL span          ← was TOOL_CALL
 ├─ type: mcp_tool_call
 ├─ name: mcp_tool: 'list_files' on 'filesystem'
 ├─ mcpServer: filesystem
 └─ serverVersion: 1.0.0

Metadata flows automatically: `MCPClient.tools()` → `mcpMetadata` on tool object → `CoreToolBuilder` reads
it at span creation time. Users don't pass anything extra.

<img width="1866" height="964" alt="Screenshot 2026-02-19 220325"
src="https://github.com/user-attachments/assets/c6330a9d-1890-44d2-845c-35101b269651" />

<img width="925" height="927" alt="image"
src="https://github.com/user-attachments/assets/7c1aef98-5345-49d8-81cd-8087e057bd12" />

## Related Issue(s)
Fixes #10887

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool calls from MCP servers now generate a distinct MCP span type showing server name and optional version in traces; UI displays an MCP-specific icon and styling.

* **Documentation**
  * Tracing docs updated to describe MCP_TOOL_CALL span behavior and UI representation.

* **Tests**
  * Added tests validating MCP metadata propagation and MCP span generation.

* **Chores**
  * Minor dependency bumps and test/style cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->