### PR TITLE
fix: respect disableInit on mastra build to skip database schema initialization

### DIFF
--- a/.changeset/fix-disable-init-bypass.md
+++ b/.changeset/fix-disable-init-bypass.md
@@ -1,0 +1,6 @@
+---
+'mastra': patch
+'@mastra/deployer-cloud': patch
+---
+
+Fixed `disableInit: true` being ignored on `mastra build`. The generated server entry point was unconditionally calling `storage.init()`, executing CREATE TABLE and ALTER TABLE statements on startup even when `disableInit` was set. The entry point now checks `storage.disableInit` before triggering initialization. ([#13570](https://github.com/mastra-ai/mastra/issues/13570))

--- a/.changeset/fix-disable-init-bypass.md
+++ b/.changeset/fix-disable-init-bypass.md
@@ -3,4 +3,4 @@
 '@mastra/deployer-cloud': patch
 ---
 
-Fixed `disableInit: true` being ignored on `mastra build`. The generated server entry point was unconditionally calling `storage.init()`, executing CREATE TABLE and ALTER TABLE statements on startup even when `disableInit` was set. The entry point now checks `storage.disableInit` before triggering initialization. ([#13570](https://github.com/mastra-ai/mastra/issues/13570))
+Fixed `mastra build` ignoring `disableInit: true` — the built server no longer runs CREATE TABLE / ALTER TABLE statements on startup when `disableInit` is set. ([#13570](https://github.com/mastra-ai/mastra/issues/13570))

--- a/deployers/cloud/src/index.test.ts
+++ b/deployers/cloud/src/index.test.ts
@@ -272,7 +272,8 @@ describe('CloudDeployer', () => {
       expect(entry).toContain('mastra.setLogger');
 
       // Check for storage initialization
-      expect(entry).toContain('mastra.storage.init()');
+      expect(entry).toContain('!userStorage.disableInit');
+      expect(entry).toContain('userStorage.init()');
       expect(entry).toContain('new LibSQLStore');
       expect(entry).toContain('new LibSQLVector');
       // Check for server creation (default: studio disabled)

--- a/deployers/cloud/src/index.ts
+++ b/deployers/cloud/src/index.ts
@@ -160,8 +160,11 @@ if (process.env.MASTRA_STORAGE_URL && process.env.MASTRA_STORAGE_AUTH_TOKEN) {
 
   await storage.init()
   mastra?.setStorage(storage)
-} else if (mastra?.storage) {
-  mastra.storage.init()
+} else {
+  const userStorage = mastra?.getStorage();
+  if (userStorage && !userStorage.disableInit) {
+    userStorage.init();
+  }
 }
 
 if (mastra?.getStorage()) {

--- a/deployers/cloud/src/server-runtime.test.ts
+++ b/deployers/cloud/src/server-runtime.test.ts
@@ -102,9 +102,9 @@ describe('CloudDeployer Server Runtime', () => {
       // @ts-expect-error - accessing private method for testing
       const entry = deployer.getEntry();
 
-      // Check storage initialization
-      expect(entry).toContain('if (mastra?.storage) {');
-      expect(entry).toContain('mastra.storage.init()');
+      // Check storage initialization respects disableInit
+      expect(entry).toContain('!userStorage.disableInit');
+      expect(entry).toContain('userStorage.init()');
 
       // Check LibSQL setup
       expect(entry).toContain('const storage = new LibSQLStore({');
@@ -117,6 +117,11 @@ describe('CloudDeployer Server Runtime', () => {
 
       expect(entry).toContain('await storage.init()');
       expect(entry).toContain('mastra?.setStorage(storage)');
+
+      // Check that user storage respects disableInit
+      expect(entry).toContain('const userStorage = mastra?.getStorage()');
+      expect(entry).toContain('if (userStorage && !userStorage.disableInit)');
+      expect(entry).toContain('userStorage.init()');
     });
 
     it('should create node server with correct configuration', () => {
@@ -194,7 +199,7 @@ describe('CloudDeployer Server Runtime', () => {
 
       // Check optional chaining for mastra
       expect(entry).toContain('mastra?.getLogger()');
-      expect(entry).toContain('mastra?.storage');
+      expect(entry).toContain('mastra?.getStorage()');
       expect(entry).toContain('mastra?.setStorage');
     });
 

--- a/packages/cli/src/commands/build/BuildBundler.ts
+++ b/packages/cli/src/commands/build/BuildBundler.ts
@@ -84,9 +84,11 @@ export class BuildBundler extends Bundler {
     // @ts-expect-error
     await createNodeServer(mastra, { tools: getToolExports(tools), studio: ${this.studio} });
 
-    if (mastra.getStorage()) {
-      // start storage init in the background
-      mastra.getStorage().init();
+    const storage = mastra.getStorage();
+    if (storage) {
+      if (!storage.disableInit) {
+        storage.init();
+      }
       mastra.__registerInternalWorkflow(scoreTracesWorkflow);
     }
     `;


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

When `PostgresStore` is configured with `disableInit: true`, the server still executes CREATE TABLE and ALTER TABLE statements on startup. Both
`BuildBundler.getEntry()` and `CloudDeployer.getEntry()` generate entry point code that unconditionally calls `storage.init()`, bypassing the
`disableInit` flag.

The `augmentWithInit` proxy correctly respects `disableInit` for auto-initialization, but the generated entry points call `.init()` explicitly without
checking `disableInit` first.

**Changes:**
- `BuildBundler.getEntry()` now checks `!storage.disableInit` before calling `storage.init()`
- `CloudDeployer.getEntry()` now checks `!userStorage.disableInit` before calling `userStorage.init()`, and fixes dead code (`mastra.storage` →
`mastra.getStorage()`)

## Before 
<img width="1919" height="840" alt="image" src="https://github.com/user-attachments/assets/4d11c213-5d3c-4d47-99e6-936d19f3171c" />

## After
<img width="1919" height="826" alt="image" src="https://github.com/user-attachments/assets/5e1a1db9-9cc3-49f2-bf82-d305e9f57bd7" />

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #13570

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Respect `disableInit: true` during builds and runtime so storage initialization (e.g., CREATE/ALTER TABLE) is no longer executed when disabled.

* **Tests**
  * Updated tests to assert the revised storage initialization behavior and control flow.

* **Chores**
  * Added a release note entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->