### PR TITLE
feat(harness): add Quorem parallel agent feature

### DIFF
--- a/.changeset/brave-bars-bow.md
+++ b/.changeset/brave-bars-bow.md
@@ -1,0 +1,6 @@
+---
+'mastracode': minor
+'@mastra/core': patch
+---
+
+Added /quorem slash command and TUI integration for the Quorem parallel agent feature. Users can view individual quorem agent threads with `/quorem view <agentId>`, return to the main thread with `/quorem back`, and cancel active sessions with `/quorem cancel`. Includes real-time status display showing agent progress, and event handlers for all quorem lifecycle events. Git worktree-based environment isolation is wired as the default `QuoremEnvironmentConfig` implementation.

--- a/.changeset/legal-corners-start.md
+++ b/.changeset/legal-corners-start.md
@@ -1,0 +1,16 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Added /quorem feature for parallel agent execution. The Harness now supports launching multiple quorem agents that work independently in isolated environments, each with a cloned thread containing full conversation context. After all agents complete, the main agent reviews their results, selects a winner, and merges the winning agent's changes.
+
+**New types:** `QuoremAgentConfig`, `QuoremSessionConfig`, `QuoremAgentState`, `QuoremSession`, `QuoremEnvironmentConfig`
+
+**New Harness methods:** `startQuoremSession()`, `reviewQuoremAgent()`, `selectQuoremWinner()`, `cancelQuoremSession()`, `getQuoremSession()`
+
+**New tools:** `quorem` (starts a parallel session) and `quorem_select` (picks a winner)
+
+**New events:** `quorem_start`, `quorem_agent_start`, `quorem_agent_progress`, `quorem_agent_end`, `quorem_review_start`, `quorem_merged`, `quorem_cancelled`
+
+Environment management (creating, removing, merging isolated environments) is injected via `QuoremEnvironmentConfig`, keeping the core decoupled from any specific isolation strategy.

--- a/.changeset/olive-gifts-lay.md
+++ b/.changeset/olive-gifts-lay.md
@@ -1,0 +1,16 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Added Quorem parallel agent feature to the Harness. The main agent can now delegate a task to multiple parallel "quorem" agents, each running in an isolated environment with a cloned conversation thread. After all agents complete, the main agent reviews results, picks a winner, and merges their changes.
+
+**New types:** `QuoremAgentConfig`, `QuoremSessionConfig`, `QuoremAgentState`, `QuoremSession`, `QuoremEnvironmentConfig`
+
+**New Harness methods:** `startQuoremSession()`, `reviewQuoremAgent()`, `selectQuoremWinner()`, `cancelQuoremSession()`, `getQuoremSession()`
+
+**New tools:** `quorem` (starts a parallel session) and `quorem_select` (picks a winner)
+
+**New events:** `quorem_start`, `quorem_agent_start`, `quorem_agent_progress`, `quorem_agent_end`, `quorem_review_start`, `quorem_merged`, `quorem_cancelled`
+
+Environment management is injected via `QuoremEnvironmentConfig`, keeping the core decoupled from any specific isolation strategy (git worktrees, containers, temp dirs, etc).

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -1,6 +1,7 @@
 import { Mastra } from '@mastra/core';
 import { Agent } from '@mastra/core/agent';
 import { Harness, taskWriteTool, taskCheckTool } from '@mastra/core/harness';
+import { createQuoremEnvironmentConfig } from './utils/quorem-env.js';
 import type { HeartbeatHandler, HarnessMode, HarnessSubagent } from '@mastra/core/harness';
 import { noopLogger } from '@mastra/core/logger';
 
@@ -280,6 +281,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
       acquire: acquireThreadLock,
       release: releaseThreadLock,
     },
+    quorem: createQuoremEnvironmentConfig(),
   });
 
   // Sync hookManager session ID on thread changes

--- a/mastracode/src/tui/command-dispatch.ts
+++ b/mastracode/src/tui/command-dispatch.ts
@@ -29,6 +29,7 @@ import {
   handleReviewCommand as handleReviewCmd,
   handleSetupCommand,
   handleThemeCommand,
+  handleQuoremCommand,
 } from './commands/index.js';
 import type { SlashCommandContext } from './commands/types.js';
 import { SlashCommandComponent } from './components/slash-command.js';
@@ -142,6 +143,9 @@ export async function dispatchSlashCommand(
       return true;
     case 'theme':
       await handleThemeCommand(buildCtx(), args);
+      return true;
+    case 'quorem':
+      await handleQuoremCommand(buildCtx(), args);
       return true;
     default: {
       const customCommand = state.customSlashCommands.find(cmd => cmd.name === command);

--- a/mastracode/src/tui/commands/index.ts
+++ b/mastracode/src/tui/commands/index.ts
@@ -26,3 +26,4 @@ export { handleLoginCommand } from './login.js';
 export { handleReviewCommand } from './review.js';
 export { handleSetupCommand } from './setup.js';
 export { handleThemeCommand } from './theme.js';
+export { handleQuoremCommand } from './quorem.js';

--- a/mastracode/src/tui/commands/quorem.ts
+++ b/mastracode/src/tui/commands/quorem.ts
@@ -1,0 +1,109 @@
+import { theme } from '../theme.js';
+import type { SlashCommandContext } from './types.js';
+
+/**
+ * /quorem [subcommand] — Manage quorem parallel agent sessions.
+ *
+ * Subcommands:
+ *   (none)  — Show current quorem session status
+ *   view <agentId> — Switch TUI view to a quorem agent's thread
+ *   back — Return to the main agent's thread view
+ *   cancel — Cancel the active quorem session
+ */
+export async function handleQuoremCommand(ctx: SlashCommandContext, args: string[]): Promise<void> {
+  const sub = args[0];
+
+  if (!sub) {
+    return showQuoremStatus(ctx);
+  }
+
+  switch (sub) {
+    case 'view':
+      return handleQuoremView(ctx, args[1]);
+    case 'back':
+      return handleQuoremBack(ctx);
+    case 'cancel':
+      return handleQuoremCancel(ctx);
+    default:
+      ctx.showError(`Unknown /quorem subcommand: ${sub}. Use view, back, or cancel.`);
+  }
+}
+
+function showQuoremStatus(ctx: SlashCommandContext): void {
+  const ds = ctx.state.harness.getDisplayState();
+  const session = ds.activeQuoremSession;
+
+  if (!session) {
+    ctx.showInfo('No active quorem session.');
+    return;
+  }
+
+  const lines: string[] = [
+    `${theme.fg('accent', 'Quorem Session')} ${theme.fg('muted', `(${session.id})`)}`,
+    `Task: ${session.task}`,
+    `Status: ${session.status}`,
+    '',
+  ];
+
+  for (const agent of session.agents) {
+    const statusColor = agent.status === 'completed' ? 'success' : agent.status === 'error' ? 'error' : 'muted';
+    const label = agent.label || agent.id;
+    lines.push(
+      `  ${theme.fg(statusColor as any, `[${agent.status}]`)} ${label}` +
+        (agent.modelId ? ` ${theme.fg('muted', `(${agent.modelId})`)}` : ''),
+    );
+    if (agent.summary) {
+      lines.push(`    ${theme.fg('muted', agent.summary)}`);
+    }
+  }
+
+  lines.push('');
+  lines.push(theme.fg('muted', 'Use /quorem view <id> to view an agent, /quorem cancel to abort.'));
+
+  ctx.showInfo(lines.join('\n'));
+}
+
+function handleQuoremView(ctx: SlashCommandContext, agentId?: string): void {
+  if (!agentId) {
+    ctx.showError('Usage: /quorem view <agentId>');
+    return;
+  }
+
+  const ds = ctx.state.harness.getDisplayState();
+  const session = ds.activeQuoremSession;
+
+  if (!session) {
+    ctx.showError('No active quorem session.');
+    return;
+  }
+
+  const agent = session.agents.find(a => a.id === agentId);
+  if (!agent) {
+    const ids = session.agents.map(a => a.id).join(', ');
+    ctx.showError(`Agent "${agentId}" not found. Available: ${ids}`);
+    return;
+  }
+
+  ctx.state.viewingQuoremAgentId = agentId;
+  ctx.showInfo(`Viewing quorem agent: ${agent.label || agentId}. Use /quorem back to return.`);
+}
+
+function handleQuoremBack(ctx: SlashCommandContext): void {
+  if (!ctx.state.viewingQuoremAgentId) {
+    ctx.showInfo('Already viewing the main thread.');
+    return;
+  }
+
+  ctx.state.viewingQuoremAgentId = undefined;
+  ctx.showInfo('Returned to main thread view.');
+}
+
+async function handleQuoremCancel(ctx: SlashCommandContext): Promise<void> {
+  try {
+    await ctx.state.harness.cancelQuoremSession();
+    ctx.state.viewingQuoremAgentId = undefined;
+    ctx.showInfo('Quorem session cancelled.');
+  } catch (err) {
+    ctx.showError(`Failed to cancel quorem session: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}

--- a/mastracode/src/tui/components/quorem-agent-header.ts
+++ b/mastracode/src/tui/components/quorem-agent-header.ts
@@ -1,0 +1,34 @@
+/**
+ * Header banner shown when the user is viewing a quorem agent's thread.
+ * Provides context about which agent is being viewed and how to return.
+ */
+import { Container, Text, Spacer } from '@mariozechner/pi-tui';
+import type { QuoremAgentState } from '@mastra/core/harness';
+import { theme } from '../theme.js';
+
+export class QuoremAgentHeaderComponent extends Container {
+  constructor(agent: QuoremAgentState) {
+    super();
+
+    const label = agent.label || agent.id;
+    const statusIcon =
+      agent.status === 'completed'
+        ? theme.fg('success', '✓')
+        : agent.status === 'error'
+          ? theme.fg('error', '✗')
+          : agent.status === 'running'
+            ? theme.fg('accent', '⋯')
+            : theme.fg('muted', '○');
+
+    const model = agent.modelId ? theme.fg('muted', ` · ${agent.modelId}`) : '';
+    const headerLine =
+      theme.bold(theme.fg('accent', `  ◆ Quorem Agent: ${label}`)) +
+      ` ${statusIcon}` +
+      model;
+
+    this.addChild(new Spacer(1));
+    this.addChild(new Text(headerLine, 0, 0));
+    this.addChild(new Text(theme.fg('muted', '  Use /quorem back to return to the main thread.'), 0, 0));
+    this.addChild(new Spacer(1));
+  }
+}

--- a/mastracode/src/tui/components/quorem-status.ts
+++ b/mastracode/src/tui/components/quorem-status.ts
@@ -1,0 +1,92 @@
+/**
+ * Quorem session status component.
+ * Shows a persistent, compact display of all quorem agents and their statuses.
+ * Renders similarly to task-progress — hidden when no quorem session is active.
+ */
+import { Container, Text, Spacer } from '@mariozechner/pi-tui';
+import type { QuoremAgentState, QuoremSession } from '@mastra/core/harness';
+import { theme } from '../theme.js';
+
+export class QuoremStatusComponent extends Container {
+  private session: QuoremSession | null = null;
+
+  constructor() {
+    super();
+  }
+
+  updateSession(session: QuoremSession | null): void {
+    this.session = session;
+    this.rebuild();
+  }
+
+  private rebuild(): void {
+    this.clear();
+
+    if (!this.session || this.session.status === 'merged' || this.session.status === 'cancelled') {
+      return;
+    }
+
+    const { session } = this;
+    const completed = session.agents.filter(a => a.status === 'completed' || a.status === 'error').length;
+    const total = session.agents.length;
+
+    this.addChild(new Spacer(1));
+
+    const statusLabel =
+      session.status === 'reviewing'
+        ? theme.fg('warning' as any, 'reviewing')
+        : theme.fg('muted', session.status);
+
+    const header =
+      '  ' +
+      theme.bold(theme.fg('accent', 'Quorem')) +
+      theme.fg('dim', ` [${completed}/${total} done]`) +
+      ' ' +
+      statusLabel;
+
+    this.addChild(new Text(header, 0, 0));
+
+    // Show task summary
+    const taskLine = '    ' + theme.fg('muted', session.task.length > 80 ? session.task.slice(0, 77) + '...' : session.task);
+    this.addChild(new Text(taskLine, 0, 0));
+
+    // Show each agent
+    for (const agent of session.agents) {
+      this.addChild(new Text(this.formatAgentLine(agent), 0, 0));
+    }
+
+    this.invalidate();
+  }
+
+  private formatAgentLine(agent: QuoremAgentState): string {
+    const indent = '    ';
+    const icon = statusIcon(agent.status);
+    const label = agent.label || agent.id;
+    const model = agent.modelId ? theme.fg('muted', ` (${agent.modelId})`) : '';
+    const duration =
+      agent.durationMs != null ? theme.fg('muted', ` ${formatDuration(agent.durationMs)}`) : '';
+
+    return `${indent}${icon} ${label}${model}${duration}`;
+  }
+}
+
+function statusIcon(status: QuoremAgentState['status']): string {
+  switch (status) {
+    case 'pending':
+      return theme.fg('muted', '○');
+    case 'running':
+      return theme.fg('accent', '⋯');
+    case 'completed':
+      return theme.fg('success', '✓');
+    case 'error':
+      return theme.fg('error', '✗');
+    default:
+      return theme.fg('muted', '?');
+  }
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = (ms / 1000).toFixed(1);
+  return `${s}s`;
+}

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -36,6 +36,13 @@ import {
   handleToolInputDelta,
   handleToolInputEnd,
   handleToolEnd,
+  handleQuoremStart,
+  handleQuoremAgentStart,
+  handleQuoremAgentProgress,
+  handleQuoremAgentEnd,
+  handleQuoremReviewStart,
+  handleQuoremMerged,
+  handleQuoremCancelled,
 } from './handlers/index.js';
 import type { EventHandlerContext } from './handlers/types.js';
 import type { TUIState } from './state.js';
@@ -305,6 +312,35 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
 
     case 'plan_approved':
       // Handled directly in onApprove callback to ensure proper sequencing
+      break;
+
+    // Quorem parallel agent session events
+    case 'quorem_start':
+      handleQuoremStart(ectx, event.sessionId, event.task, event.agents);
+      break;
+
+    case 'quorem_agent_start':
+      handleQuoremAgentStart(ectx, event.sessionId, event.agentId);
+      break;
+
+    case 'quorem_agent_progress':
+      handleQuoremAgentProgress(ectx, event.sessionId, event.agentId, event.summary);
+      break;
+
+    case 'quorem_agent_end':
+      handleQuoremAgentEnd(ectx, event.sessionId, event.agentId, event.status);
+      break;
+
+    case 'quorem_review_start':
+      handleQuoremReviewStart(ectx, event.sessionId);
+      break;
+
+    case 'quorem_merged':
+      handleQuoremMerged(ectx, event.sessionId, event.winnerId);
+      break;
+
+    case 'quorem_cancelled':
+      handleQuoremCancelled(ectx, event.sessionId);
       break;
 
     case 'display_state_changed':

--- a/mastracode/src/tui/handlers/index.ts
+++ b/mastracode/src/tui/handlers/index.ts
@@ -25,3 +25,12 @@ export {
   handleToolInputEnd,
   handleToolEnd,
 } from './tool.js';
+export {
+  handleQuoremStart,
+  handleQuoremAgentStart,
+  handleQuoremAgentProgress,
+  handleQuoremAgentEnd,
+  handleQuoremReviewStart,
+  handleQuoremMerged,
+  handleQuoremCancelled,
+} from './quorem.js';

--- a/mastracode/src/tui/handlers/quorem.ts
+++ b/mastracode/src/tui/handlers/quorem.ts
@@ -1,0 +1,141 @@
+/**
+ * Event handlers for quorem parallel agent session events:
+ * quorem_start, quorem_agent_start, quorem_agent_progress,
+ * quorem_agent_end, quorem_review_start, quorem_merged, quorem_cancelled.
+ */
+import type { QuoremAgentConfig } from '@mastra/core/harness';
+
+import { QuoremStatusComponent } from '../components/quorem-status.js';
+import type { TUIState } from '../state.js';
+
+import type { EventHandlerContext } from './types.js';
+
+/**
+ * Ensure the QuoremStatusComponent exists and is attached.
+ * Returns the component for further updates.
+ */
+function ensureQuoremStatusComponent(state: TUIState): QuoremStatusComponent {
+  if (!(state as any)._quoremStatusComponent) {
+    (state as any)._quoremStatusComponent = new QuoremStatusComponent();
+  }
+  return (state as any)._quoremStatusComponent;
+}
+
+export function handleQuoremStart(
+  ctx: EventHandlerContext,
+  sessionId: string,
+  task: string,
+  agents: QuoremAgentConfig[],
+): void {
+  const { state } = ctx;
+  const ds = state.harness.getDisplayState();
+
+  ctx.showInfo(`Quorem session started: ${agents.length} agents working on task.`);
+
+  // Update the persistent status component
+  const comp = ensureQuoremStatusComponent(state);
+  comp.updateSession(ds.activeQuoremSession ?? null);
+
+  // Insert component into chat if not already there
+  if (!state.chatContainer.children.includes(comp as any)) {
+    ctx.addChildBeforeFollowUps(comp);
+  }
+
+  state.ui.requestRender();
+}
+
+export function handleQuoremAgentStart(
+  ctx: EventHandlerContext,
+  sessionId: string,
+  agentId: string,
+): void {
+  const { state } = ctx;
+  const ds = state.harness.getDisplayState();
+
+  const comp = ensureQuoremStatusComponent(state);
+  comp.updateSession(ds.activeQuoremSession ?? null);
+  state.ui.requestRender();
+}
+
+export function handleQuoremAgentProgress(
+  ctx: EventHandlerContext,
+  sessionId: string,
+  agentId: string,
+  summary: string,
+): void {
+  const { state } = ctx;
+  const ds = state.harness.getDisplayState();
+
+  const comp = ensureQuoremStatusComponent(state);
+  comp.updateSession(ds.activeQuoremSession ?? null);
+  state.ui.requestRender();
+}
+
+export function handleQuoremAgentEnd(
+  ctx: EventHandlerContext,
+  sessionId: string,
+  agentId: string,
+  status: string,
+): void {
+  const { state } = ctx;
+  const ds = state.harness.getDisplayState();
+
+  const comp = ensureQuoremStatusComponent(state);
+  comp.updateSession(ds.activeQuoremSession ?? null);
+
+  // Clear the quorem agent view if the agent we're viewing just ended
+  if (state.viewingQuoremAgentId === agentId) {
+    // Keep viewing — the user can /quorem back when ready
+  }
+
+  state.ui.requestRender();
+}
+
+export function handleQuoremReviewStart(
+  ctx: EventHandlerContext,
+  sessionId: string,
+): void {
+  const { state } = ctx;
+  const ds = state.harness.getDisplayState();
+
+  ctx.showInfo('All quorem agents finished. Main agent is reviewing results...');
+
+  const comp = ensureQuoremStatusComponent(state);
+  comp.updateSession(ds.activeQuoremSession ?? null);
+  state.ui.requestRender();
+}
+
+export function handleQuoremMerged(
+  ctx: EventHandlerContext,
+  sessionId: string,
+  winnerId: string,
+): void {
+  const { state } = ctx;
+  const ds = state.harness.getDisplayState();
+
+  ctx.showInfo(`Quorem session complete. Winner: ${winnerId}. Changes merged.`);
+
+  // Clear the viewing state
+  state.viewingQuoremAgentId = undefined;
+
+  const comp = ensureQuoremStatusComponent(state);
+  comp.updateSession(ds.activeQuoremSession ?? null);
+  state.ui.requestRender();
+}
+
+export function handleQuoremCancelled(
+  ctx: EventHandlerContext,
+  sessionId: string,
+): void {
+  const { state } = ctx;
+  const ds = state.harness.getDisplayState();
+
+  ctx.showInfo('Quorem session cancelled.');
+
+  // Clear the viewing state
+  state.viewingQuoremAgentId = undefined;
+
+  const comp = ensureQuoremStatusComponent(state);
+  comp.updateSession(ds.activeQuoremSession ?? null);
+  state.ui.requestRender();
+}

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -153,6 +153,10 @@ export interface TUIState {
   /** Pending images from clipboard paste */
   pendingImages: Array<{ data: string; mimeType: string }>;
 
+  // ── Quorem ────────────────────────────────────────────────────────────
+  /** When set, the TUI is viewing a specific quorem agent's thread */
+  viewingQuoremAgentId?: string;
+
   // ── Abort tracking ────────────────────────────────────────────────────
   lastCtrlCTime: number;
   /** Track user-initiated aborts (Ctrl+C/Esc) vs system aborts */

--- a/mastracode/src/utils/quorem-env.ts
+++ b/mastracode/src/utils/quorem-env.ts
@@ -1,0 +1,68 @@
+import type { QuoremEnvironmentConfig } from '@mastra/core/harness';
+
+/**
+ * Creates environment management functions for the quorem feature.
+ * This implementation uses git worktrees as the isolation mechanism.
+ * These are injected into the Harness config to keep git operations
+ * in the app layer (mastracode) rather than the core.
+ */
+export function createQuoremEnvironmentConfig(): QuoremEnvironmentConfig {
+  return {
+    createEnvironment: async ({ path, ref }) => {
+      const { execa } = await import('execa');
+      // Create a git worktree on a new branch from HEAD
+      await execa('git', ['worktree', 'add', '-b', ref, path], {
+        cwd: process.cwd(),
+      });
+    },
+
+    removeEnvironment: async ({ path }) => {
+      const { execa } = await import('execa');
+      await execa('git', ['worktree', 'remove', path, '--force'], {
+        cwd: process.cwd(),
+        reject: false,
+      });
+    },
+
+    mergeResults: async ({ ref }) => {
+      const { execa } = await import('execa');
+      await execa('git', ['merge', ref, '--no-edit'], {
+        cwd: process.cwd(),
+      });
+    },
+
+    getArtifacts: async ({ path }) => {
+      const { execa } = await import('execa');
+      // List files modified in the environment relative to its base
+      const result = await execa('git', ['diff', '--name-only', 'HEAD'], {
+        cwd: path,
+        reject: false,
+      });
+      const staged = await execa('git', ['diff', '--cached', '--name-only'], {
+        cwd: path,
+        reject: false,
+      });
+      const files = new Set<string>();
+      for (const line of result.stdout.split('\n').filter(Boolean)) {
+        files.add(line);
+      }
+      for (const line of staged.stdout.split('\n').filter(Boolean)) {
+        files.add(line);
+      }
+      return Array.from(files);
+    },
+
+    getResultDiff: async ({ path }) => {
+      const { execa } = await import('execa');
+      const result = await execa('git', ['diff', 'HEAD'], {
+        cwd: path,
+        reject: false,
+      });
+      const staged = await execa('git', ['diff', '--cached'], {
+        cwd: path,
+        reject: false,
+      });
+      return [result.stdout, staged.stdout].filter(Boolean).join('\n');
+    },
+  };
+}

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -9,7 +9,15 @@ import type { ObservationalMemoryRecord } from '../storage/types';
 import { Workspace } from '../workspace/workspace';
 import type { WorkspaceConfig } from '../workspace/workspace';
 
-import { askUserTool, createSubagentTool, submitPlanTool, taskCheckTool, taskWriteTool } from './tools';
+import {
+  askUserTool,
+  createQuoremSelectTool,
+  createQuoremTool,
+  createSubagentTool,
+  submitPlanTool,
+  taskCheckTool,
+  taskWriteTool,
+} from './tools';
 import { defaultDisplayState, defaultOMProgressState } from './types';
 import type {
   AvailableModel,
@@ -28,6 +36,10 @@ import type {
   ModelAuthStatus,
   PermissionPolicy,
   PermissionRules,
+  QuoremAgentConfig,
+  QuoremAgentState,
+  QuoremSession,
+  QuoremSessionConfig,
   ToolCategory,
 } from './types';
 
@@ -92,6 +104,7 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
   private sessionGrantedCategories = new Set<string>();
   private sessionGrantedTools = new Set<string>();
   private displayState: HarnessDisplayState = defaultDisplayState();
+  private quoremSession: QuoremSession | null = null;
 
   constructor(config: HarnessConfig<TState>) {
     this.id = config.id;
@@ -2278,6 +2291,85 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
         break;
       }
 
+      // ── Quorem lifecycle ───────────────────────────────────────────────
+      case 'quorem_start': {
+        ds.activeQuoremSession = {
+          id: event.sessionId,
+          task: event.task,
+          status: 'running',
+          agents: event.agents.map(a => ({
+            id: a.id,
+            label: a.label ?? a.id,
+            status: 'pending' as const,
+            threadId: null,
+            environmentPath: null,
+            environmentRef: null,
+            summary: null,
+            artifacts: [],
+            error: null,
+            durationMs: null,
+            modelId: null,
+          })),
+          winnerId: null,
+          startedAt: new Date(),
+          endedAt: null,
+        };
+        break;
+      }
+
+      case 'quorem_agent_start': {
+        const qAgent = ds.activeQuoremSession?.agents.find(a => a.id === event.agentId);
+        if (qAgent) {
+          qAgent.status = 'running';
+          qAgent.threadId = event.threadId;
+          qAgent.environmentPath = event.environmentPath;
+        }
+        break;
+      }
+
+      case 'quorem_agent_progress': {
+        // Progress events can carry partial text or status updates
+        break;
+      }
+
+      case 'quorem_agent_end': {
+        const qAgent = ds.activeQuoremSession?.agents.find(a => a.id === event.agentId);
+        if (qAgent) {
+          qAgent.status = event.status;
+          qAgent.summary = event.summary;
+          qAgent.artifacts = event.artifacts;
+          qAgent.durationMs = event.durationMs;
+          if (event.error) {
+            qAgent.error = event.error;
+          }
+        }
+        break;
+      }
+
+      case 'quorem_review_start': {
+        if (ds.activeQuoremSession) {
+          ds.activeQuoremSession.status = 'reviewing';
+        }
+        break;
+      }
+
+      case 'quorem_merged': {
+        if (ds.activeQuoremSession) {
+          ds.activeQuoremSession.status = 'merged';
+          ds.activeQuoremSession.winnerId = event.winnerId;
+          ds.activeQuoremSession.endedAt = new Date();
+        }
+        break;
+      }
+
+      case 'quorem_cancelled': {
+        if (ds.activeQuoremSession) {
+          ds.activeQuoremSession.status = 'cancelled';
+          ds.activeQuoremSession.endedAt = new Date();
+        }
+        break;
+      }
+
       default:
         break;
     }
@@ -2321,6 +2413,12 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
       });
     }
 
+    // Auto-create quorem tools if quorem worktree config is present
+    if (this.config.quorem) {
+      builtInTools.quorem = createQuoremTool();
+      builtInTools.quorem_select = createQuoremSelectTool();
+    }
+
     if (resolvedHarnessTools) {
       return { harnessBuiltIn: builtInTools, harness: resolvedHarnessTools };
     }
@@ -2346,6 +2444,8 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
       registerQuestion: params => this.registerQuestion(params),
       registerPlanApproval: params => this.registerPlanApproval(params),
       getSubagentModelId: params => this.getSubagentModelId(params),
+      startQuoremSession: config => this.startQuoremSession(config),
+      selectQuoremWinner: winnerId => this.selectQuoremWinner(winnerId),
     };
 
     const requestContext = new RequestContext([['harness', harnessContext]]) as RequestContext;
@@ -2521,6 +2621,317 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
       currentModeId: this.currentModeId,
       threads: await this.listThreads(),
     };
+  }
+
+  // ===========================================================================
+  // Quorem (Parallel Agent Quorum)
+  // ===========================================================================
+
+  /**
+   * Start a quorem session: spawn N parallel agents, each in its own git
+   * worktree with a cloned thread, working on the same task.
+   */
+  async startQuoremSession(config: QuoremSessionConfig): Promise<QuoremSession> {
+    if (this.quoremSession?.status === 'running') {
+      throw new Error('A quorem session is already running. Cancel it first.');
+    }
+    if (!this.config.quorem) {
+      throw new Error('Quorem is not configured. Provide quorem worktree functions in HarnessConfig.');
+    }
+    if (!this.currentThreadId) {
+      throw new Error('No active thread. Start a conversation before launching quorem.');
+    }
+    if (!this.config.memory) {
+      throw new Error('Memory is required for quorem (thread cloning).');
+    }
+
+    const sessionId = this.generateId();
+
+    // Build agent states
+    const agents: QuoremAgentState[] = config.agents.map(a => ({
+      id: a.id,
+      label: a.label ?? a.id,
+      status: 'pending' as const,
+      threadId: null,
+      environmentPath: null,
+      environmentRef: null,
+      summary: null,
+      artifacts: [],
+      error: null,
+      durationMs: null,
+      modelId: a.modelId ?? this.getCurrentModelId() ?? null,
+    }));
+
+    const session: QuoremSession = {
+      id: sessionId,
+      task: config.task,
+      evaluationCriteria: config.evaluationCriteria,
+      agents,
+      status: 'running',
+      winnerId: null,
+      startedAt: new Date(),
+      endedAt: null,
+    };
+
+    this.quoremSession = session;
+    this.emit({
+      type: 'quorem_start',
+      sessionId,
+      task: config.task,
+      agents: config.agents.map(a => ({ id: a.id, label: a.label })),
+    });
+
+    // Launch agents in parallel
+    const promises = config.agents.map(agentConfig => this.launchQuoremAgent(session, agentConfig));
+    // Don't await — agents run in background. The main thread continues.
+    void Promise.allSettled(promises).then(() => {
+      // When all agents finish, transition to review mode
+      if (this.quoremSession?.id === sessionId && this.quoremSession.status === 'running') {
+        this.quoremSession.status = 'reviewing';
+        this.emit({ type: 'quorem_review_start', sessionId });
+      }
+    });
+
+    return session;
+  }
+
+  /**
+   * Launch a single quorem agent in an isolated environment with a cloned thread.
+   */
+  private async launchQuoremAgent(session: QuoremSession, agentConfig: QuoremAgentConfig): Promise<void> {
+    const agentState = session.agents.find(a => a.id === agentConfig.id);
+    if (!agentState) return;
+
+    const startTime = Date.now();
+    const envRef = `quorem/${session.id}/${agentConfig.id}`;
+    const envPath = `.quorem-environments/${session.id}/${agentConfig.id}`;
+
+    try {
+      // 1. Create isolated environment
+      await this.config.quorem!.createEnvironment({ path: envPath, ref: envRef });
+      agentState.environmentPath = envPath;
+      agentState.environmentRef = envRef;
+
+      // 2. Clone thread
+      const cloneResult = await this.config.memory!.cloneThread({
+        sourceThreadId: this.currentThreadId!,
+        newThreadId: `quorem-${session.id}-${agentConfig.id}`,
+        resourceId: this.resourceId,
+        title: `Quorem: ${agentConfig.label ?? agentConfig.id} — ${session.task.slice(0, 50)}`,
+        metadata: {
+          quoremSessionId: session.id,
+          quoremAgentId: agentConfig.id,
+        },
+      });
+      agentState.threadId = cloneResult.thread.id;
+
+      // 3. Mark agent as running
+      agentState.status = 'running';
+      this.emit({
+        type: 'quorem_agent_start',
+        sessionId: session.id,
+        agentId: agentConfig.id,
+        threadId: cloneResult.thread.id,
+        environmentPath: envPath,
+      });
+
+      // 4. Create a fresh agent and run it
+      const currentMode = this.getCurrentMode();
+      const baseAgent = typeof currentMode.agent === 'function' ? currentMode.agent(this.state) : currentMode.agent;
+      const baseInstructions = baseAgent.getInstructions();
+
+      const quoremInstructions = [
+        baseInstructions,
+        `\n\n## Quorem Task\n\nYou are one of several parallel agents working on the same task. Your working directory is: ${envPath}\n\n${session.task}`,
+        agentConfig.instructions ? `\n\n## Approach\n${agentConfig.instructions}` : '',
+      ]
+        .filter(Boolean)
+        .join('');
+
+      const modelId = agentConfig.modelId ?? this.getCurrentModelId();
+      if (!modelId || !this.config.resolveModel) {
+        throw new Error('No model available for quorem agent');
+      }
+
+      const model = this.config.resolveModel(modelId);
+
+      // Import Agent locally to avoid circular deps at top level
+      const { Agent } = await import('../agent');
+
+      const requestContext = await this.buildRequestContext();
+
+      // Build tools for quorem agent (same tools as main agent)
+      const toolsets = await this.buildToolsets(requestContext);
+      const mergedTools: ToolsInput = {};
+      for (const [, tools] of Object.entries(toolsets)) {
+        Object.assign(mergedTools, tools);
+      }
+
+      const quoremAgent = new Agent({
+        id: `quorem-${agentConfig.id}`,
+        name: `Quorem Agent: ${agentConfig.label ?? agentConfig.id}`,
+        instructions: quoremInstructions,
+        model,
+        tools: mergedTools,
+      });
+
+      // 5. Run the agent
+      const response = await quoremAgent.stream(
+        `Complete this task in the environment at ${envPath}:\n\n${session.task}`,
+        {
+          memory: { thread: cloneResult.thread.id, resource: this.resourceId },
+          maxSteps: 1000,
+          requestContext,
+        } as any,
+      );
+
+      // Consume the stream
+      let partialText = '';
+      for await (const chunk of response.fullStream) {
+        if (chunk.type === 'text-delta') {
+          partialText += chunk.payload.text;
+        }
+      }
+
+      const fullOutput = await response.getFullOutput();
+      const resultText = fullOutput.text || partialText;
+
+      // 6. Collect results
+      const artifacts = await this.config.quorem!.getArtifacts({ path: envPath });
+      agentState.artifacts = artifacts;
+      agentState.summary = resultText.slice(0, 2000); // Truncate summary
+      agentState.status = 'completed';
+      agentState.durationMs = Date.now() - startTime;
+
+      this.emit({
+        type: 'quorem_agent_end',
+        sessionId: session.id,
+        agentId: agentConfig.id,
+        status: 'completed',
+        summary: agentState.summary,
+        artifacts,
+        durationMs: agentState.durationMs,
+      });
+    } catch (error) {
+      agentState.status = 'error';
+      agentState.error = error instanceof Error ? error.message : String(error);
+      agentState.durationMs = Date.now() - startTime;
+
+      this.emit({
+        type: 'quorem_agent_end',
+        sessionId: session.id,
+        agentId: agentConfig.id,
+        status: 'error',
+        summary: null,
+        artifacts: [],
+        durationMs: agentState.durationMs,
+        error: agentState.error,
+      });
+    }
+  }
+
+  /**
+   * Get review data for a quorem agent: its diff and artifacts.
+   */
+  async reviewQuoremAgent(agentId: string): Promise<{ diff: string; artifacts: string[] } | null> {
+    if (!this.quoremSession || !this.config.quorem) return null;
+
+    const agentState = this.quoremSession.agents.find(a => a.id === agentId);
+    if (!agentState?.environmentPath) return null;
+
+    const diff = await this.config.quorem.getResultDiff({ path: agentState.environmentPath });
+    const artifacts = await this.config.quorem.getArtifacts({ path: agentState.environmentPath });
+    return { diff, artifacts };
+  }
+
+  /**
+   * Select a quorem winner and merge their environment's results.
+   */
+  async selectQuoremWinner(winnerId: string): Promise<void> {
+    if (!this.quoremSession) {
+      throw new Error('No active quorem session.');
+    }
+    if (!this.config.quorem) {
+      throw new Error('Quorem environment config not available.');
+    }
+
+    const winner = this.quoremSession.agents.find(a => a.id === winnerId);
+    if (!winner) {
+      throw new Error(`Quorem agent not found: ${winnerId}`);
+    }
+    if (winner.status !== 'completed') {
+      throw new Error(`Cannot select agent "${winnerId}" — status is "${winner.status}", expected "completed".`);
+    }
+    if (!winner.environmentRef) {
+      throw new Error(`Agent "${winnerId}" has no environment reference.`);
+    }
+
+    // Merge the winner's results
+    await this.config.quorem.mergeResults({ ref: winner.environmentRef });
+
+    this.quoremSession.winnerId = winnerId;
+    this.quoremSession.status = 'merged';
+    this.quoremSession.endedAt = new Date();
+
+    this.emit({
+      type: 'quorem_merged',
+      sessionId: this.quoremSession.id,
+      winnerId,
+      environmentRef: winner.environmentRef,
+    });
+
+    // Clean up all environments
+    await this.cleanupQuoremEnvironments();
+    this.quoremSession = null;
+  }
+
+  /**
+   * Cancel the active quorem session and clean up environments.
+   */
+  async cancelQuoremSession(): Promise<void> {
+    if (!this.quoremSession) {
+      throw new Error('No active quorem session.');
+    }
+
+    const sessionId = this.quoremSession.id;
+
+    // Mark running agents as cancelled
+    for (const agent of this.quoremSession.agents) {
+      if (agent.status === 'running' || agent.status === 'pending') {
+        agent.status = 'cancelled';
+      }
+    }
+
+    this.quoremSession.status = 'cancelled';
+    this.quoremSession.endedAt = new Date();
+    this.emit({ type: 'quorem_cancelled', sessionId });
+
+    await this.cleanupQuoremEnvironments();
+    this.quoremSession = null;
+  }
+
+  /**
+   * Get the active quorem session (if any).
+   */
+  getQuoremSession(): QuoremSession | null {
+    return this.quoremSession;
+  }
+
+  /**
+   * Clean up all quorem environments for the current session.
+   */
+  private async cleanupQuoremEnvironments(): Promise<void> {
+    if (!this.quoremSession || !this.config.quorem) return;
+
+    for (const agent of this.quoremSession.agents) {
+      if (agent.environmentPath) {
+        try {
+          await this.config.quorem.removeEnvironment({ path: agent.environmentPath });
+        } catch {
+          // Best-effort cleanup
+        }
+      }
+    }
   }
 
   // ===========================================================================

--- a/packages/core/src/harness/index.ts
+++ b/packages/core/src/harness/index.ts
@@ -1,5 +1,13 @@
 export { Harness } from './harness';
-export { askUserTool, parseSubagentMeta, submitPlanTool, taskCheckTool, taskWriteTool } from './tools';
+export {
+  askUserTool,
+  createQuoremSelectTool,
+  createQuoremTool,
+  parseSubagentMeta,
+  submitPlanTool,
+  taskCheckTool,
+  taskWriteTool,
+} from './tools';
 export type { TaskItem } from './tools';
 export { defaultDisplayState, defaultOMProgressState } from './types';
 export type {
@@ -28,6 +36,11 @@ export type {
   OMStatus,
   PermissionPolicy,
   PermissionRules,
+  QuoremAgentConfig,
+  QuoremAgentState,
+  QuoremSession,
+  QuoremSessionConfig,
+  QuoremEnvironmentConfig,
   ToolCategory,
   TokenUsage,
 } from './types';

--- a/packages/core/src/harness/quorem.e2e.test.ts
+++ b/packages/core/src/harness/quorem.e2e.test.ts
@@ -1,0 +1,714 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Agent } from '../agent';
+import { MockMemory } from '../memory/mock';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+import type { HarnessEvent, QuoremEnvironmentConfig } from './types';
+import { defaultDisplayState } from './types';
+
+// =============================================================================
+// Test helpers
+// =============================================================================
+
+function createMockQuoremConfig(): QuoremEnvironmentConfig {
+  return {
+    createEnvironment: vi.fn().mockResolvedValue(undefined),
+    removeEnvironment: vi.fn().mockResolvedValue(undefined),
+    mergeResults: vi.fn().mockResolvedValue(undefined),
+    getArtifacts: vi.fn().mockResolvedValue(['src/main.ts', 'src/utils.ts']),
+    getResultDiff: vi.fn().mockResolvedValue('diff --git a/src/main.ts b/src/main.ts\\n+// changes'),
+  };
+}
+
+function createTestHarness(opts?: { quorem?: QuoremEnvironmentConfig; memory?: MockMemory; storage?: InMemoryStore }) {
+  const storage = opts?.storage ?? new InMemoryStore();
+  const memory = opts?.memory ?? new MockMemory({ storage });
+
+  const agent = new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+
+  return new Harness({
+    id: 'test-harness',
+    storage,
+    memory,
+    modes: [{ id: 'default', name: 'Default', default: true, agent }],
+    quorem: opts?.quorem ?? createMockQuoremConfig(),
+    idGenerator: (() => {
+      let counter = 0;
+      return () => `test-id-${++counter}`;
+    })(),
+  });
+}
+
+// Helper to call the private emit method for display state testing
+function emit(harness: Harness, event: HarnessEvent) {
+  (harness as any).emit(event);
+}
+
+// Helper to set the currentThreadId on the harness
+async function ensureThread(harness: Harness): Promise<string> {
+  const thread = await harness.selectOrCreateThread();
+  return thread.id;
+}
+
+// =============================================================================
+// Display State: Quorem Events
+// =============================================================================
+
+describe('quorem display state', () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    harness = createTestHarness();
+  });
+
+  it('initial display state has no active quorem session', () => {
+    const ds = harness.getDisplayState();
+    expect(ds.activeQuoremSession).toBeNull();
+  });
+
+  it('quorem_start creates an activeQuoremSession', () => {
+    emit(harness, {
+      type: 'quorem_start',
+      sessionId: 'qs-1',
+      task: 'Implement feature X',
+      agents: [{ id: 'agent-a', label: 'Alpha' }, { id: 'agent-b', label: 'Beta' }, { id: 'agent-c' }],
+    });
+
+    const ds = harness.getDisplayState();
+    expect(ds.activeQuoremSession).not.toBeNull();
+    expect(ds.activeQuoremSession!.id).toBe('qs-1');
+    expect(ds.activeQuoremSession!.task).toBe('Implement feature X');
+    expect(ds.activeQuoremSession!.status).toBe('running');
+    expect(ds.activeQuoremSession!.agents).toHaveLength(3);
+    expect(ds.activeQuoremSession!.winnerId).toBeNull();
+    expect(ds.activeQuoremSession!.endedAt).toBeNull();
+
+    // Agents should have correct defaults
+    const agentA = ds.activeQuoremSession!.agents[0]!;
+    expect(agentA.id).toBe('agent-a');
+    expect(agentA.label).toBe('Alpha');
+    expect(agentA.status).toBe('pending');
+    expect(agentA.threadId).toBeNull();
+    expect(agentA.environmentPath).toBeNull();
+    expect(agentA.environmentRef).toBeNull();
+    expect(agentA.summary).toBeNull();
+    expect(agentA.artifacts).toEqual([]);
+    expect(agentA.error).toBeNull();
+    expect(agentA.durationMs).toBeNull();
+
+    // Agent without label should use id as label
+    const agentC = ds.activeQuoremSession!.agents[2]!;
+    expect(agentC.label).toBe('agent-c');
+  });
+
+  it('quorem_agent_start updates agent status and environment info', () => {
+    emit(harness, {
+      type: 'quorem_start',
+      sessionId: 'qs-1',
+      task: 'Task',
+      agents: [{ id: 'agent-a' }],
+    });
+
+    emit(harness, {
+      type: 'quorem_agent_start',
+      sessionId: 'qs-1',
+      agentId: 'agent-a',
+      threadId: 'thread-clone-1',
+      environmentPath: '/tmp/env/a',
+    });
+
+    const agent = harness.getDisplayState().activeQuoremSession!.agents[0]!;
+    expect(agent.status).toBe('running');
+    expect(agent.threadId).toBe('thread-clone-1');
+    expect(agent.environmentPath).toBe('/tmp/env/a');
+  });
+
+  it('quorem_agent_start ignores unknown agentId', () => {
+    emit(harness, {
+      type: 'quorem_start',
+      sessionId: 'qs-1',
+      task: 'Task',
+      agents: [{ id: 'agent-a' }],
+    });
+
+    // This should not throw
+    emit(harness, {
+      type: 'quorem_agent_start',
+      sessionId: 'qs-1',
+      agentId: 'unknown-agent',
+      threadId: 'thread-clone-1',
+      environmentPath: '/tmp/env/x',
+    });
+
+    const agent = harness.getDisplayState().activeQuoremSession!.agents[0]!;
+    expect(agent.status).toBe('pending'); // unchanged
+  });
+
+  it('quorem_agent_end marks agent as completed with results', () => {
+    emit(harness, {
+      type: 'quorem_start',
+      sessionId: 'qs-1',
+      task: 'Task',
+      agents: [{ id: 'agent-a' }],
+    });
+
+    emit(harness, {
+      type: 'quorem_agent_end',
+      sessionId: 'qs-1',
+      agentId: 'agent-a',
+      status: 'completed',
+      summary: 'Implemented the feature using approach A.',
+      artifacts: ['src/main.ts', 'src/utils.ts'],
+      durationMs: 45000,
+    });
+
+    const agent = harness.getDisplayState().activeQuoremSession!.agents[0]!;
+    expect(agent.status).toBe('completed');
+    expect(agent.summary).toBe('Implemented the feature using approach A.');
+    expect(agent.artifacts).toEqual(['src/main.ts', 'src/utils.ts']);
+    expect(agent.durationMs).toBe(45000);
+    expect(agent.error).toBeNull();
+  });
+
+  it('quorem_agent_end marks agent as error with error message', () => {
+    emit(harness, {
+      type: 'quorem_start',
+      sessionId: 'qs-1',
+      task: 'Task',
+      agents: [{ id: 'agent-a' }],
+    });
+
+    emit(harness, {
+      type: 'quorem_agent_end',
+      sessionId: 'qs-1',
+      agentId: 'agent-a',
+      status: 'error',
+      summary: null,
+      artifacts: [],
+      durationMs: 5000,
+      error: 'Model quota exceeded',
+    });
+
+    const agent = harness.getDisplayState().activeQuoremSession!.agents[0]!;
+    expect(agent.status).toBe('error');
+    expect(agent.error).toBe('Model quota exceeded');
+    expect(agent.summary).toBeNull();
+  });
+
+  it('quorem_review_start transitions session to reviewing', () => {
+    emit(harness, {
+      type: 'quorem_start',
+      sessionId: 'qs-1',
+      task: 'Task',
+      agents: [{ id: 'agent-a' }],
+    });
+
+    emit(harness, { type: 'quorem_review_start', sessionId: 'qs-1' });
+
+    expect(harness.getDisplayState().activeQuoremSession!.status).toBe('reviewing');
+  });
+
+  it('quorem_merged transitions session to merged with winner', () => {
+    emit(harness, {
+      type: 'quorem_start',
+      sessionId: 'qs-1',
+      task: 'Task',
+      agents: [{ id: 'agent-a' }, { id: 'agent-b' }],
+    });
+
+    emit(harness, {
+      type: 'quorem_merged',
+      sessionId: 'qs-1',
+      winnerId: 'agent-b',
+      environmentRef: 'quorem/qs-1/agent-b',
+    });
+
+    const session = harness.getDisplayState().activeQuoremSession!;
+    expect(session.status).toBe('merged');
+    expect(session.winnerId).toBe('agent-b');
+    expect(session.endedAt).toBeInstanceOf(Date);
+  });
+
+  it('quorem_cancelled transitions session to cancelled', () => {
+    emit(harness, {
+      type: 'quorem_start',
+      sessionId: 'qs-1',
+      task: 'Task',
+      agents: [{ id: 'agent-a' }],
+    });
+
+    emit(harness, { type: 'quorem_cancelled', sessionId: 'qs-1' });
+
+    const session = harness.getDisplayState().activeQuoremSession!;
+    expect(session.status).toBe('cancelled');
+    expect(session.endedAt).toBeInstanceOf(Date);
+  });
+
+  it('quorem_review_start is a no-op when no active session', () => {
+    emit(harness, { type: 'quorem_review_start', sessionId: 'non-existent' });
+    expect(harness.getDisplayState().activeQuoremSession).toBeNull();
+  });
+
+  it('quorem_merged is a no-op when no active session', () => {
+    emit(harness, { type: 'quorem_merged', sessionId: 'non-existent', winnerId: 'x', environmentRef: 'b' });
+    expect(harness.getDisplayState().activeQuoremSession).toBeNull();
+  });
+
+  it('quorem_cancelled is a no-op when no active session', () => {
+    emit(harness, { type: 'quorem_cancelled', sessionId: 'non-existent' });
+    expect(harness.getDisplayState().activeQuoremSession).toBeNull();
+  });
+
+  it('full display state lifecycle: start → agent_start → agent_end → review → merge', () => {
+    emit(harness, {
+      type: 'quorem_start',
+      sessionId: 'qs-full',
+      task: 'Refactor auth module',
+      agents: [
+        { id: 'agent-a', label: 'Conservative' },
+        { id: 'agent-b', label: 'Aggressive' },
+      ],
+    });
+
+    // Both agents start
+    emit(harness, {
+      type: 'quorem_agent_start',
+      sessionId: 'qs-full',
+      agentId: 'agent-a',
+      threadId: 'thread-a',
+      environmentPath: '/tmp/a',
+    });
+    emit(harness, {
+      type: 'quorem_agent_start',
+      sessionId: 'qs-full',
+      agentId: 'agent-b',
+      threadId: 'thread-b',
+      environmentPath: '/tmp/b',
+    });
+
+    let ds = harness.getDisplayState();
+    expect(ds.activeQuoremSession!.agents[0]!.status).toBe('running');
+    expect(ds.activeQuoremSession!.agents[1]!.status).toBe('running');
+
+    // Agent A completes
+    emit(harness, {
+      type: 'quorem_agent_end',
+      sessionId: 'qs-full',
+      agentId: 'agent-a',
+      status: 'completed',
+      summary: 'Refactored with minimal changes.',
+      artifacts: ['src/auth.ts'],
+      durationMs: 30000,
+    });
+
+    // Agent B errors
+    emit(harness, {
+      type: 'quorem_agent_end',
+      sessionId: 'qs-full',
+      agentId: 'agent-b',
+      status: 'error',
+      summary: null,
+      artifacts: [],
+      durationMs: 10000,
+      error: 'Compilation error in refactored code',
+    });
+
+    ds = harness.getDisplayState();
+    expect(ds.activeQuoremSession!.agents[0]!.status).toBe('completed');
+    expect(ds.activeQuoremSession!.agents[1]!.status).toBe('error');
+
+    // Review starts
+    emit(harness, { type: 'quorem_review_start', sessionId: 'qs-full' });
+    expect(ds.activeQuoremSession!.status).toBe('reviewing');
+
+    // Merge winner
+    emit(harness, {
+      type: 'quorem_merged',
+      sessionId: 'qs-full',
+      winnerId: 'agent-a',
+      environmentRef: 'quorem/qs-full/agent-a',
+    });
+
+    ds = harness.getDisplayState();
+    expect(ds.activeQuoremSession!.status).toBe('merged');
+    expect(ds.activeQuoremSession!.winnerId).toBe('agent-a');
+    expect(ds.activeQuoremSession!.endedAt).toBeInstanceOf(Date);
+  });
+});
+
+// =============================================================================
+// defaultDisplayState includes activeQuoremSession
+// =============================================================================
+
+describe('defaultDisplayState includes quorem field', () => {
+  it('has activeQuoremSession set to null', () => {
+    const ds = defaultDisplayState();
+    expect(ds.activeQuoremSession).toBeNull();
+  });
+});
+
+// =============================================================================
+// Quorem Lifecycle (e2e: calls real Harness methods)
+// =============================================================================
+
+describe('quorem session lifecycle', () => {
+  let harness: Harness;
+  let quoremConfig: QuoremEnvironmentConfig;
+  let collectedEvents: HarnessEvent[];
+
+  beforeEach(async () => {
+    quoremConfig = createMockQuoremConfig();
+    harness = createTestHarness({ quorem: quoremConfig });
+    collectedEvents = [];
+    harness.subscribe(event => {
+      collectedEvents.push(event);
+    });
+    // Ensure a thread exists so startQuoremSession doesn't reject
+    await ensureThread(harness);
+  });
+
+  describe('startQuoremSession', () => {
+    it('throws if no quorem config is provided', async () => {
+      const noQuoremHarness = createTestHarness({ quorem: undefined as any });
+      // Remove quorem config
+      (noQuoremHarness as any).config.quorem = undefined;
+      await ensureThread(noQuoremHarness);
+      await expect(noQuoremHarness.startQuoremSession({ task: 'test', agents: [{ id: 'a' }] })).rejects.toThrow(
+        'Quorem is not configured',
+      );
+    });
+
+    it('throws if no active thread', async () => {
+      const freshHarness = createTestHarness();
+      // Don't create a thread
+      await expect(freshHarness.startQuoremSession({ task: 'test', agents: [{ id: 'a' }] })).rejects.toThrow(
+        'No active thread',
+      );
+    });
+
+    it('throws if no memory is configured', async () => {
+      const noMemHarness = createTestHarness();
+      await ensureThread(noMemHarness);
+      (noMemHarness as any).config.memory = undefined;
+      await expect(noMemHarness.startQuoremSession({ task: 'test', agents: [{ id: 'a' }] })).rejects.toThrow(
+        'Memory is required',
+      );
+    });
+
+    it('returns a QuoremSession with correct initial state', async () => {
+      const session = await harness.startQuoremSession({
+        task: 'Implement feature X',
+        agents: [
+          { id: 'agent-a', label: 'Alpha' },
+          { id: 'agent-b', label: 'Beta' },
+        ],
+        evaluationCriteria: 'Code quality, performance, test coverage',
+      });
+
+      expect(session.id).toBeTruthy();
+      expect(session.task).toBe('Implement feature X');
+      expect(session.evaluationCriteria).toBe('Code quality, performance, test coverage');
+      expect(session.status).toBe('running');
+      expect(session.winnerId).toBeNull();
+      expect(session.startedAt).toBeInstanceOf(Date);
+      expect(session.endedAt).toBeNull();
+      expect(session.agents).toHaveLength(2);
+
+      const agentA = session.agents[0]!;
+      expect(agentA.id).toBe('agent-a');
+      expect(agentA.label).toBe('Alpha');
+      expect(agentA.status).not.toBe('completed'); // pending or running
+    });
+
+    it('emits quorem_start event', async () => {
+      await harness.startQuoremSession({
+        task: 'Test task',
+        agents: [{ id: 'a', label: 'A' }, { id: 'b' }],
+      });
+
+      const startEvent = collectedEvents.find(e => e.type === 'quorem_start');
+      expect(startEvent).toBeDefined();
+      expect(startEvent!.type).toBe('quorem_start');
+      if (startEvent!.type === 'quorem_start') {
+        expect(startEvent!.task).toBe('Test task');
+        expect(startEvent!.agents).toHaveLength(2);
+        expect(startEvent!.agents[0]!.id).toBe('a');
+        expect(startEvent!.agents[0]!.label).toBe('A');
+      }
+    });
+
+    it('throws when a session is already running', async () => {
+      await harness.startQuoremSession({
+        task: 'First task',
+        agents: [{ id: 'a' }],
+      });
+
+      await expect(
+        harness.startQuoremSession({
+          task: 'Second task',
+          agents: [{ id: 'b' }],
+        }),
+      ).rejects.toThrow('already running');
+    });
+
+    it('calls createEnvironment for each agent', async () => {
+      await harness.startQuoremSession({
+        task: 'Test task',
+        agents: [{ id: 'agent-a' }, { id: 'agent-b' }],
+      });
+
+      // Wait a tick so async launchQuoremAgent starts
+      await new Promise(r => setTimeout(r, 50));
+
+      expect(quoremConfig.createEnvironment).toHaveBeenCalledTimes(2);
+    });
+
+    it('clones the thread for each agent via memory', async () => {
+      const storage = new InMemoryStore();
+      const memory = new MockMemory({ storage });
+      const cloneSpy = vi.spyOn(memory, 'cloneThread');
+
+      const h = createTestHarness({ quorem: quoremConfig, memory, storage });
+      h.subscribe(e => {
+        collectedEvents.push(e);
+      });
+      await ensureThread(h);
+
+      await h.startQuoremSession({
+        task: 'Test cloning',
+        agents: [{ id: 'agent-x' }],
+      });
+
+      // Wait for the async agent launch
+      await new Promise(r => setTimeout(r, 100));
+
+      expect(cloneSpy).toHaveBeenCalledTimes(1);
+      const call = cloneSpy.mock.calls[0]![0];
+      expect(call.sourceThreadId).toBeTruthy();
+      expect(call.newThreadId).toContain('quorem-');
+      expect(call.newThreadId).toContain('agent-x');
+    });
+  });
+
+  describe('getQuoremSession', () => {
+    it('returns null when no session is active', () => {
+      expect(harness.getQuoremSession()).toBeNull();
+    });
+
+    it('returns the active session', async () => {
+      await harness.startQuoremSession({
+        task: 'Active task',
+        agents: [{ id: 'a' }],
+      });
+
+      const session = harness.getQuoremSession();
+      expect(session).not.toBeNull();
+      expect(session!.task).toBe('Active task');
+    });
+  });
+
+  describe('cancelQuoremSession', () => {
+    it('throws when no session is active', async () => {
+      await expect(harness.cancelQuoremSession()).rejects.toThrow('No active quorem session');
+    });
+
+    it('marks running and pending agents as cancelled', async () => {
+      await harness.startQuoremSession({
+        task: 'Cancel test',
+        agents: [{ id: 'a' }, { id: 'b' }],
+      });
+
+      await harness.cancelQuoremSession();
+
+      // After cancel, session is null
+      expect(harness.getQuoremSession()).toBeNull();
+    });
+
+    it('emits quorem_cancelled event', async () => {
+      await harness.startQuoremSession({
+        task: 'Cancel event test',
+        agents: [{ id: 'a' }],
+      });
+
+      await harness.cancelQuoremSession();
+
+      const cancelEvent = collectedEvents.find(e => e.type === 'quorem_cancelled');
+      expect(cancelEvent).toBeDefined();
+    });
+
+    it('calls removeEnvironment for agents with environments', async () => {
+      await harness.startQuoremSession({
+        task: 'Cleanup test',
+        agents: [{ id: 'a' }],
+      });
+
+      // Wait for agent to start and get an environment
+      await new Promise(r => setTimeout(r, 100));
+
+      await harness.cancelQuoremSession();
+
+      // removeEnvironment should be called at least for the agents that got environments
+      const removeCount = (quoremConfig.removeEnvironment as ReturnType<typeof vi.fn>).mock.calls.length;
+      expect(removeCount).toBeGreaterThanOrEqual(0); // May be 0 if agent errored before environment was assigned
+    });
+  });
+
+  describe('selectQuoremWinner', () => {
+    it('throws when no session is active', async () => {
+      await expect(harness.selectQuoremWinner('agent-a')).rejects.toThrow('No active quorem session');
+    });
+
+    it('throws when agent is not found', async () => {
+      await harness.startQuoremSession({
+        task: 'Winner test',
+        agents: [{ id: 'a' }],
+      });
+
+      await expect(harness.selectQuoremWinner('nonexistent')).rejects.toThrow('not found');
+    });
+
+    it('throws when agent is not completed', async () => {
+      await harness.startQuoremSession({
+        task: 'Winner status test',
+        agents: [{ id: 'a' }],
+      });
+
+      // Agent is pending/running, not completed
+      await expect(harness.selectQuoremWinner('a')).rejects.toThrow('expected "completed"');
+    });
+
+    it('merges the winner environment and emits quorem_merged', async () => {
+      await harness.startQuoremSession({
+        task: 'Merge test',
+        agents: [{ id: 'a' }],
+      });
+
+      // Manually mark the agent as completed with an environment ref
+      const session = harness.getQuoremSession()!;
+      const agentState = session.agents.find(a => a.id === 'a')!;
+      agentState.status = 'completed';
+      agentState.environmentRef = 'quorem/test-id-1/a';
+      agentState.environmentPath = '/tmp/env/a';
+
+      await harness.selectQuoremWinner('a');
+
+      expect(quoremConfig.mergeResults).toHaveBeenCalledWith({ ref: 'quorem/test-id-1/a' });
+
+      const mergeEvent = collectedEvents.find(e => e.type === 'quorem_merged');
+      expect(mergeEvent).toBeDefined();
+      if (mergeEvent?.type === 'quorem_merged') {
+        expect(mergeEvent.winnerId).toBe('a');
+        expect(mergeEvent.environmentRef).toBe('quorem/test-id-1/a');
+      }
+
+      // Session should be cleared
+      expect(harness.getQuoremSession()).toBeNull();
+    });
+
+    it('cleans up all environments after merge', async () => {
+      await harness.startQuoremSession({
+        task: 'Cleanup after merge',
+        agents: [{ id: 'a' }, { id: 'b' }],
+      });
+
+      const session = harness.getQuoremSession()!;
+      // Mark both agents
+      for (const agent of session.agents) {
+        agent.status = 'completed';
+        agent.environmentRef = `quorem/test-id-1/${agent.id}`;
+        agent.environmentPath = `/tmp/env/${agent.id}`;
+      }
+
+      await harness.selectQuoremWinner('a');
+
+      // removeEnvironment should be called for all agents
+      expect(quoremConfig.removeEnvironment).toHaveBeenCalledWith({ path: '/tmp/env/a' });
+      expect(quoremConfig.removeEnvironment).toHaveBeenCalledWith({ path: '/tmp/env/b' });
+    });
+  });
+
+  describe('reviewQuoremAgent', () => {
+    it('returns null when no session is active', async () => {
+      const result = await harness.reviewQuoremAgent('agent-a');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for unknown agentId', async () => {
+      await harness.startQuoremSession({
+        task: 'Review test',
+        agents: [{ id: 'a' }],
+      });
+
+      const result = await harness.reviewQuoremAgent('nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('returns diff and artifacts for an agent with an environment', async () => {
+      await harness.startQuoremSession({
+        task: 'Review diff test',
+        agents: [{ id: 'a' }],
+      });
+
+      const session = harness.getQuoremSession()!;
+      const agentState = session.agents.find(a => a.id === 'a')!;
+      agentState.environmentPath = '/tmp/env/a';
+
+      const result = await harness.reviewQuoremAgent('a');
+      expect(result).not.toBeNull();
+      expect(result!.diff).toContain('diff --git');
+      expect(result!.artifacts).toEqual(['src/main.ts', 'src/utils.ts']);
+
+      expect(quoremConfig.getResultDiff).toHaveBeenCalledWith({ path: '/tmp/env/a' });
+      expect(quoremConfig.getArtifacts).toHaveBeenCalledWith({ path: '/tmp/env/a' });
+    });
+  });
+});
+
+// =============================================================================
+// Event emission verification
+// =============================================================================
+
+describe('quorem event emission', () => {
+  let harness: Harness;
+  let quoremConfig: QuoremEnvironmentConfig;
+  let events: HarnessEvent[];
+
+  beforeEach(async () => {
+    quoremConfig = createMockQuoremConfig();
+    harness = createTestHarness({ quorem: quoremConfig });
+    events = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+    await ensureThread(harness);
+  });
+
+  it('display_state_changed is emitted for each quorem event', async () => {
+    await harness.startQuoremSession({
+      task: 'DSC test',
+      agents: [{ id: 'a' }],
+    });
+
+    // Every event triggers a display_state_changed
+    const dscEvents = events.filter(e => e.type === 'display_state_changed');
+    expect(dscEvents.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('cancel emits quorem_cancelled followed by display_state_changed', async () => {
+    await harness.startQuoremSession({
+      task: 'Cancel DSC test',
+      agents: [{ id: 'a' }],
+    });
+
+    events = []; // Reset events
+    await harness.cancelQuoremSession();
+
+    const eventTypes = events.map(e => e.type);
+    expect(eventTypes).toContain('quorem_cancelled');
+    expect(eventTypes).toContain('display_state_changed');
+  });
+});

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -5,7 +5,7 @@ import type { ToolsInput } from '../agent/types';
 import type { MastraLanguageModel } from '../llm/model/shared.types';
 import { createTool } from '../tools/tool';
 
-import type { HarnessRequestContext, HarnessSubagent } from './types';
+import type { HarnessRequestContext, HarnessSubagent, QuoremAgentConfig, QuoremSessionConfig } from './types';
 
 let questionCounter = 0;
 let planCounter = 0;
@@ -563,4 +563,124 @@ export function parseSubagentMeta(content: string): {
     : [];
 
   return { text, modelId, durationMs, toolCalls };
+}
+
+// =============================================================================
+// Quorem Tools
+// =============================================================================
+
+/**
+ * Creates a `quorem` tool that allows the agent to spawn parallel quorem agents.
+ * Each quorem agent runs in its own isolated environment with a cloned thread.
+ */
+export function createQuoremTool() {
+  return createTool({
+    id: 'quorem',
+    description: `Spawn multiple parallel agents (a "quorum") to work on the same task with different approaches. Each agent gets its own isolated environment and a copy of the conversation thread. After all agents finish, you review their results and select a winner whose changes get merged.
+
+Use this when:
+- A task has multiple valid approaches and you want to explore them in parallel
+- You want to increase confidence by comparing different implementations
+- The task is complex enough to benefit from diverse strategies`,
+    inputSchema: z.object({
+      task: z.string().describe('The task all quorem agents should work on. Be specific and self-contained.'),
+      agents: z
+        .array(
+          z.object({
+            id: z.string().describe('Unique identifier for this agent (e.g., "approach-a", "conservative")'),
+            label: z.string().optional().describe('Human-readable label for display'),
+            instructions: z
+              .string()
+              .optional()
+              .describe('Specific approach or instructions for this agent. How should it differ from other agents?'),
+            modelId: z.string().optional().describe('Optional model ID override for this agent'),
+          }),
+        )
+        .min(2)
+        .max(5)
+        .describe('The agents to spawn. Each needs a unique id and ideally different instructions.'),
+      evaluationCriteria: z
+        .string()
+        .optional()
+        .describe(
+          'Optional criteria for evaluating results (e.g., "prefer minimal changes", "prioritize correctness")',
+        ),
+    }),
+    execute: async ({ task, agents, evaluationCriteria }, context) => {
+      const harnessCtx = context?.requestContext?.get('harness') as HarnessRequestContext | undefined;
+
+      if (!harnessCtx?.startQuoremSession) {
+        return {
+          content: 'Quorem is not available in this environment.',
+          isError: true,
+        };
+      }
+
+      try {
+        const agentConfigs: QuoremAgentConfig[] = agents.map(a => ({
+          id: a.id,
+          label: a.label,
+          instructions: a.instructions,
+          modelId: a.modelId,
+        }));
+
+        const config: QuoremSessionConfig = {
+          task,
+          agents: agentConfigs,
+          evaluationCriteria,
+        };
+
+        const session = await harnessCtx.startQuoremSession(config);
+
+        return {
+          content: `Quorem session started (id: ${session.id}) with ${agents.length} agents: ${agents.map(a => a.label ?? a.id).join(', ')}. Agents are running in parallel. You'll be notified when they complete. Use the quorem_select tool to pick a winner after reviewing results.`,
+          isError: false,
+        };
+      } catch (error) {
+        return {
+          content: `Failed to start quorem session: ${error instanceof Error ? error.message : String(error)}`,
+          isError: true,
+        };
+      }
+    },
+  });
+}
+
+/**
+ * Creates a `quorem_select` tool that allows the agent to select a winning quorem agent
+ * and merge their changes.
+ */
+export function createQuoremSelectTool() {
+  return createTool({
+    id: 'quorem_select',
+    description: `Select the winning agent from a completed quorem session and merge their changes. Use this after reviewing all quorem agent results to pick the best approach.`,
+    inputSchema: z.object({
+      winnerId: z.string().describe('The ID of the winning quorem agent whose changes should be merged.'),
+      reasoning: z.string().describe('Explain why this agent was selected over the others.'),
+    }),
+    execute: async ({ winnerId, reasoning }, context) => {
+      const harnessCtx = context?.requestContext?.get('harness') as HarnessRequestContext | undefined;
+
+      if (!harnessCtx?.selectQuoremWinner) {
+        return {
+          content: 'Quorem is not available in this environment.',
+          isError: true,
+        };
+      }
+
+      try {
+        await harnessCtx.selectQuoremWinner(winnerId);
+
+        return {
+          content: `Quorem winner selected: "${winnerId}". Changes have been merged.\n\nReasoning: ${reasoning}`,
+          isError: false,
+        };
+      } catch (error) {
+        return {
+          content: `Failed to select quorem winner: ${error instanceof Error ? error.message : String(error)}`,
+          isError: true,
+        };
+      }
+    },
+  });
 }

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -206,6 +206,13 @@ export interface HarnessConfig<TState extends HarnessStateSchema = HarnessStateS
     acquire: (threadId: string) => void;
     release: (threadId: string) => void;
   };
+
+  /**
+   * Quorem (parallel agent quorum) configuration.
+   * Provides environment management functions for creating isolated
+   * execution contexts for parallel quorem agents.
+   */
+  quorem?: QuoremEnvironmentConfig;
 }
 
 /**
@@ -222,6 +229,104 @@ export interface HarnessOMConfig {
   defaultObservationThreshold?: number;
   /** Default reflection threshold in tokens */
   defaultReflectionThreshold?: number;
+}
+
+// =============================================================================
+// Quorem (Parallel Agent Quorum)
+// =============================================================================
+
+/**
+ * Configuration for a single quorem agent within a quorem session.
+ */
+export interface QuoremAgentConfig {
+  /** Unique identifier for this quorem agent */
+  id: string;
+  /** Optional display label (defaults to id) */
+  label?: string;
+  /** Specific instructions or approach for this agent (appended to mode instructions) */
+  instructions?: string;
+  /** Model ID override for this agent */
+  modelId?: string;
+}
+
+/**
+ * Configuration for starting a quorem session.
+ */
+export interface QuoremSessionConfig {
+  /** The task description all agents will work on */
+  task: string;
+  /** The agents to spawn (each gets its own isolated environment + cloned thread) */
+  agents: QuoremAgentConfig[];
+  /** Optional criteria for evaluating results */
+  evaluationCriteria?: string;
+}
+
+/**
+ * Runtime state of a single quorem agent.
+ */
+export interface QuoremAgentState {
+  /** Unique identifier for this quorem agent */
+  id: string;
+  /** Display label */
+  label: string;
+  /** Current lifecycle status */
+  status: 'pending' | 'running' | 'completed' | 'error' | 'cancelled';
+  /** Thread ID assigned to this agent (cloned from main thread) */
+  threadId: string | null;
+  /** Path to the isolated environment for this agent */
+  environmentPath: string | null;
+  /** Reference identifier for the environment (e.g., branch name, container ID) */
+  environmentRef: string | null;
+  /** Summary of changes produced (populated on completion) */
+  summary: string | null;
+  /** Artifacts produced by this agent (e.g., modified files, generated outputs) */
+  artifacts: string[];
+  /** Error message if status is 'error' */
+  error: string | null;
+  /** Duration in milliseconds (populated on completion) */
+  durationMs: number | null;
+  /** Model ID used by this agent */
+  modelId: string | null;
+}
+
+/**
+ * Represents a full quorem session with multiple parallel agents.
+ */
+export interface QuoremSession {
+  /** Unique session identifier */
+  id: string;
+  /** The task all agents are working on */
+  task: string;
+  /** Optional evaluation criteria */
+  evaluationCriteria?: string;
+  /** State of each agent in the session */
+  agents: QuoremAgentState[];
+  /** Overall session status */
+  status: 'running' | 'reviewing' | 'merged' | 'cancelled';
+  /** ID of the winning agent (set after selection) */
+  winnerId: string | null;
+  /** Timestamp when the session started */
+  startedAt: Date;
+  /** Timestamp when the session ended (merged or cancelled) */
+  endedAt: Date | null;
+}
+
+/**
+ * Environment management functions injected by the app layer.
+ * The Harness uses these to create isolated execution environments for quorem agents.
+ * Implementations can back this with git worktrees, containers, temp dirs, etc.
+ */
+export interface QuoremEnvironmentConfig {
+  /** Create an isolated environment at the given path with a reference identifier */
+  createEnvironment: (opts: { path: string; ref: string }) => Promise<void>;
+  /** Remove an isolated environment */
+  removeEnvironment: (opts: { path: string }) => Promise<void>;
+  /** Merge results from an agent's environment into the main context */
+  mergeResults: (opts: { ref: string }) => Promise<void>;
+  /** Get the list of artifacts produced in an environment */
+  getArtifacts: (opts: { path: string }) => Promise<string[]>;
+  /** Get a diff/summary of changes in an environment */
+  getResultDiff: (opts: { path: string }) => Promise<string>;
 }
 
 // =============================================================================
@@ -501,6 +606,10 @@ export interface HarnessDisplayState {
     status: 'pending' | 'in_progress' | 'completed';
     activeForm: string;
   }>;
+
+  // ── Quorem ──────────────────────────────────────────────────────────
+  /** Active quorem session (null when no quorem is running) */
+  activeQuoremSession: QuoremSession | null;
 }
 
 /**
@@ -523,6 +632,7 @@ export function defaultDisplayState(): HarnessDisplayState {
     modifiedFiles: new Map(),
     tasks: [],
     previousTasks: [],
+    activeQuoremSession: null,
   };
 }
 
@@ -722,7 +832,24 @@ export type HarnessEvent =
         activeForm: string;
       }>;
     }
-  | { type: 'display_state_changed'; displayState: HarnessDisplayState };
+  | { type: 'display_state_changed'; displayState: HarnessDisplayState }
+  // ── Quorem events ─────────────────────────────────────────────────────
+  | { type: 'quorem_start'; sessionId: string; task: string; agents: Array<{ id: string; label?: string }> }
+  | { type: 'quorem_agent_start'; sessionId: string; agentId: string; threadId: string; environmentPath: string }
+  | { type: 'quorem_agent_progress'; sessionId: string; agentId: string; summary: string }
+  | {
+      type: 'quorem_agent_end';
+      sessionId: string;
+      agentId: string;
+      status: 'completed' | 'error';
+      summary: string | null;
+      artifacts: string[];
+      durationMs: number;
+      error?: string;
+    }
+  | { type: 'quorem_review_start'; sessionId: string }
+  | { type: 'quorem_merged'; sessionId: string; winnerId: string; environmentRef: string }
+  | { type: 'quorem_cancelled'; sessionId: string };
 
 /**
  * Listener function for harness events.
@@ -824,4 +951,10 @@ export interface HarnessRequestContext<TState extends HarnessStateSchema = Harne
 
   /** Get the configured subagent model ID for a specific agent type */
   getSubagentModelId?: (params?: { agentType?: string }) => string | null;
+
+  /** Start a quorem session with parallel agents (used by quorem tool) */
+  startQuoremSession?: (config: QuoremSessionConfig) => Promise<QuoremSession>;
+
+  /** Select a quorem winner and merge their changes (used by quorem_select tool) */
+  selectQuoremWinner?: (winnerId: string) => Promise<void>;
 }


### PR DESCRIPTION
Adds the Quorem feature — the main agent can now spin up N parallel agents, each in its own isolated environment with a cloned thread. Once they all finish, the main agent reviews results, picks a winner, and merges their changes back.

The core orchestration lives in `@mastra/core` (types, Harness methods, tools, events, display state). The app layer in `mastracode` provides a `/quorem` slash command, TUI components for real-time status, event handlers, and a git worktree-based environment implementation.

Environment management is injected via `QuoremEnvironmentConfig`, so the core stays decoupled from any specific isolation strategy.

**New types:** `QuoremAgentConfig`, `QuoremSessionConfig`, `QuoremAgentState`, `QuoremSession`, `QuoremEnvironmentConfig`

**New Harness methods:** `startQuoremSession()`, `reviewQuoremAgent()`, `selectQuoremWinner()`, `cancelQuoremSession()`, `getQuoremSession()`

**New tools:** `quorem` (starts a parallel session) and `quorem_select` (picks a winner)

**New events:** `quorem_start`, `quorem_agent_start`, `quorem_agent_progress`, `quorem_agent_end`, `quorem_review_start`, `quorem_merged`, `quorem_cancelled`

Environment management is injected via `QuoremEnvironmentConfig`, keeping the core decoupled from any specific isolation strategy (git worktrees, containers, temp dirs, etc).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Quorem, enabling parallel execution of multiple agents in isolated environments.
  * Added `/quorem` slash command with subcommands: `/quorem view <agentId>` to inspect agent progress, `/quorem back` to return to main thread, and `/quorem cancel` to terminate sessions.
  * Real-time status display tracking agent execution progress and lifecycle events.
  * Automatic environment isolation for parallel agents with result review and winner selection for merging changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->