### PR TITLE
fix(tui): preserve assistant message text across todo_write tool calls

### DIFF
--- a/.changeset/new-horses-trade.md
+++ b/.changeset/new-horses-trade.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed assistant message text disappearing when todo_write tool calls were made during streaming

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -2103,6 +2103,13 @@ ${instructions}`,
     if (toolName === 'todo_write') {
       // Record position so todo_updated can place inline completed/cleared display here
       this.todoWriteInsertIndex = this.chatContainer.children.length;
+
+      // Create a new post-tool AssistantMessageComponent so pre-tool text is preserved
+      // (even though todo_write doesn't render a tool component inline, we still need
+      // to split the streaming component so getTrailingContentParts doesn't overwrite it)
+      this.streamingComponent = new AssistantMessageComponent(undefined, this.hideThinkingBlock, getMarkdownTheme());
+      this.addChildBeforeFollowUps(this.streamingComponent);
+      this.ui.requestRender();
     } else if (toolName !== 'subagent') {
       this.addChildBeforeFollowUps(new Text('', 0, 0));
       const component = new ToolExecutionComponentEnhanced(


### PR DESCRIPTION
When `todo_write` tool calls were made during streaming, the assistant message text before the tool call would disappear. This happened because `handleToolInputStart` for `todo_write` added the tool call ID to `seenToolCallIds` but didn't create a new `AssistantMessageComponent`, so `getTrailingContentParts` would overwrite the original component with only post-tool content.

The fix creates a new streaming component for `todo_write` in `handleToolInputStart`, matching what already happens for other tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where assistant message text would disappear when todo_write tool calls occurred during streaming operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->