### PR TITLE
 feat(harness): add getObservationalMemoryRecord() public method

### DIFF
--- a/.changeset/harness-expose-om-record.md
+++ b/.changeset/harness-expose-om-record.md
@@ -2,7 +2,9 @@
 "@mastra/core": minor
 ---
 
-Added `getObservationalMemoryRecord()` method to the `Harness` class. This provides public access to the full `ObservationalMemoryRecord` for the current thread, including `activeObservations`, `generationCount`, and `observationTokenCount`. Previously, accessing raw observation text required bypassing the Harness abstraction by reaching into private storage internals.
+Added `getObservationalMemoryRecord()` method to the `Harness` class. Fixes #13392.
+
+This provides public access to the full `ObservationalMemoryRecord` for the current thread, including `activeObservations`, `generationCount`, and `observationTokenCount`. Previously, accessing raw observation text required bypassing the Harness abstraction by reaching into private storage internals.
 
 ```typescript
 const record = await harness.getObservationalMemoryRecord();

--- a/.changeset/harness-expose-om-record.md
+++ b/.changeset/harness-expose-om-record.md
@@ -1,0 +1,12 @@
+---
+"@mastra/core": minor
+---
+
+Added `getObservationalMemoryRecord()` method to the `Harness` class. This provides public access to the full `ObservationalMemoryRecord` for the current thread, including `activeObservations`, `generationCount`, and `observationTokenCount`. Previously, accessing raw observation text required bypassing the Harness abstraction by reaching into private storage internals.
+
+```typescript
+const record = await harness.getObservationalMemoryRecord();
+if (record) {
+  console.log(record.activeObservations);
+}
+```

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -639,6 +639,20 @@ Load observational memory records for the current thread and emit an `om_status`
 await harness.loadOMProgress();
 ```
 
+#### `getObservationalMemoryRecord()`
+
+Return the full `ObservationalMemoryRecord` for the current thread and resource, or `null` if no thread is selected or no record exists.
+
+```typescript
+const record = await harness.getObservationalMemoryRecord();
+
+if (record) {
+  console.log(record.activeObservations);
+  console.log(record.generationCount);
+  console.log(record.observationTokenCount);
+}
+```
+
 #### `getObserverModelId()`
 
 Return the observer model ID from state or the default from `omConfig`.

--- a/packages/core/src/harness/get-om-record.test.ts
+++ b/packages/core/src/harness/get-om-record.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+
+function createHarness(storage: InMemoryStore) {
+  const agent = new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+
+  return new Harness({
+    id: 'test-harness',
+    storage,
+    modes: [{ id: 'default', name: 'Default', default: true, agent }],
+  });
+}
+
+async function seedObservationalMemory(
+  storage: InMemoryStore,
+  threadId: string,
+  resourceId: string,
+  observations: string,
+) {
+  const memoryStorage = (await storage.getStore('memory'))!;
+  const record = await memoryStorage.initializeObservationalMemory({
+    threadId,
+    resourceId,
+    scope: 'thread',
+    config: {},
+  });
+  if (observations) {
+    await memoryStorage.updateActiveObservations({
+      id: record.id,
+      observations,
+      tokenCount: observations.length,
+      lastObservedAt: new Date(),
+    });
+  }
+  return record;
+}
+
+describe('Harness.getObservationalMemoryRecord', () => {
+  let storage: InMemoryStore;
+  let harness: ReturnType<typeof createHarness>;
+
+  beforeEach(async () => {
+    storage = new InMemoryStore();
+    harness = createHarness(storage);
+    await harness.init();
+  });
+
+  it('returns null when no thread is selected', async () => {
+    const record = await harness.getObservationalMemoryRecord();
+    expect(record).toBeNull();
+  });
+
+  it('returns null when no OM record exists for the thread', async () => {
+    await harness.createThread();
+    const record = await harness.getObservationalMemoryRecord();
+    expect(record).toBeNull();
+  });
+
+  it('returns the OM record with activeObservations when one exists', async () => {
+    const thread = await harness.createThread();
+    const resourceId = harness.getResourceId();
+    const observationText = '- User prefers dark mode\n- User is building a web UI';
+
+    await seedObservationalMemory(storage, thread.id, resourceId, observationText);
+
+    const record = await harness.getObservationalMemoryRecord();
+    expect(record).not.toBeNull();
+    expect(record!.activeObservations).toBe(observationText);
+    expect(record!.threadId).toBe(thread.id);
+    expect(record!.resourceId).toBe(resourceId);
+    expect(record!.generationCount).toBe(0);
+  });
+
+  it('returns record for the current thread after switching threads', async () => {
+    const threadA = await harness.createThread();
+    const threadB = await harness.createThread();
+    const resourceId = harness.getResourceId();
+
+    await seedObservationalMemory(storage, threadA.id, resourceId, 'Thread A observations');
+    await seedObservationalMemory(storage, threadB.id, resourceId, 'Thread B observations');
+
+    // Currently on thread B
+    let record = await harness.getObservationalMemoryRecord();
+    expect(record!.activeObservations).toBe('Thread B observations');
+
+    // Switch to thread A
+    await harness.switchThread({ threadId: threadA.id });
+    record = await harness.getObservationalMemoryRecord();
+    expect(record!.activeObservations).toBe('Thread A observations');
+  });
+});

--- a/packages/core/src/harness/get-om-record.test.ts
+++ b/packages/core/src/harness/get-om-record.test.ts
@@ -87,11 +87,13 @@ describe('Harness.getObservationalMemoryRecord', () => {
 
     // Currently on thread B
     let record = await harness.getObservationalMemoryRecord();
+    expect(record).not.toBeNull();
     expect(record!.activeObservations).toBe('Thread B observations');
 
     // Switch to thread A
     await harness.switchThread({ threadId: threadA.id });
     record = await harness.getObservationalMemoryRecord();
+    expect(record).not.toBeNull();
     expect(record!.activeObservations).toBe('Thread A observations');
   });
 });

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -5,6 +5,7 @@ import type { ToolsInput, ToolsetsInput } from '../agent/types';
 import type { StorageThreadType } from '../memory/types';
 import { RequestContext } from '../request-context';
 import type { MemoryStorage } from '../storage/domains/memory/base';
+import type { ObservationalMemoryRecord } from '../storage/types';
 import { Workspace } from '../workspace/workspace';
 import type { WorkspaceConfig } from '../workspace/workspace';
 
@@ -859,6 +860,17 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
       });
     } catch {
       // OM not available or not initialized — that's fine
+    }
+  }
+
+  async getObservationalMemoryRecord(): Promise<ObservationalMemoryRecord | null> {
+    if (!this.currentThreadId) return null;
+
+    try {
+      const memoryStorage = await this.getMemoryStorage();
+      return await memoryStorage.getObservationalMemory(this.currentThreadId, this.resourceId);
+    } catch {
+      return null;
     }
   }
 


### PR DESCRIPTION
## Description

Added `getObservationalMemoryRecord()` public method to the `Harness` class. This returns the full `ObservationalMemoryRecord` for the current thread, giving UIs direct
 access to `activeObservations` text, `generationCount`, and `observationTokenCount` without bypassing Harness encapsulation.

Previously, `getMemoryStorage()` was private so there was no public way to retrieve raw observation text. The `om_status` event only provides token counts and
thresholds. Consumers had to export storage instances separately and call `storage.getStore('memory').getObservationalMemory()` directly.

## Related Issue(s)

Fixes #13392

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API to retrieve the observational memory record for the current thread, including active observations and generation info.

* **Documentation**
  * Added docs and usage examples for the new observational memory access method.

* **Tests**
  * Added tests covering retrieval, thread switching, and empty/no-thread scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->