### PR TITLE
fix: handle ZodNull in Anthropic and OpenAI reasoning schema compat layers

### DIFF
--- a/.changeset/fix-zodnull-anthropic-compat.md
+++ b/.changeset/fix-zodnull-anthropic-compat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fix `ZodNull` throwing "does not support zod type: ZodNull" for Anthropic and OpenAI reasoning models. MCP tools with nullable properties in their JSON Schema produce `z.null()` which was unhandled by these provider compat layers.

--- a/packages/schema-compat/src/provider-compats/anthropic.test.ts
+++ b/packages/schema-compat/src/provider-compats/anthropic.test.ts
@@ -772,4 +772,30 @@ describe('AnthropicSchemaCompatLayer', () => {
       expect(jsonSchema).toMatchSnapshot();
     });
   });
+
+  describe('processZodType - ZodNull', () => {
+    const modelInfo: ModelInformation = {
+      provider: 'anthropic',
+      modelId: 'claude-3-5-sonnet',
+      supportsStructuredOutputs: false,
+    };
+
+    it('should handle standalone z.null() without throwing', () => {
+      const schema = z.object({
+        value: z.null(),
+      });
+
+      const layer = new AnthropicSchemaCompatLayer(modelInfo);
+      expect(() => layer.toJSONSchema(schema)).not.toThrow();
+    });
+
+    it('should handle z.null() inside a union', () => {
+      const schema = z.object({
+        name: z.union([z.string(), z.null()]),
+      });
+
+      const layer = new AnthropicSchemaCompatLayer(modelInfo);
+      expect(() => layer.toJSONSchema(schema)).not.toThrow();
+    });
+  });
 });

--- a/packages/schema-compat/src/provider-compats/anthropic.ts
+++ b/packages/schema-compat/src/provider-compats/anthropic.ts
@@ -1,9 +1,11 @@
 import type { JSONSchema7 } from 'json-schema';
+import { z } from 'zod';
 import type { Targets } from 'zod-to-json-schema';
 import { isArraySchema, isObjectSchema, isStringSchema, isUnionSchema } from '../json-schema/utils';
 import { SchemaCompatLayer } from '../schema-compatibility';
 import type { ZodType } from '../schema.types';
 import type { ModelInformation } from '../types';
+import { isNull } from '../zodTypes';
 
 export class AnthropicSchemaCompatLayer extends SchemaCompatLayer {
   constructor(model: ModelInformation) {
@@ -38,6 +40,11 @@ export class AnthropicSchemaCompatLayer extends SchemaCompatLayer {
       } else {
         return value;
       }
+    } else if (isNull(z)(value)) {
+      return z
+        .any()
+        .refine(v => v === null, { message: 'must be null' })
+        .describe(value.description || 'must be null');
     }
 
     return this.defaultUnsupportedZodTypeHandler(value);

--- a/packages/schema-compat/src/provider-compats/openai-reasoning.ts
+++ b/packages/schema-compat/src/provider-compats/openai-reasoning.ts
@@ -7,7 +7,18 @@ import { isArraySchema, isNumberSchema, isObjectSchema, isStringSchema, isUnionS
 import { SchemaCompatLayer } from '../schema-compatibility';
 import type { ZodType } from '../schema.types';
 import type { ModelInformation } from '../types';
-import { isOptional, isObj, isArr, isUnion, isDefault, isNumber, isString, isDate, isNullable } from '../zodTypes';
+import {
+  isOptional,
+  isObj,
+  isArr,
+  isUnion,
+  isDefault,
+  isNumber,
+  isString,
+  isDate,
+  isNullable,
+  isNull,
+} from '../zodTypes';
 
 export class OpenAIReasoningSchemaCompatLayer extends SchemaCompatLayer {
   constructor(model: ModelInformation) {
@@ -104,6 +115,11 @@ export class OpenAIReasoningSchemaCompatLayer extends SchemaCompatLayer {
       return this.defaultZodStringHandler(value);
     } else if (isDate(z)(value)) {
       return this.defaultZodDateHandler(value);
+    } else if (isNull(z)(value)) {
+      return z
+        .any()
+        .refine(v => v === null, { message: 'must be null' })
+        .describe(value.description || 'must be null');
     } else if (value.constructor.name === 'ZodAny') {
       // It's bad practice in the tool to use any, it's not reasonable for models that don't support that OOTB, to cast every single possible type
       // in the schema. Usually when it's "any" it could be a json object or a union of specific types.


### PR DESCRIPTION
MCP tools with nullable properties in their JSON Schema (e.g. `{"type": ["string", "null"]}`) get converted to `z.null()` by `zod-from-json-schema`. The Anthropic and OpenAI reasoning compat layers had no handler for this, so they threw:

```
Error: claude-opus-4-6 does not support zod type: ZodNull
```

The fix adds a `ZodNull` branch in both compat layers, converting it to `z.any().refine(v => v === null)` — the same approach already used by the Google compat layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Resolved an error where nullable properties caused failures in Anthropic and OpenAI reasoning model integrations. Null values are now correctly validated in schema compatibility layers.

## Tests
- Added test coverage for null value handling in schema compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->