### PR TITLE
fix(client-js): add missing JSON-RPC 2.0 envelope to A2A client requests

### DIFF
--- a/client-sdks/client-js/src/resources/a2a.ts
+++ b/client-sdks/client-js/src/resources/a2a.ts
@@ -38,6 +38,8 @@ export class A2A extends BaseResource {
     const response = await this.request<SendMessageResponse>(`/a2a/${this.agentId}`, {
       method: 'POST',
       body: {
+        jsonrpc: '2.0',
+        id: crypto.randomUUID(),
         method: 'message/send',
         params,
       },
@@ -56,6 +58,8 @@ export class A2A extends BaseResource {
     const response = await this.request<AsyncIterable<SendStreamingMessageResponse>>(`/a2a/${this.agentId}`, {
       method: 'POST',
       body: {
+        jsonrpc: '2.0',
+        id: crypto.randomUUID(),
         method: 'message/stream',
         params,
       },
@@ -74,6 +78,8 @@ export class A2A extends BaseResource {
     const response = await this.request<GetTaskResponse>(`/a2a/${this.agentId}`, {
       method: 'POST',
       body: {
+        jsonrpc: '2.0',
+        id: crypto.randomUUID(),
         method: 'tasks/get',
         params,
       },
@@ -91,6 +97,8 @@ export class A2A extends BaseResource {
     return this.request(`/a2a/${this.agentId}`, {
       method: 'POST',
       body: {
+        jsonrpc: '2.0',
+        id: crypto.randomUUID(),
         method: 'tasks/cancel',
         params,
       },


### PR DESCRIPTION
## Description

The A2A client was sending requests without the required `jsonrpc: '2.0'` and `id` fields, causing validation errors. Added the JSON-RPC 2.0 envelope to all four A2A methods to comply with the server's schema validation.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * A2A messaging requests now include JSON-RPC 2.0 standard fields for enhanced protocol compliance.

* **Tests**
  * Added validation test to verify JSON-RPC 2.0 request structure in A2A messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->