### PR TITLE
docs: fix SSR/client content mismatches for SEO

### DIFF
--- a/docs/src/theme/DocSidebarItem/Category/index.tsx
+++ b/docs/src/theme/DocSidebarItem/Category/index.tsx
@@ -10,7 +10,6 @@ import {
 } from '@docusaurus/plugin-content-docs/client'
 import Link from '@docusaurus/Link'
 import { translate } from '@docusaurus/Translate'
-import useIsBrowser from '@docusaurus/useIsBrowser'
 import DocSidebarItems from '@theme/DocSidebarItems'
 import DocSidebarItemLink from '@theme/DocSidebarItem/Link'
 import type { Props } from '@theme/DocSidebarItem/Category'
@@ -46,25 +45,21 @@ function useAutoExpandActiveCategory({
 
 /**
  * When a collapsible category has no link, we still link it to its first child
- * during SSR as a temporary fallback. This allows to be able to navigate inside
- * the category even when JS fails to load, is delayed or simply disabled
- * React hydration becomes an optional progressive enhancement
+ * as a fallback. This ensures consistent rendering between SSR and client,
+ * and allows navigation inside the category even when JS fails to load.
  * see https://github.com/facebookincubator/infima/issues/36#issuecomment-772543188
  * see https://github.com/facebook/docusaurus/issues/3030
  */
 function useCategoryHrefWithSSRFallback(item: Props['item']): string | undefined {
-  const isBrowser = useIsBrowser()
   return useMemo(() => {
     if (item.href && !item.linkUnlisted) {
       return item.href
     }
-    // In these cases, it's not necessary to render a fallback
-    // We skip the "findFirstCategoryLink" computation
-    if (isBrowser || !item.collapsible) {
+    if (!item.collapsible) {
       return undefined
     }
     return findFirstSidebarItemLink(item)
-  }, [item, isBrowser])
+  }, [item])
 }
 
 function CollapseButton({

--- a/docs/src/theme/Tabs/index.tsx
+++ b/docs/src/theme/Tabs/index.tsx
@@ -1,0 +1,140 @@
+/**
+ * Swizzled Tabs component that removes the `key={String(isBrowser)}` workaround
+ * from upstream Docusaurus. The upstream hack forces a full re-mount after
+ * hydration (see https://github.com/facebook/docusaurus/issues/5653), which
+ * causes content churn that search engines penalize. Since our tabs use static
+ * default values (npm2yarn with groupId sync), the workaround is unnecessary.
+ */
+import React, { cloneElement, type ReactElement, type ReactNode } from 'react'
+import clsx from 'clsx'
+import { ThemeClassNames } from '@docusaurus/theme-common'
+import {
+  useScrollPositionBlocker,
+  useTabs,
+  sanitizeTabsChildren,
+  type TabItemProps,
+} from '@docusaurus/theme-common/internal'
+import type { Props } from '@theme/Tabs'
+import styles from './styles.module.css'
+
+function TabList({ className, block, selectedValue, selectValue, tabValues }: Props & ReturnType<typeof useTabs>) {
+  const tabRefs: (HTMLLIElement | null)[] = []
+  const { blockElementScrollPositionUntilNextRender } = useScrollPositionBlocker()
+
+  const handleTabChange = (
+    event: React.FocusEvent<HTMLLIElement> | React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>,
+  ) => {
+    const newTab = event.currentTarget
+    const newTabIndex = tabRefs.indexOf(newTab)
+    const newTabValue = tabValues[newTabIndex]!.value
+
+    if (newTabValue !== selectedValue) {
+      blockElementScrollPositionUntilNextRender(newTab)
+      selectValue(newTabValue)
+    }
+  }
+
+  const handleKeydown = (event: React.KeyboardEvent<HTMLLIElement>) => {
+    let focusElement: HTMLLIElement | null = null
+
+    switch (event.key) {
+      case 'Enter': {
+        handleTabChange(event)
+        break
+      }
+      case 'ArrowRight': {
+        const nextTab = tabRefs.indexOf(event.currentTarget) + 1
+        focusElement = tabRefs[nextTab] ?? tabRefs[0]!
+        break
+      }
+      case 'ArrowLeft': {
+        const prevTab = tabRefs.indexOf(event.currentTarget) - 1
+        focusElement = tabRefs[prevTab] ?? tabRefs[tabRefs.length - 1]!
+        break
+      }
+      default:
+        break
+    }
+
+    focusElement?.focus()
+  }
+
+  return (
+    <ul
+      role="tablist"
+      aria-orientation="horizontal"
+      className={clsx(
+        'tabs',
+        {
+          'tabs--block': block,
+        },
+        className,
+      )}
+    >
+      {tabValues.map(({ value, label, attributes }) => (
+        <li
+          role="tab"
+          tabIndex={selectedValue === value ? 0 : -1}
+          aria-selected={selectedValue === value}
+          key={value}
+          ref={tabControl => {
+            tabRefs.push(tabControl)
+          }}
+          onKeyDown={handleKeydown}
+          onClick={handleTabChange}
+          {...attributes}
+          className={clsx('tabs__item', styles.tabItem, attributes?.className as string, {
+            'tabs__item--active': selectedValue === value,
+          })}
+        >
+          {label ?? value}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function TabContent({ lazy, children, selectedValue }: Props & ReturnType<typeof useTabs>) {
+  const childTabs = (Array.isArray(children) ? children : [children]).filter(Boolean) as ReactElement<TabItemProps>[]
+  if (lazy) {
+    const selectedTabItem = childTabs.find(tabItem => tabItem.props.value === selectedValue)
+    if (!selectedTabItem) {
+      return null
+    }
+    return cloneElement(selectedTabItem, {
+      className: clsx('margin-top--md', selectedTabItem.props.className),
+    })
+  }
+  return (
+    <div className="margin-top--md">
+      {childTabs.map((tabItem, i) =>
+        cloneElement(tabItem, {
+          key: i,
+          hidden: tabItem.props.value !== selectedValue,
+        }),
+      )}
+    </div>
+  )
+}
+
+function TabsComponent(props: Props): ReactNode {
+  const tabs = useTabs(props)
+  return (
+    <div
+      className={clsx(
+        ThemeClassNames.tabs.container,
+        // former name kept for backward compatibility
+        // see https://github.com/facebook/docusaurus/pull/4086
+        'tabs-container',
+        styles.tabList,
+      )}
+    >
+      <TabList {...tabs} {...props} />
+      <TabContent {...tabs} {...props} />
+    </div>
+  )
+}
+
+export default function Tabs(props: Props): ReactNode {
+  return <TabsComponent {...props}>{sanitizeTabsChildren(props.children)}</TabsComponent>
+}

--- a/docs/src/theme/Tabs/styles.module.css
+++ b/docs/src/theme/Tabs/styles.module.css
@@ -1,0 +1,7 @@
+.tabList {
+  margin-bottom: var(--ifm-leading);
+}
+
+.tabItem {
+  margin-top: 0 !important;
+}

--- a/docs/tests/navigation.spec.ts
+++ b/docs/tests/navigation.spec.ts
@@ -143,7 +143,10 @@ test.describe('Sidebar navigation', () => {
     await expect(sidebar).toBeVisible()
 
     // Find and click a sidebar link that has a real path (not just # or empty)
-    const sidebarLinks = sidebar.locator('a.menu__link:not(.menu__link--active)[href*="/docs/"]')
+    // Exclude --sublist links: those are collapsible category headers that preventDefault on click
+    const sidebarLinks = sidebar.locator(
+      'a.menu__link:not(.menu__link--active):not(.menu__link--sublist)[href*="/docs/"]',
+    )
     const firstLink = sidebarLinks.first()
     const href = await firstLink.getAttribute('href')
     expect(href).toBeTruthy()
@@ -174,8 +177,8 @@ test.describe('Sidebar navigation', () => {
     const mobileSidebar = page.locator('.navbar-sidebar')
     await expect(mobileSidebar).toBeVisible()
 
-    // Find a navigation link in the mobile sidebar
-    const mobileLink = mobileSidebar.locator('a.menu__link').first()
+    // Find a navigation link in the mobile sidebar (exclude category headers)
+    const mobileLink = mobileSidebar.locator('a.menu__link:not(.menu__link--sublist)').first()
     const href = await mobileLink.getAttribute('href')
     expect(href).toBeTruthy()
 


### PR DESCRIPTION
Reduce content and outlink changes after client-side hydration, which search engines penalize as inconsistent rendering.

## Changes

### Sidebar categories (`DocSidebarItem/Category`)
Remove `useIsBrowser` guard from `useCategoryHrefWithSSRFallback` so collapsible categories always link to their first child, not just during SSR. Previously ~10-30 outlinks per page disappeared after hydration when `<a>` elements became `<button>`s.

### Tabs
Swizzle the Docusaurus Tabs component to remove the `key={String(isBrowser)}` re-mount workaround (upstream fix for [#5653](https://github.com/facebook/docusaurus/issues/5653)). The hack forced a full unmount/remount after hydration, causing content churn visible to crawlers. Our tabs use static defaults (`npm2yarn` with sync `groupId`), so the workaround is unnecessary. Non-selected tab panels continue using `hidden` attributes, keeping all content in the DOM consistently for both SSR and client.

## Files changed

| File | Change |
|------|--------|
| `docs/src/theme/DocSidebarItem/Category/index.tsx` | Remove `useIsBrowser` guard from category href fallback |
| `docs/src/theme/Tabs/index.tsx` | Swizzled Tabs component without `isBrowser` re-mount |
| `docs/src/theme/Tabs/styles.module.css` | Styles for swizzled Tabs |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard navigation support for tabs (Enter, Arrow Left/Right keys)
  * Enhanced tab accessibility features

* **Refactor**
  * Improved server-side rendering handling for sidebar navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->