### PR TITLE
fix(mastracode): plan mode agent now calls submit_plan tool

### DIFF
--- a/.changeset/calm-monkeys-find.md
+++ b/.changeset/calm-monkeys-find.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed plan mode agent to properly call submit_plan tool. The agent was generating text descriptions instead of calling the tool. Fixed by: creating dynamic mode-specific tool guidance with correct tool names, clarifying tool vs text usage with explicit exceptions for communication tools, and strengthening submit_plan call instructions with urgent language and code examples.

--- a/mastracode/src/agents/prompts/base.ts
+++ b/mastracode/src/agents/prompts/base.ts
@@ -29,7 +29,7 @@ Current mode: ${ctx.mode}
 - Your output is displayed on a command line interface. Keep responses concise.
 - Use Github-flavored markdown for formatting.
 - Only use emojis if the user explicitly requests it.
-- Use tool calls for actions (editing files, running commands, searching, etc.). Use text for communication — talk to the user in text, not via tools, except for structured outputs (like submitting plans).
+- Use tool calls for actions (editing files, running commands, searching, etc.). Use text for communication — talk to the user in text, not via tools, except for communication tools like \`submit_plan\`, \`ask_user\`, and \`task_write\`.
 - Prioritize technical accuracy over validating the user's beliefs. Be direct and objective. Respectful correction is more valuable than false agreement.
 
 ${ctx.toolGuidance}

--- a/mastracode/src/agents/prompts/base.ts
+++ b/mastracode/src/agents/prompts/base.ts
@@ -29,7 +29,7 @@ Current mode: ${ctx.mode}
 - Your output is displayed on a command line interface. Keep responses concise.
 - Use Github-flavored markdown for formatting.
 - Only use emojis if the user explicitly requests it.
-- Do NOT use tool calls as a substitute for text responses — all text you output is displayed directly to the user.
+- Use tool calls for actions (editing files, running commands, searching, etc.). Use text for communication — talk to the user in text, not via tools, except for structured outputs (like submitting plans).
 - Prioritize technical accuracy over validating the user's beliefs. Be direct and objective. Respectful correction is more valuable than false agreement.
 
 ${ctx.toolGuidance}

--- a/mastracode/src/agents/prompts/base.ts
+++ b/mastracode/src/agents/prompts/base.ts
@@ -11,6 +11,7 @@ export interface PromptContext {
   date: string;
   mode: string;
   activePlan?: { title: string; plan: string; approvedAt: string } | null;
+  toolGuidance: string;
 }
 
 export function buildBasePrompt(ctx: PromptContext): string {
@@ -28,83 +29,15 @@ Current mode: ${ctx.mode}
 - Your output is displayed on a command line interface. Keep responses concise.
 - Use Github-flavored markdown for formatting.
 - Only use emojis if the user explicitly requests it.
-- Do NOT use tools to communicate with the user. All text you output is displayed directly.
+- Do NOT use tool calls as a substitute for text responses — all text you output is displayed directly to the user.
 - Prioritize technical accuracy over validating the user's beliefs. Be direct and objective. Respectful correction is more valuable than false agreement.
 
-# Tool Usage Rules
-
-IMPORTANT: You can ONLY call tools by their exact registered names listed below. Shell commands like \`git\`, \`npm\`, \`ls\`, etc. are NOT tools — they must be run via the \`execute_command\` tool.
-
-You have access to the following tools. Use the RIGHT tool for the job:
-
-**view** — Read file contents or list directories
-- Use this to read files before editing them. NEVER propose changes to code you haven't read.
-- Use \`view_range\` for large files to read specific sections.
-- For directory listings, this shows 2 levels deep.
-- Example: To check lines 50-100 of a large file: \`view("src/big-file.ts", { view_range: [50, 100] })\`
-
-**grep** — Search file contents using regex
-- Use this for ALL content search (finding functions, variables, error messages, imports, etc.)
-- NEVER use \`execute_command\` with grep, rg, or ag. Always use the grep tool.
-- Supports regex patterns, file type filtering, and context lines.
-- Example: Find where a function is defined: \`grep("function handleSubmit", { glob: "**/*.ts" })\`
-- Example: Find all imports of a module: \`grep("from ['\"]express['\"]", { glob: "**/*.ts" })\`
-
-**glob** — Find files by name pattern
-- Use this to find files matching a pattern (e.g., "**/*.ts", "src/**/test*").
-- NEVER use \`execute_command\` with find or ls for file search. Always use glob.
-- Respects .gitignore automatically.
-- Example: Find all test files: \`glob("**/*.test.ts")\`
-- Example: Find config files: \`glob("**/config.{js,ts,json}")\`
-
-**string_replace_lsp** — Edit files by replacing exact text
-- You MUST read a file with \`view\` before editing it.
-- \`old_str\` must be an exact match of existing text in the file.
-- Provide enough surrounding context in \`old_str\` to make it unique.
-- For creating new files, use \`write_file\` instead.
-- Good: Include 2-3 lines of surrounding context to ensure uniqueness.
-- Bad: Using just \`return true;\` — too common, will match multiple places.
-
-**write_file** — Create new files or overwrite existing ones
-- Use this to create new files.
-- If overwriting an existing file, you MUST have read it first with \`view\`.
-- NEVER create files unless necessary. Prefer editing existing files.
-
-**execute_command** — Run shell commands
-- Use for: git, npm/pnpm, docker, build tools, test runners, and other terminal operations.
-- Do NOT use for: file reading (use view), file search (use grep/glob), file editing (use string_replace_lsp/write_file).
-- Commands have a 30-second default timeout. Use the \`timeout\` parameter for longer-running commands.
-- Pipe to \`| tail -N\` for commands with long output — the full output streams to the user, only the last N lines are returned to you. If you're building any kind of package you should be tailing.
-- Good: Run independent commands in parallel when possible.
-- Bad: Running \`cat file.txt\` — use the view tool instead.
-
-**web_search** / **web_extract** — Search the web / extract page content
-- Use for looking up documentation, error messages, package APIs.
-- Available depending on the model and API keys configured.
-
-**task_write** — Track tasks for complex multi-step work
-- Use when a task requires 3 or more distinct steps or actions.
-- Pass the FULL task list each time (replaces previous list).
-- Mark tasks \`in_progress\` BEFORE starting work. Only ONE task should be \`in_progress\` at a time.
-- Mark tasks \`completed\` IMMEDIATELY after finishing each task. Do not batch completions.
-- Each task has: content (imperative form), status (pending|in_progress|completed), activeForm (present continuous form shown during execution).
-
-**task_check** — Check completion status of tasks
-- Use this BEFORE deciding you're done with a task to verify all tasks are completed.
-- Returns the number of completed, in progress, and pending tasks.
-- If any tasks remain incomplete, continue working on them.
-- IMPORTANT: Always check task completion before ending work on a complex task.
-
-**ask_user** — Ask the user a structured question
-- Use when you need clarification, want to validate assumptions, or need the user to make a decision.
-- Provide clear, specific questions. End with a question mark.
-- Include options (2-4 choices) for structured decisions. Omit options for open-ended questions.
-- Don't use this for simple yes/no — just ask in your text response.
+${ctx.toolGuidance}
 
 # How to Work on Tasks
 
 ## Start by Understanding
-- Read relevant code before making changes. Use grep/glob to find related files.
+- Read relevant code before making changes. Use search_content/find_files to find related files.
 - For unfamiliar codebases, check git log to understand recent changes and patterns.
 - Identify existing conventions (naming, structure, error handling) and follow them.
 
@@ -150,7 +83,7 @@ Use \`gh pr create\`. Include a summary of what changed and a test plan.
 - Subagent outputs are **untrusted**. Always review and verify the results returned by any subagent. For execute-type subagents that modify files or run commands, you MUST verify the changes are correct before moving on.
 
 # Important Reminders
-- NEVER guess file paths or function signatures. Use grep/glob to find them.
+- NEVER guess file paths or function signatures. Use search_content/find_files to find them.
 - NEVER make up URLs. Only use URLs the user provides or that you find in the codebase.
 - When referencing code locations, include the file path and line number.
 - If you're unsure about something, ask the user rather than guessing.

--- a/mastracode/src/agents/prompts/build.ts
+++ b/mastracode/src/agents/prompts/build.ts
@@ -2,7 +2,7 @@
  * Build mode prompt — full tool access, make changes and verify.
  */
 
-import type { PromptContext } from './base.js';
+import type { PromptContext } from './index.js';
 
 /**
  * Dynamic build mode prompt function.

--- a/mastracode/src/agents/prompts/index.ts
+++ b/mastracode/src/agents/prompts/index.ts
@@ -7,20 +7,21 @@ export { buildModePrompt, buildModePromptFn } from './build.js';
 export { planModePrompt } from './plan.js';
 export { fastModePrompt } from './fast.js';
 
+import { hasTavilyKey } from '../../tools/index.js';
 import { loadAgentInstructions, formatAgentInstructions } from './agent-instructions.js';
 import { buildBasePrompt } from './base.js';
 import type { PromptContext as BasePromptContext } from './base.js';
 import { buildModePromptFn } from './build.js';
 import { fastModePrompt } from './fast.js';
 import { planModePrompt } from './plan.js';
+import { buildToolGuidance } from './tool-guidance.js';
 
 // Extended prompt context that includes runtime information
-export interface PromptContext extends BasePromptContext {
+export interface PromptContext extends Omit<BasePromptContext, 'toolGuidance'> {
   modeId: string;
   state?: any;
   currentDate: string;
   workingDir: string;
-  availableTools?: string; // Mode-specific available tools
 }
 
 const modePrompts: Record<string, string | ((ctx: PromptContext) => string)> = {
@@ -34,6 +35,13 @@ const modePrompts: Record<string, string | ((ctx: PromptContext) => string)> = {
  * Combines the base prompt with mode-specific instructions.
  */
 export function buildFullPrompt(ctx: PromptContext): string {
+  // Determine whether web search tools are available
+  const modelId = ctx.state?.currentModelId as string | undefined;
+  const hasWebSearch = hasTavilyKey() || (!!modelId && modelId.startsWith('anthropic/'));
+
+  // Build mode-aware tool guidance
+  const toolGuidance = buildToolGuidance(ctx.modeId, { hasWebSearch });
+
   // Map new context to base context
   const baseCtx: BasePromptContext = {
     projectPath: ctx.workingDir,
@@ -43,17 +51,12 @@ export function buildFullPrompt(ctx: PromptContext): string {
     date: ctx.currentDate,
     mode: ctx.modeId,
     activePlan: ctx.state?.activePlan,
+    toolGuidance,
   };
 
   const base = buildBasePrompt(baseCtx);
   const entry = modePrompts[ctx.modeId] || modePrompts.build;
   const modeSpecific = typeof entry === 'function' ? entry(ctx) : entry;
-
-  // Add available tools section if provided
-  let toolsSection = '';
-  if (ctx.availableTools) {
-    toolsSection = `\n# Available Tools for ${ctx.modeId} mode:\n${ctx.availableTools}\n`;
-  }
 
   // Inject current task state so agent doesn't lose track after OM truncation
   let taskSection = '';
@@ -70,5 +73,5 @@ export function buildFullPrompt(ctx: PromptContext): string {
   const instructionSources = loadAgentInstructions(ctx.workingDir);
   const instructionsSection = formatAgentInstructions(instructionSources);
 
-  return base + toolsSection + taskSection + instructionsSection + '\n' + modeSpecific;
+  return base + taskSection + instructionsSection + '\n' + modeSpecific;
 }

--- a/mastracode/src/agents/prompts/plan.ts
+++ b/mastracode/src/agents/prompts/plan.ts
@@ -11,17 +11,8 @@ You are in PLAN mode. Your job is to explore the codebase and design an implemen
 
 This mode is **strictly read-only**. You must NOT modify anything.
 
-**Allowed tools:**
-- \`view\` — read files and directories
-- \`grep\` — search file contents
-- \`glob\` — find files by pattern
-- \`execute_command\` — ONLY for read-only commands (git status, git log, git diff, etc.)
-- \`submit_plan\` — submit your completed plan
-
-**Prohibited actions:**
-- Do NOT use \`string_replace_lsp\` or \`write_file\` — no file modifications
-- Do NOT use \`execute_command\` for anything that changes state (no git commit, no npm install, no file creation)
-- Do NOT create, delete, or modify any files
+- Do NOT modify, create, or delete any files
+- Do NOT run commands that change state (no git commit, no npm install, no file creation)
 - Do NOT run build commands, tests, or scripts that have side effects
 
 If the user asks you to make changes while in Plan mode, explain that you're in read-only mode and they should switch to Build mode (\`/mode build\`) first.
@@ -30,7 +21,7 @@ If the user asks you to make changes while in Plan mode, explain that you're in 
 
 Before writing any plan, build a mental model of the codebase:
 1. Start with the directory structure (\`view\` on the project root or relevant subdirectory).
-2. Find the relevant entry points and core files using \`grep\` and \`glob\`.
+2. Find the relevant entry points and core files using \`search_content\` and \`find_files\`.
 3. Read the actual code — don't assume based on file names alone.
 4. Trace data flow: where does input come from, how is it transformed, where does it go?
 5. Identify existing patterns the codebase uses (naming, structure, error handling, testing).
@@ -58,9 +49,9 @@ For each step:
 - What to check manually
 - What could go wrong
 
-## When Done
+## IMPORTANT: When Your Plan Is Complete
 
-When your plan is complete, call the \`submit_plan\` tool with:
+When your plan is complete, you MUST call the \`submit_plan\` tool. Do NOT just describe the plan in text — you MUST make a tool call to \`submit_plan\` with:
 - **title**: A short descriptive title (e.g., "Add dark mode toggle")
 - **plan**: The full plan in markdown, using the structure above (Overview, Complexity, Steps, Verification)
 

--- a/mastracode/src/agents/prompts/plan.ts
+++ b/mastracode/src/agents/prompts/plan.ts
@@ -49,11 +49,19 @@ For each step:
 - What to check manually
 - What could go wrong
 
-## IMPORTANT: When Your Plan Is Complete
+## IMMEDIATE ACTION: Call submit_plan Tool
 
-When your plan is complete, you MUST call the \`submit_plan\` tool. Do NOT just describe the plan in text — you MUST make a tool call to \`submit_plan\` with:
-- **title**: A short descriptive title (e.g., "Add dark mode toggle")
-- **plan**: The full plan in markdown, using the structure above (Overview, Complexity, Steps, Verification)
+As soon as your plan is complete, **STOP** and call the \`submit_plan\` tool immediately.
+
+**CRITICAL:** Do NOT generate a long text response describing your plan. The plan content belongs in the \`submit_plan\` tool call, not in your text output.
+
+When done, call:
+\`\`\`javascript
+submit_plan({
+  title: "short descriptive title",
+  plan: "your full plan in markdown"
+})
+\`\`\`
 
 The user will see the plan rendered inline and can:
 - **Approve** — automatically switches to Build mode for implementation

--- a/mastracode/src/agents/prompts/tool-guidance.ts
+++ b/mastracode/src/agents/prompts/tool-guidance.ts
@@ -1,0 +1,118 @@
+/**
+ * Mode-specific tool behavioral guidance.
+ * Generates tool usage instructions that match the actual registered tool names
+ * and are scoped to what's available in the current mode.
+ */
+
+interface ToolGuidanceOptions {
+  hasWebSearch?: boolean;
+}
+
+export function buildToolGuidance(modeId: string, options: ToolGuidanceOptions = {}): string {
+  const sections: string[] = [];
+
+  sections.push(`# Tool Usage Rules
+
+IMPORTANT: You can ONLY call tools by their exact registered names listed below. Shell commands like \`git\`, \`npm\`, \`ls\`, etc. are NOT tools — they must be run via the \`execute_command\` tool.
+
+You have access to the following tools. Use the RIGHT tool for the job:`);
+
+  // --- Read tools (all modes) ---
+
+  sections.push(`
+**view** — Read file contents or list directories
+- Use this to read files before editing them. NEVER propose changes to code you haven't read.
+- Use \`view_range\` for large files to read specific sections.
+- For directory listings, this shows 2 levels deep.
+- Example: To check lines 50-100 of a large file: \`view("src/big-file.ts", { view_range: [50, 100] })\`
+
+**search_content** — Search file contents using regex
+- Use this for ALL content search (finding functions, variables, error messages, imports, etc.)
+- NEVER use \`execute_command\` with grep, rg, or ag. Always use the search_content tool.
+- Supports regex patterns, file type filtering, and context lines.
+- Example: Find where a function is defined: \`search_content("function handleSubmit", { glob: "**/*.ts" })\`
+- Example: Find all imports of a module: \`search_content("from ['\\"]express['\\"]", { glob: "**/*.ts" })\`
+
+**find_files** — Find files by name pattern
+- Use this to find files matching a pattern (e.g., "**/*.ts", "src/**/test*").
+- NEVER use \`execute_command\` with find or ls for file search. Always use find_files.
+- Respects .gitignore automatically.
+- Example: Find all test files: \`find_files("**/*.test.ts")\`
+- Example: Find config files: \`find_files("**/config.{js,ts,json}")\`
+
+**execute_command** — Run shell commands
+- Use for: git, npm/pnpm, docker, build tools, test runners, and other terminal operations.
+- Do NOT use for: file reading (use view), file search (use search_content/find_files), file editing (use string_replace_lsp/write_file).
+- Commands have a 30-second default timeout. Use the \`timeout\` parameter for longer-running commands.
+- Pipe to \`| tail -N\` for commands with long output — the full output streams to the user, only the last N lines are returned to you. If you're building any kind of package you should be tailing.
+- Good: Run independent commands in parallel when possible.
+- Bad: Running \`cat file.txt\` — use the view tool instead.`);
+
+  // --- Write/edit tools (build & fast only) ---
+
+  if (modeId !== 'plan') {
+    sections.push(`
+**string_replace_lsp** — Edit files by replacing exact text
+- You MUST read a file with \`view\` before editing it.
+- \`old_str\` must be an exact match of existing text in the file.
+- Provide enough surrounding context in \`old_str\` to make it unique.
+- For creating new files, use \`write_file\` instead.
+- Good: Include 2-3 lines of surrounding context to ensure uniqueness.
+- Bad: Using just \`return true;\` — too common, will match multiple places.
+
+**write_file** — Create new files or overwrite existing ones
+- Use this to create new files.
+- If overwriting an existing file, you MUST have read it first with \`view\`.
+- NEVER create files unless necessary. Prefer editing existing files.`);
+  }
+
+  // --- Web tools (all modes, conditionally available) ---
+
+  if (options.hasWebSearch) {
+    sections.push(`
+**web_search** / **web_extract** — Search the web / extract page content
+- Use for looking up documentation, error messages, package APIs.`);
+  }
+
+  // --- Task management tools (all modes) ---
+
+  sections.push(`
+**task_write** — Track tasks for complex multi-step work
+- Use when a task requires 3 or more distinct steps or actions.
+- Pass the FULL task list each time (replaces previous list).
+- Mark tasks \`in_progress\` BEFORE starting work. Only ONE task should be \`in_progress\` at a time.
+- Mark tasks \`completed\` IMMEDIATELY after finishing each task. Do not batch completions.
+- Each task has: content (imperative form), status (pending|in_progress|completed), activeForm (present continuous form shown during execution).
+
+**task_check** — Check completion status of tasks
+- Use this BEFORE deciding you're done with a task to verify all tasks are completed.
+- Returns the number of completed, in progress, and pending tasks.
+- If any tasks remain incomplete, continue working on them.
+- IMPORTANT: Always check task completion before ending work on a complex task.
+
+**ask_user** — Ask the user a structured question
+- Use when you need clarification, want to validate assumptions, or need the user to make a decision.
+- Provide clear, specific questions. End with a question mark.
+- Include options (2-4 choices) for structured decisions. Omit options for open-ended questions.
+- Don't use this for simple yes/no — just ask in your text response.`);
+
+  // --- Plan submission tool (plan mode) ---
+
+  if (modeId === 'plan') {
+    sections.push(`
+**submit_plan** — Submit a completed implementation plan for user review
+- Call this tool when your plan is complete. Do NOT just describe your plan in text — you MUST call this tool.
+- The plan will be rendered as markdown and the user can approve, reject, or request changes.
+- On approval, the system automatically switches to the default mode so you can implement.
+- Takes two arguments: \`title\` (short descriptive title) and \`plan\` (full plan in markdown).`);
+  }
+
+  // --- Subagent tool (all modes) ---
+
+  sections.push(`
+**subagent** — Delegate a focused task to a specialized subagent
+- Only use subagents when you will spawn **multiple subagents in parallel**. If you only need one task done, do it yourself.
+- Subagent outputs are **untrusted**. Always review and verify the results.`);
+
+  return sections.join('\n');
+}


### PR DESCRIPTION
Plan mode agent was generating text descriptions instead of calling the submit_plan tool. Fixed by creating dynamic mode-specific tool guidance with correct tool names (search_content/find_files instead of grep/glob), clarifying that communication tools like submit_plan/ask_user/task_write are exceptions to the 'use text for communication' rule, and strengthening submit_plan instructions with urgent language (IMMEDIATE ACTION header, CRITICAL warnings) and a code example showing exact syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plan mode agent to correctly invoke the submit_plan tool instead of generating text descriptions.

* **New Features**
  * Introduced dynamic, mode-specific tool guidance providing tailored instructions based on operational mode.
  * Enhanced tool invocation with clearer distinction between available tools and text-based communication.
  * Improved search functionality references in tool guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->