### PR TITLE
fix(mastracode): exclude hidden files from directory listings

### DIFF
--- a/.changeset/proud-lizards-decide.md
+++ b/.changeset/proud-lizards-decide.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed hidden files not being excluded from directory listings

--- a/.changeset/proud-lizards-decide.md
+++ b/.changeset/proud-lizards-decide.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Fixed hidden files not being excluded from directory listings
+Exclude hidden files from directory listings

--- a/mastracode/src/tools/file-editor.ts
+++ b/mastracode/src/tools/file-editor.ts
@@ -68,7 +68,7 @@ export class FileEditor {
   async view(args: ViewArgs) {
     await validatePath('view', args.path);
     if (await this.isDirectory(args.path)) {
-      const { stdout, stderr } = await this.execAsync(`find "${args.path}" -maxdepth 2 -not -path '*/\\\\.*'`);
+      const { stdout, stderr } = await this.execAsync(`find "${args.path}" -maxdepth 2 -not -path '*/.*'`);
       if (stderr) return stderr;
       return `Here's the files and directories up to 2 levels deep in ${args.path}, excluding hidden items:\n${stdout}\n`;
     }

--- a/mastracode/src/tools/file-view.ts
+++ b/mastracode/src/tools/file-view.ts
@@ -138,7 +138,7 @@ Usage notes:
 
         // Handle directory listing
         if (await isDirectory(absolutePath)) {
-          const { stdout, stderr } = await execAsync(`find "${absolutePath}" -maxdepth 2 -not -path '*/\\\\.*'`);
+          const { stdout, stderr } = await execAsync(`find "${absolutePath}" -maxdepth 2 -not -path '*/.*'`);
 
           if (stderr) {
             throw new Error(stderr);


### PR DESCRIPTION
## Summary

The `find` command pattern in `file-view.ts` and `file-editor.ts` used double-escaped backslashes (`'*/\\\\.*'`) which produced `*/\\.*` in the shell — matching paths with a literal backslash-then-dot instead of hidden files (`*/.*`).

This caused hidden files and directories (e.g. `.git/`, `.env`) to appear in directory listing output despite the tool description claiming they are excluded.

## Changes

- **`mastracode/src/tools/file-view.ts`** — Fix shell glob from `'*/\\\\.*'` to `'*/.*'`
- **`mastracode/src/tools/file-editor.ts`** — Same fix

## Test Plan

- Existing `file-editor.test.ts` tests pass (6/6)
- Manual verification: created a directory with hidden files/dirs, confirmed they are now properly excluded from `find` output


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hidden files and directories are now properly excluded from directory listings in file operations.

* **Chores**
  * Added a changeset to mark a patch release noting the directory-listing behavior update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->