### PR TITLE
feat(core): add setToolsConfig to Workspace

### DIFF
--- a/.changeset/long-crews-grin.md
+++ b/.changeset/long-crews-grin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added `setToolsConfig()` method to Workspace class for dynamically updating per-tool configuration (e.g., disabling write tools in plan mode) without recreating the workspace instance.

--- a/.changeset/long-crews-grin.md
+++ b/.changeset/long-crews-grin.md
@@ -2,4 +2,17 @@
 '@mastra/core': minor
 ---
 
-Added `setToolsConfig()` method to Workspace class for dynamically updating per-tool configuration (e.g., disabling write tools in plan mode) without recreating the workspace instance.
+Added `Workspace.setToolsConfig()` method for dynamically updating per-tool configuration at runtime without recreating the workspace instance. Passing `undefined` re-enables all tools.
+
+```ts
+const workspace = new Workspace({ filesystem, sandbox });
+
+// Disable write tools (e.g., in plan/read-only mode)
+workspace.setToolsConfig({
+  mastra_workspace_write_file: { enabled: false },
+  mastra_workspace_edit_file: { enabled: false },
+});
+
+// Re-enable all tools
+workspace.setToolsConfig(undefined);
+```

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { RequestContext } from '../request-context';
+import { WORKSPACE_TOOLS } from './constants';
 import {
   WorkspaceError,
   FilesystemNotAvailableError,
@@ -12,6 +13,7 @@ import {
 } from './errors';
 import { CompositeFilesystem, LocalFilesystem } from './filesystem';
 import { LocalSandbox } from './sandbox';
+import { createWorkspaceTools } from './tools';
 import { Workspace } from './workspace';
 
 // =============================================================================
@@ -813,48 +815,66 @@ Line 3 conclusion`;
   // setToolsConfig
   // ===========================================================================
   describe('setToolsConfig', () => {
-    it('should update tools config from undefined', () => {
+    it('should disable tools excluded by config on next createWorkspaceTools call', () => {
       const filesystem = new LocalFilesystem({ basePath: tempDir });
       const workspace = new Workspace({ filesystem });
 
-      expect(workspace.getToolsConfig()).toBeUndefined();
+      // All tools available initially
+      const toolsBefore = createWorkspaceTools(workspace);
+      expect(toolsBefore[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]).toBeDefined();
+      expect(toolsBefore[WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE]).toBeDefined();
 
-      const newConfig = {
-        mastra_workspace_write_file: { enabled: false },
-      };
-      workspace.setToolsConfig(newConfig);
-
-      expect(workspace.getToolsConfig()).toEqual(newConfig);
-    });
-
-    it('should replace existing tools config', () => {
-      const filesystem = new LocalFilesystem({ basePath: tempDir });
-      const workspace = new Workspace({
-        filesystem,
-        tools: { mastra_workspace_read_file: { enabled: true } },
-      });
-
-      const newConfig = {
+      // Disable write and edit tools
+      workspace.setToolsConfig({
         mastra_workspace_write_file: { enabled: false },
         mastra_workspace_edit_file: { enabled: false },
-      };
-      workspace.setToolsConfig(newConfig);
+      });
 
-      expect(workspace.getToolsConfig()).toEqual(newConfig);
+      const toolsAfter = createWorkspaceTools(workspace);
+      expect(toolsAfter[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]).toBeUndefined();
+      expect(toolsAfter[WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE]).toBeUndefined();
+      // Other tools still available
+      expect(toolsAfter[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]).toBeDefined();
     });
 
-    it('should clear tools config when set to undefined', () => {
+    it('should re-enable all tools when config is cleared', () => {
       const filesystem = new LocalFilesystem({ basePath: tempDir });
       const workspace = new Workspace({
         filesystem,
         tools: { mastra_workspace_write_file: { enabled: false } },
       });
 
-      expect(workspace.getToolsConfig()).toBeDefined();
+      // Write tool disabled initially
+      const toolsBefore = createWorkspaceTools(workspace);
+      expect(toolsBefore[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]).toBeUndefined();
 
+      // Clear config — all tools re-enabled
       workspace.setToolsConfig(undefined);
 
-      expect(workspace.getToolsConfig()).toBeUndefined();
+      const toolsAfter = createWorkspaceTools(workspace);
+      expect(toolsAfter[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]).toBeDefined();
+    });
+
+    it('should replace existing config entirely', () => {
+      const filesystem = new LocalFilesystem({ basePath: tempDir });
+      const workspace = new Workspace({
+        filesystem,
+        tools: { mastra_workspace_write_file: { enabled: false } },
+      });
+
+      // Write disabled, edit enabled
+      const tools1 = createWorkspaceTools(workspace);
+      expect(tools1[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]).toBeUndefined();
+      expect(tools1[WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE]).toBeDefined();
+
+      // Replace: now edit disabled, write re-enabled
+      workspace.setToolsConfig({
+        mastra_workspace_edit_file: { enabled: false },
+      });
+
+      const tools2 = createWorkspaceTools(workspace);
+      expect(tools2[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]).toBeDefined();
+      expect(tools2[WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE]).toBeUndefined();
     });
   });
 

--- a/packages/core/src/workspace/workspace.test.ts
+++ b/packages/core/src/workspace/workspace.test.ts
@@ -810,6 +810,55 @@ Line 3 conclusion`;
   });
 
   // ===========================================================================
+  // setToolsConfig
+  // ===========================================================================
+  describe('setToolsConfig', () => {
+    it('should update tools config from undefined', () => {
+      const filesystem = new LocalFilesystem({ basePath: tempDir });
+      const workspace = new Workspace({ filesystem });
+
+      expect(workspace.getToolsConfig()).toBeUndefined();
+
+      const newConfig = {
+        mastra_workspace_write_file: { enabled: false },
+      };
+      workspace.setToolsConfig(newConfig);
+
+      expect(workspace.getToolsConfig()).toEqual(newConfig);
+    });
+
+    it('should replace existing tools config', () => {
+      const filesystem = new LocalFilesystem({ basePath: tempDir });
+      const workspace = new Workspace({
+        filesystem,
+        tools: { mastra_workspace_read_file: { enabled: true } },
+      });
+
+      const newConfig = {
+        mastra_workspace_write_file: { enabled: false },
+        mastra_workspace_edit_file: { enabled: false },
+      };
+      workspace.setToolsConfig(newConfig);
+
+      expect(workspace.getToolsConfig()).toEqual(newConfig);
+    });
+
+    it('should clear tools config when set to undefined', () => {
+      const filesystem = new LocalFilesystem({ basePath: tempDir });
+      const workspace = new Workspace({
+        filesystem,
+        tools: { mastra_workspace_write_file: { enabled: false } },
+      });
+
+      expect(workspace.getToolsConfig()).toBeDefined();
+
+      workspace.setToolsConfig(undefined);
+
+      expect(workspace.getToolsConfig()).toBeUndefined();
+    });
+  });
+
+  // ===========================================================================
   // __setLogger
   // ===========================================================================
   describe('__setLogger', () => {

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -524,7 +524,7 @@ export class Workspace<
    * ```
    */
   setToolsConfig(config: WorkspaceToolsConfig | undefined): void {
-    (this._config as { tools?: WorkspaceToolsConfig }).tools = config;
+    this._config.tools = config;
   }
 
   /**

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -508,6 +508,26 @@ export class Workspace<
   }
 
   /**
+   * Update the per-tool configuration for this workspace.
+   * Takes effect on the next `createWorkspaceTools()` call.
+   *
+   * @example
+   * ```typescript
+   * // Disable write tools for read-only mode
+   * workspace.setToolsConfig({
+   *   mastra_workspace_write_file: { enabled: false },
+   *   mastra_workspace_edit_file: { enabled: false },
+   * });
+   *
+   * // Re-enable all tools
+   * workspace.setToolsConfig(undefined);
+   * ```
+   */
+  setToolsConfig(config: WorkspaceToolsConfig | undefined): void {
+    (this._config as { tools?: WorkspaceToolsConfig }).tools = config;
+  }
+
+  /**
    * Access skills stored in this workspace.
    * Skills are SKILL.md files discovered from the configured skillPaths.
    *


### PR DESCRIPTION
## Summary
- Adds `setToolsConfig()` method to the `Workspace` class for dynamically updating per-tool configuration without recreating the workspace instance
- Useful for toggling tools at runtime (e.g., disabling write tools in plan/read-only mode)

## Test plan
- [ ] Verify `setToolsConfig()` updates the internal config
- [ ] Verify `createWorkspaceTools()` respects the updated config on next call
- [ ] Verify passing `undefined` re-enables all tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime update of per-tool configurations for a workspace; updated tool settings take effect the next time tools are initialized (can disable or re-enable tools).

* **Tests**
  * Added tests covering setting, replacing, and clearing per-tool configurations and verifying behavior.

* **Chores**
  * Added a changeset for a minor package version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->