### PR TITLE
fix: handle ERR_STREAM_DESTROYED as non-fatal in global error handlers

### DIFF
--- a/.changeset/sweet-trams-sniff.md
+++ b/.changeset/sweet-trams-sniff.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed a crash where ERR_STREAM_DESTROYED errors would fatally exit the process. These errors occur routinely during cancelled LLM streams, LSP shutdown, or killed subprocesses and are now silently ignored instead of crashing mastracode.

--- a/mastracode/src/__tests__/stream-destroyed-error.test.ts
+++ b/mastracode/src/__tests__/stream-destroyed-error.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from 'vitest';
 
 import { isStreamDestroyedError } from '../error-classification.js';
 
+type ErrorWithCode = Error & { code?: string; cause?: unknown; errors?: unknown[] };
+
 describe('isStreamDestroyedError', () => {
   it('should detect a real ERR_STREAM_DESTROYED from a destroyed writable stream', async () => {
     const writable = new Writable({
@@ -24,8 +26,8 @@ describe('isStreamDestroyedError', () => {
   });
 
   it('should detect ERR_STREAM_DESTROYED by error code', () => {
-    const error = new Error('write EPIPE');
-    (error as any).code = 'ERR_STREAM_DESTROYED';
+    const error: ErrorWithCode = new Error('write EPIPE');
+    error.code = 'ERR_STREAM_DESTROYED';
     expect(isStreamDestroyedError(error)).toBe(true);
   });
 
@@ -35,10 +37,10 @@ describe('isStreamDestroyedError', () => {
   });
 
   it('should detect ERR_STREAM_DESTROYED in nested cause', () => {
-    const inner = new Error('stream was destroyed');
-    (inner as any).code = 'ERR_STREAM_DESTROYED';
-    const outer = new Error('write failed');
-    (outer as any).cause = inner;
+    const inner: ErrorWithCode = new Error('stream was destroyed');
+    inner.code = 'ERR_STREAM_DESTROYED';
+    const outer: ErrorWithCode = new Error('write failed');
+    outer.cause = inner;
     expect(isStreamDestroyedError(outer)).toBe(true);
   });
 
@@ -47,8 +49,8 @@ describe('isStreamDestroyedError', () => {
   });
 
   it('should NOT match ECONNREFUSED errors', () => {
-    const error = new Error('connect ECONNREFUSED');
-    (error as any).code = 'ECONNREFUSED';
+    const error: ErrorWithCode = new Error('connect ECONNREFUSED');
+    error.code = 'ECONNREFUSED';
     expect(isStreamDestroyedError(error)).toBe(false);
   });
 
@@ -60,8 +62,8 @@ describe('isStreamDestroyedError', () => {
   });
 
   it('should detect ERR_STREAM_DESTROYED in AggregateError.errors', () => {
-    const streamError = new Error('stream was destroyed');
-    (streamError as any).code = 'ERR_STREAM_DESTROYED';
+    const streamError: ErrorWithCode = new Error('stream was destroyed');
+    streamError.code = 'ERR_STREAM_DESTROYED';
     const otherError = new Error('unrelated error');
     const aggregate = new AggregateError([otherError, streamError], 'Multiple errors');
     expect(isStreamDestroyedError(aggregate)).toBe(true);
@@ -73,21 +75,20 @@ describe('isStreamDestroyedError', () => {
   });
 
   it('should check .errors even when .cause exists and does not match', () => {
-    const streamError = new Error('stream was destroyed');
-    (streamError as any).code = 'ERR_STREAM_DESTROYED';
-    const error: any = new Error('wrapper');
+    const streamError: ErrorWithCode = new Error('stream was destroyed');
+    streamError.code = 'ERR_STREAM_DESTROYED';
+    const error: ErrorWithCode = new Error('wrapper');
     error.cause = new Error('unrelated cause');
     error.errors = [streamError];
     expect(isStreamDestroyedError(error)).toBe(true);
   });
 
   it('should handle deeply nested causes with depth limit', () => {
-    // Build a chain deeper than the depth limit
-    let error: any = new Error('stream was destroyed');
+    let error: ErrorWithCode = new Error('stream was destroyed');
     error.code = 'ERR_STREAM_DESTROYED';
     for (let i = 0; i < 10; i++) {
-      const wrapper = new Error(`wrapper ${i}`);
-      (wrapper as any).cause = error;
+      const wrapper: ErrorWithCode = new Error(`wrapper ${i}`);
+      wrapper.cause = error;
       error = wrapper;
     }
     // Should stop searching after reasonable depth and return false
@@ -95,100 +96,91 @@ describe('isStreamDestroyedError', () => {
   });
 });
 
-describe('uncaughtException handler integration', () => {
-  function spawnWithHandler(useFilter: boolean): Promise<{ code: number | null; stderr: string }> {
-    return new Promise(resolve => {
-      // Spawn a Node process that reproduces the exact main.ts pattern:
-      // - Sets up uncaughtException handler (with or without the filter)
-      // - Triggers an uncaught ERR_STREAM_DESTROYED via a destroyed stream's error event
-      // - If the handler filters correctly, the process exits 0
-      // - If not, it calls process.exit(1) like handleFatalError does
-      const script = `
-        const { Writable } = require('node:stream');
+// Inline JS detector shared by both integration test suites.
+// Must be kept in sync with isStreamDestroyedError in error-classification.ts.
+const detectorScript = `
+  function isStreamDestroyedError(err, depth) {
+    depth = depth || 0;
+    if (!err || depth > 5) return false;
+    if (err.code === 'ERR_STREAM_DESTROYED') return true;
+    if (typeof err.message === 'string' && err.message.includes('stream was destroyed')) return true;
+    if (err.cause && isStreamDestroyedError(err.cause, depth + 1)) return true;
+    if (Array.isArray(err.errors) && err.errors.some(function(inner) { return isStreamDestroyedError(inner, depth + 1); })) return true;
+    return false;
+  }
+`;
 
-        function isStreamDestroyedError(err, depth = 0) {
-          if (!err || depth > 5) return false;
-          if (err.code === 'ERR_STREAM_DESTROYED') return true;
-          if (typeof err.message === 'string' && err.message.includes('stream was destroyed')) return true;
-          if (err.cause && isStreamDestroyedError(err.cause, depth + 1)) return true;
-          if (Array.isArray(err.errors) && err.errors.some(inner => isStreamDestroyedError(inner, depth + 1))) return true;
-          return false;
-        }
-
-        process.on('uncaughtException', (error) => {
-          ${useFilter ? 'if (isStreamDestroyedError(error)) return;' : ''}
-          process.exit(1);
-        });
-
-        // Trigger a real uncaught ERR_STREAM_DESTROYED:
-        // Emitting 'error' on a destroyed stream with no error listener causes
-        // the error to bubble up as an uncaughtException — this is the same
-        // mechanism that crashes mastracode in issues #13548 and #13549.
-        const w = new Writable({ write(c, e, cb) { cb(); } });
-        w.destroy();
-        const err = new Error('Cannot call write after a stream was destroyed');
-        err.code = 'ERR_STREAM_DESTROYED';
-        w.emit('error', err);
-
-        // If we survive the uncaught exception, exit cleanly
-        setTimeout(() => process.exit(0), 50);
-      `;
-
-      execFile('node', ['-e', script], { timeout: 5000 }, (err, _stdout, stderr) => {
-        resolve({ code: err ? ((err as any).code ?? 1) : 0, stderr });
-      });
+function spawnScript(script: string): Promise<{ code: number | null; stderr: string }> {
+  return new Promise(resolve => {
+    execFile('node', ['-e', script], { timeout: 5000 }, (err, _stdout, stderr) => {
+      const code = err && typeof (err as NodeJS.ErrnoException).code === 'number' ? (err as NodeJS.ErrnoException).code : err ? 1 : 0;
+      resolve({ code: code as number | null, stderr });
     });
+  });
+}
+
+describe('uncaughtException handler integration', () => {
+  function buildScript(useFilter: boolean): string {
+    return `
+      const { Writable } = require('node:stream');
+      ${detectorScript}
+
+      process.on('uncaughtException', (error) => {
+        ${useFilter ? 'if (isStreamDestroyedError(error)) return;' : ''}
+        process.exit(1);
+      });
+
+      // Trigger a real uncaught ERR_STREAM_DESTROYED:
+      // Emitting 'error' on a destroyed stream with no error listener causes
+      // the error to bubble up as an uncaughtException — this is the same
+      // mechanism that crashes mastracode in issues #13548 and #13549.
+      const w = new Writable({ write(c, e, cb) { cb(); } });
+      w.destroy();
+      const err = new Error('Cannot call write after a stream was destroyed');
+      err.code = 'ERR_STREAM_DESTROYED';
+      w.emit('error', err);
+
+      // If we survive the uncaught exception, exit cleanly
+      setTimeout(() => process.exit(0), 50);
+    `;
   }
 
   it('should crash without the ERR_STREAM_DESTROYED filter (reproduces the bug)', async () => {
-    const result = await spawnWithHandler(false);
+    const result = await spawnScript(buildScript(false));
     expect(result.code).not.toBe(0);
   });
 
   it('should survive with the ERR_STREAM_DESTROYED filter (the fix)', async () => {
-    const result = await spawnWithHandler(true);
+    const result = await spawnScript(buildScript(true));
     expect(result.code).toBe(0);
   });
 });
 
 describe('unhandledRejection handler integration', () => {
-  function spawnWithRejectionHandler(useFilter: boolean): Promise<{ code: number | null; stderr: string }> {
-    return new Promise(resolve => {
-      const script = `
-        function isStreamDestroyedError(err, depth = 0) {
-          if (!err || depth > 5) return false;
-          if (err.code === 'ERR_STREAM_DESTROYED') return true;
-          if (typeof err.message === 'string' && err.message.includes('stream was destroyed')) return true;
-          if (err.cause && isStreamDestroyedError(err.cause, depth + 1)) return true;
-          if (Array.isArray(err.errors) && err.errors.some(inner => isStreamDestroyedError(inner, depth + 1))) return true;
-          return false;
-        }
+  function buildScript(useFilter: boolean): string {
+    return `
+      ${detectorScript}
 
-        process.on('unhandledRejection', (reason) => {
-          ${useFilter ? 'if (isStreamDestroyedError(reason)) return;' : ''}
-          process.exit(1);
-        });
-
-        const err = new Error('Cannot call write after a stream was destroyed');
-        err.code = 'ERR_STREAM_DESTROYED';
-        Promise.reject(err);
-
-        setTimeout(() => process.exit(0), 50);
-      `;
-
-      execFile('node', ['-e', script], { timeout: 5000 }, (err, _stdout, stderr) => {
-        resolve({ code: err ? ((err as any).code ?? 1) : 0, stderr });
+      process.on('unhandledRejection', (reason) => {
+        ${useFilter ? 'if (isStreamDestroyedError(reason)) return;' : ''}
+        process.exit(1);
       });
-    });
+
+      const err = new Error('Cannot call write after a stream was destroyed');
+      err.code = 'ERR_STREAM_DESTROYED';
+      Promise.reject(err);
+
+      setTimeout(() => process.exit(0), 50);
+    `;
   }
 
   it('should crash without the ERR_STREAM_DESTROYED filter', async () => {
-    const result = await spawnWithRejectionHandler(false);
+    const result = await spawnScript(buildScript(false));
     expect(result.code).not.toBe(0);
   });
 
   it('should survive with the ERR_STREAM_DESTROYED filter', async () => {
-    const result = await spawnWithRejectionHandler(true);
+    const result = await spawnScript(buildScript(true));
     expect(result.code).toBe(0);
   });
 });

--- a/mastracode/src/__tests__/stream-destroyed-error.test.ts
+++ b/mastracode/src/__tests__/stream-destroyed-error.test.ts
@@ -1,8 +1,27 @@
+import { Writable } from 'node:stream';
 import { describe, expect, it } from 'vitest';
 
 import { isStreamDestroyedError } from '../error-classification.js';
 
 describe('isStreamDestroyedError', () => {
+  it('should detect a real ERR_STREAM_DESTROYED from a destroyed writable stream', async () => {
+    const writable = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+    writable.destroy();
+
+    const error = await new Promise<Error>(resolve => {
+      writable.write('data', err => {
+        resolve(err as Error);
+      });
+    });
+
+    expect(error).toBeDefined();
+    expect(isStreamDestroyedError(error)).toBe(true);
+  });
+
   it('should detect ERR_STREAM_DESTROYED by error code', () => {
     const error = new Error('write EPIPE');
     (error as any).code = 'ERR_STREAM_DESTROYED';

--- a/mastracode/src/__tests__/stream-destroyed-error.test.ts
+++ b/mastracode/src/__tests__/stream-destroyed-error.test.ts
@@ -59,6 +59,28 @@ describe('isStreamDestroyedError', () => {
     expect(isStreamDestroyedError(42)).toBe(false);
   });
 
+  it('should detect ERR_STREAM_DESTROYED in AggregateError.errors', () => {
+    const streamError = new Error('stream was destroyed');
+    (streamError as any).code = 'ERR_STREAM_DESTROYED';
+    const otherError = new Error('unrelated error');
+    const aggregate = new AggregateError([otherError, streamError], 'Multiple errors');
+    expect(isStreamDestroyedError(aggregate)).toBe(true);
+  });
+
+  it('should return false for AggregateError without stream destroyed errors', () => {
+    const aggregate = new AggregateError([new Error('error 1'), new Error('error 2')], 'Multiple errors');
+    expect(isStreamDestroyedError(aggregate)).toBe(false);
+  });
+
+  it('should check .errors even when .cause exists and does not match', () => {
+    const streamError = new Error('stream was destroyed');
+    (streamError as any).code = 'ERR_STREAM_DESTROYED';
+    const error: any = new Error('wrapper');
+    error.cause = new Error('unrelated cause');
+    error.errors = [streamError];
+    expect(isStreamDestroyedError(error)).toBe(true);
+  });
+
   it('should handle deeply nested causes with depth limit', () => {
     // Build a chain deeper than the depth limit
     let error: any = new Error('stream was destroyed');
@@ -88,8 +110,8 @@ describe('uncaughtException handler integration', () => {
           if (!err || depth > 5) return false;
           if (err.code === 'ERR_STREAM_DESTROYED') return true;
           if (typeof err.message === 'string' && err.message.includes('stream was destroyed')) return true;
-          if (err.cause) return isStreamDestroyedError(err.cause, depth + 1);
-          if (Array.isArray(err.errors)) return err.errors.some(inner => isStreamDestroyedError(inner, depth + 1));
+          if (err.cause && isStreamDestroyedError(err.cause, depth + 1)) return true;
+          if (Array.isArray(err.errors) && err.errors.some(inner => isStreamDestroyedError(inner, depth + 1))) return true;
           return false;
         }
 

--- a/mastracode/src/__tests__/stream-destroyed-error.test.ts
+++ b/mastracode/src/__tests__/stream-destroyed-error.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { isStreamDestroyedError } from '../error-classification.js';
+
+describe('isStreamDestroyedError', () => {
+  it('should detect ERR_STREAM_DESTROYED by error code', () => {
+    const error = new Error('write EPIPE');
+    (error as any).code = 'ERR_STREAM_DESTROYED';
+    expect(isStreamDestroyedError(error)).toBe(true);
+  });
+
+  it('should detect ERR_STREAM_DESTROYED by message', () => {
+    const error = new Error('Cannot call write after a stream was destroyed');
+    expect(isStreamDestroyedError(error)).toBe(true);
+  });
+
+  it('should detect ERR_STREAM_DESTROYED in nested cause', () => {
+    const inner = new Error('stream was destroyed');
+    (inner as any).code = 'ERR_STREAM_DESTROYED';
+    const outer = new Error('write failed');
+    (outer as any).cause = inner;
+    expect(isStreamDestroyedError(outer)).toBe(true);
+  });
+
+  it('should NOT match unrelated errors', () => {
+    expect(isStreamDestroyedError(new Error('Something else went wrong'))).toBe(false);
+  });
+
+  it('should NOT match ECONNREFUSED errors', () => {
+    const error = new Error('connect ECONNREFUSED');
+    (error as any).code = 'ECONNREFUSED';
+    expect(isStreamDestroyedError(error)).toBe(false);
+  });
+
+  it('should handle non-Error values', () => {
+    expect(isStreamDestroyedError(null)).toBe(false);
+    expect(isStreamDestroyedError(undefined)).toBe(false);
+    expect(isStreamDestroyedError('some string')).toBe(false);
+    expect(isStreamDestroyedError(42)).toBe(false);
+  });
+
+  it('should handle deeply nested causes with depth limit', () => {
+    // Build a chain deeper than the depth limit
+    let error: any = new Error('stream was destroyed');
+    error.code = 'ERR_STREAM_DESTROYED';
+    for (let i = 0; i < 10; i++) {
+      const wrapper = new Error(`wrapper ${i}`);
+      (wrapper as any).cause = error;
+      error = wrapper;
+    }
+    // Should stop searching after reasonable depth and return false
+    expect(isStreamDestroyedError(error)).toBe(false);
+  });
+});

--- a/mastracode/src/__tests__/stream-destroyed-error.test.ts
+++ b/mastracode/src/__tests__/stream-destroyed-error.test.ts
@@ -135,7 +135,7 @@ describe('uncaughtException handler integration', () => {
       `;
 
       execFile('node', ['-e', script], { timeout: 5000 }, (err, _stdout, stderr) => {
-        resolve({ code: err ? (err as any).code ?? 1 : 0, stderr });
+        resolve({ code: err ? ((err as any).code ?? 1) : 0, stderr });
       });
     });
   }

--- a/mastracode/src/__tests__/stream-destroyed-error.test.ts
+++ b/mastracode/src/__tests__/stream-destroyed-error.test.ts
@@ -113,7 +113,12 @@ const detectorScript = `
 function spawnScript(script: string): Promise<{ code: number | null; stderr: string }> {
   return new Promise(resolve => {
     execFile('node', ['-e', script], { timeout: 5000 }, (err, _stdout, stderr) => {
-      const code = err && typeof (err as NodeJS.ErrnoException).code === 'number' ? (err as NodeJS.ErrnoException).code : err ? 1 : 0;
+      const code =
+        err && typeof (err as NodeJS.ErrnoException).code === 'number'
+          ? (err as NodeJS.ErrnoException).code
+          : err
+            ? 1
+            : 0;
       resolve({ code: code as number | null, stderr });
     });
   });

--- a/mastracode/src/__tests__/stream-destroyed-error.test.ts
+++ b/mastracode/src/__tests__/stream-destroyed-error.test.ts
@@ -1,3 +1,4 @@
+import { execFile } from 'node:child_process';
 import { Writable } from 'node:stream';
 import { describe, expect, it } from 'vitest';
 
@@ -69,5 +70,61 @@ describe('isStreamDestroyedError', () => {
     }
     // Should stop searching after reasonable depth and return false
     expect(isStreamDestroyedError(error)).toBe(false);
+  });
+});
+
+describe('uncaughtException handler integration', () => {
+  function spawnWithHandler(useFilter: boolean): Promise<{ code: number | null; stderr: string }> {
+    return new Promise(resolve => {
+      // Spawn a Node process that reproduces the exact main.ts pattern:
+      // - Sets up uncaughtException handler (with or without the filter)
+      // - Triggers an uncaught ERR_STREAM_DESTROYED via a destroyed stream's error event
+      // - If the handler filters correctly, the process exits 0
+      // - If not, it calls process.exit(1) like handleFatalError does
+      const script = `
+        const { Writable } = require('node:stream');
+
+        function isStreamDestroyedError(err, depth = 0) {
+          if (!err || depth > 5) return false;
+          if (err.code === 'ERR_STREAM_DESTROYED') return true;
+          if (typeof err.message === 'string' && err.message.includes('stream was destroyed')) return true;
+          if (err.cause) return isStreamDestroyedError(err.cause, depth + 1);
+          if (Array.isArray(err.errors)) return err.errors.some(inner => isStreamDestroyedError(inner, depth + 1));
+          return false;
+        }
+
+        process.on('uncaughtException', (error) => {
+          ${useFilter ? 'if (isStreamDestroyedError(error)) return;' : ''}
+          process.exit(1);
+        });
+
+        // Trigger a real uncaught ERR_STREAM_DESTROYED:
+        // Emitting 'error' on a destroyed stream with no error listener causes
+        // the error to bubble up as an uncaughtException — this is the same
+        // mechanism that crashes mastracode in issues #13548 and #13549.
+        const w = new Writable({ write(c, e, cb) { cb(); } });
+        w.destroy();
+        const err = new Error('Cannot call write after a stream was destroyed');
+        err.code = 'ERR_STREAM_DESTROYED';
+        w.emit('error', err);
+
+        // If we survive the uncaught exception, exit cleanly
+        setTimeout(() => process.exit(0), 50);
+      `;
+
+      execFile('node', ['-e', script], { timeout: 5000 }, (err, _stdout, stderr) => {
+        resolve({ code: err ? (err as any).code ?? 1 : 0, stderr });
+      });
+    });
+  }
+
+  it('should crash without the ERR_STREAM_DESTROYED filter (reproduces the bug)', async () => {
+    const result = await spawnWithHandler(false);
+    expect(result.code).not.toBe(0);
+  });
+
+  it('should survive with the ERR_STREAM_DESTROYED filter (the fix)', async () => {
+    const result = await spawnWithHandler(true);
+    expect(result.code).toBe(0);
   });
 });

--- a/mastracode/src/__tests__/stream-destroyed-error.test.ts
+++ b/mastracode/src/__tests__/stream-destroyed-error.test.ts
@@ -177,7 +177,7 @@ describe('unhandledRejection handler integration', () => {
       `;
 
       execFile('node', ['-e', script], { timeout: 5000 }, (err, _stdout, stderr) => {
-        resolve({ code: err ? (err as any).code ?? 1 : 0, stderr });
+        resolve({ code: err ? ((err as any).code ?? 1) : 0, stderr });
       });
     });
   }

--- a/mastracode/src/__tests__/stream-destroyed-error.test.ts
+++ b/mastracode/src/__tests__/stream-destroyed-error.test.ts
@@ -150,3 +150,45 @@ describe('uncaughtException handler integration', () => {
     expect(result.code).toBe(0);
   });
 });
+
+describe('unhandledRejection handler integration', () => {
+  function spawnWithRejectionHandler(useFilter: boolean): Promise<{ code: number | null; stderr: string }> {
+    return new Promise(resolve => {
+      const script = `
+        function isStreamDestroyedError(err, depth = 0) {
+          if (!err || depth > 5) return false;
+          if (err.code === 'ERR_STREAM_DESTROYED') return true;
+          if (typeof err.message === 'string' && err.message.includes('stream was destroyed')) return true;
+          if (err.cause && isStreamDestroyedError(err.cause, depth + 1)) return true;
+          if (Array.isArray(err.errors) && err.errors.some(inner => isStreamDestroyedError(inner, depth + 1))) return true;
+          return false;
+        }
+
+        process.on('unhandledRejection', (reason) => {
+          ${useFilter ? 'if (isStreamDestroyedError(reason)) return;' : ''}
+          process.exit(1);
+        });
+
+        const err = new Error('Cannot call write after a stream was destroyed');
+        err.code = 'ERR_STREAM_DESTROYED';
+        Promise.reject(err);
+
+        setTimeout(() => process.exit(0), 50);
+      `;
+
+      execFile('node', ['-e', script], { timeout: 5000 }, (err, _stdout, stderr) => {
+        resolve({ code: err ? (err as any).code ?? 1 : 0, stderr });
+      });
+    });
+  }
+
+  it('should crash without the ERR_STREAM_DESTROYED filter', async () => {
+    const result = await spawnWithRejectionHandler(false);
+    expect(result.code).not.toBe(0);
+  });
+
+  it('should survive with the ERR_STREAM_DESTROYED filter', async () => {
+    const result = await spawnWithRejectionHandler(true);
+    expect(result.code).toBe(0);
+  });
+});

--- a/mastracode/src/error-classification.ts
+++ b/mastracode/src/error-classification.ts
@@ -11,7 +11,7 @@ export function isStreamDestroyedError(err: unknown, depth = 0): boolean {
   const e = err as any;
   if (e.code === 'ERR_STREAM_DESTROYED') return true;
   if (typeof e.message === 'string' && e.message.includes('stream was destroyed')) return true;
-  if (e.cause) return isStreamDestroyedError(e.cause, depth + 1);
-  if (Array.isArray(e.errors)) return e.errors.some((inner: unknown) => isStreamDestroyedError(inner, depth + 1));
+  if (e.cause && isStreamDestroyedError(e.cause, depth + 1)) return true;
+  if (Array.isArray(e.errors) && e.errors.some((inner: unknown) => isStreamDestroyedError(inner, depth + 1))) return true;
   return false;
 }

--- a/mastracode/src/error-classification.ts
+++ b/mastracode/src/error-classification.ts
@@ -1,0 +1,17 @@
+/**
+ * Checks whether an error is an ERR_STREAM_DESTROYED error, which is a
+ * non-fatal condition that occurs when code writes to a stream after it
+ * has been closed (e.g., client disconnect, cancelled LLM stream, LSP
+ * shutdown, killed subprocess).
+ *
+ * Walks the `.cause` chain up to a depth limit.
+ */
+export function isStreamDestroyedError(err: unknown, depth = 0): boolean {
+  if (!err || depth > 5) return false;
+  const e = err as any;
+  if (e.code === 'ERR_STREAM_DESTROYED') return true;
+  if (typeof e.message === 'string' && e.message.includes('stream was destroyed')) return true;
+  if (e.cause) return isStreamDestroyedError(e.cause, depth + 1);
+  if (Array.isArray(e.errors)) return e.errors.some((inner: unknown) => isStreamDestroyedError(inner, depth + 1));
+  return false;
+}

--- a/mastracode/src/error-classification.ts
+++ b/mastracode/src/error-classification.ts
@@ -12,6 +12,7 @@ export function isStreamDestroyedError(err: unknown, depth = 0): boolean {
   if (e.code === 'ERR_STREAM_DESTROYED') return true;
   if (typeof e.message === 'string' && e.message.includes('stream was destroyed')) return true;
   if (e.cause && isStreamDestroyedError(e.cause, depth + 1)) return true;
-  if (Array.isArray(e.errors) && e.errors.some((inner: unknown) => isStreamDestroyedError(inner, depth + 1))) return true;
+  if (Array.isArray(e.errors) && e.errors.some((inner: unknown) => isStreamDestroyedError(inner, depth + 1)))
+    return true;
   return false;
 }

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -27,7 +27,7 @@ process.on('uncaughtException', error => {
   handleFatalError(error);
 });
 process.on('unhandledRejection', reason => {
-  if (reason instanceof Error && isStreamDestroyedError(reason)) return;
+  if (isStreamDestroyedError(reason)) return;
   handleFatalError(reason instanceof Error ? reason : new Error(String(reason)));
 });
 

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -5,6 +5,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { isStreamDestroyedError } from './error-classification.js';
 import { loadSettings } from './onboarding/settings.js';
 import { detectTerminalTheme } from './tui/detect-theme.js';
 import { MastraTUI } from './tui/index.js';
@@ -20,9 +21,13 @@ let authStorage: Awaited<ReturnType<typeof createMastraCode>>['authStorage'];
 
 // Global safety nets — catch any uncaught errors from storage init, etc.
 process.on('uncaughtException', error => {
+  // ERR_STREAM_DESTROYED is non-fatal — happens routinely when streams close
+  // during shutdown, cancelled LLM requests, or LSP/subprocess exits (#13548, #13549)
+  if (isStreamDestroyedError(error)) return;
   handleFatalError(error);
 });
 process.on('unhandledRejection', reason => {
+  if (reason instanceof Error && isStreamDestroyedError(reason)) return;
   handleFatalError(reason instanceof Error ? reason : new Error(String(reason)));
 });
 


### PR DESCRIPTION
## Description

`ERR_STREAM_DESTROYED` errors occur routinely when Node.js streams close during shutdown, cancelled LLM requests, or LSP/subprocess exits. Previously these would hit the `uncaughtException`/`unhandledRejection` handlers in `main.ts` and fatally exit the process with a `Fatal error: Cannot call write after a stream was destroyed` message.

This PR extracts an `isStreamDestroyedError()` classifier into `error-classification.ts` and uses it to filter these errors in both global handlers, matching the existing pattern used for `ECONNREFUSED`. The classifier checks `error.code`, `error.message`, and walks `.cause` chains / `AggregateError.errors` arrays (depth-limited).

## Related Issue(s)

Fixes #13548
Fixes #13549

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Test Plan

- 7 new unit tests in `stream-destroyed-error.test.ts` covering:
  - Detection by `error.code === 'ERR_STREAM_DESTROYED'`
  - Detection by message containing `"stream was destroyed"`
  - Detection in nested `.cause` chains
  - Non-matching for unrelated errors and `ECONNREFUSED`
  - Non-Error values (null, undefined, string, number)
  - Depth limit on cause chain traversal
- All existing mastracode tests continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Silence non-fatal ERR_STREAM_DESTROYED errors so they no longer crash the process during cancelled streams, shutdown sequences, or terminated subprocesses.

* **Tests**
  * Added comprehensive unit and integration tests for detecting stream-destroyed errors (including nested, aggregated, and depth-limited cases) and verifying clean process exit behavior when the filter is applied.

* **Notes**
  * No public API or exported declaration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->