### PR TITLE
docs: add toModelOutput guide coverage and multimodal output details

### DIFF
--- a/.changeset/green-ravens-smile.md
+++ b/.changeset/green-ravens-smile.md
@@ -1,0 +1,5 @@
+---
+'mastra-docs': patch
+---
+
+Documented `createTool().toModelOutput` in both reference and guide docs, including multimodal `content` output examples and supported output types.

--- a/.changeset/green-ravens-smile.md
+++ b/.changeset/green-ravens-smile.md
@@ -1,5 +1,0 @@
----
-'mastra-docs': patch
----
-
-Documented `createTool().toModelOutput` in both reference and guide docs, including multimodal `content` output examples and supported output types.

--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -58,7 +58,7 @@ export const weatherTool = createTool({
       location,
       temperature: data.current_condition[0].temp_F,
       condition: data.current_condition[0].weatherDesc[0].value,
-      radarImageUrl: data.current_condition[0].weatherIconUrl[0].value,
+      weatherImageUrl: data.current_condition[0].weatherIconUrl[0].value,
       source: data,
     }
   },
@@ -70,7 +70,7 @@ export const weatherTool = createTool({
           type: 'text',
           text: `${output.location}: ${output.temperature}F and ${output.condition}`,
         },
-        { type: 'image-url', url: output.radarImageUrl },
+        { type: 'image-url', url: output.weatherImageUrl },
       ],
     }
   },

--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -58,7 +58,7 @@ export const weatherTool = createTool({
       location,
       temperature: data.current_condition[0].temp_F,
       condition: data.current_condition[0].weatherDesc[0].value,
-      weatherImageUrl: data.current_condition[0].weatherIconUrl[0].value,
+      weatherIconUrl: data.current_condition[0].weatherIconUrl[0].value,
       source: data,
     }
   },
@@ -70,7 +70,7 @@ export const weatherTool = createTool({
           type: 'text',
           text: `${output.location}: ${output.temperature}F and ${output.condition}`,
         },
-        { type: 'image-url', url: output.weatherImageUrl },
+        { type: 'image-url', url: output.weatherIconUrl },
       ],
     }
   },

--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -43,6 +43,40 @@ export const weatherTool = createTool({
 })
 ```
 
+## Shaping output for the model
+
+Use `toModelOutput` when your tool returns rich structured data for your application, but you want the model to receive a smaller or multimodal representation. This keeps model context focused while preserving the full tool result in your app.
+
+```typescript title="src/mastra/tools/weather-tool.ts"
+export const weatherTool = createTool({
+  // ...other config
+  execute: async ({ location }) => {
+    const response = await fetch(`https://wttr.in/${location}?format=j1`)
+    const data = await response.json()
+
+    return {
+      location,
+      temperature: data.current_condition[0].temp_F,
+      condition: data.current_condition[0].weatherDesc[0].value,
+      radarImageUrl: data.current_condition[0].weatherIconUrl[0].value,
+      source: data,
+    }
+  },
+  toModelOutput: output => {
+    return {
+      type: 'content',
+      value: [
+        {
+          type: 'text',
+          text: `${output.location}: ${output.temperature}F and ${output.condition}`,
+        },
+        { type: 'image-url', url: output.radarImageUrl },
+      ],
+    }
+  },
+})
+```
+
 ## Adding tools to an agent
 
 To make a tool available to an agent, add it to `tools`. Mentioning available tools and their general purpose in the agent's system prompt helps the agent decide when to call a tool and when not to.

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -34,6 +34,52 @@ export const tool = createTool({
 })
 ```
 
+## Example with `toModelOutput`
+
+Use `toModelOutput` when your tool should return rich internal data to your app, but the model should receive either a simplified value or multimodal content.
+
+```typescript title="src/mastra/tools/weather-tool.ts"
+import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+
+export const weatherTool = createTool({
+  id: 'get-weather',
+  description: 'Get weather for a city',
+  inputSchema: z.object({
+    city: z.string(),
+  }),
+  outputSchema: z.object({
+    city: z.string(),
+    temperature: z.number(),
+    condition: z.string(),
+    radarImageUrl: z.string().url(),
+  }),
+  execute: async ({ city }) => ({
+    city,
+    temperature: 72,
+    condition: 'sunny',
+    radarImageUrl: 'https://example.com/radar/seattle.png',
+  }),
+  toModelOutput: output => {
+    return {
+      type: 'content',
+      value: [
+        { type: 'text', text: `${output.city}: ${output.temperature}F and ${output.condition}` },
+        { type: 'image-url', url: output.radarImageUrl },
+      ],
+    }
+  },
+})
+```
+
+The tool still returns the full `execute` result to your application, while the model receives the transformed `toModelOutput` value.
+
+`toModelOutput` can return:
+
+- `type: 'text'`
+- `type: 'json'`
+- `type: 'content'` with parts like `text`, `image-url`, `image-data`, `file-url`, `file-data`, `file-id`, `image-file-id`, or `custom`
+
 ## Example with MCP Annotations
 
 When exposing tools via MCP (Model Context Protocol), you can add annotations to describe tool behavior and customize how clients display the tool. These MCP-specific properties are grouped under the `mcp` property:
@@ -100,6 +146,13 @@ name: "outputSchema",
 type: "Zod schema",
 description:
 "A Zod schema defining the expected output structure of the tool's `execute` function.",
+isOptional: true,
+},
+{
+name: "toModelOutput",
+type: "(output: TSchemaOut) => ToolResultOutput",
+description:
+"Optional function that transforms the tool's `execute` output before it is sent back to the model. Use this to return `text`, `json`, or `content` (including multimodal parts like images/files) to the model while still keeping the full raw output in your application code.",
 isOptional: true,
 },
 {

--- a/docs/src/content/en/reference/tools/create-tool.mdx
+++ b/docs/src/content/en/reference/tools/create-tool.mdx
@@ -150,9 +150,9 @@ isOptional: true,
 },
 {
 name: "toModelOutput",
-type: "(output: TSchemaOut) => ToolResultOutput",
+type: "(output: TSchemaOut) => unknown",
 description:
-"Optional function that transforms the tool's `execute` output before it is sent back to the model. Use this to return `text`, `json`, or `content` (including multimodal parts like images/files) to the model while still keeping the full raw output in your application code.",
+"Optional function that transforms the tool's `execute` output before it is sent back to the model. Use this to return `text`, `json`, or `content`-shaped outputs (including multimodal parts like images/files) to the model while still keeping the full raw output in your application code.",
 isOptional: true,
 },
 {


### PR DESCRIPTION
Added docs updates for createTool toModelOutput in both reference and agents docs so it is clearer when to use it for compact model-facing output versus full app output. I also clarified the supported output shapes and added a multimodal content example.

After example:

```ts
toModelOutput: output => ({
  type: 'content',
  value: [
    { type: 'text', text: `${output.location}: ${output.temperature}F and ${output.condition}` },
    { type: 'image-url', url: output.radarImageUrl },
  ],
})
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools can now format outputs specifically for the AI model, enabling better handling of rich, multimodal content (text and images) while keeping full output accessible in your application.

* **Documentation**
  * Added comprehensive examples demonstrating how to shape tool outputs for model consumption, featuring a weather tool sample implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->