### PR TITLE
feat(mastracode): include model name in Co-Authored-By commit message

### DIFF
--- a/.changeset/model-id-co-author.md
+++ b/.changeset/model-id-co-author.md
@@ -1,0 +1,5 @@
+---
+'mastracode': minor
+---
+
+Added model name to Co-Authored-By in commit messages. Commits now include the active model (e.g. `Co-Authored-By: Mastra Code (anthropic/claude-opus-4-6) <noreply@mastra.ai>`) for traceability when switching between models. Falls back to the original static format when no model is set.

--- a/mastracode/src/agents/instructions.ts
+++ b/mastracode/src/agents/instructions.ts
@@ -15,6 +15,7 @@ export function getDynamicInstructions({ requestContext }: { requestContext: { g
     platform: process.platform,
     date: new Date().toISOString().split('T')[0]!,
     mode: modeId,
+    modelId: state?.currentModelId || undefined,
     activePlan: state?.activePlan ?? null,
     modeId: modeId,
     currentDate: new Date().toISOString().split('T')[0]!,

--- a/mastracode/src/agents/prompts/base.ts
+++ b/mastracode/src/agents/prompts/base.ts
@@ -10,6 +10,7 @@ export interface PromptContext {
   platform: string;
   date: string;
   mode: string;
+  modelId?: string;
   activePlan?: { title: string; plan: string; approvedAt: string } | null;
 }
 
@@ -140,7 +141,7 @@ You have access to the following tools. Use the RIGHT tool for the job:
 Don't commit files likely to contain secrets (\`.env\`, \`*.key\`, \`credentials.json\`). Warn if asked.
 
 ## Commits
-Write commit messages that explain WHY, not just WHAT. Match the repo's existing style. Include \`Co-Authored-By: Mastra Code <noreply@mastra.ai>\` in the message body.
+Write commit messages that explain WHY, not just WHAT. Match the repo's existing style. Include \`Co-Authored-By: Mastra Code${ctx.modelId ? ` (${ctx.modelId})` : ''} <noreply@mastra.ai>\` in the message body.
 
 ## Pull Requests
 Use \`gh pr create\`. Include a summary of what changed and a test plan.

--- a/mastracode/src/agents/prompts/index.ts
+++ b/mastracode/src/agents/prompts/index.ts
@@ -42,6 +42,7 @@ export function buildFullPrompt(ctx: PromptContext): string {
     platform: process.platform,
     date: ctx.currentDate,
     mode: ctx.modeId,
+    modelId: ctx.modelId,
     activePlan: ctx.state?.activePlan,
   };
 


### PR DESCRIPTION
## Description

- Wire `currentModelId` from harness state through `PromptContext` into the Co-Authored-By instruction.
- Commits now include the model identifier in the format:  
  `Co-Authored-By: Mastra Code (anthropic/claude-opus-4-6) <noreply@mastra.ai>`
- Falls back to the static format  
  `Co-Authored-By: Mastra Code <noreply@mastra.ai>`  
  when no model is set.

<img width="1183" height="351" alt="image" src="https://github.com/user-attachments/assets/fdddb148-0272-4b94-8900-dbd7ed3e8cf5" />

## Related Issue(s)

Closes #13312

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model tracking so the active model name can appear in generated commit messages when available.
  * Co‑Authored‑By header now conditionally includes the active model name, with a fallback to the original format.

* **Documentation**
  * Added a changeset describing the commit-message behavior and version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->