### PR TITLE
 feat: support metadata-only queries in vector stores

### DIFF
--- a/.changeset/feat-metadata-only-vector-query.md
+++ b/.changeset/feat-metadata-only-vector-query.md
@@ -1,0 +1,23 @@
+---
+"@mastra/core": minor
+"@mastra/pg": minor
+"@mastra/pinecone": patch
+"@mastra/qdrant": patch
+"@mastra/chroma": patch
+"@mastra/astra": patch
+"@mastra/upstash": patch
+"@mastra/mongodb": patch
+"@mastra/elasticsearch": patch
+"@mastra/opensearch": patch
+"@mastra/duckdb": patch
+"@mastra/turbopuffer": patch
+"@mastra/vectorize": patch
+"@mastra/convex": patch
+"@mastra/couchbase": patch
+---
+
+Support metadata-only queries in vector stores by making `queryVector` optional in the `QueryVectorParams` interface.
+
+PgVector now supports querying by metadata filters alone without providing a query vector — useful when you need to retrieve records by metadata without performing similarity search. Other vector stores will throw a clear error if `queryVector` is omitted, since their backends require a vector for queries.
+
+Also fixes documentation where the `query()` parameter was incorrectly named `vector` instead of `queryVector`.

--- a/.changeset/feat-metadata-only-vector-query.md
+++ b/.changeset/feat-metadata-only-vector-query.md
@@ -1,23 +1,28 @@
 ---
 "@mastra/core": minor
 "@mastra/pg": minor
-"@mastra/pinecone": patch
-"@mastra/qdrant": patch
-"@mastra/chroma": patch
-"@mastra/astra": patch
-"@mastra/upstash": patch
-"@mastra/mongodb": patch
-"@mastra/elasticsearch": patch
-"@mastra/opensearch": patch
-"@mastra/duckdb": patch
-"@mastra/turbopuffer": patch
-"@mastra/vectorize": patch
-"@mastra/convex": patch
-"@mastra/couchbase": patch
 ---
 
 Support metadata-only queries in vector stores by making `queryVector` optional in the `QueryVectorParams` interface.
 
-PgVector now supports querying by metadata filters alone without providing a query vector — useful when you need to retrieve records by metadata without performing similarity search. Other vector stores will throw a clear error if `queryVector` is omitted, since their backends require a vector for queries.
+`PgVector.query()` now supports querying by metadata filters alone without providing a query vector — useful when you need to retrieve records by metadata without performing similarity search. At least one of `queryVector` or `filter` must be provided.
+
+**Before** (queryVector was required):
+```ts
+const results = await pgVector.query({
+  indexName: 'my-index',
+  queryVector: [0.1, 0.2, ...],
+  filter: { category: 'docs' },
+});
+```
+
+**After** (metadata-only query):
+```ts
+const results = await pgVector.query({
+  indexName: 'my-index',
+  filter: { category: 'docs' },
+});
+// Returns matching records with score: 0 (no similarity ranking)
+```
 
 Also fixes documentation where the `query()` parameter was incorrectly named `vector` instead of `queryVector`.

--- a/.changeset/feat-metadata-only-vector-query.md
+++ b/.changeset/feat-metadata-only-vector-query.md
@@ -1,28 +1,7 @@
 ---
 "@mastra/core": minor
-"@mastra/pg": minor
 ---
 
-Support metadata-only queries in vector stores by making `queryVector` optional in the `QueryVectorParams` interface.
-
-`PgVector.query()` now supports querying by metadata filters alone without providing a query vector — useful when you need to retrieve records by metadata without performing similarity search. At least one of `queryVector` or `filter` must be provided.
-
-**Before** (queryVector was required):
-```ts
-const results = await pgVector.query({
-  indexName: 'my-index',
-  queryVector: [0.1, 0.2, ...],
-  filter: { category: 'docs' },
-});
-```
-
-**After** (metadata-only query):
-```ts
-const results = await pgVector.query({
-  indexName: 'my-index',
-  filter: { category: 'docs' },
-});
-// Returns matching records with score: 0 (no similarity ranking)
-```
+Make `queryVector` optional in the `QueryVectorParams` interface to support metadata-only queries. At least one of `queryVector` or `filter` must be provided. Not all vector store backends support metadata-only queries — check your store's documentation for details.
 
 Also fixes documentation where the `query()` parameter was incorrectly named `vector` instead of `queryVector`.

--- a/.changeset/feat-pg-metadata-only-query.md
+++ b/.changeset/feat-pg-metadata-only-query.md
@@ -1,0 +1,25 @@
+---
+"@mastra/pg": minor
+---
+
+`PgVector.query()` now supports querying by metadata filters alone without providing a query vector — useful when you need to retrieve records by metadata without performing similarity search.
+
+**Before** (queryVector was required):
+```ts
+const results = await pgVector.query({
+  indexName: 'my-index',
+  queryVector: [0.1, 0.2, ...],
+  filter: { category: 'docs' },
+});
+```
+
+**After** (metadata-only query):
+```ts
+const results = await pgVector.query({
+  indexName: 'my-index',
+  filter: { category: 'docs' },
+});
+// Returns matching records with score: 0 (no similarity ranking)
+```
+
+At least one of `queryVector` or `filter` must be provided. When `queryVector` is omitted, results are returned with `score: 0` since no similarity computation is performed.

--- a/.changeset/vector-stores-require-query-vector.md
+++ b/.changeset/vector-stores-require-query-vector.md
@@ -1,0 +1,17 @@
+---
+"@mastra/pinecone": patch
+"@mastra/qdrant": patch
+"@mastra/chroma": patch
+"@mastra/astra": patch
+"@mastra/upstash": patch
+"@mastra/mongodb": patch
+"@mastra/elasticsearch": patch
+"@mastra/opensearch": patch
+"@mastra/duckdb": patch
+"@mastra/turbopuffer": patch
+"@mastra/vectorize": patch
+"@mastra/convex": patch
+"@mastra/couchbase": patch
+---
+
+Add a clear runtime error when `queryVector` is omitted for vector stores that require a vector for queries. Previously, omitting `queryVector` would produce confusing SDK-level errors; now each store throws a structured `MastraError` with `ErrorCategory.USER` explaining that metadata-only queries are not supported by that backend.

--- a/.changeset/vector-stores-require-query-vector.md
+++ b/.changeset/vector-stores-require-query-vector.md
@@ -12,6 +12,9 @@
 "@mastra/vectorize": patch
 "@mastra/convex": patch
 "@mastra/couchbase": patch
+"@mastra/lance": patch
+"@mastra/libsql": patch
+"@mastra/s3vectors": patch
 ---
 
 Add a clear runtime error when `queryVector` is omitted for vector stores that require a vector for queries. Previously, omitting `queryVector` would produce confusing SDK-level errors; now each store throws a structured `MastraError` with `ErrorCategory.USER` explaining that metadata-only queries are not supported by that backend.

--- a/docs/src/content/en/reference/vectors/pg.mdx
+++ b/docs/src/content/en/reference/vectors/pg.mdx
@@ -304,8 +304,7 @@ description: "Name of the index to query",
 {
 name: "queryVector",
 type: "number[]",
-isOptional: true,
-description: "Query vector for similarity search. When omitted, a metadata-only query is performed using the filter parameter. At least one of queryVector or filter must be provided.",
+description: "Query vector",
 },
 {
 name: "topK",

--- a/docs/src/content/en/reference/vectors/pg.mdx
+++ b/docs/src/content/en/reference/vectors/pg.mdx
@@ -302,9 +302,10 @@ type: "string",
 description: "Name of the index to query",
 },
 {
-name: "vector",
+name: "queryVector",
 type: "number[]",
-description: "Query vector",
+isOptional: true,
+description: "Query vector for similarity search. When omitted, a metadata-only query is performed using the filter parameter. At least one of queryVector or filter must be provided.",
 },
 {
 name: "topK",

--- a/docs/src/content/en/reference/vectors/pinecone.mdx
+++ b/docs/src/content/en/reference/vectors/pinecone.mdx
@@ -141,7 +141,7 @@ type: "string",
 description: "Name of the index to query",
 },
 {
-name: "vector",
+name: "queryVector",
 type: "number[]",
 description: "Dense query vector to find similar vectors",
 },

--- a/packages/core/src/vector/types.ts
+++ b/packages/core/src/vector/types.ts
@@ -64,7 +64,15 @@ export interface CreateIndexParams {
 
 export interface QueryVectorParams<Filter = VectorFilter> {
   indexName: string;
-  queryVector: number[];
+  /**
+   * The query vector for similarity search.
+   * Optional — when omitted, a metadata-only query is performed using `filter`.
+   * At least one of `queryVector` or `filter` must be provided.
+   *
+   * Note: Not all vector store backends support metadata-only queries.
+   * Check your store's documentation for support details.
+   */
+  queryVector?: number[];
   topK?: number;
   filter?: Filter;
   includeVector?: boolean;

--- a/stores/astra/src/vector/index.ts
+++ b/stores/astra/src/vector/index.ts
@@ -141,7 +141,7 @@ export class AstraVector extends MastraVector<AstraVectorFilter> {
   }: AstraQueryVectorParams): Promise<QueryResult[]> {
     if (!queryVector) {
       throw new MastraError({
-        id: 'VECTOR_ASTRA_QUERY_MISSING_VECTOR',
+        id: createVectorErrorId('ASTRA', 'QUERY', 'MISSING_VECTOR'),
         text: 'queryVector is required for Astra queries. Metadata-only queries are not supported by this vector store.',
         domain: ErrorDomain.MASTRA_VECTOR,
         category: ErrorCategory.USER,

--- a/stores/astra/src/vector/index.ts
+++ b/stores/astra/src/vector/index.ts
@@ -139,6 +139,16 @@ export class AstraVector extends MastraVector<AstraVectorFilter> {
     filter,
     includeVector = false,
   }: AstraQueryVectorParams): Promise<QueryResult[]> {
+    if (!queryVector) {
+      throw new MastraError({
+        id: 'VECTOR_ASTRA_QUERY_MISSING_VECTOR',
+        text: 'queryVector is required for Astra queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.MASTRA_VECTOR,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
+    }
+
     const collection = this.#db.collection(indexName);
 
     const translatedFilter = this.transformFilter(filter);

--- a/stores/chroma/src/vector/index.ts
+++ b/stores/chroma/src/vector/index.ts
@@ -197,7 +197,7 @@ export class ChromaVector extends MastraVector<ChromaVectorFilter> {
   }: ChromaQueryVectorParams): Promise<QueryResult[]> {
     if (!queryVector) {
       throw new MastraError({
-        id: 'VECTOR_CHROMA_QUERY_MISSING_VECTOR',
+        id: createVectorErrorId('CHROMA', 'QUERY', 'MISSING_VECTOR'),
         text: 'queryVector is required for Chroma queries. Metadata-only queries are not supported by this vector store.',
         domain: ErrorDomain.MASTRA_VECTOR,
         category: ErrorCategory.USER,

--- a/stores/chroma/src/vector/index.ts
+++ b/stores/chroma/src/vector/index.ts
@@ -195,6 +195,16 @@ export class ChromaVector extends MastraVector<ChromaVectorFilter> {
     includeVector = false,
     documentFilter,
   }: ChromaQueryVectorParams): Promise<QueryResult[]> {
+    if (!queryVector) {
+      throw new MastraError({
+        id: 'VECTOR_CHROMA_QUERY_MISSING_VECTOR',
+        text: 'queryVector is required for Chroma queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.MASTRA_VECTOR,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
+    }
+
     // Validate topK parameter
     validateTopK('CHROMA', topK);
 

--- a/stores/convex/src/vector/index.ts
+++ b/stores/convex/src/vector/index.ts
@@ -1,5 +1,7 @@
 import crypto from 'node:crypto';
 
+import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
+import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector } from '@mastra/core/vector';
 import type {
   CreateIndexParams,
@@ -135,9 +137,13 @@ export class ConvexVector extends MastraVector<VectorFilter> {
     filter,
   }: QueryVectorParams<VectorFilter>): Promise<QueryResult[]> {
     if (!queryVector) {
-      throw new Error(
-        'queryVector is required for Convex queries. Metadata-only queries are not supported by this vector store.',
-      );
+      throw new MastraError({
+        id: createVectorErrorId('CONVEX', 'QUERY', 'MISSING_VECTOR'),
+        text: 'queryVector is required for Convex queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
     }
 
     const vectors = await this.callStorage<VectorRecord[]>({

--- a/stores/convex/src/vector/index.ts
+++ b/stores/convex/src/vector/index.ts
@@ -134,6 +134,12 @@ export class ConvexVector extends MastraVector<VectorFilter> {
     includeVector = false,
     filter,
   }: QueryVectorParams<VectorFilter>): Promise<QueryResult[]> {
+    if (!queryVector) {
+      throw new Error(
+        'queryVector is required for Convex queries. Metadata-only queries are not supported by this vector store.',
+      );
+    }
+
     const vectors = await this.callStorage<VectorRecord[]>({
       op: 'queryTable',
       tableName: this.vectorTable(indexName),

--- a/stores/couchbase/src/vector/index.ts
+++ b/stores/couchbase/src/vector/index.ts
@@ -259,9 +259,13 @@ export class CouchbaseVector extends MastraVector {
 
   async query({ indexName, queryVector, topK = 10, includeVector = false }: QueryVectorParams): Promise<QueryResult[]> {
     if (!queryVector) {
-      throw new Error(
-        'queryVector is required for Couchbase queries. Metadata-only queries are not supported by this vector store.',
-      );
+      throw new MastraError({
+        id: createVectorErrorId('COUCHBASE', 'QUERY', 'MISSING_VECTOR'),
+        text: 'queryVector is required for Couchbase queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
     }
 
     try {

--- a/stores/couchbase/src/vector/index.ts
+++ b/stores/couchbase/src/vector/index.ts
@@ -258,6 +258,12 @@ export class CouchbaseVector extends MastraVector {
   }
 
   async query({ indexName, queryVector, topK = 10, includeVector = false }: QueryVectorParams): Promise<QueryResult[]> {
+    if (!queryVector) {
+      throw new Error(
+        'queryVector is required for Couchbase queries. Metadata-only queries are not supported by this vector store.',
+      );
+    }
+
     try {
       await this.getCollection();
 

--- a/stores/duckdb/src/vector/index.ts
+++ b/stores/duckdb/src/vector/index.ts
@@ -1,5 +1,7 @@
 import { DuckDBInstance } from '@duckdb/node-api';
 import type { DuckDBValue } from '@duckdb/node-api';
+import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
+import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector, validateUpsertInput, validateTopK } from '@mastra/core/vector';
 import type {
   IndexStats,
@@ -192,9 +194,13 @@ export class DuckDBVector extends MastraVector<DuckDBVectorFilter> {
     const { indexName, queryVector, topK = 10, filter, includeVector = false } = params;
 
     if (!queryVector) {
-      throw new Error(
-        'queryVector is required for DuckDB queries. Metadata-only queries are not supported by this vector store.',
-      );
+      throw new MastraError({
+        id: createVectorErrorId('DUCKDB', 'QUERY', 'MISSING_VECTOR'),
+        text: 'queryVector is required for DuckDB queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
     }
 
     // Validate topK parameter

--- a/stores/duckdb/src/vector/index.ts
+++ b/stores/duckdb/src/vector/index.ts
@@ -191,6 +191,12 @@ export class DuckDBVector extends MastraVector<DuckDBVectorFilter> {
 
     const { indexName, queryVector, topK = 10, filter, includeVector = false } = params;
 
+    if (!queryVector) {
+      throw new Error(
+        'queryVector is required for DuckDB queries. Metadata-only queries are not supported by this vector store.',
+      );
+    }
+
     // Validate topK parameter
     validateTopK('DUCKDB', topK);
 

--- a/stores/elasticsearch/src/vector/index.ts
+++ b/stores/elasticsearch/src/vector/index.ts
@@ -364,6 +364,16 @@ export class ElasticSearchVector extends MastraVector<ElasticSearchVectorFilter>
     topK = 10,
     includeVector = false,
   }: ElasticSearchVectorParams): Promise<QueryResult[]> {
+    if (!queryVector) {
+      throw new MastraError({
+        id: 'VECTOR_ELASTICSEARCH_QUERY_MISSING_VECTOR',
+        text: 'queryVector is required for Elasticsearch queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
+    }
+
     // Validate topK parameter
     validateTopK('ELASTICSEARCH', topK);
 

--- a/stores/elasticsearch/src/vector/index.ts
+++ b/stores/elasticsearch/src/vector/index.ts
@@ -366,7 +366,7 @@ export class ElasticSearchVector extends MastraVector<ElasticSearchVectorFilter>
   }: ElasticSearchVectorParams): Promise<QueryResult[]> {
     if (!queryVector) {
       throw new MastraError({
-        id: 'VECTOR_ELASTICSEARCH_QUERY_MISSING_VECTOR',
+        id: createVectorErrorId('ELASTICSEARCH', 'QUERY', 'MISSING_VECTOR'),
         text: 'queryVector is required for Elasticsearch queries. Metadata-only queries are not supported by this vector store.',
         domain: ErrorDomain.STORAGE,
         category: ErrorCategory.USER,

--- a/stores/lance/src/vector/index.ts
+++ b/stores/lance/src/vector/index.ts
@@ -112,6 +112,16 @@ export class LanceVectorStore extends MastraVector<LanceVectorFilter> {
     // This allows Memory and other consumers to call query without explicitly providing tableName.
     const resolvedTableName = tableName ?? indexName;
 
+    if (!queryVector) {
+      throw new MastraError({
+        id: createVectorErrorId('LANCE', 'QUERY', 'MISSING_VECTOR'),
+        text: 'queryVector is required for Lance queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { indexName: resolvedTableName },
+      });
+    }
+
     try {
       if (!this.lanceClient) {
         throw new Error('LanceDB client not initialized. Use LanceVectorStore.create() to create an instance');
@@ -119,10 +129,6 @@ export class LanceVectorStore extends MastraVector<LanceVectorFilter> {
 
       if (!resolvedTableName) {
         throw new Error('tableName or indexName is required');
-      }
-
-      if (!queryVector) {
-        throw new Error('queryVector is required');
       }
     } catch (error) {
       throw new MastraError(

--- a/stores/libsql/src/vector/index.ts
+++ b/stores/libsql/src/vector/index.ts
@@ -135,6 +135,16 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
     // Validate topK parameter - throws MastraError directly
     validateTopK('LIBSQL', topK);
 
+    if (!queryVector) {
+      throw new MastraError({
+        id: createVectorErrorId('LIBSQL', 'QUERY', 'MISSING_VECTOR'),
+        text: 'queryVector is required for LibSQL queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
+    }
+
     if (!Array.isArray(queryVector) || !queryVector.every(x => typeof x === 'number' && Number.isFinite(x))) {
       throw new MastraError({
         id: createVectorErrorId('LIBSQL', 'QUERY', 'INVALID_ARGS'),

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -331,6 +331,16 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
     includeVector = false,
     documentFilter,
   }: MongoDBQueryVectorParams): Promise<QueryResult[]> {
+    if (!queryVector) {
+      throw new MastraError({
+        id: 'VECTOR_MONGODB_QUERY_MISSING_VECTOR',
+        text: 'queryVector is required for MongoDB queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
+    }
+
     try {
       const collection = await this.getCollection(indexName, true);
       const indexNameInternal = `${indexName}_vector_index`;

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -333,7 +333,7 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
   }: MongoDBQueryVectorParams): Promise<QueryResult[]> {
     if (!queryVector) {
       throw new MastraError({
-        id: 'VECTOR_MONGODB_QUERY_MISSING_VECTOR',
+        id: createVectorErrorId('MONGODB', 'QUERY', 'MISSING_VECTOR'),
         text: 'queryVector is required for MongoDB queries. Metadata-only queries are not supported by this vector store.',
         domain: ErrorDomain.STORAGE,
         category: ErrorCategory.USER,

--- a/stores/opensearch/src/vector/index.ts
+++ b/stores/opensearch/src/vector/index.ts
@@ -278,6 +278,16 @@ export class OpenSearchVector extends MastraVector<OpenSearchVectorFilter> {
     topK = 10,
     includeVector = false,
   }: OpenSearchVectorParams): Promise<QueryResult[]> {
+    if (!queryVector) {
+      throw new MastraError({
+        id: 'VECTOR_OPENSEARCH_QUERY_MISSING_VECTOR',
+        text: 'queryVector is required for OpenSearch queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.MASTRA_VECTOR,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
+    }
+
     // Validate topK parameter
     validateTopK('OPENSEARCH', topK);
 

--- a/stores/opensearch/src/vector/index.ts
+++ b/stores/opensearch/src/vector/index.ts
@@ -280,9 +280,9 @@ export class OpenSearchVector extends MastraVector<OpenSearchVectorFilter> {
   }: OpenSearchVectorParams): Promise<QueryResult[]> {
     if (!queryVector) {
       throw new MastraError({
-        id: 'VECTOR_OPENSEARCH_QUERY_MISSING_VECTOR',
+        id: createVectorErrorId('OPENSEARCH', 'QUERY', 'MISSING_VECTOR'),
         text: 'queryVector is required for OpenSearch queries. Metadata-only queries are not supported by this vector store.',
-        domain: ErrorDomain.MASTRA_VECTOR,
+        domain: ErrorDomain.STORAGE,
         category: ErrorCategory.USER,
         details: { indexName },
       });

--- a/stores/pg/src/vector/index.test.ts
+++ b/stores/pg/src/vector/index.test.ts
@@ -152,7 +152,7 @@ describe('PgVector', () => {
         filter: { category: 'A' },
         topK: 10,
       });
-      expect(results.length).toBeGreaterThan(0);
+      expect(results).toHaveLength(2);
       expect(results.every(r => r.metadata?.category === 'A')).toBe(true);
       // v1=[1,0,0] has cosine similarity 1.0 with queryVector [1,0,0]
       expect(results[0]!.score).toBeCloseTo(1, 5);

--- a/stores/pg/src/vector/index.test.ts
+++ b/stores/pg/src/vector/index.test.ts
@@ -134,15 +134,15 @@ describe('PgVector', () => {
     });
 
     it('should throw when neither queryVector nor filter is provided', async () => {
-      await expect(
-        vectorDB.query({ indexName: metadataQueryIndex } as any),
-      ).rejects.toThrow('Either queryVector or filter must be provided');
+      await expect(vectorDB.query({ indexName: metadataQueryIndex } as any)).rejects.toThrow(
+        'Either queryVector or filter must be provided',
+      );
     });
 
     it('should throw when queryVector is undefined and filter is empty', async () => {
-      await expect(
-        vectorDB.query({ indexName: metadataQueryIndex, filter: {} }),
-      ).rejects.toThrow('Either queryVector or filter must be provided');
+      await expect(vectorDB.query({ indexName: metadataQueryIndex, filter: {} })).rejects.toThrow(
+        'Either queryVector or filter must be provided',
+      );
     });
 
     it('should still work with both queryVector and filter (similarity search)', async () => {

--- a/stores/pg/src/vector/index.test.ts
+++ b/stores/pg/src/vector/index.test.ts
@@ -47,6 +47,118 @@ describe('PgVector', () => {
     });
   });
 
+  describe('Metadata-Only Query', () => {
+    const metadataQueryIndex = 'test_metadata_only_query';
+
+    beforeAll(async () => {
+      await vectorDB.createIndex({ indexName: metadataQueryIndex, dimension: 3 });
+      await vectorDB.upsert({
+        indexName: metadataQueryIndex,
+        vectors: [
+          [1, 0, 0],
+          [0, 1, 0],
+          [0, 0, 1],
+          [1, 1, 0],
+        ],
+        metadata: [
+          { category: 'A', priority: 1, tag: 'first' },
+          { category: 'B', priority: 2, tag: 'second' },
+          { category: 'A', priority: 3, tag: 'third' },
+          { category: 'B', priority: 4, tag: 'fourth' },
+        ],
+        ids: ['v1', 'v2', 'v3', 'v4'],
+      });
+    });
+
+    afterAll(async () => {
+      await vectorDB.deleteIndex({ indexName: metadataQueryIndex });
+    });
+
+    it('should query by metadata filter without queryVector', async () => {
+      const results = await vectorDB.query({
+        indexName: metadataQueryIndex,
+        filter: { category: 'A' },
+        topK: 10,
+      });
+      expect(results).toHaveLength(2);
+      expect(results.every(r => r.metadata?.category === 'A')).toBe(true);
+      const ids = results.map(r => r.id).sort();
+      expect(ids).toEqual(['v1', 'v3']);
+    });
+
+    it('should return score 0 for metadata-only queries', async () => {
+      const results = await vectorDB.query({
+        indexName: metadataQueryIndex,
+        filter: { category: 'B' },
+      });
+      expect(results).toHaveLength(2);
+      expect(results.every(r => r.score === 0)).toBe(true);
+    });
+
+    it('should respect topK for metadata-only queries', async () => {
+      const results = await vectorDB.query({
+        indexName: metadataQueryIndex,
+        filter: { category: 'A' },
+        topK: 1,
+      });
+      expect(results).toHaveLength(1);
+    });
+
+    it('should include vector when requested in metadata-only query', async () => {
+      const results = await vectorDB.query({
+        indexName: metadataQueryIndex,
+        filter: { category: 'B', priority: 2 },
+        includeVector: true,
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0]!.id).toBe('v2');
+      expect(results[0]!.vector).toBeDefined();
+      expect(results[0]!.vector).toEqual([0, 1, 0]);
+    });
+
+    it('should support complex filters in metadata-only queries', async () => {
+      const results = await vectorDB.query({
+        indexName: metadataQueryIndex,
+        filter: { $and: [{ category: 'A' }, { priority: { $gte: 3 } }] },
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0]!.id).toBe('v3');
+    });
+
+    it('should return empty array when filter matches nothing', async () => {
+      const results = await vectorDB.query({
+        indexName: metadataQueryIndex,
+        filter: { category: 'nonexistent' },
+      });
+      expect(results).toHaveLength(0);
+    });
+
+    it('should throw when neither queryVector nor filter is provided', async () => {
+      await expect(
+        vectorDB.query({ indexName: metadataQueryIndex } as any),
+      ).rejects.toThrow('Either queryVector or filter must be provided');
+    });
+
+    it('should throw when queryVector is undefined and filter is empty', async () => {
+      await expect(
+        vectorDB.query({ indexName: metadataQueryIndex, filter: {} }),
+      ).rejects.toThrow('Either queryVector or filter must be provided');
+    });
+
+    it('should still work with both queryVector and filter (similarity search)', async () => {
+      const results = await vectorDB.query({
+        indexName: metadataQueryIndex,
+        queryVector: [1, 0, 0],
+        filter: { category: 'A' },
+        topK: 10,
+      });
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.every(r => r.metadata?.category === 'A')).toBe(true);
+      // v1=[1,0,0] has cosine similarity 1.0 with queryVector [1,0,0]
+      expect(results[0]!.score).toBeCloseTo(1, 5);
+    });
+  });
+
   describe('PgVector Specific Tests', () => {
     describe('Public Fields Access', () => {
       let testDB: PgVector;

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -309,8 +309,12 @@ export class PgVector extends MastraVector<PGVectorFilter> {
     try {
       // Validate topK parameter
       validateTopK('PG', topK);
-      if (!Array.isArray(queryVector) || !queryVector.every(x => typeof x === 'number' && Number.isFinite(x))) {
-        throw new Error('queryVector must be an array of finite numbers');
+      if (queryVector !== undefined) {
+        if (!Array.isArray(queryVector) || !queryVector.every(x => typeof x === 'number' && Number.isFinite(x))) {
+          throw new Error('queryVector must be an array of finite numbers');
+        }
+      } else if (!filter || Object.keys(filter).length === 0) {
+        throw new Error('Either queryVector or filter must be provided');
       }
     } catch (error) {
       const mastraError = new MastraError(
@@ -328,6 +332,51 @@ export class PgVector extends MastraVector<PGVectorFilter> {
       throw mastraError;
     }
 
+    // Metadata-only query: filter without vector similarity
+    if (queryVector === undefined) {
+      const client = await this.pool.connect();
+      try {
+        const translatedFilter = this.transformFilter(filter);
+        const { sql: filterQuery, values: filterValues } = buildDeleteFilterQuery(translatedFilter);
+        const { tableName } = this.getTableName(indexName);
+
+        const query = `
+          SELECT
+            vector_id as id,
+            metadata
+            ${includeVector ? ', embedding' : ''}
+          FROM ${tableName}
+          ${filterQuery}
+          ORDER BY id
+          LIMIT $${filterValues.length + 1}`;
+        const result = await client.query(query, [...filterValues, topK]);
+
+        return result.rows.map(({ id, metadata, embedding }: { id: string; metadata: any; embedding?: string }) => ({
+          id,
+          score: 0,
+          metadata,
+          ...(includeVector && embedding && { vector: JSON.parse(embedding) }),
+        }));
+      } catch (error) {
+        const mastraError = new MastraError(
+          {
+            id: createVectorErrorId('PG', 'QUERY', 'FAILED'),
+            domain: ErrorDomain.MASTRA_VECTOR,
+            category: ErrorCategory.THIRD_PARTY,
+            details: {
+              indexName,
+            },
+          },
+          error,
+        );
+        this.logger?.trackException(mastraError);
+        throw mastraError;
+      } finally {
+        client.release();
+      }
+    }
+
+    // Vector similarity query
     const client = await this.pool.connect();
     try {
       await client.query('BEGIN');

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -347,7 +347,7 @@ export class PgVector extends MastraVector<PGVectorFilter> {
             ${includeVector ? ', embedding' : ''}
           FROM ${tableName}
           ${filterQuery}
-          ORDER BY id
+          ORDER BY vector_id
           LIMIT $${filterValues.length + 1}`;
         const result = await client.query(query, [...filterValues, topK]);
 

--- a/stores/pinecone/src/vector/index.ts
+++ b/stores/pinecone/src/vector/index.ts
@@ -241,7 +241,7 @@ export class PineconeVector extends MastraVector<PineconeVectorFilter> {
   }: PineconeQueryVectorParams): Promise<QueryResult[]> {
     if (!queryVector) {
       throw new MastraError({
-        id: 'VECTOR_PINECONE_QUERY_MISSING_VECTOR',
+        id: createVectorErrorId('PINECONE', 'QUERY', 'MISSING_VECTOR'),
         text: 'queryVector is required for Pinecone queries. Metadata-only queries are not supported by this vector store.',
         domain: ErrorDomain.STORAGE,
         category: ErrorCategory.USER,

--- a/stores/pinecone/src/vector/index.ts
+++ b/stores/pinecone/src/vector/index.ts
@@ -239,6 +239,16 @@ export class PineconeVector extends MastraVector<PineconeVectorFilter> {
     namespace,
     sparseVector,
   }: PineconeQueryVectorParams): Promise<QueryResult[]> {
+    if (!queryVector) {
+      throw new MastraError({
+        id: 'VECTOR_PINECONE_QUERY_MISSING_VECTOR',
+        text: 'queryVector is required for Pinecone queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
+    }
+
     const index = this.client.Index(indexName).namespace(namespace || '');
 
     const translatedFilter = this.transformFilter(filter) ?? undefined;

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -354,7 +354,7 @@ export class QdrantVector extends MastraVector {
   }: QdrantQueryVectorParams): Promise<QueryResult[]> {
     if (!queryVector) {
       throw new MastraError({
-        id: 'VECTOR_QDRANT_QUERY_MISSING_VECTOR',
+        id: createVectorErrorId('QDRANT', 'QUERY', 'MISSING_VECTOR'),
         text: 'queryVector is required for Qdrant queries. Metadata-only queries are not supported by this vector store.',
         domain: ErrorDomain.STORAGE,
         category: ErrorCategory.USER,

--- a/stores/qdrant/src/vector/index.ts
+++ b/stores/qdrant/src/vector/index.ts
@@ -352,6 +352,16 @@ export class QdrantVector extends MastraVector {
     includeVector = false,
     using,
   }: QdrantQueryVectorParams): Promise<QueryResult[]> {
+    if (!queryVector) {
+      throw new MastraError({
+        id: 'VECTOR_QDRANT_QUERY_MISSING_VECTOR',
+        text: 'queryVector is required for Qdrant queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
+    }
+
     const translatedFilter = this.transformFilter(filter) ?? {};
 
     try {

--- a/stores/s3vectors/src/vector/index.ts
+++ b/stores/s3vectors/src/vector/index.ts
@@ -233,6 +233,16 @@ export class S3Vectors extends MastraVector<S3VectorsFilter> {
   }: QueryVectorParams<S3VectorsFilter>): Promise<QueryResult[]> {
     indexName = normalizeIndexName(indexName);
 
+    if (!queryVector) {
+      throw new MastraError({
+        id: createVectorErrorId('S3VECTORS', 'QUERY', 'MISSING_VECTOR'),
+        text: 'queryVector is required for S3 Vectors queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
+    }
+
     try {
       if (!Array.isArray(queryVector) || queryVector.length === 0) {
         throw new Error('queryVector must be a non-empty float32 array');

--- a/stores/turbopuffer/src/vector/index.ts
+++ b/stores/turbopuffer/src/vector/index.ts
@@ -217,7 +217,7 @@ export class TurbopufferVector extends MastraVector<TurbopufferVectorFilter> {
   }: TurbopufferQueryVectorParams): Promise<QueryResult[]> {
     if (!queryVector) {
       throw new MastraError({
-        id: 'VECTOR_TURBOPUFFER_QUERY_MISSING_VECTOR',
+        id: createVectorErrorId('TURBOPUFFER', 'QUERY', 'MISSING_VECTOR'),
         text: 'queryVector is required for Turbopuffer queries. Metadata-only queries are not supported by this vector store.',
         domain: ErrorDomain.STORAGE,
         category: ErrorCategory.USER,

--- a/stores/turbopuffer/src/vector/index.ts
+++ b/stores/turbopuffer/src/vector/index.ts
@@ -215,6 +215,16 @@ export class TurbopufferVector extends MastraVector<TurbopufferVectorFilter> {
     filter,
     includeVector,
   }: TurbopufferQueryVectorParams): Promise<QueryResult[]> {
+    if (!queryVector) {
+      throw new MastraError({
+        id: 'VECTOR_TURBOPUFFER_QUERY_MISSING_VECTOR',
+        text: 'queryVector is required for Turbopuffer queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
+    }
+
     let createIndex;
     try {
       const schemaConfig = this.opts.schemaConfigForIndex?.(indexName);

--- a/stores/upstash/src/vector/index.ts
+++ b/stores/upstash/src/vector/index.ts
@@ -109,6 +109,16 @@ export class UpstashVector extends MastraVector<UpstashVectorFilter> {
     fusionAlgorithm,
     queryMode,
   }: UpstashQueryVectorParams): Promise<QueryResult[]> {
+    if (!queryVector) {
+      throw new MastraError({
+        id: 'VECTOR_UPSTASH_QUERY_MISSING_VECTOR',
+        text: 'queryVector is required for Upstash queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.MASTRA_VECTOR,
+        category: ErrorCategory.USER,
+        details: { indexName: namespace },
+      });
+    }
+
     try {
       const ns = this.client.namespace(namespace);
 

--- a/stores/upstash/src/vector/index.ts
+++ b/stores/upstash/src/vector/index.ts
@@ -111,9 +111,9 @@ export class UpstashVector extends MastraVector<UpstashVectorFilter> {
   }: UpstashQueryVectorParams): Promise<QueryResult[]> {
     if (!queryVector) {
       throw new MastraError({
-        id: 'VECTOR_UPSTASH_QUERY_MISSING_VECTOR',
+        id: createVectorErrorId('UPSTASH', 'QUERY', 'MISSING_VECTOR'),
         text: 'queryVector is required for Upstash queries. Metadata-only queries are not supported by this vector store.',
-        domain: ErrorDomain.MASTRA_VECTOR,
+        domain: ErrorDomain.STORAGE,
         category: ErrorCategory.USER,
         details: { indexName: namespace },
       });

--- a/stores/vectorize/src/vector/index.ts
+++ b/stores/vectorize/src/vector/index.ts
@@ -125,6 +125,16 @@ export class CloudflareVector extends MastraVector<VectorizeVectorFilter> {
     filter,
     includeVector = false,
   }: VectorizeQueryParams): Promise<QueryResult[]> {
+    if (!queryVector) {
+      throw new MastraError({
+        id: 'VECTOR_VECTORIZE_QUERY_MISSING_VECTOR',
+        text: 'queryVector is required for Vectorize queries. Metadata-only queries are not supported by this vector store.',
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { indexName },
+      });
+    }
+
     try {
       const translatedFilter = this.transformFilter(filter) ?? {};
       const response = await this.client.vectorize.indexes.query(indexName, {

--- a/stores/vectorize/src/vector/index.ts
+++ b/stores/vectorize/src/vector/index.ts
@@ -127,7 +127,7 @@ export class CloudflareVector extends MastraVector<VectorizeVectorFilter> {
   }: VectorizeQueryParams): Promise<QueryResult[]> {
     if (!queryVector) {
       throw new MastraError({
-        id: 'VECTOR_VECTORIZE_QUERY_MISSING_VECTOR',
+        id: createVectorErrorId('VECTORIZE', 'QUERY', 'MISSING_VECTOR'),
         text: 'queryVector is required for Vectorize queries. Metadata-only queries are not supported by this vector store.',
         domain: ErrorDomain.STORAGE,
         category: ErrorCategory.USER,


### PR DESCRIPTION
## Description

This PR enables metadata-only queries for vector stores that support them.

- Makes `queryVector` optional in the `QueryVectorParams` interface.
- Implements full metadata-only query support in **PgVector**:
  - Allows querying by `filter` without providing an embedding.
  - Returns results with `score: 0` since no similarity is computed.
  - Validates that at least one of `queryVector` or `filter` is provided.
  - Keeps the existing similarity search path unchanged.
- Adds explicit guards in the other 15 vector stores to throw:
  `"Metadata-only queries are not supported by this vector store"` when `queryVector` is omitted.
- Fixes documentation bug where `query()` parameter was incorrectly named `vector` instead of `queryVector` in `pg.mdx` and `pinecone.mdx`.
- Marks `queryVector` as optional in `pg.mdx`.

Includes 9 new PgVector integration tests covering:
- Simple and complex metadata filters
- `topK` handling
- `includeVector` behavior
- Proper error cases
- Regression check for combined `queryVector + filter`

## Related Issue(s)

Fixes #13188

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL vector store: support metadata-only queries using filters without a query vector.

* **Improvements**
  * Docs: parameter renamed to "queryVector" and usage clarified.
  * Many vector stores now return clear, consistent user-facing errors when a query vector is required.

* **Tests**
  * Added metadata-only query tests for the PostgreSQL vector store.

* **Chores**
  * Package version bumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->