### PR TITLE
feat: track per-step provider token usage on assistant messages

### DIFF
--- a/.changeset/nice-guests-drop.md
+++ b/.changeset/nice-guests-drop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': minor
+---
+
+Update peer dependencies to match core package version bump (1.5.1)

--- a/.changeset/tiny-banks-lie.md
+++ b/.changeset/tiny-banks-lie.md
@@ -1,0 +1,6 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Improved token counting accuracy for Observational Memory. Each LLM step now appends a per-step usage entry (`stepTokenCounts[]`) to the assistant message metadata, recording `outputTokens`, `inputTokens`, `reasoningTokens`, and other provider-reported counts. When `inputTokens` are available, OM uses an input-token delta formula to accurately account for text, reasoning, tool-call arguments, and tool results. Falls back to summing `outputTokens` when `inputTokens` are unavailable, and to tiktoken estimation when no provider counts exist.

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -191,6 +191,10 @@ const memory = new Memory({
 })
 ```
 
+### Token counting accuracy
+
+OM counts message tokens to decide when thresholds are reached. Each LLM step annotates the assistant message with a per-step usage entry (via `content.metadata.mastra.stepTokenCounts[]`), recording `outputTokens`, `inputTokens`, `reasoningTokens`, and other provider-reported counts. OM sums the `outputTokens` across all steps to get the exact provider count instead of estimating with tiktoken. User messages and other messages without provider counts fall back to a tiktoken-based estimator.
+
 ## Async Buffering
 
 Without async buffering, the Observer runs synchronously when the message threshold is reached — the agent pauses mid-conversation while the Observer LLM call completes. With async buffering (enabled by default), observations are pre-computed in the background as the conversation grows. When the threshold is hit, buffered observations activate instantly with no pause.

--- a/packages/core/src/loop/__snapshots__/loop.test.ts.snap
+++ b/packages/core/src/loop/__snapshots__/loop.test.ts.snap
@@ -4506,6 +4506,17 @@ exports[`Loop Tests > AISDK v5 > result.response > should resolve with response 
       "content": {
         "content": "Hello",
         "format": 2,
+        "metadata": {
+          "mastra": {
+            "stepTokenCounts": [
+              {
+                "inputTokens": 3,
+                "outputTokens": 10,
+                "totalTokens": 13,
+              },
+            ],
+          },
+        },
         "parts": [
           {
             "text": "Hello",
@@ -4545,6 +4556,15 @@ exports[`Loop Tests > AISDK v5 > result.response > should resolve with response 
       "id": "msg-0",
       "metadata": {
         "createdAt": 2024-01-01T00:00:00.001Z,
+        "mastra": {
+          "stepTokenCounts": [
+            {
+              "inputTokens": 3,
+              "outputTokens": 10,
+              "totalTokens": 13,
+            },
+          ],
+        },
       },
       "parts": [
         {
@@ -4713,6 +4733,15 @@ exports[`Loop Tests > AISDK v5 > result.steps > should add the files from the mo
           "id": "msg-0",
           "metadata": {
             "createdAt": 2024-01-01T00:00:00.001Z,
+            "mastra": {
+              "stepTokenCounts": [
+                {
+                  "inputTokens": 3,
+                  "outputTokens": 10,
+                  "totalTokens": 13,
+                },
+              ],
+            },
           },
           "parts": [
             {
@@ -10357,6 +10386,17 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.response > should resolve wi
       "content": {
         "content": "Hello",
         "format": 2,
+        "metadata": {
+          "mastra": {
+            "stepTokenCounts": [
+              {
+                "inputTokens": 3,
+                "outputTokens": 10,
+                "totalTokens": 13,
+              },
+            ],
+          },
+        },
         "parts": [
           {
             "text": "Hello",
@@ -10396,6 +10436,15 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.response > should resolve wi
       "id": "msg-0",
       "metadata": {
         "createdAt": 2024-01-01T00:00:00.001Z,
+        "mastra": {
+          "stepTokenCounts": [
+            {
+              "inputTokens": 3,
+              "outputTokens": 10,
+              "totalTokens": 13,
+            },
+          ],
+        },
       },
       "parts": [
         {
@@ -10564,6 +10613,15 @@ exports[`Loop Tests > AISDK v6 (V3 models) > result.steps > should add the files
           "id": "msg-0",
           "metadata": {
             "createdAt": 2024-01-01T00:00:00.001Z,
+            "mastra": {
+              "stepTokenCounts": [
+                {
+                  "inputTokens": 3,
+                  "outputTokens": 10,
+                  "totalTokens": 13,
+                },
+              ],
+            },
           },
           "parts": [
             {

--- a/packages/core/src/loop/loop.test.ts
+++ b/packages/core/src/loop/loop.test.ts
@@ -4,6 +4,7 @@ import { fullStreamTests } from './test-utils/fullStream';
 import { generateTextTestsV5 } from './test-utils/generateText';
 import { optionsTests } from './test-utils/options';
 import { resultObjectTests } from './test-utils/resultObject';
+import { stepTokenCountsTests } from './test-utils/stepTokenCounts';
 import { streamObjectTests } from './test-utils/streamObject';
 import { textStreamTests } from './test-utils/textStream';
 import { toolsTests } from './test-utils/tools';
@@ -27,6 +28,7 @@ describe('Loop Tests', () => {
     optionsTests({ loopFn: loop, runId: 'test-run-id' });
     generateTextTestsV5({ loopFn: loop, runId: 'test-run-id' });
     toolsTests({ loopFn: loop, runId: 'test-run-id' });
+    stepTokenCountsTests({ loopFn: loop, runId: 'test-run-id' });
 
     streamObjectTests({ loopFn: loop, runId: 'test-run-id' });
   });

--- a/packages/core/src/loop/test-utils/generateText.ts
+++ b/packages/core/src/loop/test-utils/generateText.ts
@@ -766,6 +766,15 @@ export function generateTextTestsV5({ loopFn, runId }: { loopFn: typeof loop; ru
                 "id": "1234",
                 "metadata": {
                   "createdAt": 2024-01-01T00:00:00.001Z,
+                  "mastra": {
+                    "stepTokenCounts": [
+                      {
+                        "inputTokens": 3,
+                        "outputTokens": 10,
+                        "totalTokens": 13,
+                      },
+                    ],
+                  },
                 },
                 "parts": [
                   {
@@ -786,6 +795,17 @@ export function generateTextTestsV5({ loopFn, runId }: { loopFn: typeof loop; ru
                 "content": {
                   "content": "Hello, world!",
                   "format": 2,
+                  "metadata": {
+                    "mastra": {
+                      "stepTokenCounts": [
+                        {
+                          "inputTokens": 3,
+                          "outputTokens": 10,
+                          "totalTokens": 13,
+                        },
+                      ],
+                    },
+                  },
                   "parts": [
                     {
                       "text": "Hello, world!",
@@ -827,6 +847,15 @@ export function generateTextTestsV5({ loopFn, runId }: { loopFn: typeof loop; ru
                 "id": "1234",
                 "metadata": {
                   "createdAt": 2024-01-01T00:00:00.001Z,
+                  "mastra": {
+                    "stepTokenCounts": [
+                      {
+                        "inputTokens": 3,
+                        "outputTokens": 10,
+                        "totalTokens": 13,
+                      },
+                    ],
+                  },
                 },
                 "parts": [
                   {

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -2576,6 +2576,17 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
                 {
                   "content": {
                     "format": 2,
+                    "metadata": {
+                      "mastra": {
+                        "stepTokenCounts": [
+                          {
+                            "inputTokens": 3,
+                            "outputTokens": 10,
+                            "totalTokens": 13,
+                          },
+                        ],
+                      },
+                    },
                     "parts": [
                       {
                         "providerExecuted": undefined,

--- a/packages/core/src/loop/test-utils/stepTokenCounts.ts
+++ b/packages/core/src/loop/test-utils/stepTokenCounts.ts
@@ -1,0 +1,320 @@
+import { convertArrayToReadableStream, mockId, mockValues } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
+import z from 'zod';
+import type { MastraDBMessage } from '../../agent/message-list/state/types';
+import type { loop } from '../loop';
+import { createMessageListWithUserMessage, defaultSettings } from './utils';
+import { MastraLanguageModelV2Mock as MockLanguageModelV2 } from './MastraLanguageModelV2Mock';
+
+function getMastraMetadata(m: MastraDBMessage): Record<string, unknown> | undefined {
+  return (m.content?.metadata as Record<string, unknown> | undefined)?.mastra as Record<string, unknown> | undefined;
+}
+
+const step0Usage = {
+  inputTokens: 50,
+  outputTokens: 20,
+  totalTokens: 70,
+  reasoningTokens: undefined,
+  cachedInputTokens: undefined,
+};
+
+const step1Usage = {
+  inputTokens: 150,
+  outputTokens: 35,
+  totalTokens: 185,
+  reasoningTokens: 5,
+  cachedInputTokens: undefined,
+};
+
+export function stepTokenCountsTests({ loopFn, runId }: { loopFn: typeof loop; runId: string }) {
+  describe('stepTokenCounts accumulation', () => {
+    it('should accumulate stepTokenCounts on a single assistant message across tool-call steps', async () => {
+      const messageList = createMessageListWithUserMessage();
+
+      let responseCount = 0;
+      const result = await loopFn({
+        methodType: 'stream',
+        runId,
+        models: [
+          {
+            id: 'test-model',
+            maxRetries: 0,
+            model: new MockLanguageModelV2({
+              doStream: async () => {
+                switch (responseCount++) {
+                  case 0: {
+                    // Step 0: model calls a tool
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'response-metadata',
+                          id: 'id-0',
+                          modelId: 'mock-model-id',
+                          timestamp: new Date(0),
+                        },
+                        {
+                          type: 'tool-call',
+                          id: 'call-1',
+                          toolCallId: 'call-1',
+                          toolName: 'calculator',
+                          input: '{ "a": 1, "b": 2 }',
+                        },
+                        {
+                          type: 'finish',
+                          finishReason: 'tool-calls',
+                          usage: step0Usage,
+                        },
+                      ]),
+                    };
+                  }
+                  case 1: {
+                    // Step 1: model responds with text after tool result
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'response-metadata',
+                          id: 'id-1',
+                          modelId: 'mock-model-id',
+                          timestamp: new Date(1000),
+                        },
+                        { type: 'text-start', id: 'text-1' },
+                        { type: 'text-delta', id: 'text-1', delta: 'The result is 3.' },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: step1Usage,
+                        },
+                      ]),
+                    };
+                  }
+                  default:
+                    throw new Error(`Unexpected response count: ${responseCount}`);
+                }
+              },
+            }),
+          },
+        ],
+        tools: {
+          calculator: {
+            inputSchema: z.object({ a: z.number(), b: z.number() }),
+            execute: async ({ a, b }: { a: number; b: number }) => ({ sum: a + b }),
+          },
+        },
+        messageList,
+        ...defaultSettings(),
+        _internal: {
+          now: mockValues(0, 100, 500, 600, 1000),
+          generateId: mockId({ prefix: 'id' }),
+        },
+      });
+
+      await result.consumeStream();
+
+      // Find all assistant response messages
+      const responseMessages = messageList.get.response.db();
+
+      // There should be assistant message(s) with stepTokenCounts
+      const messagesWithTokenCounts = responseMessages.filter(
+        (m: MastraDBMessage) => m.role === 'assistant' && Array.isArray(getMastraMetadata(m)?.stepTokenCounts),
+      );
+
+      expect(messagesWithTokenCounts.length).toBeGreaterThanOrEqual(1);
+
+      // Collect all stepTokenCounts across assistant messages
+      const allStepTokenCounts: Record<string, number>[] = [];
+      for (const msg of messagesWithTokenCounts) {
+        const mastra = getMastraMetadata(msg)!;
+        const counts = mastra.stepTokenCounts as Record<string, number>[];
+        allStepTokenCounts.push(...counts);
+      }
+
+      // Should have entries from both steps
+      expect(allStepTokenCounts.length).toBe(2);
+
+      // Step 0: tool-call step
+      expect(allStepTokenCounts[0]).toEqual(
+        expect.objectContaining({
+          outputTokens: step0Usage.outputTokens,
+          inputTokens: step0Usage.inputTokens,
+          totalTokens: step0Usage.totalTokens,
+        }),
+      );
+
+      // Step 1: text response step
+      expect(allStepTokenCounts[1]).toEqual(
+        expect.objectContaining({
+          outputTokens: step1Usage.outputTokens,
+          inputTokens: step1Usage.inputTokens,
+          totalTokens: step1Usage.totalTokens,
+          reasoningTokens: step1Usage.reasoningTokens,
+        }),
+      );
+    });
+
+    it('should have tool-invocation parts on the same assistant message as stepTokenCounts', async () => {
+      const messageList = createMessageListWithUserMessage();
+
+      let responseCount = 0;
+      const result = await loopFn({
+        methodType: 'stream',
+        runId,
+        models: [
+          {
+            id: 'test-model',
+            maxRetries: 0,
+            model: new MockLanguageModelV2({
+              doStream: async () => {
+                switch (responseCount++) {
+                  case 0: {
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'response-metadata',
+                          id: 'id-0',
+                          modelId: 'mock-model-id',
+                          timestamp: new Date(0),
+                        },
+                        {
+                          type: 'tool-call',
+                          id: 'call-1',
+                          toolCallId: 'call-1',
+                          toolName: 'greet',
+                          input: '{ "name": "Alice" }',
+                        },
+                        {
+                          type: 'finish',
+                          finishReason: 'tool-calls',
+                          usage: step0Usage,
+                        },
+                      ]),
+                    };
+                  }
+                  case 1: {
+                    return {
+                      stream: convertArrayToReadableStream([
+                        {
+                          type: 'response-metadata',
+                          id: 'id-1',
+                          modelId: 'mock-model-id',
+                          timestamp: new Date(1000),
+                        },
+                        { type: 'text-start', id: 'text-1' },
+                        { type: 'text-delta', id: 'text-1', delta: 'Done!' },
+                        { type: 'text-end', id: 'text-1' },
+                        {
+                          type: 'finish',
+                          finishReason: 'stop',
+                          usage: step1Usage,
+                        },
+                      ]),
+                    };
+                  }
+                  default:
+                    throw new Error(`Unexpected response count: ${responseCount}`);
+                }
+              },
+            }),
+          },
+        ],
+        tools: {
+          greet: {
+            inputSchema: z.object({ name: z.string() }),
+            execute: async ({ name }: { name: string }) => `Hello, ${name}!`,
+          },
+        },
+        messageList,
+        ...defaultSettings(),
+        _internal: {
+          now: mockValues(0, 100, 500, 600, 1000),
+          generateId: mockId({ prefix: 'id' }),
+        },
+      });
+
+      await result.consumeStream();
+
+      // Find assistant messages with stepTokenCounts
+      const responseMessages = messageList.get.response.db();
+      const assistantMessages = responseMessages.filter(
+        (m: MastraDBMessage) => m.role === 'assistant' && Array.isArray(getMastraMetadata(m)?.stepTokenCounts),
+      );
+
+      // The tool-invocation parts should be on one of these messages
+      const messagesWithToolParts = assistantMessages.filter((m: MastraDBMessage) =>
+        m.content?.parts?.some(p => p.type === 'tool-invocation'),
+      );
+
+      expect(messagesWithToolParts.length).toBeGreaterThanOrEqual(1);
+
+      // The tool-invocation should include both call and result states
+      const toolParts = messagesWithToolParts[0]!.content.parts.filter(p => p.type === 'tool-invocation');
+      expect(toolParts.length).toBeGreaterThanOrEqual(1);
+
+      // At least one tool invocation should have a result
+      const resultParts = toolParts.filter(p => p.type === 'tool-invocation' && p.toolInvocation.state === 'result');
+      expect(resultParts.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should annotate stepTokenCounts for a single text-only step', async () => {
+      const messageList = createMessageListWithUserMessage();
+
+      const result = await loopFn({
+        methodType: 'stream',
+        runId,
+        models: [
+          {
+            id: 'test-model',
+            maxRetries: 0,
+            model: new MockLanguageModelV2({
+              doStream: async () => ({
+                stream: convertArrayToReadableStream([
+                  {
+                    type: 'response-metadata',
+                    id: 'id-0',
+                    modelId: 'mock-model-id',
+                    timestamp: new Date(0),
+                  },
+                  { type: 'text-start', id: 'text-1' },
+                  { type: 'text-delta', id: 'text-1', delta: 'Hello, world!' },
+                  { type: 'text-end', id: 'text-1' },
+                  {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    usage: {
+                      inputTokens: 10,
+                      outputTokens: 5,
+                      totalTokens: 15,
+                    },
+                  },
+                ]),
+              }),
+            }),
+          },
+        ],
+        messageList,
+        ...defaultSettings(),
+      });
+
+      await result.consumeStream();
+
+      const responseMessages = messageList.get.response.db();
+      const assistantMsg = responseMessages.find(
+        (m: MastraDBMessage) => m.role === 'assistant' && Array.isArray(getMastraMetadata(m)?.stepTokenCounts),
+      );
+
+      expect(assistantMsg).toBeDefined();
+
+      const mastra = getMastraMetadata(assistantMsg!)!;
+      const stepTokenCounts = mastra.stepTokenCounts as Record<string, number>[];
+
+      expect(stepTokenCounts).toHaveLength(1);
+      expect(stepTokenCounts[0]).toEqual(
+        expect.objectContaining({
+          outputTokens: 5,
+          inputTokens: 10,
+          totalTokens: 15,
+        }),
+      );
+    });
+  });
+}

--- a/packages/core/src/loop/test-utils/streamObject.ts
+++ b/packages/core/src/loop/test-utils/streamObject.ts
@@ -529,6 +529,15 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
               {
                 id: expect.any(String),
                 metadata: {
+                  mastra: {
+                    stepTokenCounts: [
+                      {
+                        inputTokens: 3,
+                        outputTokens: 10,
+                        totalTokens: 13,
+                      },
+                    ],
+                  },
                   structuredOutput: {
                     content: 'Hello, world!',
                   },
@@ -551,6 +560,15 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                   content: '{"content": "Hello, world!"}',
                   format: 2,
                   metadata: {
+                    mastra: {
+                      stepTokenCounts: [
+                        {
+                          inputTokens: 3,
+                          outputTokens: 10,
+                          totalTokens: 13,
+                        },
+                      ],
+                    },
                     structuredOutput: {
                       content: 'Hello, world!',
                     },
@@ -867,6 +885,15 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                       "content": "{ "content": "Hello, world!" }",
                       "format": 2,
                       "metadata": {
+                        "mastra": {
+                          "stepTokenCounts": [
+                            {
+                              "inputTokens": 3,
+                              "outputTokens": 10,
+                              "totalTokens": 13,
+                            },
+                          ],
+                        },
                         "structuredOutput": {
                           "content": "Hello, world!",
                         },
@@ -908,6 +935,15 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                     "id": "1234",
                     "metadata": {
                       "createdAt": 2024-01-01T00:00:00.001Z,
+                      "mastra": {
+                        "stepTokenCounts": [
+                          {
+                            "inputTokens": 3,
+                            "outputTokens": 10,
+                            "totalTokens": 13,
+                          },
+                        ],
+                      },
                       "structuredOutput": {
                         "content": "Hello, world!",
                       },
@@ -971,6 +1007,15 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                         "id": "1234",
                         "metadata": {
                           "createdAt": 2024-01-01T00:00:00.001Z,
+                          "mastra": {
+                            "stepTokenCounts": [
+                              {
+                                "inputTokens": 3,
+                                "outputTokens": 10,
+                                "totalTokens": 13,
+                              },
+                            ],
+                          },
                           "structuredOutput": {
                             "content": "Hello, world!",
                           },
@@ -1110,6 +1155,17 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                     "content": {
                       "content": "{ "invalid": "Hello, world!" }",
                       "format": 2,
+                      "metadata": {
+                        "mastra": {
+                          "stepTokenCounts": [
+                            {
+                              "inputTokens": 3,
+                              "outputTokens": 10,
+                              "totalTokens": 13,
+                            },
+                          ],
+                        },
+                      },
                       "parts": [
                         {
                           "text": "{ "invalid": "Hello, world!" }",
@@ -1147,6 +1203,15 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                     "id": "1234",
                     "metadata": {
                       "createdAt": 2024-01-01T00:00:00.001Z,
+                      "mastra": {
+                        "stepTokenCounts": [
+                          {
+                            "inputTokens": 3,
+                            "outputTokens": 10,
+                            "totalTokens": 13,
+                          },
+                        ],
+                      },
                     },
                     "parts": [
                       {
@@ -1203,6 +1268,15 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                         "id": "1234",
                         "metadata": {
                           "createdAt": 2024-01-01T00:00:00.001Z,
+                          "mastra": {
+                            "stepTokenCounts": [
+                              {
+                                "inputTokens": 3,
+                                "outputTokens": 10,
+                                "totalTokens": 13,
+                              },
+                            ],
+                          },
                         },
                         "parts": [
                           {
@@ -1339,6 +1413,17 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                     "content": {
                       "content": "{ "invalid": "Hello, world!" }",
                       "format": 2,
+                      "metadata": {
+                        "mastra": {
+                          "stepTokenCounts": [
+                            {
+                              "inputTokens": 3,
+                              "outputTokens": 10,
+                              "totalTokens": 13,
+                            },
+                          ],
+                        },
+                      },
                       "parts": [
                         {
                           "text": "{ "invalid": "Hello, world!" }",
@@ -1376,6 +1461,15 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                     "id": "1234",
                     "metadata": {
                       "createdAt": 2024-01-01T00:00:00.001Z,
+                      "mastra": {
+                        "stepTokenCounts": [
+                          {
+                            "inputTokens": 3,
+                            "outputTokens": 10,
+                            "totalTokens": 13,
+                          },
+                        ],
+                      },
                     },
                     "parts": [
                       {
@@ -1432,6 +1526,15 @@ export function streamObjectTests({ loopFn, runId }: { loopFn: typeof loop; runI
                         "id": "1234",
                         "metadata": {
                           "createdAt": 2024-01-01T00:00:00.001Z,
+                          "mastra": {
+                            "stepTokenCounts": [
+                              {
+                                "inputTokens": 3,
+                                "outputTokens": 10,
+                                "totalTokens": 13,
+                              },
+                            ],
+                          },
                         },
                         "parts": [
                           {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1010,6 +1010,50 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
         messageList.add(message, 'response');
       }
 
+      /**
+       * Annotate the response message with per-step token usage from the provider.
+       * Each LLM step appends an entry to `metadata.mastra.stepTokenCounts[]`
+       * so that downstream consumers (e.g. Observational Memory's TokenCounter)
+       * can sum accurate per-step deltas instead of relying on tiktoken estimates.
+       *
+       * This runs AFTER tool calls are added to the message list, so that even
+       * tool-call-only steps (no text output) have a message to annotate.
+       *
+       * The same `messageId` is reused across all iterations of the agentic loop,
+       * and `MessageMerger.merge()` operates on the existing message in-place,
+       * so the `stepTokenCounts` array correctly accumulates entries from each step.
+       *
+       * Note: if the message is sealed between iterations (by Observational Memory),
+       * a new message with a different ID is created and this annotation will land
+       * on the original sealed message rather than the new one. This is acceptable
+       * because the observer has already processed the sealed message's token count.
+       */
+      const stepUsage = outputStream._getImmediateUsage();
+      if (stepUsage && typeof stepUsage.outputTokens === 'number') {
+        const responseMsg = messageList.get.response.db().find(m => m.id === messageId);
+        if (responseMsg && responseMsg.content && typeof responseMsg.content === 'object') {
+          const mastra = ((responseMsg.content.metadata as Record<string, unknown> | undefined)?.mastra ??
+            {}) as Record<string, unknown>;
+          const existing = Array.isArray(mastra.stepTokenCounts) ? mastra.stepTokenCounts : [];
+
+          const entry: Record<string, number> = {
+            outputTokens: stepUsage.outputTokens,
+          };
+          if (typeof stepUsage.inputTokens === 'number') entry.inputTokens = stepUsage.inputTokens;
+          if (typeof stepUsage.reasoningTokens === 'number') entry.reasoningTokens = stepUsage.reasoningTokens;
+          if (typeof stepUsage.cachedInputTokens === 'number') entry.cachedInputTokens = stepUsage.cachedInputTokens;
+          if (typeof stepUsage.totalTokens === 'number') entry.totalTokens = stepUsage.totalTokens;
+
+          responseMsg.content.metadata = {
+            ...(responseMsg.content.metadata as Record<string, unknown> | undefined),
+            mastra: {
+              ...mastra,
+              stepTokenCounts: [...existing, entry],
+            },
+          };
+        }
+      }
+
       // Call processOutputStep for processors (runs AFTER LLM response, BEFORE tool execution)
       // This allows processors to validate/modify the response and trigger retries if needed
       let processOutputStepTripwire: TripWire | null = null;

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -1206,6 +1206,146 @@ describe('Token Counter', () => {
       // data-* parts should be skipped, so counts should be equal
       expect(countWith).toBe(countWithout);
     });
+
+    it('should use message-level stepTokenCounts when available (single step)', () => {
+      const veryLargeText = 'word '.repeat(5000); // ~5000 tokens via tiktoken
+
+      const msgWithProvider: MastraDBMessage = {
+        id: 'msg-provider',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [{ type: 'text' as const, text: veryLargeText }],
+          metadata: { mastra: { stepTokenCounts: [{ outputTokens: 42, inputTokens: 100 }] } },
+        },
+        type: 'text',
+        createdAt: new Date(),
+      };
+
+      const msgWithout: MastraDBMessage = {
+        id: 'msg-no-provider',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [{ type: 'text' as const, text: veryLargeText }],
+        },
+        type: 'text',
+        createdAt: new Date(),
+      };
+
+      const countWithProvider = counter.countMessage(msgWithProvider);
+      const countWithoutProvider = counter.countMessage(msgWithout);
+
+      // With provider metadata the count should be exactly 42 (no overhead added)
+      expect(countWithProvider).toBeLessThan(countWithoutProvider);
+      expect(countWithProvider).toBe(42);
+    });
+
+    it('should use input token deltas to capture tool result tokens across steps', () => {
+      // Scenario: 3-step agentic loop
+      // Step 0: inputTokens=500 (baseline prompt), outputTokens=100 (text + tool calls)
+      // Step 1: inputTokens=750 (500 + 100 output + 150 tool results), outputTokens=80
+      // Step 2: inputTokens=900 (750 + 80 output + 70 tool results), outputTokens=50 (final text)
+      //
+      // Total message footprint = last.inputTokens - first.inputTokens + last.outputTokens
+      //                         = 900 - 500 + 50 = 450
+      // This correctly includes tool result tokens (150 + 70 = 220) that outputTokens alone would miss.
+      const msgMultiStep: MastraDBMessage = {
+        id: 'msg-multi-step',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [{ type: 'text' as const, text: 'hello' }],
+          metadata: {
+            mastra: {
+              stepTokenCounts: [
+                { inputTokens: 500, outputTokens: 100, reasoningTokens: 10 },
+                { inputTokens: 750, outputTokens: 80 },
+                { inputTokens: 900, outputTokens: 50 },
+              ],
+            },
+          },
+        },
+        type: 'text',
+        createdAt: new Date(),
+      };
+
+      const count = counter.countMessage(msgMultiStep);
+      // 900 - 500 + 50 = 450
+      expect(count).toBe(450);
+    });
+
+    it('should fall back to summing outputTokens when inputTokens are missing', () => {
+      const msg: MastraDBMessage = {
+        id: 'msg-no-input',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [{ type: 'text' as const, text: 'hello' }],
+          metadata: {
+            mastra: {
+              stepTokenCounts: [{ outputTokens: 100 }, { outputTokens: 200 }],
+            },
+          },
+        },
+        type: 'text',
+        createdAt: new Date(),
+      };
+
+      const count = counter.countMessage(msg);
+      // No inputTokens available, falls back to summing outputTokens: 100 + 200 = 300
+      expect(count).toBe(300);
+    });
+
+    it('should fall back to tiktoken when no stepTokenCounts are set', () => {
+      const text = 'The quick brown fox jumps over the lazy dog';
+
+      const msg: MastraDBMessage = {
+        id: 'msg-fallback',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [{ type: 'text' as const, text }],
+        },
+        type: 'text',
+        createdAt: new Date(),
+      };
+
+      const count = counter.countMessage(msg);
+      // tiktoken estimate: role + text + overhead ≈ 14 tokens
+      expect(count).toBeGreaterThan(5);
+      expect(count).toBeLessThan(30);
+    });
+
+    it('should fall back to tiktoken when stepTokenCounts is empty', () => {
+      const text = 'Some text content';
+
+      const msgEmpty: MastraDBMessage = {
+        id: 'msg-empty-steps',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [{ type: 'text' as const, text }],
+          metadata: { mastra: { stepTokenCounts: [] } },
+        },
+        type: 'text',
+        createdAt: new Date(),
+      };
+
+      const msgNoProvider: MastraDBMessage = {
+        id: 'msg-no-provider',
+        role: 'assistant',
+        content: {
+          format: 2,
+          parts: [{ type: 'text' as const, text }],
+        },
+        type: 'text',
+        createdAt: new Date(),
+      };
+
+      // Empty array should fall back to tiktoken, same as no provider metadata
+      expect(counter.countMessage(msgEmpty)).toBe(counter.countMessage(msgNoProvider));
+    });
   });
 
   describe('countMessages', () => {

--- a/packages/memory/src/processors/observational-memory/token-counter.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.ts
@@ -21,8 +21,10 @@ function getDefaultEncoder(): Tiktoken {
 
 /**
  * Token counting utility using tiktoken.
- * For POC we use o200k_base (GPT-4o encoding) as a reasonable default.
- * Production will add provider-aware counting.
+ * Uses o200k_base (GPT-4o encoding) as a reasonable default estimator.
+ * When a message carries provider-supplied step token counts at the message level
+ * (via `content.metadata.mastra.stepTokenCounts[]`), those exact values
+ * are summed instead of re-estimating with tiktoken.
  */
 export class TokenCounter {
   private encoder: Tiktoken;
@@ -48,9 +50,64 @@ export class TokenCounter {
   }
 
   /**
-   * Count tokens in a single message
+   * Extract a provider-supplied token count from a message's content-level metadata.
+   * Uses `stepTokenCounts[]` to compute the total context-window footprint of this message:
+   *   lastStep.inputTokens - firstStep.inputTokens + lastStep.outputTokens
+   *
+   * The first step's inputTokens is the baseline (prompt before this message).
+   * The delta between steps captures tool results added between steps.
+   * The last step's outputTokens captures the final model output.
+   *
+   * Falls back to summing outputTokens if inputTokens aren't available.
+   * Returns `undefined` when no provider counts are available.
+   */
+  private static getMessageTokenCount(message: MastraDBMessage): number | undefined {
+    if (message.content && typeof message.content === 'object') {
+      const mastra = (message.content as any).metadata?.mastra;
+      if (mastra && typeof mastra === 'object') {
+        if (Array.isArray(mastra.stepTokenCounts) && mastra.stepTokenCounts.length > 0) {
+          const steps = mastra.stepTokenCounts;
+          const first = steps[0];
+          const last = steps[steps.length - 1];
+
+          // Use input token deltas when available to capture tool results accurately
+          if (
+            first &&
+            typeof first.inputTokens === 'number' &&
+            last &&
+            typeof last.inputTokens === 'number' &&
+            typeof last.outputTokens === 'number'
+          ) {
+            return last.inputTokens - first.inputTokens + last.outputTokens;
+          }
+
+          // Fallback: sum outputTokens only (misses tool result tokens)
+          let total = 0;
+          for (const entry of steps) {
+            if (entry && typeof entry.outputTokens === 'number') {
+              total += entry.outputTokens;
+            }
+          }
+          return total;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Count tokens in a single message.
+   * If provider-supplied step token counts are available at the message level
+   * (via `content.metadata.mastra.stepTokenCounts[]`) the sum of
+   * outputTokens is used directly. Otherwise the message parts are estimated
+   * with tiktoken.
    */
   countMessage(message: MastraDBMessage): number {
+    const providerCount = TokenCounter.getMessageTokenCount(message);
+    if (providerCount !== undefined) {
+      return providerCount;
+    }
+
     let tokenString = message.role;
     let overhead = TokenCounter.TOKENS_PER_MESSAGE;
     let toolResultCount = 0;


### PR DESCRIPTION
After each LLM step, provider-reported token usage is now stamped on assistant messages at `content.metadata.mastra.stepTokenCounts[]`. This gives Observational Memory accurate token counts instead of relying solely on tiktoken estimates.

`TokenCounter` checks for these provider counts first and uses an input-token delta formula to capture tool result tokens across multi-step loops. Falls back to tiktoken when provider counts aren't available.

Example of what gets stamped on an assistant message after two steps (tool call then text response):

```ts
message.content.metadata.mastra.stepTokenCounts = [
  { inputTokens: 50, outputTokens: 100, totalTokens: 150 },
  { inputTokens: 150, outputTokens: 200, totalTokens: 350 },
]
```

`TokenCounter` then computes the message's token size as `lastStep.inputTokens - firstStep.inputTokens + lastStep.outputTokens` (= 300), which captures text, reasoning, tool call args, and tool result tokens using only provider-reported numbers.