### PR TITLE
feat(core): add SDK setters for platform config injection

### DIFF
--- a/.changeset/platform-config-setters.md
+++ b/.changeset/platform-config-setters.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Add `setObservability()` and `setServer()` public methods to the Mastra class, enabling post-construction configuration of observability and server settings. This allows platform tooling to inject defaults (e.g. tracing, auth) into user-created Mastra instances at deploy time.

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -17,7 +17,7 @@ import { LogLevel, noopLogger, ConsoleLogger } from '../logger';
 import type { IMastraLogger } from '../logger';
 import type { MCPServerBase } from '../mcp';
 import type { MastraMemory } from '../memory';
-import type { ObservabilityEntrypoint } from '../observability';
+import type { ObservabilityEntrypoint, ObservabilityInstance } from '../observability';
 import { NoOpObservability } from '../observability';
 import type { Processor } from '../processors';
 import type { MastraServerBase } from '../server/base';
@@ -505,6 +505,31 @@ export class Mastra<
     this.#observability = observability;
     this.#observability.setLogger({ logger: this.#logger });
     this.#observability.setMastraContext({ mastra: this });
+  }
+
+  /**
+   * Registers an observability instance, ensuring a real observability entrypoint exists.
+   *
+   * If the current observability is a no-op (user didn't configure any), this method
+   * first replaces it with the provided entrypoint, then registers the instance.
+   * If a real observability entrypoint already exists, it simply registers the instance
+   * into the existing one.
+   *
+   * @param name - The name to register the instance under
+   * @param instance - The observability instance to register
+   * @param entrypoint - A real ObservabilityEntrypoint to use if the current one is a no-op
+   * @param isDefault - Whether this instance should be the default
+   */
+  public registerObservabilityInstance(
+    name: string,
+    instance: ObservabilityInstance,
+    entrypoint: ObservabilityEntrypoint,
+    isDefault = false,
+  ): void {
+    if (this.#observability instanceof NoOpObservability) {
+      this.setObservability(entrypoint);
+    }
+    this.#observability.registerInstance(name, instance, isDefault);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds `setObservability()` and `setServer()` public methods to the `Mastra` class for post-construction configuration
- Adds `registerObservabilityInstance()` which safely extends existing observability (or bootstraps from NoOp) without replacing user config
- These methods enable platform tooling (e.g. the studio runner) to inject defaults like `CloudExporter` and `MastraAuthWorkos` at deploy time without requiring users to configure them manually

## Test plan
- [ ] `setObservability()` replaces NoOp with a real instance, shuts down existing non-NoOp before replacing
- [ ] `setServer()` assigns server config
- [ ] `registerObservabilityInstance()` bootstraps from NoOp when no observability exists
- [ ] `registerObservabilityInstance()` extends existing observability via `registerInstance` when user already has one
- [ ] Publish snapshot and verify wrapper integration in studio runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic configuration for observability settings
  * Added dynamic configuration for server settings
  * Support for registering and managing multiple observability instances

<!-- end of auto-generated comment: release notes by coderabbit.ai -->