### PR TITLE
fix(rag): eliminate redundant tiktoken instantiation and excessive encoding

### DIFF
--- a/.changeset/warm-falcons-float.md
+++ b/.changeset/warm-falcons-float.md
@@ -1,0 +1,5 @@
+---
+'@mastra/rag': patch
+---
+
+Fixed severe performance bottleneck in token-based chunking (`token` and `semantic-markdown` strategies). Eliminated redundant tiktoken encoder instantiation and excessive token re-encoding during section merging, resulting in significantly faster chunking for markdown knowledge bases.

--- a/.changeset/warm-falcons-float.md
+++ b/.changeset/warm-falcons-float.md
@@ -2,4 +2,4 @@
 '@mastra/rag': patch
 ---
 
-Fixed severe performance bottleneck in token-based chunking (`token` and `semantic-markdown` strategies). Eliminated redundant tiktoken encoder instantiation and excessive token re-encoding during section merging, resulting in significantly faster chunking for markdown knowledge bases.
+Improved token-based chunking performance in `token` and `semantic-markdown` strategies. Markdown knowledge bases now chunk significantly faster with lower tokenization overhead.

--- a/packages/rag/src/document/transformers/semantic-markdown.test.ts
+++ b/packages/rag/src/document/transformers/semantic-markdown.test.ts
@@ -1,0 +1,78 @@
+import { getEncoding, encodingForModel } from 'js-tiktoken';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { SemanticMarkdownTransformer } from './semantic-markdown';
+
+let totalEncodeCallCount = 0;
+
+vi.mock('js-tiktoken', () => {
+  const createMockTokenizer = () => ({
+    encode: (text: string) => {
+      totalEncodeCallCount++;
+      return Array.from({ length: Math.ceil(text.length / 4) }, (_, i) => i);
+    },
+    decode: (tokens: number[]) => 'x'.repeat(tokens.length * 4),
+  });
+
+  return {
+    getEncoding: vi.fn(() => createMockTokenizer()),
+    encodingForModel: vi.fn(() => createMockTokenizer()),
+  };
+});
+
+describe('SemanticMarkdownTransformer', () => {
+  beforeEach(() => {
+    vi.mocked(getEncoding).mockClear();
+    vi.mocked(encodingForModel).mockClear();
+    totalEncodeCallCount = 0;
+  });
+
+  describe('fromTikToken', () => {
+    it('should create only one encoder when using encodingName', () => {
+      SemanticMarkdownTransformer.fromTikToken({
+        encodingName: 'cl100k_base',
+        options: {},
+      });
+
+      expect(getEncoding).toHaveBeenCalledTimes(1);
+      expect(encodingForModel).not.toHaveBeenCalled();
+    });
+
+    it('should create only one encoder when using modelName', () => {
+      SemanticMarkdownTransformer.fromTikToken({
+        modelName: 'gpt-4',
+        options: {},
+      });
+
+      expect(encodingForModel).toHaveBeenCalledTimes(1);
+      expect(getEncoding).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('token counting efficiency', () => {
+    it('should not re-encode merged content during section merging', () => {
+      // Generate markdown with many small sections that will all be merged
+      const sections = [];
+      for (let i = 0; i < 10; i++) {
+        sections.push(`## Section ${i}\nShort content ${i}.`);
+      }
+      const markdown = `# Main\n\n${sections.join('\n\n')}`;
+
+      const transformer = SemanticMarkdownTransformer.fromTikToken({
+        encodingName: 'cl100k_base',
+        options: { joinThreshold: 10000 },
+      });
+
+      // Reset counter after construction (construction may call encode internally)
+      totalEncodeCallCount = 0;
+
+      transformer.splitText({ text: markdown });
+
+      // splitMarkdownByHeaders calls countTokens once per section (11 sections total).
+      // mergeSemanticSections should combine token counts arithmetically,
+      // NOT re-encode the entire growing merged content on every merge.
+      const sectionCount = 11; // 1 main + 10 subsections
+      expect(totalEncodeCallCount).toBeLessThanOrEqual(sectionCount);
+    });
+  });
+});

--- a/packages/rag/src/document/transformers/semantic-markdown.test.ts
+++ b/packages/rag/src/document/transformers/semantic-markdown.test.ts
@@ -3,12 +3,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { SemanticMarkdownTransformer } from './semantic-markdown';
 
-let totalEncodeCallCount = 0;
+let totalCharsEncoded = 0;
 
 vi.mock('js-tiktoken', () => {
   const createMockTokenizer = () => ({
     encode: (text: string) => {
-      totalEncodeCallCount++;
+      totalCharsEncoded += text.length;
       return Array.from({ length: Math.ceil(text.length / 4) }, (_, i) => i);
     },
     decode: (tokens: number[]) => 'x'.repeat(tokens.length * 4),
@@ -24,7 +24,7 @@ describe('SemanticMarkdownTransformer', () => {
   beforeEach(() => {
     vi.mocked(getEncoding).mockClear();
     vi.mocked(encodingForModel).mockClear();
-    totalEncodeCallCount = 0;
+    totalCharsEncoded = 0;
   });
 
   describe('fromTikToken', () => {
@@ -64,15 +64,17 @@ describe('SemanticMarkdownTransformer', () => {
       });
 
       // Reset counter after construction (construction may call encode internally)
-      totalEncodeCallCount = 0;
+      totalCharsEncoded = 0;
 
-      transformer.splitText({ text: markdown });
+      const chunks = transformer.splitText({ text: markdown });
 
-      // splitMarkdownByHeaders calls countTokens once per section (11 sections total).
-      // mergeSemanticSections should combine token counts arithmetically,
+      // Verify merging actually occurred — all sections should merge into one chunk
+      expect(chunks).toHaveLength(1);
+
+      // mergeSemanticSections should encode only short header strings during merging,
       // NOT re-encode the entire growing merged content on every merge.
-      const sectionCount = 11; // 1 main + 10 subsections
-      expect(totalEncodeCallCount).toBeLessThanOrEqual(sectionCount);
+      // Total chars encoded should stay proportional to input size, not grow quadratically.
+      expect(totalCharsEncoded).toBeLessThan(markdown.length * 2);
     });
   });
 });

--- a/packages/rag/src/document/transformers/semantic-markdown.ts
+++ b/packages/rag/src/document/transformers/semantic-markdown.ts
@@ -15,36 +15,38 @@ interface MarkdownNode {
 export class SemanticMarkdownTransformer extends TextTransformer {
   private tokenizer: Tiktoken;
   private joinThreshold: number;
-  private allowedSpecial: Set<string> | 'all';
-  private disallowedSpecial: Set<string> | 'all';
+  private allowedArray: string[] | 'all';
+  private disallowedArray: string[] | 'all';
 
   constructor({
     joinThreshold = 500,
     encodingName = 'cl100k_base',
     modelName,
+    tokenizer: existingTokenizer,
     allowedSpecial = new Set(),
     disallowedSpecial = 'all',
     ...baseOptions
-  }: SemanticMarkdownChunkOptions = {}) {
+  }: SemanticMarkdownChunkOptions & { tokenizer?: Tiktoken } = {}) {
     super(baseOptions);
 
     this.joinThreshold = joinThreshold;
-    this.allowedSpecial = allowedSpecial;
-    this.disallowedSpecial = disallowedSpecial;
+    this.allowedArray = allowedSpecial === 'all' ? 'all' : Array.from(allowedSpecial);
+    this.disallowedArray = disallowedSpecial === 'all' ? 'all' : Array.from(disallowedSpecial);
 
-    try {
-      this.tokenizer = modelName ? encodingForModel(modelName) : getEncoding(encodingName);
-    } catch {
-      throw new Error('Could not load tiktoken encoding. Please install it with `npm install js-tiktoken`.');
+    if (existingTokenizer) {
+      this.tokenizer = existingTokenizer;
+    } else {
+      try {
+        this.tokenizer = modelName ? encodingForModel(modelName) : getEncoding(encodingName);
+      } catch {
+        throw new Error('Could not load tiktoken encoding. Please install it with `npm install js-tiktoken`.');
+      }
     }
   }
 
   private countTokens(text: string): number {
-    const allowed = this.allowedSpecial === 'all' ? 'all' : Array.from(this.allowedSpecial);
-    const disallowed = this.disallowedSpecial === 'all' ? 'all' : Array.from(this.disallowedSpecial);
-
     const processedText = this.stripWhitespace ? text.trim() : text;
-    return this.tokenizer.encode(processedText, allowed, disallowed).length;
+    return this.tokenizer.encode(processedText, this.allowedArray, this.disallowedArray).length;
   }
 
   private splitMarkdownByHeaders(markdown: string): MarkdownNode[] {
@@ -125,7 +127,7 @@ export class SemanticMarkdownTransformer extends TextTransformer {
 
             prev.content += `${formattedTitle}\n${current.content}`;
 
-            prev.length = this.countTokens(prev.content);
+            prev.length = prev.length + current.length;
 
             workingSections.splice(j, 1);
             j--;
@@ -221,6 +223,7 @@ export class SemanticMarkdownTransformer extends TextTransformer {
       ...options,
       encodingName,
       modelName,
+      tokenizer,
       lengthFunction: tikTokenCounter,
     });
   }

--- a/packages/rag/src/document/transformers/semantic-markdown.ts
+++ b/packages/rag/src/document/transformers/semantic-markdown.ts
@@ -123,7 +123,11 @@ export class SemanticMarkdownTransformer extends TextTransformer {
 
           const title = `${'#'.repeat(current.depth)} ${current.title}`;
           const formattedTitle = `\n\n${title}`;
-          const headerLength = this.countTokens(`${formattedTitle}\n`);
+          const headerLength = this.tokenizer.encode(
+            `${formattedTitle}\n`,
+            this.allowedArray,
+            this.disallowedArray,
+          ).length;
           const mergedLength = prev.length + current.length + headerLength;
 
           if (mergedLength < this.joinThreshold && prev.depth <= current.depth) {

--- a/packages/rag/src/document/transformers/semantic-markdown.ts
+++ b/packages/rag/src/document/transformers/semantic-markdown.ts
@@ -121,13 +121,15 @@ export class SemanticMarkdownTransformer extends TextTransformer {
         if (current.depth === depth) {
           const prev = workingSections[j - 1]!;
 
-          if (prev.length + current.length < this.joinThreshold && prev.depth <= current.depth) {
-            const title = `${'#'.repeat(current.depth)} ${current.title}`;
-            const formattedTitle = `\n\n${title}`;
+          const title = `${'#'.repeat(current.depth)} ${current.title}`;
+          const formattedTitle = `\n\n${title}`;
+          const headerLength = this.countTokens(`${formattedTitle}\n`);
+          const mergedLength = prev.length + current.length + headerLength;
 
+          if (mergedLength < this.joinThreshold && prev.depth <= current.depth) {
             prev.content += `${formattedTitle}\n${current.content}`;
 
-            prev.length = prev.length + current.length;
+            prev.length = mergedLength;
 
             workingSections.splice(j, 1);
             j--;

--- a/packages/rag/src/document/transformers/token.test.ts
+++ b/packages/rag/src/document/transformers/token.test.ts
@@ -1,0 +1,45 @@
+import { getEncoding, encodingForModel } from 'js-tiktoken';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { TokenTransformer } from './token';
+
+vi.mock('js-tiktoken', () => {
+  const createMockTokenizer = () => ({
+    encode: (text: string) => Array.from({ length: Math.ceil(text.length / 4) }, (_, i) => i),
+    decode: (tokens: number[]) => 'x'.repeat(tokens.length * 4),
+  });
+
+  return {
+    getEncoding: vi.fn(() => createMockTokenizer()),
+    encodingForModel: vi.fn(() => createMockTokenizer()),
+  };
+});
+
+describe('TokenTransformer', () => {
+  beforeEach(() => {
+    vi.mocked(getEncoding).mockClear();
+    vi.mocked(encodingForModel).mockClear();
+  });
+
+  describe('fromTikToken', () => {
+    it('should create only one encoder when using encodingName', () => {
+      TokenTransformer.fromTikToken({
+        encodingName: 'cl100k_base',
+        options: { maxSize: 500, overlap: 0 },
+      });
+
+      expect(getEncoding).toHaveBeenCalledTimes(1);
+      expect(encodingForModel).not.toHaveBeenCalled();
+    });
+
+    it('should create only one encoder when using modelName', () => {
+      TokenTransformer.fromTikToken({
+        modelName: 'gpt-4',
+        options: { maxSize: 500, overlap: 0 },
+      });
+
+      expect(encodingForModel).toHaveBeenCalledTimes(1);
+      expect(getEncoding).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fixes severe performance bottleneck in token-based chunking where `js-tiktoken` encoders were being created redundantly and token counting was done far more than necessary.

Three targeted fixes:
1. **Eliminate double encoder creation** — `fromTikToken()` factory methods now pass the already-created tokenizer to the constructor instead of having it create a second one
2. **Optimize merge token counting** — `mergeSemanticSections()` sums known token counts arithmetically instead of re-encoding the entire growing merged content on every merge (O(n) vs O(n²))
3. **Pre-compute allowed/disallowed arrays** — Convert `Set<string> → Array` once in constructors instead of on every `encode` call

## Related Issue(s)

Fixes #13225

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster markdown chunking with reduced redundant tokenizer usage and re-encoding, lowering tokenization overhead for knowledge bases.
* **New Features**
  * Option to provide an existing tokenizer instance for workflows that manage tokenizers externally; token counting and section merging improved for accuracy and efficiency.
* **Tests**
  * Added unit tests covering encoder initialization paths and token-counting/merging efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->