### PR TITLE
feat(mastracode): support external tool injection and auth storage init

### DIFF
--- a/mastracode/src/__tests__/create-auth-storage.test.ts
+++ b/mastracode/src/__tests__/create-auth-storage.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { createAuthStorage } from '../index.js';
+import { getAuthStorage as getClaudeAuthStorage } from '../providers/claude-max.js';
+import { getAuthStorage as getOpenAIAuthStorage } from '../providers/openai-codex.js';
+
+describe('createAuthStorage', () => {
+  it('wires a shared auth storage instance to provider modules', () => {
+    const authStorage = createAuthStorage();
+
+    expect(getClaudeAuthStorage()).toBe(authStorage);
+    expect(getOpenAIAuthStorage()).toBe(authStorage);
+  });
+});

--- a/mastracode/src/agents/__tests__/tools.test.ts
+++ b/mastracode/src/agents/__tests__/tools.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createDynamicTools } from '../tools.js';
+
+function createRequestContext(state: Record<string, unknown>, modeId: string = 'build') {
+  return {
+    get(key: string) {
+      if (key !== 'harness') return undefined;
+      return {
+        modeId,
+        getState: () => state,
+      };
+    },
+  } as any;
+}
+
+describe('createDynamicTools', () => {
+  it('merges extra tools into the exposed tool map', () => {
+    const customTool = {
+      description: 'custom',
+      async execute() {
+        return { ok: true };
+      },
+    };
+
+    const getDynamicTools = createDynamicTools(undefined, {
+      custom_tool: customTool,
+    });
+
+    const allowedTools = getDynamicTools({
+      requestContext: createRequestContext({
+        projectPath: process.cwd(),
+      }),
+    });
+    expect(allowedTools.custom_tool).toBeDefined();
+  });
+
+  it('runs pre/post hooks around tool execution', async () => {
+    const execute = vi.fn(async () => ({ ok: true }));
+    const hookManager = {
+      runPreToolUse: vi.fn(async () => ({ allowed: true, results: [], warnings: [] })),
+      runPostToolUse: vi.fn(async () => ({ allowed: true, results: [], warnings: [] })),
+    };
+
+    const getDynamicTools = createDynamicTools(
+      undefined,
+      {
+        custom_tool: {
+          description: 'custom',
+          execute,
+        },
+      },
+      hookManager as any,
+    );
+
+    const tools = getDynamicTools({
+      requestContext: createRequestContext({
+        projectPath: process.cwd(),
+      }),
+    });
+
+    const input = { foo: 'bar' };
+    const output = await tools.custom_tool.execute(input, {});
+
+    expect(output).toEqual({ ok: true });
+    expect(execute).toHaveBeenCalledWith(input, {});
+    expect(hookManager.runPreToolUse).toHaveBeenCalledWith('custom_tool', input);
+    expect(hookManager.runPostToolUse).toHaveBeenCalledWith('custom_tool', input, { ok: true }, false);
+  });
+
+  it('blocks tool execution when PreToolUse denies access', async () => {
+    const execute = vi.fn(async () => ({ ok: true }));
+    const hookManager = {
+      runPreToolUse: vi.fn(async () => ({ allowed: false, blockReason: 'blocked by policy', results: [], warnings: [] })),
+      runPostToolUse: vi.fn(async () => ({ allowed: true, results: [], warnings: [] })),
+    };
+
+    const getDynamicTools = createDynamicTools(
+      undefined,
+      {
+        custom_tool: {
+          description: 'custom',
+          execute,
+        },
+      },
+      hookManager as any,
+    );
+
+    const tools = getDynamicTools({
+      requestContext: createRequestContext({
+        projectPath: process.cwd(),
+      }),
+    });
+
+    const result = await tools.custom_tool.execute({ foo: 'bar' }, {});
+    expect(result).toEqual({ error: 'blocked by policy' });
+    expect(execute).not.toHaveBeenCalled();
+    expect(hookManager.runPostToolUse).not.toHaveBeenCalled();
+  });
+
+  it('still runs PostToolUse when tool execution throws', async () => {
+    const execute = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const hookManager = {
+      runPreToolUse: vi.fn(async () => ({ allowed: true, results: [], warnings: [] })),
+      runPostToolUse: vi.fn(async () => ({ allowed: true, results: [], warnings: [] })),
+    };
+
+    const getDynamicTools = createDynamicTools(
+      undefined,
+      {
+        custom_tool: {
+          description: 'custom',
+          execute,
+        },
+      },
+      hookManager as any,
+    );
+
+    const tools = getDynamicTools({
+      requestContext: createRequestContext({
+        projectPath: process.cwd(),
+      }),
+    });
+
+    await expect(tools.custom_tool.execute({ foo: 'bar' }, {})).rejects.toThrow('boom');
+    expect(hookManager.runPostToolUse).toHaveBeenCalledWith(
+      'custom_tool',
+      { foo: 'bar' },
+      { error: 'boom' },
+      true,
+    );
+  });
+});

--- a/mastracode/src/agents/tools.ts
+++ b/mastracode/src/agents/tools.ts
@@ -1,6 +1,7 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
 import type { HarnessRequestContext } from '@mastra/core/harness';
 import type { RequestContext } from '@mastra/core/request-context';
+import type { HookManager } from '../hooks';
 import type { McpManager } from '../mcp';
 import type { stateSchema } from '../schema';
 import {
@@ -17,7 +18,40 @@ import {
   requestSandboxAccessTool,
 } from '../tools';
 
-export function createDynamicTools(mcpManager?: McpManager) {
+function wrapToolWithHooks(toolName: string, tool: any, hookManager?: HookManager): any {
+  if (!hookManager || typeof tool?.execute !== 'function') {
+    return tool;
+  }
+
+  return {
+    ...tool,
+    async execute(input: unknown, toolContext: unknown) {
+      const preResult = await hookManager.runPreToolUse(toolName, input);
+      if (!preResult.allowed) {
+        return {
+          error: preResult.blockReason ?? `Blocked by PreToolUse hook for tool "${toolName}"`,
+        };
+      }
+
+      let output: unknown;
+      let toolError = false;
+      try {
+        output = await tool.execute(input, toolContext);
+        return output;
+      } catch (error) {
+        toolError = true;
+        output = {
+          error: error instanceof Error ? error.message : String(error),
+        };
+        throw error;
+      } finally {
+        await hookManager.runPostToolUse(toolName, input, output, toolError).catch(() => undefined);
+      }
+    },
+  };
+}
+
+export function createDynamicTools(mcpManager?: McpManager, extraTools: Record<string, any> = {}, hookManager?: HookManager) {
   return function getDynamicTools({ requestContext }: { requestContext: RequestContext }) {
     const ctx = requestContext.get('harness') as HarnessRequestContext<typeof stateSchema> | undefined;
     const state = ctx?.getState?.();
@@ -64,6 +98,12 @@ export function createDynamicTools(mcpManager?: McpManager) {
     if (mcpManager) {
       const mcpTools = mcpManager.getTools();
       Object.assign(tools, mcpTools);
+    }
+
+    Object.assign(tools, extraTools);
+
+    for (const [toolName, tool] of Object.entries(tools)) {
+      tools[toolName] = wrapToolWithHooks(toolName, tool, hookManager);
     }
 
     return tools;

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -63,13 +63,18 @@ export interface MastraCodeConfig {
   disableHooks?: boolean;
 }
 
+export function createAuthStorage() {
+  const authStorage = new AuthStorage();
+  setAuthStorage(authStorage);
+  setOpenAIAuthStorage(authStorage);
+  return authStorage;
+}
+
 export async function createMastraCode(config?: MastraCodeConfig) {
   const cwd = config?.cwd ?? process.cwd();
 
   // Auth storage (shared with Claude Max / OpenAI providers and Harness)
-  const authStorage = new AuthStorage();
-  setAuthStorage(authStorage);
-  setOpenAIAuthStorage(authStorage);
+  const authStorage = createAuthStorage();
 
   // Project detection
   const project = detectProject(cwd);
@@ -94,15 +99,6 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   // MCP
   const mcpManager = config?.disableMcp ? undefined : createMcpManager(project.rootPath);
 
-  // Agent
-  const codeAgent = new Agent({
-    id: 'code-agent',
-    name: 'Code Agent',
-    instructions: getDynamicInstructions,
-    model: getDynamicModel,
-    tools: createDynamicTools(mcpManager),
-  });
-
   // Hooks
   const hookManager = config?.disableHooks ? undefined : new HookManager(project.rootPath, 'session-init');
 
@@ -111,6 +107,15 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     const hookCount = Object.values(hookConfig).reduce((sum, hooks) => sum + (hooks?.length ?? 0), 0);
     console.info(`Hooks: ${hookCount} hook(s) configured`);
   }
+
+  // Agent
+  const codeAgent = new Agent({
+    id: 'code-agent',
+    name: 'Code Agent',
+    instructions: getDynamicInstructions,
+    model: getDynamicModel,
+    tools: createDynamicTools(mcpManager, config?.extraTools ?? {}, hookManager),
+  });
 
   // Build subagent definitions with project-scoped tools
   const viewTool = createViewTool(project.rootPath);


### PR DESCRIPTION
## Summary
- add `createAuthStorage()` export so auth providers can be initialized without creating a full `createMastraCode` instance
- wire `createMastraCode` to use `createAuthStorage`
- allow `createDynamicTools` to merge `extraTools` and wrap tool execution with `HookManager` pre/post hooks
- add unit tests for auth storage wiring, extra tool merging, and hook behavior

## Validation
- `pnpm -C mastracode test --run src/__tests__/create-auth-storage.test.ts src/agents/__tests__/tools.test.ts`

## Notes
- branch is rebased/merged on latest upstream main, including recent tool path-resolution fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `createAuthStorage()` for explicit authentication storage initialization
  * Added tool execution hooks for pre- and post-execution custom logic
  * Extended tools system to accept extra tools at runtime

* **Tests**
  * Added comprehensive test coverage for tool hook execution flow
  * Added test coverage for authentication storage initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->