### PR TITLE
chore(core): remove redundant vercel PROVIDER_OVERRIDES entry

### DIFF
--- a/.changeset/busy-aliens-hug.md
+++ b/.changeset/busy-aliens-hug.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Removed redundant Vercel AI Gateway `apiKeyEnvVar` override from `PROVIDER_OVERRIDES` since models.dev already provides it.

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -43,9 +43,6 @@ const PROVIDER_OVERRIDES: Record<string, Partial<ProviderConfig>> = {
   groq: {
     url: 'https://api.groq.com/openai/v1',
   },
-  vercel: {
-    apiKeyEnvVar: 'AI_GATEWAY_API_KEY',
-  },
   // moonshotai uses Anthropic-compatible API, not OpenAI-compatible
   moonshotai: {
     url: 'https://api.moonshot.ai/anthropic/v1',


### PR DESCRIPTION
Follow-up to #13287.

The `apiKeyEnvVar: 'AI_GATEWAY_API_KEY'` override for vercel was the last remaining property in its `PROVIDER_OVERRIDES` entry. models.dev already provides `env: ['AI_GATEWAY_API_KEY']` for vercel, so the override is redundant. This removes the entire vercel entry from `PROVIDER_OVERRIDES`.

Vercel is still included in the registry via `PROVIDERS_WITH_INSTALLED_PACKAGES` and `npm: '@ai-sdk/gateway'` from models.dev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Removed redundant API key environment variable configuration for Vercel AI Gateway provider. Environment variable settings are now automatically derived from provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->