### PR TITLE
fix(mastracode): wire extraTools into tool builder and filter denied tools

### DIFF
--- a/.changeset/great-pugs-itch.md
+++ b/.changeset/great-pugs-itch.md
@@ -1,0 +1,9 @@
+---
+'mastracode': patch
+---
+
+Fixed two bugs in Mastra Code tool handling:
+
+**extraTools not merged** — The `extraTools` parameter in `createMastraCode` was accepted but never passed through to the dynamic tool builder. Extra tools are now correctly merged into the tool set (without overwriting built-in tools).
+
+**Denied tools still advertised** — Tools with a per-tool `deny` policy in `permissionRules` were still included in the tool set and system prompt guidance, causing the model to attempt using them only to be blocked at execution time. Denied tools are now filtered from both the tool set and the tool guidance, so the model never sees them.

--- a/mastracode/src/agents/__tests__/extra-tools.test.ts
+++ b/mastracode/src/agents/__tests__/extra-tools.test.ts
@@ -1,0 +1,218 @@
+import { RequestContext } from '@mastra/core/request-context';
+import { createTool } from '@mastra/core/tools';
+import { describe, it, expect } from 'vitest';
+import z from 'zod';
+
+import { getToolCategory } from '../../permissions.js';
+import { buildToolGuidance } from '../prompts/tool-guidance.js';
+import { createDynamicTools } from '../tools.js';
+
+// Minimal mock of HarnessRequestContext shape that createDynamicTools reads
+function makeRequestContext(
+  overrides: {
+    modeId?: string;
+    projectPath?: string;
+    permissionRules?: { categories?: Record<string, string>; tools?: Record<string, string> };
+  } = {},
+) {
+  const ctx = new RequestContext();
+  ctx.set('harness', {
+    modeId: overrides.modeId ?? 'build',
+    getState: () => ({
+      projectPath: overrides.projectPath ?? '/tmp/test-project',
+      currentModelId: 'anthropic/claude-opus-4-6',
+      permissionRules: overrides.permissionRules ?? { categories: {}, tools: {} },
+    }),
+  });
+  return ctx;
+}
+
+describe('createDynamicTools – extraTools', () => {
+  it('should include extraTools in the returned tool set', () => {
+    const myCustomTool = createTool({
+      id: 'my_custom_tool',
+      description: 'A custom tool provided via extraTools',
+      inputSchema: z.object({ query: z.string() }),
+      execute: async () => ({ result: 'custom' }),
+    });
+
+    const getDynamicTools = createDynamicTools(undefined, { my_custom_tool: myCustomTool });
+    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+
+    // The extra tool must be present alongside the built-in tools
+    expect(tools).toHaveProperty('my_custom_tool');
+    expect(tools.my_custom_tool).toBe(myCustomTool);
+
+    // Built-in tools should still be present
+    expect(tools).toHaveProperty('view');
+    expect(tools).toHaveProperty('search_content');
+    expect(tools).toHaveProperty('find_files');
+    expect(tools).toHaveProperty('execute_command');
+  });
+
+  it('should not overwrite built-in tools with extraTools of the same name', () => {
+    const sneakyTool = createTool({
+      id: 'view',
+      description: 'Trying to overwrite the built-in view tool',
+      inputSchema: z.object({}),
+      execute: async () => ({ result: 'sneaky' }),
+    });
+
+    const getDynamicTools = createDynamicTools(undefined, { view: sneakyTool });
+    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+
+    // Built-in view should NOT be replaced by the extra tool
+    expect(tools.view).not.toBe(sneakyTool);
+  });
+
+  it('should return extraTools even when no MCP manager is provided', () => {
+    const toolA = createTool({
+      id: 'tool_a',
+      description: 'Tool A',
+      inputSchema: z.object({}),
+      execute: async () => ({ result: 'a' }),
+    });
+    const toolB = createTool({
+      id: 'tool_b',
+      description: 'Tool B',
+      inputSchema: z.object({}),
+      execute: async () => ({ result: 'b' }),
+    });
+
+    const getDynamicTools = createDynamicTools(undefined, { tool_a: toolA, tool_b: toolB });
+    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+
+    expect(tools).toHaveProperty('tool_a');
+    expect(tools).toHaveProperty('tool_b');
+  });
+
+  it('should return only built-in tools when extraTools is undefined', () => {
+    const getDynamicTools = createDynamicTools(undefined, undefined);
+    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+
+    // Should have built-in tools but nothing extra
+    expect(tools).toHaveProperty('view');
+    expect(tools).toHaveProperty('search_content');
+    expect(tools).not.toHaveProperty('my_custom_tool');
+  });
+});
+
+describe('getToolCategory – extra tools', () => {
+  it('should categorize unknown/extra tools as "mcp"', () => {
+    expect(getToolCategory('my_custom_tool')).toBe('mcp');
+    expect(getToolCategory('tool_a')).toBe('mcp');
+    expect(getToolCategory('some_random_extra_tool')).toBe('mcp');
+  });
+
+  it('should still categorize built-in tools correctly', () => {
+    expect(getToolCategory('view')).toBe('read');
+    expect(getToolCategory('search_content')).toBe('read');
+    expect(getToolCategory('string_replace_lsp')).toBe('edit');
+    expect(getToolCategory('execute_command')).toBe('execute');
+  });
+
+  it('should return null for always-allowed tools', () => {
+    expect(getToolCategory('ask_user')).toBeNull();
+    expect(getToolCategory('task_write')).toBeNull();
+    expect(getToolCategory('task_check')).toBeNull();
+  });
+});
+
+describe('createDynamicTools – denied tool filtering', () => {
+  it('should omit tools with a per-tool deny policy', () => {
+    const getDynamicTools = createDynamicTools();
+    const tools = getDynamicTools({
+      requestContext: makeRequestContext({
+        permissionRules: { categories: {}, tools: { execute_command: 'deny' } },
+      }),
+    });
+
+    expect(tools).not.toHaveProperty('execute_command');
+    // Other tools should still be present
+    expect(tools).toHaveProperty('view');
+    expect(tools).toHaveProperty('search_content');
+  });
+
+  it('should omit multiple denied tools', () => {
+    const getDynamicTools = createDynamicTools();
+    const tools = getDynamicTools({
+      requestContext: makeRequestContext({
+        permissionRules: {
+          categories: {},
+          tools: { execute_command: 'deny', view: 'deny', find_files: 'deny' },
+        },
+      }),
+    });
+
+    expect(tools).not.toHaveProperty('execute_command');
+    expect(tools).not.toHaveProperty('view');
+    expect(tools).not.toHaveProperty('find_files');
+    expect(tools).toHaveProperty('search_content');
+  });
+
+  it('should keep tools with allow or ask policies', () => {
+    const getDynamicTools = createDynamicTools();
+    const tools = getDynamicTools({
+      requestContext: makeRequestContext({
+        permissionRules: {
+          categories: {},
+          tools: { execute_command: 'allow', view: 'ask' },
+        },
+      }),
+    });
+
+    expect(tools).toHaveProperty('execute_command');
+    expect(tools).toHaveProperty('view');
+  });
+
+  it('should also deny extraTools when they have a deny policy', () => {
+    const myTool = createTool({
+      id: 'my_tool',
+      description: 'A custom tool',
+      inputSchema: z.object({}),
+      execute: async () => ({ result: 'custom' }),
+    });
+
+    const getDynamicTools = createDynamicTools(undefined, { my_tool: myTool });
+    const tools = getDynamicTools({
+      requestContext: makeRequestContext({
+        permissionRules: { categories: {}, tools: { my_tool: 'deny' } },
+      }),
+    });
+
+    expect(tools).not.toHaveProperty('my_tool');
+  });
+});
+
+describe('buildToolGuidance – denied tool filtering', () => {
+  it('should omit guidance for denied tools', () => {
+    const guidance = buildToolGuidance('build', {
+      deniedTools: new Set(['execute_command']),
+    });
+
+    expect(guidance).not.toContain('**execute_command**');
+    expect(guidance).toContain('**view**');
+    expect(guidance).toContain('**search_content**');
+  });
+
+  it('should omit multiple denied tools from guidance', () => {
+    const guidance = buildToolGuidance('build', {
+      deniedTools: new Set(['execute_command', 'write_file', 'subagent']),
+    });
+
+    expect(guidance).not.toContain('**execute_command**');
+    expect(guidance).not.toContain('**write_file**');
+    expect(guidance).not.toContain('**subagent**');
+    expect(guidance).toContain('**view**');
+    expect(guidance).toContain('**string_replace_lsp**');
+  });
+
+  it('should include all tools when no denied set is provided', () => {
+    const guidance = buildToolGuidance('build');
+
+    expect(guidance).toContain('**execute_command**');
+    expect(guidance).toContain('**view**');
+    expect(guidance).toContain('**string_replace_lsp**');
+    expect(guidance).toContain('**subagent**');
+  });
+});

--- a/mastracode/src/agents/prompts/tool-guidance.ts
+++ b/mastracode/src/agents/prompts/tool-guidance.ts
@@ -6,9 +6,12 @@
 
 interface ToolGuidanceOptions {
   hasWebSearch?: boolean;
+  /** Tool names that have been denied — omit their guidance sections. */
+  deniedTools?: Set<string>;
 }
 
 export function buildToolGuidance(modeId: string, options: ToolGuidanceOptions = {}): string {
+  const denied = options.deniedTools ?? new Set<string>();
   const sections: string[] = [];
 
   sections.push(`# Tool Usage Rules
@@ -19,27 +22,39 @@ You have access to the following tools. Use the RIGHT tool for the job:`);
 
   // --- Read tools (all modes) ---
 
-  sections.push(`
+  const readTools: string[] = [];
+
+  if (!denied.has('view')) {
+    readTools.push(`
 **view** — Read file contents or list directories
 - Use this to read files before editing them. NEVER propose changes to code you haven't read.
 - Use \`view_range\` for large files to read specific sections.
 - For directory listings, this shows 2 levels deep.
-- Example: To check lines 50-100 of a large file: \`view("src/big-file.ts", { view_range: [50, 100] })\`
+- Example: To check lines 50-100 of a large file: \`view("src/big-file.ts", { view_range: [50, 100] })\``);
+  }
 
+  if (!denied.has('search_content')) {
+    readTools.push(`
 **search_content** — Search file contents using regex
 - Use this for ALL content search (finding functions, variables, error messages, imports, etc.)
 - NEVER use \`execute_command\` with grep, rg, or ag. Always use the search_content tool.
 - Supports regex patterns, file type filtering, and context lines.
 - Example: Find where a function is defined: \`search_content("function handleSubmit", { glob: "**/*.ts" })\`
-- Example: Find all imports of a module: \`search_content("from ['\\"]express['\\"]", { glob: "**/*.ts" })\`
+- Example: Find all imports of a module: \`search_content("from ['\\"\\]express['\\"\\]", { glob: "**/*.ts" })\``);
+  }
 
+  if (!denied.has('find_files')) {
+    readTools.push(`
 **find_files** — Find files by name pattern
 - Use this to find files matching a pattern (e.g., "**/*.ts", "src/**/test*").
 - NEVER use \`execute_command\` with find or ls for file search. Always use find_files.
 - Respects .gitignore automatically.
 - Example: Find all test files: \`find_files("**/*.test.ts")\`
-- Example: Find config files: \`find_files("**/config.{js,ts,json}")\`
+- Example: Find config files: \`find_files("**/config.{js,ts,json}")\``);
+  }
 
+  if (!denied.has('execute_command')) {
+    readTools.push(`
 **execute_command** — Run shell commands
 - Use for: git, npm/pnpm, docker, build tools, test runners, and other terminal operations.
 - Do NOT use for: file reading (use view), file search (use search_content/find_files), file editing (use string_replace_lsp/write_file).
@@ -47,58 +62,93 @@ You have access to the following tools. Use the RIGHT tool for the job:`);
 - Pipe to \`| tail -N\` for commands with long output — the full output streams to the user, only the last N lines are returned to you. If you're building any kind of package you should be tailing.
 - Good: Run independent commands in parallel when possible.
 - Bad: Running \`cat file.txt\` — use the view tool instead.`);
+  }
+
+  if (readTools.length > 0) {
+    sections.push(readTools.join('\n'));
+  }
 
   // --- Write/edit tools (build & fast only) ---
 
   if (modeId !== 'plan') {
-    sections.push(`
+    const writeTools: string[] = [];
+
+    if (!denied.has('string_replace_lsp')) {
+      writeTools.push(`
 **string_replace_lsp** — Edit files by replacing exact text
 - You MUST read a file with \`view\` before editing it.
 - \`old_str\` must be an exact match of existing text in the file.
 - Provide enough surrounding context in \`old_str\` to make it unique.
 - For creating new files, use \`write_file\` instead.
 - Good: Include 2-3 lines of surrounding context to ensure uniqueness.
-- Bad: Using just \`return true;\` — too common, will match multiple places.
+- Bad: Using just \`return true;\` — too common, will match multiple places.`);
+    }
 
+    if (!denied.has('write_file')) {
+      writeTools.push(`
 **write_file** — Create new files or overwrite existing ones
 - Use this to create new files.
 - If overwriting an existing file, you MUST have read it first with \`view\`.
 - NEVER create files unless necessary. Prefer editing existing files.`);
+    }
+
+    if (writeTools.length > 0) {
+      sections.push(writeTools.join('\n'));
+    }
   }
 
   // --- Web tools (all modes, conditionally available) ---
 
   if (options.hasWebSearch) {
-    sections.push(`
-**web_search** / **web_extract** — Search the web / extract page content
+    const webTools: string[] = [];
+    if (!denied.has('web_search')) webTools.push('**web_search**');
+    if (!denied.has('web_extract')) webTools.push('**web_extract**');
+    if (webTools.length > 0) {
+      sections.push(`
+${webTools.join(' / ')} — Search the web / extract page content
 - Use for looking up documentation, error messages, package APIs.`);
+    }
   }
 
   // --- Task management tools (all modes) ---
 
-  sections.push(`
+  const taskTools: string[] = [];
+
+  if (!denied.has('task_write')) {
+    taskTools.push(`
 **task_write** — Track tasks for complex multi-step work
 - Use when a task requires 3 or more distinct steps or actions.
 - Pass the FULL task list each time (replaces previous list).
 - Mark tasks \`in_progress\` BEFORE starting work. Only ONE task should be \`in_progress\` at a time.
 - Mark tasks \`completed\` IMMEDIATELY after finishing each task. Do not batch completions.
-- Each task has: content (imperative form), status (pending|in_progress|completed), activeForm (present continuous form shown during execution).
+- Each task has: content (imperative form), status (pending|in_progress|completed), activeForm (present continuous form shown during execution).`);
+  }
 
+  if (!denied.has('task_check')) {
+    taskTools.push(`
 **task_check** — Check completion status of tasks
 - Use this BEFORE deciding you're done with a task to verify all tasks are completed.
 - Returns the number of completed, in progress, and pending tasks.
 - If any tasks remain incomplete, continue working on them.
-- IMPORTANT: Always check task completion before ending work on a complex task.
+- IMPORTANT: Always check task completion before ending work on a complex task.`);
+  }
 
+  if (!denied.has('ask_user')) {
+    taskTools.push(`
 **ask_user** — Ask the user a structured question
 - Use when you need clarification, want to validate assumptions, or need the user to make a decision.
 - Provide clear, specific questions. End with a question mark.
 - Include options (2-4 choices) for structured decisions. Omit options for open-ended questions.
 - Don't use this for simple yes/no — just ask in your text response.`);
+  }
+
+  if (taskTools.length > 0) {
+    sections.push(taskTools.join('\n'));
+  }
 
   // --- Plan submission tool (plan mode) ---
 
-  if (modeId === 'plan') {
+  if (modeId === 'plan' && !denied.has('submit_plan')) {
     sections.push(`
 **submit_plan** — Submit a completed implementation plan for user review
 - Call this tool when your plan is complete. Do NOT just describe your plan in text — you MUST call this tool.
@@ -109,10 +159,12 @@ You have access to the following tools. Use the RIGHT tool for the job:`);
 
   // --- Subagent tool (all modes) ---
 
-  sections.push(`
+  if (!denied.has('subagent')) {
+    sections.push(`
 **subagent** — Delegate a focused task to a specialized subagent
 - Only use subagents when you will spawn **multiple subagents in parallel**. If you only need one task done, do it yourself.
 - Subagent outputs are **untrusted**. Always review and verify the results.`);
+  }
 
   return sections.join('\n');
 }

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -100,7 +100,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     name: 'Code Agent',
     instructions: getDynamicInstructions,
     model: getDynamicModel,
-    tools: createDynamicTools(mcpManager),
+    tools: createDynamicTools(mcpManager, config?.extraTools),
   });
 
   // Hooks


### PR DESCRIPTION
## Description

Two bugs fixed in Mastra Code tool handling:

1. **extraTools not merged** — The `extraTools` parameter in `createMastraCode` was accepted via `MastraCodeConfig` but never passed through to `createDynamicTools`, so extra tools were silently dropped. They are now correctly merged into the tool set (without overwriting built-in tools).

2. **Denied tools still advertised** — Tools with a per-tool `deny` policy in `permissionRules` were still included in the tool set and system prompt guidance, causing the model to attempt using them only to be blocked at execution time. Denied tools are now filtered from both the dynamic tool map and the tool guidance sections, so the model never sees them.

## Related Issue(s)

Fixes #13550

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Test Plan

- **14 new automated tests** in `mastracode/src/agents/__tests__/extra-tools.test.ts` covering:
  - extraTools merge into tool set
  - Built-in tools take precedence over extraTools with the same name
  - extraTools work without MCP manager
  - Per-tool deny filtering removes tools from tool set
  - Multiple denied tools filtered simultaneously
  - Allow/ask policies preserve tools
  - Denied extraTools also filtered
  - Denied tools omitted from `buildToolGuidance` output
  - All tools included when no denied set is provided
- **Manual testing** confirmed:
  - Bug #1: `test_extra_tool` injected via `extraTools` appears and executes correctly
  - Bug #2: `execute_command` with deny rule is completely invisible to the model — model uses alternative tools and reports it doesn't have `execute_command` available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed extra tools not merging properly with built-in tools—they are now combined without overwriting existing functionality.
* Fixed tools with deny policies still appearing in guidance—denied tools are now excluded from prompts and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->