### PR TITLE
fix: preserve assistant text after tool updates and add openai web_search fallback

### DIFF
--- a/.changeset/quick-cameras-trade.md
+++ b/.changeset/quick-cameras-trade.md
@@ -1,0 +1,7 @@
+---
+'mastracode': minor
+---
+
+Fix assistant streaming updates so tool-result-only chunks do not overwrite visible assistant text with empty content.
+
+Also add an OpenAI native `web_search` fallback when no Tavily key is configured and the current model is `openai/*`.

--- a/mastracode/src/agents/tools.ts
+++ b/mastracode/src/agents/tools.ts
@@ -1,4 +1,5 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
+import { createOpenAI } from '@ai-sdk/openai';
 import type { HarnessRequestContext } from '@mastra/core/harness';
 import type { RequestContext } from '@mastra/core/request-context';
 import type { McpManager } from '../mcp';
@@ -25,6 +26,7 @@ export function createDynamicTools(mcpManager?: McpManager, extraTools?: Record<
 
     const modelId = state?.currentModelId;
     const isAnthropicModel = modelId?.startsWith('anthropic/');
+    const isOpenAIModel = modelId?.startsWith('openai/');
 
     const projectPath = state?.projectPath ?? '';
 
@@ -59,6 +61,9 @@ export function createDynamicTools(mcpManager?: McpManager, extraTools?: Record<
     } else if (isAnthropicModel) {
       const anthropic = createAnthropic({});
       tools.web_search = anthropic.tools.webSearch_20250305();
+    } else if (isOpenAIModel) {
+      const openai = createOpenAI({});
+      tools.web_search = openai.tools.webSearch();
     }
 
     if (mcpManager) {


### PR DESCRIPTION
This fixes the TUI case where assistant text could disappear right after tool runs (including web_search) when a tool-result-only chunk arrived and replaced visible content with an empty trailing segment.

Before:
```ts
const trailingParts = getTrailingContentParts(message);
state.streamingComponent.updateContent({ ...message, content: trailingParts });
```

After:
```ts
const trailingParts = getTrailingContentParts(message);
if (trailingParts.length > 0 || message.stopReason === 'aborted' || message.stopReason === 'error') {
  state.streamingComponent.updateContent({ ...message, content: trailingParts });
}
```

It also adds a native OpenAI web_search fallback when Tavily is not configured and the active model is openai/*.

After:
```ts
} else if (isOpenAIModel) {
  const openai = createOpenAI({});
  tools.web_search = openai.tools.webSearch();
}
```

I re-ran targeted tests for these areas and they pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed assistant streaming to prevent tool-result updates from clearing visible assistant text.

* **New Features**
  * Added OpenAI native web search fallback when Tavily is not configured and using OpenAI models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->