### PR TITLE
fix(express): scope context and auth middleware to route prefix

### DIFF
--- a/.changeset/fix-express-prefix-scoped-middleware.md
+++ b/.changeset/fix-express-prefix-scoped-middleware.md
@@ -1,0 +1,5 @@
+---
+'@mastra/express': patch
+---
+
+Fixed context and auth middleware being applied globally instead of scoped to the configured route prefix. Routes outside the Mastra prefix (e.g. `/health`) are no longer affected by Mastra's authentication middleware.

--- a/.changeset/fix-express-prefix-scoped-middleware.md
+++ b/.changeset/fix-express-prefix-scoped-middleware.md
@@ -2,4 +2,4 @@
 '@mastra/express': patch
 ---
 
-Fixed context and auth middleware being applied globally instead of scoped to the configured route prefix. Routes outside the Mastra prefix (e.g. `/health`) are no longer affected by Mastra's authentication middleware.
+Fixed context and auth middleware being applied globally instead of scoped to the configured route prefix. Routes outside the Mastra prefix (e.g. `/health`) are no longer affected by Mastra's context or authentication middleware.

--- a/docs/src/content/en/docs/server/server-adapters.mdx
+++ b/docs/src/content/en/docs/server/server-adapters.mdx
@@ -205,7 +205,7 @@ See the [Koa Adapter](/reference/server/koa-adapter) documentation for full conf
 
 Calling `init()` runs three steps in order. Understanding this flow helps when you need to insert your own middleware at specific points.
 
-1. `registerContextMiddleware()`: Attaches the Mastra instance, request context, tools, and abort signal to every request. This makes Mastra available to all subsequent middleware and route handlers.
+1. `registerContextMiddleware()`: Attaches the Mastra instance, request context, tools, and abort signal to incoming requests. When a `prefix` is configured, this middleware only applies to routes under that prefix.
 2. `registerAuthMiddleware()`: Adds authentication and authorization middleware, but only if `server.auth` is configured in your Mastra instance. Skipped entirely if no auth is configured.
 3. `registerRoutes()`: Registers all Mastra API routes for agents, workflows, and other features. Also registers MCP routes if MCP servers are configured.
 

--- a/docs/src/content/en/docs/server/server-adapters.mdx
+++ b/docs/src/content/en/docs/server/server-adapters.mdx
@@ -206,7 +206,7 @@ See the [Koa Adapter](/reference/server/koa-adapter) documentation for full conf
 Calling `init()` runs three steps in order. Understanding this flow helps when you need to insert your own middleware at specific points.
 
 1. `registerContextMiddleware()`: Attaches the Mastra instance, request context, tools, and abort signal to incoming requests. When a `prefix` is configured, this middleware only applies to routes under that prefix.
-2. `registerAuthMiddleware()`: Adds authentication and authorization middleware, but only if `server.auth` is configured in your Mastra instance. Skipped entirely if no auth is configured.
+2. `registerAuthMiddleware()`: Adds authentication and authorization middleware, but only if `server.auth` is configured in your Mastra instance. Skipped entirely if no auth is configured. Like context middleware, this is scoped to the configured `prefix`.
 3. `registerRoutes()`: Registers all Mastra API routes for agents, workflows, and other features. Also registers MCP routes if MCP servers are configured.
 
 ### Manual initialization

--- a/docs/src/content/en/docs/server/server-adapters.mdx
+++ b/docs/src/content/en/docs/server/server-adapters.mdx
@@ -262,7 +262,16 @@ const server = new MastraServer({
 });
 ```
 
-With this prefix, Mastra routes become `/api/v2/agents`, `/api/v2/workflows`, etc. Custom routes you add directly to the app are not affected by this prefix.
+With this prefix, Mastra routes become `/api/v2/agents`, `/api/v2/workflows`, etc. Mastra's context and auth middleware are also scoped to this prefix, so routes you add directly to the app are not affected.
+
+```typescript
+// Mastra handles /api/v2/* (with auth + context middleware)
+const server = new MastraServer({ app, mastra, prefix: '/api/v2' });
+await server.init();
+
+// Your own routes — no Mastra middleware runs here
+app.get('/health', (req, res) => res.json({ status: 'ok' }));
+```
 
 ## OpenAPI spec
 

--- a/server-adapters/express/src/__tests__/express-adapter.test.ts
+++ b/server-adapters/express/src/__tests__/express-adapter.test.ts
@@ -907,6 +907,7 @@ describe('Express Server Adapter', () => {
               if (token === 'valid-token') return { id: 'user-1' };
               return null;
             },
+            authorizeUser: async () => true,
           },
         },
       });

--- a/server-adapters/express/src/auth-middleware.ts
+++ b/server-adapters/express/src/auth-middleware.ts
@@ -17,7 +17,11 @@ export const authenticationMiddleware = async (req: Request, res: Response, next
     return next();
   }
 
-  const path = req.path;
+  // Use baseUrl + path to get the full path regardless of mount prefix.
+  // When mounted via app.use('/prefix', middleware), Express strips the prefix
+  // from req.path. Prepending req.baseUrl restores it so auth pattern matching
+  // works correctly against full paths like '/api/agents/*'.
+  const path = req.baseUrl + req.path;
   const method = req.method;
   const getHeader = (name: string) => req.headers[name.toLowerCase()] as string | undefined;
 
@@ -26,12 +30,12 @@ export const authenticationMiddleware = async (req: Request, res: Response, next
     return next();
   }
 
-  if (!isProtectedPath(req.path, req.method, authConfig, customRouteAuthConfig)) {
+  if (!isProtectedPath(path, method, authConfig, customRouteAuthConfig)) {
     return next();
   }
 
   // Skip authentication for public routes
-  if (canAccessPublicly(req.path, req.method, authConfig)) {
+  if (canAccessPublicly(path, method, authConfig)) {
     return next();
   }
 
@@ -88,7 +92,8 @@ export const authorizationMiddleware = async (req: Request, res: Response, next:
     return next();
   }
 
-  const path = req.path;
+  // Use baseUrl + path to get the full path (see authenticationMiddleware comment).
+  const path = req.baseUrl + req.path;
   const method = req.method;
   const getHeader = (name: string) => req.headers[name.toLowerCase()] as string | undefined;
 
@@ -97,7 +102,7 @@ export const authorizationMiddleware = async (req: Request, res: Response, next:
     return next();
   }
 
-  if (!isProtectedPath(req.path, req.method, authConfig, customRouteAuthConfig)) {
+  if (!isProtectedPath(path, method, authConfig, customRouteAuthConfig)) {
     return next();
   }
 

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -495,18 +495,28 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
     });
   }
 
+  private useScopedMiddleware(
+    ...middlewares: Array<(req: Request, res: Response, next: NextFunction) => void | Promise<void>>
+  ): void {
+    for (const mw of middlewares) {
+      if (this.prefix) {
+        this.app.use(this.prefix, mw);
+      } else {
+        this.app.use(mw);
+      }
+    }
+  }
+
   registerContextMiddleware(): void {
-    this.app.use(this.createContextMiddleware());
+    this.useScopedMiddleware(this.createContextMiddleware());
   }
 
   registerAuthMiddleware(): void {
     const authConfig = this.mastra.getServer()?.auth;
     if (!authConfig) {
-      // No auth config, skip registration
       return;
     }
 
-    this.app.use(authenticationMiddleware);
-    this.app.use(authorizationMiddleware);
+    this.useScopedMiddleware(authenticationMiddleware, authorizationMiddleware);
   }
 }


### PR DESCRIPTION
## Description

Fixes an issue in the Express adapter where context and auth middleware were
registered globally using `app.use(middleware)`, ignoring the configured
`prefix`. As a result, Mastra's auth middleware was unintentionally blocking
user-defined routes outside the prefix (e.g., `/health`).

Middleware registration has been updated to use `app.use(prefix, middleware)`
when a prefix is configured. This ensures that auth and context middleware
only apply to routes under the Mastra prefix, leaving external routes
unaffected.

## Related Issue(s)

Closes #13321

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying middleware applies only to routes under the configured prefix and that auth/context behave correctly inside vs. outside the prefix.

* **Bug Fixes**
  * Middleware now correctly respects route prefixes so endpoints mounted outside the prefix (e.g., health checks) are not subject to auth/context.

* **Chores**
  * Centralized middleware registration for clearer scoping and maintainability.

* **Docs**
  * Updated docs and examples to show prefix-scoped middleware and independent routes.

* **Chore/Release**
  * Added patch release note for middleware scoping change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->