### PR TITLE
fix: keep submitted plan visible when requesting changes

### DIFF
--- a/.changeset/afraid-donuts-bathe.md
+++ b/.changeset/afraid-donuts-bathe.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed plan approval flow so selecting Request changes keeps the submitted plan visible while entering feedback in the TUI.

--- a/mastracode/src/tui/components/plan-approval-inline.ts
+++ b/mastracode/src/tui/components/plan-approval-inline.ts
@@ -124,8 +124,15 @@ export class PlanApprovalInlineComponent extends Container implements Focusable 
     this.mode = 'feedback';
     this.selectList = undefined;
 
-    // Rebuild content box with feedback input
+    // Rebuild content box with feedback input while keeping the plan visible
     this.contentBox.clear();
+    this.contentBox.addChild(new Text(theme.bold(theme.fg('accent', `Plan: ${this.planTitle}`)), 0, 0));
+    this.contentBox.addChild(new Spacer(1));
+
+    const md = new Markdown(this.planContent, 1, 0, getMarkdownTheme());
+    this.contentBox.addChild(md);
+    this.contentBox.addChild(new Spacer(1));
+
     this.contentBox.addChild(new Text(theme.fg('accent', 'Provide feedback for revision:'), 0, 0));
     this.contentBox.addChild(new Spacer(1));
 


### PR DESCRIPTION
This fixes the inline plan approval flow so the submitted plan stays visible after choosing Request changes.

Before the feedback mode cleared the content box and only showed the input field.

After switching modes, we re-render the plan title and plan markdown, then show the feedback prompt and input.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the plan approval flow so the submitted plan remains visible when requesting changes, allowing users to reference it while providing feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->