### PR TITLE
fix(tests): fix CI test failures across multiple packages

### DIFF
--- a/packages/core/src/llm/model/router.e2e.test.ts
+++ b/packages/core/src/llm/model/router.e2e.test.ts
@@ -11,7 +11,7 @@ const testConfigs = [
   },
   {
     provider: 'anthropic',
-    model: 'claude-3-5-haiku-20241022',
+    model: 'claude-haiku-4-5',
     envVar: 'ANTHROPIC_API_KEY',
   },
   {
@@ -72,7 +72,7 @@ describe('ModelRouter Integration Tests', () => {
         name: 'test-agent',
         instructions: 'You are a helpful assistant.',
         model: {
-          id: 'custom-anthropic/claude-3-5-haiku-20241022',
+          id: 'custom-anthropic/claude-haiku-4-5',
           url: 'https://api.anthropic.com/v1',
           apiKey: process.env.ANTHROPIC_API_KEY,
           headers: {

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -2578,6 +2578,8 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                     "format": 2,
                     "parts": [
                       {
+                        "providerExecuted": undefined,
+                        "providerMetadata": undefined,
                         "toolInvocation": {
                           "args": {
                             "value": "value",

--- a/packages/memory/src/processors/observational-memory/__tests__/om-error-and-persistence.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/om-error-and-persistence.test.ts
@@ -301,7 +301,7 @@ const longResponseText = `I understand your request completely. Let me provide y
 // Test 1: Error State - Observer fails, agent still completes
 // =============================================================================
 
-describe('OM Error State', () => {
+describe('OM Error State', { timeout: 30_000 }, () => {
   let store: InMemoryStore;
   let memory: Memory;
   let agent: Agent;

--- a/server-adapters/_test-utils/src/test-helpers.ts
+++ b/server-adapters/_test-utils/src/test-helpers.ts
@@ -461,6 +461,12 @@ export async function createDefaultTestContext(): Promise<AdapterTestContext> {
     listTools: vi.fn().mockResolvedValue({ data: [], total: 0, page: 0, perPage: 20, hasMore: false }),
     getToolSchema: vi.fn().mockResolvedValue({ name: 'test-tool-slug', inputSchema: {}, outputSchema: {} }),
   };
+  const mockProcessorProvider = {
+    info: { id: 'test-provider', name: 'Test Processor Provider', description: 'A test processor provider' },
+    configSchema: z.object({}),
+    availablePhases: ['processInput'] as const,
+    createProcessor: vi.fn(),
+  };
   vi.spyOn(mastra, 'getEditor').mockReturnValue({
     prompt: {
       preview: vi.fn().mockResolvedValue('resolved instructions preview'),
@@ -490,6 +496,10 @@ export async function createDefaultTestContext(): Promise<AdapterTestContext> {
     getToolProvider: vi
       .fn()
       .mockImplementation((id: string) => (id === 'test-provider' ? mockToolProvider : undefined)),
+    getProcessorProviders: vi.fn().mockReturnValue({ 'test-provider': mockProcessorProvider }),
+    getProcessorProvider: vi
+      .fn()
+      .mockImplementation((id: string) => (id === 'test-provider' ? mockProcessorProvider : undefined)),
   } as any);
 
   await mockWorkflowRun(workflow);


### PR DESCRIPTION
## Summary

Fixes several CI test failures affecting the Core Package Tests and Full Test Suite workflows.

### Changes

1. **Loop test snapshot update** (`packages/core/src/loop/test-utils/options.ts`)
   - Updated snapshot to include `providerExecuted: undefined` and `providerMetadata: undefined` fields added to tool invocation content

2. **Server adapter test helpers** (`server-adapters/_test-utils/src/test-helpers.ts`)
   - Added mock `getProcessorProviders()` and `getProcessorProvider()` methods to the editor mock
   - Fixes 12 test failures across express, hono, and fastify adapter suites (`/processor-providers` routes returning 500)

3. **OM error test timeout** (`packages/memory/.../om-error-and-persistence.test.ts`)
   - Increased `OM Error State` describe block timeout from 5s (default) to 30s
   - Tests take ~3.8s locally due to p-retry backoff on the intentionally-failing observer model, exceeding 5s on CI

4. **Deprecated Anthropic model** (`packages/core/src/llm/model/router.e2e.test.ts`)
   - Replaced `claude-3-5-haiku-20241022` with `claude-haiku-4-5`
   - The old model was retired by Anthropic on Feb 19, 2026

### Test Plan

All affected test suites verified passing locally:
- `packages/core` loop tests: 140 passed, 0 failed
- `server-adapters/fastify`: 1,688 passed, 0 failed
- `server-adapters/express`: 1,690 passed, 0 failed
- `server-adapters/hono`: 1,692 passed, 0 failed
- `packages/memory` OM error tests: 5 passed, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configurations for improved test execution and reliability.
  * Enhanced test utilities with additional metadata fields for tool invocations.
  * Expanded testing infrastructure with mock processor provider support for editor tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->