### PR TITLE
fix(mastracode): allow onboarding to proceed with API keys only

### DIFF
--- a/.changeset/fix-onboarding-key-only-access.md
+++ b/.changeset/fix-onboarding-key-only-access.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed onboarding to allow API-key-only setup without requiring OAuth login. Previously, users with API keys configured as environment variables were blocked at the model pack selection step if they skipped OAuth login during onboarding. The auth step now clearly indicates that OAuth is optional when API keys are set.

--- a/docs/src/content/en/docs/mastra-code/configuration.mdx
+++ b/docs/src/content/en/docs/mastra-code/configuration.mdx
@@ -258,10 +258,10 @@ Mastra Code detects your terminal's color scheme and applies a matching dark or 
 ### Detection order
 
 1. `MASTRA_THEME` environment variable — explicit `dark` or `light`
-2. Persisted setting from `/theme` command (stored in `settings.json`)
-3. OSC 11 query — asks your terminal for its actual background color
-4. `COLORFGBG` environment variable (set by some terminals like iTerm2 and Konsole)
-5. Falls back to dark theme
+1. Persisted setting from `/theme` command (stored in `settings.json`)
+1. OSC 11 query — asks your terminal for its actual background color
+1. `COLORFGBG` environment variable (set by some terminals like iTerm2 and Konsole)
+1. Falls back to dark theme
 
 ### Switching themes
 

--- a/docs/src/content/en/docs/mastra-code/configuration.mdx
+++ b/docs/src/content/en/docs/mastra-code/configuration.mdx
@@ -11,26 +11,32 @@ Mastra Code is configured through project-level files, global settings, and envi
 
 ## Authentication
 
-Mastra Code authenticates with AI providers through OAuth. Run `/login` in the TUI to start the flow.
+Mastra Code supports two authentication methods: **API keys** (environment variables) and **OAuth** (provider subscriptions). You can use either or both.
 
-### Supported providers
+### API keys
+
+The simplest way to get started is to set API key environment variables for the providers you want to use. Mastra Code auto-detects these on startup:
+
+```sh
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_API_KEY=sk-...
+export GOOGLE_GENERATIVE_AI_API_KEY=...
+export DEEPSEEK_API_KEY=...
+export CEREBRAS_API_KEY=...
+```
+
+Mastra Code uses Mastra's [model router](/models), which routes requests to the correct provider based on the model ID and available API keys. No OAuth login is required when using API keys.
+
+### OAuth login (optional)
+
+If you have an Anthropic Claude Max or OpenAI ChatGPT Plus subscription, you can authenticate via OAuth to use your subscription instead of API keys. Run `/login` in the TUI to start the flow.
 
 | Provider | OAuth flow | What you get |
 | - | - | - |
 | **Anthropic** | Claude Max subscription | Access to Claude models via your subscription |
 | **OpenAI** | ChatGPT Plus / Codex | Access to OpenAI models via your subscription |
 
-OAuth credentials are stored in `auth.json` alongside the database in the [app data directory](#database-location).
-
-### Model routing
-
-For providers not covered by OAuth, Mastra Code uses Mastra's [model router](/models), which auto-detects API keys from environment variables:
-
-```sh
-export OPENAI_API_KEY=sk-...
-export ANTHROPIC_API_KEY=sk-ant-...
-export GOOGLE_GENERATIVE_AI_API_KEY=...
-```
+OAuth credentials are stored in `auth.json` alongside the database in the [app data directory](#database-location). During onboarding, you can skip the OAuth step if you already have API keys configured.
 
 ## MCP servers
 

--- a/docs/src/content/en/docs/mastra-code/overview.mdx
+++ b/docs/src/content/en/docs/mastra-code/overview.mdx
@@ -57,7 +57,7 @@ Mastra Code requires Node.js 22.13.0 or later.
   </StepItem>
 
   <StepItem>
-    Run the `/login` command to authenticate with your AI providers (Anthropic, OpenAI).
+    Set an API key for your preferred provider (e.g. `export ANTHROPIC_API_KEY=sk-ant-...`), or run `/login` to authenticate with an Anthropic or OpenAI subscription. See [Configuration](/docs/mastra-code/configuration#authentication) for all supported providers.
   </StepItem>
 
   <StepItem>

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -639,12 +639,17 @@ export class MastraTUI {
         },
         onLogin: (providerId: string, done: () => void) => {
           this.performLogin(providerId).then(async () => {
-            const updatedAccess = await buildAccess();
-            const updatedHasAccess = Object.values(updatedAccess).some(Boolean);
-            component.updateModePacks(getAvailableModePacks(updatedAccess, savedSettings.customModelPacks));
-            component.updateOmPacks(getAvailableOmPacks(updatedAccess));
-            component.updateHasProviderAccess(updatedHasAccess);
-            done();
+            try {
+              const updatedAccess = await buildAccess();
+              const updatedHasAccess = Object.values(updatedAccess).some(Boolean);
+              component.updateModePacks(getAvailableModePacks(updatedAccess, savedSettings.customModelPacks));
+              component.updateOmPacks(getAvailableOmPacks(updatedAccess));
+              component.updateHasProviderAccess(updatedHasAccess);
+            } catch (err) {
+              console.error('Failed to refresh provider access after login:', err);
+            } finally {
+              done();
+            }
           });
         },
         onSelectModel: async (title: string, modeColor?: string): Promise<string | undefined> => {

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -545,6 +545,7 @@ export class MastraTUI {
     };
 
     const access = await buildAccess();
+    const hasProviderAccess = Object.values(access).some(Boolean);
 
     const savedSettings = loadSettings();
     const modePacks = getAvailableModePacks(access, savedSettings.customModelPacks);
@@ -568,6 +569,7 @@ export class MastraTUI {
         authProviders,
         modePacks,
         omPacks,
+        hasProviderAccess,
         previous,
         onComplete: async (result: OnboardingResult) => {
           this.state.activeOnboarding = undefined;
@@ -587,8 +589,10 @@ export class MastraTUI {
         onLogin: (providerId: string, done: () => void) => {
           this.performLogin(providerId).then(async () => {
             const updatedAccess = await buildAccess();
+            const updatedHasAccess = Object.values(updatedAccess).some(Boolean);
             component.updateModePacks(getAvailableModePacks(updatedAccess, savedSettings.customModelPacks));
             component.updateOmPacks(getAvailableOmPacks(updatedAccess));
+            component.updateHasProviderAccess(updatedHasAccess);
             done();
           });
         },


### PR DESCRIPTION
Onboarding was blocking users who had API keys set but skipped OAuth login. The mode pack step checked for non-custom packs to determine access, so providers without built-in packs (Cerebras, DeepSeek, etc.) were treated as having no access at all.

Now we pass an explicit `hasProviderAccess` flag computed from the full access object, so any valid API key lets you through onboarding without needing OAuth.

Also updated the auth step copy to clarify that OAuth is optional when API keys are configured, and updated docs to lead with API keys as the primary/simplest auth method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Onboarding no longer blocks model selection when API keys are provided; OAuth is optional if keys are configured.

* **New Features**
  * Onboarding UI now detects API-key access and lets users skip OAuth when keys are present.

* **Documentation**
  * Authentication docs expanded to cover both API-key (env var) and OAuth methods, auto-detection, and updated onboarding instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->