### PR TITLE
fix(core): sort unlisted models to end in reorderModels()

### DIFF
--- a/.changeset/fix-reorder-models-unknown-ids.md
+++ b/.changeset/fix-reorder-models-unknown-ids.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix `reorderModels()` sorting unknown model IDs to the front of the list instead of keeping them at the end. Models not present in the `modelIds` parameter now sort to the end of the array, preventing them from silently becoming the primary model.

--- a/.changeset/fix-reorder-models-unknown-ids.md
+++ b/.changeset/fix-reorder-models-unknown-ids.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fix `reorderModels()` sorting unknown model IDs to the front of the list instead of keeping them at the end. Models not present in the `modelIds` parameter now sort to the end of the array, preventing them from silently becoming the primary model.
+Prevent unknown model IDs from being sorted to the front in `reorderModels()`. Models not present in the `modelIds` parameter are now moved to the end of the array. Fixes #13410.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1526,7 +1526,9 @@ export class Agent<
     this.model = this.model.sort((a, b) => {
       const aIndex = modelIds.indexOf(a.id);
       const bIndex = modelIds.indexOf(b.id);
-      return aIndex - bIndex;
+      const aPos = aIndex === -1 ? Infinity : aIndex;
+      const bPos = bIndex === -1 ? Infinity : bIndex;
+      return aPos - bPos;
     });
     this.logger.debug(`[Agents:${this.name}] Models reordered`);
   }


### PR DESCRIPTION
## Description

Fixed `reorderModels()` in `Agent` class where `Array.indexOf()` returns `-1` for model IDs not present in the `modelIds` parameter. The sort comparator
`aIndex - bIndex` computes `(-1) - 0 = -1`, causing unlisted models to sort to the **front** of the array instead of the end. This silently makes an
unlisted model the primary model (position 0), affecting all subsequent `getModel()` and `getLLM()` calls. The fix replaces `-1` with `Infinity` so
unlisted models sort to the end.

## Related Issue(s)

Fixes #13410

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model reordering now consistently places unknown or unlisted model IDs at the end of the list instead of moving them to the front, preventing unexpected changes to primary model order and ensuring predictable behavior during partial reorders.
* **Tests**
  * Added a test to verify unlisted models remain at the end after reordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->