### PR TITLE
fix(playground-ui): disable publish button when no draft exists and fix cache invalidation

### DIFF
--- a/.changeset/yummy-waves-battle.md
+++ b/.changeset/yummy-waves-battle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed publish button in agent CMS to be disabled when no draft exists, preventing unnecessary error toasts. Also fixed stale agent data after saving a draft or publishing by invalidating the agent query cache.

--- a/.changeset/yummy-waves-battle.md
+++ b/.changeset/yummy-waves-battle.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Fixed publish button in agent CMS to be disabled when no draft exists, preventing unnecessary error toasts. Also fixed stale agent data after saving a draft or publishing by invalidating the agent query cache.
+Fixed publish button in agent CMS to be disabled when no draft exists, preventing unnecessary error toasts. Also fixed stale agent data after saving a draft or publishing by invalidating the agent query cache. Fixed tool count in the CMS sidebar and tools page to correctly include integration tools.

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-pages/tools-page.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-pages/tools-page.tsx
@@ -45,7 +45,9 @@ export function ToolsPage() {
   }, [tools]);
 
   const selectedToolIds = Object.keys(selectedTools || {});
-  const totalCount = selectedToolIds.length;
+  const totalCount =
+    selectedToolIds.length +
+    Object.keys(selectedIntegrationTools ?? {}).length;
 
   const getOriginalDescription = (id: string): string => {
     const option = options.find(opt => opt.value === id);

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-pages/tools-page.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-pages/tools-page.tsx
@@ -45,9 +45,7 @@ export function ToolsPage() {
   }, [tools]);
 
   const selectedToolIds = Object.keys(selectedTools || {});
-  const totalCount =
-    selectedToolIds.length +
-    Object.keys(selectedIntegrationTools ?? {}).length;
+  const totalCount = selectedToolIds.length + Object.keys(selectedIntegrationTools ?? {}).length;
 
   const getOriginalDescription = (id: string): string => {
     const option = options.find(opt => opt.value === id);

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-sidebar/use-sidebar-descriptions.ts
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-sidebar/use-sidebar-descriptions.ts
@@ -19,8 +19,7 @@ export function useSidebarDescriptions(control: Control<AgentFormValues>) {
 
     const toolCount =
       Object.keys(values.tools ?? {}).length +
-      Object.keys(values.integrationTools ?? {}).length +
-      (values.mcpClients ?? []).length;
+      Object.keys(values.integrationTools ?? {}).length;
     const tools = toolCount === 0 ? 'None selected' : pluralize(toolCount, 'tool');
 
     const agentCount = Object.keys(values.agents ?? {}).length;

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-sidebar/use-sidebar-descriptions.ts
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-sidebar/use-sidebar-descriptions.ts
@@ -17,9 +17,7 @@ export function useSidebarDescriptions(control: Control<AgentFormValues>) {
     const blockCount = (values.instructionBlocks ?? []).filter(b => b.content?.trim()).length;
     const instructions = blockCount === 0 ? 'Required' : pluralize(blockCount, 'block');
 
-    const toolCount =
-      Object.keys(values.tools ?? {}).length +
-      Object.keys(values.integrationTools ?? {}).length;
+    const toolCount = Object.keys(values.tools ?? {}).length + Object.keys(values.integrationTools ?? {}).length;
     const tools = toolCount === 0 ? 'None selected' : pluralize(toolCount, 'tool');
 
     const agentCount = Object.keys(values.agents ?? {}).length;

--- a/packages/playground-ui/src/domains/agents/hooks/use-agent-cms-form.ts
+++ b/packages/playground-ui/src/domains/agents/hooks/use-agent-cms-form.ts
@@ -193,6 +193,7 @@ export function useAgentCmsForm(options: UseAgentCmsFormOptions) {
       // Reset form dirty state so publish can detect unsaved changes
       form.reset(values);
       queryClient.invalidateQueries({ queryKey: ['agent-versions', agentId] });
+      queryClient.invalidateQueries({ queryKey: ['agent', agentId] });
       toast.success('Draft saved');
     } catch (error) {
       toast.error(`Failed to save draft: ${error instanceof Error ? error.message : 'Unknown error'}`);
@@ -230,6 +231,7 @@ export function useAgentCmsForm(options: UseAgentCmsFormOptions) {
         await Promise.all([
           queryClient.invalidateQueries({ queryKey: ['agent-versions', agentId] }),
           queryClient.invalidateQueries({ queryKey: ['stored-agent', agentId] }),
+          queryClient.invalidateQueries({ queryKey: ['agent', agentId] }),
           queryClient.invalidateQueries({ queryKey: ['agents'] }),
           queryClient.invalidateQueries({ queryKey: ['stored-agents'] }),
         ]);

--- a/packages/playground/src/pages/cms/agents/edit-layout.tsx
+++ b/packages/playground/src/pages/cms/agents/edit-layout.tsx
@@ -108,7 +108,7 @@ function EditLayoutWrapper() {
   const selectedVersionId = searchParams.get('versionId');
 
   const { data: agent, isLoading: isLoadingAgent } = useStoredAgent(agentId, { status: 'draft' });
-  const { data: versionData, isLoading: isLoadingVersion } = useAgentVersion({
+  const { data: versionData } = useAgentVersion({
     agentId: agentId ?? '',
     versionId: selectedVersionId ?? '',
   });
@@ -178,7 +178,7 @@ function EditLayoutWrapper() {
                 </>
               )}
             </Button>
-            <Button variant="primary" onClick={handlePublish} disabled={isSubmitting || isSavingDraft}>
+            <Button variant="primary" onClick={handlePublish} disabled={isSubmitting || isSavingDraft || !hasDraft}>
               {isSubmitting ? (
                 <>
                   <Spinner className="h-4 w-4" />


### PR DESCRIPTION
The publish button in the agent CMS edit page was clickable even when there was no draft to publish, leading to a confusing error toast. Now it's disabled proactively when `hasDraft` is false.

Also added `['agent', agentId]` cache invalidation after saving a draft and after publishing, so runtime agent data stays fresh without a manual refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Publish button is now disabled when there is no draft, preventing unnecessary error notifications
  * Agent data automatically refreshes after saving or publishing drafts to ensure the latest information is displayed
  * Tool count in the CMS sidebar and tools page now accurately includes integration tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->