### PR TITLE
fix(playground): fix e2e test for adding multiple instruction blocks

### DIFF
--- a/packages/playground/e2e/tests/cms/agents/create/page.spec.ts
+++ b/packages/playground/e2e/tests/cms/agents/create/page.spec.ts
@@ -284,8 +284,9 @@ test.describe('Agent Creation Persistence - Instruction Blocks', () => {
     await editor1.click();
     await page.keyboard.type(block1Content);
 
-    // Add second block
+    // Add second block (click dropdown trigger, then select inline option)
     await page.getByRole('button', { name: 'Add Instruction block' }).click();
+    await page.getByRole('menuitem', { name: 'Write inline block' }).click();
     await page.waitForTimeout(500);
 
     // Fill second block


### PR DESCRIPTION
The "Add Instruction block" button was changed to a dropdown menu with two options ("Write inline block" and "Reference saved prompt block"), but the e2e test was only clicking the dropdown trigger without selecting an option — so the second editor never appeared and the test timed out.

Fixed by adding the missing click on the "Write inline block" menu item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced agent creation tests to cover inline block selection scenarios in instruction block workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->