### PR TITLE
feat(plans): persist approved plans to disk (#13401)

### DIFF
--- a/.changeset/cold-drinks-wink.md
+++ b/.changeset/cold-drinks-wink.md
@@ -1,0 +1,5 @@
+---
+'mastracode': minor
+---
+
+Added plan persistence: approved plans are now saved as markdown files to disk. Plans are stored at the platform-specific app data directory (e.g. ~/Library/Application Support/mastracode/plans/ on macOS). Set the MASTRA_PLANS_DIR environment variable to override the storage location.

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -8,6 +8,7 @@ A terminal-based coding agent TUI built with [Mastra](https://mastra.ai) and [pi
 - 🔐 **OAuth login**: Authenticate with Anthropic (Claude Max) and OpenAI (ChatGPT Plus/Codex)
 - 💾 **Persistent conversations**: Threads are saved per-project and resume automatically
 - 🛠️ **Coding tools**: View files, edit code, run shell commands
+- 📋 **Plan persistence**: Approved plans are saved as markdown files for future reference
 - 📊 **Token tracking**: Monitor usage with persistent token counts per thread
 - 🎨 **Beautiful TUI**: Polished terminal interface with streaming responses
 
@@ -132,6 +133,22 @@ The SQLite database is stored in your system's application data directory:
 ### Authentication
 
 OAuth credentials are stored alongside the database in `auth.json`.
+
+### Plan persistence
+
+When you approve a plan (via `submit_plan`), it is saved as a markdown file in the app data directory:
+
+- **macOS**: `~/Library/Application Support/mastracode/plans/<resourceId>/`
+- **Linux**: `~/.local/share/mastracode/plans/<resourceId>/`
+- **Windows**: `%APPDATA%/mastracode/plans/<resourceId>/`
+
+Files are named `<timestamp>-<slugified-title>.md` and contain the plan title, approval timestamp, and full plan body.
+
+To save plans to a project-local directory instead, set the `MASTRA_PLANS_DIR` environment variable:
+
+```bash
+export MASTRA_PLANS_DIR=.mastracode/plans
+```
 
 ## Architecture
 

--- a/mastracode/src/tui/handlers/prompts.ts
+++ b/mastracode/src/tui/handlers/prompts.ts
@@ -4,6 +4,7 @@
  */
 import { Spacer } from '@mariozechner/pi-tui';
 
+import { savePlanToDisk } from '../../utils/plans.js';
 import { AskQuestionDialogComponent } from '../components/ask-question-dialog.js';
 import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
 import { PlanApprovalInlineComponent } from '../components/plan-approval-inline.js';
@@ -193,6 +194,12 @@ export async function handlePlanApproval(
               approvedAt: new Date().toISOString(),
             },
           });
+          // Persist plan to disk (fire-and-forget, best-effort)
+          savePlanToDisk({
+            title,
+            plan,
+            resourceId: state.harness.getResourceId(),
+          }).catch(() => {});
           // Wait for plan approval to complete (switches mode, aborts stream)
           await state.harness.respondToPlanApproval({
             planId,

--- a/mastracode/src/utils/__tests__/save-plan.test.ts
+++ b/mastracode/src/utils/__tests__/save-plan.test.ts
@@ -1,0 +1,120 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, it, expect, afterEach, afterAll } from 'vitest';
+import { savePlanToDisk } from '../plans.js';
+
+const projectRoot = path.resolve(import.meta.dirname, '../../..');
+const tmpDir = path.join(projectRoot, '.test-tmp-plans');
+
+afterEach(() => {
+  if (fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true });
+  }
+});
+
+afterAll(() => {
+  if (fs.existsSync(tmpDir)) {
+    fs.rmSync(tmpDir, { recursive: true });
+  }
+});
+
+describe('savePlanToDisk', () => {
+  it('writes a markdown file to the plans directory', async () => {
+    await savePlanToDisk({
+      title: 'Add dark mode toggle',
+      plan: '## Steps\n\n1. Add theme context\n2. Create toggle component',
+      resourceId: 'my-project-abc123',
+      plansDir: tmpDir,
+    });
+
+    const files = fs.readdirSync(path.join(tmpDir, 'my-project-abc123'));
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}T.*-add-dark-mode-toggle\.md$/);
+  });
+
+  it('includes title, timestamp, and plan content in the file', async () => {
+    const before = new Date();
+    await savePlanToDisk({
+      title: 'Refactor auth module',
+      plan: 'Extract shared helpers into a utils file.',
+      resourceId: 'test-proj-def456',
+      plansDir: tmpDir,
+    });
+    const after = new Date();
+
+    const dir = path.join(tmpDir, 'test-proj-def456');
+    const files = fs.readdirSync(dir);
+    const content = fs.readFileSync(path.join(dir, files[0]!), 'utf-8');
+
+    // Title is present as a heading
+    expect(content).toContain('# Refactor auth module');
+    // Plan body is present
+    expect(content).toContain('Extract shared helpers into a utils file.');
+    // Timestamp is present and within the window
+    const match = content.match(/Approved: (.+)/);
+    expect(match).not.toBeNull();
+    const ts = new Date(match![1]!);
+    expect(ts.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(ts.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+
+  it('creates the resource subdirectory if it does not exist', async () => {
+    const resourceDir = path.join(tmpDir, 'new-project-ghi789');
+    expect(fs.existsSync(resourceDir)).toBe(false);
+
+    await savePlanToDisk({
+      title: 'Initial setup',
+      plan: 'Scaffold the project.',
+      resourceId: 'new-project-ghi789',
+      plansDir: tmpDir,
+    });
+
+    expect(fs.existsSync(resourceDir)).toBe(true);
+    expect(fs.readdirSync(resourceDir)).toHaveLength(1);
+  });
+
+  it('handles special characters in the title', async () => {
+    await savePlanToDisk({
+      title: 'Fix bug #42: handle "quotes" & <brackets>',
+      plan: 'Escape properly.',
+      resourceId: 'proj-special',
+      plansDir: tmpDir,
+    });
+
+    const files = fs.readdirSync(path.join(tmpDir, 'proj-special'));
+    expect(files).toHaveLength(1);
+    // Should be slugified — no special chars
+    expect(files[0]).toMatch(/\.md$/);
+    expect(files[0]).not.toMatch(/[#"&<>]/);
+  });
+
+  it('falls back to "untitled" when title has only special characters', async () => {
+    await savePlanToDisk({
+      title: '#@!$%',
+      plan: 'Some plan.',
+      resourceId: 'proj-empty-slug',
+      plansDir: tmpDir,
+    });
+
+    const files = fs.readdirSync(path.join(tmpDir, 'proj-empty-slug'));
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/-untitled\.md$/);
+  });
+
+  it('does not overwrite existing plans', async () => {
+    const opts = {
+      title: 'Same plan',
+      plan: 'Content v1.',
+      resourceId: 'proj-dupes',
+      plansDir: tmpDir,
+    };
+
+    await savePlanToDisk(opts);
+    // Small delay so timestamp differs
+    await new Promise(r => setTimeout(r, 10));
+    await savePlanToDisk({ ...opts, plan: 'Content v2.' });
+
+    const files = fs.readdirSync(path.join(tmpDir, 'proj-dupes'));
+    expect(files).toHaveLength(2);
+  });
+});

--- a/mastracode/src/utils/plans.ts
+++ b/mastracode/src/utils/plans.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { getAppDataDir } from './project.js';
+
+function slugify(str: string): string {
+  const slug = str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+  return slug || 'untitled';
+}
+
+export async function savePlanToDisk(opts: {
+  title: string;
+  plan: string;
+  resourceId: string;
+  plansDir?: string;
+}): Promise<void> {
+  const { title, plan, resourceId } = opts;
+  const plansDir = opts.plansDir ?? process.env.MASTRA_PLANS_DIR ?? path.join(getAppDataDir(), 'plans');
+  const dir = path.join(plansDir, resourceId);
+
+  await fs.mkdir(dir, { recursive: true });
+
+  const now = new Date();
+  const timestamp = now.toISOString().replace(/:/g, '-');
+  const slug = slugify(title);
+  const filename = `${timestamp}-${slug}.md`;
+
+  const content = `# ${title}\n\nApproved: ${now.toISOString()}\n\n${plan}\n`;
+
+  await fs.writeFile(path.join(dir, filename), content, 'utf-8');
+}


### PR DESCRIPTION
## Description

When a plan is approved in Mastra Code, it is now persisted to disk as a markdown file. This gives users an archive of approved plans they can reference later — a feature expected by users migrating from Claude Code.

Plans are saved to the platform-specific app data directory:
- **macOS**: `~/Library/Application Support/mastracode/plans/<resourceId>/`
- **Linux**: `~/.local/share/mastracode/plans/<resourceId>/`
- **Windows**: `%APPDATA%\mastracode\plans\<resourceId>\`

Files are named `<ISO-timestamp>-<slugified-title>.md` and contain the plan title, approval timestamp, and full plan body.

The `MASTRA_PLANS_DIR` environment variable overrides the default location for project-local storage.

Persistence is fire-and-forget with `.catch(() => {})` — a write failure never blocks or breaks the plan approval flow.

## Related Issue(s)

Fixes #13401

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Approved plans are now saved as Markdown files in a platform-specific application data folder (can be overridden with MASTRA_PLANS_DIR).
  * Saved files include the plan title, an Approved timestamp, and the full plan body; filenames use a timestamped, slugified title. Persistence is best-effort and does not block approval.

* **Documentation**
  * Configuration and modes docs updated with storage locations, file format, and environment-variable override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->