### PR TITLE
fix(core): pass traceId to scores during experiment runs

### DIFF
--- a/.changeset/fix-score-trace-link-experiment.md
+++ b/.changeset/fix-score-trace-link-experiment.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Include traceId on scores generated during experiment runs to restore traceability of experiment results

--- a/packages/core/src/datasets/experiment/index.ts
+++ b/packages/core/src/datasets/experiment/index.ts
@@ -277,6 +277,7 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
           item.id,
           execResult.scorerInput,
           execResult.scorerOutput,
+          execResult.traceId ?? undefined,
         );
 
         // Persist result with scores (if storage available)

--- a/packages/core/src/datasets/experiment/scorer.ts
+++ b/packages/core/src/datasets/experiment/scorer.ts
@@ -46,6 +46,7 @@ export async function runScorersForItem(
   itemId: string,
   scorerInput?: ScorerRunInputForAgent,
   scorerOutput?: ScorerRunOutputForAgent,
+  traceId?: string,
 ): Promise<ScorerResult[]> {
   if (scorers.length === 0) return [];
 
@@ -67,6 +68,7 @@ export async function runScorersForItem(
             entityId: itemId,
             source: 'TEST',
             runId,
+            traceId,
             scorer: {
               id: scorer.id,
               name: scorer.name,


### PR DESCRIPTION
Scores produced during experiment runs were missing the `traceId` field, so they couldn't be linked back to the agent trace that generated them.

The `traceId` was already captured by `executeAgent()` but never forwarded to `runScorersForItem()`. Now it's threaded through and included in the `validateAndSaveScore` payload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scores produced during experiment runs now include trace identifiers, restoring linkage between results and execution traces for improved observability and debugging.

* **Documentation**
  * Added a changelog entry describing the patch release and the restored traceability behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->