### PR TITLE
fix(schema-compat): coerce ZodNull instead of throwing for MCP tool schemas

### DIFF
--- a/.changeset/fix-zod-null-mcp.md
+++ b/.changeset/fix-zod-null-mcp.md
@@ -2,6 +2,6 @@
 "@mastra/schema-compat": patch
 ---
 
-fix(schema-compat): coerce ZodNull instead of throwing for MCP tool schemas
+Null types from MCP tool schemas no longer cause startup crashes.
 
-MCP servers using `{ "type": "null" }` in tool JSON Schemas no longer crash mastracode. ZodNull is now coerced to `z.any().optional()` across all provider compatibility layers.
+MCP servers that expose `{ "type": "null" }` in their tool JSON Schemas caused `@mastra/schema-compat` to throw on startup. These null types are now coerced to an optional schema so tools load correctly. Fixes [#13315](https://github.com/mastra-ai/mastra/issues/13315).

--- a/.changeset/fix-zod-null-mcp.md
+++ b/.changeset/fix-zod-null-mcp.md
@@ -1,0 +1,7 @@
+---
+"@mastra/schema-compat": patch
+---
+
+fix(schema-compat): coerce ZodNull instead of throwing for MCP tool schemas
+
+MCP servers using `{ "type": "null" }` in tool JSON Schemas no longer crash mastracode. ZodNull is now coerced to `z.any().optional()` across all provider compatibility layers.

--- a/packages/schema-compat/src/provider-compats/anthropic.test.ts
+++ b/packages/schema-compat/src/provider-compats/anthropic.test.ts
@@ -772,4 +772,55 @@ describe('AnthropicSchemaCompatLayer', () => {
       expect(jsonSchema).toMatchSnapshot();
     });
   });
+
+  describe('processZodType - ZodNull handling', () => {
+    it('should not throw on z.null() (MCP JSON Schema { "type": "null" })', () => {
+      const modelInfo: ModelInformation = {
+        provider: 'anthropic',
+        modelId: 'claude-3-5-sonnet',
+        supportsStructuredOutputs: false,
+      };
+
+      const layer = new AnthropicSchemaCompatLayer(modelInfo);
+
+      // z.null() should be coerced, not throw
+      expect(() => {
+        layer.processZodType(z.null());
+      }).not.toThrow();
+    });
+
+    it('should coerce z.null() to an optional type', () => {
+      const modelInfo: ModelInformation = {
+        provider: 'anthropic',
+        modelId: 'claude-3-5-sonnet',
+        supportsStructuredOutputs: false,
+      };
+
+      const layer = new AnthropicSchemaCompatLayer(modelInfo);
+      const result = layer.processZodType(z.null());
+
+      // The coerced type should accept undefined (optional)
+      expect(result.safeParse(undefined).success).toBe(true);
+    });
+
+    it('should handle z.null() inside an object schema', () => {
+      const modelInfo: ModelInformation = {
+        provider: 'anthropic',
+        modelId: 'claude-3-5-sonnet',
+        supportsStructuredOutputs: false,
+      };
+
+      const schema = z.object({
+        name: z.string(),
+        deletedAt: z.null(),
+      });
+
+      const layer = new AnthropicSchemaCompatLayer(modelInfo);
+
+      // Should not throw when processing the full schema
+      expect(() => {
+        layer.processToAISDKSchema(schema);
+      }).not.toThrow();
+    });
+  });
 });

--- a/packages/schema-compat/src/provider-compats/anthropic.test.ts
+++ b/packages/schema-compat/src/provider-compats/anthropic.test.ts
@@ -774,13 +774,13 @@ describe('AnthropicSchemaCompatLayer', () => {
   });
 
   describe('processZodType - ZodNull handling', () => {
-    it('should not throw on z.null() (MCP JSON Schema { "type": "null" })', () => {
-      const modelInfo: ModelInformation = {
-        provider: 'anthropic',
-        modelId: 'claude-3-5-sonnet',
-        supportsStructuredOutputs: false,
-      };
+    const modelInfo: ModelInformation = {
+      provider: 'anthropic',
+      modelId: 'claude-3-5-sonnet',
+      supportsStructuredOutputs: false,
+    };
 
+    it('should not throw on z.null() (MCP JSON Schema { "type": "null" })', () => {
       const layer = new AnthropicSchemaCompatLayer(modelInfo);
 
       // z.null() should be coerced, not throw
@@ -790,12 +790,6 @@ describe('AnthropicSchemaCompatLayer', () => {
     });
 
     it('should coerce z.null() to an optional type', () => {
-      const modelInfo: ModelInformation = {
-        provider: 'anthropic',
-        modelId: 'claude-3-5-sonnet',
-        supportsStructuredOutputs: false,
-      };
-
       const layer = new AnthropicSchemaCompatLayer(modelInfo);
       const result = layer.processZodType(z.null());
 
@@ -803,13 +797,21 @@ describe('AnthropicSchemaCompatLayer', () => {
       expect(result.safeParse(undefined).success).toBe(true);
     });
 
-    it('should handle z.null() inside an object schema', () => {
-      const modelInfo: ModelInformation = {
-        provider: 'anthropic',
-        modelId: 'claude-3-5-sonnet',
-        supportsStructuredOutputs: false,
-      };
+    it('should propagate custom description from z.null().describe()', () => {
+      const layer = new AnthropicSchemaCompatLayer(modelInfo);
+      const result = layer.processZodType(z.null().describe('custom description'));
 
+      expect(result.description).toBe('custom description');
+    });
+
+    it('should use fallback description for z.null() without description', () => {
+      const layer = new AnthropicSchemaCompatLayer(modelInfo);
+      const result = layer.processZodType(z.null());
+
+      expect(result.description).toBe('null value');
+    });
+
+    it('should handle z.null() inside an object schema', () => {
       const schema = z.object({
         name: z.string(),
         deletedAt: z.null(),

--- a/packages/schema-compat/src/provider-compats/anthropic.ts
+++ b/packages/schema-compat/src/provider-compats/anthropic.ts
@@ -1,4 +1,5 @@
 import type { JSONSchema7 } from 'json-schema';
+import { z } from 'zod';
 import type { Targets } from 'zod-to-json-schema';
 import { isArraySchema, isObjectSchema, isStringSchema, isUnionSchema } from '../json-schema/utils';
 import { SchemaCompatLayer } from '../schema-compatibility';
@@ -23,6 +24,13 @@ export class AnthropicSchemaCompatLayer extends SchemaCompatLayer {
       const handleTypes: string[] = ['ZodObject', 'ZodArray', 'ZodUnion', 'ZodNever', 'ZodUndefined', 'ZodTuple'];
       if (this.getModel().modelId.includes('claude-3.5-haiku')) handleTypes.push('ZodString');
       return this.defaultZodOptionalHandler(value, handleTypes);
+    } else if (this.isNull(value)) {
+      // Coerce z.null() (from MCP JSON Schema { "type": "null" }) to z.any().optional()
+      // so it doesn't crash the provider compat layer.
+      return z
+        .any()
+        .optional()
+        .describe(value.description ?? 'null value');
     } else if (this.isObj(value)) {
       return this.defaultZodObjectHandler(value);
     } else if (this.isArr(value)) {

--- a/packages/schema-compat/src/provider-compats/anthropic.ts
+++ b/packages/schema-compat/src/provider-compats/anthropic.ts
@@ -1,5 +1,4 @@
 import type { JSONSchema7 } from 'json-schema';
-import { z } from 'zod';
 import type { Targets } from 'zod-to-json-schema';
 import { isArraySchema, isObjectSchema, isStringSchema, isUnionSchema } from '../json-schema/utils';
 import { SchemaCompatLayer } from '../schema-compatibility';
@@ -25,12 +24,7 @@ export class AnthropicSchemaCompatLayer extends SchemaCompatLayer {
       if (this.getModel().modelId.includes('claude-3.5-haiku')) handleTypes.push('ZodString');
       return this.defaultZodOptionalHandler(value, handleTypes);
     } else if (this.isNull(value)) {
-      // Coerce z.null() (from MCP JSON Schema { "type": "null" }) to z.any().optional()
-      // so it doesn't crash the provider compat layer.
-      return z
-        .any()
-        .optional()
-        .describe(value.description ?? 'null value');
+      return this.defaultZodNullHandler(value);
     } else if (this.isObj(value)) {
       return this.defaultZodObjectHandler(value);
     } else if (this.isArr(value)) {

--- a/packages/schema-compat/src/provider-compats/deepseek.ts
+++ b/packages/schema-compat/src/provider-compats/deepseek.ts
@@ -6,7 +6,7 @@ import type { Targets } from 'zod-to-json-schema';
 import { isArraySchema, isObjectSchema, isStringSchema, isUnionSchema } from '../json-schema/utils';
 import { SchemaCompatLayer } from '../schema-compatibility';
 import type { ModelInformation } from '../types';
-import { isOptional, isObj, isArr, isUnion, isString } from '../zodTypes';
+import { isOptional, isNull, isObj, isArr, isUnion, isString } from '../zodTypes';
 
 export class DeepSeekSchemaCompatLayer extends SchemaCompatLayer {
   constructor(model: ModelInformation) {
@@ -27,6 +27,11 @@ export class DeepSeekSchemaCompatLayer extends SchemaCompatLayer {
   processZodType(value: ZodTypeV3 | ZodTypeV4): ZodTypeV3 | ZodTypeV4 {
     if (isOptional(z)(value)) {
       return this.defaultZodOptionalHandler(value, ['ZodObject', 'ZodArray', 'ZodUnion', 'ZodString', 'ZodNumber']);
+    } else if (isNull(z)(value)) {
+      return z
+        .any()
+        .optional()
+        .describe(value.description ?? 'null value');
     } else if (isObj(z)(value)) {
       return this.defaultZodObjectHandler(value);
     } else if (isArr(z)(value)) {

--- a/packages/schema-compat/src/provider-compats/deepseek.ts
+++ b/packages/schema-compat/src/provider-compats/deepseek.ts
@@ -28,10 +28,7 @@ export class DeepSeekSchemaCompatLayer extends SchemaCompatLayer {
     if (isOptional(z)(value)) {
       return this.defaultZodOptionalHandler(value, ['ZodObject', 'ZodArray', 'ZodUnion', 'ZodString', 'ZodNumber']);
     } else if (isNull(z)(value)) {
-      return z
-        .any()
-        .optional()
-        .describe(value.description ?? 'null value');
+      return this.defaultZodNullHandler(value);
     } else if (isObj(z)(value)) {
       return this.defaultZodObjectHandler(value);
     } else if (isArr(z)(value)) {

--- a/packages/schema-compat/src/provider-compats/meta.ts
+++ b/packages/schema-compat/src/provider-compats/meta.ts
@@ -27,10 +27,7 @@ export class MetaSchemaCompatLayer extends SchemaCompatLayer {
     if (isOptional(z)(value)) {
       return this.defaultZodOptionalHandler(value, ['ZodObject', 'ZodArray', 'ZodUnion', 'ZodString', 'ZodNumber']);
     } else if (isNull(z)(value)) {
-      return z
-        .any()
-        .optional()
-        .describe(value.description ?? 'null value');
+      return this.defaultZodNullHandler(value);
     } else if (isObj(z)(value)) {
       return this.defaultZodObjectHandler(value);
     } else if (isArr(z)(value)) {

--- a/packages/schema-compat/src/provider-compats/meta.ts
+++ b/packages/schema-compat/src/provider-compats/meta.ts
@@ -6,7 +6,7 @@ import type { Targets } from 'zod-to-json-schema';
 import { isArraySchema, isNumberSchema, isObjectSchema, isStringSchema, isUnionSchema } from '../json-schema/utils';
 import { SchemaCompatLayer } from '../schema-compatibility';
 import type { ModelInformation } from '../types';
-import { isOptional, isObj, isArr, isUnion, isNumber, isString } from '../zodTypes';
+import { isOptional, isNull, isObj, isArr, isUnion, isNumber, isString } from '../zodTypes';
 
 export class MetaSchemaCompatLayer extends SchemaCompatLayer {
   constructor(model: ModelInformation) {
@@ -26,6 +26,11 @@ export class MetaSchemaCompatLayer extends SchemaCompatLayer {
   processZodType(value: ZodTypeV3 | ZodTypeV4): ZodTypeV3 | ZodTypeV4 {
     if (isOptional(z)(value)) {
       return this.defaultZodOptionalHandler(value, ['ZodObject', 'ZodArray', 'ZodUnion', 'ZodString', 'ZodNumber']);
+    } else if (isNull(z)(value)) {
+      return z
+        .any()
+        .optional()
+        .describe(value.description ?? 'null value');
     } else if (isObj(z)(value)) {
       return this.defaultZodObjectHandler(value);
     } else if (isArr(z)(value)) {

--- a/packages/schema-compat/src/provider-compats/openai-reasoning.ts
+++ b/packages/schema-compat/src/provider-compats/openai-reasoning.ts
@@ -86,6 +86,8 @@ export class OpenAIReasoningSchemaCompatLayer extends SchemaCompatLayer {
         return processedInner.nullable();
       }
       return value;
+    } else if (isNull(z)(value)) {
+      return this.defaultZodNullHandler(value);
     } else if (isObj(z)(value)) {
       return this.defaultZodObjectHandler(value, { passthrough: false });
     } else if (isArr(z)(value)) {
@@ -111,11 +113,6 @@ export class OpenAIReasoningSchemaCompatLayer extends SchemaCompatLayer {
       return result;
     } else if (isNumber(z)(value)) {
       return this.defaultZodNumberHandler(value);
-    } else if (isNull(z)(value)) {
-      return z
-        .any()
-        .optional()
-        .describe(value.description ?? 'null value');
     } else if (isString(z)(value)) {
       return this.defaultZodStringHandler(value);
     } else if (isDate(z)(value)) {

--- a/packages/schema-compat/src/provider-compats/openai-reasoning.ts
+++ b/packages/schema-compat/src/provider-compats/openai-reasoning.ts
@@ -7,7 +7,18 @@ import { isArraySchema, isNumberSchema, isObjectSchema, isStringSchema, isUnionS
 import { SchemaCompatLayer } from '../schema-compatibility';
 import type { ZodType } from '../schema.types';
 import type { ModelInformation } from '../types';
-import { isOptional, isObj, isArr, isUnion, isDefault, isNumber, isString, isDate, isNullable } from '../zodTypes';
+import {
+  isOptional,
+  isNull,
+  isObj,
+  isArr,
+  isUnion,
+  isDefault,
+  isNumber,
+  isString,
+  isDate,
+  isNullable,
+} from '../zodTypes';
 
 export class OpenAIReasoningSchemaCompatLayer extends SchemaCompatLayer {
   constructor(model: ModelInformation) {
@@ -100,6 +111,11 @@ export class OpenAIReasoningSchemaCompatLayer extends SchemaCompatLayer {
       return result;
     } else if (isNumber(z)(value)) {
       return this.defaultZodNumberHandler(value);
+    } else if (isNull(z)(value)) {
+      return z
+        .any()
+        .optional()
+        .describe(value.description ?? 'null value');
     } else if (isString(z)(value)) {
       return this.defaultZodStringHandler(value);
     } else if (isDate(z)(value)) {

--- a/packages/schema-compat/src/provider-compats/openai.ts
+++ b/packages/schema-compat/src/provider-compats/openai.ts
@@ -7,7 +7,7 @@ import { isArraySchema, isObjectSchema, isStringSchema, isUnionSchema } from '..
 import { SchemaCompatLayer } from '../schema-compatibility';
 import type { ZodType } from '../schema.types';
 import type { ModelInformation } from '../types';
-import { isOptional, isObj, isUnion, isArr, isString, isNullable, isDefault } from '../zodTypes';
+import { isOptional, isNull, isObj, isUnion, isArr, isString, isNullable, isDefault } from '../zodTypes';
 
 export class OpenAISchemaCompatLayer extends SchemaCompatLayer {
   constructor(model: ModelInformation) {
@@ -91,6 +91,11 @@ export class OpenAISchemaCompatLayer extends SchemaCompatLayer {
       }
 
       return value;
+    } else if (isNull(z)(value)) {
+      return z
+        .any()
+        .optional()
+        .describe(value.description ?? 'null value');
     } else if (isObj(z)(value)) {
       return this.defaultZodObjectHandler(value);
     } else if (isUnion(z)(value)) {

--- a/packages/schema-compat/src/provider-compats/openai.ts
+++ b/packages/schema-compat/src/provider-compats/openai.ts
@@ -92,10 +92,7 @@ export class OpenAISchemaCompatLayer extends SchemaCompatLayer {
 
       return value;
     } else if (isNull(z)(value)) {
-      return z
-        .any()
-        .optional()
-        .describe(value.description ?? 'null value');
+      return this.defaultZodNullHandler(value);
     } else if (isObj(z)(value)) {
       return this.defaultZodObjectHandler(value);
     } else if (isUnion(z)(value)) {

--- a/packages/schema-compat/src/schema-compatibility-v3.ts
+++ b/packages/schema-compat/src/schema-compatibility-v3.ts
@@ -71,6 +71,7 @@ export const SUPPORTED_ZOD_TYPES = [
   'ZodAny',
   'ZodDefault',
   'ZodNullable',
+  'ZodNull',
 ] as const;
 
 /**

--- a/packages/schema-compat/src/schema-compatibility-v3.ts
+++ b/packages/schema-compat/src/schema-compatibility-v3.ts
@@ -55,7 +55,7 @@ export const isDefault = (v: ZodTypeAny): v is ZodDefault<any> => v instanceof Z
  * Zod types that are not supported by most AI model providers and should be avoided.
  * @constant
  */
-export const UNSUPPORTED_ZOD_TYPES = ['ZodIntersection', 'ZodNever', 'ZodNull', 'ZodTuple', 'ZodUndefined'] as const;
+export const UNSUPPORTED_ZOD_TYPES = ['ZodIntersection', 'ZodNever', 'ZodTuple', 'ZodUndefined'] as const;
 
 /**
  * Zod types that are generally supported by AI model providers.

--- a/packages/schema-compat/src/schema-compatibility-v4.ts
+++ b/packages/schema-compat/src/schema-compatibility-v4.ts
@@ -66,6 +66,7 @@ export const SUPPORTED_ZOD_TYPES = [
   'ZodAny',
   'ZodDefault',
   'ZodNullable',
+  'ZodNull',
 ] as const;
 
 /**

--- a/packages/schema-compat/src/schema-compatibility-v4.ts
+++ b/packages/schema-compat/src/schema-compatibility-v4.ts
@@ -50,7 +50,7 @@ export const ALL_ARRAY_CHECKS = ['min', 'max', 'length'] as const;
  * Zod types that are not supported by most AI model providers and should be avoided.
  * @constant
  */
-export const UNSUPPORTED_ZOD_TYPES = ['ZodIntersection', 'ZodNever', 'ZodNull', 'ZodTuple', 'ZodUndefined'] as const;
+export const UNSUPPORTED_ZOD_TYPES = ['ZodIntersection', 'ZodNever', 'ZodTuple', 'ZodUndefined'] as const;
 
 /**
  * Zod types that are generally supported by AI model providers.

--- a/packages/schema-compat/src/schema-compatibility.ts
+++ b/packages/schema-compat/src/schema-compatibility.ts
@@ -1,5 +1,6 @@
 import type { StandardJSONSchemaV1 } from '@standard-schema/spec';
 import traverse from 'json-schema-traverse';
+import { z } from 'zod';
 import type { z as zV3 } from 'zod/v3';
 import type { z as zV4 } from 'zod/v4';
 import type { Targets } from 'zod-to-json-schema';
@@ -246,6 +247,17 @@ export abstract class SchemaCompatLayer {
     } else {
       return this.v3Layer.defaultZodDateHandler(value);
     }
+  }
+
+  /**
+   * Default handler for ZodNull types. Coerces z.null() to z.any().optional()
+   * so that MCP tool schemas using { "type": "null" } don't crash provider compats.
+   */
+  public defaultZodNullHandler(value: zV3.ZodNull | zV4.ZodNull): zV3.ZodType | zV4.ZodType {
+    return z
+      .any()
+      .optional()
+      .describe(value.description ?? 'null value');
   }
 
   public defaultZodOptionalHandler(

--- a/packages/schema-compat/src/zodTypes.ts
+++ b/packages/schema-compat/src/zodTypes.ts
@@ -27,7 +27,7 @@ export const ALL_ARRAY_CHECKS = ['min', 'max', 'length'] as const;
  * Zod types that are not supported by most AI model providers and should be avoided.
  * @constant
  */
-export const UNSUPPORTED_ZOD_TYPES = ['ZodIntersection', 'ZodNever', 'ZodNull', 'ZodTuple', 'ZodUndefined'] as const;
+export const UNSUPPORTED_ZOD_TYPES = ['ZodIntersection', 'ZodNever', 'ZodTuple', 'ZodUndefined'] as const;
 
 /**
  * Zod types that are generally supported by AI model providers.

--- a/packages/schema-compat/src/zodTypes.ts
+++ b/packages/schema-compat/src/zodTypes.ts
@@ -43,6 +43,7 @@ export const SUPPORTED_ZOD_TYPES = [
   'ZodAny',
   'ZodDefault',
   'ZodNullable',
+  'ZodNull',
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

MCP servers that use `{ "type": "null" }` in their tool JSON Schemas crash mastracode on startup:

```
Error: claude-opus-4-6 does not support zod type: ZodNull
```

## Root Cause

`@mastra/schema-compat` lists `ZodNull` in `UNSUPPORTED_ZOD_TYPES` and throws unconditionally in `defaultUnsupportedZodTypeHandler`. When `@mastra/mcp` converts MCP tool JSON Schemas to Zod, `{ "type": "null" }` becomes `z.null()`, which hits this error in Anthropic, DeepSeek, Meta, and OpenAI Reasoning provider compats.

`{ "type": "null" }` is valid JSON Schema (draft-07 §6.1). MCP servers using it (e.g. `chrome-devtools-mcp`) should not crash the client.

## Fix

- Remove `ZodNull` from `UNSUPPORTED_ZOD_TYPES` in v3, v4, and `zodTypes.ts`
- Add explicit `isNull` handler in all provider compats (Anthropic, OpenAI, OpenAI Reasoning, DeepSeek, Meta) that coerces `z.null()` → `z.any().optional()` instead of throwing
  - Google already had a `ZodNull` handler
- Add tests for ZodNull handling in Anthropic compat

## Testing

- Added 3 test cases in `anthropic.test.ts`:
  - `z.null()` does not throw
  - `z.null()` coerces to an optional type
  - `z.null()` inside an object schema works with `processToAISDKSchema`

Fixes #13315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes when tool schemas contain null types by gracefully coercing them to optional types instead of throwing errors.

* **Tests**
  * Added test coverage for null type handling across all provider compatibility layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->