### PR TITLE
fix(playground) Print string or object type result Error value

### DIFF
--- a/.changeset/empty-ends-camp.md
+++ b/.changeset/empty-ends-camp.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed rendering Object type error on Experiment Result panel

--- a/packages/playground-ui/src/domains/experiments/components/experiment-result-panel.tsx
+++ b/packages/playground-ui/src/domains/experiments/components/experiment-result-panel.tsx
@@ -1,15 +1,13 @@
 'use client';
 
 import { DatasetExperimentResult } from '@mastra/client-js';
-import { Section } from '@/ds/components/Section';
-import { TextAndIcon, getShortId } from '@/ds/components/Text';
-import { CopyButton } from '@/ds/components/CopyButton';
-import { FileOutputIcon, AlertCircleIcon, Calendar1Icon, PlayIcon, FileCodeIcon, PanelRightIcon } from 'lucide-react';
+import { TextAndIcon } from '@/ds/components/Text';
+import { FileOutputIcon, Calendar1Icon, PlayIcon, FileCodeIcon, PanelRightIcon, OctagonAlertIcon } from 'lucide-react';
 import { format } from 'date-fns/format';
 import { SideDialog } from '@/ds/components/SideDialog';
 import { ListAndDetails } from '@/ds/components/ListAndDetails';
 import { MainHeader } from '@/ds/components/MainHeader';
-import { Button, ButtonsGroup } from '@/index';
+import { Button, ButtonsGroup, Notice } from '@/index';
 
 export type ExperimentResultPanelProps = {
   result: DatasetExperimentResult;
@@ -26,9 +24,9 @@ export function ExperimentResultPanel({
   onClose,
   onShowTrace,
 }: ExperimentResultPanelProps) {
-  const hasError = Boolean(result.error);
-  const inputStr = formatValue(result.input);
-  const outputStr = formatValue(result.output);
+  const hasError = Boolean(result?.error);
+  const inputStr = formatValue(result?.input);
+  const outputStr = formatValue(result?.output);
 
   return (
     <>
@@ -62,6 +60,20 @@ export function ExperimentResultPanel({
           </MainHeader.Column>
         </MainHeader>
 
+        {hasError && (
+          <Notice variant="destructive">
+            <OctagonAlertIcon />
+            <Notice.Message>
+              <strong>Error: </strong>
+              {formatValue(
+                result?.error && typeof result.error === 'object'
+                  ? (result.error as Record<string, unknown>).message
+                  : result?.error,
+              )}
+            </Notice.Message>
+          </Notice>
+        )}
+
         <SideDialog.CodeSection title="Input" icon={<FileCodeIcon />} codeStr={inputStr} />
         <SideDialog.CodeSection title="Output" icon={<FileOutputIcon />} codeStr={outputStr} />
 
@@ -71,20 +83,6 @@ export function ExperimentResultPanel({
           </h4>
           <p className="text-sm text-neutral4">{format(new Date(result.createdAt), "MMM d, yyyy 'at' h:mm a")}</p>
         </div>
-
-        {hasError && (
-          <Section>
-            <Section.Header>
-              <Section.Heading>
-                <AlertCircleIcon /> Error
-              </Section.Heading>
-              <CopyButton content={result.error || ''} />
-            </Section.Header>
-            <div className="bg-black/20 p-4 overflow-hidden rounded-xl border border-white/10 text-neutral4 text-ui-md">
-              <pre className="text-wrap font-mono text-sm whitespace-pre-wrap break-all">{result.error}</pre>
-            </div>
-          </Section>
-        )}
       </ListAndDetails.ColumnContent>
     </>
   );


### PR DESCRIPTION
## Description

- move Error section at the top of panel
- fix code to render the string error or message property from object type error value

<!-- Provide a brief description of the changes in this PR -->

<img width="1222" height="714" alt="CleanShot 2026-02-19 at 14 43 33" src="https://github.com/user-attachments/assets/30288559-2041-4348-b8ff-b0efba651d78" />

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Error display in the experiment results panel replaced with a destructive notice that uses an alert icon and improved formatting. Object-type errors are rendered more clearly and the notice appears above the input/output sections.

* **Bug Fixes**
  * Safer rendering to avoid errors when result, input, or output are missing.

* **Chores**
  * Added a changeset entry for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->