### PR TITLE
fix(core): pass writer to runOutputProcessors in outer MastraModelOutput

### DIFF
--- a/.changeset/salty-chairs-move.md
+++ b/.changeset/salty-chairs-move.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed writer being undefined in processOutputResult. The writer was not being passed to runOutputProcessors in the outer MastraModelOutput finish handler, so custom output processors could not emit stream events when processing the final result.

--- a/.changeset/salty-chairs-move.md
+++ b/.changeset/salty-chairs-move.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed writer being undefined in processOutputResult. The writer was not being passed to runOutputProcessors in the outer MastraModelOutput finish handler, so custom output processors could not emit stream events when processing the final result.
+Fixed a bug where custom output processors could not emit stream events during final output processing. The `writer` object was always `undefined` when passed to output processors in the finish phase, preventing use cases like streaming moderation updates or custom UI events back to the client.

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -1,0 +1,173 @@
+import { ReadableStream } from 'node:stream/web';
+import { describe, expect, it } from 'vitest';
+import { MessageList } from '../../agent/message-list';
+import type { Processor, ProcessorStreamWriter } from '../../processors';
+import { ChunkFrom } from '../types';
+import type { ChunkType } from '../types';
+import { MastraModelOutput } from './output';
+
+/**
+ * Creates a ReadableStream that emits the given chunks in order.
+ */
+function createChunkStream<OUTPUT = undefined>(chunks: ChunkType<OUTPUT>[]): ReadableStream<ChunkType<OUTPUT>> {
+  return new ReadableStream<ChunkType<OUTPUT>>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+/**
+ * Minimal step-finish chunk to populate bufferedSteps before the finish chunk.
+ */
+function createStepFinishChunk(runId: string): ChunkType {
+  return {
+    type: 'step-finish',
+    runId,
+    from: ChunkFrom.AGENT,
+    payload: {
+      id: 'step-1',
+      output: {
+        steps: [],
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      },
+      stepResult: {
+        reason: 'stop',
+        warnings: [],
+        isContinued: false,
+      },
+      metadata: {},
+      messages: { nonUser: [], all: [] },
+    },
+  } as ChunkType;
+}
+
+/**
+ * Minimal finish chunk for the outer MastraModelOutput.
+ */
+function createFinishChunk(runId: string): ChunkType {
+  return {
+    type: 'finish',
+    runId,
+    from: ChunkFrom.AGENT,
+    payload: {
+      id: 'finish-1',
+      output: {
+        steps: [],
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      },
+      stepResult: {
+        reason: 'stop',
+        warnings: [],
+        isContinued: false,
+      },
+      metadata: {},
+      messages: { nonUser: [], all: [] },
+    },
+  } as ChunkType;
+}
+
+describe('MastraModelOutput', () => {
+  describe('writer in output processors (outer context)', () => {
+    it('should pass a defined writer to processOutputResult', async () => {
+      let receivedWriter: ProcessorStreamWriter | undefined;
+
+      const processor: Processor = {
+        id: 'writer-capture',
+        name: 'Writer Capture',
+        processOutputResult: async ({ messages, writer }) => {
+          receivedWriter = writer;
+          return messages;
+        },
+      };
+
+      const runId = 'test-run';
+      const messageList = new MessageList({ threadId: 'test-thread' });
+
+      // Add a response message so the processor has something to work with
+      messageList.add(
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          content: { format: 2 as const, parts: [{ type: 'text' as const, text: 'hello' }] },
+          createdAt: new Date(),
+        },
+        'response',
+      );
+
+      const stream = createChunkStream([createStepFinishChunk(runId), createFinishChunk(runId)]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: {
+          runId,
+          outputProcessors: [processor],
+          // isLLMExecutionStep is NOT set — this is the outer context
+        },
+      });
+
+      await output.consumeStream();
+
+      expect(receivedWriter).toBeDefined();
+      expect(typeof receivedWriter!.custom).toBe('function');
+    });
+
+    it('should deliver custom chunks emitted via writer before the finish chunk', async () => {
+      const processor: Processor = {
+        id: 'custom-emitter',
+        name: 'Custom Emitter',
+        processOutputResult: async ({ messages, writer }) => {
+          await writer!.custom({ type: 'data-moderation', data: { flagged: true } });
+          return messages;
+        },
+      };
+
+      const runId = 'test-run';
+      const messageList = new MessageList({ threadId: 'test-thread' });
+
+      messageList.add(
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          content: { format: 2 as const, parts: [{ type: 'text' as const, text: 'hello' }] },
+          createdAt: new Date(),
+        },
+        'response',
+      );
+
+      const stream = createChunkStream([createStepFinishChunk(runId), createFinishChunk(runId)]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: {
+          runId,
+          outputProcessors: [processor],
+        },
+      });
+
+      // Collect all chunks from the fullStream
+      const chunks: ChunkType[] = [];
+      for await (const chunk of output.fullStream) {
+        chunks.push(chunk);
+      }
+
+      const customChunk = chunks.find(c => c.type === 'data-moderation');
+      const finishIndex = chunks.findIndex(c => c.type === 'finish');
+      const customIndex = chunks.findIndex(c => c.type === 'data-moderation');
+
+      expect(customChunk).toBeDefined();
+      expect((customChunk as any).data).toEqual({ flagged: true });
+      // Custom chunk should appear before the finish chunk
+      expect(customIndex).toBeLessThan(finishIndex);
+    });
+  });
+});

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -721,9 +721,14 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                   const lastStep = self.#bufferedSteps[self.#bufferedSteps.length - 1];
                   const originalText = lastStep?.text || '';
 
-                  // Create a writer from the controller so processOutputResult can emit custom chunks
+                  // Create a writer from the controller so processOutputResult can emit custom chunks.
+                  // Must use both #emitChunk (for fullStream/EventEmitter consumers) and
+                  // controller.enqueue (for raw stream consumers) to ensure visibility.
                   const outputResultWriter = {
-                    custom: async (data: { type: string }) => controller.enqueue(data as ChunkType<OUTPUT>),
+                    custom: async (data: { type: string }) => {
+                      self.#emitChunk(data as ChunkType<OUTPUT>);
+                      controller.enqueue(data as ChunkType<OUTPUT>);
+                    },
                   };
 
                   self.messageList = await self.processorRunner.runOutputProcessors(

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -721,10 +721,17 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                   const lastStep = self.#bufferedSteps[self.#bufferedSteps.length - 1];
                   const originalText = lastStep?.text || '';
 
+                  // Create a writer from the controller so processOutputResult can emit custom chunks
+                  const outputResultWriter = {
+                    custom: async (data: { type: string }) => controller.enqueue(data as ChunkType<OUTPUT>),
+                  };
+
                   self.messageList = await self.processorRunner.runOutputProcessors(
                     self.messageList,
                     options.tracingContext,
                     self.#options.requestContext,
+                    0,
+                    outputResultWriter,
                   );
 
                   // Get text from the latest response message (the last assistant message)


### PR DESCRIPTION
## Description

Fixed writer being undefined in `processOutputResult`. The writer object was not being passed to `runOutputProcessors` in the outer `MastraModelOutput` finish handler, preventing custom output processors from emitting stream events.

**Changes:**
- Create a `ProcessorStreamWriter` from the outer transform controller
- Pass it as the 5th argument to `runOutputProcessors` 
- Custom data chunks emitted via `writer.custom()` are now enqueued into the consumer stream

This fix completes PR #13056's plumbing by connecting the writer at the `processOutputResult` call site. Custom output processors can now emit and stream moderation updates or other events back to clients when running in the outer execution context.

## Related Issue(s)

Relates to discussion about guardrails/moderation implementation with custom output processors.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored ability for custom output processors to emit stream events during final output handling, ensuring streaming updates and UI events are delivered correctly.

* **Tests**
  * Added tests covering processor writer behavior, custom chunk emission ordering, and stream consumption scenarios.

* **Chores**
  * Added a changeset entry to patch the core package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->