### PR TITLE
fix(evals): show N/A instead of null for code-based scorers in studio

### DIFF
--- a/.changeset/improve-scorer-null-values-studio-core.md
+++ b/.changeset/improve-scorer-null-values-studio-core.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added `hasJudge` metadata to scorer records so the studio can distinguish code-based scorers (e.g., textual-difference, content-similarity) from LLM-based scorers. This metadata is now included in all four score-saving paths: `runEvals`, scorer hooks, trace scoring, and dataset experiments.

--- a/.changeset/improve-scorer-null-values-studio-ui.md
+++ b/.changeset/improve-scorer-null-values-studio-ui.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved the score dialog to show "N/A" with an explanation instead of "null" for code-based scorers that don't use prompts or generate reasons. The dialog now detects code-based scorers via the `hasJudge` metadata flag, with a heuristic fallback for older data.

--- a/.changeset/improve-scorer-null-values-studio-ui.md
+++ b/.changeset/improve-scorer-null-values-studio-ui.md
@@ -2,4 +2,4 @@
 '@mastra/playground-ui': patch
 ---
 
-Improved the score dialog to show "N/A" with an explanation instead of "null" for code-based scorers that don't use prompts or generate reasons. The dialog now detects code-based scorers via the `hasJudge` metadata flag, with a heuristic fallback for older data.
+Improved the score dialog to show "N/A" with an explanation instead of "null" for empty scorer fields. Code-based scorers show "N/A — code-based scorer does not use prompts" and LLM scorers with unconfigured steps show "N/A — step not configured". Detection uses the `hasJudge` metadata flag with a heuristic fallback for older data.

--- a/packages/core/src/datasets/experiment/scorer.ts
+++ b/packages/core/src/datasets/experiment/scorer.ts
@@ -71,6 +71,7 @@ export async function runScorersForItem(
               id: scorer.id,
               name: scorer.name,
               description: scorer.description ?? '',
+              hasJudge: !!scorer.judge,
             },
             entity: {
               id: targetId,

--- a/packages/core/src/evals/run/index.ts
+++ b/packages/core/src/evals/run/index.ts
@@ -499,6 +499,7 @@ async function saveSingleScore({
         name: scorer?.name || scorerId,
         description: scorer?.description || '',
         type: scorer?.type || 'unknown',
+        hasJudge: !!scorer?.judge,
       },
       entity: {
         id: target.id,

--- a/packages/core/src/evals/run/index.ts
+++ b/packages/core/src/evals/run/index.ts
@@ -499,7 +499,7 @@ async function saveSingleScore({
         name: scorer?.name || scorerId,
         description: scorer?.description || '',
         type: scorer?.type || 'unknown',
-        hasJudge: !!scorer?.judge,
+        ...(scorer ? { hasJudge: !!scorer.judge } : {}),
       },
       entity: {
         id: target.id,

--- a/packages/core/src/evals/scoreTraces/scoreTracesWorkflow.ts
+++ b/packages/core/src/evals/scoreTraces/scoreTracesWorkflow.ts
@@ -148,6 +148,7 @@ export async function runScorerOnTarget({
       id: scorer.id,
       name: scorer.name || scorer.id,
       description: scorer.description,
+      hasJudge: !!scorer.judge,
     },
     traceId: target.traceId,
     spanId: target.spanId,

--- a/packages/core/src/mastra/hooks.ts
+++ b/packages/core/src/mastra/hooks.ts
@@ -62,6 +62,10 @@ export function createOnScorerHook(mastra: Mastra) {
         scorerId: scorerId,
         spanId,
         traceId,
+        scorer: {
+          ...rest.scorer,
+          hasJudge: !!scorerToUse.scorer.judge,
+        },
         metadata: {
           structuredOutput: !!structuredOutput,
         },

--- a/packages/playground-ui/src/domains/scores/components/score-dialog.tsx
+++ b/packages/playground-ui/src/domains/scores/components/score-dialog.tsx
@@ -146,7 +146,7 @@ export function ScoreDialog({
           <SideDialog.CodeSection
             title={`Score: ${Number.isNaN(score?.score) ? 'n/a' : score?.score}`}
             icon={<GaugeIcon />}
-            codeStr={score?.reason || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not generate a reason' : 'null')}
+            codeStr={score?.reason || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not generate a reason' : 'N/A — step not configured')}
             simplified={true}
           />
 
@@ -165,28 +165,28 @@ export function ScoreDialog({
           <SideDialog.CodeSection
             title="Preprocess Prompt"
             icon={<ReceiptText />}
-            codeStr={score?.preprocessPrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'null')}
+            codeStr={score?.preprocessPrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'N/A — step not configured')}
             simplified={true}
           />
 
           <SideDialog.CodeSection
             title="Analyze Prompt"
             icon={<ReceiptText />}
-            codeStr={score?.analyzePrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'null')}
+            codeStr={score?.analyzePrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'N/A — step not configured')}
             simplified={true}
           />
 
           <SideDialog.CodeSection
             title="Generate Score Prompt"
             icon={<ReceiptText />}
-            codeStr={score?.generateScorePrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'null')}
+            codeStr={score?.generateScorePrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'N/A — step not configured')}
             simplified={true}
           />
 
           <SideDialog.CodeSection
             title="Generate Reason Prompt"
             icon={<ReceiptText />}
-            codeStr={score?.generateReasonPrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'null')}
+            codeStr={score?.generateReasonPrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'N/A — step not configured')}
             simplified={true}
           />
         </Sections>

--- a/packages/playground-ui/src/domains/scores/components/score-dialog.tsx
+++ b/packages/playground-ui/src/domains/scores/components/score-dialog.tsx
@@ -18,11 +18,12 @@ import { Sections } from '@/index';
 import { format } from 'date-fns/format';
 
 function isCodeBasedScorer(score?: ScoreRowData): boolean {
-  const scorer = score?.scorer as Record<string, unknown> | undefined;
+  if (!score) return false;
+  const scorer = score.scorer as Record<string, unknown> | undefined;
   if (scorer?.hasJudge === false) return true;
   if (scorer?.hasJudge === true) return false;
   // Heuristic fallback for old data without hasJudge
-  return !score?.preprocessPrompt && !score?.analyzePrompt && !score?.generateScorePrompt && !score?.generateReasonPrompt;
+  return !score.preprocessPrompt && !score.analyzePrompt && !score.generateScorePrompt && !score.generateReasonPrompt;
 }
 
 type ScoreDialogProps = {
@@ -49,6 +50,7 @@ export function ScoreDialog({
   usageContext = 'scorerPage',
 }: ScoreDialogProps) {
   const { Link } = useLinkComponent();
+  const isCodeBased = isCodeBased;
 
   return (
     <SideDialog
@@ -146,7 +148,7 @@ export function ScoreDialog({
           <SideDialog.CodeSection
             title={`Score: ${Number.isNaN(score?.score) ? 'n/a' : score?.score}`}
             icon={<GaugeIcon />}
-            codeStr={score?.reason || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not generate a reason' : 'N/A — step not configured')}
+            codeStr={score?.reason || (isCodeBased ? 'N/A — code-based scorer does not generate a reason' : 'N/A — step not configured')}
             simplified={true}
           />
 
@@ -165,28 +167,28 @@ export function ScoreDialog({
           <SideDialog.CodeSection
             title="Preprocess Prompt"
             icon={<ReceiptText />}
-            codeStr={score?.preprocessPrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'N/A — step not configured')}
+            codeStr={score?.preprocessPrompt || (isCodeBased ? 'N/A — code-based scorer does not use prompts' : 'N/A — step not configured')}
             simplified={true}
           />
 
           <SideDialog.CodeSection
             title="Analyze Prompt"
             icon={<ReceiptText />}
-            codeStr={score?.analyzePrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'N/A — step not configured')}
+            codeStr={score?.analyzePrompt || (isCodeBased ? 'N/A — code-based scorer does not use prompts' : 'N/A — step not configured')}
             simplified={true}
           />
 
           <SideDialog.CodeSection
             title="Generate Score Prompt"
             icon={<ReceiptText />}
-            codeStr={score?.generateScorePrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'N/A — step not configured')}
+            codeStr={score?.generateScorePrompt || (isCodeBased ? 'N/A — code-based scorer does not use prompts' : 'N/A — step not configured')}
             simplified={true}
           />
 
           <SideDialog.CodeSection
             title="Generate Reason Prompt"
             icon={<ReceiptText />}
-            codeStr={score?.generateReasonPrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'N/A — step not configured')}
+            codeStr={score?.generateReasonPrompt || (isCodeBased ? 'N/A — code-based scorer does not use prompts' : 'N/A — step not configured')}
             simplified={true}
           />
         </Sections>

--- a/packages/playground-ui/src/domains/scores/components/score-dialog.tsx
+++ b/packages/playground-ui/src/domains/scores/components/score-dialog.tsx
@@ -17,6 +17,14 @@ import { useLinkComponent } from '@/lib/framework';
 import { Sections } from '@/index';
 import { format } from 'date-fns/format';
 
+function isCodeBasedScorer(score?: ScoreRowData): boolean {
+  const scorer = score?.scorer as Record<string, unknown> | undefined;
+  if (scorer?.hasJudge === false) return true;
+  if (scorer?.hasJudge === true) return false;
+  // Heuristic fallback for old data without hasJudge
+  return !score?.preprocessPrompt && !score?.analyzePrompt && !score?.generateScorePrompt && !score?.generateReasonPrompt;
+}
+
 type ScoreDialogProps = {
   score?: ScoreRowData;
   scorerName?: string;
@@ -138,7 +146,7 @@ export function ScoreDialog({
           <SideDialog.CodeSection
             title={`Score: ${Number.isNaN(score?.score) ? 'n/a' : score?.score}`}
             icon={<GaugeIcon />}
-            codeStr={score?.reason || 'null'}
+            codeStr={score?.reason || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not generate a reason' : 'null')}
             simplified={true}
           />
 
@@ -157,28 +165,28 @@ export function ScoreDialog({
           <SideDialog.CodeSection
             title="Preprocess Prompt"
             icon={<ReceiptText />}
-            codeStr={score?.preprocessPrompt || 'null'}
+            codeStr={score?.preprocessPrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'null')}
             simplified={true}
           />
 
           <SideDialog.CodeSection
             title="Analyze Prompt"
             icon={<ReceiptText />}
-            codeStr={score?.analyzePrompt || 'null'}
+            codeStr={score?.analyzePrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'null')}
             simplified={true}
           />
 
           <SideDialog.CodeSection
             title="Generate Score Prompt"
             icon={<ReceiptText />}
-            codeStr={score?.generateScorePrompt || 'null'}
+            codeStr={score?.generateScorePrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'null')}
             simplified={true}
           />
 
           <SideDialog.CodeSection
             title="Generate Reason Prompt"
             icon={<ReceiptText />}
-            codeStr={score?.generateReasonPrompt || 'null'}
+            codeStr={score?.generateReasonPrompt || (isCodeBasedScorer(score) ? 'N/A — code-based scorer does not use prompts' : 'null')}
             simplified={true}
           />
         </Sections>

--- a/packages/playground-ui/src/domains/scores/components/score-dialog.tsx
+++ b/packages/playground-ui/src/domains/scores/components/score-dialog.tsx
@@ -50,7 +50,7 @@ export function ScoreDialog({
   usageContext = 'scorerPage',
 }: ScoreDialogProps) {
   const { Link } = useLinkComponent();
-  const isCodeBased = isCodeBased;
+  const isCodeBased = isCodeBasedScorer(score);
 
   return (
     <SideDialog


### PR DESCRIPTION
## Description

Add `hasJudge` metadata to scorer records in all 4 save paths so the studio can distinguish code-based scorers from LLM-based ones. Score dialog now shows
 "N/A — code-based scorer does not use prompts" instead of "null" for fields like reason, preprocessPrompt, analyzePrompt, etc. Includes heuristic
fallback for older data without `hasJudge`.
## Before
<img width="2190" height="1198" alt="image" src="https://github.com/user-attachments/assets/9435b831-40d4-45b1-b1ce-c2363724504a" />
<img width="2190" height="1198" alt="image" src="https://github.com/user-attachments/assets/9435b831-40d4-45b1-b1ce-c2363724504a" />

## After
<img width="1214" height="202" alt="image" src="https://github.com/user-attachments/assets/418cab34-2f19-43f2-8b19-a887325d8147" />
<img width="1268" height="716" alt="image" src="https://github.com/user-attachments/assets/68cbda41-9958-42a0-bf84-bb80a199b7c1" />

## Related Issue(s)

Fixes #11769

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metadata to identify and differentiate code-based scorers from LLM-based scorers across all scoring and score-saving paths.

* **Improvements**
  * Score dialog now displays "N/A" with clear explanatory messages when code-based scorers don't use prompts or generate reasons, replacing nulls. A heuristic fallback handles older data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->