### PR TITLE
Dataset lists selection mode update

### DIFF
--- a/.changeset/refactor-item-list-selection.md
+++ b/.changeset/refactor-item-list-selection.md
@@ -2,4 +2,8 @@
 '@mastra/playground-ui': patch
 ---
 
-Refactor ItemList selection pattern across dataset views. Checkbox cells now use a dedicated `LabelCell` component placed outside `RowButton` as a sibling in `ItemList.Row`. Replaced `Badge` with `Chip` in experiments toolbar for consistency. Experiment comparison selection now keeps the first pick and replaces the most recent when selecting a third item.
+Improved dataset selection behavior in Playground UI.
+
+- Improved selection UX in dataset lists with clearer checkbox interaction.
+- Updated the experiments toolbar selection counter styling for consistency.
+- Updated compare selection behavior: when a third item is selected, the earliest selection is kept and the other selection is replaced.

--- a/.changeset/refactor-item-list-selection.md
+++ b/.changeset/refactor-item-list-selection.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Refactor ItemList selection pattern across dataset views. Checkbox cells now use a dedicated `LabelCell` component placed outside `RowButton` as a sibling in `ItemList.Row`. Replaced `Badge` with `Chip` in experiments toolbar for consistency. Experiment comparison selection now keeps the first pick and replaces the most recent when selecting a third item.

--- a/packages/playground-ui/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
@@ -15,7 +15,6 @@ const experimentsListColumns = [
   { name: 'date', label: 'Created', size: '10rem' },
 ];
 
-const experimentsListColumnsWithCheckbox = [{ name: 'checkbox', label: '', size: '2.5rem' }, ...experimentsListColumns];
 
 /**
  * Truncate experiment ID to first 8 characters or until the first dash
@@ -57,7 +56,7 @@ export function DatasetExperimentsList({
   onRowClick,
   onToggleSelection,
 }: DatasetExperimentsListProps) {
-  const columns = isSelectionActive ? experimentsListColumnsWithCheckbox : experimentsListColumns;
+  const columns = experimentsListColumns;
 
   if (experiments.length === 0) {
     return <EmptyDatasetExperimentsList />;
@@ -65,7 +64,7 @@ export function DatasetExperimentsList({
 
   return (
     <ItemList>
-      <ItemList.Header columns={columns}>
+      <ItemList.Header columns={columns} isSelectionActive={isSelectionActive}>
         {columns.map(col => (
           <ItemList.HeaderCol key={col.name}>{col.label}</ItemList.HeaderCol>
         ))}
@@ -80,25 +79,25 @@ export function DatasetExperimentsList({
 
             return (
               <ItemList.Row key={experiment.id} isSelected={isSelected}>
+                {isSelectionActive && (
+                  <ItemList.LabelCell>
+                    <Checkbox
+                      checked={isSelected}
+                      onCheckedChange={() => {}}
+                      onClick={e => {
+                        e.stopPropagation();
+                        onToggleSelection(experiment.id);
+                      }}
+                      aria-label={`Select experiment ${experiment.id}`}
+                    />
+                  </ItemList.LabelCell>
+                )}
                 <ItemList.RowButton
                   item={entry}
                   isFeatured={isSelected}
-                  columns={columns}
+                  columns={experimentsListColumns}
                   onClick={() => onRowClick(experiment.id)}
                 >
-                  {isSelectionActive && (
-                    <div className="flex items-center justify-center" onClick={e => e.stopPropagation()}>
-                      <Checkbox
-                        checked={isSelected}
-                        onCheckedChange={() => {}}
-                        onClick={e => {
-                          e.stopPropagation();
-                          onToggleSelection(experiment.id);
-                        }}
-                        aria-label={`Select experiment ${experiment.id}`}
-                      />
-                    </div>
-                  )}
                   <ItemList.IdCell id={experiment.id} />
                   <ItemList.StatusCell status={status} />
                   <ItemList.TextCell>{experiment.targetType}</ItemList.TextCell>

--- a/packages/playground-ui/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
@@ -82,11 +82,7 @@ export function DatasetExperimentsList({
                   <ItemList.LabelCell>
                     <Checkbox
                       checked={isSelected}
-                      onCheckedChange={() => {}}
-                      onClick={e => {
-                        e.stopPropagation();
-                        onToggleSelection(experiment.id);
-                      }}
+                      onCheckedChange={() => onToggleSelection(experiment.id)}
                       aria-label={`Select experiment ${experiment.id}`}
                     />
                   </ItemList.LabelCell>

--- a/packages/playground-ui/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
@@ -15,7 +15,6 @@ const experimentsListColumns = [
   { name: 'date', label: 'Created', size: '10rem' },
 ];
 
-
 /**
  * Truncate experiment ID to first 8 characters or until the first dash
  */

--- a/packages/playground-ui/src/domains/datasets/components/experiments/dataset-experiments-toolbar.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/experiments/dataset-experiments-toolbar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '@/ds/components/Button';
-import { Badge } from '@/ds/components/Badge';
+import { Chip } from '@/ds/components/Chip';
 import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
 import { SelectField } from '@/ds/components/FormFields';
 import { Icon } from '@/ds/icons/Icon';
@@ -54,7 +54,9 @@ export function DatasetExperimentsToolbar({
       <div className="flex items-center justify-end gap-4 w-full">
         <div className="flex gap-5">
           <div className="text-sm text-neutral3 flex items-center gap-2 pl-6">
-            <Badge className="text-ui-md">{selectedCount}</Badge>
+            <Chip size="large" color={selectedCount < 2 ? 'red' : 'green'}>
+              {selectedCount}
+            </Chip>
             <span>of 2 experiments selected</span>
             <MoveRightIcon />
           </div>

--- a/packages/playground-ui/src/domains/datasets/components/experiments/dataset-experiments.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/experiments/dataset-experiments.tsx
@@ -40,9 +40,9 @@ export function DatasetExperiments({
       if (prev.includes(experimentId)) {
         return prev.filter(id => id !== experimentId);
       }
-      // Only allow selecting 2 experiments max - replace oldest if selecting 3rd
+      // Only allow selecting 2 experiments max - keep oldest, replace most recent
       if (prev.length >= 2) {
-        return [prev[1], experimentId];
+        return [prev[0], experimentId];
       }
       return [...prev, experimentId];
     });

--- a/packages/playground-ui/src/domains/datasets/components/items/dataset-items-list.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/items/dataset-items-list.tsx
@@ -4,7 +4,6 @@ import { EmptyState } from '@/ds/components/EmptyState';
 import { ItemList } from '@/ds/components/ItemList';
 import { Checkbox } from '@/ds/components/Checkbox';
 import { Plus, Upload, FileJson } from 'lucide-react';
-import { isToday } from 'date-fns';
 import { ButtonsGroup } from '@/ds/components/ButtonsGroup';
 
 export interface DatasetItemsListProps {
@@ -72,8 +71,6 @@ export function DatasetItemsList({
   }
 
   const allIds = items.map(i => i.id);
-  const itemsListColumnsWithCheckbox = [{ name: 'checkbox', label: 'c', size: '1.25rem' }, ...columns];
-  const columnsToRender = isSelectionActive ? itemsListColumnsWithCheckbox : columns;
 
   // Select all state
   const selectedCount = selectedIds.size;
@@ -104,23 +101,18 @@ export function DatasetItemsList({
 
   return (
     <ItemList>
-      <ItemList.Header columns={columnsToRender}>
-        {columnsToRender?.map(col => (
-          <>
-            {col.name === 'checkbox' ? (
-              <ItemList.Cell key={col.name}>
-                {!maxSelection && (
-                  <Checkbox
-                    checked={isIndeterminate ? 'indeterminate' : isAllSelected}
-                    onCheckedChange={handleSelectAllToggle}
-                    aria-label="Select all items"
-                  />
-                )}
-              </ItemList.Cell>
-            ) : (
-              <ItemList.HeaderCol key={col.name}>{col.label || col.name}</ItemList.HeaderCol>
-            )}
-          </>
+      <ItemList.Header columns={columns} isSelectionActive={isSelectionActive}>
+        {isSelectionActive && !maxSelection && (
+          <ItemList.LabelCell className="">
+            <Checkbox
+              checked={isIndeterminate ? 'indeterminate' : isAllSelected}
+              onCheckedChange={handleSelectAllToggle}
+              aria-label="Select all items"
+            />
+          </ItemList.LabelCell>
+        )}
+        {columns?.map(col => (
+          <ItemList.HeaderCol key={col.name}>{col.label || col.name}</ItemList.HeaderCol>
         ))}
       </ItemList.Header>
 
@@ -131,21 +123,19 @@ export function DatasetItemsList({
           ) : (
             items.map(item => {
               const createdAtDate = new Date(item.createdAt);
-              const isTodayDate = isToday(createdAtDate);
 
               const listItem = {
                 id: item.id,
                 input: truncateValue(item.input, 60),
                 groundTruth: item.groundTruth ? truncateValue(item.groundTruth, 40) : '-',
                 metadata: item.metadata ? Object.keys(item.metadata).length + ' keys' : '-',
-                // date: isTodayDate ? 'Today' : format(createdAtDate, 'MMM dd'),
                 date: createdAtDate,
               };
 
               return (
                 <ItemList.Row key={item.id} isSelected={selectedIds.has(item.id)}>
                   {isSelectionActive && (
-                    <ItemList.Cell className="w-12 pl-4">
+                    <ItemList.LabelCell>
                       <Checkbox
                         checked={selectedIds.has(item.id)}
                         onCheckedChange={() => {}}
@@ -155,7 +145,7 @@ export function DatasetItemsList({
                         }}
                         aria-label={`Select item ${item.id}`}
                       />
-                    </ItemList.Cell>
+                    </ItemList.LabelCell>
                   )}
                   <ItemList.RowButton
                     item={listItem}

--- a/packages/playground-ui/src/domains/datasets/components/items/dataset-items-toolbar.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/items/dataset-items-toolbar.tsx
@@ -160,7 +160,7 @@ export function DatasetItemsToolbar({
                 >
                   {selectedCount}
                 </Chip>
-                <span>selected items</span>
+                <span>{selectionMode === 'compare-items' ? 'of 2 items selected' : 'items selected'}</span>
                 <MoveRightIcon />
               </div>
             </TooltipTrigger>

--- a/packages/playground-ui/src/domains/datasets/components/items/dataset-versions-panel.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/items/dataset-versions-panel.tsx
@@ -19,7 +19,6 @@ export interface DatasetVersionsPanelProps {
   activeVersion?: number | null;
 }
 
-
 /**
  * Panel showing dataset version history with optional compare selection.
  */

--- a/packages/playground-ui/src/domains/datasets/components/items/dataset-versions-panel.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/items/dataset-versions-panel.tsx
@@ -19,7 +19,6 @@ export interface DatasetVersionsPanelProps {
   activeVersion?: number | null;
 }
 
-const versionsListColumns = [{ name: 'version', label: 'Dataset Version History', size: '1fr' }];
 
 /**
  * Panel showing dataset version history with optional compare selection.
@@ -111,10 +110,8 @@ export function DatasetVersionsPanel({
           <DatasetVersionsListSkeleton />
         ) : (
           <ItemList>
-            <ItemList.Header columns={versionsListColumns}>
-              {versionsListColumns.map(col => (
-                <ItemList.HeaderCol key={col.name}>{col.label}</ItemList.HeaderCol>
-              ))}
+            <ItemList.Header>
+              <ItemList.HeaderCol>Dataset Version History</ItemList.HeaderCol>
             </ItemList.Header>
 
             <ItemList.Scroller>
@@ -130,7 +127,7 @@ export function DatasetVersionsPanel({
                   return (
                     <ItemList.Row key={String(item.version)} isSelected={isSelectionActive && selectedKeys.has(key)}>
                       {isSelectionActive && (
-                        <ItemList.Cell className={cn('w-12 pl-2 ')}>
+                        <ItemList.LabelCell>
                           <Checkbox
                             checked={selectedKeys.has(key)}
                             onCheckedChange={() => {}}
@@ -144,12 +141,12 @@ export function DatasetVersionsPanel({
                                 : `v${item.version}`
                             }`}
                           />
-                        </ItemList.Cell>
+                        </ItemList.LabelCell>
                       )}
                       <ItemList.RowButton
                         item={item}
                         isFeatured={isVersionSelected(item)}
-                        columns={versionsListColumns}
+                        columns={[{ name: 'version', label: 'Dataset Version History', size: '1fr' }]}
                         onClick={() => handleVersionClick(item)}
                         className="py-2"
                       >
@@ -181,16 +178,14 @@ export function DatasetVersionsPanel({
 function DatasetVersionsListSkeleton() {
   return (
     <ItemList>
-      <ItemList.Header columns={versionsListColumns} />
+      <ItemList.Header>
+        <ItemList.HeaderCol>Dataset Version History</ItemList.HeaderCol>
+      </ItemList.Header>
       <ItemList.Items>
         {Array.from({ length: 3 }).map((_, index) => (
           <ItemList.Row key={index}>
-            <ItemList.RowButton columns={versionsListColumns}>
-              {versionsListColumns.map((col, colIndex) => (
-                <ItemList.TextCell key={colIndex} isLoading>
-                  Loading...
-                </ItemList.TextCell>
-              ))}
+            <ItemList.RowButton columns={[{ name: 'version', label: 'Dataset Version History', size: '1fr' }]}>
+              <ItemList.TextCell isLoading>Loading...</ItemList.TextCell>
             </ItemList.RowButton>
           </ItemList.Row>
         ))}

--- a/packages/playground-ui/src/domains/datasets/components/versions/dataset-item-versions-panel.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/versions/dataset-item-versions-panel.tsx
@@ -18,8 +18,6 @@ export interface DatasetItemVersionsPanelProps {
   activeVersion?: number | null;
 }
 
-const versionsListColumns = [{ name: 'version', label: 'Item Version History', size: '1fr' }];
-
 /**
  * Panel showing dataset item version history.
  */
@@ -111,14 +109,8 @@ export function DatasetItemVersionsPanel({
         <DatasetItemVersionsListSkeleton />
       ) : (
         <ItemList>
-          <ItemList.Header columns={versionsListColumns}>
-            {versionsListColumns.map(col =>
-              col.name === 'checkbox' ? (
-                <ItemList.Cell key={col.name}>.</ItemList.Cell>
-              ) : (
-                <ItemList.HeaderCol key={col.name}>{col.label}</ItemList.HeaderCol>
-              ),
-            )}
+          <ItemList.Header>
+            <ItemList.HeaderCol>Item Version History</ItemList.HeaderCol>
           </ItemList.Header>
 
           <ItemList.Scroller>
@@ -133,7 +125,7 @@ export function DatasetItemVersionsPanel({
                     isSelected={isSelectionActive && selectedIds.has(versionKey)}
                   >
                     {isSelectionActive && (
-                      <ItemList.Cell className="w-12 pl-2 ">
+                      <ItemList.LabelCell>
                         <Checkbox
                           checked={selectedIds.has(versionKey)}
                           disabled={item.isDeleted}
@@ -146,11 +138,11 @@ export function DatasetItemVersionsPanel({
                           }}
                           aria-label={`Select version ${item.datasetVersion}`}
                         />
-                      </ItemList.Cell>
+                      </ItemList.LabelCell>
                     )}
                     <ItemList.RowButton
                       item={item}
-                      columns={versionsListColumns}
+                      columns={[{ name: 'version', label: 'Item Version History', size: '1fr' }]}
                       isFeatured={isVersionSelected(item)}
                       onClick={() => handleVersionClick(item)}
                       className="py-2"
@@ -176,16 +168,14 @@ export function DatasetItemVersionsPanel({
 function DatasetItemVersionsListSkeleton() {
   return (
     <ItemList>
-      <ItemList.Header columns={versionsListColumns} />
+      <ItemList.Header columns={[{ name: 'version', label: 'Item Version History', size: '1fr' }]}>
+        <ItemList.HeaderCol>Item Version History</ItemList.HeaderCol>
+      </ItemList.Header>
       <ItemList.Items>
         {Array.from({ length: 3 }).map((_, index) => (
           <ItemList.Row key={index}>
-            <ItemList.RowButton columns={versionsListColumns}>
-              {versionsListColumns.map((col, colIndex) => (
-                <ItemList.TextCell key={colIndex} isLoading>
-                  Loading...
-                </ItemList.TextCell>
-              ))}
+            <ItemList.RowButton columns={[{ name: 'version', label: 'Item Version History', size: '1fr' }]}>
+              <ItemList.TextCell isLoading>Loading...</ItemList.TextCell>
             </ItemList.RowButton>
           </ItemList.Row>
         ))}

--- a/packages/playground-ui/src/ds/components/ItemList/item-list-header-col.tsx
+++ b/packages/playground-ui/src/ds/components/ItemList/item-list-header-col.tsx
@@ -1,8 +1,10 @@
+import { cn } from '@/lib/utils';
+
 export type ItemListHeaderColProps = {
   children?: React.ReactNode;
   className?: string;
 };
 
 export function ItemListHeaderCol({ children, className }: ItemListHeaderColProps) {
-  return <span className={className}>{children}</span>;
+  return <span className={cn('py-3', className)}>{children}</span>;
 }

--- a/packages/playground-ui/src/ds/components/ItemList/item-list-header.tsx
+++ b/packages/playground-ui/src/ds/components/ItemList/item-list-header.tsx
@@ -5,14 +5,17 @@ import { cn } from '@/lib/utils';
 
 export type ItemListHeaderProps = {
   columns?: ItemListColumn[];
+  isSelectionActive?: boolean;
   children?: React.ReactNode;
 };
 
-export function ItemListHeader({ columns, children }: ItemListHeaderProps & { children?: React.ReactNode }) {
+export function ItemListHeader({ columns, isSelectionActive, children }: ItemListHeaderProps) {
   return (
     <div className={cn('sticky top-0 bg-surface3 z-10 rounded-lg px-4 mb-4')}>
       <div
-        className={cn('grid gap-6 text-left items-center uppercase py-3 text-neutral3 tracking-widest text-ui-xs')}
+        className={cn('grid gap-6 text-left items-center uppercase  text-neutral3 tracking-widest text-ui-xs', {
+          'pl-12 [&>label]:absolute [&>label]:left-0': isSelectionActive,
+        })}
         style={{ gridTemplateColumns: getItemListColumnTemplate(columns) }}
       >
         {children}

--- a/packages/playground-ui/src/ds/components/ItemList/item-list-label-cell.tsx
+++ b/packages/playground-ui/src/ds/components/ItemList/item-list-label-cell.tsx
@@ -1,0 +1,14 @@
+import { cn } from '@/lib/utils';
+
+export type ItemListLabelCellProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export function ItemListLabelCell({ children, className }: ItemListLabelCellProps) {
+  return (
+    <label className={cn('flex w-14 h-full justify-center items-center hover:bg-surface5 rounded-lg', className)}>
+      {children}
+    </label>
+  );
+}

--- a/packages/playground-ui/src/ds/components/ItemList/item-list.tsx
+++ b/packages/playground-ui/src/ds/components/ItemList/item-list.tsx
@@ -15,6 +15,7 @@ import { ItemListVersionCell } from './item-list-version-cell';
 import { ItemListIdCell } from './item-list-id-cell';
 import { ItemListDateCell } from './item-list-date-cell';
 import { ItemListLinkCell } from './item-list-link-cell';
+import { ItemListLabelCell } from './item-list-label-cell';
 
 export const ItemList = Object.assign(ItemListRoot, {
   Header: ItemListHeader,
@@ -33,4 +34,5 @@ export const ItemList = Object.assign(ItemListRoot, {
   IdCell: ItemListIdCell,
   DateCell: ItemListDateCell,
   LinkCell: ItemListLinkCell,
+  LabelCell: ItemListLabelCell,
 });


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

Wrap selection Checkbox with <label so selection area extends the checkbox itself

![CleanShot 2026-02-27 at 16 29 30](https://github.com/user-attachments/assets/44fc009c-9ae8-4c36-90be-abcfc1c5fe5c)


## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Improved selection UX with clearer, dedicated checkbox controls in dataset and item lists
  - Compare selection updated to preserve the oldest selection when adding a third item

* **Style**
  - Updated selection counter presentation and toolbar styling for clearer, more consistent visuals
<!-- end of auto-generated comment: release notes by coderabbit.ai -->