### PR TITLE
feat(harness): Async thread lock release/acquire

### DIFF
--- a/.changeset/sour-timers-hear.md
+++ b/.changeset/sour-timers-hear.md
@@ -1,0 +1,8 @@
+---
+'@mastra/core': patch
+---
+
+Added test coverage for async thread locking in `Harness`.
+
+- Verifies `createThread` waits for a Promise-returning `threadLock.acquire` before releasing the previous thread lock.
+- Verifies `switchThread` does not resolve until a Promise-returning `threadLock.release` completes.

--- a/.changeset/sour-timers-hear.md
+++ b/.changeset/sour-timers-hear.md
@@ -1,8 +1,0 @@
----
-'@mastra/core': patch
----
-
-Added test coverage for async thread locking in `Harness`.
-
-- Verifies `createThread` waits for a Promise-returning `threadLock.acquire` before releasing the previous thread lock.
-- Verifies `switchThread` does not resolve until a Promise-returning `threadLock.release` completes.

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -207,7 +207,7 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
 
     const sortedThreads = [...threads].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
     const mostRecent = sortedThreads[0]!;
-    this.config.threadLock?.acquire(mostRecent.id);
+    await this.config.threadLock?.acquire(mostRecent.id);
     this.currentThreadId = mostRecent.id;
     await this.loadThreadMetadata();
 
@@ -579,11 +579,11 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
     const oldThreadId = this.currentThreadId;
     if (this.config.threadLock) {
       try {
-        this.config.threadLock.acquire(thread.id);
+        await this.config.threadLock.acquire(thread.id);
       } catch (err) {
         if (oldThreadId) {
           try {
-            this.config.threadLock.acquire(oldThreadId);
+            await this.config.threadLock.acquire(oldThreadId);
           } catch {
             // Best-effort re-acquire; original error is more important
           }
@@ -591,7 +591,7 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
         throw err;
       }
       if (oldThreadId) {
-        this.config.threadLock.release(oldThreadId);
+        await this.config.threadLock.release(oldThreadId);
       }
     }
 
@@ -631,11 +631,11 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
     }
 
     // Acquire lock on new thread before releasing old one
-    this.config.threadLock?.acquire(threadId);
+    await this.config.threadLock?.acquire(threadId);
 
     const previousThreadId = this.currentThreadId;
     if (previousThreadId) {
-      this.config.threadLock?.release(previousThreadId);
+      await this.config.threadLock?.release(previousThreadId);
     }
     this.currentThreadId = threadId;
 

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -31,7 +31,7 @@ export interface HeartbeatHandler {
 
 // =============================================================================
 // Harness Configuration
-// =============================================================================
+// ===================
 
 /**
  * Configuration for a single agent mode within the harness.
@@ -209,8 +209,8 @@ export interface HarnessConfig<TState extends HarnessStateSchema = HarnessStateS
    * `acquire` should throw if the lock is held by another process.
    */
   threadLock?: {
-    acquire: (threadId: string) => void;
-    release: (threadId: string) => void;
+    acquire: (threadId: string) => void | Promise<void>;
+    release: (threadId: string) => void | Promise<void>;
   };
 }
 


### PR DESCRIPTION
## Description

Allow harness thread lock release and acquire to be a promise

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thread locking operations now support asynchronous execution, enabling better coordination in async workflows.

* **Tests**
  * Added comprehensive test coverage to verify correct sequencing of async thread lock operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->