### PR TITLE
fix(mcp): preserve tool output fields when output schema doesn't match

### DIFF
--- a/.changeset/solid-wasps-listen.md
+++ b/.changeset/solid-wasps-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed MCP tool results being silently stripped to empty objects (`{}`) when the server's output schema doesn't exactly match the returned data. Zod's default behavior removes unknown keys during validation, which caused tools (especially FastMCP servers) to return `{}` instead of the full result. Output schemas now preserve all fields returned by the MCP server.

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -284,6 +284,132 @@ describe('MastraMCPClient - outputSchema without structuredContent', () => {
   });
 });
 
+describe('MastraMCPClient - outputSchema Zod stripping', () => {
+  // Reproduces the bug where the Zod output schema converted from the MCP tool's
+  // JSON Schema strips unknown keys from the result. This happens because Zod's
+  // default mode is "strip" which silently removes unknown keys.
+  //
+  // Example: FastMCP server returns structuredContent with fields like
+  // { success, events, count, message, tool } but the outputSchema only defines
+  // { events, count } — Zod strips success, message, and tool.
+  //
+  // Worse case: outputSchema is { type: "object" } with no properties, which
+  // produces z.object({}) and strips ALL keys, returning {}.
+  let testServer: {
+    httpServer: HttpServer;
+    mcpServer: McpServer;
+    serverTransport: StreamableHTTPServerTransport;
+    baseUrl: URL;
+  };
+  let client: InternalMastraMCPClient;
+
+  beforeEach(async () => {
+    testServer = await setupTestServer(false);
+    client = new InternalMastraMCPClient({
+      name: 'zod-stripping-test-client',
+      server: { url: testServer.baseUrl },
+    });
+    await client.connect();
+  });
+
+  afterEach(async () => {
+    await client?.disconnect().catch(() => {});
+    await testServer?.mcpServer.close().catch(() => {});
+    await testServer?.serverTransport.close().catch(() => {});
+    testServer?.httpServer.close();
+  });
+
+  it('should not strip extra fields from structuredContent when outputSchema has fewer properties', async () => {
+    const sdkClient = (client as any).client as Client;
+
+    // outputSchema only defines "count" and "events", but the server returns
+    // additional fields like "success", "message", and "tool"
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'calendar_search',
+          description: 'Search calendar events',
+          inputSchema: {
+            type: 'object' as const,
+            properties: {
+              startdate: { type: 'string' },
+              enddate: { type: 'string' },
+            },
+          },
+          outputSchema: {
+            type: 'object' as const,
+            properties: {
+              count: { type: 'number' },
+              events: { type: 'array', items: { type: 'object' } },
+            },
+          },
+        },
+      ],
+    });
+
+    const fullResult = {
+      success: true,
+      events: [{ id: 1, title: 'Meeting' }],
+      count: 1,
+      message: 'Found 1 calendar event(s)',
+      tool: 'microsoft_calendar_search',
+    };
+
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
+      structuredContent: fullResult,
+      content: [{ type: 'text', text: JSON.stringify(fullResult) }],
+      isError: false,
+    });
+
+    const tools = await client.tools();
+    const tool = tools['calendar_search'];
+    const result = await tool.execute?.({
+      startdate: '2026-02-27T00:00:00Z',
+      enddate: '2026-02-27T23:59:59Z',
+    });
+
+    // All fields should be preserved, including those not in the outputSchema
+    expect(result).toEqual(fullResult);
+  });
+
+  it('should not return {} when outputSchema is a generic object with no properties', async () => {
+    const sdkClient = (client as any).client as Client;
+
+    // outputSchema is just { type: "object" } with no properties defined
+    // This converts to z.object({}) which strips ALL keys by default
+    vi.spyOn(sdkClient, 'listTools').mockResolvedValue({
+      tools: [
+        {
+          name: 'generic_tool',
+          description: 'A tool with generic output',
+          inputSchema: {
+            type: 'object' as const,
+            properties: { query: { type: 'string' } },
+          },
+          outputSchema: {
+            type: 'object' as const,
+          },
+        },
+      ],
+    });
+
+    const fullResult = { data: 'hello', count: 42 };
+
+    vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
+      structuredContent: fullResult,
+      content: [{ type: 'text', text: JSON.stringify(fullResult) }],
+      isError: false,
+    });
+
+    const tools = await client.tools();
+    const tool = tools['generic_tool'];
+    const result = await tool.execute?.({ query: 'test' });
+
+    // Should return the full result, not {}
+    expect(result).toEqual(fullResult);
+  });
+});
+
 describe('MastraMCPClient - Elicitation Tests', () => {
   let testServer: {
     httpServer: HttpServer;

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -692,6 +692,32 @@ export class InternalMastraMCPClient extends MastraBase {
     }
   }
 
+  /**
+   * Recursively applies `.passthrough()` to all ZodObject schemas so that
+   * unknown keys returned by an MCP server are preserved instead of being
+   * silently stripped by Zod's default "strip" mode.
+   */
+  private applyPassthrough(schema: z.ZodType): z.ZodType {
+    if (schema instanceof z.ZodObject) {
+      const shape = schema.shape;
+      const newShape: Record<string, z.ZodType> = {};
+      for (const key of Object.keys(shape)) {
+        newShape[key] = this.applyPassthrough(shape[key]);
+      }
+      return z.object(newShape).passthrough();
+    }
+    if (schema instanceof z.ZodArray) {
+      return z.array(this.applyPassthrough(schema.element));
+    }
+    if (schema instanceof z.ZodOptional) {
+      return this.applyPassthrough(schema.unwrap()).optional();
+    }
+    if (schema instanceof z.ZodNullable) {
+      return this.applyPassthrough(schema.unwrap()).nullable();
+    }
+    return schema;
+  }
+
   private async convertOutputSchema(
     outputSchema: Awaited<ReturnType<Client['listTools']>>['tools'][0]['outputSchema'] | JSONSchema,
   ): Promise<z.ZodType | undefined> {
@@ -703,12 +729,16 @@ export class InternalMastraMCPClient extends MastraBase {
     try {
       await $RefParser.dereference(outputSchema);
       const jsonSchemaToConvert = ('jsonSchema' in outputSchema ? outputSchema.jsonSchema : outputSchema) as JSONSchema;
+      let zodSchema: z.ZodType;
       if ('toJSONSchema' in z) {
         //@ts-expect-error - zod type issue
-        return convertJsonSchemaToZod(jsonSchemaToConvert);
+        zodSchema = convertJsonSchemaToZod(jsonSchemaToConvert);
       } else {
-        return convertJsonSchemaToZodV3(jsonSchemaToConvert);
+        zodSchema = convertJsonSchemaToZodV3(jsonSchemaToConvert);
       }
+      // Apply passthrough to all ZodObject schemas so that extra fields
+      // returned by the MCP server are not silently stripped by Zod.
+      return this.applyPassthrough(zodSchema);
     } catch (error: unknown) {
       let errorDetails: string | undefined;
       if (error instanceof Error) {


### PR DESCRIPTION
## Description

Fixed MCP tool results being silently stripped to empty objects (`{}`) when the server's output schema doesn't exactly match the returned data. 

### Root Cause
When converting an MCP tool's JSON Schema `outputSchema` to a Zod schema, the converter produces a schema with Zod's default "strip" mode enabled. This silently removes any keys not explicitly defined in the schema during validation, causing:
- Generic schemas like `{type: "object"}` (no properties) to strip ALL keys → returns `{}`
- Partial schemas to strip fields returned by the server but not in the schema definition
- Nested objects (array items of `{type: "object"}`) to have all properties stripped

This especially affects FastMCP servers and other non-SDK MCP implementations that return `structuredContent` with fields beyond what their declared `outputSchema` specifies.

### Solution
Added `applyPassthrough()` method that recursively applies `.passthrough()` to all `ZodObject` schemas in the converted output schema tree. This preserves unknown keys at every nesting level while still validating known properties.

### Validation
- All 39 existing MCP client tests pass
- 2 new unit tests verify the fix for both scenarios (extra fields and generic schemas)
- Integration tested with a simulated FastMCP server returning data with undeclared fields

## Related Issue(s)

Fixes issue where MCP tools return empty `{}` in Mastra v1 when using FastMCP servers with generic outputSchemas.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MCP tool results being stripped to empty objects when server output didn't exactly match the defined schema. Tool responses now preserve all returned fields.

* **Tests**
  * Added test coverage validating output schema field preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->