### PR TITLE
feat(workspace): pass abortSignal to workspace tools and spawned processes

### DIFF
--- a/packages/core/src/workspace/sandbox/types.ts
+++ b/packages/core/src/workspace/sandbox/types.ts
@@ -76,6 +76,8 @@ export interface ExecuteCommandOptions {
   onStdout?: (data: string) => void;
   /** Callback for stderr chunks (enables streaming) */
   onStderr?: (data: string) => void;
+  /** Abort signal to cancel the command */
+  abortSignal?: AbortSignal;
 }
 
 // =============================================================================

--- a/packages/core/src/workspace/tools/__tests__/execute-command.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/execute-command.test.ts
@@ -288,6 +288,40 @@ describe('executeCommandTool data chunks', () => {
     });
   });
 
+  describe('abort signal', () => {
+    it('passes context.abortSignal to sandbox.executeCommand', async () => {
+      const controller = new AbortController();
+      let receivedOptions: ExecuteCommandOptions | undefined;
+
+      const { context } = createMockContext({
+        executeCommand: async (_cmd, _args, opts) => {
+          receivedOptions = opts;
+          return { success: true, exitCode: 0, stdout: '', stderr: '', executionTimeMs: 1 };
+        },
+      });
+
+      context.abortSignal = controller.signal;
+      await execute({ command: 'echo', args: ['hi'], timeout: null, cwd: null }, context);
+
+      expect(receivedOptions?.abortSignal).toBe(controller.signal);
+    });
+
+    it('passes undefined abortSignal when context has none', async () => {
+      let receivedOptions: ExecuteCommandOptions | undefined;
+
+      const { context } = createMockContext({
+        executeCommand: async (_cmd, _args, opts) => {
+          receivedOptions = opts;
+          return { success: true, exitCode: 0, stdout: '', stderr: '', executionTimeMs: 1 };
+        },
+      });
+
+      await execute({ command: 'echo', args: ['hi'], timeout: null, cwd: null }, context);
+
+      expect(receivedOptions?.abortSignal).toBeUndefined();
+    });
+  });
+
   describe('streaming chunks match return value', () => {
     it('streamed stdout chunks contain same data as final result', async () => {
       const stdoutLines = ['line 1\n', 'line 2\n', 'line 3\n'];

--- a/packages/core/src/workspace/tools/execute-command.ts
+++ b/packages/core/src/workspace/tools/execute-command.ts
@@ -36,6 +36,7 @@ Usage:
       const result = await sandbox.executeCommand(command, args ?? [], {
         timeout: timeout ?? undefined,
         cwd: cwd ?? undefined,
+        abortSignal: context?.abortSignal,
         onStdout: async (data: string) => {
           stdout += data;
           await context?.writer?.custom({

--- a/packages/core/src/workspace/tools/grep.ts
+++ b/packages/core/src/workspace/tools/grep.ts
@@ -59,6 +59,7 @@ Usage:
     context,
   ) => {
     const { filesystem } = requireFilesystem(context);
+    const abortSignal = context?.abortSignal;
     await emitWorkspaceMetadata(context, WORKSPACE_TOOLS.FILESYSTEM.GREP);
 
     // Guard against excessively long patterns as a cheap ReDoS heuristic
@@ -99,6 +100,7 @@ Usage:
       } else {
         // Directory — walk recursively
         const collectFiles = async (dir: string): Promise<string[]> => {
+          if (abortSignal?.aborted) return [];
           const files: string[] = [];
           let entries;
           try {
@@ -108,6 +110,7 @@ Usage:
           }
 
           for (const entry of entries) {
+            if (abortSignal?.aborted) break;
             // Skip hidden files/dirs unless includeHidden is set
             if (!includeHidden && entry.name.startsWith('.')) continue;
 
@@ -139,7 +142,7 @@ Usage:
     const GLOBAL_CAP = 1000;
 
     for (const filePath of filePaths) {
-      if (truncated) break;
+      if (truncated || abortSignal?.aborted) break;
 
       let content: string;
       try {

--- a/packages/core/src/workspace/tools/list-files.ts
+++ b/packages/core/src/workspace/tools/list-files.ts
@@ -56,6 +56,7 @@ Examples:
       exclude: exclude || undefined,
       extension: extension || undefined,
       pattern: pattern || undefined,
+      abortSignal: context?.abortSignal,
     });
 
     return `${result.tree}\n\n${result.summary}`;


### PR DESCRIPTION
## Summary

- Add `abortSignal` to `ExecuteCommandOptions` so sandbox implementations can kill spawned processes when an agent stream is aborted
- Wire abort signal through `LocalSandbox.execWithStreaming` — listens for abort and sends SIGTERM to the child process
- Pass `context.abortSignal` from `execute_command`, `grep`, and `list_files` workspace tools
- Check abort signal in grep's file collection/scanning loops and tree-formatter's recursive walk

Closes COR-543

## Test plan

- [ ] Existing workspace tool tests pass (101 tests across 14 files)
- [ ] Existing local-sandbox tests pass (41 existing + 3 new)
- [ ] New tests: abort running command, pre-aborted signal, partial stdout before abort
- [ ] New tests: execute-command tool passes abortSignal through to sandbox