### PR TITLE
fix(memory): improve OM continuity at low activation

### DIFF
--- a/.changeset/thin-jokes-cough.md
+++ b/.changeset/thin-jokes-cough.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Added safety guards against degenerate LLM output in observational memory. Individual observation lines are now capped at 10,000 characters to prevent runaway output from inflating token counts. Repetitive output patterns (e.g., Gemini Flash repeat-penalty loops) are automatically detected and the observation is retried once before discarding. This prevents inflated observation token counts that could previously cause excessive context usage after activation.

--- a/.changeset/tiny-geckos-build.md
+++ b/.changeset/tiny-geckos-build.md
@@ -1,0 +1,7 @@
+---
+'@mastra/memory': minor
+---
+
+Improved conversational continuity after async buffered observation activation. Background buffered observations now include continuation hints (suggestedResponse and currentTask), so the main agent maintains conversational context when the message window shrinks during activation.
+
+Also improved the Observer's extraction instructions to capture user messages near-verbatim (with discretion for very long messages), reduce repetitive observations with grouping, and updated the main agent's context instructions to treat the most recent user message as the highest-priority signal.

--- a/.changeset/warm-buses-flow.md
+++ b/.changeset/warm-buses-flow.md
@@ -1,0 +1,8 @@
+---
+'@mastra/core': patch
+'@mastra/pg': patch
+'@mastra/libsql': patch
+'@mastra/mongodb': patch
+---
+
+Extended `SwapBufferedToActiveResult` to include `suggestedContinuation` and `currentTask` from the most recent activated buffered chunk. Updated all storage adapters to populate these fields during activation.

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -200,6 +200,8 @@ As the agent converses, message tokens accumulate. At regular intervals (`buffer
 
 When message tokens reach the `messageTokens` threshold, buffered chunks activate: their observations move into the active observation log, and the corresponding raw messages are removed from the context window. The agent never pauses.
 
+Buffered observations also include continuation hints — a suggested next response and the current task — so the main agent maintains conversational continuity after activation shrinks the context window.
+
 If the agent produces messages faster than the Observer can process them, a `blockAfter` safety threshold forces a synchronous observation as a last resort.
 
 Reflection works similarly — the Reflector runs in the background when observations reach a fraction of the reflection threshold.

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -374,6 +374,7 @@ The lifecycle is: **buffer → activate → remove messages → repeat**. Backgr
 Default settings:
 - `observation.bufferTokens: 0.2` — buffer every 20% of `messageTokens` (e.g. every ~6k tokens with a 30k threshold)
 - `observation.bufferActivation: 0.8` — on activation, remove enough messages to keep only 20% of the threshold remaining
+- Buffered observations include continuation hints (`suggestedResponse`, `currentTask`) that survive activation to maintain conversational continuity
 - `reflection.bufferActivation: 0.5` — start background reflection at 50% of observation threshold
 
 To customize:

--- a/mastracode/src/mcp/manager.ts
+++ b/mastracode/src/mcp/manager.ts
@@ -38,7 +38,9 @@ export function createMcpManager(projectDir: string): McpManager {
   let serverStatuses = new Map<string, McpServerStatus>();
   let initialized = false;
 
-  function buildServerDefs(servers: Record<string, { command: string; args?: string[]; env?: Record<string, string> }>) {
+  function buildServerDefs(
+    servers: Record<string, { command: string; args?: string[]; env?: Record<string, string> }>,
+  ) {
     const defs: Record<string, { command: string; args?: string[]; env?: Record<string, string> }> = {};
     for (const [name, cfg] of Object.entries(servers)) {
       defs[name] = { command: cfg.command, args: cfg.args, env: cfg.env };

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -4,13 +4,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import {
-  CombinedAutocompleteProvider,
-  Container,
-  Spacer,
-  Text,
-  visibleWidth,
-} from '@mariozechner/pi-tui';
+import { CombinedAutocompleteProvider, Container, Spacer, Text, visibleWidth } from '@mariozechner/pi-tui';
 import type { Component, SlashCommand } from '@mariozechner/pi-tui';
 import type {
   HarnessEvent,
@@ -1375,7 +1369,8 @@ ${instructions}`,
     const obsThreshold = this.state.harness.getObservationThreshold();
     const refThreshold = this.state.harness.getReflectionThreshold();
     this.state.omProgress.threshold = obsThreshold;
-    this.state.omProgress.thresholdPercent = obsThreshold > 0 ? (this.state.omProgress.pendingTokens / obsThreshold) * 100 : 0;
+    this.state.omProgress.thresholdPercent =
+      obsThreshold > 0 ? (this.state.omProgress.pendingTokens / obsThreshold) * 100 : 0;
     this.state.omProgress.reflectionThreshold = refThreshold;
     this.state.omProgress.reflectionThresholdPercent =
       refThreshold > 0 ? (this.state.omProgress.observationTokens / refThreshold) * 100 : 0;
@@ -1517,7 +1512,9 @@ ${instructions}`,
     // Update observation tokens to show the total being reflected
     this.state.omProgress.observationTokens = tokensToReflect;
     this.state.omProgress.reflectionThresholdPercent =
-      this.state.omProgress.reflectionThreshold > 0 ? (tokensToReflect / this.state.omProgress.reflectionThreshold) * 100 : 0;
+      this.state.omProgress.reflectionThreshold > 0
+        ? (tokensToReflect / this.state.omProgress.reflectionThreshold) * 100
+        : 0;
     // Show in-progress marker in chat
     this.state.activeOMMarker = new OMMarkerComponent({
       type: 'om_observation_start',
@@ -1542,7 +1539,9 @@ ${instructions}`,
     // Observations were compressed — update token count
     this.state.omProgress.observationTokens = compressedTokens;
     this.state.omProgress.reflectionThresholdPercent =
-      this.state.omProgress.reflectionThreshold > 0 ? (compressedTokens / this.state.omProgress.reflectionThreshold) * 100 : 0;
+      this.state.omProgress.reflectionThreshold > 0
+        ? (compressedTokens / this.state.omProgress.reflectionThreshold) * 100
+        : 0;
     // Remove in-progress marker — the output box replaces it
     if (this.state.activeOMMarker) {
       const idx = this.state.chatContainer.children.indexOf(this.state.activeOMMarker);
@@ -1688,7 +1687,11 @@ ${instructions}`,
       this.state.lastAskUserComponent = undefined;
       this.state.lastSubmitPlanComponent = undefined;
       if (!this.state.streamingComponent) {
-        this.state.streamingComponent = new AssistantMessageComponent(undefined, this.state.hideThinkingBlock, getMarkdownTheme());
+        this.state.streamingComponent = new AssistantMessageComponent(
+          undefined,
+          this.state.hideThinkingBlock,
+          getMarkdownTheme(),
+        );
         this.addChildBeforeFollowUps(this.state.streamingComponent);
         this.state.streamingMessage = message;
         const trailingParts = this.getTrailingContentParts(message);
@@ -1933,7 +1936,11 @@ ${instructions}`,
       this.state.allToolComponents.push(component);
 
       // Create a new post-tool AssistantMessageComponent so pre-tool text is preserved
-      this.state.streamingComponent = new AssistantMessageComponent(undefined, this.state.hideThinkingBlock, getMarkdownTheme());
+      this.state.streamingComponent = new AssistantMessageComponent(
+        undefined,
+        this.state.hideThinkingBlock,
+        getMarkdownTheme(),
+      );
       this.addChildBeforeFollowUps(this.state.streamingComponent);
 
       this.state.ui.requestRender();
@@ -2005,7 +2012,11 @@ ${instructions}`,
       // Create a new post-tool AssistantMessageComponent so pre-tool text is preserved
       // (even though task_write doesn't render a tool component inline, we still need
       // to split the streaming component so getTrailingContentParts doesn't overwrite it)
-      this.state.streamingComponent = new AssistantMessageComponent(undefined, this.state.hideThinkingBlock, getMarkdownTheme());
+      this.state.streamingComponent = new AssistantMessageComponent(
+        undefined,
+        this.state.hideThinkingBlock,
+        getMarkdownTheme(),
+      );
       this.addChildBeforeFollowUps(this.state.streamingComponent);
       this.state.ui.requestRender();
     } else if (toolName !== 'subagent') {
@@ -2022,7 +2033,11 @@ ${instructions}`,
       this.state.allToolComponents.push(component);
 
       // Create a new post-tool AssistantMessageComponent so pre-tool text is preserved
-      this.state.streamingComponent = new AssistantMessageComponent(undefined, this.state.hideThinkingBlock, getMarkdownTheme());
+      this.state.streamingComponent = new AssistantMessageComponent(
+        undefined,
+        this.state.hideThinkingBlock,
+        getMarkdownTheme(),
+      );
       this.addChildBeforeFollowUps(this.state.streamingComponent);
 
       this.state.ui.requestRender();
@@ -3272,7 +3287,8 @@ ${instructions}`,
           onObservationThresholdChange: value => {
             this.state.harness.setState({ observationThreshold: value } as any);
             this.state.omProgress.threshold = value;
-            this.state.omProgress.thresholdPercent = value > 0 ? (this.state.omProgress.pendingTokens / value) * 100 : 0;
+            this.state.omProgress.thresholdPercent =
+              value > 0 ? (this.state.omProgress.pendingTokens / value) * 100 : 0;
             this.updateStatusLine();
           },
           onReflectionThresholdChange: value => {
@@ -4358,7 +4374,11 @@ Keyboard shortcuts:
             ...message,
             content: accumulatedContent,
           };
-          const textComponent = new AssistantMessageComponent(textMessage, this.state.hideThinkingBlock, getMarkdownTheme());
+          const textComponent = new AssistantMessageComponent(
+            textMessage,
+            this.state.hideThinkingBlock,
+            getMarkdownTheme(),
+          );
           this.state.chatContainer.addChild(textComponent);
         }
       }

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -4,21 +4,9 @@
  * and other modules can operate on the state without coupling to the
  * MastraTUI class.
  */
-import {
-  Container,
-  TUI,
-  ProcessTerminal,
-} from '@mariozechner/pi-tui';
-import type {
-  CombinedAutocompleteProvider,
-  Text,
-} from '@mariozechner/pi-tui';
-import type {
-  Harness,
-  HarnessMessage,
-  TokenUsage,
-  TaskItem,
-} from '@mastra/core/harness';
+import { Container, TUI, ProcessTerminal } from '@mariozechner/pi-tui';
+import type { CombinedAutocompleteProvider, Text } from '@mariozechner/pi-tui';
+import type { Harness, HarnessMessage, TokenUsage, TaskItem } from '@mastra/core/harness';
 import type { Workspace } from '@mastra/core/workspace';
 import type { AuthStorage } from '../auth/storage.js';
 import type { HookManager } from '../hooks/index.js';

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -1034,6 +1034,9 @@ export class InMemoryMemory extends MemoryStorage {
     record.lastObservedAt = derivedLastObservedAt;
     record.updatedAt = new Date();
 
+    // Use hints from the most recent activated chunk only — stale hints from older chunks are discarded
+    const latestChunkHints = activatedChunks[activatedChunks.length - 1];
+
     return {
       chunksActivated: activatedChunks.length,
       messageTokensActivated: activatedMessageTokens,
@@ -1049,6 +1052,8 @@ export class InMemoryMemory extends MemoryStorage {
         messageCount: c.messageIds.length,
         observations: c.observations,
       })),
+      suggestedContinuation: latestChunkHints?.suggestedContinuation ?? undefined,
+      currentTask: latestChunkHints?.currentTask ?? undefined,
     };
   }
 

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -1249,6 +1249,10 @@ export interface SwapBufferedToActiveResult {
     messageCount: number;
     observations: string;
   }>;
+  /** Suggested continuation from the most recent activated chunk (if any) */
+  suggestedContinuation?: string;
+  /** Current task from the most recent activated chunk (if any) */
+  currentTask?: string;
 }
 
 /**

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -553,7 +553,9 @@ export const OBSERVATION_CONTEXT_INSTRUCTIONS = `IMPORTANT: When responding, ref
 
 KNOWLEDGE UPDATES: When asked about current state (e.g., "where do I currently...", "what is my current..."), always prefer the MOST RECENT information. Observations include dates - if you see conflicting information, the newer observation supersedes the older one. Look for phrases like "will start", "is switching", "changed to", "moved to" as indicators that previous information has been updated.
 
-PLANNED ACTIONS: If the user stated they planned to do something (e.g., "I'm going to...", "I'm looking forward to...", "I will...") and the date they planned to do it is now in the past (check the relative time like "3 weeks ago"), assume they completed the action unless there's evidence they didn't. For example, if someone said "I'll start my new diet on Monday" and that was 2 weeks ago, assume they started the diet.`;
+PLANNED ACTIONS: If the user stated they planned to do something (e.g., "I'm going to...", "I'm looking forward to...", "I will...") and the date they planned to do it is now in the past (check the relative time like "3 weeks ago"), assume they completed the action unless there's evidence they didn't. For example, if someone said "I'll start my new diet on Monday" and that was 2 weeks ago, assume they started the diet.
+
+MOST RECENT USER INPUT: Treat the most recent user message as the highest-priority signal for what to do next. Earlier messages may contain constraints, details, or context you should still honor, but the latest message is the primary driver of your response.`;
 
 /**
  * ObservationalMemory - A three-agent memory system for long conversations.
@@ -2182,20 +2184,35 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
 
     const prompt = buildObserverPrompt(existingObservations, messagesToObserve, options);
 
-    const result = await this.withAbortCheck(
-      () =>
-        agent.generate(prompt, {
-          modelSettings: {
-            ...this.observationConfig.modelSettings,
-          },
-          providerOptions: this.observationConfig.providerOptions as any,
-          ...(abortSignal ? { abortSignal } : {}),
-          ...(options?.requestContext ? { requestContext: options.requestContext } : {}),
-        }),
-      abortSignal,
-    );
+    const doGenerate = async () => {
+      const result = await this.withAbortCheck(
+        () =>
+          agent.generate(prompt, {
+            modelSettings: {
+              ...this.observationConfig.modelSettings,
+            },
+            providerOptions: this.observationConfig.providerOptions as any,
+            ...(abortSignal ? { abortSignal } : {}),
+            ...(options?.requestContext ? { requestContext: options.requestContext } : {}),
+          }),
+        abortSignal,
+      );
+      return result;
+    };
 
-    const parsed = parseObserverOutput(result.text);
+    let result = await doGenerate();
+    let parsed = parseObserverOutput(result.text);
+
+    // Retry once if degenerate repetition was detected
+    if (parsed.degenerate) {
+      omDebug(`[OM:callObserver] degenerate repetition detected, retrying once`);
+      result = await doGenerate();
+      parsed = parseObserverOutput(result.text);
+      if (parsed.degenerate) {
+        omDebug(`[OM:callObserver] degenerate repetition on retry, returning empty observations`);
+        return { observations: '' };
+      }
+    }
 
     // Extract usage from result (totalUsage or usage)
     const usage = result.totalUsage ?? result.usage;
@@ -2258,20 +2275,38 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
       this.observedMessageIds.add(msg.id);
     }
 
-    const result = await this.withAbortCheck(
-      () =>
-        agent.generate(prompt, {
-          modelSettings: {
-            ...this.observationConfig.modelSettings,
-          },
-          providerOptions: this.observationConfig.providerOptions as any,
-          ...(abortSignal ? { abortSignal } : {}),
-          ...(requestContext ? { requestContext } : {}),
-        }),
-      abortSignal,
-    );
+    const doGenerate = async () => {
+      return this.withAbortCheck(
+        () =>
+          agent.generate(prompt, {
+            modelSettings: {
+              ...this.observationConfig.modelSettings,
+            },
+            providerOptions: this.observationConfig.providerOptions as any,
+            ...(abortSignal ? { abortSignal } : {}),
+            ...(requestContext ? { requestContext } : {}),
+          }),
+        abortSignal,
+      );
+    };
 
-    const parsed = parseMultiThreadObserverOutput(result.text);
+    let result = await doGenerate();
+    let parsed = parseMultiThreadObserverOutput(result.text);
+
+    // Retry once if degenerate repetition was detected
+    if (parsed.degenerate) {
+      omDebug(`[OM:callMultiThreadObserver] degenerate repetition detected, retrying once`);
+      result = await doGenerate();
+      parsed = parseMultiThreadObserverOutput(result.text);
+      if (parsed.degenerate) {
+        omDebug(`[OM:callMultiThreadObserver] degenerate repetition on retry, returning empty`);
+        const emptyResults = new Map<string, { observations: string }>();
+        for (const threadId of threadOrder) {
+          emptyResults.set(threadId, { observations: '' });
+        }
+        return { results: emptyResults };
+      }
+    }
 
     // Convert to the expected return format
     const results = new Map<
@@ -2419,13 +2454,22 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
       }
 
       parsed = parseReflectorOutput(result.text);
-      reflectedTokens = this.tokenCounter.countObservations(parsed.observations);
+
+      // If degenerate repetition detected, treat as compression failure
+      if (parsed.degenerate) {
+        omDebug(
+          `[OM:callReflector] attempt #${attemptNumber}: degenerate repetition detected, treating as compression failure`,
+        );
+        reflectedTokens = originalTokens; // Force retry
+      } else {
+        reflectedTokens = this.tokenCounter.countObservations(parsed.observations);
+      }
       omDebug(
-        `[OM:callReflector] attempt #${attemptNumber} parsed: reflectedTokens=${reflectedTokens}, targetThreshold=${targetThreshold}, compressionValid=${validateCompression(reflectedTokens, targetThreshold)}, parsedObsLen=${parsed.observations?.length}`,
+        `[OM:callReflector] attempt #${attemptNumber} parsed: reflectedTokens=${reflectedTokens}, targetThreshold=${targetThreshold}, compressionValid=${validateCompression(reflectedTokens, targetThreshold)}, parsedObsLen=${parsed.observations?.length}, degenerate=${parsed.degenerate ?? false}`,
       );
 
       // If compression succeeded or we've exhausted all levels, stop
-      if (validateCompression(reflectedTokens, targetThreshold) || currentLevel >= maxLevel) {
+      if (!parsed.degenerate && (validateCompression(reflectedTokens, targetThreshold) || currentLevel >= maxLevel)) {
         break;
       }
 
@@ -2827,6 +2871,8 @@ ${suggestedResponse}
         updatedRecord?: ObservationalMemoryRecord;
         messageTokensActivated?: number;
         activatedMessageIds?: string[];
+        suggestedContinuation?: string;
+        currentTask?: string;
       } = { success: false };
       if (this.isAsyncObservationEnabled()) {
         // Wait for any in-flight async buffering to complete first
@@ -2870,6 +2916,22 @@ ${suggestedResponse}
           omDebug(
             `[OM:threshold] activation succeeded, obsTokens=${updatedRecord.observationTokenCount}, activeObsLen=${updatedRecord.activeObservations?.length}`,
           );
+
+          // Propagate continuation hints from activation to thread metadata
+          if (activationResult.suggestedContinuation || activationResult.currentTask) {
+            const thread = await this.storage.getThreadById({ threadId });
+            if (thread) {
+              const newMetadata = setThreadOMMetadata(thread.metadata, {
+                suggestedResponse: activationResult.suggestedContinuation,
+                currentTask: activationResult.currentTask,
+              });
+              await this.storage.updateThread({
+                id: threadId,
+                title: thread.title ?? '',
+                metadata: newMetadata,
+              });
+            }
+          }
 
           // Note: lastBufferedBoundary is updated by the caller AFTER cleanupAfterObservation
           // removes the activated messages from messageList and recounts the actual context size.
@@ -3371,6 +3433,23 @@ ${suggestedResponse}
             const bufKey = this.getObservationBufferKey(lockKey);
             ObservationalMemory.lastBufferedBoundary.set(bufKey, 0);
             this.storage.setBufferingObservationFlag(record.id, false, 0).catch(() => {});
+
+            // Propagate continuation hints from activation to thread metadata so
+            // injectObservationsIntoContext can include them immediately.
+            if (activationResult.suggestedContinuation || activationResult.currentTask) {
+              const thread = await this.storage.getThreadById({ threadId });
+              if (thread) {
+                const newMetadata = setThreadOMMetadata(thread.metadata, {
+                  suggestedResponse: activationResult.suggestedContinuation,
+                  currentTask: activationResult.currentTask,
+                });
+                await this.storage.updateThread({
+                  id: threadId,
+                  title: thread.title ?? '',
+                  metadata: newMetadata,
+                });
+              }
+            }
 
             // Check if reflection should be triggered or activated
             await this.maybeReflect({
@@ -4465,13 +4544,21 @@ ${formattedMessages}
     const bufferedChunksText = bufferedChunks.map(c => c.observations).join('\n\n');
     const combinedObservations = this.combineObservationsForBuffering(record.activeObservations, bufferedChunksText);
 
-    // Call observer with combined context (skip continuation hints for async buffering)
+    // Call observer with combined context
+    // Allow the observer to produce suggestedResponse/currentTask so they survive
+    // activation and maintain continuity when the context window shrinks
     const result = await this.callObserver(
       combinedObservations,
       messagesToBuffer,
       undefined, // No abort signal for background ops
-      { skipContinuationHints: true, requestContext },
+      { requestContext },
     );
+
+    // If the observer returned empty observations (e.g., degenerate output), skip buffering
+    if (!result.observations) {
+      omDebug(`[OM:doAsyncBufferedObservation] empty observations returned, skipping buffer storage`);
+      return;
+    }
 
     // Get the new observations to buffer (just the new content, not merged)
     // The storage adapter will handle appending to existing buffered content
@@ -4503,6 +4590,8 @@ ${formattedMessages}
         messageIds: newMessageIds,
         messageTokens,
         lastObservedAt,
+        suggestedContinuation: result.suggestedContinuation,
+        currentTask: result.currentTask,
       },
       lastBufferedAtTime: lastObservedAt,
     });
@@ -4570,6 +4659,8 @@ ${formattedMessages}
     updatedRecord?: ObservationalMemoryRecord;
     messageTokensActivated?: number;
     activatedMessageIds?: string[];
+    suggestedContinuation?: string;
+    currentTask?: string;
   }> {
     // Check if there's buffered content to activate
     const chunks = this.getBufferedChunks(record);
@@ -4688,6 +4779,8 @@ ${formattedMessages}
       updatedRecord: updatedRecord ?? undefined,
       messageTokensActivated: activationResult.messageTokensActivated,
       activatedMessageIds: activationResult.activatedMessageIds,
+      suggestedContinuation: activationResult.suggestedContinuation,
+      currentTask: activationResult.currentTask,
     };
   }
 

--- a/packages/memory/src/processors/observational-memory/reflector-agent.ts
+++ b/packages/memory/src/processors/observational-memory/reflector-agent.ts
@@ -1,4 +1,10 @@
-import { OBSERVER_EXTRACTION_INSTRUCTIONS, OBSERVER_OUTPUT_FORMAT_BASE, OBSERVER_GUIDELINES } from './observer-agent';
+import {
+  OBSERVER_EXTRACTION_INSTRUCTIONS,
+  OBSERVER_OUTPUT_FORMAT_BASE,
+  OBSERVER_GUIDELINES,
+  sanitizeObservationLines,
+  detectDegenerateRepetition,
+} from './observer-agent';
 import type { ReflectorResult as BaseReflectorResult } from './types';
 
 /**
@@ -229,11 +235,19 @@ ${guidance}`;
  * Uses XML tag parsing for structured extraction.
  */
 export function parseReflectorOutput(output: string): ReflectorResult {
+  // Check for degenerate repetition before parsing
+  if (detectDegenerateRepetition(output)) {
+    return {
+      observations: '',
+      degenerate: true,
+    };
+  }
+
   const parsed = parseReflectorSectionXml(output);
 
   // Return observations WITHOUT current-task/suggested-response tags
   // Those are stored separately in thread metadata and injected dynamically
-  const observations = parsed.observations || '';
+  const observations = sanitizeObservationLines(parsed.observations || '');
 
   return {
     observations,

--- a/packages/memory/src/processors/observational-memory/types.ts
+++ b/packages/memory/src/processors/observational-memory/types.ts
@@ -240,6 +240,9 @@ export interface ReflectorResult {
 
   /** Suggested continuation for the Actor */
   suggestedContinuation?: string;
+
+  /** True if the output was detected as degenerate (repetition loop) and should be discarded/retried */
+  degenerate?: boolean;
 }
 
 /**

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -2149,6 +2149,9 @@ export class MemoryLibSQL extends MemoryStorage {
         ],
       });
 
+      // Use hints from the most recent activated chunk only — stale hints from older chunks are discarded
+      const latestChunkHints = activatedChunks[activatedChunks.length - 1];
+
       return {
         chunksActivated: activatedChunks.length,
         messageTokensActivated: activatedMessageTokens,
@@ -2164,6 +2167,8 @@ export class MemoryLibSQL extends MemoryStorage {
           messageCount: c.messageIds.length,
           observations: c.observations,
         })),
+        suggestedContinuation: latestChunkHints?.suggestedContinuation ?? undefined,
+        currentTask: latestChunkHints?.currentTask ?? undefined,
       };
     } catch (error) {
       if (error instanceof MastraError) {

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -1808,6 +1808,9 @@ export class MemoryStorageMongoDB extends MemoryStorage {
         },
       );
 
+      // Use hints from the most recent activated chunk only — stale hints from older chunks are discarded
+      const latestChunkHints = activatedChunks[activatedChunks.length - 1];
+
       return {
         chunksActivated: activatedChunks.length,
         messageTokensActivated: activatedMessageTokens,
@@ -1823,6 +1826,8 @@ export class MemoryStorageMongoDB extends MemoryStorage {
           messageCount: c.messageIds.length,
           observations: c.observations,
         })),
+        suggestedContinuation: latestChunkHints?.suggestedContinuation ?? undefined,
+        currentTask: latestChunkHints?.currentTask ?? undefined,
       };
     } catch (error) {
       if (error instanceof MastraError) {

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -2437,6 +2437,9 @@ export class MemoryPG extends MemoryStorage {
         ],
       );
 
+      // Use hints from the most recent activated chunk only — stale hints from older chunks are discarded
+      const latestChunkHints = activatedChunks[activatedChunks.length - 1];
+
       return {
         chunksActivated: activatedChunks.length,
         messageTokensActivated: activatedMessageTokens,
@@ -2452,6 +2455,8 @@ export class MemoryPG extends MemoryStorage {
           messageCount: c.messageIds.length,
           observations: c.observations,
         })),
+        suggestedContinuation: latestChunkHints?.suggestedContinuation ?? undefined,
+        currentTask: latestChunkHints?.currentTask ?? undefined,
       };
     } catch (error) {
       if (error instanceof MastraError) {


### PR DESCRIPTION
When observational memory activates buffered observations and the message window shrinks, the agent was losing conversational context — responding as if starting fresh instead of continuing naturally.

This fixes it by propagating continuation hints (`suggestedContinuation`, `currentTask`) through async buffering and activation, so the agent knows what it was doing and what to say next after activation.

Also adds some quality-of-life improvements:
- Observer now captures user messages near-verbatim instead of overly summarizing them
- Groups repetitive tool/browsing observations instead of listing each one separately
- Main agent treats the most recent user message as the highest-priority signal (without ignoring previous messages)
- Safety guards against degenerate LLM output (line cap at 10k chars, repetition loop detection with retry)

The degenerate output guards address a real issue where Gemini Flash occasionally enters a repeat loop, producing 300k+ tokens of garbage observations that inflate the context.

All 4 storage adapters (inmemory, pg, libsql, mongodb) updated to return hints from the most recent activated chunk only — stale hints from older chunks are discarded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observation safety: individual observation lines capped at 10,000 characters; repetitive/degenerate observer output is detected and automatically retried once before being discarded.
  * Continuity hints: buffered observations now include continuation hints (suggested response and current task) that survive activation to preserve conversational context.

* **Documentation**
  * Updated observational memory docs to describe continuation hints and new observation safety behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->