### PR TITLE
fix(mastracode): append unused arguments to slash command output

### DIFF
--- a/.changeset/sweet-cobras-fall.md
+++ b/.changeset/sweet-cobras-fall.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed slash command arguments being silently discarded when the command template doesn't use $ARGUMENTS or positional variables ($1, $2, etc.). Arguments are now appended to the output so the model can see what the user provided.

--- a/mastracode/src/utils/slash-command-processor.ts
+++ b/mastracode/src/utils/slash-command-processor.ts
@@ -11,16 +11,19 @@ export async function processSlashCommand(
   args: string[],
   workingDir: string,
 ): Promise<string> {
-  let result = command.template;
-
-  // Replace arguments
-  result = replaceArguments(result, args);
+  const { result: withArgs, shouldAppendRawArgs } = replaceArguments(command.template, args);
+  let result = withArgs;
 
   // Replace shell commands
   result = await replaceShellOutput(result, workingDir);
 
   // Replace file references
   result = await replaceFileReferences(result, workingDir);
+
+  // Append raw args after shell/file processing to avoid executing user input
+  if (shouldAppendRawArgs) {
+    result = result.trimEnd() + `\n\nARGUMENTS: ${args.join(' ')}`;
+  }
 
   return result;
 }
@@ -30,7 +33,10 @@ export async function processSlashCommand(
  * $ARGUMENTS - all arguments joined
  * $1, $2, etc. - positional arguments
  */
-function replaceArguments(template: string, args: string[]): string {
+function replaceArguments(
+  template: string,
+  args: string[],
+): { result: string; shouldAppendRawArgs: boolean } {
   let result = template;
 
   // Check if template references any argument variables
@@ -49,13 +55,10 @@ function replaceArguments(template: string, args: string[]): string {
   // Clear unused positional arguments
   result = result.replace(/\$\d+/g, '');
 
-  // If the template didn't reference any argument variables, append
-  // the arguments so the model can still see what the user provided.
-  if (!hasArgumentsVar && !hasPositionalVar && args.length > 0) {
-    result = result.trimEnd() + `\n\nARGUMENTS: ${args.join(' ')}`;
-  }
-
-  return result;
+  return {
+    result,
+    shouldAppendRawArgs: !hasArgumentsVar && !hasPositionalVar && args.length > 0,
+  };
 }
 
 /**

--- a/mastracode/src/utils/slash-command-processor.ts
+++ b/mastracode/src/utils/slash-command-processor.ts
@@ -50,7 +50,7 @@ function replaceArguments(template: string, args: string[]): { result: string; s
   });
 
   // Clear unused positional arguments
-  result = result.replace(/\$\d+/g, '');
+  result = result.replace(/\$[1-9]\d*/g, '');
 
   return {
     result,

--- a/mastracode/src/utils/slash-command-processor.ts
+++ b/mastracode/src/utils/slash-command-processor.ts
@@ -33,10 +33,7 @@ export async function processSlashCommand(
  * $ARGUMENTS - all arguments joined
  * $1, $2, etc. - positional arguments
  */
-function replaceArguments(
-  template: string,
-  args: string[],
-): { result: string; shouldAppendRawArgs: boolean } {
+function replaceArguments(template: string, args: string[]): { result: string; shouldAppendRawArgs: boolean } {
   let result = template;
 
   // Check if template references any argument variables

--- a/mastracode/src/utils/slash-command-processor.ts
+++ b/mastracode/src/utils/slash-command-processor.ts
@@ -41,7 +41,7 @@ function replaceArguments(
 
   // Check if template references any argument variables
   const hasArgumentsVar = /\$ARGUMENTS/.test(template);
-  const hasPositionalVar = /\$\d+/.test(template);
+  const hasPositionalVar = /\$[1-9]\d*/.test(template);
 
   // Replace $ARGUMENTS with all args joined
   result = result.replace(/\$ARGUMENTS/g, args.join(' '));

--- a/mastracode/src/utils/slash-command-processor.ts
+++ b/mastracode/src/utils/slash-command-processor.ts
@@ -33,6 +33,10 @@ export async function processSlashCommand(
 function replaceArguments(template: string, args: string[]): string {
   let result = template;
 
+  // Check if template references any argument variables
+  const hasArgumentsVar = /\$ARGUMENTS/.test(template);
+  const hasPositionalVar = /\$\d+/.test(template);
+
   // Replace $ARGUMENTS with all args joined
   result = result.replace(/\$ARGUMENTS/g, args.join(' '));
 
@@ -44,6 +48,12 @@ function replaceArguments(template: string, args: string[]): string {
 
   // Clear unused positional arguments
   result = result.replace(/\$\d+/g, '');
+
+  // If the template didn't reference any argument variables, append
+  // the arguments so the model can still see what the user provided.
+  if (!hasArgumentsVar && !hasPositionalVar && args.length > 0) {
+    result = result.trimEnd() + `\n\nARGUMENTS: ${args.join(' ')}`;
+  }
 
   return result;
 }


### PR DESCRIPTION
## Description

When a slash command template doesn't reference `$ARGUMENTS` or any positional variables (`$1`, `$2`, etc.), the user's arguments were silently discarded. This meant commands like `/gh-debug-issue 123` where the template uses custom placeholders like `$ISSUE` would lose the argument entirely.

Now, if no argument variables are present in the template, the arguments are appended as `ARGUMENTS: <args>` at the end of the processed content, matching Claude Code's behavior and allowing the model to see what the user provided.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed slash command argument handling so user-provided arguments are no longer discarded when templates omit argument placeholders; inputs are now preserved and appended to the final output.

* **Chores**
  * Added a changelog entry documenting the slash command argument preservation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->