### PR TITLE
fix(mastracode): allow view_range for directory listings

### DIFF
--- a/.changeset/quick-hats-shine.md
+++ b/.changeset/quick-hats-shine.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed the view tool to gracefully handle view_range when viewing directories. Previously, passing view_range with a directory path would throw an error, and passing undefined values would fail schema validation. Now, view_range slices the directory listing to show a subset of entries, enabling pagination through large directories.

--- a/mastracode/src/tools/file-editor.ts
+++ b/mastracode/src/tools/file-editor.ts
@@ -68,10 +68,7 @@ export class FileEditor {
   async view(args: ViewArgs) {
     await validatePath('view', args.path);
     if (await this.isDirectory(args.path)) {
-      if (args.view_range) {
-        return 'The `view_range` parameter is not allowed when `path` points to a directory.';
-      }
-      const { stdout, stderr } = await this.execAsync(`find "${args.path}" -maxdepth 2 -not -path '*/\\.*'`);
+      const { stdout, stderr } = await this.execAsync(`find "${args.path}" -maxdepth 2 -not -path '*/\\\\.*'`);
       if (stderr) return stderr;
       return `Here's the files and directories up to 2 levels deep in ${args.path}, excluding hidden items:\n${stdout}\n`;
     }

--- a/mastracode/src/tools/file-view.ts
+++ b/mastracode/src/tools/file-view.ts
@@ -116,7 +116,11 @@ Usage notes:
 - Output is truncated if the file is very large. Use view_range to see specific sections.`,
     inputSchema: z.object({
       path: z.string().describe('Path to the file or directory (relative to project root)'),
-      view_range: z.array(z.number()).length(2).optional().describe('Optional range of lines to view [start, end]'),
+      view_range: z
+        .array(z.number().nullable())
+        .length(2)
+        .optional()
+        .describe('Optional range of lines to view [start, end]'),
     }),
     execute: async (context, toolContext) => {
       try {
@@ -134,11 +138,7 @@ Usage notes:
 
         // Handle directory listing
         if (await isDirectory(absolutePath)) {
-          if (view_range) {
-            throw new Error('The `view_range` parameter is not allowed when `path` points to a directory.');
-          }
-
-          const { stdout, stderr } = await execAsync(`find "${absolutePath}" -maxdepth 2 -not -path '*/\\.*'`);
+          const { stdout, stderr } = await execAsync(`find "${absolutePath}" -maxdepth 2 -not -path '*/\\\\.*'`);
 
           if (stderr) {
             throw new Error(stderr);
@@ -146,13 +146,21 @@ Usage notes:
 
           // Shorten paths in output to save tokens
           const cwd = projectRoot || process.cwd();
-          const shortenedPaths = stdout
+          let lines = stdout
             .split('\n')
             .map(line => (line.trim() ? shortenPath(line.trim(), cwd) : ''))
-            .join('\n');
+            .filter(Boolean);
 
+          const totalLines = lines.length;
           const displayPath = shortenPath(absolutePath, cwd);
-          const dirOutput = `Here's the files and directories up to 2 levels deep in ${displayPath}, excluding hidden items:\n${shortenedPaths}\n`;
+
+          // Apply view_range to slice the directory listing
+          if (view_range && view_range[0] != null && view_range[1] != null) {
+            const [start, end] = view_range as [number, number];
+            lines = lines.slice(Math.max(0, start - 1), end === -1 ? undefined : end);
+          }
+
+          const dirOutput = `Here's the files and directories up to 2 levels deep in ${displayPath}, excluding hidden items (${totalLines} entries):\n${lines.join('\n')}\n`;
           return {
             content: truncateStringForTokenEstimate(dirOutput, MAX_VIEW_TOKENS, false),
             isError: false,
@@ -161,7 +169,7 @@ Usage notes:
 
         // Handle file viewing
         const fileContent = await readFile(absolutePath);
-        if (view_range) {
+        if (view_range && view_range[0] != null && view_range[1] != null) {
           const fileLines = fileContent.split('\n');
           const nLinesFile = fileLines.length;
           let [start, end] = view_range as [number, number];


### PR DESCRIPTION
The view tool was throwing an error when `view_range` was passed with a directory path, and passing `undefined` values failed schema validation.

Now `view_range` is accepted for directories and slices the listing for pagination. Null/undefined range values are handled gracefully instead of blowing up.

Before:
```
view('some/directory', [1, 5])
// Error: The `view_range` parameter is not allowed when `path` points to a directory.
```

After:
```
view('some/directory', [1, 5])
// Returns entries 1-5 out of N total
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed view tool to properly handle range-based directory viewing. Users can now paginate through large directory listings using view_range parameter, which previously caused errors and validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->