### PR TITLE
fix(mastracode): use correct LSP language identifier for TS/JS files

### DIFF
--- a/.changeset/warm-bears-brake.md
+++ b/.changeset/warm-bears-brake.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed LSP diagnostics using wrong language identifier for TypeScript and JavaScript files

--- a/.changeset/warm-bears-brake.md
+++ b/.changeset/warm-bears-brake.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Fixed LSP diagnostics using wrong language identifier for TypeScript and JavaScript files
+LSP now shows correct diagnostics for TypeScript and JavaScript files

--- a/mastracode/src/tools/string-replace-lsp.ts
+++ b/mastracode/src/tools/string-replace-lsp.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createTool } from '@mastra/core/tools';
 import { z } from 'zod';
+import { getLanguageId } from '../lsp/language.js';
 import { lspManager } from '../lsp/manager.js';
 import { findWorkspaceRoot } from '../lsp/workspace.js';
 import { truncateStringForTokenEstimate } from '../utils/token-estimator.js';
@@ -55,7 +56,7 @@ Usage notes:
         if (client) {
           // Read the modified file content
           const contentNew = fs.readFileSync(absoluteFilePath, 'utf-8');
-          const languageId = path.extname(absoluteFilePath).slice(1);
+          const languageId = getLanguageId(absoluteFilePath) || path.extname(absoluteFilePath).slice(1);
 
           client.notifyOpen(absoluteFilePath, contentNew, languageId);
           client.notifyChange(absoluteFilePath, contentNew, 1);


### PR DESCRIPTION
## Summary

The `languageId` passed to the LSP `textDocument/didOpen` notification was computed by stripping the leading dot from the file extension (`path.extname(...).slice(1)`), producing `"ts"` for TypeScript files. However, the LSP protocol expects `"typescript"`.

A correct mapping already existed in `mastracode/src/lsp/language.ts` (`LANGUAGE_EXTENSIONS` / `getLanguageId()`) but was never used in `string-replace-lsp.ts`.

## Changes

- **`mastracode/src/tools/string-replace-lsp.ts`** — Import `getLanguageId` from `../lsp/language.js` and use it to resolve the correct language identifier, with a fallback to the extension-based approach for unmapped file types.

## Test Plan

- All 3 existing `string-replace-lsp.test.ts` tests pass, including the one that validates LSP diagnostics are returned for TypeScript type errors (which requires the correct `"typescript"` language ID)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed language identifier detection for TypeScript and JavaScript files to ensure accurate LSP diagnostics.
* **Documentation**
  * Added a patch-level changelog entry documenting the diagnostics fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->