### PR TITLE
Add @mastra/auth-studio stub package

### DIFF
--- a/auth/studio/README.md
+++ b/auth/studio/README.md
@@ -1,0 +1,3 @@
+# @mastra/auth-studio
+
+Mastra Studio Auth integration. Coming soon.

--- a/auth/studio/package.json
+++ b/auth/studio/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@mastra/auth-studio",
+  "version": "0.0.0",
+  "description": "Mastra Studio Auth integration",
+  "license": "Apache-2.0",
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "auth/studio"
+  }
+}


### PR DESCRIPTION
Minimal stub to enable initial npm publish so snapshots can be created.

Same pattern as #12928 which added the `@mastra/auth-cloud` stub.

### Changes
- `auth/studio/package.json` — minimal package at `0.0.0`
- `auth/studio/README.md` — placeholder description

### Test plan
- Verified `pnpm ls --filter @mastra/auth-studio` picks up the package via the existing `auth/*` workspace glob.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Mastra Studio Auth integration (coming soon)

* **Chores**
  * Initialized package structure for the new auth studio module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->