### PR TITLE
fix(mastracode): remove individual theme function exports to fix startup crash

### DIFF
--- a/.changeset/goofy-toys-behave.md
+++ b/.changeset/goofy-toys-behave.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed fatal "fg is not defined" crash on startup by removing individual exports of theme functions (fg, bg, bold, italic, dim) from theme.ts. All TUI files now use the theme object exclusively, preventing undefined reference errors.

--- a/.changeset/goofy-toys-behave.md
+++ b/.changeset/goofy-toys-behave.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Fixed fatal "fg is not defined" crash on startup by removing individual exports of theme functions (fg, bg, bold, italic, dim) from theme.ts. All TUI files now use the theme object exclusively, preventing undefined reference errors.
+Fixed a fatal crash on startup that caused the TUI to fail immediately on launch.

--- a/mastracode/src/onboarding/onboarding-inline.ts
+++ b/mastracode/src/onboarding/onboarding-inline.ts
@@ -15,7 +15,7 @@
 import { Box, Container, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, SelectItem, TUI } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
-import { theme, getSelectListTheme, fg, bold, mastra } from '../tui/theme.js';
+import { theme, getSelectListTheme, mastra } from '../tui/theme.js';
 import type { ModePack, OMPack } from './packs.js';
 
 // ---------------------------------------------------------------------------
@@ -203,15 +203,15 @@ export class OnboardingInlineComponent extends Container implements Focusable {
 
   private renderWelcome(): void {
     const box = this.makeBox();
-    box.addChild(new Text(bold(fg('accent', '👋 Welcome to Mastra Code')), 0, 0));
+    box.addChild(new Text(theme.bold(theme.fg('accent', '👋 Welcome to Mastra Code')), 0, 0));
     box.addChild(new Spacer(1));
-    box.addChild(new Text(fg('text', "Let's configure your models and preferences."), 0, 0));
+    box.addChild(new Text(theme.fg('text', "Let's configure your models and preferences."), 0, 0));
     box.addChild(new Text(chalk.white('You can re-run this anytime with /setup.'), 0, 0));
     box.addChild(new Spacer(1));
 
     const items: SelectItem[] = [
-      { value: 'continue', label: `  ${fg('success', 'Continue')}` },
-      { value: 'skip', label: `  ${fg('dim', 'Skip')}` },
+      { value: 'continue', label: `  ${theme.fg('success', 'Continue')}` },
+      { value: 'skip', label: `  ${theme.fg('dim', 'Skip')}` },
     ];
     this.selectList = new SelectList(items, items.length, getSelectListTheme());
     this.selectList.onSelect = (item: SelectItem) => {
@@ -238,26 +238,26 @@ export class OnboardingInlineComponent extends Container implements Focusable {
 
   private renderAuth(): void {
     const box = this.makeBox();
-    box.addChild(new Text(bold(fg('accent', '🔑 Authentication')), 0, 0));
+    box.addChild(new Text(theme.bold(theme.fg('accent', '🔑 Authentication')), 0, 0));
     box.addChild(new Spacer(1));
 
     const providers = this.options.authProviders;
     if (providers.length === 0) {
-      box.addChild(new Text(fg('dim', 'No OAuth providers available. Skipping.'), 0, 0));
+      box.addChild(new Text(theme.fg('dim', 'No OAuth providers available. Skipping.'), 0, 0));
       // auto-advance after brief moment
       setTimeout(() => this.renderStep('modePack'), 100);
       return;
     }
 
-    box.addChild(new Text(fg('text', 'Log in with an AI provider to use your subscription,'), 0, 0));
-    box.addChild(new Text(fg('text', 'or skip if you have API keys configured as environment variables.'), 0, 0));
+    box.addChild(new Text(theme.fg('text', 'Log in with an AI provider to use your subscription,'), 0, 0));
+    box.addChild(new Text(theme.fg('text', 'or skip if you have API keys configured as environment variables.'), 0, 0));
     box.addChild(new Spacer(1));
 
     const items: SelectItem[] = providers.map(p => ({
       value: p.value,
-      label: p.loggedIn ? `  ${p.label}  ${fg('success', '✓ logged in')}` : `  ${p.label}`,
+      label: p.loggedIn ? `  ${p.label}  ${theme.fg('success', '✓ logged in')}` : `  ${p.label}`,
     }));
-    items.push({ value: '__skip', label: `  ${fg('dim', 'Skip (use API keys or configure later with /login)')}` });
+    items.push({ value: '__skip', label: `  ${theme.fg('dim', 'Skip (use API keys or configure later with /login)')}` });
 
     this.selectList = new SelectList(items, Math.min(items.length, 8), getSelectListTheme());
     this.selectList.onSelect = (item: SelectItem) => {
@@ -278,7 +278,7 @@ export class OnboardingInlineComponent extends Container implements Focusable {
 
     box.addChild(this.selectList);
     box.addChild(new Spacer(1));
-    box.addChild(new Text(fg('dim', '↑↓ navigate · Enter select · Esc skip'), 0, 0));
+    box.addChild(new Text(theme.fg('dim', '↑↓ navigate · Enter select · Esc skip'), 0, 0));
   }
 
   // ---------------------------------------------------------------------------
@@ -294,16 +294,16 @@ export class OnboardingInlineComponent extends Container implements Focusable {
     // No API keys and no OAuth logins — can't proceed
     if (!this.options.hasProviderAccess) {
       const box = this.makeBox();
-      box.addChild(new Text(bold(fg('error', 'No model providers configured')), 0, 0));
+      box.addChild(new Text(theme.bold(theme.fg('error', 'No model providers configured')), 0, 0));
       box.addChild(new Spacer(1));
-      box.addChild(new Text(fg('text', 'To use Mastra Code you need at least one API key or OAuth login'), 0, 0));
-      box.addChild(new Text(fg('text', 'for Anthropic, OpenAI, or another supported provider.'), 0, 0));
+      box.addChild(new Text(theme.fg('text', 'To use Mastra Code you need at least one API key or OAuth login'), 0, 0));
+      box.addChild(new Text(theme.fg('text', 'for Anthropic, OpenAI, or another supported provider.'), 0, 0));
       box.addChild(new Spacer(1));
       box.addChild(
-        new Text(fg('dim', 'See https://mastra.ai/models for supported providers and API key env vars.'), 0, 0),
+        new Text(theme.fg('dim', 'See https://mastra.ai/models for supported providers and API key env vars.'), 0, 0),
       );
       box.addChild(new Spacer(1));
-      box.addChild(new Text(fg('dim', 'Set an API key and restart, or run /login to authenticate via OAuth.'), 0, 0));
+      box.addChild(new Text(theme.fg('dim', 'Set an API key and restart, or run /login to authenticate via OAuth.'), 0, 0));
       this._finished = true;
       // Give the TUI time to render the message before exiting
       setTimeout(() => process.exit(1), 3000);
@@ -311,15 +311,15 @@ export class OnboardingInlineComponent extends Container implements Focusable {
     }
 
     const box = this.makeBox();
-    box.addChild(new Text(bold(fg('accent', 'Model Packs')), 0, 0));
+    box.addChild(new Text(theme.bold(theme.fg('accent', 'Model Packs')), 0, 0));
     box.addChild(new Spacer(1));
-    box.addChild(new Text(fg('text', 'Choose default models for each mode (build / plan / fast):'), 0, 0));
+    box.addChild(new Text(theme.fg('text', 'Choose default models for each mode (build / plan / fast):'), 0, 0));
     box.addChild(new Spacer(1));
 
     const prevId = this.options.previous?.modePackId ?? null;
     const items: SelectItem[] = packs.map(p => ({
       value: p.id,
-      label: `  ${p.name}  ${fg('dim', p.description)}${p.id === prevId ? fg('dim', ' (current)') : ''}`,
+      label: `  ${p.name}  ${theme.fg('dim', p.description)}${p.id === prevId ? theme.fg('dim', ' (current)') : ''}`,
     }));
 
     this.selectList = new SelectList(items, items.length, getSelectListTheme());
@@ -334,12 +334,12 @@ export class OnboardingInlineComponent extends Container implements Focusable {
         this.runCustomPackFlow();
       } else {
         this.selectedModePack = pack;
-        this.collapseStep(`Model pack → ${bold(this.selectedModePack.name)}`);
+        this.collapseStep(`Model pack → ${theme.bold(this.selectedModePack.name)}`);
         this.renderStep('omPack');
       }
     };
     this.selectList.onCancel = () => {
-      this.collapseStep(`Model pack → ${bold(this.selectedModePack.name)} (default)`);
+      this.collapseStep(`Model pack → ${theme.bold(this.selectedModePack.name)} (default)`);
       this.renderStep('omPack');
     };
     this.selectList.onSelectionChange = (item: SelectItem) => {
@@ -358,7 +358,7 @@ export class OnboardingInlineComponent extends Container implements Focusable {
     this.updateModePackDetail(packs, initialId);
 
     box.addChild(new Spacer(1));
-    box.addChild(new Text(fg('dim', '↑↓ navigate · Enter select · Esc use default'), 0, 0));
+    box.addChild(new Text(theme.fg('dim', '↑↓ navigate · Enter select · Esc use default'), 0, 0));
   }
 
   private updateModePackDetail(packs: ModePack[], highlightedId: string): void {
@@ -366,12 +366,12 @@ export class OnboardingInlineComponent extends Container implements Focusable {
     if (!pack || !this.modePackDetail) return;
 
     if (pack.id === 'custom') {
-      this.modePackDetail.setText(fg('dim', "  You'll pick a model for each mode in the next steps."));
+      this.modePackDetail.setText(theme.fg('dim', "  You'll pick a model for each mode in the next steps."));
     } else {
       const detail = [
-        `  ${chalk.hex(mastra.blue)('plan')}  → ${fg('text', pack.models.plan)}`,
-        `  ${chalk.hex(mastra.purple)('build')} → ${fg('text', pack.models.build)}`,
-        `  ${chalk.hex(mastra.green)('fast')}  → ${fg('text', pack.models.fast)}`,
+        `  ${chalk.hex(mastra.blue)('plan')}  → ${theme.fg('text', pack.models.plan)}`,
+        `  ${chalk.hex(mastra.purple)('build')} → ${theme.fg('text', pack.models.build)}`,
+        `  ${chalk.hex(mastra.green)('fast')}  → ${theme.fg('text', pack.models.fast)}`,
       ].join('\n');
       this.modePackDetail.setText(detail);
     }
@@ -403,7 +403,7 @@ export class OnboardingInlineComponent extends Container implements Focusable {
         // User cancelled — fall back to first non-custom pack (or keep current)
         const fallback = this.options.modePacks.find(p => p.id !== 'custom') ?? this.options.modePacks[0]!;
         this.selectedModePack = fallback;
-        this.collapseStep(`Model pack → ${bold(this.selectedModePack.name)} (cancelled custom)`);
+        this.collapseStep(`Model pack → ${theme.bold(this.selectedModePack.name)} (cancelled custom)`);
         this.renderStep('omPack');
         this.tui.requestRender();
         return;
@@ -420,7 +420,7 @@ export class OnboardingInlineComponent extends Container implements Focusable {
     };
 
     this.collapseStep(
-      `Model pack → ${bold('Custom')}  ` +
+      `Model pack → ${theme.bold('Custom')}  ` +
         `${chalk.hex(mastra.blue)('plan')} ${models.plan}  ` +
         `${chalk.hex(mastra.purple)('build')} ${models.build}  ` +
         `${chalk.hex(mastra.green)('fast')} ${models.fast}`,
@@ -444,16 +444,16 @@ export class OnboardingInlineComponent extends Container implements Focusable {
     }
 
     const box = this.makeBox();
-    box.addChild(new Text(bold(fg('accent', '🧠 Observational Memory')), 0, 0));
+    box.addChild(new Text(theme.bold(theme.fg('accent', '🧠 Observational Memory')), 0, 0));
     box.addChild(new Spacer(1));
-    box.addChild(new Text(fg('text', 'Choose the model for observational memory:'), 0, 0));
-    box.addChild(new Text(fg('dim', 'https://mastra.ai/docs/memory/observational-memory'), 0, 0));
+    box.addChild(new Text(theme.fg('text', 'Choose the model for observational memory:'), 0, 0));
+    box.addChild(new Text(theme.fg('dim', 'https://mastra.ai/docs/memory/observational-memory'), 0, 0));
     box.addChild(new Spacer(1));
 
     const prevOmId = this.options.previous?.omPackId ?? null;
     const items: SelectItem[] = omPacks.map(p => ({
       value: p.id,
-      label: `  ${p.name}  ${fg('dim', p.description)}${p.id === prevOmId ? fg('dim', ' (current)') : ''}`,
+      label: `  ${p.name}  ${theme.fg('dim', p.description)}${p.id === prevOmId ? theme.fg('dim', ' (current)') : ''}`,
     }));
 
     this.selectList = new SelectList(items, items.length, getSelectListTheme());
@@ -468,36 +468,36 @@ export class OnboardingInlineComponent extends Container implements Focusable {
         this.runCustomOmFlow();
       } else {
         this.selectedOmPack = pack;
-        this.collapseStep(`Observational memory → ${bold(this.selectedOmPack.name)}`);
+        this.collapseStep(`Observational memory → ${theme.bold(this.selectedOmPack.name)}`);
         this.renderStep('yolo');
       }
     };
     this.selectList.onCancel = () => {
-      this.collapseStep(`Observational memory → ${bold(this.selectedOmPack.name)} (default)`);
+      this.collapseStep(`Observational memory → ${theme.bold(this.selectedOmPack.name)} (default)`);
       this.renderStep('yolo');
     };
 
     box.addChild(this.selectList);
     box.addChild(new Spacer(1));
-    box.addChild(new Text(fg('dim', '↑↓ navigate · Enter select · Esc use default'), 0, 0));
+    box.addChild(new Text(theme.fg('dim', '↑↓ navigate · Enter select · Esc use default'), 0, 0));
   }
 
   private async runCustomOmFlow(): Promise<void> {
     this.selectList = undefined;
-    this.collapseStep(`Observational memory → ${bold('Custom')}`);
+    this.collapseStep(`Observational memory → ${theme.bold('Custom')}`);
 
     const modelId = await this.options.onSelectModel('Select model for observational memory');
     if (modelId) {
       this.selectedOmPack = { id: 'custom', name: 'Custom', description: 'User-selected model', modelId };
-      this.collapseStep(`Observational memory → ${bold('Custom')}  ${modelId}`);
+      this.collapseStep(`Observational memory → ${theme.bold('Custom')}  ${modelId}`);
     } else {
       // Cancelled — fall back to first non-custom pack
       const fallback = this.options.omPacks.find(p => p.id !== 'custom');
       if (fallback) {
         this.selectedOmPack = fallback;
-        this.collapseStep(`Observational memory → ${bold(fallback.name)} (cancelled custom)`);
+        this.collapseStep(`Observational memory → ${theme.bold(fallback.name)} (cancelled custom)`);
       } else {
-        this.collapseStep(`Observational memory → ${bold('Custom')} (cancelled)`);
+        this.collapseStep(`Observational memory → ${theme.bold('Custom')} (cancelled)`);
       }
     }
     this.renderStep('yolo');
@@ -510,23 +510,23 @@ export class OnboardingInlineComponent extends Container implements Focusable {
 
   private renderYolo(): void {
     const box = this.makeBox();
-    box.addChild(new Text(bold(fg('accent', '⚡ Tool Approval')), 0, 0));
+    box.addChild(new Text(theme.bold(theme.fg('accent', '⚡ Tool Approval')), 0, 0));
     box.addChild(new Spacer(1));
-    box.addChild(new Text(fg('text', 'YOLO mode auto-approves all tool calls (edits, commands, etc).'), 0, 0));
-    box.addChild(new Text(fg('text', 'You can toggle this anytime with Ctrl+Y or /yolo.'), 0, 0));
+    box.addChild(new Text(theme.fg('text', 'YOLO mode auto-approves all tool calls (edits, commands, etc).'), 0, 0));
+    box.addChild(new Text(theme.fg('text', 'You can toggle this anytime with Ctrl+Y or /yolo.'), 0, 0));
     box.addChild(new Spacer(1));
 
     const prevYolo = this.options.previous?.yolo ?? null;
-    const currentOn = prevYolo === true ? fg('dim', ' (current)') : '';
-    const currentOff = prevYolo === false ? fg('dim', ' (current)') : '';
+    const currentOn = prevYolo === true ? theme.fg('dim', ' (current)') : '';
+    const currentOff = prevYolo === false ? theme.fg('dim', ' (current)') : '';
     const items: SelectItem[] = [
       {
         value: 'on',
-        label: `  ${fg('success', 'Enable YOLO')}  ${fg('dim', '(recommended — auto-approve everything)')}${currentOn}`,
+        label: `  ${theme.fg('success', 'Enable YOLO')}  ${theme.fg('dim', '(recommended — auto-approve everything)')}${currentOn}`,
       },
       {
         value: 'off',
-        label: `  ${fg('warning', 'Disable YOLO')}  ${fg('dim', '(ask before each tool call)')}${currentOff}`,
+        label: `  ${theme.fg('warning', 'Disable YOLO')}  ${theme.fg('dim', '(ask before each tool call)')}${currentOff}`,
       },
     ];
 
@@ -537,17 +537,17 @@ export class OnboardingInlineComponent extends Container implements Focusable {
     this.selectList.onSelect = (item: SelectItem) => {
       this.selectedYolo = item.value === 'on';
       const label = this.selectedYolo ? 'enabled' : 'disabled';
-      this.collapseStep(`YOLO mode → ${bold(label)}`);
+      this.collapseStep(`YOLO mode → ${theme.bold(label)}`);
       this.renderStep('done');
     };
     this.selectList.onCancel = () => {
-      this.collapseStep(`YOLO mode → ${bold('enabled')} (default)`);
+      this.collapseStep(`YOLO mode → ${theme.bold('enabled')} (default)`);
       this.renderStep('done');
     };
 
     box.addChild(this.selectList);
     box.addChild(new Spacer(1));
-    box.addChild(new Text(fg('dim', '↑↓ navigate · Enter select · Esc use default'), 0, 0));
+    box.addChild(new Text(theme.fg('dim', '↑↓ navigate · Enter select · Esc use default'), 0, 0));
   }
 
   // ---------------------------------------------------------------------------
@@ -557,22 +557,22 @@ export class OnboardingInlineComponent extends Container implements Focusable {
   private renderDone(): void {
     this._finished = true;
     const box = this.makeBox();
-    box.addChild(new Text(bold(fg('success', '✓ Setup complete!')), 0, 0));
+    box.addChild(new Text(theme.bold(theme.fg('success', '✓ Setup complete!')), 0, 0));
     box.addChild(new Spacer(1));
 
     const lines = [
-      `Model pack: ${bold(this.selectedModePack.name)}`,
+      `Model pack: ${theme.bold(this.selectedModePack.name)}`,
       `  ${chalk.hex(mastra.blue)('plan')}  → ${this.selectedModePack.models.plan}`,
       `  ${chalk.hex(mastra.purple)('build')} → ${this.selectedModePack.models.build}`,
       `  ${chalk.hex(mastra.green)('fast')}  → ${this.selectedModePack.models.fast}`,
-      `Observational memory: ${bold(this.selectedOmPack.name)}`,
-      `YOLO mode: ${bold(this.selectedYolo ? 'enabled' : 'disabled')}`,
+      `Observational memory: ${theme.bold(this.selectedOmPack.name)}`,
+      `YOLO mode: ${theme.bold(this.selectedYolo ? 'enabled' : 'disabled')}`,
     ];
     for (const line of lines) {
-      box.addChild(new Text(fg('text', line), 0, 0));
+      box.addChild(new Text(theme.fg('text', line), 0, 0));
     }
     box.addChild(new Spacer(1));
-    box.addChild(new Text(fg('dim', 'Type a message to start coding, or use /help for commands.'), 0, 0));
+    box.addChild(new Text(theme.fg('dim', 'Type a message to start coding, or use /help for commands.'), 0, 0));
 
     this.options.onComplete({
       modePack: this.selectedModePack,
@@ -591,7 +591,7 @@ export class OnboardingInlineComponent extends Container implements Focusable {
     if (!this.stepBox) return;
     this.stepBox.clear();
     this.stepBox.setBgFn((text: string) => theme.bg('toolSuccessBg', text));
-    this.stepBox.addChild(new Text(`${fg('success', '✓')} ${fg('text', summary)}`, 0, 0));
+    this.stepBox.addChild(new Text(`${theme.fg('success', '✓')} ${theme.fg('text', summary)}`, 0, 0));
     this.selectList = undefined;
   }
 

--- a/mastracode/src/onboarding/onboarding-inline.ts
+++ b/mastracode/src/onboarding/onboarding-inline.ts
@@ -257,7 +257,10 @@ export class OnboardingInlineComponent extends Container implements Focusable {
       value: p.value,
       label: p.loggedIn ? `  ${p.label}  ${theme.fg('success', '✓ logged in')}` : `  ${p.label}`,
     }));
-    items.push({ value: '__skip', label: `  ${theme.fg('dim', 'Skip (use API keys or configure later with /login)')}` });
+    items.push({
+      value: '__skip',
+      label: `  ${theme.fg('dim', 'Skip (use API keys or configure later with /login)')}`,
+    });
 
     this.selectList = new SelectList(items, Math.min(items.length, 8), getSelectListTheme());
     this.selectList.onSelect = (item: SelectItem) => {
@@ -303,7 +306,9 @@ export class OnboardingInlineComponent extends Container implements Focusable {
         new Text(theme.fg('dim', 'See https://mastra.ai/models for supported providers and API key env vars.'), 0, 0),
       );
       box.addChild(new Spacer(1));
-      box.addChild(new Text(theme.fg('dim', 'Set an API key and restart, or run /login to authenticate via OAuth.'), 0, 0));
+      box.addChild(
+        new Text(theme.fg('dim', 'Set an API key and restart, or run /login to authenticate via OAuth.'), 0, 0),
+      );
       this._finished = true;
       // Give the TUI time to render the message before exiting
       setTimeout(() => process.exit(1), 3000);

--- a/mastracode/src/tui/commands/diff.ts
+++ b/mastracode/src/tui/commands/diff.ts
@@ -1,5 +1,5 @@
 import { DiffOutputComponent } from '../components/diff-output.js';
-import { fg } from '../theme.js';
+import { theme } from '../theme.js';
 import type { SlashCommandContext } from './types.js';
 
 export async function handleDiffCommand(ctx: SlashCommandContext, filePath?: string): Promise<void> {
@@ -75,10 +75,10 @@ export async function handleDiffCommand(ctx: SlashCommandContext, filePath?: str
     const ops = Array.from(opCounts.entries())
       .map(([op, count]) => (count > 1 ? `${op}×${count}` : op))
       .join(', ');
-    lines.push(`  ${fg('path', fp)} ${fg('muted', `(${ops})`)}`);
+    lines.push(`  ${theme.fg('path', fp)} ${theme.fg('muted', `(${ops})`)}`);
   }
   lines.push('');
-  lines.push(fg('muted', 'Use /diff <path> to see the git diff for a specific file.'));
+  lines.push(theme.fg('muted', 'Use /diff <path> to see the git diff for a specific file.'));
 
   ctx.showInfo(lines.join('\n'));
 }

--- a/mastracode/src/tui/commands/models-pack.ts
+++ b/mastracode/src/tui/commands/models-pack.ts
@@ -8,7 +8,7 @@ import { loadSettings, saveSettings } from '../../onboarding/settings.js';
 import { ModelSelectorComponent } from '../components/model-selector.js';
 import type { ModelItem } from '../components/model-selector.js';
 import { updateStatusLine } from '../status-line.js';
-import { getSelectListTheme, fg, bold, mastra } from '../theme.js';
+import { getSelectListTheme, theme, mastra } from '../theme.js';
 import type { SlashCommandContext } from './types.js';
 
 async function selectModel(ctx: SlashCommandContext, title: string, modeColor?: string): Promise<string | undefined> {
@@ -121,12 +121,12 @@ function applyPack(ctx: SlashCommandContext, pack: ModePack): void {
 
 function getPackDetail(pack: ModePack): string {
   if (pack.id === 'custom') {
-    return fg('dim', "  You'll pick a model for each mode.");
+    return theme.fg('dim', "  You'll pick a model for each mode.");
   }
   return [
-    `  ${chalk.hex(mastra.blue)('plan')}  → ${fg('text', pack.models.plan)}`,
-    `  ${chalk.hex(mastra.purple)('build')} → ${fg('text', pack.models.build)}`,
-    `  ${chalk.hex(mastra.green)('fast')}  → ${fg('text', pack.models.fast)}`,
+    `  ${chalk.hex(mastra.blue)('plan')}  → ${theme.fg('text', pack.models.plan)}`,
+    `  ${chalk.hex(mastra.purple)('build')} → ${theme.fg('text', pack.models.build)}`,
+    `  ${chalk.hex(mastra.green)('fast')}  → ${theme.fg('text', pack.models.fast)}`,
   ].join('\n');
 }
 
@@ -160,12 +160,12 @@ export async function handleModelsPackCommand(ctx: SlashCommandContext): Promise
 
   const items: SelectItem[] = packs.map(p => ({
     value: p.id,
-    label: `  ${p.name}  ${fg('dim', p.description)}${p.id === currentPackId ? fg('dim', ' (current)') : ''}`,
+    label: `  ${p.name}  ${theme.fg('dim', p.description)}${p.id === currentPackId ? theme.fg('dim', ' (current)') : ''}`,
   }));
 
   return new Promise<void>(resolve => {
     const container = new Box(1, 1);
-    container.addChild(new Text(bold(fg('accent', 'Switch model pack')), 0, 0));
+    container.addChild(new Text(theme.bold(theme.fg('accent', 'Switch model pack')), 0, 0));
     container.addChild(new Spacer(1));
 
     const selectList = new SelectList(items, items.length, getSelectListTheme());
@@ -195,14 +195,14 @@ export async function handleModelsPackCommand(ctx: SlashCommandContext): Promise
         const customPack = await runCustomFlow(ctx);
         if (customPack) {
           applyPack(ctx, customPack);
-          collapseResult(`Model pack → ${bold('Custom')}`);
+          collapseResult(`Model pack → ${theme.bold('Custom')}`);
           ctx.showInfo('Switched to Custom pack');
         } else {
           collapseResult('cancelled');
         }
       } else {
         applyPack(ctx, pack);
-        collapseResult(`Model pack → ${bold(pack.name)}`);
+        collapseResult(`Model pack → ${theme.bold(pack.name)}`);
         ctx.showInfo(`Switched to ${pack.name} pack`);
       }
 
@@ -223,7 +223,7 @@ export async function handleModelsPackCommand(ctx: SlashCommandContext): Promise
     container.addChild(new Spacer(1));
     container.addChild(detailText);
     container.addChild(new Spacer(1));
-    container.addChild(new Text(fg('dim', '↑↓ navigate · Enter select · Esc cancel'), 0, 0));
+    container.addChild(new Text(theme.fg('dim', '↑↓ navigate · Enter select · Esc cancel'), 0, 0));
 
     // Initialize detail for first item
     const currentIdx = packs.findIndex(p => p.id === currentPackId);
@@ -238,9 +238,9 @@ export async function handleModelsPackCommand(ctx: SlashCommandContext): Promise
     const collapseResult = (result: string | null) => {
       container.clear();
       if (result === 'cancelled') {
-        container.addChild(new Text(fg('dim', `${fg('error', '✗')} Model pack (cancelled)`), 0, 0));
+        container.addChild(new Text(theme.fg('dim', `${theme.fg('error', '✗')} Model pack (cancelled)`), 0, 0));
       } else if (result) {
-        container.addChild(new Text(fg('text', `${fg('success', '✓')} ${result}`), 0, 0));
+        container.addChild(new Text(theme.fg('text', `${theme.fg('success', '✓')} ${result}`), 0, 0));
       }
     };
 

--- a/mastracode/src/tui/commands/thread-tag-dir.ts
+++ b/mastracode/src/tui/commands/thread-tag-dir.ts
@@ -1,6 +1,6 @@
 import { Spacer } from '@mariozechner/pi-tui';
 import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
-import { fg } from '../theme.js';
+import { theme } from '../theme.js';
 import type { SlashCommandContext } from './types.js';
 
 export async function handleThreadTagDirCommand(ctx: SlashCommandContext): Promise<void> {
@@ -26,7 +26,7 @@ export async function handleThreadTagDirCommand(ctx: SlashCommandContext): Promi
   return new Promise<void>(resolve => {
     const questionComponent = new AskQuestionInlineComponent(
       {
-        question: `Tag this thread with directory "${dirName}"?\n  ${fg('dim', projectPath)}`,
+        question: `Tag this thread with directory "${dirName}"?\n  ${theme.fg('dim', projectPath)}`,
         options: [{ label: 'Yes' }, { label: 'No' }],
         formatResult: answer => (answer === 'Yes' ? `Tagged thread with: ${dirName}` : `Thread not tagged`),
         onSubmit: async answer => {

--- a/mastracode/src/tui/components/ask-question-dialog.ts
+++ b/mastracode/src/tui/components/ask-question-dialog.ts
@@ -6,7 +6,7 @@
 
 import { Box, getEditorKeybindings, Input, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, SelectItem } from '@mariozechner/pi-tui';
-import { bg, fg, bold, getSelectListTheme } from '../theme.js';
+import { theme, getSelectListTheme } from '../theme.js';
 
 export interface AskQuestionDialogOptions {
   question: string;
@@ -31,18 +31,18 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
   }
 
   constructor(options: AskQuestionDialogOptions) {
-    super(2, 1, text => bg('overlayBg', text));
+    super(2, 1, text => theme.bg('overlayBg', text));
 
     this.onSubmit = options.onSubmit;
     this.onCancel = options.onCancel;
 
     // Title
-    this.addChild(new Text(bold(fg('accent', 'Question')), 0, 0));
+    this.addChild(new Text(theme.bold(theme.fg('accent', 'Question')), 0, 0));
     this.addChild(new Spacer(1));
 
     // Question text (may be multi-line)
     for (const line of options.question.split('\n')) {
-      this.addChild(new Text(fg('text', line), 0, 0));
+      this.addChild(new Text(theme.fg('text', line), 0, 0));
     }
     this.addChild(new Spacer(1));
 
@@ -56,7 +56,7 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
   private buildSelectMode(opts: Array<{ label: string; description?: string }>): void {
     const items: SelectItem[] = opts.map(opt => ({
       value: opt.label,
-      label: opt.description ? `  ${opt.label}  ${fg('dim', opt.description)}` : `  ${opt.label}`,
+      label: opt.description ? `  ${opt.label}  ${theme.fg('dim', opt.description)}` : `  ${opt.label}`,
     }));
 
     this.selectList = new SelectList(items, Math.min(items.length, 8), getSelectListTheme());
@@ -68,7 +68,7 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
 
     this.addChild(this.selectList);
     this.addChild(new Spacer(1));
-    this.addChild(new Text(fg('dim', '  ↑↓ to navigate · Enter to select · Esc to skip'), 0, 0));
+    this.addChild(new Text(theme.fg('dim', '  ↑↓ to navigate · Enter to select · Esc to skip'), 0, 0));
   }
 
   private buildInputMode(): void {
@@ -82,7 +82,7 @@ export class AskQuestionDialogComponent extends Box implements Focusable {
 
     this.addChild(this.input);
     this.addChild(new Spacer(1));
-    this.addChild(new Text(fg('dim', '  Enter to submit · Esc to skip'), 0, 0));
+    this.addChild(new Text(theme.fg('dim', '  Enter to submit · Esc to skip'), 0, 0));
   }
 
   handleInput(data: string): void {

--- a/mastracode/src/tui/components/banner.ts
+++ b/mastracode/src/tui/components/banner.ts
@@ -4,7 +4,7 @@
  */
 import chalk from 'chalk';
 
-import { fg, bold } from '../theme.js';
+import { theme } from '../theme.js';
 
 // Mastra brand purple gradient stops (left → right)
 const GRADIENT_STOPS = ['#5b21b6', '#6d28d9', '#7c3aed', '#8b5cf6', '#a78bfa'];
@@ -65,14 +65,14 @@ export function renderBanner(version: string, appName?: string): string {
 
   // Custom app names get the simple text format (no Mastra branding)
   if (name !== 'Mastra Code') {
-    return fg('accent', '◆') + ' ' + bold(fg('accent', name)) + fg('dim', ` v${version}`);
+    return theme.fg('accent', '◆') + ' ' + theme.bold(theme.fg('accent', name)) + theme.fg('dim', ` v${version}`);
   }
 
   const cols = process.stdout.columns || 80;
 
   // Narrow terminal — compact single line
   if (cols < 30) {
-    return fg('accent', '◆') + ' ' + bold(fg('accent', 'Mastra Code')) + fg('dim', ` v${version}`);
+    return theme.fg('accent', '◆') + ' ' + theme.bold(theme.fg('accent', 'Mastra Code')) + theme.fg('dim', ` v${version}`);
   }
 
   // Select art based on available width
@@ -80,7 +80,7 @@ export function renderBanner(version: string, appName?: string): string {
   const coloredLines = art.map(line => colorLine(line));
 
   // Append version below the art
-  coloredLines.push(fg('dim', `v${version}`));
+  coloredLines.push(theme.fg('dim', `v${version}`));
 
   return coloredLines.join('\n');
 }

--- a/mastracode/src/tui/components/banner.ts
+++ b/mastracode/src/tui/components/banner.ts
@@ -72,7 +72,9 @@ export function renderBanner(version: string, appName?: string): string {
 
   // Narrow terminal — compact single line
   if (cols < 30) {
-    return theme.fg('accent', '◆') + ' ' + theme.bold(theme.fg('accent', 'Mastra Code')) + theme.fg('dim', ` v${version}`);
+    return (
+      theme.fg('accent', '◆') + ' ' + theme.bold(theme.fg('accent', 'Mastra Code')) + theme.fg('dim', ` v${version}`)
+    );
   }
 
   // Select art based on available width

--- a/mastracode/src/tui/components/diff-output.ts
+++ b/mastracode/src/tui/components/diff-output.ts
@@ -4,7 +4,7 @@
 
 import { Container, Spacer, Text } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
-import { fg, bold, mastra, getTheme } from '../theme.js';
+import { theme, mastra, getTheme } from '../theme.js';
 
 function colorizeDiffLine(line: string): string {
   const t = getTheme();
@@ -58,7 +58,7 @@ export class DiffOutputComponent extends Container {
     this.addChild(new Spacer(1));
 
     // Command header
-    this.addChild(new Text(`${fg('success', '✓')} ${bold(fg('muted', '$'))} ${fg('text', command)}`, 1, 0));
+    this.addChild(new Text(`${theme.fg('success', '✓')} ${theme.bold(theme.fg('muted', '$'))} ${theme.fg('text', command)}`, 1, 0));
 
     const output = diffOutput.trimEnd();
     if (output) {

--- a/mastracode/src/tui/components/diff-output.ts
+++ b/mastracode/src/tui/components/diff-output.ts
@@ -58,7 +58,9 @@ export class DiffOutputComponent extends Container {
     this.addChild(new Spacer(1));
 
     // Command header
-    this.addChild(new Text(`${theme.fg('success', '✓')} ${theme.bold(theme.fg('muted', '$'))} ${theme.fg('text', command)}`, 1, 0));
+    this.addChild(
+      new Text(`${theme.fg('success', '✓')} ${theme.bold(theme.fg('muted', '$'))} ${theme.fg('text', command)}`, 1, 0),
+    );
 
     const output = diffOutput.trimEnd();
     if (output) {

--- a/mastracode/src/tui/components/diff-output.ts
+++ b/mastracode/src/tui/components/diff-output.ts
@@ -4,10 +4,10 @@
 
 import { Container, Spacer, Text } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
-import { theme, mastra, getTheme } from '../theme.js';
+import { theme, mastra } from '../theme.js';
 
 function colorizeDiffLine(line: string): string {
-  const t = getTheme();
+  const t = theme.getTheme();
   const addedColor = chalk.hex(t.success);
   const hunkHeaderColor = chalk.hex(t.toolBorderPending);
   const fileHeaderColor = chalk.bold.hex(t.accent);

--- a/mastracode/src/tui/components/error-display.ts
+++ b/mastracode/src/tui/components/error-display.ts
@@ -5,7 +5,7 @@
 
 import { Container, Text, Spacer } from '@mariozechner/pi-tui';
 import type { TUI } from '@mariozechner/pi-tui';
-import { fg, bold, bg } from '../theme.js';
+import { theme } from '../theme.js';
 import { CollapsibleComponent } from './collapsible.js';
 
 export interface ErrorInfo {
@@ -99,13 +99,13 @@ function formatStackTrace(stack: string): string[] {
       return line.replace(
         /(\s+at\s+)([^(]+)(\s*\()([^)]+)(\))/,
         (match, at, fn, open, loc, close) =>
-          `${fg('muted', at)}${fg('function', fn)}${fg('muted', open)}${fg('path', loc)}${fg('muted', close)}`,
+          `${theme.fg('muted', at)}${theme.fg('function', fn)}${theme.fg('muted', open)}${theme.fg('path', loc)}${theme.fg('muted', close)}`,
       );
     }
 
     // Mute empty lines and framework traces
     if (!line.trim() || line.includes('node_modules')) {
-      return fg('muted', line);
+      return theme.fg('muted', line);
     }
 
     return line;
@@ -155,33 +155,33 @@ export class ErrorDisplayComponent extends Container {
     const info = parseErrorInfo(this.error);
 
     // Add a visible border around the entire error display
-    const borderTop = new Text(fg('error', '┌─ Error ─' + '─'.repeat(50) + '┐'), 0, 0);
+    const borderTop = new Text(theme.fg('error', '┌─ Error ─' + '─'.repeat(50) + '┐'), 0, 0);
     this.addChild(borderTop);
 
     // Error header container with background
     const errorContainer = new Container();
 
     // Add a colored background to the error message
-    const errorBg = (text: string) => bg('errorBg', text);
+    const errorBg = (text: string) => theme.bg('errorBg', text);
 
     // Error type and message with proper formatting
     if (info.name && info.name !== 'Error') {
       const typeLine = new Container();
       typeLine.addChild(new Text('│ ', 0, 0));
-      typeLine.addChild(new Text(errorBg(` ${bold(fg('error', info.name))} `), 0, 0));
+      typeLine.addChild(new Text(errorBg(` ${theme.bold(theme.fg('error', info.name))} `), 0, 0));
       errorContainer.addChild(typeLine);
     }
 
     // Error message
     const msgLine = new Container();
     msgLine.addChild(new Text('│ ', 0, 0));
-    msgLine.addChild(new Text(bold(info.message), 0, 0));
+    msgLine.addChild(new Text(theme.bold(info.message), 0, 0));
     errorContainer.addChild(msgLine);
 
     // File location if available
     if (info.file && info.line) {
       const location = `${info.file}:${info.line}${info.column ? `:${info.column}` : ''}`;
-      errorContainer.addChild(new Text(fg('muted', `  at ${location}`), 0, 0));
+      errorContainer.addChild(new Text(theme.fg('muted', `  at ${location}`), 0, 0));
     }
 
     this.addChild(errorContainer);
@@ -199,7 +199,7 @@ export class ErrorDisplayComponent extends Container {
     }
 
     // Add bottom border
-    const borderBottom = new Text(fg('error', '└' + '─'.repeat(60) + '┘'), 0, 0);
+    const borderBottom = new Text(theme.fg('error', '└' + '─'.repeat(60) + '┘'), 0, 0);
     this.addChild(borderBottom);
   }
 
@@ -208,26 +208,26 @@ export class ErrorDisplayComponent extends Container {
     const codeBlock = new Container();
 
     // Add a header
-    codeBlock.addChild(new Text(fg('muted', 'Code context:'), 0, 0));
+    codeBlock.addChild(new Text(theme.fg('muted', 'Code context:'), 0, 0));
 
     // Before lines
     if (context.before) {
       context.before.forEach((line, i) => {
         const lineNum = errorLine ? errorLine - context.before!.length + i : i + 1;
-        codeBlock.addChild(new Text(fg('muted', `${lineNum.toString().padStart(4)} │ ${line}`), 0, 0));
+        codeBlock.addChild(new Text(theme.fg('muted', `${lineNum.toString().padStart(4)} │ ${line}`), 0, 0));
       });
     }
 
     // Error line (highlighted)
     if (context.line && errorLine) {
-      codeBlock.addChild(new Text(fg('error', `${errorLine.toString().padStart(4)} │ ${context.line}`), 0, 0));
+      codeBlock.addChild(new Text(theme.fg('error', `${errorLine.toString().padStart(4)} │ ${context.line}`), 0, 0));
     }
 
     // After lines
     if (context.after) {
       context.after.forEach((line, i) => {
         const lineNum = errorLine ? errorLine + i + 1 : i + 1;
-        codeBlock.addChild(new Text(fg('muted', `${lineNum.toString().padStart(4)} │ ${line}`), 0, 0));
+        codeBlock.addChild(new Text(theme.fg('muted', `${lineNum.toString().padStart(4)} │ ${line}`), 0, 0));
       });
     }
 

--- a/mastracode/src/tui/components/login-dialog.ts
+++ b/mastracode/src/tui/components/login-dialog.ts
@@ -6,7 +6,7 @@ import { exec } from 'node:child_process';
 import { Box, Container, getEditorKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, TUI } from '@mariozechner/pi-tui';
 import { getOAuthProviders } from '../../auth/index.js';
-import { bg, fg } from '../theme.js';
+import { theme } from '../theme.js';
 
 export class LoginDialogComponent extends Box implements Focusable {
   private contentContainer: Container;
@@ -32,14 +32,14 @@ export class LoginDialogComponent extends Box implements Focusable {
     private onComplete: (success: boolean, message?: string) => void,
   ) {
     // Box with padding and background
-    super(2, 1, text => bg('overlayBg', text));
+    super(2, 1, text => theme.bg('overlayBg', text));
     this.tui = tui;
 
     const providerInfo = getOAuthProviders().find(p => p.id === providerId);
     const providerName = providerInfo?.name || providerId;
 
     // Title
-    this.addChild(new Text(fg('warning', `Login to ${providerName}`)));
+    this.addChild(new Text(theme.fg('warning', `Login to ${providerName}`)));
     this.addChild(new Spacer(1));
 
     // Dynamic content area
@@ -82,15 +82,15 @@ export class LoginDialogComponent extends Box implements Focusable {
   showAuth(url: string, instructions?: string): void {
     this.contentContainer.clear();
 
-    this.contentContainer.addChild(new Text(fg('accent', url)));
+    this.contentContainer.addChild(new Text(theme.fg('accent', url)));
 
     const clickHint = process.platform === 'darwin' ? 'Cmd+click to open' : 'Ctrl+click to open';
     const hyperlink = `\x1b]8;;${url}\x07${clickHint}\x1b]8;;\x07`;
-    this.contentContainer.addChild(new Text(fg('muted', hyperlink)));
+    this.contentContainer.addChild(new Text(theme.fg('muted', hyperlink)));
 
     if (instructions) {
       this.contentContainer.addChild(new Spacer(1));
-      this.contentContainer.addChild(new Text(fg('warning', instructions)));
+      this.contentContainer.addChild(new Text(theme.fg('warning', instructions)));
     }
 
     // Try to open browser
@@ -105,12 +105,12 @@ export class LoginDialogComponent extends Box implements Focusable {
    */
   showPrompt(message: string, placeholder?: string): Promise<string> {
     this.contentContainer.addChild(new Spacer(1));
-    this.contentContainer.addChild(new Text(fg('text', message)));
+    this.contentContainer.addChild(new Text(theme.fg('text', message)));
     if (placeholder) {
-      this.contentContainer.addChild(new Text(fg('muted', `e.g., ${placeholder}`)));
+      this.contentContainer.addChild(new Text(theme.fg('muted', `e.g., ${placeholder}`)));
     }
     this.contentContainer.addChild(this.input);
-    this.contentContainer.addChild(new Text(fg('muted', '(Escape to cancel, Enter to submit)')));
+    this.contentContainer.addChild(new Text(theme.fg('muted', '(Escape to cancel, Enter to submit)')));
 
     this.input.setValue('');
     this.tui.requestRender();
@@ -125,7 +125,7 @@ export class LoginDialogComponent extends Box implements Focusable {
    * Show progress message
    */
   showProgress(message: string): void {
-    this.contentContainer.addChild(new Text(fg('muted', message)));
+    this.contentContainer.addChild(new Text(theme.fg('muted', message)));
     this.tui.requestRender();
   }
 

--- a/mastracode/src/tui/components/login-selector.ts
+++ b/mastracode/src/tui/components/login-selector.ts
@@ -4,7 +4,7 @@
 
 import { Box, Container, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { OAuthProviderInterface } from '../../auth/types.js';
-import { bg, fg } from '../theme.js';
+import { theme } from '../theme.js';
 
 /**
  * Interface for auth provider that the selector needs.
@@ -31,7 +31,7 @@ export class LoginSelectorComponent extends Box {
     onCancel: () => void,
   ) {
     // Box with padding and background
-    super(2, 1, text => bg('overlayBg', text));
+    super(2, 1, text => theme.bg('overlayBg', text));
 
     this.mode = mode;
     this.authSource = authSource;
@@ -43,7 +43,7 @@ export class LoginSelectorComponent extends Box {
 
     // Add title
     const title = mode === 'login' ? 'Select provider to login:' : 'Select provider to logout:';
-    this.addChild(new Text(fg('text', title)));
+    this.addChild(new Text(theme.fg('text', title)));
     this.addChild(new Spacer(1));
 
     // Create list container
@@ -51,7 +51,7 @@ export class LoginSelectorComponent extends Box {
     this.addChild(this.listContainer);
 
     this.addChild(new Spacer(1));
-    this.addChild(new Text(fg('muted', 'Press Enter to select, Escape to cancel')));
+    this.addChild(new Text(theme.fg('muted', 'Press Enter to select, Escape to cancel')));
 
     // Initial render
     this.updateList();
@@ -72,11 +72,11 @@ export class LoginSelectorComponent extends Box {
 
       // Check if user is logged in for this provider
       const isLoggedIn = this.authSource.isLoggedIn(provider.id);
-      const statusIndicator = isLoggedIn ? fg('success', ' ✓ logged in') : '';
+      const statusIndicator = isLoggedIn ? theme.fg('success', ' ✓ logged in') : '';
 
       let line = '';
       if (isSelected) {
-        line = fg('accent', '→ ' + provider.name) + statusIndicator;
+        line = theme.fg('accent', '→ ' + provider.name) + statusIndicator;
       } else {
         line = '  ' + provider.name + statusIndicator;
       }
@@ -88,7 +88,7 @@ export class LoginSelectorComponent extends Box {
     if (this.allProviders.length === 0) {
       const message =
         this.mode === 'login' ? 'No OAuth providers available' : 'No OAuth providers logged in. Use /login first.';
-      this.listContainer.addChild(new Text(fg('muted', message)));
+      this.listContainer.addChild(new Text(theme.fg('muted', message)));
     }
   }
 

--- a/mastracode/src/tui/components/model-selector.ts
+++ b/mastracode/src/tui/components/model-selector.ts
@@ -6,7 +6,7 @@
 import { Box, Container, fuzzyFilter, getEditorKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, TUI } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
-import { bg, fg, bold } from '../theme.js';
+import { theme } from '../theme.js';
 
 // =============================================================================
 // Types
@@ -73,7 +73,7 @@ export class ModelSelectorComponent extends Box implements Focusable {
 
   constructor(options: ModelSelectorOptions) {
     // Box with padding and background
-    super(2, 1, text => bg('overlayBg', text));
+    super(2, 1, text => theme.bg('overlayBg', text));
 
     this.tui = options.tui;
     this.title = options.title ?? 'Select Model';
@@ -92,12 +92,12 @@ export class ModelSelectorComponent extends Box implements Focusable {
     // Title — optionally with a mode-colored background
     const titleText = this.titleColor
       ? chalk.bgHex(this.titleColor).white.bold(` ${this.title} `)
-      : bold(fg('accent', this.title));
+      : theme.bold(theme.fg('accent', this.title));
     this.addChild(new Text(titleText, 0, 0));
     this.addChild(new Spacer(1));
 
     // Hint
-    this.addChild(new Text(fg('muted', 'Type to search • ↑↓ navigate • Enter select • Esc cancel'), 0, 0));
+    this.addChild(new Text(theme.fg('muted', 'Type to search • ↑↓ navigate • Enter select • Esc cancel'), 0, 0));
     this.addChild(new Spacer(1));
 
     // Search input (Input has built-in "> " prompt)
@@ -195,8 +195,8 @@ export class ModelSelectorComponent extends Box implements Focusable {
         const query = this.searchInput.getValue().trim();
         const isSelected = this.selectedIndex === 0;
         const line = isSelected
-          ? fg('accent', '→ ') + bold(fg('accent', `Use: ${query}`))
-          : '  ' + fg('muted', `Use: ${query}`);
+          ? theme.fg('accent', '→ ') + theme.bold(theme.fg('accent', `Use: ${query}`))
+          : '  ' + theme.fg('muted', `Use: ${query}`);
         this.listContainer.addChild(new Text(line, 0, 0));
         continue;
       }
@@ -208,16 +208,16 @@ export class ModelSelectorComponent extends Box implements Focusable {
 
       const isSelected = i === this.selectedIndex;
       const isCurrent = item.id === this.currentModelId;
-      const checkmark = isCurrent ? fg('success', ' ✓') : '';
+      const checkmark = isCurrent ? theme.fg('success', ' ✓') : '';
       const noKeyIndicator = !item.hasApiKey
-        ? fg('error', ' ✗') + fg('muted', item.apiKeyEnvVar ? ` (${item.apiKeyEnvVar})` : ' (no key)')
+        ? theme.fg('error', ' ✗') + theme.fg('muted', item.apiKeyEnvVar ? ` (${item.apiKeyEnvVar})` : ' (no key)')
         : '';
 
       let line = '';
       if (isSelected) {
-        line = fg('accent', '→ ' + item.id) + checkmark + noKeyIndicator;
+        line = theme.fg('accent', '→ ' + item.id) + checkmark + noKeyIndicator;
       } else {
-        const modelText = item.hasApiKey ? item.id : fg('muted', item.id);
+        const modelText = item.hasApiKey ? item.id : theme.fg('muted', item.id);
         line = '  ' + modelText + checkmark + noKeyIndicator;
       }
 
@@ -226,13 +226,13 @@ export class ModelSelectorComponent extends Box implements Focusable {
 
     // Scroll indicator
     if (startIndex > 0 || endIndex < totalItems) {
-      const scrollInfo = fg('muted', `(${this.selectedIndex + 1}/${totalItems})`);
+      const scrollInfo = theme.fg('muted', `(${this.selectedIndex + 1}/${totalItems})`);
       this.listContainer.addChild(new Text(scrollInfo, 0, 0));
     }
 
     // Empty state
     if (totalItems === 0) {
-      this.listContainer.addChild(new Text(fg('muted', 'No matching models'), 0, 0));
+      this.listContainer.addChild(new Text(theme.fg('muted', 'No matching models'), 0, 0));
     }
   }
 

--- a/mastracode/src/tui/components/multi-step-progress.ts
+++ b/mastracode/src/tui/components/multi-step-progress.ts
@@ -5,7 +5,7 @@
 
 import { Container, Text, Spacer } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
-import { fg, bold, mastra } from '../theme.js';
+import { theme, mastra } from '../theme.js';
 
 export interface ProgressStep {
   id: string;
@@ -121,7 +121,7 @@ export class MultiStepProgressComponent extends Container {
     // Header with title and overall progress
     const progressBar = this.renderProgressBar(overallProgress, 20);
     const elapsed = this.formatDuration(now - this.startTime);
-    const headerText = `${bold(fg('accent', this.options.title))} ${progressBar} ${overallProgress}% (${elapsed})`;
+    const headerText = `${theme.bold(theme.fg('accent', this.options.title))} ${progressBar} ${overallProgress}% (${elapsed})`;
 
     this.addChild(new Spacer(1));
     this.addChild(new Text(headerText, 0, 0));
@@ -133,11 +133,11 @@ export class MultiStepProgressComponent extends Container {
       if (activeStep) {
         const spinner = this.getSpinner();
         const summaryText = `  ${spinner} ${activeStep.title}${activeStep.progress ? ` (${activeStep.progress}%)` : ''}`;
-        this.addChild(new Text(fg('warning', summaryText), 0, 0));
+        this.addChild(new Text(theme.fg('warning', summaryText), 0, 0));
       } else if (failed > 0) {
-        this.addChild(new Text(fg('error', `  ✗ ${failed} step${failed > 1 ? 's' : ''} failed`), 0, 0));
+        this.addChild(new Text(theme.fg('error', `  ✗ ${failed} step${failed > 1 ? 's' : ''} failed`), 0, 0));
       } else if (completed === total) {
-        this.addChild(new Text(fg('success', '  ✓ All steps completed'), 0, 0));
+        this.addChild(new Text(theme.fg('success', '  ✓ All steps completed'), 0, 0));
       }
     } else {
       // Full detail view
@@ -155,7 +155,7 @@ export class MultiStepProgressComponent extends Container {
         if (step.status === 'failed' && step.error) {
           const errorLines = step.error.split('\n');
           errorLines.forEach(line => {
-            this.addChild(new Text(fg('error', `      ${line}`), 0, 0));
+            this.addChild(new Text(theme.fg('error', `      ${line}`), 0, 0));
           });
         }
       });
@@ -166,7 +166,7 @@ export class MultiStepProgressComponent extends Container {
         const estimatedRemaining = Math.max(0, this.options.estimatedTime - elapsed);
         if (estimatedRemaining > 0) {
           const remaining = this.formatDuration(estimatedRemaining);
-          this.addChild(new Text(fg('dim', `  Est. time remaining: ${remaining}`), 0, 0));
+          this.addChild(new Text(theme.fg('dim', `  Est. time remaining: ${remaining}`), 0, 0));
         }
       }
     }
@@ -181,25 +181,25 @@ export class MultiStepProgressComponent extends Container {
 
     switch (step.status) {
       case 'completed':
-        icon = fg('success', '✓');
-        color = (t: string) => fg('success', t);
+        icon = theme.fg('success', '✓');
+        color = (t: string) => theme.fg('success', t);
         break;
       case 'active':
-        icon = fg('warning', this.getSpinner());
-        color = (t: string) => bold(fg('warning', t));
+        icon = theme.fg('warning', this.getSpinner());
+        color = (t: string) => theme.bold(theme.fg('warning', t));
         break;
       case 'failed':
-        icon = fg('error', '✗');
-        color = (t: string) => fg('error', t);
+        icon = theme.fg('error', '✗');
+        color = (t: string) => theme.fg('error', t);
         break;
       case 'skipped':
-        icon = fg('dim', '—');
-        color = (t: string) => fg('dim', t);
+        icon = theme.fg('dim', '—');
+        color = (t: string) => theme.fg('dim', t);
         break;
       case 'pending':
       default:
-        icon = fg('dim', '○');
-        color = (t: string) => fg('dim', t);
+        icon = theme.fg('dim', '○');
+        color = (t: string) => theme.fg('dim', t);
         break;
     }
 
@@ -209,10 +209,10 @@ export class MultiStepProgressComponent extends Container {
     if (this.options.showTimings && step.startTime) {
       if (step.endTime) {
         const duration = this.formatDuration(step.endTime - step.startTime);
-        text += fg('dim', ` (${duration})`);
+        text += theme.fg('dim', ` (${duration})`);
       } else if (step.status === 'active') {
         const elapsed = this.formatDuration(Date.now() - step.startTime);
-        text += fg('dim', ` (${elapsed})`);
+        text += theme.fg('dim', ` (${elapsed})`);
       }
     }
 

--- a/mastracode/src/tui/components/om-marker.ts
+++ b/mastracode/src/tui/components/om-marker.ts
@@ -4,7 +4,7 @@
  */
 
 import { Container, Text, Spacer } from '@mariozechner/pi-tui';
-import { fg } from '../theme.js';
+import { theme } from '../theme.js';
 
 /**
  * Format token count for display (e.g., 7234 -> "7.2k", 234 -> "0.2k", 0 -> "0")
@@ -86,7 +86,7 @@ function formatMarker(data: OMMarkerData): string {
   switch (data.type) {
     case 'om_observation_start': {
       const tokens = data.tokensToObserve > 0 ? ` ~${formatTokens(data.tokensToObserve)} tokens` : '';
-      return fg('muted', `  🧠 ${label} in progress${tokens}...`);
+      return theme.fg('muted', `  🧠 ${label} in progress${tokens}...`);
     }
     case 'om_observation_end': {
       const observed = formatTokens(data.tokensObserved);
@@ -97,15 +97,15 @@ function formatMarker(data: OMMarkerData): string {
           : '';
       const duration = (data.durationMs / 1000).toFixed(1);
       const ratioStr = ratio ? ` (${ratio} compression)` : '';
-      return fg('success', `  🧠 Observed: ${observed} → ${compressed} tokens${ratioStr} in ${duration}s ✓`);
+      return theme.fg('success', `  🧠 Observed: ${observed} → ${compressed} tokens${ratioStr} in ${duration}s ✓`);
     }
     case 'om_observation_failed': {
       const tokens = data.tokensAttempted ? ` (${formatTokens(data.tokensAttempted)} tokens)` : '';
-      return fg('error', `  ✗ ${label} failed${tokens}: ${data.error}`);
+      return theme.fg('error', `  ✗ ${label} failed${tokens}: ${data.error}`);
     }
     case 'om_buffering_start': {
       const tokens = data.tokensToBuffer > 0 ? ` ~${formatTokens(data.tokensToBuffer)} tokens` : '';
-      return fg('muted', `  ⟳ Buffering ${label.toLowerCase()}${tokens}...`);
+      return theme.fg('muted', `  ⟳ Buffering ${label.toLowerCase()}${tokens}...`);
     }
     case 'om_buffering_end': {
       const input = formatTokens(data.tokensBuffered);
@@ -119,16 +119,16 @@ function formatMarker(data: OMMarkerData): string {
       const output = formatTokens(outputTokens);
       const ratio =
         data.tokensBuffered > 0 && outputTokens > 0 ? ` (${Math.round(data.tokensBuffered / outputTokens)}x)` : '';
-      return fg('success', `  ✓ Buffered ${label.toLowerCase()}: ${input} → ${output} tokens${ratio}`);
+      return theme.fg('success', `  ✓ Buffered ${label.toLowerCase()}: ${input} → ${output} tokens${ratio}`);
     }
     case 'om_buffering_failed': {
-      return fg('error', `  ✗ Buffering ${label.toLowerCase()} failed: ${data.error}`);
+      return theme.fg('error', `  ✗ Buffering ${label.toLowerCase()} failed: ${data.error}`);
     }
     case 'om_activation': {
       const kind = data.operationType === 'reflection' ? 'reflection' : 'observations';
       const msgTokens = formatTokens(data.tokensActivated);
       const obsTokens = formatTokens(data.observationTokens);
-      return fg('success', `  ✓ Activated ${kind}: -${msgTokens} msg tokens, +${obsTokens} obs tokens`);
+      return theme.fg('success', `  ✓ Activated ${kind}: -${msgTokens} msg tokens, +${obsTokens} obs tokens`);
     }
   }
 }

--- a/mastracode/src/tui/components/om-progress.ts
+++ b/mastracode/src/tui/components/om-progress.ts
@@ -6,7 +6,7 @@ import { Container, Text } from '@mariozechner/pi-tui';
 import { defaultOMProgressState } from '@mastra/core/harness';
 import type { OMBufferedStatus, OMProgressState, OMStatus } from '@mastra/core/harness';
 import chalk from 'chalk';
-import { fg, mastra } from '../theme.js';
+import { theme, mastra } from '../theme.js';
 
 // Re-export types from core for backward compatibility
 export type { OMBufferedStatus, OMProgressState, OMStatus };
@@ -88,7 +88,7 @@ export class OMProgressComponent extends Container {
       if (this.state.thresholdPercent > 0) {
         const percent = Math.round(this.state.thresholdPercent);
         const bar = this.renderProgressBar(percent, 10);
-        this.statusText.setText(fg('muted', `OM ${bar} ${percent}%`));
+        this.statusText.setText(theme.fg('muted', `OM ${bar} ${percent}%`));
       } else {
         this.statusText.setText('');
       }
@@ -178,7 +178,7 @@ export function formatObservationStatus(
   const fraction = `${formatTokensValue(state.pendingTokens)}/${formatTokensThreshold(state.threshold)}`;
   const buffered =
     compact !== 'noBuffer' && state.buffered.observations.projectedMessageRemoval > 0
-      ? fg('muted', ` ↓${formatTokensThreshold(state.buffered.observations.projectedMessageRemoval)}`)
+      ? theme.fg('muted', ` ↓${formatTokensThreshold(state.buffered.observations.projectedMessageRemoval)}`)
       : '';
   return styleLabel(`${label} `) + colorByPercent(fraction, percent) + buffered;
 }
@@ -211,7 +211,7 @@ export function formatReflectionStatus(
   const savings = state.buffered.reflection.inputObservationTokens - state.buffered.reflection.observationTokens;
   const buffered =
     compact !== 'noBuffer' && state.buffered.reflection.status === 'complete'
-      ? fg('muted', ` ↓${formatTokensThreshold(savings)}`)
+      ? theme.fg('muted', ` ↓${formatTokensThreshold(savings)}`)
       : '';
   return label + colorByPercent(fraction, percent) + buffered;
 }

--- a/mastracode/src/tui/components/om-settings.ts
+++ b/mastracode/src/tui/components/om-settings.ts
@@ -18,7 +18,7 @@ import {
   Text,
 } from '@mariozechner/pi-tui';
 import type { Focusable, SelectItem, SettingItem, TUI } from '@mariozechner/pi-tui';
-import { fg, bg, bold, getSettingsListTheme, getSelectListTheme } from '../theme.js';
+import { theme, getSettingsListTheme, getSelectListTheme } from '../theme.js';
 
 // =============================================================================
 // Types
@@ -102,17 +102,17 @@ class ThresholdSubmenu extends Container {
     this.onDone = onDone;
     this.onBack = onBack;
 
-    this.addChild(new Text(bold(fg('accent', title)), 0, 0));
+    this.addChild(new Text(theme.bold(theme.fg('accent', title)), 0, 0));
     this.addChild(new Spacer(1));
 
     // Input for custom value — type a number like 30 for 30k
-    this.addChild(new Text(fg('muted', '  _k tokens (type a number, e.g. 30 for 30k):'), 0, 0));
+    this.addChild(new Text(theme.fg('muted', '  _k tokens (type a number, e.g. 30 for 30k):'), 0, 0));
     this.input = new Input();
     this.addChild(this.input);
     this.addChild(new Spacer(1));
 
     // Preset list
-    this.addChild(new Text(fg('muted', '  Or pick a preset:'), 0, 0));
+    this.addChild(new Text(theme.fg('muted', '  Or pick a preset:'), 0, 0));
 
     const items: SelectItem[] = presets.map(p => ({
       value: String(p),
@@ -134,7 +134,7 @@ class ThresholdSubmenu extends Container {
 
     this.addChild(this.selectList);
     this.addChild(new Spacer(1));
-    this.addChild(new Text(fg('dim', '  Enter to confirm · ↓ for presets · Esc to go back'), 0, 0));
+    this.addChild(new Text(theme.fg('dim', '  Enter to confirm · ↓ for presets · Esc to go back'), 0, 0));
   }
 
   handleInput(data: string): void {
@@ -201,9 +201,9 @@ class ModelSelectSubmenu extends Container {
     this.onCancel = onCancel;
     this.tui = tui;
 
-    this.addChild(new Text(bold(fg('accent', title)), 0, 0));
+    this.addChild(new Text(theme.bold(theme.fg('accent', title)), 0, 0));
     this.addChild(new Spacer(1));
-    this.addChild(new Text(fg('muted', 'Type to search · ↑↓ navigate · Enter select · Esc back'), 0, 0));
+    this.addChild(new Text(theme.fg('muted', 'Type to search · ↑↓ navigate · Enter select · Esc back'), 0, 0));
     this.addChild(new Spacer(1));
 
     this.searchInput = new Input();
@@ -241,19 +241,19 @@ class ModelSelectSubmenu extends Container {
       const item = this.filteredModels[i]!;
       const isSelected = i === this.selectedIndex;
       const isCurrent = item.id === this.currentModelId;
-      const checkmark = isCurrent ? fg('success', ' ✓') : '';
+      const checkmark = isCurrent ? theme.fg('success', ' ✓') : '';
 
-      const line = isSelected ? fg('accent', `→ ${item.label}`) + checkmark : `  ${item.label}` + checkmark;
+      const line = isSelected ? theme.fg('accent', `→ ${item.label}`) + checkmark : `  ${item.label}` + checkmark;
 
       this.listContainer.addChild(new Text(line, 0, 0));
     }
 
     if (startIndex > 0 || endIndex < total) {
-      this.listContainer.addChild(new Text(fg('muted', `(${this.selectedIndex + 1}/${total})`), 0, 0));
+      this.listContainer.addChild(new Text(theme.fg('muted', `(${this.selectedIndex + 1}/${total})`), 0, 0));
     }
 
     if (total === 0) {
-      this.listContainer.addChild(new Text(fg('muted', 'No matching models'), 0, 0));
+      this.listContainer.addChild(new Text(theme.fg('muted', 'No matching models'), 0, 0));
     }
   }
 
@@ -301,10 +301,10 @@ export class OMSettingsComponent extends Box implements Focusable {
   }
 
   constructor(config: OMSettingsConfig, callbacks: OMSettingsCallbacks, models: ModelOption[], tui: TUI) {
-    super(2, 1, (text: string) => bg('overlayBg', text));
+    super(2, 1, (text: string) => theme.bg('overlayBg', text));
 
     // Title
-    this.addChild(new Text(bold(fg('accent', 'Observational Memory Settings')), 0, 0));
+    this.addChild(new Text(theme.bold(theme.fg('accent', 'Observational Memory Settings')), 0, 0));
     this.addChild(new Spacer(1));
 
     // Build settings items

--- a/mastracode/src/tui/components/settings.ts
+++ b/mastracode/src/tui/components/settings.ts
@@ -10,7 +10,7 @@ import { Box, Container, Input, SelectList, SettingsList, Spacer, Text } from '@
 import type { Focusable, SelectItem, SettingItem } from '@mariozechner/pi-tui';
 import type { StorageBackend } from '../../onboarding/settings.js';
 import type { NotificationMode } from '../notify.js';
-import { fg, bg, bold, getSettingsListTheme, getSelectListTheme } from '../theme.js';
+import { theme, getSettingsListTheme, getSelectListTheme } from '../theme.js';
 
 // =============================================================================
 // Types
@@ -113,15 +113,15 @@ class StorageBackendSubmenu extends Container {
     this.clear();
 
     if (this.pendingBackend === 'pg') {
-      this.addChild(new Text(bold(fg('accent', 'PostgreSQL Connection')), 0, 0));
+      this.addChild(new Text(theme.bold(theme.fg('accent', 'PostgreSQL Connection')), 0, 0));
       this.addChild(new Spacer(1));
-      this.addChild(new Text(fg('muted', 'Enter a connection string:'), 0, 0));
-      this.addChild(new Text(fg('dim', 'e.g. postgresql://user:pass@localhost:5432/mydb'), 0, 0));
+      this.addChild(new Text(theme.fg('muted', 'Enter a connection string:'), 0, 0));
+      this.addChild(new Text(theme.fg('dim', 'e.g. postgresql://user:pass@localhost:5432/mydb'), 0, 0));
     } else {
-      this.addChild(new Text(bold(fg('accent', 'LibSQL Connection')), 0, 0));
+      this.addChild(new Text(theme.bold(theme.fg('accent', 'LibSQL Connection')), 0, 0));
       this.addChild(new Spacer(1));
-      this.addChild(new Text(fg('muted', 'Enter a URL or leave empty for default local file:'), 0, 0));
-      this.addChild(new Text(fg('dim', 'e.g. libsql://your-db.turso.io'), 0, 0));
+      this.addChild(new Text(theme.fg('muted', 'Enter a URL or leave empty for default local file:'), 0, 0));
+      this.addChild(new Text(theme.fg('dim', 'e.g. libsql://your-db.turso.io'), 0, 0));
     }
     this.addChild(new Spacer(1));
 
@@ -133,7 +133,7 @@ class StorageBackendSubmenu extends Container {
     this.addChild(this.input);
 
     this.addChild(new Spacer(1));
-    this.addChild(new Text(fg('dim', 'Enter to save · Esc to go back'), 0, 0));
+    this.addChild(new Text(theme.fg('dim', 'Enter to save · Esc to go back'), 0, 0));
   }
 
   handleInput(data: string): void {
@@ -192,10 +192,10 @@ export class SettingsComponent extends Box implements Focusable {
   }
 
   constructor(config: SettingsConfig, callbacks: SettingsCallbacks) {
-    super(2, 1, (text: string) => bg('overlayBg', text));
+    super(2, 1, (text: string) => theme.bg('overlayBg', text));
 
     // Title
-    this.addChild(new Text(bold(fg('accent', 'Settings')), 0, 0));
+    this.addChild(new Text(theme.bold(theme.fg('accent', 'Settings')), 0, 0));
     this.addChild(new Spacer(1));
 
     // Build settings items

--- a/mastracode/src/tui/components/shell-output.ts
+++ b/mastracode/src/tui/components/shell-output.ts
@@ -13,7 +13,13 @@ export class ShellOutputComponent extends Container {
     // Command header
     const statusIcon = exitCode === 0 ? '✓' : '✗';
     const statusColor = exitCode === 0 ? 'success' : 'error';
-    this.addChild(new Text(`${theme.fg(statusColor, statusIcon)} ${theme.bold(theme.fg('muted', '$'))} ${theme.fg('text', command)}`, 1, 0));
+    this.addChild(
+      new Text(
+        `${theme.fg(statusColor, statusIcon)} ${theme.bold(theme.fg('muted', '$'))} ${theme.fg('text', command)}`,
+        1,
+        0,
+      ),
+    );
 
     // Output
     const output = (stdout + (stderr ? (stdout ? '\n' : '') + stderr : '')).trimEnd();

--- a/mastracode/src/tui/components/shell-output.ts
+++ b/mastracode/src/tui/components/shell-output.ts
@@ -3,7 +3,7 @@
  */
 
 import { Container, Spacer, Text } from '@mariozechner/pi-tui';
-import { fg, bold } from '../theme.js';
+import { theme } from '../theme.js';
 
 export class ShellOutputComponent extends Container {
   constructor(command: string, stdout: string, stderr: string, exitCode: number) {
@@ -13,7 +13,7 @@ export class ShellOutputComponent extends Container {
     // Command header
     const statusIcon = exitCode === 0 ? '✓' : '✗';
     const statusColor = exitCode === 0 ? 'success' : 'error';
-    this.addChild(new Text(`${fg(statusColor, statusIcon)} ${bold(fg('muted', '$'))} ${fg('text', command)}`, 1, 0));
+    this.addChild(new Text(`${theme.fg(statusColor, statusIcon)} ${theme.bold(theme.fg('muted', '$'))} ${theme.fg('text', command)}`, 1, 0));
 
     // Output
     const output = (stdout + (stderr ? (stdout ? '\n' : '') + stderr : '')).trimEnd();
@@ -21,13 +21,13 @@ export class ShellOutputComponent extends Container {
       // Indent each line by 2 spaces
       const lines = output.split('\n');
       for (const line of lines) {
-        this.addChild(new Text(fg('toolOutput', `  ${line}`), 0, 0));
+        this.addChild(new Text(theme.fg('toolOutput', `  ${line}`), 0, 0));
       }
     }
 
     // Show exit code if non-zero
     if (exitCode !== 0) {
-      this.addChild(new Text(fg('error', `  Exit code: ${exitCode}`), 0, 0));
+      this.addChild(new Text(theme.fg('error', `  Exit code: ${exitCode}`), 0, 0));
     }
   }
 }

--- a/mastracode/src/tui/components/simple-progress.ts
+++ b/mastracode/src/tui/components/simple-progress.ts
@@ -4,7 +4,7 @@
  */
 
 import { Container, Text } from '@mariozechner/pi-tui';
-import { fg } from '../theme.js';
+import { theme } from '../theme.js';
 
 export interface SimpleProgressOptions {
   prefix?: string;
@@ -108,11 +108,11 @@ export class SimpleProgressComponent extends Container {
     // Add spinner or status icon
     if (this.isActive) {
       const spinner = this.getSpinner();
-      text += fg('accent', spinner) + ' ';
+      text += theme.fg('accent', spinner) + ' ';
     } else if (this.progress === 100) {
-      text += fg('success', '✓') + ' ';
+      text += theme.fg('success', '✓') + ' ';
     } else {
-      text += fg('error', '✗') + ' ';
+      text += theme.fg('error', '✗') + ' ';
     }
 
     // Add status text
@@ -120,13 +120,13 @@ export class SimpleProgressComponent extends Container {
 
     // Add progress percentage if enabled and available
     if (this.options.showPercentage && this.progress !== undefined) {
-      text += fg('dim', ` (${this.progress}%)`);
+      text += theme.fg('dim', ` (${this.progress}%)`);
     }
 
     // Add elapsed time if enabled
     if (this.options.showElapsed && this.isActive) {
       const elapsed = Math.floor((now - this.startTime) / 1000);
-      text += fg('dim', ` ${elapsed}s`);
+      text += theme.fg('dim', ` ${elapsed}s`);
     }
 
     this.addChild(new Text(text, 0, 0));

--- a/mastracode/src/tui/components/task-progress.ts
+++ b/mastracode/src/tui/components/task-progress.ts
@@ -7,7 +7,7 @@
 import { Container, Text, Spacer } from '@mariozechner/pi-tui';
 import type { TaskItem } from '@mastra/core/harness';
 import chalk from 'chalk';
-import { theme, getTheme } from '../theme.js';
+import { theme } from '../theme.js';
 
 export class TaskProgressComponent extends Container {
   private tasks: TaskItem[] = [];
@@ -61,7 +61,7 @@ export class TaskProgressComponent extends Container {
     switch (task.status) {
       case 'completed': {
         const icon = theme.fg('success', '\u2713');
-        const text = chalk.hex(getTheme().success).strikethrough(task.content);
+        const text = chalk.hex(theme.getTheme().success).strikethrough(task.content);
         return `${indent}${icon} ${text}`;
       }
       case 'in_progress': {

--- a/mastracode/src/tui/components/task-progress.ts
+++ b/mastracode/src/tui/components/task-progress.ts
@@ -43,7 +43,8 @@ export class TaskProgressComponent extends Container {
 
     // Hide the component when all tasks are completed
     if (completed === total) return;
-    const headerText = '  ' + theme.bold(theme.fg('accent', 'Tasks')) + theme.fg('dim', ` [${completed}/${total} completed]`);
+    const headerText =
+      '  ' + theme.bold(theme.fg('accent', 'Tasks')) + theme.fg('dim', ` [${completed}/${total} completed]`);
 
     this.addChild(new Spacer(1));
     this.addChild(new Text(headerText, 0, 0));

--- a/mastracode/src/tui/components/task-progress.ts
+++ b/mastracode/src/tui/components/task-progress.ts
@@ -7,7 +7,7 @@
 import { Container, Text, Spacer } from '@mariozechner/pi-tui';
 import type { TaskItem } from '@mastra/core/harness';
 import chalk from 'chalk';
-import { fg, bold, getTheme } from '../theme.js';
+import { theme, getTheme } from '../theme.js';
 
 export class TaskProgressComponent extends Container {
   private tasks: TaskItem[] = [];
@@ -43,7 +43,7 @@ export class TaskProgressComponent extends Container {
 
     // Hide the component when all tasks are completed
     if (completed === total) return;
-    const headerText = '  ' + bold(fg('accent', 'Tasks')) + fg('dim', ` [${completed}/${total} completed]`);
+    const headerText = '  ' + theme.bold(theme.fg('accent', 'Tasks')) + theme.fg('dim', ` [${completed}/${total} completed]`);
 
     this.addChild(new Spacer(1));
     this.addChild(new Text(headerText, 0, 0));
@@ -59,18 +59,18 @@ export class TaskProgressComponent extends Container {
 
     switch (task.status) {
       case 'completed': {
-        const icon = fg('success', '\u2713');
+        const icon = theme.fg('success', '\u2713');
         const text = chalk.hex(getTheme().success).strikethrough(task.content);
         return `${indent}${icon} ${text}`;
       }
       case 'in_progress': {
-        const icon = fg('warning', '\u25B6');
-        const text = bold(fg('warning', task.activeForm));
+        const icon = theme.fg('warning', '\u25B6');
+        const text = theme.bold(theme.fg('warning', task.activeForm));
         return `${indent}${icon} ${text}`;
       }
       case 'pending': {
-        const icon = fg('dim', '\u25CB');
-        const text = fg('dim', task.content);
+        const icon = theme.fg('dim', '\u25CB');
+        const text = theme.fg('dim', task.content);
         return `${indent}${icon} ${text}`;
       }
     }

--- a/mastracode/src/tui/components/thinking-settings.ts
+++ b/mastracode/src/tui/components/thinking-settings.ts
@@ -7,7 +7,7 @@
 
 import { Box, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
 import type { SelectItem, Focusable } from '@mariozechner/pi-tui';
-import { fg, bg, bold, getSelectListTheme } from '../theme.js';
+import { theme, getSelectListTheme } from '../theme.js';
 
 // =============================================================================
 // Types
@@ -47,18 +47,18 @@ export class ThinkingSettingsComponent extends Box implements Focusable {
   }
 
   constructor(currentLevel: string, callbacks: ThinkingSettingsCallbacks) {
-    super(2, 1, (text: string) => bg('overlayBg', text));
+    super(2, 1, (text: string) => theme.bg('overlayBg', text));
 
     // Title
-    this.addChild(new Text(bold(fg('accent', 'Thinking Level')), 0, 0));
+    this.addChild(new Text(theme.bold(theme.fg('accent', 'Thinking Level')), 0, 0));
     this.addChild(new Spacer(1));
-    this.addChild(new Text(fg('muted', 'Extended thinking for Anthropic models'), 0, 0));
+    this.addChild(new Text(theme.fg('muted', 'Extended thinking for Anthropic models'), 0, 0));
     this.addChild(new Spacer(1));
 
     // Build items
     const items: SelectItem[] = THINKING_LEVELS.map(level => ({
       value: level.id,
-      label: `  ${level.label}  ${fg('dim', level.description)}`,
+      label: `  ${level.label}  ${theme.fg('dim', level.description)}`,
     }));
 
     this.selectList = new SelectList(items, items.length, getSelectListTheme());
@@ -77,7 +77,7 @@ export class ThinkingSettingsComponent extends Box implements Focusable {
 
     this.addChild(this.selectList);
     this.addChild(new Spacer(1));
-    this.addChild(new Text(fg('dim', '  Enter to select · Esc to close'), 0, 0));
+    this.addChild(new Text(theme.fg('dim', '  Enter to select · Esc to close'), 0, 0));
   }
 
   handleInput(data: string): void {

--- a/mastracode/src/tui/components/thread-selector.ts
+++ b/mastracode/src/tui/components/thread-selector.ts
@@ -6,7 +6,7 @@
 import { Box, Container, fuzzyFilter, getEditorKeybindings, Input, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, TUI } from '@mariozechner/pi-tui';
 import type { HarnessThread } from '@mastra/core/harness';
-import { bg, fg, bold } from '../theme.js';
+import { theme } from '../theme.js';
 
 // =============================================================================
 // Types
@@ -53,7 +53,7 @@ export class ThreadSelectorComponent extends Box implements Focusable {
   }
 
   constructor(options: ThreadSelectorOptions) {
-    super(2, 1, text => bg('overlayBg', text));
+    super(2, 1, text => theme.bg('overlayBg', text));
 
     this.tui = options.tui;
     this.currentResourceId = options.currentResourceId;
@@ -87,9 +87,9 @@ export class ThreadSelectorComponent extends Box implements Focusable {
   }
 
   private buildUI(): void {
-    this.addChild(new Text(bold(fg('accent', 'Select Thread')), 0, 0));
+    this.addChild(new Text(theme.bold(theme.fg('accent', 'Select Thread')), 0, 0));
     this.addChild(new Spacer(1));
-    this.addChild(new Text(fg('muted', 'Type to search • ↑↓ navigate • Enter select • Esc cancel'), 0, 0));
+    this.addChild(new Text(theme.fg('muted', 'Type to search • ↑↓ navigate • Enter select • Esc cancel'), 0, 0));
     this.addChild(new Spacer(1));
 
     this.searchInput = new Input();
@@ -168,19 +168,19 @@ export class ThreadSelectorComponent extends Box implements Focusable {
 
       const isSelected = i === this.selectedIndex;
       const isCurrent = thread.id === this.currentThreadId;
-      const checkmark = isCurrent ? fg('success', ' ✓') : '';
+      const checkmark = isCurrent ? theme.fg('success', ' ✓') : '';
       const shortId = thread.id.slice(-6);
       const threadPath = thread.metadata?.projectPath as string | undefined;
-      const pathTag = threadPath ? fg('dim', ` [${threadPath.split('/').pop()}]`) : '';
+      const pathTag = threadPath ? theme.fg('dim', ` [${threadPath.split('/').pop()}]`) : '';
       const displayId = `${thread.resourceId}/${shortId}`;
-      const timeAgo = fg('muted', ` (${this.formatTimeAgo(thread.updatedAt)})`);
+      const timeAgo = theme.fg('muted', ` (${this.formatTimeAgo(thread.updatedAt)})`);
 
       // Only show custom titles (not auto-generated "New Thread")
       const hasCustomTitle = thread.title && thread.title !== 'New Thread';
 
       let line = '';
       if (isSelected) {
-        line = fg('accent', `→ ${displayId}`) + pathTag + timeAgo + checkmark;
+        line = theme.fg('accent', `→ ${displayId}`) + pathTag + timeAgo + checkmark;
       } else {
         line = `  ${displayId}` + pathTag + timeAgo + checkmark;
       }
@@ -190,19 +190,19 @@ export class ThreadSelectorComponent extends Box implements Focusable {
       // Show message preview or custom title on second line
       const preview = this.messagePreviews.get(thread.id);
       if (preview) {
-        this.listContainer.addChild(new Text(`     ${fg('muted', `"${preview}"`)}`, 0, 0));
+        this.listContainer.addChild(new Text(`     ${theme.fg('muted', `"${preview}"`)}`, 0, 0));
       } else if (hasCustomTitle) {
-        this.listContainer.addChild(new Text(`     ${fg('muted', `"${thread.title}"`)}`, 0, 0));
+        this.listContainer.addChild(new Text(`     ${theme.fg('muted', `"${thread.title}"`)}`, 0, 0));
       }
     }
 
     if (startIndex > 0 || endIndex < this.filteredThreads.length) {
-      const scrollInfo = fg('muted', `(${this.selectedIndex + 1}/${this.filteredThreads.length})`);
+      const scrollInfo = theme.fg('muted', `(${this.selectedIndex + 1}/${this.filteredThreads.length})`);
       this.listContainer.addChild(new Text(scrollInfo, 0, 0));
     }
 
     if (this.filteredThreads.length === 0) {
-      this.listContainer.addChild(new Text(fg('muted', 'No matching threads'), 0, 0));
+      this.listContainer.addChild(new Text(theme.fg('muted', 'No matching threads'), 0, 0));
     }
   }
 

--- a/mastracode/src/tui/components/tool-approval-dialog.ts
+++ b/mastracode/src/tui/components/tool-approval-dialog.ts
@@ -81,19 +81,19 @@ export class ToolApprovalDialogComponent extends Box implements Focusable {
     const categoryHint = this.categoryLabel
       ? `lways allow ${this.categoryLabel.toLowerCase()}`
       : 'lways allow category';
-    const dim = chalk.hex(getTheme().dim);
+    const dimColor = chalk.hex(getTheme().dim);
     const key = chalk.hex(getTheme().text).bold;
     this.addChild(
       new Text(
         theme.fg('accent', 'Allow? ') +
           key('y') +
-          theme.dim('es  ') +
+          dimColor('es  ') +
           key('n') +
-          theme.dim('o  ') +
+          dimColor('o  ') +
           key('a') +
-          theme.dim(categoryHint + '  ') +
+          dimColor(categoryHint + '  ') +
           key('Y') +
-          theme.dim('olo'),
+          dimColor('olo'),
         0,
         0,
       ),

--- a/mastracode/src/tui/components/tool-approval-dialog.ts
+++ b/mastracode/src/tui/components/tool-approval-dialog.ts
@@ -11,7 +11,7 @@
 import { Box, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
-import { theme, getTheme } from '../theme.js';
+import { theme } from '../theme.js';
 
 export type ApprovalAction =
   | { type: 'approve' }
@@ -81,8 +81,8 @@ export class ToolApprovalDialogComponent extends Box implements Focusable {
     const categoryHint = this.categoryLabel
       ? `lways allow ${this.categoryLabel.toLowerCase()}`
       : 'lways allow category';
-    const dimColor = chalk.hex(getTheme().dim);
-    const key = chalk.hex(getTheme().text).bold;
+    const dimColor = chalk.hex(theme.getTheme().dim);
+    const key = chalk.hex(theme.getTheme().text).bold;
     this.addChild(
       new Text(
         theme.fg('accent', 'Allow? ') +

--- a/mastracode/src/tui/components/tool-approval-dialog.ts
+++ b/mastracode/src/tui/components/tool-approval-dialog.ts
@@ -11,7 +11,7 @@
 import { Box, getEditorKeybindings, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
-import { bg, fg, getTheme } from '../theme.js';
+import { theme, getTheme } from '../theme.js';
 
 export type ApprovalAction =
   | { type: 'approve' }
@@ -44,7 +44,7 @@ export class ToolApprovalDialogComponent extends Box implements Focusable {
   }
 
   constructor(options: ToolApprovalDialogOptions) {
-    super(2, 1, text => bg('overlayBg', text));
+    super(2, 1, text => theme.bg('overlayBg', text));
 
     this.toolName = options.toolName;
     this.args = options.args;
@@ -56,24 +56,24 @@ export class ToolApprovalDialogComponent extends Box implements Focusable {
 
   private buildUI(): void {
     // Title
-    this.addChild(new Text(fg('warning', '⚠ Tool Approval Required'), 0, 0));
+    this.addChild(new Text(theme.fg('warning', '⚠ Tool Approval Required'), 0, 0));
     this.addChild(new Spacer(1));
 
     // Tool name
-    this.addChild(new Text(fg('accent', `Tool: `) + fg('text', this.toolName), 0, 0));
+    this.addChild(new Text(theme.fg('accent', `Tool: `) + theme.fg('text', this.toolName), 0, 0));
     if (this.categoryLabel) {
-      this.addChild(new Text(fg('accent', `Category: `) + fg('text', this.categoryLabel), 0, 0));
+      this.addChild(new Text(theme.fg('accent', `Category: `) + theme.fg('text', this.categoryLabel), 0, 0));
     }
     this.addChild(new Spacer(1));
 
     // Arguments (formatted)
-    this.addChild(new Text(fg('muted', 'Arguments:'), 0, 0));
+    this.addChild(new Text(theme.fg('muted', 'Arguments:'), 0, 0));
     const argsText = this.formatArgs(this.args);
     for (const line of argsText.split('\n').slice(0, 10)) {
-      this.addChild(new Text(fg('text', '  ' + line), 0, 0));
+      this.addChild(new Text(theme.fg('text', '  ' + line), 0, 0));
     }
     if (argsText.split('\n').length > 10) {
-      this.addChild(new Text(fg('muted', '  ... (truncated)'), 0, 0));
+      this.addChild(new Text(theme.fg('muted', '  ... (truncated)'), 0, 0));
     }
 
     this.addChild(new Spacer(1));
@@ -85,15 +85,15 @@ export class ToolApprovalDialogComponent extends Box implements Focusable {
     const key = chalk.hex(getTheme().text).bold;
     this.addChild(
       new Text(
-        fg('accent', 'Allow? ') +
+        theme.fg('accent', 'Allow? ') +
           key('y') +
-          dim('es  ') +
+          theme.dim('es  ') +
           key('n') +
-          dim('o  ') +
+          theme.dim('o  ') +
           key('a') +
-          dim(categoryHint + '  ') +
+          theme.dim(categoryHint + '  ') +
           key('Y') +
-          dim('olo'),
+          theme.dim('olo'),
         0,
         0,
       ),

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -9,7 +9,7 @@ import type { TUI } from '@mariozechner/pi-tui';
 import type { TaskItem } from '@mastra/core/harness';
 import chalk from 'chalk';
 import { highlight } from 'cli-highlight';
-import { theme, mastra, getTheme } from '../theme.js';
+import { theme, mastra } from '../theme.js';
 import { CollapsibleComponent } from './collapsible.js';
 import { ErrorDisplayComponent } from './error-display.js';
 import type { IToolExecutionComponent, ToolResult } from './tool-execution-interface.js';
@@ -572,7 +572,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       const maxDiags = shouldCollapse ? COLLAPSED_DIAG_LINES : diagnostics.entries.length;
       const entriesToShow = diagnostics.entries.slice(0, maxDiags);
       for (const diag of entriesToShow) {
-        const t = getTheme();
+        const t = theme.getTheme();
         const color = diag.severity === 'error' ? t.error : diag.severity === 'warning' ? t.warning : t.muted;
         const icon = diag.severity === 'error' ? '✗' : diag.severity === 'warning' ? '⚠' : 'ℹ';
         const location = diag.location ? chalk.hex(color)(diag.location) + ' ' : '';
@@ -649,7 +649,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
 
     // Use soft red for removed, green for added
     const removedColor = chalk.hex(mastra.red); // soft red
-    const addedColor = chalk.hex(getTheme().success); // soft green
+    const addedColor = chalk.hex(theme.getTheme().success); // soft green
 
     const maxLines = Math.max(oldLines.length, newLines.length);
 

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -576,14 +576,14 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
         const color = diag.severity === 'error' ? t.error : diag.severity === 'warning' ? t.warning : t.muted;
         const icon = diag.severity === 'error' ? '✗' : diag.severity === 'warning' ? '⚠' : 'ℹ';
         const location = diag.location ? chalk.hex(color)(diag.location) + ' ' : '';
-        const line = `  ${chalk.hex(color)(icon)} ${location}${fg('thinkingText', diag.message)}`;
+        const line = `  ${chalk.hex(color)(icon)} ${location}${theme.fg('thinkingText', diag.message)}`;
         this.contentBox.addChild(new Text(line, 0, 0));
       }
       if (shouldCollapse) {
         const remaining = diagnostics.entries.length - COLLAPSED_DIAG_LINES;
         this.contentBox.addChild(
           new Text(
-            fg('muted', `  ... ${remaining} more diagnostic${remaining > 1 ? 's' : ''} (ctrl+e to expand)`),
+            theme.fg('muted', `  ... ${remaining} more diagnostic${remaining > 1 ? 's' : ''} (ctrl+e to expand)`),
             0,
             0,
           ),

--- a/mastracode/src/tui/display.ts
+++ b/mastracode/src/tui/display.ts
@@ -7,17 +7,17 @@ import { parseError } from '../utils/errors.js';
 import type { NotificationMode, NotificationReason } from './notify.js';
 import { sendNotification } from './notify.js';
 import type { TUIState } from './state.js';
-import { fg } from './theme.js';
+import { theme } from './theme.js';
 
 export function showError(state: TUIState, message: string): void {
   state.chatContainer.addChild(new Spacer(1));
-  state.chatContainer.addChild(new Text(fg('error', `Error: ${message}`), 1, 0));
+  state.chatContainer.addChild(new Text(theme.fg('error', `Error: ${message}`), 1, 0));
   state.ui.requestRender();
 }
 
 export function showInfo(state: TUIState, message: string): void {
   state.chatContainer.addChild(new Spacer(1));
-  state.chatContainer.addChild(new Text(fg('muted', message), 1, 0));
+  state.chatContainer.addChild(new Text(theme.fg('muted', message), 1, 0));
   state.ui.requestRender();
 }
 
@@ -46,9 +46,9 @@ export function showFormattedError(
 
   if (isValidationError) {
     // Show a simplified message for validation errors
-    state.chatContainer.addChild(new Text(fg('error', 'Tool validation error - see details above'), 1, 0));
+    state.chatContainer.addChild(new Text(theme.fg('error', 'Tool validation error - see details above'), 1, 0));
     state.chatContainer.addChild(
-      new Text(fg('muted', '  Check the tool execution box for specific parameter requirements'), 1, 0),
+      new Text(theme.fg('muted', '  Check the tool execution box for specific parameter requirements'), 1, 0),
     );
   } else {
     // Show the main error message
@@ -59,15 +59,15 @@ export function showFormattedError(
     const retryDelay = 'retryDelay' in event ? event.retryDelay : parsed.retryDelay;
     if (retryable && retryDelay) {
       const seconds = Math.ceil(retryDelay / 1000);
-      errorText += fg('muted', ` (retry in ${seconds}s)`);
+      errorText += theme.fg('muted', ` (retry in ${seconds}s)`);
     }
 
-    state.chatContainer.addChild(new Text(fg('error', errorText), 1, 0));
+    state.chatContainer.addChild(new Text(theme.fg('error', errorText), 1, 0));
 
     // Add helpful hints based on error type
     const hint = getErrorHint(parsed.type);
     if (hint) {
-      state.chatContainer.addChild(new Text(fg('muted', `  Hint: ${hint}`), 1, 0));
+      state.chatContainer.addChild(new Text(theme.fg('muted', `  Hint: ${hint}`), 1, 0));
     }
   }
 

--- a/mastracode/src/tui/handlers/prompts.ts
+++ b/mastracode/src/tui/handlers/prompts.ts
@@ -7,7 +7,7 @@ import { Spacer } from '@mariozechner/pi-tui';
 import { AskQuestionDialogComponent } from '../components/ask-question-dialog.js';
 import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
 import { PlanApprovalInlineComponent } from '../components/plan-approval-inline.js';
-import { fg } from '../theme.js';
+import { theme } from '../theme.js';
 
 import type { EventHandlerContext } from './types.js';
 
@@ -127,7 +127,7 @@ export async function handleSandboxAccessRequest(
   return new Promise(resolve => {
     const questionComponent = new AskQuestionInlineComponent(
       {
-        question: `Grant sandbox access to "${requestedPath}"?\n${fg('dim', `Reason: ${reason}`)}`,
+        question: `Grant sandbox access to "${requestedPath}"?\n${theme.fg('dim', `Reason: ${reason}`)}`,
         options: [
           { label: 'Yes', description: 'Allow access to this directory' },
           { label: 'No', description: 'Deny access' },

--- a/mastracode/src/tui/index.ts
+++ b/mastracode/src/tui/index.ts
@@ -19,8 +19,6 @@ export { LoginSelectorComponent } from './components/login-selector.js';
 export { LoginDialogComponent } from './components/login-dialog.js';
 export {
   theme,
-  getTheme,
-  setTheme,
   applyThemeMode,
   getThemeMode,
   getMarkdownTheme,

--- a/mastracode/src/tui/index.ts
+++ b/mastracode/src/tui/index.ts
@@ -17,13 +17,5 @@ export { UserMessageComponent } from './components/user-message.js';
 export { ModelSelectorComponent, type ModelItem, type ModelSelectorOptions } from './components/model-selector.js';
 export { LoginSelectorComponent } from './components/login-selector.js';
 export { LoginDialogComponent } from './components/login-dialog.js';
-export {
-  theme,
-  applyThemeMode,
-  getThemeMode,
-  getMarkdownTheme,
-  getEditorTheme,
-  mastra,
-  mastraBrand,
-} from './theme.js';
+export { theme, applyThemeMode, getThemeMode, getMarkdownTheme, getEditorTheme, mastra, mastraBrand } from './theme.js';
 export type { ThemeColor, ThemeBg, ThemeColors, ThemeMode } from './theme.js';

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -36,7 +36,8 @@ export function renderCompletedTasksInline(
   insertIndex = -1,
   collapsed = false,
 ): void {
-  const headerText = theme.bold(theme.fg('accent', 'Tasks')) + theme.fg('dim', ` [${tasks.length}/${tasks.length} completed]`);
+  const headerText =
+    theme.bold(theme.fg('accent', 'Tasks')) + theme.fg('dim', ` [${tasks.length}/${tasks.length} completed]`);
 
   const container = new Container();
   container.addChild(new Spacer(1));
@@ -53,7 +54,11 @@ export function renderCompletedTasksInline(
   }
   if (remaining > 0) {
     container.addChild(
-      new Text(theme.fg('dim', `  ... ${remaining} more completed task${remaining > 1 ? 's' : ''} (ctrl+e to expand)`), 0, 0),
+      new Text(
+        theme.fg('dim', `  ... ${remaining} more completed task${remaining > 1 ? 's' : ''} (ctrl+e to expand)`),
+        0,
+        0,
+      ),
     );
   }
 

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -18,7 +18,7 @@ import { ToolExecutionComponentEnhanced } from './components/tool-execution-enha
 import { UserMessageComponent } from './components/user-message.js';
 import { formatToolResult } from './handlers/tool.js';
 import type { TUIState } from './state.js';
-import { getMarkdownTheme, theme, mastra, getTheme } from './theme.js';
+import { getMarkdownTheme, theme, mastra } from './theme.js';
 
 // Re-export so existing consumers can still import from here
 export { formatToolResult };
@@ -81,7 +81,7 @@ export function renderClearedTasksInline(state: TUIState, clearedTasks: TaskItem
   container.addChild(new Text(theme.fg('accent', `${label} cleared`), 0, 0));
   for (const task of clearedTasks) {
     const icon = task.status === 'completed' ? chalk.hex(mastra.green)('✓') : chalk.hex(mastra.darkGray)('○');
-    const text = chalk.hex(getTheme().dim).strikethrough(task.content);
+    const text = chalk.hex(theme.getTheme().dim).strikethrough(task.content);
     container.addChild(new Text(`  ${icon} ${text}`, 0, 0));
   }
   if (insertIndex >= 0) {

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -18,7 +18,7 @@ import { ToolExecutionComponentEnhanced } from './components/tool-execution-enha
 import { UserMessageComponent } from './components/user-message.js';
 import { formatToolResult } from './handlers/tool.js';
 import type { TUIState } from './state.js';
-import { getMarkdownTheme, fg, bold, mastra, getTheme } from './theme.js';
+import { getMarkdownTheme, theme, mastra, getTheme } from './theme.js';
 
 // Re-export so existing consumers can still import from here
 export { formatToolResult };
@@ -36,7 +36,7 @@ export function renderCompletedTasksInline(
   insertIndex = -1,
   collapsed = false,
 ): void {
-  const headerText = bold(fg('accent', 'Tasks')) + fg('dim', ` [${tasks.length}/${tasks.length} completed]`);
+  const headerText = theme.bold(theme.fg('accent', 'Tasks')) + theme.fg('dim', ` [${tasks.length}/${tasks.length} completed]`);
 
   const container = new Container();
   container.addChild(new Spacer(1));
@@ -53,7 +53,7 @@ export function renderCompletedTasksInline(
   }
   if (remaining > 0) {
     container.addChild(
-      new Text(fg('dim', `  ... ${remaining} more completed task${remaining > 1 ? 's' : ''} (ctrl+e to expand)`), 0, 0),
+      new Text(theme.fg('dim', `  ... ${remaining} more completed task${remaining > 1 ? 's' : ''} (ctrl+e to expand)`), 0, 0),
     );
   }
 
@@ -73,7 +73,7 @@ export function renderClearedTasksInline(state: TUIState, clearedTasks: TaskItem
   container.addChild(new Spacer(1));
   const count = clearedTasks.length;
   const label = count === 1 ? 'Task' : 'Tasks';
-  container.addChild(new Text(fg('accent', `${label} cleared`), 0, 0));
+  container.addChild(new Text(theme.fg('accent', `${label} cleared`), 0, 0));
   for (const task of clearedTasks) {
     const icon = task.status === 'completed' ? chalk.hex(mastra.green)('✓') : chalk.hex(mastra.darkGray)('○');
     const text = chalk.hex(getTheme().dim).strikethrough(task.content);

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -17,7 +17,7 @@ import { showError, showInfo } from './display.js';
 import { addUserMessage } from './render-messages.js';
 import type { TUIState } from './state.js';
 import { updateStatusLine } from './status-line.js';
-import { fg } from './theme.js';
+import { theme } from './theme.js';
 
 // =============================================================================
 // Keyboard Shortcuts
@@ -171,15 +171,15 @@ export function buildLayout(state: TUIState, refreshModelAuthStatus: () => Promi
     `User: ${getUserId(state.projectInfo.rootPath)}`,
   ]
     .filter(Boolean)
-    .map(line => fg('muted', line as string))
+    .map(line => theme.fg('muted', line as string))
     .join('\n');
 
-  const sep = fg('dim', ' · ');
+  const sep = theme.fg('dim', ' · ');
   const hintParts: string[] = [];
   if (state.harness.listModes().length > 1) {
-    hintParts.push(`${fg('accent', '⇧+Tab')} ${fg('muted', 'cycle modes')}`);
+    hintParts.push(`${theme.fg('accent', '⇧+Tab')} ${theme.fg('muted', 'cycle modes')}`);
   }
-  hintParts.push(`${fg('accent', '/help')} ${fg('muted', 'info & shortcuts')}`);
+  hintParts.push(`${theme.fg('accent', '/help')} ${theme.fg('muted', 'info & shortcuts')}`);
   const instructions = `  ${hintParts.join(sep)}`;
 
   state.ui.addChild(new Spacer(1));

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -7,7 +7,7 @@ import chalk from 'chalk';
 import { applyGradientSweep } from './components/obi-loader.js';
 import { formatObservationStatus, formatReflectionStatus } from './components/om-progress.js';
 import type { TUIState } from './state.js';
-import { fg, mastra, tintHex, getThemeMode } from './theme.js';
+import { theme, mastra, tintHex, getThemeMode } from './theme.js';
 
 // Colors for OM modes
 const OBSERVER_COLOR = mastra.orange;
@@ -90,7 +90,7 @@ export function updateStatusLine(state: TUIState): void {
     modeBadge = chalk.bgRgb(mr, mg, mb).hex('#000000').bold(` ${badgeName.toLowerCase()} `);
     modeBadgeWidth = badgeName.length + 2;
   } else if (badgeName) {
-    modeBadge = fg('dim', badgeName) + ' ';
+    modeBadge = theme.fg('dim', badgeName) + ' ';
     modeBadgeWidth = badgeName.length + 1;
   }
 
@@ -135,7 +135,7 @@ export function updateStatusLine(state: TUIState): void {
   const styleModelId = (id: string): string => {
     if (!state.modelAuthStatus.hasAuth) {
       const envVar = state.modelAuthStatus.apiKeyEnvVar;
-      return fg('dim', id) + fg('error', ' ✗') + fg('muted', envVar ? ` (${envVar})` : ' (no key)');
+      return theme.fg('dim', id) + theme.fg('error', ' ✗') + theme.fg('muted', envVar ? ` (${envVar})` : ' (no key)');
     }
     // Tinted near-black background from mode color
     const tintBg = modeColor ? tintHex(modeColor, 0.15) : undefined;
@@ -202,7 +202,7 @@ export function updateStatusLine(state: TUIState): void {
     shortModeBadgeWidth = shortName.length + 2;
   } else if (badgeName) {
     const shortName = badgeName.toLowerCase().charAt(0);
-    shortModeBadge = fg('dim', shortName) + ' ';
+    shortModeBadge = theme.fg('dim', shortName) + ' ';
     shortModeBadgeWidth = shortName.length + 1;
   }
 
@@ -266,7 +266,7 @@ export function updateStatusLine(state: TUIState): void {
     if (dirText) {
       parts.push({
         plain: dirText,
-        styled: fg('dim', dirText),
+        styled: theme.fg('dim', dirText),
       });
     }
     const totalPlain =

--- a/mastracode/src/tui/theme.ts
+++ b/mastracode/src/tui/theme.ts
@@ -273,14 +273,14 @@ let currentTheme: ThemeColors = darkTheme;
 /**
  * Get the current theme colors.
  */
-export function getTheme(): ThemeColors {
+function getTheme(): ThemeColors {
   return currentTheme;
 }
 
 /**
  * Set the current theme.
  */
-export function setTheme(colors: ThemeColors): void {
+function setTheme(colors: ThemeColors): void {
   currentTheme = colors;
 }
 

--- a/mastracode/src/tui/theme.ts
+++ b/mastracode/src/tui/theme.ts
@@ -299,7 +299,7 @@ export function applyThemeMode(mode: ThemeMode): void {
 /**
  * Apply foreground color from theme.
  */
-export function fg(color: ThemeColor, text: string): string {
+function fg(color: ThemeColor, text: string): string {
   const hex = currentTheme[color];
   if (!hex) return text;
   return chalk.hex(hex)(text);
@@ -308,7 +308,7 @@ export function fg(color: ThemeColor, text: string): string {
 /**
  * Apply background color from theme.
  */
-export function bg(color: ThemeBg, text: string): string {
+function bg(color: ThemeBg, text: string): string {
   const hex = currentTheme[color];
   if (!hex) return text;
   return chalk.bgHex(hex)(text);
@@ -317,21 +317,21 @@ export function bg(color: ThemeBg, text: string): string {
 /**
  * Apply bold styling.
  */
-export function bold(text: string): string {
+function bold(text: string): string {
   return chalk.bold(text);
 }
 
 /**
  * Apply italic styling.
  */
-export function italic(text: string): string {
+function italic(text: string): string {
   return chalk.italic(text);
 }
 
 /**
  * Apply dim styling.
  */
-export function dim(text: string): string {
+function dim(text: string): string {
   return chalk.dim(text);
 }
 
@@ -350,7 +350,7 @@ export function getContrastText(hexBg: string): string {
 }
 
 // =============================================================================
-// Theme Object (for compatibility with pi-tui components)
+// Theme Object
 // =============================================================================
 
 export const theme = {


### PR DESCRIPTION
## Description

Remove individual exports of theme helper functions (`fg`, `bg`, `bold`, `italic`, `dim`) from `theme.ts` and migrate all 28 consuming files to use the `theme` object exclusively.

This fixes a fatal "fg is not defined" crash on startup introduced in #13487, where `tool-execution-enhanced.ts` used bare `fg()` without importing it. The root cause was that theme functions were exported both individually and as properties of the `theme` object, leading to inconsistent usage across the codebase. By making the `theme` object the single access point, this class of error becomes impossible.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Code refactoring

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a fatal startup crash so the TUI no longer fails immediately on launch.

* **Refactor**
  * Unified theming across the TUI: consistent color and emphasis handling applied to dialogs, lists, progress indicators, outputs, and status lines for more consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->