### PR TITLE
fix: scope thread auto resume to current directory to make worktrees easier to use

### DIFF
--- a/.changeset/tiny-crabs-drive.md
+++ b/.changeset/tiny-crabs-drive.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'mastracode': patch
+---
+
+Fixed thread resuming in git worktrees. Previously, starting mastracode in a new worktree would resume a thread from another worktree of the same repo. Threads are now auto-tagged with the project path and filtered on resume so each worktree gets its own thread scope.

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -604,7 +604,9 @@ export class MastraTUI {
     const currentPath = this.projectInfo.rootPath;
     const threads = allThreads.filter(t => {
       const threadPath = t.metadata?.projectPath as string | undefined;
-      return threadPath === currentPath;
+      // Include threads that match this path, or legacy threads with no tag
+      // (only exclude threads explicitly tagged with a different path)
+      return !threadPath || threadPath === currentPath;
     });
 
     if (threads.length === 0) {

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -602,11 +602,23 @@ export class MastraTUI {
     // This prevents worktrees (which share the same resourceId) from
     // resuming each other's threads.
     const currentPath = this.projectInfo.rootPath;
+    // TEMPORARY: Threads created before auto-tagging don't have projectPath
+    // metadata. To avoid resuming another worktree's untagged threads, we
+    // compare against the directory's birthtime — if the thread predates the
+    // directory it can't belong here. Once all legacy threads have been
+    // retroactively tagged (see below), this check can be removed.
+    let dirCreatedAt: Date | undefined;
+    try {
+      const stat = fs.statSync(currentPath);
+      dirCreatedAt = stat.birthtime;
+    } catch {
+      // fall through – treat all untagged threads as candidates
+    }
     const threads = allThreads.filter(t => {
       const threadPath = t.metadata?.projectPath as string | undefined;
-      // Include threads that match this path, or legacy threads with no tag
-      // (only exclude threads explicitly tagged with a different path)
-      return !threadPath || threadPath === currentPath;
+      if (threadPath) return threadPath === currentPath;
+      if (dirCreatedAt) return t.createdAt >= dirCreatedAt;
+      return true;
     });
 
     if (threads.length === 0) {
@@ -621,6 +633,11 @@ export class MastraTUI {
     // Auto-resume the most recent thread for this directory
     try {
       await this.harness.switchThread(mostRecent.id);
+      // Retroactively tag untagged legacy threads so the birthtime check
+      // above can eventually be removed.
+      if (!mostRecent.metadata?.projectPath) {
+        await this.harness.persistThreadSetting('projectPath', currentPath);
+      }
     } catch (error) {
       if (error instanceof ThreadLockError) {
         // Defer the lock conflict prompt until after the TUI is started

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -604,9 +604,7 @@ export class MastraTUI {
     const currentPath = this.projectInfo.rootPath;
     const threads = allThreads.filter(t => {
       const threadPath = t.metadata?.projectPath as string | undefined;
-      // Include threads that match the current path, or threads that
-      // were never tagged (legacy threads before auto-tagging).
-      return !threadPath || threadPath === currentPath;
+      return threadPath === currentPath;
     });
 
     if (threads.length === 0) {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -522,6 +522,12 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
       metadata[`modeModelId_${this.currentModeId}`] = modelId;
     }
 
+    // Auto-tag with projectPath from state so threads are scoped to the working directory
+    const projectPath = (this.state as any).projectPath;
+    if (projectPath) {
+      metadata.projectPath = projectPath;
+    }
+
     if (this.config.storage) {
       const memoryStorage = await this.getMemoryStorage();
       await memoryStorage.saveThread({


### PR DESCRIPTION
Worktrees of the same repo share the same git remote URL and thus the same `resourceId`, so starting mc in a new worktree would auto-resume a thread from another worktree.

New threads are now auto-tagged with `projectPath` metadata on creation (in `harness.createThread`), and `promptForThreadSelection` filters by it when picking a thread to resume.

For legacy untagged threads, we compare `thread.createdAt` against the directory's birthtime — if the thread predates the directory, it can't belong here. When an untagged thread is resumed it gets retroactively tagged so the birthtime check is just a temporary migration shim to not confuse the team when their threads stop resuming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed thread resuming in git worktrees to ensure each worktree maintains its own separate thread scope, preventing interference between worktrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->