### PR TITLE
fix(mastracode): wire fdPath to enable @ file autocomplete

### DIFF
--- a/.changeset/fix-file-autocomplete-fd.md
+++ b/.changeset/fix-file-autocomplete-fd.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed `@` file autocomplete so fuzzy file search works when `fd` or `fdfind` is installed.

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -34,25 +34,73 @@ On first launch, an interactive onboarding wizard guides you through:
 
 You can re-run setup anytime with `/setup`.
 
+## Prerequisites
+
+### Optional: `fd` for file autocomplete
+
+The `@` file autocomplete feature uses [`fd`](https://github.com/sharkdp/fd), a fast file finder that respects `.gitignore`. Without it, `@` autocomplete silently does nothing.
+
+Install with your package manager:
+
+```bash
+# macOS
+brew install fd
+
+# Ubuntu/Debian
+sudo apt install fd-find
+
+# Arch
+sudo pacman -S fd
+```
+
+On Ubuntu/Debian the binary is called `fdfind` — mastracode detects both `fd` and `fdfind` automatically.
+
 ## Usage
 
 ### Starting a conversation
 
-Simply type your message and press Enter. The agent will respond with streaming text.
+Type your message and press Enter. The agent responds with streaming text.
+
+### `@` file references
+
+Type `@` followed by a partial filename to fuzzy-search project files and reference them in your message. This requires `fd` to be installed (see [Prerequisites](#prerequisites)).
+
+- `@setup` — fuzzy-matches files like `setup.ts`, `setup.py`, etc.
+- `@src/tui` — scoped search within a directory
+- `@"path with spaces"` — quoted form for paths containing spaces
+
+Select a suggestion with arrow keys and press Tab to insert it.
 
 ### Slash commands
 
-| Command    | Description                               |
-| ---------- | ----------------------------------------- |
-| `/new`     | Start a new conversation thread           |
-| `/threads` | List all threads for this project         |
-| `/models`  | Select a different AI model               |
-| `/cost`    | Show token usage for current conversation |
-| `/login`   | Authenticate with OAuth providers         |
-| `/logout`  | Log out from a provider                   |
-| `/setup`   | Re-run the interactive setup wizard       |
-| `/help`    | Show available commands                   |
-| `/exit`    | Exit the TUI                              |
+| Command         | Description                                  |
+| --------------- | -------------------------------------------- |
+| `/new`          | Start a new conversation thread              |
+| `/threads`      | List and switch between threads              |
+| `/models`       | Configure model (global/thread/mode)         |
+| `/models:pack`  | Switch model pack                            |
+| `/mode`         | Switch agent mode                            |
+| `/subagents`    | Configure subagent model defaults            |
+| `/om`           | Configure Observational Memory models        |
+| `/think`        | Set thinking level (Anthropic)               |
+| `/skills`       | List available skills                        |
+| `/diff`         | Show modified files or git diff              |
+| `/name`         | Rename current thread                        |
+| `/cost`         | Show token usage and estimated costs         |
+| `/review`       | Review a GitHub pull request                 |
+| `/hooks`        | Show/reload configured hooks                 |
+| `/mcp`          | Show/reload MCP server connections           |
+| `/sandbox`      | Manage allowed paths (add/remove dirs)       |
+| `/permissions`  | View/manage tool approval permissions        |
+| `/settings`     | General settings (notifications, YOLO, etc.) |
+| `/yolo`         | Toggle YOLO mode (auto-approve all tools)    |
+| `/resource`     | Show/switch resource ID (tag for sharing)    |
+| `/thread:tag-dir` | Tag current thread with this directory     |
+| `/login`        | Authenticate with OAuth providers            |
+| `/logout`       | Log out from a provider                      |
+| `/setup`        | Re-run the interactive setup wizard          |
+| `/help`         | Show available commands                      |
+| `/exit`         | Exit the TUI                                 |
 
 ### Keyboard shortcuts
 

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -73,34 +73,34 @@ Select a suggestion with arrow keys and press Tab to insert it.
 
 ### Slash commands
 
-| Command         | Description                                  |
-| --------------- | -------------------------------------------- |
-| `/new`          | Start a new conversation thread              |
-| `/threads`      | List and switch between threads              |
-| `/models`       | Configure model (global/thread/mode)         |
-| `/models:pack`  | Switch model pack                            |
-| `/mode`         | Switch agent mode                            |
-| `/subagents`    | Configure subagent model defaults            |
-| `/om`           | Configure Observational Memory models        |
-| `/think`        | Set thinking level (Anthropic)               |
-| `/skills`       | List available skills                        |
-| `/diff`         | Show modified files or git diff              |
-| `/name`         | Rename current thread                        |
-| `/cost`         | Show token usage and estimated costs         |
-| `/review`       | Review a GitHub pull request                 |
-| `/hooks`        | Show/reload configured hooks                 |
-| `/mcp`          | Show/reload MCP server connections           |
-| `/sandbox`      | Manage allowed paths (add/remove dirs)       |
-| `/permissions`  | View/manage tool approval permissions        |
-| `/settings`     | General settings (notifications, YOLO, etc.) |
-| `/yolo`         | Toggle YOLO mode (auto-approve all tools)    |
-| `/resource`     | Show/switch resource ID (tag for sharing)    |
-| `/thread:tag-dir` | Tag current thread with this directory     |
-| `/login`        | Authenticate with OAuth providers            |
-| `/logout`       | Log out from a provider                      |
-| `/setup`        | Re-run the interactive setup wizard          |
-| `/help`         | Show available commands                      |
-| `/exit`         | Exit the TUI                                 |
+| Command           | Description                                  |
+| ----------------- | -------------------------------------------- |
+| `/new`            | Start a new conversation thread              |
+| `/threads`        | List and switch between threads              |
+| `/models`         | Configure model (global/thread/mode)         |
+| `/models:pack`    | Switch model pack                            |
+| `/mode`           | Switch agent mode                            |
+| `/subagents`      | Configure subagent model defaults            |
+| `/om`             | Configure Observational Memory models        |
+| `/think`          | Set thinking level (Anthropic)               |
+| `/skills`         | List available skills                        |
+| `/diff`           | Show modified files or git diff              |
+| `/name`           | Rename current thread                        |
+| `/cost`           | Show token usage and estimated costs         |
+| `/review`         | Review a GitHub pull request                 |
+| `/hooks`          | Show/reload configured hooks                 |
+| `/mcp`            | Show/reload MCP server connections           |
+| `/sandbox`        | Manage allowed paths (add/remove dirs)       |
+| `/permissions`    | View/manage tool approval permissions        |
+| `/settings`       | General settings (notifications, YOLO, etc.) |
+| `/yolo`           | Toggle YOLO mode (auto-approve all tools)    |
+| `/resource`       | Show/switch resource ID (tag for sharing)    |
+| `/thread:tag-dir` | Tag current thread with this directory       |
+| `/login`          | Authenticate with OAuth providers            |
+| `/logout`         | Log out from a provider                      |
+| `/setup`          | Re-run the interactive setup wizard          |
+| `/help`           | Show available commands                      |
+| `/exit`           | Exit the TUI                                 |
 
 ### Keyboard shortcuts
 

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -1,6 +1,7 @@
 /**
  * TUI setup: keyboard shortcuts, layout building, autocomplete, key handlers.
  */
+import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 
 import { CombinedAutocompleteProvider, Spacer, Text } from '@mariozechner/pi-tui';
@@ -213,6 +214,19 @@ export function buildLayout(state: TUIState, refreshModelAuthStatus: () => Promi
 // Autocomplete
 // =============================================================================
 
+/** Detect the fd binary (fast file finder) for @ fuzzy file autocomplete */
+function detectFdPath(): string | null {
+  for (const bin of ['fd', 'fdfind']) {
+    try {
+      const resolved = execSync(`which ${bin}`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+      if (resolved) return resolved;
+    } catch {
+      // not found, try next
+    }
+  }
+  return null;
+}
+
 export function setupAutocomplete(state: TUIState): void {
   const slashCommands: SlashCommand[] = [
     { name: 'new', description: 'Start a new thread' },
@@ -275,7 +289,8 @@ export function setupAutocomplete(state: TUIState): void {
     });
   }
 
-  state.autocompleteProvider = new CombinedAutocompleteProvider(slashCommands, process.cwd());
+  const fdPath = detectFdPath();
+  state.autocompleteProvider = new CombinedAutocompleteProvider(slashCommands, process.cwd(), fdPath);
   state.editor.setAutocompleteProvider(state.autocompleteProvider);
 }
 

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -1,7 +1,7 @@
 /**
  * TUI setup: keyboard shortcuts, layout building, autocomplete, key handlers.
  */
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 
 import { CombinedAutocompleteProvider, Spacer, Text } from '@mariozechner/pi-tui';
@@ -216,9 +216,12 @@ export function buildLayout(state: TUIState, refreshModelAuthStatus: () => Promi
 
 /** Detect the fd binary (fast file finder) for @ fuzzy file autocomplete */
 function detectFdPath(): string | null {
+  const whichCmd = process.platform === 'win32' ? 'where' : 'which';
   for (const bin of ['fd', 'fdfind']) {
     try {
-      const resolved = execSync(`which ${bin}`, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+      const resolved = execFileSync(whichCmd, [bin], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
+        .trim()
+        .split(/\r?\n/)[0];
       if (resolved) return resolved;
     } catch {
       // not found, try next


### PR DESCRIPTION
## Summary

The `@` file autocomplete (fuzzy file search powered by `fd`) was silently broken. Typing `@` followed by a filename never showed file suggestions, even with `fd` or `fdfind` installed.

## Root cause

`CombinedAutocompleteProvider` from `@mariozechner/pi-tui` accepts an optional 3rd argument `fdPath` (the path to the `fd` binary). Without it, `getFuzzyFileSuggestions()` returns early and no suggestions are generated.

## Fix

Added a `detectFdPath()` helper in `setup.ts` that checks for `fd` then `fdfind` via `which`, and passes the result as the 3rd argument to `CombinedAutocompleteProvider`.

If neither binary is found, `null` is passed and behavior is unchanged (graceful fallback).

Supersedes #13373 (which has a merge conflict against `main`).

## Test plan

- `pnpm -C mastracode build:lib` — passes
- Manual: with `fd` installed, type `@` in the editor and verify fuzzy file suggestions appear
- Manual: without `fd`, verify no errors and autocomplete degrades gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File autocomplete now supports fuzzy file search when fd/fdfind is available.

* **Documentation**
  * Added Prerequisites and installation guidance for optional fd; expanded Usage with file-reference examples and a much larger Slash Commands table.

* **Chores**
  * Added a changelog entry documenting this patch-level update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->