### PR TITLE
fix(tui): fix view tool rendering for workspace read_file output

### DIFF
--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -99,6 +99,11 @@ export function getDynamicWorkspace({ requestContext }: { requestContext: Reques
       workingDirectory: projectPath,
       env: process.env,
     }),
+    // Disable workspace tools — built-in tools are used instead.
+    // Workspace tools use different output formats (e.g. → separator, offset/limit params)
+    // that the TUI renderers don't fully support yet.
+    // We will update to use workspace tools very soon - just disabling until then
+    tools: { enabled: false },
     ...(skillPaths.length > 0 ? { skills: skillPaths } : {}),
   });
 

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -249,9 +249,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       const path = argsObj?.path ? shortenPath(String(argsObj.path)) : '...';
       const rangeDisplay = viewRange ? theme.fg('muted', `:${viewRange[0]},${viewRange[1]}`) : '';
       const status = this.getStatusIndicator();
-      const pathDisplay = fullPath
-        ? fileLink(theme.fg('accent', path), fullPath, startLine)
-        : theme.fg('accent', path);
+      const pathDisplay = fullPath ? fileLink(theme.fg('accent', path), fullPath, startLine) : theme.fg('accent', path);
       const headerText = `${theme.bold(theme.fg('toolTitle', 'view'))} ${pathDisplay}${rangeDisplay}${status}`;
       this.contentBox.addChild(new Text(headerText, 0, 0));
       return;
@@ -270,9 +268,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       path = '…' + path.slice(-(availableForPath - 1));
     }
 
-    const pathDisplay = fullPath
-      ? fileLink(theme.fg('accent', path), fullPath, startLine)
-      : theme.fg('accent', path);
+    const pathDisplay = fullPath ? fileLink(theme.fg('accent', path), fullPath, startLine) : theme.fg('accent', path);
     const footerText = `${theme.bold(theme.fg('toolTitle', 'view'))} ${pathDisplay}${rangeDisplay}${status}`;
 
     // Empty line padding above

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -241,7 +241,8 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const argsObj = this.args as Record<string, unknown> | undefined;
     const fullPath = argsObj?.path ? String(argsObj.path) : '';
     const viewRange = argsObj?.view_range as [number, number] | undefined;
-    const startLine = viewRange?.[0] ?? 1;
+    // view tool uses view_range[0], workspace read_file uses offset
+    const startLine = viewRange?.[0] ?? (argsObj?.offset as number | undefined) ?? 1;
     // Don't show border until we have a result
     if (!this.result || this.isPartial) {
       // Just show pending indicator
@@ -249,7 +250,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       const rangeDisplay = viewRange ? theme.fg('muted', `:${viewRange[0]},${viewRange[1]}`) : '';
       const status = this.getStatusIndicator();
       const pathDisplay = fullPath
-        ? fileLink(theme.fg('accent', path), fullPath, viewRange?.[0])
+        ? fileLink(theme.fg('accent', path), fullPath, startLine)
         : theme.fg('accent', path);
       const headerText = `${theme.bold(theme.fg('toolTitle', 'view'))} ${pathDisplay}${rangeDisplay}${status}`;
       this.contentBox.addChild(new Text(headerText, 0, 0));
@@ -270,7 +271,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     }
 
     const pathDisplay = fullPath
-      ? fileLink(theme.fg('accent', path), fullPath, viewRange?.[0])
+      ? fileLink(theme.fg('accent', path), fullPath, startLine)
       : theme.fg('accent', path);
     const footerText = `${theme.bold(theme.fg('toolTitle', 'view'))} ${pathDisplay}${rangeDisplay}${status}`;
 
@@ -1108,27 +1109,35 @@ function getLanguageFromPath(path: string): string | undefined {
   return ext ? langMap[ext] : undefined;
 }
 
-/** Strip cat -n formatting and apply syntax highlighting */
+/** Strip line number formatting (cat -n or workspace →) and apply syntax highlighting */
 function highlightCode(content: string, path: string, startLine?: number): string {
   let lines = content.split('\n').map(line => line.trimEnd());
-  // Remove "[Truncated N tokens]" and "Here's the result of running `cat -n`..." headers
+  // Remove known headers:
+  // - "[Truncated N tokens]" from token truncation
+  // - "Here's the result of running `cat -n`..." from view tool
+  // - "/path/to/file (NNN bytes)" or "/path/to/file (lines N-M of T, NNN bytes)" from workspace read_file
   while (
     lines.length > 0 &&
-    (lines[0]!.includes("Here's the result of running") || lines[0]!.match(/^\[Truncated \d+ tokens\]$/))
+    (lines[0]!.includes("Here's the result of running") ||
+      lines[0]!.match(/^\[Truncated \d+ tokens\]$/) ||
+      lines[0]!.match(/^.*\(\d+ bytes\)$/) ||
+      lines[0]!.match(/^.*\(lines \d+-\d+ of \d+, \d+ bytes\)$/))
   ) {
     lines = lines.slice(1);
   }
 
   // Strip line numbers - we know they're sequential starting from startLine
+  // Supports two formats:
+  //   view tool:           "   123\tcode" (tab separator)
+  //   workspace read_file: "     123→code" (arrow separator)
+  // Separator is optional because trimEnd() strips trailing tabs on blank lines
   let expectedLineNum = startLine ?? 1;
   const codeLines = lines.map(line => {
     const numStr = String(expectedLineNum);
-    // Line format is like "   123\tcode" or "   123" for blank lines
-    // Check if line starts with spaces + our expected number
-    const match = line.match(/^(\s*)(\d+)(\t?)(.*)$/);
+    const match = line.match(/^(\s*)(\d+)[\t→]?(.*)$/);
     if (match && match[2] === numStr) {
       expectedLineNum++;
-      return match[4]; // Return just the code part after the tab
+      return match[3]; // Return just the code part after the separator
     }
     return line;
   });


### PR DESCRIPTION
The TUI view renderer only handled the built-in `view` tool's output format (tab separator between line numbers and code, `cat -n` headers). When `mastra_workspace_read_file` was used instead, its different format (→ arrow separator, different headers like `/path/to/file (N bytes)`) leaked through unprocessed, causing arrow characters to appear in rendered output.

Fixed `highlightCode()` to handle both formats:

```
// before: only matched tab separator
line.match(/^(\s*)(\d+)(\t?)(.*)$/)

// after: matches both tab and → separator
line.match(/^(\s*)(\d+)[\t→](.*)$/)
```

Also added header stripping for workspace tool headers and fixed `startLine` extraction to read the `offset` param when `view_range` isn't present.

As a secondary fix, disabled workspace tools entirely via `tools: { enabled: false }` in the workspace config since they duplicate built-in tools and the renderers weren't designed for their output formats. Skills still work since the workspace itself is preserved. In a follow up PR we will remove all the local tools in favor of workspace tools, but that needs more testing, can't yolo such a significant change rn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to disable built-in workspace tools during dynamic workspace creation.

* **Bug Fixes**
  * Aligned line-number handling so view links and offsets use a consistent start line.
  * Improved header/link generation to use the correct start line.
  * Stripped extra headers/metadata and preserved code content for highlighting.
  * Supported two common line-number formats and their separators for robust code rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->