### PR TITLE
fix(editor): agent publish flow and recursive processor graph schema

### DIFF
--- a/.changeset/chilly-vans-cover.md
+++ b/.changeset/chilly-vans-cover.md
@@ -3,3 +3,8 @@
 ---
 
 Fixed agent publish flow to no longer auto-save a draft. Publish now only activates the latest saved version. Save and Publish buttons are disabled when there are no changes or no unpublished draft, respectively.
+
+Memory page improvements:
+- Renamed "Last Messages" to "Message History" and added a toggle switch for consistency with other memory options.
+- Moved Observational Memory to the top of the memory list.
+- Observational Memory and Message History are now mutually exclusive — enabling one disables the other.

--- a/.changeset/chilly-vans-cover.md
+++ b/.changeset/chilly-vans-cover.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed agent publish flow to no longer auto-save a draft. Publish now only activates the latest saved version. Save and Publish buttons are disabled when there are no changes or no unpublished draft, respectively.

--- a/.changeset/proud-windows-behave.md
+++ b/.changeset/proud-windows-behave.md
@@ -1,0 +1,6 @@
+---
+'@mastra/server': patch
+'@mastra/core': patch
+---
+
+Fixed recursive schema warnings for processor graph entries by unrolling to a fixed depth of 3 levels, matching the existing rule group pattern

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-pages/agents-page.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-pages/agents-page.tsx
@@ -55,27 +55,39 @@ export function AgentsPage() {
     if (isSet) {
       const next = { ...selectedAgents };
       delete next[agentId];
-      form.setValue('agents', next);
+      form.setValue('agents', next, { shouldDirty: true });
     } else {
-      form.setValue('agents', {
-        ...selectedAgents,
-        [agentId]: { ...selectedAgents?.[agentId], description: getOriginalDescription(agentId) },
-      });
+      form.setValue(
+        'agents',
+        {
+          ...selectedAgents,
+          [agentId]: { ...selectedAgents?.[agentId], description: getOriginalDescription(agentId) },
+        },
+        { shouldDirty: true },
+      );
     }
   };
 
   const handleDescriptionChange = (agentId: string, description: string) => {
-    form.setValue('agents', {
-      ...selectedAgents,
-      [agentId]: { ...selectedAgents?.[agentId], description },
-    });
+    form.setValue(
+      'agents',
+      {
+        ...selectedAgents,
+        [agentId]: { ...selectedAgents?.[agentId], description },
+      },
+      { shouldDirty: true },
+    );
   };
 
   const handleRulesChange = (agentId: string, rules: RuleGroup | undefined) => {
-    form.setValue('agents', {
-      ...selectedAgents,
-      [agentId]: { ...selectedAgents?.[agentId], rules },
-    });
+    form.setValue(
+      'agents',
+      {
+        ...selectedAgents,
+        [agentId]: { ...selectedAgents?.[agentId], rules },
+      },
+      { shouldDirty: true },
+    );
   };
 
   const filteredOptions = useMemo(() => {

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-pages/memory-page.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-pages/memory-page.tsx
@@ -64,10 +64,10 @@ export function MemoryPage() {
 
         {isEnabled && (
           <div className="flex flex-col gap-2">
+            <ObservationalMemoryEntity />
             <LastMessagesEntity />
             <SemanticRecallEntity />
             <ReadOnlyEntity />
-            <ObservationalMemoryEntity />
           </div>
         )}
       </div>
@@ -78,38 +78,60 @@ export function MemoryPage() {
 function LastMessagesEntity() {
   const { form, readOnly } = useAgentEditFormContext();
   const { control } = form;
+  const lastMessages = useWatch({ control, name: 'memory.lastMessages' });
+  const lastMessagesEnabled = lastMessages !== false;
 
   return (
     <Entity className="flex-col gap-0 p-0 overflow-hidden">
       <div className="flex gap-3 py-3 px-4">
         <EntityContent>
-          <EntityName>Last Messages</EntityName>
+          <EntityName>Message History</EntityName>
           <EntityDescription>Number of recent messages to include in context</EntityDescription>
         </EntityContent>
+
+        {!readOnly && (
+          <Controller
+            name="memory.lastMessages"
+            control={control}
+            render={({ field }) => (
+              <Switch
+                checked={lastMessagesEnabled}
+                onCheckedChange={checked => {
+                  field.onChange(checked ? 40 : false);
+                  if (checked) {
+                    form.setValue('memory.observationalMemory.enabled', false, { shouldDirty: true });
+                  }
+                }}
+              />
+            )}
+          />
+        )}
       </div>
 
-      <div className="bg-surface2 border-t border-border1 p-4">
-        <Controller
-          name="memory.lastMessages"
-          control={control}
-          render={({ field }) => (
-            <Input
-              id="memory-last-messages"
-              type="number"
-              min="1"
-              step="1"
-              value={field.value === false ? '' : (field.value ?? 40)}
-              onChange={e => {
-                const value = e.target.value;
-                field.onChange(value === '' ? false : parseInt(value, 10));
-              }}
-              placeholder="40"
-              className="bg-surface3"
-              disabled={readOnly}
-            />
-          )}
-        />
-      </div>
+      {lastMessagesEnabled && (
+        <div className="bg-surface2 border-t border-border1 p-4">
+          <Controller
+            name="memory.lastMessages"
+            control={control}
+            render={({ field }) => (
+              <Input
+                id="memory-last-messages"
+                type="number"
+                min="1"
+                step="1"
+                value={field.value === false ? '' : (field.value ?? 40)}
+                onChange={e => {
+                  const value = e.target.value;
+                  field.onChange(value === '' ? false : parseInt(value, 10));
+                }}
+                placeholder="40"
+                className="bg-surface3"
+                disabled={readOnly}
+              />
+            )}
+          />
+        </div>
+      )}
     </Entity>
   );
 }
@@ -239,7 +261,17 @@ function ObservationalMemoryEntity() {
           <Controller
             name="memory.observationalMemory.enabled"
             control={control}
-            render={({ field }) => <Switch checked={field.value ?? false} onCheckedChange={field.onChange} />}
+            render={({ field }) => (
+              <Switch
+                checked={field.value ?? false}
+                onCheckedChange={checked => {
+                  field.onChange(checked);
+                  if (checked) {
+                    form.setValue('memory.lastMessages', false, { shouldDirty: true });
+                  }
+                }}
+              />
+            )}
           />
         )}
       </div>
@@ -275,7 +307,7 @@ function ObservationalMemoryFields() {
                   value={field.value ?? ''}
                   onValueChange={v => {
                     field.onChange(v);
-                    setValue('memory.observationalMemory.model.name', '');
+                    setValue('memory.observationalMemory.model.name', '', { shouldDirty: true });
                   }}
                   variant="light"
                 />
@@ -377,7 +409,7 @@ function ObserverFields({ observerProvider }: { observerProvider: string }) {
                   value={field.value ?? ''}
                   onValueChange={v => {
                     field.onChange(v);
-                    setValue('memory.observationalMemory.observation.model.name', '');
+                    setValue('memory.observationalMemory.observation.model.name', '', { shouldDirty: true });
                   }}
                   variant="light"
                 />
@@ -581,7 +613,7 @@ function ReflectorFields({ reflectorProvider }: { reflectorProvider: string }) {
                   value={field.value ?? ''}
                   onValueChange={v => {
                     field.onChange(v);
-                    setValue('memory.observationalMemory.reflection.model.name', '');
+                    setValue('memory.observationalMemory.reflection.model.name', '', { shouldDirty: true });
                   }}
                   variant="light"
                 />

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-pages/scorers-page.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-pages/scorers-page.tsx
@@ -50,34 +50,50 @@ export function ScorersPage() {
     if (isSet) {
       const next = { ...selectedScorers };
       delete next[scorerId];
-      form.setValue('scorers', next);
+      form.setValue('scorers', next, { shouldDirty: true });
     } else {
-      form.setValue('scorers', {
-        ...selectedScorers,
-        [scorerId]: { ...selectedScorers?.[scorerId], description: getOriginalDescription(scorerId) },
-      });
+      form.setValue(
+        'scorers',
+        {
+          ...selectedScorers,
+          [scorerId]: { ...selectedScorers?.[scorerId], description: getOriginalDescription(scorerId) },
+        },
+        { shouldDirty: true },
+      );
     }
   };
 
   const handleDescriptionChange = (scorerId: string, description: string) => {
-    form.setValue('scorers', {
-      ...selectedScorers,
-      [scorerId]: { ...selectedScorers?.[scorerId], description },
-    });
+    form.setValue(
+      'scorers',
+      {
+        ...selectedScorers,
+        [scorerId]: { ...selectedScorers?.[scorerId], description },
+      },
+      { shouldDirty: true },
+    );
   };
 
   const handleSamplingChange = (scorerId: string, samplingConfig: ScorerConfig['sampling'] | undefined) => {
-    form.setValue('scorers', {
-      ...selectedScorers,
-      [scorerId]: { ...selectedScorers?.[scorerId], sampling: samplingConfig },
-    });
+    form.setValue(
+      'scorers',
+      {
+        ...selectedScorers,
+        [scorerId]: { ...selectedScorers?.[scorerId], sampling: samplingConfig },
+      },
+      { shouldDirty: true },
+    );
   };
 
   const handleRulesChange = (scorerId: string, rules: RuleGroup | undefined) => {
-    form.setValue('scorers', {
-      ...selectedScorers,
-      [scorerId]: { ...selectedScorers?.[scorerId], rules },
-    });
+    form.setValue(
+      'scorers',
+      {
+        ...selectedScorers,
+        [scorerId]: { ...selectedScorers?.[scorerId], rules },
+      },
+      { shouldDirty: true },
+    );
   };
 
   const filteredOptions = useMemo(() => {

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-pages/tools-page.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-pages/tools-page.tsx
@@ -57,27 +57,39 @@ export function ToolsPage() {
     if (isSet) {
       const next = { ...selectedTools };
       delete next[toolId];
-      form.setValue('tools', next);
+      form.setValue('tools', next, { shouldDirty: true });
     } else {
-      form.setValue('tools', {
-        ...selectedTools,
-        [toolId]: { ...selectedTools?.[toolId], description: getOriginalDescription(toolId) },
-      });
+      form.setValue(
+        'tools',
+        {
+          ...selectedTools,
+          [toolId]: { ...selectedTools?.[toolId], description: getOriginalDescription(toolId) },
+        },
+        { shouldDirty: true },
+      );
     }
   };
 
   const handleDescriptionChange = (toolId: string, description: string) => {
-    form.setValue('tools', {
-      ...selectedTools,
-      [toolId]: { ...selectedTools?.[toolId], description },
-    });
+    form.setValue(
+      'tools',
+      {
+        ...selectedTools,
+        [toolId]: { ...selectedTools?.[toolId], description },
+      },
+      { shouldDirty: true },
+    );
   };
 
   const handleRulesChange = (toolId: string, rules: RuleGroup | undefined) => {
-    form.setValue('tools', {
-      ...selectedTools,
-      [toolId]: { ...selectedTools?.[toolId], rules },
-    });
+    form.setValue(
+      'tools',
+      {
+        ...selectedTools,
+        [toolId]: { ...selectedTools?.[toolId], rules },
+      },
+      { shouldDirty: true },
+    );
   };
 
   const handleIntegrationToolsSubmit = useCallback(
@@ -96,7 +108,7 @@ export function ToolsPage() {
         next[id] = selectedIntegrationTools?.[id] || { description };
       }
 
-      form.setValue('integrationTools', next);
+      form.setValue('integrationTools', next, { shouldDirty: true });
     },
     [form, selectedIntegrationTools],
   );

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-pages/workflows-page.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-pages/workflows-page.tsx
@@ -46,27 +46,39 @@ export function WorkflowsPage() {
     if (isSet) {
       const next = { ...selectedWorkflows };
       delete next[workflowId];
-      form.setValue('workflows', next);
+      form.setValue('workflows', next, { shouldDirty: true });
     } else {
-      form.setValue('workflows', {
-        ...selectedWorkflows,
-        [workflowId]: { ...selectedWorkflows?.[workflowId], description: getOriginalDescription(workflowId) },
-      });
+      form.setValue(
+        'workflows',
+        {
+          ...selectedWorkflows,
+          [workflowId]: { ...selectedWorkflows?.[workflowId], description: getOriginalDescription(workflowId) },
+        },
+        { shouldDirty: true },
+      );
     }
   };
 
   const handleDescriptionChange = (workflowId: string, description: string) => {
-    form.setValue('workflows', {
-      ...selectedWorkflows,
-      [workflowId]: { ...selectedWorkflows?.[workflowId], description },
-    });
+    form.setValue(
+      'workflows',
+      {
+        ...selectedWorkflows,
+        [workflowId]: { ...selectedWorkflows?.[workflowId], description },
+      },
+      { shouldDirty: true },
+    );
   };
 
   const handleRulesChange = (workflowId: string, rules: RuleGroup | undefined) => {
-    form.setValue('workflows', {
-      ...selectedWorkflows,
-      [workflowId]: { ...selectedWorkflows?.[workflowId], rules },
-    });
+    form.setValue(
+      'workflows',
+      {
+        ...selectedWorkflows,
+        [workflowId]: { ...selectedWorkflows?.[workflowId], rules },
+      },
+      { shouldDirty: true },
+    );
   };
 
   const filteredOptions = useMemo(() => {

--- a/packages/playground-ui/src/domains/agents/hooks/use-agent-cms-form.ts
+++ b/packages/playground-ui/src/domains/agents/hooks/use-agent-cms-form.ts
@@ -261,16 +261,7 @@ export function useAgentCmsForm(options: UseAgentCmsFormOptions) {
     } finally {
       setIsSubmitting(false);
     }
-  }, [
-    form,
-    isEdit,
-    client,
-    createStoredAgent,
-    options,
-    agentId,
-    buildSharedParams,
-    queryClient,
-  ]);
+  }, [form, isEdit, client, createStoredAgent, options, agentId, buildSharedParams, queryClient]);
 
   const watched = useWatch({ control: form.control });
 

--- a/packages/playground-ui/src/domains/agents/hooks/use-agent-cms-form.ts
+++ b/packages/playground-ui/src/domains/agents/hooks/use-agent-cms-form.ts
@@ -188,6 +188,8 @@ export function useAgentCmsForm(options: UseAgentCmsFormOptions) {
         memory: editMemory,
       });
 
+      // Reset form dirty state so publish can detect unsaved changes
+      form.reset(values);
       queryClient.invalidateQueries({ queryKey: ['agent-versions', agentId] });
       toast.success('Draft saved');
     } catch (error) {
@@ -209,23 +211,19 @@ export function useAgentCmsForm(options: UseAgentCmsFormOptions) {
 
     try {
       if (isEdit) {
-        const sharedParams = await buildSharedParams(values);
-        const editMemory = buildMemoryParams(values);
+        // Check if there's an unpublished draft version to activate
+        const [agentDetails, versionsResponse] = await Promise.all([
+          client.getStoredAgent(options.agentId).details(),
+          client.getStoredAgent(options.agentId).listVersions({ sortDirection: 'DESC', perPage: 1 }),
+        ]);
 
-        // Save draft first
-        await updateStoredAgent.mutateAsync({
-          ...sharedParams,
-          memory: editMemory,
-        });
-
-        // Fetch latest version and activate it
-        const versionsResponse = await client
-          .getStoredAgent(options.agentId)
-          .listVersions({ sortDirection: 'DESC', perPage: 1 });
         const latestVersion = versionsResponse.versions[0];
-        if (latestVersion) {
-          await client.getStoredAgent(options.agentId).activateVersion(latestVersion.id);
+        if (!latestVersion || latestVersion.id === agentDetails.activeVersionId) {
+          toast.error('No draft changes to publish. Save a draft first.');
+          return;
         }
+
+        await client.getStoredAgent(options.agentId).activateVersion(latestVersion.id);
 
         await Promise.all([
           queryClient.invalidateQueries({ queryKey: ['agent-versions', agentId] }),
@@ -268,11 +266,9 @@ export function useAgentCmsForm(options: UseAgentCmsFormOptions) {
     isEdit,
     client,
     createStoredAgent,
-    updateStoredAgent,
     options,
     agentId,
     buildSharedParams,
-    buildMemoryParams,
     queryClient,
   ]);
 
@@ -284,5 +280,7 @@ export function useAgentCmsForm(options: UseAgentCmsFormOptions) {
     return identityDone && instructionsDone;
   }, [watched.name, watched.model?.provider, watched.model?.name, watched.instructionBlocks]);
 
-  return { form, handlePublish, handleSaveDraft, isSubmitting, isSavingDraft, canPublish };
+  const isDirty = form.formState.isDirty;
+
+  return { form, handlePublish, handleSaveDraft, isSubmitting, isSavingDraft, canPublish, isDirty };
 }

--- a/packages/playground-ui/src/domains/agents/hooks/use-agent-cms-form.ts
+++ b/packages/playground-ui/src/domains/agents/hooks/use-agent-cms-form.ts
@@ -74,7 +74,7 @@ export function useAgentCmsForm(options: UseAgentCmsFormOptions) {
           servers: r.servers,
           selectedTools: mcpClientRecord?.[r.id]?.tools ?? {},
         }));
-        form.setValue('mcpClients', mcpClientValues);
+        form.setValue('mcpClients', mcpClientValues, { shouldDirty: true });
 
         // Sync MCP tools into form.tools
         const currentTools = form.getValues('tools') ?? {};
@@ -84,7 +84,7 @@ export function useAgentCmsForm(options: UseAgentCmsFormOptions) {
             next[name] = { description: config.description };
           }
         }
-        form.setValue('tools', next);
+        form.setValue('tools', next, { shouldDirty: true });
       })
       .catch(() => {
         // Silently ignore — clients may have been deleted

--- a/packages/playground/src/pages/cms/agents/edit-layout.tsx
+++ b/packages/playground/src/pages/cms/agents/edit-layout.tsx
@@ -102,7 +102,7 @@ function EditLayoutWrapper() {
 
   const activeVersionId = agent?.activeVersionId;
   const latestVersion = versionsData?.versions?.[0];
-  const hasDraft = !!(latestVersion && activeVersionId && latestVersion.id !== activeVersionId);
+  const hasDraft = !!(latestVersion && latestVersion.id !== activeVersionId);
 
   const isViewingVersion = !!selectedVersionId && !!versionData;
   const dataSource = useMemo<AgentDataSource>(() => {
@@ -111,7 +111,7 @@ function EditLayoutWrapper() {
     return {} as AgentDataSource;
   }, [isViewingVersion, versionData, agent]);
 
-  const { form, handlePublish, handleSaveDraft, isSubmitting, isSavingDraft } = useAgentCmsForm({
+  const { form, handlePublish, handleSaveDraft, isSubmitting, isSavingDraft, isDirty } = useAgentCmsForm({
     mode: 'edit',
     agentId: agentId ?? '',
     dataSource,
@@ -155,7 +155,11 @@ function EditLayoutWrapper() {
             />
             {!selectedVersionId && (
               <>
-                <Button variant="outline" onClick={handleSaveDraft} disabled={isSavingDraft || isSubmitting}>
+                <Button
+                  variant="outline"
+                  onClick={handleSaveDraft}
+                  disabled={!isDirty || isSavingDraft || isSubmitting}
+                >
                   {isSavingDraft ? (
                     <>
                       <Spinner className="h-4 w-4" />
@@ -170,7 +174,11 @@ function EditLayoutWrapper() {
                     </>
                   )}
                 </Button>
-                <Button variant="primary" onClick={handlePublish} disabled={isSubmitting || isSavingDraft}>
+                <Button
+                  variant="primary"
+                  onClick={handlePublish}
+                  disabled={!hasDraft || isDirty || isSubmitting || isSavingDraft}
+                >
                   {isSubmitting ? (
                     <>
                       <Spinner className="h-4 w-4" />

--- a/packages/server/src/server/schemas/agent-versions.ts
+++ b/packages/server/src/server/schemas/agent-versions.ts
@@ -147,4 +147,6 @@ export const restoreVersionResponseSchema = agentVersionSchema.describe(
 /**
  * Response for GET /stored/agents/:agentId/versions/compare
  */
-export const compareVersionsResponseSchema = createCompareVersionsResponseSchema(agentVersionSchema);
+export const compareVersionsResponseSchema: ReturnType<
+  typeof createCompareVersionsResponseSchema<typeof agentVersionSchema>
+> = createCompareVersionsResponseSchema(agentVersionSchema);

--- a/packages/server/src/server/schemas/stored-agents.ts
+++ b/packages/server/src/server/schemas/stored-agents.ts
@@ -130,24 +130,47 @@ const processorGraphStepSchema = z.object({
 });
 
 /**
- * Processor graph entry schema (recursive via lazy).
+ * Processor graph entry schema.
  * Simplified version of SerializedStepFlowEntry, supporting step, parallel, and conditional.
+ *
+ * Uses a fixed nesting depth (3 levels) to avoid infinite recursion
+ * when converting to JSON Schema / OpenAPI.
  */
-const processorGraphEntrySchema: z.ZodType = z.lazy(() =>
-  z.discriminatedUnion('type', [
-    z.object({ type: z.literal('step'), step: processorGraphStepSchema }),
-    z.object({ type: z.literal('parallel'), branches: z.array(z.array(processorGraphEntrySchema)) }),
-    z.object({
-      type: z.literal('conditional'),
-      conditions: z.array(
-        z.object({
-          steps: z.array(processorGraphEntrySchema),
-          rules: ruleGroupSchema.optional(),
-        }),
-      ),
-    }),
-  ]),
-);
+
+/** Depth 3 (leaf): only step entries allowed */
+const processorGraphEntryDepth3 = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('step'), step: processorGraphStepSchema }),
+]);
+
+/** Depth 2: step, parallel, and conditional — children limited to depth 3 */
+const processorGraphEntryDepth2 = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('step'), step: processorGraphStepSchema }),
+  z.object({ type: z.literal('parallel'), branches: z.array(z.array(processorGraphEntryDepth3)) }),
+  z.object({
+    type: z.literal('conditional'),
+    conditions: z.array(
+      z.object({
+        steps: z.array(processorGraphEntryDepth3),
+        rules: ruleGroupSchema.optional(),
+      }),
+    ),
+  }),
+]);
+
+/** Depth 1 (top-level): step, parallel, and conditional — children limited to depth 2 */
+const processorGraphEntrySchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('step'), step: processorGraphStepSchema }),
+  z.object({ type: z.literal('parallel'), branches: z.array(z.array(processorGraphEntryDepth2)) }),
+  z.object({
+    type: z.literal('conditional'),
+    conditions: z.array(
+      z.object({
+        steps: z.array(processorGraphEntryDepth2),
+        rules: ruleGroupSchema.optional(),
+      }),
+    ),
+  }),
+]);
 
 /**
  * A stored processor graph representing a pipeline of processors.


### PR DESCRIPTION
The publish button was auto-saving a draft before activating, which created a new version every time you published. Now publish only activates the latest saved version — no extra version rows.

Save and Publish buttons are also properly greyed out now: Save is disabled when there are no form changes, Publish is disabled when there's no unpublished draft (or when there are unsaved changes that need to be saved first).

Separately, `processorGraphEntrySchema` used `z.lazy()` for recursion which caused "Recursive reference detected" warnings when generating JSON Schema. Unrolled it to 3 fixed depth levels, matching the existing `ruleGroupSchema` pattern. Updated the corresponding TypeScript types in core to match.

Memory page improvements:
- Renamed "Last Messages" to "Message History" and added a toggle switch for consistency with other memory options.
- Moved Observational Memory to the top of the memory list.
- Observational Memory and Message History are now mutually exclusive — enabling one disables the other.