### PR TITLE
feat(processors): add onDetection callback to PromptInjectionDetector and PIIDetector

### DIFF
--- a/.changeset/add-ondetection-callback.md
+++ b/.changeset/add-ondetection-callback.md
@@ -1,5 +1,16 @@
 ---
-'@mastra/core': patch
+'@mastra/core': minor
 ---
 
 Added `onDetection` callback to `PromptInjectionDetector` and `PIIDetector` processors, allowing custom handling (logging, alerting, metrics) when threats or sensitive data are detected without needing to subclass.
+
+**Usage**
+
+```ts
+const detector = new PIIDetector({
+  model: 'openai/gpt-4o',
+  onDetection: ({ detectionResult, input, strategyApplied }) => {
+    console.log('PII detection:', { detectionResult, strategyApplied });
+  },
+});
+```

--- a/.changeset/add-ondetection-callback.md
+++ b/.changeset/add-ondetection-callback.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added `onDetection` callback to `PromptInjectionDetector` and `PIIDetector` processors, allowing custom handling (logging, alerting, metrics) when threats or sensitive data are detected without needing to subclass.

--- a/.changeset/imkooy-aior-hakw.md
+++ b/.changeset/imkooy-aior-hakw.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed an issue where custom `data-*` chunks written in a tool's `execute` function (via `writer.custom()`) bypassed output processors entirely. These chunks now pass through output processors just like `tool-result` and other chunk types.

--- a/packages/core/src/processors/processors/pii-detector.ts
+++ b/packages/core/src/processors/processors/pii-detector.ts
@@ -150,7 +150,7 @@ export interface PIIDetectorOptions {
   onDetection?: (event: {
     detectionResult: PIIDetectionResult;
     input: string;
-    strategyApplied: string;
+    strategyApplied: 'block' | 'warn' | 'filter' | 'redact';
   }) => void | Promise<void>;
 }
 

--- a/packages/core/src/processors/processors/prompt-injection-detector.ts
+++ b/packages/core/src/processors/processors/prompt-injection-detector.ts
@@ -97,7 +97,7 @@ export interface PromptInjectionOptions {
   onDetection?: (event: {
     detectionResult: PromptInjectionResult;
     input: string;
-    strategyApplied: string;
+    strategyApplied: 'block' | 'warn' | 'filter' | 'rewrite';
   }) => void | Promise<void>;
 }
 

--- a/packages/core/src/processors/processors/prompt-injection-detector.ts
+++ b/packages/core/src/processors/processors/prompt-injection-detector.ts
@@ -88,6 +88,17 @@ export interface PromptInjectionOptions {
    * ```
    */
   providerOptions?: ProviderOptions;
+
+  /**
+   * Optional callback invoked after each detection, whether or not injection was found.
+   * Receives the detection result, the original input text, and the strategy that was applied.
+   * May return a Promise, which will be awaited before continuing.
+   */
+  onDetection?: (event: {
+    detectionResult: PromptInjectionResult;
+    input: string;
+    strategyApplied: string;
+  }) => void | Promise<void>;
 }
 
 /**
@@ -108,6 +119,7 @@ export class PromptInjectionDetector implements Processor<'prompt-injection-dete
   private includeScores: boolean;
   private structuredOutputOptions?: PromptInjectionOptions['structuredOutputOptions'];
   private providerOptions?: ProviderOptions;
+  private onDetection?: PromptInjectionOptions['onDetection'];
 
   // Default detection categories based on OWASP LLM01 and common attack patterns
   private static readonly DEFAULT_DETECTION_TYPES = [
@@ -126,6 +138,7 @@ export class PromptInjectionDetector implements Processor<'prompt-injection-dete
     this.includeScores = options.includeScores ?? false;
     this.structuredOutputOptions = options.structuredOutputOptions;
     this.providerOptions = options.providerOptions;
+    this.onDetection = options.onDetection;
 
     this.detectionAgent = new Agent({
       id: 'prompt-injection-detector',
@@ -161,6 +174,8 @@ export class PromptInjectionDetector implements Processor<'prompt-injection-dete
 
         const detectionResult = await this.detectPromptInjection(textContent, tracingContext);
         results.push(detectionResult);
+
+        await this.onDetection?.({ detectionResult, input: textContent, strategyApplied: this.strategy });
 
         if (this.isInjectionFlagged(detectionResult)) {
           const processedMessage = this.handleDetectedInjection(message, detectionResult, this.strategy, abort);

--- a/packages/core/src/tools/tool-stream.test.ts
+++ b/packages/core/src/tools/tool-stream.test.ts
@@ -560,4 +560,57 @@ describe('ToolStream - writer.custom', () => {
     // data-* chunks should now be persisted to storage
     expect(hasDataParts).toBe(true);
   });
+
+  it('should pass custom data-* chunks from writer.custom through output processors', async () => {
+    const capturedChunkTypes: string[] = [];
+    const capturedDataChunks: any[] = [];
+
+    // Output processor that captures all chunks it sees
+    const trackingProcessor = {
+      id: 'tracking-processor',
+      async processOutputStream({ part }: any) {
+        capturedChunkTypes.push(part.type);
+        if (part.type.startsWith('data-')) {
+          capturedDataChunks.push(part);
+        }
+        return part;
+      },
+    };
+
+    const customTool = createTool({
+      id: 'custom-data-tool',
+      description: 'A tool that emits custom data chunks',
+      inputSchema: z.object({ message: z.string() }),
+      execute: async (inputData, context) => {
+        await context?.writer?.custom({
+          type: 'data-custom-event',
+          data: { eventType: 'progress', value: inputData.message },
+        });
+        return { success: true };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'processor-test-agent',
+      name: 'Processor Test Agent',
+      instructions: 'Test agent',
+      model: mockModel,
+      tools: { customTool },
+      outputProcessors: [trackingProcessor],
+    });
+
+    const stream = await agent.stream('Call custom-data-tool with message "hello"');
+    const chunks: ChunkType[] = [];
+    for await (const chunk of stream.fullStream) {
+      chunks.push(chunk);
+    }
+
+    // Verify the data chunk appeared in the stream
+    const dataChunk = chunks.find(c => c.type === 'data-custom-event');
+    expect(dataChunk).toBeDefined();
+
+    // The output processor should have seen the data-custom-event chunk
+    expect(capturedChunkTypes).toContain('data-custom-event');
+    expect(capturedDataChunks.length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Description

Detection results from `PromptInjectionDetector` and `PIIDetector` were computed internally but never surfaced to consumers, making it impossible to observe what was detected, which strategy fired, or whether content was modified.

### Changes

- **`PromptInjectionOptions` / `PIIDetectorOptions`** — Added optional `onDetection` callback
- **`PromptInjectionDetector`** — Fires `onDetection` with detection results (strategy, action taken, matched patterns)
- **`PIIDetector`** — Fires `onDetection` with PII entities found and redaction details
- Tests for both detectors verifying callback invocation and payload shape

## Related Issue(s)

Fixes #13336

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional onDetection callbacks to prompt-injection and PII detectors to notify callers after each detection attempt (supports async hooks).

* **Bug Fixes**
  * Ensured custom data-* output chunks are routed through output processors so all chunk types receive consistent processing and persistence.

* **Tests**
  * Expanded tests for onDetection across input/output/streaming scenarios and added coverage verifying data-* chunks are processed by output processors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->