### PR TITLE
docs: fix SSR/client content mismatches for SEO

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -12,6 +12,7 @@ const config: Config = {
   favicon: '/img/favicon.ico',
   url: 'https://mastra.ai',
   baseUrl: '/',
+  trailingSlash: false,
   onBrokenLinks: 'throw',
   markdown: {
     hooks: {

--- a/docs/src/theme/DocSidebarItem/Category/index.tsx
+++ b/docs/src/theme/DocSidebarItem/Category/index.tsx
@@ -10,7 +10,6 @@ import {
 } from '@docusaurus/plugin-content-docs/client'
 import Link from '@docusaurus/Link'
 import { translate } from '@docusaurus/Translate'
-import useIsBrowser from '@docusaurus/useIsBrowser'
 import DocSidebarItems from '@theme/DocSidebarItems'
 import DocSidebarItemLink from '@theme/DocSidebarItem/Link'
 import type { Props } from '@theme/DocSidebarItem/Category'
@@ -46,25 +45,21 @@ function useAutoExpandActiveCategory({
 
 /**
  * When a collapsible category has no link, we still link it to its first child
- * during SSR as a temporary fallback. This allows to be able to navigate inside
- * the category even when JS fails to load, is delayed or simply disabled
- * React hydration becomes an optional progressive enhancement
+ * as a fallback. This ensures consistent rendering between SSR and client,
+ * and allows navigation inside the category even when JS fails to load.
  * see https://github.com/facebookincubator/infima/issues/36#issuecomment-772543188
  * see https://github.com/facebook/docusaurus/issues/3030
  */
 function useCategoryHrefWithSSRFallback(item: Props['item']): string | undefined {
-  const isBrowser = useIsBrowser()
   return useMemo(() => {
     if (item.href && !item.linkUnlisted) {
       return item.href
     }
-    // In these cases, it's not necessary to render a fallback
-    // We skip the "findFirstCategoryLink" computation
-    if (isBrowser || !item.collapsible) {
+    if (!item.collapsible) {
       return undefined
     }
     return findFirstSidebarItemLink(item)
-  }, [item, isBrowser])
+  }, [item])
 }
 
 function CollapseButton({

--- a/docs/src/theme/Tabs/index.tsx
+++ b/docs/src/theme/Tabs/index.tsx
@@ -1,0 +1,140 @@
+/**
+ * Swizzled Tabs component that removes the `key={String(isBrowser)}` workaround
+ * from upstream Docusaurus. The upstream hack forces a full re-mount after
+ * hydration (see https://github.com/facebook/docusaurus/issues/5653), which
+ * causes content churn that search engines penalize. Since our tabs use static
+ * default values (npm2yarn with groupId sync), the workaround is unnecessary.
+ */
+import React, { cloneElement, type ReactElement, type ReactNode } from 'react'
+import clsx from 'clsx'
+import { ThemeClassNames } from '@docusaurus/theme-common'
+import {
+  useScrollPositionBlocker,
+  useTabs,
+  sanitizeTabsChildren,
+  type TabItemProps,
+} from '@docusaurus/theme-common/internal'
+import type { Props } from '@theme/Tabs'
+import styles from './styles.module.css'
+
+function TabList({ className, block, selectedValue, selectValue, tabValues }: Props & ReturnType<typeof useTabs>) {
+  const tabRefs: (HTMLLIElement | null)[] = []
+  const { blockElementScrollPositionUntilNextRender } = useScrollPositionBlocker()
+
+  const handleTabChange = (
+    event: React.FocusEvent<HTMLLIElement> | React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>,
+  ) => {
+    const newTab = event.currentTarget
+    const newTabIndex = tabRefs.indexOf(newTab)
+    const newTabValue = tabValues[newTabIndex]!.value
+
+    if (newTabValue !== selectedValue) {
+      blockElementScrollPositionUntilNextRender(newTab)
+      selectValue(newTabValue)
+    }
+  }
+
+  const handleKeydown = (event: React.KeyboardEvent<HTMLLIElement>) => {
+    let focusElement: HTMLLIElement | null = null
+
+    switch (event.key) {
+      case 'Enter': {
+        handleTabChange(event)
+        break
+      }
+      case 'ArrowRight': {
+        const nextTab = tabRefs.indexOf(event.currentTarget) + 1
+        focusElement = tabRefs[nextTab] ?? tabRefs[0]!
+        break
+      }
+      case 'ArrowLeft': {
+        const prevTab = tabRefs.indexOf(event.currentTarget) - 1
+        focusElement = tabRefs[prevTab] ?? tabRefs[tabRefs.length - 1]!
+        break
+      }
+      default:
+        break
+    }
+
+    focusElement?.focus()
+  }
+
+  return (
+    <ul
+      role="tablist"
+      aria-orientation="horizontal"
+      className={clsx(
+        'tabs',
+        {
+          'tabs--block': block,
+        },
+        className,
+      )}
+    >
+      {tabValues.map(({ value, label, attributes }) => (
+        <li
+          role="tab"
+          tabIndex={selectedValue === value ? 0 : -1}
+          aria-selected={selectedValue === value}
+          key={value}
+          ref={tabControl => {
+            tabRefs.push(tabControl)
+          }}
+          onKeyDown={handleKeydown}
+          onClick={handleTabChange}
+          {...attributes}
+          className={clsx('tabs__item', styles.tabItem, attributes?.className as string, {
+            'tabs__item--active': selectedValue === value,
+          })}
+        >
+          {label ?? value}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function TabContent({ lazy, children, selectedValue }: Props & ReturnType<typeof useTabs>) {
+  const childTabs = (Array.isArray(children) ? children : [children]).filter(Boolean) as ReactElement<TabItemProps>[]
+  if (lazy) {
+    const selectedTabItem = childTabs.find(tabItem => tabItem.props.value === selectedValue)
+    if (!selectedTabItem) {
+      return null
+    }
+    return cloneElement(selectedTabItem, {
+      className: clsx('margin-top--md', selectedTabItem.props.className),
+    })
+  }
+  return (
+    <div className="margin-top--md">
+      {childTabs.map((tabItem, i) =>
+        cloneElement(tabItem, {
+          key: i,
+          hidden: tabItem.props.value !== selectedValue,
+        }),
+      )}
+    </div>
+  )
+}
+
+function TabsComponent(props: Props): ReactNode {
+  const tabs = useTabs(props)
+  return (
+    <div
+      className={clsx(
+        ThemeClassNames.tabs.container,
+        // former name kept for backward compatibility
+        // see https://github.com/facebook/docusaurus/pull/4086
+        'tabs-container',
+        styles.tabList,
+      )}
+    >
+      <TabList {...tabs} {...props} />
+      <TabContent {...tabs} {...props} />
+    </div>
+  )
+}
+
+export default function Tabs(props: Props): ReactNode {
+  return <TabsComponent {...props}>{sanitizeTabsChildren(props.children)}</TabsComponent>
+}

--- a/docs/src/theme/Tabs/styles.module.css
+++ b/docs/src/theme/Tabs/styles.module.css
@@ -1,0 +1,7 @@
+.tabList {
+  margin-bottom: var(--ifm-leading);
+}
+
+.tabItem {
+  margin-top: 0 !important;
+}

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,4 +1,5 @@
 {
+  "trailingSlash": false,
   "redirects": [
     {
       "source": "/docs/v1/:path*",


### PR DESCRIPTION
## Problem

Many pages on mastra.ai show decreased word count and outlinks after client-side rendering. Search engines penalize this as inconsistent rendering.

Analysis of 1,068 affected pages showed two main causes:

### 1. Sidebar category links disappear after hydration
`useCategoryHrefWithSSRFallback` provided `<a href>` links during SSR but returned `undefined` after hydration (when `useIsBrowser()` became `true`), turning links into `<button>` elements. This removed ~10-30 outlinks per page.

### 2. Tabs component re-mounts after hydration
The upstream Docusaurus `Tabs` component uses `key={String(isBrowser)}` to force a full re-mount after hydration (workaround for [facebook/docusaurus#5653](https://github.com/facebook/docusaurus/issues/5653)). This causes content churn visible to crawlers. Our tabs use static defaults (npm2yarn with `sync: true` and `groupId`), so the workaround is unnecessary.

## Changes

- **Sidebar categories**: Remove `useIsBrowser` guard from `useCategoryHrefWithSSRFallback` so collapsible categories always link to their first child, not just during SSR.
- **Tabs**: Swizzle the Docusaurus `Tabs` component to remove the `key={String(isBrowser)}` re-mount hack. Non-selected tab panels continue using `hidden` attributes, keeping all content in the DOM consistently.

## Verification

- `npx tsc --noEmit` — no new type errors
- `npx docusaurus build` — builds successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard navigation support for Tabs component (Enter and arrow keys).
  * Improved tab accessibility with enhanced focus and selection state management.

* **Improvements**
  * Updated documentation URLs to remove trailing slashes.
  * Enhanced sidebar rendering for consistent behavior.
  * Refined tab styling and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->