### PR TITLE
 feat(core): add onStepFinish and onError callbacks to NetworkOptions

### DIFF
--- a/.changeset/add-network-onstepfinish-onerror.md
+++ b/.changeset/add-network-onstepfinish-onerror.md
@@ -1,0 +1,22 @@
+---
+"@mastra/core": minor
+---
+
+Added `onStepFinish` and `onError` callbacks to `NetworkOptions`. These callbacks are forwarded to sub-agent `stream()` and `resumeStream()` calls during network execution, enabling per-LLM-step progress monitoring and error handling — the same observability that `agent.stream()` already provides.
+
+**Example usage:**
+
+```typescript
+const stream = await agent.network("Research AI trends", {
+  onStepFinish: (event) => {
+    console.log("Step completed:", event.finishReason, event.usage);
+  },
+  onError: ({ error }) => {
+    console.error("Network error:", error);
+  },
+  memory: {
+    thread: "my-thread",
+    resource: "my-resource",
+  },
+});
+```

--- a/.changeset/add-network-onstepfinish-onerror.md
+++ b/.changeset/add-network-onstepfinish-onerror.md
@@ -2,9 +2,17 @@
 "@mastra/core": minor
 ---
 
-Added `onStepFinish` and `onError` callbacks to `NetworkOptions`. These callbacks are forwarded to sub-agent `stream()` and `resumeStream()` calls during network execution, enabling per-LLM-step progress monitoring and error handling — the same observability that `agent.stream()` already provides.
+Added `onStepFinish` and `onError` callbacks to `NetworkOptions`. These callbacks are forwarded to sub-agent `stream()` and `resumeStream()` calls during network execution, enabling per-LLM-step progress monitoring and error handling. Closes #13362.
 
-**Example usage:**
+**Before:** No way to observe per-step progress or handle errors during network execution.
+
+```typescript
+const stream = await agent.network("Research AI trends", {
+  memory: { thread: "my-thread", resource: "my-resource" },
+});
+```
+
+**After:** `onStepFinish` and `onError` are now available in `NetworkOptions`.
 
 ```typescript
 const stream = await agent.network("Research AI trends", {
@@ -14,9 +22,6 @@ const stream = await agent.network("Research AI trends", {
   onError: ({ error }) => {
     console.error("Network error:", error);
   },
-  memory: {
-    thread: "my-thread",
-    resource: "my-resource",
-  },
+  memory: { thread: "my-thread", resource: "my-resource" },
 });
 ```

--- a/.changeset/add-network-onstepfinish-onerror.md
+++ b/.changeset/add-network-onstepfinish-onerror.md
@@ -2,7 +2,7 @@
 "@mastra/core": minor
 ---
 
-Added `onStepFinish` and `onError` callbacks to `NetworkOptions`. These callbacks are forwarded to sub-agent `stream()` and `resumeStream()` calls during network execution, enabling per-LLM-step progress monitoring and error handling. Closes #13362.
+Added `onStepFinish` and `onError` callbacks to `NetworkOptions`, allowing per-LLM-step progress monitoring and custom error handling during network execution. Closes #13362.
 
 **Before:** No way to observe per-step progress or handle errors during network execution.
 

--- a/docs/src/content/en/reference/agents/network.mdx
+++ b/docs/src/content/en/reference/agents/network.mdx
@@ -328,27 +328,6 @@ isOptional: true,
 description:
 "Callback fired when an error occurs during sub-agent execution.",
 },
-{
-name: "onIterationComplete",
-type: "(context: { iteration: number; primitiveId: string; primitiveType: string; result: string; isComplete: boolean }) => void | Promise<void>",
-isOptional: true,
-description:
-"Callback fired after each network iteration completes. Receives iteration details including which primitive was selected and the result.",
-},
-{
-name: "onAbort",
-type: "(event: any) => Promise<void> | void",
-isOptional: true,
-description:
-"Callback fired when the streaming operation is aborted.",
-},
-{
-name: "abortSignal",
-type: "AbortSignal",
-isOptional: true,
-description:
-"Signal to abort the streaming operation.",
-},
 ]}
 />
 

--- a/docs/src/content/en/reference/agents/network.mdx
+++ b/docs/src/content/en/reference/agents/network.mdx
@@ -314,6 +314,41 @@ isOptional: true,
 description:
 "The trace ID associated with this execution when Tracing is enabled. Use this to correlate logs and debug execution flow.",
 },
+{
+name: "onStepFinish",
+type: "(event: any) => Promise<void> | void",
+isOptional: true,
+description:
+"Callback fired after each LLM step within a sub-agent execution. Receives step details including finish reason and token usage.",
+},
+{
+name: "onError",
+type: "({ error }: { error: Error | string }) => Promise<void> | void",
+isOptional: true,
+description:
+"Callback fired when an error occurs during sub-agent execution.",
+},
+{
+name: "onIterationComplete",
+type: "(context: { iteration: number; primitiveId: string; primitiveType: string; result: string; isComplete: boolean }) => void | Promise<void>",
+isOptional: true,
+description:
+"Callback fired after each network iteration completes. Receives iteration details including which primitive was selected and the result.",
+},
+{
+name: "onAbort",
+type: "(event: any) => Promise<void> | void",
+isOptional: true,
+description:
+"Callback fired when the streaming operation is aborted.",
+},
+{
+name: "abortSignal",
+type: "AbortSignal",
+isOptional: true,
+description:
+"Signal to abort the streaming operation.",
+},
 ]}
 />
 

--- a/packages/core/src/agent/agent-network.test.ts
+++ b/packages/core/src/agent/agent-network.test.ts
@@ -6244,10 +6244,14 @@ describe('Agent - network - onStepFinish and onError callbacks', () => {
     // Verify onStepFinish was called at least once
     expect(stepFinishCallbacks.length).toBeGreaterThan(0);
 
-    // Verify the callback received step data with expected properties
+    // Verify the callback received step data with exact expected values
     const lastStep = stepFinishCallbacks[stepFinishCallbacks.length - 1];
-    expect(lastStep).toHaveProperty('finishReason');
-    expect(lastStep).toHaveProperty('usage');
+    expect(lastStep.finishReason).toBe('stop');
+    expect(lastStep.usage).toMatchObject({
+      inputTokens: 5,
+      outputTokens: 10,
+      totalTokens: 15,
+    });
   });
 
   it('should call onError callback when sub-agent encounters an error', async () => {

--- a/packages/core/src/agent/agent-network.test.ts
+++ b/packages/core/src/agent/agent-network.test.ts
@@ -6144,3 +6144,212 @@ describe('Agent - network - metadata on forwarded messages (issue #13106)', () =
     }
   });
 });
+
+describe('Agent - network - onStepFinish and onError callbacks', () => {
+  it('should call onStepFinish callback during sub-agent execution', async () => {
+    const memory = new MockMemory();
+    const stepFinishCallbacks: any[] = [];
+
+    // Routing agent selects sub-agent, then marks complete
+    const routingSelectAgent = JSON.stringify({
+      primitiveId: 'stepFinishSubAgent',
+      primitiveType: 'agent',
+      prompt: 'Say hello',
+      selectionReason: 'Delegating to sub-agent',
+    });
+
+    const completionResponse = JSON.stringify({
+      isComplete: true,
+      finalResult: 'Done',
+      completionReason: 'Task complete',
+    });
+
+    let routingCallCount = 0;
+    const routingModel = new MockLanguageModelV2({
+      doGenerate: async () => {
+        routingCallCount++;
+        const text = routingCallCount === 1 ? routingSelectAgent : completionResponse;
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          content: [{ type: 'text', text }],
+          warnings: [],
+        };
+      },
+      doStream: async () => {
+        routingCallCount++;
+        const text = routingCallCount === 1 ? routingSelectAgent : completionResponse;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-delta', id: 'id-0', delta: text },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+          ]),
+        };
+      },
+    });
+
+    const subAgentModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+        content: [{ type: 'text', text: 'Hello from sub-agent!' }],
+        warnings: [],
+      }),
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-delta', id: 'id-0', delta: 'Hello from sub-agent!' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 } },
+        ]),
+      }),
+    });
+
+    const subAgent = new Agent({
+      id: 'stepFinishSubAgent',
+      name: 'Step Finish Sub Agent',
+      description: 'A sub-agent for testing onStepFinish',
+      instructions: 'Say hello.',
+      model: subAgentModel,
+    });
+
+    const networkAgent = new Agent({
+      id: 'step-finish-network',
+      name: 'Step Finish Network',
+      instructions: 'Delegate tasks to sub-agents.',
+      model: routingModel,
+      agents: { stepFinishSubAgent: subAgent },
+      memory,
+    });
+
+    const anStream = await networkAgent.network('Say hello', {
+      onStepFinish: event => {
+        stepFinishCallbacks.push(event);
+      },
+      memory: {
+        thread: 'step-finish-test-thread',
+        resource: 'step-finish-test-resource',
+      },
+    });
+
+    // Consume the stream
+    for await (const _chunk of anStream) {
+      // Process stream
+    }
+
+    // Verify onStepFinish was called at least once
+    expect(stepFinishCallbacks.length).toBeGreaterThan(0);
+
+    // Verify the callback received step data with expected properties
+    const lastStep = stepFinishCallbacks[stepFinishCallbacks.length - 1];
+    expect(lastStep).toHaveProperty('finishReason');
+    expect(lastStep).toHaveProperty('usage');
+  });
+
+  it('should call onError callback when sub-agent encounters an error', async () => {
+    const memory = new MockMemory();
+    const errorCallbacks: any[] = [];
+
+    // Routing agent selects the error-throwing sub-agent
+    const routingSelectAgent = JSON.stringify({
+      primitiveId: 'errorSubAgent',
+      primitiveType: 'agent',
+      prompt: 'Do something',
+      selectionReason: 'Delegating to sub-agent',
+    });
+
+    const completionResponse = JSON.stringify({
+      isComplete: true,
+      finalResult: 'Done',
+      completionReason: 'Task complete',
+    });
+
+    let routingCallCount = 0;
+    const routingModel = new MockLanguageModelV2({
+      doGenerate: async () => {
+        routingCallCount++;
+        const text = routingCallCount === 1 ? routingSelectAgent : completionResponse;
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          content: [{ type: 'text', text }],
+          warnings: [],
+        };
+      },
+      doStream: async () => {
+        routingCallCount++;
+        const text = routingCallCount === 1 ? routingSelectAgent : completionResponse;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-delta', id: 'id-0', delta: text },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+          ]),
+        };
+      },
+    });
+
+    // Sub-agent model that throws an error during streaming
+    const errorSubAgentModel = new MockLanguageModelV2({
+      doGenerate: async () => {
+        throw new Error('Sub-agent model error');
+      },
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'error', error: new Error('Sub-agent stream error') },
+          { type: 'finish', finishReason: 'error', usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+        ]),
+      }),
+    });
+
+    const errorSubAgent = new Agent({
+      id: 'errorSubAgent',
+      name: 'Error Sub Agent',
+      description: 'A sub-agent that errors',
+      instructions: 'This agent will error.',
+      model: errorSubAgentModel,
+    });
+
+    const networkAgent = new Agent({
+      id: 'error-callback-network',
+      name: 'Error Callback Network',
+      instructions: 'Delegate tasks to sub-agents.',
+      model: routingModel,
+      agents: { errorSubAgent },
+      memory,
+    });
+
+    try {
+      const anStream = await networkAgent.network('Do something', {
+        onError: ({ error }) => {
+          errorCallbacks.push({ error });
+        },
+        memory: {
+          thread: 'error-test-thread',
+          resource: 'error-test-resource',
+        },
+      });
+
+      // Consume the stream - may throw
+      for await (const _chunk of anStream) {
+        // Process stream
+      }
+    } catch {
+      // Expected - the stream may throw due to the error
+    }
+
+    // Verify onError was called
+    expect(errorCallbacks.length).toBeGreaterThan(0);
+
+    // Verify the callback received error data
+    const errorEvent = errorCallbacks[0];
+    expect(errorEvent.error).toBeDefined();
+  });
+});

--- a/packages/core/src/agent/agent-network.test.ts
+++ b/packages/core/src/agent/agent-network.test.ts
@@ -6348,8 +6348,9 @@ describe('Agent - network - onStepFinish and onError callbacks', () => {
     // Verify onError was called
     expect(errorCallbacks.length).toBeGreaterThan(0);
 
-    // Verify the callback received error data
+    // Verify the callback received the expected error
     const errorEvent = errorCallbacks[0];
-    expect(errorEvent.error).toBeDefined();
+    expect(errorEvent.error).toBeInstanceOf(Error);
+    expect(errorEvent.error.message).toContain('Sub-agent stream error');
   });
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4182,6 +4182,8 @@ export class Agent<
       autoResumeSuspendedTools: mergedOptions?.autoResumeSuspendedTools,
       mastra: this.#mastra,
       structuredOutput: mergedOptions?.structuredOutput as OUTPUT extends {} ? StructuredOutputOptions<OUTPUT> : never,
+      onStepFinish: mergedOptions?.onStepFinish as NetworkOptions<OUTPUT>['onStepFinish'],
+      onError: mergedOptions?.onError,
       onAbort: mergedOptions?.onAbort,
       abortSignal: mergedOptions?.abortSignal,
     });
@@ -4256,6 +4258,8 @@ export class Agent<
       onIterationComplete: mergedOptions?.onIterationComplete,
       autoResumeSuspendedTools: mergedOptions?.autoResumeSuspendedTools,
       mastra: this.#mastra,
+      onStepFinish: mergedOptions?.onStepFinish,
+      onError: mergedOptions?.onError,
       onAbort: mergedOptions?.onAbort,
       abortSignal: mergedOptions?.abortSignal,
     });

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -407,6 +407,12 @@ export type NetworkOptions<OUTPUT = undefined> = {
    */
   structuredOutput?: StructuredOutputOptions<OUTPUT extends {} ? OUTPUT : never>;
 
+  /** Callback fired after each LLM step within a sub-agent execution */
+  onStepFinish?: LoopConfig<OUTPUT>['onStepFinish'];
+
+  /** Callback fired when an error occurs during sub-agent execution */
+  onError?: LoopConfig<OUTPUT>['onError'];
+
   /** Callback fired when streaming is aborted */
   onAbort?: LoopConfig<OUTPUT>['onAbort'];
 

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -456,6 +456,8 @@ export async function createNetworkLoop({
   generateId,
   routingAgentOptions,
   routing,
+  onStepFinish,
+  onError,
   onAbort,
   abortSignal,
 }: {
@@ -469,6 +471,8 @@ export async function createNetworkLoop({
     additionalInstructions?: string;
     verboseIntrospection?: boolean;
   };
+  onStepFinish?: (event: any) => Promise<void> | void;
+  onError?: ({ error }: { error: Error | string }) => Promise<void> | void;
   onAbort?: (event: any) => Promise<void> | void;
   abortSignal?: AbortSignal;
 }) {
@@ -795,6 +799,8 @@ export async function createNetworkLoop({
                 lastMessages: 0,
               },
             },
+            onStepFinish,
+            onError,
             abortSignal,
             onAbort,
           })
@@ -808,6 +814,8 @@ export async function createNetworkLoop({
                 lastMessages: 0,
               },
             },
+            onStepFinish,
+            onError,
             abortSignal,
             onAbort,
           }));
@@ -2017,6 +2025,8 @@ export async function networkLoop<OUTPUT = undefined>({
   autoResumeSuspendedTools,
   mastra,
   structuredOutput,
+  onStepFinish,
+  onError,
   onAbort,
   abortSignal,
 }: {
@@ -2061,6 +2071,8 @@ export async function networkLoop<OUTPUT = undefined>({
   resumeData?: any;
   autoResumeSuspendedTools?: boolean;
   mastra?: Mastra;
+  onStepFinish?: NetworkOptions<OUTPUT>['onStepFinish'];
+  onError?: NetworkOptions<OUTPUT>['onError'];
   onAbort?: NetworkOptions<OUTPUT>['onAbort'];
   abortSignal?: NetworkOptions<OUTPUT>['abortSignal'];
 }): Promise<MastraAgentNetworkStream<OUTPUT>> {
@@ -2177,6 +2189,8 @@ export async function networkLoop<OUTPUT = undefined>({
     routingAgentOptions: routingAgentOptionsWithoutMemory,
     generateId,
     routing,
+    onStepFinish,
+    onError,
     onAbort,
     abortSignal,
   });


### PR DESCRIPTION
## Description

- Add `onStepFinish` and `onError` callbacks to the `NetworkOptions` type.
- Thread these callbacks through `createNetworkLoop()` and `networkLoop()` into sub-agent `stream()` and `resumeStream()` calls.
- Update the network reference documentation to include the missing callback options.

## Related Issue(s)

Fixes #13362

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Test Plan

- [x] `pnpm build:core` passes  
- [x] Two new tests covering `onStepFinish` and `onError` callbacks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional network callbacks for per-step progress and error handling (onStepFinish, onError), plus iteration completion, abort events, and an abort signal to cancel streaming.

* **Documentation**
  * Updated network reference to describe the new callbacks, iteration/abort behavior, and abortSignal usage.

* **Tests**
  * Added tests validating onStepFinish and onError callback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->