### PR TITLE
chore(mastracode): Update installation instructions

### DIFF
--- a/.changeset/real-garlics-smell.md
+++ b/.changeset/real-garlics-smell.md
@@ -1,0 +1,5 @@
+---
+"mastracode": patch
+---
+
+Update README to include updated install instructions

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -25,7 +25,7 @@ If you prefer not to install packages globally, you can use `npx`:
 npx mastracode
 ```
 
-Once you started `mastracode`, execute the `/login` command to authenticate with your AI providers.
+Once you start `mastracode`, execute the `/login` command to authenticate with your AI providers.
 
 ## Usage
 

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -18,13 +18,14 @@ Clone the repository and install its dependencies.
 ```bash
 # Clone the repository
 git clone https://github.com/mastra-ai/mastra.git
-cd mastracode
+cd mastra
 
-# Install dependencies
+# Install dependencies and build all workspace packages
 pnpm install
+pnpm build
 ```
 
-To use Mastra Code, we recommend creating an alias in your shell configuration to launch it from any directory. You have to specify the absolute path to `main.ts` and then run it with `tsx`.
+To use Mastra Code, we recommend creating an alias in your shell configuration to launch it from any directory. You have to specify the absolute path to `mastracode/src/main.ts` and then run it with `tsx`.
 
 ```bash
 # Add this to your .bashrc, .zshrc, etc.

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -19,7 +19,7 @@ Install `mastracode` globally with your package manager of choice.
 npm install -g mastracode
 ```
 
-If you prefer to not install packages globally, you can use `npx`:
+If you prefer not to install packages globally, you can use `npx`:
 
 ```bash
 npx mastracode

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -4,35 +4,28 @@ A terminal-based coding agent TUI built with [Mastra](https://mastra.ai) and [pi
 
 ## Features
 
-- 🤖 **Multi-model support** - Use Claude, GPT, Gemini, and 70+ other models via Mastra's unified model router
-- 🔐 **OAuth login** - Authenticate with Anthropic (Claude Max) and OpenAI (ChatGPT Plus/Codex)
-- 💾 **Persistent conversations** - Threads are saved per-project and resume automatically
-- 🛠️ **Coding tools** - View files, edit code, run shell commands
-- 📊 **Token tracking** - Monitor usage with persistent token counts per thread
-- 🎨 **Beautiful TUI** - Polished terminal interface with streaming responses
+- 🤖 **Multi-model support**: Use Claude, GPT, Gemini, and 70+ other models via Mastra's unified model router
+- 🔐 **OAuth login**: Authenticate with Anthropic (Claude Max) and OpenAI (ChatGPT Plus/Codex)
+- 💾 **Persistent conversations**: Threads are saved per-project and resume automatically
+- 🛠️ **Coding tools**: View files, edit code, run shell commands
+- 📊 **Token tracking**: Monitor usage with persistent token counts per thread
+- 🎨 **Beautiful TUI**: Polished terminal interface with streaming responses
 
 ## Installation
 
-Clone the repository and install its dependencies.
+Install `mastracode` globally with your package manager of choice.
 
 ```bash
-# Clone the repository
-git clone https://github.com/mastra-ai/mastra.git
-cd mastra
-
-# Install dependencies and build all workspace packages
-pnpm install
-pnpm build
+npm install -g mastracode
 ```
 
-To use Mastra Code, we recommend creating an alias in your shell configuration to launch it from any directory. You have to specify the absolute path to `mastracode/src/main.ts` and then run it with `tsx`.
+If you prefer to not install packages globally, you can use `npx`:
 
 ```bash
-# Add this to your .bashrc, .zshrc, etc.
-alias mastracode="pnpm dlx tsx /absolute/path/mastracode/src/main.ts"
+npx mastracode
 ```
 
-Lastly, start the TUI and execute the `/login` command to authenticate with your AI providers.
+Once you started `mastracode`, execute the `/login` command to authenticate with your AI providers.
 
 ## Usage
 
@@ -131,13 +124,6 @@ pnpm typecheck
 # Build
 pnpm build
 ```
-
-## Roadmap
-
-- [ ] Tool approval UI for dangerous operations
-- [ ] Streaming tool output
-- [ ] More tools (search, grep, etc.)
-- [ ] Multi-agent collaboration (network mode)
 
 ## Credits
 


### PR DESCRIPTION
Mastra Code requires workspace packages to be built before it can be run since it relies on `@mastra/*` dependencies. This updates the README to instruct users to run `pnpm build` from the workspace root. Also corrects the `cd` directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reformatted Features list for clearer inline wording; updated install and startup guidance to recommend global install and npx-based usage; clarified start/login wording; removed the Roadmap section; minor wording and consistency edits.

* **Chores**
  * Added a patch-level changeset noting the README installation update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->