### PR TITLE
fix: raise memory buffer activation threshold to prevent aggressive window shrinking

### DIFF
--- a/.changeset/lucky-rockets-design.md
+++ b/.changeset/lucky-rockets-design.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed an issue where memory activation could shrink the message window too aggressively due to a token counting inaccuracy, resulting in very small context windows (~300 tokens). Temporarily raised the buffer activation threshold to prevent this.

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -62,7 +62,7 @@ export function getDynamicMemory(storage: MastraCompositeStore) {
           scope: omScope,
           observation: {
             bufferTokens: 1 / 10,
-            bufferActivation: 2000,
+            bufferActivation: 4000,
             model: getObserverModel,
             messageTokens: obsThreshold,
             blockAfter: 1.2,


### PR DESCRIPTION
There's a token counting inaccuracy bug that's causing memory activation to shrink the message window way too aggressively (down to ~300 tokens). This temporarily raises `bufferActivation` from 2000 to 4000 to give more headroom while we track down the root cause.

```diff
- bufferActivation: 2000,
+ bufferActivation: 4000,
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a token-counting accuracy issue that was causing memory activation to aggressively reduce context windows to approximately 300 tokens, severely limiting conversation history. Adjusted buffer thresholds to maintain adequate message capacity, improving conversational continuity and system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->