### PR TITLE
fix(cli): add analytics tracking to mastra studio command

### DIFF
--- a/packages/cli/src/commands/actions/start-studio.ts
+++ b/packages/cli/src/commands/actions/start-studio.ts
@@ -1,0 +1,21 @@
+import { analytics, origin } from '../..';
+import { studio } from '../studio';
+
+interface StudioArgs {
+  port?: string | number;
+  env?: string;
+  serverHost?: string;
+  serverPort?: string | number;
+  serverProtocol?: string;
+  serverApiPrefix?: string;
+  requestContextPresets?: string;
+}
+
+export const startStudio = async (args: StudioArgs) => {
+  analytics.trackCommand({
+    command: 'studio',
+    origin,
+  });
+
+  await studio(args);
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,8 +15,8 @@ import { listScorers } from './commands/actions/list-scorers';
 import { migrate } from './commands/actions/migrate';
 import { startDevServer } from './commands/actions/start-dev-server';
 import { startProject } from './commands/actions/start-project';
+import { startStudio } from './commands/actions/start-studio';
 import { COMPONENTS, LLMProvider } from './commands/init/utils';
-import { studio } from './commands/studio';
 import { parseComponents, parseLlmProvider, parseMcp, parseSkills } from './commands/utils';
 
 const mastraPkg = pkgJson as PackageJson;
@@ -162,7 +162,7 @@ program
   .option('-x, --server-protocol <serverProtocol>', 'Protocol of the Mastra API server (default: http)')
   .option('--server-api-prefix <serverApiPrefix>', 'API route prefix of the Mastra server (default: /api)')
   .option('--request-context-presets <file>', 'Path to request context presets JSON file')
-  .action(studio);
+  .action(startStudio);
 
 program
   .command('migrate')


### PR DESCRIPTION
The studio command was not wired up to send analytics events to PostHog, unlike all other CLI commands. Created a startStudio action wrapper that tracks command execution using the same fire-and-forget pattern as the dev command (since studio is a long-running server process).

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the CLI studio command structure to improve code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->