### PR TITLE
fix(memory): improve OM activation chunk selection and safeguards

### DIFF
--- a/.changeset/fix-om-activation.md
+++ b/.changeset/fix-om-activation.md
@@ -4,6 +4,7 @@
 '@mastra/libsql': patch
 '@mastra/pg': patch
 '@mastra/mongodb': patch
+'mastracode': patch
 ---
 
 Improve OM activation chunk selection to land closer to retention target

--- a/.changeset/fix-om-activation.md
+++ b/.changeset/fix-om-activation.md
@@ -1,0 +1,16 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/pg': patch
+'@mastra/mongodb': patch
+---
+
+Improve OM activation chunk selection to land closer to retention target
+
+- Bias chunk selection "over" the target instead of "under", so post-activation context lands at or below the retention floor rather than above it
+- Add overshoot safeguard: if bias-over would consume more than 95% of the retention floor, fall back to bias-under
+- Add 1000-token floor: prevent bias-over from leaving fewer than 1000 raw tokens remaining
+- Add `forceMaxActivation`: when pending tokens exceed `blockAfter`, bypass safeguards to aggressively reduce context
+- Halve the async buffer interval when approaching the activation threshold for finer-grained chunks
+- Allow `bufferActivation` to accept absolute token retention values (>= 1000) in addition to ratios (0-1)

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -62,10 +62,10 @@ export function getDynamicMemory(storage: MastraCompositeStore) {
           scope: omScope,
           observation: {
             bufferTokens: 1 / 10,
-            bufferActivation: 4 / 5,
+            bufferActivation: 1000,
             model: getObserverModel,
             messageTokens: obsThreshold,
-            blockAfter: 1,
+            blockAfter: 1.2,
             modelSettings: {
               maxOutputTokens: 60000,
             },

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -62,7 +62,7 @@ export function getDynamicMemory(storage: MastraCompositeStore) {
           scope: omScope,
           observation: {
             bufferTokens: 1 / 10,
-            bufferActivation: 1000,
+            bufferActivation: 2000,
             model: getObserverModel,
             messageTokens: obsThreshold,
             blockAfter: 1.2,

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -968,7 +968,7 @@ export class InMemoryMemory extends MemoryStorage {
     // This prevents edge cases where a large chunk overshoots dramatically.
     // When forceMaxActivation is set (above blockAfter), skip the safeguard
     // and always prefer the over boundary to aggressively reduce context.
-    // Additionally, never bias over if it would leave fewer than 500 tokens
+    // Additionally, never bias over if it would leave fewer than 1000 tokens
     // remaining — at that level the agent may lose all meaningful context.
     const maxOvershoot = retentionFloor * 0.95;
     const overshoot = bestOverTokens - targetMessageTokens;

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -934,47 +934,53 @@ export class InMemoryMemory extends MemoryStorage {
     const retentionFloor = input.messageTokensThreshold * (1 - activationRatio);
     const targetMessageTokens = Math.max(0, input.currentPendingTokens - retentionFloor);
 
-    // Find the closest chunk boundary to the target, biased under
+    // Find the closest chunk boundary to the target, biased over (prefer removing
+    // slightly more than the target so remaining context lands at or below retentionFloor).
+    // Track both best-over and best-under boundaries so we can fall back to under
+    // if the over boundary would overshoot by too much.
     let cumulativeMessageTokens = 0;
-    let bestBoundary = 0;
-    let bestBoundaryMessageTokens = 0;
+    let bestOverBoundary = 0;
+    let bestOverTokens = 0;
+    let bestUnderBoundary = 0;
+    let bestUnderTokens = 0;
 
     for (let i = 0; i < chunks.length; i++) {
       cumulativeMessageTokens += chunks[i]!.messageTokens ?? 0;
       const boundary = i + 1;
 
-      // Prefer boundaries that are under the target (leaves more raw messages in context)
-      // Only go over if there's no under option
-      const isUnder = cumulativeMessageTokens <= targetMessageTokens;
-      const bestIsUnder = bestBoundaryMessageTokens <= targetMessageTokens;
-
-      if (bestBoundary === 0) {
-        // First boundary, take it
-        bestBoundary = boundary;
-        bestBoundaryMessageTokens = cumulativeMessageTokens;
-      } else if (isUnder && !bestIsUnder) {
-        // Current is under, best is over - prefer under
-        bestBoundary = boundary;
-        bestBoundaryMessageTokens = cumulativeMessageTokens;
-      } else if (isUnder && bestIsUnder) {
-        // Both under - prefer the one closer to target (higher)
-        if (cumulativeMessageTokens > bestBoundaryMessageTokens) {
-          bestBoundary = boundary;
-          bestBoundaryMessageTokens = cumulativeMessageTokens;
+      if (cumulativeMessageTokens >= targetMessageTokens) {
+        // Over or equal — track the closest (lowest) over boundary
+        if (bestOverBoundary === 0 || cumulativeMessageTokens < bestOverTokens) {
+          bestOverBoundary = boundary;
+          bestOverTokens = cumulativeMessageTokens;
         }
-      } else if (!isUnder && !bestIsUnder) {
-        // Both over - prefer the one closer to target (lower)
-        if (cumulativeMessageTokens < bestBoundaryMessageTokens) {
-          bestBoundary = boundary;
-          bestBoundaryMessageTokens = cumulativeMessageTokens;
+      } else {
+        // Under — track the closest (highest) under boundary
+        if (cumulativeMessageTokens > bestUnderTokens) {
+          bestUnderBoundary = boundary;
+          bestUnderTokens = cumulativeMessageTokens;
         }
       }
-      // If current is over and best is under, keep best (do nothing)
     }
 
-    // If bestBoundary is 0 (no boundary under target), activate at least 1 chunk
-    // since we've reached threshold and need to clear some context
-    const chunksToActivate = bestBoundary === 0 ? 1 : bestBoundary;
+    // Safeguard: if the over boundary would eat into more than 95% of the
+    // retention floor, fall back to the best under boundary instead.
+    // This prevents edge cases where a large chunk overshoots dramatically.
+    const maxOvershoot = retentionFloor * 0.95;
+    const overshoot = bestOverTokens - targetMessageTokens;
+
+    let chunksToActivate: number;
+    if (bestOverBoundary > 0 && overshoot <= maxOvershoot) {
+      chunksToActivate = bestOverBoundary;
+    } else if (bestUnderBoundary > 0) {
+      chunksToActivate = bestUnderBoundary;
+    } else if (bestOverBoundary > 0) {
+      // All boundaries are over and exceed the safeguard — still activate
+      // the closest over boundary (better than nothing)
+      chunksToActivate = bestOverBoundary;
+    } else {
+      chunksToActivate = 1;
+    }
     const activatedChunks = chunks.slice(0, chunksToActivate);
     const remainingChunks = chunks.slice(chunksToActivate);
 

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -966,11 +966,22 @@ export class InMemoryMemory extends MemoryStorage {
     // Safeguard: if the over boundary would eat into more than 95% of the
     // retention floor, fall back to the best under boundary instead.
     // This prevents edge cases where a large chunk overshoots dramatically.
+    // When forceMaxActivation is set (above blockAfter), skip the safeguard
+    // and always prefer the over boundary to aggressively reduce context.
+    // Additionally, never bias over if it would leave fewer than 500 tokens
+    // remaining — at that level the agent may lose all meaningful context.
     const maxOvershoot = retentionFloor * 0.95;
     const overshoot = bestOverTokens - targetMessageTokens;
+    const remainingAfterOver = input.currentPendingTokens - bestOverTokens;
 
     let chunksToActivate: number;
-    if (bestOverBoundary > 0 && overshoot <= maxOvershoot) {
+    if (input.forceMaxActivation && bestOverBoundary > 0) {
+      chunksToActivate = bestOverBoundary;
+    } else if (
+      bestOverBoundary > 0 &&
+      overshoot <= maxOvershoot &&
+      (remainingAfterOver >= 1000 || retentionFloor === 0)
+    ) {
       chunksToActivate = bestOverBoundary;
     } else if (bestUnderBoundary > 0) {
       chunksToActivate = bestUnderBoundary;

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1190,10 +1190,13 @@ export interface UpdateBufferedObservationsInput {
 export interface SwapBufferedToActiveInput {
   id: string;
   /**
-   * Ratio controlling how much context to retain after activation (0-1 float).
+   * Normalized ratio (0-1) controlling how much context to activate.
    * `1 - activationRatio` is the fraction of the threshold to keep as raw messages.
    * Target tokens to remove = `currentPendingTokens - messageTokensThreshold * (1 - activationRatio)`.
    * Chunks are selected by boundary, biased over the target (to ensure remaining context stays at or below the retention floor).
+   *
+   * Note: this is always a ratio. The caller resolves absolute `bufferActivation` values (> 1)
+   * into the equivalent ratio before passing to the storage layer.
    */
   activationRatio: number;
   /**

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1193,7 +1193,7 @@ export interface SwapBufferedToActiveInput {
    * Ratio controlling how much context to retain after activation (0-1 float).
    * `1 - activationRatio` is the fraction of the threshold to keep as raw messages.
    * Target tokens to remove = `currentPendingTokens - messageTokensThreshold * (1 - activationRatio)`.
-   * Chunks are selected by boundary, biased under the target.
+   * Chunks are selected by boundary, biased over the target (to ensure remaining context stays at or below the retention floor).
    */
   activationRatio: number;
   /**

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1210,6 +1210,12 @@ export interface SwapBufferedToActiveInput {
    */
   currentPendingTokens: number;
   /**
+   * When true, bypass the overshoot safeguard and always prefer removing more chunks.
+   * Set when pending tokens are above `blockAfter` — in this "emergency" mode,
+   * aggressively reducing context is more important than preserving the retention floor.
+   */
+  forceMaxActivation?: boolean;
+  /**
    * Optional timestamp to use as lastObservedAt after swap.
    * If not provided, the adapter will use the lastObservedAt from the latest activated chunk.
    */

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -817,39 +817,52 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     const retentionFloor = messageTokensThreshold * (1 - activationRatio);
     const targetMessageTokens = Math.max(0, currentPendingTokens - retentionFloor);
 
-    // Find the closest chunk boundary to the target, biased under
+    // Find the closest chunk boundary to the target, biased over (prefer removing
+    // slightly more than the target so remaining context lands at or below retentionFloor).
+    // Track both best-over and best-under boundaries so we can fall back to under
+    // if the over boundary would overshoot by too much.
     let cumulativeMessageTokens = 0;
-    let bestBoundary = 0;
-    let bestBoundaryMessageTokens = 0;
+    let bestOverBoundary = 0;
+    let bestOverTokens = 0;
+    let bestUnderBoundary = 0;
+    let bestUnderTokens = 0;
 
     for (let i = 0; i < chunks.length; i++) {
       cumulativeMessageTokens += chunks[i]!.messageTokens ?? 0;
       const boundary = i + 1;
 
-      const isUnder = cumulativeMessageTokens <= targetMessageTokens;
-      const bestIsUnder = bestBoundaryMessageTokens <= targetMessageTokens;
-
-      if (bestBoundary === 0) {
-        bestBoundary = boundary;
-        bestBoundaryMessageTokens = cumulativeMessageTokens;
-      } else if (isUnder && !bestIsUnder) {
-        bestBoundary = boundary;
-        bestBoundaryMessageTokens = cumulativeMessageTokens;
-      } else if (isUnder && bestIsUnder) {
-        if (cumulativeMessageTokens > bestBoundaryMessageTokens) {
-          bestBoundary = boundary;
-          bestBoundaryMessageTokens = cumulativeMessageTokens;
+      if (cumulativeMessageTokens >= targetMessageTokens) {
+        // Over or equal — track the closest (lowest) over boundary
+        if (bestOverBoundary === 0 || cumulativeMessageTokens < bestOverTokens) {
+          bestOverBoundary = boundary;
+          bestOverTokens = cumulativeMessageTokens;
         }
-      } else if (!isUnder && !bestIsUnder) {
-        if (cumulativeMessageTokens < bestBoundaryMessageTokens) {
-          bestBoundary = boundary;
-          bestBoundaryMessageTokens = cumulativeMessageTokens;
+      } else {
+        // Under — track the closest (highest) under boundary
+        if (cumulativeMessageTokens > bestUnderTokens) {
+          bestUnderBoundary = boundary;
+          bestUnderTokens = cumulativeMessageTokens;
         }
       }
     }
 
-    // If bestBoundary is 0, at least 1 chunk would activate
-    if (bestBoundary === 0) {
+    // Safeguard: if the over boundary would eat into more than 95% of the
+    // retention floor, fall back to the best under boundary instead.
+    // This prevents edge cases where a large chunk overshoots dramatically.
+    const maxOvershoot = retentionFloor * 0.95;
+    const overshoot = bestOverTokens - targetMessageTokens;
+
+    let bestBoundaryMessageTokens: number;
+
+    if (bestOverBoundary > 0 && overshoot <= maxOvershoot) {
+      bestBoundaryMessageTokens = bestOverTokens;
+    } else if (bestUnderBoundary > 0) {
+      bestBoundaryMessageTokens = bestUnderTokens;
+    } else if (bestOverBoundary > 0) {
+      // All boundaries are over and exceed the safeguard — still activate
+      // the closest over boundary (better than nothing)
+      bestBoundaryMessageTokens = bestOverTokens;
+    } else {
       return chunks[0]?.messageTokens ?? 0;
     }
 
@@ -859,11 +872,16 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
   /**
    * Check if we've crossed a new bufferTokens interval boundary.
    * Returns true if async buffering should be triggered.
+   *
+   * When pending tokens are within ~1 bufferTokens of the observation threshold,
+   * the buffer interval is halved to produce finer-grained chunks right before
+   * activation. This improves chunk boundary selection, reducing overshoot.
    */
   private shouldTriggerAsyncObservation(
     currentTokens: number,
     lockKey: string,
     record: ObservationalMemoryRecord,
+    messageTokensThreshold?: number,
   ): boolean {
     if (!this.isAsyncObservationEnabled()) return false;
 
@@ -887,14 +905,19 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     const memBoundary = ObservationalMemory.lastBufferedBoundary.get(bufferKey) ?? 0;
     const lastBoundary = Math.max(dbBoundary, memBoundary);
 
+    // Halve the buffer interval when within ~1 bufferTokens of the activation threshold.
+    // This produces finer-grained chunks right before activation, improving boundary selection.
+    const rampPoint = messageTokensThreshold ? messageTokensThreshold - bufferTokens * 1.1 : Infinity;
+    const effectiveBufferTokens = currentTokens >= rampPoint ? bufferTokens / 2 : bufferTokens;
+
     // Calculate which interval we're in
-    const currentInterval = Math.floor(currentTokens / bufferTokens);
-    const lastInterval = Math.floor(lastBoundary / bufferTokens);
+    const currentInterval = Math.floor(currentTokens / effectiveBufferTokens);
+    const lastInterval = Math.floor(lastBoundary / effectiveBufferTokens);
 
     const shouldTrigger = currentInterval > lastInterval;
 
     omDebug(
-      `[OM:shouldTriggerAsyncObs] tokens=${currentTokens}, bufferTokens=${bufferTokens}, currentInterval=${currentInterval}, lastInterval=${lastInterval}, lastBoundary=${lastBoundary} (db=${dbBoundary}, mem=${memBoundary}), shouldTrigger=${shouldTrigger}`,
+      `[OM:shouldTriggerAsyncObs] tokens=${currentTokens}, bufferTokens=${bufferTokens}, effectiveBufferTokens=${effectiveBufferTokens}, rampPoint=${rampPoint}, currentInterval=${currentInterval}, lastInterval=${lastInterval}, lastBoundary=${lastBoundary} (db=${dbBoundary}, mem=${memBoundary}), shouldTrigger=${shouldTrigger}`,
     );
 
     // Trigger if we've crossed into a new interval
@@ -3401,7 +3424,7 @@ ${suggestedResponse}
       // ════════════════════════════════════════════════════════════════════════
 
       if (this.isAsyncObservationEnabled() && totalPendingTokens < threshold) {
-        const shouldTrigger = this.shouldTriggerAsyncObservation(unbufferedPendingTokens, lockKey, record);
+        const shouldTrigger = this.shouldTriggerAsyncObservation(unbufferedPendingTokens, lockKey, record, threshold);
         omDebug(
           `[OM:async-obs] belowThreshold: pending=${totalPendingTokens}, unbuffered=${unbufferedPendingTokens}, threshold=${threshold}, shouldTrigger=${shouldTrigger}, isBufferingObs=${record.isBufferingObservation}, lastBufferedAt=${record.lastBufferedAtTokens}`,
         );
@@ -3420,7 +3443,7 @@ ${suggestedResponse}
         // Above threshold but we still need to check async buffering:
         // - At step 0, sync observation won't run, so we need chunks ready
         // - Below blockAfter, sync observation won't run, so we need chunks ready
-        const shouldTrigger = this.shouldTriggerAsyncObservation(unbufferedPendingTokens, lockKey, record);
+        const shouldTrigger = this.shouldTriggerAsyncObservation(unbufferedPendingTokens, lockKey, record, threshold);
         omDebug(
           `[OM:async-obs] atOrAboveThreshold: pending=${totalPendingTokens}, unbuffered=${unbufferedPendingTokens}, threshold=${threshold}, step=${stepNumber}, shouldTrigger=${shouldTrigger}`,
         );

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -871,7 +871,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     // Safeguard: if the over boundary would eat into more than 95% of the
     // retention floor, fall back to the best under boundary instead.
     // This prevents edge cases where a large chunk overshoots dramatically.
-    // Additionally, never bias over if it would leave fewer than 500 tokens
+    // Additionally, never bias over if it would leave fewer than 1000 tokens
     // remaining — at that level the agent may lose all meaningful context.
     const maxOvershoot = retentionFloor * 0.95;
     const overshoot = bestOverTokens - targetMessageTokens;

--- a/packages/memory/src/processors/observational-memory/types.ts
+++ b/packages/memory/src/processors/observational-memory/types.ts
@@ -111,12 +111,21 @@ export interface ObservationConfig {
   bufferTokens?: number | false;
 
   /**
-   * Ratio (0-1) of buffered observations to activate when threshold is reached.
-   * Setting this below 1 keeps some observations in reserve for continuity.
+   * Controls how many raw message tokens to retain after activation.
+   *
+   * - **Ratio (0 < value <= 1):** fraction of `messageTokens` to activate.
+   *   The retention floor is `messageTokens * (1 - ratio)`.
+   *   e.g. `0.8` with `messageTokens: 30000` → retain ~6000 tokens.
+   *
+   * - **Absolute (value >= 1000):** exact number of message tokens to retain.
+   *   e.g. `3000` → always aim to keep ~3000 tokens of raw message history.
+   *   Must be less than `messageTokens`.
+   *
+   * Values between 1 and 1000 are invalid.
    *
    * Requires `bufferTokens` to also be set.
    *
-   * @default 0.8 (activate 80% of buffered observations, keeping 20% in reserve)
+   * @default 0.8 (retain ~20% of messageTokens as raw messages)
    */
   bufferActivation?: number;
 

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -2036,47 +2036,53 @@ export class MemoryLibSQL extends MemoryStorage {
       const retentionFloor = input.messageTokensThreshold * (1 - input.activationRatio);
       const targetMessageTokens = Math.max(0, input.currentPendingTokens - retentionFloor);
 
-      // Find the closest chunk boundary to the target, biased under
+      // Find the closest chunk boundary to the target, biased over (prefer removing
+      // slightly more than the target so remaining context lands at or below retentionFloor).
+      // Track both best-over and best-under boundaries so we can fall back to under
+      // if the over boundary would overshoot by too much.
       let cumulativeMessageTokens = 0;
-      let bestBoundary = 0;
-      let bestBoundaryMessageTokens = 0;
+      let bestOverBoundary = 0;
+      let bestOverTokens = 0;
+      let bestUnderBoundary = 0;
+      let bestUnderTokens = 0;
 
       for (let i = 0; i < chunks.length; i++) {
         cumulativeMessageTokens += chunks[i]!.messageTokens ?? 0;
         const boundary = i + 1;
 
-        // Prefer boundaries that are under the target (leaves more raw messages in context)
-        // Only go over if there's no under option
-        const isUnder = cumulativeMessageTokens <= targetMessageTokens;
-        const bestIsUnder = bestBoundaryMessageTokens <= targetMessageTokens;
-
-        if (bestBoundary === 0) {
-          // First boundary, take it
-          bestBoundary = boundary;
-          bestBoundaryMessageTokens = cumulativeMessageTokens;
-        } else if (isUnder && !bestIsUnder) {
-          // Current is under, best is over - prefer under
-          bestBoundary = boundary;
-          bestBoundaryMessageTokens = cumulativeMessageTokens;
-        } else if (isUnder && bestIsUnder) {
-          // Both under - prefer the one closer to target (higher)
-          if (cumulativeMessageTokens > bestBoundaryMessageTokens) {
-            bestBoundary = boundary;
-            bestBoundaryMessageTokens = cumulativeMessageTokens;
+        if (cumulativeMessageTokens >= targetMessageTokens) {
+          // Over or equal — track the closest (lowest) over boundary
+          if (bestOverBoundary === 0 || cumulativeMessageTokens < bestOverTokens) {
+            bestOverBoundary = boundary;
+            bestOverTokens = cumulativeMessageTokens;
           }
-        } else if (!isUnder && !bestIsUnder) {
-          // Both over - prefer the one closer to target (lower)
-          if (cumulativeMessageTokens < bestBoundaryMessageTokens) {
-            bestBoundary = boundary;
-            bestBoundaryMessageTokens = cumulativeMessageTokens;
+        } else {
+          // Under — track the closest (highest) under boundary
+          if (cumulativeMessageTokens > bestUnderTokens) {
+            bestUnderBoundary = boundary;
+            bestUnderTokens = cumulativeMessageTokens;
           }
         }
-        // If current is over and best is under, keep best (do nothing)
       }
 
-      // If bestBoundary is 0 (no boundary under target), activate at least 1 chunk
-      // since we've reached threshold and need to clear some context
-      const chunksToActivate = bestBoundary === 0 ? 1 : bestBoundary;
+      // Safeguard: if the over boundary would eat into more than 95% of the
+      // retention floor, fall back to the best under boundary instead.
+      // This prevents edge cases where a large chunk overshoots dramatically.
+      const maxOvershoot = retentionFloor * 0.95;
+      const overshoot = bestOverTokens - targetMessageTokens;
+
+      let chunksToActivate: number;
+      if (bestOverBoundary > 0 && overshoot <= maxOvershoot) {
+        chunksToActivate = bestOverBoundary;
+      } else if (bestUnderBoundary > 0) {
+        chunksToActivate = bestUnderBoundary;
+      } else if (bestOverBoundary > 0) {
+        // All boundaries are over and exceed the safeguard — still activate
+        // the closest over boundary (better than nothing)
+        chunksToActivate = bestOverBoundary;
+      } else {
+        chunksToActivate = 1;
+      }
 
       // Split chunks
       const activatedChunks = chunks.slice(0, chunksToActivate);

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -2070,7 +2070,7 @@ export class MemoryLibSQL extends MemoryStorage {
       // This prevents edge cases where a large chunk overshoots dramatically.
       // When forceMaxActivation is set (above blockAfter), skip the safeguard
       // and always prefer the over boundary to aggressively reduce context.
-      // Additionally, never bias over if it would leave fewer than 500 tokens
+      // Additionally, never bias over if it would leave fewer than 1000 tokens
       // remaining — at that level the agent may lose all meaningful context.
       const maxOvershoot = retentionFloor * 0.95;
       const overshoot = bestOverTokens - targetMessageTokens;

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -1701,47 +1701,53 @@ export class MemoryStorageMongoDB extends MemoryStorage {
       const retentionFloor = input.messageTokensThreshold * (1 - input.activationRatio);
       const targetMessageTokens = Math.max(0, input.currentPendingTokens - retentionFloor);
 
-      // Find the closest chunk boundary to the target, biased under
+      // Find the closest chunk boundary to the target, biased over (prefer removing
+      // slightly more than the target so remaining context lands at or below retentionFloor).
+      // Track both best-over and best-under boundaries so we can fall back to under
+      // if the over boundary would overshoot by too much.
       let cumulativeMessageTokens = 0;
-      let bestBoundary = 0;
-      let bestBoundaryMessageTokens = 0;
+      let bestOverBoundary = 0;
+      let bestOverTokens = 0;
+      let bestUnderBoundary = 0;
+      let bestUnderTokens = 0;
 
       for (let i = 0; i < chunks.length; i++) {
         cumulativeMessageTokens += chunks[i]!.messageTokens ?? 0;
         const boundary = i + 1;
 
-        // Prefer boundaries that are under the target (leaves more raw messages in context)
-        // Only go over if there's no under option
-        const isUnder = cumulativeMessageTokens <= targetMessageTokens;
-        const bestIsUnder = bestBoundaryMessageTokens <= targetMessageTokens;
-
-        if (bestBoundary === 0) {
-          // First boundary, take it
-          bestBoundary = boundary;
-          bestBoundaryMessageTokens = cumulativeMessageTokens;
-        } else if (isUnder && !bestIsUnder) {
-          // Current is under, best is over - prefer under
-          bestBoundary = boundary;
-          bestBoundaryMessageTokens = cumulativeMessageTokens;
-        } else if (isUnder && bestIsUnder) {
-          // Both under - prefer the one closer to target (higher)
-          if (cumulativeMessageTokens > bestBoundaryMessageTokens) {
-            bestBoundary = boundary;
-            bestBoundaryMessageTokens = cumulativeMessageTokens;
+        if (cumulativeMessageTokens >= targetMessageTokens) {
+          // Over or equal — track the closest (lowest) over boundary
+          if (bestOverBoundary === 0 || cumulativeMessageTokens < bestOverTokens) {
+            bestOverBoundary = boundary;
+            bestOverTokens = cumulativeMessageTokens;
           }
-        } else if (!isUnder && !bestIsUnder) {
-          // Both over - prefer the one closer to target (lower)
-          if (cumulativeMessageTokens < bestBoundaryMessageTokens) {
-            bestBoundary = boundary;
-            bestBoundaryMessageTokens = cumulativeMessageTokens;
+        } else {
+          // Under — track the closest (highest) under boundary
+          if (cumulativeMessageTokens > bestUnderTokens) {
+            bestUnderBoundary = boundary;
+            bestUnderTokens = cumulativeMessageTokens;
           }
         }
-        // If current is over and best is under, keep best (do nothing)
       }
 
-      // If bestBoundary is 0 (no boundary under target), activate at least 1 chunk
-      // since we've reached threshold and need to clear some context
-      const chunksToActivate = bestBoundary === 0 ? 1 : bestBoundary;
+      // Safeguard: if the over boundary would eat into more than 95% of the
+      // retention floor, fall back to the best under boundary instead.
+      // This prevents edge cases where a large chunk overshoots dramatically.
+      const maxOvershoot = retentionFloor * 0.95;
+      const overshoot = bestOverTokens - targetMessageTokens;
+
+      let chunksToActivate: number;
+      if (bestOverBoundary > 0 && overshoot <= maxOvershoot) {
+        chunksToActivate = bestOverBoundary;
+      } else if (bestUnderBoundary > 0) {
+        chunksToActivate = bestUnderBoundary;
+      } else if (bestOverBoundary > 0) {
+        // All boundaries are over and exceed the safeguard — still activate
+        // the closest over boundary (better than nothing)
+        chunksToActivate = bestOverBoundary;
+      } else {
+        chunksToActivate = 1;
+      }
 
       // Split chunks
       const activatedChunks = chunks.slice(0, chunksToActivate);

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -1733,11 +1733,22 @@ export class MemoryStorageMongoDB extends MemoryStorage {
       // Safeguard: if the over boundary would eat into more than 95% of the
       // retention floor, fall back to the best under boundary instead.
       // This prevents edge cases where a large chunk overshoots dramatically.
+      // When forceMaxActivation is set (above blockAfter), skip the safeguard
+      // and always prefer the over boundary to aggressively reduce context.
+      // Additionally, never bias over if it would leave fewer than 500 tokens
+      // remaining — at that level the agent may lose all meaningful context.
       const maxOvershoot = retentionFloor * 0.95;
       const overshoot = bestOverTokens - targetMessageTokens;
+      const remainingAfterOver = input.currentPendingTokens - bestOverTokens;
 
       let chunksToActivate: number;
-      if (bestOverBoundary > 0 && overshoot <= maxOvershoot) {
+      if (input.forceMaxActivation && bestOverBoundary > 0) {
+        chunksToActivate = bestOverBoundary;
+      } else if (
+        bestOverBoundary > 0 &&
+        overshoot <= maxOvershoot &&
+        (remainingAfterOver >= 1000 || retentionFloor === 0)
+      ) {
         chunksToActivate = bestOverBoundary;
       } else if (bestUnderBoundary > 0) {
         chunksToActivate = bestUnderBoundary;

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -1735,7 +1735,7 @@ export class MemoryStorageMongoDB extends MemoryStorage {
       // This prevents edge cases where a large chunk overshoots dramatically.
       // When forceMaxActivation is set (above blockAfter), skip the safeguard
       // and always prefer the over boundary to aggressively reduce context.
-      // Additionally, never bias over if it would leave fewer than 500 tokens
+      // Additionally, never bias over if it would leave fewer than 1000 tokens
       // remaining — at that level the agent may lose all meaningful context.
       const maxOvershoot = retentionFloor * 0.95;
       const overshoot = bestOverTokens - targetMessageTokens;

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -2359,10 +2359,21 @@ export class MemoryPG extends MemoryStorage {
       // Safeguard: if the over boundary would eat into more than 95% of the
       // retention floor, fall back to the best under boundary instead.
       // This prevents edge cases where a large chunk overshoots dramatically.
+      // When forceMaxActivation is set (above blockAfter), skip the safeguard
+      // and always prefer the over boundary to aggressively reduce context.
+      // Additionally, never bias over if it would leave fewer than 500 tokens
+      // remaining — at that level the agent may lose all meaningful context.
       const maxOvershoot = retentionFloor * 0.95;
       const overshoot = bestOverTokens - targetMessageTokens;
+      const remainingAfterOver = input.currentPendingTokens - bestOverTokens;
 
-      if (bestOverBoundary > 0 && overshoot <= maxOvershoot) {
+      if (input.forceMaxActivation && bestOverBoundary > 0) {
+        chunksToActivate = bestOverBoundary;
+      } else if (
+        bestOverBoundary > 0 &&
+        overshoot <= maxOvershoot &&
+        (remainingAfterOver >= 1000 || retentionFloor === 0)
+      ) {
         chunksToActivate = bestOverBoundary;
       } else if (bestUnderBoundary > 0) {
         chunksToActivate = bestUnderBoundary;

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -2361,7 +2361,7 @@ export class MemoryPG extends MemoryStorage {
       // This prevents edge cases where a large chunk overshoots dramatically.
       // When forceMaxActivation is set (above blockAfter), skip the safeguard
       // and always prefer the over boundary to aggressively reduce context.
-      // Additionally, never bias over if it would leave fewer than 500 tokens
+      // Additionally, never bias over if it would leave fewer than 1000 tokens
       // remaining — at that level the agent may lose all meaningful context.
       const maxOvershoot = retentionFloor * 0.95;
       const overshoot = bestOverTokens - targetMessageTokens;

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -2326,48 +2326,53 @@ export class MemoryPG extends MemoryStorage {
       const retentionFloor = input.messageTokensThreshold * (1 - input.activationRatio);
       const targetMessageTokens = Math.max(0, input.currentPendingTokens - retentionFloor);
 
-      // Find the closest chunk boundary to the target, biased under
+      // Find the closest chunk boundary to the target, biased over (prefer removing
+      // slightly more than the target so remaining context lands at or below retentionFloor).
+      // Track both best-over and best-under boundaries so we can fall back to under
+      // if the over boundary would overshoot by too much.
       let cumulativeMessageTokens = 0;
       let chunksToActivate = 0;
-      let bestBoundary = 0;
-      let bestBoundaryMessageTokens = 0;
+      let bestOverBoundary = 0;
+      let bestOverTokens = 0;
+      let bestUnderBoundary = 0;
+      let bestUnderTokens = 0;
 
       for (let i = 0; i < chunks.length; i++) {
         cumulativeMessageTokens += chunks[i]!.messageTokens ?? 0;
         const boundary = i + 1;
 
-        // Prefer boundaries that are under the target (leaves more raw messages in context)
-        // Only go over if there's no under option
-        const isUnder = cumulativeMessageTokens <= targetMessageTokens;
-        const bestIsUnder = bestBoundaryMessageTokens <= targetMessageTokens;
-
-        if (bestBoundary === 0) {
-          // First boundary, take it
-          bestBoundary = boundary;
-          bestBoundaryMessageTokens = cumulativeMessageTokens;
-        } else if (isUnder && !bestIsUnder) {
-          // Current is under, best is over - prefer under
-          bestBoundary = boundary;
-          bestBoundaryMessageTokens = cumulativeMessageTokens;
-        } else if (isUnder && bestIsUnder) {
-          // Both under - prefer the one closer to target (higher)
-          if (cumulativeMessageTokens > bestBoundaryMessageTokens) {
-            bestBoundary = boundary;
-            bestBoundaryMessageTokens = cumulativeMessageTokens;
+        if (cumulativeMessageTokens >= targetMessageTokens) {
+          // Over or equal — track the closest (lowest) over boundary
+          if (bestOverBoundary === 0 || cumulativeMessageTokens < bestOverTokens) {
+            bestOverBoundary = boundary;
+            bestOverTokens = cumulativeMessageTokens;
           }
-        } else if (!isUnder && !bestIsUnder) {
-          // Both over - prefer the one closer to target (lower)
-          if (cumulativeMessageTokens < bestBoundaryMessageTokens) {
-            bestBoundary = boundary;
-            bestBoundaryMessageTokens = cumulativeMessageTokens;
+        } else {
+          // Under — track the closest (highest) under boundary
+          if (cumulativeMessageTokens > bestUnderTokens) {
+            bestUnderBoundary = boundary;
+            bestUnderTokens = cumulativeMessageTokens;
           }
         }
-        // If current is over and best is under, keep best (do nothing)
       }
 
-      // If bestBoundary is 0 (no boundary under target), activate at least 1 chunk
-      // since we've reached threshold and need to clear some context
-      chunksToActivate = bestBoundary === 0 ? 1 : bestBoundary;
+      // Safeguard: if the over boundary would eat into more than 95% of the
+      // retention floor, fall back to the best under boundary instead.
+      // This prevents edge cases where a large chunk overshoots dramatically.
+      const maxOvershoot = retentionFloor * 0.95;
+      const overshoot = bestOverTokens - targetMessageTokens;
+
+      if (bestOverBoundary > 0 && overshoot <= maxOvershoot) {
+        chunksToActivate = bestOverBoundary;
+      } else if (bestUnderBoundary > 0) {
+        chunksToActivate = bestUnderBoundary;
+      } else if (bestOverBoundary > 0) {
+        // All boundaries are over and exceed the safeguard — still activate
+        // the closest over boundary (better than nothing)
+        chunksToActivate = bestOverBoundary;
+      } else {
+        chunksToActivate = 1;
+      }
 
       // Split chunks
       const activatedChunks = chunks.slice(0, chunksToActivate);


### PR DESCRIPTION
OM activation was landing far from the intended retention target. A few issues stacked up:

**Chunk selection bias was backwards** — we were biasing "under" the target (keeping more raw messages) instead of "over" (removing more to land closer to `retentionFloor`). Flipped this so post-activation context lands at or below the retention floor.

**Overshoot safeguard** — if the best "over" boundary would blow past 95% of `retentionFloor`, fall back to the "under" boundary. Also never bias over if it would leave < 1000 tokens remaining.

**`forceMaxActivation` when above `blockAfter`** — when pending tokens are in emergency territory (above `blockAfter`), bypass the overshoot safeguard entirely and aggressively reduce context.

**Dynamic buffer interval** — `shouldTriggerAsyncObservation` now halves the buffer interval when approaching the activation threshold (within 1.1x of `bufferTokens`). This produces finer-grained chunks near the threshold, so boundary selection lands closer to the target.

**`bufferActivation` supports absolute token values** — instead of only accepting a ratio like `0.8`, you can now pass `>= 1000` to specify an absolute number of tokens to retain after activation:

```ts
observation: {
  bufferActivation: 1000, // keep ~1000 raw message tokens after activation
  // vs the old way (which still works):
  // bufferActivation: 0.8, // keep 20% of threshold (6000 tokens at 30k threshold)
}
```

Values `(0, 1]` are ratios, `>= 1000` are absolute token counts, `(1, 1000)` is an error.

Updated mastracode defaults to use `bufferActivation: 1000` and `blockAfter: 1.2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support for absolute token retention values in memory configuration (in addition to ratio-based settings).
  * Added forceMaxActivation option to enable aggressive context reduction when needed.

* **Bug Fixes**
  * Improved observational memory activation with enhanced safeguards against overshooting token limits.
  * Fixed edge case handling in chunk selection logic.

* **Documentation**
  * Updated memory configuration documentation to clarify retention behavior and new configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->