### PR TITLE
fix: make Codex models work with OM and mastracode streams

### DIFF
--- a/.changeset/better-wings-type.md
+++ b/.changeset/better-wings-type.md
@@ -2,4 +2,6 @@
 '@mastra/memory': patch
 ---
 
-Adjusted observational memory defaults so maxOutputTokens is only auto-applied when using the built-in default model selection.
+Stop auto-applying `maxOutputTokens: 100_000` to observer and reflector models when users supply their own model.
+
+Previously, the 100k default was always injected regardless of model choice. Now it is only applied when using the built-in default model (`google/gemini-2.5-flash`). If you set a custom `observation.model` or `reflection.model`, no `maxOutputTokens` default is added — pass it explicitly in `modelSettings` if your model needs it.

--- a/.changeset/better-wings-type.md
+++ b/.changeset/better-wings-type.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Adjusted observational memory defaults so maxOutputTokens is only auto-applied when using the built-in default model selection.

--- a/.changeset/fair-toes-help.md
+++ b/.changeset/fair-toes-help.md
@@ -1,0 +1,9 @@
+---
+'mastracode': patch
+---
+
+Fixed OpenAI Codex OAuth model routing for observational memory.
+
+When Codex OAuth is active, observer and reflector model IDs now remap GPT-5 OpenAI models to Codex-compatible variants before provider resolution. This prevents observational memory runs from failing when a non-codex GPT-5 model ID is selected.
+
+Also enforced a minimum reasoning level of `low` for GPT-5 Codex requests so `off` is not sent to Codex for those models.

--- a/.changeset/funny-rivers-smile.md
+++ b/.changeset/funny-rivers-smile.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed harness handling for observational memory failures so streams stop immediately when OM reports a failed run or buffering cycle.
+
+The harness now emits the existing OM failure event (`om_observation_failed`, `om_reflection_failed`, or `om_buffering_failed`), emits a top-level error with OM context, and aborts the active stream. This prevents normal assistant output from continuing after an OM model failure.

--- a/.changeset/shaggy-zebras-fail.md
+++ b/.changeset/shaggy-zebras-fail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed observational memory to run observer and reflector models through streaming output. This keeps observation and reflection compatible with providers that require stream-based requests, including Codex-backed models.

--- a/.changeset/shaggy-zebras-fail.md
+++ b/.changeset/shaggy-zebras-fail.md
@@ -2,4 +2,4 @@
 '@mastra/memory': patch
 ---
 
-Fixed observational memory to run observer and reflector models through streaming output. This keeps observation and reflection compatible with providers that require stream-based requests, including Codex-backed models.
+Fixed observational memory compatibility with Codex and other stream-only providers. Observer and reflector calls now use the streaming API internally, so providers that require `stream: true` in requests work correctly out of the box.

--- a/.changeset/shaky-feet-attack.md
+++ b/.changeset/shaky-feet-attack.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed OpenAI Codex OAuth requests to remove unsupported max_output_tokens at the Codex proxy boundary.

--- a/.changeset/shaky-feet-attack.md
+++ b/.changeset/shaky-feet-attack.md
@@ -1,5 +1,0 @@
----
-'mastracode': patch
----
-
-Fixed OpenAI Codex OAuth requests to remove unsupported max_output_tokens at the Codex proxy boundary.

--- a/mastracode/src/__tests__/codex-model-routing.test.ts
+++ b/mastracode/src/__tests__/codex-model-routing.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { remapOpenAIModelForCodexOAuth } from '../agents/model.js';
+import { getEffectiveThinkingLevel } from '../providers/openai-codex.js';
+
+describe('remapOpenAIModelForCodexOAuth', () => {
+  it('maps only explicit GPT-5 models to codex variants for OAuth', () => {
+    expect(remapOpenAIModelForCodexOAuth('openai/gpt-5.3')).toBe('openai/gpt-5.3-codex');
+    expect(remapOpenAIModelForCodexOAuth('openai/gpt-5.2')).toBe('openai/gpt-5.2-codex');
+    expect(remapOpenAIModelForCodexOAuth('openai/gpt-5.1')).toBe('openai/gpt-5.1-codex');
+    expect(remapOpenAIModelForCodexOAuth('openai/gpt-5.1-mini')).toBe('openai/gpt-5.1-codex-mini');
+    expect(remapOpenAIModelForCodexOAuth('openai/gpt-5')).toBe('openai/gpt-5-codex');
+  });
+
+  it('keeps codex and non-compatible models unchanged', () => {
+    expect(remapOpenAIModelForCodexOAuth('openai/gpt-5.3-codex')).toBe('openai/gpt-5.3-codex');
+    expect(remapOpenAIModelForCodexOAuth('openai/gpt-5.1-codex-mini')).toBe('openai/gpt-5.1-codex-mini');
+    expect(remapOpenAIModelForCodexOAuth('openai/gpt-5.4')).toBe('openai/gpt-5.4');
+    expect(remapOpenAIModelForCodexOAuth('openai/gpt-5-mini')).toBe('openai/gpt-5-mini');
+    expect(remapOpenAIModelForCodexOAuth('openai/gpt-5-nano')).toBe('openai/gpt-5-nano');
+    expect(remapOpenAIModelForCodexOAuth('anthropic/claude-sonnet-4-5')).toBe('anthropic/claude-sonnet-4-5');
+  });
+});
+
+describe('getEffectiveThinkingLevel', () => {
+  it('enforces low minimum for GPT-5 models when requested level is off', () => {
+    expect(getEffectiveThinkingLevel('gpt-5.3-codex', 'off')).toBe('low');
+    expect(getEffectiveThinkingLevel('gpt-5.1-codex-mini', 'off')).toBe('low');
+  });
+
+  it('preserves requested level for non-GPT-5 models', () => {
+    expect(getEffectiveThinkingLevel('gpt-4.1', 'off')).toBe('off');
+    expect(getEffectiveThinkingLevel('gpt-4.1', 'high')).toBe('high');
+  });
+});

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -24,7 +24,7 @@ function getHarnessState(requestContext: RequestContext) {
  */
 function getObserverModel({ requestContext }: { requestContext: RequestContext }) {
   const state = getHarnessState(requestContext);
-  return resolveModel(state?.observerModelId ?? DEFAULT_OM_MODEL_ID);
+  return resolveModel(state?.observerModelId ?? DEFAULT_OM_MODEL_ID, { remapForCodexOAuth: true });
 }
 
 /**
@@ -33,7 +33,7 @@ function getObserverModel({ requestContext }: { requestContext: RequestContext }
  */
 function getReflectorModel({ requestContext }: { requestContext: RequestContext }) {
   const state = getHarnessState(requestContext);
-  return resolveModel(state?.reflectorModelId ?? DEFAULT_OM_MODEL_ID);
+  return resolveModel(state?.reflectorModelId ?? DEFAULT_OM_MODEL_ID, { remapForCodexOAuth: true });
 }
 
 /**

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -66,18 +66,12 @@ export function getDynamicMemory(storage: MastraCompositeStore) {
             model: getObserverModel,
             messageTokens: obsThreshold,
             blockAfter: 2,
-            modelSettings: {
-              maxOutputTokens: 60000,
-            },
           },
           reflection: {
             bufferActivation: 1 / 2,
             blockAfter: 1.1,
             model: getReflectorModel,
             observationTokens: refThreshold,
-            modelSettings: {
-              maxOutputTokens: 60000,
-            },
           },
         },
       },

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -88,11 +88,7 @@ export function resolveModel(
  * Dynamic model function that reads the current model from harness state.
  * This allows runtime model switching via the /models picker.
  */
-export function getDynamicModel({
-  requestContext,
-}: {
-  requestContext: RequestContext;
-}): ResolvedModel {
+export function getDynamicModel({ requestContext }: { requestContext: RequestContext }): ResolvedModel {
   const harnessContext = requestContext.get('harness') as HarnessRequestContext<typeof stateSchema> | undefined;
 
   const modelId = harnessContext?.state?.currentModelId;

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -1,6 +1,4 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
-import type { LanguageModelV1 } from '@ai-sdk/provider';
-import type { MastraLanguageModel } from '@mastra/core/agent';
 import type { HarnessRequestContext } from '@mastra/core/harness';
 import { ModelRouterLanguageModel } from '@mastra/core/llm';
 import type { RequestContext } from '@mastra/core/request-context';
@@ -11,6 +9,41 @@ import type { ThinkingLevel } from '../providers/openai-codex.js';
 import type { stateSchema } from '../schema.js';
 
 const authStorage = new AuthStorage();
+
+const OPENAI_PREFIX = 'openai/';
+
+const CODEX_OPENAI_MODEL_REMAPS: Record<string, string> = {
+  'gpt-5.3': 'gpt-5.3-codex',
+  'gpt-5.2': 'gpt-5.2-codex',
+  'gpt-5.1': 'gpt-5.1-codex',
+  'gpt-5.1-mini': 'gpt-5.1-codex-mini',
+  'gpt-5': 'gpt-5-codex',
+};
+
+type ResolvedModel =
+  | ReturnType<typeof openaiCodexProvider>
+  | ReturnType<typeof opencodeClaudeMaxProvider>
+  | ModelRouterLanguageModel
+  | ReturnType<ReturnType<typeof createAnthropic>>;
+
+export function remapOpenAIModelForCodexOAuth(modelId: string): string {
+  if (!modelId.startsWith(OPENAI_PREFIX)) {
+    return modelId;
+  }
+
+  const openaiModelId = modelId.substring(OPENAI_PREFIX.length);
+
+  if (openaiModelId.includes('-codex')) {
+    return modelId;
+  }
+
+  const codexModelId = CODEX_OPENAI_MODEL_REMAPS[openaiModelId];
+  if (!codexModelId) {
+    return modelId;
+  }
+
+  return `${OPENAI_PREFIX}${codexModelId}`;
+}
 
 /**
  * Resolve a model ID to the correct provider instance.
@@ -23,11 +56,11 @@ const authStorage = new AuthStorage();
  */
 export function resolveModel(
   modelId: string,
-  options?: { thinkingLevel?: ThinkingLevel },
-): LanguageModelV1 | MastraLanguageModel {
+  options?: { thinkingLevel?: ThinkingLevel; remapForCodexOAuth?: boolean },
+): ResolvedModel {
   authStorage.reload();
   const isAnthropicModel = modelId.startsWith('anthropic/');
-  const isOpenAIModel = modelId.startsWith('openai/');
+  const isOpenAIModel = modelId.startsWith(OPENAI_PREFIX);
   const isMoonshotModel = modelId.startsWith('moonshotai/');
 
   if (isMoonshotModel) {
@@ -42,7 +75,8 @@ export function resolveModel(
   } else if (isAnthropicModel) {
     return opencodeClaudeMaxProvider(modelId.substring(`anthropic/`.length));
   } else if (isOpenAIModel && authStorage.isLoggedIn('openai-codex')) {
-    return openaiCodexProvider(modelId.substring(`openai/`.length), {
+    const resolvedModelId = options?.remapForCodexOAuth ? remapOpenAIModelForCodexOAuth(modelId) : modelId;
+    return openaiCodexProvider(resolvedModelId.substring(OPENAI_PREFIX.length), {
       thinkingLevel: options?.thinkingLevel,
     });
   } else {
@@ -58,7 +92,7 @@ export function getDynamicModel({
   requestContext,
 }: {
   requestContext: RequestContext;
-}): LanguageModelV1 | MastraLanguageModel {
+}): ResolvedModel {
   const harnessContext = requestContext.get('harness') as HarnessRequestContext<typeof stateSchema> | undefined;
 
   const modelId = harnessContext?.state?.currentModelId;

--- a/mastracode/src/providers/openai-codex.ts
+++ b/mastracode/src/providers/openai-codex.ts
@@ -197,8 +197,26 @@ export function openaiCodexProvider(
     const shouldRewrite = parsed.pathname.includes('/v1/responses') || parsed.pathname.includes('/chat/completions');
     const finalUrl = shouldRewrite ? new URL(CODEX_API_ENDPOINT) : parsed;
 
+    // Patch the request body for the Codex proxy which has different
+    // requirements than the standard OpenAI API:
+    //  - max_output_tokens is not supported (causes 400)
+    let finalBody = init?.body;
+    if (shouldRewrite && finalBody && typeof finalBody === 'string') {
+      try {
+        const bodyObj = JSON.parse(finalBody);
+
+        if ('max_output_tokens' in bodyObj) {
+          delete bodyObj.max_output_tokens;
+          finalBody = JSON.stringify(bodyObj);
+        }
+      } catch {
+        // not JSON, leave as-is
+      }
+    }
+
     return fetch(finalUrl, {
       ...init,
+      body: finalBody,
       headers,
     });
   };

--- a/mastracode/src/providers/openai-codex.ts
+++ b/mastracode/src/providers/openai-codex.ts
@@ -197,26 +197,8 @@ export function openaiCodexProvider(
     const shouldRewrite = parsed.pathname.includes('/v1/responses') || parsed.pathname.includes('/chat/completions');
     const finalUrl = shouldRewrite ? new URL(CODEX_API_ENDPOINT) : parsed;
 
-    // Patch the request body for the Codex proxy which has different
-    // requirements than the standard OpenAI API:
-    //  - max_output_tokens is not supported (causes 400)
-    let finalBody = init?.body;
-    if (shouldRewrite && finalBody && typeof finalBody === 'string') {
-      try {
-        const bodyObj = JSON.parse(finalBody);
-
-        if ('max_output_tokens' in bodyObj) {
-          delete bodyObj.max_output_tokens;
-          finalBody = JSON.stringify(bodyObj);
-        }
-      } catch {
-        // not JSON, leave as-is
-      }
-    }
-
     return fetch(finalUrl, {
       ...init,
-      body: finalBody,
       headers,
     });
   };

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1310,6 +1310,21 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
 
     const textContentById = new Map<string, { index: number; text: string }>();
     const thinkingContentById = new Map<string, { index: number; text: string }>();
+    const abortForOmFailure = ({
+      operationType,
+      stage,
+      error,
+    }: {
+      operationType: string;
+      stage: string;
+      error: string;
+    }) => {
+      this.emit({
+        type: 'error',
+        error: new Error(`Observational memory ${operationType} ${stage} failed: ${error}`),
+      });
+      this.abort();
+    };
 
     for await (const chunk of response.fullStream) {
       if ('runId' in chunk && chunk.runId) {
@@ -1585,21 +1600,27 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
         case 'data-om-observation-failed': {
           const payload = (chunk as any).data as Record<string, any> | undefined;
           if (payload) {
-            if (payload.operationType === 'reflection') {
+            const operationType = payload.operationType === 'reflection' ? 'reflection' : 'observation';
+            const error = payload.error ?? 'Unknown error';
+
+            if (operationType === 'reflection') {
               this.emit({
                 type: 'om_reflection_failed',
                 cycleId: payload.cycleId ?? 'unknown',
-                error: payload.error ?? 'Unknown error',
+                error,
                 durationMs: payload.durationMs ?? 0,
               });
             } else {
               this.emit({
                 type: 'om_observation_failed',
                 cycleId: payload.cycleId ?? 'unknown',
-                error: payload.error ?? 'Unknown error',
+                error,
                 durationMs: payload.durationMs ?? 0,
               });
             }
+
+            abortForOmFailure({ operationType, stage: 'run', error });
+            return { message: currentMessage };
           }
           break;
         }
@@ -1633,12 +1654,18 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
         case 'data-om-buffering-failed': {
           const payload = (chunk as any).data as Record<string, any> | undefined;
           if (payload && payload.cycleId) {
+            const operationType = payload.operationType ?? 'observation';
+            const error = payload.error ?? 'Unknown error';
+
             this.emit({
               type: 'om_buffering_failed',
               cycleId: payload.cycleId,
-              operationType: payload.operationType ?? 'observation',
-              error: payload.error ?? 'Unknown error',
+              operationType,
+              error,
             });
+
+            abortForOmFailure({ operationType, stage: 'buffering', error });
+            return { message: currentMessage };
           }
           break;
         }

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1653,7 +1653,7 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
         }
         case 'data-om-buffering-failed': {
           const payload = (chunk as any).data as Record<string, any> | undefined;
-          if (payload && payload.cycleId) {
+          if (payload) {
             const operationType = payload.operationType ?? 'observation';
             const error = payload.error ?? 'Unknown error';
 

--- a/packages/core/src/harness/om-failure-abort.test.ts
+++ b/packages/core/src/harness/om-failure-abort.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+import type { HarnessEvent } from './types';
+
+function createHarness() {
+  const agent = new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+
+  return new Harness({
+    id: 'test-harness',
+    storage: new InMemoryStore(),
+    modes: [{ id: 'default', name: 'Default', default: true, agent }],
+  });
+}
+
+describe('Harness OM failure abort behavior', () => {
+  it('aborts stream and emits an error when OM buffering fails', async () => {
+    const harness = createHarness();
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => events.push(event));
+
+    (harness as any).abortController = new AbortController();
+
+    await (harness as any).processStream({
+      fullStream: (async function* () {
+        yield {
+          type: 'data-om-buffering-failed',
+          data: {
+            cycleId: 'c1',
+            operationType: 'observation',
+            error: 'Bad Request',
+          },
+        };
+        yield { type: 'text-start', payload: { id: 't1' } };
+      })(),
+    });
+
+    expect(events.some(e => e.type === 'om_buffering_failed')).toBe(true);
+    const errorEvent = events.find(e => e.type === 'error');
+    expect(errorEvent?.type).toBe('error');
+    expect((errorEvent as Extract<HarnessEvent, { type: 'error' }>).error.message).toContain(
+      'Observational memory observation buffering failed: Bad Request',
+    );
+    expect((harness as any).abortRequested).toBe(true);
+    expect((harness as any).abortController).toBeNull();
+    expect(events.some(e => e.type === 'message_start')).toBe(false);
+  });
+
+  it('aborts stream and emits an error when OM observation run fails', async () => {
+    const harness = createHarness();
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => events.push(event));
+
+    (harness as any).abortController = new AbortController();
+
+    await (harness as any).processStream({
+      fullStream: (async function* () {
+        yield {
+          type: 'data-om-observation-failed',
+          data: {
+            cycleId: 'c2',
+            operationType: 'reflection',
+            error: 'Model unavailable',
+            durationMs: 50,
+          },
+        };
+        yield { type: 'text-start', payload: { id: 't2' } };
+      })(),
+    });
+
+    expect(events.some(e => e.type === 'om_reflection_failed')).toBe(true);
+    const errorEvent = events.find(e => e.type === 'error');
+    expect(errorEvent?.type).toBe('error');
+    expect((errorEvent as Extract<HarnessEvent, { type: 'error' }>).error.message).toContain(
+      'Observational memory reflection run failed: Model unavailable',
+    );
+    expect((harness as any).abortRequested).toBe(true);
+    expect(events.some(e => e.type === 'message_start')).toBe(false);
+  });
+});

--- a/packages/memory/src/processors/observational-memory/__tests__/mid-loop-observation.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/mid-loop-observation.test.ts
@@ -51,6 +51,17 @@ function createInMemoryStorage(): InMemoryMemory {
 }
 
 function createMockObserverModel() {
+  const observationText = `<observations>
+* User discussed topic X
+* Assistant explained Y
+</observations>
+<current-task>
+- Primary: Testing mid-loop observation
+</current-task>
+<suggested-response>
+Continue testing
+</suggested-response>`;
+
   return new MockLanguageModelV2({
     doGenerate: async () => ({
       rawCall: { rawPrompt: null, rawSettings: {} },
@@ -60,19 +71,38 @@ function createMockObserverModel() {
       content: [
         {
           type: 'text',
-          text: `<observations>
-* User discussed topic X
-* Assistant explained Y
-</observations>
-<current-task>
-- Primary: Testing mid-loop observation
-</current-task>
-<suggested-response>
-Continue testing
-</suggested-response>`,
+          text: observationText,
         },
       ],
     }),
+    doStream: async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: 'stream-start', warnings: [] });
+          controller.enqueue({
+            type: 'response-metadata',
+            id: 'obs-1',
+            modelId: 'mock-observer-model',
+            timestamp: new Date(),
+          });
+          controller.enqueue({ type: 'text-start', id: 'text-1' });
+          controller.enqueue({ type: 'text-delta', id: 'text-1', delta: observationText });
+          controller.enqueue({ type: 'text-end', id: 'text-1' });
+          controller.enqueue({
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+          });
+          controller.close();
+        },
+      });
+
+      return {
+        stream,
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      };
+    },
   } as any);
 }
 

--- a/packages/memory/src/processors/observational-memory/__tests__/mid-loop-observation.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/mid-loop-observation.test.ts
@@ -166,7 +166,6 @@ describe('Mid-Loop Observation', () => {
       ];
 
       const totalTokens = tokenCounter.countMessages(messages);
-      console.log('Total tokens for 2 messages:', totalTokens);
 
       expect(totalTokens).toBeGreaterThan(0);
     });
@@ -180,7 +179,6 @@ describe('Mid-Loop Observation', () => {
       }
 
       const totalTokens = tokenCounter.countMessages(messages);
-      console.log('Total tokens for 20 messages:', totalTokens);
 
       // With 500 token threshold, 20 150-char messages should exceed it
       expect(totalTokens).toBeGreaterThan(500);
@@ -209,9 +207,6 @@ describe('Mid-Loop Observation', () => {
         messageList.add(msg, 'memory');
       }
 
-      console.log('Messages in list:', messageList.get.all.db().length);
-      console.log('Total tokens:', tokenCounter.countMessages(messageList.get.all.db()));
-
       // Step 0: Initialize the record (no observation yet)
       await om.processInputStep({
         messageList,
@@ -224,14 +219,6 @@ describe('Mid-Loop Observation', () => {
         model: createMockObserverModel() as any,
         retryCount: 0,
         abort: new AbortController().signal,
-      });
-
-      // Check record was created
-      const recordAfterStep0 = await storage.getObservationalMemory(threadId, resourceId);
-      console.log('Record after step 0:', {
-        id: recordAfterStep0?.id,
-        lastObservedAt: recordAfterStep0?.lastObservedAt,
-        activeObservations: recordAfterStep0?.activeObservations?.slice(0, 50),
       });
 
       // Step 1: Should trigger observation since threshold is exceeded
@@ -250,11 +237,6 @@ describe('Mid-Loop Observation', () => {
 
       // Check observation was triggered
       const recordAfterStep1 = await storage.getObservationalMemory(threadId, resourceId);
-      console.log('Record after step 1:', {
-        id: recordAfterStep1?.id,
-        lastObservedAt: recordAfterStep1?.lastObservedAt,
-        activeObservations: recordAfterStep1?.activeObservations?.slice(0, 100),
-      });
 
       // Observations should be saved
       expect(recordAfterStep1?.activeObservations).toBeTruthy();
@@ -294,11 +276,6 @@ describe('Mid-Loop Observation', () => {
 
       // Check record was created but no observations yet
       const record = await storage.getObservationalMemory(threadId, resourceId);
-      console.log('Record after step 0:', {
-        id: record?.id,
-        lastObservedAt: record?.lastObservedAt,
-        activeObservations: record?.activeObservations,
-      });
 
       // No observations should be saved on step 0
       expect(record?.activeObservations).toBeFalsy();
@@ -343,8 +320,6 @@ describe('Mid-Loop Observation', () => {
         messageList.add(msg, 'memory');
       }
 
-      console.log('Step 0 - Total tokens:', tokenCounter.countMessages(messageList.get.all.db()));
-
       await omWithBuffering.processInputStep({
         messageList,
         messages: messageList.get.all.db(),
@@ -367,18 +342,6 @@ describe('Mid-Loop Observation', () => {
         recordAfterStep0 = await storage.getObservationalMemory(threadId, resourceId);
       }
 
-      console.log('Record after step 0:', {
-        id: recordAfterStep0?.id,
-        lastObservedAt: recordAfterStep0?.lastObservedAt,
-        activeObservations: recordAfterStep0?.activeObservations?.slice(0, 50),
-        bufferedChunks: recordAfterStep0?.bufferedObservationChunks?.length,
-        bufferedChunkDetails: recordAfterStep0?.bufferedObservationChunks?.map(c => ({
-          cycleId: c.cycleId,
-          messageTokens: c.messageTokens,
-          tokenCount: c.tokenCount,
-        })),
-      });
-
       // Should have buffered chunks but no active observations yet (below threshold).
       expect(recordAfterStep0?.bufferedObservationChunks?.length).toBeGreaterThan(0);
       expect(recordAfterStep0?.activeObservations).toBeFalsy();
@@ -395,8 +358,6 @@ describe('Mid-Loop Observation', () => {
         messageList.add(msg, 'memory');
       }
 
-      console.log('Step 1 - Total tokens:', tokenCounter.countMessages(messageList.get.all.db()));
-
       await omWithBuffering.processInputStep({
         messageList,
         messages: messageList.get.all.db(),
@@ -411,18 +372,6 @@ describe('Mid-Loop Observation', () => {
       });
 
       const recordAfterStep1 = await storage.getObservationalMemory(threadId, resourceId);
-      console.log('Record after step 1:', {
-        id: recordAfterStep1?.id,
-        lastObservedAt: recordAfterStep1?.lastObservedAt,
-        activeObservations: recordAfterStep1?.activeObservations?.slice(0, 100),
-        bufferedChunks: recordAfterStep1?.bufferedObservationChunks?.length,
-        bufferedChunkDetails: recordAfterStep1?.bufferedObservationChunks?.map(c => ({
-          cycleId: c.cycleId?.slice(0, 20),
-          messageTokens: c.messageTokens,
-          tokenCount: c.tokenCount,
-          messageIds: c.messageIds?.slice(0, 3),
-        })),
-      });
 
       // CRITICAL ASSERTION: Mid-step activation should have happened on step 1.
       // If this fails (activeObservations is empty), it means activation was deferred

--- a/packages/memory/src/processors/observational-memory/__tests__/mock-om-agent.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/mock-om-agent.test.ts
@@ -522,16 +522,25 @@ describe('Mock OM Agent Integration', () => {
     expect(primaryRecord!.activeObservations).toContain('User asked for help');
 
     // Sub-agent should have its own thread with a separate resourceId
-    const subAgentThreads = await memoryStore!.listThreads({
-      filter: { resourceId: 'primary-agent-researcher' },
+    const subAgentResourceId = 'test-resource-researcher';
+    let subAgentThreads = await memoryStore!.listThreads({
+      filter: { resourceId: subAgentResourceId },
     });
+
+    for (let i = 0; i < 20 && subAgentThreads.threads.length === 0; i++) {
+      await new Promise(resolve => setTimeout(resolve, 20));
+      subAgentThreads = await memoryStore!.listThreads({
+        filter: { resourceId: subAgentResourceId },
+      });
+    }
+
     expect(subAgentThreads.threads.length).toBe(1);
 
     // Sub-agent's OM record should have its own observations under its own identity
     const subThreadId = subAgentThreads.threads[0]!.id;
-    const subRecord = await memoryStore!.getObservationalMemory(subThreadId, 'primary-agent-researcher');
+    const subRecord = await memoryStore!.getObservationalMemory(subThreadId, subAgentResourceId);
     expect(subRecord).toBeTruthy();
-    expect(subRecord!.resourceId).toBe('primary-agent-researcher');
+    expect(subRecord!.resourceId).toBe(subAgentResourceId);
     expect(subRecord!.activeObservations).toContain('User asked for help');
   });
 });

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -55,10 +55,15 @@ function createInMemoryStorage(): InMemoryMemory {
 
 function createStreamCapableMockModel(config: Record<string, any>) {
   if (config.doGenerate && !config.doStream) {
+    const originalDoGenerate = config.doGenerate;
     return new MockLanguageModelV2({
       ...config,
+      // Replace doGenerate so any accidental generate-path call fails fast
+      doGenerate: async () => {
+        throw new Error('Unexpected doGenerate call — OM should use the stream path');
+      },
       doStream: async (options: any) => {
-        const generated = await config.doGenerate(options);
+        const generated = await originalDoGenerate(options);
         const text = generated.content?.find((part: any) => part?.type === 'text')?.text ?? generated.text ?? '';
         const usage = generated.usage ?? { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
 

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -53,6 +53,44 @@ function createInMemoryStorage(): InMemoryMemory {
   return new InMemoryMemory({ db });
 }
 
+function createStreamCapableMockModel(config: Record<string, any>) {
+  if (config.doGenerate && !config.doStream) {
+    return new MockLanguageModelV2({
+      ...config,
+      doStream: async (options: any) => {
+        const generated = await config.doGenerate(options);
+        const text = generated.content?.find((part: any) => part?.type === 'text')?.text ?? generated.text ?? '';
+        const usage = generated.usage ?? { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: 'stream-start', warnings: generated.warnings ?? [] });
+            controller.enqueue({
+              type: 'response-metadata',
+              id: 'mock-response',
+              modelId: 'mock-model',
+              timestamp: new Date(),
+            });
+            controller.enqueue({ type: 'text-start', id: 'text-1' });
+            controller.enqueue({ type: 'text-delta', id: 'text-1', delta: text });
+            controller.enqueue({ type: 'text-end', id: 'text-1' });
+            controller.enqueue({ type: 'finish', finishReason: generated.finishReason ?? 'stop', usage });
+            controller.close();
+          },
+        });
+
+        return {
+          stream,
+          rawCall: generated.rawCall ?? { rawPrompt: null, rawSettings: {} },
+          warnings: generated.warnings ?? [],
+        };
+      },
+    });
+  }
+
+  return new MockLanguageModelV2(config);
+}
+
 // =============================================================================
 // Unit Tests: Storage Operations
 // =============================================================================
@@ -2235,7 +2273,7 @@ describe('Instruction property integration', () => {
     const customInstruction = 'Focus on capturing user dietary preferences and allergies.';
 
     let capturedPrompt: any = null;
-    const mockModel = new MockLanguageModelV2({
+    const mockModel = createStreamCapableMockModel({
       doGenerate: async options => {
         capturedPrompt = options.prompt;
         return {
@@ -2305,7 +2343,7 @@ Ask about favorite vegetarian dishes
     const customInstruction = 'Consolidate observations about user preferences and remove duplicates.';
 
     let capturedPrompt: any = null;
-    const mockObserverModel = new MockLanguageModelV2({
+    const mockObserverModel = createStreamCapableMockModel({
       doGenerate: async () => ({
         rawCall: { rawPrompt: null, rawSettings: {} },
         finishReason: 'stop' as const,
@@ -2328,7 +2366,7 @@ Ask about favorite pizza toppings
       }),
     });
 
-    const mockReflectorModel = new MockLanguageModelV2({
+    const mockReflectorModel = createStreamCapableMockModel({
       doGenerate: async options => {
         capturedPrompt = options.prompt;
         return {
@@ -2495,7 +2533,7 @@ describe('Thread Attribution Helpers', () => {
     storage = createInMemoryStorage();
     om = new ObservationalMemory({
       storage,
-      model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+      model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
       observation: { messageTokens: 100 },
       reflection: { observationTokens: 1000 },
       scope: 'resource',
@@ -2617,7 +2655,7 @@ describe('Resource Scope Observation Flow', () => {
       },
     });
 
-    const mockModel = new MockLanguageModelV2({
+    const mockModel = createStreamCapableMockModel({
       doGenerate: async () => ({
         rawCall: { rawPrompt: null, rawSettings: {} },
         finishReason: 'stop' as const,
@@ -2692,7 +2730,7 @@ Ask about preferred brewing method
       },
     });
 
-    const mockModel = new MockLanguageModelV2({
+    const mockModel = createStreamCapableMockModel({
       doGenerate: async () => ({
         rawCall: { rawPrompt: null, rawSettings: {} },
         finishReason: 'stop' as const,
@@ -2750,7 +2788,7 @@ describe('Locking Behavior', () => {
     const storage = createInMemoryStorage();
 
     let reflectorCalled = false;
-    const mockReflectorModel = new MockLanguageModelV2({
+    const mockReflectorModel = createStreamCapableMockModel({
       doGenerate: async () => {
         reflectorCalled = true;
         return {
@@ -2772,7 +2810,7 @@ describe('Locking Behavior', () => {
       },
     });
 
-    const mockObserverModel = new MockLanguageModelV2({
+    const mockObserverModel = createStreamCapableMockModel({
       doGenerate: async () => ({
         rawCall: { rawPrompt: null, rawSettings: {} },
         finishReason: 'stop' as const,
@@ -2845,7 +2883,7 @@ describe('Locking Behavior', () => {
     const storage = createInMemoryStorage();
 
     let _observerCalled = false;
-    const mockObserverModel = new MockLanguageModelV2({
+    const mockObserverModel = createStreamCapableMockModel({
       doGenerate: async () => {
         _observerCalled = true;
         return {
@@ -2933,7 +2971,7 @@ describe('Reflection with Thread Attribution', () => {
   it('should create a new record after reflection', async () => {
     const storage = createInMemoryStorage();
 
-    const mockReflectorModel = new MockLanguageModelV2({
+    const mockReflectorModel = createStreamCapableMockModel({
       doGenerate: async () => ({
         rawCall: { rawPrompt: null, rawSettings: {} },
         finishReason: 'stop' as const,
@@ -3012,7 +3050,7 @@ describe('Reflection with Thread Attribution', () => {
     const storage = createInMemoryStorage();
 
     // Reflector that maintains thread attribution
-    const mockReflectorModel = new MockLanguageModelV2({
+    const mockReflectorModel = createStreamCapableMockModel({
       doGenerate: async () => ({
         rawCall: { rawPrompt: null, rawSettings: {} },
         finishReason: 'stop' as const,
@@ -3094,7 +3132,7 @@ describe('Reflection with Thread Attribution', () => {
   it('should update lastObservedAt cursor after reflection', async () => {
     const storage = createInMemoryStorage();
 
-    const mockReflectorModel = new MockLanguageModelV2({
+    const mockReflectorModel = createStreamCapableMockModel({
       doGenerate: async () => ({
         rawCall: { rawPrompt: null, rawSettings: {} },
         finishReason: 'stop' as const,
@@ -3267,7 +3305,7 @@ describe('Resource Scope: other-conversation blocks after observation', () => {
     expect(setupRecord?.activeObservations).toContain('favorite color is blue');
 
     // Create OM with resource scope
-    const mockModel = new MockLanguageModelV2({
+    const mockModel = createStreamCapableMockModel({
       doGenerate: async () => ({
         rawCall: { rawPrompt: null, rawSettings: {} },
         finishReason: 'stop' as const,
@@ -4048,7 +4086,7 @@ describe('Model Requirement', () => {
         new ObservationalMemory({
           storage: createInMemoryStorage(),
           scope: 'thread',
-          model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+          model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           observation: { messageTokens: 50000 },
           reflection: { observationTokens: 20000 },
         }),
@@ -4063,7 +4101,7 @@ describe('Model Requirement', () => {
           scope: 'thread',
           observation: {
             messageTokens: 50000,
-            model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+            model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           },
           reflection: { observationTokens: 20000 },
         }),
@@ -4079,7 +4117,7 @@ describe('Model Requirement', () => {
           observation: { messageTokens: 50000 },
           reflection: {
             observationTokens: 20000,
-            model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+            model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           },
         }),
     ).not.toThrow();
@@ -4104,10 +4142,10 @@ describe('Model Requirement', () => {
         new ObservationalMemory({
           storage: createInMemoryStorage(),
           scope: 'thread',
-          model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+          model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           observation: {
             messageTokens: 50000,
-            model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+            model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           },
           reflection: { observationTokens: 20000 },
         }),
@@ -4122,7 +4160,7 @@ describe('Async Buffering Config Validation', () => {
         new ObservationalMemory({
           storage: createInMemoryStorage(),
           scope: 'thread',
-          model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+          model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           shareTokenBudget: true,
           observation: {
             messageTokens: 50000,
@@ -4142,7 +4180,7 @@ describe('Async Buffering Config Validation', () => {
         new ObservationalMemory({
           storage: createInMemoryStorage(),
           scope: 'thread',
-          model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+          model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           shareTokenBudget: true,
           observation: { messageTokens: 50000 },
           reflection: { observationTokens: 20000 },
@@ -4154,7 +4192,7 @@ describe('Async Buffering Config Validation', () => {
     const om = new ObservationalMemory({
       storage: createInMemoryStorage(),
       scope: 'thread',
-      model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+      model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
       shareTokenBudget: true,
       observation: { messageTokens: 50000, bufferTokens: false },
       reflection: { observationTokens: 20000 },
@@ -4169,7 +4207,7 @@ describe('Async Buffering Config Validation', () => {
         new ObservationalMemory({
           storage: createInMemoryStorage(),
           scope: 'thread',
-          model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+          model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           observation: {
             messageTokens: 50000,
             bufferTokens: 10000,
@@ -4189,7 +4227,7 @@ describe('Async Buffering Config Validation', () => {
         new ObservationalMemory({
           storage: createInMemoryStorage(),
           scope: 'thread',
-          model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+          model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           observation: {
             messageTokens: 50000,
             bufferTokens: 10000,
@@ -4209,7 +4247,7 @@ describe('Async Buffering Config Validation', () => {
         new ObservationalMemory({
           storage: createInMemoryStorage(),
           scope: 'thread',
-          model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+          model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           observation: {
             messageTokens: 50000,
             bufferTokens: 10000,
@@ -4229,7 +4267,7 @@ describe('Async Buffering Config Validation', () => {
         new ObservationalMemory({
           storage: createInMemoryStorage(),
           scope: 'thread',
-          model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+          model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           observation: {
             messageTokens: 50000,
             bufferTokens: 10000,
@@ -4250,7 +4288,7 @@ describe('Async Buffering Config Validation', () => {
         new ObservationalMemory({
           storage: createInMemoryStorage(),
           scope: 'thread',
-          model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+          model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           observation: {
             messageTokens: 50000,
             bufferTokens: 10000,
@@ -4270,7 +4308,7 @@ describe('Async Buffering Config Validation', () => {
         new ObservationalMemory({
           storage: createInMemoryStorage(),
           scope: 'thread',
-          model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+          model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           observation: {
             messageTokens: 10000,
             bufferTokens: 15000,
@@ -4290,7 +4328,7 @@ describe('Async Buffering Config Validation', () => {
         new ObservationalMemory({
           storage: createInMemoryStorage(),
           scope: 'thread',
-          model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+          model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           observation: {
             messageTokens: 50000,
             bufferTokens: 10000,
@@ -4310,7 +4348,7 @@ describe('Async Buffering Config Validation', () => {
         new ObservationalMemory({
           storage: createInMemoryStorage(),
           scope: 'thread',
-          model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+          model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           observation: {
             messageTokens: 50000,
             bufferTokens: 10000,
@@ -4330,7 +4368,7 @@ describe('Async Buffering Config Validation', () => {
         new ObservationalMemory({
           storage: createInMemoryStorage(),
           scope: 'thread',
-          model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+          model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           observation: {
             messageTokens: 50000,
             bufferTokens: 10000,
@@ -4354,7 +4392,7 @@ describe('Async Buffering Defaults & Disabling', () => {
     const om = new ObservationalMemory({
       storage: createInMemoryStorage(),
       scope: 'thread',
-      model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+      model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
       observation: { messageTokens: 50000 },
       reflection: { observationTokens: 20000 },
     });
@@ -4367,7 +4405,7 @@ describe('Async Buffering Defaults & Disabling', () => {
     const om = new ObservationalMemory({
       storage: createInMemoryStorage(),
       scope: 'thread',
-      model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+      model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
       observation: { messageTokens: 50000 },
       reflection: { observationTokens: 20000 },
     });
@@ -4391,7 +4429,7 @@ describe('Async Buffering Defaults & Disabling', () => {
     const om = new ObservationalMemory({
       storage: createInMemoryStorage(),
       scope: 'thread',
-      model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+      model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
       observation: { messageTokens: 50000, bufferTokens: false },
       reflection: { observationTokens: 20000 },
     });
@@ -4413,7 +4451,7 @@ describe('Async Buffering Defaults & Disabling', () => {
     const om = new ObservationalMemory({
       storage: createInMemoryStorage(),
       scope: 'resource',
-      model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+      model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
       observation: { messageTokens: 50000 },
       reflection: { observationTokens: 20000 },
     });
@@ -4428,7 +4466,7 @@ describe('Async Buffering Defaults & Disabling', () => {
         new ObservationalMemory({
           storage: createInMemoryStorage(),
           scope: 'resource',
-          model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+          model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
           observation: {
             messageTokens: 50000,
             bufferTokens: 10000,
@@ -4442,7 +4480,7 @@ describe('Async Buffering Defaults & Disabling', () => {
     const om = new ObservationalMemory({
       storage: createInMemoryStorage(),
       scope: 'thread',
-      model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+      model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
       observation: { messageTokens: 50000, bufferTokens: 5000 },
       reflection: { observationTokens: 20000 },
     });
@@ -4456,7 +4494,7 @@ describe('Async Buffering Defaults & Disabling', () => {
     const om = new ObservationalMemory({
       storage: createInMemoryStorage(),
       scope: 'thread',
-      model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+      model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
       observation: { messageTokens: 50000, bufferActivation: 0.7 },
       reflection: { observationTokens: 20000, bufferActivation: 0.3 },
     });
@@ -4472,7 +4510,7 @@ describe('Async Buffering Defaults & Disabling', () => {
     const om = new ObservationalMemory({
       storage: createInMemoryStorage(),
       scope: 'thread',
-      model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+      model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
       observation: { messageTokens: 100000, bufferTokens: 0.1 },
       reflection: { observationTokens: 20000 },
     });
@@ -4493,7 +4531,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage,
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -4544,7 +4582,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage,
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -4567,7 +4605,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage,
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -4629,7 +4667,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -4642,7 +4680,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -4655,7 +4693,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -4673,7 +4711,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -4686,7 +4724,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -4701,7 +4739,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -4714,7 +4752,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -4726,7 +4764,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -4738,7 +4776,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -4757,7 +4795,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000, bufferTokens: false },
         reflection: { observationTokens: 20000 },
       });
@@ -4769,7 +4807,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 50000,
           bufferTokens: 10000,
@@ -4789,7 +4827,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 50000,
           bufferTokens: 10000,
@@ -4807,7 +4845,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 50000,
           bufferTokens: 10000,
@@ -4835,7 +4873,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 50000,
           bufferTokens: 10000,
@@ -4864,7 +4902,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 40000,
           bufferTokens: 4000,
@@ -4904,7 +4942,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 40000,
           bufferTokens: 4000,
@@ -4931,7 +4969,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000, bufferTokens: false },
         reflection: { observationTokens: 20000 },
       });
@@ -4943,7 +4981,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 50000,
           bufferTokens: 10000,
@@ -4966,7 +5004,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 50000,
           bufferTokens: 10000,
@@ -4986,7 +5024,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 50000,
           bufferTokens: 10000,
@@ -5007,7 +5045,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 50000,
           bufferTokens: 10000,
@@ -5038,7 +5076,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -5050,7 +5088,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -5065,7 +5103,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -5092,7 +5130,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -5111,7 +5149,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -5140,7 +5178,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: { messageTokens: 50000 },
         reflection: { observationTokens: 20000 },
       });
@@ -5310,7 +5348,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage,
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 50000,
           bufferTokens: 10000,
@@ -5336,7 +5374,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage,
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 50000,
           bufferTokens: 10000,
@@ -5378,7 +5416,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage,
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 30000,
           bufferTokens: 6000,
@@ -5444,7 +5482,7 @@ describe('Async Buffering Processor Logic', () => {
       const om = new ObservationalMemory({
         storage,
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 50000,
           bufferTokens: 10000,
@@ -5527,7 +5565,7 @@ describe('Full Async Buffering Flow', () => {
     const observerCalls: { input: string }[] = [];
     const reflectorCalls: { input: string }[] = [];
 
-    const mockModel = new MockLanguageModelV2({
+    const mockModel = createStreamCapableMockModel({
       doGenerate: async ({ prompt }) => {
         const promptText = JSON.stringify(prompt);
 
@@ -5970,7 +6008,7 @@ describe('Full Async Buffering Flow', () => {
       new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 10000,
           bufferTokens: 5000,
@@ -5989,7 +6027,7 @@ describe('Full Async Buffering Flow', () => {
       new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 10000,
           bufferTokens: 5000,
@@ -6003,7 +6041,7 @@ describe('Full Async Buffering Flow', () => {
       new ObservationalMemory({
         storage: createInMemoryStorage(),
         scope: 'thread',
-        model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
         observation: {
           messageTokens: 10000,
           bufferTokens: 5000,
@@ -6019,7 +6057,7 @@ describe('Full Async Buffering Flow', () => {
     const om = new ObservationalMemory({
       storage: createInMemoryStorage(),
       scope: 'thread',
-      model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+      model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
       observation: {
         messageTokens: 20000,
         bufferTokens: 0.25,
@@ -6035,7 +6073,7 @@ describe('Full Async Buffering Flow', () => {
     const om = new ObservationalMemory({
       storage: createInMemoryStorage(),
       scope: 'thread',
-      model: new MockLanguageModelV2({ defaultObjectGenerationMode: 'json' }),
+      model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
       observation: {
         messageTokens: 20000,
         bufferTokens: 5000,
@@ -6512,7 +6550,7 @@ describe('Full Async Buffering Flow', () => {
       });
 
       let _reflectorCallCount = 0;
-      const mockModel = new MockLanguageModelV2({
+      const mockModel = createStreamCapableMockModel({
         doGenerate: async ({ prompt }) => {
           const promptText = JSON.stringify(prompt);
           const isReflection = promptText.includes('consolidat') || promptText.includes('reflect');

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -4153,6 +4153,34 @@ describe('Model Requirement', () => {
   });
 });
 
+describe('Model Settings Defaults', () => {
+  it('should default maxOutputTokens when using model: "default"', () => {
+    const om = new ObservationalMemory({
+      storage: createInMemoryStorage(),
+      scope: 'thread',
+      model: 'default',
+      observation: { messageTokens: 50000 },
+      reflection: { observationTokens: 20000 },
+    });
+
+    expect((om as any).observationConfig.modelSettings.maxOutputTokens).toBe(100_000);
+    expect((om as any).reflectionConfig.modelSettings.maxOutputTokens).toBe(100_000);
+  });
+
+  it('should not default maxOutputTokens for non-default models', () => {
+    const om = new ObservationalMemory({
+      storage: createInMemoryStorage(),
+      scope: 'thread',
+      model: 'openai/gpt-5.1-codex-mini',
+      observation: { messageTokens: 50000 },
+      reflection: { observationTokens: 20000 },
+    });
+
+    expect((om as any).observationConfig.modelSettings.maxOutputTokens).toBeUndefined();
+    expect((om as any).reflectionConfig.modelSettings.maxOutputTokens).toBeUndefined();
+  });
+});
+
 describe('Async Buffering Config Validation', () => {
   it('should throw if async buffering is explicitly enabled with shareTokenBudget', () => {
     expect(

--- a/packages/memory/src/processors/observational-memory/__tests__/standalone-observe.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/standalone-observe.test.ts
@@ -87,6 +87,34 @@ Continue testing
         },
       ],
     }),
+    doStream: async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: 'stream-start', warnings: [] });
+          controller.enqueue({
+            type: 'response-metadata',
+            id: 'obs-1',
+            modelId: 'mock-observer-model',
+            timestamp: new Date(),
+          });
+          controller.enqueue({ type: 'text-start', id: 'text-1' });
+          controller.enqueue({ type: 'text-delta', id: 'text-1', delta: observationText });
+          controller.enqueue({ type: 'text-end', id: 'text-1' });
+          controller.enqueue({
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+          });
+          controller.close();
+        },
+      });
+
+      return {
+        stream,
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      };
+    },
   } as any);
 }
 

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -2195,19 +2195,18 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     const prompt = buildObserverPrompt(existingObservations, messagesToObserve, options);
 
     const doGenerate = async () => {
-      const result = await this.withAbortCheck(
-        () =>
-          agent.generate(prompt, {
-            modelSettings: {
-              ...this.observationConfig.modelSettings,
-            },
-            providerOptions: this.observationConfig.providerOptions as any,
-            ...(abortSignal ? { abortSignal } : {}),
-            ...(options?.requestContext ? { requestContext: options.requestContext } : {}),
-          }),
-        abortSignal,
-      );
-      return result;
+      return this.withAbortCheck(async () => {
+        const streamResult = await agent.stream(prompt, {
+          modelSettings: {
+            ...this.observationConfig.modelSettings,
+          },
+          providerOptions: this.observationConfig.providerOptions as any,
+          ...(abortSignal ? { abortSignal } : {}),
+          ...(options?.requestContext ? { requestContext: options.requestContext } : {}),
+        });
+
+        return streamResult.getFullOutput();
+      }, abortSignal);
     };
 
     let result = await doGenerate();
@@ -2286,18 +2285,18 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     }
 
     const doGenerate = async () => {
-      return this.withAbortCheck(
-        () =>
-          agent.generate(prompt, {
-            modelSettings: {
-              ...this.observationConfig.modelSettings,
-            },
-            providerOptions: this.observationConfig.providerOptions as any,
-            ...(abortSignal ? { abortSignal } : {}),
-            ...(requestContext ? { requestContext } : {}),
-          }),
-        abortSignal,
-      );
+      return this.withAbortCheck(async () => {
+        const streamResult = await agent.stream(prompt, {
+          modelSettings: {
+            ...this.observationConfig.modelSettings,
+          },
+          providerOptions: this.observationConfig.providerOptions as any,
+          ...(abortSignal ? { abortSignal } : {}),
+          ...(requestContext ? { requestContext } : {}),
+        });
+
+        return streamResult.getFullOutput();
+      }, abortSignal);
     };
 
     let result = await doGenerate();
@@ -2407,45 +2406,45 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
       );
 
       let chunkCount = 0;
-      const result = await this.withAbortCheck(
-        () =>
-          agent.generate(prompt, {
-            modelSettings: {
-              ...this.reflectionConfig.modelSettings,
-            },
-            providerOptions: this.reflectionConfig.providerOptions as any,
-            ...(abortSignal ? { abortSignal } : {}),
-            ...(requestContext ? { requestContext } : {}),
-            ...(attemptNumber === 1
-              ? {
-                  onChunk(chunk: any) {
-                    chunkCount++;
-                    if (chunkCount === 1 || chunkCount % 50 === 0) {
-                      const preview =
-                        chunk.type === 'text-delta'
-                          ? ` text="${chunk.textDelta?.slice(0, 80)}..."`
-                          : chunk.type === 'tool-call'
-                            ? ` tool=${chunk.toolName}`
-                            : '';
-                      omDebug(`[OM:callReflector] chunk#${chunkCount}: type=${chunk.type}${preview}`);
-                    }
-                  },
-                  onFinish(event: any) {
-                    omDebug(
-                      `[OM:callReflector] onFinish: chunks=${chunkCount}, finishReason=${event.finishReason}, inputTokens=${event.usage?.inputTokens}, outputTokens=${event.usage?.outputTokens}, textLen=${event.text?.length}`,
-                    );
-                  },
-                  onAbort(event: any) {
-                    omDebug(`[OM:callReflector] onAbort: chunks=${chunkCount}, reason=${event?.reason ?? 'unknown'}`);
-                  },
-                  onError({ error }: { error: unknown }) {
-                    omError(`[OM:callReflector] onError after ${chunkCount} chunks`, error);
-                  },
-                }
-              : {}),
-          }),
-        abortSignal,
-      );
+      const result = await this.withAbortCheck(async () => {
+        const streamResult = await agent.stream(prompt, {
+          modelSettings: {
+            ...this.reflectionConfig.modelSettings,
+          },
+          providerOptions: this.reflectionConfig.providerOptions as any,
+          ...(abortSignal ? { abortSignal } : {}),
+          ...(requestContext ? { requestContext } : {}),
+          ...(attemptNumber === 1
+            ? {
+                onChunk(chunk: any) {
+                  chunkCount++;
+                  if (chunkCount === 1 || chunkCount % 50 === 0) {
+                    const preview =
+                      chunk.type === 'text-delta'
+                        ? ` text="${chunk.textDelta?.slice(0, 80)}..."`
+                        : chunk.type === 'tool-call'
+                          ? ` tool=${chunk.toolName}`
+                          : '';
+                    omDebug(`[OM:callReflector] chunk#${chunkCount}: type=${chunk.type}${preview}`);
+                  }
+                },
+                onFinish(event: any) {
+                  omDebug(
+                    `[OM:callReflector] onFinish: chunks=${chunkCount}, finishReason=${event.finishReason}, inputTokens=${event.usage?.inputTokens}, outputTokens=${event.usage?.outputTokens}, textLen=${event.text?.length}`,
+                  );
+                },
+                onAbort(event: any) {
+                  omDebug(`[OM:callReflector] onAbort: chunks=${chunkCount}, reason=${event?.reason ?? 'unknown'}`);
+                },
+                onError({ error }: { error: unknown }) {
+                  omError(`[OM:callReflector] onError after ${chunkCount} chunks`, error);
+                },
+              }
+            : {}),
+        });
+
+        return streamResult.getFullOutput();
+      }, abortSignal);
 
       omDebug(
         `[OM:callReflector] attempt #${attemptNumber} returned: textLen=${result.text?.length}, textPreview="${result.text?.slice(0, 120)}...", inputTokens=${result.usage?.inputTokens ?? result.totalUsage?.inputTokens}, outputTokens=${result.usage?.outputTokens ?? result.totalUsage?.outputTokens}`,

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -1086,6 +1086,24 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
       config.reflection?.observationTokens ?? OBSERVATIONAL_MEMORY_DEFAULTS.reflection.observationTokens;
     const isSharedBudget = config.shareTokenBudget ?? false;
 
+    const isDefaultModelSelection = (model: AgentConfig['model'] | undefined) =>
+      model === undefined || model === 'default';
+
+    const observationSelectedModel = config.model ?? config.observation?.model ?? config.reflection?.model;
+    const reflectionSelectedModel = config.model ?? config.reflection?.model ?? config.observation?.model;
+
+    const observationDefaultMaxOutputTokens =
+      config.observation?.modelSettings?.maxOutputTokens ??
+      (isDefaultModelSelection(observationSelectedModel)
+        ? OBSERVATIONAL_MEMORY_DEFAULTS.observation.modelSettings.maxOutputTokens
+        : undefined);
+
+    const reflectionDefaultMaxOutputTokens =
+      config.reflection?.modelSettings?.maxOutputTokens ??
+      (isDefaultModelSelection(reflectionSelectedModel)
+        ? OBSERVATIONAL_MEMORY_DEFAULTS.reflection.modelSettings.maxOutputTokens
+        : undefined);
+
     // Total context budget when shared budget is enabled
     const totalBudget = messageTokens + observationTokens;
 
@@ -1132,9 +1150,9 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
         temperature:
           config.observation?.modelSettings?.temperature ??
           OBSERVATIONAL_MEMORY_DEFAULTS.observation.modelSettings.temperature,
-        maxOutputTokens:
-          config.observation?.modelSettings?.maxOutputTokens ??
-          OBSERVATIONAL_MEMORY_DEFAULTS.observation.modelSettings.maxOutputTokens,
+        ...(observationDefaultMaxOutputTokens !== undefined
+          ? { maxOutputTokens: observationDefaultMaxOutputTokens }
+          : {}),
       },
       providerOptions: config.observation?.providerOptions ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.providerOptions,
       maxTokensPerBatch:
@@ -1169,9 +1187,9 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
         temperature:
           config.reflection?.modelSettings?.temperature ??
           OBSERVATIONAL_MEMORY_DEFAULTS.reflection.modelSettings.temperature,
-        maxOutputTokens:
-          config.reflection?.modelSettings?.maxOutputTokens ??
-          OBSERVATIONAL_MEMORY_DEFAULTS.reflection.modelSettings.maxOutputTokens,
+        ...(reflectionDefaultMaxOutputTokens !== undefined
+          ? { maxOutputTokens: reflectionDefaultMaxOutputTokens }
+          : {}),
       },
       providerOptions: config.reflection?.providerOptions ?? OBSERVATIONAL_MEMORY_DEFAULTS.reflection.providerOptions,
       bufferActivation: asyncBufferingDisabled

--- a/packages/memory/src/processors/observational-memory/types.ts
+++ b/packages/memory/src/processors/observational-memory/types.ts
@@ -73,7 +73,10 @@ export interface ObservationConfig {
 
   /**
    * Model settings for the Observer agent.
-   * @default { temperature: 0.3, maxOutputTokens: 100_000 }
+   * @default { temperature: 0.3 }
+   *
+   * Note: `maxOutputTokens: 100_000` is only applied by default when using
+   * the built-in default model selection.
    */
   modelSettings?: ModelSettings;
 
@@ -177,7 +180,10 @@ export interface ReflectionConfig {
 
   /**
    * Model settings for the Reflector agent.
-   * @default { temperature: 0, maxOutputTokens: 100_000 }
+   * @default { temperature: 0 }
+   *
+   * Note: `maxOutputTokens: 100_000` is only applied by default when using
+   * the built-in default model selection.
    */
   modelSettings?: ModelSettings;
 


### PR DESCRIPTION
This PR makes Codex models work reliably with observational memory in both @mastra/memory and mastracode. OM observer/reflector calls now use stream output instead of generate so Codex-compatible requests work, OM only defaults maxOutputTokens when using the built-in default model, Codex model reasoning is clamped so gpt-5.3 variants never run with reasoning "off", and mastracode now aborts the stream when OM observation/buffering fails.

Before:
```ts
const result = await agent.generate(prompt, options)
maxOutputTokens: 100_000 // defaulted even on custom models
reasoning: { effort: "off" } // could be used for gpt-5.3 codex routing
// OM failure events were surfaced but stream could continue
```

After:
```ts
const output = await agent.stream(prompt, options)
const result = await output.getFullOutput()
maxOutputTokens: 100_000 // only when default OM model selection is used
reasoning: { effort: "low" | "medium" | "high" } // gpt-5.3 codex floor
// OM failure events abort the mastracode stream
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Observational memory failures now emit appropriate OM error events and abort active streams to prevent continued assistant output.
  * Default maxOutputTokens is no longer auto-applied when a custom observation or reflection model is supplied.

* **New Features**
  * Observational memory runs use streaming-compatible model execution so stream-only providers work seamlessly.

* **Documentation**
  * Clarified modelSettings defaults for observational memory.

* **Tests**
  * Added tests covering Codex model routing, thinking-level enforcement, streaming OM behavior, and failure aborts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->