### PR TITLE
fix: limit tool result token sizes for view, grep, and web tools

### DIFF
--- a/.changeset/social-tables-try.md
+++ b/.changeset/social-tables-try.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Reduced tool result token limits to prevent oversized responses. Lowered file view and grep token limits from 3,000 to 2,000 tokens. Added 2,000 token truncation to web search and web extract tools, which previously returned unbounded results.

--- a/mastracode/src/tools/file-view.ts
+++ b/mastracode/src/tools/file-view.ts
@@ -11,7 +11,7 @@ import { assertPathAllowed, getAllowedPathsFromContext } from './utils.js';
 const execAsync = promisify(exec);
 
 // Maximum tokens for view tool output
-const MAX_VIEW_TOKENS = 3_000;
+const MAX_VIEW_TOKENS = 2_000;
 
 /**
  * Shorten an absolute path for display to save tokens

--- a/mastracode/src/tools/grep.ts
+++ b/mastracode/src/tools/grep.ts
@@ -8,7 +8,7 @@ import { z } from 'zod';
 import { truncateStringForTokenEstimate } from '../utils/token-estimator.js';
 import { assertPathAllowed, getAllowedPathsFromContext } from './utils.js';
 
-const MAX_GREP_TOKENS = 3_000;
+const MAX_GREP_TOKENS = 2_000;
 
 /**
  * Check if ripgrep is available on the system.


### PR DESCRIPTION
Lowered token limits for file view and grep tools from 3k to 2k tokens. Added 2k token truncation to web-search and web-extract tools which previously returned unbounded results — their outputSchema was removed in favor of serializing to text and applying the same truncation used by other tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized token limits for file view, grep, and web tools to enhance performance
  * Web search and extract tools now return cleaner, more readable results
  * Better error messages when required API credentials are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->