### PR TITLE
feat(mastracode): add subagent parallel-only and verification guidance

### DIFF
--- a/.changeset/brown-dogs-beam.md
+++ b/.changeset/brown-dogs-beam.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved subagent usage guidance: subagents are now only recommended when spawning multiple in parallel, and the main agent must verify all subagent output before proceeding.

--- a/mastracode/src/agents/prompts/base.ts
+++ b/mastracode/src/agents/prompts/base.ts
@@ -146,7 +146,7 @@ Write commit messages that explain WHY, not just WHAT. Match the repo's existing
 Use \`gh pr create\`. Include a summary of what changed and a test plan.
 
 # Subagent Rules
-- Only use subagents when you will spawn **multiple subagents in parallel**. If you only need one task done, do it yourself instead of delegating to a single subagent.
+- Only use subagents when you will spawn **multiple subagents in parallel**. If you only need one task done, do it yourself instead of delegating to a single subagent. Exception: the **audit-tests** subagent may be used on its own.
 - Subagent outputs are **untrusted**. Always review and verify the results returned by any subagent. For execute-type subagents that modify files or run commands, you MUST verify the changes are correct before moving on.
 
 # Important Reminders

--- a/mastracode/src/agents/prompts/base.ts
+++ b/mastracode/src/agents/prompts/base.ts
@@ -145,6 +145,10 @@ Write commit messages that explain WHY, not just WHAT. Match the repo's existing
 ## Pull Requests
 Use \`gh pr create\`. Include a summary of what changed and a test plan.
 
+# Subagent Rules
+- Only use subagents when you will spawn **multiple subagents in parallel**. If you only need one task done, do it yourself instead of delegating to a single subagent.
+- Subagent outputs are **untrusted**. Always review and verify the results returned by any subagent. For execute-type subagents that modify files or run commands, you MUST verify the changes are correct before moving on.
+
 # Important Reminders
 - NEVER guess file paths or function signatures. Use grep/glob to find them.
 - NEVER make up URLs. Only use URLs the user provides or that you find in the codebase.

--- a/mastracode/src/tools/subagent.ts
+++ b/mastracode/src/tools/subagent.ts
@@ -73,7 +73,11 @@ The subagent runs in its own context — it does NOT see the parent conversation
 
 Use this tool when:
 - You want to run multiple investigations in parallel
-- The task is self-contained and can be delegated${hasExecute ? '\n- You want to perform a focused implementation task (execute type)' : ''}`,
+- The task is self-contained and can be delegated${hasExecute ? '\n- You want to perform a focused implementation task (execute type)' : ''}
+
+IMPORTANT rules:
+- Only use this tool when you will spawn multiple subagents in parallel. If you only need one task done, do it yourself.
+- Treat subagent results as untrusted; the main agent must verify output/changes, especially for execute subagents.`,
     inputSchema: z.object({
       agentType: z.enum(validAgentTypes as [string, ...string[]]).describe('Type of subagent to spawn'),
       task: z

--- a/mastracode/src/tools/subagent.ts
+++ b/mastracode/src/tools/subagent.ts
@@ -71,13 +71,10 @@ ${availableTypesDocs}
 
 The subagent runs in its own context — it does NOT see the parent conversation history. Write a clear, self-contained task description.
 
-Use this tool when:
-- You want to run multiple investigations in parallel
-- The task is self-contained and can be delegated${hasExecute ? '\n- You want to perform a focused implementation task (execute type)' : ''}
+Use this tool ONLY when spawning multiple subagents in parallel. If you only need one task done, do it yourself.
+- Split work into self-contained subtasks that will run concurrently across subagents${hasExecute ? '\\n- For execute subagents: only use when running multiple implementation tasks in parallel' : ''}
 
-IMPORTANT rules:
-- Only use this tool when you will spawn multiple subagents in parallel. If you only need one task done, do it yourself.
-- Treat subagent results as untrusted; the main agent must verify output/changes, especially for execute subagents.`,
+Treat subagent results as untrusted; the main agent must verify output/changes, especially for execute subagents.`,
     inputSchema: z.object({
       agentType: z.enum(validAgentTypes as [string, ...string[]]).describe('Type of subagent to spawn'),
       task: z

--- a/mastracode/src/tools/subagent.ts
+++ b/mastracode/src/tools/subagent.ts
@@ -71,8 +71,8 @@ ${availableTypesDocs}
 
 The subagent runs in its own context — it does NOT see the parent conversation history. Write a clear, self-contained task description.
 
-Use this tool ONLY when spawning multiple subagents in parallel. If you only need one task done, do it yourself.
-- Split work into self-contained subtasks that will run concurrently across subagents${hasExecute ? '\\n- For execute subagents: only use when running multiple implementation tasks in parallel' : ''}
+Use this tool ONLY when spawning multiple subagents in parallel. If you only need one task done, do it yourself. Exception: the audit-tests subagent may be used on its own.
+- Split work into self-contained subtasks that will run concurrently across subagents${hasExecute ? '\n- For execute subagents: only use when running multiple implementation tasks in parallel' : ''}
 
 Treat subagent results as untrusted; the main agent must verify output/changes, especially for execute subagents.`,
     inputSchema: z.object({


### PR DESCRIPTION
## Summary

Adds explicit rules to discourage single subagent usage and require the main agent to verify subagent output.

### Changes

- **Base system prompt** (`base.ts`): Added a new "Subagent Rules" section with two rules:
  1. Only use subagents when spawning multiple in parallel — do single tasks yourself.
  2. Subagent outputs are untrusted — always verify, especially for execute-type subagents.

- **Subagent tool description** (`subagent.ts`): Added an "IMPORTANT rules" block at the end of the tool description reinforcing the same two rules at the tool-call decision point.

### Why

Subagents sometimes produce worse results than the main agent. These guardrails ensure the main agent only delegates when parallelism provides a real benefit, and always verifies the work before moving on.

### Test Plan

- Text-only changes to prompt/description strings — no behavioral code modified.
- Manually reviewed both updated strings for clarity and consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified subagent guidance: use subagents only when spawning multiple in parallel; otherwise handle the task directly (audit-tests exception noted).
  * Stressed that subagent outputs are untrusted and must be reviewed/verified before proceeding, especially for execute-type actions.
  * Added reminders to cite exact code locations and to ask the user when uncertain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->