### PR TITLE
fix(core): avoid invalid items on typeless tool schema for Gemini

### DIFF
--- a/.changeset/tough-numbers-cut.md
+++ b/.changeset/tough-numbers-cut.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent-as-tool schema normalization for Gemini by removing invalid items metadata on typeless properties.

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
@@ -1,3 +1,4 @@
+import { jsonSchema } from '@internal/ai-sdk-v5';
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
 import { createTool } from '../../../../tools/tool';
@@ -394,15 +395,45 @@ describe('prepareToolsAndToolChoice', () => {
           hasTypeKey || hasRef || hasAnyOf || hasOneOf || hasAllOf,
           `Property '${propName}' in agent tool schema must have a 'type', '$ref', 'anyOf', 'oneOf', or 'allOf' key. Got: ${JSON.stringify(schema)}`,
         ).toBe(true);
-
-        // OpenAI requires 'items' when 'array' is in the type union
-        if (Array.isArray(schema.type) && schema.type.includes('array')) {
-          expect(
-            schema.items,
-            `Property '${propName}' includes 'array' in type but is missing 'items'. OpenAI requires 'items' for array types. Got: ${JSON.stringify(schema)}`,
-          ).toBeDefined();
-        }
       }
+
+      const resumeDataSchema = properties.resumeData as Record<string, any>;
+      expect(Array.isArray(resumeDataSchema.type)).toBe(true);
+      expect(resumeDataSchema.type).not.toContain('array');
+      expect(resumeDataSchema.items).toBeUndefined();
+    });
+
+    it('should drop items for typeless properties when applying non-array fallback type', () => {
+      const toolWithTypelessItems = {
+        description: 'A tool with a typeless schema property that incorrectly includes items',
+        parameters: jsonSchema({
+          type: 'object',
+          properties: {
+            resumeData: {
+              description: 'Typeless schema with items that Gemini rejects',
+              items: {
+                type: 'string',
+              },
+            },
+          },
+        }),
+        execute: async () => 'ok',
+      };
+
+      const result = prepareToolsAndToolChoice({
+        tools: { testTool: toolWithTypelessItems as any },
+        toolChoice: undefined,
+        activeTools: undefined,
+        targetVersion: 'v2',
+      });
+
+      const toolDef = result.tools![0] as { type: string; inputSchema: Record<string, any> };
+      expect(toolDef.type).toBe('function');
+
+      const resumeDataSchema = toolDef.inputSchema.properties.resumeData as Record<string, any>;
+      expect(Array.isArray(resumeDataSchema.type)).toBe(true);
+      expect(resumeDataSchema.type).not.toContain('array');
+      expect(resumeDataSchema.items).toBeUndefined();
     });
   });
 

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
@@ -71,10 +71,18 @@ function fixTypelessProperties(schema: Record<string, unknown>): Record<string, 
         const hasAllOf = 'allOf' in propSchema;
 
         if (!hasType && !hasRef && !hasAnyOf && !hasOneOf && !hasAllOf) {
-          return [
-            key,
-            { ...propSchema, type: ['string', 'number', 'integer', 'boolean', 'object', 'array', 'null'], items: {} },
-          ];
+          // Keep this typeless fallback Gemini-safe: Google rejects `items` unless type is strictly ARRAY.
+          // We intentionally omit `array` here because this path is primarily for z.any()-style fields
+          // (e.g. resumeData) that serialize without type information.
+          const fallbackSchema = {
+            ...propSchema,
+            type: ['string', 'number', 'integer', 'boolean', 'object', 'null'],
+          } as Record<string, unknown>;
+
+          // If we just assigned a non-array type, `items` is always invalid for Gemini.
+          delete fallbackSchema.items;
+
+          return [key, fallbackSchema];
         }
         // Recurse into nested object schemas
         return [key, fixTypelessProperties(propSchema)];


### PR DESCRIPTION
This fixes agent-as-tool schema normalization when a typeless property (like `resumeData` from `z.any()`) carries `items`, which Gemini rejects unless the schema type is strictly array.

Before:
```ts
resumeData: {
  description: '...',
  items: { type: 'string' },
}
// fallback then sets a non-array type union, leaving invalid `items`
```

After:
```ts
resumeData: {
  description: '...',
  type: ['string', 'number', 'integer', 'boolean', 'object', 'null'],
}
// `items` is removed for this non-array fallback path
```

I also added a regression test that passes a JSON-schema tool parameter through `prepareToolsAndToolChoice` and verifies `items` is dropped in this case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini compatibility by fixing schema normalization for typeless agent-tool properties (removes invalid items metadata).

* **New Features**
  * Robust model initialization for the embedding provider with per-model caching and retry-on-failure.

* **Tests**
  * Added/updated tests for typeless property handling, agent v1/v2 behavior, and embedding initialization/retry and concurrency.

* **Chores**
  * Observability traces and test payloads include a suspendedToolRunId; added test config and updated playground mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->