### PR TITLE
fix(ci): build @internal/ai-v6 before generate:providers in regen workflow

### DIFF
--- a/.github/workflows/regenerate-provider-registry.yml
+++ b/.github/workflows/regenerate-provider-registry.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
 
+      - name: Build vendored ai-v6 package
+        run: pnpm --filter @internal/ai-v6 build
+
       - name: Generate provider registry
         run: pnpm --filter @mastra/core generate:providers
 


### PR DESCRIPTION
The `regenerate-provider-registry` workflow was failing because `models-dev.ts` has a top-level import from `@internal/ai-v6`, which is a workspace package that needs to be built before its `dist/index.js` exists. The workflow only ran `pnpm install` — no build step.

Added a build step for the vendored package before running the generate script:

```yaml
- name: Build vendored ai-v6 package
  run: pnpm --filter @internal/ai-v6 build

- name: Generate provider registry
  run: pnpm --filter @mastra/core generate:providers
```

Failing action for reference: https://github.com/mastra-ai/mastra/actions/workflows/regenerate-provider-registry.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the provider registry regeneration workflow to include an additional build step for internal dependencies, ensuring all required packages are properly prepared before registry generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->