### PR TITLE
fix(react): send dev playground header for localhost servers

### DIFF
--- a/.changeset/early-turtles-unite.md
+++ b/.changeset/early-turtles-unite.md
@@ -2,4 +2,4 @@
 '@mastra/react': patch
 ---
 
-Fixed dev playground header not being sent when using `mastra studio` with a separate local server (`--server-port`). The `x-mastra-dev-playground` header is now correctly included for localhost and 127.0.0.1 URLs, enabling the `MASTRA_DEV=true` auth bypass.
+Fixed `mastra studio --server-port` so requests to local servers (`localhost` and `127.0.0.1`) correctly use local development auth behavior.

--- a/.changeset/early-turtles-unite.md
+++ b/.changeset/early-turtles-unite.md
@@ -1,0 +1,5 @@
+---
+'@mastra/react': patch
+---
+
+Fixed dev playground header not being sent when using `mastra studio` with a separate local server (`--server-port`). The `x-mastra-dev-playground` header is now correctly included for localhost and 127.0.0.1 URLs, enabling the `MASTRA_DEV=true` auth bypass.

--- a/client-sdks/react/src/mastra-client-context.test.tsx
+++ b/client-sdks/react/src/mastra-client-context.test.tsx
@@ -30,6 +30,17 @@ describe('isLocalUrl', () => {
     expect(isLocalUrl('http://[::1]')).toBe(true);
   });
 
+  it('should return true for .local hostnames', () => {
+    expect(isLocalUrl('http://mastra.local:4000')).toBe(true);
+    expect(isLocalUrl('http://mastra.local')).toBe(true);
+    expect(isLocalUrl('https://my-app.local:3000')).toBe(true);
+  });
+
+  it('should return true for .localhost hostnames', () => {
+    expect(isLocalUrl('http://mastra.localhost:4000')).toBe(true);
+    expect(isLocalUrl('http://dev.localhost')).toBe(true);
+  });
+
   it('should return false for remote URLs', () => {
     expect(isLocalUrl('https://api.example.com')).toBe(false);
     expect(isLocalUrl('https://my-app.vercel.app')).toBe(false);

--- a/client-sdks/react/src/mastra-client-context.test.tsx
+++ b/client-sdks/react/src/mastra-client-context.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import React from 'react';
+
+import { isLocalUrl } from './mastra-client-context';
+
+describe('isLocalUrl', () => {
+  it('should return true when baseUrl is undefined', () => {
+    expect(isLocalUrl(undefined)).toBe(true);
+  });
+
+  it('should return true when baseUrl is empty string', () => {
+    expect(isLocalUrl('')).toBe(true);
+  });
+
+  it('should return true for localhost URLs', () => {
+    expect(isLocalUrl('http://localhost:4000')).toBe(true);
+    expect(isLocalUrl('http://localhost:4111')).toBe(true);
+    expect(isLocalUrl('http://localhost')).toBe(true);
+    expect(isLocalUrl('https://localhost:3000')).toBe(true);
+  });
+
+  it('should return true for 127.0.0.1 URLs', () => {
+    expect(isLocalUrl('http://127.0.0.1:4000')).toBe(true);
+    expect(isLocalUrl('http://127.0.0.1:4111')).toBe(true);
+    expect(isLocalUrl('http://127.0.0.1')).toBe(true);
+  });
+
+  it('should return false for remote URLs', () => {
+    expect(isLocalUrl('https://api.example.com')).toBe(false);
+    expect(isLocalUrl('https://my-app.vercel.app')).toBe(false);
+    expect(isLocalUrl('http://192.168.1.100:4000')).toBe(false);
+  });
+
+  it('should return false for URLs that contain localhost as a substring of a domain', () => {
+    expect(isLocalUrl('https://notlocalhost.com')).toBe(false);
+    expect(isLocalUrl('https://localhost.evil.com')).toBe(false);
+  });
+});

--- a/client-sdks/react/src/mastra-client-context.test.tsx
+++ b/client-sdks/react/src/mastra-client-context.test.tsx
@@ -25,6 +25,11 @@ describe('isLocalUrl', () => {
     expect(isLocalUrl('http://127.0.0.1')).toBe(true);
   });
 
+  it('should return true for IPv6 loopback URLs', () => {
+    expect(isLocalUrl('http://[::1]:4000')).toBe(true);
+    expect(isLocalUrl('http://[::1]')).toBe(true);
+  });
+
   it('should return false for remote URLs', () => {
     expect(isLocalUrl('https://api.example.com')).toBe(false);
     expect(isLocalUrl('https://my-app.vercel.app')).toBe(false);

--- a/client-sdks/react/src/mastra-client-context.test.tsx
+++ b/client-sdks/react/src/mastra-client-context.test.tsx
@@ -30,10 +30,16 @@ describe('isLocalUrl', () => {
     expect(isLocalUrl('http://[::1]')).toBe(true);
   });
 
-  it('should return true for .local hostnames', () => {
-    expect(isLocalUrl('http://mastra.local:4000')).toBe(true);
-    expect(isLocalUrl('http://mastra.local')).toBe(true);
-    expect(isLocalUrl('https://my-app.local:3000')).toBe(true);
+  it('should return false for .local hostnames', () => {
+    expect(isLocalUrl('http://mastra.local:4000')).toBe(false);
+    expect(isLocalUrl('http://mastra.local')).toBe(false);
+    expect(isLocalUrl('https://my-app.local:3000')).toBe(false);
+  });
+
+  it('should return true for 127.x.x.x loopback range', () => {
+    expect(isLocalUrl('http://127.0.0.1:4000')).toBe(true);
+    expect(isLocalUrl('http://127.0.0.2')).toBe(true);
+    expect(isLocalUrl('http://127.255.255.255')).toBe(true);
   });
 
   it('should return true for .localhost hostnames', () => {

--- a/client-sdks/react/src/mastra-client-context.test.tsx
+++ b/client-sdks/react/src/mastra-client-context.test.tsx
@@ -47,6 +47,11 @@ describe('isLocalUrl', () => {
     expect(isLocalUrl('http://dev.localhost')).toBe(true);
   });
 
+  it('should return false for hostnames that start with 127 but are not IPv4 loopback', () => {
+    expect(isLocalUrl('http://127.example.com')).toBe(false);
+    expect(isLocalUrl('http://127.0.0.256')).toBe(false);
+  });
+
   it('should return false for remote URLs', () => {
     expect(isLocalUrl('https://api.example.com')).toBe(false);
     expect(isLocalUrl('https://my-app.vercel.app')).toBe(false);

--- a/client-sdks/react/src/mastra-client-context.tsx
+++ b/client-sdks/react/src/mastra-client-context.tsx
@@ -21,11 +21,22 @@ export const MastraClientProvider = ({ children, baseUrl, headers, apiPrefix }: 
 
 export const useMastraClient = () => useContext(MastraClientContext);
 
+export const isLocalUrl = (url?: string): boolean => {
+  if (!url) return true;
+  try {
+    const { hostname } = new URL(url);
+    return hostname === 'localhost' || hostname === '127.0.0.1';
+  } catch {
+    return false;
+  }
+};
+
 const createMastraClient = (baseUrl?: string, mastraClientHeaders: Record<string, string> = {}, apiPrefix?: string) => {
   return new MastraClient({
     baseUrl: baseUrl || '',
-    // only add the header if the baseUrl is not provided i.e it's a local dev environment
-    headers: !baseUrl ? { ...mastraClientHeaders, 'x-mastra-dev-playground': 'true' } : mastraClientHeaders,
+    headers: isLocalUrl(baseUrl)
+      ? { ...mastraClientHeaders, 'x-mastra-dev-playground': 'true' }
+      : mastraClientHeaders,
     apiPrefix,
   });
 };

--- a/client-sdks/react/src/mastra-client-context.tsx
+++ b/client-sdks/react/src/mastra-client-context.tsx
@@ -25,7 +25,14 @@ export const isLocalUrl = (url?: string): boolean => {
   if (!url) return true;
   try {
     const { hostname } = new URL(url);
-    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
+    return (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '::1' ||
+      hostname === '[::1]' ||
+      hostname.endsWith('.local') ||
+      hostname.endsWith('.localhost')
+    );
   } catch {
     return false;
   }

--- a/client-sdks/react/src/mastra-client-context.tsx
+++ b/client-sdks/react/src/mastra-client-context.tsx
@@ -25,7 +25,7 @@ export const isLocalUrl = (url?: string): boolean => {
   if (!url) return true;
   try {
     const { hostname } = new URL(url);
-    return hostname === 'localhost' || hostname === '127.0.0.1';
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
   } catch {
     return false;
   }

--- a/client-sdks/react/src/mastra-client-context.tsx
+++ b/client-sdks/react/src/mastra-client-context.tsx
@@ -34,9 +34,7 @@ export const isLocalUrl = (url?: string): boolean => {
 const createMastraClient = (baseUrl?: string, mastraClientHeaders: Record<string, string> = {}, apiPrefix?: string) => {
   return new MastraClient({
     baseUrl: baseUrl || '',
-    headers: isLocalUrl(baseUrl)
-      ? { ...mastraClientHeaders, 'x-mastra-dev-playground': 'true' }
-      : mastraClientHeaders,
+    headers: isLocalUrl(baseUrl) ? { ...mastraClientHeaders, 'x-mastra-dev-playground': 'true' } : mastraClientHeaders,
     apiPrefix,
   });
 };

--- a/client-sdks/react/src/mastra-client-context.tsx
+++ b/client-sdks/react/src/mastra-client-context.tsx
@@ -21,6 +21,14 @@ export const MastraClientProvider = ({ children, baseUrl, headers, apiPrefix }: 
 
 export const useMastraClient = () => useContext(MastraClientContext);
 
+const IPV4_LOOPBACK_RE = /^127\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+
+const isIPv4Loopback = (hostname: string): boolean => {
+  const m = IPV4_LOOPBACK_RE.exec(hostname);
+  if (!m) return false;
+  return +m[1]! <= 255 && +m[2]! <= 255 && +m[3]! <= 255;
+};
+
 export const isLocalUrl = (url?: string): boolean => {
   if (!url) return true;
   try {
@@ -28,7 +36,7 @@ export const isLocalUrl = (url?: string): boolean => {
     return (
       hostname === 'localhost' ||
       hostname.endsWith('.localhost') ||
-      hostname.startsWith('127.') ||
+      isIPv4Loopback(hostname) ||
       hostname === '::1' ||
       hostname === '[::1]'
     );

--- a/client-sdks/react/src/mastra-client-context.tsx
+++ b/client-sdks/react/src/mastra-client-context.tsx
@@ -27,11 +27,10 @@ export const isLocalUrl = (url?: string): boolean => {
     const { hostname } = new URL(url);
     return (
       hostname === 'localhost' ||
-      hostname === '127.0.0.1' ||
+      hostname.endsWith('.localhost') ||
+      hostname.startsWith('127.') ||
       hostname === '::1' ||
-      hostname === '[::1]' ||
-      hostname.endsWith('.local') ||
-      hostname.endsWith('.localhost')
+      hostname === '[::1]'
     );
   } catch {
     return false;


### PR DESCRIPTION
## Description

Fixed the dev playground header not being sent when using `mastra studio --server-port`. The `x-mastra-dev-playground` header is now correctly included for localhost and 127.0.0.1 URLs, enabling the `MASTRA_DEV=true` auth bypass to work with separate local servers.

## Related Issue(s)

Fixes #13488

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dev-auth now correctly applies local development auth for requests to localhost, 127.0.0.1, IPv6 loopback, and hostnames ending with .local or .localhost; local behavior also applies when no base URL is provided.

* **Tests**
  * Added comprehensive tests validating local URL detection for empty/undefined, IPv4/IPv6 loopback, .local/.localhost, remote hosts, and edge-case hostnames.

* **Chores**
  * Added a changelog entry recording the patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->