### PR TITLE
fix(core): improve structured output processor error handling and observability

### DIFF
--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -85,6 +85,13 @@ type StructuredOutputOptionsBase<OUTPUT = {}> = {
   logger?: IMastraLogger;
 
   /**
+   * Maximum number of retries for the internal structuring agent's LLM calls.
+   * Controls the p-retry count when the inner agent encounters transient errors.
+   * If not set, the default retry behavior (2 retries) is used.
+   */
+  maxRetries?: number;
+
+  /**
    * Provider-specific options passed to the internal structuring agent.
    * Use this to control model behavior like reasoning effort for thinking models.
    *

--- a/packages/core/src/processors/processors/structured-output-repro.test.ts
+++ b/packages/core/src/processors/processors/structured-output-repro.test.ts
@@ -205,6 +205,31 @@ describe('Structured Output Processor Mode — errorStrategy forwarding (repro)'
     expect(object).toBeUndefined();
   }, 30000);
 
+  it('should throw from result.object with strict strategy when validation fails (not return undefined)', async () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'Describe colors.',
+      model: mainModel,
+    });
+
+    const result = await agent.stream('Tell me about the sky color.', {
+      structuredOutput: {
+        schema: colorSchema,
+        model: createSchemaInvalidModel(),
+        errorStrategy: 'strict',
+      },
+      modelSettings: { maxRetries: 0 },
+    });
+
+    const text = await result.text;
+    expect(text).toContain('beautiful shade of blue');
+
+    // With the fix: strict mode now rejects result.object with a meaningful error
+    // instead of silently resolving to undefined (which caused ZodError when users called schema.parse(undefined))
+    await expect(result.object).rejects.toThrow();
+  }, 30000);
+
   it('should use fallback value when inner model throws entirely', async () => {
     const throwingModel = new MockLanguageModelV2({
       doStream: async () => {

--- a/packages/core/src/processors/processors/structured-output-repro.test.ts
+++ b/packages/core/src/processors/processors/structured-output-repro.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Reproduction test for: Structured Output Processor Mode — Silent Failures with Custom Providers
+ *
+ * Bug: When users call agent.stream() with structuredOutput.model (processor mode) and
+ * the inner structuring agent's LLM returns JSON that fails schema validation, the inner
+ * agent's createObjectStreamTransformer doesn't know about errorStrategy/fallbackValue
+ * (they weren't forwarded). It defaults to 'strict' — emitting an error chunk that
+ * propagates up through the inner agent, logging "Error in agent stream" and causing
+ * unnecessary error handling in the outer processor.
+ *
+ * With the fix, errorStrategy/fallbackValue are forwarded so the inner transformer handles
+ * the validation error cleanly (e.g., emitting a fallback object-result) without triggering
+ * the error path through the inner agent's pipeline.
+ */
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import z from 'zod';
+import { Agent } from '../../agent';
+
+describe('Structured Output Processor Mode — errorStrategy forwarding (repro)', () => {
+  // Schema with enum constraint — easy to trigger validation failure
+  const colorSchema = z.object({
+    color: z.string(),
+    intensity: z.enum(['light', 'medium', 'bright', 'vibrant']),
+  });
+
+  // Main agent model — returns unstructured text
+  let mainModel: MockLanguageModelV2;
+
+  beforeEach(() => {
+    mainModel = new MockLanguageModelV2({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'main-model', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'The sky is a beautiful shade of blue today.' },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          },
+        ]),
+        rawCall: { rawPrompt: [], rawSettings: {} },
+        warnings: [],
+      }),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Creates a mock model that returns valid JSON but fails schema validation.
+   * "very bright" is NOT in the enum ['light', 'medium', 'bright', 'vibrant']
+   */
+  function createSchemaInvalidModel() {
+    return new MockLanguageModelV2({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'structuring-model', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: '{"color": "blue", "intensity": "very bright"}' },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          },
+        ]),
+        rawCall: { rawPrompt: [], rawSettings: {} },
+        warnings: [],
+      }),
+    });
+  }
+
+  it('should return fallback value when inner agent returns schema-invalid JSON (fallback strategy)', async () => {
+    const fallbackValue = { color: 'unknown', intensity: 'medium' as const };
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'Describe colors.',
+      model: mainModel,
+    });
+
+    const result = await agent.stream('Tell me about the sky color.', {
+      structuredOutput: {
+        schema: colorSchema,
+        model: createSchemaInvalidModel(),
+        errorStrategy: 'fallback',
+        fallbackValue,
+      },
+      modelSettings: { maxRetries: 0 },
+    });
+
+    const text = await result.text;
+    const object = await result.object;
+
+    expect(text).toContain('beautiful shade of blue');
+    expect(object).toEqual(fallbackValue);
+  }, 30000);
+
+  it('should not log "Error in agent stream" when errorStrategy is forwarded to inner agent', async () => {
+    // Spy on console.error to check for "Error in agent stream" from the inner agent
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const fallbackValue = { color: 'unknown', intensity: 'medium' as const };
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'Describe colors.',
+      model: mainModel,
+    });
+
+    const result = await agent.stream('Tell me about the sky color.', {
+      structuredOutput: {
+        schema: colorSchema,
+        model: createSchemaInvalidModel(),
+        errorStrategy: 'fallback',
+        fallbackValue,
+      },
+      modelSettings: { maxRetries: 0 },
+    });
+
+    await result.text;
+    await result.object;
+
+    // With the fix: errorStrategy='fallback' is forwarded to the inner agent's
+    // createObjectStreamTransformer, which emits an object-result with fallbackValue
+    // instead of an error chunk. No "Error in agent stream" should be logged.
+    const errorCalls = consoleErrorSpy.mock.calls.map(call => String(call[0]));
+    const hasAgentStreamError = errorCalls.some(msg => msg.includes('Error in agent stream'));
+    expect(hasAgentStreamError).toBe(false);
+  }, 30000);
+
+  it('should return structured object when inner agent returns schema-valid JSON', async () => {
+    const validModel = new MockLanguageModelV2({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'structuring-model', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: '{"color": "blue", "intensity": "bright"}' },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          },
+        ]),
+        rawCall: { rawPrompt: [], rawSettings: {} },
+        warnings: [],
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'Describe colors.',
+      model: mainModel,
+    });
+
+    const result = await agent.stream('Tell me about the sky color.', {
+      structuredOutput: {
+        schema: colorSchema,
+        model: validModel,
+        errorStrategy: 'strict',
+      },
+      modelSettings: { maxRetries: 0 },
+    });
+
+    const text = await result.text;
+    const object = await result.object;
+
+    expect(text).toContain('beautiful shade of blue');
+    expect(object).toEqual({ color: 'blue', intensity: 'bright' });
+  }, 30000);
+
+  it('should return undefined object with warn strategy when validation fails', async () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'Describe colors.',
+      model: mainModel,
+    });
+
+    const result = await agent.stream('Tell me about the sky color.', {
+      structuredOutput: {
+        schema: colorSchema,
+        model: createSchemaInvalidModel(),
+        errorStrategy: 'warn',
+      },
+      modelSettings: { maxRetries: 0 },
+    });
+
+    const text = await result.text;
+    const object = await result.object;
+
+    expect(text).toContain('beautiful shade of blue');
+    expect(object).toBeUndefined();
+  }, 30000);
+
+  it('should use fallback value when inner model throws entirely', async () => {
+    const throwingModel = new MockLanguageModelV2({
+      doStream: async () => {
+        throw new Error('Provider connection failed');
+      },
+    });
+
+    const fallbackValue = { color: 'unknown', intensity: 'medium' as const };
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'Describe colors.',
+      model: mainModel,
+    });
+
+    const result = await agent.stream('Tell me about the sky color.', {
+      structuredOutput: {
+        schema: colorSchema,
+        model: throwingModel,
+        errorStrategy: 'fallback',
+        fallbackValue,
+      },
+      modelSettings: { maxRetries: 0 },
+    });
+
+    const text = await result.text;
+    const object = await result.object;
+
+    expect(text).toContain('beautiful shade of blue');
+    expect(object).toEqual(fallbackValue);
+  }, 30000);
+});

--- a/packages/core/src/processors/processors/structured-output.test.ts
+++ b/packages/core/src/processors/processors/structured-output.test.ts
@@ -3,6 +3,7 @@ import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import z from 'zod';
 import type { Agent } from '../../agent';
+import { TripWire } from '../../agent/trip-wire';
 import type { ChunkType } from '../../stream/types';
 import { ChunkFrom } from '../../stream/types';
 import { StructuredOutputProcessor } from './structured-output';
@@ -450,6 +451,315 @@ describe('StructuredOutputProcessor', () => {
       expect(prompt).toContain('I need to analyze the color and intensity');
       expect(prompt).toContain('# Assistant Response');
       expect(prompt).toContain('The answer is blue and bright');
+    });
+  });
+
+  describe('errorStrategy/fallbackValue forwarding', () => {
+    it('should forward strict errorStrategy to inner structuring agent', async () => {
+      const strictProcessor = new StructuredOutputProcessor({
+        schema: testSchema,
+        model: mockModel,
+        errorStrategy: 'strict',
+      });
+
+      const { controller } = createMockController();
+      const abort = createMockAbort();
+
+      const finishChunk: ChunkType = {
+        runId: 'test-run',
+        from: ChunkFrom.AGENT,
+        type: 'finish' as const,
+        payload: {
+          stepResult: { reason: 'stop' as const },
+          output: { usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+          metadata: {},
+          messages: { all: [], user: [], nonUser: [] },
+        },
+      };
+
+      const mockStream = {
+        fullStream: convertArrayToReadableStream([
+          {
+            runId: 'test-run',
+            from: ChunkFrom.AGENT,
+            type: 'object-result',
+            object: { color: 'blue', intensity: 'bright' },
+          },
+        ]),
+      };
+
+      const streamSpy = vi.spyOn(strictProcessor['structuringAgent'], 'stream').mockResolvedValue(mockStream as any);
+
+      await strictProcessor.processOutputStream({
+        part: finishChunk,
+        streamParts: [],
+        state: { controller },
+        abort,
+      });
+
+      const streamOptions = streamSpy.mock.calls[0]![1];
+      expect(streamOptions.structuredOutput).toMatchObject({
+        schema: testSchema,
+        errorStrategy: 'strict',
+      });
+      expect(streamOptions.structuredOutput).not.toHaveProperty('fallbackValue');
+    });
+
+    it('should forward fallback errorStrategy and fallbackValue to inner structuring agent', async () => {
+      const fallbackValue = { color: 'default', intensity: 'medium' };
+      const fallbackProcessor = new StructuredOutputProcessor({
+        schema: testSchema,
+        model: mockModel,
+        errorStrategy: 'fallback',
+        fallbackValue,
+      });
+
+      const { controller } = createMockController();
+      const abort = createMockAbort();
+
+      const finishChunk: ChunkType = {
+        runId: 'test-run',
+        from: ChunkFrom.AGENT,
+        type: 'finish' as const,
+        payload: {
+          stepResult: { reason: 'stop' as const },
+          output: { usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+          metadata: {},
+          messages: { all: [], user: [], nonUser: [] },
+        },
+      };
+
+      const mockStream = {
+        fullStream: convertArrayToReadableStream([
+          {
+            runId: 'test-run',
+            from: ChunkFrom.AGENT,
+            type: 'object-result',
+            object: { color: 'blue', intensity: 'bright' },
+          },
+        ]),
+      };
+
+      const streamSpy = vi.spyOn(fallbackProcessor['structuringAgent'], 'stream').mockResolvedValue(mockStream as any);
+
+      await fallbackProcessor.processOutputStream({
+        part: finishChunk,
+        streamParts: [],
+        state: { controller },
+        abort,
+      });
+
+      const streamOptions = streamSpy.mock.calls[0]![1];
+      expect(streamOptions.structuredOutput).toMatchObject({
+        schema: testSchema,
+        errorStrategy: 'fallback',
+        fallbackValue,
+      });
+    });
+
+    it('should forward warn errorStrategy to inner structuring agent', async () => {
+      const warnProcessor = new StructuredOutputProcessor({
+        schema: testSchema,
+        model: mockModel,
+        errorStrategy: 'warn',
+      });
+
+      const { controller } = createMockController();
+      const abort = createMockAbort();
+
+      const finishChunk: ChunkType = {
+        runId: 'test-run',
+        from: ChunkFrom.AGENT,
+        type: 'finish' as const,
+        payload: {
+          stepResult: { reason: 'stop' as const },
+          output: { usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+          metadata: {},
+          messages: { all: [], user: [], nonUser: [] },
+        },
+      };
+
+      const mockStream = {
+        fullStream: convertArrayToReadableStream([
+          {
+            runId: 'test-run',
+            from: ChunkFrom.AGENT,
+            type: 'object-result',
+            object: { color: 'blue', intensity: 'bright' },
+          },
+        ]),
+      };
+
+      const streamSpy = vi.spyOn(warnProcessor['structuringAgent'], 'stream').mockResolvedValue(mockStream as any);
+
+      await warnProcessor.processOutputStream({
+        part: finishChunk,
+        streamParts: [],
+        state: { controller },
+        abort,
+      });
+
+      const streamOptions = streamSpy.mock.calls[0]![1];
+      expect(streamOptions.structuredOutput).toMatchObject({
+        schema: testSchema,
+        errorStrategy: 'warn',
+      });
+      expect(streamOptions.structuredOutput).not.toHaveProperty('fallbackValue');
+    });
+  });
+
+  describe('TripWire guard in strict mode', () => {
+    it('should not double-log errors when strict mode abort throws TripWire', async () => {
+      const mockLogger = {
+        warn: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+      };
+      const strictProcessor = new StructuredOutputProcessor({
+        schema: testSchema,
+        model: mockModel,
+        errorStrategy: 'strict',
+        logger: mockLogger as any,
+      });
+
+      const { controller } = createMockController();
+      // Use a TripWire-throwing abort, matching real behavior
+      const abort = vi.fn((reason?: string) => {
+        throw new TripWire(reason || 'Aborted');
+      }) as any;
+
+      const finishChunk: ChunkType = {
+        runId: 'test-run',
+        from: ChunkFrom.AGENT,
+        type: 'finish' as const,
+        payload: {
+          stepResult: { reason: 'stop' as const },
+          output: { usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+          metadata: {},
+          messages: { all: [], user: [], nonUser: [] },
+        },
+      };
+
+      const mockStream = {
+        fullStream: convertArrayToReadableStream([
+          {
+            runId: 'test-run',
+            from: ChunkFrom.AGENT,
+            type: 'error',
+            payload: { error: new Error('Structuring failed') },
+          },
+        ]),
+      };
+
+      vi.spyOn(strictProcessor['structuringAgent'], 'stream').mockResolvedValue(mockStream as any);
+
+      await expect(
+        strictProcessor.processOutputStream({
+          part: finishChunk,
+          streamParts: [],
+          state: { controller },
+          abort,
+        }),
+      ).rejects.toBeInstanceOf(TripWire);
+
+      // handleError should only be called once (from the error chunk), not again from the catch
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('maxRetries forwarding', () => {
+    it('should forward maxRetries via modelSettings when set', async () => {
+      const retryProcessor = new StructuredOutputProcessor({
+        schema: testSchema,
+        model: mockModel,
+        errorStrategy: 'strict',
+        maxRetries: 5,
+      });
+
+      const { controller } = createMockController();
+      const abort = createMockAbort();
+
+      const finishChunk: ChunkType = {
+        runId: 'test-run',
+        from: ChunkFrom.AGENT,
+        type: 'finish' as const,
+        payload: {
+          stepResult: { reason: 'stop' as const },
+          output: { usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+          metadata: {},
+          messages: { all: [], user: [], nonUser: [] },
+        },
+      };
+
+      const mockStream = {
+        fullStream: convertArrayToReadableStream([
+          {
+            runId: 'test-run',
+            from: ChunkFrom.AGENT,
+            type: 'object-result',
+            object: { color: 'blue', intensity: 'bright' },
+          },
+        ]),
+      };
+
+      const streamSpy = vi.spyOn(retryProcessor['structuringAgent'], 'stream').mockResolvedValue(mockStream as any);
+
+      await retryProcessor.processOutputStream({
+        part: finishChunk,
+        streamParts: [],
+        state: { controller },
+        abort,
+      });
+
+      const streamOptions = streamSpy.mock.calls[0]![1];
+      expect(streamOptions.modelSettings).toEqual({ maxRetries: 5 });
+    });
+
+    it('should omit modelSettings when maxRetries is not set', async () => {
+      const noRetryProcessor = new StructuredOutputProcessor({
+        schema: testSchema,
+        model: mockModel,
+        errorStrategy: 'strict',
+      });
+
+      const { controller } = createMockController();
+      const abort = createMockAbort();
+
+      const finishChunk: ChunkType = {
+        runId: 'test-run',
+        from: ChunkFrom.AGENT,
+        type: 'finish' as const,
+        payload: {
+          stepResult: { reason: 'stop' as const },
+          output: { usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+          metadata: {},
+          messages: { all: [], user: [], nonUser: [] },
+        },
+      };
+
+      const mockStream = {
+        fullStream: convertArrayToReadableStream([
+          {
+            runId: 'test-run',
+            from: ChunkFrom.AGENT,
+            type: 'object-result',
+            object: { color: 'blue', intensity: 'bright' },
+          },
+        ]),
+      };
+
+      const streamSpy = vi.spyOn(noRetryProcessor['structuringAgent'], 'stream').mockResolvedValue(mockStream as any);
+
+      await noRetryProcessor.processOutputStream({
+        part: finishChunk,
+        streamParts: [],
+        state: { controller },
+        abort,
+      });
+
+      const streamOptions = streamSpy.mock.calls[0]![1];
+      expect(streamOptions).not.toHaveProperty('modelSettings');
     });
   });
 });

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -1,5 +1,6 @@
 import type { TransformStreamDefaultController } from 'node:stream/web';
 import { Agent } from '../../agent';
+import { TripWire } from '../../agent/trip-wire';
 import type { StructuredOutputOptions } from '../../agent/types';
 import { ErrorCategory, ErrorDomain, MastraError } from '../../error';
 import type { ProviderOptions } from '../../llm/model/provider-options';
@@ -36,6 +37,7 @@ export class StructuredOutputProcessor<OUTPUT extends {}> implements Processor<'
   private errorStrategy: 'strict' | 'warn' | 'fallback';
   private fallbackValue?: OUTPUT;
   private isStructuringAgentStreamStarted = false;
+  private maxRetries?: number;
   private jsonPromptInjection?: boolean;
   private providerOptions?: ProviderOptions;
   private logger?: IMastraLogger;
@@ -61,6 +63,7 @@ export class StructuredOutputProcessor<OUTPUT extends {}> implements Processor<'
     this.schema = options.schema;
     this.errorStrategy = options.errorStrategy ?? 'strict';
     this.fallbackValue = options.fallbackValue;
+    this.maxRetries = options.maxRetries;
     this.jsonPromptInjection = options.jsonPromptInjection;
     this.providerOptions = options.providerOptions;
     this.logger = options.logger;
@@ -114,13 +117,20 @@ export class StructuredOutputProcessor<OUTPUT extends {}> implements Processor<'
       const structuringPrompt = this.buildStructuringPrompt(streamParts);
       const prompt = `Extract and structure the key information from the following text according to the specified schema. Keep the original meaning and details:\n\n${structuringPrompt}`;
 
+      // Build structuredOutput options respecting the FallbackFields union type
+      const structuredOutputOpts = {
+        schema: this.schema!,
+        jsonPromptInjection: this.jsonPromptInjection,
+        ...(this.errorStrategy === 'fallback'
+          ? { errorStrategy: 'fallback' as const, fallbackValue: this.fallbackValue! }
+          : { errorStrategy: this.errorStrategy }),
+      };
+
       // Use structuredOutput in 'direct' mode (no model) since this agent already has a model
       const structuringAgentStream = await this.structuringAgent.stream(prompt, {
-        structuredOutput: {
-          schema: this.schema!,
-          jsonPromptInjection: this.jsonPromptInjection,
-        },
+        structuredOutput: structuredOutputOpts,
         providerOptions: this.providerOptions,
+        ...(this.maxRetries !== undefined ? { modelSettings: { maxRetries: this.maxRetries } } : {}),
         ...observabilityContext,
       });
 
@@ -171,6 +181,7 @@ export class StructuredOutputProcessor<OUTPUT extends {}> implements Processor<'
         controller.enqueue(newChunk);
       }
     } catch (error) {
+      if (error instanceof TripWire) throw error;
       this.handleError(
         'Structured output processing failed',
         error instanceof Error ? error.message : 'Unknown error',

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -145,11 +145,15 @@ export class StructuredOutputProcessor<OUTPUT extends {}> implements Processor<'
       ];
 
       // Stream object chunks directly into the main stream
+      let objectResultEmitted = false;
+      let errorChunkSeen = false;
+
       for await (const chunk of structuringAgentStream.fullStream) {
         if (excludedChunkTypes.includes(chunk.type) || chunk.type.startsWith('data-')) {
           continue;
         }
         if (chunk.type === 'error') {
+          errorChunkSeen = true;
           this.handleError('Structuring failed', 'Internal agent did not generate structured output', abort);
 
           if (this.errorStrategy === 'warn') {
@@ -172,6 +176,10 @@ export class StructuredOutputProcessor<OUTPUT extends {}> implements Processor<'
           }
         }
 
+        if (chunk.type === 'object-result') {
+          objectResultEmitted = true;
+        }
+
         const newChunk: ChunkType<OUTPUT> = {
           ...chunk,
           metadata: {
@@ -179,6 +187,24 @@ export class StructuredOutputProcessor<OUTPUT extends {}> implements Processor<'
           },
         } as const;
         controller.enqueue(newChunk);
+      }
+
+      // If no object was produced and no error chunk was seen, the inner agent generated
+      // no parseable output (e.g. the custom model emitted no text, or empty text).
+      // Log what the model generated and surface a proper error instead of silently returning undefined.
+      if (!objectResultEmitted && !errorChunkSeen) {
+        let generatedText: string | undefined;
+        try {
+          generatedText = await structuringAgentStream.text;
+        } catch {
+          // ignore - we just want the text for diagnostics
+        }
+
+        const detail = generatedText?.trim()
+          ? `Model generated text that could not be parsed as structured output. Generated text: "${generatedText.substring(0, 300)}${generatedText.length > 300 ? '...' : ''}"`
+          : 'Model generated no text output. The custom provider may not support the response format or the model may have returned an empty response.';
+
+        this.handleError('Structuring failed', detail, abort);
       }
     } catch (error) {
       if (error instanceof TripWire) throw error;

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -161,6 +161,12 @@ export function execute<OUTPUT = undefined>({
           {
             retries: modelSettings?.maxRetries ?? 2,
             signal: abortSignal,
+            onFailedAttempt(error) {
+              const totalAttempts = (modelSettings?.maxRetries ?? 2) + 1;
+              console.warn(
+                `[Mastra] LLM call to ${model.modelId} failed (attempt ${error.attemptNumber}/${totalAttempts}): ${error.message}`,
+              );
+            },
             shouldRetry(context) {
               if (APICallError.isInstance(context.error)) {
                 return context.error.isRetryable;

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -161,10 +161,10 @@ export function execute<OUTPUT = undefined>({
           {
             retries: modelSettings?.maxRetries ?? 2,
             signal: abortSignal,
-            onFailedAttempt(error) {
+            onFailedAttempt({ error, attemptNumber }) {
               const totalAttempts = (modelSettings?.maxRetries ?? 2) + 1;
               console.warn(
-                `[Mastra] LLM call to ${model.modelId} failed (attempt ${error.attemptNumber}/${totalAttempts}): ${error.message}`,
+                `[Mastra] LLM call to ${model.modelId} failed (attempt ${attemptNumber}/${totalAttempts}): ${error.message}`,
               );
             },
             shouldRetry(context) {

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -666,6 +666,12 @@ export function createObjectStreamTransformer<OUTPUT = undefined>({
         object: structuredOutput?.fallbackValue,
       });
     } else {
+      // strict mode: always log for visibility so users can diagnose why result.object is undefined
+      if (logger) {
+        logger.warn(`[Mastra] Structured output validation failed: ${error.message}`);
+      } else {
+        console.warn(`[Mastra] Structured output validation failed: ${error.message}`);
+      }
       controller.enqueue({
         from: ChunkFrom.AGENT,
         runId: currentRunId ?? '',

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -631,7 +631,6 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               self.resolvePromises({
                 text: self.#bufferedText.join(''),
                 finishReason: 'other',
-                object: undefined,
                 usage: self.#usageCount,
                 warnings: self.#warnings,
                 providerMetadata: undefined,
@@ -651,6 +650,17 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 suspendPayload: undefined, // Tripwire doesn't suspend, so resolve to undefined
                 resumeSchema: undefined,
               });
+
+              // Reject the object promise with the failure reason so `await result.object`
+              // throws a meaningful error instead of silently resolving to undefined.
+              if (self.#delayedPromises.object.status.type === 'pending') {
+                const reason = chunk.payload?.reason;
+                if (reason) {
+                  self.#delayedPromises.object.reject(new Error(reason));
+                } else {
+                  self.#delayedPromises.object.resolve(undefined as OUTPUT);
+                }
+              }
 
               self.#closeTransportIfNeeded();
 


### PR DESCRIPTION
## Summary

Improves error handling and observability in structured output processor mode (`structuredOutput.model`):

- **Forward `errorStrategy`/`fallbackValue` to inner structuring agent** — the inner agent's `createObjectStreamTransformer` was always defaulting to strict mode because these options were never passed through, causing unnecessary error chunk propagation and "Error in agent stream" logging
- **Add TripWire guard in catch block** — prevents double error handling when strict mode's `abort()` throws a TripWire that gets caught and re-processed
- **Add `maxRetries` option to `StructuredOutputOptionsBase`** — lets users control the inner agent's p-retry count (defaults to 2 retries unchanged)
- **Add `onFailedAttempt` logging to p-retry** — LLM call retries are no longer silent; users will now see `[Mastra] LLM call to <modelId> failed (attempt N/M): <message>` on retry

## Context

A user reported that `result.object` is always `undefined` when using processor mode with a custom OpenAI-compatible provider, with the inner agent retrying silently. The retry logging added here will give us (and the user) visibility into what's actually failing. This is a draft for the user to test — the retry logs should reveal the root cause.

## Test plan

- [x] Unit tests for errorStrategy/fallbackValue forwarding
- [x] Unit test for TripWire guard (no double error logging)
- [x] Unit tests for maxRetries forwarding and omission
- [x] Integration repro tests with MockLanguageModelV2 (fallback, strict, warn, throwing model)
- [x] Verified "no error in agent stream" test fails without the fix, passes with it
- [x] All existing structured-output and output-format-handlers tests pass