### PR TITLE
fix(server): handle provider-defined tools in /tools API endpoint

### DIFF
--- a/.changeset/bright-pens-type.md
+++ b/.changeset/bright-pens-type.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added `isProviderDefinedTool` helper to detect provider-defined AI SDK tools (e.g. `google.tools.googleSearch()`, `openai.tools.webSearch()`) for proper schema handling during serialization.

--- a/.changeset/public-baths-draw.md
+++ b/.changeset/public-baths-draw.md
@@ -2,4 +2,4 @@
 '@mastra/server': minor
 ---
 
-Update peer dependencies to match core package version bump (1.7.1)
+Requires `@mastra/core` >= 1.7.1 to support provider-defined tool serialization in the `/tools` API endpoints.

--- a/.changeset/public-baths-draw.md
+++ b/.changeset/public-baths-draw.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': minor
+---
+
+Update peer dependencies to match core package version bump (1.7.1)

--- a/.changeset/public-baths-draw.md
+++ b/.changeset/public-baths-draw.md
@@ -1,5 +1,0 @@
----
-'@mastra/server': minor
----
-
-Requires `@mastra/core` >= 1.7.1 to support provider-defined tool serialization in the `/tools` API endpoints.

--- a/.changeset/vast-teams-camp.md
+++ b/.changeset/vast-teams-camp.md
@@ -1,0 +1,6 @@
+---
+'@mastra/server': patch
+'@mastra/core': patch
+---
+
+Fixed /tools API endpoint crashing with provider-defined tools (e.g. google.tools.googleSearch(), openai.tools.webSearch()). These tools have a lazy inputSchema that is not a Zod schema, which caused zodToJsonSchema to throw "Cannot read properties of undefined (reading 'typeName')".

--- a/.changeset/vast-teams-camp.md
+++ b/.changeset/vast-teams-camp.md
@@ -1,6 +1,5 @@
 ---
 '@mastra/server': patch
-'@mastra/core': patch
 ---
 
-Fixed /tools API endpoint crashing with provider-defined tools (e.g. google.tools.googleSearch(), openai.tools.webSearch()). These tools have a lazy inputSchema that is not a Zod schema, which caused zodToJsonSchema to throw "Cannot read properties of undefined (reading 'typeName')".
+Fixed /tools API endpoint crashing with provider-defined tools (e.g. `google.tools.googleSearch()`, `openai.tools.webSearch()`). These tools have a lazy `inputSchema` that is not a Zod schema, which caused `zodToJsonSchema` to throw `"Cannot read properties of undefined (reading 'typeName')"`.

--- a/packages/core/src/tools/__tests__/provider-tools-serialization.test.ts
+++ b/packages/core/src/tools/__tests__/provider-tools-serialization.test.ts
@@ -1,0 +1,34 @@
+import { google } from '@ai-sdk/google-v5';
+import { openai } from '@ai-sdk/openai-v5';
+import { describe, expect, it } from 'vitest';
+import { isProviderDefinedTool } from '../toolchecks';
+
+describe('isProviderDefinedTool', () => {
+  it('should identify Google provider-defined tools', () => {
+    expect(isProviderDefinedTool(google.tools.googleSearch({}))).toBe(true);
+    expect(isProviderDefinedTool(google.tools.urlContext({}))).toBe(true);
+  });
+
+  it('should identify OpenAI provider-defined tools', () => {
+    expect(isProviderDefinedTool(openai.tools.webSearch({}))).toBe(true);
+  });
+
+  it('should reject null, undefined, and non-objects', () => {
+    expect(isProviderDefinedTool(null)).toBe(false);
+    expect(isProviderDefinedTool(undefined)).toBe(false);
+    expect(isProviderDefinedTool('string')).toBe(false);
+    expect(isProviderDefinedTool(42)).toBe(false);
+  });
+
+  it('should reject regular tools and plain objects', () => {
+    expect(isProviderDefinedTool({})).toBe(false);
+    expect(isProviderDefinedTool({ type: 'function', id: 'test' })).toBe(false);
+    expect(isProviderDefinedTool({ type: 'provider-defined' })).toBe(false); // missing id
+    expect(isProviderDefinedTool({ type: 'provider', id: 123 })).toBe(false); // id not string
+  });
+
+  it('should accept both v5 and v6 type markers', () => {
+    expect(isProviderDefinedTool({ type: 'provider-defined', id: 'google.search' })).toBe(true);
+    expect(isProviderDefinedTool({ type: 'provider', id: 'openai.web_search' })).toBe(true);
+  });
+});

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -1,6 +1,6 @@
 export * from './tool';
 export * from './types';
 export * from './ui-types';
-export { isVercelTool } from './toolchecks';
+export { isVercelTool, isProviderDefinedTool } from './toolchecks';
 export { ToolStream } from './stream';
 export { type ValidationError } from './validation';

--- a/packages/core/src/tools/toolchecks.ts
+++ b/packages/core/src/tools/toolchecks.ts
@@ -27,3 +27,19 @@ export function isVercelTool(tool?: ToolToConvert): tool is VercelTool {
     ('parameters' in tool || ('execute' in tool && typeof tool.execute === 'function' && 'inputSchema' in tool))
   );
 }
+
+/**
+ * Checks if a tool is a provider-defined tool from the AI SDK.
+ * Provider tools (like google.tools.googleSearch(), openai.tools.webSearch()) have:
+ * - type: "provider-defined" (AI SDK v5) or "provider" (AI SDK v6)
+ * - id: in format 'provider.tool_name' (e.g., 'google.google_search')
+ *
+ * These tools have a lazy `inputSchema` function that returns an AI SDK Schema
+ * (not a Zod schema), so they require special handling during serialization.
+ */
+export function isProviderDefinedTool(tool: unknown): boolean {
+  if (typeof tool !== 'object' || tool === null) return false;
+  const t = tool as Record<string, unknown>;
+  const isProviderType = t.type === 'provider-defined' || t.type === 'provider';
+  return isProviderType && typeof t.id === 'string';
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -86,7 +86,7 @@
   "author": "",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@mastra/core": ">=1.1.0-0 <2.0.0-0",
+    "@mastra/core": ">=1.7.1-0 <2.0.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {

--- a/packages/server/src/server/handlers/tools.test.ts
+++ b/packages/server/src/server/handlers/tools.test.ts
@@ -387,6 +387,8 @@ describe('Tools Handlers', () => {
         });
         expect(result).toHaveProperty('web_search');
         expect(result['web_search']).toHaveProperty('type', 'provider-defined');
+        // Verify the lazy inputSchema was actually resolved and serialized
+        expect(result['web_search'].inputSchema).toBeDefined();
       });
 
       it('should serialize a mix of regular and provider-defined tools', async () => {

--- a/packages/server/src/server/handlers/tools.test.ts
+++ b/packages/server/src/server/handlers/tools.test.ts
@@ -1,3 +1,4 @@
+import { openai } from '@ai-sdk/openai-v5';
 import { Agent } from '@mastra/core/agent';
 import { RequestContext } from '@mastra/core/di';
 import { Mastra } from '@mastra/core/mastra';
@@ -362,6 +363,81 @@ describe('Tools Handlers', () => {
       });
       expect(result).toHaveProperty('id', mockTool.id);
       expect(result).toHaveProperty('description', mockTool.description);
+    });
+  });
+
+  describe('provider-defined tools serialization', () => {
+    const providerTool = openai.tools.webSearch({});
+
+    const providerTools = {
+      web_search: providerTool,
+    };
+
+    const mixedTools = {
+      [mockTool.id]: mockTool,
+      web_search: providerTool,
+    };
+
+    describe('listToolsHandler', () => {
+      it('should serialize provider-defined tools without crashing', async () => {
+        const mastra = new Mastra({ logger: false });
+        const result = await LIST_TOOLS_ROUTE.handler({
+          ...createTestServerContext({ mastra }),
+          registeredTools: providerTools as any,
+        });
+        expect(result).toHaveProperty('web_search');
+        expect(result['web_search']).toHaveProperty('type', 'provider-defined');
+      });
+
+      it('should serialize a mix of regular and provider-defined tools', async () => {
+        const mastra = new Mastra({ logger: false });
+        const result = await LIST_TOOLS_ROUTE.handler({
+          ...createTestServerContext({ mastra }),
+          registeredTools: mixedTools as any,
+        });
+        expect(result).toHaveProperty(mockTool.id);
+        expect(result).toHaveProperty('web_search');
+        expect(result[mockTool.id]).toHaveProperty('id', mockTool.id);
+        expect(result['web_search']).toHaveProperty('type', 'provider-defined');
+      });
+    });
+
+    describe('getToolByIdHandler', () => {
+      it('should serialize a provider-defined tool without crashing', async () => {
+        const mastra = new Mastra({ logger: false });
+        const result = await GET_TOOL_BY_ID_ROUTE.handler({
+          ...createTestServerContext({ mastra }),
+          registeredTools: providerTools as any,
+          toolId: 'openai.web_search',
+        });
+        expect(result).toHaveProperty('type', 'provider-defined');
+        expect(result).toHaveProperty('id', 'openai.web_search');
+      });
+    });
+
+    describe('getAgentToolHandler', () => {
+      it('should serialize a provider-defined agent tool without crashing', async () => {
+        const agent = new Agent({
+          id: 'provider-tool-agent',
+          name: 'provider-tool-agent',
+          instructions: 'You are a search assistant',
+          tools: providerTools as any,
+          model: 'openai/gpt-4o-mini' as any,
+        });
+
+        const result = await GET_AGENT_TOOL_ROUTE.handler({
+          ...createTestServerContext({
+            mastra: new Mastra({
+              logger: false,
+              agents: { 'provider-tool-agent': agent as any },
+            }),
+          }),
+          agentId: 'provider-tool-agent',
+          toolId: 'openai.web_search',
+        });
+        expect(result).toHaveProperty('type', 'provider-defined');
+        expect(result).toHaveProperty('id', 'openai.web_search');
+      });
     });
   });
 });

--- a/packages/server/src/server/handlers/tools.ts
+++ b/packages/server/src/server/handlers/tools.ts
@@ -1,4 +1,4 @@
-import { isVercelTool } from '@mastra/core/tools';
+import { isVercelTool, isProviderDefinedTool } from '@mastra/core/tools';
 import { zodToJsonSchema } from '@mastra/core/utils/zod-to-json';
 import { stringify } from 'superjson';
 import { HTTPException } from '../http-exception';
@@ -17,6 +17,50 @@ import { createRoute } from '../server-adapter/routes/route-builder';
 import { getAgentFromSystem } from './agents';
 import { handleError } from './error';
 import { validateBody } from './utils';
+
+/**
+ * Resolves a schema value that may be a lazy function (as used by AI SDK provider tools).
+ * Provider tools use lazy schemas: `inputSchema` is a function that returns an AI SDK Schema
+ * object with `{ jsonSchema, validate, _type }`.
+ */
+function resolveSchema(schema: unknown): unknown {
+  if (typeof schema === 'function') {
+    return schema();
+  }
+  return schema;
+}
+
+/**
+ * Serializes a tool for API responses, handling both regular tools (with Zod schemas)
+ * and provider-defined tools (with AI SDK lazy schemas).
+ */
+function serializeTool(tool: any): any {
+  // Provider-defined tools (e.g. google.tools.googleSearch(), openai.tools.webSearch())
+  // have lazy inputSchema functions that return AI SDK Schema objects, not Zod schemas.
+  // We resolve them and use the jsonSchema property directly.
+  if (isProviderDefinedTool(tool)) {
+    const resolvedInput = resolveSchema(tool.inputSchema);
+    const resolvedOutput = resolveSchema(tool.outputSchema);
+    return {
+      ...tool,
+      inputSchema:
+        resolvedInput && typeof resolvedInput === 'object' && 'jsonSchema' in resolvedInput
+          ? stringify(resolvedInput.jsonSchema)
+          : undefined,
+      outputSchema:
+        resolvedOutput && typeof resolvedOutput === 'object' && 'jsonSchema' in resolvedOutput
+          ? stringify(resolvedOutput.jsonSchema)
+          : undefined,
+    };
+  }
+
+  return {
+    ...tool,
+    inputSchema: tool.inputSchema ? stringify(zodToJsonSchema(tool.inputSchema)) : undefined,
+    outputSchema: tool.outputSchema ? stringify(zodToJsonSchema(tool.outputSchema)) : undefined,
+    requestContextSchema: tool.requestContextSchema ? stringify(zodToJsonSchema(tool.requestContextSchema)) : undefined,
+  };
+}
 
 // ============================================================================
 // Route Definitions (new pattern - handlers defined inline with createRoute)
@@ -38,17 +82,7 @@ export const LIST_TOOLS_ROUTE = createRoute({
 
       const serializedTools = Object.entries(allTools).reduce(
         (acc, [id, _tool]) => {
-          // Cast to any since we're serializing to a generic Record<string, any>
-          // and the tool types have varying property availability
-          const tool = _tool as any;
-          acc[id] = {
-            ...tool,
-            inputSchema: tool.inputSchema ? stringify(zodToJsonSchema(tool.inputSchema)) : undefined,
-            outputSchema: tool.outputSchema ? stringify(zodToJsonSchema(tool.outputSchema)) : undefined,
-            requestContextSchema: tool.requestContextSchema
-              ? stringify(zodToJsonSchema(tool.requestContextSchema))
-              : undefined,
-          };
+          acc[id] = serializeTool(_tool);
           return acc;
         },
         {} as Record<string, any>,
@@ -86,16 +120,7 @@ export const GET_TOOL_BY_ID_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Tool not found' });
       }
 
-      const serializedTool = {
-        ...tool,
-        inputSchema: tool.inputSchema ? stringify(zodToJsonSchema(tool.inputSchema)) : undefined,
-        outputSchema: tool.outputSchema ? stringify(zodToJsonSchema(tool.outputSchema)) : undefined,
-        requestContextSchema: tool.requestContextSchema
-          ? stringify(zodToJsonSchema(tool.requestContextSchema))
-          : undefined,
-      };
-
-      return serializedTool;
+      return serializeTool(tool);
     } catch (error) {
       return handleError(error, 'Error getting tool');
     }
@@ -196,16 +221,7 @@ export const GET_AGENT_TOOL_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Tool not found' });
       }
 
-      const serializedTool = {
-        ...tool,
-        inputSchema: tool.inputSchema ? stringify(zodToJsonSchema(tool.inputSchema)) : undefined,
-        outputSchema: tool.outputSchema ? stringify(zodToJsonSchema(tool.outputSchema)) : undefined,
-        requestContextSchema: tool.requestContextSchema
-          ? stringify(zodToJsonSchema(tool.requestContextSchema))
-          : undefined,
-      };
-
-      return serializedTool;
+      return serializeTool(tool);
     } catch (error) {
       return handleError(error, 'Error getting agent tool');
     }

--- a/packages/server/src/server/handlers/tools.ts
+++ b/packages/server/src/server/handlers/tools.ts
@@ -25,7 +25,11 @@ import { validateBody } from './utils';
  */
 function resolveSchema(schema: unknown): unknown {
   if (typeof schema === 'function') {
-    return schema();
+    try {
+      return schema();
+    } catch {
+      return undefined;
+    }
   }
   return schema;
 }


### PR DESCRIPTION
The `/tools`, `/tools/:toolId`, and `/agents/:agentId/tools/:toolId` endpoints crash when an agent has provider-defined tools like `google.tools.googleSearch()` or `openai.tools.webSearch()`.

These tools have a lazy `inputSchema` function that returns an AI SDK Schema object (not a Zod schema). The handler was blindly calling `zodToJsonSchema(tool.inputSchema)` on them, which blows up with:

```
TypeError: Cannot read properties of undefined (reading 'typeName')
```

The fix detects provider-defined tools (via `tool.type === 'provider-defined' || tool.type === 'provider'`) and resolves their lazy schema to extract the `jsonSchema` property directly, skipping `zodToJsonSchema` entirely. This reuses the same detection pattern already in `prepare-tools.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed /tools API crash when using provider-defined tools from external AI SDKs (e.g., Google, OpenAI).

* **New Features**
  * Added provider-defined tool detection to ensure correct tool serialization and listing.

* **Tests**
  * Added coverage for provider-defined tool recognition and serialization across handlers.

* **Chores**
  * Released @mastra/server minor and @mastra/core patch; tightened peer dependency to require @mastra/core ≥ 1.7.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->