### PR TITLE
fix(playground-ui): auto-collapse sub-agent badge when processing completes

### DIFF
--- a/.changeset/shy-ends-relate.md
+++ b/.changeset/shy-ends-relate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed sub-agent collapsible sections in Studio UI to automatically collapse after the sub-agent finishes processing. Previously the section would stay expanded for the entire agent lifecycle, creating visual noise. Now the sub-agent section expands while active and collapses when done. Users can still manually re-open it by clicking.

--- a/packages/playground-ui/src/lib/ai-ui/tools/badges/agent-badge-wrapper.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/badges/agent-badge-wrapper.tsx
@@ -11,6 +11,7 @@ interface AgentBadgeWrapperProps extends Omit<ToolApprovalButtonsProps, 'toolCal
   metadata?: MastraUIMessage['metadata'];
   suspendPayload?: any;
   toolCalled?: boolean;
+  isComplete?: boolean;
 }
 
 export const AgentBadgeWrapper = ({
@@ -23,6 +24,7 @@ export const AgentBadgeWrapper = ({
   isNetwork,
   suspendPayload,
   toolCalled,
+  isComplete,
 }: AgentBadgeWrapperProps) => {
   const { data, isLoading } = useAgentMessages({
     threadId: result?.subAgentThreadId,
@@ -48,6 +50,7 @@ export const AgentBadgeWrapper = ({
       isNetwork={isNetwork}
       suspendPayload={suspendPayload}
       toolCalled={toolCalled}
+      isComplete={isComplete}
     />
   );
 };

--- a/packages/playground-ui/src/lib/ai-ui/tools/badges/agent-badge.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/badges/agent-badge.tsx
@@ -74,7 +74,7 @@ export const AgentBadge = ({
       data-testid="agent-badge"
       icon={<AgentIcon className="text-accent1" />}
       title={agentId}
-      initialCollapsed={false}
+      initialCollapsed={toolCalled}
       extraInfo={
         metadata?.mode === 'network' && (
           <NetworkChoiceMetadataDialogTrigger

--- a/packages/playground-ui/src/lib/ai-ui/tools/badges/agent-badge.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/badges/agent-badge.tsx
@@ -32,6 +32,7 @@ export interface AgentBadgeProps extends Omit<ToolApprovalButtonsProps, 'toolCal
   metadata?: MastraUIMessage['metadata'];
   suspendPayload?: any;
   toolCalled?: boolean;
+  isComplete?: boolean;
 }
 
 export const AgentBadge = ({
@@ -44,6 +45,7 @@ export const AgentBadge = ({
   isNetwork,
   suspendPayload,
   toolCalled: toolCalledProp,
+  isComplete = false,
 }: AgentBadgeProps) => {
   const selectionReason = metadata?.mode === 'network' ? metadata.selectionReason : undefined;
   const agentNetworkInput = metadata?.mode === 'network' ? metadata.agentInput : undefined;
@@ -74,7 +76,7 @@ export const AgentBadge = ({
       data-testid="agent-badge"
       icon={<AgentIcon className="text-accent1" />}
       title={agentId}
-      initialCollapsed={toolCalled}
+      initialCollapsed={isComplete}
       extraInfo={
         metadata?.mode === 'network' && (
           <NetworkChoiceMetadataDialogTrigger

--- a/packages/playground-ui/src/lib/ai-ui/tools/tool-fallback.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/tool-fallback.tsx
@@ -49,6 +49,7 @@ const ToolFallbackInner = ({ toolName, result, args, metadata, toolCallId, ...pr
   const isWorkflow = (metadata?.mode === 'network' && metadata.from === 'WORKFLOW') || toolName.startsWith('workflow-');
 
   const isNetwork = metadata?.mode === 'network';
+  const isComplete = props.status?.type === 'complete';
 
   const agentToolName = toolName.startsWith('agent-') ? toolName.substring('agent-'.length) : toolName;
   const workflowToolName = toolName.startsWith('workflow-') ? toolName.substring('workflow-'.length) : toolName;
@@ -80,6 +81,7 @@ const ToolFallbackInner = ({ toolName, result, args, metadata, toolCallId, ...pr
         isNetwork={isNetwork}
         suspendPayload={suspendedToolMetadata?.suspendPayload}
         toolCalled={toolCalled}
+        isComplete={isComplete}
       />
     );
   }


### PR DESCRIPTION
## Summary

- Sub-agent collapsible sections in Studio UI previously stayed open throughout the entire agent lifecycle, creating visual noise
- Fixed by using `ToolCallMessagePartProps.status.type === 'complete'` as the collapse trigger, propagated through `ToolFallback → AgentBadgeWrapper → AgentBadge → BadgeWrapper`

## Why `status.type === 'complete'` instead of `messages.length > 0`

An earlier approach checked `messages.length > 0` / `toolCalled`, but this caused premature collapse. In `toAssistantUIMessage.ts`, `result` is set to `part.output` **as soon as any output exists** on the tool part — including intermediate streaming output (text deltas build `output.childMessages` while the tool is still running). This meant the badge would collapse mid-stream.

`status.type === 'complete'` is only set when the `dynamic-tool` part reaches `state: 'output-available'`, which happens at:
- `tool-result` chunk for non-network agents
- `agent-execution-end` event for network agents

## Behavior

- Sub-agent starts → badge **expands** (user can observe activity)
- Sub-agent finishes (all tool calls + text complete) → badge **auto-collapses**
- Works correctly for: no tool calls, single tool call, multiple tool calls
- User can still **manually re-open** the collapsed section at any time

## Test plan

- [ ] Chat with an agent that has a sub-agent configured
- [ ] Confirm badge stays **open** while sub-agent is actively streaming/calling tools
- [ ] Confirm badge **auto-collapses** only after the sub-agent fully completes
- [ ] Test with a sub-agent that uses no tools (pure text response) — should collapse after text finishes
- [ ] Test with a sub-agent that uses multiple tools — should collapse after the last tool result arrives
- [ ] Confirm clicking the chevron manually re-opens the collapsed badge
- [ ] Confirm previously completed sub-agent calls (loaded from history) start collapsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)