### PR TITLE
feat(tui): resolve autocomplete and queue slash commands on Ctrl+F

### DIFF
--- a/.changeset/sixty-dolls-occur.md
+++ b/.changeset/sixty-dolls-occur.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed Ctrl+F follow-up queueing to resolve autocomplete suggestions before reading editor text, so partially typed slash commands (e.g. /rev) are expanded to their full form (e.g. /review). Slash commands queued via Ctrl+F are now properly processed through the slash command handler after the agent finishes, instead of being sent as raw text to the LLM.

--- a/mastracode/src/tui/components/custom-editor.ts
+++ b/mastracode/src/tui/components/custom-editor.ts
@@ -130,6 +130,11 @@ export class CustomEditor extends Editor {
 
     // Ctrl+F - follow-up (queue message while streaming)
     if (matchesKey(data, 'ctrl+f')) {
+      // Accept autocomplete suggestion if one is showing, so the resolved
+      // text (e.g. "/review" instead of "/rev") is read by the handler.
+      if (this.isShowingAutocomplete()) {
+        super.handleInput('\t');
+      }
       const handler = this.actionHandlers.get('followUp');
       if (handler) {
         handler();

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -203,6 +203,9 @@ export class MastraTUI {
   // Follow-up messages sent via Ctrl+F while streaming
   // These must stay anchored at the bottom of the chat stream
   private followUpComponents: UserMessageComponent[] = [];
+  // Slash commands queued via Ctrl+F while the agent is running.
+  // Drained in handleAgentEnd after all harness-level follow-ups complete.
+  private pendingSlashCommands: string[] = [];
 
   // Active approval dialog dismiss callback — called on Ctrl+C to unblock the dialog
   private pendingApprovalDismiss: (() => void) | null = null;
@@ -373,20 +376,28 @@ export class MastraTUI {
       if (!text) return;
       if (!this.harness.isRunning()) return; // Only relevant while streaming
 
-      // Clear editor and add user message to chat
+      // Clear editor
       this.editor.setText('');
-      this.addUserMessage({
-        id: `user-${Date.now()}`,
-        role: 'user',
-        content: [{ type: 'text', text }],
-        createdAt: new Date(),
-      });
       this.ui.requestRender();
 
-      // Queue the follow-up
-      this.harness.followUp(text).catch(error => {
-        this.showError(error instanceof Error ? error.message : 'Follow-up failed');
-      });
+      if (text.startsWith('/')) {
+        // Queue slash command for processing after the agent completes
+        this.pendingSlashCommands.push(text);
+        this.showInfo(`Slash command queued: ${text}`);
+      } else {
+        // Queue as a regular follow-up message
+        this.addUserMessage({
+          id: `user-${Date.now()}`,
+          role: 'user',
+          content: [{ type: 'text', text }],
+          createdAt: new Date(),
+        });
+        this.ui.requestRender();
+
+        this.harness.followUp(text).catch(error => {
+          this.showError(error instanceof Error ? error.message : 'Follow-up failed');
+        });
+      }
     });
   }
 
@@ -467,6 +478,7 @@ export class MastraTUI {
           // Agent is streaming → steer (abort + resend)
           // Clear follow-up tracking since steer replaces the current response
           this.followUpComponents = [];
+          this.pendingSlashCommands = [];
           this.harness.steer(userInput).catch(error => {
             this.showError(error instanceof Error ? error.message : 'Steer failed');
           });
@@ -1371,9 +1383,11 @@ ${instructions}`,
         this.ui.requestRender();
         break;
 
-      case 'follow_up_queued':
-        this.showInfo(`Follow-up queued (${event.count} pending)`);
+      case 'follow_up_queued': {
+        const totalPending = (event.count as number) + this.pendingSlashCommands.length;
+        this.showInfo(`Follow-up queued (${totalPending} pending)`);
         break;
+      }
 
       case 'workspace_ready':
         // Workspace initialized successfully - silent unless verbose
@@ -1734,6 +1748,16 @@ ${instructions}`,
     // Keep allToolComponents so Ctrl+E continues to work after agent completes
 
     this.notify('agent_done');
+
+    // Drain queued slash commands once all harness-level follow-ups are done.
+    // Each slash command that triggers sendMessage will start a new agent
+    // operation, and handleAgentEnd will fire again to drain the next one.
+    if (this.pendingSlashCommands.length > 0 && this.harness.getFollowUpCount() === 0) {
+      const nextCommand = this.pendingSlashCommands.shift()!;
+      this.handleSlashCommand(nextCommand).catch(error => {
+        this.showError(error instanceof Error ? error.message : 'Queued slash command failed');
+      });
+    }
   }
 
   private handleAgentAborted(): void {
@@ -1758,6 +1782,7 @@ ${instructions}`,
     this.userInitiatedAbort = false;
 
     this.followUpComponents = [];
+    this.pendingSlashCommands = [];
     this.pendingTools.clear();
     this.toolInputBuffers.clear();
     // Keep allToolComponents so Ctrl+E continues to work after interruption
@@ -1777,6 +1802,7 @@ ${instructions}`,
     }
 
     this.followUpComponents = [];
+    this.pendingSlashCommands = [];
     this.pendingTools.clear();
     this.toolInputBuffers.clear();
     // Keep allToolComponents so Ctrl+E continues to work after errors


### PR DESCRIPTION
When pressing Ctrl+F to queue a follow-up while the agent is streaming, two things were broken:

1. If autocomplete was showing (e.g. you typed `/rev` and saw `/review` as a suggestion), pressing Ctrl+F would queue the partial text `/rev` instead of the resolved `/review`.

2. Slash commands queued via Ctrl+F were sent as raw text to the LLM through `harness.followUp()`, bypassing `handleSlashCommand` entirely. So `/review` would be sent as a literal message instead of triggering the review flow.

Now Ctrl+F accepts the active autocomplete suggestion before reading the editor text, and slash commands are queued in a TUI-level `pendingSlashCommands` array that gets drained through `handleSlashCommand` after the agent finishes. Regular text follow-ups still work the same way as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed Ctrl+F follow-up processing to ensure autocomplete suggestions are resolved before continuing
* Improved handling of slash commands entered while the agent is running; they are now queued and executed through the slash command handler after agent completion
* Partially typed slash commands (e.g., `/rev`) now properly expand to their full form (e.g., `/review`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->