### PR TITLE
feat(mastracode): inherit terminal color theme for light/dark mode support

### DIFF
--- a/.changeset/silent-baboons-check.md
+++ b/.changeset/silent-baboons-check.md
@@ -1,0 +1,5 @@
+---
+'mastracode': minor
+---
+
+Added light theme support and automatic terminal theme detection. Mastra Code now detects your terminal's color scheme and applies a matching dark or light theme. Use the new `/theme` slash command to switch between `auto`, `dark`, and `light` modes. The choice is persisted across sessions. You can also set the `MASTRA_THEME` environment variable to override the detected theme.

--- a/.changeset/silent-baboons-check.md
+++ b/.changeset/silent-baboons-check.md
@@ -3,3 +3,13 @@
 ---
 
 Added light theme support and automatic terminal theme detection. Mastra Code now detects your terminal's color scheme and applies a matching dark or light theme. Use the new `/theme` slash command to switch between `auto`, `dark`, and `light` modes. The choice is persisted across sessions. You can also set the `MASTRA_THEME` environment variable to override the detected theme.
+
+```sh
+# Switch theme at runtime via slash command
+/theme auto    # detect from terminal background
+/theme dark    # force dark theme
+/theme light   # force light theme
+
+# Or override via environment variable
+MASTRA_THEME=light mastracode
+```

--- a/docs/src/content/en/docs/mastra-code/configuration.mdx
+++ b/docs/src/content/en/docs/mastra-code/configuration.mdx
@@ -243,6 +243,30 @@ The observer and reflector models default to `google/gemini-2.5-flash`. Override
 | Observation threshold | 30,000 tokens | Token count that triggers an observation pass |
 | Reflection threshold | 40,000 tokens | Token count that triggers a reflection pass |
 
+## Color theme
+
+Mastra Code detects your terminal's color scheme and applies a matching dark or light theme. You can override the detected theme with the `/theme` slash command or the `MASTRA_THEME` environment variable.
+
+### Detection order
+
+1. `MASTRA_THEME` environment variable — explicit `dark` or `light`
+2. Persisted setting from `/theme` command (stored in `settings.json`)
+3. OSC 11 query — asks your terminal for its actual background color
+4. `COLORFGBG` environment variable (set by some terminals like iTerm2 and Konsole)
+5. Falls back to dark theme
+
+### Switching themes
+
+Use the `/theme` command to change the theme at runtime:
+
+```
+/theme light
+/theme dark
+/theme auto
+```
+
+Running `/theme` with no arguments shows the current theme. The choice is persisted across sessions.
+
 ## Environment variables
 
 | Variable | Description |
@@ -254,6 +278,7 @@ The observer and reflector models default to `google/gemini-2.5-flash`. Override
 | `MASTRA_RESOURCE_ID` | Override the auto-detected project resource ID |
 | `MASTRA_OM_SCOPE` | Observational memory scope (`thread` or `resource`) |
 | `DEFAULT_OM_MODEL_ID` | Default model for OM observer and reflector |
+| `MASTRA_THEME` | Color theme override (`dark` or `light`) |
 | `TAVILY_API_KEY` | Enable Tavily-powered web search and extract tools |
 
 ## Resource ID override

--- a/docs/src/content/en/docs/mastra-code/overview.mdx
+++ b/docs/src/content/en/docs/mastra-code/overview.mdx
@@ -79,6 +79,7 @@ Mastra Code provides built-in slash commands for managing sessions and settings:
 | `/login` | Authenticate with OAuth providers |
 | `/logout` | Log out from a provider |
 | `/settings` | Open the settings panel |
+| `/theme` | Switch color theme (auto, dark, or light) |
 | `/sandbox` | Add external directories to the allowed path list |
 | `/diff` | Show files modified in the current session |
 | `/help` | Show available commands |

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -6,6 +6,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { loadSettings } from './onboarding/settings.js';
+import { applyThemeMode } from './tui/theme.js';
+import { detectTerminalTheme } from './tui/detect-theme.js';
 import { MastraTUI } from './tui/index.js';
 import { getAppDataDir } from './utils/project.js';
 import { releaseAllThreadLocks } from './utils/thread-lock.js';
@@ -64,6 +66,14 @@ async function main() {
   console.warn = (...args: unknown[]) => {
     logStream.write(`[WARN] ${new Date().toISOString()} ${args.map(fmt).join(' ')}\n`);
   };
+
+  // Detect and apply terminal theme
+  const settings = loadSettings();
+  const themePref = settings.preferences.theme;
+  const themeMode = themePref === 'dark' || themePref === 'light'
+    ? themePref
+    : await detectTerminalTheme();
+  applyThemeMode(themeMode);
 
   const tui = new MastraTUI({
     harness,

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -68,11 +68,18 @@ async function main() {
   };
 
   // Detect and apply terminal theme
-  const settings = loadSettings();
-  const themePref = settings.preferences.theme;
-  const themeMode = themePref === 'dark' || themePref === 'light'
-    ? themePref
-    : await detectTerminalTheme();
+  // MASTRA_THEME env var is the highest-priority override
+  const envTheme = process.env.MASTRA_THEME?.toLowerCase();
+  let themeMode: 'dark' | 'light';
+  if (envTheme === 'dark' || envTheme === 'light') {
+    themeMode = envTheme;
+  } else {
+    const settings = loadSettings();
+    const themePref = settings.preferences.theme;
+    themeMode = themePref === 'dark' || themePref === 'light'
+      ? themePref
+      : await detectTerminalTheme();
+  }
   applyThemeMode(themeMode);
 
   const tui = new MastraTUI({

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -76,9 +76,7 @@ async function main() {
   } else {
     const settings = loadSettings();
     const themePref = settings.preferences.theme;
-    themeMode = themePref === 'dark' || themePref === 'light'
-      ? themePref
-      : await detectTerminalTheme();
+    themeMode = themePref === 'dark' || themePref === 'light' ? themePref : await detectTerminalTheme();
   }
   applyThemeMode(themeMode);
 

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -6,9 +6,9 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { loadSettings } from './onboarding/settings.js';
-import { applyThemeMode } from './tui/theme.js';
 import { detectTerminalTheme } from './tui/detect-theme.js';
 import { MastraTUI } from './tui/index.js';
+import { applyThemeMode } from './tui/theme.js';
 import { getAppDataDir } from './utils/project.js';
 import { releaseAllThreadLocks } from './utils/thread-lock.js';
 import { createMastraCode } from './index.js';

--- a/mastracode/src/onboarding/settings.ts
+++ b/mastracode/src/onboarding/settings.ts
@@ -83,6 +83,7 @@ export interface GlobalSettings {
   // Global behavior preferences
   preferences: {
     yolo: boolean | null;
+    theme: 'auto' | 'dark' | 'light';
   };
   // Storage backend configuration
   storage: StorageSettings;
@@ -115,6 +116,7 @@ const DEFAULTS: GlobalSettings = {
   },
   preferences: {
     yolo: null,
+    theme: 'auto',
   },
   storage: { ...STORAGE_DEFAULTS },
   customModelPacks: [],

--- a/mastracode/src/tui/command-dispatch.ts
+++ b/mastracode/src/tui/command-dispatch.ts
@@ -28,6 +28,7 @@ import {
   handleLoginCommand,
   handleReviewCommand as handleReviewCmd,
   handleSetupCommand,
+  handleThemeCommand,
 } from './commands/index.js';
 import type { SlashCommandContext } from './commands/types.js';
 import { SlashCommandComponent } from './components/slash-command.js';
@@ -138,6 +139,9 @@ export async function dispatchSlashCommand(
       return true;
     case 'setup':
       await handleSetupCommand(buildCtx());
+      return true;
+    case 'theme':
+      await handleThemeCommand(buildCtx(), args);
       return true;
     default: {
       const customCommand = state.customSlashCommands.find(cmd => cmd.name === command);

--- a/mastracode/src/tui/commands/index.ts
+++ b/mastracode/src/tui/commands/index.ts
@@ -25,3 +25,4 @@ export { handleSettingsCommand } from './settings.js';
 export { handleLoginCommand } from './login.js';
 export { handleReviewCommand } from './review.js';
 export { handleSetupCommand } from './setup.js';
+export { handleThemeCommand } from './theme.js';

--- a/mastracode/src/tui/commands/theme.ts
+++ b/mastracode/src/tui/commands/theme.ts
@@ -1,0 +1,36 @@
+import { loadSettings, saveSettings } from '../../onboarding/settings.js';
+import { detectTerminalTheme } from '../detect-theme.js';
+import { applyThemeMode, getThemeMode } from '../theme.js';
+import type { SlashCommandContext } from './types.js';
+
+/**
+ * /theme [auto|dark|light] — show or change the color theme.
+ */
+export async function handleThemeCommand(ctx: SlashCommandContext, args: string[]): Promise<void> {
+  const arg = args[0]?.toLowerCase();
+
+  if (!arg) {
+    const mode = getThemeMode();
+    const settings = loadSettings();
+    const pref = settings.preferences.theme ?? 'auto';
+    ctx.showInfo(`Theme: ${mode} (preference: ${pref})`);
+    return;
+  }
+
+  if (arg !== 'auto' && arg !== 'dark' && arg !== 'light') {
+    ctx.showError('Usage: /theme [auto|dark|light]');
+    return;
+  }
+
+  // Persist the preference
+  const settings = loadSettings();
+  settings.preferences.theme = arg;
+  saveSettings(settings);
+
+  // Apply immediately
+  const resolved = arg === 'auto' ? await detectTerminalTheme() : arg;
+  applyThemeMode(resolved);
+
+  ctx.showInfo(`Theme set to ${arg}${arg === 'auto' ? ` (detected: ${resolved})` : ''}`);
+  ctx.state.ui.requestRender();
+}

--- a/mastracode/src/tui/components/diff-output.ts
+++ b/mastracode/src/tui/components/diff-output.ts
@@ -4,19 +4,16 @@
 
 import { Container, Spacer, Text } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
-import { fg, bold, mastra } from '../theme.js';
-
-// const removedColor = chalk.hex("#dc6868") // soft red
-const addedColor = chalk.hex('#5cb85c'); // soft green
-const hunkHeaderColor = chalk.hex('#61afef'); // cyan-blue
-const fileHeaderColor = chalk.bold.hex('#c678dd'); // bold purple
-const removedColor = chalk.hex(mastra.red);
-// const addedColor = chalk.hex(mastra.green)
-// const hunkHeaderColor = chalk.hex(mastra.blue)
-// const fileHeaderColor = chalk.bold.hex(mastra.purple)
-const metaColor = chalk.hex(mastra.mainGray);
+import { fg, bold, mastra, getTheme } from '../theme.js';
 
 function colorizeDiffLine(line: string): string {
+  const t = getTheme();
+  const addedColor = chalk.hex(t.success);
+  const hunkHeaderColor = chalk.hex(t.toolBorderPending);
+  const fileHeaderColor = chalk.bold.hex(t.accent);
+  const removedColor = chalk.hex(mastra.red);
+  const metaColor = chalk.hex(mastra.mainGray);
+
   // Unified diff headers
   if (line.startsWith('+++') || line.startsWith('---')) {
     return fileHeaderColor(line);
@@ -43,7 +40,7 @@ function colorizeDiffLine(line: string): string {
     return metaColor(line);
   }
   // --stat lines: " file | 5 +++--" or summary "2 files changed, ..."
-  const statMatch = line.match(/^(.+\|.+?)(\++)([-]*)$/);
+  const statMatch = line.match(/^(.+\|.+?)(\++)([- ]*)$/);
   if (statMatch) {
     return statMatch[1] + addedColor(statMatch[2]) + removedColor(statMatch[3]);
   }

--- a/mastracode/src/tui/components/help-overlay.ts
+++ b/mastracode/src/tui/components/help-overlay.ts
@@ -43,6 +43,7 @@ function getCommands(modes: number): HelpEntry[] {
     { key: '/login', description: 'Login with OAuth provider' },
     { key: '/logout', description: 'Logout from OAuth provider' },
     { key: '/setup', description: 'Run the setup wizard' },
+    { key: '/theme', description: 'Switch color theme (auto/dark/light)' },
   ];
 
   if (modes > 1) {

--- a/mastracode/src/tui/components/multi-step-progress.ts
+++ b/mastracode/src/tui/components/multi-step-progress.ts
@@ -5,7 +5,7 @@
 
 import { Container, Text, Spacer } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
-import { fg, bold, mastra } from '../theme.js';
+import { fg, bold, mastra, getTheme } from '../theme.js';
 
 export interface ProgressStep {
   id: string;
@@ -133,11 +133,11 @@ export class MultiStepProgressComponent extends Container {
       if (activeStep) {
         const spinner = this.getSpinner();
         const summaryText = `  ${spinner} ${activeStep.title}${activeStep.progress ? ` (${activeStep.progress}%)` : ''}`;
-        this.addChild(new Text(chalk.yellow(summaryText), 0, 0));
+        this.addChild(new Text(fg('warning', summaryText), 0, 0));
       } else if (failed > 0) {
-        this.addChild(new Text(chalk.red(`  ✗ ${failed} step${failed > 1 ? 's' : ''} failed`), 0, 0));
+        this.addChild(new Text(fg('error', `  ✗ ${failed} step${failed > 1 ? 's' : ''} failed`), 0, 0));
       } else if (completed === total) {
-        this.addChild(new Text(chalk.green('  ✓ All steps completed'), 0, 0));
+        this.addChild(new Text(fg('success', '  ✓ All steps completed'), 0, 0));
       }
     } else {
       // Full detail view
@@ -155,7 +155,7 @@ export class MultiStepProgressComponent extends Container {
         if (step.status === 'failed' && step.error) {
           const errorLines = step.error.split('\n');
           errorLines.forEach(line => {
-            this.addChild(new Text(chalk.red(`      ${line}`), 0, 0));
+            this.addChild(new Text(fg('error', `      ${line}`), 0, 0));
           });
         }
       });
@@ -166,7 +166,7 @@ export class MultiStepProgressComponent extends Container {
         const estimatedRemaining = Math.max(0, this.options.estimatedTime - elapsed);
         if (estimatedRemaining > 0) {
           const remaining = this.formatDuration(estimatedRemaining);
-          this.addChild(new Text(chalk.dim(`  Est. time remaining: ${remaining}`), 0, 0));
+          this.addChild(new Text(fg('dim', `  Est. time remaining: ${remaining}`), 0, 0));
         }
       }
     }
@@ -181,25 +181,25 @@ export class MultiStepProgressComponent extends Container {
 
     switch (step.status) {
       case 'completed':
-        icon = chalk.green('✓');
-        color = chalk.green;
+        icon = fg('success', '✓');
+        color = (t: string) => fg('success', t);
         break;
       case 'active':
-        icon = chalk.yellow(this.getSpinner());
-        color = chalk.yellow.bold;
+        icon = fg('warning', this.getSpinner());
+        color = (t: string) => bold(fg('warning', t));
         break;
       case 'failed':
-        icon = chalk.red('✗');
-        color = chalk.red;
+        icon = fg('error', '✗');
+        color = (t: string) => fg('error', t);
         break;
       case 'skipped':
-        icon = chalk.dim('—');
-        color = chalk.dim;
+        icon = fg('dim', '—');
+        color = (t: string) => fg('dim', t);
         break;
       case 'pending':
       default:
-        icon = chalk.dim('○');
-        color = chalk.dim;
+        icon = fg('dim', '○');
+        color = (t: string) => fg('dim', t);
         break;
     }
 
@@ -209,10 +209,10 @@ export class MultiStepProgressComponent extends Container {
     if (this.options.showTimings && step.startTime) {
       if (step.endTime) {
         const duration = this.formatDuration(step.endTime - step.startTime);
-        text += chalk.dim(` (${duration})`);
+        text += fg('dim', ` (${duration})`);
       } else if (step.status === 'active') {
         const elapsed = this.formatDuration(Date.now() - step.startTime);
-        text += chalk.dim(` (${elapsed})`);
+        text += fg('dim', ` (${elapsed})`);
       }
     }
 

--- a/mastracode/src/tui/components/multi-step-progress.ts
+++ b/mastracode/src/tui/components/multi-step-progress.ts
@@ -5,7 +5,7 @@
 
 import { Container, Text, Spacer } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
-import { fg, bold, mastra, getTheme } from '../theme.js';
+import { fg, bold, mastra } from '../theme.js';
 
 export interface ProgressStep {
   id: string;

--- a/mastracode/src/tui/components/obi-loader.ts
+++ b/mastracode/src/tui/components/obi-loader.ts
@@ -1,8 +1,11 @@
 import chalk from 'chalk';
+import { getThemeMode } from '../theme.js';
 
 const GRADIENT_WIDTH = 30; // Width of the bright spot as percentage of total text
 const BASE_COLOR = [124, 58, 237]; // #b588fe Mastra purple is too washed out, using #7c3aed
-const MIN_BRIGHTNESS = 0.45; // Dimmest characters (0-1)
+function getMinBrightness(): number {
+  return getThemeMode() === 'dark' ? 0.45 : 0.55;
+}
 
 /**
  * Parse a hex color string to [r, g, b].
@@ -46,7 +49,8 @@ export function applyGradientSweep(text: string, offset: number, color?: string,
       }
 
       const normalizedDistance = Math.min(distance / (GRADIENT_WIDTH / 2), 1);
-      const animBrightness = MIN_BRIGHTNESS + (1 - MIN_BRIGHTNESS) * (1 - normalizedDistance);
+      const minBrightness = getMinBrightness();
+      const animBrightness = minBrightness + (1 - minBrightness) * (1 - normalizedDistance);
 
       // Interpolate toward idle brightness as fade progresses
       const brightness = animBrightness + (IDLE_BRIGHTNESS - animBrightness) * fadeProgress;

--- a/mastracode/src/tui/components/om-output.ts
+++ b/mastracode/src/tui/components/om-output.ts
@@ -9,8 +9,8 @@ import { Container, Text, Spacer } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
 import { mastra } from '../theme.js';
 
-const OBSERVER_COLOR = '#f59e0b';
-const REFLECTOR_COLOR = '#ef4444';
+const OBSERVER_COLOR = mastra.orange;
+const REFLECTOR_COLOR = mastra.red;
 const COLLAPSED_LINES = 10;
 
 function formatTokens(tokens: number): string {

--- a/mastracode/src/tui/components/om-progress.ts
+++ b/mastracode/src/tui/components/om-progress.ts
@@ -6,7 +6,7 @@ import { Container, Text } from '@mariozechner/pi-tui';
 import { defaultOMProgressState } from '@mastra/core/harness';
 import type { OMBufferedStatus, OMProgressState, OMStatus } from '@mastra/core/harness';
 import chalk from 'chalk';
-import { fg, mastra } from '../theme.js';
+import { fg, mastra, getTheme } from '../theme.js';
 
 // Re-export types from core for backward compatibility
 export type { OMBufferedStatus, OMProgressState, OMStatus };
@@ -178,7 +178,7 @@ export function formatObservationStatus(
   const fraction = `${formatTokensValue(state.pendingTokens)}/${formatTokensThreshold(state.threshold)}`;
   const buffered =
     compact !== 'noBuffer' && state.buffered.observations.projectedMessageRemoval > 0
-      ? chalk.hex('#555')(` ↓${formatTokensThreshold(state.buffered.observations.projectedMessageRemoval)}`)
+      ? fg('muted', ` ↓${formatTokensThreshold(state.buffered.observations.projectedMessageRemoval)}`)
       : '';
   return styleLabel(`${label} `) + colorByPercent(fraction, percent) + buffered;
 }
@@ -211,7 +211,7 @@ export function formatReflectionStatus(
   const savings = state.buffered.reflection.inputObservationTokens - state.buffered.reflection.observationTokens;
   const buffered =
     compact !== 'noBuffer' && state.buffered.reflection.status === 'complete'
-      ? chalk.hex('#555')(` ↓${formatTokensThreshold(savings)}`)
+      ? fg('muted', ` ↓${formatTokensThreshold(savings)}`)
       : '';
   return label + colorByPercent(fraction, percent) + buffered;
 }

--- a/mastracode/src/tui/components/om-progress.ts
+++ b/mastracode/src/tui/components/om-progress.ts
@@ -6,7 +6,7 @@ import { Container, Text } from '@mariozechner/pi-tui';
 import { defaultOMProgressState } from '@mastra/core/harness';
 import type { OMBufferedStatus, OMProgressState, OMStatus } from '@mastra/core/harness';
 import chalk from 'chalk';
-import { fg, mastra, getTheme } from '../theme.js';
+import { fg, mastra } from '../theme.js';
 
 // Re-export types from core for backward compatibility
 export type { OMBufferedStatus, OMProgressState, OMStatus };

--- a/mastracode/src/tui/components/simple-progress.ts
+++ b/mastracode/src/tui/components/simple-progress.ts
@@ -4,7 +4,6 @@
  */
 
 import { Container, Text } from '@mariozechner/pi-tui';
-import chalk from 'chalk';
 import { fg } from '../theme.js';
 
 export interface SimpleProgressOptions {

--- a/mastracode/src/tui/components/simple-progress.ts
+++ b/mastracode/src/tui/components/simple-progress.ts
@@ -5,6 +5,7 @@
 
 import { Container, Text } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
+import { fg } from '../theme.js';
 
 export interface SimpleProgressOptions {
   prefix?: string;
@@ -108,11 +109,11 @@ export class SimpleProgressComponent extends Container {
     // Add spinner or status icon
     if (this.isActive) {
       const spinner = this.getSpinner();
-      text += chalk.cyan(spinner) + ' ';
+      text += fg('accent', spinner) + ' ';
     } else if (this.progress === 100) {
-      text += chalk.green('✓') + ' ';
+      text += fg('success', '✓') + ' ';
     } else {
-      text += chalk.red('✗') + ' ';
+      text += fg('error', '✗') + ' ';
     }
 
     // Add status text
@@ -120,13 +121,13 @@ export class SimpleProgressComponent extends Container {
 
     // Add progress percentage if enabled and available
     if (this.options.showPercentage && this.progress !== undefined) {
-      text += chalk.dim(` (${this.progress}%)`);
+      text += fg('dim', ` (${this.progress}%)`);
     }
 
     // Add elapsed time if enabled
     if (this.options.showElapsed && this.isActive) {
       const elapsed = Math.floor((now - this.startTime) / 1000);
-      text += chalk.dim(` ${elapsed}s`);
+      text += fg('dim', ` ${elapsed}s`);
     }
 
     this.addChild(new Text(text, 0, 0));

--- a/mastracode/src/tui/components/task-progress.ts
+++ b/mastracode/src/tui/components/task-progress.ts
@@ -7,7 +7,7 @@
 import { Container, Text, Spacer } from '@mariozechner/pi-tui';
 import type { TaskItem } from '@mastra/core/harness';
 import chalk from 'chalk';
-import { fg, bold } from '../theme.js';
+import { fg, bold, getTheme } from '../theme.js';
 
 export class TaskProgressComponent extends Container {
   private tasks: TaskItem[] = [];
@@ -59,18 +59,18 @@ export class TaskProgressComponent extends Container {
 
     switch (task.status) {
       case 'completed': {
-        const icon = chalk.green('\u2713');
-        const text = chalk.green.strikethrough(task.content);
+        const icon = fg('success', '\u2713');
+        const text = chalk.hex(getTheme().success).strikethrough(task.content);
         return `${indent}${icon} ${text}`;
       }
       case 'in_progress': {
-        const icon = chalk.yellow('\u25B6');
-        const text = chalk.yellow.bold(task.activeForm);
+        const icon = fg('warning', '\u25B6');
+        const text = bold(fg('warning', task.activeForm));
         return `${indent}${icon} ${text}`;
       }
       case 'pending': {
-        const icon = chalk.dim('\u25CB');
-        const text = chalk.dim(task.content);
+        const icon = fg('dim', '\u25CB');
+        const text = fg('dim', task.content);
         return `${indent}${icon} ${text}`;
       }
     }

--- a/mastracode/src/tui/components/tool-approval-dialog.ts
+++ b/mastracode/src/tui/components/tool-approval-dialog.ts
@@ -11,7 +11,7 @@
 import { Box, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
-import { bg, fg } from '../theme.js';
+import { bg, fg, getTheme } from '../theme.js';
 
 export type ApprovalAction =
   | { type: 'approve' }
@@ -81,8 +81,8 @@ export class ToolApprovalDialogComponent extends Box implements Focusable {
     const categoryHint = this.categoryLabel
       ? `lways allow ${this.categoryLabel.toLowerCase()}`
       : 'lways allow category';
-    const dim = chalk.hex('#555');
-    const key = chalk.white.bold;
+    const dim = chalk.hex(getTheme().dim);
+    const key = chalk.hex(getTheme().text).bold;
     this.addChild(
       new Text(
         fg('accent', 'Allow? ') +

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -9,7 +9,7 @@ import type { TUI } from '@mariozechner/pi-tui';
 import type { TaskItem } from '@mastra/core/harness';
 import chalk from 'chalk';
 import { highlight } from 'cli-highlight';
-import { theme, mastra, getTheme, fg as fgTheme } from '../theme.js';
+import { theme, mastra, getTheme } from '../theme.js';
 import { CollapsibleComponent } from './collapsible.js';
 import { ErrorDisplayComponent } from './error-display.js';
 import type { IToolExecutionComponent, ToolResult } from './tool-execution-interface.js';

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -9,7 +9,7 @@ import type { TUI } from '@mariozechner/pi-tui';
 import type { TaskItem } from '@mastra/core/harness';
 import chalk from 'chalk';
 import { highlight } from 'cli-highlight';
-import { theme, mastra } from '../theme.js';
+import { theme, mastra, getTheme, fg as fgTheme } from '../theme.js';
 import { CollapsibleComponent } from './collapsible.js';
 import { ErrorDisplayComponent } from './error-display.js';
 import type { IToolExecutionComponent, ToolResult } from './tool-execution-interface.js';
@@ -572,17 +572,18 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       const maxDiags = shouldCollapse ? COLLAPSED_DIAG_LINES : diagnostics.entries.length;
       const entriesToShow = diagnostics.entries.slice(0, maxDiags);
       for (const diag of entriesToShow) {
-        const color = diag.severity === 'error' ? '#e06c75' : diag.severity === 'warning' ? '#f59e0b' : '#71717a';
+        const t = getTheme();
+        const color = diag.severity === 'error' ? t.error : diag.severity === 'warning' ? t.warning : t.muted;
         const icon = diag.severity === 'error' ? '✗' : diag.severity === 'warning' ? '⚠' : 'ℹ';
         const location = diag.location ? chalk.hex(color)(diag.location) + ' ' : '';
-        const line = `  ${chalk.hex(color)(icon)} ${location}${chalk.hex('#a1a1aa')(diag.message)}`;
+        const line = `  ${chalk.hex(color)(icon)} ${location}${fg('thinkingText', diag.message)}`;
         this.contentBox.addChild(new Text(line, 0, 0));
       }
       if (shouldCollapse) {
         const remaining = diagnostics.entries.length - COLLAPSED_DIAG_LINES;
         this.contentBox.addChild(
           new Text(
-            chalk.hex('#71717a')(`  ... ${remaining} more diagnostic${remaining > 1 ? 's' : ''} (ctrl+e to expand)`),
+            fg('muted', `  ... ${remaining} more diagnostic${remaining > 1 ? 's' : ''} (ctrl+e to expand)`),
             0,
             0,
           ),
@@ -648,7 +649,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
 
     // Use soft red for removed, green for added
     const removedColor = chalk.hex(mastra.red); // soft red
-    const addedColor = chalk.hex('#5cb85c'); // soft green
+    const addedColor = chalk.hex(getTheme().success); // soft green
 
     const maxLines = Math.max(oldLines.length, newLines.length);
 

--- a/mastracode/src/tui/detect-theme.ts
+++ b/mastracode/src/tui/detect-theme.ts
@@ -33,7 +33,7 @@ function queryTerminalBackground(timeoutMs = 200): Promise<ThemeMode | null> {
     let settled = false;
     let buffer = '';
     let wasRaw: boolean;
-    let wasPaused: boolean;
+    let wasResumed = false;
 
     const cleanup = () => {
       if (settled) return;
@@ -47,8 +47,8 @@ function queryTerminalBackground(timeoutMs = 200): Promise<ThemeMode | null> {
       } catch {
         // ignore
       }
-      // Only pause stdin if it was paused before we resumed it
-      if (wasPaused) {
+      // Only pause stdin if we were the ones who resumed it
+      if (wasResumed) {
         process.stdin.pause();
       }
     };
@@ -97,9 +97,11 @@ function queryTerminalBackground(timeoutMs = 200): Promise<ThemeMode | null> {
     try {
       // Save current state and switch to raw mode for reading the response
       wasRaw = process.stdin.isRaw ?? false;
-      wasPaused = process.stdin.isPaused();
       process.stdin.setRawMode(true);
-      process.stdin.resume();
+      if (process.stdin.isPaused()) {
+        process.stdin.resume();
+        wasResumed = true;
+      }
       process.stdin.on('data', onData);
 
       // Send OSC 11 query — use BEL (\x07) terminator for broadest compatibility

--- a/mastracode/src/tui/detect-theme.ts
+++ b/mastracode/src/tui/detect-theme.ts
@@ -1,0 +1,151 @@
+/**
+ * Terminal theme detection for Mastra Code TUI.
+ *
+ * Detection priority:
+ * 1. MASTRA_THEME env var (explicit override)
+ * 2. OSC 11 query — asks the terminal for its actual background color
+ * 3. COLORFGBG env var (set by some terminal emulators)
+ * 4. Default: 'dark'
+ */
+
+import type { ThemeMode } from './theme.js';
+
+/**
+ * Query the terminal's background color via OSC 11 and compute luminance.
+ * Returns 'dark' or 'light', or null if the terminal doesn't respond.
+ *
+ * The query sends `\x1b]11;?\x07` to stdout. Terminals that support
+ * xterm-style OSC queries reply on stdin with something like:
+ *   \x1b]11;rgb:0000/0000/0000\x07   (black background → dark)
+ *   \x1b]11;rgb:ffff/ffff/ffff\x07   (white background → light)
+ *
+ * We parse the rgb components, compute relative luminance (WCAG),
+ * and classify as dark (luma < 0.5) or light (luma >= 0.5).
+ */
+function queryTerminalBackground(timeoutMs = 200): Promise<ThemeMode | null> {
+  return new Promise(resolve => {
+    // Can't query if stdin isn't a TTY
+    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+      resolve(null);
+      return;
+    }
+
+    let settled = false;
+    let buffer = '';
+    let wasRaw: boolean;
+
+    const cleanup = () => {
+      if (settled) return;
+      settled = true;
+      process.stdin.removeListener('data', onData);
+      // Restore original raw mode state
+      try {
+        if (process.stdin.isTTY) {
+          process.stdin.setRawMode(wasRaw);
+        }
+      } catch {
+        // ignore
+      }
+      process.stdin.pause();
+    };
+
+    const onData = (data: Buffer) => {
+      buffer += data.toString();
+
+      // Look for the OSC 11 response: \x1b]11;rgb:RRRR/GGGG/BBBB\x07 or \x1b]11;rgb:RRRR/GGGG/BBBB\x1b\\
+      const match = buffer.match(/\x1b\]11;rgb:([0-9a-fA-F]+)\/([0-9a-fA-F]+)\/([0-9a-fA-F]+)/);
+      if (match) {
+        cleanup();
+
+        // Parse RGB components — terminals may respond with 2 or 4 hex digits per component
+        const rHex = match[1]!;
+        const gHex = match[2]!;
+        const bHex = match[3]!;
+
+        // Normalize to 0–1 range. If 4 digits: max is 0xFFFF. If 2 digits: max is 0xFF.
+        const normalize = (hex: string) => {
+          const val = parseInt(hex, 16);
+          return hex.length <= 2 ? val / 0xFF : val / 0xFFFF;
+        };
+
+        const r = normalize(rHex);
+        const g = normalize(gHex);
+        const b = normalize(bHex);
+
+        // WCAG relative luminance
+        const linearize = (c: number) => c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+        const luma = 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+
+        resolve(luma >= 0.5 ? 'light' : 'dark');
+        return;
+      }
+    };
+
+    // Timeout — terminal didn't respond (or doesn't support OSC 11)
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve(null);
+    }, timeoutMs);
+
+    // Ensure the timeout doesn't keep the process alive
+    if (timer.unref) timer.unref();
+
+    try {
+      // Save current raw mode state and switch to raw mode for reading the response
+      wasRaw = process.stdin.isRaw ?? false;
+      process.stdin.setRawMode(true);
+      process.stdin.resume();
+      process.stdin.on('data', onData);
+
+      // Send OSC 11 query — use BEL (\x07) terminator for broadest compatibility
+      process.stdout.write('\x1b]11;?\x07');
+    } catch {
+      // If we can't set raw mode, give up on this method
+      cleanup();
+      resolve(null);
+    }
+  });
+}
+
+/**
+ * Detect COLORFGBG env var.
+ * Format: "fg;bg" where bg is an ANSI color index.
+ * Color indices 0-6 are dark, 7+ are light.
+ */
+function detectFromColorFgBg(): ThemeMode | null {
+  const colorFgBg = process.env.COLORFGBG;
+  if (!colorFgBg) return null;
+
+  const parts = colorFgBg.split(';');
+  const bgPart = parts[parts.length - 1];
+  if (bgPart === undefined) return null;
+
+  const bgIndex = parseInt(bgPart, 10);
+  if (isNaN(bgIndex)) return null;
+
+  // Standard ANSI: 0-6 are dark colors, 7+ are light (7 = white/light gray, 15 = bright white)
+  return bgIndex >= 7 ? 'light' : 'dark';
+}
+
+/**
+ * Detect the terminal's color scheme.
+ * Returns 'dark' or 'light'. Does not check persisted settings —
+ * the caller should check settings first and only call this for 'auto' mode.
+ */
+export async function detectTerminalTheme(): Promise<ThemeMode> {
+  // 1. Explicit env var override
+  const envTheme = process.env.MASTRA_THEME?.toLowerCase();
+  if (envTheme === 'light') return 'light';
+  if (envTheme === 'dark') return 'dark';
+
+  // 2. OSC 11 query — ask the terminal for its actual background color
+  const oscResult = await queryTerminalBackground(200);
+  if (oscResult) return oscResult;
+
+  // 3. COLORFGBG env var fallback
+  const fgbgResult = detectFromColorFgBg();
+  if (fgbgResult) return fgbgResult;
+
+  // 4. Default to dark
+  return 'dark';
+}

--- a/mastracode/src/tui/detect-theme.ts
+++ b/mastracode/src/tui/detect-theme.ts
@@ -69,7 +69,7 @@ function queryTerminalBackground(timeoutMs = 200): Promise<ThemeMode | null> {
         // Normalize to 0–1 range. If 4 digits: max is 0xFFFF. If 2 digits: max is 0xFF.
         const normalize = (hex: string) => {
           const val = parseInt(hex, 16);
-          return hex.length <= 2 ? val / 0xFF : val / 0xFFFF;
+          return hex.length <= 2 ? val / 0xff : val / 0xffff;
         };
 
         const r = normalize(rHex);
@@ -77,7 +77,7 @@ function queryTerminalBackground(timeoutMs = 200): Promise<ThemeMode | null> {
         const b = normalize(bHex);
 
         // WCAG relative luminance
-        const linearize = (c: number) => c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+        const linearize = (c: number) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
         const luma = 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
 
         resolve(luma >= 0.5 ? 'light' : 'dark');

--- a/mastracode/src/tui/detect-theme.ts
+++ b/mastracode/src/tui/detect-theme.ts
@@ -34,10 +34,15 @@ function queryTerminalBackground(timeoutMs = 200): Promise<ThemeMode | null> {
     let buffer = '';
     let wasRaw: boolean;
     let wasResumed = false;
+    let timer: NodeJS.Timeout | undefined;
 
     const cleanup = () => {
       if (settled) return;
       settled = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
       process.stdin.removeListener('data', onData);
       // Restore original raw mode state
       try {
@@ -86,7 +91,7 @@ function queryTerminalBackground(timeoutMs = 200): Promise<ThemeMode | null> {
     };
 
     // Timeout — terminal didn't respond (or doesn't support OSC 11)
-    const timer = setTimeout(() => {
+    timer = setTimeout(() => {
       cleanup();
       resolve(null);
     }, timeoutMs);

--- a/mastracode/src/tui/detect-theme.ts
+++ b/mastracode/src/tui/detect-theme.ts
@@ -33,6 +33,7 @@ function queryTerminalBackground(timeoutMs = 200): Promise<ThemeMode | null> {
     let settled = false;
     let buffer = '';
     let wasRaw: boolean;
+    let wasPaused: boolean;
 
     const cleanup = () => {
       if (settled) return;
@@ -46,7 +47,10 @@ function queryTerminalBackground(timeoutMs = 200): Promise<ThemeMode | null> {
       } catch {
         // ignore
       }
-      process.stdin.pause();
+      // Only pause stdin if it was paused before we resumed it
+      if (wasPaused) {
+        process.stdin.pause();
+      }
     };
 
     const onData = (data: Buffer) => {
@@ -91,8 +95,9 @@ function queryTerminalBackground(timeoutMs = 200): Promise<ThemeMode | null> {
     if (timer.unref) timer.unref();
 
     try {
-      // Save current raw mode state and switch to raw mode for reading the response
+      // Save current state and switch to raw mode for reading the response
       wasRaw = process.stdin.isRaw ?? false;
+      wasPaused = process.stdin.isPaused();
       process.stdin.setRawMode(true);
       process.stdin.resume();
       process.stdin.on('data', onData);

--- a/mastracode/src/tui/index.ts
+++ b/mastracode/src/tui/index.ts
@@ -17,5 +17,15 @@ export { UserMessageComponent } from './components/user-message.js';
 export { ModelSelectorComponent, type ModelItem, type ModelSelectorOptions } from './components/model-selector.js';
 export { LoginSelectorComponent } from './components/login-selector.js';
 export { LoginDialogComponent } from './components/login-dialog.js';
-export { theme, getTheme, setTheme, applyThemeMode, getThemeMode, getMarkdownTheme, getEditorTheme, mastra, mastraBrand } from './theme.js';
+export {
+  theme,
+  getTheme,
+  setTheme,
+  applyThemeMode,
+  getThemeMode,
+  getMarkdownTheme,
+  getEditorTheme,
+  mastra,
+  mastraBrand,
+} from './theme.js';
 export type { ThemeColor, ThemeBg, ThemeColors, ThemeMode } from './theme.js';

--- a/mastracode/src/tui/index.ts
+++ b/mastracode/src/tui/index.ts
@@ -17,5 +17,5 @@ export { UserMessageComponent } from './components/user-message.js';
 export { ModelSelectorComponent, type ModelItem, type ModelSelectorOptions } from './components/model-selector.js';
 export { LoginSelectorComponent } from './components/login-selector.js';
 export { LoginDialogComponent } from './components/login-dialog.js';
-export { theme, getTheme, setTheme, getMarkdownTheme, getEditorTheme } from './theme.js';
-export type { ThemeColor, ThemeBg, ThemeColors } from './theme.js';
+export { theme, getTheme, setTheme, applyThemeMode, getThemeMode, getMarkdownTheme, getEditorTheme, mastra, mastraBrand } from './theme.js';
+export type { ThemeColor, ThemeBg, ThemeColors, ThemeMode } from './theme.js';

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -18,7 +18,7 @@ import { ToolExecutionComponentEnhanced } from './components/tool-execution-enha
 import { UserMessageComponent } from './components/user-message.js';
 import { formatToolResult } from './handlers/tool.js';
 import type { TUIState } from './state.js';
-import { getMarkdownTheme, fg, bold, mastra } from './theme.js';
+import { getMarkdownTheme, fg, bold, mastra, getTheme } from './theme.js';
 
 // Re-export so existing consumers can still import from here
 export { formatToolResult };
@@ -76,7 +76,7 @@ export function renderClearedTasksInline(state: TUIState, clearedTasks: TaskItem
   container.addChild(new Text(fg('accent', `${label} cleared`), 0, 0));
   for (const task of clearedTasks) {
     const icon = task.status === 'completed' ? chalk.hex(mastra.green)('✓') : chalk.hex(mastra.darkGray)('○');
-    const text = chalk.dim.strikethrough(task.content);
+    const text = chalk.hex(getTheme().dim).strikethrough(task.content);
     container.addChild(new Text(`  ${icon} ${text}`, 0, 0));
   }
   if (insertIndex >= 0) {

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -273,6 +273,7 @@ export function setupAutocomplete(state: TUIState): void {
     },
     { name: 'review', description: 'Review a GitHub pull request' },
     { name: 'setup', description: 'Re-run the setup wizard' },
+    { name: 'theme', description: 'Switch color theme (auto/dark/light)' },
     { name: 'exit', description: 'Exit the TUI' },
     { name: 'help', description: 'Show available commands' },
   ];

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -7,11 +7,30 @@ import chalk from 'chalk';
 import { applyGradientSweep } from './components/obi-loader.js';
 import { formatObservationStatus, formatReflectionStatus } from './components/om-progress.js';
 import type { TUIState } from './state.js';
-import { fg, mastra, tintHex, getContrastText } from './theme.js';
+import { fg, mastra, tintHex, getThemeMode } from './theme.js';
 
 // Colors for OM modes
 const OBSERVER_COLOR = mastra.orange;
 const REFLECTOR_COLOR = mastra.pink;
+
+/**
+ * Lighten a color by blending toward white. factor 0 = original, 1 = white.
+ */
+function lighten(r: number, g: number, b: number, factor: number): [number, number, number] {
+  return [Math.floor(r + (255 - r) * factor), Math.floor(g + (255 - g) * factor), Math.floor(b + (255 - b) * factor)];
+}
+
+/**
+ * For light mode, purple and blue badge backgrounds are too dark.
+ * Lighten them slightly so they look better on light terminals.
+ */
+function adjustBadgeColor(r: number, g: number, b: number, modeColor: string): [number, number, number] {
+  if (getThemeMode() !== 'light') return [r, g, b];
+  if (modeColor === mastra.purple || modeColor === mastra.blue) {
+    return lighten(r, g, b, 0.25);
+  }
+  return [r, g, b];
+}
 
 /**
  * Update the status line at the bottom of the TUI.
@@ -62,12 +81,13 @@ export function updateStatusLine(state: TUIState): void {
         badgeBrightness = animBrightness + (0.9 - animBrightness) * fade;
       }
     }
-    const [mr, mg, mb] = [
+    const [mr, mg, mb] = adjustBadgeColor(
       Math.floor(mcr * badgeBrightness),
       Math.floor(mcg * badgeBrightness),
       Math.floor(mcb * badgeBrightness),
-    ];
-    modeBadge = chalk.bgRgb(mr, mg, mb).hex(getContrastText(`#${mr.toString(16).padStart(2, '0')}${mg.toString(16).padStart(2, '0')}${mb.toString(16).padStart(2, '0')}`)).bold(` ${badgeName.toLowerCase()} `);
+      modeColor,
+    );
+    modeBadge = chalk.bgRgb(mr, mg, mb).hex('#000000').bold(` ${badgeName.toLowerCase()} `);
     modeBadgeWidth = badgeName.length + 2;
   } else if (badgeName) {
     modeBadge = fg('dim', badgeName) + ' ';
@@ -136,11 +156,12 @@ export function updateStatusLine(state: TUIState): void {
     }
     if (modeColor) {
       // Idle state
-      const [r, g, b] = [
+      const [r, g, b] = adjustBadgeColor(
         parseInt(modeColor.slice(1, 3), 16),
         parseInt(modeColor.slice(3, 5), 16),
         parseInt(modeColor.slice(5, 7), 16),
-      ];
+        modeColor,
+      );
       const dim = 0.8;
       const fgStyled = chalk.rgb(Math.floor(r * dim), Math.floor(g * dim), Math.floor(b * dim)).bold(padded);
       return tintBg ? chalk.bgHex(tintBg)(fgStyled) : fgStyled;
@@ -171,12 +192,13 @@ export function updateStatusLine(state: TUIState): void {
         sBadgeBrightness = animBrightness + (0.9 - animBrightness) * fade;
       }
     }
-    const [sr, sg, sb] = [
+    const [sr, sg, sb] = adjustBadgeColor(
       Math.floor(mcr * sBadgeBrightness),
       Math.floor(mcg * sBadgeBrightness),
       Math.floor(mcb * sBadgeBrightness),
-    ];
-    shortModeBadge = chalk.bgRgb(sr, sg, sb).hex(getContrastText(`#${sr.toString(16).padStart(2, '0')}${sg.toString(16).padStart(2, '0')}${sb.toString(16).padStart(2, '0')}`)).bold(` ${shortName} `);
+      modeColor,
+    );
+    shortModeBadge = chalk.bgRgb(sr, sg, sb).hex('#000000').bold(` ${shortName} `);
     shortModeBadgeWidth = shortName.length + 2;
   } else if (badgeName) {
     const shortName = badgeName.toLowerCase().charAt(0);

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -7,7 +7,7 @@ import chalk from 'chalk';
 import { applyGradientSweep } from './components/obi-loader.js';
 import { formatObservationStatus, formatReflectionStatus } from './components/om-progress.js';
 import type { TUIState } from './state.js';
-import { fg, mastra, tintHex } from './theme.js';
+import { fg, mastra, tintHex, getContrastText } from './theme.js';
 
 // Colors for OM modes
 const OBSERVER_COLOR = mastra.orange;
@@ -67,7 +67,7 @@ export function updateStatusLine(state: TUIState): void {
       Math.floor(mcg * badgeBrightness),
       Math.floor(mcb * badgeBrightness),
     ];
-    modeBadge = chalk.bgRgb(mr, mg, mb).hex(mastra.bg).bold(` ${badgeName.toLowerCase()} `);
+    modeBadge = chalk.bgRgb(mr, mg, mb).hex(getContrastText(`#${mr.toString(16).padStart(2, '0')}${mg.toString(16).padStart(2, '0')}${mb.toString(16).padStart(2, '0')}`)).bold(` ${badgeName.toLowerCase()} `);
     modeBadgeWidth = badgeName.length + 2;
   } else if (badgeName) {
     modeBadge = fg('dim', badgeName) + ' ';
@@ -176,7 +176,7 @@ export function updateStatusLine(state: TUIState): void {
       Math.floor(mcg * sBadgeBrightness),
       Math.floor(mcb * sBadgeBrightness),
     ];
-    shortModeBadge = chalk.bgRgb(sr, sg, sb).hex(mastra.bg).bold(` ${shortName} `);
+    shortModeBadge = chalk.bgRgb(sr, sg, sb).hex(getContrastText(`#${sr.toString(16).padStart(2, '0')}${sg.toString(16).padStart(2, '0')}${sb.toString(16).padStart(2, '0')}`)).bold(` ${shortName} `);
     shortModeBadgeWidth = shortName.length + 2;
   } else if (badgeName) {
     const shortName = badgeName.toLowerCase().charAt(0);


### PR DESCRIPTION
## Summary

Mastra Code's TUI now detects the terminal's color scheme and applies a matching dark or light theme, instead of forcing a dark-only palette. This fixes modals/overlays being unreadable in light-themed terminals.

### What changed

**Theme detection** (`detect-theme.ts` — new file)
- Primary: OSC 11 query — asks the terminal for its actual background RGB, computes WCAG luminance to classify dark/light
- Fallback: `COLORFGBG` env var (set by iTerm2, Konsole, rxvt)
- Override: `MASTRA_THEME=dark|light` env var
- Default: dark

**Light theme** (`theme.ts`)
- Added `lightTheme` color set with inverted surface/text/border colors for light backgrounds
- Split `mastra` palette into immutable brand colors + theme-dependent surface colors via Proxy
- `applyThemeMode()` switches between dark and light themes at runtime

**`/theme` slash command** (`commands/theme.ts` — new file)
- `/theme` — shows current theme and preference
- `/theme dark|light|auto` — switches theme and persists to settings.json

**Color migration** (15 component files)
- Replaced hardcoded hex colors (`#5cb85c`, `#e06c75`, `#555`, etc.) with theme system references
- Replaced `chalk.green/red/yellow` calls with `fg('success'/'error'/'warning', ...)`
- Status line badges now use `getContrastText()` for dynamic text color on animated backgrounds
- Obi-loader gradient brightness range adjusts for light/dark backgrounds

**Settings** (`settings.ts`)
- Added `theme: 'auto' | 'dark' | 'light'` to preferences (default: `'auto'`)

### Files changed (24)
- 1 new utility (`detect-theme.ts`)
- 1 new command (`commands/theme.ts`)
- 15 component files migrated to theme system
- 3 infrastructure files (`theme.ts`, `main.ts`, `settings.ts`)
- 2 doc files, 1 changeset, 1 index/export update

## Test plan

- Set terminal to light theme → verify modals, overlays, status line, progress bars are readable
- Set terminal to dark theme → verify no visual regressions
- Test `MASTRA_THEME=light` and `MASTRA_THEME=dark` env var overrides
- Test `/theme dark`, `/theme light`, `/theme auto` slash command
- Verify Mastra header banner stays purple gradient in both modes
- Verify theme preference persists across restarts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Light theme support with automatic terminal color-scheme detection (auto/dark/light)
  * New /theme slash command to view or switch theme (auto, dark, light); choice persists across sessions
  * App visuals now adapt to the active theme (UI elements, progress, diffs, badges, loaders, etc.)
  * MASTRA_THEME environment variable can override detection

* **Documentation**
  * Added docs for color theme configuration, detection order, and the /theme command
<!-- end of auto-generated comment: release notes by coderabbit.ai -->