### PR TITLE
Add OTEL log export to OtelExporter and OtelBridge

### DIFF
--- a/.changeset/chubby-bars-behave.md
+++ b/.changeset/chubby-bars-behave.md
@@ -1,0 +1,28 @@
+---
+'@mastra/otel-exporter': minor
+---
+
+Added log export to `@mastra/otel-exporter`. Logs emitted on the Mastra observability bus are now forwarded to the configured OTLP endpoint alongside traces, using the same provider configuration.
+
+```ts
+import { OtelExporter } from '@mastra/otel-exporter';
+
+new OtelExporter({
+  provider: {
+    custom: { endpoint: 'http://localhost:4318', protocol: 'http/json' },
+  },
+  // signals.logs defaults to true; set to false to disable.
+  signals: { traces: true, logs: true },
+});
+```
+
+Requires the matching OTLP log exporter package to be installed (e.g. `@opentelemetry/exporter-logs-otlp-http` for HTTP/JSON, or `-proto` / `-grpc` variants).
+
+**Trace correlation:** Logs that carry `traceId` and `spanId` are attached to the OTEL log record's native trace context, so backends like Datadog, Grafana, and Honeycomb auto-correlate logs to traces.
+
+**Other improvements:**
+
+- Trace and log endpoints are always normalized to a single signal-path suffix, so `http://host:4318/`, `http://host:4318`, and `http://host:4318/v1/traces/` all produce well-formed URLs instead of malformed variants like `//v1/logs`.
+- Calling `flush()` or `shutdown()` immediately after init no longer drops telemetry — teardown waits for setup to finish before draining providers.
+- Debug log output no longer exposes credential fragments. Provider header values are fully redacted instead of printing prefix/suffix slices.
+- When a dynamically-loaded OTLP exporter package is installed but does not expose the expected named export, Mastra now disables that signal with a clear error message instead of failing later with an opaque "X is not a constructor" error.

--- a/.changeset/some-seas-speak.md
+++ b/.changeset/some-seas-speak.md
@@ -1,0 +1,22 @@
+---
+'@mastra/otel-bridge': minor
+---
+
+Added log forwarding to `@mastra/otel-bridge`. The bridge now also subscribes to Mastra log events and forwards them to the globally-registered OpenTelemetry `LoggerProvider`, alongside the spans it already creates.
+
+Logs that originate inside a Mastra span are emitted under that span's OTEL context, so backends like Datadog, Grafana, and Honeycomb correlate them with the surrounding trace automatically. Logs without trace context fall through to the currently active OTEL context.
+
+To wire up logs alongside traces, register a `logRecordProcessor` on `NodeSDK`:
+
+```ts
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
+import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
+
+const sdk = new NodeSDK({
+  // ...trace config as usual
+  logRecordProcessor: new BatchLogRecordProcessor(new OTLPLogExporter()),
+});
+```
+
+If no `LoggerProvider` is registered, log emission is a silent no-op — traces continue to work as configured.

--- a/docs/src/content/en/docs/observability/tracing/bridges/otel.mdx
+++ b/docs/src/content/en/docs/observability/tracing/bridges/otel.mdx
@@ -47,6 +47,7 @@ The OtelBridge provides two-way integration:
 - Creates native OTEL spans for Mastra operations (agents, LLM calls, tools, workflows)
 - Maintains proper parent-child relationships in distributed traces
 - Allows OTEL-instrumented code (HTTP clients, database calls) within Mastra operations to nest correctly
+- Forwards Mastra log events to the globally-registered OTEL `LoggerProvider`. Logs that originate inside a Mastra span are emitted under that span's OTEL context so backends correlate them with the trace. If no `LoggerProvider` is registered, log emission is a silent no-op.
 
 ## Installation
 
@@ -63,6 +64,7 @@ The bridge works with your existing OpenTelemetry setup. Depending on your confi
 - `@opentelemetry/exporter-trace-otlp-grpc` - OTLP exporter (gRPC)
 - `@opentelemetry/sdk-trace-base` - Base tracing SDK (for BatchSpanProcessor, etc.)
 - `@opentelemetry/core` - Core utilities (for W3CTraceContextPropagator, etc.)
+- `@opentelemetry/sdk-logs` and an OTLP log exporter (e.g. `@opentelemetry/exporter-logs-otlp-http`) - Required if you want the bridge to forward Mastra log events too
 
 ## Configuration
 
@@ -125,6 +127,29 @@ export const mastra = new Mastra({
 ```
 
 No Mastra exporters are required when using the bridge — traces are sent via your OTEL SDK configuration. You can optionally add Mastra exporters if you want to send traces to additional destinations.
+
+### Forwarding logs (optional)
+
+The bridge also forwards Mastra log events to the globally-registered OTEL `LoggerProvider`. To wire up logs alongside traces, register a `logRecordProcessor` on `NodeSDK`:
+
+```typescript title="instrumentation.ts"
+import { NodeSDK } from '@opentelemetry/sdk-node'
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
+import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs'
+
+const sdk = new NodeSDK({
+  // ...trace config as usual
+  logRecordProcessor: new BatchLogRecordProcessor(
+    new OTLPLogExporter({
+      url: process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT || 'http://localhost:4318/v1/logs',
+    }),
+  ),
+})
+```
+
+Logs that originate inside a Mastra span are emitted under that span's OTEL context, so backends like Datadog, Grafana, and Honeycomb correlate them with the surrounding trace automatically. Logs without trace context fall through to the currently active OTEL context.
+
+If you do not register a `LoggerProvider`, log emission is a silent no-op — traces continue to work as configured.
 
 ### Running Your Application
 

--- a/docs/src/content/en/docs/observability/tracing/exporters/otel.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/otel.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpenTelemetry exporter | Tracing | Observability"
-description: "Send traces to any OpenTelemetry-compatible observability platform"
+description: "Send traces and logs to any OpenTelemetry-compatible observability platform"
 packages:
   - "@mastra/observability"
   - "@mastra/otel-exporter"
@@ -8,7 +8,7 @@ packages:
 
 # OpenTelemetry exporter
 
-The OpenTelemetry (OTEL) exporter sends your traces to any OTEL-compatible observability platform using standardized [OpenTelemetry Semantic Conventions for GenAI](https://opentelemetry.io/docs/specs/semconv/gen-ai/). This ensures broad compatibility with platforms like Datadog, New Relic, SigNoz, MLflow, Dash0, Traceloop, Laminar, and more.
+The OpenTelemetry (OTEL) exporter sends your traces and logs to any OTEL-compatible observability platform using standardized [OpenTelemetry Semantic Conventions for GenAI](https://opentelemetry.io/docs/specs/semconv/gen-ai/). This ensures broad compatibility with platforms like Datadog, New Relic, SigNoz, MLflow, Dash0, Traceloop, Laminar, and more.
 
 :::info Looking for bidirectional OTEL integration?
 
@@ -361,6 +361,42 @@ new OtelExporter({
 })
 ```
 
+## Signals
+
+The exporter sends two OpenTelemetry signals:
+
+- Traces: Mastra spans, exported via `BatchSpanProcessor`.
+- Logs: Mastra log events, exported via `BatchLogRecordProcessor`. Logs that carry `traceId` and `spanId` are correlated with traces using both the OTEL log record's native trace context and `mastra.traceId` / `mastra.spanId` attributes, so backends like Datadog, Grafana, and Honeycomb can join logs to traces automatically.
+
+Both signals are enabled by default and share the same provider configuration. The log endpoint is derived from the trace endpoint by replacing the `/v1/traces` suffix with `/v1/logs`.
+
+To disable a signal, set the `signals` option:
+
+```typescript title="src/mastra/index.ts"
+new OtelExporter({
+  provider: {
+    /* ... */
+  },
+  signals: {
+    traces: true, // default
+    logs: false, // disable log export
+  },
+})
+```
+
+Log export requires installing the matching OTLP log exporter package for your protocol:
+
+```bash npm2yarn
+# HTTP/JSON
+npm install @opentelemetry/exporter-logs-otlp-http
+# HTTP/Protobuf
+npm install @opentelemetry/exporter-logs-otlp-proto
+# gRPC
+npm install @opentelemetry/exporter-logs-otlp-grpc @grpc/grpc-js
+```
+
+If the matching log exporter package is not installed, log export is silently disabled and traces continue to work.
+
 ## Configuration options
 
 ### Complete Configuration
@@ -372,9 +408,15 @@ new OtelExporter({
     // Use one of: dash0, signoz, newrelic, traceloop, laminar, custom
   },
 
+  // Per-signal toggles. Both default to true.
+  signals: {
+    traces: true,
+    logs: true,
+  },
+
   // Export configuration
   timeout: 30000, // Export timeout in milliseconds
-  batchSize: 100, // Number of spans per batch
+  batchSize: 100, // Number of spans/logs per batch
 
   // Debug options
   logLevel: 'info', // 'debug' | 'info' | 'warn' | 'error'

--- a/docs/src/content/en/reference/observability/tracing/bridges/otel.mdx
+++ b/docs/src/content/en/reference/observability/tracing/bridges/otel.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Reference: OtelBridge | Observability"
-description: OpenTelemetry bridge for Tracing
+description: OpenTelemetry bridge for traces and logs
 packages:
   - "@mastra/core"
   - "@mastra/langfuse"
@@ -18,7 +18,7 @@ The OpenTelemetry Bridge is currently **experimental**. APIs and configuration o
 
 :::
 
-Enables bidirectional integration between Mastra tracing and OpenTelemetry infrastructure. Creates native OTEL spans for Mastra operations and inherits context from active OTEL spans.
+Enables bidirectional integration between Mastra tracing and OpenTelemetry infrastructure. Creates native OTEL spans for Mastra operations and inherits context from active OTEL spans. Also forwards Mastra log events to the globally-registered OTEL `LoggerProvider`, emitting each log under the OTEL context of the originating Mastra span so trace-log correlation works automatically.
 
 ## Constructor
 
@@ -82,7 +82,40 @@ Executes a synchronous function within the OTEL context of a Mastra span.
 
 **Returns:** `T` - The result of the function execution.
 
-### shutdown
+### `onLogEvent`
+
+```typescript prettier:false
+async onLogEvent(event: LogEvent): Promise<void>
+```
+
+Forwards a Mastra log event to the globally-registered OTEL `LoggerProvider`. Trace correlation is resolved in this order:
+
+1. If the log carries a `spanId` the bridge has an OTEL span for, the log is emitted under that span's stored OTEL context.
+1. Otherwise, if the log carries `traceId` and `spanId`, those IDs are attached to the emitted log record's `SpanContext`.
+1. Otherwise, the log is emitted under whatever OTEL context is currently active.
+
+If no `LoggerProvider` is registered globally, emission is a silent no-op.
+
+<PropertiesTable
+  props={[
+  {
+    name: 'event',
+    type: 'LogEvent',
+    description: 'The Mastra log event to forward, as delivered by the observability bus',
+    required: true,
+  },
+]}
+/>
+
+### `flush`
+
+```typescript prettier:false
+async flush(): Promise<void>
+```
+
+Force flushes the global OTEL tracer provider and logger provider if they support `forceFlush`. Useful in serverless environments where you need to drain telemetry before the runtime terminates.
+
+### `shutdown`
 
 ```typescript prettier:false
 async shutdown(): Promise<void>

--- a/docs/src/content/en/reference/observability/tracing/exporters/otel.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/otel.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Reference: OtelExporter | Observability"
-description: OpenTelemetry exporter for Tracing
+description: OpenTelemetry exporter for traces and logs
 packages:
   - "@mastra/otel-exporter"
 ---
@@ -9,7 +9,7 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 # OtelExporter
 
-Sends Tracing data to any OpenTelemetry-compatible observability platform using standardized GenAI semantic conventions.
+Sends traces and logs to any OpenTelemetry-compatible observability platform. Traces use the standardized GenAI semantic conventions; logs carry their original severity and message body and are correlated to traces via both the OTEL log record's native trace context and `mastra.traceId` / `mastra.spanId` attributes.
 
 ## Constructor
 
@@ -22,6 +22,10 @@ new OtelExporter(config: OtelExporterConfig)
 ```typescript
 interface OtelExporterConfig {
   provider?: ProviderConfig
+  signals?: {
+    traces?: boolean
+    logs?: boolean
+  }
   timeout?: number
   batchSize?: number
   logLevel?: 'debug' | 'info' | 'warn' | 'error'
@@ -37,6 +41,13 @@ interface OtelExporterConfig {
     required: true,
   },
   {
+    name: 'signals',
+    type: '{ traces?: boolean; logs?: boolean }',
+    description:
+      'Per-signal toggle. Both default to true. Set a value to false to disable that signal. Log export also requires the matching `@opentelemetry/exporter-logs-otlp-*` package to be installed for the chosen protocol.',
+    required: false,
+  },
+  {
     name: 'timeout',
     type: 'number',
     description: 'Export timeout in milliseconds (default: 30000)',
@@ -45,7 +56,7 @@ interface OtelExporterConfig {
   {
     name: 'batchSize',
     type: 'number',
-    description: 'Number of spans per batch (default: 100)',
+    description: 'Number of spans/logs per batch (default: 512)',
     required: false,
   },
   {
@@ -329,14 +340,14 @@ const exporter = new OtelExporter({
 
 ## Protocol requirements
 
-Different providers require different OTEL exporter packages:
+Different providers require different OTEL exporter packages. Trace and log export are independent: install only the trace package if you only need traces, or install both the trace and log packages for the chosen protocol if you also want log export. Zipkin does not support OTLP logs.
 
-| Protocol | Required Package | Providers |
+| Protocol | Trace package | Log package |
 | - | - | - |
-| gRPC | `@opentelemetry/exporter-trace-otlp-grpc` | Dash0 |
-| HTTP/Protobuf | `@opentelemetry/exporter-trace-otlp-proto` | SigNoz, New Relic, Laminar |
-| HTTP/JSON | `@opentelemetry/exporter-trace-otlp-http` | Traceloop, Custom |
-| Zipkin | `@opentelemetry/exporter-zipkin` | Zipkin collectors |
+| gRPC | `@opentelemetry/exporter-trace-otlp-grpc` (+ `@grpc/grpc-js`) | `@opentelemetry/exporter-logs-otlp-grpc` (+ `@grpc/grpc-js`) |
+| HTTP/Protobuf | `@opentelemetry/exporter-trace-otlp-proto` | `@opentelemetry/exporter-logs-otlp-proto` |
+| HTTP/JSON | `@opentelemetry/exporter-trace-otlp-http` | `@opentelemetry/exporter-logs-otlp-http` |
+| Zipkin | `@opentelemetry/exporter-zipkin` | not supported |
 
 ## Tags support
 

--- a/observability/otel-bridge/README.md
+++ b/observability/otel-bridge/README.md
@@ -20,6 +20,7 @@ Enables bidirectional integration between Mastra and OpenTelemetry infrastructur
 - Maintains proper parent-child relationships in distributed traces
 - Allows OTEL-instrumented code (DB calls, HTTP clients) within Mastra operations to nest correctly
 - Exports spans with OTEL semantic conventions for GenAI operations
+- Forwards Mastra log events to the globally-registered OTEL `LoggerProvider`. Logs that originate inside a Mastra span are emitted under that span's OTEL context, so backends correlate logs to traces using the standard OTLP fields. If no `LoggerProvider` is registered, log emission is a silent no-op.
 
 ## Installation
 
@@ -155,16 +156,45 @@ When a Mastra span ends:
 
 The bridge provides `executeInContext()` and `executeInContextSync()` to run code within a Mastra span's OTEL context. This allows OTEL-instrumented code (DB clients, HTTP clients) to nest correctly under Mastra spans.
 
+### Log Forwarding
+
+When a `LoggerProvider` is registered globally (e.g. via `@opentelemetry/sdk-logs`, or via `NodeSDK`'s `logRecordProcessor` option), the bridge forwards every Mastra log event to it as an OTEL `LogRecord`. Trace correlation is automatic:
+
+1. If the log carries a `spanId` the bridge created an OTEL span for, the log is emitted under that span's stored OTEL context — so it nests beneath the Mastra span in distributed traces.
+2. Otherwise, if the log carries `traceId` and `spanId`, those are attached to the emitted log record's `SpanContext` so backends can still correlate by ID.
+3. Otherwise, the log is emitted under whatever OTEL context is currently active.
+
+Log severity, message body, structured `data`, and `metadata` are mapped to the OTEL `LogRecord` shape. `mastra.traceId` / `mastra.spanId` attributes are also attached for backends that key off attributes only.
+
+To wire up logs alongside traces, pass `logRecordProcessor` to `NodeSDK`:
+
+```javascript
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
+import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
+
+const sdk = new NodeSDK({
+  // ...trace config as usual
+  logRecordProcessor: new BatchLogRecordProcessor(new OTLPLogExporter()),
+});
+```
+
 ## Requirements
 
 - **Dependencies**:
   - `@mastra/core` >= 1.0.0
   - `@opentelemetry/api` >= 1.9.0
+  - `@opentelemetry/api-logs` >= 0.215.0
 
 **For Standard OTEL Setup:**
 
 - `@opentelemetry/sdk-node` >= 0.205.0
 - `@opentelemetry/auto-instrumentations-node` >= 0.64.1
+
+**For Log Forwarding (optional):**
+
+- `@opentelemetry/sdk-logs` >= 0.215.0
+- An OTLP log exporter for your protocol (e.g. `@opentelemetry/exporter-logs-otlp-http`)
 
 ## License
 

--- a/observability/otel-bridge/package.json
+++ b/observability/otel-bridge/package.json
@@ -33,12 +33,14 @@
   "dependencies": {
     "@mastra/observability": "workspace:*",
     "@mastra/otel-exporter": "workspace:*",
-    "@opentelemetry/api": "^1.9.1"
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/api-logs": "^0.215.0"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",
     "@internal/types-builder": "workspace:*",
     "@mastra/core": "workspace:*",
+    "@opentelemetry/sdk-logs": "^0.215.0",
     "@types/node": "22.19.15",
     "eslint": "^10.2.1",
     "tsup": "^8.5.1",

--- a/observability/otel-bridge/src/bridge.test.ts
+++ b/observability/otel-bridge/src/bridge.test.ts
@@ -7,9 +7,11 @@
  * These unit tests focus on the bridge's core logic and API surface.
  */
 
-import type { CreateSpanOptions } from '@mastra/core/observability';
+import type { CreateSpanOptions, LogEvent } from '@mastra/core/observability';
 import { SpanType } from '@mastra/core/observability';
 import { isSpanContextValid, trace } from '@opentelemetry/api';
+import { logs as otelLogs, SeverityNumber } from '@opentelemetry/api-logs';
+import { InMemoryLogRecordExporter, LoggerProvider, SimpleLogRecordProcessor } from '@opentelemetry/sdk-logs';
 import { tracing } from '@opentelemetry/sdk-node';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { OtelBridge } from './bridge.js';
@@ -24,15 +26,25 @@ describe('OtelBridge', () => {
   // no-op tracer whose spans carry all-zero IDs (see issue #15589 regression
   // tests below).
   let tracerProvider: tracing.BasicTracerProvider;
+  let loggerProvider: LoggerProvider;
+  let logExporter: InMemoryLogRecordExporter;
 
   beforeAll(() => {
     tracerProvider = new tracing.BasicTracerProvider();
     trace.setGlobalTracerProvider(tracerProvider);
+
+    logExporter = new InMemoryLogRecordExporter();
+    loggerProvider = new LoggerProvider({
+      processors: [new SimpleLogRecordProcessor(logExporter)],
+    });
+    otelLogs.setGlobalLoggerProvider(loggerProvider);
   });
 
   afterAll(async () => {
     await tracerProvider.shutdown();
+    await loggerProvider.shutdown();
     trace.disable();
+    otelLogs.disable();
   });
 
   describe('createSpan', () => {
@@ -350,6 +362,116 @@ describe('OtelBridge', () => {
 
       // Tags should NOT be present when array is empty
       expect(readableSpan.attributes['mastra.tags']).toBeUndefined();
+    });
+  });
+
+  describe('onLogEvent', () => {
+    function makeLogEvent(overrides: Partial<LogEvent['log']> = {}): LogEvent {
+      return {
+        type: 'log',
+        log: {
+          logId: 'log-1',
+          timestamp: new Date(),
+          level: 'info',
+          message: 'hello',
+          ...overrides,
+        },
+      };
+    }
+
+    it('emits a log record through the global LoggerProvider with mapped severity and body', async () => {
+      logExporter.reset();
+      const bridge = new OtelBridge();
+
+      await bridge.onLogEvent(makeLogEvent({ level: 'warn', message: 'something happened' }));
+
+      const records = logExporter.getFinishedLogRecords();
+      expect(records).toHaveLength(1);
+      expect(records[0]!.body).toBe('something happened');
+      expect(records[0]!.severityNumber).toBe(SeverityNumber.WARN);
+      expect(records[0]!.severityText).toBe('WARN');
+    });
+
+    it('attaches mastra.traceId / mastra.spanId attributes when the log carries trace context', async () => {
+      logExporter.reset();
+      const bridge = new OtelBridge();
+
+      await bridge.onLogEvent(
+        makeLogEvent({
+          traceId: '0af7651916cd43dd8448eb211c80319c',
+          spanId: 'b7ad6b7169203331',
+        }),
+      );
+
+      const records = logExporter.getFinishedLogRecords();
+      expect(records).toHaveLength(1);
+      expect(records[0]!.attributes['mastra.traceId']).toBe('0af7651916cd43dd8448eb211c80319c');
+      expect(records[0]!.attributes['mastra.spanId']).toBe('b7ad6b7169203331');
+    });
+
+    it('emits the OTEL log record with the trace context for the matching Mastra span', async () => {
+      logExporter.reset();
+      const bridge = new OtelBridge();
+
+      const ids = bridge.createSpan({
+        type: SpanType.AGENT_RUN,
+        name: 'agent',
+        attributes: {},
+      } as CreateSpanOptions<SpanType.AGENT_RUN>);
+      expect(ids).toBeDefined();
+
+      await bridge.onLogEvent(makeLogEvent({ traceId: ids!.traceId, spanId: ids!.spanId, message: 'inside agent' }));
+
+      const records = logExporter.getFinishedLogRecords();
+      expect(records).toHaveLength(1);
+      // The OTEL SDK populates spanContext on the log record from the emit-time Context.
+      const spanContext = records[0]!.spanContext;
+      expect(spanContext?.traceId).toBe(ids!.traceId);
+      expect(spanContext?.spanId).toBe(ids!.spanId);
+    });
+
+    it('falls back to a SpanContext built from raw IDs when the span is not in the local map', async () => {
+      logExporter.reset();
+      const bridge = new OtelBridge();
+
+      const traceId = '11111111111111111111111111111111';
+      const spanId = '2222222222222222';
+      await bridge.onLogEvent(makeLogEvent({ traceId, spanId, message: 'orphan' }));
+
+      const records = logExporter.getFinishedLogRecords();
+      expect(records).toHaveLength(1);
+      expect(records[0]!.spanContext?.traceId).toBe(traceId);
+      expect(records[0]!.spanContext?.spanId).toBe(spanId);
+    });
+
+    it('emits without a spanContext when the log carries no trace IDs', async () => {
+      logExporter.reset();
+      const bridge = new OtelBridge();
+
+      await bridge.onLogEvent(makeLogEvent({ message: 'no trace context' }));
+
+      const records = logExporter.getFinishedLogRecords();
+      expect(records).toHaveLength(1);
+      expect(records[0]!.spanContext).toBeUndefined();
+    });
+
+    it('is a silent no-op when no global LoggerProvider is registered', async () => {
+      // Tear down the suite-level LoggerProvider so otelLogs.getLogger(...)
+      // resolves to a NoopLogger via the api-logs proxy. This mirrors a real
+      // user who configures OtelBridge without also wiring up sdk-logs.
+      otelLogs.disable();
+      try {
+        const bridge = new OtelBridge();
+        logExporter.reset();
+
+        await expect(bridge.onLogEvent(makeLogEvent({ message: 'dropped silently' }))).resolves.toBeUndefined();
+
+        // The in-memory exporter is not on the registered provider any more,
+        // so it should never receive the record either.
+        expect(logExporter.getFinishedLogRecords()).toHaveLength(0);
+      } finally {
+        otelLogs.setGlobalLoggerProvider(loggerProvider);
+      }
     });
   });
 });

--- a/observability/otel-bridge/src/bridge.ts
+++ b/observability/otel-bridge/src/bridge.ts
@@ -15,6 +15,7 @@
 import type {
   ObservabilityBridge,
   TracingEvent,
+  LogEvent,
   CreateSpanOptions,
   SpanType,
   SpanIds,
@@ -22,9 +23,11 @@ import type {
 } from '@mastra/core/observability';
 import { TracingEventType } from '@mastra/core/observability';
 import { BaseExporter, getExternalParentId } from '@mastra/observability';
-import { SpanConverter, getSpanKind } from '@mastra/otel-exporter';
-import { trace as otelTrace, context as otelContext, isSpanContextValid } from '@opentelemetry/api';
+import { SpanConverter, convertLog, getSpanKind } from '@mastra/otel-exporter';
+import { trace as otelTrace, context as otelContext, isSpanContextValid, TraceFlags } from '@opentelemetry/api';
 import type { Span as OtelSpan, Context as OtelContext } from '@opentelemetry/api';
+import { logs as otelLogs } from '@opentelemetry/api-logs';
+import type { Logger as OtelLogger } from '@opentelemetry/api-logs';
 
 /**
  * Configuration for the OtelBridge
@@ -61,6 +64,7 @@ export type OtelBridgeConfig = {
 export class OtelBridge extends BaseExporter implements ObservabilityBridge {
   name = 'otel';
   private otelTracer = otelTrace.getTracer('@mastra/otel-bridge', '1.0.0');
+  private otelLogger: OtelLogger = otelLogs.getLogger('@mastra/otel-bridge', '1.0.0');
   private otelSpanMap = new Map<string, { otelSpan: OtelSpan; otelContext: OtelContext }>();
   private spanConverter?: SpanConverter;
 
@@ -80,6 +84,74 @@ export class OtelBridge extends BaseExporter implements ObservabilityBridge {
     if (event.type === TracingEventType.SPAN_ENDED) {
       await this.handleSpanEnded(event);
     }
+  }
+
+  /**
+   * Forward Mastra log events into the globally-registered OTEL LoggerProvider.
+   *
+   * If the user has not registered a LoggerProvider (e.g. via @opentelemetry/sdk-logs
+   * or NodeSDK's logRecordProcessor option), the API returns a no-op logger and
+   * emit() is a silent no-op — the bridge degrades gracefully.
+   *
+   * Trace correlation:
+   * - If the log carries a spanId we have an OTEL span for, emit under that span's
+   *   stored context so the log nests beneath it in the trace.
+   * - Else if the log carries traceId+spanId, attach a SpanContext built from those
+   *   IDs so backends still correlate by ID.
+   * - Else emit under whatever context is currently active.
+   */
+  async onLogEvent(event: LogEvent): Promise<void> {
+    if (this.isDisabled) return;
+
+    try {
+      const params = convertLog(event.log);
+
+      const attributes = { ...params.attributes };
+      if (params.traceId) attributes['mastra.traceId'] = params.traceId;
+      if (params.spanId) attributes['mastra.spanId'] = params.spanId;
+
+      const logContext = this.resolveLogContext(params.traceId, params.spanId);
+
+      this.otelLogger.emit({
+        timestamp: params.timestamp,
+        severityNumber: params.severityNumber,
+        severityText: params.severityText,
+        body: params.body,
+        attributes,
+        context: logContext,
+      });
+    } catch (error) {
+      this.logger.error('[OtelBridge] Failed to emit log:', error);
+    }
+  }
+
+  /**
+   * Pick the OTEL Context to emit a log under so trace correlation is correct.
+   */
+  private resolveLogContext(traceId?: string, spanId?: string): OtelContext {
+    // 1. Prefer the stored OTEL context for the originating Mastra span.
+    if (spanId) {
+      const entry = this.otelSpanMap.get(spanId);
+      if (entry) return entry.otelContext;
+    }
+
+    // 2. Fall back to a context with a span context built from the raw IDs,
+    //    but only when both IDs form a valid W3C span context. Injecting
+    //    malformed IDs would surface as garbage trace links downstream.
+    if (traceId && spanId) {
+      const candidate = {
+        traceId,
+        spanId,
+        traceFlags: TraceFlags.SAMPLED,
+        isRemote: false,
+      };
+      if (isSpanContextValid(candidate)) {
+        return otelTrace.setSpanContext(otelContext.active(), candidate);
+      }
+    }
+
+    // 3. Fall through to whatever is currently active.
+    return otelContext.active();
   }
 
   /**
@@ -284,17 +356,27 @@ export class OtelBridge extends BaseExporter implements ObservabilityBridge {
    * instance is terminated.
    */
   async flush(): Promise<void> {
+    await this.flushProvider(otelTrace.getTracerProvider(), 'tracer');
+    await this.flushProvider(otelLogs.getLoggerProvider(), 'logger');
+  }
+
+  private async flushProvider(provider: unknown, label: 'tracer' | 'logger'): Promise<void> {
     try {
-      const provider = otelTrace.getTracerProvider();
-      // Check if the provider supports forceFlush (not all implementations do)
-      if (provider && 'forceFlush' in provider && typeof provider.forceFlush === 'function') {
-        await provider.forceFlush();
-        this.logger.debug('[OtelBridge] Flushed tracer provider');
+      if (
+        provider &&
+        typeof provider === 'object' &&
+        'forceFlush' in provider &&
+        typeof (provider as { forceFlush: unknown }).forceFlush === 'function'
+      ) {
+        await (provider as { forceFlush: () => Promise<void> }).forceFlush();
+        this.logger.debug(`[OtelBridge] Flushed ${label} provider`);
       } else {
-        this.logger.debug('[OtelBridge] Tracer provider does not support forceFlush');
+        this.logger.debug(
+          `[OtelBridge] ${label === 'tracer' ? 'Tracer' : 'Logger'} provider does not support forceFlush`,
+        );
       }
     } catch (error) {
-      this.logger.error('[OtelBridge] Failed to flush tracer provider:', error);
+      this.logger.error(`[OtelBridge] Failed to flush ${label} provider:`, error);
     }
   }
 

--- a/observability/otel-exporter/README.md
+++ b/observability/otel-exporter/README.md
@@ -1,8 +1,42 @@
-# OtelExporter - OpenTelemetry Tracing Exporter
+# OtelExporter - OpenTelemetry Exporter
 
-Export Mastra traces to any OpenTelemetry-compatible observability platform.
+Export Mastra traces and logs to any OpenTelemetry-compatible observability platform.
 
 > **⚠️ Important:** This package requires you to install an additional exporter package based on your provider. Each provider section below includes the specific installation command.
+
+## Signals
+
+The exporter forwards two OpenTelemetry signals:
+
+- **Traces** — Mastra spans, exported via `BatchSpanProcessor` over an OTLP `SpanExporter`.
+- **Logs** — Mastra log events, exported via `BatchLogRecordProcessor` over an OTLP `LogRecordExporter`. When a log carries `traceId`/`spanId`, both the OTEL log record's native trace context and `mastra.traceId`/`mastra.spanId` attributes are populated so backends like Grafana, Datadog, and Honeycomb can correlate logs to traces automatically.
+
+Both signals are enabled by default and share the same provider configuration. Toggle individual signals via `signals`:
+
+```typescript
+new OtelExporter({
+  provider: {
+    /* ... */
+  },
+  signals: {
+    traces: true, // default
+    logs: true, // default
+  },
+});
+```
+
+Log export requires the matching OTLP log exporter package for your protocol — install one of:
+
+```bash
+# HTTP/JSON
+npm install @opentelemetry/exporter-logs-otlp-http
+# HTTP/Protobuf
+npm install @opentelemetry/exporter-logs-otlp-proto
+# gRPC
+npm install @opentelemetry/exporter-logs-otlp-grpc @grpc/grpc-js
+```
+
+If the matching log exporter package is not installed, log export is silently disabled and traces continue to work.
 
 ## Environment Variables
 
@@ -397,7 +431,13 @@ interface OtelExporterConfig {
 
   // Export configuration
   timeout?: number; // Export timeout in milliseconds (default: 30000)
-  batchSize?: number; // Max spans per batch (default: 512)
+  batchSize?: number; // Max spans/logs per batch (default: 512)
+
+  // Per-signal toggles. All signals are enabled by default.
+  signals?: {
+    traces?: boolean;
+    logs?: boolean;
+  };
 
   // Debug
   logLevel?: 'debug' | 'info' | 'warn' | 'error';

--- a/observability/otel-exporter/package.json
+++ b/observability/otel-exporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mastra/otel-exporter",
   "version": "1.0.23-alpha.2",
-  "description": "OpenTelemetry observability exporter for Mastra - supports OTLP, Zipkin, and multiple cloud providers",
+  "description": "OpenTelemetry observability exporter for Mastra - supports OTLP traces and logs with multiple cloud providers",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -33,14 +33,19 @@
   "dependencies": {
     "@mastra/observability": "workspace:*",
     "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/api-logs": "^0.215.0",
     "@opentelemetry/core": "^2.7.0",
     "@opentelemetry/resources": "^2.7.0",
+    "@opentelemetry/sdk-logs": "^0.215.0",
     "@opentelemetry/sdk-trace-base": "^2.7.0",
     "@opentelemetry/sdk-trace-node": "^2.7.0",
     "@opentelemetry/semantic-conventions": "^1.40.0"
   },
   "optionalDependencies": {
     "@grpc/grpc-js": "^1.14.3",
+    "@opentelemetry/exporter-logs-otlp-grpc": "^0.215.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.215.0",
+    "@opentelemetry/exporter-logs-otlp-proto": "^0.215.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.215.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.215.0",
@@ -61,13 +66,25 @@
   "peerDependencies": {
     "@grpc/grpc-js": "^1.13.4",
     "@mastra/core": ">=1.16.0-0 <2.0.0-0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "^0.205.0",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.205.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "^0.205.0",
+    "@opentelemetry/exporter-logs-otlp-grpc": "^0.215.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.215.0",
+    "@opentelemetry/exporter-logs-otlp-proto": "^0.215.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.215.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.215.0",
     "@opentelemetry/exporter-zipkin": "^2.6.0"
   },
   "peerDependenciesMeta": {
     "@grpc/grpc-js": {
+      "optional": true
+    },
+    "@opentelemetry/exporter-logs-otlp-grpc": {
+      "optional": true
+    },
+    "@opentelemetry/exporter-logs-otlp-http": {
+      "optional": true
+    },
+    "@opentelemetry/exporter-logs-otlp-proto": {
       "optional": true
     },
     "@opentelemetry/exporter-trace-otlp-http": {

--- a/observability/otel-exporter/src/index.ts
+++ b/observability/otel-exporter/src/index.ts
@@ -1,6 +1,8 @@
 export { OtelExporter } from './tracing.js';
 export { SpanConverter, getSpanKind } from './span-converter.js';
 export { getAttributes, getSpanName } from './gen-ai-semantics.js';
+export { convertLog, mapSeverity, buildLogAttributes } from './log-converter.js';
+export type { OtelLogEmitParams } from './log-converter.js';
 export type {
   OtelExporterConfig,
   ProviderConfig,

--- a/observability/otel-exporter/src/loadExporter.ts
+++ b/observability/otel-exporter/src/loadExporter.ts
@@ -1,83 +1,118 @@
 /**
- * Dynamic loader for optional OtelExporters
+ * Dynamic loader for optional OTel signal exporters.
+ *
+ * Each combination of signal (traces/logs) and protocol (http/json,
+ * http/protobuf, grpc, zipkin) maps to a different npm package. We dynamically
+ * import only the one the user's provider config requires, and cache the
+ * constructor so subsequent calls are free.
  */
 
 import type { ExportProtocol } from './types.js';
 
-// Dynamic imports for optional dependencies
-let OTLPHttpExporter: any;
-let OTLPGrpcExporter: any;
-let OTLPProtoExporter: any;
-let ZipkinExporter: any;
+export type SignalType = 'traces' | 'logs';
 
+// ---------------------------------------------------------------------------
+// Package / export-name matrix
+// ---------------------------------------------------------------------------
+
+interface ExporterSpec {
+  /** npm package to dynamic-import */
+  pkg: string;
+  /** Named export to pull from the package */
+  exportName: string;
+  /** Extra packages to mention in the install hint (e.g. @grpc/grpc-js) */
+  extras?: string[];
+}
+
+type ProtocolKey = 'http/json' | 'http/protobuf' | 'grpc' | 'zipkin';
+
+const EXPORTER_SPECS: Record<SignalType, Partial<Record<ProtocolKey, ExporterSpec>>> = {
+  traces: {
+    'http/json': { pkg: '@opentelemetry/exporter-trace-otlp-http', exportName: 'OTLPTraceExporter' },
+    'http/protobuf': { pkg: '@opentelemetry/exporter-trace-otlp-proto', exportName: 'OTLPTraceExporter' },
+    grpc: {
+      pkg: '@opentelemetry/exporter-trace-otlp-grpc',
+      exportName: 'OTLPTraceExporter',
+      extras: ['@grpc/grpc-js'],
+    },
+    zipkin: { pkg: '@opentelemetry/exporter-zipkin', exportName: 'ZipkinExporter' },
+  },
+  logs: {
+    'http/json': { pkg: '@opentelemetry/exporter-logs-otlp-http', exportName: 'OTLPLogExporter' },
+    'http/protobuf': { pkg: '@opentelemetry/exporter-logs-otlp-proto', exportName: 'OTLPLogExporter' },
+    grpc: {
+      pkg: '@opentelemetry/exporter-logs-otlp-grpc',
+      exportName: 'OTLPLogExporter',
+      extras: ['@grpc/grpc-js'],
+    },
+    // zipkin: not supported
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Cache + loader
+// ---------------------------------------------------------------------------
+
+/** Cache keyed by "signal:protocol" */
+const cache = new Map<string, any>();
+
+/**
+ * Load a trace exporter for the given protocol.
+ * Backward-compatible with existing usage in tracing.ts.
+ */
 export async function loadExporter(protocol: ExportProtocol, provider?: string): Promise<any> {
-  switch (protocol) {
-    case 'zipkin':
-      if (!ZipkinExporter) {
-        try {
-          const module = await import('@opentelemetry/exporter-zipkin');
-          ZipkinExporter = module.ZipkinExporter;
-        } catch {
-          console.error(
-            `[OtelExporter] Zipkin exporter is not installed.\n` +
-              `To use Zipkin export, install the required package:\n` +
-              `  npm install @opentelemetry/exporter-zipkin`,
-          );
-          return null;
-        }
-      }
-      return ZipkinExporter;
+  return loadSignalExporter('traces', protocol, provider);
+}
 
-    case 'grpc':
-      if (!OTLPGrpcExporter) {
-        try {
-          const module = await import('@opentelemetry/exporter-trace-otlp-grpc');
-          OTLPGrpcExporter = module.OTLPTraceExporter;
-        } catch {
-          const providerInfo = provider ? ` (required for ${provider})` : '';
-          console.error(
-            `[OtelExporter] gRPC exporter is not installed${providerInfo}.\n` +
-              `To use gRPC export, install the required packages:\n` +
-              `  npm install @opentelemetry/exporter-trace-otlp-grpc @grpc/grpc-js`,
-          );
-          return null;
-        }
-      }
-      return OTLPGrpcExporter;
+/**
+ * Load a signal-specific exporter class for the given protocol.
+ * Returns the constructor, or null if the package isn't installed.
+ */
+export async function loadSignalExporter(
+  signal: SignalType,
+  protocol: ExportProtocol,
+  provider?: string,
+): Promise<any> {
+  const spec = EXPORTER_SPECS[signal]?.[protocol];
 
-    case 'http/protobuf':
-      if (!OTLPProtoExporter) {
-        try {
-          const module = await import('@opentelemetry/exporter-trace-otlp-proto');
-          OTLPProtoExporter = module.OTLPTraceExporter;
-        } catch {
-          const providerInfo = provider ? ` (required for ${provider})` : '';
-          console.error(
-            `[OtelExporter] HTTP/Protobuf exporter is not installed${providerInfo}.\n` +
-              `To use HTTP/Protobuf export, install the required package:\n` +
-              `  npm install @opentelemetry/exporter-trace-otlp-proto`,
-          );
-          return null;
-        }
-      }
-      return OTLPProtoExporter;
-
-    case 'http/json':
-    default:
-      if (!OTLPHttpExporter) {
-        try {
-          const module = await import('@opentelemetry/exporter-trace-otlp-http');
-          OTLPHttpExporter = module.OTLPTraceExporter;
-        } catch {
-          const providerInfo = provider ? ` (required for ${provider})` : '';
-          console.error(
-            `[OtelExporter] HTTP/JSON exporter is not installed${providerInfo}.\n` +
-              `To use HTTP/JSON export, install the required package:\n` +
-              `  npm install @opentelemetry/exporter-trace-otlp-http`,
-          );
-          return null;
-        }
-      }
-      return OTLPHttpExporter;
+  if (!spec) {
+    if (protocol === 'zipkin') {
+      console.warn(
+        `[OtelExporter] Zipkin does not support OTLP ${signal}. ${capitalize(signal)} export will be disabled.`,
+      );
+    }
+    return null;
   }
+
+  const cacheKey = `${signal}:${protocol}`;
+  if (cache.has(cacheKey)) {
+    return cache.get(cacheKey);
+  }
+
+  try {
+    const mod = await import(spec.pkg);
+    const ExporterClass = mod[spec.exportName];
+    if (typeof ExporterClass !== 'function') {
+      console.error(
+        `[OtelExporter] ${capitalize(signal)} ${protocol} exporter package "${spec.pkg}" did not expose a "${spec.exportName}" export. ` +
+          `${capitalize(signal)} export will be disabled.`,
+      );
+      return null;
+    }
+    cache.set(cacheKey, ExporterClass);
+    return ExporterClass;
+  } catch {
+    const providerInfo = provider ? ` (required for ${provider})` : '';
+    const allPkgs = [spec.pkg, ...(spec.extras ?? [])].join(' ');
+    console.error(
+      `[OtelExporter] ${capitalize(signal)} ${protocol} exporter is not installed${providerInfo}.\n` +
+        `  Install the required package(s):\n` +
+        `  npm install ${allPkgs}`,
+    );
+    return null;
+  }
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
 }

--- a/observability/otel-exporter/src/log-converter.test.ts
+++ b/observability/otel-exporter/src/log-converter.test.ts
@@ -1,0 +1,187 @@
+import type { ExportedLog } from '@mastra/core/observability';
+import { SeverityNumber } from '@opentelemetry/api-logs';
+import { describe, it, expect } from 'vitest';
+
+import { convertLog, mapSeverity, buildLogAttributes } from './log-converter';
+
+describe('log-converter', () => {
+  describe('mapSeverity', () => {
+    it('should map debug to SeverityNumber.DEBUG', () => {
+      expect(mapSeverity('debug')).toBe(SeverityNumber.DEBUG);
+    });
+
+    it('should map info to SeverityNumber.INFO', () => {
+      expect(mapSeverity('info')).toBe(SeverityNumber.INFO);
+    });
+
+    it('should map warn to SeverityNumber.WARN', () => {
+      expect(mapSeverity('warn')).toBe(SeverityNumber.WARN);
+    });
+
+    it('should map error to SeverityNumber.ERROR', () => {
+      expect(mapSeverity('error')).toBe(SeverityNumber.ERROR);
+    });
+
+    it('should map fatal to SeverityNumber.FATAL', () => {
+      expect(mapSeverity('fatal')).toBe(SeverityNumber.FATAL);
+    });
+  });
+
+  describe('buildLogAttributes', () => {
+    it('should include data fields with mastra.log prefix', () => {
+      const log: ExportedLog = {
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+        level: 'info',
+        message: 'test',
+        data: { requestId: '123', statusCode: 200 },
+      };
+
+      const attrs = buildLogAttributes(log);
+      expect(attrs['mastra.log.requestId']).toBe('123');
+      expect(attrs['mastra.log.statusCode']).toBe(200);
+    });
+
+    it('should JSON-stringify object values in data', () => {
+      const log: ExportedLog = {
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+        level: 'info',
+        message: 'test',
+        data: { headers: { 'content-type': 'application/json' } },
+      };
+
+      const attrs = buildLogAttributes(log);
+      expect(attrs['mastra.log.headers']).toBe('{"content-type":"application/json"}');
+    });
+
+    it('should include metadata fields with mastra.metadata prefix', () => {
+      const log: ExportedLog = {
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+        level: 'info',
+        message: 'test',
+        metadata: { environment: 'production', userId: 'user-1' },
+      };
+
+      const attrs = buildLogAttributes(log);
+      expect(attrs['mastra.metadata.environment']).toBe('production');
+      expect(attrs['mastra.metadata.userId']).toBe('user-1');
+    });
+
+    it('should include tags as JSON-stringified array', () => {
+      const log: ExportedLog = {
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+        level: 'info',
+        message: 'test',
+        tags: ['auth', 'error'],
+      };
+
+      const attrs = buildLogAttributes(log);
+      expect(attrs['mastra.tags']).toBe(JSON.stringify(['auth', 'error']));
+    });
+
+    it('should skip null/undefined values in data and metadata', () => {
+      const log: ExportedLog = {
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+        level: 'info',
+        message: 'test',
+        data: { present: 'yes', absent: undefined, empty: null } as any,
+        metadata: { valid: 'value', missing: undefined } as any,
+      };
+
+      const attrs = buildLogAttributes(log);
+      expect(attrs['mastra.log.present']).toBe('yes');
+      expect(attrs['mastra.log.absent']).toBeUndefined();
+      expect(attrs['mastra.log.empty']).toBeUndefined();
+      expect(attrs['mastra.metadata.valid']).toBe('value');
+      expect(attrs['mastra.metadata.missing']).toBeUndefined();
+    });
+
+    it('should return empty attributes when log has no data/metadata/tags', () => {
+      const log: ExportedLog = {
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+        level: 'info',
+        message: 'test',
+      };
+
+      const attrs = buildLogAttributes(log);
+      expect(Object.keys(attrs).length).toBe(0);
+    });
+
+    it('should not include mastra.tags when tags is empty', () => {
+      const log: ExportedLog = {
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+        level: 'info',
+        message: 'test',
+        tags: [],
+      };
+
+      const attrs = buildLogAttributes(log);
+      expect(attrs['mastra.tags']).toBeUndefined();
+    });
+  });
+
+  describe('convertLog', () => {
+    it('should convert a full ExportedLog to OtelLogEmitParams', () => {
+      const log: ExportedLog = {
+        timestamp: new Date('2024-06-15T12:30:00Z'),
+        level: 'error',
+        message: 'Database connection failed',
+        data: { host: 'db.example.com', port: 5432 },
+        traceId: 'abc123',
+        spanId: 'def456',
+        tags: ['database', 'critical'],
+        metadata: { environment: 'production' },
+      };
+
+      const params = convertLog(log);
+
+      expect(params.severityNumber).toBe(SeverityNumber.ERROR);
+      expect(params.severityText).toBe('ERROR');
+      expect(params.body).toBe('Database connection failed');
+      expect(params.traceId).toBe('abc123');
+      expect(params.spanId).toBe('def456');
+
+      // Timestamp should be HrTime [seconds, nanoseconds]
+      expect(params.timestamp).toHaveLength(2);
+      expect(params.timestamp[0]).toBeGreaterThan(0);
+      expect(params.timestamp[1]).toBeGreaterThanOrEqual(0);
+
+      // Attributes should include data, metadata, and tags
+      expect(params.attributes['mastra.log.host']).toBe('db.example.com');
+      expect(params.attributes['mastra.log.port']).toBe(5432);
+      expect(params.attributes['mastra.metadata.environment']).toBe('production');
+      expect(params.attributes['mastra.tags']).toBe(JSON.stringify(['database', 'critical']));
+    });
+
+    it('should handle a minimal ExportedLog', () => {
+      const log: ExportedLog = {
+        timestamp: new Date('2024-01-01T00:00:00Z'),
+        level: 'debug',
+        message: 'simple message',
+      };
+
+      const params = convertLog(log);
+
+      expect(params.severityNumber).toBe(SeverityNumber.DEBUG);
+      expect(params.severityText).toBe('DEBUG');
+      expect(params.body).toBe('simple message');
+      expect(params.traceId).toBeUndefined();
+      expect(params.spanId).toBeUndefined();
+      expect(Object.keys(params.attributes).length).toBe(0);
+    });
+
+    it('should correctly convert timestamp to HrTime', () => {
+      // 1704067200000 ms = 2024-01-01T00:00:00Z
+      const log: ExportedLog = {
+        timestamp: new Date('2024-01-01T00:00:00.123Z'),
+        level: 'info',
+        message: 'test',
+      };
+
+      const params = convertLog(log);
+      const [seconds, nanoseconds] = params.timestamp;
+
+      expect(seconds).toBe(Math.floor(new Date('2024-01-01T00:00:00.123Z').getTime() / 1000));
+      expect(nanoseconds).toBe(123 * 1_000_000);
+    });
+  });
+});

--- a/observability/otel-exporter/src/log-converter.ts
+++ b/observability/otel-exporter/src/log-converter.ts
@@ -1,0 +1,112 @@
+/**
+ * Convert Mastra ExportedLog to OpenTelemetry LogRecord format
+ */
+
+import type { ExportedLog, LogLevel } from '@mastra/core/observability';
+import type { HrTime } from '@opentelemetry/api';
+import type { LogAttributes } from '@opentelemetry/api-logs';
+import { SeverityNumber } from '@opentelemetry/api-logs';
+
+/**
+ * Map Mastra LogLevel to OTEL SeverityNumber
+ */
+export function mapSeverity(level: LogLevel): SeverityNumber {
+  switch (level) {
+    case 'debug':
+      return SeverityNumber.DEBUG;
+    case 'info':
+      return SeverityNumber.INFO;
+    case 'warn':
+      return SeverityNumber.WARN;
+    case 'error':
+      return SeverityNumber.ERROR;
+    case 'fatal':
+      return SeverityNumber.FATAL;
+    default:
+      return SeverityNumber.UNSPECIFIED;
+  }
+}
+
+/**
+ * Convert a Date to OTEL HrTime [seconds, nanoseconds]
+ */
+function dateToHrTime(date: Date): HrTime {
+  const ms = date.getTime();
+  const seconds = Math.floor(ms / 1000);
+  const nanoseconds = (ms % 1000) * 1_000_000;
+  return [seconds, nanoseconds];
+}
+
+/**
+ * Stringify a value for use as an OTEL log attribute. Falls back to a
+ * placeholder rather than throwing if the value contains a circular
+ * reference, throws from a custom toJSON, or otherwise cannot be serialized.
+ */
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '[unserializable]';
+  }
+}
+
+/**
+ * Build OTEL log attributes from ExportedLog fields.
+ * Includes trace correlation and metadata.
+ */
+export function buildLogAttributes(log: ExportedLog): LogAttributes {
+  const attributes: LogAttributes = {};
+
+  // Add structured data fields as attributes
+  if (log.data) {
+    for (const [key, value] of Object.entries(log.data)) {
+      if (value === null || value === undefined) continue;
+      attributes[`mastra.log.${key}`] =
+        typeof value === 'object' ? safeStringify(value) : (value as string | number | boolean);
+    }
+  }
+
+  // Add metadata as attributes
+  if (log.metadata) {
+    for (const [key, value] of Object.entries(log.metadata)) {
+      if (value === null || value === undefined) continue;
+      attributes[`mastra.metadata.${key}`] =
+        typeof value === 'object' ? safeStringify(value) : (value as string | number | boolean);
+    }
+  }
+
+  // Add tags if present
+  if (log.tags?.length) {
+    attributes['mastra.tags'] = safeStringify(log.tags);
+  }
+
+  return attributes;
+}
+
+/**
+ * Parameters for emitting an OTEL log record from a Mastra ExportedLog.
+ */
+export interface OtelLogEmitParams {
+  timestamp: HrTime;
+  severityNumber: SeverityNumber;
+  severityText: string;
+  body: string;
+  attributes: LogAttributes;
+  traceId?: string;
+  spanId?: string;
+}
+
+/**
+ * Convert an ExportedLog into parameters suitable for OTEL Logger.emit()
+ */
+export function convertLog(log: ExportedLog): OtelLogEmitParams {
+  return {
+    timestamp: dateToHrTime(log.timestamp),
+    severityNumber: mapSeverity(log.level),
+    severityText: log.level.toUpperCase(),
+    body: log.message,
+    attributes: buildLogAttributes(log),
+    traceId: log.traceId,
+    spanId: log.spanId,
+  };
+}

--- a/observability/otel-exporter/src/provider-configs.ts
+++ b/observability/otel-exporter/src/provider-configs.ts
@@ -19,24 +19,50 @@ export interface ResolvedProviderConfig {
   protocol: ExportProtocol;
 }
 
-export function resolveProviderConfig(config: ProviderConfig): ResolvedProviderConfig | null {
+export function resolveProviderConfig(config: ProviderConfig, debug?: boolean): ResolvedProviderConfig | null {
+  const providerName = Object.keys(config)[0];
+
+  if (debug) {
+    console.info(`[OtelExporter:debug] Resolving provider config for: ${providerName}`);
+  }
+
+  let resolved: ResolvedProviderConfig | null;
+
   if ('dash0' in config) {
-    return resolveDash0Config(config.dash0);
+    resolved = resolveDash0Config(config.dash0);
   } else if ('signoz' in config) {
-    return resolveSignozConfig(config.signoz);
+    resolved = resolveSignozConfig(config.signoz);
   } else if ('newrelic' in config) {
-    return resolveNewRelicConfig(config.newrelic);
+    resolved = resolveNewRelicConfig(config.newrelic);
   } else if ('traceloop' in config) {
-    return resolveTraceloopConfig(config.traceloop);
+    resolved = resolveTraceloopConfig(config.traceloop);
   } else if ('laminar' in config) {
-    return resolveLaminarConfig(config.laminar);
+    resolved = resolveLaminarConfig(config.laminar);
   } else if ('custom' in config) {
-    return resolveCustomConfig(config.custom);
+    resolved = resolveCustomConfig(config.custom);
   } else {
     // TypeScript exhaustiveness check
     const _exhaustive: never = config;
     return _exhaustive;
   }
+
+  if (debug && resolved) {
+    // Header values frequently carry credentials (Bearer tokens, API keys, Basic auth).
+    // Don't log any portion of the value — even prefix/suffix slices can leak.
+    const maskedHeaders: Record<string, string> = {};
+    for (const [key, value] of Object.entries(resolved.headers)) {
+      maskedHeaders[key] = value ? '[REDACTED]' : '[EMPTY]';
+    }
+    console.info(`[OtelExporter:debug] Provider "${providerName}" resolved:`, {
+      endpoint: resolved.endpoint,
+      protocol: resolved.protocol,
+      headers: maskedHeaders,
+    });
+  } else if (debug && !resolved) {
+    console.info(`[OtelExporter:debug] Provider "${providerName}" resolution returned null (disabled)`);
+  }
+
+  return resolved;
 }
 
 function resolveDash0Config(config: Dash0Config): ResolvedProviderConfig | null {

--- a/observability/otel-exporter/src/tracing.test.ts
+++ b/observability/otel-exporter/src/tracing.test.ts
@@ -1,5 +1,6 @@
 import { SpanType, TracingEventType } from '@mastra/core/observability';
-import type { AnyExportedSpan } from '@mastra/core/observability';
+import type { AnyExportedSpan, LogEvent } from '@mastra/core/observability';
+import { trace } from '@opentelemetry/api';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { OtelExporter } from './tracing';
 
@@ -42,9 +43,29 @@ vi.mock('@opentelemetry/resources', () => ({
   resourceFromAttributes: vi.fn().mockReturnValue({}),
 }));
 
+const mockEmit = vi.fn();
+vi.mock('@opentelemetry/sdk-logs', () => ({
+  LoggerProvider: vi.fn().mockImplementation(function () {
+    return {
+      getLogger: vi.fn().mockReturnValue({ emit: mockEmit }),
+      forceFlush: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    };
+  }),
+  BatchLogRecordProcessor: vi.fn().mockImplementation(function () {
+    return {};
+  }),
+}));
+
 vi.mock('./loadExporter', () => ({
   loadExporter: vi.fn().mockResolvedValue(
     class MockExporter {
+      export = vi.fn().mockResolvedValue(undefined);
+      shutdown = vi.fn().mockResolvedValue(undefined);
+    },
+  ),
+  loadSignalExporter: vi.fn().mockResolvedValue(
+    class MockSignalExporter {
       export = vi.fn().mockResolvedValue(undefined);
       shutdown = vi.fn().mockResolvedValue(undefined);
     },
@@ -525,6 +546,272 @@ describe('OtelExporter', () => {
       // Tags should be present as mastra.tags attribute (JSON-stringified for backend compatibility)
       expect(readableSpan.attributes['mastra.tags']).toBeDefined();
       expect(readableSpan.attributes['mastra.tags']).toBe(JSON.stringify(['batch-processing', 'priority-high']));
+    });
+  });
+
+  describe('Log Export (onLogEvent)', () => {
+    beforeEach(() => {
+      mockEmit.mockClear();
+    });
+
+    it('should export a log event via OTEL LoggerProvider', async () => {
+      exporter = new OtelExporter({
+        provider: {
+          custom: {
+            endpoint: 'http://localhost:4318',
+          },
+        },
+      });
+
+      const logEvent: LogEvent = {
+        type: 'log',
+        log: {
+          timestamp: new Date('2024-06-15T12:00:00Z'),
+          level: 'error',
+          message: 'Something went wrong',
+          data: { requestId: 'req-123' },
+          traceId: 'trace-abc',
+          spanId: 'span-def',
+          metadata: { environment: 'production' },
+        },
+      };
+
+      await exporter.onLogEvent(logEvent);
+
+      expect(mockEmit).toHaveBeenCalledTimes(1);
+      const emitArgs = mockEmit.mock.calls[0]![0];
+      expect(emitArgs.body).toBe('Something went wrong');
+      expect(emitArgs.severityText).toBe('ERROR');
+      expect(emitArgs.attributes['mastra.log.requestId']).toBe('req-123');
+      expect(emitArgs.attributes['mastra.metadata.environment']).toBe('production');
+      expect(emitArgs.attributes['mastra.traceId']).toBe('trace-abc');
+      expect(emitArgs.attributes['mastra.spanId']).toBe('span-def');
+      // Native OTEL trace context is set so backends correlate by ID, not just by attribute
+      const emittedSpanContext = trace.getSpanContext(emitArgs.context);
+      expect(emittedSpanContext?.traceId).toBe('trace-abc');
+      expect(emittedSpanContext?.spanId).toBe('span-def');
+    });
+
+    it('should not export logs when signals.logs is false', async () => {
+      exporter = new OtelExporter({
+        provider: {
+          custom: {
+            endpoint: 'http://localhost:4318',
+          },
+        },
+        signals: { logs: false },
+      });
+
+      const logEvent: LogEvent = {
+        type: 'log',
+        log: {
+          timestamp: new Date(),
+          level: 'info',
+          message: 'Should not be exported',
+        },
+      };
+
+      await exporter.onLogEvent(logEvent);
+
+      expect(mockEmit).not.toHaveBeenCalled();
+    });
+
+    it('should handle log events without trace context', async () => {
+      exporter = new OtelExporter({
+        provider: {
+          custom: {
+            endpoint: 'http://localhost:4318',
+          },
+        },
+      });
+
+      const logEvent: LogEvent = {
+        type: 'log',
+        log: {
+          timestamp: new Date(),
+          level: 'debug',
+          message: 'No trace context',
+        },
+      };
+
+      await exporter.onLogEvent(logEvent);
+
+      expect(mockEmit).toHaveBeenCalledTimes(1);
+      const emitArgs = mockEmit.mock.calls[0]![0];
+      expect(emitArgs.body).toBe('No trace context');
+      expect(emitArgs.attributes['mastra.traceId']).toBeUndefined();
+      expect(emitArgs.attributes['mastra.spanId']).toBeUndefined();
+      // No span context attached when the log carries none
+      expect(trace.getSpanContext(emitArgs.context)).toBeUndefined();
+    });
+  });
+
+  describe('Signal toggles', () => {
+    it('should not initialize a trace exporter when signals.traces is false', async () => {
+      const { loadExporter } = await import('./loadExporter');
+      vi.mocked(loadExporter).mockClear();
+
+      exporter = new OtelExporter({
+        provider: {
+          custom: {
+            endpoint: 'http://localhost:4318',
+          },
+        },
+        signals: { traces: false },
+      });
+
+      const exportedSpan = {
+        id: 'span-1',
+        traceId: 'trace-1',
+        parent: undefined,
+        type: SpanType.AGENT_RUN,
+        name: 'Test Span',
+        startTime: new Date(),
+        endTime: new Date(),
+      } as unknown as AnyExportedSpan;
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan,
+      });
+
+      expect(loadExporter).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Signal Endpoint Resolution', () => {
+    beforeEach(() => {
+      mockEmit.mockClear();
+    });
+
+    it('rewrites a trace endpoint to /v1/logs when constructing the log exporter', async () => {
+      const ctorArgs: Array<Record<string, unknown>> = [];
+      const { loadSignalExporter } = await import('./loadExporter');
+      vi.mocked(loadSignalExporter).mockResolvedValueOnce(
+        class MockLogExporter {
+          constructor(options: Record<string, unknown>) {
+            ctorArgs.push(options);
+          }
+          export = vi.fn().mockResolvedValue(undefined);
+          shutdown = vi.fn().mockResolvedValue(undefined);
+        },
+      );
+
+      exporter = new OtelExporter({
+        provider: {
+          custom: {
+            endpoint: 'http://localhost:4318/v1/traces',
+          },
+        },
+      });
+
+      await exporter.onLogEvent({
+        type: 'log',
+        log: {
+          timestamp: new Date(),
+          level: 'info',
+          message: 'Test endpoint resolution',
+        },
+      });
+
+      expect(ctorArgs[0]).toMatchObject({ url: 'http://localhost:4318/v1/logs' });
+      expect(mockEmit).toHaveBeenCalledTimes(1);
+    });
+
+    it('appends /v1/logs without producing double slashes when the endpoint has a trailing slash', async () => {
+      const ctorArgs: Array<Record<string, unknown>> = [];
+      const { loadSignalExporter } = await import('./loadExporter');
+      vi.mocked(loadSignalExporter).mockResolvedValueOnce(
+        class MockLogExporter {
+          constructor(options: Record<string, unknown>) {
+            ctorArgs.push(options);
+          }
+          export = vi.fn().mockResolvedValue(undefined);
+          shutdown = vi.fn().mockResolvedValue(undefined);
+        },
+      );
+
+      exporter = new OtelExporter({
+        provider: {
+          custom: {
+            endpoint: 'http://localhost:4318/',
+          },
+        },
+      });
+
+      await exporter.onLogEvent({
+        type: 'log',
+        log: { timestamp: new Date(), level: 'info', message: 'trailing slash' },
+      });
+
+      expect(ctorArgs[0]).toMatchObject({ url: 'http://localhost:4318/v1/logs' });
+    });
+  });
+
+  describe('Lifecycle with multiple signals', () => {
+    it('should flush all active providers', async () => {
+      exporter = new OtelExporter({
+        provider: {
+          custom: {
+            endpoint: 'http://localhost:4318',
+          },
+        },
+      });
+
+      // Trigger trace setup
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan: {
+          id: 'span-1',
+          traceId: 'trace-1',
+          type: SpanType.AGENT_RUN,
+          name: 'Test',
+          startTime: new Date(),
+          endTime: new Date(),
+        } as unknown as AnyExportedSpan,
+      });
+
+      // Trigger log setup
+      await exporter.onLogEvent({
+        type: 'log',
+        log: { timestamp: new Date(), level: 'info', message: 'test' },
+      });
+
+      // Flush should succeed without errors
+      await exporter.flush();
+      expect(exporter).toBeDefined();
+    });
+
+    it('should shutdown all active providers', async () => {
+      exporter = new OtelExporter({
+        provider: {
+          custom: {
+            endpoint: 'http://localhost:4318',
+          },
+        },
+      });
+
+      // Trigger all signal setups
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_ENDED,
+        exportedSpan: {
+          id: 'span-1',
+          traceId: 'trace-1',
+          type: SpanType.AGENT_RUN,
+          name: 'Test',
+          startTime: new Date(),
+          endTime: new Date(),
+        } as unknown as AnyExportedSpan,
+      });
+
+      await exporter.onLogEvent({
+        type: 'log',
+        log: { timestamp: new Date(), level: 'info', message: 'test' },
+      });
+
+      // Shutdown should succeed without errors
+      await exporter.shutdown();
+      expect(exporter).toBeDefined();
     });
   });
 });

--- a/observability/otel-exporter/src/tracing.ts
+++ b/observability/otel-exporter/src/tracing.ts
@@ -1,32 +1,119 @@
 /**
- * OpenTelemetry Tracing Exporter for Mastra
+ * OpenTelemetry Exporter for Mastra
+ *
+ * Exports traces and logs to any OTLP-compatible endpoint.
  */
 
 import type {
   TracingEvent,
-  AnyExportedSpan,
+  LogEvent,
   InitExporterOptions,
   ObservabilityInstanceConfig,
 } from '@mastra/core/observability';
 import { TracingEventType } from '@mastra/core/observability';
 import { BaseExporter } from '@mastra/observability';
-import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
+import { context as apiContext, diag, DiagConsoleLogger, DiagLogLevel, trace, TraceFlags } from '@opentelemetry/api';
+import type { Logger } from '@opentelemetry/api-logs';
 
+import type { ExportResult } from '@opentelemetry/core';
+import { ExportResultCode } from '@opentelemetry/core';
+
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import { LoggerProvider, BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
+import type { SpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import type { SpanExporter } from '@opentelemetry/sdk-trace-base';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
-import { loadExporter } from './loadExporter.js';
+import { loadExporter, loadSignalExporter } from './loadExporter.js';
+import { convertLog } from './log-converter.js';
 import { resolveProviderConfig } from './provider-configs.js';
+import type { ResolvedProviderConfig } from './provider-configs.js';
 import { SpanConverter } from './span-converter.js';
-import type { OtelExporterConfig } from './types.js';
+import type { ExportProtocol, OtelExporterConfig } from './types.js';
+
+/**
+ * Wrapper around a SpanExporter that logs export results when debug mode is enabled.
+ * The OTel SDK intentionally does not log on success, making debugging difficult.
+ * This wrapper adds visibility into each batch export's outcome.
+ */
+class DebugSpanExporterWrapper implements SpanExporter {
+  constructor(
+    private inner: SpanExporter,
+    private debugLog: (msg: string) => void,
+  ) {}
+
+  export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    const count = spans.length;
+    this.inner.export(spans, (result: ExportResult) => {
+      if (result.code === ExportResultCode.SUCCESS) {
+        this.debugLog(`[OtelExporter] Export completed: ${count} spans sent successfully`);
+      } else {
+        this.debugLog(`[OtelExporter] Export FAILED: ${count} spans, error: ${result.error?.message ?? 'unknown'}`);
+      }
+      resultCallback(result);
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    return this.inner.shutdown();
+  }
+
+  async forceFlush(): Promise<void> {
+    return this.inner.forceFlush?.();
+  }
+}
+
+/**
+ * Wrapper around a LogRecordExporter that logs export results when debug mode is enabled.
+ * Same pattern as DebugSpanExporterWrapper but for log records.
+ */
+class DebugLogExporterWrapper {
+  constructor(
+    private inner: any,
+    private debugLog: (msg: string) => void,
+  ) {}
+
+  export(logs: any[], resultCallback: (result: ExportResult) => void): void {
+    const count = logs.length;
+    this.inner.export(logs, (result: ExportResult) => {
+      if (result.code === ExportResultCode.SUCCESS) {
+        this.debugLog(`[OtelExporter] Log export completed: ${count} logs sent successfully`);
+      } else {
+        this.debugLog(`[OtelExporter] Log export FAILED: ${count} logs, error: ${result.error?.message ?? 'unknown'}`);
+      }
+      resultCallback(result);
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    return this.inner.shutdown();
+  }
+
+  async forceFlush(): Promise<void> {
+    return this.inner.forceFlush?.();
+  }
+}
 
 export class OtelExporter extends BaseExporter {
   private config: OtelExporterConfig;
   private observabilityConfig?: ObservabilityInstanceConfig;
+
+  // Trace signal
   private spanConverter?: SpanConverter;
   private processor?: BatchSpanProcessor;
   private exporter?: SpanExporter;
-  private isSetup: boolean = false;
+
+  // Log signal
+  private loggerProvider?: LoggerProvider;
+  private otelLogger?: Logger;
+
+  // Provider config (resolved once, shared across signals)
+  private resolvedConfig?: ResolvedProviderConfig | null;
+  private providerName?: string;
+
+  // Single setup promise — all signals initialize together at init() time.
+  // Event handlers await this before processing. Never rejects.
+  private setupPromise?: Promise<void>;
 
   name = 'opentelemetry';
 
@@ -35,196 +122,411 @@ export class OtelExporter extends BaseExporter {
 
     this.config = config;
 
-    // Set up OpenTelemetry diagnostics if debug mode
+    // Set OTel SDK diagnostics to INFO level so we see warnings/errors from
+    // the SDK internals. We intentionally do NOT use DEBUG here because:
+    // 1. OTLPExportDelegate dumps enormous payloads at DEBUG level
+    // 2. diag.setLogger() is global and can be overwritten by other code
+    // Our DebugSpanExporterWrapper provides export-result logging instead.
     if (config.logLevel === 'debug') {
-      diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+      diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
     }
   }
 
   /**
-   * Initialize with tracing configuration
+   * Initialize with observability configuration and eagerly set up the trace
+   * and log signal exporters in parallel.
+   *
+   * Called by Mastra during component registration. The async setup runs in the
+   * background — event handlers await the resulting promise before processing.
    */
   init(options: InitExporterOptions) {
     this.observabilityConfig = options.config;
+    this.setupPromise = this.setupAllSignals();
   }
 
-  private async setupExporter() {
-    // already setup or exporter already set
-    if (this.isSetup || this.exporter) return;
+  // ===========================================================================
+  // Provider config resolution (shared across all signals)
+  // ===========================================================================
 
-    // Provider configuration is required
+  private get isDebug(): boolean {
+    return this.config.logLevel === 'debug';
+  }
+
+  /**
+   * Debug logging that bypasses the Mastra logger.
+   *
+   * The Mastra framework replaces our logger via __setLogger() with one at
+   * INFO level, which silently swallows all this.logger.debug() calls.
+   * For debug output we need to go through console.info directly.
+   */
+
+  private debugLog = (...args: unknown[]) => this.isDebug && console.info('[OtelExporter:debug]', ...args);
+
+  private resolveProvider(): ResolvedProviderConfig | null {
+    if (this.resolvedConfig !== undefined) {
+      return this.resolvedConfig;
+    }
+
     if (!this.config.provider) {
       this.setDisabled(
         '[OtelExporter] Provider configuration is required. Use the "custom" provider for generic endpoints.',
       );
-      this.isSetup = true;
-      return;
+      this.resolvedConfig = null;
+      return null;
     }
 
-    // Resolve provider configuration
-    const resolved = resolveProviderConfig(this.config.provider);
+    this.providerName = Object.keys(this.config.provider)[0];
+    const resolved = resolveProviderConfig(this.config.provider, this.isDebug);
     if (!resolved) {
-      // Configuration validation failed, disable tracing
       this.setDisabled('[OtelExporter] Provider configuration validation failed.');
-      this.isSetup = true;
+      this.resolvedConfig = null;
+      return null;
+    }
+
+    this.resolvedConfig = resolved;
+    return resolved;
+  }
+
+  /**
+   * Derive the endpoint for a specific signal from the resolved provider config.
+   * Strips trailing slashes and any existing signal-path suffix so we never
+   * produce a doubled "//v1/logs" or leave a stale "/v1/traces" on a logs URL.
+   */
+  private getSignalEndpoint(resolved: ResolvedProviderConfig, signal: 'traces' | 'logs'): string {
+    const signalPaths: Record<string, string> = {
+      traces: '/v1/traces',
+      logs: '/v1/logs',
+    };
+
+    // Drop trailing slashes first so the suffix check below also matches
+    // endpoints written like ".../v1/traces/". Bounded loop instead of
+    // /\/+$/ to avoid the polynomial-regex pattern CodeQL flags.
+    let base = resolved.endpoint;
+    while (base.endsWith('/')) {
+      base = base.slice(0, -1);
+    }
+
+    // Strip any existing signal-path suffix (with or without leading slash variations)
+    for (const path of Object.values(signalPaths)) {
+      if (base.endsWith(path)) {
+        base = base.slice(0, -path.length);
+        break;
+      }
+    }
+
+    return base + signalPaths[signal];
+  }
+
+  /**
+   * Build exporter constructor options for the given signal endpoint.
+   * For gRPC, converts headers to Metadata. For HTTP protocols, passes headers directly.
+   */
+  private async buildExporterOptions(
+    protocol: ExportProtocol,
+    url: string,
+    headers: Record<string, string>,
+  ): Promise<Record<string, unknown>> {
+    if (protocol === 'grpc') {
+      const grpcModule = await import('@grpc/grpc-js');
+      const metadata = new grpcModule.Metadata();
+      for (const [key, value] of Object.entries(headers)) {
+        metadata.set(key, value);
+      }
+      return { url, metadata, timeoutMillis: this.config.timeout };
+    }
+    return { url, headers, timeoutMillis: this.config.timeout };
+  }
+
+  // ===========================================================================
+  // Setup — eager, parallel initialization of all signals
+  // ===========================================================================
+
+  /**
+   * Wait for setup to complete. If init() was called, this awaits the
+   * already-in-flight setup promise. If init() was never called (standalone
+   * usage without Mastra), this triggers setup on first use.
+   */
+  private ensureSetup(): Promise<void> {
+    if (!this.setupPromise) {
+      this.setupPromise = this.setupAllSignals();
+    }
+    return this.setupPromise;
+  }
+
+  /**
+   * Resolve provider config once and set up all enabled signals in parallel.
+   * Each signal setup catches its own errors — this method never rejects.
+   */
+  private async setupAllSignals(): Promise<void> {
+    const resolved = this.resolveProvider();
+    if (!resolved) {
+      this.debugLog('Setup skipped: provider not resolved');
       return;
     }
 
-    // user provided an instantiated SpanExporter, use it
-    if (this.config.exporter) {
-      this.exporter = this.config.exporter;
-      return;
-    }
-
-    const endpoint = resolved.endpoint;
-    const headers = resolved.headers;
     const protocol = resolved.protocol;
+    const setupTasks: Promise<void>[] = [];
 
-    // Load and create the appropriate exporter based on protocol
-    const providerName = Object.keys(this.config.provider)[0];
-    const ExporterClass = await loadExporter(protocol, providerName);
-
-    if (!ExporterClass) {
-      // Exporter not available, disable tracing
-      this.setDisabled(`[OtelExporter] Exporter not available for protocol: ${protocol}`);
-      this.isSetup = true;
-      return;
+    if (this.config.signals?.traces !== false) {
+      setupTasks.push(this.setupTraces(resolved, protocol));
+    } else {
+      this.debugLog('Trace export disabled via config');
     }
 
+    if (this.config.signals?.logs !== false) {
+      setupTasks.push(this.setupLogs(resolved, protocol));
+    } else {
+      this.debugLog('Log export disabled via config');
+    }
+
+    await Promise.all(setupTasks);
+
+    this.debugLog(`Setup complete [traces=${!!this.processor}, logs=${!!this.otelLogger}]`);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Trace setup
+  // ---------------------------------------------------------------------------
+
+  private async setupTraces(resolved: ResolvedProviderConfig, protocol: ExportProtocol): Promise<void> {
     try {
-      if (protocol === 'zipkin') {
-        this.exporter = new ExporterClass({
-          url: endpoint,
-          headers,
-        });
-      } else if (protocol === 'grpc') {
-        // gRPC uses Metadata object instead of headers
-        // Dynamically import @grpc/grpc-js to create metadata
-        let metadata: any;
-        try {
-          const grpcModule = await import('@grpc/grpc-js');
-          metadata = new grpcModule.Metadata();
-          Object.entries(headers).forEach(([key, value]) => {
-            metadata.set(key, value);
-          });
-        } catch (grpcError) {
-          this.setDisabled(
-            `[OtelExporter] Failed to load gRPC metadata. Install required packages:\n` +
-              `  npm install @opentelemetry/exporter-trace-otlp-grpc @grpc/grpc-js`,
-          );
-          this.logger.error('[OtelExporter] gRPC error details:', grpcError);
-          this.isSetup = true;
+      // Create or use the provided SpanExporter
+      if (this.config.exporter) {
+        this.exporter = this.config.exporter;
+      } else {
+        const headers = resolved.headers;
+        // Zipkin doesn't follow OTLP signal-path conventions; pass its endpoint through unchanged.
+        const endpoint = protocol === 'zipkin' ? resolved.endpoint : this.getSignalEndpoint(resolved, 'traces');
+
+        this.debugLog(`Setting up trace exporter: protocol=${protocol}, endpoint=${endpoint}`);
+
+        const ExporterClass = await loadExporter(protocol, this.providerName);
+        if (!ExporterClass) {
+          this.debugLog(`Trace exporter not available for protocol: ${protocol}`);
           return;
         }
 
-        this.exporter = new ExporterClass({
-          url: endpoint,
-          metadata,
-          timeoutMillis: this.config.timeout,
-        });
-      } else {
-        // HTTP/JSON and HTTP/Protobuf use headers
-        this.exporter = new ExporterClass({
-          url: endpoint,
-          headers,
-          timeoutMillis: this.config.timeout,
-        });
+        const exporterOptions =
+          protocol === 'zipkin'
+            ? { url: endpoint, headers }
+            : await this.buildExporterOptions(protocol, endpoint, headers);
+        this.exporter = new ExporterClass(exporterOptions);
+
+        this.debugLog(`Trace exporter created: ${this.exporter?.constructor?.name ?? 'unknown'} -> ${endpoint}`);
       }
-    } catch (error) {
-      this.setDisabled('[OtelExporter] Failed to create exporter.');
-      this.logger.error('[OtelExporter] Exporter creation error details:', error);
-      this.isSetup = true;
-      return;
-    }
-  }
 
-  private async setupProcessor() {
-    if (this.processor || this.isSetup) return;
+      // Create processor
+      const serviceName = this.observabilityConfig?.serviceName || 'mastra-service';
 
-    this.spanConverter = new SpanConverter({
-      packageName: '@mastra/otel-exporter',
-      serviceName: this.observabilityConfig?.serviceName,
-      config: this.config,
-      format: 'GenAI_v1_38_0',
-    });
-
-    // Always use BatchSpanProcessor for production
-    // It queues spans and exports them in batches for better performance
-    this.processor = new BatchSpanProcessor(this.exporter!, {
-      maxExportBatchSize: this.config.batchSize || 512, // Default batch size
-      maxQueueSize: 2048, // Maximum spans to queue
-      scheduledDelayMillis: 5000, // Export every 5 seconds
-      exportTimeoutMillis: this.config.timeout || 30000, // Export timeout
-    });
-
-    this.logger.debug(
-      `[OtelExporter] Using BatchSpanProcessor (batch size: ${this.config.batchSize || 512}, delay: 5s)`,
-    );
-  }
-
-  private async setup() {
-    if (this.isSetup) return;
-    await this.setupExporter();
-    await this.setupProcessor();
-    this.isSetup = true;
-  }
-
-  protected async _exportTracingEvent(event: TracingEvent): Promise<void> {
-    // Only process SPAN_ENDED events for OTEL
-    // OTEL expects complete spans with start and end times
-    if (event.type !== TracingEventType.SPAN_ENDED) {
-      return;
-    }
-
-    const span = event.exportedSpan;
-    await this.exportSpan(span);
-  }
-
-  private async exportSpan(span: AnyExportedSpan): Promise<void> {
-    // Ensure exporter is set up
-    if (!this.isSetup) {
-      await this.setup();
-    }
-
-    // Skip if disabled
-    if (this.isDisabled || !this.processor) {
-      return;
-    }
-
-    try {
-      // Convert the span to OTEL format
-      const otelSpan = await this.spanConverter!.convertSpan(span);
-
-      // Export the span immediately through the processor
-      // The processor will handle batching if configured
-      await new Promise<void>(resolve => {
-        this.processor!.onEnd(otelSpan);
-        resolve();
+      this.spanConverter = new SpanConverter({
+        packageName: '@mastra/otel-exporter',
+        serviceName,
+        config: this.config,
+        format: 'GenAI_v1_38_0',
       });
 
-      this.logger.debug(
-        `[OtelExporter] Exported span ${span.id} (trace: ${span.traceId}, parent: ${span.parentSpanId || 'none'}, type: ${span.type})`,
+      const exporterForProcessor = this.isDebug
+        ? new DebugSpanExporterWrapper(this.exporter!, msg => this.debugLog(msg))
+        : this.exporter!;
+
+      this.processor = new BatchSpanProcessor(exporterForProcessor, {
+        maxExportBatchSize: this.config.batchSize || 512,
+        maxQueueSize: 2048,
+        scheduledDelayMillis: 5000,
+        exportTimeoutMillis: this.config.timeout || 30000,
+      });
+
+      this.debugLog(
+        `Trace export initialized (service.name: "${serviceName}", batch size: ${this.config.batchSize || 512}, delay: 5s)`,
+      );
+    } catch (error) {
+      this.logger.warn('[OtelExporter] Failed to initialize trace export');
+      this.debugLog('Trace setup error:', error);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Log setup
+  // ---------------------------------------------------------------------------
+
+  private async setupLogs(resolved: ResolvedProviderConfig, protocol: ExportProtocol): Promise<void> {
+    try {
+      const LogExporterClass = await loadSignalExporter('logs', protocol, this.providerName);
+      if (!LogExporterClass) {
+        this.debugLog(`Log exporter package not available for protocol "${protocol}". Log export disabled.`);
+        return;
+      }
+
+      const logEndpoint = this.getSignalEndpoint(resolved, 'logs');
+      const headers = resolved.headers;
+
+      this.debugLog(`Setting up log exporter: protocol=${protocol}, endpoint=${logEndpoint}`);
+
+      const logExporterOptions = await this.buildExporterOptions(protocol, logEndpoint, headers);
+      const logExporter = new LogExporterClass(logExporterOptions);
+
+      const exporterForProcessor = this.isDebug
+        ? new DebugLogExporterWrapper(logExporter, msg => this.debugLog(msg))
+        : logExporter;
+
+      const resource = resourceFromAttributes({
+        ...(this.config.resourceAttributes ?? {}),
+        [ATTR_SERVICE_NAME]: this.observabilityConfig?.serviceName || 'mastra-service',
+      });
+
+      this.loggerProvider = new LoggerProvider({
+        resource,
+        processors: [
+          new BatchLogRecordProcessor(exporterForProcessor, {
+            maxExportBatchSize: this.config.batchSize || 512,
+            maxQueueSize: 2048,
+            scheduledDelayMillis: 5000,
+            exportTimeoutMillis: this.config.timeout || 30000,
+          }),
+        ],
+      });
+
+      this.otelLogger = this.loggerProvider.getLogger('@mastra/otel-exporter');
+
+      this.debugLog(`Log export initialized (endpoint: ${logEndpoint})`);
+    } catch (error) {
+      this.logger.warn('[OtelExporter] Failed to initialize log export');
+      this.debugLog('Log setup error:', error);
+    }
+  }
+
+  // ===========================================================================
+  // Trace event handler
+  // ===========================================================================
+
+  protected async _exportTracingEvent(event: TracingEvent): Promise<void> {
+    if (this.config.signals?.traces === false) return;
+    if (event.type !== TracingEventType.SPAN_ENDED) return;
+
+    await this.ensureSetup();
+
+    if (this.isDisabled || !this.processor) return;
+
+    const span = event.exportedSpan;
+
+    try {
+      const otelSpan = await this.spanConverter!.convertSpan(span);
+      this.processor.onEnd(otelSpan);
+
+      this.debugLog(
+        `Queued span ${span.id} (trace: ${span.traceId}, parent: ${span.parentSpanId || 'none'}, type: ${span.type})`,
       );
     } catch (error) {
       this.logger.error(`[OtelExporter] Failed to export span ${span.id}:`, error);
     }
   }
 
+  // ===========================================================================
+  // Log event handler
+  // ===========================================================================
+
+  async onLogEvent(event: LogEvent): Promise<void> {
+    this.debugLog(`onLogEvent received (level: ${event.log.level}, message: "${event.log.message}")`);
+
+    await this.ensureSetup();
+
+    if (this.isDisabled) {
+      this.debugLog('Log event skipped: exporter is disabled');
+      return;
+    }
+
+    if (!this.otelLogger) {
+      this.debugLog('Log event skipped: log exporter not available');
+      return;
+    }
+
+    try {
+      const logParams = convertLog(event.log);
+
+      // Mirror trace context into the OTEL log Context so backends (Grafana, Datadog,
+      // Honeycomb, etc.) correlate logs with traces using the standard OTLP fields.
+      // Also keep mastra.traceId / mastra.spanId attributes for backends that key
+      // off attributes only.
+      const attributes = { ...logParams.attributes };
+      let logContext = apiContext.active();
+      if (logParams.traceId && logParams.spanId) {
+        attributes['mastra.traceId'] = logParams.traceId;
+        attributes['mastra.spanId'] = logParams.spanId;
+        logContext = trace.setSpanContext(logContext, {
+          traceId: logParams.traceId,
+          spanId: logParams.spanId,
+          traceFlags: TraceFlags.SAMPLED,
+          isRemote: false,
+        });
+      }
+
+      this.otelLogger.emit({
+        timestamp: logParams.timestamp,
+        severityNumber: logParams.severityNumber,
+        severityText: logParams.severityText,
+        body: logParams.body,
+        attributes,
+        context: logContext,
+      });
+
+      this.debugLog(`Exported log (level: ${event.log.level}, trace: ${event.log.traceId || 'none'})`);
+    } catch (error) {
+      this.logger.error('[OtelExporter] Failed to export log:', error);
+    }
+  }
+
+  // ===========================================================================
+  // Lifecycle
+  // ===========================================================================
+
   /**
-   * Force flush any buffered spans without shutting down the exporter.
-   * Delegates to the BatchSpanProcessor's forceFlush() method.
+   * Force flush any buffered data without shutting down the exporter.
+   * Delegates to all active processors/providers.
    */
   async flush(): Promise<void> {
+    // Wait for setup so we don't miss providers that are still being initialized.
+    if (this.setupPromise) {
+      await this.setupPromise;
+    }
+
+    const flushPromises: Promise<void>[] = [];
+    const signals: string[] = [];
+
     if (this.processor) {
-      await this.processor.forceFlush();
-      this.logger.debug('[OtelExporter] Flushed pending spans');
+      flushPromises.push(this.processor.forceFlush());
+      signals.push('traces');
+    }
+    if (this.loggerProvider) {
+      flushPromises.push(this.loggerProvider.forceFlush());
+      signals.push('logs');
+    }
+
+    if (flushPromises.length > 0) {
+      this.debugLog(`Flushing signals: ${signals.join(', ')}...`);
+      await Promise.all(flushPromises);
+      this.debugLog('Flushed all pending data');
+    } else {
+      this.debugLog('Flush called but no active exporters');
     }
   }
 
   async shutdown(): Promise<void> {
-    // Shutdown the processor to flush any remaining spans
+    // Wait for setup so we don't shut down before providers finish initializing.
+    if (this.setupPromise) {
+      await this.setupPromise;
+    }
+
+    const shutdownPromises: Promise<void>[] = [];
+
     if (this.processor) {
-      await this.processor.shutdown();
+      shutdownPromises.push(this.processor.shutdown());
+    }
+    if (this.loggerProvider) {
+      shutdownPromises.push(this.loggerProvider.shutdown());
+    }
+
+    if (shutdownPromises.length > 0) {
+      await Promise.all(shutdownPromises);
     }
   }
 }

--- a/observability/otel-exporter/src/types.ts
+++ b/observability/otel-exporter/src/types.ts
@@ -72,6 +72,17 @@ export interface OtelExporterConfig extends BaseExporterConfig {
 
   // Override or provide a custom span exporter
   exporter?: SpanExporter;
+
+  /**
+   * Signal enablement. All signals are enabled by default when their
+   * required OTEL packages are installed. Set to false to disable.
+   */
+  signals?: {
+    /** Enable trace export (default: true) */
+    traces?: boolean;
+    /** Enable log export (default: true) */
+    logs?: boolean;
+  };
 }
 
 export interface SpanData {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2140,6 +2140,9 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
+      '@opentelemetry/api-logs':
+        specifier: ^0.215.0
+        version: 0.215.0
       '@opentelemetry/auto-instrumentations-node':
         specifier: '>=0.50.0'
         version: 0.71.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))
@@ -2156,6 +2159,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@opentelemetry/sdk-logs':
+        specifier: ^0.215.0
+        version: 0.215.0(@opentelemetry/api@1.9.1)
       '@types/node':
         specifier: 22.19.15
         version: 22.19.15
@@ -2180,12 +2186,18 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
+      '@opentelemetry/api-logs':
+        specifier: ^0.215.0
+        version: 0.215.0
       '@opentelemetry/core':
         specifier: ^2.7.0
         version: 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources':
         specifier: ^2.7.0
         version: 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs':
+        specifier: ^0.215.0
+        version: 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base':
         specifier: ^2.7.0
         version: 2.7.0(@opentelemetry/api@1.9.1)
@@ -2230,6 +2242,15 @@ importers:
       '@grpc/grpc-js':
         specifier: ^1.14.3
         version: 1.14.3
+      '@opentelemetry/exporter-logs-otlp-grpc':
+        specifier: ^0.215.0
+        version: 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-http':
+        specifier: ^0.215.0
+        version: 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto':
+        specifier: ^0.215.0
+        version: 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-grpc':
         specifier: ^0.215.0
         version: 0.215.0(@opentelemetry/api@1.9.1)
@@ -12661,6 +12682,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-logs-otlp-grpc@0.215.0':
+    resolution: {integrity: sha512-MVq+9ma/63XRXc0AcnS+XyWSD6VBYn39OucsvpzjqxTpzTOiGXNxTwsbV3zbnvgUexb5hc2ZjJlZUK2W/19UUw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-logs-otlp-http@0.207.0':
     resolution: {integrity: sha512-JpOh7MguEUls8eRfkVVW3yRhClo5b9LqwWTOg8+i4gjr/+8eiCtquJnC7whvpTIGyff06cLZ2NsEj+CVP3Mjeg==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -12679,6 +12706,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
+  '@opentelemetry/exporter-logs-otlp-http@0.215.0':
+    resolution: {integrity: sha512-U7Qb+TVX2GZH5RSC+Gx9aE5zChKP1kPg87X3PlI/41lWVPJdBIzmgMmuE28MmQlrK84nLHCIqUOOben8YkSzBw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/exporter-logs-otlp-proto@0.207.0':
     resolution: {integrity: sha512-RQJEV/K6KPbQrIUbsrRkEe0ufks1o5OGLHy6jbDD8tRjeCsbFHWfg99lYBRqBV33PYZJXsigqMaAbjWGTFYzLw==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -12687,6 +12720,12 @@ packages:
 
   '@opentelemetry/exporter-logs-otlp-proto@0.213.0':
     resolution: {integrity: sha512-gQk41nqfK3KhDk8jbSo3LR/fQBlV7f6Q5xRcfDmL1hZlbgXQPdVFV9/rIfYUrCoq1OM+2NnKnFfGjBt6QpLSsA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.215.0':
+    resolution: {integrity: sha512-vs2xKKTdt/vKWMuBzw+LZYYCKqulodCRoonWWiyToIQfa6JgbyWjTu/iy6qpBLhLi+t6fNc1bwJGwu3vkot2Jg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -33874,6 +33913,17 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.213.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/exporter-logs-otlp-grpc@0.215.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.1)
+    optional: true
+
   '@opentelemetry/exporter-logs-otlp-http@0.207.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -33901,6 +33951,16 @@ snapshots:
       '@opentelemetry/otlp-transformer': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.213.0(@opentelemetry/api@1.9.1)
 
+  '@opentelemetry/exporter-logs-otlp-http@0.215.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.215.0
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.1)
+    optional: true
+
   '@opentelemetry/exporter-logs-otlp-proto@0.207.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -33922,6 +33982,18 @@ snapshots:
       '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.215.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.215.0
+      '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
+    optional: true
 
   '@opentelemetry/exporter-metrics-otlp-grpc@0.207.0(@opentelemetry/api@1.9.1)':
     dependencies:


### PR DESCRIPTION
## Summary

Adds OpenTelemetry log support to the `@mastra/otel-exporter` and `@mastra/otel-bridge` packages. Mastra log events now flow to OTEL-compatible backends through the same channels that already carry traces. Trace correlation is preserved end-to-end, so backends like Datadog, Grafana, and Honeycomb can join logs to the surrounding trace automatically.

## `@mastra/otel-exporter`

Forwards Mastra log events to the configured OTLP endpoint alongside traces, sharing the provider configuration. The trace endpoint's `/v1/traces` suffix is normalized to `/v1/logs` for the log exporter.

```ts
import { OtelExporter } from '@mastra/otel-exporter';

new OtelExporter({
  provider: {
    custom: { endpoint: 'http://localhost:4318', protocol: 'http/json' },
  },
  // signals.logs defaults to true; set to false to disable.
  signals: { traces: true, logs: true },
});
```

Implementation:

- New `log-converter.ts` maps `ExportedLog` to OTEL `LogRecord` parameters: severity number/text from Mastra `LogLevel`, body, attributes built from `data` / `metadata` / `tags`, and trace correlation.
- `onLogEvent` mirrors `traceId`/`spanId` into the OTEL log record's native `Context` via `trace.setSpanContext`. `mastra.traceId` / `mastra.spanId` attributes are also kept for attribute-only backends.
- `BatchLogRecordProcessor` batches log export with the same `batchSize` / `timeout` knobs as traces.
- Per-signal toggle via `signals: { traces?, logs? }`; both default to `true`. Log export requires the matching `@opentelemetry/exporter-logs-otlp-{http,proto,grpc}` package; a missing package disables logs only and traces continue to work.

Other improvements made along the way:

- `loadExporter` now validates the imported package exposes the expected named export and emits a clear error rather than silently caching `undefined`.
- `getSignalEndpoint` strips trailing slashes and any existing signal-path suffix so endpoints like `http://host:4318/` no longer produce `//v1/logs`. Trace setup also routes through it (Zipkin bypassed).
- `flush()` and `shutdown()` await `setupPromise` so providers initialized after lifecycle calls are not missed and telemetry is not dropped.
- Provider-config debug masking now fully redacts header values (was leaking 8-char prefix + 4-char suffix from tokens).

## `@mastra/otel-bridge`

The bridge already creates real OTEL spans for Mastra operations. This adds the analogous log path: subscribe to Mastra log events and forward them as OTEL `LogRecord`s on the globally-registered `LoggerProvider`, so users running `NodeSDK` with a `logRecordProcessor` get logs alongside traces in their backend without any extra wiring.

```ts
// instrumentation.ts
import { NodeSDK } from '@opentelemetry/sdk-node';
import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';

const sdk = new NodeSDK({
  // ...trace config as usual
  logRecordProcessor: new BatchLogRecordProcessor(new OTLPLogExporter()),
});

// src/mastra/index.ts — unchanged
new OtelBridge();
```

Trace correlation in `OtelBridge.onLogEvent`:

1. If the log carries a `spanId` the bridge has an OTEL span for, emit under that span's stored OTEL context — logs nest beneath the corresponding Mastra span.
2. Else if the log carries `traceId`+`spanId`, attach a `SpanContext` built from those IDs so backends correlate by ID.
3. Else emit under whatever OTEL context is currently active.

`flush()` now also flushes the global `LoggerProvider` when it supports `forceFlush`, mirroring the existing tracer-provider flush.

If no `LoggerProvider` is registered globally, log emission is a silent no-op via the api-logs proxy — traces continue to work as configured.

## Tests

- `@mastra/otel-exporter`: severity mapping, attribute building, trace correlation, signal-endpoint normalization (including trailing-slash and `/v1/traces` → `/v1/logs` rewrites), per-signal toggle behavior, lifecycle.
- `@mastra/otel-bridge`: wires up a real `@opentelemetry/sdk-logs` `LoggerProvider` with an `InMemoryLogRecordExporter` in setup; asserts severity mapping, mastra-prefixed correlation attributes, `spanContext` propagation when a Mastra span is in the bridge map, fallback `SpanContext` from raw IDs, and no-context emission when the log carries none.

## Type of change

- [x] New feature (non-breaking change that adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds the ability to send application logs (in addition to traces) to OpenTelemetry-compatible observability platforms. When Mastra records a log event, it now automatically forwards that log to the same OTLP backend alongside your traces, and automatically connects logs to their traces so backends can show them together.

---

## Overview

This PR extends `@mastra/otel-exporter` and `@mastra/otel-bridge` to forward Mastra log events to OpenTelemetry-compatible backends alongside traces, with automatic trace-log correlation.

**Key Features:**
- **Log Export**: Mastra log events are converted to OTEL LogRecords and sent to configured OTLP endpoints
- **Trace Correlation**: Logs include `traceId`/`spanId` as both OTEL native trace context and `mastra.*` attributes
- **Per-Signal Control**: New `signals: { traces?, logs? }` config toggle to enable/disable each independently (both default to `true`)
- **Graceful Degradation**: Missing OTLP log exporter packages silently disable logs while traces continue
- **Endpoint Normalization**: Trace endpoint path is automatically rewritten from `/v1/traces` to `/v1/logs` for consistency

---

## Changes in @mastra/otel-exporter

### Core Implementation
- **log-converter.ts** (new): Converts Mastra `ExportedLog` → OTEL `LogRecord`
  - `mapSeverity()` maps Mastra LogLevel to OTEL SeverityNumber
  - `buildLogAttributes()` constructs attributes from log data/metadata/tags with `mastra.*` prefixes
  - `convertLog()` performs full conversion including trace context and HrTime timestamps
  - `OtelLogEmitParams` interface specifies log emission parameters

- **tracing.ts**: Refactored to multi-signal architecture
  - `setupLogs()` creates LoggerProvider with BatchLogRecordProcessor
  - `onLogEvent()` subscribes to Mastra log events, converts them with `convertLog()`, and emits through OTEL logger
  - `getSignalEndpoint()` normalizes endpoint paths and derives per-signal URLs
  - Trace context mirrored into OTEL log context via `setSpanContext()` when traceId/spanId present
  - Setup now uses shared `setupPromise` for parallel initialization; `flush()`/`shutdown()` await setup completion
  - Debug diagnostics wrap exporters with `DebugSpanExporterWrapper` / `DebugLogExporterWrapper` for batch logging

- **loadExporter.ts**: Dynamic exporter loading refactored for signals
  - New `SignalType` union (`'traces' | 'logs'`)
  - New `loadSignalExporter()` function with `EXPORTER_SPECS` matrix mapping (signal, protocol) → npm package
  - Validates expected named export existence; logs npm install hint with computed package names on import failure
  - Removes hardcoded per-protocol switch logic

- **provider-configs.ts**: Added optional `debug` parameter
  - When enabled, logs provider config resolution with fully redacted header values

- **types.ts**: Added `signals` to `OtelExporterConfig`
  - Optional `signals?: { traces?: boolean; logs?: boolean }` with defaults to `true`

### Package & Exports
- **package.json**: 
  - Added dependencies: `@opentelemetry/api-logs`, `@opentelemetry/sdk-logs`
  - Added optional peers: OTLP log exporters (gRPC, HTTP, Proto)
  - Updated OTLP trace exporter peers from `^0.205.0` → `^0.215.0`
  
- **index.ts**: Re-exports `convertLog`, `mapSeverity`, `buildLogAttributes`, and `OtelLogEmitParams`

### Testing
- **log-converter.test.ts** (new): 187 lines covering severity mapping, attribute building, trace correlation, timestamp conversion, and edge cases
- **tracing.test.ts**: Extended with 281 new lines for log export, per-signal toggles, endpoint normalization, lifecycle coordination

---

## Changes in @mastra/otel-bridge

### Core Implementation
- **bridge.ts**: Added log forwarding to globally-registered OTEL LoggerProvider
  - `onLogEvent()` method subscribes to Mastra log events and emits OTEL LogRecords
  - Trace correlation strategy: (1) prefers stored OTEL span context if span exists locally; (2) builds SpanContext from traceId+spanId if present; (3) falls back to current OTEL context
  - Attaches `mastra.traceId`/`mastra.spanId` attributes for backend correlation
  - Silent no-op if no global LoggerProvider registered
  - `flush()` now flushes both TracerProvider and LoggerProvider with runtime capability checks

### Package & Exports
- **package.json**: Added `@opentelemetry/api-logs` to dependencies, `@opentelemetry/sdk-logs` to devDependencies

### Testing
- **bridge.test.ts**: Extended with 104 new lines validating severity mapping, mastra-prefixed attributes, span context propagation, fallback behavior, and context-less emission

---

## Documentation Updates

- **otel.mdx** (exporter): Updated to describe trace+log support, added "Signals" section explaining per-signal control and log endpoint derivation, updated examples with `signals` config option, documented log exporter dependencies per protocol
- **otel.mdx** (bridge): Added log forwarding explanation, updated "How it works" with trace-log correlation details, added "Forwarding logs" section with `logRecordProcessor` setup example
- **Reference docs**: Updated OtelExporter and OtelBridge API docs with new `signals` option and `onLogEvent()` method
- **READMEs**: Both `@mastra/otel-exporter` and `@mastra/otel-bridge` updated with log forwarding documentation and dependency lists

---

## Changesets

- `.changeset/chubby-bars-behave.md`: Documents @mastra/otel-exporter minor bump with log export feature, improvements (endpoint normalization, setup coordination, debug masking, dynamic loading validation)
- `.changeset/some-seas-speak.md`: Documents @mastra/otel-exporter patch and @mastra/otel-bridge minor with log forwarding, span context correlation, and LoggerProvider integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->