### PR TITLE
docs: clarify lastMessages option behavior in memory reference

### DIFF
--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -77,7 +77,7 @@ export const agent = new Agent({
       name: "lastMessages",
       type: "number | false",
       description:
-        "Number of most recent messages to retrieve. Set to false to disable.",
+        "Number of most recent messages to include in context. Set to `false` to disable loading conversation history into context. Use `Number.MAX_SAFE_INTEGER` to retrieve all messages with no limit. To prevent saving new messages, use the `readOnly` option instead.",
       isOptional: true,
       defaultValue: "10",
     },


### PR DESCRIPTION
The `lastMessages` description was vague — just said "set to false to disable" without explaining what gets disabled. Updated it to clarify:

- `false` disables loading and saving conversation history
- `Number.MAX_SAFE_INTEGER` retrieves all messages with no limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Memory.lastMessages behavior: now documents that the value controls how many recent messages are included in context, that setting it to false disables loading conversation history, recommends using a very large integer to indicate no limit, and suggests the read-only option to prevent saving new messages. No functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->