### PR TITLE
fix(tools): schema-aware null stripping preserves .nullable() fields (#13419)

### DIFF
--- a/.changeset/fix-parallel-workflow-runid.md
+++ b/.changeset/fix-parallel-workflow-runid.md
@@ -1,0 +1,7 @@
+---
+"@mastra/core": patch
+---
+
+fix(agent): use unique runId per parallel workflow tool call (#13473)
+
+When an agent makes multiple parallel tool calls to the same workflow, all calls shared the agent's runId, causing `createRun()` to return the same cached Run instance. Only the first call's `start()` would process its input; the rest received identical results. Now each non-resume workflow tool call generates a unique runId via `randomUUID()`.

--- a/.changeset/fix-schema-aware-null-stripping.md
+++ b/.changeset/fix-schema-aware-null-stripping.md
@@ -2,6 +2,6 @@
 "@mastra/core": patch
 ---
 
-fix(tools): schema-aware null stripping preserves .nullable() fields (#13419)
+Fixed input validation to preserve null for nullable fields and strip null for optional-only fields.
 
-When LLMs send null for optional fields, `stripNullishValues` now checks the Zod schema to preserve null for `.nullable()` fields while still stripping null from `.optional()`-only fields.
+When LLMs send null for optional fields, input validation now checks the schema to distinguish `.nullable()` from `.optional()`. Nullable fields keep their null values, while optional-only fields have null stripped as before.

--- a/.changeset/fix-schema-aware-null-stripping.md
+++ b/.changeset/fix-schema-aware-null-stripping.md
@@ -1,0 +1,7 @@
+---
+"@mastra/core": patch
+---
+
+fix(tools): schema-aware null stripping preserves .nullable() fields (#13419)
+
+When LLMs send null for optional fields, `stripNullishValues` now checks the Zod schema to preserve null for `.nullable()` fields while still stripping null from `.optional()`-only fields.

--- a/.changeset/schema-aware-null-stripping.md
+++ b/.changeset/schema-aware-null-stripping.md
@@ -2,4 +2,4 @@
 "@mastra/core": patch
 ---
 
-fix: schema-aware null stripping for optional fields (#13419)
+Fixed input validation to preserve null for nullable fields and strip null for optional-only fields.

--- a/.changeset/schema-aware-null-stripping.md
+++ b/.changeset/schema-aware-null-stripping.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+fix: schema-aware null stripping for optional fields (#13419)

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2744,7 +2744,10 @@ export class Agent<
           execute: async (inputData, context) => {
             try {
               const { initialState, inputData: workflowInputData, suspendedToolRunId } = inputData as any;
-              const runIdToUse = suspendedToolRunId || runId;
+              // Use a unique runId for each workflow tool call to prevent parallel calls
+              // from sharing the same cached Run instance (see #13473).
+              // For resume cases, suspendedToolRunId correctly identifies the existing run.
+              const runIdToUse = suspendedToolRunId || randomUUID();
               this.logger.debug(`[Agent:${this.name}] - Executing workflow as tool ${workflowName}`, {
                 name: workflowName,
                 description: workflow.description,

--- a/packages/core/src/tools/validation.test.ts
+++ b/packages/core/src/tools/validation.test.ts
@@ -1155,19 +1155,13 @@ describe('validateToolInput - Null Stripping for Optional Fields (GitHub #12362)
 
     const result = validateToolInput(schema, input);
 
-    // First try: { name: 'test', bio: null, status: null }
-    //   bio fails (.optional() doesn't accept null), status passes (.nullable() accepts null)
-    // Retry with stripped: { name: 'test' }
-    //   bio passes (absent = undefined for .optional()), status fails (required field missing)
-    // Neither attempt fully succeeds, so this should fail
-    // ...unless the schema allows status to be absent too
-
-    // Actually, status is required (not optional), so stripping null from it makes it missing.
-    // The first attempt fails because bio: null is invalid for .optional().
-    // The retry fails because status is missing (it's required).
-    // This IS the expected behavior - the schema design is contradictory with null input for bio.
-    // The user should use .nullable().optional() for bio or .nullable() for both.
-    expect(result.error).toBeDefined();
+    // Schema-aware null stripping (GitHub #13419):
+    //   bio: null is stripped (field is .optional() but not .nullable())
+    //   status: null is preserved (field is .nullable())
+    // Retry with: { name: 'test', status: null }
+    //   bio passes (absent = undefined for .optional()), status passes (.nullable() accepts null)
+    expect(result.error).toBeUndefined();
+    expect(result.data).toEqual({ name: 'test', status: null });
   });
 
   it('should handle .nullable().optional() fields receiving null', () => {

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -194,7 +194,17 @@ function stripNullishValues(input: unknown, schema?: z.ZodTypeAny): unknown {
   if (Array.isArray(input)) {
     // For arrays, recursively process elements but keep nulls in arrays
     // (array elements with null may be intentional)
-    return input.map(item => (item === null ? null : stripNullishValues(item)));
+    // Pass the array's element schema so nested objects preserve nullable fields
+    let itemSchema: z.ZodTypeAny | undefined;
+    if (schema) {
+      const unwrappedArray = unwrapZodType(schema);
+      if (isZodArray(unwrappedArray)) {
+        // Zod 4: def.element, Zod 3: _def.type
+        const arrAny = unwrappedArray as any;
+        itemSchema = arrAny.element ?? arrAny._zod?.def?.element ?? arrAny._def?.type;
+      }
+    }
+    return input.map(item => (item === null ? null : stripNullishValues(item, itemSchema)));
   }
 
   // Only recurse into plain objects - preserve class instances, built-in objects

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -2,7 +2,7 @@ import type { z } from 'zod';
 import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../request-context';
 import type { RequestContext } from '../request-context';
 import type { SchemaWithValidation } from '../stream/base/schema';
-import { getZodTypeName, isZodArray, isZodObject, unwrapZodType } from '../utils/zod-utils';
+import { getZodTypeName, getZodInnerType, isZodArray, isZodObject, unwrapZodType } from '../utils/zod-utils';
 
 /**
  * Keys that should be redacted from error messages to prevent sensitive data leakage.
@@ -141,24 +141,47 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Recursively strips null and undefined values from object properties.
+ * Checks whether a Zod schema accepts null values by walking its wrapper chain.
+ * A field is nullable if ZodNullable appears anywhere in the wrapper chain
+ * (e.g. z.string().nullable(), z.string().nullable().optional()).
+ *
+ * @param schema The Zod field schema to check
+ * @returns true if the schema accepts null
+ */
+function isFieldNullable(schema: z.ZodTypeAny): boolean {
+  let current = schema;
+  while (true) {
+    const typeName = getZodTypeName(current);
+    if (!typeName) break;
+    if (typeName === 'ZodNullable') return true;
+    const inner = getZodInnerType(current, typeName);
+    if (!inner) break;
+    current = inner;
+  }
+  return false;
+}
+
+/**
+ * Schema-aware stripping of null/undefined values from object properties.
  * This handles LLMs (e.g. Gemini) that send null for optional fields,
  * since Zod's .optional() only accepts undefined, not null. (GitHub #12362)
  *
- * When a property value is null or undefined, it is omitted from the result
- * object entirely, which is equivalent to "not provided" for Zod validation.
+ * When a schema is provided, only strips null from fields that are NOT
+ * .nullable() — preserving null for fields where it's a valid value.
+ * This fixes the issue where mixing .optional() and .nullable() fields
+ * caused required nullable fields to lose their null values. (GitHub #13419)
+ *
+ * When no schema is provided, falls back to stripping all null/undefined
+ * values (original behavior).
  *
  * Only recurses into plain objects to preserve class instances and built-in objects
  * like Date, Map, URL, etc.
  *
- * NOTE: This function should NOT be called unconditionally because it breaks
- * schemas that use .nullable() (where null is a valid value). It is used as
- * a fallback when initial validation fails. See validateToolInput for usage.
- *
  * @param input The input to process
- * @returns The processed input with null/undefined values stripped
+ * @param schema Optional Zod schema to check which fields accept null
+ * @returns The processed input with null/undefined values stripped where appropriate
  */
-function stripNullishValues(input: unknown): unknown {
+function stripNullishValues(input: unknown, schema?: z.ZodTypeAny): unknown {
   // Top-level null/undefined becomes undefined
   if (input === null || input === undefined) {
     return undefined;
@@ -179,14 +202,26 @@ function stripNullishValues(input: unknown): unknown {
     return input;
   }
 
-  // It's a plain object - recursively process all properties, omitting null/undefined values
+  // Try to get the object schema's shape for field-level nullable checks
+  const unwrapped = schema ? unwrapZodType(schema) : undefined;
+  const shape = unwrapped && isZodObject(unwrapped) ? (unwrapped as any).shape : undefined;
+
+  // It's a plain object - recursively process all properties
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(input)) {
     if (value === null || value === undefined) {
-      // Omit null/undefined values - equivalent to "not provided" for optional fields
+      // If we have schema info and this field is .nullable(), preserve null
+      if (value === null && shape && shape[key] && isFieldNullable(shape[key])) {
+        result[key] = null;
+        continue;
+      }
+      // Otherwise omit - equivalent to "not provided" for optional fields
       continue;
     }
-    result[key] = stripNullishValues(value);
+    // Recurse into nested objects with their sub-schema if available
+    const fieldSchema = shape?.[key];
+    const innerSchema = fieldSchema ? unwrapZodType(fieldSchema) : undefined;
+    result[key] = stripNullishValues(value, innerSchema);
   }
   return result;
 }
@@ -371,11 +406,12 @@ export function validateToolInput<T = any>(
     }
   }
 
-  // Step 5: Retry with null values stripped (GitHub #12362)
+  // Step 5: Retry with null values stripped (GitHub #12362, #13419)
   // LLMs like Gemini send null for optional fields, but Zod's .optional() only
   // accepts undefined, not null. By stripping nullish values and retrying, we
-  // handle this case without breaking .nullable() schemas that passed in step 3.
-  const strippedInput = stripNullishValues(input);
+  // handle this case. The schema is passed so that .nullable() fields preserve
+  // their null values instead of being stripped. (GitHub #13419)
+  const strippedInput = stripNullishValues(input, schema as z.ZodTypeAny);
   const normalizedStripped = normalizeNullishInput(schema, strippedInput);
   const retryValidation = schema.safeParse(normalizedStripped);
 


### PR DESCRIPTION
## Summary

Fixes #13419 — `stripNullishValues` strips null from ALL fields indiscriminately, breaking schemas that mix `.optional()` and `.nullable()` fields.

## Root Cause

When LLMs (e.g. Gemini) send `null` for optional fields, `validateToolInput` falls back to `stripNullishValues` which removes all null/undefined values. This works for `.optional()` fields but breaks required `.nullable()` fields — their valid `null` values get stripped, making the field missing and failing validation.

## Fix

Make `stripNullishValues` schema-aware:

1. Added `isFieldNullable()` helper that walks a Zod schema's wrapper chain to detect `ZodNullable`
2. `stripNullishValues` now accepts an optional Zod schema parameter
3. When a schema is available, it checks each field — `.nullable()` fields preserve their null values, `.optional()`-only fields get null stripped as before
4. Without a schema, falls back to original behavior (strip all)

### Example

```ts
const schema = z.object({
  name: z.string(),
  bio: z.string().optional(),    // null → stripped (not nullable)
  status: z.string().nullable(), // null → preserved (nullable)
});

// Input:  { name: 'test', bio: null, status: null }
// Before: { name: 'test' }              // status missing → ❌ fails
// After:  { name: 'test', status: null } // status preserved → ✅ passes
```

## Tests

- Updated existing test `should handle mix of .optional() and .nullable() fields` to expect success (was previously expected to fail)
- All 78 validation tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented parallel workflow tool calls from sharing the same execution instance so concurrent calls run independently and no longer overwrite or reuse each other’s state.
  * Corrected input validation to preserve null for fields explicitly marked nullable in schemas while still stripping null from fields that are optional but not nullable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->