### PR TITLE
feat(mastracode): refresh git branch on thread resume & abbreviate long branch names

### DIFF
--- a/.changeset/ready-books-scream.md
+++ b/.changeset/ready-books-scream.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed stale git branch in system prompt when resuming a thread on a different branch. The branch is now refreshed on every agent request and when switching threads. Also improved the status line to show abbreviated branch names instead of hiding the branch entirely when the name is too long.

--- a/.changeset/ready-books-scream.md
+++ b/.changeset/ready-books-scream.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Fixed stale git branch in system prompt when resuming a thread on a different branch. The branch is now refreshed on every agent request and when switching threads. Also improved the status line to show abbreviated branch names instead of hiding the branch entirely when the name is too long.
+Fixed stale git branch in system prompt and TUI status bar. The branch is now refreshed on every agent request and when switching threads, so both the system prompt and status bar reflect the current branch. Also improved the status line to show abbreviated branch names instead of hiding the branch entirely when the name is too long.

--- a/mastracode/src/agents/instructions.ts
+++ b/mastracode/src/agents/instructions.ts
@@ -1,5 +1,6 @@
 import type { HarnessRequestContext } from '@mastra/core/harness';
 import type { stateSchema } from '../schema.js';
+import { getCurrentGitBranch } from '../utils/project.js';
 import type { PromptContext } from './prompts/index.js';
 import { buildFullPrompt } from './prompts/index.js';
 
@@ -7,11 +8,12 @@ export function getDynamicInstructions({ requestContext }: { requestContext: { g
   const harnessContext = requestContext.get('harness') as HarnessRequestContext<typeof stateSchema> | undefined;
   const state = harnessContext?.state;
   const modeId = harnessContext?.modeId ?? 'build';
+  const projectPath = state?.projectPath ?? process.cwd();
 
   const promptCtx: PromptContext = {
-    projectPath: state?.projectPath ?? process.cwd(),
+    projectPath,
     projectName: state?.projectName ?? '',
-    gitBranch: state?.gitBranch,
+    gitBranch: getCurrentGitBranch(projectPath) ?? state?.gitBranch,
     platform: process.platform,
     date: new Date().toISOString().split('T')[0]!,
     mode: modeId,

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -3,6 +3,7 @@
  */
 import type { HarnessEvent, TaskItem } from '@mastra/core/harness';
 
+import { getCurrentGitBranch } from '../utils/project.js';
 import {
   handleAgentStart,
   handleAgentEnd,
@@ -122,6 +123,11 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
       ectx.showInfo(`Switched to thread: ${event.threadId}`);
       await ectx.renderExistingMessages();
       await state.harness.loadOMProgress();
+      // Refresh git branch so TUI status line reflects the current branch
+      const freshBranch = getCurrentGitBranch(state.projectInfo.rootPath);
+      if (freshBranch) {
+        state.projectInfo.gitBranch = freshBranch;
+      }
       // Restore tasks from thread state
       const threadState = state.harness.getState() as {
         tasks?: TaskItem[];

--- a/mastracode/src/tui/handlers/agent-lifecycle.ts
+++ b/mastracode/src/tui/handlers/agent-lifecycle.ts
@@ -4,6 +4,7 @@
  */
 import { Spacer, Text } from '@mariozechner/pi-tui';
 
+import { getCurrentGitBranch } from '../../utils/project.js';
 import { GradientAnimator } from '../components/obi-loader.js';
 import { theme } from '../theme.js';
 
@@ -11,6 +12,13 @@ import type { EventHandlerContext } from './types.js';
 
 export function handleAgentStart(ctx: EventHandlerContext): void {
   const { state } = ctx;
+
+  // Refresh git branch so status line reflects the current branch
+  const freshBranch = getCurrentGitBranch(state.projectInfo.rootPath);
+  if (freshBranch) {
+    state.projectInfo.gitBranch = freshBranch;
+  }
+
   if (!state.gradientAnimator) {
     state.gradientAnimator = new GradientAnimator(() => {
       ctx.updateStatusLine();

--- a/mastracode/src/tui/handlers/agent-lifecycle.ts
+++ b/mastracode/src/tui/handlers/agent-lifecycle.ts
@@ -33,6 +33,12 @@ export function handleAgentEnd(ctx: EventHandlerContext): void {
     state.gradientAnimator.fadeOut();
   }
 
+  // Refresh git branch — tool calls during this turn may have switched branches
+  const freshBranch = getCurrentGitBranch(state.projectInfo.rootPath);
+  if (freshBranch) {
+    state.projectInfo.gitBranch = freshBranch;
+  }
+
   if (state.streamingComponent) {
     state.streamingComponent = undefined;
     state.streamingMessage = undefined;

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -108,8 +108,7 @@ export function updateStatusLine(state: TUIState): void {
   const dirFull = branch ? `${displayPath} (${branch})` : displayPath;
   const dirBranchOnly = branch || null;
   // Abbreviate long branches: keep first 12 + last 8 chars with ".." in between
-  const dirBranchShort =
-    branch && branch.length > 24 ? branch.slice(0, 12) + '..' + branch.slice(-8) : dirBranchOnly;
+  const dirBranchShort = branch && branch.length > 24 ? branch.slice(0, 12) + '..' + branch.slice(-8) : dirBranchOnly;
 
   // --- Helper to style the model ID ---
   const isYolo = (state.harness.getState() as any).yolo === true;

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -103,9 +103,13 @@ export function updateStatusLine(state: TUIState): void {
   if (homedir && displayPath.startsWith(homedir)) {
     displayPath = '~' + displayPath.slice(homedir.length);
   }
-  if (state.projectInfo.gitBranch) {
-    displayPath = `${displayPath} (${state.projectInfo.gitBranch})`;
-  }
+  const branch = state.projectInfo.gitBranch;
+  // Build progressively shorter directory strings for layout fallback
+  const dirFull = branch ? `${displayPath} (${branch})` : displayPath;
+  const dirBranchOnly = branch || null;
+  // Abbreviate long branches: keep first 12 + last 8 chars with ".." in between
+  const dirBranchShort =
+    branch && branch.length > 24 ? branch.slice(0, 12) + '..' + branch.slice(-8) : dirBranchOnly;
 
   // --- Helper to style the model ID ---
   const isYolo = (state.harness.getState() as any).yolo === true;
@@ -185,6 +189,7 @@ export function updateStatusLine(state: TUIState): void {
     modelId: string;
     memCompact?: 'percentOnly' | 'noBuffer' | 'full';
     showDir: boolean;
+    dir?: string | null;
     badge?: 'full' | 'short';
   }): { plain: string; styled: string } | null => {
     const parts: Array<{ plain: string; styled: string }> = [];
@@ -235,11 +240,12 @@ export function updateStatusLine(state: TUIState): void {
     if (ref) {
       parts.push({ plain: ref, styled: ref });
     }
-    // Directory (lowest priority on line 1)
-    if (opts.showDir) {
+    // Directory / branch (lowest priority on line 1)
+    const dirText = opts.dir !== undefined ? opts.dir : opts.showDir ? dirFull : null;
+    if (dirText) {
       parts.push({
-        plain: displayPath,
-        styled: fg('dim', displayPath),
+        plain: dirText,
+        styled: fg('dim', dirText),
       });
     }
     const totalPlain =
@@ -248,7 +254,8 @@ export function updateStatusLine(state: TUIState): void {
     if (totalPlain > termWidth) return null;
 
     let styledLine: string;
-    if (opts.showDir && parts.length >= 3) {
+    const hasDir = !!dirText;
+    if (hasDir && parts.length >= 3) {
       // Three groups: left (model), center (mem/tokens/thinking), right (dir)
       const leftPart = parts[0]!; // model
       const centerParts = parts.slice(1, -1); // mem, tokens, thinking
@@ -269,7 +276,7 @@ export function updateStatusLine(state: TUIState): void {
         centerParts.map(p => p.styled).join(SEP) +
         ' '.repeat(Math.max(gapRight, 1)) +
         dirPart.styled;
-    } else if (opts.showDir && parts.length === 2) {
+    } else if (hasDir && parts.length === 2) {
       // Just model + dir, right-align dir
       const mainStr = useBadge + parts[0]!.styled;
       const dirPart = parts[parts.length - 1]!;
@@ -283,30 +290,34 @@ export function updateStatusLine(state: TUIState): void {
   // Try progressively more compact layouts.
   // Priority: token fractions + buffer > labels > provider > badge > buffer > fractions
   const result =
-    // 1. Full badge + full model + long labels + fractions + buffer + dir
-    buildLine({ modelId: fullModelId, memCompact: 'full', showDir: true }) ??
-    // 2. Drop directory
+    // 1. Full badge + full model + long labels + fractions + buffer + full dir
+    buildLine({ modelId: fullModelId, memCompact: 'full', showDir: false, dir: dirFull }) ??
+    // 2. Full badge + full model + branch only (drop path)
+    buildLine({ modelId: fullModelId, memCompact: 'full', showDir: false, dir: dirBranchOnly }) ??
+    // 3. Full badge + full model + abbreviated branch
+    buildLine({ modelId: fullModelId, memCompact: 'full', showDir: false, dir: dirBranchShort }) ??
+    // 4. Drop directory entirely
     buildLine({ modelId: fullModelId, memCompact: 'full', showDir: false }) ??
-    // 3. Drop provider + "claude-" prefix, keep full labels + fractions + buffer
+    // 5. Drop provider + "claude-" prefix, keep full labels + fractions + buffer
     buildLine({ modelId: tinyModelId, memCompact: 'full', showDir: false }) ??
-    // 4. Short labels (msg/mem) + fractions + buffer
+    // 6. Short labels (msg/mem) + fractions + buffer
     buildLine({ modelId: tinyModelId, showDir: false }) ??
-    // 5. Short badge + short labels + fractions + buffer
+    // 7. Short badge + short labels + fractions + buffer
     buildLine({ modelId: tinyModelId, showDir: false, badge: 'short' }) ??
-    // 6. Short badge + fractions (drop buffer indicator)
+    // 8. Short badge + fractions (drop buffer indicator)
     buildLine({
       modelId: tinyModelId,
       memCompact: 'noBuffer',
       showDir: false,
       badge: 'short',
     }) ??
-    // 7. Full badge + percent only
+    // 9. Full badge + percent only
     buildLine({
       modelId: tinyModelId,
       memCompact: 'percentOnly',
       showDir: false,
     }) ??
-    // 8. Short badge + percent only
+    // 10. Short badge + percent only
     buildLine({
       modelId: tinyModelId,
       memCompact: 'percentOnly',

--- a/mastracode/src/utils/project.ts
+++ b/mastracode/src/utils/project.ts
@@ -153,6 +153,14 @@ export function detectProject(projectPath: string): ProjectInfo {
 }
 
 /**
+ * Get the current git branch for a given directory.
+ * Lightweight alternative to detectProject() for refreshing just the branch.
+ */
+export function getCurrentGitBranch(cwd: string): string | undefined {
+  return git('rev-parse --abbrev-ref HEAD', cwd);
+}
+
+/**
  * Get the application data directory for mastracode
  * - macOS: ~/Library/Application Support/mastracode
  * - Linux: ~/.local/share/mastracode


### PR DESCRIPTION
## Summary

Fixes #13372
Fixes #13371

The git branch shown in both the **system prompt** and the **TUI status bar** was set once at harness creation and never refreshed. When a user resumed a thread on a different branch, or switched branches mid-session, both the agent context and the status bar showed a stale branch.

## Changes

### System prompt refresh (#13372)
- **`mastracode/src/utils/project.ts`**: Added `getCurrentGitBranch(cwd)` — a lightweight helper that runs `git rev-parse --abbrev-ref HEAD`.
- **`mastracode/src/agents/instructions.ts`**: `getDynamicInstructions()` now calls `getCurrentGitBranch()` on every request, falling back to stored `state.gitBranch`.

### Status bar refresh (#13371)
- **`mastracode/src/tui/event-dispatch.ts`**: Refreshes `state.projectInfo.gitBranch` on `thread_changed` events.
- **`mastracode/src/tui/handlers/agent-lifecycle.ts`**: Refreshes `state.projectInfo.gitBranch` on `agent_start`, so the status bar updates when a message is sent (handles mid-session branch switches).

### Status line layout improvement
- **`mastracode/src/tui/status-line.ts`**: Instead of dropping the directory+branch entirely when the status line is too wide, the layout now progressively falls back to: full path+branch → branch only → abbreviated branch → no directory.

## Test plan

1. Start mastracode on branch A, send a message — status bar and system prompt show branch A
2. Switch to branch B in another terminal, send another message — status bar and system prompt now show branch B
3. Resume a thread created on branch A while on branch B — system prompt shows branch B
4. Use a long branch name — status bar abbreviates it instead of hiding it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale Git branch shown in system prompts and the status bar.
  * Branch now refreshes on every agent request and when switching threads.
  * Status bar shows abbreviated branch names when space is limited instead of hiding them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->