### PR TITLE
fix(mastracode): default codex model from 5.3 to 5.2

### DIFF
--- a/mastracode/src/auth/storage.ts
+++ b/mastracode/src/auth/storage.ts
@@ -22,7 +22,7 @@ import type {
  */
 export const PROVIDER_DEFAULT_MODELS: Record<OAuthProviderId, string> = {
   anthropic: 'anthropic/claude-opus-4-6',
-  'openai-codex': 'openai/gpt-5.3-codex',
+  'openai-codex': 'openai/gpt-5.2-codex',
 };
 
 // Provider registry

--- a/mastracode/src/onboarding/packs.ts
+++ b/mastracode/src/onboarding/packs.ts
@@ -56,7 +56,7 @@ export function getAvailableModePacks(
 ): ModePack[] {
   const packs: ModePack[] = [];
 
-  const openaiCodex = access.openai === 'oauth' ? 'openai/gpt-5.3-codex' : 'openai/gpt-5.2-codex';
+  const openaiCodex = 'openai/gpt-5.2-codex';
   const anthropicBuild = access.anthropic === 'oauth' ? 'anthropic/claude-opus-4-6' : 'anthropic/claude-sonnet-4-5';
 
   // Varied — needs both Anthropic + OpenAI.  Cerebras is nice-to-have; fall


### PR DESCRIPTION
Changes the default Codex model from 5.3 to 5.2 since 5.3 is not working well right now - 5.3 seems to very strictly adhere to system prompt and our system prompt needs work to not confuse 5.3. Will follow up with a proper fix for 5.3 later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default OpenAI Codex model version to ensure consistent behavior and reliability across code generation and onboarding workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->