### PR TITLE
fix(harness): propagate tracingOptions through sendMessage to agent.stream()

### DIFF
--- a/.changeset/cool-taxes-float.md
+++ b/.changeset/cool-taxes-float.md
@@ -2,11 +2,18 @@
 '@mastra/core': patch
 ---
 
----
-'@mastra/core': patch
----
+Added optional `tracingOptions` parameter to `Harness.sendMessage()` so that traces from Harness interactions are properly linked in observability tools like Datadog instead of appearing as disconnected entries.
 
-Added optional `tracingOptions` parameter to `Harness.sendMessage()`. Agent operations initiated through the Harness now properly link to parent traces in your observability tools, ensuring complete trace visibility.
+```ts
+await harness.sendMessage({
+  content: 'Hello!',
+  tracingOptions: {
+    traceId: 'abc123',
+    parentSpanId: 'def456',
+    metadata: { userId: 'u-1' },
+    tags: ['production'],
+  },
+});
+```
 
-**Example:**
-
+See [#13540](https://github.com/mastra-ai/mastra/issues/13540).

--- a/.changeset/cool-taxes-float.md
+++ b/.changeset/cool-taxes-float.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added optional `tracingOptions` parameter to `Harness.sendMessage()`. This allows tracing context (trace ID, parent span ID, metadata, tags) to be forwarded to `agent.stream()`, `agent.approveToolCall()`, and `agent.declineToolCall()`, fixing orphaned root spans when using the Harness with observability backends like Datadog. See #13540.

--- a/.changeset/cool-taxes-float.md
+++ b/.changeset/cool-taxes-float.md
@@ -2,4 +2,11 @@
 '@mastra/core': patch
 ---
 
-Added optional `tracingOptions` parameter to `Harness.sendMessage()`. This allows tracing context (trace ID, parent span ID, metadata, tags) to be forwarded to `agent.stream()`, `agent.approveToolCall()`, and `agent.declineToolCall()`, fixing orphaned root spans when using the Harness with observability backends like Datadog. See #13540.
+---
+'@mastra/core': patch
+---
+
+Added optional `tracingOptions` parameter to `Harness.sendMessage()`. Agent operations initiated through the Harness now properly link to parent traces in your observability tools, ensuring complete trace visibility.
+
+**Example:**
+

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -4,6 +4,7 @@ import type { Agent } from '../agent';
 import type { ToolsInput, ToolsetsInput } from '../agent/types';
 import { Mastra } from '../mastra';
 import type { StorageThreadType } from '../memory/types';
+import type { TracingOptions } from '../observability/types';
 import { RequestContext } from '../request-context';
 import type { MemoryStorage } from '../storage/domains/memory/base';
 import type { ObservationalMemoryRecord } from '../storage/types';
@@ -93,6 +94,7 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
   private sessionGrantedCategories = new Set<string>();
   private sessionGrantedTools = new Set<string>();
   private displayState: HarnessDisplayState = defaultDisplayState();
+  private currentTracingOptions: TracingOptions | undefined = undefined;
   #internalMastra: Mastra | undefined = undefined;
 
   constructor(config: HarnessConfig<TState>) {
@@ -1059,9 +1061,11 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
   async sendMessage({
     content,
     images,
+    tracingOptions,
   }: {
     content: string;
     images?: Array<{ data: string; mimeType: string }>;
+    tracingOptions?: TracingOptions;
   }): Promise<void> {
     if (!this.currentThreadId) {
       const thread = await this.createThread();
@@ -1070,6 +1074,7 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
 
     const operationId = ++this.currentOperationId;
     this.abortController = new AbortController();
+    this.currentTracingOptions = tracingOptions;
     const agent = this.getCurrentAgent();
 
     this.emit({ type: 'agent_start' });
@@ -1086,6 +1091,7 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
         maxSteps: 1000,
         requireToolApproval: !isYolo,
         modelSettings: { temperature: 1 },
+        ...(tracingOptions ? { tracingOptions } : {}),
       };
 
       streamOptions.toolsets = await this.buildToolsets(requestContext);
@@ -1141,7 +1147,11 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
 
       if (this.currentOperationId === operationId && this.followUpQueue.length > 0) {
         const next = this.followUpQueue.shift()!;
-        await this.sendMessage({ content: next });
+        await this.sendMessage({ content: next, tracingOptions });
+      }
+
+      if (this.currentOperationId === operationId) {
+        this.currentTracingOptions = undefined;
       }
     }
   }
@@ -1856,6 +1866,7 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
       abortSignal: this.abortController.signal,
       requestContext,
       toolsets: await this.buildToolsets(requestContext),
+      ...(this.currentTracingOptions ? { tracingOptions: this.currentTracingOptions } : {}),
     });
 
     return await this.processStream(response);
@@ -1880,6 +1891,7 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
       abortSignal: this.abortController.signal,
       requestContext,
       toolsets: await this.buildToolsets(requestContext),
+      ...(this.currentTracingOptions ? { tracingOptions: this.currentTracingOptions } : {}),
     });
 
     return await this.processStream(response);

--- a/packages/core/src/harness/tracing-propagation.test.ts
+++ b/packages/core/src/harness/tracing-propagation.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Agent } from '../agent';
+import type { TracingOptions } from '../observability/types';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+
+/**
+ * Creates a Harness with an agent whose stream method is spied on.
+ * The spy captures the options passed to agent.stream() and returns
+ * a minimal valid stream response so processStream() completes.
+ */
+function createHarnessWithStreamSpy() {
+  const agent = new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+
+  const streamSpy = vi.fn();
+
+  // Replace agent.stream with a spy that captures args and returns a minimal stream
+  agent.stream = vi.fn(async (input: any, options: any) => {
+    streamSpy(input, options);
+    // Return a minimal response with an empty async iterable for fullStream
+    return {
+      fullStream: (async function* () {
+        // Yield a text chunk then finish
+        yield { type: 'text-delta', payload: { delta: 'ok' } };
+        yield {
+          type: 'finish',
+          payload: { finishReason: 'stop', usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 } },
+        };
+      })(),
+      text: Promise.resolve('ok'),
+      usage: Promise.resolve({ promptTokens: 1, completionTokens: 1, totalTokens: 2 }),
+      finishReason: Promise.resolve('stop'),
+      response: Promise.resolve({}),
+      rawResponse: Promise.resolve(undefined),
+      warnings: Promise.resolve([]),
+    };
+  }) as any;
+
+  const harness = new Harness({
+    id: 'test-harness',
+    storage: new InMemoryStore(),
+    modes: [{ id: 'default', name: 'Default', default: true, agent }],
+  });
+
+  return { harness, agent, streamSpy };
+}
+
+describe('Harness tracing propagation', () => {
+  describe('sendMessage passes tracingOptions to agent.stream()', () => {
+    it('forwards tracingOptions with traceId and parentSpanId', async () => {
+      const { harness, streamSpy } = createHarnessWithStreamSpy();
+      await harness.init();
+
+      const tracingOptions: TracingOptions = {
+        traceId: 'abc123',
+        parentSpanId: 'def456',
+      };
+
+      await harness.sendMessage({ content: 'hello', tracingOptions });
+
+      expect(streamSpy).toHaveBeenCalledTimes(1);
+      const [, options] = streamSpy.mock.calls[0];
+      expect(options.tracingOptions).toEqual(tracingOptions);
+    });
+
+    it('forwards tracingOptions with all fields', async () => {
+      const { harness, streamSpy } = createHarnessWithStreamSpy();
+      await harness.init();
+
+      const tracingOptions: TracingOptions = {
+        traceId: 'aabbcc',
+        parentSpanId: '112233',
+        metadata: { userId: 'u-1', env: 'test' },
+        tags: ['test-run', 'ci'],
+        hideInput: true,
+        hideOutput: false,
+        requestContextKeys: ['session.id'],
+      };
+
+      await harness.sendMessage({ content: 'test', tracingOptions });
+
+      expect(streamSpy).toHaveBeenCalledTimes(1);
+      const [, options] = streamSpy.mock.calls[0];
+      expect(options.tracingOptions).toEqual(tracingOptions);
+      expect(options.tracingOptions.traceId).toBe('aabbcc');
+      expect(options.tracingOptions.parentSpanId).toBe('112233');
+      expect(options.tracingOptions.metadata).toEqual({ userId: 'u-1', env: 'test' });
+      expect(options.tracingOptions.tags).toEqual(['test-run', 'ci']);
+      expect(options.tracingOptions.hideInput).toBe(true);
+      expect(options.tracingOptions.hideOutput).toBe(false);
+    });
+
+    it('does not include tracingOptions key when not provided', async () => {
+      const { harness, streamSpy } = createHarnessWithStreamSpy();
+      await harness.init();
+
+      await harness.sendMessage({ content: 'hello' });
+
+      expect(streamSpy).toHaveBeenCalledTimes(1);
+      const [, options] = streamSpy.mock.calls[0];
+      expect(options.tracingOptions).toBeUndefined();
+      expect('tracingOptions' in options).toBe(false);
+    });
+  });
+
+  describe('sendMessage preserves other stream options alongside tracingOptions', () => {
+    it('includes memory, requestContext, and tracingOptions together', async () => {
+      const { harness, streamSpy } = createHarnessWithStreamSpy();
+      await harness.init();
+
+      await harness.sendMessage({
+        content: 'hello',
+        tracingOptions: { traceId: 'trace1' },
+      });
+
+      expect(streamSpy).toHaveBeenCalledTimes(1);
+      const [, options] = streamSpy.mock.calls[0];
+
+      // Verify tracingOptions is present
+      expect(options.tracingOptions).toEqual({ traceId: 'trace1' });
+
+      // Verify standard stream options are still present
+      expect(options.memory).toBeDefined();
+      expect(options.memory.thread).toBeDefined();
+      expect(options.memory.resource).toBeDefined();
+      expect(options.abortSignal).toBeDefined();
+      expect(options.requestContext).toBeDefined();
+      expect(options.maxSteps).toBe(1000);
+      expect(options.modelSettings).toEqual({ temperature: 1 });
+    });
+  });
+
+  describe('currentTracingOptions is set and cleared correctly', () => {
+    it('clears currentTracingOptions after sendMessage completes', async () => {
+      const { harness } = createHarnessWithStreamSpy();
+      await harness.init();
+
+      await harness.sendMessage({
+        content: 'hello',
+        tracingOptions: { traceId: 'trace1' },
+      });
+
+      // After sendMessage completes, currentTracingOptions should be cleared
+      expect((harness as any).currentTracingOptions).toBeUndefined();
+    });
+
+    it('clears currentTracingOptions after sendMessage with no tracing', async () => {
+      const { harness } = createHarnessWithStreamSpy();
+      await harness.init();
+
+      await harness.sendMessage({ content: 'hello' });
+
+      expect((harness as any).currentTracingOptions).toBeUndefined();
+    });
+
+    it('clears currentTracingOptions even when stream throws', async () => {
+      const agent = new Agent({
+        name: 'test-agent',
+        instructions: 'You are a test agent.',
+        model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+      });
+
+      agent.stream = vi.fn(async () => {
+        throw new Error('stream failed');
+      }) as any;
+
+      const harness = new Harness({
+        id: 'test-harness',
+        storage: new InMemoryStore(),
+        modes: [{ id: 'default', name: 'Default', default: true, agent }],
+      });
+
+      await harness.init();
+
+      // Subscribe to catch the error event so it doesn't propagate
+      const events: any[] = [];
+      harness.subscribe(event => {
+        events.push(event);
+      });
+
+      await harness.sendMessage({
+        content: 'hello',
+        tracingOptions: { traceId: 'will-fail' },
+      });
+
+      // currentTracingOptions should still be cleaned up
+      expect((harness as any).currentTracingOptions).toBeUndefined();
+
+      // Verify an error event was emitted
+      expect(events.some(e => e.type === 'error')).toBe(true);
+    });
+  });
+
+  describe('tracingOptions type compatibility', () => {
+    it('accepts empty tracingOptions object', async () => {
+      const { harness, streamSpy } = createHarnessWithStreamSpy();
+      await harness.init();
+
+      await harness.sendMessage({ content: 'hello', tracingOptions: {} });
+
+      expect(streamSpy).toHaveBeenCalledTimes(1);
+      const [, options] = streamSpy.mock.calls[0];
+      expect(options.tracingOptions).toEqual({});
+    });
+
+    it('accepts tracingOptions with only metadata', async () => {
+      const { harness, streamSpy } = createHarnessWithStreamSpy();
+      await harness.init();
+
+      await harness.sendMessage({
+        content: 'hello',
+        tracingOptions: { metadata: { source: 'test' } },
+      });
+
+      expect(streamSpy).toHaveBeenCalledTimes(1);
+      const [, options] = streamSpy.mock.calls[0];
+      expect(options.tracingOptions).toEqual({ metadata: { source: 'test' } });
+    });
+
+    it('accepts tracingOptions with only tags', async () => {
+      const { harness, streamSpy } = createHarnessWithStreamSpy();
+      await harness.init();
+
+      await harness.sendMessage({
+        content: 'hello',
+        tracingOptions: { tags: ['canary', 'v2'] },
+      });
+
+      expect(streamSpy).toHaveBeenCalledTimes(1);
+      const [, options] = streamSpy.mock.calls[0];
+      expect(options.tracingOptions.tags).toEqual(['canary', 'v2']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `Harness.sendMessage()` now accepts an optional `tracingOptions` parameter and forwards it to `agent.stream()`, `agent.approveToolCall()`, `agent.declineToolCall()`, and follow-up queue re-invocations
- Without this, all agent spans created through the Harness were orphaned root traces disconnected from the incoming request trace
- Stores `currentTracingOptions` on the Harness instance for the duration of a `sendMessage()` call so tool approval/decline flows inherit the same tracing context

## Test plan

- [x] 10 new tests in `tracing-propagation.test.ts` covering:
  - tracingOptions with traceId/parentSpanId forwarded to agent.stream()
  - All TracingOptions fields (metadata, tags, hideInput, hideOutput, requestContextKeys) propagate
  - tracingOptions key absent when not provided
  - Other stream options preserved alongside tracingOptions
  - currentTracingOptions cleaned up after success, no-tracing calls, and errors
- [x] All 122 existing harness tests pass
- [x] All 54 observability context tests pass

Towards #13540

This does not address the observability proxy issue. Leaving that to the team as that is a bigger architectural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracing support for message operations: you can pass tracing context (trace ID, parent span ID, metadata, tags, and visibility flags) which is forwarded through agent interactions and cleared after operations to avoid orphaned traces.

* **Tests**
  * New test suite validates tracing propagation across streaming and tool flows, lifecycle handling (set/clear), type variations, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->