### PR TITLE
fix(observability): handle non-Set keysToStrip in deepClean()

### DIFF
--- a/.changeset/yummy-snakes-punch.md
+++ b/.changeset/yummy-snakes-punch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed `keysToStrip.has is not a function` crash in `deepClean()` when bundlers transform `new Set([...])` into a plain object or array. This affected agents with memory deployed to Mastra Cloud.

--- a/observability/mastra/src/spans/base.test.ts
+++ b/observability/mastra/src/spans/base.test.ts
@@ -581,7 +581,7 @@ describe('Span', () => {
       const input = { name: 'test', logger: { level: 'info' }, tracingContext: { traceId: '123' }, data: 'keep' };
       const options = {
         ...DEFAULT_DEEP_CLEAN_OPTIONS,
-        keysToStrip: { logger: true, tracingContext: true } as any,
+        keysToStrip: { logger: true, tracingContext: true },
       };
       const result = deepClean(input, options);
       expect(result.name).toBe('test');
@@ -594,7 +594,7 @@ describe('Span', () => {
       const input = { name: 'test', logger: { level: 'info' }, tracingContext: { traceId: '123' }, data: 'keep' };
       const options = {
         ...DEFAULT_DEEP_CLEAN_OPTIONS,
-        keysToStrip: ['logger', 'tracingContext'] as any,
+        keysToStrip: ['logger', 'tracingContext'],
       };
       const result = deepClean(input, options);
       expect(result.name).toBe('test');

--- a/observability/mastra/src/spans/base.test.ts
+++ b/observability/mastra/src/spans/base.test.ts
@@ -578,7 +578,7 @@ describe('Span', () => {
     });
 
     it('should handle keysToStrip as a plain object (bundler compatibility)', () => {
-      const input = { name: 'test', logger: { level: 'info' }, data: 'keep' };
+      const input = { name: 'test', logger: { level: 'info' }, tracingContext: { traceId: '123' }, data: 'keep' };
       const options = {
         ...DEFAULT_DEEP_CLEAN_OPTIONS,
         keysToStrip: { logger: true, tracingContext: true } as any,
@@ -587,10 +587,11 @@ describe('Span', () => {
       expect(result.name).toBe('test');
       expect(result.data).toBe('keep');
       expect(result.logger).toBeUndefined();
+      expect(result.tracingContext).toBeUndefined();
     });
 
     it('should handle keysToStrip as an array (bundler compatibility)', () => {
-      const input = { name: 'test', logger: { level: 'info' }, data: 'keep' };
+      const input = { name: 'test', logger: { level: 'info' }, tracingContext: { traceId: '123' }, data: 'keep' };
       const options = {
         ...DEFAULT_DEEP_CLEAN_OPTIONS,
         keysToStrip: ['logger', 'tracingContext'] as any,
@@ -599,6 +600,7 @@ describe('Span', () => {
       expect(result.name).toBe('test');
       expect(result.data).toBe('keep');
       expect(result.logger).toBeUndefined();
+      expect(result.tracingContext).toBeUndefined();
     });
 
     it('should handle max depth', () => {

--- a/observability/mastra/src/spans/base.test.ts
+++ b/observability/mastra/src/spans/base.test.ts
@@ -577,6 +577,30 @@ describe('Span', () => {
       expect(result.tracingContext).toBeUndefined();
     });
 
+    it('should handle keysToStrip as a plain object (bundler compatibility)', () => {
+      const input = { name: 'test', logger: { level: 'info' }, data: 'keep' };
+      const options = {
+        ...DEFAULT_DEEP_CLEAN_OPTIONS,
+        keysToStrip: { logger: true, tracingContext: true } as any,
+      };
+      const result = deepClean(input, options);
+      expect(result.name).toBe('test');
+      expect(result.data).toBe('keep');
+      expect(result.logger).toBeUndefined();
+    });
+
+    it('should handle keysToStrip as an array (bundler compatibility)', () => {
+      const input = { name: 'test', logger: { level: 'info' }, data: 'keep' };
+      const options = {
+        ...DEFAULT_DEEP_CLEAN_OPTIONS,
+        keysToStrip: ['logger', 'tracingContext'] as any,
+      };
+      const result = deepClean(input, options);
+      expect(result.name).toBe('test');
+      expect(result.data).toBe('keep');
+      expect(result.logger).toBeUndefined();
+    });
+
     it('should handle max depth', () => {
       const deepObj: any = { level: 0 };
       let current = deepObj;

--- a/observability/mastra/src/spans/serialization.ts
+++ b/observability/mastra/src/spans/serialization.ts
@@ -41,7 +41,7 @@ export const DEFAULT_KEYS_TO_STRIP = new Set([
 ]);
 
 export interface DeepCleanOptions {
-  keysToStrip: Set<string>;
+  keysToStrip: Set<string> | string[] | Record<string, unknown>;
   maxDepth: number;
   maxStringLength: number;
   maxArrayLength: number;
@@ -198,13 +198,12 @@ export function deepClean(value: any, options: DeepCleanOptions = DEFAULT_DEEP_C
 
   // Bundlers can transform `new Set([...])` into a plain object or array,
   // so we build a resilient lookup once (no per-object overhead).
-  const strip: unknown = keysToStrip;
   const shouldStripKey: (key: string) => boolean =
-    strip instanceof Set
-      ? (key: string) => (strip as Set<string>).has(key)
-      : Array.isArray(strip)
-        ? (key: string) => (strip as string[]).includes(key)
-        : (key: string) => key in (strip as Record<string, unknown>);
+    keysToStrip instanceof Set
+      ? (key: string) => keysToStrip.has(key)
+      : Array.isArray(keysToStrip)
+        ? (key: string) => keysToStrip.includes(key)
+        : (key: string) => key in keysToStrip;
 
   const seen = new WeakSet<any>();
 


### PR DESCRIPTION
Bundlers (e.g. when deploying agents with memory to Mastra Cloud) can transform `new Set([...])` into a plain object or array, which makes `keysToStrip.has(key)` blow up in `deepClean()`.

The fix builds a resilient lookup function once at `deepClean()` scope that handles all three forms:

```ts
const strip: unknown = keysToStrip;
const shouldStripKey =
  strip instanceof Set
    ? (key: string) => (strip as Set<string>).has(key)
    : Array.isArray(strip)
      ? (key: string) => (strip as string[]).includes(key)
      : (key: string) => key in (strip as Record<string, unknown>);
```

Tests confirm the crash reproduces without the fix and passes with it.

Closes #13295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a crash for agents with memory on Mastra Cloud by making key-stripping tolerant of bundler-produced formats.

* **Tests**
  * Added tests to verify key-stripping handles different formats created by bundlers.

* **Chores**
  * Added a patch release entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->