### PR TITLE
feat: add AiList to MCP registry registry

### DIFF
--- a/.changeset/add-ailist-registry.md
+++ b/.changeset/add-ailist-registry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp-registry-registry': patch
+---
+
+feat: add AiList to registry — a directory of 1,200+ Ai projects

--- a/packages/mcp-registry-registry/src/registry/processors/ailist.ts
+++ b/packages/mcp-registry-registry/src/registry/processors/ailist.ts
@@ -1,0 +1,19 @@
+import type { ServerEntry } from '../types';
+import { createServerEntry } from './utils';
+
+/**
+ * Post-processor for AiList registry
+ * Handles the specific format of AiList's project data
+ */
+export function processAiListServers(data: unknown): ServerEntry[] {
+  if (!data || typeof data !== 'object') {
+    return [];
+  }
+
+  const dataObj = data as Record<string, unknown>;
+  const serversList = Array.isArray(dataObj.projects) ? dataObj.projects : [];
+
+  return serversList
+    .filter((item: unknown) => item && typeof item === 'object')
+    .map((item: unknown) => createServerEntry(item as Record<string, unknown>));
+}

--- a/packages/mcp-registry-registry/src/registry/registry.ts
+++ b/packages/mcp-registry-registry/src/registry/registry.ts
@@ -1,3 +1,4 @@
+import { processAiListServers } from './processors/ailist';
 import { processApifyServers } from './processors/apify';
 import { processApiTrackerServers } from './processors/apitracker';
 import { processDockerServers } from './processors/docker';
@@ -9,6 +10,16 @@ import type { RegistryFile } from './types';
 // Registry data with post-processing functions
 export const registryData: RegistryFile = {
   registries: [
+    {
+      id: 'ailist',
+      name: 'AiList',
+      description: 'A directory of 1,200+ Ai projects including MCP servers, CLI tools, libraries, and APIs.',
+      url: 'https://hifriendbot.com/ai-list/',
+      servers_url: 'https://hifriendbot.com/wp-json/ailist/v1/projects',
+      tags: ['verified'],
+      count: '1200+',
+      postProcessServers: processAiListServers,
+    },
     {
       id: 'apitracker',
       name: 'API Tracker',


### PR DESCRIPTION
Add [AiList](https://hifriendbot.com/ai-list/) to the MCP Registry Registry.

AiList is a public directory of 1,200+ Ai projects (MCP servers, CLI tools, libraries, APIs, and more). It has a free public REST API and an MCP server (`npx ailist-mcp`) that lets AI agents auto-submit projects.

- **URL:** https://hifriendbot.com/ai-list/
- **API:** https://hifriendbot.com/wp-json/ailist/v1/projects
- **MCP Server:** [ailist-mcp](https://www.npmjs.com/package/ailist-mcp)