### PR TITLE
fix(schema-compat): add Groq provider to OpenAI compat layer

### DIFF
--- a/.changeset/brown-bags-dress.md
+++ b/.changeset/brown-bags-dress.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed Groq provider not receiving schema compatibility transformations, which caused HTTP 400 errors when AI models omitted optional parameters from workspace tool calls (e.g. list_files). Groq now correctly gets the same optional-to-nullable schema handling as OpenAI.

--- a/packages/schema-compat/src/provider-compats/__snapshots__/groq.test.ts.snap
+++ b/packages/schema-compat/src/provider-compats/__snapshots__/groq.test.ts.snap
@@ -1,0 +1,1141 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > Snapshot Tests - Full JSON Schema Output > should match snapshot for API response schema 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "data": {
+      "properties": {
+        "items": {
+          "items": {
+            "properties": {
+              "createdAt": {
+                "type": "string",
+              },
+              "id": {
+                "type": "string",
+              },
+              "metadata": {
+                "additionalProperties": {
+                  "type": "string",
+                },
+                "propertyNames": {
+                  "type": "string",
+                },
+                "type": "object",
+              },
+              "name": {
+                "type": "string",
+              },
+              "updatedAt": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "id",
+              "name",
+              "createdAt",
+            ],
+            "type": "object",
+          },
+          "type": "array",
+        },
+        "pagination": {
+          "properties": {
+            "page": {
+              "type": "number",
+            },
+            "pageSize": {
+              "type": "number",
+            },
+            "totalItems": {
+              "type": "number",
+            },
+            "totalPages": {
+              "type": "number",
+            },
+          },
+          "required": [
+            "page",
+            "pageSize",
+            "totalPages",
+            "totalItems",
+          ],
+          "type": "object",
+        },
+      },
+      "required": [
+        "items",
+        "pagination",
+      ],
+      "type": "object",
+    },
+    "error": {
+      "properties": {
+        "code": {
+          "type": "string",
+        },
+        "details": {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+        "message": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "code",
+        "message",
+      ],
+      "type": "object",
+    },
+    "status": {
+      "type": "number",
+    },
+  },
+  "required": [
+    "status",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > Snapshot Tests - Full JSON Schema Output > should match snapshot for discriminated union pattern 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "result": {
+      "anyOf": [
+        {
+          "properties": {
+            "data": {
+              "properties": {
+                "id": {
+                  "type": "string",
+                },
+                "value": {
+                  "type": "number",
+                },
+              },
+              "required": [
+                "id",
+                "value",
+              ],
+              "type": "object",
+            },
+            "type": {
+              "const": "success",
+              "type": "string",
+            },
+          },
+          "required": [
+            "type",
+            "data",
+          ],
+          "type": "object",
+        },
+        {
+          "properties": {
+            "error": {
+              "properties": {
+                "code": {
+                  "type": "string",
+                },
+                "message": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "code",
+                "message",
+              ],
+              "type": "object",
+            },
+            "type": {
+              "const": "error",
+              "type": "string",
+            },
+          },
+          "required": [
+            "type",
+            "error",
+          ],
+          "type": "object",
+        },
+      ],
+    },
+  },
+  "required": [
+    "result",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > Snapshot Tests - Full JSON Schema Output > should match snapshot for groq with complete schema 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "metadata": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "string",
+          },
+          {
+            "type": "number",
+          },
+          {
+            "type": "boolean",
+          },
+        ],
+      },
+      "propertyNames": {
+        "type": "string",
+      },
+      "type": "object",
+    },
+    "preferences": {
+      "properties": {
+        "language": {
+          "type": "string",
+        },
+        "notifications": {
+          "type": "boolean",
+        },
+        "theme": {
+          "enum": [
+            "light",
+            "dark",
+          ],
+          "type": "string",
+        },
+      },
+      "required": [
+        "theme",
+        "notifications",
+        "language",
+      ],
+      "type": "object",
+    },
+    "settings": {
+      "properties": {
+        "featured": {
+          "type": "boolean",
+        },
+        "public": {
+          "type": "boolean",
+        },
+      },
+      "required": [
+        "public",
+      ],
+      "type": "object",
+    },
+    "tags": {
+      "items": {
+        "type": "string",
+      },
+      "maxItems": 5,
+      "minItems": 1,
+      "type": "array",
+    },
+    "user": {
+      "properties": {
+        "age": {
+          "maximum": 120,
+          "minimum": 0,
+          "type": "number",
+        },
+        "email": {
+          "description": "Email address",
+          "format": "email",
+          "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+          "type": "string",
+        },
+        "id": {
+          "description": "User ID",
+          "type": "string",
+        },
+        "name": {
+          "description": "Full name",
+          "type": "string",
+        },
+      },
+      "required": [
+        "id",
+        "name",
+        "email",
+      ],
+      "type": "object",
+    },
+  },
+  "required": [
+    "user",
+    "preferences",
+    "tags",
+    "metadata",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Arrays > should handle arrays with min/max constraints (moved to description) 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "tags": {
+      "items": {
+        "type": "string",
+      },
+      "maxItems": 10,
+      "minItems": 1,
+      "type": "array",
+    },
+  },
+  "required": [
+    "tags",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Arrays > should handle arrays with object items 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "users": {
+      "items": {
+        "properties": {
+          "email": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+        ],
+        "type": "object",
+      },
+      "type": "array",
+    },
+  },
+  "required": [
+    "users",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Arrays > should handle nested arrays 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "matrix": {
+      "items": {
+        "items": {
+          "type": "number",
+        },
+        "type": "array",
+      },
+      "type": "array",
+    },
+  },
+  "required": [
+    "matrix",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Arrays > should handle optional arrays 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "name": {
+      "type": "string",
+    },
+    "tags": {
+      "items": {
+        "type": "string",
+      },
+      "type": "array",
+    },
+  },
+  "required": [
+    "name",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Arrays > should handle simple array schema 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "tags": {
+      "items": {
+        "type": "string",
+      },
+      "type": "array",
+    },
+  },
+  "required": [
+    "tags",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Basic Transformations > should handle nullable fields 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "deletedAt": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string",
+        },
+        {
+          "type": "null",
+        },
+      ],
+    },
+    "name": {
+      "type": "string",
+    },
+  },
+  "required": [
+    "name",
+    "deletedAt",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Basic Transformations > should handle optional fields 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "age": {
+      "type": "number",
+    },
+    "name": {
+      "type": "string",
+    },
+  },
+  "required": [
+    "name",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Basic Transformations > should handle simple object schema 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "age": {
+      "type": "number",
+    },
+    "name": {
+      "type": "string",
+    },
+  },
+  "required": [
+    "name",
+    "age",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Complex Schemas > should handle complex real-world schema 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "avatar": {
+      "type": "string",
+    },
+    "bio": {
+      "type": "string",
+    },
+    "deletedAt": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string",
+        },
+        {
+          "type": "null",
+        },
+      ],
+    },
+    "email": {
+      "type": "string",
+    },
+    "id": {
+      "type": "string",
+    },
+    "name": {
+      "type": "string",
+    },
+    "settings": {
+      "properties": {
+        "notifications": {
+          "type": "boolean",
+        },
+        "theme": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "notifications",
+      ],
+      "type": "object",
+    },
+    "tags": {
+      "items": {
+        "type": "string",
+      },
+      "type": "array",
+    },
+  },
+  "required": [
+    "id",
+    "email",
+    "name",
+    "deletedAt",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Complex Schemas > should handle partial objects 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "City": {
+      "type": "string",
+    },
+    "Name": {
+      "type": "string",
+    },
+    "Slug": {
+      "type": "string",
+    },
+  },
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Complex Schemas > should handle passthrough objects 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": true,
+  "properties": {
+    "queryText": {
+      "description": "The query text",
+      "type": "string",
+    },
+    "topK": {
+      "description": "Number of results",
+      "type": "number",
+    },
+  },
+  "required": [
+    "queryText",
+    "topK",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Complex Schemas > should handle schema with all basic types 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "arrayField": {
+      "items": {
+        "type": "string",
+      },
+      "type": "array",
+    },
+    "booleanField": {
+      "type": "boolean",
+    },
+    "enumField": {
+      "enum": [
+        "a",
+        "b",
+        "c",
+      ],
+      "type": "string",
+    },
+    "numberField": {
+      "type": "number",
+    },
+    "objectField": {
+      "properties": {
+        "nested": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "nested",
+      ],
+      "type": "object",
+    },
+    "stringField": {
+      "type": "string",
+    },
+    "unionField": {
+      "anyOf": [
+        {
+          "type": "string",
+        },
+        {
+          "type": "number",
+        },
+      ],
+    },
+  },
+  "required": [
+    "stringField",
+    "numberField",
+    "booleanField",
+    "arrayField",
+    "objectField",
+    "enumField",
+    "unionField",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Default Values > should handle array defaults 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "name": {
+      "type": "string",
+    },
+    "tags": {
+      "default": [],
+      "items": {
+        "type": "string",
+      },
+      "type": "array",
+    },
+  },
+  "required": [
+    "name",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Default Values > should handle boolean defaults 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "active": {
+      "default": true,
+      "type": "boolean",
+    },
+    "enabled": {
+      "default": false,
+      "type": "boolean",
+    },
+    "name": {
+      "type": "string",
+    },
+  },
+  "required": [
+    "name",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Default Values > should handle default values 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "confidence": {
+      "default": 1,
+      "type": "number",
+    },
+    "name": {
+      "type": "string",
+    },
+  },
+  "required": [
+    "name",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Default Values > should handle string defaults 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "explanation": {
+      "default": "",
+      "type": "string",
+    },
+    "name": {
+      "type": "string",
+    },
+  },
+  "required": [
+    "name",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Descriptions > should handle descriptions with nested objects 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "user": {
+      "description": "User object",
+      "properties": {
+        "name": {
+          "description": "User name",
+          "type": "string",
+        },
+        "profile": {
+          "description": "User profile",
+          "properties": {
+            "bio": {
+              "description": "User bio",
+              "type": "string",
+            },
+          },
+          "required": [
+            "bio",
+          ],
+          "type": "object",
+        },
+      },
+      "required": [
+        "name",
+        "profile",
+      ],
+      "type": "object",
+    },
+  },
+  "required": [
+    "user",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Descriptions > should preserve field descriptions 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "age": {
+      "description": "The user age",
+      "type": "number",
+    },
+    "email": {
+      "description": "The user email address",
+      "type": "string",
+    },
+    "name": {
+      "description": "The user name",
+      "type": "string",
+    },
+  },
+  "required": [
+    "name",
+    "age",
+    "email",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Enums > should handle enum schema 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "status": {
+      "enum": [
+        "pending",
+        "active",
+        "completed",
+      ],
+      "type": "string",
+    },
+  },
+  "required": [
+    "status",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Enums > should handle optional enum schema 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "name": {
+      "type": "string",
+    },
+    "status": {
+      "enum": [
+        "pending",
+        "active",
+        "completed",
+      ],
+      "type": "string",
+    },
+  },
+  "required": [
+    "name",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Nested Objects > should handle deeply nested objects 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "user": {
+      "properties": {
+        "profile": {
+          "properties": {
+            "bio": {
+              "type": "string",
+            },
+            "settings": {
+              "properties": {
+                "notifications": {
+                  "type": "boolean",
+                },
+                "theme": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "notifications",
+              ],
+              "type": "object",
+            },
+          },
+          "required": [
+            "settings",
+          ],
+          "type": "object",
+        },
+      },
+      "required": [
+        "profile",
+      ],
+      "type": "object",
+    },
+  },
+  "required": [
+    "user",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Nested Objects > should handle nested object schema 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "user": {
+      "properties": {
+        "email": {
+          "type": "string",
+        },
+        "name": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "name",
+        "email",
+      ],
+      "type": "object",
+    },
+  },
+  "required": [
+    "user",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Nested Objects > should handle optional nested objects 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "address": {
+      "properties": {
+        "city": {
+          "type": "string",
+        },
+        "street": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "street",
+      ],
+      "type": "object",
+    },
+    "name": {
+      "type": "string",
+    },
+  },
+  "required": [
+    "name",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Number Constraints > should handle numbers with constraints 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "age": {
+      "maximum": 120,
+      "minimum": 0,
+      "type": "number",
+    },
+    "score": {
+      "maximum": 9007199254740991,
+      "minimum": -9007199254740991,
+      "type": "integer",
+    },
+  },
+  "required": [
+    "age",
+    "score",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Number Constraints > should handle optional numbers 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "count": {
+      "type": "number",
+    },
+  },
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Records > should handle record schema 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "settings": {
+      "additionalProperties": {
+        "type": "boolean",
+      },
+      "propertyNames": {
+        "type": "string",
+      },
+      "type": "object",
+    },
+  },
+  "required": [
+    "settings",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Records > should handle record with key and value types 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "metadata": {
+      "additionalProperties": {
+        "type": "number",
+      },
+      "propertyNames": {
+        "type": "string",
+      },
+      "type": "object",
+    },
+  },
+  "required": [
+    "metadata",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - String Constraints > should handle optional strings 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "bio": {
+      "type": "string",
+    },
+    "name": {
+      "type": "string",
+    },
+  },
+  "required": [
+    "name",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - String Constraints > should handle string with constraints (moved to description) 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "email": {
+      "format": "email",
+      "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
+      "type": "string",
+    },
+    "text": {
+      "maxLength": 1000,
+      "minLength": 10,
+      "type": "string",
+    },
+    "url": {
+      "format": "uri",
+      "type": "string",
+    },
+  },
+  "required": [
+    "email",
+    "url",
+    "text",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - String Constraints > should handle string with description and constraints 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "text": {
+      "description": "A text field with constraints",
+      "maxLength": 1000,
+      "minLength": 10,
+      "type": "string",
+    },
+  },
+  "required": [
+    "text",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Unions > should handle optional union schema 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "name": {
+      "type": "string",
+    },
+    "value": {
+      "anyOf": [
+        {
+          "type": "string",
+        },
+        {
+          "type": "number",
+        },
+      ],
+    },
+  },
+  "required": [
+    "name",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Unions > should handle simple union schema 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "value": {
+      "anyOf": [
+        {
+          "type": "string",
+        },
+        {
+          "type": "number",
+        },
+      ],
+    },
+  },
+  "required": [
+    "value",
+  ],
+  "type": "object",
+}
+`;
+
+exports[`OpenAISchemaCompatLayer - Groq Provider > processZodType - Unions > should handle union of objects 1`] = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "result": {
+      "anyOf": [
+        {
+          "properties": {
+            "data": {
+              "type": "string",
+            },
+            "success": {
+              "type": "boolean",
+            },
+          },
+          "required": [
+            "success",
+            "data",
+          ],
+          "type": "object",
+        },
+        {
+          "properties": {
+            "error": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "error",
+          ],
+          "type": "object",
+        },
+      ],
+    },
+  },
+  "required": [
+    "result",
+  ],
+  "type": "object",
+}
+`;

--- a/packages/schema-compat/src/provider-compats/groq.test.ts
+++ b/packages/schema-compat/src/provider-compats/groq.test.ts
@@ -1,0 +1,783 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import type { ModelInformation } from '../types';
+import { OpenAISchemaCompatLayer } from './openai';
+
+describe('OpenAISchemaCompatLayer - Groq Provider', () => {
+  describe('shouldApply', () => {
+    it('should apply for groq models', () => {
+      const modelInfo: ModelInformation = {
+        provider: 'groq.chat',
+        modelId: 'llama-3.1-8b-instant',
+        supportsStructuredOutputs: false,
+      };
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      expect(layer.shouldApply()).toBe(true);
+    });
+
+    it('should apply for groq llama-3.3-70b model', () => {
+      const modelInfo: ModelInformation = {
+        provider: 'groq.chat',
+        modelId: 'llama-3.3-70b-versatile',
+        supportsStructuredOutputs: false,
+      };
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      expect(layer.shouldApply()).toBe(true);
+    });
+
+    it('should apply for groq mixtral model', () => {
+      const modelInfo: ModelInformation = {
+        provider: 'groq.chat',
+        modelId: 'mixtral-8x7b-32768',
+        supportsStructuredOutputs: false,
+      };
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      expect(layer.shouldApply()).toBe(true);
+    });
+
+    it('should not apply for non-Groq models', () => {
+      const modelInfo: ModelInformation = {
+        provider: 'anthropic',
+        modelId: 'claude-3-5-sonnet-20241022',
+        supportsStructuredOutputs: false,
+      };
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      expect(layer.shouldApply()).toBe(false);
+    });
+  });
+
+  describe('getSchemaTarget', () => {
+    it('should return jsonSchema7', () => {
+      const modelInfo: ModelInformation = {
+        provider: 'groq.chat',
+        modelId: 'llama-3.1-8b-instant',
+        supportsStructuredOutputs: false,
+      };
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      expect(layer.getSchemaTarget()).toBe('jsonSchema7');
+    });
+  });
+
+  describe('processZodType - Basic Transformations', () => {
+    const modelInfo: ModelInformation = {
+      provider: 'groq.chat',
+      modelId: 'llama-3.1-8b-instant',
+      supportsStructuredOutputs: false,
+    };
+
+    it('should handle simple object schema', () => {
+      const schema = z.object({
+        name: z.string(),
+        age: z.number(),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle optional fields', () => {
+      const schema = z.object({
+        name: z.string(),
+        age: z.number().optional(),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle nullable fields', () => {
+      const schema = z.object({
+        name: z.string(),
+        deletedAt: z.date().nullable(),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+  });
+
+  describe('processZodType - Nested Objects', () => {
+    const modelInfo: ModelInformation = {
+      provider: 'groq.chat',
+      modelId: 'llama-3.1-8b-instant',
+      supportsStructuredOutputs: false,
+    };
+
+    it('should handle nested object schema', () => {
+      const schema = z.object({
+        user: z.object({
+          name: z.string(),
+          email: z.string(),
+        }),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle deeply nested objects', () => {
+      const schema = z.object({
+        user: z.object({
+          profile: z.object({
+            bio: z.string().optional(),
+            settings: z.object({
+              theme: z.string().optional(),
+              notifications: z.boolean(),
+            }),
+          }),
+        }),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle optional nested objects', () => {
+      const schema = z.object({
+        name: z.string(),
+        address: z
+          .object({
+            street: z.string(),
+            city: z.string().optional(),
+          })
+          .optional(),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+  });
+
+  describe('processZodType - Arrays', () => {
+    const modelInfo: ModelInformation = {
+      provider: 'groq.chat',
+      modelId: 'llama-3.1-8b-instant',
+      supportsStructuredOutputs: false,
+    };
+
+    it('should handle simple array schema', () => {
+      const schema = z.object({
+        tags: z.array(z.string()),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle optional arrays', () => {
+      const schema = z.object({
+        name: z.string(),
+        tags: z.array(z.string()).optional(),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle arrays with min/max constraints (moved to description)', () => {
+      const schema = z.object({
+        tags: z.array(z.string()).min(1).max(10),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle arrays with object items', () => {
+      const schema = z.object({
+        users: z.array(
+          z.object({
+            name: z.string(),
+            email: z.string().optional(),
+          }),
+        ),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle nested arrays', () => {
+      const schema = z.object({
+        matrix: z.array(z.array(z.number())),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+  });
+
+  describe('processZodType - Unions', () => {
+    const modelInfo: ModelInformation = {
+      provider: 'groq.chat',
+      modelId: 'llama-3.1-8b-instant',
+      supportsStructuredOutputs: false,
+    };
+
+    it('should handle simple union schema', () => {
+      const schema = z.object({
+        value: z.union([z.string(), z.number()]),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle optional union schema', () => {
+      const schema = z.object({
+        name: z.string(),
+        value: z.union([z.string(), z.number()]).optional(),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle union of objects', () => {
+      const schema = z.object({
+        result: z.union([z.object({ success: z.boolean(), data: z.string() }), z.object({ error: z.string() })]),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+  });
+
+  describe('processZodType - String Constraints', () => {
+    const modelInfo: ModelInformation = {
+      provider: 'groq.chat',
+      modelId: 'llama-3.1-8b-instant',
+      supportsStructuredOutputs: false,
+    };
+
+    it('should handle string with constraints (moved to description)', () => {
+      const schema = z.object({
+        email: z.string().email(),
+        url: z.string().url(),
+        text: z.string().min(10).max(1000),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle optional strings', () => {
+      const schema = z.object({
+        name: z.string(),
+        bio: z.string().optional(),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle string with description and constraints', () => {
+      const schema = z.object({
+        text: z.string().min(10).max(1000).describe('A text field with constraints'),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+  });
+
+  describe('processZodType - Number Constraints', () => {
+    const modelInfo: ModelInformation = {
+      provider: 'groq.chat',
+      modelId: 'llama-3.1-8b-instant',
+      supportsStructuredOutputs: false,
+    };
+
+    it('should handle optional numbers', () => {
+      const schema = z.object({
+        count: z.number().optional(),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle numbers with constraints', () => {
+      const schema = z.object({
+        age: z.number().min(0).max(120),
+        score: z.number().int(),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+  });
+
+  describe('processZodType - Enums', () => {
+    const modelInfo: ModelInformation = {
+      provider: 'groq.chat',
+      modelId: 'llama-3.1-8b-instant',
+      supportsStructuredOutputs: false,
+    };
+
+    it('should handle enum schema', () => {
+      const schema = z.object({
+        status: z.enum(['pending', 'active', 'completed']),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle optional enum schema', () => {
+      const schema = z.object({
+        name: z.string(),
+        status: z.enum(['pending', 'active', 'completed']).optional(),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+  });
+
+  describe('processZodType - Complex Schemas', () => {
+    const modelInfo: ModelInformation = {
+      provider: 'groq.chat',
+      modelId: 'llama-3.1-8b-instant',
+      supportsStructuredOutputs: false,
+    };
+
+    it('should handle complex real-world schema', () => {
+      const schema = z.object({
+        id: z.string(),
+        email: z.string(),
+        name: z.string(),
+        avatar: z.string().optional(),
+        bio: z.string().optional(),
+        deletedAt: z.date().nullable(),
+        settings: z
+          .object({
+            theme: z.string().optional(),
+            notifications: z.boolean(),
+          })
+          .optional(),
+        tags: z.array(z.string()).optional(),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle schema with all basic types', () => {
+      const schema = z.object({
+        stringField: z.string(),
+        numberField: z.number(),
+        booleanField: z.boolean(),
+        arrayField: z.array(z.string()),
+        objectField: z.object({ nested: z.string() }),
+        enumField: z.enum(['a', 'b', 'c']),
+        unionField: z.union([z.string(), z.number()]),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle partial objects', () => {
+      const schema = z
+        .object({
+          City: z.string(),
+          Name: z.string(),
+          Slug: z.string(),
+        })
+        .partial();
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle passthrough objects', () => {
+      const schema = z
+        .object({
+          queryText: z.string().describe('The query text'),
+          topK: z.number().describe('Number of results'),
+        })
+        .passthrough();
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+  });
+
+  describe('processZodType - Descriptions', () => {
+    const modelInfo: ModelInformation = {
+      provider: 'groq.chat',
+      modelId: 'llama-3.1-8b-instant',
+      supportsStructuredOutputs: false,
+    };
+
+    it('should preserve field descriptions', () => {
+      const schema = z.object({
+        name: z.string().describe('The user name'),
+        age: z.number().describe('The user age'),
+        email: z.string().describe('The user email address'),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle descriptions with nested objects', () => {
+      const schema = z.object({
+        user: z
+          .object({
+            name: z.string().describe('User name'),
+            profile: z
+              .object({
+                bio: z.string().describe('User bio'),
+              })
+              .describe('User profile'),
+          })
+          .describe('User object'),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+  });
+
+  describe('processZodType - Default Values', () => {
+    const modelInfo: ModelInformation = {
+      provider: 'groq.chat',
+      modelId: 'llama-3.1-8b-instant',
+      supportsStructuredOutputs: false,
+    };
+
+    it('should handle default values', () => {
+      const schema = z.object({
+        name: z.string(),
+        confidence: z.number().default(1),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle string defaults', () => {
+      const schema = z.object({
+        name: z.string(),
+        explanation: z.string().default(''),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle boolean defaults', () => {
+      const schema = z.object({
+        name: z.string(),
+        enabled: z.boolean().default(false),
+        active: z.boolean().default(true),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle array defaults', () => {
+      const schema = z.object({
+        name: z.string(),
+        tags: z.array(z.string()).default([]),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+  });
+
+  describe('processZodType - Records', () => {
+    const modelInfo: ModelInformation = {
+      provider: 'groq.chat',
+      modelId: 'llama-3.1-8b-instant',
+      supportsStructuredOutputs: false,
+    };
+
+    it('should handle record schema', () => {
+      let schema;
+      // @ts-expect-error - check if zod v4
+      if ('_zod' in z.object()) {
+        schema = z.object({
+          settings: z.record(z.string(), z.boolean()),
+        });
+      } else {
+        schema = z.object({
+          settings: z.record(z.boolean()),
+        });
+      }
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should handle record with key and value types', () => {
+      let schema;
+      // @ts-expect-error - check if zod v4
+      if ('_zod' in z.object()) {
+        schema = z.object({
+          metadata: z.record(z.string(), z.number()),
+        });
+      } else {
+        schema = z.object({
+          metadata: z.record(z.number()),
+        });
+      }
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+  });
+
+  describe('processToAISDKSchema', () => {
+    const modelInfo: ModelInformation = {
+      provider: 'groq.chat',
+      modelId: 'llama-3.1-8b-instant',
+      supportsStructuredOutputs: false,
+    };
+
+    it('should return schema with jsonSchema and validate function', () => {
+      const schema = z.object({
+        text: z.string().min(1).max(100),
+        count: z.number().min(1),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const result = layer.processToAISDKSchema(schema);
+
+      expect(result).toHaveProperty('jsonSchema');
+      expect(result).toHaveProperty('validate');
+      expect(typeof result.validate).toBe('function');
+    });
+
+    it('should validate correct data', () => {
+      const schema = z.object({
+        name: z.string(),
+        age: z.number(),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const result = layer.processToAISDKSchema(schema);
+
+      const validationResult = result.validate!({ name: 'John', age: 30 });
+      expect(validationResult).toHaveProperty('success');
+      expect(validationResult.success).toBe(true);
+    });
+
+    it('should reject invalid data', () => {
+      const schema = z.object({
+        name: z.string(),
+        age: z.number(),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const result = layer.processToAISDKSchema(schema);
+
+      const validationResult = result.validate!({ name: 'John', age: 'not a number' });
+      expect(validationResult).toHaveProperty('success');
+      expect(validationResult.success).toBe(false);
+    });
+  });
+
+  describe('Snapshot Tests - Full JSON Schema Output', () => {
+    it('should match snapshot for groq with complete schema', () => {
+      const modelInfo: ModelInformation = {
+        provider: 'groq.chat',
+        modelId: 'llama-3.1-8b-instant',
+        supportsStructuredOutputs: false,
+      };
+
+      let metadataSchema;
+      // @ts-expect-error - check if zod v4
+      if ('_zod' in z.object()) {
+        metadataSchema = z.record(z.string(), z.union([z.string(), z.number(), z.boolean()]));
+      } else {
+        metadataSchema = z.record(z.union([z.string(), z.number(), z.boolean()]));
+      }
+
+      const schema = z.object({
+        user: z.object({
+          id: z.string().describe('User ID'),
+          name: z.string().describe('Full name'),
+          email: z.string().email().describe('Email address'),
+          age: z.number().min(0).max(120).optional(),
+        }),
+        preferences: z.object({
+          theme: z.enum(['light', 'dark']),
+          notifications: z.boolean(),
+          language: z.string(),
+        }),
+        tags: z.array(z.string()).min(1).max(5),
+        metadata: metadataSchema,
+        settings: z
+          .object({
+            public: z.boolean(),
+            featured: z.boolean().optional(),
+          })
+          .optional(),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should match snapshot for discriminated union pattern', () => {
+      const modelInfo: ModelInformation = {
+        provider: 'groq.chat',
+        modelId: 'llama-3.1-8b-instant',
+        supportsStructuredOutputs: false,
+      };
+
+      const schema = z.object({
+        result: z.union([
+          z.object({
+            type: z.literal('success'),
+            data: z.object({
+              id: z.string(),
+              value: z.number(),
+            }),
+          }),
+          z.object({
+            type: z.literal('error'),
+            error: z.object({
+              code: z.string(),
+              message: z.string(),
+            }),
+          }),
+        ]),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+
+    it('should match snapshot for API response schema', () => {
+      const modelInfo: ModelInformation = {
+        provider: 'groq.chat',
+        modelId: 'llama-3.1-8b-instant',
+        supportsStructuredOutputs: false,
+      };
+
+      let metadataSchema;
+      if ('_zod' in z.object()) {
+        metadataSchema = z.record(z.string(), z.string());
+      } else {
+        // @ts-expect-error - zod v3 does not support record with key and value types
+        metadataSchema = z.record(z.string());
+      }
+
+      const schema = z.object({
+        status: z.number(),
+        data: z
+          .object({
+            items: z.array(
+              z.object({
+                id: z.string(),
+                name: z.string(),
+                createdAt: z.string(),
+                updatedAt: z.string().optional(),
+                metadata: metadataSchema.optional(),
+              }),
+            ),
+            pagination: z.object({
+              page: z.number(),
+              pageSize: z.number(),
+              totalPages: z.number(),
+              totalItems: z.number(),
+            }),
+          })
+          .optional(),
+        error: z
+          .object({
+            code: z.string(),
+            message: z.string(),
+            details: z.array(z.string()).optional(),
+          })
+          .optional(),
+      });
+
+      const layer = new OpenAISchemaCompatLayer(modelInfo);
+      const jsonSchema = layer.processToJSONSchema(schema);
+
+      expect(jsonSchema).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/schema-compat/src/provider-compats/openai.ts
+++ b/packages/schema-compat/src/provider-compats/openai.ts
@@ -21,7 +21,9 @@ export class OpenAISchemaCompatLayer extends SchemaCompatLayer {
   shouldApply(): boolean {
     if (
       !this.getModel().supportsStructuredOutputs &&
-      (this.getModel().provider.includes(`openai`) || this.getModel().modelId.includes(`openai`))
+      (this.getModel().provider.includes(`openai`) ||
+        this.getModel().modelId.includes(`openai`) ||
+        this.getModel().provider.includes(`groq`))
     ) {
       return true;
     }


### PR DESCRIPTION
## Description

  Groq uses an OpenAI-compatible API but was not matched by the `OpenAISchemaCompatLayer`'s `shouldApply()`, so optional/default fields never got the nullable transformations that strict validators require. This caused HTTP 400 errors when AI models reasonably omitted
  nullable/optional fields from tool calls (e.g., workspace tools like `list_files` where all parameters are optional).

  The fix adds `provider.includes('groq')` to `shouldApply()` so Groq models receive the same optional-to-nullable schema transformations as OpenAI models.

  ## Related Issue(s)

  Fixes #13223

  ## Type of Change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [x] Test update

  ## Checklist

  - [x] I have made corresponding changes to the documentation (if applicable)
  - [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Groq provider now correctly applies schema transformations for optional parameters in AI model tool calls. This resolves HTTP 400 errors that previously occurred when AI models omitted optional fields from workspace tool invocations.

* **Tests**
  * Added comprehensive test coverage for Groq provider schema compatibility, validating proper handling across diverse schema types and structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->