### PR TITLE
fix(server): prepend references/ in skill reference route handler

### DIFF
--- a/.changeset/fix-skill-reference-path-handler.md
+++ b/.changeset/fix-skill-reference-path-handler.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fix skill reference endpoint returning 404 by prepending `references/` to the path passed to `getReference()`, aligning the HTTP handler with the skill-root-relative path contract introduced in #13363.

--- a/.changeset/fix-skill-reference-path-handler.md
+++ b/.changeset/fix-skill-reference-path-handler.md
@@ -2,4 +2,4 @@
 '@mastra/server': patch
 ---
 
-Fix skill reference endpoint returning 404 by prepending `references/` to the path passed to `getReference()`, aligning the HTTP handler with the skill-root-relative path contract introduced in #13363.
+Fixed the skill reference endpoint (`GET /workspaces/:workspaceId/skills/:skillName/references/:referencePath`) returning 404 for valid reference files.

--- a/packages/server/src/server/handlers/workspace.test.ts
+++ b/packages/server/src/server/handlers/workspace.test.ts
@@ -1259,7 +1259,7 @@ describe('Workspace Handlers', () => {
       });
 
       expect(skills.maybeRefresh).toHaveBeenCalledWith({ requestContext: mockRequestContext });
-      expect(skills.getReference).toHaveBeenCalledWith('my-skill', 'api.md');
+      expect(skills.getReference).toHaveBeenCalledWith('my-skill', 'references/api.md');
     });
 
     it('WORKSPACE_SEARCH_SKILLS_ROUTE should call maybeRefresh with requestContext', async () => {

--- a/packages/server/src/server/handlers/workspace.ts
+++ b/packages/server/src/server/handlers/workspace.ts
@@ -1047,7 +1047,9 @@ export const WORKSPACE_GET_SKILL_REFERENCE_ROUTE = createRoute({
       // Decode the reference path (it may be URL encoded)
       const decodedPath = decodeURIComponent(referencePath);
 
-      const content = await skills.getReference(skillName, decodedPath);
+      // getReference expects a path relative to skill.path, so prepend 'references/'
+      // since the URL path already contains the literal /references/ segment
+      const content = await skills.getReference(skillName, `references/${decodedPath}`);
       if (content === null) {
         throw new HTTPException(404, { message: `Reference "${decodedPath}" not found in skill "${skillName}"` });
       }

--- a/packages/server/src/server/handlers/workspace.ts
+++ b/packages/server/src/server/handlers/workspace.ts
@@ -1047,6 +1047,9 @@ export const WORKSPACE_GET_SKILL_REFERENCE_ROUTE = createRoute({
       // Decode the reference path (it may be URL encoded)
       const decodedPath = decodeURIComponent(referencePath);
 
+      // Prevent path traversal via the reference path parameter
+      assertSafeFilePath(decodedPath);
+
       // getReference expects a path relative to skill.path, so prepend 'references/'
       // since the URL path already contains the literal /references/ segment
       const content = await skills.getReference(skillName, `references/${decodedPath}`);


### PR DESCRIPTION
## Description

After #13363 changed `getReference()` to accept skill-root-relative paths (removing the hardcoded `references/` prefix), the HTTP handler for `GET /workspaces/:workspaceId/skills/:skillName/references/:referencePath` was not updated. The handler passed the raw `:referencePath` param (e.g. `api.md`) but `getReference()` now expects `references/api.md` since it no longer auto-prepends the subdirectory.

This caused a 404 for every call to the skill reference endpoint, failing all server adapter tests (Express, Fastify, Hono, Koa).

## Related Issue(s)

Regression from #13363

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed skill reference endpoint returning 404 errors, enabling proper access to skill reference documentation.
* **Chores**
  * Added a release metadata entry to mark the patch release for the server package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->