### PR TITLE
feat(harness): add optional threadLock config for concurrent thread access protection

### DIFF
--- a/.changeset/sharp-carrots-beam.md
+++ b/.changeset/sharp-carrots-beam.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Added optional threadLock callbacks to HarnessConfig for preventing concurrent thread access across processes. The Harness now calls acquire/release during selectOrCreateThread, createThread, and switchThread when configured. This is a non-breaking addition — locking is opt-in via the new config field.

--- a/.changeset/sharp-carrots-beam.md
+++ b/.changeset/sharp-carrots-beam.md
@@ -3,4 +3,18 @@
 'mastracode': patch
 ---
 
-Added optional threadLock callbacks to HarnessConfig for preventing concurrent thread access across processes. The Harness now calls acquire/release during selectOrCreateThread, createThread, and switchThread when configured. This is a non-breaking addition — locking is opt-in via the new config field.
+**@mastra/core:** Added optional `threadLock` callbacks to `HarnessConfig` for preventing concurrent thread access across processes. The Harness calls `acquire`/`release` during `selectOrCreateThread`, `createThread`, and `switchThread` when configured. Locking is opt-in — when `threadLock` is not provided, behavior is unchanged.
+
+```ts
+const harness = new Harness({
+  id: 'my-harness',
+  storage: myStore,
+  modes: [{ id: 'default', agent: myAgent }],
+  threadLock: {
+    acquire: (threadId) => acquireThreadLock(threadId),
+    release: (threadId) => releaseThreadLock(threadId),
+  },
+});
+```
+
+**mastracode:** Wires the existing filesystem-based thread lock (`thread-lock.ts`) into the new `threadLock` config, restoring the concurrent access protection that was lost during the monorepo migration.

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -18,6 +18,7 @@ import { AuthStorage } from './auth/storage.js';
 import { HookManager } from './hooks/index.js';
 import { MCPManager } from './mcp/index.js';
 import { getToolCategory } from './permissions.js';
+import { acquireThreadLock, releaseThreadLock } from './utils/thread-lock.js';
 import { setAuthStorage } from './providers/claude-max.js';
 import { setAuthStorage as setOpenAIAuthStorage } from './providers/openai-codex.js';
 import { stateSchema } from './schema.js';
@@ -233,6 +234,10 @@ export function createMastraCode(config?: MastraCodeConfig) {
       return undefined;
     },
     modelUseCountProvider: () => authStorage.getAllModelUseCounts(),
+    threadLock: {
+      acquire: acquireThreadLock,
+      release: releaseThreadLock,
+    },
   });
 
   // Sync hookManager session ID on thread changes

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -18,7 +18,6 @@ import { AuthStorage } from './auth/storage.js';
 import { HookManager } from './hooks/index.js';
 import { MCPManager } from './mcp/index.js';
 import { getToolCategory } from './permissions.js';
-import { acquireThreadLock, releaseThreadLock } from './utils/thread-lock.js';
 import { setAuthStorage } from './providers/claude-max.js';
 import { setAuthStorage as setOpenAIAuthStorage } from './providers/openai-codex.js';
 import { stateSchema } from './schema.js';
@@ -35,6 +34,7 @@ import {
 import { mastra } from './tui/theme.js';
 import { syncGateways } from './utils/gateway-sync.js';
 import { detectProject, getStorageConfig, getUserId, getResourceIdOverride } from './utils/project.js';
+import { acquireThreadLock, releaseThreadLock } from './utils/thread-lock.js';
 
 const PROVIDER_TO_OAUTH_ID: Record<string, string> = {
   anthropic: 'anthropic',

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -195,6 +195,17 @@ export interface HarnessConfig<TState extends HarnessStateSchema = HarnessStateS
    * If not provided, all tools default to the "other" category.
    */
   toolCategoryResolver?: (toolName: string) => ToolCategory | null;
+
+  /**
+   * Optional thread locking callbacks.
+   * Called during selectOrCreateThread, createThread, and switchThread
+   * to prevent concurrent access to the same thread from multiple processes.
+   * `acquire` should throw if the lock is held by another process.
+   */
+  threadLock?: {
+    acquire: (threadId: string) => void;
+    release: (threadId: string) => void;
+  };
 }
 
 /**


### PR DESCRIPTION
Thread locking was lost when mastra-code moved into the monorepo — the standalone repo had acquire/release calls baked into its Harness, but `@mastra/core`'s generic Harness didn't have them.

This adds an optional `threadLock` config to `HarnessConfig` with `acquire`/`release` callbacks. When provided, the Harness calls them during `selectOrCreateThread`, `createThread`, and `switchThread`. When not provided, behavior is unchanged.

```ts
const harness = new Harness({
  // ...
  threadLock: {
    acquire: (threadId) => acquireThreadLock(threadId),
    release: (threadId) => releaseThreadLock(threadId),
  },
});
```

mastracode now wires its existing filesystem-based lock into this config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional thread-locking capability that, when enabled, acquires/releases locks around thread select/create/switch operations; opt-in and backwards-compatible.
  * Exposed a bundled filesystem-based lock implementation for easy opt-in.

* **Bug Fixes**
  * Restored protection against concurrent thread access that was lost during a prior migration.

* **Tests**
  * Added comprehensive tests validating lock behavior and correct acquire/release ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->