### PR TITLE
fix: resolve processor-added tools on resume (COR-535)

### DIFF
--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -43,6 +43,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
   inputProcessors,
   processorStates,
   agentId,
+  models,
 }: OuterLLMRun<Tools, OUTPUT>) {
   return createStep({
     id: 'toolCallStep',
@@ -77,6 +78,8 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
             steps: [],
             tools: stepTools,
             requestContext,
+            model: models?.[0]?.model!,
+            retryCount: 0,
           });
 
           if (result.tools?.[inputData.toolName]) {
@@ -84,7 +87,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
             stepTools = result.tools as Tools;
             // Update _internal so subsequent tool calls in this foreach don't re-run processors
             if (_internal) {
-              _internal.stepTools = result.tools;
+              _internal.stepTools = result.tools as ToolSet;
             }
           }
         } catch (error) {


### PR DESCRIPTION
## Summary

Fixes [COR-535](https://linear.app/kepler-crm/issue/COR-535/agentic-loop-workflow-suspendresume-breaks-tools-added-mid-stream): processor-added tools are lost after suspend/resume because `_internal.stepTools` (which holds tools with their `execute` functions) isn't serialized to storage.

**The bug:** When a processor adds a tool via `processInputStep` and that tool requires approval, the workflow suspends. On resume, execution jumps to `toolCallStep` — skipping `llmExecutionStep` where processors run. `_internal.stepTools` is empty, the tool isn't in the original closure tools, so it hits `ToolNotFoundError`. This creates an infinite approval loop: approve → not found → LLM retries → approval again → suspend → resume → not found.

**The fix:** In `toolCallStep`, when a tool isn't found on the resume path, re-run `processInputStep` on the input processors as a fallback. The processor re-provides the tool with its `execute` function intact. Results are cached on `_internal.stepTools` so subsequent tool calls in the same `.foreach()` batch don't re-run processors.

**Limitation:** This works when the processor instance is still alive (same process). For cross-process resume (server restart), processors need to persist their state to storage — that's a separate follow-up for durable agents.

- Repro test: #13288

## Test plan
- [x] New integration test: processor adds tool → approval suspends → `resumeStream` resumes → tool executes (was failing, now passes)
- [x] Existing tool-approval tests pass
- [x] Existing tool-call-step unit tests pass