### PR TITLE
docs(course): fix missing Zapier MCP authentication in course chapters

### DIFF
--- a/docs/src/course/02-agent-tools-mcp/07-what-is-zapier-mcp.md
+++ b/docs/src/course/02-agent-tools-mcp/07-what-is-zapier-mcp.md
@@ -1,6 +1,6 @@
 # Adding the Zapier MCP Server
 
-In this step, we'll add the Zapier MCP server to our agent, which will give it access to email, social media, and many other integrations available through Zapier.
+In this step, you'll add the Zapier MCP server to your agent, giving it access to email, social media, and many other integrations available through Zapier.
 
 ## What is Zapier MCP?
 
@@ -12,3 +12,12 @@ Zapier MCP is a server that provides access to thousands of apps and services th
 - And many more
 
 By integrating the Zapier MCP server with your Mastra agent, you can give it access to all these services without having to write custom tool functions for each one. This significantly expands your agent's capabilities and makes it more useful for a wide range of tasks.
+
+## Authentication
+
+Zapier MCP requires authentication to connect. You will need two things from Zapier:
+
+1. **MCP Server URL**: The endpoint your agent connects to
+2. **API Key**: A secret key sent with every request to prove your identity
+
+The next step walks through getting both of these from the Zapier dashboard.

--- a/docs/src/course/02-agent-tools-mcp/08-getting-zapier-mcp-url.md
+++ b/docs/src/course/02-agent-tools-mcp/08-getting-zapier-mcp-url.md
@@ -1,16 +1,46 @@
-# Getting a Zapier MCP URL
+# Getting Your Zapier MCP URL and API Key
 
-First, you'll need to get a Zapier MCP URL. This typically requires:
+To connect your Mastra agent to Zapier MCP, you need a **Server URL** and an **API Key**. Follow these steps to get both from the Zapier dashboard.
 
-1. Creating a Zapier account if you don't have one
-2. Setting up the Zapier MCP integration by adding some tools (we will use Gmail in this example)
-3. Getting your unique MCP URL
+## Step 1: Create a Zapier Account
 
-For this example, we'll use an environment variable to store the URL:
+If you don't have a Zapier account, sign up at [zapier.com](https://zapier.com). Zapier MCP is included in your existing Zapier plan.
+
+## Step 2: Create a New MCP Server
+
+1. Go to [mcp.zapier.com](https://mcp.zapier.com)
+2. Select **+ New MCP Server**
+3. When asked to choose a client, select **OpenAI API**: This provides API Key authentication, which works well with custom MCP clients like Mastra
+4. Give your server a name (or keep the default) and select **Create MCP Server**
+
+## Step 3: Add Tools to Your Server
+
+After creating the server, you'll be taken to the server dashboard where you can add actions:
+
+1. Type an app name (e.g., "Gmail") in the search bar
+2. Select the actions you want (e.g., "Find Email", "Send Email")
+3. When prompted, connect your Gmail (or other app) account by signing in
+4. Repeat for any other apps you want your agent to use
+
+## Step 4: Get Your URL and API Key
+
+1. Select the **Connect** tab at the top of your MCP server dashboard
+2. You will see two pieces of information:
+   - **MCP Server URL**: `https://mcp.zapier.com/api/v1/connect`
+   - **API Key**: A long string of characters (select **Rotate token** to generate one if you don't have one yet)
+
+**Important:** Copy your API key immediately when it is shown. Zapier only displays it once. If you lose it, generate a new one by selecting **Rotate token**.
+
+## Step 5: Add to Your Environment Variables
+
+Add both values to your `.env` file:
 
 ```bash
-# Add this to your .env file
-ZAPIER_MCP_URL=https://your-zapier-mcp-url.zapier.app
+# Add these to your .env file
+ZAPIER_MCP_URL=https://mcp.zapier.com/api/v1/connect
+ZAPIER_MCP_API_KEY=your-api-key-here
 ```
 
-Using an environment variable is a good practice for storing sensitive information like API URLs. It keeps the URL out of your code, making it easier to manage and more secure. It also allows you to use different URLs for different environments (development, staging, production) without changing your code.
+Replace `your-api-key-here` with the API key you copied from the Zapier dashboard.
+
+Using environment variables keeps your credentials out of your source code. Never commit your `.env` file to version control. Ensure `.env` is listed in your `.gitignore` file.

--- a/docs/src/course/02-agent-tools-mcp/08-getting-zapier-mcp-url.md
+++ b/docs/src/course/02-agent-tools-mcp/08-getting-zapier-mcp-url.md
@@ -1,37 +1,14 @@
-# Getting Your Zapier MCP URL and API Key
+# Getting a Zapier MCP URL and API key
 
-To connect your Mastra agent to Zapier MCP, you need a **Server URL** and an **API Key**. Follow these steps to get both from the Zapier dashboard.
+First, you'll need to get a Zapier MCP URL and API key. This requires:
 
-## Step 1: Create a Zapier Account
-
-If you don't have a Zapier account, sign up at [zapier.com](https://zapier.com). Zapier MCP is included in your existing Zapier plan.
-
-## Step 2: Create a New MCP Server
-
-1. Go to [mcp.zapier.com](https://mcp.zapier.com)
-2. Select **+ New MCP Server**
-3. When asked to choose a client, select **OpenAI API**: This provides API Key authentication, which works well with custom MCP clients like Mastra
-4. Give your server a name (or keep the default) and select **Create MCP Server**
-
-## Step 3: Add Tools to Your Server
-
-After creating the server, you'll be taken to the server dashboard where you can add actions:
-
-1. Type an app name (e.g., "Gmail") in the search bar
-2. Select the actions you want (e.g., "Find Email", "Send Email")
-3. When prompted, connect your Gmail (or other app) account by signing in
-4. Repeat for any other apps you want your agent to use
-
-## Step 4: Get Your URL and API Key
-
-1. Select the **Connect** tab at the top of your MCP server dashboard
-2. You will see two pieces of information:
-   - **MCP Server URL**: `https://mcp.zapier.com/api/v1/connect`
-   - **API Key**: A long string of characters (select **Rotate token** to generate one if you don't have one yet)
+1. Creating a Zapier account at [zapier.com](https://zapier.com) if you don't have one
+2. Going to [mcp.zapier.com](https://mcp.zapier.com) and selecting **+ New MCP Server**
+3. Choosing **OpenAI API** as the client type: This provides API Key authentication, which works well with custom MCP clients like Mastra
+4. Adding tools to your server (e.g., search for "Gmail" and add "Find Email" and "Send Email")
+5. Selecting the **Connect** tab to find your **MCP Server URL** and **API Key** (select **Rotate token** to generate one if needed)
 
 **Important:** Copy your API key immediately when it is shown. Zapier only displays it once. If you lose it, generate a new one by selecting **Rotate token**.
-
-## Step 5: Add to Your Environment Variables
 
 Add both values to your `.env` file:
 
@@ -41,6 +18,4 @@ ZAPIER_MCP_URL=https://mcp.zapier.com/api/v1/connect
 ZAPIER_MCP_API_KEY=your-api-key-here
 ```
 
-Replace `your-api-key-here` with the API key you copied from the Zapier dashboard.
-
-Using environment variables keeps your credentials out of your source code. Never commit your `.env` file to version control. Ensure `.env` is listed in your `.gitignore` file.
+Using environment variables keeps your credentials out of your source code. Ensure `.env` is listed in your `.gitignore` file.

--- a/docs/src/course/02-agent-tools-mcp/09-updating-mcp-config-zapier.md
+++ b/docs/src/course/02-agent-tools-mcp/09-updating-mcp-config-zapier.md
@@ -7,11 +7,23 @@ const mcp = new MCPClient({
   servers: {
     zapier: {
       url: new URL(process.env.ZAPIER_MCP_URL || ''),
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${process.env.ZAPIER_MCP_API_KEY}`,
+        },
+      },
     },
   },
 })
 ```
 
-This configuration tells your agent how to connect to the Zapier MCP server. The `zapier` key is a unique identifier for this server in your configuration, and the `url` property specifies the URL of the Zapier MCP server.
+This configuration tells your agent how to connect to the Zapier MCP server. Here is what each part does:
+
+- **`zapier`**: A unique identifier for this server in your configuration
+- **`url`**: The Zapier MCP server endpoint, read from your `.env` file
+- **`requestInit.headers`**: HTTP headers sent with every request to the server
+- **`Authorization: Bearer ...`**: Your API key, sent as a Bearer token to authenticate with Zapier
 
 The `new URL()` constructor creates a URL object from the string provided by the environment variable. The `|| ""` part provides a default empty string in case the environment variable is not set, which prevents your application from crashing if the environment variable is missing.
+
+The `requestInit` option lets you customize HTTP requests to the MCP server. Zapier requires an `Authorization` header with your API key in `Bearer {apiKey}` format to verify your identity on every request.

--- a/docs/src/course/02-agent-tools-mcp/12-troubleshooting-zapier.md
+++ b/docs/src/course/02-agent-tools-mcp/12-troubleshooting-zapier.md
@@ -1,62 +1,19 @@
 # Troubleshooting
 
-If your agent can't access the Zapier tools, here are the most common issues and how to fix them.
+If your agent can't access the Zapier tools, check:
 
-## 401 Unauthorized / "Missing OAuth authorization header"
+1. That your `.env` file has both `ZAPIER_MCP_URL` and `ZAPIER_MCP_API_KEY` set
+2. That your MCP config includes `requestInit.headers` with the `Authorization: Bearer` header
+3. That you've added actions to your Zapier MCP server at [mcp.zapier.com](https://mcp.zapier.com)
+4. That the tools are properly loaded by checking the Tools tab in the playground
 
-This means your request is missing authentication. Check:
+Common issues include:
 
-1. **Your `.env` file has both variables set:**
+- **401 "Missing OAuth authorization header"**: Your config is missing the `requestInit.headers` block. Zapier MCP requires an `Authorization` header on every request.
+- **401 "Invalid OAuth token"**: Your API key is incorrect or expired. Copy it again from the Zapier MCP dashboard (**Connect** tab), or select **Rotate token** to generate a new one.
+- **No tools besides `zapier_get_configuration_url`**: You haven't added actions (e.g., Gmail) to your MCP server on the Zapier dashboard, or you haven't connected your app accounts.
+- **Environment variables not loading**: Restart your development server after changing `.env` values. Environment variables are read at startup.
 
-   ```bash
-   ZAPIER_MCP_URL=https://mcp.zapier.com/api/v1/connect
-   ZAPIER_MCP_API_KEY=your-actual-api-key
-   ```
-
-2. **Your MCP config includes `requestInit.headers`:**
-
-   ```typescript
-   const mcp = new MCPClient({
-     servers: {
-       zapier: {
-         url: new URL(process.env.ZAPIER_MCP_URL || ''),
-         requestInit: {
-           headers: {
-             Authorization: `Bearer ${process.env.ZAPIER_MCP_API_KEY}`,
-           },
-         },
-       },
-     },
-   })
-   ```
-
-   A common mistake is configuring only the `url` without the `requestInit.headers`. Zapier MCP requires an `Authorization` header on every request.
-
-3. **Restart your development server** after changing `.env` values. Environment variables are read at startup, so changes won't take effect until you restart with `npm run dev`.
-
-## 401 "Invalid OAuth token - please re-authenticate"
-
-This means an `Authorization` header is being sent, but the token is invalid. Check:
-
-1. **Your API key is correct**: Copy it again from the Zapier MCP dashboard (**Connect** tab). If you can't see it, select **Rotate token** to generate a new one and update your `.env` file.
-2. **No extra spaces or quotes** around the API key value in your `.env` file.
-3. **The URL matches**: Ensure you're using `https://mcp.zapier.com/api/v1/connect` (not a different URL from a different server type).
-
-## No tools showing up
-
-If the connection succeeds but you don't see any tools besides `zapier_get_configuration_url`:
-
-1. Go back to [mcp.zapier.com](https://mcp.zapier.com) and open your MCP server
-2. Ensure you've added actions (e.g., Gmail → Find Email, Send Email)
-3. Ensure you've connected your app accounts (e.g., signed into Gmail)
-4. Restart your development server
-
-## Other common issues
-
-- **Network connectivity problems**: Ensure you can reach `mcp.zapier.com` from your machine.
-- **Outdated packages**: Run `npm update @mastra/mcp` to get the latest version.
-- **Environment variable not loaded**: Ensure your `.env` file is in the project root (same directory as `package.json`).
-
-If you're still having trouble, check the terminal output when running `npm run dev` for error messages. The MCPClient logs connection errors with details about what went wrong.
+If you're having trouble, check the terminal output when running `npm run dev` for error messages. The MCPClient logs connection errors with details about what went wrong.
 
 In the next step, you'll add the GitHub MCP server to give your agent the ability to monitor and interact with GitHub repositories.

--- a/docs/src/course/02-agent-tools-mcp/12-troubleshooting-zapier.md
+++ b/docs/src/course/02-agent-tools-mcp/12-troubleshooting-zapier.md
@@ -1,17 +1,62 @@
 # Troubleshooting
 
-If your agent can't access the Zapier tools, check:
+If your agent can't access the Zapier tools, here are the most common issues and how to fix them.
 
-1. That your Zapier MCP URL is correct in your environment variables
-2. That you've properly set up the Zapier MCP integration
-3. That the tools are properly loaded by checking the Tools tab in the playground
+## 401 Unauthorized / "Missing OAuth authorization header"
 
-Common issues include:
+This means your request is missing authentication. Check:
 
-- Incorrect or missing environment variables
-- Network connectivity problems
-- Authentication issues with the Zapier MCP server
+1. **Your `.env` file has both variables set:**
 
-If you're having trouble, try restarting your development server after making changes to your environment variables or configuration. This ensures that the changes are properly loaded.
+   ```bash
+   ZAPIER_MCP_URL=https://mcp.zapier.com/api/v1/connect
+   ZAPIER_MCP_API_KEY=your-actual-api-key
+   ```
 
-In the next step, we'll add the GitHub MCP server to give your agent the ability to monitor and interact with GitHub repositories.
+2. **Your MCP config includes `requestInit.headers`:**
+
+   ```typescript
+   const mcp = new MCPClient({
+     servers: {
+       zapier: {
+         url: new URL(process.env.ZAPIER_MCP_URL || ''),
+         requestInit: {
+           headers: {
+             Authorization: `Bearer ${process.env.ZAPIER_MCP_API_KEY}`,
+           },
+         },
+       },
+     },
+   })
+   ```
+
+   A common mistake is configuring only the `url` without the `requestInit.headers`. Zapier MCP requires an `Authorization` header on every request.
+
+3. **Restart your development server** after changing `.env` values. Environment variables are read at startup, so changes won't take effect until you restart with `npm run dev`.
+
+## 401 "Invalid OAuth token - please re-authenticate"
+
+This means an `Authorization` header is being sent, but the token is invalid. Check:
+
+1. **Your API key is correct**: Copy it again from the Zapier MCP dashboard (**Connect** tab). If you can't see it, select **Rotate token** to generate a new one and update your `.env` file.
+2. **No extra spaces or quotes** around the API key value in your `.env` file.
+3. **The URL matches**: Ensure you're using `https://mcp.zapier.com/api/v1/connect` (not a different URL from a different server type).
+
+## No tools showing up
+
+If the connection succeeds but you don't see any tools besides `zapier_get_configuration_url`:
+
+1. Go back to [mcp.zapier.com](https://mcp.zapier.com) and open your MCP server
+2. Ensure you've added actions (e.g., Gmail → Find Email, Send Email)
+3. Ensure you've connected your app accounts (e.g., signed into Gmail)
+4. Restart your development server
+
+## Other common issues
+
+- **Network connectivity problems**: Ensure you can reach `mcp.zapier.com` from your machine.
+- **Outdated packages**: Run `npm update @mastra/mcp` to get the latest version.
+- **Environment variable not loaded**: Ensure your `.env` file is in the project root (same directory as `package.json`).
+
+If you're still having trouble, check the terminal output when running `npm run dev` for error messages. The MCPClient logs connection errors with details about what went wrong.
+
+In the next step, you'll add the GitHub MCP server to give your agent the ability to monitor and interact with GitHub repositories.

--- a/docs/src/course/02-agent-tools-mcp/15-updating-mcp-config-github.md
+++ b/docs/src/course/02-agent-tools-mcp/15-updating-mcp-config-github.md
@@ -7,6 +7,11 @@ const mcp = new MCPClient({
   servers: {
     zapier: {
       url: new URL(process.env.ZAPIER_MCP_URL || ''),
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${process.env.ZAPIER_MCP_API_KEY}`,
+        },
+      },
     },
     github: {
       url: smitheryGithubMCPServerUrl,

--- a/docs/src/course/02-agent-tools-mcp/20-updating-mcp-config-hackernews.md
+++ b/docs/src/course/02-agent-tools-mcp/20-updating-mcp-config-hackernews.md
@@ -9,6 +9,11 @@ const mcp = new MCPClient({
   servers: {
     zapier: {
       url: new URL(process.env.ZAPIER_MCP_URL || ''),
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${process.env.ZAPIER_MCP_API_KEY}`,
+        },
+      },
     },
     github: {
       url: new URL(process.env.COMPOSIO_MCP_GITHUB || ''),

--- a/docs/src/course/02-agent-tools-mcp/26-updating-mcp-config-filesystem.md
+++ b/docs/src/course/02-agent-tools-mcp/26-updating-mcp-config-filesystem.md
@@ -9,6 +9,11 @@ const mcp = new MCPClient({
   servers: {
     zapier: {
       url: new URL(process.env.ZAPIER_MCP_URL || ''),
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${process.env.ZAPIER_MCP_API_KEY}`,
+        },
+      },
     },
     github: {
       url: new URL(process.env.COMPOSIO_MCP_GITHUB || ''),


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

The Mastra 101 course chapters on Zapier MCP integration were missing authentication configuration, causing users to get 401 errors when following the
course. This PR adds the required `requestInit.headers` with `Authorization: Bearer` token to all Zapier MCP code snippets, updates the setup
instructions to use the correct "OpenAI API" client type on Zapier (which provides API Key auth), and adds a troubleshooting section for common auth
errors.

<img width="1912" height="976" alt="Screenshot 2026-02-27 233326" src="https://github.com/user-attachments/assets/a175ee3d-f360-4910-bffb-a3ba622284ed" />

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #13581

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Zapier MCP authentication documentation with API key and server URL requirements
  * Expanded step-by-step setup guide for integrating Zapier MCP with configuration examples
  * Added comprehensive troubleshooting section covering common error scenarios and solutions
  * Improved security guidance for managing credentials and environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->