### PR TITLE
fix(core): remove nullable/describe from suspension schema fields for Vertex AI compat

### DIFF
--- a/.changeset/fix-vertex-ai-tool-schema.md
+++ b/.changeset/fix-vertex-ai-tool-schema.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fix Vertex AI 400 error caused by auto-injected `suspendedToolRunId` and `resumeData` tool schema fields. Removed `.nullable()` and `.describe()` modifiers that produced `anyOf` alongside `description` in JSON Schema, which Vertex AI rejects.
+Fix Vertex AI 400 errors when using agent or workflow tools with Google Vertex AI models. The auto-injected `suspendedToolRunId` and `resumeData` fields now produce schemas compatible with Vertex AI's strict validation.

--- a/.changeset/fix-vertex-ai-tool-schema.md
+++ b/.changeset/fix-vertex-ai-tool-schema.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix Vertex AI 400 error caused by auto-injected `suspendedToolRunId` and `resumeData` tool schema fields. Removed `.nullable()` and `.describe()` modifiers that produced `anyOf` alongside `description` in JSON Schema, which Vertex AI rejects.

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
@@ -344,6 +344,69 @@ describe('prepareToolsAndToolChoice', () => {
     });
   });
 
+  describe('agent-as-tools schema serialization', () => {
+    it('should produce valid JSON Schema with type keys for all properties including resumeData: z.any()', () => {
+      const agentTool = createTool({
+        id: 'agent-subAgent',
+        description: 'A sub-agent tool',
+        inputSchema: z.object({
+          prompt: z.string().describe('The prompt for the agent'),
+          suspendedToolRunId: z.string().optional().default(''),
+          resumeData: z.any().optional(),
+        }),
+        execute: async () => 'result',
+      });
+
+      const result = prepareToolsAndToolChoice({
+        tools: { 'agent-subAgent': agentTool as any },
+        toolChoice: undefined,
+        activeTools: undefined,
+        targetVersion: 'v2',
+      });
+
+      expect(result.tools).toBeDefined();
+      expect(result.tools).toHaveLength(1);
+
+      const toolDef = result.tools![0] as { type: string; inputSchema: Record<string, any> };
+      expect(toolDef.type).toBe('function');
+
+      const properties = toolDef.inputSchema.properties;
+      expect(properties).toBeDefined();
+
+      for (const [propName, propSchema] of Object.entries(properties)) {
+        const schema = propSchema as Record<string, any>;
+        const hasTypeKey = 'type' in schema;
+        const hasRef = '$ref' in schema;
+        const hasAnyOf = 'anyOf' in schema;
+        const hasOneOf = 'oneOf' in schema;
+        const hasAllOf = 'allOf' in schema;
+
+        expect(
+          hasTypeKey || hasRef || hasAnyOf || hasOneOf || hasAllOf,
+          `Property '${propName}' in agent tool schema must have a 'type', '$ref', 'anyOf', 'oneOf', or 'allOf' key. Got: ${JSON.stringify(schema)}`,
+        ).toBe(true);
+
+        if (Array.isArray(schema.type) && schema.type.includes('array')) {
+          expect(
+            schema.items,
+            `Property '${propName}' includes 'array' in type but is missing 'items'. OpenAI requires 'items' for array types. Got: ${JSON.stringify(schema)}`,
+          ).toBeDefined();
+        }
+      }
+
+      // Verify suspension fields don't produce anyOf or description (Vertex AI compat)
+      const suspendedSchema = properties.suspendedToolRunId as Record<string, any>;
+      expect(suspendedSchema.type).toBeDefined();
+      expect(suspendedSchema.default).toBe('');
+      expect(suspendedSchema.anyOf).toBeUndefined();
+      expect(suspendedSchema.description).toBeUndefined();
+
+      const resumeSchema = properties.resumeData as Record<string, any>;
+      expect(resumeSchema.anyOf).toBeUndefined();
+      expect(resumeSchema.description).toBeUndefined();
+    });
+  });
+
   describe('default targetVersion', () => {
     it('should default to v2 when targetVersion is not specified', () => {
       const providerTool = {

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
@@ -396,12 +396,14 @@ describe('prepareToolsAndToolChoice', () => {
 
       // Verify suspension fields don't produce anyOf or description (Vertex AI compat)
       const suspendedSchema = properties.suspendedToolRunId as Record<string, any>;
-      expect(suspendedSchema.type).toBeDefined();
+      expect(suspendedSchema).toBeDefined();
+      expect(suspendedSchema.type).toBe('string');
       expect(suspendedSchema.default).toBe('');
       expect(suspendedSchema.anyOf).toBeUndefined();
       expect(suspendedSchema.description).toBeUndefined();
 
       const resumeSchema = properties.resumeData as Record<string, any>;
+      expect(resumeSchema).toBeDefined();
       expect(resumeSchema.anyOf).toBeUndefined();
       expect(resumeSchema.description).toBeUndefined();
     });

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -75,11 +75,8 @@ export class CoreToolBuilder extends MastraBase {
 
       if (isZodObject(schema)) {
         this.originalTool.inputSchema = schema.extend({
-          suspendedToolRunId: z.string().describe('The runId of the suspended tool').nullable().optional().default(''),
-          resumeData: z
-            .any()
-            .describe('The resumeData object created from the resumeSchema of suspended tool')
-            .optional(),
+          suspendedToolRunId: z.string().optional().default(''),
+          resumeData: z.any().optional(),
         });
       } else {
         // Non-Zod StandardSchemaWithJSON (e.g. JsonSchemaWrapper from JSONSchema7).
@@ -90,13 +87,9 @@ export class CoreToolBuilder extends MastraBase {
             ...jsonSchema.properties,
             suspendedToolRunId: {
               type: 'string',
-              description: 'The runId of the suspended tool',
-              anyOf: [{ type: 'string' }, { type: 'null' }],
               default: '',
             },
-            resumeData: {
-              description: 'The resumeData object created from the resumeSchema of suspended tool',
-            },
+            resumeData: {},
           };
           this.originalTool.inputSchema = toStandardSchema(jsonSchema) as any;
         }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Auto-injected `suspendedToolRunId` and `resumeData` schema fields in `CoreToolBuilder` used `.nullable()` and `.describe()` modifiers that produced
`anyOf` alongside `description` in JSON Schema. The AI SDK Google provider converts `type: ["string", "null"]` to `anyOf: [{type: "string"}]` with
`nullable: true`, and the `description` carries over — Vertex AI strictly rejects `anyOf` when any other field is present on the same node, returning a
400 error.

Removed `.nullable()` and `.describe()` from both fields. `.nullable()` was unnecessary since `suspendedToolRunId` is only ever set to `''` or a string
runId, never `null`. `.describe()` was redundant since the LLM receives instructions about these fields via a system prompt in `llm-execution-step.ts`,
not from schema descriptions. Validation behavior is unchanged — `.optional()` and `.default('')` are preserved.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

Fixes #13528

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Vertex AI 400 errors with agent/workflow tools by making auto-injected tool fields schema-compatible with Vertex AI strict validation.

* **Tests**
  * Updated tests to assert the new serialized schema shapes for suspended tool run IDs and resume data.

* **Chores**
  * Added a changeset and bumped the package patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->