### PR TITLE
fix(core): fix build error in embedding router doEmbed return type

### DIFF
--- a/.changeset/fix-embedding-router-warnings.md
+++ b/.changeset/fix-embedding-router-warnings.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed build error in `ModelRouterEmbeddingModel.doEmbed()` caused by `warnings` not existing on the return type.

--- a/packages/core/src/llm/model/embedding-router.ts
+++ b/packages/core/src/llm/model/embedding-router.ts
@@ -219,7 +219,9 @@ export class ModelRouterEmbeddingModel<VALUE extends string = string> implements
     args: Parameters<EmbeddingModelV2<VALUE>['doEmbed']>[0],
   ): Promise<Awaited<ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>>> {
     const result = await this.providerModel.doEmbed(args);
+    // Ensure warnings is always an array — AI SDK v6's embedMany spreads
+    // result.warnings and crashes if it's undefined.
     const warnings = (result as { warnings?: unknown[] }).warnings ?? [];
-    return { ...result, warnings };
+    return { ...result, warnings } as Awaited<ReturnType<EmbeddingModelV2<VALUE>['doEmbed']>>;
   }
 }


### PR DESCRIPTION
## Summary

`pnpm build:core` fails on `main` with:

```
TS2353: Object literal may only specify known properties, and 'warnings' does not exist in type ...
```

This was introduced by #13369 which added a `warnings` array to the `doEmbed()` return for AI SDK v6 compatibility. The runtime behavior is correct, but the TypeScript return type (`EmbeddingModelV2.doEmbed`) does not include `warnings`, causing a build error.

## Fix

Added a type assertion (`as Awaited<ReturnType<...>>`) so TypeScript accepts the return value while preserving the runtime `warnings` array that AI SDK v6 needs.

## Test plan

- `pnpm build:core` — passes (previously failed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a build error in the embedding model router that prevented successful compilation. The issue involved inconsistent handling of warnings in the return type, causing type validation failures. This patch ensures proper type alignment and consistency, restoring the ability to build the package successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->