### PR TITLE
Improve limited selction behaviour

### DIFF
--- a/.changeset/eighty-geese-cut.md
+++ b/.changeset/eighty-geese-cut.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Improved comparison selection behavior: selecting a third item now replaces the most recent selection instead of being blocked. Applies to dataset version, item version, and dataset item comparison flows.

--- a/packages/playground-ui/src/domains/datasets/components/items/dataset-items-list.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/items/dataset-items-list.tsx
@@ -4,7 +4,7 @@ import { EmptyState } from '@/ds/components/EmptyState';
 import { ItemList } from '@/ds/components/ItemList';
 import { Checkbox } from '@/ds/components/Checkbox';
 import { Plus, Upload, FileJson } from 'lucide-react';
-import { format, isToday } from 'date-fns';
+import { isToday } from 'date-fns';
 import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
 
 export interface DatasetItemsListProps {
@@ -89,7 +89,12 @@ export function DatasetItemsList({
   };
 
   const handleToggleSelection = (id: string, shiftKey: boolean, allIds: string[]) => {
-    if (maxSelection && !selectedIds.has(id) && selectedIds.size >= maxSelection) return;
+    if (maxSelection && !selectedIds.has(id) && selectedIds.size >= maxSelection) {
+      // Drop most recent selection, keep oldest + add new one
+      const [first] = Array.from(selectedIds);
+      onSelectAll([first, id]);
+      return;
+    }
     onToggleSelection(id, shiftKey, allIds);
   };
 

--- a/packages/playground-ui/src/domains/datasets/components/items/dataset-versions-panel.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/items/dataset-versions-panel.tsx
@@ -50,7 +50,11 @@ export function DatasetVersionsPanel({
       const next = new Set(prev);
       if (next.has(key)) {
         next.delete(key);
-      } else if (next.size < 2) {
+      } else if (next.size >= 2) {
+        // Drop most recent selection, keep oldest + add new one
+        const [first] = Array.from(next);
+        return new Set([first, key]);
+      } else {
         next.add(key);
       }
       return next;

--- a/packages/playground-ui/src/domains/datasets/components/versions/dataset-item-versions-panel.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/versions/dataset-item-versions-panel.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { format } from 'date-fns';
-import { BanIcon, ClockIcon, GitCompareIcon } from 'lucide-react';
+import { GitCompareIcon } from 'lucide-react';
 import { Button, ButtonWithTooltip } from '@/ds/components/Button';
 import { ItemList } from '@/ds/components/ItemList';
 import { Checkbox } from '@/ds/components/Checkbox';
@@ -50,7 +49,11 @@ export function DatasetItemVersionsPanel({
       const next = new Set(prev);
       if (next.has(id)) {
         next.delete(id);
-      } else if (next.size < 2) {
+      } else if (next.size >= 2) {
+        // Drop most recent selection, keep oldest + add new one
+        const [first] = Array.from(next);
+        return new Set([first, id]);
+      } else {
         next.add(id);
       }
       return next;


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Now for limited selection mode, when a user can select only two items/versions to compare, we block adding a third item, the PR changes the behaviour. With PR when a user tries to select a third item the recent one is uhchecked and a new one replace it place. This behaviour seems more self-explanatory without any additional instruction.



https://github.com/user-attachments/assets/108a0373-5db8-4d1a-a38a-5bc63356b3ff



## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection behavior in dataset version, item version, and dataset item comparisons: selecting a third item now replaces the most recent selection instead of being blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->