### PR TITLE
fix(mastracode): detect API keys for all registry providers in setup flow

### DIFF
--- a/.changeset/fancy-eels-speak.md
+++ b/.changeset/fancy-eels-speak.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed setup flow to detect API keys for all providers in the model registry, not just the five hardcoded ones (Anthropic, OpenAI, Cerebras, Google, DeepSeek). Users with API keys for other supported providers like Groq, Mistral, or any provider in the registry will no longer see a "No model providers configured" error. Changed the missing provider error to a warning that allows users to continue setup.

--- a/.changeset/fancy-eels-speak.md
+++ b/.changeset/fancy-eels-speak.md
@@ -2,4 +2,6 @@
 'mastracode': patch
 ---
 
-Fixed setup flow to detect API keys for all providers in the model registry, not just the five hardcoded ones (Anthropic, OpenAI, Cerebras, Google, DeepSeek). Users with API keys for other supported providers like Groq, Mistral, or any provider in the registry will no longer see a "No model providers configured" error. Changed the missing provider error to a warning that allows users to continue setup.
+The setup flow now detects API keys for all providers listed in the model registry, not just a fixed set.
+Users with API keys for providers like Groq, Mistral, or any supported provider will no longer see a "No model providers configured" error.
+Missing provider detection is now a warning, allowing users to continue setup.

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -209,10 +209,10 @@ export async function createMastraCode(config?: MastraCodeConfig) {
   try {
     const registry = PROVIDER_REGISTRY as Record<string, ProviderConfig>;
     for (const [provider, config] of Object.entries(registry)) {
-      if (startupAccess[provider] !== undefined) continue; // Already checked above
+      if (startupAccess[provider] && startupAccess[provider] !== false) continue; // Already enabled above
       const envVars = config?.apiKeyEnvVar;
-      const envVar = Array.isArray(envVars) ? envVars[0] : envVars;
-      if (envVar && process.env[envVar]) {
+      const envVarList = Array.isArray(envVars) ? envVars : envVars ? [envVars] : [];
+      if (envVarList.some(envVar => process.env[envVar])) {
         startupAccess[provider] = 'apikey';
       }
     }

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -1,6 +1,8 @@
 import { Agent } from '@mastra/core/agent';
 import { Harness, taskWriteTool, taskCheckTool } from '@mastra/core/harness';
 import type { HeartbeatHandler, HarnessMode, HarnessSubagent } from '@mastra/core/harness';
+import { PROVIDER_REGISTRY } from '@mastra/core/llm';
+import type { ProviderConfig } from '@mastra/core/llm';
 
 import { getDynamicInstructions } from './agents/instructions.js';
 import { getDynamicMemory } from './agents/memory.js';
@@ -195,6 +197,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
 
   // Build lightweight provider access for resolving built-in packs at startup.
   // OAuth providers are checked via authStorage, env-only providers via process.env.
+  // Also scan the full provider registry so any configured API key satisfies access checks.
   const startupAccess: ProviderAccess = {
     anthropic: authStorage.isLoggedIn('anthropic') ? 'oauth' : process.env.ANTHROPIC_API_KEY ? 'apikey' : false,
     openai: authStorage.isLoggedIn('openai-codex') ? 'oauth' : process.env.OPENAI_API_KEY ? 'apikey' : false,
@@ -202,6 +205,20 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     google: process.env.GOOGLE_GENERATIVE_AI_API_KEY ? 'apikey' : false,
     deepseek: process.env.DEEPSEEK_API_KEY ? 'apikey' : false,
   };
+  // Check all providers in the registry for API keys
+  try {
+    const registry = PROVIDER_REGISTRY as Record<string, ProviderConfig>;
+    for (const [provider, config] of Object.entries(registry)) {
+      if (startupAccess[provider] !== undefined) continue; // Already checked above
+      const envVars = config?.apiKeyEnvVar;
+      const envVar = Array.isArray(envVars) ? envVars[0] : envVars;
+      if (envVar && process.env[envVar]) {
+        startupAccess[provider] = 'apikey';
+      }
+    }
+  } catch {
+    // Registry may not be loaded yet; the 5 hardcoded providers are sufficient fallback
+  }
   const builtinPacks = getAvailableModePacks(startupAccess);
   const builtinOmPacks = getAvailableOmPacks(startupAccess);
   const effectiveDefaults = resolveModelDefaults(globalSettings, builtinPacks);

--- a/mastracode/src/onboarding/onboarding-inline.ts
+++ b/mastracode/src/onboarding/onboarding-inline.ts
@@ -339,10 +339,10 @@ export class OnboardingInlineComponent extends Container implements Focusable {
 
   private renderModePack(): void {
     const packs = this.options.modePacks;
+    const box = this.makeBox();
 
     // No API keys and no OAuth logins — show warning but allow the user to continue
     if (!this.options.hasProviderAccess) {
-      const box = this.makeBox();
       box.addChild(new Text(theme.bold(theme.fg('warning', 'No model providers configured')), 0, 0));
       box.addChild(new Spacer(1));
       box.addChild(new Text(theme.fg('text', 'To use Mastra Code you need at least one API key or OAuth login'), 0, 0));
@@ -355,9 +355,9 @@ export class OnboardingInlineComponent extends Container implements Focusable {
       box.addChild(
         new Text(theme.fg('dim', 'Set an API key and restart, or run /login to authenticate via OAuth.'), 0, 0),
       );
+      box.addChild(new Spacer(1));
     }
 
-    const box = this.makeBox();
     box.addChild(new Text(theme.bold(theme.fg('accent', 'Model Packs')), 0, 0));
     box.addChild(new Spacer(1));
     box.addChild(new Text(theme.fg('text', 'Choose default models for each mode (build / plan / fast):'), 0, 0));

--- a/mastracode/src/onboarding/onboarding-inline.ts
+++ b/mastracode/src/onboarding/onboarding-inline.ts
@@ -340,10 +340,10 @@ export class OnboardingInlineComponent extends Container implements Focusable {
   private renderModePack(): void {
     const packs = this.options.modePacks;
 
-    // No API keys and no OAuth logins — can't proceed
+    // No API keys and no OAuth logins — show warning but allow the user to continue
     if (!this.options.hasProviderAccess) {
       const box = this.makeBox();
-      box.addChild(new Text(theme.bold(theme.fg('error', 'No model providers configured')), 0, 0));
+      box.addChild(new Text(theme.bold(theme.fg('warning', 'No model providers configured')), 0, 0));
       box.addChild(new Spacer(1));
       box.addChild(new Text(theme.fg('text', 'To use Mastra Code you need at least one API key or OAuth login'), 0, 0));
       box.addChild(new Text(theme.fg('text', 'for Anthropic, OpenAI, or another supported provider.'), 0, 0));
@@ -355,10 +355,6 @@ export class OnboardingInlineComponent extends Container implements Focusable {
       box.addChild(
         new Text(theme.fg('dim', 'Set an API key and restart, or run /login to authenticate via OAuth.'), 0, 0),
       );
-      this._finished = true;
-      // Give the TUI time to render the message before exiting
-      setTimeout(() => process.exit(1), 3000);
-      return;
     }
 
     const box = this.makeBox();

--- a/mastracode/src/onboarding/packs.ts
+++ b/mastracode/src/onboarding/packs.ts
@@ -37,6 +37,7 @@ export interface ProviderAccess {
   cerebras: ProviderAccessLevel;
   google: ProviderAccessLevel;
   deepseek: ProviderAccessLevel;
+  [provider: string]: ProviderAccessLevel;
 }
 
 // ---------------------------------------------------------------------------

--- a/mastracode/src/tui/commands/models-pack.ts
+++ b/mastracode/src/tui/commands/models-pack.ts
@@ -481,6 +481,14 @@ export async function handleModelsPackCommand(ctx: SlashCommandContext): Promise
     google: hasEnv('google') ? ('apikey' as const) : false,
     deepseek: hasEnv('deepseek') ? ('apikey' as const) : false,
   };
+  // Include all other providers that have API keys configured
+  const seen = new Set(Object.keys(access));
+  for (const m of models) {
+    if (!seen.has(m.provider) && m.hasApiKey) {
+      access[m.provider] = 'apikey';
+      seen.add(m.provider);
+    }
+  }
 
   const settings = loadSettings();
   const packs = getAvailableModePacks(access, settings.customModelPacks);

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -339,13 +339,22 @@ export class MastraTUI {
       if (hasEnv(provider)) return 'apikey';
       return false;
     };
-    return {
+    const access: ProviderAccess = {
       anthropic: accessLevel('anthropic', 'anthropic'),
       openai: accessLevel('openai', 'openai-codex'),
       cerebras: hasEnv('cerebras') ? ('apikey' as const) : false,
       google: hasEnv('google') ? ('apikey' as const) : false,
       deepseek: hasEnv('deepseek') ? ('apikey' as const) : false,
     };
+    // Include all other providers that have API keys configured
+    const seen = new Set(Object.keys(access));
+    for (const m of models) {
+      if (!seen.has(m.provider) && m.hasApiKey) {
+        access[m.provider] = 'apikey';
+        seen.add(m.provider);
+      }
+    }
+    return access;
   }
 
   private async syncThreadActivePackMetadata(thread?: {


### PR DESCRIPTION
The setup flow only checked 5 hardcoded providers (Anthropic, OpenAI, Cerebras, Google, DeepSeek) for API keys. If you had a key for any other supported provider like Groq or Mistral, you'd get a fatal "No model providers configured" error and the process would exit.

Now it scans all providers in the registry at startup and at runtime, so any configured API key satisfies the access check. Also changed the error to a non-blocking warning so users can still proceed and configure keys via `/login` or env vars.

https://x.com/tylbar/status/2027175273301471265?s=20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup now autodetects API keys for any provider listed in the model registry, expanding support beyond the previously hardcoded providers.

* **Bug Fixes**
  * Missing provider API keys are reported as warnings (not fatal), allowing setup and onboarding to continue with partial provider configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->