### PR TITLE
fix(core): skills tests

### DIFF
--- a/packages/core/src/workspace/skills/skill-versioning.test.ts
+++ b/packages/core/src/workspace/skills/skill-versioning.test.ts
@@ -882,7 +882,7 @@ describe('WorkspaceSkillsImpl with VersionedSkillSource', () => {
 
   it('should read references through versioned source', async () => {
     const { workspaceSkills, skillARef } = createIntegrationSetup();
-    const refContent = await workspaceSkills.getReference('brand-guidelines', 'colors.md');
+    const refContent = await workspaceSkills.getReference('brand-guidelines', 'references/colors.md');
 
     expect(refContent).not.toBeNull();
     expect(refContent).toBe(skillARef);

--- a/packages/editor/src/editor-skills.test.ts
+++ b/packages/editor/src/editor-skills.test.ts
@@ -938,7 +938,7 @@ describe('editor.skill — end-to-end: publish → agent → skill discovery', (
     expect(fullSkill!.references).toContain('guide.md');
 
     // 9. Verify reference content can be read from the blob store
-    const guideContent = await workspace!.skills!.getReference('e2e-skill', 'guide.md');
+    const guideContent = await workspace!.skills!.getReference('e2e-skill', 'references/guide.md');
     expect(guideContent).toBeDefined();
     expect(guideContent).toContain('This is a reference guide.');
   });
@@ -1966,7 +1966,7 @@ describe('editor.skill — live strategy execution', () => {
     expect(workspace).toBeInstanceOf(Workspace);
 
     const skills = workspace!.skills!;
-    const refContent = await skills.getReference('api-docs', 'endpoints.md');
+    const refContent = await skills.getReference('api-docs', 'references/endpoints.md');
     expect(refContent).toContain('GET /users - List all users');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes adjusting expected reference paths; no production logic is modified.
> 
> **Overview**
> Updates skills-related tests to use **skill-root-relative reference paths** when calling `WorkspaceSkillsImpl.getReference()` against versioned/blob-backed sources (e.g., `references/guide.md` instead of `guide.md`).
> 
> This aligns the core and editor E2E test suites with the current reference path resolution behavior for published skills.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f733e50de0db65843b7a214f46590ee155b35f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test path references to maintain consistency with internal reference organization. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->