### PR TITLE
chore(repo): Improve changeset CLI

### DIFF
--- a/.claude/commands/changeset.md
+++ b/.claude/commands/changeset.md
@@ -1,6 +1,6 @@
 # Changeset
 
-Create a changeset using the CLI. The CLI will automatically detect changed packages and create the changeset file.
+Create a changeset using the CLI. The goal of changesets are to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ## CLI Usage
 
@@ -41,4 +41,4 @@ pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--p
 
 If the changes span multiple packages (e.g. `@mastra/core`, `@mastra/memory`, `mastra`, so 3 packages) and each change is different from another, you MUST create multiple changeset files. Otherwise you'll mix different changes into changeset files where they don't belong. For this you must decide what logical groups exist. Example: The majority of the main feature was changed in `@mastra/memory` and only supporting changes were done in `@mastra/core` and `mastra`. Then `@mastra/memory` needs its own changeset separate from the others. You can achieve this by running the CLI multiple times and selecting the appropriate packages for each changeset.
 
-**Important:** Very long changesets in one file (with multiple packages in the frontmatter) are an anti-pattern. This will lead to multiple packages having really large changelog entries. This must be avoided.
+**Important:** Very long changesets in one file (with multiple packages in the frontmatter) are an anti-pattern. This will lead to multiple packages having really large changelog entries. This must be avoided. If you have multiple packages likely there is one or two main packages where the majority of change lives.

--- a/.claude/commands/changeset.md
+++ b/.claude/commands/changeset.md
@@ -7,7 +7,7 @@ Create a changeset using the CLI. The goal of changesets is to use it for genera
 Run the CLI with the following command to create a changeset:
 
 ```bash
-pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) `@scope/pkg
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) @scope/pkg
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.

--- a/.claude/commands/changeset.md
+++ b/.claude/commands/changeset.md
@@ -7,22 +7,22 @@ Create a changeset using the CLI. The goal of changesets is to use it for genera
 Run the CLI with the following command to create a changeset:
 
 ```bash
-pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg1] [--patch pkg1]
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) `@scope/pkg
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
 
 **Arguments:**
 
-- `-s` or `--skipPrompt`: Run non-interactively (required for automation)
+- `-s` or `--skipPrompt`: Run non-interactively; requires at least one of `--major`, `--minor`, or `--patch` (required for automation)
 - `-m "message"` or `--message "message"`: The changeset message (required)
 - `--major @scope/pkg`: Packages that should have a major version bump
 - `--minor @scope/pkg`: Packages that should have a minor version bump
-- `--patch @scope/pkg`: Packages that should have a patch version bump (default for detected changes)
+- `--patch @scope/pkg`: Packages that should have a patch version bump
 
 **Notes:**
 
-- You can override the bump type by specifying `--major` or `--minor` for specific packages
+- The bump type must be specified explicitly for each package; use `--major` or `--minor` for non-patch bumps
 - Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor mastra`
 
 ## Version Bump Types

--- a/.claude/commands/changeset.md
+++ b/.claude/commands/changeset.md
@@ -4,29 +4,32 @@ Create a changeset using the CLI. The goal of changesets are to use it for gener
 
 ## CLI Usage
 
+Run the CLI with the following command to create a changeset:
+
 ```bash
-pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--patch pkg3]
+pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg1] [--patch pkg1]
 ```
+
+For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
 
 **Arguments:**
 
-- `-s` or `--skipPrompt` - Run non-interactively (required for automation)
-- `-m "message"` or `--message "message"` - The changeset message (required)
-- `--major @scope/pkg` - Packages that should have a major version bump
-- `--minor @scope/pkg` - Packages that should have a minor version bump
-- `--patch @scope/pkg` - Packages that should have a patch version bump (default for detected changes)
+- `-s` or `--skipPrompt`: Run non-interactively (required for automation)
+- `-m "message"` or `--message "message"`: The changeset message (required)
+- `--major @scope/pkg`: Packages that should have a major version bump
+- `--minor @scope/pkg`: Packages that should have a minor version bump
+- `--patch @scope/pkg`: Packages that should have a patch version bump (default for detected changes)
 
 **Notes:**
 
-- The CLI auto-detects changed packages from git and defaults them to `patch` bumps
 - You can override the bump type by specifying `--major` or `--minor` for specific packages
 - Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor mastra`
 
 ## Version Bump Types
 
-- `patch` - Bugfixes with backward-compatible changes
-- `minor` - New features with backward-compatible changes
-- `major` - Breaking changes that are not backward-compatible
+- `patch`: Bugfixes with backward-compatible changes
+- `minor`: New features with backward-compatible changes
+- `major`: Breaking changes that are not backward-compatible
 
 ## Message Guidelines
 

--- a/.claude/commands/changeset.md
+++ b/.claude/commands/changeset.md
@@ -1,6 +1,6 @@
 # Changeset
 
-Create a changeset using the CLI. The goal of changesets are to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
+Create a changeset using the CLI. The goal of changesets is to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ## CLI Usage
 

--- a/.claude/commands/changeset.md
+++ b/.claude/commands/changeset.md
@@ -7,7 +7,7 @@ Create a changeset using the CLI. The goal of changesets is to use it for genera
 Run the CLI with the following command to create a changeset:
 
 ```bash
-pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) @scope/pkg
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) pkg-name
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
@@ -16,9 +16,9 @@ For each package that has changes, run the CLI once and specify the appropriate 
 
 - `-s` or `--skipPrompt`: Run non-interactively; requires at least one of `--major`, `--minor`, or `--patch` (required for automation)
 - `-m "message"` or `--message "message"`: The changeset message (required)
-- `--major @scope/pkg`: Packages that should have a major version bump
-- `--minor @scope/pkg`: Packages that should have a minor version bump
-- `--patch @scope/pkg`: Packages that should have a patch version bump
+- `--major pkg-name`: Packages that should have a major version bump
+- `--minor pkg-name`: Packages that should have a minor version bump
+- `--patch pkg-name`: Packages that should have a patch version bump
 
 **Notes:**
 

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -4,7 +4,7 @@ The user will issue this command. You will need to do two things.
 
 ## Create a changeset using the CLI
 
-Create a changeset using the CLI. The CLI will automatically detect changed packages and create the changeset file.
+Create a changeset using the CLI. The goal of changesets are to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
 pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--patch pkg3]
@@ -37,7 +37,7 @@ pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--p
 
 If the changes span multiple packages (e.g. `@mastra/core`, `@mastra/memory`, `mastra`, so 3 packages) and each change is different from another, you MUST create multiple changeset files. Otherwise you'll mix different changes into changeset files where they don't belong. For this you must decide what logical groups exist. Example: The majority of the main feature was changed in `@mastra/memory` and only supporting changes were done in `@mastra/core` and `mastra`. Then `@mastra/memory` needs its own changeset separate from the others. You can achieve this by running the CLI multiple times and selecting the appropriate packages for each changeset.
 
-**Important:** Very long changesets in one file (with multiple packages in the frontmatter) are an anti-pattern. This will lead to multiple packages having really large changelog entries. This must be avoided.
+**Important:** Very long changesets in one file (with multiple packages in the frontmatter) are an anti-pattern. This will lead to multiple packages having really large changelog entries. This must be avoided. If you have multiple packages likely there is one or two main packages where the majority of change lives.
 
 ## Open a PR using the GitHub CLI
 

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -25,7 +25,7 @@ For each package that has changes, run the CLI once and specify the appropriate 
 - You can override the bump type by specifying `--major` or `--minor` for specific packages
 - Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor mastra`
 
-## Version Bump Types
+**Version Bump Types:**
 
 - `patch`: Bugfixes with backward-compatible changes
 - `minor`: New features with backward-compatible changes

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -7,22 +7,29 @@ The user will issue this command. You will need to do two things.
 Create a changeset using the CLI. The goal of changesets are to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
-pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--patch pkg3]
+pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg1] [--patch pkg1]
 ```
+
+For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
 
 **Arguments:**
 
-- `-s` or `--skipPrompt` - Run non-interactively (required for automation)
-- `-m "message"` or `--message "message"` - The changeset message (required)
-- `--major @scope/pkg` - Packages that should have a major version bump
-- `--minor @scope/pkg` - Packages that should have a minor version bump
-- `--patch @scope/pkg` - Packages that should have a patch version bump (default for detected changes)
+- `-s` or `--skipPrompt`: Run non-interactively (required for automation)
+- `-m "message"` or `--message "message"`: The changeset message (required)
+- `--major @scope/pkg`: Packages that should have a major version bump
+- `--minor @scope/pkg`: Packages that should have a minor version bump
+- `--patch @scope/pkg`: Packages that should have a patch version bump (default for detected changes)
 
-**Version bump types:**
+**Notes:**
 
-- `patch` - Bugfixes with backward-compatible changes
-- `minor` - New features with backward-compatible changes
-- `major` - Breaking changes that are not backward-compatible
+- You can override the bump type by specifying `--major` or `--minor` for specific packages
+- Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor mastra`
+
+## Version Bump Types
+
+- `patch`: Bugfixes with backward-compatible changes
+- `minor`: New features with backward-compatible changes
+- `major`: Breaking changes that are not backward-compatible
 
 **Message guidelines:**
 

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -7,22 +7,22 @@ The user will issue this command. You will need to do two things.
 Create a changeset using the CLI. The goal of changesets is to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
-pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg1] [--patch pkg1]
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) `@scope/pkg
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
 
 **Arguments:**
 
-- `-s` or `--skipPrompt`: Run non-interactively (required for automation)
+- `-s` or `--skipPrompt`: Run non-interactively; requires at least one of `--major`, `--minor`, or `--patch` (required for automation)
 - `-m "message"` or `--message "message"`: The changeset message (required)
 - `--major @scope/pkg`: Packages that should have a major version bump
 - `--minor @scope/pkg`: Packages that should have a minor version bump
-- `--patch @scope/pkg`: Packages that should have a patch version bump (default for detected changes)
+- `--patch @scope/pkg`: Packages that should have a patch version bump
 
 **Notes:**
 
-- You can override the bump type by specifying `--major` or `--minor` for specific packages
+- The bump type must be specified explicitly for each package; use `--major` or `--minor` for non-patch bumps
 - Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor mastra`
 
 **Version Bump Types:**

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -4,7 +4,7 @@ The user will issue this command. You will need to do two things.
 
 ## Create a changeset using the CLI
 
-Create a changeset using the CLI. The goal of changesets are to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
+Create a changeset using the CLI. The goal of changesets is to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
 pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg1] [--patch pkg1]

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -7,7 +7,7 @@ The user will issue this command. You will need to do two things.
 Create a changeset using the CLI. The goal of changesets is to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
-pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) @scope/pkg
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) pkg-name
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
@@ -16,9 +16,9 @@ For each package that has changes, run the CLI once and specify the appropriate 
 
 - `-s` or `--skipPrompt`: Run non-interactively; requires at least one of `--major`, `--minor`, or `--patch` (required for automation)
 - `-m "message"` or `--message "message"`: The changeset message (required)
-- `--major @scope/pkg`: Packages that should have a major version bump
-- `--minor @scope/pkg`: Packages that should have a minor version bump
-- `--patch @scope/pkg`: Packages that should have a patch version bump
+- `--major pkg-name`: Packages that should have a major version bump
+- `--minor pkg-name`: Packages that should have a minor version bump
+- `--patch pkg-name`: Packages that should have a patch version bump
 
 **Notes:**
 

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -7,7 +7,7 @@ The user will issue this command. You will need to do two things.
 Create a changeset using the CLI. The goal of changesets is to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
-pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) `@scope/pkg
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) @scope/pkg
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.

--- a/.cursor/commands/changeset.md
+++ b/.cursor/commands/changeset.md
@@ -1,6 +1,6 @@
 # Changeset
 
-Create a changeset using the CLI. The CLI will automatically detect changed packages and create the changeset file.
+Create a changeset using the CLI. The goal of changesets are to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ## CLI Usage
 
@@ -41,4 +41,4 @@ pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--p
 
 If the changes span multiple packages (e.g. `@mastra/core`, `@mastra/memory`, `mastra`, so 3 packages) and each change is different from another, you MUST create multiple changeset files. Otherwise you'll mix different changes into changeset files where they don't belong. For this you must decide what logical groups exist. Example: The majority of the main feature was changed in `@mastra/memory` and only supporting changes were done in `@mastra/core` and `mastra`. Then `@mastra/memory` needs its own changeset separate from the others. You can achieve this by running the CLI multiple times and selecting the appropriate packages for each changeset.
 
-**Important:** Very long changesets in one file (with multiple packages in the frontmatter) are an anti-pattern. This will lead to multiple packages having really large changelog entries. This must be avoided.
+**Important:** Very long changesets in one file (with multiple packages in the frontmatter) are an anti-pattern. This will lead to multiple packages having really large changelog entries. This must be avoided. If you have multiple packages likely there is one or two main packages where the majority of change lives.

--- a/.cursor/commands/changeset.md
+++ b/.cursor/commands/changeset.md
@@ -7,7 +7,7 @@ Create a changeset using the CLI. The goal of changesets is to use it for genera
 Run the CLI with the following command to create a changeset:
 
 ```bash
-pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) `@scope/pkg
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) @scope/pkg
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.

--- a/.cursor/commands/changeset.md
+++ b/.cursor/commands/changeset.md
@@ -7,22 +7,22 @@ Create a changeset using the CLI. The goal of changesets is to use it for genera
 Run the CLI with the following command to create a changeset:
 
 ```bash
-pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg1] [--patch pkg1]
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) `@scope/pkg
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
 
 **Arguments:**
 
-- `-s` or `--skipPrompt`: Run non-interactively (required for automation)
+- `-s` or `--skipPrompt`: Run non-interactively; requires at least one of `--major`, `--minor`, or `--patch` (required for automation)
 - `-m "message"` or `--message "message"`: The changeset message (required)
 - `--major @scope/pkg`: Packages that should have a major version bump
 - `--minor @scope/pkg`: Packages that should have a minor version bump
-- `--patch @scope/pkg`: Packages that should have a patch version bump (default for detected changes)
+- `--patch @scope/pkg`: Packages that should have a patch version bump
 
 **Notes:**
 
-- You can override the bump type by specifying `--major` or `--minor` for specific packages
+- The bump type must be specified explicitly for each package; use `--major` or `--minor` for non-patch bumps
 - Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor mastra`
 
 ## Version Bump Types

--- a/.cursor/commands/changeset.md
+++ b/.cursor/commands/changeset.md
@@ -4,29 +4,32 @@ Create a changeset using the CLI. The goal of changesets are to use it for gener
 
 ## CLI Usage
 
+Run the CLI with the following command to create a changeset:
+
 ```bash
-pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--patch pkg3]
+pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg1] [--patch pkg1]
 ```
+
+For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
 
 **Arguments:**
 
-- `-s` or `--skipPrompt` - Run non-interactively (required for automation)
-- `-m "message"` or `--message "message"` - The changeset message (required)
-- `--major @scope/pkg` - Packages that should have a major version bump
-- `--minor @scope/pkg` - Packages that should have a minor version bump
-- `--patch @scope/pkg` - Packages that should have a patch version bump (default for detected changes)
+- `-s` or `--skipPrompt`: Run non-interactively (required for automation)
+- `-m "message"` or `--message "message"`: The changeset message (required)
+- `--major @scope/pkg`: Packages that should have a major version bump
+- `--minor @scope/pkg`: Packages that should have a minor version bump
+- `--patch @scope/pkg`: Packages that should have a patch version bump (default for detected changes)
 
 **Notes:**
 
-- The CLI auto-detects changed packages from git and defaults them to `patch` bumps
 - You can override the bump type by specifying `--major` or `--minor` for specific packages
 - Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor mastra`
 
 ## Version Bump Types
 
-- `patch` - Bugfixes with backward-compatible changes
-- `minor` - New features with backward-compatible changes
-- `major` - Breaking changes that are not backward-compatible
+- `patch`: Bugfixes with backward-compatible changes
+- `minor`: New features with backward-compatible changes
+- `major`: Breaking changes that are not backward-compatible
 
 ## Message Guidelines
 

--- a/.cursor/commands/changeset.md
+++ b/.cursor/commands/changeset.md
@@ -1,6 +1,6 @@
 # Changeset
 
-Create a changeset using the CLI. The goal of changesets are to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
+Create a changeset using the CLI. The goal of changesets is to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ## CLI Usage
 

--- a/.cursor/commands/changeset.md
+++ b/.cursor/commands/changeset.md
@@ -7,7 +7,7 @@ Create a changeset using the CLI. The goal of changesets is to use it for genera
 Run the CLI with the following command to create a changeset:
 
 ```bash
-pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) @scope/pkg
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) pkg-name
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
@@ -16,9 +16,9 @@ For each package that has changes, run the CLI once and specify the appropriate 
 
 - `-s` or `--skipPrompt`: Run non-interactively; requires at least one of `--major`, `--minor`, or `--patch` (required for automation)
 - `-m "message"` or `--message "message"`: The changeset message (required)
-- `--major @scope/pkg`: Packages that should have a major version bump
-- `--minor @scope/pkg`: Packages that should have a minor version bump
-- `--patch @scope/pkg`: Packages that should have a patch version bump
+- `--major pkg-name`: Packages that should have a major version bump
+- `--minor pkg-name`: Packages that should have a minor version bump
+- `--patch pkg-name`: Packages that should have a patch version bump
 
 **Notes:**
 

--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -4,7 +4,7 @@ The user will issue this command. You will need to do two things.
 
 ## Create a changeset using the CLI
 
-Create a changeset using the CLI. The CLI will automatically detect changed packages and create the changeset file.
+Create a changeset using the CLI. The goal of changesets are to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
 pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--patch pkg3]
@@ -37,7 +37,7 @@ pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--p
 
 If the changes span multiple packages (e.g. `@mastra/core`, `@mastra/memory`, `mastra`, so 3 packages) and each change is different from another, you MUST create multiple changeset files. Otherwise you'll mix different changes into changeset files where they don't belong. For this you must decide what logical groups exist. Example: The majority of the main feature was changed in `@mastra/memory` and only supporting changes were done in `@mastra/core` and `mastra`. Then `@mastra/memory` needs its own changeset separate from the others. You can achieve this by running the CLI multiple times and selecting the appropriate packages for each changeset.
 
-**Important:** Very long changesets in one file (with multiple packages in the frontmatter) are an anti-pattern. This will lead to multiple packages having really large changelog entries. This must be avoided.
+**Important:** Very long changesets in one file (with multiple packages in the frontmatter) are an anti-pattern. This will lead to multiple packages having really large changelog entries. This must be avoided. If you have multiple packages likely there is one or two main packages where the majority of change lives.
 
 ## Open a PR using the GitHub CLI
 

--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -25,7 +25,7 @@ For each package that has changes, run the CLI once and specify the appropriate 
 - You can override the bump type by specifying `--major` or `--minor` for specific packages
 - Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor mastra`
 
-## Version Bump Types
+**Version Bump Types:**
 
 - `patch`: Bugfixes with backward-compatible changes
 - `minor`: New features with backward-compatible changes

--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -7,22 +7,29 @@ The user will issue this command. You will need to do two things.
 Create a changeset using the CLI. The goal of changesets are to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
-pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--patch pkg3]
+pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg1] [--patch pkg1]
 ```
+
+For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
 
 **Arguments:**
 
-- `-s` or `--skipPrompt` - Run non-interactively (required for automation)
-- `-m "message"` or `--message "message"` - The changeset message (required)
-- `--major @scope/pkg` - Packages that should have a major version bump
-- `--minor @scope/pkg` - Packages that should have a minor version bump
-- `--patch @scope/pkg` - Packages that should have a patch version bump (default for detected changes)
+- `-s` or `--skipPrompt`: Run non-interactively (required for automation)
+- `-m "message"` or `--message "message"`: The changeset message (required)
+- `--major @scope/pkg`: Packages that should have a major version bump
+- `--minor @scope/pkg`: Packages that should have a minor version bump
+- `--patch @scope/pkg`: Packages that should have a patch version bump (default for detected changes)
 
-**Version bump types:**
+**Notes:**
 
-- `patch` - Bugfixes with backward-compatible changes
-- `minor` - New features with backward-compatible changes
-- `major` - Breaking changes that are not backward-compatible
+- You can override the bump type by specifying `--major` or `--minor` for specific packages
+- Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor mastra`
+
+## Version Bump Types
+
+- `patch`: Bugfixes with backward-compatible changes
+- `minor`: New features with backward-compatible changes
+- `major`: Breaking changes that are not backward-compatible
 
 **Message guidelines:**
 

--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -7,22 +7,22 @@ The user will issue this command. You will need to do two things.
 Create a changeset using the CLI. The goal of changesets is to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
-pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg1] [--patch pkg1]
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) `@scope/pkg
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
 
 **Arguments:**
 
-- `-s` or `--skipPrompt`: Run non-interactively (required for automation)
+- `-s` or `--skipPrompt`: Run non-interactively; requires at least one of `--major`, `--minor`, or `--patch` (required for automation)
 - `-m "message"` or `--message "message"`: The changeset message (required)
 - `--major @scope/pkg`: Packages that should have a major version bump
 - `--minor @scope/pkg`: Packages that should have a minor version bump
-- `--patch @scope/pkg`: Packages that should have a patch version bump (default for detected changes)
+- `--patch @scope/pkg`: Packages that should have a patch version bump
 
 **Notes:**
 
-- You can override the bump type by specifying `--major` or `--minor` for specific packages
+- The bump type must be specified explicitly for each package; use `--major` or `--minor` for non-patch bumps
 - Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor mastra`
 
 **Version Bump Types:**

--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -4,7 +4,7 @@ The user will issue this command. You will need to do two things.
 
 ## Create a changeset using the CLI
 
-Create a changeset using the CLI. The goal of changesets are to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
+Create a changeset using the CLI. The goal of changesets is to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
 pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg1] [--patch pkg1]

--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -7,7 +7,7 @@ The user will issue this command. You will need to do two things.
 Create a changeset using the CLI. The goal of changesets is to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
-pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) @scope/pkg
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) pkg-name
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
@@ -16,9 +16,9 @@ For each package that has changes, run the CLI once and specify the appropriate 
 
 - `-s` or `--skipPrompt`: Run non-interactively; requires at least one of `--major`, `--minor`, or `--patch` (required for automation)
 - `-m "message"` or `--message "message"`: The changeset message (required)
-- `--major @scope/pkg`: Packages that should have a major version bump
-- `--minor @scope/pkg`: Packages that should have a minor version bump
-- `--patch @scope/pkg`: Packages that should have a patch version bump
+- `--major pkg-name`: Packages that should have a major version bump
+- `--minor pkg-name`: Packages that should have a minor version bump
+- `--patch pkg-name`: Packages that should have a patch version bump
 
 **Notes:**
 

--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -7,7 +7,7 @@ The user will issue this command. You will need to do two things.
 Create a changeset using the CLI. The goal of changesets is to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
-pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) `@scope/pkg
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) @scope/pkg
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.

--- a/.github/prompts/changeset.prompt.md
+++ b/.github/prompts/changeset.prompt.md
@@ -5,7 +5,7 @@ description: Create a changeset for version bumps
 
 # Changeset
 
-Create a changeset using the CLI. The goal of changesets are to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
+Create a changeset using the CLI. The goal of changesets is to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ## CLI Usage
 

--- a/.github/prompts/changeset.prompt.md
+++ b/.github/prompts/changeset.prompt.md
@@ -12,7 +12,7 @@ Create a changeset using the CLI. The goal of changesets is to use it for genera
 Run the CLI with the following command to create a changeset:
 
 ```bash
-pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) `@scope/pkg
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) @scope/pkg
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.

--- a/.github/prompts/changeset.prompt.md
+++ b/.github/prompts/changeset.prompt.md
@@ -12,22 +12,22 @@ Create a changeset using the CLI. The goal of changesets is to use it for genera
 Run the CLI with the following command to create a changeset:
 
 ```bash
-pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg1] [--patch pkg1]
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) `@scope/pkg
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
 
 **Arguments:**
 
-- `-s` or `--skipPrompt`: Run non-interactively (required for automation)
+- `-s` or `--skipPrompt`: Run non-interactively; requires at least one of `--major`, `--minor`, or `--patch` (required for automation)
 - `-m "message"` or `--message "message"`: The changeset message (required)
 - `--major @scope/pkg`: Packages that should have a major version bump
 - `--minor @scope/pkg`: Packages that should have a minor version bump
-- `--patch @scope/pkg`: Packages that should have a patch version bump (default for detected changes)
+- `--patch @scope/pkg`: Packages that should have a patch version bump
 
 **Notes:**
 
-- You can override the bump type by specifying `--major` or `--minor` for specific packages
+- The bump type must be specified explicitly for each package; use `--major` or `--minor` for non-patch bumps
 - Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor mastra`
 
 ## Version Bump Types

--- a/.github/prompts/changeset.prompt.md
+++ b/.github/prompts/changeset.prompt.md
@@ -5,7 +5,7 @@ description: Create a changeset for version bumps
 
 # Changeset
 
-Create a changeset using the CLI. The CLI will automatically detect changed packages and create the changeset file.
+Create a changeset using the CLI. The goal of changesets are to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ## CLI Usage
 
@@ -46,4 +46,4 @@ pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--p
 
 If the changes span multiple packages (e.g. `@mastra/core`, `@mastra/memory`, `mastra`, so 3 packages) and each change is different from another, you MUST create multiple changeset files. Otherwise you'll mix different changes into changeset files where they don't belong. For this you must decide what logical groups exist. Example: The majority of the main feature was changed in `@mastra/memory` and only supporting changes were done in `@mastra/core` and `mastra`. Then `@mastra/memory` needs its own changeset separate from the others. You can achieve this by running the CLI multiple times and selecting the appropriate packages for each changeset.
 
-**Important:** Very long changesets in one file (with multiple packages in the frontmatter) are an anti-pattern. This will lead to multiple packages having really large changelog entries. This must be avoided.
+**Important:** Very long changesets in one file (with multiple packages in the frontmatter) are an anti-pattern. This will lead to multiple packages having really large changelog entries. This must be avoided. If you have multiple packages likely there is one or two main packages where the majority of change lives.

--- a/.github/prompts/changeset.prompt.md
+++ b/.github/prompts/changeset.prompt.md
@@ -9,29 +9,32 @@ Create a changeset using the CLI. The goal of changesets are to use it for gener
 
 ## CLI Usage
 
+Run the CLI with the following command to create a changeset:
+
 ```bash
-pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--patch pkg3]
+pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg1] [--patch pkg1]
 ```
+
+For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
 
 **Arguments:**
 
-- `-s` or `--skipPrompt` - Run non-interactively (required for automation)
-- `-m "message"` or `--message "message"` - The changeset message (required)
-- `--major @scope/pkg` - Packages that should have a major version bump
-- `--minor @scope/pkg` - Packages that should have a minor version bump
-- `--patch @scope/pkg` - Packages that should have a patch version bump (default for detected changes)
+- `-s` or `--skipPrompt`: Run non-interactively (required for automation)
+- `-m "message"` or `--message "message"`: The changeset message (required)
+- `--major @scope/pkg`: Packages that should have a major version bump
+- `--minor @scope/pkg`: Packages that should have a minor version bump
+- `--patch @scope/pkg`: Packages that should have a patch version bump (default for detected changes)
 
 **Notes:**
 
-- The CLI auto-detects changed packages from git and defaults them to `patch` bumps
 - You can override the bump type by specifying `--major` or `--minor` for specific packages
 - Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor mastra`
 
 ## Version Bump Types
 
-- `patch` - Bugfixes with backward-compatible changes
-- `minor` - New features with backward-compatible changes
-- `major` - Breaking changes that are not backward-compatible
+- `patch`: Bugfixes with backward-compatible changes
+- `minor`: New features with backward-compatible changes
+- `major`: Breaking changes that are not backward-compatible
 
 ## Message Guidelines
 

--- a/.github/prompts/changeset.prompt.md
+++ b/.github/prompts/changeset.prompt.md
@@ -12,7 +12,7 @@ Create a changeset using the CLI. The goal of changesets is to use it for genera
 Run the CLI with the following command to create a changeset:
 
 ```bash
-pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) @scope/pkg
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) pkg-name
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
@@ -21,9 +21,9 @@ For each package that has changes, run the CLI once and specify the appropriate 
 
 - `-s` or `--skipPrompt`: Run non-interactively; requires at least one of `--major`, `--minor`, or `--patch` (required for automation)
 - `-m "message"` or `--message "message"`: The changeset message (required)
-- `--major @scope/pkg`: Packages that should have a major version bump
-- `--minor @scope/pkg`: Packages that should have a minor version bump
-- `--patch @scope/pkg`: Packages that should have a patch version bump
+- `--major pkg-name`: Packages that should have a major version bump
+- `--minor pkg-name`: Packages that should have a minor version bump
+- `--patch pkg-name`: Packages that should have a patch version bump
 
 **Notes:**
 

--- a/.github/prompts/pr.prompt.md
+++ b/.github/prompts/pr.prompt.md
@@ -12,7 +12,7 @@ The user will issue this command. You will need to do two things.
 Create a changeset using the CLI. The goal of changesets is to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
-pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) `@scope/pkg
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) @scope/pkg
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.

--- a/.github/prompts/pr.prompt.md
+++ b/.github/prompts/pr.prompt.md
@@ -9,7 +9,7 @@ The user will issue this command. You will need to do two things.
 
 ## Create a changeset using the CLI
 
-Create a changeset using the CLI. The CLI will automatically detect changed packages and create the changeset file.
+Create a changeset using the CLI. The goal of changesets are to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
 pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--patch pkg3]
@@ -42,7 +42,7 @@ pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--p
 
 If the changes span multiple packages (e.g. `@mastra/core`, `@mastra/memory`, `mastra`, so 3 packages) and each change is different from another, you MUST create multiple changeset files. Otherwise you'll mix different changes into changeset files where they don't belong. For this you must decide what logical groups exist. Example: The majority of the main feature was changed in `@mastra/memory` and only supporting changes were done in `@mastra/core` and `mastra`. Then `@mastra/memory` needs its own changeset separate from the others. You can achieve this by running the CLI multiple times and selecting the appropriate packages for each changeset.
 
-**Important:** Very long changesets in one file (with multiple packages in the frontmatter) are an anti-pattern. This will lead to multiple packages having really large changelog entries. This must be avoided.
+**Important:** Very long changesets in one file (with multiple packages in the frontmatter) are an anti-pattern. This will lead to multiple packages having really large changelog entries. This must be avoided. If you have multiple packages likely there is one or two main packages where the majority of change lives.
 
 ## Open a PR using the GitHub CLI
 

--- a/.github/prompts/pr.prompt.md
+++ b/.github/prompts/pr.prompt.md
@@ -9,7 +9,7 @@ The user will issue this command. You will need to do two things.
 
 ## Create a changeset using the CLI
 
-Create a changeset using the CLI. The goal of changesets are to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
+Create a changeset using the CLI. The goal of changesets is to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
 pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg1] [--patch pkg1]

--- a/.github/prompts/pr.prompt.md
+++ b/.github/prompts/pr.prompt.md
@@ -30,7 +30,7 @@ For each package that has changes, run the CLI once and specify the appropriate 
 - You can override the bump type by specifying `--major` or `--minor` for specific packages
 - Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor mastra`
 
-## Version Bump Types
+**Version Bump Types:**
 
 - `patch`: Bugfixes with backward-compatible changes
 - `minor`: New features with backward-compatible changes

--- a/.github/prompts/pr.prompt.md
+++ b/.github/prompts/pr.prompt.md
@@ -12,22 +12,29 @@ The user will issue this command. You will need to do two things.
 Create a changeset using the CLI. The goal of changesets are to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
-pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg2] [--patch pkg3]
+pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg1] [--patch pkg1]
 ```
+
+For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
 
 **Arguments:**
 
-- `-s` or `--skipPrompt` - Run non-interactively (required for automation)
-- `-m "message"` or `--message "message"` - The changeset message (required)
-- `--major @scope/pkg` - Packages that should have a major version bump
-- `--minor @scope/pkg` - Packages that should have a minor version bump
-- `--patch @scope/pkg` - Packages that should have a patch version bump (default for detected changes)
+- `-s` or `--skipPrompt`: Run non-interactively (required for automation)
+- `-m "message"` or `--message "message"`: The changeset message (required)
+- `--major @scope/pkg`: Packages that should have a major version bump
+- `--minor @scope/pkg`: Packages that should have a minor version bump
+- `--patch @scope/pkg`: Packages that should have a patch version bump (default for detected changes)
 
-**Version bump types:**
+**Notes:**
 
-- `patch` - Bugfixes with backward-compatible changes
-- `minor` - New features with backward-compatible changes
-- `major` - Breaking changes that are not backward-compatible
+- You can override the bump type by specifying `--major` or `--minor` for specific packages
+- Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor mastra`
+
+## Version Bump Types
+
+- `patch`: Bugfixes with backward-compatible changes
+- `minor`: New features with backward-compatible changes
+- `major`: Breaking changes that are not backward-compatible
 
 **Message guidelines:**
 

--- a/.github/prompts/pr.prompt.md
+++ b/.github/prompts/pr.prompt.md
@@ -12,22 +12,22 @@ The user will issue this command. You will need to do two things.
 Create a changeset using the CLI. The goal of changesets is to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
-pnpm changeset -s -m "your changeset message" [--major pkg1] [--minor pkg1] [--patch pkg1]
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) `@scope/pkg
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
 
 **Arguments:**
 
-- `-s` or `--skipPrompt`: Run non-interactively (required for automation)
+- `-s` or `--skipPrompt`: Run non-interactively; requires at least one of `--major`, `--minor`, or `--patch` (required for automation)
 - `-m "message"` or `--message "message"`: The changeset message (required)
 - `--major @scope/pkg`: Packages that should have a major version bump
 - `--minor @scope/pkg`: Packages that should have a minor version bump
-- `--patch @scope/pkg`: Packages that should have a patch version bump (default for detected changes)
+- `--patch @scope/pkg`: Packages that should have a patch version bump
 
 **Notes:**
 
-- You can override the bump type by specifying `--major` or `--minor` for specific packages
+- The bump type must be specified explicitly for each package; use `--major` or `--minor` for non-patch bumps
 - Multiple packages can be specified by repeating the flag: `--minor @mastra/core --minor mastra`
 
 **Version Bump Types:**

--- a/.github/prompts/pr.prompt.md
+++ b/.github/prompts/pr.prompt.md
@@ -12,7 +12,7 @@ The user will issue this command. You will need to do two things.
 Create a changeset using the CLI. The goal of changesets is to use it for generating changelogs. Individual package changelogs will later be combined into a single changelog that is published with each release.
 
 ```bash
-pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) @scope/pkg
+pnpm changeset -s -m "your changeset message" (--major | --minor | --patch) pkg-name
 ```
 
 For each package that has changes, run the CLI once and specify the appropriate version bump type (`--major`, `--minor`, or `--patch`) and message for that package. This will create a separate changeset file for each package, which is important for generating accurate changelogs.
@@ -21,9 +21,9 @@ For each package that has changes, run the CLI once and specify the appropriate 
 
 - `-s` or `--skipPrompt`: Run non-interactively; requires at least one of `--major`, `--minor`, or `--patch` (required for automation)
 - `-m "message"` or `--message "message"`: The changeset message (required)
-- `--major @scope/pkg`: Packages that should have a major version bump
-- `--minor @scope/pkg`: Packages that should have a minor version bump
-- `--patch @scope/pkg`: Packages that should have a patch version bump
+- `--major pkg-name`: Packages that should have a major version bump
+- `--minor pkg-name`: Packages that should have a minor version bump
+- `--patch pkg-name`: Packages that should have a patch version bump
 
 **Notes:**
 

--- a/packages/_changeset-cli/src/changeset/getVersionBumps.ts
+++ b/packages/_changeset-cli/src/changeset/getVersionBumps.ts
@@ -113,7 +113,7 @@ export async function getVersionBumps(
     patch: string[];
   },
   onCancel: (message?: string) => never,
-  skipPrompt?: boolean,
+  skipPrompt: boolean,
 ): Promise<VersionBumps> {
   let versionBumps: VersionBumps = {};
 

--- a/packages/_changeset-cli/src/changeset/getVersionBumps.ts
+++ b/packages/_changeset-cli/src/changeset/getVersionBumps.ts
@@ -113,6 +113,7 @@ export async function getVersionBumps(
     patch: string[];
   },
   onCancel: (message?: string) => never,
+  skipPrompt?: boolean,
 ): Promise<VersionBumps> {
   let versionBumps: VersionBumps = {};
 
@@ -125,10 +126,14 @@ export async function getVersionBumps(
     patch: patch.filter(pkg => packagesByName.has(pkg)),
   };
 
-  const bumpSelections = await promptForVersionBumps({ preSelectedPackages, onCancel });
+  if (skipPrompt) {
+    versionBumps = processBumpSelections(preSelectedPackages, versionBumps);
+  } else {
+    const bumpSelections = await promptForVersionBumps({ preSelectedPackages, onCancel });
 
-  if (bumpSelections) {
-    versionBumps = processBumpSelections(bumpSelections, versionBumps);
+    if (bumpSelections) {
+      versionBumps = processBumpSelections(bumpSelections, versionBumps);
+    }
   }
 
   return versionBumps;

--- a/packages/_changeset-cli/src/changeset/getVersionBumps.ts
+++ b/packages/_changeset-cli/src/changeset/getVersionBumps.ts
@@ -113,7 +113,6 @@ export async function getVersionBumps(
     patch: string[];
   },
   onCancel: (message?: string) => never,
-  skipPrompt: boolean,
 ): Promise<VersionBumps> {
   let versionBumps: VersionBumps = {};
 
@@ -126,19 +125,10 @@ export async function getVersionBumps(
     patch: patch.filter(pkg => packagesByName.has(pkg)),
   };
 
-  if (skipPrompt) {
-    const bumpTypes: Array<keyof PreSelectedPackages> = ['major', 'minor', 'patch'];
-    bumpTypes.forEach(bumpType => {
-      preSelectedPackages[bumpType].forEach(pkg => {
-        versionBumps[pkg] = bumpType as BumpType;
-      });
-    });
-  } else {
-    const bumpSelections = await promptForVersionBumps({ preSelectedPackages, onCancel });
+  const bumpSelections = await promptForVersionBumps({ preSelectedPackages, onCancel });
 
-    if (bumpSelections) {
-      versionBumps = processBumpSelections(bumpSelections, versionBumps);
-    }
+  if (bumpSelections) {
+    versionBumps = processBumpSelections(bumpSelections, versionBumps);
   }
 
   return versionBumps;

--- a/packages/_changeset-cli/src/index.ts
+++ b/packages/_changeset-cli/src/index.ts
@@ -116,11 +116,27 @@ async function main() {
     // Detect changed packages
     const changedPackages = await detectChangedPackages();
 
+    // No changes detected, exit early
+    if (changedPackages.length === 0) {
+      p.outro('No changed packages detected. Exiting.');
+      process.exit(0);
+    }
+
+    // Error early if --skipPrompt is used but no --major, --minor, or --patch flags are provided
+    if (parsedArgs.skipPrompt) {
+      const hasVersionBumps = parsedArgs.major.length > 0 || parsedArgs.minor.length > 0 || parsedArgs.patch.length > 0;
+
+      if (!hasVersionBumps) {
+        p.cancel(`Please provide at least one of --major, --minor, or --patch flags when using --skipPrompt.`);
+        process.exit(1);
+      }
+    }
+
     // Prepare version bump inputs
     const versionBumpInputs = prepareVersionBumpInputs(changedPackages, parsedArgs);
 
     // Get version bumps from user
-    const versionBumps = await getVersionBumps(versionBumpInputs, onCancel, parsedArgs.skipPrompt);
+    const versionBumps = await getVersionBumps(versionBumpInputs, onCancel);
 
     // Initialize peer dependency tracking
     let updatedPeerDeps: UpdatedPeerDependencies = getDefaultUpdatedPeerDependencies();

--- a/packages/_changeset-cli/src/index.ts
+++ b/packages/_changeset-cli/src/index.ts
@@ -16,6 +16,10 @@ function onCancel(message = 'Interrupted...'): never {
   process.exit(0);
 }
 
+function nonEmptyArray(arr: string[]): boolean {
+  return arr.filter(Boolean).length > 0;
+}
+
 function parseArguments(args: string[]): CliArgs {
   const parsedArgs = mri<{
     message: string;
@@ -124,7 +128,8 @@ async function main() {
 
     // Error early if --skipPrompt is used but no --major, --minor, or --patch flags are provided
     if (parsedArgs.skipPrompt) {
-      const hasVersionBumps = parsedArgs.major.length > 0 || parsedArgs.minor.length > 0 || parsedArgs.patch.length > 0;
+      const hasVersionBumps =
+        nonEmptyArray(parsedArgs.major) || nonEmptyArray(parsedArgs.minor) || nonEmptyArray(parsedArgs.patch);
 
       if (!hasVersionBumps) {
         p.cancel(`Please provide at least one of --major, --minor, or --patch flags when using --skipPrompt.`);
@@ -136,7 +141,7 @@ async function main() {
     const versionBumpInputs = prepareVersionBumpInputs(changedPackages, parsedArgs);
 
     // Get version bumps from user
-    const versionBumps = await getVersionBumps(versionBumpInputs, onCancel);
+    const versionBumps = await getVersionBumps(versionBumpInputs, onCancel, parsedArgs.skipPrompt);
 
     // Initialize peer dependency tracking
     let updatedPeerDeps: UpdatedPeerDependencies = getDefaultUpdatedPeerDependencies();

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -1,5 +1,7 @@
 # Mastra Codemods
 
+test
+
 Mastra provides automated code transformations (codemods) to help upgrade your codebase when features are deprecated, removed, or changed between versions.
 
 Codemods are transformations that run on your codebase programmatically, allowing you to apply many changes without manually editing every file.

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -1,7 +1,5 @@
 # Mastra Codemods
 
-test
-
 Mastra provides automated code transformations (codemods) to help upgrade your codebase when features are deprecated, removed, or changed between versions.
 
 Codemods are transformations that run on your codebase programmatically, allowing you to apply many changes without manually editing every file.


### PR DESCRIPTION
## Description

When using --skipPrompt, require to pass bump type flags, so that if you just pass a message it doesn't create one, single changeset will all packages marked as "patch".

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified changeset workflow: per-package changesets combined into a release changelog.
  * Updated CLI examples and guidance to show running the CLI once per changed package with explicit bump types.
  * Improved message/guideline wording, standardized "Version Bump Types" formatting, and added advice to avoid very long multi-package changesets.

* **Bug Fixes**
  * Added CLI validations: require a bump flag when using automated (skipPrompt) mode.
  * Added clear early-exit messaging when no changed packages are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->