### PR TITLE
fix(core): ensure doEmbed returns warnings array for AI SDK v6 compatibility

### DIFF
--- a/.changeset/fix-embed-many-warnings.md
+++ b/.changeset/fix-embed-many-warnings.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed `ModelRouterEmbeddingModel.doEmbed()` crashing with `TypeError: result.warnings is not iterable` when used with AI SDK v6's `embedMany`. The result now always includes a `warnings` array, ensuring forward compatibility across AI SDK versions.

--- a/packages/core/src/llm/model/embedding-router.ts
+++ b/packages/core/src/llm/model/embedding-router.ts
@@ -219,9 +219,7 @@ export class ModelRouterEmbeddingModel<VALUE extends string = string> implements
     args: Parameters<EmbeddingModelV2<VALUE>['doEmbed']>[0],
   ): Promise<Awaited<ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>>> {
     const result = await this.providerModel.doEmbed(args);
-    return {
-      ...result,
-      warnings: (result as any).warnings ?? [],
-    };
+    const warnings = (result as { warnings?: unknown[] }).warnings ?? [];
+    return { ...result, warnings };
   }
 }

--- a/packages/core/src/llm/model/embedding-router.ts
+++ b/packages/core/src/llm/model/embedding-router.ts
@@ -218,6 +218,10 @@ export class ModelRouterEmbeddingModel<VALUE extends string = string> implements
   async doEmbed(
     args: Parameters<EmbeddingModelV2<VALUE>['doEmbed']>[0],
   ): Promise<Awaited<ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>>> {
-    return this.providerModel.doEmbed(args);
+    const result = await this.providerModel.doEmbed(args);
+    return {
+      ...result,
+      warnings: (result as any).warnings ?? [],
+    };
   }
 }


### PR DESCRIPTION
## Description

Ensure `ModelRouterEmbeddingModel.doEmbed()` always returns a `warnings` array in the result.  
If the underlying provider does not include `warnings`, it now defaults to an empty array (`[]`).

This prevents crashes when using AI SDK v6's `embedMany`, which expects `result.warnings` to be iterable and spreads it internally (`warnings.push(...result.warnings)`).

Without this fix, V2 embedding providers that omit `warnings` cause:
`TypeError: result.warnings is not iterable`.

## Related Issue(s)

Fixes #13238

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Embedding responses now always include a warnings array, preventing a TypeError when used with AI SDK v6. This ensures embedding results consistently provide warning information, improving reliability and forward compatibility across embedding providers and configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->