### PR TITLE
fix: fallback to original schema when compat layer breaks optional fields (#13480)

### DIFF
--- a/.changeset/original-schema-fallback.md
+++ b/.changeset/original-schema-fallback.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+fix: fallback to original schema when compat layer breaks optional fields (#13480)

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -245,6 +245,7 @@ export class CoreToolBuilder extends MastraBase {
     options: ToolOptions,
     logType?: 'tool' | 'toolset' | 'client-tool',
     processedSchema?: z.ZodTypeAny,
+    originalSchema?: z.ZodTypeAny,
   ) {
     // don't add memory, mastra, or tracing context to logging (tracingContext may contain sensitive observability credentials)
     const {
@@ -475,7 +476,7 @@ export class CoreToolBuilder extends MastraBase {
         // Validate input parameters if schema exists
         // Use the processed schema for validation if available, otherwise fall back to original
         const parameters = processedSchema || this.getParameters();
-        const { data, error } = validateToolInput(parameters, args, options.name);
+        const { data, error } = validateToolInput(parameters, args, options.name, originalSchema);
         if (error) {
           logger.warn(error.message);
           return error;
@@ -651,6 +652,7 @@ export class CoreToolBuilder extends MastraBase {
             { ...this.options, description: this.originalTool.description },
             this.logType,
             processedZodSchema, // Pass the processed Zod schema for validation
+            originalSchema, // Pass the original schema as fallback (GitHub #13480)
           )
         : undefined,
     };

--- a/packages/core/src/tools/validation.test.ts
+++ b/packages/core/src/tools/validation.test.ts
@@ -1823,3 +1823,167 @@ describe('validateToolInput - Stringified JSON Coercion (GitHub #12757)', () => 
     });
   });
 });
+
+describe('validateToolInput - Original Schema Fallback (GitHub #13480)', () => {
+  // These tests verify the fix for https://github.com/mastra-ai/mastra/issues/13480
+  // When schemas are processed through OpenAI compat layers, .optional() is converted
+  // to .nullable().transform(), which removes the optional wrapper and makes the field
+  // required (but nullable). When the LLM omits optional fields entirely (key not
+  // present in input), the processed schema rejects it because the field is now required.
+  // The fix adds a fallback to the original (pre-compat) schema which still has .optional().
+
+  it('should fallback to originalSchema when LLM omits optional fields (key not present)', () => {
+    // Original schema: field is optional
+    const originalSchema = z.object({
+      query: z.string(),
+      limit: z.number().optional(),
+    });
+
+    // Processed schema: compat layer converted .optional() to .nullable().transform()
+    // This makes `limit` required (but nullable)
+    const processedSchema = z.object({
+      query: z.string(),
+      limit: z
+        .number()
+        .nullable()
+        .transform((val: number | null) => (val === null ? undefined : val)),
+    });
+
+    // LLM omits the optional field entirely (key not in input)
+    const input = { query: 'hello' };
+
+    // Without originalSchema, this would fail because `limit` is required in processedSchema
+    const result = validateToolInput(processedSchema, input, 'test-tool', originalSchema);
+
+    expect(result.error).toBeUndefined();
+    expect(result.data).toEqual({ query: 'hello' });
+  });
+
+  it('should fallback to originalSchema with multiple optional fields omitted', () => {
+    const originalSchema = z.object({
+      name: z.string(),
+      age: z.number().optional(),
+      email: z.string().email().optional(),
+      bio: z.string().optional(),
+    });
+
+    const processedSchema = z.object({
+      name: z.string(),
+      age: z
+        .number()
+        .nullable()
+        .transform((val: number | null) => (val === null ? undefined : val)),
+      email: z
+        .string()
+        .nullable()
+        .transform((val: string | null) => (val === null ? undefined : val)),
+      bio: z
+        .string()
+        .nullable()
+        .transform((val: string | null) => (val === null ? undefined : val)),
+    });
+
+    // LLM only provides the required field
+    const input = { name: 'Alice' };
+
+    const result = validateToolInput(processedSchema, input, 'test-tool', originalSchema);
+
+    expect(result.error).toBeUndefined();
+    expect(result.data).toEqual({ name: 'Alice' });
+  });
+
+  it('should still use processedSchema when input is valid against it', () => {
+    const originalSchema = z.object({
+      query: z.string(),
+      limit: z.number().optional(),
+    });
+
+    const processedSchema = z.object({
+      query: z.string(),
+      limit: z
+        .number()
+        .nullable()
+        .transform((val: number | null) => (val === null ? undefined : val)),
+    });
+
+    // LLM provides null for the optional field (handled by Step 2: undefined→null)
+    const input = { query: 'hello', limit: null };
+
+    const result = validateToolInput(processedSchema, input, 'test-tool', originalSchema);
+
+    expect(result.error).toBeUndefined();
+    // processedSchema's transform converts null → undefined
+    expect(result.data).toEqual({ query: 'hello', limit: undefined });
+  });
+
+  it('should still fail when input is invalid against both schemas', () => {
+    const originalSchema = z.object({
+      query: z.string(),
+      count: z.number(),
+    });
+
+    const processedSchema = z.object({
+      query: z.string(),
+      count: z.number(),
+    });
+
+    // Missing required field `count` in both schemas
+    const input = { query: 'hello' };
+
+    const result = validateToolInput(processedSchema, input, 'test-tool', originalSchema);
+
+    expect(result.error).toBeDefined();
+    expect(result.error!.message).toContain('Tool input validation failed');
+  });
+
+  it('should handle nested optional fields with originalSchema fallback', () => {
+    const originalSchema = z.object({
+      config: z.object({
+        host: z.string(),
+        port: z.number().optional(),
+        ssl: z.boolean().optional(),
+      }),
+    });
+
+    const processedSchema = z.object({
+      config: z.object({
+        host: z.string(),
+        port: z
+          .number()
+          .nullable()
+          .transform((val: number | null) => (val === null ? undefined : val)),
+        ssl: z
+          .boolean()
+          .nullable()
+          .transform((val: boolean | null) => (val === null ? undefined : val)),
+      }),
+    });
+
+    // LLM omits nested optional fields
+    const input = { config: { host: 'localhost' } };
+
+    const result = validateToolInput(processedSchema, input, 'test-tool', originalSchema);
+
+    expect(result.error).toBeUndefined();
+    expect(result.data).toEqual({ config: { host: 'localhost' } });
+  });
+
+  it('should not use originalSchema when not provided (backward compat)', () => {
+    const processedSchema = z.object({
+      query: z.string(),
+      limit: z
+        .number()
+        .nullable()
+        .transform((val: number | null) => (val === null ? undefined : val)),
+    });
+
+    // LLM omits optional field, no originalSchema provided
+    const input = { query: 'hello' };
+
+    const result = validateToolInput(processedSchema, input, 'test-tool');
+
+    // Should fail because limit is required in processedSchema and no fallback
+    expect(result.error).toBeDefined();
+    expect(result.error!.message).toContain('Tool input validation failed');
+  });
+});

--- a/packages/core/src/tools/validation.test.ts
+++ b/packages/core/src/tools/validation.test.ts
@@ -1968,6 +1968,38 @@ describe('validateToolInput - Original Schema Fallback (GitHub #13480)', () => {
     expect(result.data).toEqual({ config: { host: 'localhost' } });
   });
 
+  it('should fallback to original schema with null-stripped input (Step 6b)', () => {
+    // Edge case: LLM sends null for optional fields AND compat layer removed .optional()
+    // Step 5 strips nulls but processed schema still requires the key (.nullable(), not .optional())
+    // Step 6 tries original schema with raw input but null ≠ undefined, so .optional() rejects
+    // Step 6b strips nulls then tries original schema → .optional() accepts missing keys
+    const originalSchema = z.object({
+      query: z.string(),
+      format: z.string().optional(),
+      verbose: z.boolean().optional(),
+    });
+
+    const processedSchema = z.object({
+      query: z.string(),
+      format: z
+        .string()
+        .nullable()
+        .transform((val: string | null) => (val === null ? undefined : val)),
+      verbose: z
+        .boolean()
+        .nullable()
+        .transform((val: boolean | null) => (val === null ? undefined : val)),
+    });
+
+    // LLM sends explicit null for optional fields
+    const input = { query: 'test', format: null, verbose: null };
+
+    const result = validateToolInput(processedSchema, input, 'test-tool', originalSchema);
+
+    expect(result.error).toBeUndefined();
+    expect(result.data).toEqual({ query: 'test' });
+  });
+
   it('should not use originalSchema when not provided (backward compat)', () => {
     const processedSchema = z.object({
       query: z.string(),

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -389,6 +389,8 @@ export function validateToolInput<T = any>(
   // making fields required in the processed schema. When the LLM omits optional
   // fields entirely (key not present in input), the processed schema rejects it.
   // The original schema still has .optional() and accepts missing keys.
+  // Note: We intentionally only apply normalizeNullishInput here (not convertUndefinedToNull
+  // or coerceStringifiedJsonValues) because the original schema accepts undefined natively.
   if (originalSchema && 'safeParse' in originalSchema) {
     const originalNormalized = normalizeNullishInput(originalSchema, input);
     const originalValidation = originalSchema.safeParse(originalNormalized);

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -321,6 +321,7 @@ export function validateToolInput<T = any>(
   schema: SchemaWithValidation<T> | undefined,
   input: unknown,
   toolId?: string,
+  originalSchema?: SchemaWithValidation<T>,
 ): { data: T | unknown; error?: ValidationError<T> } {
   // If no schema, return input as-is
   if (!schema || !('safeParse' in schema)) {
@@ -381,6 +382,19 @@ export function validateToolInput<T = any>(
 
   if (retryValidation.success) {
     return { data: retryValidation.data };
+  }
+
+  // Step 6: Fallback to original (pre-compat) schema (GitHub #13480)
+  // The OpenAI compat layer converts .optional() to .nullable().transform(),
+  // making fields required in the processed schema. When the LLM omits optional
+  // fields entirely (key not present in input), the processed schema rejects it.
+  // The original schema still has .optional() and accepts missing keys.
+  if (originalSchema && 'safeParse' in originalSchema) {
+    const originalNormalized = normalizeNullishInput(originalSchema, input);
+    const originalValidation = originalSchema.safeParse(originalNormalized);
+    if (originalValidation.success) {
+      return { data: originalValidation.data };
+    }
   }
 
   // All attempts failed - return the original (non-stripped) error since it's

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -397,6 +397,18 @@ export function validateToolInput<T = any>(
     if (originalValidation.success) {
       return { data: originalValidation.data };
     }
+
+    // Step 6b: Retry original schema with null values stripped (CodeRabbit review)
+    // Handles: LLM sends null for optional fields AND compat layer removed .optional().
+    // Step 5 strips nulls but processed schema still requires the key (.nullable(), not .optional()).
+    // Step 6 tries original schema with raw input but null ≠ undefined, so .optional() rejects it.
+    // Stripping nulls makes keys absent → original schema's .optional() accepts missing keys.
+    const originalStrippedInput = stripNullishValues(input);
+    const originalNormalizedStripped = normalizeNullishInput(originalSchema, originalStrippedInput);
+    const originalStrippedValidation = originalSchema.safeParse(originalNormalizedStripped);
+    if (originalStrippedValidation.success) {
+      return { data: originalStrippedValidation.data };
+    }
   }
 
   // All attempts failed - return the original (non-stripped) error since it's

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -312,9 +312,12 @@ function coerceStringifiedJsonValues(schema: SchemaWithValidation<unknown>, inpu
 /**
  * Validates raw input data against a Zod schema.
  *
- * @param schema The Zod schema to validate against
+ * @param schema The Zod schema to validate against (may be processed by OpenAI compat layer)
  * @param input The raw input data to validate
  * @param toolId Optional tool ID for better error messages
+ * @param originalSchema The original unmodified schema before compat processing. Used as a
+ *   fallback when the processed schema rejects valid input (e.g., compat layer converts
+ *   `.optional()` to `.nullable().transform()`, making optional fields required). (GitHub #13480)
  * @returns The validated data or a validation error
  */
 export function validateToolInput<T = any>(


### PR DESCRIPTION
## Summary

Fixes #13480

When OpenAI compat layers process tool schemas, `.optional()` is converted to `.nullable().transform()`. This removes the optional wrapper, making the field **required** (but nullable) in the processed schema. If the LLM omits optional fields entirely (key not present in input), all existing validation steps fail because the processed schema expects the key to exist.

## Solution

Add a Step 6 fallback to `validateToolInput`: after all other attempts fail, try validating against the original (pre-compat) schema which still has `.optional()` and accepts missing keys.

### Changes

- **`validation.ts`**: Add optional `originalSchema` parameter to `validateToolInput`. After Steps 1-5 fail, attempt validation with the original schema as a last resort.
- **`builder.ts`**: Pass `originalSchema` through `createExecute` to `validateToolInput`.
- **`validation.test.ts`**: 6 new tests covering:
  - Single optional field omitted → fallback succeeds
  - Multiple optional fields omitted → fallback succeeds
  - Valid input against processed schema → no fallback needed
  - Invalid input against both schemas → still fails correctly
  - Nested optional fields → fallback succeeds
  - No originalSchema provided → backward compatible (still fails)

## Validation pipeline (updated)

1. `normalizeNullishInput` — top-level null/undefined → {} or []
2. `convertUndefinedToNull` — undefined → null for compat layers (#11457)
3. First validation with null preserved
4. Retry with stringified JSON coercion (#12757)
5. Retry with null values stripped (#12362)
6. **NEW: Fallback to original schema (#13480)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tool input validation: when compatibility transforms make optional fields behave oddly, the system now falls back to the original input schema during execution so valid inputs are accepted.

* **Tests**
  * Added comprehensive test coverage for schema-fallback behavior, nested optionals, multiple omissions, null-stripping edge cases, and backward-compatibility scenarios.

* **Chores**
  * Added release metadata for publishing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->