### PR TITLE
feat(mastracode): add audit-tests subagent

### DIFF
--- a/.changeset/empty-laws-love.md
+++ b/.changeset/empty-laws-love.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Added audit-tests subagent that reviews test quality in a branch. The parent agent passes a description of the branch work along with changed files to this read-only subagent, which explores existing test conventions then audits for behavioral coverage, intent-vs-test alignment, LLM-generated test slop, redundant assertions, file organization, and missing edge cases.

--- a/mastracode/src/agents/subagents/audit-tests.ts
+++ b/mastracode/src/agents/subagents/audit-tests.ts
@@ -1,0 +1,121 @@
+/**
+ * Audit-tests subagent — read-only test quality auditor.
+ *
+ * This subagent reviews test files provided by the parent agent,
+ * explores the repo's existing testing conventions, and produces
+ * a detailed audit report with actionable improvement recommendations.
+ */
+import type { SubagentDefinition } from './types.js';
+
+export const auditTestsSubagent: SubagentDefinition = {
+  id: 'audit-tests',
+  name: 'Audit Tests',
+  instructions: `You are an expert test auditor. Your job is to review test files and provide detailed, actionable feedback on test quality, coverage gaps, and organization.
+
+You will be given:
+- A **description of the work done on the branch** — what features were added, bugs fixed, or changes made. Use this to understand the intent behind the tests.
+- A list of **test files** to audit
+- A list of **source files** those tests are meant to cover
+- Optionally, instructions on how to find these files (e.g., specific paths or patterns)
+
+## Process
+
+### Phase 1: Understand the Repo's Testing Conventions
+
+Before auditing, explore the repo's existing test patterns so your feedback is grounded in how *this* codebase does things. Do this by:
+
+1. **Find the test config** — look for vitest.config.ts, jest.config.ts, playwright.config.ts, or similar near the project root or in the relevant package.
+2. **Read 2-3 existing test files** in the same directory or package as the files under review. Study:
+   - Test framework and assertion style (e.g., vitest expect, jest matchers, chai)
+   - Mocking strategy — what gets mocked, what doesn't, are there shared mock utilities?
+   - File organization — are tests co-located with source, in a \`__tests__/\` directory, or elsewhere?
+   - Naming conventions — how are describe blocks and test names written?
+   - Shared utilities — are there test helpers, fixtures, factories, or shared setup functions?
+3. **Summarize the conventions** briefly in your report so it's clear what baseline you're comparing against.
+
+### Phase 2: Audit the Test Files
+
+Read each provided test file AND its corresponding source file(s). Use the **branch work description** as context — understanding what the changes are meant to accomplish helps you judge whether the tests actually validate the intended behavior.
+
+Evaluate against these criteria:
+
+#### Behavioral Coverage
+- Do tests verify **outcomes and behavior**, not just that functions were called?
+- Are tests exercising the **public API** rather than internal implementation details?
+- Would the tests break if the implementation changed but the behavior stayed the same? (Bad sign)
+- Do the tests **cover the stated intent** of the branch work? If the work adds feature X, is feature X actually tested end-to-end?
+
+#### Missing Scenarios
+- Based on the branch description and source code, what **key behaviors** are untested?
+- What **error paths** specific to the changes are untested?
+- Are there **edge cases** (empty inputs, null/undefined, boundary values) that should be tested?
+- Are there **branching paths** in the source that have no corresponding test?
+
+#### Redundancy & LLM Slop
+This is critical. LLMs frequently produce bloated, repetitive tests. Look for:
+- **Duplicate test cases** that assert the same behavior with trivially different inputs
+- **Copy-paste tests** where the setup and assertion are nearly identical — these should be parameterized (e.g., \`test.each\`, \`describe.each\`)
+- **Verbose boilerplate** that could use shared setup/teardown or helper functions
+- **Obvious/trivial assertions** that add no value (e.g., testing that a constructor creates an object, testing default values that are self-evident)
+- **Over-testing** — multiple tests that verify the same code path from slightly different angles
+
+#### File Organization
+- Are tests scattered across **too many files** when they could be consolidated? LLMs often create a new file for every test you ask for.
+- Does the file structure **match the repo's conventions**? If existing tests group by feature, do the new tests do the same?
+- Are there test files that logically belong together and should be merged?
+- Would renaming or moving files improve discoverability?
+
+#### Mocking Correctness
+- Is the mocking approach **consistent with the repo's conventions**?
+- Is there **over-mocking** — mocking things the repo normally doesn't mock?
+- Is there **under-mocking** — hitting real services/filesystem when the repo uses mocks?
+- Are mocks **realistic** — do they return data shaped like real responses?
+
+#### Test Isolation & Reliability
+- Is there **shared mutable state** between tests that could cause ordering dependencies?
+- Are there **timing-sensitive assertions** that could be flaky?
+- Is cleanup (afterEach, afterAll) used where needed?
+
+#### Naming & Readability
+- Do test names describe the **expected behavior**, not the implementation?
+- Is the **arrange/act/assert** structure clear in each test?
+- Are test descriptions useful for someone reading a failure report?
+
+### Phase 3: Report
+
+Structure your output exactly as follows:
+
+## Test Audit Report
+
+### Conventions Found
+Brief summary of the repo's testing patterns you observed (2-3 sentences).
+
+### Overall Assessment
+1-2 sentence quality summary. Be direct — is this good, mediocre, or needs significant rework?
+
+### Intent Coverage
+Based on the branch work description, do the tests validate the intended behavior? Call out any stated goals that lack test coverage.
+
+### File Organization
+Should any files be consolidated, renamed, or restructured? Be specific about which files and where they should go.
+
+### Per-File Findings
+For each test file, list specific issues with **file path and line references**. Group by severity:
+- **Issues**: Things that are wrong or will cause problems
+- **Improvements**: Things that would make the tests better
+- **Redundancies**: Specific tests that are duplicates or should be parameterized
+
+### Missing Coverage
+Specific scenarios from the source code that should have tests but don't. Reference the source file and the untested code path.
+
+### Recommendations
+Prioritized, actionable list. Most impactful improvements first. Be specific — don't say "add more tests", say "add a test for the error case when X returns null (source.ts:42)".
+
+## Rules
+- You have READ-ONLY access. You cannot modify files or run commands.
+- Be thorough but concise — reference by file path and line number, don't copy large blocks of code.
+- Ground all feedback in the repo's actual conventions, not generic best practices.
+- Be direct. If tests are sloppy, say so. If they're good, say that too.
+- Focus on **actionable feedback** — every finding should have a clear "do this instead" recommendation.`,
+  allowedTools: ['view', 'search_content', 'find_files'],
+};

--- a/mastracode/src/agents/subagents/index.ts
+++ b/mastracode/src/agents/subagents/index.ts
@@ -13,6 +13,7 @@ import {
   todoCheckTool,
 } from '../../tools/index.js';
 import { resolveModel } from '../model.js';
+import { auditTestsSubagent } from './audit-tests.js';
 import { executeSubagent } from './execute.js';
 import { exploreSubagent } from './explore.js';
 import { planSubagent } from './plan.js';
@@ -23,6 +24,7 @@ const subagentRegistry: Record<string, SubagentDefinition> = {
   explore: exploreSubagent,
   plan: planSubagent,
   execute: executeSubagent,
+  'audit-tests': auditTestsSubagent,
 };
 
 /**

--- a/mastracode/src/tools/subagent.ts
+++ b/mastracode/src/tools/subagent.ts
@@ -55,6 +55,7 @@ export function createSubagentTool(deps: SubagentToolDeps) {
     explore: `- **explore**: Read-only codebase exploration. Has access to view, search_content, and find_files. Use for questions like "find all usages of X", "how does module Y work", "what files are related to Z".`,
     plan: `- **plan**: Read-only analysis and planning. Same tools as explore. Use for "create an implementation plan for X", "analyze the architecture of Y".`,
     execute: `- **execute**: Task execution with write capabilities. Has access to all tools including string_replace_lsp, write_file, and execute_command. Use for "implement feature X", "fix bug Y", "refactor module Z".`,
+    'audit-tests': `- **audit-tests**: Read-only test quality auditor. Has access to view, search_content, and find_files. Provide it with a description of the work done on the branch, the list of test files, and the source files to review. It will explore the repo's testing conventions and produce a detailed audit report with actionable feedback on coverage gaps, redundancy, file organization, and test quality.`,
   };
 
   const availableTypesDocs = validAgentTypes.map(t => typeDescriptions[t] ?? `- **${t}**`).join('\n');


### PR DESCRIPTION
Adds a new read-only `audit-tests` subagent that reviews test quality on a branch.

The parent agent passes a branch work description + list of changed test/source files to the subagent. It then explores the repo's existing test conventions (mocking, organization, naming) and audits against them — focusing on behavioral coverage, intent alignment, LLM-generated slop (duplicate tests, copy-paste boilerplate, over-testing), file organization, and missing edge cases.

Usage from the parent agent:

```
subagent({
  agentType: 'audit-tests',
  task: `
    Branch work: Added retry logic to the HTTP client...
    Test files: src/http/__tests__/retry.test.ts
    Source files: src/http/client.ts
  `
})
```

The subagent produces a structured report with conventions found, overall assessment, intent coverage, per-file findings with line references, missing coverage gaps, and prioritized recommendations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added test audit functionality via a new subagent that analyzes test quality, evaluates behavioral coverage, reviews testing conventions, identifies redundant assertions, and recommends missing edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->