### PR TITLE
ci: auto-discover workspace packages in CI workflows

### DIFF
--- a/.github/workflows/secrets.test-workspaces.yml
+++ b/.github/workflows/secrets.test-workspaces.yml
@@ -169,12 +169,12 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@v5
-      - name: Set status for skipped tests (fork PR)
+      - name: Set status for skipped tests
         uses: ./.github/workflows/shared-actions/set-pr-status
         with:
           status: 'success'
           context: 'Workspace Cloud Tests'
-          description: 'Cloud tests skipped for fork PR'
+          description: 'Cloud tests skipped (fork PR or setup issue)'
           sha: ${{ github.event.workflow_run.head_sha }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           target_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/secrets.test-workspaces.yml
+++ b/.github/workflows/secrets.test-workspaces.yml
@@ -145,7 +145,7 @@ jobs:
 
   test-failure:
     needs: [check-changes, setup, test-cloud]
-    if: ${{ always() && needs.check-changes.outputs.workspaces-changed == 'true' && needs.test-cloud.result == 'failure' }}
+    if: ${{ always() && needs.check-changes.outputs.workspaces-changed == 'true' && (needs.setup.result == 'failure' || needs.test-cloud.result == 'failure') }}
     runs-on: ubuntu-latest
     permissions:
       statuses: write
@@ -163,7 +163,7 @@ jobs:
 
   test-skipped:
     needs: [check-changes, setup, test-cloud]
-    if: ${{ always() && needs.check-changes.outputs.workspaces-changed == 'true' && needs.test-cloud.result == 'skipped' }}
+    if: ${{ always() && needs.check-changes.outputs.workspaces-changed == 'true' && needs.setup.result != 'failure' && needs.test-cloud.result == 'skipped' }}
     runs-on: ubuntu-latest
     permissions:
       statuses: write

--- a/.github/workflows/secrets.test-workspaces.yml
+++ b/.github/workflows/secrets.test-workspaces.yml
@@ -65,7 +65,7 @@ jobs:
 
   setup:
     needs: check-changes
-    if: needs.check-changes.outputs.workspaces-changed == 'true'
+    if: ${{ needs.check-changes.outputs.workspaces-changed == 'true' && github.event.workflow_run.head_repository.full_name == github.repository }}
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.set-packages.outputs.packages }}
@@ -76,6 +76,10 @@ jobs:
       - id: set-packages
         run: |
           PACKAGES=$(ls -d workspaces/*/ | grep -v '_test-utils' | xargs -I{} basename {} | jq -R -s -c 'split("\n")[:-1]')
+          if [ "$PACKAGES" = "[]" ]; then
+            echo "::error::No workspace packages found"
+            exit 1
+          fi
           echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
 
   test-cloud:

--- a/.github/workflows/secrets.test-workspaces.yml
+++ b/.github/workflows/secrets.test-workspaces.yml
@@ -63,13 +63,32 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           target_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-  test-cloud:
+  setup:
     needs: check-changes
+    if: needs.check-changes.outputs.workspaces-changed == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.set-packages.outputs.packages }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - id: set-packages
+        run: |
+          PACKAGES=$(ls -d workspaces/*/ | grep -v '_test-utils' | xargs -I{} basename {} | jq -R -s -c 'split("\n")[:-1]')
+          echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
+
+  test-cloud:
+    needs: [check-changes, setup]
     if: ${{ github.repository == 'mastra-ai/mastra' && needs.check-changes.outputs.workspaces-changed == 'true' && github.event.workflow_run.head_repository.full_name == github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.setup.outputs.packages) }}
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
@@ -83,15 +102,17 @@ jobs:
         uses: ./.github/actions/setup-pnpm-node
 
       - name: Build packages
-        run: pnpm turbo build --filter "@mastra/e2b" --filter "@mastra/daytona"
+        run: pnpm turbo build --filter "@mastra/${{ matrix.package }}"
 
-      - name: Run E2B cloud integration tests
-        continue-on-error: true
+      - name: Run ${{ matrix.package }} cloud integration tests
         run: pnpm test:cloud
-        working-directory: workspaces/e2b
+        working-directory: workspaces/${{ matrix.package }}
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          BL_API_KEY: ${{ secrets.BL_API_KEY }}
+          BL_WORKSPACE: ${{ secrets.BL_WORKSPACE }}
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
           S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
           S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
@@ -100,16 +121,8 @@ jobs:
           GCS_SERVICE_ACCOUNT_KEY: ${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}
           TEST_GCS_BUCKET: ${{ secrets.TEST_GCS_BUCKET }}
 
-      - name: Run Daytona cloud integration tests
-        continue-on-error: true
-        run: pnpm test:cloud
-        working-directory: workspaces/daytona
-        env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
-          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-
   test-success:
-    needs: [check-changes, test-cloud]
+    needs: [check-changes, setup, test-cloud]
     if: ${{ always() && needs.check-changes.outputs.workspaces-changed == 'true' && needs.test-cloud.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
@@ -127,7 +140,7 @@ jobs:
           target_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   test-failure:
-    needs: [check-changes, test-cloud]
+    needs: [check-changes, setup, test-cloud]
     if: ${{ always() && needs.check-changes.outputs.workspaces-changed == 'true' && needs.test-cloud.result == 'failure' }}
     runs-on: ubuntu-latest
     permissions:
@@ -145,7 +158,7 @@ jobs:
           target_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   test-skipped:
-    needs: [check-changes, test-cloud]
+    needs: [check-changes, setup, test-cloud]
     if: ${{ always() && needs.check-changes.outputs.workspaces-changed == 'true' && needs.test-cloud.result == 'skipped' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/test-workspaces.yml
+++ b/.github/workflows/test-workspaces.yml
@@ -12,7 +12,20 @@ on:
       - '.github/workflows/test-workspaces.yml'
 
 jobs:
+  setup:
+    if: ${{ github.repository == 'mastra-ai/mastra' }}
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.set-packages.outputs.packages }}
+    steps:
+      - uses: actions/checkout@v5
+      - id: set-packages
+        run: |
+          PACKAGES=$(ls -d workspaces/*/ | grep -v '_test-utils' | xargs -I{} basename {} | jq -R -s -c 'split("\n")[:-1]')
+          echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
+
   test-unit:
+    needs: setup
     # Only run on the main repository, not on forks
     if: ${{ github.repository == 'mastra-ai/mastra' }}
     runs-on: ubuntu-latest
@@ -23,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [e2b, s3, gcs, daytona]
+        package: ${{ fromJson(needs.setup.outputs.packages) }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/test-workspaces.yml
+++ b/.github/workflows/test-workspaces.yml
@@ -22,6 +22,10 @@ jobs:
       - id: set-packages
         run: |
           PACKAGES=$(ls -d workspaces/*/ | grep -v '_test-utils' | xargs -I{} basename {} | jq -R -s -c 'split("\n")[:-1]')
+          if [ "$PACKAGES" = "[]" ]; then
+            echo "::error::No workspace packages found"
+            exit 1
+          fi
           echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
 
   test-unit:


### PR DESCRIPTION
## Summary
- Replace hardcoded package lists in workspace CI workflows with filesystem auto-discovery (`ls -d workspaces/*/ | grep -v '_test-utils'`), matching the pattern already used in `secrets.test-combined-stores.yml`
- `test-workspaces.yml`: unit test matrix is now dynamic; docker test matrix stays hardcoded to `[s3, gcs]` (only packages with `docker-compose.yml`)
- `secrets.test-workspaces.yml`: replace sequential per-provider steps with a single matrix job, injecting the union of all secrets (each package skips gracefully via `describe.skipIf` when credentials are missing)

## Test plan
- [ ] Verify new workspace packages (e.g. `blaxel`) are auto-discovered by the `ls` command
- [ ] Verify `_test-utils` is excluded from the matrix
- [ ] Confirm YAML structure matches the pattern in `secrets.test-combined-stores.yml`
- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now discovers workspace packages dynamically and runs per-package workflows, enabling parallel per-package status messages and non-failing setup of matrix runs.
* **Tests**
  * Unit and cloud integration tests run per-package with expanded environment secrets (DAYTONA_API_KEY, BL_API_KEY, BL_WORKSPACE); job status conditions and skipped/failure messaging updated for per-package outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->