### PR TITLE
fix(mastracode): wire mcpManager to TUI so /mcp command works

### DIFF
--- a/.changeset/fix-mcp-status-display.md
+++ b/.changeset/fix-mcp-status-display.md
@@ -2,6 +2,6 @@
 "mastracode": patch
 ---
 
-Fix /mcp slash command always showing "MCP system not initialized"
+Fix /mcp slash command now correctly displays MCP server status
 
-The `/mcp` command was calling `this.harness.getMcpManager?.()` but the Harness class has no such method, so it always returned undefined. Fixed by passing the `mcpManager` instance directly to the TUI via `MastraTUIOptions`, following the same pattern used for `hookManager` and `authStorage`.
+The `/mcp` command always showed "MCP system not initialized" even when MCP servers were configured and working. Server status and `/mcp reload` now work as expected.

--- a/.changeset/fix-mcp-status-display.md
+++ b/.changeset/fix-mcp-status-display.md
@@ -1,0 +1,7 @@
+---
+"mastracode": patch
+---
+
+Fix /mcp slash command always showing "MCP system not initialized"
+
+The `/mcp` command was calling `this.harness.getMcpManager?.()` but the Harness class has no such method, so it always returned undefined. Fixed by passing the `mcpManager` instance directly to the TUI via `MastraTUIOptions`, following the same pattern used for `hookManager` and `authStorage`.

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -16,6 +16,7 @@ const tui = new MastraTUI({
   harness,
   hookManager,
   authStorage,
+  mcpManager,
   appName: 'Mastra Code',
   version: '0.1.0',
   inlineQuestions: true,

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -86,6 +86,9 @@ export interface MastraTUIOptions {
   /** Auth storage for OAuth login/logout */
   authStorage?: AuthStorage;
 
+  /** MCP manager for server status and reload */
+  mcpManager?: import('../mcp/manager.js').MCPManager;
+
   /**
    * @deprecated Workspace is now obtained from the Harness.
    * Configure workspace via HarnessConfig.workspace instead.
@@ -118,6 +121,7 @@ export class MastraTUI {
   private options: MastraTUIOptions;
   private hookManager?: HookManager;
   private authStorage?: AuthStorage;
+  private mcpManager?: import('../mcp/manager.js').MCPManager;
 
   // TUI components
   private ui: TUI;
@@ -218,6 +222,7 @@ export class MastraTUI {
     this.options = options;
     this.hookManager = options.hookManager;
     this.authStorage = options.authStorage;
+    this.mcpManager = options.mcpManager;
     this.workspace = options.workspace;
 
     // Detect project info for status line
@@ -3843,7 +3848,7 @@ Keyboard shortcuts:
       }
 
       case 'mcp': {
-        const mm = this.harness.getMcpManager?.();
+        const mm = this.mcpManager;
         if (!mm) {
           this.showInfo('MCP system not initialized.');
           return true;

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -27,6 +27,7 @@ import chalk from 'chalk';
 import type { AuthStorage } from '../auth/storage.js';
 import { getOAuthProviders } from '../auth/storage.js';
 import type { HookManager } from '../hooks/index.js';
+import type { MCPManager } from '../mcp/manager.js';
 import { getToolCategory, TOOL_CATEGORIES } from '../permissions.js';
 import { parseSubagentMeta } from '../tools/subagent.js';
 import { parseError } from '../utils/errors.js';
@@ -87,7 +88,7 @@ export interface MastraTUIOptions {
   authStorage?: AuthStorage;
 
   /** MCP manager for server status and reload */
-  mcpManager?: import('../mcp/manager.js').MCPManager;
+  mcpManager?: MCPManager;
 
   /**
    * @deprecated Workspace is now obtained from the Harness.
@@ -121,7 +122,7 @@ export class MastraTUI {
   private options: MastraTUIOptions;
   private hookManager?: HookManager;
   private authStorage?: AuthStorage;
-  private mcpManager?: import('../mcp/manager.js').MCPManager;
+  private mcpManager?: MCPManager;
 
   // TUI components
   private ui: TUI;


### PR DESCRIPTION
## Problem

The `/mcp` slash command always shows **"MCP system not initialized"** even when MCP servers are configured and working. This is because the handler calls `this.harness.getMcpManager?.()` — a method that doesn't exist on the `Harness` class — so it always returns `undefined`.

MCP tools work fine during conversations (they're injected via `createDynamicTools(mcpManager)`), but the `/mcp` status display and `/mcp reload` are broken.

## Fix

Pass `mcpManager` directly to `MastraTUI` via `MastraTUIOptions`, following the same pattern already used for `hookManager` and `authStorage`.

**2 files, +5/-1 lines:**
- `mastracode/src/tui/mastra-tui.ts` — add `mcpManager?` to options interface, store as class property, use in `/mcp` handler
- `mastracode/src/main.ts` — pass `mcpManager` to TUI constructor

## Test Plan

- All existing tests pass (9/9)
- Zero new TypeScript errors introduced
- Verified `/mcp` handler now receives the manager instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved MCP integration in the CLI/UI initialization to better surface server status.

* **Bug Fixes**
  * Fixed the /mcp slash command always showing "MCP system not initialized"; status now reflects real server state and `/mcp reload` updates status correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->