### PR TITLE
fix(schema-compat): coerce ZodNull to z.any().optional() instead of throwing

### DIFF
--- a/.changeset/tough-kings-argue.md
+++ b/.changeset/tough-kings-argue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed `ZodNull` types (from MCP tool schemas with `{ "type": "null" }`) causing a startup crash instead of being gracefully handled. MCP servers that use null types in their tool schemas will now work correctly with all AI providers.

--- a/packages/schema-compat/src/provider-compats/__snapshots__/anthropic.test.ts.snap
+++ b/packages/schema-compat/src/provider-compats/__snapshots__/anthropic.test.ts.snap
@@ -1174,3 +1174,27 @@ exports[`AnthropicSchemaCompatLayer > processZodType - Unions > should handle un
   "type": "object",
 }
 `;
+
+exports[`AnthropicSchemaCompatLayer > processZodType - ZodNull Handling > should handle object schema with null field (MCP use case) 1`] = `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "extra": {
+      "type": [
+        "string",
+        "number",
+        "boolean",
+        "null",
+      ],
+    },
+    "result": {
+      "type": "string",
+    },
+  },
+  "required": [
+    "result",
+  ],
+  "type": "object",
+}
+`;

--- a/packages/schema-compat/src/provider-compats/anthropic.test.ts
+++ b/packages/schema-compat/src/provider-compats/anthropic.test.ts
@@ -109,7 +109,7 @@ describe('AnthropicSchemaCompatLayer', () => {
       });
 
       const layer = new AnthropicSchemaCompatLayer(modelInfo);
-      expect(() => layer.processToAISDKSchema(schema)).not.toThrow();
+      expect(() => layer.toJSONSchema(schema)).not.toThrow();
     });
 
     it('should handle object schema with null field (MCP use case)', () => {
@@ -119,16 +119,28 @@ describe('AnthropicSchemaCompatLayer', () => {
       });
 
       const layer = new AnthropicSchemaCompatLayer(modelInfo);
-      const aiSDKSchema = layer.processToAISDKSchema(schema);
-
-      expect(aiSDKSchema.jsonSchema).toMatchSnapshot();
+      expect(layer.toJSONSchema(schema)).toMatchSnapshot();
     });
 
     it('should handle standalone z.null() schema without throwing', () => {
       const schema = z.null();
 
       const layer = new AnthropicSchemaCompatLayer(modelInfo);
-      expect(() => layer.processZodType(schema)).not.toThrow();
+      let result: ReturnType<typeof layer.processZodType>;
+      expect(() => {
+        result = layer.processZodType(schema);
+      }).not.toThrow();
+      // Verify the coercion: ZodNull → z.any().optional()
+      expect(result!).toBeInstanceOf(z.ZodOptional);
+    });
+
+    it('should handle z.null().optional() field without throwing', () => {
+      const schema = z.object({
+        value: z.null().optional(),
+      });
+      const layer = new AnthropicSchemaCompatLayer(modelInfo);
+      expect(() => layer.toJSONSchema(schema)).not.toThrow();
+      expect(layer.toJSONSchema(schema)).toMatchSnapshot();
     });
   });
 

--- a/packages/schema-compat/src/schema-compatibility-v3.ts
+++ b/packages/schema-compat/src/schema-compatibility-v3.ts
@@ -352,6 +352,8 @@ export class SchemaCompatLayer {
 
   /**
    * Default handler for unsupported Zod types. Throws an error for specified unsupported types.
+   * ZodNull is coerced to z.any().optional() instead of throwing, since { "type": "null" } is
+   * valid JSON Schema (used by MCP servers) and should not crash the compatibility layer.
    *
    * @param value - The Zod type to check
    * @param throwOnTypes - Array of type names to throw errors for
@@ -362,6 +364,9 @@ export class SchemaCompatLayer {
     value: z.ZodTypeAny,
     throwOnTypes: readonly UnsupportedZodType[] = UNSUPPORTED_ZOD_TYPES,
   ): ShapeValue<T> {
+    if (value instanceof ZodNull) {
+      return z.any().optional() as ShapeValue<T>;
+    }
     if (throwOnTypes.includes(value._def?.typeName as UnsupportedZodType)) {
       throw new Error(`${this.model.modelId} does not support zod type: ${value._def?.typeName}`);
     }

--- a/packages/schema-compat/src/schema-compatibility-v4.ts
+++ b/packages/schema-compat/src/schema-compatibility-v4.ts
@@ -351,6 +351,8 @@ export class SchemaCompatLayer {
 
   /**
    * Default handler for unsupported Zod types. Throws an error for specified unsupported types.
+   * ZodNull is coerced to z.any().optional() instead of throwing, since { "type": "null" } is
+   * valid JSON Schema (used by MCP servers) and should not crash the compatibility layer.
    *
    * @param value - The Zod type to check
    * @param throwOnTypes - Array of type names to throw errors for
@@ -361,6 +363,9 @@ export class SchemaCompatLayer {
     value: z.ZodAny,
     throwOnTypes: readonly UnsupportedZodType[] = UNSUPPORTED_ZOD_TYPES,
   ): ShapeValue<T> {
+    if (value instanceof ZodNull) {
+      return z.any().optional() as ShapeValue<T>;
+    }
     if (throwOnTypes.includes(value.constructor.name as UnsupportedZodType)) {
       throw new Error(`${this.model.modelId} does not support zod type: ${value.constructor.name}`);
     }


### PR DESCRIPTION
## Description

MCP servers using `{ "type": "null" }` in tool JSON Schemas caused a startup crash because `@mastra/schema-compat` unconditionally threw when encountering `ZodNull` (which `@mastra/mcp` produces from null-typed JSON Schema fields).

### Changes

- **`schema-compatibility-v4.ts` / `schema-compatibility-v3.ts`** — Coerce `ZodNull` to `z.any().optional()` instead of throwing
- **`anthropic.test.ts`** — Added test coverage for ZodNull handling
- Updated snapshot

## Related Issue(s)

Fixes #13315

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented startup crashes caused by null types in tool schemas; MCP servers using null fields now operate correctly with all AI providers.

* **Tests**
  * Added test coverage for null type handling to ensure graceful processing and compatibility.

* **Chores**
  * Added a changelog entry for the patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->