### PR TITLE
fix(mastracode): strengthen Claude Max OAuth risk warning

### DIFF
--- a/.changeset/stronger-claude-max-warning.md
+++ b/.changeset/stronger-claude-max-warning.md
@@ -1,0 +1,5 @@
+---
+"mastracode": patch
+---
+
+Strengthened the Anthropic Claude Max OAuth warning language to explicitly call out account-ban risk and potential Terms of Service violations before users continue with OAuth.

--- a/docs/src/content/en/docs/mastra-code/configuration.mdx
+++ b/docs/src/content/en/docs/mastra-code/configuration.mdx
@@ -40,9 +40,7 @@ OAuth credentials are stored in `auth.json` alongside the database in the [app d
 
 ### Anthropic OAuth warning
 
-Authenticating with a Claude Max subscription is a grey area that may violate Anthropic's Terms of Service. Mastra Code displays a warning each time you start the Anthropic OAuth flow (via `/login` or during onboarding) with **Continue** and **Cancel** options. Cancel returns you to the provider selection screen.
-
-If you already have Anthropic OAuth credentials and have not previously acknowledged the warning, Mastra Code also shows the warning once at startup with **Continue** (keep credentials) and **Remove OAuth** (log out from Anthropic) options.
+Authenticating with a Claude Max subscription through OAuth is a grey area. Anthropic has reportedly banned users for using Claude max credentials outside of Claude Code, so it may violate Anthropic Terms of Service.
 
 ## MCP servers
 

--- a/mastracode/src/auth/claude-max-warning.ts
+++ b/mastracode/src/auth/claude-max-warning.ts
@@ -8,4 +8,4 @@
 export const ANTHROPIC_OAUTH_PROVIDER_ID = 'anthropic';
 
 export const CLAUDE_MAX_OAUTH_WARNING_MESSAGE =
-  'OAuth with a Claude Max plan is a grey area and may violate your Terms of Service with Anthropic. Proceed at your own risk.';
+  'OAuth with a Claude Max plan is a grey area. Anthropic has reportedly banned users for using Claude max credentials outside of Claude Code, and it may violate Anthropic Terms of Service. Proceed at your own risk.';


### PR DESCRIPTION
Makes the Anthropic Claude Max OAuth warning more explicit about risk.
Also updates the Mastra Code configuration docs to match the stronger warning text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Strengthened Claude Max OAuth warning to explicitly alert users about potential account bans and Terms of Service violations when authenticating with Claude Max credentials outside Claude Code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->