### PR TITLE
refactor(harness): use object parameters for all Harness methods + add reference docs

### DIFF
--- a/.changeset/calm-rings-travel.md
+++ b/.changeset/calm-rings-travel.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Adapted TUI and tool call sites to the updated Harness object-parameter API, ensuring commands, approvals, and thread flows continue to work.

--- a/.changeset/twenty-pianos-deny.md
+++ b/.changeset/twenty-pianos-deny.md
@@ -1,0 +1,35 @@
+---
+'@mastra/core': minor
+---
+
+Refactored all Harness class methods to accept object parameters instead of positional arguments, and standardized method naming.
+
+**Why:** Positional arguments make call sites harder to read, especially for methods with optional middle parameters or multiple string arguments. Object parameters are self-documenting and easier to extend without breaking changes.
+
+- Methods returning arrays use `list` prefix (`listModes`, `listAvailableModels`, `listMessages`, `listMessagesForThread`)
+- `persistThreadSetting` → `setThreadSetting`
+- `resolveToolApprovalDecision` → `respondToToolApproval` (consistent with `respondToQuestion` / `respondToPlanApproval`)
+- `setPermissionCategory` → `setPermissionForCategory`
+- `setPermissionTool` → `setPermissionForTool`
+
+**Before:**
+
+```typescript
+await harness.switchMode('build');
+await harness.sendMessage('Hello', { images });
+const modes = harness.getModes();
+const models = await harness.getAvailableModels();
+harness.resolveToolApprovalDecision('approve');
+```
+
+**After:**
+
+```typescript
+await harness.switchMode({ modeId: 'build' });
+await harness.sendMessage({ content: 'Hello', images });
+const modes = harness.listModes();
+const models = await harness.listAvailableModels();
+harness.respondToToolApproval({ decision: 'approve' });
+```
+
+The `HarnessRequestContext` interface methods (`registerQuestion`, `registerPlanApproval`, `getSubagentModelId`) are also updated to use object parameters.

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -1,0 +1,793 @@
+---
+title: "Reference: Harness Class | Harness"
+description: "Documentation for the Harness class, the core orchestrator for multi-mode agents, shared state, memory, and storage in Mastra."
+packages:
+  - "@mastra/core"
+---
+
+# Harness Class
+
+**Added in:** `@mastra/core@1.1.0`
+
+The `Harness` class orchestrates multiple agent modes, shared state, memory, and storage. It provides a control layer that a TUI or other UI can drive to manage threads, switch models and modes, send messages, handle tool approvals, and track events.
+
+## Usage example
+
+```typescript
+import { Harness } from '@mastra/core/harness';
+import { LibSQLStore } from '@mastra/libsql';
+import { z } from 'zod';
+
+const harness = new Harness({
+  id: 'my-coding-agent',
+  storage: new LibSQLStore({ url: 'file:./data.db' }),
+  stateSchema: z.object({
+    currentModelId: z.string().optional(),
+  }),
+  modes: [
+    { id: 'plan', name: 'Plan', default: true, agent: planAgent },
+    { id: 'build', name: 'Build', agent: buildAgent },
+  ],
+});
+
+harness.subscribe((event) => {
+  if (event.type === 'message_update') {
+    renderMessage(event.message);
+  }
+});
+
+await harness.init();
+await harness.selectOrCreateThread();
+await harness.sendMessage({ content: 'Hello!' });
+```
+
+## Constructor parameters
+
+<PropertiesTable
+  content={[
+    {
+      name: "id",
+      type: "string",
+      description: "Unique identifier for this harness instance.",
+    },
+    {
+      name: "resourceId",
+      type: "string",
+      description: "Resource ID for grouping threads (e.g., project identifier). Threads are scoped to this resource ID. Defaults to `id`.",
+      isOptional: true,
+    },
+    {
+      name: "storage",
+      type: "MastraCompositeStore",
+      description: "Storage backend for persistence (threads, messages, state).",
+      isOptional: true,
+    },
+    {
+      name: "stateSchema",
+      type: "z.ZodObject",
+      description: "Zod schema defining the shape of harness state. Used for validation and extracting defaults.",
+      isOptional: true,
+    },
+    {
+      name: "initialState",
+      type: "Partial<z.infer<TState>>",
+      description: "Initial state values. Must conform to the schema if provided.",
+      isOptional: true,
+    },
+    {
+      name: "memory",
+      type: "MastraMemory",
+      description: "Memory configuration shared across all modes. Propagated to mode agents that don't have their own memory.",
+      isOptional: true,
+    },
+    {
+      name: "modes",
+      type: "HarnessMode[]",
+      description: "Available agent modes. At least one mode is required. Each mode defines an agent and optional defaults.",
+    },
+    {
+      name: "tools",
+      type: "ToolsInput | ((ctx) => ToolsInput)",
+      description: "Tools available to all agents across all modes. It can be a static tools object or a dynamic function that receives the request context.",
+      isOptional: true,
+    },
+    {
+      name: "workspace",
+      type: "Workspace | WorkspaceConfig | ((ctx) => Workspace)",
+      description: "Workspace configuration. Accepts a pre-constructed Workspace, a WorkspaceConfig for the harness to construct internally, or a dynamic factory function.",
+      isOptional: true,
+    },
+    {
+      name: "subagents",
+      type: "HarnessSubagent[]",
+      description: "Subagent definitions. When provided, the harness creates a built-in `subagent` tool that parent agents can call to spawn focused subagents.",
+      isOptional: true,
+    },
+    {
+      name: "resolveModel",
+      type: "(modelId: string) => MastraLanguageModel",
+      description: "Converts a model ID string (e.g., `\"anthropic/claude-sonnet-4\"`) to a language model instance. Used by subagents and observational memory model resolution.",
+      isOptional: true,
+    },
+    {
+      name: "omConfig",
+      type: "HarnessOMConfig",
+      description: "Default configuration for observational memory (observer/reflector model IDs and thresholds).",
+      isOptional: true,
+    },
+    {
+      name: "heartbeatHandlers",
+      type: "HeartbeatHandler[]",
+      description: "Periodic background tasks started during `init()`. Use for gateway sync, cache refresh, and similar tasks.",
+      isOptional: true,
+    },
+    {
+      name: "idGenerator",
+      type: "() => string",
+      description: "Custom ID generator for threads, messages, and other entities.",
+      isOptional: true,
+      defaultValue: "timestamp + random string",
+    },
+    {
+      name: "modelAuthChecker",
+      type: "ModelAuthChecker",
+      description: "Custom auth checker for model providers. Return `true`/`false` to override the default environment variable check, or `undefined` to fall back to defaults.",
+      isOptional: true,
+    },
+    {
+      name: "modelUseCountProvider",
+      type: "ModelUseCountProvider",
+      description: "Provides per-model use counts for sorting and display in `listAvailableModels()`.",
+      isOptional: true,
+    },
+    {
+      name: "toolCategoryResolver",
+      type: "(toolName: string) => ToolCategory | null",
+      description: "Maps tool names to permission categories (`'read'`, `'edit'`, `'execute'`, `'mcp'`, `'other'`). Used by the permission system to resolve category-level policies.",
+      isOptional: true,
+    },
+    {
+      name: "threadLock",
+      type: "{ acquire, release }",
+      description: "Thread locking callbacks to prevent concurrent access from multiple processes. `acquire` should throw if the lock is held.",
+      isOptional: true,
+    },
+  ]}
+/>
+
+### HarnessMode
+
+Each entry in the `modes` array configures a single agent mode.
+
+<PropertiesTable
+  content={[
+    {
+      name: "id",
+      type: "string",
+      description: "Unique identifier for this mode (e.g., `\"plan\"`, `\"build\"`).",
+    },
+    {
+      name: "name",
+      type: "string",
+      description: "Human-readable name for display.",
+      isOptional: true,
+    },
+    {
+      name: "default",
+      type: "boolean",
+      description: "Whether this is the default mode when the harness starts.",
+      isOptional: true,
+      defaultValue: "false",
+    },
+    {
+      name: "defaultModelId",
+      type: "string",
+      description: "Default model ID for this mode (e.g., `\"anthropic/claude-sonnet-4-20250514\"`). Used when no per-mode model has been explicitly selected.",
+      isOptional: true,
+    },
+    {
+      name: "color",
+      type: "string",
+      description: "Hex color for the mode indicator (e.g., `\"#7c3aed\"`).",
+      isOptional: true,
+    },
+    {
+      name: "agent",
+      type: "Agent | ((state) => Agent)",
+      description: "The agent for this mode. It can be a static Agent instance or a function that receives harness state and returns an Agent.",
+    },
+  ]}
+/>
+
+### HarnessSubagent
+
+Each entry in the `subagents` array defines a subagent the harness can spawn.
+
+<PropertiesTable
+  content={[
+    {
+      name: "id",
+      type: "string",
+      description: "Unique identifier for this subagent type (e.g., `\"explore\"`, `\"execute\"`).",
+    },
+    {
+      name: "name",
+      type: "string",
+      description: "Human-readable name shown in tool output.",
+    },
+    {
+      name: "description",
+      type: "string",
+      description: "Description of what this subagent does. Used in the auto-generated tool description.",
+    },
+    {
+      name: "instructions",
+      type: "string",
+      description: "System prompt for this subagent.",
+    },
+    {
+      name: "tools",
+      type: "ToolsInput",
+      description: "Tools this subagent has direct access to.",
+      isOptional: true,
+    },
+    {
+      name: "allowedHarnessTools",
+      type: "string[]",
+      description: "Tool IDs from the harness's shared `tools` config. Merged with `tools` above to let subagents use a subset of harness tools.",
+      isOptional: true,
+    },
+    {
+      name: "defaultModelId",
+      type: "string",
+      description: "Default model ID for this subagent type.",
+      isOptional: true,
+    },
+  ]}
+/>
+
+## Properties
+
+<PropertiesTable
+  content={[
+    {
+      name: "id",
+      type: "string",
+      description: "Harness identifier, set at construction.",
+    },
+  ]}
+/>
+
+## Methods
+
+### Lifecycle
+
+#### `init()`
+
+Initialize the harness. Loads storage, initializes the workspace, propagates memory and workspace to mode agents, and starts heartbeat handlers. Call this before using the harness.
+
+```typescript
+await harness.init();
+```
+
+#### `selectOrCreateThread()`
+
+Select the most recent thread for the current resource, or create one if none exist. Loads thread metadata and acquires a thread lock.
+
+```typescript
+const thread = await harness.selectOrCreateThread();
+```
+
+#### `destroy()`
+
+Stop all heartbeat handlers and clean up resources.
+
+```typescript
+await harness.destroy();
+```
+
+### State
+
+#### `getState()`
+
+Return a read-only snapshot of the current harness state.
+
+```typescript
+const state = harness.getState();
+```
+
+#### `setState(updates)`
+
+Update the harness state. Validates against `stateSchema` if provided, and emits a `state_changed` event with the new state and changed keys.
+
+```typescript
+await harness.setState({ currentModelId: 'anthropic/claude-sonnet-4-20250514' });
+```
+
+### Modes
+
+#### `listModes()`
+
+Return all configured `HarnessMode` instances.
+
+```typescript
+const modes = harness.listModes();
+```
+
+#### `getCurrentModeId()`
+
+Return the ID of the currently active mode.
+
+```typescript
+const modeId = harness.getCurrentModeId();
+```
+
+#### `getCurrentMode()`
+
+Return the `HarnessMode` object for the current mode.
+
+```typescript
+const mode = harness.getCurrentMode();
+```
+
+#### `switchMode({ modeId })`
+
+Switch to a different mode. Aborts any in-progress generation, saves the current model to the outgoing mode, loads the incoming mode's model, and emits `mode_changed` and `model_changed` events.
+
+```typescript
+await harness.switchMode({ modeId: 'build' });
+```
+
+### Models
+
+#### `getCurrentModelId()`
+
+Return the ID of the currently selected model from state.
+
+```typescript
+const modelId = harness.getCurrentModelId();
+```
+
+#### `getModelName()`
+
+Return a short display name from the current model ID. For example, `"claude-sonnet-4"` from `"anthropic/claude-sonnet-4"`.
+
+```typescript
+const name = harness.getModelName();
+```
+
+#### `getFullModelId()`
+
+Return the complete model ID string.
+
+```typescript
+const fullId = harness.getFullModelId();
+```
+
+#### `hasModelSelected()`
+
+Check if a model ID is currently selected.
+
+```typescript
+if (harness.hasModelSelected()) {
+  // Ready to send messages
+}
+```
+
+#### `switchModel({ modelId, scope?, modeId? })`
+
+Switch the active model. When `scope` is `'thread'`, the model ID is persisted to thread metadata so it's restored when switching back. Emits a `model_changed` event.
+
+```typescript
+// Set for current session only
+await harness.switchModel({ modelId: 'anthropic/claude-sonnet-4-20250514' });
+
+// Persist to the current thread
+await harness.switchModel({ modelId: 'anthropic/claude-sonnet-4-20250514', scope: 'thread' });
+```
+
+#### `getCurrentModelAuthStatus()`
+
+Check if the current model's provider has authentication configured. Uses `modelAuthChecker` if provided, falling back to environment variable checks from the provider registry.
+
+```typescript
+const status = await harness.getCurrentModelAuthStatus();
+// { hasAuth: true, apiKeyEnvVar: 'ANTHROPIC_API_KEY' }
+```
+
+#### `listAvailableModels()`
+
+Retrieve all available models from the provider registry, including their authentication status and use counts.
+
+```typescript
+const models = await harness.listAvailableModels();
+// [{ id, provider, modelName, hasApiKey, apiKeyEnvVar, useCount }]
+```
+
+### Threads
+
+#### `getCurrentThreadId()`
+
+Return the ID of the currently active thread.
+
+```typescript
+const threadId = harness.getCurrentThreadId();
+```
+
+#### `createThread({ title? })`
+
+Create a new thread. Initializes thread metadata, saves it to storage, acquires a thread lock, and emits a `thread_created` event.
+
+```typescript
+const thread = await harness.createThread({ title: 'New conversation' });
+```
+
+#### `switchThread({ threadId })`
+
+Switch to a different thread. Aborts any in-progress operations, acquires a lock on the new thread, releases the lock on the previous thread, loads the thread's metadata, and emits a `thread_changed` event.
+
+```typescript
+await harness.switchThread({ threadId: 'thread-abc123' });
+```
+
+#### `listThreads(options?)`
+
+List threads from storage. By default, only threads for the current resource are returned.
+
+```typescript
+// List threads for current resource
+const threads = await harness.listThreads();
+
+// List all threads across resources
+const allThreads = await harness.listThreads({ allResources: true });
+```
+
+#### `renameThread({ title })`
+
+Update the title of the current thread.
+
+```typescript
+await harness.renameThread({ title: 'Updated title' });
+```
+
+#### `getResourceId()`
+
+Return the current resource ID.
+
+```typescript
+const resourceId = harness.getResourceId();
+```
+
+#### `setResourceId({ resourceId })`
+
+Set the resource ID and clear the current thread.
+
+```typescript
+harness.setResourceId({ resourceId: 'project-xyz' });
+```
+
+#### `getSession()`
+
+Return current session information including thread ID, mode ID, and the list of threads.
+
+```typescript
+const session = await harness.getSession();
+// { currentThreadId, currentModeId, threads }
+```
+
+### Messages
+
+#### `sendMessage({ content, images? })`
+
+Send a message to the current agent. Creates a thread if none exists, builds a `RequestContext` and toolsets, and streams the agent's response. Handles tool calls, approvals, and errors automatically.
+
+```typescript
+await harness.sendMessage({ content: 'Explain the authentication flow' });
+```
+
+#### `listMessages(options?)`
+
+Retrieve messages for the current thread.
+
+```typescript
+const messages = await harness.listMessages();
+
+// Limit to the last 50 messages
+const recent = await harness.listMessages({ limit: 50 });
+```
+
+#### `listMessagesForThread({ threadId, limit? })`
+
+Retrieve messages for a specific thread.
+
+```typescript
+const messages = await harness.listMessagesForThread({ threadId: 'thread-abc123' });
+```
+
+#### `getFirstUserMessageForThread({ threadId })`
+
+Retrieve the first user message for a given thread.
+
+```typescript
+const firstMsg = await harness.getFirstUserMessageForThread({ threadId: 'thread-abc123' });
+```
+
+### Flow control
+
+#### `abort()`
+
+Abort any in-progress generation.
+
+```typescript
+harness.abort();
+```
+
+#### `steer({ content })`
+
+Steer the agent mid-stream by injecting an instruction into the current generation.
+
+```typescript
+harness.steer({ content: 'Focus on security implications' });
+```
+
+#### `followUp({ content })`
+
+Queue a follow-up message to be sent after the current generation completes. If no operation is running, sends the message immediately.
+
+```typescript
+harness.followUp({ content: 'Now apply those changes' });
+```
+
+### Tool approvals
+
+#### `respondToToolApproval({ decision })`
+
+Respond to a pending tool approval request. Called when a `tool_approval_required` event is received.
+
+```typescript
+harness.respondToToolApproval({ decision: 'approve' });
+harness.respondToToolApproval({ decision: 'decline' });
+```
+
+### Questions and plans
+
+#### `respondToQuestion({ questionId, answer })`
+
+Respond to a pending question from the `ask_user` built-in tool.
+
+```typescript
+harness.respondToQuestion({ questionId: 'q-123', answer: 'Yes, proceed with the refactor' });
+```
+
+#### `respondToPlanApproval({ planId, response })`
+
+Respond to a pending plan approval from the `submit_plan` built-in tool. The `response` object contains `action` (`'approved'` or `'rejected'`) and an optional `feedback` string.
+
+```typescript
+harness.respondToPlanApproval({ planId: 'plan-123', response: { action: 'approved' } });
+harness.respondToPlanApproval({ planId: 'plan-123', response: { action: 'rejected', feedback: 'Needs more detail' } });
+```
+
+### Permissions
+
+#### `grantSessionCategory({ category })`
+
+Grant a tool category for the current session. Tools in this category are auto-approved without prompting.
+
+```typescript
+harness.grantSessionCategory({ category: 'edit' });
+```
+
+#### `grantSessionTool({ toolName })`
+
+Grant a specific tool for the current session.
+
+```typescript
+harness.grantSessionTool({ toolName: 'mastra_workspace_execute_command' });
+```
+
+#### `getSessionGrants()`
+
+Return currently granted session categories and tools.
+
+```typescript
+const grants = harness.getSessionGrants();
+// { categories: Set<string>, tools: Set<string> }
+```
+
+#### `setPermissionForCategory({ category, policy })`
+
+Set the permission policy for a tool category.
+
+```typescript
+harness.setPermissionForCategory({ category: 'execute', policy: 'ask' });
+```
+
+#### `setPermissionForTool({ toolName, policy })`
+
+Set the permission policy for a specific tool. Per-tool policies take precedence over category policies.
+
+```typescript
+harness.setPermissionForTool({ toolName: 'dangerous_tool', policy: 'deny' });
+```
+
+#### `getPermissionRules()`
+
+Return the current permission rules.
+
+```typescript
+const rules = harness.getPermissionRules();
+// { categories: { execute: 'ask' }, tools: { dangerous_tool: 'deny' } }
+```
+
+#### `getToolCategory({ toolName })`
+
+Resolve a tool's category using the configured `toolCategoryResolver`.
+
+```typescript
+const category = harness.getToolCategory({ toolName: 'mastra_workspace_write_file' });
+// 'edit'
+```
+
+### Observational memory
+
+#### `loadOMProgress()`
+
+Load observational memory records for the current thread and emit an `om_status` event with reconstructed progress.
+
+```typescript
+await harness.loadOMProgress();
+```
+
+#### `getObserverModelId()`
+
+Return the observer model ID from state or the default from `omConfig`.
+
+```typescript
+const modelId = harness.getObserverModelId();
+```
+
+#### `getReflectorModelId()`
+
+Return the reflector model ID from state or the default from `omConfig`.
+
+```typescript
+const modelId = harness.getReflectorModelId();
+```
+
+#### `switchObserverModel({ modelId })`
+
+Switch the observer model. Persists the setting to thread metadata and emits an `om_model_changed` event.
+
+```typescript
+await harness.switchObserverModel({ modelId: 'anthropic/claude-haiku-3.5' });
+```
+
+#### `switchReflectorModel({ modelId })`
+
+Switch the reflector model. Persists the setting to thread metadata and emits an `om_model_changed` event.
+
+```typescript
+await harness.switchReflectorModel({ modelId: 'anthropic/claude-haiku-3.5' });
+```
+
+#### `getObservationThreshold()`
+
+Return the observation threshold in tokens from state or the default from `omConfig`.
+
+```typescript
+const threshold = harness.getObservationThreshold();
+```
+
+#### `getReflectionThreshold()`
+
+Return the reflection threshold in tokens from state or the default from `omConfig`.
+
+```typescript
+const threshold = harness.getReflectionThreshold();
+```
+
+### Subagents
+
+#### `getSubagentModelId({ agentType? })`
+
+Retrieve the subagent model ID. Prioritizes per-type settings over the global setting.
+
+```typescript
+const modelId = harness.getSubagentModelId({ agentType: 'explore' });
+```
+
+#### `setSubagentModelId({ modelId, agentType? })`
+
+Set the subagent model ID. Pass an `agentType` to set a per-type override, or omit it to set the global default. Persists to thread settings and emits a `subagent_model_changed` event.
+
+```typescript
+// Set global subagent model
+await harness.setSubagentModelId({ modelId: 'anthropic/claude-sonnet-4-20250514' });
+
+// Set per-type model
+await harness.setSubagentModelId({ modelId: 'anthropic/claude-haiku-3.5', agentType: 'explore' });
+```
+
+### Events
+
+#### `subscribe(listener)`
+
+Register an event listener. Returns an unsubscribe function.
+
+```typescript
+const unsubscribe = harness.subscribe((event) => {
+  switch (event.type) {
+    case 'message_update':
+      renderMessage(event.message);
+      break;
+    case 'tool_approval_required':
+      showApprovalPrompt(event.toolName);
+      break;
+    case 'error':
+      console.error(event.error);
+      break;
+  }
+});
+
+// Later:
+unsubscribe();
+```
+
+## Events
+
+The harness emits events through registered listeners. The following table lists the available event types:
+
+| Event type | Description |
+|---|---|
+| `mode_changed` | The active mode changed. |
+| `model_changed` | The active model changed. |
+| `thread_changed` | The active thread changed. |
+| `thread_created` | A new thread was created. |
+| `state_changed` | Harness state was updated. |
+| `agent_start` | The agent started processing. |
+| `agent_end` | The agent finished processing. |
+| `message_start` | A new message started streaming. |
+| `message_update` | A message was updated with new content. |
+| `message_end` | A message finished streaming. |
+| `tool_start` | A tool call started. |
+| `tool_approval_required` | A tool call requires user approval. |
+| `tool_update` | A tool call was updated with progress. |
+| `tool_end` | A tool call finished. |
+| `tool_input_start` | Tool input started streaming. |
+| `tool_input_delta` | Tool input received a streaming delta. |
+| `tool_input_end` | Tool input finished streaming. |
+| `usage_update` | Token usage was updated. |
+| `error` | An error occurred. |
+| `info` | An informational message was emitted. |
+| `follow_up_queued` | A follow-up message was queued. |
+| `workspace_status_changed` | The workspace status changed. |
+| `workspace_ready` | The workspace finished initializing. |
+| `workspace_error` | The workspace encountered an error. |
+| `om_status` | Observational memory status update. |
+| `om_observation_start` | An observation started. |
+| `om_observation_end` | An observation completed. |
+| `om_reflection_start` | A reflection started. |
+| `om_reflection_end` | A reflection completed. |
+| `ask_question` | The agent asked a question via the `ask_user` tool. |
+| `plan_approval_required` | The agent submitted a plan for approval via the `submit_plan` tool. |
+| `plan_approved` | A plan was approved. |
+| `subagent_start` | A subagent started processing. |
+| `subagent_text_delta` | A subagent emitted a text delta. |
+| `subagent_tool_start` | A subagent started a tool call. |
+| `subagent_tool_end` | A subagent finished a tool call. |
+| `subagent_end` | A subagent finished processing. |
+| `subagent_model_changed` | A subagent's model changed. |
+| `task_updated` | A task list was updated. |
+
+## Built-in tools
+
+The harness provides built-in tools to agents in every mode:
+
+| Tool | Description |
+|---|---|
+| `ask_user` | Ask the user a question and wait for their response. |
+| `submit_plan` | Submit a plan for user review and approval. |
+| `task_write` | Create or update a structured task list for tracking progress. |
+| `task_check` | Check the completion status of the current task list. |
+| `subagent` | Spawn a focused subagent with constrained tools (only available when `subagents` is configured). |

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -685,6 +685,21 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'Harness',
+      collapsed: true,
+      customProps: {
+        tags: ['new'],
+      },
+      items: [
+        {
+          type: 'doc',
+          id: 'harness/harness-class',
+          label: 'Harness Class',
+        },
+      ],
+    },
+    {
+      type: 'category',
       label: 'Streaming',
       collapsed: true,
       items: [

--- a/mastracode/src/mcp/manager.ts
+++ b/mastracode/src/mcp/manager.ts
@@ -38,7 +38,9 @@ export function createMcpManager(projectDir: string): McpManager {
   let serverStatuses = new Map<string, McpServerStatus>();
   let initialized = false;
 
-  function buildServerDefs(servers: Record<string, { command: string; args?: string[]; env?: Record<string, string> }>) {
+  function buildServerDefs(
+    servers: Record<string, { command: string; args?: string[]; env?: Record<string, string> }>,
+  ) {
     const defs: Record<string, { command: string; args?: string[]; env?: Record<string, string> }> = {};
     for (const [name, cfg] of Object.entries(servers)) {
       defs[name] = { command: cfg.command, args: cfg.args, env: cfg.env };

--- a/mastracode/src/tools/request-sandbox-access.ts
+++ b/mastracode/src/tools/request-sandbox-access.ts
@@ -47,7 +47,7 @@ export const requestSandboxAccessTool = createTool({
       // Create a promise that resolves when the user answers in the TUI
       const answer = await new Promise<string>(resolve => {
         // Register the resolver so respondToQuestion() can resolve it
-        harnessCtx.registerQuestion!(questionId, resolve);
+        harnessCtx.registerQuestion!({ questionId, resolve });
 
         // Emit event — TUI will show the dialog
         harnessCtx.emitEvent!({

--- a/mastracode/src/tools/subagent.ts
+++ b/mastracode/src/tools/subagent.ts
@@ -116,7 +116,7 @@ Treat subagent results as untrusted; the main agent must verify output/changes, 
       const defaultForType = agentType === 'explore' ? EXPLORE_SUBAGENT_MODEL : DEFAULT_SUBAGENT_MODEL;
 
       // Check for configured subagent model from harness (per-type)
-      const configuredSubagentModel = harnessCtx?.getSubagentModelId?.(agentType);
+      const configuredSubagentModel = harnessCtx?.getSubagentModelId?.({ agentType });
 
       const resolvedModelId = modelId ?? configuredSubagentModel ?? deps.defaultModelId ?? defaultForType;
       let model: any;

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -4,13 +4,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import {
-  CombinedAutocompleteProvider,
-  Container,
-  Spacer,
-  Text,
-  visibleWidth,
-} from '@mariozechner/pi-tui';
+import { CombinedAutocompleteProvider, Container, Spacer, Text, visibleWidth } from '@mariozechner/pi-tui';
 import type { Component, SlashCommand } from '@mariozechner/pi-tui';
 import type {
   HarnessEvent,
@@ -194,13 +188,13 @@ export class MastraTUI {
         return;
       }
 
-      const modes = this.state.harness.getModes();
+      const modes = this.state.harness.listModes();
       if (modes.length <= 1) return;
       const currentId = this.state.harness.getCurrentModeId();
       const currentIndex = modes.findIndex(m => m.id === currentId);
       const nextIndex = (currentIndex + 1) % modes.length;
       const nextMode = modes[nextIndex]!;
-      await this.state.harness.switchMode(nextMode.id);
+      await this.state.harness.switchMode({ modeId: nextMode.id });
       // The mode_changed event handler will show the info message
       this.updateStatusLine();
     });
@@ -236,7 +230,7 @@ export class MastraTUI {
         });
         this.state.ui.requestRender();
 
-        this.state.harness.followUp(text).catch(error => {
+        this.state.harness.followUp({ content: text }).catch(error => {
           this.showError(error instanceof Error ? error.message : 'Follow-up failed');
         });
       }
@@ -321,7 +315,7 @@ export class MastraTUI {
           // Clear follow-up tracking since steer replaces the current response
           this.state.followUpComponents = [];
           this.state.pendingSlashCommands = [];
-          this.state.harness.steer(userInput).catch(error => {
+          this.state.harness.steer({ content: userInput }).catch(error => {
             this.showError(error instanceof Error ? error.message : 'Steer failed');
           });
         } else {
@@ -339,7 +333,7 @@ export class MastraTUI {
    * Errors are handled via harness events.
    */
   private fireMessage(content: string, images?: Array<{ data: string; mimeType: string }>): void {
-    this.state.harness.sendMessage(content, images ? { images } : undefined).catch(error => {
+    this.state.harness.sendMessage({ content, images: images ? images : undefined }).catch(error => {
       this.showError(error instanceof Error ? error.message : 'Unknown error');
     });
   }
@@ -486,11 +480,11 @@ export class MastraTUI {
     const mostRecent = sortedThreads[0]!;
     // Auto-resume the most recent thread for this directory
     try {
-      await this.state.harness.switchThread(mostRecent.id);
+      await this.state.harness.switchThread({ threadId: mostRecent.id });
       // Retroactively tag untagged legacy threads so the birthtime check
       // above can eventually be removed.
       if (!mostRecent.metadata?.projectPath) {
-        await this.state.harness.persistThreadSetting('projectPath', currentPath);
+        await this.state.harness.setThreadSetting({ key: 'projectPath', value: currentPath });
       }
     } catch (error) {
       if (error instanceof ThreadLockError) {
@@ -536,7 +530,7 @@ export class MastraTUI {
     const instructions = [
       `  ${keyStyle('Ctrl+C')} ${fg('muted', 'interrupt/clear')}${sep}${keyStyle('Ctrl+C×2')} ${fg('muted', 'exit')}`,
       `  ${keyStyle('Enter')} ${fg('muted', 'while working → steer')}${sep}${keyStyle('Ctrl+F')} ${fg('muted', '→ queue follow-up')}`,
-      `  ${keyStyle('/')} ${fg('muted', 'commands')}${sep}${keyStyle('!')} ${fg('muted', 'shell')}${sep}${keyStyle('Ctrl+T')} ${fg('muted', 'thinking')}${sep}${keyStyle('Ctrl+E')} ${fg('muted', 'tools')}${this.state.harness.getModes().length > 1 ? `${sep}${keyStyle('⇧Tab')} ${fg('muted', 'mode')}` : ''}`,
+      `  ${keyStyle('/')} ${fg('muted', 'commands')}${sep}${keyStyle('!')} ${fg('muted', 'shell')}${sep}${keyStyle('Ctrl+T')} ${fg('muted', 'thinking')}${sep}${keyStyle('Ctrl+E')} ${fg('muted', 'tools')}${this.state.harness.listModes().length > 1 ? `${sep}${keyStyle('⇧Tab')} ${fg('muted', 'mode')}` : ''}`,
     ].join('\n');
 
     this.state.ui.addChild(new Spacer(1));
@@ -594,7 +588,7 @@ ${instructions}`,
     // --- Mode badge ---
     let modeBadge = '';
     let modeBadgeWidth = 0;
-    const modes = this.state.harness.getModes();
+    const modes = this.state.harness.listModes();
     const currentMode = modes.length > 1 ? this.state.harness.getCurrentMode() : undefined;
     // Use OM color when observing/reflecting, otherwise mode color
     const mainModeColor = currentMode?.color;
@@ -943,7 +937,7 @@ ${instructions}`,
     ];
 
     // Only show /mode if there's more than one mode
-    const modes = this.state.harness.getModes();
+    const modes = this.state.harness.listModes();
     if (modes.length > 1) {
       slashCommands.push({ name: 'mode', description: 'Switch agent mode' });
     }
@@ -1375,7 +1369,8 @@ ${instructions}`,
     const obsThreshold = this.state.harness.getObservationThreshold();
     const refThreshold = this.state.harness.getReflectionThreshold();
     this.state.omProgress.threshold = obsThreshold;
-    this.state.omProgress.thresholdPercent = obsThreshold > 0 ? (this.state.omProgress.pendingTokens / obsThreshold) * 100 : 0;
+    this.state.omProgress.thresholdPercent =
+      obsThreshold > 0 ? (this.state.omProgress.pendingTokens / obsThreshold) * 100 : 0;
     this.state.omProgress.reflectionThreshold = refThreshold;
     this.state.omProgress.reflectionThresholdPercent =
       refThreshold > 0 ? (this.state.omProgress.observationTokens / refThreshold) * 100 : 0;
@@ -1517,7 +1512,9 @@ ${instructions}`,
     // Update observation tokens to show the total being reflected
     this.state.omProgress.observationTokens = tokensToReflect;
     this.state.omProgress.reflectionThresholdPercent =
-      this.state.omProgress.reflectionThreshold > 0 ? (tokensToReflect / this.state.omProgress.reflectionThreshold) * 100 : 0;
+      this.state.omProgress.reflectionThreshold > 0
+        ? (tokensToReflect / this.state.omProgress.reflectionThreshold) * 100
+        : 0;
     // Show in-progress marker in chat
     this.state.activeOMMarker = new OMMarkerComponent({
       type: 'om_observation_start',
@@ -1542,7 +1539,9 @@ ${instructions}`,
     // Observations were compressed — update token count
     this.state.omProgress.observationTokens = compressedTokens;
     this.state.omProgress.reflectionThresholdPercent =
-      this.state.omProgress.reflectionThreshold > 0 ? (compressedTokens / this.state.omProgress.reflectionThreshold) * 100 : 0;
+      this.state.omProgress.reflectionThreshold > 0
+        ? (compressedTokens / this.state.omProgress.reflectionThreshold) * 100
+        : 0;
     // Remove in-progress marker — the output box replaces it
     if (this.state.activeOMMarker) {
       const idx = this.state.chatContainer.children.indexOf(this.state.activeOMMarker);
@@ -1688,7 +1687,11 @@ ${instructions}`,
       this.state.lastAskUserComponent = undefined;
       this.state.lastSubmitPlanComponent = undefined;
       if (!this.state.streamingComponent) {
-        this.state.streamingComponent = new AssistantMessageComponent(undefined, this.state.hideThinkingBlock, getMarkdownTheme());
+        this.state.streamingComponent = new AssistantMessageComponent(
+          undefined,
+          this.state.hideThinkingBlock,
+          getMarkdownTheme(),
+        );
         this.addChildBeforeFollowUps(this.state.streamingComponent);
         this.state.streamingMessage = message;
         const trailingParts = this.getTrailingContentParts(message);
@@ -1875,15 +1878,15 @@ ${instructions}`,
         this.state.ui.hideOverlay();
         this.state.pendingApprovalDismiss = null;
         if (action.type === 'approve') {
-          this.state.harness.resolveToolApprovalDecision('approve');
+          this.state.harness.respondToToolApproval({ decision: 'approve' });
         } else if (action.type === 'always_allow_category') {
-          this.state.harness.resolveToolApprovalDecision('always_allow_category');
+          this.state.harness.respondToToolApproval({ decision: 'always_allow_category' });
         } else if (action.type === 'yolo') {
           this.state.harness.setState({ yolo: true } as any);
-          this.state.harness.resolveToolApprovalDecision('approve');
+          this.state.harness.respondToToolApproval({ decision: 'approve' });
           this.updateStatusLine();
         } else {
-          this.state.harness.resolveToolApprovalDecision('decline');
+          this.state.harness.respondToToolApproval({ decision: 'decline' });
         }
       },
     });
@@ -1892,7 +1895,7 @@ ${instructions}`,
     this.state.pendingApprovalDismiss = () => {
       this.state.ui.hideOverlay();
       this.state.pendingApprovalDismiss = null;
-      this.state.harness.resolveToolApprovalDecision('decline');
+      this.state.harness.respondToToolApproval({ decision: 'decline' });
     };
 
     // Show the dialog as an overlay
@@ -1933,7 +1936,11 @@ ${instructions}`,
       this.state.allToolComponents.push(component);
 
       // Create a new post-tool AssistantMessageComponent so pre-tool text is preserved
-      this.state.streamingComponent = new AssistantMessageComponent(undefined, this.state.hideThinkingBlock, getMarkdownTheme());
+      this.state.streamingComponent = new AssistantMessageComponent(
+        undefined,
+        this.state.hideThinkingBlock,
+        getMarkdownTheme(),
+      );
       this.addChildBeforeFollowUps(this.state.streamingComponent);
 
       this.state.ui.requestRender();
@@ -2005,7 +2012,11 @@ ${instructions}`,
       // Create a new post-tool AssistantMessageComponent so pre-tool text is preserved
       // (even though task_write doesn't render a tool component inline, we still need
       // to split the streaming component so getTrailingContentParts doesn't overwrite it)
-      this.state.streamingComponent = new AssistantMessageComponent(undefined, this.state.hideThinkingBlock, getMarkdownTheme());
+      this.state.streamingComponent = new AssistantMessageComponent(
+        undefined,
+        this.state.hideThinkingBlock,
+        getMarkdownTheme(),
+      );
       this.addChildBeforeFollowUps(this.state.streamingComponent);
       this.state.ui.requestRender();
     } else if (toolName !== 'subagent') {
@@ -2022,7 +2033,11 @@ ${instructions}`,
       this.state.allToolComponents.push(component);
 
       // Create a new post-tool AssistantMessageComponent so pre-tool text is preserved
-      this.state.streamingComponent = new AssistantMessageComponent(undefined, this.state.hideThinkingBlock, getMarkdownTheme());
+      this.state.streamingComponent = new AssistantMessageComponent(
+        undefined,
+        this.state.hideThinkingBlock,
+        getMarkdownTheme(),
+      );
       this.addChildBeforeFollowUps(this.state.streamingComponent);
 
       this.state.ui.requestRender();
@@ -2111,12 +2126,12 @@ ${instructions}`,
             options,
             onSubmit: answer => {
               this.state.activeInlineQuestion = undefined;
-              this.state.harness.respondToQuestion(questionId, answer);
+              this.state.harness.respondToQuestion({ questionId, answer });
               resolve();
             },
             onCancel: () => {
               this.state.activeInlineQuestion = undefined;
-              this.state.harness.respondToQuestion(questionId, '(skipped)');
+              this.state.harness.respondToQuestion({ questionId, answer: '(skipped)' });
               resolve();
             },
           },
@@ -2179,12 +2194,12 @@ ${instructions}`,
           options,
           onSubmit: answer => {
             this.state.ui.hideOverlay();
-            this.state.harness.respondToQuestion(questionId, answer);
+            this.state.harness.respondToQuestion({ questionId, answer });
             resolve();
           },
           onCancel: () => {
             this.state.ui.hideOverlay();
-            this.state.harness.respondToQuestion(questionId, '(skipped)');
+            this.state.harness.respondToQuestion({ questionId, answer: '(skipped)' });
             resolve();
           },
         });
@@ -2211,12 +2226,12 @@ ${instructions}`,
           ],
           onSubmit: answer => {
             this.state.activeInlineQuestion = undefined;
-            this.state.harness.respondToQuestion(questionId, answer);
+            this.state.harness.respondToQuestion({ questionId, answer });
             resolve();
           },
           onCancel: () => {
             this.state.activeInlineQuestion = undefined;
-            this.state.harness.respondToQuestion(questionId, 'No');
+            this.state.harness.respondToQuestion({ questionId, answer: 'No' });
             resolve();
           },
           formatResult: answer => {
@@ -2264,8 +2279,9 @@ ${instructions}`,
               },
             });
             // Wait for plan approval to complete (switches mode, aborts stream)
-            await this.state.harness.respondToPlanApproval(planId, {
-              action: 'approved',
+            await this.state.harness.respondToPlanApproval({
+              planId,
+              response: { action: 'approved' },
             });
             this.updateStatusLine();
 
@@ -2287,9 +2303,9 @@ ${instructions}`,
           },
           onReject: async (feedback?: string) => {
             this.state.activeInlinePlanApproval = undefined;
-            this.state.harness.respondToPlanApproval(planId, {
-              action: 'rejected',
-              feedback,
+            this.state.harness.respondToPlanApproval({
+              planId,
+              response: { action: 'rejected', feedback },
             });
             resolve();
           },
@@ -2571,7 +2587,7 @@ ${instructions}`,
         currentThreadId: currentId,
         currentResourceId,
         getMessagePreview: async (threadId: string) => {
-          const firstUserMessage = await this.state.harness.getFirstUserMessageForThread(threadId);
+          const firstUserMessage = await this.state.harness.getFirstUserMessageForThread({ threadId });
           if (firstUserMessage) {
             const text = this.extractTextContent(firstUserMessage);
             return this.truncatePreview(text);
@@ -2588,10 +2604,10 @@ ${instructions}`,
 
           // If thread is from a different resource, switch resource first
           if (thread.resourceId !== currentResourceId) {
-            this.state.harness.setResourceId(thread.resourceId);
+            this.state.harness.setResourceId({ resourceId: thread.resourceId });
           }
           try {
-            await this.state.harness.switchThread(thread.id);
+            await this.state.harness.switchThread({ threadId: thread.id });
           } catch (error) {
             if (error instanceof ThreadLockError) {
               this.showThreadLockPrompt(thread.title || thread.id, error.ownerPid);
@@ -2660,7 +2676,7 @@ ${instructions}`,
           onSubmit: async answer => {
             this.state.activeInlineQuestion = undefined;
             if (answer.toLowerCase().startsWith('y')) {
-              await this.state.harness.persistThreadSetting('projectPath', projectPath);
+              await this.state.harness.setThreadSetting({ key: 'projectPath', value: projectPath });
             }
             resolve();
           },
@@ -2851,7 +2867,7 @@ ${instructions}`,
     }
     const updated = [...currentPaths, resolved];
     this.state.harness.setState({ sandboxAllowedPaths: updated } as any);
-    await this.state.harness.persistThreadSetting('sandboxAllowedPaths', updated);
+    await this.state.harness.setThreadSetting({ key: 'sandboxAllowedPaths', value: updated });
     this.showInfo(`Added to sandbox: ${resolved}`);
   }
 
@@ -2864,7 +2880,7 @@ ${instructions}`,
     }
     const updated = currentPaths.filter(p => p !== match);
     this.state.harness.setState({ sandboxAllowedPaths: updated } as any);
-    await this.state.harness.persistThreadSetting('sandboxAllowedPaths', updated);
+    await this.state.harness.setThreadSetting({ key: 'sandboxAllowedPaths', value: updated });
     this.showInfo(`Removed from sandbox: ${match}`);
   }
 
@@ -2932,7 +2948,7 @@ ${instructions}`,
    * Flow: Mode → Scope → Model
    */
   private async showModelScopeSelector(): Promise<void> {
-    const modes = this.state.harness.getModes();
+    const modes = this.state.harness.listModes();
     const currentMode = this.state.harness.getCurrentMode();
 
     // Sort modes with active mode first
@@ -3037,7 +3053,7 @@ ${instructions}`,
    * Show the model list for a specific mode and scope.
    */
   private async showModelListForScope(scope: 'global' | 'thread', modeId: string, modeName: string): Promise<void> {
-    const availableModels = await this.state.harness.getAvailableModels();
+    const availableModels = await this.state.harness.listAvailableModels();
 
     if (availableModels.length === 0) {
       this.showInfo('No models available. Check your Mastra configuration.');
@@ -3055,7 +3071,7 @@ ${instructions}`,
         title: `Select model (${scopeLabel})`,
         onSelect: async (model: ModelItem) => {
           this.state.ui.hideOverlay();
-          await this.state.harness.switchModel(model.id, scope, modeId);
+          await this.state.harness.switchModel({ modelId: model.id, scope, modeId });
           this.showInfo(`Model set for ${scopeLabel}: ${model.id}`);
           this.updateStatusLine();
           resolve();
@@ -3191,7 +3207,7 @@ ${instructions}`,
     agentType: string,
     agentTypeLabel: string,
   ): Promise<void> {
-    const availableModels = await this.state.harness.getAvailableModels();
+    const availableModels = await this.state.harness.listAvailableModels();
 
     if (availableModels.length === 0) {
       this.showInfo('No models available. Check your Mastra configuration.');
@@ -3199,7 +3215,7 @@ ${instructions}`,
     }
 
     // Get current subagent model if set
-    const currentSubagentModel = await this.state.harness.getSubagentModelId(agentType);
+    const currentSubagentModel = await this.state.harness.getSubagentModelId({ agentType });
     const scopeLabel = scope === 'global' ? `${agentTypeLabel} · Global` : `${agentTypeLabel} · Thread`;
 
     return new Promise(resolve => {
@@ -3210,7 +3226,7 @@ ${instructions}`,
         title: `Select subagent model (${scopeLabel})`,
         onSelect: async (model: ModelItem) => {
           this.state.ui.hideOverlay();
-          await this.state.harness.setSubagentModelId(model.id, agentType);
+          await this.state.harness.setSubagentModelId({ modelId: model.id, agentType });
           if (scope === 'global') {
             if (this.state.authStorage) {
               this.state.authStorage.setSubagentModelId(model.id, agentType);
@@ -3244,7 +3260,7 @@ ${instructions}`,
 
   private async showOMSettings(): Promise<void> {
     // Get available models for the model submenus
-    const availableModels = await this.state.harness.getAvailableModels();
+    const availableModels = await this.state.harness.listAvailableModels();
     const modelOptions = availableModels.map(m => ({
       id: m.id,
       label: m.id,
@@ -3262,17 +3278,18 @@ ${instructions}`,
         config,
         {
           onObserverModelChange: async modelId => {
-            await this.state.harness.switchObserverModel(modelId);
+            await this.state.harness.switchObserverModel({ modelId });
             this.showInfo(`Observer model → ${modelId}`);
           },
           onReflectorModelChange: async modelId => {
-            await this.state.harness.switchReflectorModel(modelId);
+            await this.state.harness.switchReflectorModel({ modelId });
             this.showInfo(`Reflector model → ${modelId}`);
           },
           onObservationThresholdChange: value => {
             this.state.harness.setState({ observationThreshold: value } as any);
             this.state.omProgress.threshold = value;
-            this.state.omProgress.thresholdPercent = value > 0 ? (this.state.omProgress.pendingTokens / value) * 100 : 0;
+            this.state.omProgress.thresholdPercent =
+              value > 0 ? (this.state.omProgress.pendingTokens / value) * 100 : 0;
             this.updateStatusLine();
           },
           onReflectionThresholdChange: value => {
@@ -3382,7 +3399,7 @@ ${instructions}`,
         onEscapeAsCancelChange: async enabled => {
           this.state.editor.escapeEnabled = enabled;
           await this.state.harness.setState({ escapeAsCancel: enabled });
-          await this.state.harness.persistThreadSetting('escapeAsCancel', enabled);
+          await this.state.harness.setThreadSetting({ key: 'escapeAsCancel', value: enabled });
         },
         onClose: () => {
           this.state.ui.hideOverlay();
@@ -3512,7 +3529,7 @@ ${instructions}`,
           // Auto-switch to the provider's default model
           const defaultModel = this.state.authStorage?.getDefaultModelForProvider(providerId as any);
           if (defaultModel) {
-            await this.state.harness.switchModel(defaultModel);
+            await this.state.harness.switchModel({ modelId: defaultModel });
             this.updateStatusLine();
             this.showInfo(`Logged in to ${providerName} - switched to ${defaultModel}`);
           } else {
@@ -3619,13 +3636,13 @@ ${instructions}`,
       }
 
       case 'mode': {
-        const modes = this.state.harness.getModes();
+        const modes = this.state.harness.listModes();
         if (modes.length <= 1) {
           this.showInfo('Only one mode available');
           return true;
         }
         if (args[0]) {
-          await this.state.harness.switchMode(args[0]);
+          await this.state.harness.switchMode({ modeId: args[0] });
         } else {
           const currentMode = this.state.harness.getCurrentMode();
           const modeList = modes
@@ -3682,7 +3699,7 @@ ${modeList}`);
             this.showInfo(`Invalid policy: ${policy}. Must be one of: ${validPolicies.join(', ')}`);
             return true;
           }
-          this.state.harness.setPermissionCategory(category, policy);
+          this.state.harness.setPermissionForCategory({ category, policy });
           this.showInfo(`Set ${category} policy to: ${policy}`);
           return true;
         }
@@ -3730,7 +3747,7 @@ ${modeList}`);
           this.showInfo('No active thread. Send a message first.');
           return true;
         }
-        await this.state.harness.renameThread(title);
+        await this.state.harness.renameThread({ title });
         this.showInfo(`Thread renamed to: ${title}`);
         return true;
       }
@@ -3755,7 +3772,7 @@ ${modeList}`);
           ];
           this.showInfo(lines.join('\n'));
         } else if (sub === 'reset') {
-          this.state.harness.setResourceId(defaultId);
+          this.state.harness.setResourceId({ resourceId: defaultId });
           this.state.pendingNewThread = true;
           this.state.chatContainer.clear();
           this.state.pendingTools.clear();
@@ -3766,7 +3783,7 @@ ${modeList}`);
           this.showInfo(`Resource ID reset to: ${defaultId}`);
         } else {
           const newId = args.join(' ').trim();
-          this.state.harness.setResourceId(newId);
+          this.state.harness.setResourceId({ resourceId: newId });
           this.state.pendingNewThread = true;
           this.state.chatContainer.clear();
           this.state.pendingTools.clear();
@@ -3784,7 +3801,7 @@ ${modeList}`);
         process.exit(0);
 
       case 'help': {
-        const modes = this.state.harness.getModes();
+        const modes = this.state.harness.listModes();
         const modeHelp = modes.length > 1 ? '\n/mode     - Switch or list modes' : '';
 
         // Build custom commands help
@@ -4054,7 +4071,7 @@ Keyboard shortcuts:
     this.state.ui.requestRender();
 
     // Send to the agent
-    this.state.harness.sendMessage(prompt).catch(error => {
+    this.state.harness.sendMessage({ content: prompt }).catch(error => {
       this.showError(error instanceof Error ? error.message : 'Review failed');
     });
   }
@@ -4077,7 +4094,7 @@ Keyboard shortcuts:
         // Wrap in <slash-command> tags so the assistant sees the full
         // content but addUserMessage won't double-render it.
         const wrapped = `<slash-command name="${command.name}">\n${processedContent.trim()}\n</slash-command>`;
-        await this.state.harness.sendMessage(wrapped);
+        await this.state.harness.sendMessage({ content: wrapped });
       } else {
         this.showInfo(`Executed //${command.name} (no output)`);
       }
@@ -4150,7 +4167,7 @@ Keyboard shortcuts:
     this.state.toolInputBuffers.clear();
     this.state.allToolComponents = [];
 
-    const messages = await this.state.harness.getMessages({ limit: 40 });
+    const messages = await this.state.harness.listMessages({ limit: 40 });
 
     for (const message of messages) {
       if (message.role === 'user') {
@@ -4358,7 +4375,11 @@ Keyboard shortcuts:
             ...message,
             content: accumulatedContent,
           };
-          const textComponent = new AssistantMessageComponent(textMessage, this.state.hideThinkingBlock, getMarkdownTheme());
+          const textComponent = new AssistantMessageComponent(
+            textMessage,
+            this.state.hideThinkingBlock,
+            getMarkdownTheme(),
+          );
           this.state.chatContainer.addChild(textComponent);
         }
       }

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -4,21 +4,9 @@
  * and other modules can operate on the state without coupling to the
  * MastraTUI class.
  */
-import {
-  Container,
-  TUI,
-  ProcessTerminal,
-} from '@mariozechner/pi-tui';
-import type {
-  CombinedAutocompleteProvider,
-  Text,
-} from '@mariozechner/pi-tui';
-import type {
-  Harness,
-  HarnessMessage,
-  TokenUsage,
-  TaskItem,
-} from '@mastra/core/harness';
+import { Container, TUI, ProcessTerminal } from '@mariozechner/pi-tui';
+import type { CombinedAutocompleteProvider, Text } from '@mariozechner/pi-tui';
+import type { Harness, HarnessMessage, TokenUsage, TaskItem } from '@mastra/core/harness';
 import type { Workspace } from '@mastra/core/workspace';
 import type { AuthStorage } from '../auth/storage.js';
 import type { HookManager } from '../hooks/index.js';

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -53,9 +53,12 @@ export const askUserTool = createTool({
         const onAbort = () => reject(new DOMException('Aborted', 'AbortError'));
         signal?.addEventListener('abort', onAbort, { once: true });
 
-        harnessCtx.registerQuestion!(questionId, answer => {
-          signal?.removeEventListener('abort', onAbort);
-          resolve(answer);
+        harnessCtx.registerQuestion!({
+          questionId,
+          resolve: answer => {
+            signal?.removeEventListener('abort', onAbort);
+            resolve(answer);
+          },
         });
 
         harnessCtx.emitEvent!({
@@ -112,9 +115,12 @@ export const submitPlanTool = createTool({
         const onAbort = () => reject(new DOMException('Aborted', 'AbortError'));
         signal?.addEventListener('abort', onAbort, { once: true });
 
-        harnessCtx.registerPlanApproval!(planId, res => {
-          signal?.removeEventListener('abort', onAbort);
-          resolve(res);
+        harnessCtx.registerPlanApproval!({
+          planId,
+          resolve: res => {
+            signal?.removeEventListener('abort', onAbort);
+            resolve(res);
+          },
         });
 
         harnessCtx.emitEvent!({
@@ -382,7 +388,7 @@ Use this tool when:
       }
 
       // Resolve model: explicit arg → harness setting → subagent default → fallback
-      const harnessModelId = harnessCtx?.getSubagentModelId?.(agentType) ?? undefined;
+      const harnessModelId = harnessCtx?.getSubagentModelId?.({ agentType }) ?? undefined;
       const resolvedModelId = modelId ?? harnessModelId ?? definition.defaultModelId ?? fallbackModelId;
       if (!resolvedModelId) {
         return { content: 'No model ID available for subagent. Configure defaultModelId.', isError: true };

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -165,7 +165,7 @@ export interface HarnessConfig<TState extends HarnessStateSchema = HarnessStateS
   modelAuthChecker?: ModelAuthChecker;
 
   /**
-   * Provides per-model use counts for `getAvailableModels()` sorting/display.
+   * Provides per-model use counts for `listAvailableModels()` sorting/display.
    * Lets the app layer track and report how often each model has been used.
    */
   modelUseCountProvider?: ModelUseCountProvider;
@@ -280,7 +280,7 @@ export interface AvailableModel {
 
 /**
  * Custom auth checker for model providers.
- * Called by `getCurrentModelAuthStatus()` and `getAvailableModels()` to determine
+ * Called by `getCurrentModelAuthStatus()` and `listAvailableModels()` to determine
  * whether a provider has valid authentication beyond just env var checks
  * (e.g., OAuth tokens, stored credentials).
  *
@@ -290,7 +290,7 @@ export interface AvailableModel {
 export type ModelAuthChecker = (provider: string) => boolean | undefined;
 
 /**
- * Provides per-model use counts for sorting in `getAvailableModels()`.
+ * Provides per-model use counts for sorting in `listAvailableModels()`.
  * Return a map of model ID → use count.
  */
 export type ModelUseCountProvider = () => Record<string, number>;
@@ -585,14 +585,14 @@ export interface HarnessRequestContext<TState extends HarnessStateSchema = Harne
   emitEvent?: (event: HarnessEvent) => void;
 
   /** Register a pending question resolver (used by ask_user tools) */
-  registerQuestion?: (questionId: string, resolve: (answer: string) => void) => void;
+  registerQuestion?: (params: { questionId: string; resolve: (answer: string) => void }) => void;
 
   /** Register a pending plan approval resolver (used by submit_plan tools) */
-  registerPlanApproval?: (
-    planId: string,
-    resolve: (result: { action: 'approved' | 'rejected'; feedback?: string }) => void,
-  ) => void;
+  registerPlanApproval?: (params: {
+    planId: string;
+    resolve: (result: { action: 'approved' | 'rejected'; feedback?: string }) => void;
+  }) => void;
 
   /** Get the configured subagent model ID for a specific agent type */
-  getSubagentModelId?: (agentType?: string) => string | null;
+  getSubagentModelId?: (params?: { agentType?: string }) => string | null;
 }


### PR DESCRIPTION
## Summary

Refactors all `Harness` class methods from positional arguments to named object parameters, improving readability and making the API easier to extend without future breaking changes. Also adds the first reference documentation page for the `Harness` class.

## Changes

### API refactor (`@mastra/core`)
- **`packages/core/src/harness/harness.ts`** — Converted 28 public method signatures from positional to object params, updated all internal self-calls
- **`packages/core/src/harness/types.ts`** — Updated `HarnessRequestContext` interface methods (`registerQuestion`, `registerPlanApproval`, `getSubagentModelId`)
- **`packages/core/src/harness/tools.ts`** — Updated built-in tool callers (`ask_user`, `submit_plan`, `subagent`)
- **`packages/core/src/harness/thread-locking.test.ts`** — Updated test callers

### Consumer updates (`mastracode`)
- **`mastracode/src/tui/mastra-tui.ts`** — Updated all TUI call sites
- **`mastracode/src/tools/subagent.ts`** — Updated subagent tool caller
- **`mastracode/src/tools/request-sandbox-access.ts`** — Updated sandbox access tool caller

### Documentation
- **`docs/src/content/en/reference/harness/harness-class.mdx`** — New reference page documenting the `Harness` class (constructor params, properties, 28 methods across 11 categories, events table, built-in tools table)
- **`docs/src/content/en/reference/sidebars.js`** — Added Harness category to reference sidebar

## Example

Before:
```typescript
await harness.switchMode('build');
await harness.sendMessage('Hello', { images });
harness.switchModel('anthropic/claude-sonnet-4', 'thread');
harness.respondToQuestion('q-123', 'Yes');
```

After:
```typescript
await harness.switchMode({ modeId: 'build' });
await harness.sendMessage({ content: 'Hello', images });
harness.switchModel({ modelId: 'anthropic/claude-sonnet-4', scope: 'thread' });
harness.respondToQuestion({ questionId: 'q-123', answer: 'Yes' });
```

## Test plan

- `packages/core/src/harness/thread-locking.test.ts` — all 11 tests pass
- `packages/core` builds cleanly (`pnpm build:lib` + `tsc --project tsconfig.build.json`)
- `mastracode` typechecks with only 2 pre-existing errors unrelated to this change
- Documentation builds successfully (`npm run build` in `docs/`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized the public Harness API to accept single object-style parameters and updated several method names and list/get conventions—simplifies mode switching, messaging, thread and model management, permissions, and approval/question flows.

* **Documentation**
  * Added a comprehensive Harness reference page and a new Harness section in the reference sidebar.

* **Tests**
  * Updated test suites to use the new object-parameter call shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->