### PR TITLE
fix(mcp): extract tool results from content array when structuredContent is absent

### DIFF
--- a/.changeset/dull-lands-press.md
+++ b/.changeset/dull-lands-press.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed MCP tool results returning empty `{}` when the server does not include `structuredContent` in responses (e.g. FastMCP, older MCP protocol versions). The client now extracts the actual result from the `content` array instead of returning the raw protocol envelope, which previously caused output schema validation to strip all properties.

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -782,18 +782,14 @@ export class InternalMastraMCPClient extends MastraBase {
               // Without this, the raw CallToolResult envelope ({ content, isError,
               // _meta }) gets validated against the outputSchema and Zod strips all
               // unrecognised keys, producing {}.
-              if (tool.outputSchema) {
+              if (tool.outputSchema && !res.isError) {
                 const content = res.content as Array<{ type: string; text?: string }> | undefined;
-                if (content && content.length > 0) {
-                  if (content.length === 1 && content[0]!.type === 'text' && content[0]!.text !== undefined) {
-                    try {
-                      return JSON.parse(content[0]!.text);
-                    } catch {
-                      return content[0]!.text;
-                    }
+                if (content && content.length === 1 && content[0]!.type === 'text' && content[0]!.text !== undefined) {
+                  try {
+                    return JSON.parse(content[0]!.text);
+                  } catch {
+                    return content[0]!.text;
                   }
-                  // Multiple content blocks or non-text blocks – return the array as-is
-                  return content;
                 }
               }
 

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -776,6 +776,27 @@ export class InternalMastraMCPClient extends MastraBase {
                 return res.structuredContent;
               }
 
+              // When the tool has an outputSchema but the server didn't return
+              // structuredContent (e.g. older MCP protocol versions that predate the
+              // structuredContent spec), extract the result from the content array.
+              // Without this, the raw CallToolResult envelope ({ content, isError,
+              // _meta }) gets validated against the outputSchema and Zod strips all
+              // unrecognised keys, producing {}.
+              if (tool.outputSchema) {
+                const content = res.content as Array<{ type: string; text?: string }> | undefined;
+                if (content && content.length > 0) {
+                  if (content.length === 1 && content[0]!.type === 'text' && content[0]!.text !== undefined) {
+                    try {
+                      return JSON.parse(content[0]!.text);
+                    } catch {
+                      return content[0]!.text;
+                    }
+                  }
+                  // Multiple content blocks or non-text blocks – return the array as-is
+                  return content;
+                }
+              }
+
               return res;
             };
 


### PR DESCRIPTION
## Description

Fixed MCP tool results returning empty `{}` when the server doesn't include `structuredContent` in responses (e.g. FastMCP, older MCP protocol versions).

Before: A tool with `outputSchema` would receive `{ content: [...], isError, _meta }` as the result, which Zod would validate and strip all unrecognized keys, returning `{}`.

After: The client now extracts the actual result from the `content` array for tools with `outputSchema`, while tools without `outputSchema` remain unchanged.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MCP tool results returning empty objects when servers omit structuredContent; client now extracts results from the content array so outputs validate and work with older/non-SDK MCP servers.
* **Tests**
  * Added tests verifying parsing of tool results when responses advertise an output schema but lack structuredContent.
* **Chores**
  * Added a changeset entry marking a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->