### PR TITLE
feat(playground-ui): add Preprocessors CMS page for agent create/edit

### DIFF
--- a/.changeset/quick-terms-obey.md
+++ b/.changeset/quick-terms-obey.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added Preprocessors CMS page for configuring processor providers on agents. Users can now toggle processor providers on/off and configure which processing phases (input, output) are enabled per provider during agent create and edit.

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-pages/index.ts
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-pages/index.ts
@@ -7,3 +7,4 @@ export * from './workflows-page';
 export * from './memory-page';
 export * from './variables-page';
 export * from './skills-page';
+export * from './processors-page';

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-pages/processors-page.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-pages/processors-page.tsx
@@ -143,9 +143,7 @@ function PhaseSelection({ providerId, availablePhases }: { providerId: string; a
                 onCheckedChange={checked => handlePhaseToggle(phase, checked)}
               />
             )}
-            {readOnly && (
-              <span className="text-xs text-neutral3">{enabledPhases.includes(phase) ? 'On' : 'Off'}</span>
-            )}
+            {readOnly && <span className="text-xs text-neutral3">{enabledPhases.includes(phase) ? 'On' : 'Off'}</span>}
           </div>
         ))}
       </div>
@@ -153,13 +151,7 @@ function PhaseSelection({ providerId, availablePhases }: { providerId: string; a
   );
 }
 
-function ConfigFields({
-  providerId,
-  configSchema,
-}: {
-  providerId: string;
-  configSchema: Record<string, unknown>;
-}) {
+function ConfigFields({ providerId, configSchema }: { providerId: string; configSchema: Record<string, unknown> }) {
   const { form, readOnly } = useAgentEditFormContext();
   const { control } = form;
 

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-pages/processors-page.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-pages/processors-page.tsx
@@ -1,0 +1,288 @@
+import { Controller, useWatch } from 'react-hook-form';
+
+import { SectionHeader } from '@/domains/cms';
+import { ScrollArea } from '@/ds/components/ScrollArea';
+import { Label } from '@/ds/components/Label';
+import { Input } from '@/ds/components/Input';
+import { Switch } from '@/ds/components/Switch';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/ds/components/Select';
+import { Entity, EntityContent, EntityName, EntityDescription } from '@/ds/components/Entity';
+import { EmptyState } from '@/ds/components/EmptyState';
+import { ProcessorIcon } from '@/ds/icons/ProcessorIcon';
+import { useProcessorProviders } from '@/domains/processor-providers/hooks/use-processor-providers';
+import { useProcessorProvider } from '@/domains/processor-providers/hooks/use-processor-provider';
+
+import { useAgentEditFormContext } from '../../context/agent-edit-form-context';
+
+const PHASE_LABELS: Record<string, string> = {
+  processInput: 'Process Input',
+  processInputStep: 'Process Input Step',
+  processOutputStream: 'Process Output Stream',
+  processOutputResult: 'Process Output Result',
+  processOutputStep: 'Process Output Step',
+};
+
+export function ProcessorsPage() {
+  const { form, readOnly } = useAgentEditFormContext();
+  const { control } = form;
+  const { data, isLoading } = useProcessorProviders();
+  const providers = data?.providers ?? [];
+  return (
+    <ScrollArea className="h-full">
+      <div className="flex flex-col gap-6">
+        <SectionHeader
+          title="Preprocessors"
+          subtitle="Attach processor providers to transform inputs and outputs for this agent."
+        />
+
+        {!isLoading && providers.length === 0 && (
+          <div className="py-12">
+            <EmptyState
+              iconSlot={<ProcessorIcon height={40} width={40} />}
+              titleSlot="No processor providers registered"
+              descriptionSlot="Register processor providers in your Mastra configuration to attach them to agents."
+            />
+          </div>
+        )}
+
+        {providers.length > 0 && (
+          <div className="flex flex-col gap-2">
+            {providers.map(provider => (
+              <ProcessorProviderEntity
+                key={provider.id}
+                providerId={provider.id}
+                name={provider.name}
+                description={provider.description}
+                availablePhases={provider.availablePhases}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}
+
+function ProcessorProviderEntity({
+  providerId,
+  name,
+  description,
+  availablePhases,
+}: {
+  providerId: string;
+  name: string;
+  description?: string;
+  availablePhases: string[];
+}) {
+  const { form, readOnly } = useAgentEditFormContext();
+  const { control } = form;
+  const processorValue = useWatch({ control, name: `inputProcessors.${providerId}` });
+  const isEnabled = processorValue !== undefined;
+
+  const { data: providerDetails } = useProcessorProvider(providerId, { enabled: isEnabled });
+  const configSchema = providerDetails?.configSchema as Record<string, unknown> | undefined;
+
+  const handleToggle = (checked: boolean) => {
+    const current = form.getValues('inputProcessors') ?? {};
+    if (checked) {
+      form.setValue(
+        'inputProcessors',
+        { ...current, [providerId]: { config: {}, enabledPhases: [...availablePhases] } },
+        { shouldDirty: true },
+      );
+    } else {
+      const next = { ...current };
+      delete next[providerId];
+      form.setValue('inputProcessors', next, { shouldDirty: true });
+    }
+  };
+
+  return (
+    <Entity className="flex-col gap-0 p-0 overflow-hidden">
+      <div className="flex gap-3 py-3 px-4">
+        <EntityContent>
+          <EntityName>{name}</EntityName>
+          {description && <EntityDescription>{description}</EntityDescription>}
+        </EntityContent>
+
+        {!readOnly && <Switch checked={isEnabled} onCheckedChange={handleToggle} />}
+      </div>
+
+      {isEnabled && (
+        <div className="bg-surface2 border-t border-border1 p-4 flex flex-col gap-4">
+          <PhaseSelection providerId={providerId} availablePhases={availablePhases} />
+          {configSchema && <ConfigFields providerId={providerId} configSchema={configSchema} />}
+        </div>
+      )}
+    </Entity>
+  );
+}
+
+function PhaseSelection({ providerId, availablePhases }: { providerId: string; availablePhases: string[] }) {
+  const { form, readOnly } = useAgentEditFormContext();
+  const { control } = form;
+  const enabledPhases = (useWatch({ control, name: `inputProcessors.${providerId}.enabledPhases` }) ?? []) as string[];
+
+  const handlePhaseToggle = (phase: string, checked: boolean) => {
+    const current = form.getValues(`inputProcessors.${providerId}`) ?? { config: {}, enabledPhases: [] };
+    const currentPhases = (current.enabledPhases ?? []) as string[];
+    const next = checked ? [...currentPhases, phase] : currentPhases.filter(p => p !== phase);
+    form.setValue(`inputProcessors.${providerId}.enabledPhases`, next, { shouldDirty: true });
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Label className="text-sm text-neutral5">Enabled Phases</Label>
+      <div className="flex flex-col gap-1.5">
+        {availablePhases.map(phase => (
+          <div key={phase} className="flex items-center justify-between">
+            <span className="text-sm text-neutral4">{PHASE_LABELS[phase] ?? phase}</span>
+            {!readOnly && (
+              <Switch
+                checked={enabledPhases.includes(phase)}
+                onCheckedChange={checked => handlePhaseToggle(phase, checked)}
+              />
+            )}
+            {readOnly && (
+              <span className="text-xs text-neutral3">{enabledPhases.includes(phase) ? 'On' : 'Off'}</span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ConfigFields({
+  providerId,
+  configSchema,
+}: {
+  providerId: string;
+  configSchema: Record<string, unknown>;
+}) {
+  const { form, readOnly } = useAgentEditFormContext();
+  const { control } = form;
+
+  const properties = (configSchema as { properties?: Record<string, Record<string, unknown>> }).properties;
+  if (!properties || Object.keys(properties).length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Label className="text-sm text-neutral5">Configuration</Label>
+      <div className="grid grid-cols-2 gap-4">
+        {Object.entries(properties).map(([key, schema]) => (
+          <ConfigField key={key} providerId={providerId} fieldKey={key} schema={schema} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ConfigField({
+  providerId,
+  fieldKey,
+  schema,
+}: {
+  providerId: string;
+  fieldKey: string;
+  schema: Record<string, unknown>;
+}) {
+  const { form, readOnly } = useAgentEditFormContext();
+  const { control } = form;
+  const fieldName = `inputProcessors.${providerId}.config.${fieldKey}` as const;
+  const fieldType = schema.type as string | undefined;
+  const fieldEnum = schema.enum as string[] | undefined;
+  const fieldDescription = schema.description as string | undefined;
+  const fieldTitle = (schema.title as string | undefined) ?? fieldKey;
+
+  if (fieldEnum) {
+    return (
+      <Controller
+        name={fieldName}
+        control={control}
+        render={({ field }) => (
+          <div className="flex flex-col gap-1.5">
+            <Label className="text-sm text-neutral5">{fieldTitle}</Label>
+            {fieldDescription && <span className="text-xs text-neutral2">{fieldDescription}</span>}
+            <Select value={(field.value as string) ?? ''} onValueChange={field.onChange} disabled={readOnly}>
+              <SelectTrigger className="bg-surface3">
+                <SelectValue placeholder={`Select ${fieldTitle}`} />
+              </SelectTrigger>
+              <SelectContent>
+                {fieldEnum.map(opt => (
+                  <SelectItem key={opt} value={opt}>
+                    {opt}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+      />
+    );
+  }
+
+  if (fieldType === 'boolean') {
+    return (
+      <Controller
+        name={fieldName}
+        control={control}
+        render={({ field }) => (
+          <div className="flex flex-col gap-1.5">
+            <Label className="text-sm text-neutral5">{fieldTitle}</Label>
+            {fieldDescription && <span className="text-xs text-neutral2">{fieldDescription}</span>}
+            <Switch checked={(field.value as boolean) ?? false} onCheckedChange={field.onChange} disabled={readOnly} />
+          </div>
+        )}
+      />
+    );
+  }
+
+  if (fieldType === 'number' || fieldType === 'integer') {
+    return (
+      <Controller
+        name={fieldName}
+        control={control}
+        render={({ field }) => (
+          <div className="flex flex-col gap-1.5">
+            <Label className="text-sm text-neutral5">{fieldTitle}</Label>
+            {fieldDescription && <span className="text-xs text-neutral2">{fieldDescription}</span>}
+            <Input
+              type="number"
+              value={(field.value as number) ?? ''}
+              onChange={e => {
+                const v = e.target.value;
+                field.onChange(v === '' ? undefined : Number(v));
+              }}
+              placeholder={fieldTitle}
+              className="bg-surface3"
+              disabled={readOnly}
+            />
+          </div>
+        )}
+      />
+    );
+  }
+
+  // Default: string input
+  return (
+    <Controller
+      name={fieldName}
+      control={control}
+      render={({ field }) => (
+        <div className="flex flex-col gap-1.5">
+          <Label className="text-sm text-neutral5">{fieldTitle}</Label>
+          {fieldDescription && <span className="text-xs text-neutral2">{fieldDescription}</span>}
+          <Input
+            type="text"
+            value={(field.value as string) ?? ''}
+            onChange={e => field.onChange(e.target.value)}
+            placeholder={fieldTitle}
+            className="bg-surface3"
+            disabled={readOnly}
+          />
+        </div>
+      )}
+    />
+  );
+}

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-sidebar/agent-cms-sections.ts
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-sidebar/agent-cms-sections.ts
@@ -15,6 +15,7 @@ export const AGENT_CMS_SECTIONS: AgentCmsSection[] = [
   { name: 'Scorers', pathSuffix: '/scorers', descriptionKey: 'scorers', required: false },
   { name: 'Workflows', pathSuffix: '/workflows', descriptionKey: 'workflows', required: false },
   { name: 'Skills', pathSuffix: '/skills', descriptionKey: 'skills', required: false },
+  { name: 'Preprocessors', pathSuffix: '/processors', descriptionKey: 'processors', required: false },
   { name: 'Memory', pathSuffix: '/memory', descriptionKey: 'memory', required: false },
   { name: 'Variables', pathSuffix: '/variables', descriptionKey: 'variables', required: false },
 ];

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-sidebar/use-sidebar-descriptions.ts
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-sidebar/use-sidebar-descriptions.ts
@@ -31,6 +31,9 @@ export function useSidebarDescriptions(control: Control<AgentFormValues>) {
     const workflowCount = Object.keys(values.workflows ?? {}).length;
     const workflows = workflowCount === 0 ? 'None selected' : pluralize(workflowCount, 'workflow');
 
+    const processorCount = Object.keys(values.inputProcessors ?? {}).length;
+    const processors = processorCount === 0 ? 'None selected' : pluralize(processorCount, 'processor');
+
     const memory = values.memory?.enabled ? 'Enabled' : 'Disabled';
 
     const skillCount = Object.keys(values.skills ?? {}).length;
@@ -47,6 +50,7 @@ export function useSidebarDescriptions(control: Control<AgentFormValues>) {
       scorers: { description: scorers, done: scorerCount > 0 },
       workflows: { description: workflows, done: workflowCount > 0 },
       skills: { description: skills, done: skillCount > 0 },
+      processors: { description: processors, done: processorCount > 0 },
       memory: { description: memory, done: !!values.memory?.enabled },
       variables: { description: variables, done: variableCount > 0 },
     };

--- a/packages/playground-ui/src/domains/agents/components/agent-edit-page/utils/form-validation.ts
+++ b/packages/playground-ui/src/domains/agents/components/agent-edit-page/utils/form-validation.ts
@@ -238,6 +238,16 @@ export const agentFormSchema = z.object({
     .optional()
     .default([]),
   mcpClientsToDelete: z.array(z.string()).optional().default([]),
+  inputProcessors: z
+    .record(
+      z.string(),
+      z.object({
+        config: z.record(z.string(), z.unknown()).optional(),
+        enabledPhases: z.array(z.string()).optional(),
+      }),
+    )
+    .optional()
+    .default({}),
   skills: z.record(z.string(), skillConfigSchema).optional().default({}),
   workspace: z
     .discriminatedUnion('type', [

--- a/packages/playground-ui/src/domains/agents/hooks/use-agent-cms-form.ts
+++ b/packages/playground-ui/src/domains/agents/hooks/use-agent-cms-form.ts
@@ -16,6 +16,7 @@ import {
   mapScorersToApi,
   buildObservationalMemoryForApi,
   transformIntegrationToolsForApi,
+  mapInputProcessorsToApi,
 } from '../utils/agent-form-mappers';
 
 type CreateOptions = {
@@ -140,6 +141,7 @@ export function useAgentCmsForm(options: UseAgentCmsFormOptions) {
         agents: values.agents && Object.keys(values.agents).length > 0 ? values.agents : undefined,
         mcpClients: mcpClientsParam,
         scorers: mapScorersToApi(values.scorers),
+        inputProcessors: mapInputProcessorsToApi(values.inputProcessors),
         skills: values.skills,
         workspace: values.workspace,
         requestContextSchema: values.variables ? Object.fromEntries(Object.entries(values.variables)) : undefined,

--- a/packages/playground-ui/src/domains/agents/utils/compute-agent-initial-values.ts
+++ b/packages/playground-ui/src/domains/agents/utils/compute-agent-initial-values.ts
@@ -10,6 +10,7 @@ import {
   normalizeWorkspaceFromApi,
   mapInstructionBlocksFromApi,
   parseObservationalMemoryFromApi,
+  parseInputProcessorsFromApi,
 } from './agent-form-mappers';
 
 export interface AgentDataSource {
@@ -24,6 +25,7 @@ export interface AgentDataSource {
   scorers?: unknown;
   memory?: unknown;
   mcpClients?: unknown;
+  inputProcessors?: unknown;
   skills?: StoredAgentResponse['skills'];
   workspace?: StoredAgentResponse['workspace'];
   requestContextSchema?: unknown;
@@ -92,6 +94,9 @@ export function computeAgentInitialValues(dataSource: AgentDataSource): Partial<
         }
       : undefined,
     instructionBlocks,
+    inputProcessors: parseInputProcessorsFromApi(
+      dataSource.inputProcessors as Parameters<typeof parseInputProcessorsFromApi>[0],
+    ),
     skills: normalizeSkillsFromApi(dataSource.skills),
     workspace: normalizeWorkspaceFromApi(dataSource.workspace),
     variables: dataSource.requestContextSchema as AgentFormValues['variables'],

--- a/packages/playground-ui/src/domains/processor-providers/hooks/index.ts
+++ b/packages/playground-ui/src/domains/processor-providers/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './use-processor-providers';
+export * from './use-processor-provider';

--- a/packages/playground-ui/src/domains/processor-providers/hooks/use-processor-provider.ts
+++ b/packages/playground-ui/src/domains/processor-providers/hooks/use-processor-provider.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMastraClient } from '@mastra/react';
+
+export const useProcessorProvider = (providerId: string, options?: { enabled?: boolean }) => {
+  const client = useMastraClient();
+  return useQuery({
+    queryKey: ['processor-provider', providerId],
+    queryFn: () => client.getProcessorProvider(providerId).details(),
+    enabled: options?.enabled !== false,
+  });
+};

--- a/packages/playground-ui/src/domains/processor-providers/hooks/use-processor-providers.ts
+++ b/packages/playground-ui/src/domains/processor-providers/hooks/use-processor-providers.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMastraClient } from '@mastra/react';
+
+export const useProcessorProviders = () => {
+  const client = useMastraClient();
+  return useQuery({
+    queryKey: ['processor-providers'],
+    queryFn: () => client.getProcessorProviders(),
+  });
+};

--- a/packages/playground-ui/src/domains/processor-providers/index.ts
+++ b/packages/playground-ui/src/domains/processor-providers/index.ts
@@ -1,0 +1,1 @@
+export * from './hooks';

--- a/packages/playground/e2e/kitchen-sink/src/mastra/index.ts
+++ b/packages/playground/e2e/kitchen-sink/src/mastra/index.ts
@@ -8,7 +8,12 @@ import { complexWorkflow, lessComplexWorkflow } from './workflows/complex-workfl
 import { simpleMcpServer } from './mcps';
 import { registerApiRoute } from '@mastra/core/server';
 import { responseQualityScorer, responseTimeScorer } from './scorers';
-import { loggingProcessor, contentFilterProcessor } from './processors';
+import {
+  loggingProcessor,
+  contentFilterProcessor,
+  loggingProcessorProvider,
+  contentFilterProcessorProvider,
+} from './processors';
 
 export const mastra = new Mastra({
   workflows: { complexWorkflow, lessComplexWorkflow },
@@ -18,7 +23,12 @@ export const mastra = new Mastra({
     level: 'error',
   }),
   storage,
-  editor: new MastraEditor(),
+  editor: new MastraEditor({
+    processorProviders: {
+      'logging-processor': loggingProcessorProvider,
+      'content-filter': contentFilterProcessorProvider,
+    },
+  }),
   mcpServers: {
     simpleMcpServer,
   },

--- a/packages/playground/e2e/kitchen-sink/src/mastra/processors/index.ts
+++ b/packages/playground/e2e/kitchen-sink/src/mastra/processors/index.ts
@@ -1,4 +1,6 @@
+import { z } from 'zod';
 import type { Processor } from '@mastra/core/processors';
+import type { ProcessorProvider, ProcessorPhase } from '@mastra/core/processor-provider';
 
 export const loggingProcessor: Processor<'logging-processor'> = {
   id: 'logging-processor',
@@ -13,4 +15,30 @@ export const contentFilterProcessor: Processor<'content-filter'> = {
   description: 'Filters content based on rules',
   processInput: async args => args.messages,
   processOutputResult: async args => args.messages,
+};
+
+export const loggingProcessorProvider: ProcessorProvider = {
+  info: {
+    id: 'logging-processor',
+    name: 'Logging Processor',
+    description: 'Logs all input messages for debugging',
+  },
+  configSchema: z.object({}),
+  availablePhases: ['processInput'] as ProcessorPhase[],
+  createProcessor() {
+    return loggingProcessor;
+  },
+};
+
+export const contentFilterProcessorProvider: ProcessorProvider = {
+  info: {
+    id: 'content-filter',
+    name: 'Content Filter Processor',
+    description: 'Filters content based on rules',
+  },
+  configSchema: z.object({}),
+  availablePhases: ['processInput', 'processOutputResult'] as ProcessorPhase[],
+  createProcessor() {
+    return contentFilterProcessor;
+  },
 };

--- a/packages/playground/e2e/tests/cms/agents/create/page.spec.ts
+++ b/packages/playground/e2e/tests/cms/agents/create/page.spec.ts
@@ -14,6 +14,7 @@ const SIDEBAR_PATHS: Record<string, string> = {
   Agents: '/agents',
   Scorers: '/scorers',
   Workflows: '/workflows',
+  Preprocessors: '/processors',
   Memory: '/memory',
   Variables: '/variables',
 };
@@ -676,6 +677,139 @@ test.describe('Agent Creation Persistence - Variables', () => {
 
     await expect(page.getByPlaceholder('Variable name').first()).toHaveValue('firstName', { timeout: 10000 });
     await expect(page.getByPlaceholder('Variable name').nth(1)).toHaveValue('age');
+  });
+});
+
+test.describe('Agent Creation Persistence - Preprocessors', () => {
+  // Helper: find a provider's toggle switch by locating the provider name, then traversing
+  // up to the header row (EntityName -> EntityContent -> flex div) and finding the switch.
+  function getProviderToggle(page: Page, providerName: string) {
+    return page.getByText(providerName, { exact: true }).locator('..').locator('..').getByRole('switch');
+  }
+
+  test('displays available processor providers', async ({ page }) => {
+    await page.goto('/cms/agents/create');
+
+    await clickSidebarLink(page, 'Preprocessors');
+
+    await expect(page.getByText('Logging Processor', { exact: true })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Content Filter Processor', { exact: true })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('toggling processor on enables phase switches', async ({ page }) => {
+    await page.goto('/cms/agents/create');
+
+    await clickSidebarLink(page, 'Preprocessors');
+    await expect(page.getByText('Logging Processor', { exact: true })).toBeVisible({ timeout: 10000 });
+
+    // Toggle logging processor on
+    const loggingToggle = getProviderToggle(page, 'Logging Processor');
+    await loggingToggle.click();
+    await expect(loggingToggle).toBeChecked();
+
+    // Phase label "Process Input" should appear with its switch checked by default
+    await expect(page.getByText('Process Input')).toBeVisible({ timeout: 5000 });
+    const processInputSwitch = page.getByText('Process Input').locator('..').getByRole('switch');
+    await expect(processInputSwitch).toBeChecked();
+  });
+
+  test('processor selection persists after agent creation', async ({ page }) => {
+    await page.goto('/cms/agents/create');
+
+    const agentName = uniqueAgentName('Processor');
+    await fillRequiredFields(page, agentName);
+
+    // Enable logging processor
+    await clickSidebarLink(page, 'Preprocessors');
+    await expect(page.getByText('Logging Processor', { exact: true })).toBeVisible({ timeout: 10000 });
+    const loggingToggle = getProviderToggle(page, 'Logging Processor');
+    await loggingToggle.click();
+    await expect(loggingToggle).toBeChecked();
+
+    const agentId = await createAgentAndGetId(page);
+
+    // Verify on edit page
+    await page.goto(`/cms/agents/${agentId}/edit/processors`);
+    await page.waitForTimeout(2000);
+
+    // Logging processor toggle should be checked
+    const editLoggingToggle = getProviderToggle(page, 'Logging Processor');
+    await expect(editLoggingToggle).toBeChecked({ timeout: 10000 });
+
+    // Content filter should remain unchecked
+    const editContentToggle = getProviderToggle(page, 'Content Filter Processor');
+    await expect(editContentToggle).not.toBeChecked();
+  });
+
+  test('phase toggle changes persist after agent creation', async ({ page }) => {
+    await page.goto('/cms/agents/create');
+
+    const agentName = uniqueAgentName('Phase Toggle');
+    await fillRequiredFields(page, agentName);
+
+    // Enable content filter processor
+    await clickSidebarLink(page, 'Preprocessors');
+    await expect(page.getByText('Content Filter Processor', { exact: true })).toBeVisible({ timeout: 10000 });
+    const contentToggle = getProviderToggle(page, 'Content Filter Processor');
+    await contentToggle.click();
+    await expect(contentToggle).toBeChecked();
+
+    // Both phases should be enabled by default
+    await expect(page.getByText('Process Output Result')).toBeVisible({ timeout: 5000 });
+
+    // Toggle off Process Output Result phase
+    const processOutputSwitch = page.getByText('Process Output Result').locator('..').getByRole('switch');
+    await processOutputSwitch.click();
+    await expect(processOutputSwitch).not.toBeChecked();
+
+    const agentId = await createAgentAndGetId(page);
+
+    // Verify on edit page
+    await page.goto(`/cms/agents/${agentId}/edit/processors`);
+    await page.waitForTimeout(2000);
+
+    // Content filter should be enabled
+    const editContentToggle = getProviderToggle(page, 'Content Filter Processor');
+    await expect(editContentToggle).toBeChecked({ timeout: 10000 });
+
+    // Process Output Result should be unchecked (we toggled it off)
+    const editProcessOutputSwitch = page.getByText('Process Output Result').locator('..').getByRole('switch');
+    await expect(editProcessOutputSwitch).not.toBeChecked();
+  });
+
+  test('multiple processors can be enabled simultaneously', async ({ page }) => {
+    await page.goto('/cms/agents/create');
+
+    const agentName = uniqueAgentName('Multi Processor');
+    await fillRequiredFields(page, agentName);
+
+    await clickSidebarLink(page, 'Preprocessors');
+    await expect(page.getByText('Logging Processor', { exact: true })).toBeVisible({ timeout: 10000 });
+
+    // Enable both processors by name
+    const loggingToggle = getProviderToggle(page, 'Logging Processor');
+    await loggingToggle.click();
+    await expect(loggingToggle).toBeChecked();
+
+    const contentToggle = getProviderToggle(page, 'Content Filter Processor');
+    await contentToggle.click();
+    await expect(contentToggle).toBeChecked();
+
+    const agentId = await createAgentAndGetId(page);
+
+    // Verify on edit page
+    await page.goto(`/cms/agents/${agentId}/edit/processors`);
+    await page.waitForTimeout(2000);
+
+    // Both providers should be enabled
+    const editLoggingToggle = getProviderToggle(page, 'Logging Processor');
+    await expect(editLoggingToggle).toBeChecked({ timeout: 10000 });
+    const editContentToggle = getProviderToggle(page, 'Content Filter Processor');
+    await expect(editContentToggle).toBeChecked({ timeout: 10000 });
+
+    // Content filter's unique phase "Process Output Result" should be checked
+    const editProcessOutputSwitch = page.getByText('Process Output Result').locator('..').getByRole('switch');
+    await expect(editProcessOutputSwitch).toBeChecked();
   });
 });
 

--- a/packages/playground/e2e/tests/cms/agents/edit/page.spec.ts
+++ b/packages/playground/e2e/tests/cms/agents/edit/page.spec.ts
@@ -1,0 +1,276 @@
+import { test, expect, Page } from '@playwright/test';
+import { resetStorage } from '../../../__utils__/reset-storage';
+
+// Helper to generate unique agent names
+function uniqueAgentName(prefix = 'Test Agent') {
+  return `${prefix} ${Date.now().toString(36)}`;
+}
+
+// Sidebar link paths for each page
+const SIDEBAR_PATHS: Record<string, string> = {
+  Identity: '',
+  Instructions: '/instruction-blocks',
+  Tools: '/tools',
+  Agents: '/agents',
+  Scorers: '/scorers',
+  Workflows: '/workflows',
+  Preprocessors: '/processors',
+  Memory: '/memory',
+  Variables: '/variables',
+};
+
+// Navigate to a create sub-page via sidebar link (client-side, preserves form state).
+async function clickCreateSidebarLink(page: Page, linkName: string) {
+  const pathSuffix = SIDEBAR_PATHS[linkName];
+  if (pathSuffix === undefined) throw new Error(`Unknown sidebar link: ${linkName}`);
+  const href = `/cms/agents/create${pathSuffix}`;
+  const link = page.locator(`a[href="${href}"]`);
+  await link.click();
+  await page.waitForTimeout(500);
+}
+
+// Fill the identity fields on the create page
+async function fillIdentityFields(
+  page: Page,
+  options: { name: string; description?: string; provider?: string; model?: string },
+) {
+  const nameInput = page.locator('#agent-name');
+  await nameInput.clear();
+  await nameInput.fill(options.name);
+
+  if (options.description) {
+    const descInput = page.locator('#agent-description');
+    await descInput.clear();
+    await descInput.fill(options.description);
+  }
+
+  const providerCombobox = page.getByRole('combobox').nth(0);
+  await providerCombobox.click();
+  await page.getByRole('option', { name: options.provider ?? 'OpenAI' }).click();
+
+  const modelCombobox = page.getByRole('combobox').nth(1);
+  await modelCombobox.click();
+  await page.getByRole('option', { name: options.model ?? 'gpt-4o-mini' }).click();
+}
+
+// Fill required fields (identity + minimal instruction block) using sidebar navigation
+async function fillRequiredFields(page: Page, agentName?: string) {
+  const name = agentName || uniqueAgentName();
+
+  await fillIdentityFields(page, { name });
+
+  await clickCreateSidebarLink(page, 'Instructions');
+  const editor = page.locator('.cm-content').first();
+  await editor.click();
+  await page.keyboard.type('You are a helpful test agent.');
+}
+
+// Create agent and extract ID from redirect URL
+async function createAgentAndGetId(page: Page): Promise<string> {
+  await page.getByRole('button', { name: 'Create agent' }).click();
+
+  await expect(page).toHaveURL(/\/agents\/[a-zA-Z0-9-]+\/chat/, { timeout: 30000 });
+
+  const url = page.url();
+  const agentId = url.split('/agents/')[1]?.split('/')[0];
+  if (!agentId) throw new Error('Could not extract agent ID from URL: ' + url);
+  return agentId;
+}
+
+// Navigate directly to an edit sub-page (full page load, for verification).
+async function goToEditSubPage(page: Page, agentId: string, subPage = '') {
+  await page.goto(`/cms/agents/${agentId}/edit${subPage}`);
+  await page.locator('#agent-name').waitFor({ state: 'visible', timeout: 15000 });
+}
+
+// Navigate to an edit sub-page via sidebar link (client-side navigation).
+async function clickEditSidebarLink(page: Page, agentId: string, linkName: string) {
+  const pathSuffix = SIDEBAR_PATHS[linkName];
+  if (pathSuffix === undefined) throw new Error(`Unknown sidebar link: ${linkName}`);
+  const href = `/cms/agents/${agentId}/edit${pathSuffix}`;
+  const link = page.locator(`a[href="${href}"]`);
+  await link.click();
+  await page.waitForTimeout(1000);
+}
+
+// Find a provider's toggle switch by name (EntityName -> EntityContent -> header div -> switch)
+function getProviderToggle(page: Page, providerName: string) {
+  return page.getByText(providerName, { exact: true }).locator('..').locator('..').getByRole('switch');
+}
+
+// Save draft on edit page and wait for success
+async function saveDraft(page: Page) {
+  const saveButton = page.getByRole('button', { name: 'Save' });
+  await expect(saveButton).toBeEnabled({ timeout: 5000 });
+  await saveButton.click();
+  await expect(page.getByText('Draft saved')).toBeVisible({ timeout: 10000 });
+}
+
+test.afterEach(async () => {
+  await resetStorage();
+});
+
+test.describe('Preprocessors Edit Persistence', () => {
+  test('can enable processor on existing agent and save draft', async ({ page }) => {
+    // Create agent without processors
+    await page.goto('/cms/agents/create');
+    const agentName = uniqueAgentName('Edit Processor');
+    await fillRequiredFields(page, agentName);
+    const agentId = await createAgentAndGetId(page);
+
+    // Navigate to edit page -> Preprocessors
+    await goToEditSubPage(page, agentId);
+    await expect(page.locator('#agent-name')).not.toHaveValue('', { timeout: 15000 });
+    await clickEditSidebarLink(page, agentId, 'Preprocessors');
+
+    // Wait for providers to load
+    await expect(page.getByText('Logging Processor', { exact: true })).toBeVisible({ timeout: 10000 });
+
+    // Logging should be unchecked initially
+    const loggingToggle = getProviderToggle(page, 'Logging Processor');
+    await expect(loggingToggle).not.toBeChecked();
+
+    // Enable logging processor
+    await loggingToggle.click();
+    await expect(loggingToggle).toBeChecked();
+
+    // Save draft
+    await saveDraft(page);
+
+    // Reload and verify persistence
+    await page.goto(`/cms/agents/${agentId}/edit/processors`);
+    await page.waitForTimeout(2000);
+
+    const editLoggingToggle = getProviderToggle(page, 'Logging Processor');
+    await expect(editLoggingToggle).toBeChecked({ timeout: 10000 });
+    await expect(page.getByText('Process Input')).toBeVisible();
+  });
+
+  test('can disable one processor while keeping another on existing agent', async ({ page }) => {
+    // Create agent with both processors enabled
+    await page.goto('/cms/agents/create');
+    const agentName = uniqueAgentName('Disable Processor');
+    await fillRequiredFields(page, agentName);
+
+    await clickCreateSidebarLink(page, 'Preprocessors');
+    await expect(page.getByText('Logging Processor', { exact: true })).toBeVisible({ timeout: 10000 });
+    const loggingToggle = getProviderToggle(page, 'Logging Processor');
+    await loggingToggle.click();
+    await expect(loggingToggle).toBeChecked();
+
+    const contentToggle = getProviderToggle(page, 'Content Filter Processor');
+    await contentToggle.click();
+    await expect(contentToggle).toBeChecked();
+
+    const agentId = await createAgentAndGetId(page);
+
+    // Navigate to edit page -> Preprocessors
+    await goToEditSubPage(page, agentId);
+    await expect(page.locator('#agent-name')).not.toHaveValue('', { timeout: 15000 });
+    await clickEditSidebarLink(page, agentId, 'Preprocessors');
+
+    // Both should be enabled
+    const editLoggingToggle = getProviderToggle(page, 'Logging Processor');
+    await expect(editLoggingToggle).toBeChecked({ timeout: 10000 });
+    const editContentToggle = getProviderToggle(page, 'Content Filter Processor');
+    await expect(editContentToggle).toBeChecked({ timeout: 10000 });
+
+    // Disable logging processor only
+    await editLoggingToggle.click();
+    await expect(editLoggingToggle).not.toBeChecked();
+
+    // Save draft
+    await saveDraft(page);
+
+    // Reload and verify logging is disabled but content filter remains
+    await page.goto(`/cms/agents/${agentId}/edit/processors`);
+    await page.waitForTimeout(2000);
+
+    const reloadLoggingToggle = getProviderToggle(page, 'Logging Processor');
+    await expect(reloadLoggingToggle).not.toBeChecked({ timeout: 10000 });
+    const reloadContentToggle = getProviderToggle(page, 'Content Filter Processor');
+    await expect(reloadContentToggle).toBeChecked({ timeout: 10000 });
+  });
+
+  test('phase changes persist after save draft', async ({ page }) => {
+    // Create agent with content filter (both phases enabled)
+    await page.goto('/cms/agents/create');
+    const agentName = uniqueAgentName('Phase Edit');
+    await fillRequiredFields(page, agentName);
+
+    await clickCreateSidebarLink(page, 'Preprocessors');
+    await expect(page.getByText('Content Filter Processor', { exact: true })).toBeVisible({ timeout: 10000 });
+
+    const contentToggle = getProviderToggle(page, 'Content Filter Processor');
+    await contentToggle.click();
+    await expect(contentToggle).toBeChecked();
+
+    // Both phases should be on by default
+    await expect(page.getByText('Process Output Result')).toBeVisible({ timeout: 5000 });
+
+    const agentId = await createAgentAndGetId(page);
+
+    // Navigate to edit page -> Preprocessors
+    await goToEditSubPage(page, agentId);
+    await expect(page.locator('#agent-name')).not.toHaveValue('', { timeout: 15000 });
+    await clickEditSidebarLink(page, agentId, 'Preprocessors');
+
+    // Content filter should be enabled with both phases
+    const editContentToggle = getProviderToggle(page, 'Content Filter Processor');
+    await expect(editContentToggle).toBeChecked({ timeout: 10000 });
+    await expect(page.getByText('Process Output Result')).toBeVisible({ timeout: 5000 });
+
+    // Toggle off Process Output Result phase
+    const processOutputSwitch = page.getByText('Process Output Result').locator('..').getByRole('switch');
+    await processOutputSwitch.click();
+    await expect(processOutputSwitch).not.toBeChecked();
+
+    // Save draft
+    await saveDraft(page);
+
+    // Reload and verify phase change persisted
+    await page.goto(`/cms/agents/${agentId}/edit/processors`);
+    await page.waitForTimeout(2000);
+
+    // Content filter should still be enabled
+    const reloadContentToggle = getProviderToggle(page, 'Content Filter Processor');
+    await expect(reloadContentToggle).toBeChecked({ timeout: 10000 });
+
+    // Process Output Result should be unchecked
+    const reloadProcessOutputSwitch = page.getByText('Process Output Result').locator('..').getByRole('switch');
+    await expect(reloadProcessOutputSwitch).not.toBeChecked();
+  });
+
+  test('adding processor to existing agent includes it in published version', async ({ page }) => {
+    // Create and publish agent without processors
+    await page.goto('/cms/agents/create');
+    const agentName = uniqueAgentName('Publish Processor');
+    await fillRequiredFields(page, agentName);
+    const agentId = await createAgentAndGetId(page);
+
+    // Navigate to edit page -> Preprocessors
+    await goToEditSubPage(page, agentId);
+    await expect(page.locator('#agent-name')).not.toHaveValue('', { timeout: 15000 });
+    await clickEditSidebarLink(page, agentId, 'Preprocessors');
+
+    // Enable logging processor
+    await expect(page.getByText('Logging Processor', { exact: true })).toBeVisible({ timeout: 10000 });
+    const loggingToggle = getProviderToggle(page, 'Logging Processor');
+    await loggingToggle.click();
+    await expect(loggingToggle).toBeChecked();
+
+    // Save draft first
+    await saveDraft(page);
+
+    // Then publish
+    await page.getByRole('button', { name: 'Publish' }).click();
+    await expect(page.getByText('Agent published')).toBeVisible({ timeout: 10000 });
+
+    // Navigate back to edit page and verify processor persists
+    await page.goto(`/cms/agents/${agentId}/edit/processors`);
+    await page.waitForTimeout(2000);
+
+    const editLoggingToggle = getProviderToggle(page, 'Logging Processor');
+    await expect(editLoggingToggle).toBeChecked({ timeout: 10000 });
+  });
+});

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -66,6 +66,7 @@ import CmsAgentWorkflowsPage from './pages/cms/agents/workflows';
 import CmsAgentMemoryPage from './pages/cms/agents/memory';
 import CmsAgentVariablesPage from './pages/cms/agents/variables';
 import CmsAgentSkillsPage from './pages/cms/agents/skills';
+import CmsAgentProcessorsPage from './pages/cms/agents/processors';
 import CmsAgentInstructionBlocksPage from './pages/cms/agents/instruction-blocks';
 import CmsScorersCreatePage from './pages/cms/scorers/create';
 import CmsScorersEditPage from './pages/cms/scorers/edit';
@@ -149,6 +150,7 @@ const agentCmsChildRoutes = [
   { path: 'scorers', element: <CmsAgentScorersPage /> },
   { path: 'workflows', element: <CmsAgentWorkflowsPage /> },
   { path: 'skills', element: <CmsAgentSkillsPage /> },
+  { path: 'processors', element: <CmsAgentProcessorsPage /> },
   { path: 'memory', element: <CmsAgentMemoryPage /> },
   { path: 'variables', element: <CmsAgentVariablesPage /> },
 ];

--- a/packages/playground/src/pages/cms/agents/processors.tsx
+++ b/packages/playground/src/pages/cms/agents/processors.tsx
@@ -1,0 +1,5 @@
+import { ProcessorsPage } from '@mastra/playground-ui';
+
+export default function CmsAgentProcessorsPage() {
+  return <ProcessorsPage />;
+}


### PR DESCRIPTION


https://github.com/user-attachments/assets/da35bec7-d2e9-4880-957f-10c5a87bfe0d



Adds a Preprocessors page to the agent CMS (create + edit) so users can attach processor providers to agents, toggle them on/off, and configure which phases are enabled per provider.

The kitchen-sink E2E setup now registers `ProcessorProvider` wrappers for the test processors so the `/processor-providers` API serves them correctly. 9 E2E tests cover provider listing, toggling, phase selection, create persistence, edit/save-draft persistence, and publish flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Preprocessors configuration section to agent creation and editing workflows
  * Toggle processor providers on/off for agents
  * Configure processing phases (input/output) per enabled provider
  * Dynamic configuration UI for processor-specific settings

* **Tests**
  * Added comprehensive end-to-end tests for processor configuration and persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->