### PR TITLE
feat(mastracode): add Claude Max OAuth ToS warning

### DIFF
--- a/.changeset/claude-max-oauth-warning.md
+++ b/.changeset/claude-max-oauth-warning.md
@@ -1,0 +1,11 @@
+---
+'mastracode': patch
+---
+
+Added Claude Max OAuth warning for Anthropic authentication
+
+A warning now appears when authenticating with Anthropic via OAuth, alerting that using a Claude Max subscription through OAuth is a grey area that may violate Anthropic's Terms of Service.
+
+- During `/login` or onboarding: **Continue** proceeds with OAuth, **Cancel** returns to the provider selection screen.
+- At startup (when existing Anthropic OAuth credentials are detected and the warning has not been acknowledged): **Continue** keeps credentials, **Remove OAuth** logs out from Anthropic.
+- The startup warning only appears once — acknowledging it persists the choice in settings.

--- a/docs/src/content/en/docs/mastra-code/configuration.mdx
+++ b/docs/src/content/en/docs/mastra-code/configuration.mdx
@@ -22,6 +22,12 @@ Mastra Code authenticates with AI providers through OAuth. Run `/login` in the T
 
 OAuth credentials are stored in `auth.json` alongside the database in the [app data directory](#database-location).
 
+### Anthropic OAuth warning
+
+Authenticating with a Claude Max subscription is a grey area that may violate Anthropic's Terms of Service. Mastra Code displays a warning each time you start the Anthropic OAuth flow (via `/login` or during onboarding) with **Continue** and **Cancel** options. Cancel returns you to the provider selection screen.
+
+If you already have Anthropic OAuth credentials and have not previously acknowledged the warning, Mastra Code also shows the warning once at startup with **Continue** (keep credentials) and **Remove OAuth** (log out from Anthropic) options.
+
 ### Model routing
 
 For providers not covered by OAuth, Mastra Code uses Mastra's [model router](/models), which auto-detects API keys from environment variables:
@@ -252,10 +258,10 @@ Mastra Code detects your terminal's color scheme and applies a matching dark or 
 ### Detection order
 
 1. `MASTRA_THEME` environment variable — explicit `dark` or `light`
-2. Persisted setting from `/theme` command (stored in `settings.json`)
-3. OSC 11 query — asks your terminal for its actual background color
-4. `COLORFGBG` environment variable (set by some terminals like iTerm2 and Konsole)
-5. Falls back to dark theme
+1. Persisted setting from `/theme` command (stored in `settings.json`)
+1. OSC 11 query — asks your terminal for its actual background color
+1. `COLORFGBG` environment variable (set by some terminals like iTerm2 and Konsole)
+1. Falls back to dark theme
 
 ### Switching themes
 

--- a/mastracode/src/auth/claude-max-warning.ts
+++ b/mastracode/src/auth/claude-max-warning.ts
@@ -1,0 +1,11 @@
+/**
+ * Claude Max OAuth warning constants.
+ *
+ * Shared between the TUI startup check, the /login command, and onboarding so
+ * the provider ID and user-facing message stay in sync.
+ */
+
+export const ANTHROPIC_OAUTH_PROVIDER_ID = 'anthropic';
+
+export const CLAUDE_MAX_OAUTH_WARNING_MESSAGE =
+  'OAuth with a Claude Max plan is a grey area and may violate your Terms of Service with Anthropic. Proceed at your own risk.';

--- a/mastracode/src/onboarding/onboarding-inline.ts
+++ b/mastracode/src/onboarding/onboarding-inline.ts
@@ -15,6 +15,7 @@
 import { Box, Container, SelectList, Spacer, Text } from '@mariozechner/pi-tui';
 import type { Focusable, SelectItem, TUI } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
+import { ANTHROPIC_OAUTH_PROVIDER_ID, CLAUDE_MAX_OAUTH_WARNING_MESSAGE } from '../auth/claude-max-warning.js';
 import { theme, getSelectListTheme, fg, bold, mastra } from '../tui/theme.js';
 import type { ModePack, OMPack } from './packs.js';
 
@@ -62,7 +63,7 @@ export interface OnboardingOptions {
 // Steps
 // ---------------------------------------------------------------------------
 
-type StepId = 'welcome' | 'auth' | 'modePack' | 'omPack' | 'yolo' | 'done';
+type StepId = 'welcome' | 'auth' | 'claudeMaxWarning' | 'modePack' | 'omPack' | 'yolo' | 'done';
 
 // ---------------------------------------------------------------------------
 // Component
@@ -165,6 +166,8 @@ export class OnboardingInlineComponent extends Container implements Focusable {
         return this.renderWelcome();
       case 'auth':
         return this.renderAuth();
+      case 'claudeMaxWarning':
+        return this.renderClaudeMaxWarning();
       case 'modePack':
         return this.renderModePack();
       case 'omPack':
@@ -255,6 +258,9 @@ export class OnboardingInlineComponent extends Container implements Focusable {
     this.selectList.onSelect = (item: SelectItem) => {
       if (item.value === '__skip') {
         this.renderStep('modePack');
+      } else if (item.value === ANTHROPIC_OAUTH_PROVIDER_ID) {
+        // Show Claude Max ToS warning before proceeding
+        this.renderStep('claudeMaxWarning');
       } else {
         this.loginRequested = true;
         this.loginProvider = item.value;
@@ -271,6 +277,44 @@ export class OnboardingInlineComponent extends Container implements Focusable {
     box.addChild(this.selectList);
     box.addChild(new Spacer(1));
     box.addChild(new Text(fg('dim', '↑↓ navigate · Enter select · Esc skip'), 0, 0));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step: Claude Max OAuth Warning
+  // ---------------------------------------------------------------------------
+
+  private renderClaudeMaxWarning(): void {
+    const box = this.makeBox();
+    box.addChild(new Text(bold(fg('warning', '⚠ Claude Max OAuth Warning')), 0, 0));
+    box.addChild(new Spacer(1));
+    box.addChild(new Text(fg('text', CLAUDE_MAX_OAUTH_WARNING_MESSAGE), 0, 0));
+    box.addChild(new Spacer(1));
+
+    const items: SelectItem[] = [
+      { value: 'continue', label: `  ${fg('success', 'Continue')}` },
+      { value: 'cancel', label: `  ${fg('dim', 'Cancel')}` },
+    ];
+    this.selectList = new SelectList(items, items.length, getSelectListTheme());
+    this.selectList.onSelect = (item: SelectItem) => {
+      if (item.value === 'continue') {
+        this.loginRequested = true;
+        this.loginProvider = ANTHROPIC_OAUTH_PROVIDER_ID;
+        this.options.onLogin(ANTHROPIC_OAUTH_PROVIDER_ID, () => {
+          this.renderStep('modePack');
+        });
+      } else {
+        // Cancel — go back to auth provider list
+        this.renderStep('auth');
+      }
+    };
+    this.selectList.onCancel = () => {
+      // Esc — go back to auth provider list
+      this.renderStep('auth');
+    };
+
+    box.addChild(this.selectList);
+    box.addChild(new Spacer(1));
+    box.addChild(new Text(fg('dim', '↑↓ navigate · Enter select · Esc go back'), 0, 0));
   }
 
   // ---------------------------------------------------------------------------

--- a/mastracode/src/onboarding/settings.ts
+++ b/mastracode/src/onboarding/settings.ts
@@ -55,6 +55,8 @@ export interface GlobalSettings {
     version: number;
     modePackId: string | null;
     omPackId: string | null;
+    /** ISO timestamp when the user acknowledged the Claude Max OAuth ToS warning. */
+    claudeMaxOAuthWarningAcknowledgedAt: string | null;
   };
   // Global model preferences (applied to new threads)
   models: {
@@ -106,6 +108,7 @@ const DEFAULTS: GlobalSettings = {
     version: 0,
     modePackId: null,
     omPackId: null,
+    claudeMaxOAuthWarningAcknowledgedAt: null,
   },
   models: {
     activeModelPackId: null,

--- a/mastracode/src/tui/claude-max-warning.ts
+++ b/mastracode/src/tui/claude-max-warning.ts
@@ -1,0 +1,69 @@
+/**
+ * Claude Max OAuth warning prompt.
+ *
+ * Renders an inline question asking the user whether to proceed with
+ * Anthropic OAuth (grey-area ToS), with different options depending on
+ * whether we're in the login/onboarding flow or the startup check.
+ */
+
+import { Spacer } from '@mariozechner/pi-tui';
+import { CLAUDE_MAX_OAUTH_WARNING_MESSAGE } from '../auth/claude-max-warning.js';
+import { AskQuestionInlineComponent } from './components/ask-question-inline.js';
+import type { TUIState } from './state.js';
+
+export type ClaudeMaxWarningMode = 'login' | 'startup';
+export type ClaudeMaxWarningResult = 'continue' | 'cancel' | 'remove';
+
+/**
+ * Show the Claude Max OAuth warning inline and return the user's choice.
+ *
+ * - **login** mode: "Continue" / "Cancel"
+ * - **startup** mode: "Continue" / "Remove OAuth"
+ */
+export function showClaudeMaxOAuthWarning(
+  state: TUIState,
+  mode: ClaudeMaxWarningMode,
+): Promise<ClaudeMaxWarningResult> {
+  const options =
+    mode === 'login'
+      ? [
+          { label: 'Continue', description: 'Proceed with Anthropic OAuth' },
+          { label: 'Cancel', description: 'Go back' },
+        ]
+      : [
+          { label: 'Continue', description: 'Keep Anthropic OAuth credentials' },
+          { label: 'Remove OAuth', description: 'Log out from Anthropic' },
+        ];
+
+  return new Promise<ClaudeMaxWarningResult>(resolve => {
+    const questionComponent = new AskQuestionInlineComponent(
+      {
+        question: CLAUDE_MAX_OAUTH_WARNING_MESSAGE,
+        options,
+        formatResult: answer => `Claude Max OAuth warning → ${answer}`,
+        isNegativeAnswer: answer => answer !== 'Continue',
+        onSubmit: answer => {
+          state.activeInlineQuestion = undefined;
+          if (answer === 'Continue') {
+            resolve('continue');
+          } else if (answer === 'Cancel') {
+            resolve('cancel');
+          } else {
+            resolve('remove');
+          }
+        },
+        onCancel: () => {
+          state.activeInlineQuestion = undefined;
+          resolve('cancel');
+        },
+      },
+      state.ui,
+    );
+
+    state.activeInlineQuestion = questionComponent;
+    state.chatContainer.addChild(questionComponent);
+    state.chatContainer.addChild(new Spacer(1));
+    state.ui.requestRender();
+    state.chatContainer.invalidate();
+  });
+}

--- a/mastracode/src/tui/commands/login.ts
+++ b/mastracode/src/tui/commands/login.ts
@@ -1,5 +1,8 @@
 import { Spacer } from '@mariozechner/pi-tui';
+import { ANTHROPIC_OAUTH_PROVIDER_ID } from '../../auth/claude-max-warning.js';
 import { getOAuthProviders, PROVIDER_DEFAULT_MODELS } from '../../auth/storage.js';
+import { loadSettings, saveSettings } from '../../onboarding/settings.js';
+import { showClaudeMaxOAuthWarning } from '../claude-max-warning.js';
 import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
 import { LoginDialogComponent } from '../components/login-dialog.js';
 import type { SlashCommandContext } from './types.js';
@@ -11,6 +14,17 @@ async function performLogin(ctx: SlashCommandContext, providerId: string): Promi
   if (!ctx.authStorage) {
     ctx.showError('Auth storage not configured');
     return;
+  }
+
+  // Show Claude Max OAuth warning every time the user attempts Anthropic login
+  if (providerId === ANTHROPIC_OAUTH_PROVIDER_ID) {
+    const warningResult = await showClaudeMaxOAuthWarning(ctx.state, 'login');
+    if (warningResult !== 'continue') {
+      return; // cancel — caller returns to provider selection
+    }
+    const settings = loadSettings();
+    settings.onboarding.claudeMaxOAuthWarningAcknowledgedAt = new Date().toISOString();
+    saveSettings(settings);
   }
 
   return new Promise(resolve => {

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -6,6 +6,7 @@ import { Spacer } from '@mariozechner/pi-tui';
 import type { Component } from '@mariozechner/pi-tui';
 import type { HarnessEvent } from '@mastra/core/harness';
 import type { Workspace } from '@mastra/core/workspace';
+import { ANTHROPIC_OAUTH_PROVIDER_ID } from '../auth/claude-max-warning.js';
 import { getOAuthProviders } from '../auth/storage.js';
 import {
   OnboardingInlineComponent,
@@ -18,6 +19,7 @@ import {
 import type { OnboardingResult, ProviderAccess, ProviderAccessLevel } from '../onboarding/index.js';
 import { dispatchSlashCommand } from './command-dispatch.js';
 import type { SlashCommandContext } from './commands/types.js';
+import { showClaudeMaxOAuthWarning } from './claude-max-warning.js';
 import { AskQuestionInlineComponent } from './components/ask-question-inline.js';
 import { LoginDialogComponent } from './components/login-dialog.js';
 import { ModelSelectorComponent } from './components/model-selector.js';
@@ -281,6 +283,9 @@ export class MastraTUI {
     // Render existing tasks if any
     await renderExistingTasks(this.state);
 
+    // One-time Claude Max OAuth warning at startup
+    await this.checkClaudeMaxOAuthWarning();
+
     // Show deferred thread lock prompt (must happen after TUI is started)
     if (this.state.pendingLockConflict) {
       this.showThreadLockPrompt(this.state.pendingLockConflict.threadTitle, this.state.pendingLockConflict.ownerPid);
@@ -433,6 +438,31 @@ export class MastraTUI {
     this.state.chatContainer.addChild(new Spacer(1));
     this.state.ui.requestRender();
     this.state.chatContainer.invalidate();
+  }
+
+  /**
+   * One-time startup check: if the user has Anthropic OAuth credentials and
+   * hasn't yet acknowledged the Claude Max ToS warning, show it now.
+   */
+  private async checkClaudeMaxOAuthWarning(): Promise<void> {
+    const authStorage = this.state.authStorage;
+    if (!authStorage || !authStorage.isLoggedIn(ANTHROPIC_OAUTH_PROVIDER_ID)) return;
+
+    const settings = loadSettings();
+    if (settings.onboarding.claudeMaxOAuthWarningAcknowledgedAt) return;
+
+    const result = await showClaudeMaxOAuthWarning(this.state, 'startup');
+
+    if (result === 'continue') {
+      settings.onboarding.claudeMaxOAuthWarningAcknowledgedAt = new Date().toISOString();
+      saveSettings(settings);
+    } else if (result === 'remove') {
+      authStorage.logout(ANTHROPIC_OAUTH_PROVIDER_ID);
+      settings.onboarding.claudeMaxOAuthWarningAcknowledgedAt = new Date().toISOString();
+      saveSettings(settings);
+      await this.refreshModelAuthStatus();
+    }
+    // 'cancel' (Esc) — leave settings unchanged, will show again next startup
   }
 
   /**
@@ -636,6 +666,13 @@ export class MastraTUI {
           resolve();
         },
         onLogin: (providerId: string, done: () => void) => {
+          // Persist Claude Max OAuth warning acknowledgement when proceeding
+          // through onboarding (the warning step already showed in the wizard).
+          if (providerId === ANTHROPIC_OAUTH_PROVIDER_ID) {
+            const s = loadSettings();
+            s.onboarding.claudeMaxOAuthWarningAcknowledgedAt = new Date().toISOString();
+            saveSettings(s);
+          }
           this.performLogin(providerId).then(async () => {
             const updatedAccess = await buildAccess();
             component.updateModePacks(getAvailableModePacks(updatedAccess, savedSettings.customModelPacks));


### PR DESCRIPTION
Adds a warning before Anthropic OAuth authentication alerting users that using a Claude Max subscription via OAuth may violate Anthropic's Terms of Service.

The warning appears in three places:

- **`/login`**: Every time the user selects Anthropic, a Continue/Cancel prompt appears before starting the OAuth flow. Cancel returns to the provider list.
- **Onboarding**: Same behavior as `/login` — an inline wizard step shows the warning before proceeding to login.
- **Startup**: If existing Anthropic OAuth credentials are detected and haven't been acknowledged yet, a one-time Continue/Remove OAuth prompt appears. "Remove OAuth" logs out the Anthropic provider. Acknowledgement is persisted in settings so it only shows once.

No new dependencies. No test changes (no existing TUI test harness for this flow).

<img width="766" height="750" alt="Screenshot 2026-02-25 at 12 31 54 PM" src="https://github.com/user-attachments/assets/8f9134b1-6f83-4bc2-84dc-67a7989932dd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a Claude Max OAuth warning during Anthropic authentication (login/onboarding) with Continue or Cancel; Continue records acknowledgment.
  * Shows a one-time startup warning if Anthropic OAuth credentials exist; Continue keeps credentials, Remove logs out from Anthropic, acknowledgment is persisted.

* **Documentation**
  * Documents the Anthropic OAuth warning behavior and user flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->