### PR TITLE
fix: clear stale OM continuation hints when omitted

### DIFF
--- a/.changeset/fresh-seals-sparkle.md
+++ b/.changeset/fresh-seals-sparkle.md
@@ -2,6 +2,6 @@
 "@mastra/memory": patch
 ---
 
-Fix stale observational-memory continuation hints by explicitly clearing thread OM metadata when newer observation/activation results omit `<current-task>` or `<suggested-response>`.
+Fixed stale continuation hints in observational memory.
 
-This updates observation and activation metadata writes to always set `currentTask` and `suggestedResponse` (including `undefined`), preventing previously stored hints from being re-injected into context after they are no longer present in the latest model output.
+When newer outputs omit continuation hints, old hints are now cleared. This prevents outdated task and response guidance from appearing in later turns.

--- a/.changeset/fresh-seals-sparkle.md
+++ b/.changeset/fresh-seals-sparkle.md
@@ -1,0 +1,7 @@
+---
+"@mastra/memory": patch
+---
+
+Fix stale observational-memory continuation hints by explicitly clearing thread OM metadata when newer observation/activation results omit `<current-task>` or `<suggested-response>`.
+
+This updates observation and activation metadata writes to always set `currentTask` and `suggestedResponse` (including `undefined`), preventing previously stored hints from being re-injected into context after they are no longer present in the latest model output.

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -5579,6 +5579,8 @@ describe('Full Async Buffering Flow', () => {
     blockAfter?: number;
     /** Number of messages to pre-save (each ~200 tokens via repeated filler text) */
     messageCount?: number;
+    /** Optional fixed observer responses in call order */
+    observerResponses?: string[];
   }) {
     const { MessageList } = await import('@mastra/core/agent');
     const { RequestContext } = await import('@mastra/core/di');
@@ -5622,6 +5624,9 @@ describe('Full Async Buffering Flow', () => {
 
         // Observer call
         observerCalls.push({ input: promptText.slice(0, 200) });
+        const observerResponse =
+          opts.observerResponses?.[observerCalls.length - 1] ??
+          `<observations>\nDate: Jan 1, 2025\n* 🔴 Observed at call ${observerCalls.length}\n* User discussed topic ${observerCalls.length}\n</observations>`;
         return {
           rawCall: { rawPrompt: null, rawSettings: {} },
           finishReason: 'stop' as const,
@@ -5629,7 +5634,7 @@ describe('Full Async Buffering Flow', () => {
           content: [
             {
               type: 'text' as const,
-              text: `<observations>\nDate: Jan 1, 2025\n* 🔴 Observed at call ${observerCalls.length}\n* User discussed topic ${observerCalls.length}\n</observations>`,
+              text: observerResponse,
             },
           ],
           warnings: [],
@@ -6033,6 +6038,110 @@ describe('Full Async Buffering Flow', () => {
     const lastCall = observerCalls[observerCalls.length - 1];
     expect(lastCall).toBeDefined();
     expect(lastCall.input.length).toBeGreaterThan(0);
+  });
+
+  it('should clear stale thread continuation hints on sync observation when latest output omits them', async () => {
+    const { storage, threadId, resourceId, step } = await setupAsyncBufferingScenario({
+      messageTokens: 1000,
+      bufferTokens: 500,
+      bufferActivation: 0.7,
+      reflectionObservationTokens: 50000,
+      blockAfter: 0,
+      messageCount: 10,
+      observerResponses: [
+        '<observations>\n- 🔴 Initial observation\n</observations>\n<current-task>Implement sync path</current-task>\n<suggested-response>Continue with step 2</suggested-response>',
+        '<observations>\n- 🟡 Follow-up observation without hints\n</observations>',
+      ],
+    });
+
+    await step(0);
+    const threadAfterFirstObservation = await storage.getThreadById({ threadId });
+    const firstOM = ((threadAfterFirstObservation?.metadata as any)?.mastra?.om ?? {}) as any;
+    expect(firstOM.currentTask).toBe('Implement sync path');
+    expect(firstOM.suggestedResponse).toBe('Continue with step 2');
+
+    await storage.saveMessages({
+      messages: [
+        {
+          id: 'sync-clear-msg-1',
+          threadId,
+          resourceId,
+          role: 'user',
+          content: { format: 2 as const, parts: [{ type: 'text' as const, text: 'New message to trigger observation' }] },
+          type: 'text',
+          createdAt: new Date('2025-01-01T12:30:00Z'),
+        },
+      ],
+    });
+
+    await step(1);
+    const threadAfterSecondObservation = await storage.getThreadById({ threadId });
+    const secondOM = ((threadAfterSecondObservation?.metadata as any)?.mastra?.om ?? {}) as any;
+    expect(secondOM.currentTask).toBeUndefined();
+    expect(secondOM.suggestedResponse).toBeUndefined();
+  });
+
+  it('should clear stale thread continuation hints after buffered activation when latest activated chunk has no hints', async () => {
+    const { storage, threadId, resourceId, step } = await setupAsyncBufferingScenario({
+      messageTokens: 1000,
+      bufferTokens: 200,
+      bufferActivation: 1,
+      reflectionObservationTokens: 50000,
+      messageCount: 10,
+    });
+
+    const record = await storage.getObservationalMemory(threadId, resourceId);
+    expect(record).toBeDefined();
+
+    await storage.updateBufferedObservations({
+      id: record!.id,
+      chunk: {
+        observations: '- 🔴 Older chunk with hints',
+        tokenCount: 30,
+        messageIds: ['buf-msg-1'],
+        messageTokens: 600,
+        lastObservedAt: new Date('2025-01-01T10:00:00Z'),
+        cycleId: 'buf-cycle-1',
+        currentTask: 'Old buffered task',
+        suggestedContinuation: 'Old buffered suggestion',
+      },
+    });
+
+    await storage.updateBufferedObservations({
+      id: record!.id,
+      chunk: {
+        observations: '- 🟡 Latest chunk without hints',
+        tokenCount: 30,
+        messageIds: ['buf-msg-2'],
+        messageTokens: 600,
+        lastObservedAt: new Date('2025-01-01T10:05:00Z'),
+        cycleId: 'buf-cycle-2',
+      },
+    });
+
+    const existingThread = await storage.getThreadById({ threadId });
+    await storage.updateThread({
+      id: threadId,
+      title: existingThread?.title ?? 'Test Thread',
+      metadata: {
+        ...(existingThread?.metadata ?? {}),
+        mastra: {
+          ...((existingThread?.metadata as any)?.mastra ?? {}),
+          om: {
+            ...((existingThread?.metadata as any)?.mastra?.om ?? {}),
+            currentTask: 'Stale task before activation',
+            suggestedResponse: 'Stale suggestion before activation',
+          },
+        },
+      },
+    });
+
+    await step(0, { freshState: true });
+
+    const threadAfterActivation = await storage.getThreadById({ threadId });
+    const omAfterActivation = ((threadAfterActivation?.metadata as any)?.mastra?.om ?? {}) as any;
+    expect(omAfterActivation.currentTask).toBeUndefined();
+    expect(omAfterActivation.suggestedResponse).toBeUndefined();
   });
 
   it('should default reflection.bufferActivation when observation.bufferTokens is set', () => {

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -6067,7 +6067,10 @@ describe('Full Async Buffering Flow', () => {
           threadId,
           resourceId,
           role: 'user',
-          content: { format: 2 as const, parts: [{ type: 'text' as const, text: 'New message to trigger observation' }] },
+          content: {
+            format: 2 as const,
+            parts: [{ type: 'text' as const, text: 'New message to trigger observation' }],
+          },
           type: 'text',
           createdAt: new Date('2025-01-01T12:30:00Z'),
         },


### PR DESCRIPTION
This fixes stale observational-memory continuation hints persisting across cycles. We now always write thread OM metadata for currentTask/suggestedResponse during observation and activation, including undefined when omitted, so old values are cleared instead of lingering.

Before: setThreadOMMetadata was only called when hints were present, so older hints could stick around and be reinjected later.
After: setThreadOMMetadata is called on these paths every time, and omitted hints clear previous values.

Example after activation when latest chunk has no hints:

```ts
setThreadOMMetadata(thread.metadata, {
  suggestedResponse: activationResult.suggestedContinuation,
  currentTask: activationResult.currentTask,
});
```

I also added regression tests for sync observation and buffered activation to verify stale hints are cleared when latest output/chunk omits them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clears stale continuation hints in observational memory so outdated suggestions no longer reappear when newer outputs omit continuation guidance.

* **Tests**
  * Added deterministic observer-response tests covering clearing of stale continuation hints during synchronous observation and after buffered activation.

* **Chores**
  * Added a patch release note entry for the memory package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->