### PR TITLE
fix: add fetch-depth to checkout step in prebuild workflow

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
 
       - name: Setup custom action
         continue-on-error: true


### PR DESCRIPTION
## What changed

Added `fetch-depth: 2` to the checkout action in the prebuild workflow, placed under the proper `with:` block.

## Why

Without `fetch-depth`, the checkout defaults to a shallow clone with depth 1, which prevents diff-based operations that need at least 2 commits of history.

## Test plan

- Verify the workflow YAML is valid
- Trigger the prebuild workflow and confirm the checkout step succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to enhance repository history access during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->