### PR TITLE
fix(core): stop overriding Vercel AI Gateway base URL in model router

### DIFF
--- a/.changeset/good-llamas-travel.md
+++ b/.changeset/good-llamas-travel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Vercel AI Gateway failing when using the model router string format (e.g. `vercel/openai/gpt-oss-120b`). The provider registry was overriding `createGateway`'s base URL with an incorrect value, causing API requests to hit the wrong endpoint. Removed the URL override so the AI SDK uses its own correct default. Closes #13280.

--- a/packages/core/src/llm/model/gateways/models-dev.e2e.test.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.e2e.test.ts
@@ -53,7 +53,8 @@ describe('ModelsDevGateway - Real API Integration', () => {
     }
 
     if (providers.vercel) {
-      expect(providers.vercel.url).toBe('https://ai-gateway.vercel.sh/v1');
+      // No URL override — createGateway uses its own default base URL
+      expect(providers.vercel.url).toBeUndefined();
       expect(providers.vercel.apiKeyEnvVar).toBe('AI_GATEWAY_API_KEY');
       // apiKeyHeader is undefined for installed packages (auth handled by SDK)
       expect(providers.vercel.apiKeyHeader).toBeUndefined();

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -44,7 +44,6 @@ const PROVIDER_OVERRIDES: Record<string, Partial<ProviderConfig>> = {
     url: 'https://api.groq.com/openai/v1',
   },
   vercel: {
-    url: 'https://ai-gateway.vercel.sh/v1',
     apiKeyEnvVar: 'AI_GATEWAY_API_KEY',
   },
   // moonshotai uses Anthropic-compatible API, not OpenAI-compatible
@@ -235,7 +234,7 @@ export class ModelsDevGateway extends MastraModelGateway {
       case 'deepinfra':
         return createDeepInfra({ apiKey })(modelId);
       case 'vercel':
-        return createGateway({ apiKey, baseURL, headers })(modelId);
+        return createGateway({ apiKey, headers })(modelId);
       case 'moonshotai':
       case 'moonshotai-cn': {
         // moonshotai uses Anthropic-compatible API endpoint


### PR DESCRIPTION
Fixes #13280

Using `model: "vercel/openai/gpt-oss-120b"` was failing because `PROVIDER_OVERRIDES` hardcoded a base URL for the Vercel AI Gateway that was passed to `createGateway()`, overriding the SDK's own correct default. Using `gateway("openai/gpt-oss-120b")` directly worked fine since it bypassed the model router entirely.

The fix removes the URL override and stops passing `baseURL` to `createGateway`, letting the AI SDK use its own default:

```diff
  vercel: {
-   url: 'https://ai-gateway.vercel.sh/v1',
    apiKeyEnvVar: 'AI_GATEWAY_API_KEY',
  },
```

```diff
  case 'vercel':
-   return createGateway({ apiKey, baseURL, headers })(modelId);
+   return createGateway({ apiKey, headers })(modelId);
```