### PR TITLE
feat(mastracode): support Anthropic API key as fallback auth for model resolution

### DIFF
--- a/.changeset/cute-maps-give.md
+++ b/.changeset/cute-maps-give.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Added ANTHROPIC_API_KEY support as a fallback for Anthropic model resolution. Previously, anthropic/\* models always required Claude Max OAuth. Now, when not logged in via OAuth, mastracode falls back to the ANTHROPIC_API_KEY environment variable or a stored API key credential.

--- a/.changeset/fiery-roses-beam.md
+++ b/.changeset/fiery-roses-beam.md
@@ -1,5 +1,0 @@
----
-'mastracode': minor
----
-
-Added support for ANTHROPIC_API_KEY as the primary authentication method for Anthropic models. When the environment variable is set, mastracode now uses it directly instead of requiring Claude Max OAuth. OAuth remains as a fallback when no API key is configured.

--- a/.changeset/fiery-roses-beam.md
+++ b/.changeset/fiery-roses-beam.md
@@ -1,0 +1,5 @@
+---
+'mastracode': minor
+---
+
+Added support for ANTHROPIC_API_KEY as the primary authentication method for Anthropic models. When the environment variable is set, mastracode now uses it directly instead of requiring Claude Max OAuth. OAuth remains as a fallback when no API key is configured.

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -27,15 +27,13 @@ export CEREBRAS_API_KEY=...
 
 Mastra Code uses Mastra's [model router](https://mastra.ai/models), which routes requests to the correct provider based on the model ID and available API keys. No OAuth login is required when using API keys.
 
-For Anthropic models, the API key is the **primary** authentication method. If `ANTHROPIC_API_KEY` is set, Mastra Code uses it directly with the Anthropic API. This is the recommended path for most users. Claude Max OAuth is only used as a fallback when no API key is available.
-
 ### OAuth login (optional)
 
 If you have an Anthropic Claude Max or OpenAI ChatGPT Plus subscription, you can authenticate via OAuth to use your subscription instead of API keys. Run `/login` in the TUI to start the flow.
 
 | Provider | OAuth flow | What you get |
 | - | - | - |
-| **Anthropic** | Claude Max subscription | Access to Claude models via your subscription (used only when no API key is set) |
+| **Anthropic** | Claude Max subscription | Access to Claude models via your subscription |
 | **OpenAI** | ChatGPT Plus / Codex | Access to OpenAI models via your subscription |
 
 OAuth credentials are stored in `auth.json` alongside the database in the app data directory. During onboarding, you can skip the OAuth step if you already have API keys configured.
@@ -44,11 +42,11 @@ OAuth credentials are stored in `auth.json` alongside the database in the app da
 
 When resolving Anthropic models, Mastra Code checks for credentials in this order:
 
-1. `ANTHROPIC_API_KEY` environment variable
-1. Stored API key credential (set via the TUI)
-1. Claude Max OAuth (fallback)
+1. Claude Max OAuth (if logged in via `/login`)
+1. `ANTHROPIC_API_KEY` environment variable or stored API key credential
+1. OAuth login prompt (if nothing else is configured)
 
-If you have both an API key and OAuth credentials, the API key is used. To use Claude Max OAuth instead, unset the `ANTHROPIC_API_KEY` environment variable.
+To switch from OAuth to API key usage, log out with `/logout` and set your `ANTHROPIC_API_KEY` environment variable.
 
 ### Anthropic OAuth warning
 

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -27,16 +27,28 @@ export CEREBRAS_API_KEY=...
 
 Mastra Code uses Mastra's [model router](https://mastra.ai/models), which routes requests to the correct provider based on the model ID and available API keys. No OAuth login is required when using API keys.
 
+For Anthropic models, the API key is the **primary** authentication method. If `ANTHROPIC_API_KEY` is set, Mastra Code uses it directly with the Anthropic API. This is the recommended path for most users. Claude Max OAuth is only used as a fallback when no API key is available.
+
 ### OAuth login (optional)
 
 If you have an Anthropic Claude Max or OpenAI ChatGPT Plus subscription, you can authenticate via OAuth to use your subscription instead of API keys. Run `/login` in the TUI to start the flow.
 
 | Provider | OAuth flow | What you get |
 | - | - | - |
-| **Anthropic** | Claude Max subscription | Access to Claude models via your subscription |
+| **Anthropic** | Claude Max subscription | Access to Claude models via your subscription (used only when no API key is set) |
 | **OpenAI** | ChatGPT Plus / Codex | Access to OpenAI models via your subscription |
 
 OAuth credentials are stored in `auth.json` alongside the database in the app data directory. During onboarding, you can skip the OAuth step if you already have API keys configured.
+
+### Authentication priority for Anthropic
+
+When resolving Anthropic models, Mastra Code checks for credentials in this order:
+
+1. `ANTHROPIC_API_KEY` environment variable
+1. Stored API key credential (set via the TUI)
+1. Claude Max OAuth (fallback)
+
+If you have both an API key and OAuth credentials, the API key is used. To use Claude Max OAuth instead, unset the `ANTHROPIC_API_KEY` environment variable.
 
 ### Anthropic OAuth warning
 

--- a/mastracode/README.md
+++ b/mastracode/README.md
@@ -132,7 +132,16 @@ The SQLite database is stored in your system's application data directory:
 
 ### Authentication
 
-OAuth credentials are stored alongside the database in `auth.json`.
+For **Anthropic** models, mastracode supports two authentication methods:
+
+1. **Claude Max OAuth (primary)** — Use `/login` to authenticate with a Claude Pro/Max subscription. This is the recommended approach.
+2. **API key (fallback)** — Set the `ANTHROPIC_API_KEY` environment variable for direct API access. This is used when not logged in via OAuth.
+
+When both are available, Claude Max OAuth takes priority.
+
+For **other providers** (OpenAI, Google, etc.), set the corresponding environment variable (e.g., `OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`) or use OAuth where supported.
+
+Credentials are stored alongside the database in `auth.json`.
 
 ### Plan persistence
 

--- a/mastracode/src/agents/__tests__/model.test.ts
+++ b/mastracode/src/agents/__tests__/model.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Use vi.hoisted so the mock instance is available when vi.mock factory runs (hoisted above imports)
+const mockAuthStorageInstance = vi.hoisted(() => ({
+  reload: vi.fn(),
+  get: vi.fn(),
+  isLoggedIn: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../auth/storage.js', () => {
+  return {
+    AuthStorage: class MockAuthStorage {
+      reload = mockAuthStorageInstance.reload;
+      get = mockAuthStorageInstance.get;
+      isLoggedIn = mockAuthStorageInstance.isLoggedIn;
+    },
+  };
+});
+
+// Mock claude-max provider
+vi.mock('../../providers/claude-max.js', () => ({
+  opencodeClaudeMaxProvider: vi.fn(() => ({ __provider: 'claude-max-oauth' })),
+  promptCacheMiddleware: { specificationVersion: 'v3', transformParams: vi.fn() },
+}));
+
+// Mock openai-codex provider
+vi.mock('../../providers/openai-codex.js', () => ({
+  openaiCodexProvider: vi.fn(() => ({ __provider: 'openai-codex' })),
+}));
+
+// Mock @ai-sdk/anthropic
+vi.mock('@ai-sdk/anthropic', () => ({
+  createAnthropic: vi.fn((_opts: Record<string, unknown>) => {
+    return (modelId: string) => ({ __provider: 'anthropic-direct', modelId });
+  }),
+}));
+
+// Mock ai SDK's wrapLanguageModel to pass through with a marker
+vi.mock('ai', () => ({
+  wrapLanguageModel: vi.fn(({ model }: { model: Record<string, unknown> }) => ({
+    ...model,
+    __wrapped: true,
+  })),
+}));
+
+// Mock ModelRouterLanguageModel
+vi.mock('@mastra/core/llm', () => ({
+  ModelRouterLanguageModel: vi.fn(function (this: Record<string, unknown>, modelId: string) {
+    this.__provider = 'model-router';
+    this.modelId = modelId;
+  }),
+}));
+
+import { resolveModel, getAnthropicApiKey } from '../model.js';
+import { opencodeClaudeMaxProvider } from '../../providers/claude-max.js';
+
+describe('resolveModel', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.MOONSHOT_AI_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe('anthropic/* models', () => {
+    it('prefers Claude Max OAuth when logged in, even if API key is present', () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-test-key-123';
+      mockAuthStorageInstance.isLoggedIn.mockImplementation((p: string) => p === 'anthropic');
+
+      resolveModel('anthropic/claude-sonnet-4-20250514');
+
+      expect(opencodeClaudeMaxProvider).toHaveBeenCalledWith('claude-sonnet-4-20250514');
+    });
+
+    it('falls back to API key when not logged in via OAuth', () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-test-key-123';
+      mockAuthStorageInstance.isLoggedIn.mockReturnValue(false);
+
+      const result = resolveModel('anthropic/claude-sonnet-4-20250514') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('anthropic-direct');
+      expect(result.__wrapped).toBe(true);
+      expect(result.modelId).toBe('claude-sonnet-4-20250514');
+      expect(opencodeClaudeMaxProvider).not.toHaveBeenCalled();
+    });
+
+    it('uses stored API key credential when not logged in via OAuth', () => {
+      mockAuthStorageInstance.isLoggedIn.mockReturnValue(false);
+      mockAuthStorageInstance.get.mockReturnValue({ type: 'api_key', key: 'sk-stored-key-456' });
+
+      const result = resolveModel('anthropic/claude-sonnet-4-20250514') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('anthropic-direct');
+      expect(result.__wrapped).toBe(true);
+      expect(result.modelId).toBe('claude-sonnet-4-20250514');
+      expect(opencodeClaudeMaxProvider).not.toHaveBeenCalled();
+    });
+
+    it('falls back to OAuth provider when no auth is configured (to prompt login)', () => {
+      mockAuthStorageInstance.isLoggedIn.mockReturnValue(false);
+      mockAuthStorageInstance.get.mockReturnValue(undefined);
+
+      resolveModel('anthropic/claude-sonnet-4-20250514');
+
+      expect(opencodeClaudeMaxProvider).toHaveBeenCalledWith('claude-sonnet-4-20250514');
+    });
+
+    it('reloads auth storage before resolving', () => {
+      mockAuthStorageInstance.isLoggedIn.mockImplementation((p: string) => p === 'anthropic');
+      resolveModel('anthropic/claude-sonnet-4-20250514');
+      expect(mockAuthStorageInstance.reload).toHaveBeenCalled();
+    });
+  });
+
+  describe('openai/* models', () => {
+    it('uses codex provider when logged in via OAuth', () => {
+      mockAuthStorageInstance.isLoggedIn.mockReturnValue(true);
+      const result = resolveModel('openai/gpt-4o') as Record<string, unknown>;
+      expect(result.__provider).toBe('openai-codex');
+    });
+
+    it('uses model router when not logged in via OAuth', () => {
+      mockAuthStorageInstance.isLoggedIn.mockReturnValue(false);
+      const result = resolveModel('openai/gpt-4o') as Record<string, unknown>;
+      expect(result.__provider).toBe('model-router');
+    });
+  });
+
+  describe('other providers', () => {
+    it('uses model router for unknown providers', () => {
+      const result = resolveModel('google/gemini-2.0-flash') as Record<string, unknown>;
+      expect(result.__provider).toBe('model-router');
+    });
+  });
+});
+
+describe('getAnthropicApiKey', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns env var when ANTHROPIC_API_KEY is set', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-env-key';
+    expect(getAnthropicApiKey()).toBe('sk-env-key');
+  });
+
+  it('returns stored API key when no env var is set', () => {
+    mockAuthStorageInstance.get.mockReturnValue({ type: 'api_key', key: 'sk-stored-key' });
+    expect(getAnthropicApiKey()).toBe('sk-stored-key');
+  });
+
+  it('returns undefined when no API key is available', () => {
+    mockAuthStorageInstance.get.mockReturnValue(undefined);
+    expect(getAnthropicApiKey()).toBeUndefined();
+  });
+
+  it('returns undefined when stored credential is OAuth type', () => {
+    mockAuthStorageInstance.get.mockReturnValue({ type: 'oauth', access: 'token', refresh: 'r', expires: 0 });
+    expect(getAnthropicApiKey()).toBeUndefined();
+  });
+
+  it('prefers env var over stored credential', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-env-key';
+    mockAuthStorageInstance.get.mockReturnValue({ type: 'api_key', key: 'sk-stored-key' });
+    expect(getAnthropicApiKey()).toBe('sk-env-key');
+  });
+});

--- a/mastracode/src/agents/__tests__/model.test.ts
+++ b/mastracode/src/agents/__tests__/model.test.ts
@@ -51,8 +51,8 @@ vi.mock('@mastra/core/llm', () => ({
   }),
 }));
 
-import { resolveModel, getAnthropicApiKey } from '../model.js';
 import { opencodeClaudeMaxProvider } from '../../providers/claude-max.js';
+import { resolveModel, getAnthropicApiKey } from '../model.js';
 
 describe('resolveModel', () => {
   const originalEnv = { ...process.env };

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -2,8 +2,9 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 import type { HarnessRequestContext } from '@mastra/core/harness';
 import { ModelRouterLanguageModel } from '@mastra/core/llm';
 import type { RequestContext } from '@mastra/core/request-context';
+import { wrapLanguageModel } from 'ai';
 import { AuthStorage } from '../auth/storage.js';
-import { opencodeClaudeMaxProvider } from '../providers/claude-max.js';
+import { opencodeClaudeMaxProvider, promptCacheMiddleware } from '../providers/claude-max.js';
 import { openaiCodexProvider } from '../providers/openai-codex.js';
 import type { ThinkingLevel } from '../providers/openai-codex.js';
 import type { stateSchema } from '../schema.js';
@@ -46,10 +47,40 @@ export function remapOpenAIModelForCodexOAuth(modelId: string): string {
 }
 
 /**
+ * Resolve the Anthropic API key from environment or stored credentials.
+ * Returns the key if available, undefined otherwise.
+ */
+export function getAnthropicApiKey(): string | undefined {
+  // Environment variable takes priority
+  if (process.env.ANTHROPIC_API_KEY) {
+    return process.env.ANTHROPIC_API_KEY;
+  }
+  // Check stored API key credential (set via /apikey or TUI prompt)
+  const storedCred = authStorage.get('anthropic');
+  if (storedCred?.type === 'api_key') {
+    return storedCred.key;
+  }
+  return undefined;
+}
+
+/**
+ * Create an Anthropic model using a direct API key (no OAuth).
+ * Applies prompt caching but NOT the Claude Code identity middleware
+ * (which is only required for Claude Max OAuth).
+ */
+function anthropicApiKeyProvider(modelId: string, apiKey: string): LanguageModelV1 {
+  const anthropic = createAnthropic({ apiKey });
+  return wrapLanguageModel({
+    model: anthropic(modelId),
+    middleware: [promptCacheMiddleware],
+  });
+}
+
+/**
  * Resolve a model ID to the correct provider instance.
  * Shared by the main agent, observer, and reflector.
  *
- * - For anthropic/* models: Uses Claude Max OAuth provider (opencode auth)
+ * - For anthropic/* models: Prefers Claude Max OAuth, falls back to direct API key
  * - For openai/* models with OAuth: Uses OpenAI Codex OAuth provider
  * - For moonshotai/* models: Uses Moonshot AI Anthropic-compatible endpoint
  * - For all other providers: Uses Mastra's model router (models.dev gateway)
@@ -73,7 +104,18 @@ export function resolveModel(
       name: 'moonshotai.anthropicv1',
     })(modelId.substring('moonshotai/'.length));
   } else if (isAnthropicModel) {
-    return opencodeClaudeMaxProvider(modelId.substring(`anthropic/`.length));
+    const bareModelId = modelId.substring('anthropic/'.length);
+    // Primary path: Claude Max OAuth
+    if (authStorage.isLoggedIn('anthropic')) {
+      return opencodeClaudeMaxProvider(bareModelId);
+    }
+    // Fallback: direct API key (env var or stored credential)
+    const apiKey = getAnthropicApiKey();
+    if (apiKey) {
+      return anthropicApiKeyProvider(bareModelId, apiKey);
+    }
+    // No auth configured — attempt OAuth provider which will prompt login
+    return opencodeClaudeMaxProvider(bareModelId);
   } else if (isOpenAIModel && authStorage.isLoggedIn('openai-codex')) {
     const resolvedModelId = options?.remapForCodexOAuth ? remapOpenAIModelForCodexOAuth(modelId) : modelId;
     return openaiCodexProvider(resolvedModelId.substring(OPENAI_PREFIX.length), {

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -1,4 +1,5 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
+import type { LanguageModelV1 } from '@ai-sdk/provider';
 import type { HarnessRequestContext } from '@mastra/core/harness';
 import { ModelRouterLanguageModel } from '@mastra/core/llm';
 import type { RequestContext } from '@mastra/core/request-context';

--- a/mastracode/src/providers/claude-max.ts
+++ b/mastracode/src/providers/claude-max.ts
@@ -69,7 +69,7 @@ const claudeCodeMiddleware: LanguageModelMiddleware = {
  * - System prompts and instructions (rarely change)
  * - Conversation history up to the last message
  */
-const promptCacheMiddleware: LanguageModelMiddleware = {
+export const promptCacheMiddleware: LanguageModelMiddleware = {
   specificationVersion: 'v3',
   transformParams: async ({ params }) => {
     const prompt = [...params.prompt];


### PR DESCRIPTION
Fixes #13575

`resolveModel()` previously always routed `anthropic/*` models through the Claude Max OAuth provider, ignoring any `ANTHROPIC_API_KEY` that was set.

Now it checks auth in this order:

1. Claude Max OAuth (if logged in via `/login`) — primary path
2. `ANTHROPIC_API_KEY` env var or stored API key credential — fallback
3. Falls through to OAuth provider to prompt login if nothing is configured

This means users with a Claude Max subscription get the OAuth experience by default, while users with direct API keys can still use mastracode without OAuth.

Also exports `promptCacheMiddleware` from the Claude Max provider so the API key path can reuse it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anthropic models now fall back to an ANTHROPIC_API_KEY (env var or stored API key) when not authenticated via Claude Max OAuth; env var takes precedence.

* **Documentation**
  * Authentication docs and README updated to clarify Anthropic credential lookup order and how to switch between OAuth and API-key usage.

* **Tests**
  * Added tests for model credential resolution, provider selection, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->