### PR TITLE
fix(mastracode): wire fdPath to enable @ file autocomplete

### DIFF
--- a/.changeset/fix-file-autocomplete-fd.md
+++ b/.changeset/fix-file-autocomplete-fd.md
@@ -1,0 +1,5 @@
+---
+"mastracode": patch
+---
+
+Fixed `@` file autocomplete so fuzzy file search works when `fd` or `fdfind` is installed. Previously, typing `@` followed by a filename never showed file suggestions even with `fd` available.


### PR DESCRIPTION
## Summary

The `@` file autocomplete (fuzzy file search powered by `fd`) was silently broken. Typing `@` followed by a filename never showed file suggestions, even with `fd` or `fdfind` installed.

## Root cause

`CombinedAutocompleteProvider` from `@mariozechner/pi-tui` accepts an optional 3rd argument `fdPath` (the path to the `fd` binary). Without it, `getFuzzyFileSuggestions()` returns early and no suggestions are generated.

mastracode was constructing it with only 2 arguments:
```ts
new CombinedAutocompleteProvider(slashCommands, process.cwd())
```

## Fix

Added a `detectFdPath()` helper that checks for `fd` then `fdfind` via `which`, and passes the result as the 3rd argument:
```ts
const fdPath = detectFdPath();
new CombinedAutocompleteProvider(slashCommands, process.cwd(), fdPath)
```

If neither binary is found, `null` is passed and behavior is unchanged (graceful fallback).

## Test plan

- `pnpm -C mastracode build:lib` — passes
- `pnpm -C mastracode test -- --run` — 9/9 tests pass
- Manual: with `fd` installed, type `@` in the editor and verify fuzzy file suggestions appear
- Manual: without `fd` installed, verify no errors and autocomplete degrades gracefully (slash commands and path completion still work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed `@` file autocomplete to enable fuzzy search when fd or fdfind is installed. Typing `@` followed by a filename now yields suggestions as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->