### PR TITLE
fix(core): handle nested workflows throwing tripwire

### DIFF
--- a/.changeset/afraid-buckets-stay.md
+++ b/.changeset/afraid-buckets-stay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Propagate tripwire's that are thrown from a nested workflow.

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2278,6 +2278,18 @@ export class Workflow<
       throw res.error;
     }
 
+    if (res.status === 'tripwire') {
+      const tripwire = res.tripwire;
+      throw new TripWire(
+        tripwire?.reason || 'Processor tripwire triggered',
+        {
+          retry: tripwire?.retry,
+          metadata: tripwire?.metadata,
+        },
+        tripwire?.processorId,
+      );
+    }
+
     return res.status === 'success' ? res.result : undefined;
   }
 


### PR DESCRIPTION
Propagate tripwire's that are thrown from a nested workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes nested-workflow execution to throw `TripWire` on `tripwire` results, which can alter control flow and short-circuit downstream steps across any composed workflows.
> 
> **Overview**
> **Nested workflow `tripwire` results now bubble up as errors.** When `Workflow.execute()` is invoked as a nested step and the nested run returns `status: 'tripwire'`, it now throws a `TripWire` (preserving `reason`, `retry`, `metadata`, and `processorId`) instead of returning `undefined`.
> 
> **Adds coverage for composed processor workflows.** New tests ensure a `TripWire` triggered inside an inner workflow built via `.then().parallel().map()` propagates to the parent and prevents subsequent steps from running, while confirming no propagation when the inner workflow succeeds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55282975667cd8f1bda7887b9edb45ee09244981. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed error propagation in nested workflows - errors raised within inner workflow steps now properly cascade to parent workflows, ensuring correct workflow execution and preventing unintended parent workflow continuation when inner errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->