### PR TITLE
feat(playground-ui): add nested folder creation in skill tree editor

### DIFF
--- a/.changeset/sunny-poets-share.md
+++ b/.changeset/sunny-poets-share.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added nested folder creation support in the skill tree editor for references and scripts folders


### PR DESCRIPTION
The skill tree editor only supported flat files in references/scripts/assets. This adds nested folder support for references and scripts folders so users can organize their skill files in subdirectories.

What changed in `skill-file-tree.tsx`:
- New `UserNodeList` recursive component replaces the flat `UserFileList` — renders folders with `<Tree.Folder>` and files with `<Tree.File>` at any depth
- Hover actions on references/scripts folders now show both "New file" and "New folder" buttons
- User-created folders get "New file", "New folder", and "Delete folder" actions
- Deleting a folder that contains the selected file clears the selection
- New folders default to open
- Assets folder unchanged (image-only, no folder support)

No changes to the data model (`InMemoryFileNode`), tree utilities (`insertNode`/`removeNode`), or any other files — the existing recursive infrastructure already handled nesting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added nested folder creation capability in the skill tree editor, enabling users to organize references and scripts in hierarchical folder structures.
- Introduced enhanced folder management with new action controls, allowing users to create new files and folders directly from folder headers, and delete folders as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->