### PR TITLE
fix(memory): address OM degenerate output handling and changeset wording

### DIFF
--- a/.changeset/thin-jokes-cough.md
+++ b/.changeset/thin-jokes-cough.md
@@ -2,4 +2,4 @@
 '@mastra/memory': patch
 ---
 
-Added safety guards against degenerate LLM output in observational memory. Individual observation lines are now capped at 10,000 characters to prevent runaway output from inflating token counts. Repetitive output patterns (e.g., Gemini Flash repeat-penalty loops) are automatically detected and the observation is retried once before discarding. This prevents inflated observation token counts that could previously cause excessive context usage after activation.
+Observations no longer inflate token counts from degenerate LLM output. Runaway or repetitive observer/reflector output is automatically detected and retried, preventing excessive context usage after activation.

--- a/.changeset/tiny-geckos-build.md
+++ b/.changeset/tiny-geckos-build.md
@@ -2,6 +2,6 @@
 '@mastra/memory': minor
 ---
 
-Improved conversational continuity after async buffered observation activation. Background buffered observations now include continuation hints (suggestedResponse and currentTask), so the main agent maintains conversational context when the message window shrinks during activation.
+Improved conversational continuity when the message window shrinks during observation activation. The agent now preserves `suggestedResponse` and `currentTask` across async buffered observation activation, so it maintains conversational context instead of losing track of what it was doing.
 
-Also improved the Observer's extraction instructions to capture user messages near-verbatim (with discretion for very long messages), reduce repetitive observations with grouping, and updated the main agent's context instructions to treat the most recent user message as the highest-priority signal.
+Also improved the Observer's extraction to capture user messages near-verbatim and reduce repetitive observations, and updated the agent's context instructions to treat the most recent user message as the highest-priority signal.

--- a/.changeset/warm-buses-flow.md
+++ b/.changeset/warm-buses-flow.md
@@ -5,4 +5,4 @@
 '@mastra/mongodb': patch
 ---
 
-Extended `SwapBufferedToActiveResult` to include `suggestedContinuation` and `currentTask` from the most recent activated buffered chunk. Updated all storage adapters to populate these fields during activation.
+`SwapBufferedToActiveResult` now includes `suggestedContinuation` and `currentTask` from the last activated buffered chunk. Storage adapters return these fields on activation so callers can propagate continuation context.


### PR DESCRIPTION
Follow-up to #13301. Addresses PR review comments:

**Degenerate output handling:** `callObserver` and `callMultiThreadObserver` now throw on degenerate retry instead of returning empty results. Previously, returning `{ observations: '' }` still advanced cursors (`lastObservedAt`, `observedMessageIds`), marking messages as observed even though nothing was actually extracted. Now the error propagates to the caller's existing try/catch, which emits a failed marker and skips cursor updates.

**Reflector infinite loop fix:** When `parsed.degenerate` was true and `currentLevel` reached `maxLevel`, the loop could spin forever — the break condition required `!parsed.degenerate`, and `Math.min(currentLevel + 1, maxLevel)` kept `currentLevel` pinned at `maxLevel`. Added a guard to break when degenerate persists at maxLevel.

**Changesets:** Rewritten to be outcome-focused and developer-facing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced safety guards to detect and prevent excessive token usage from repetitive output
* Improved error handling with clearer failure reporting instead of silent empty results
* Better context preservation during asynchronous operations to maintain conversational continuity and reduce redundant observations

## Documentation
* Updated documentation reflecting improved context handling across buffered operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->