### PR TITLE
feat(mastracode): support HTTP MCP servers in config

### DIFF
--- a/.changeset/support-http-mcp-servers.md
+++ b/.changeset/support-http-mcp-servers.md
@@ -1,0 +1,29 @@
+---
+'mastracode': minor
+---
+
+Support HTTP MCP servers in mastracode config
+
+MCP server entries with a `url` field are now recognized as HTTP (Streamable HTTP / SSE) servers. Previously only stdio-based servers (with `command`) were loaded from `mcp.json`; entries with `url` were silently dropped.
+
+**What's new:**
+- Add `url` + optional `headers` config for HTTP MCP servers
+- Invalid or ambiguous entries are tracked as "skipped" with a human-readable reason
+- `/mcp` command shows transport type (`[stdio]` / `[http]`) and lists skipped servers
+- Startup logs report skipped servers with reasons
+
+**Example mcp.json:**
+```json
+{
+  "mcpServers": {
+    "local-fs": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path"]
+    },
+    "remote-api": {
+      "url": "https://mcp.example.com/sse",
+      "headers": { "Authorization": "Bearer <token>" }
+    }
+  }
+}
+```

--- a/docs/src/mastra-code/configuration.mdx
+++ b/docs/src/mastra-code/configuration.mdx
@@ -66,6 +66,12 @@ Project config overrides global config by server name. Claude Code settings are 
 
 ### MCP config format
 
+Mastra Code supports two transport types for MCP servers: **stdio** (local process) and **HTTP** (remote server via Streamable HTTP or SSE).
+
+#### Stdio servers
+
+Launch a local process that communicates via stdin/stdout. Requires a `command` field. The `args` and `env` fields are optional.
+
 ```json title=".mastracode/mcp.json"
 {
   "mcpServers": {
@@ -80,7 +86,26 @@ Project config overrides global config by server name. Claude Code settings are 
 }
 ```
 
-Each server entry requires a `command` field. The `args` and `env` fields are optional.
+#### HTTP servers
+
+Connect to a remote MCP server via URL. Requires a `url` field. The optional `headers` field lets you pass static headers such as authentication tokens.
+
+```json title=".mastracode/mcp.json"
+{
+  "mcpServers": {
+    "remote-api": {
+      "url": "https://mcp.example.com/sse",
+      "headers": {
+        "Authorization": "Bearer your-token"
+      }
+    }
+  }
+}
+```
+
+Since `headers` only supports static values, use a stdio wrapper for dynamic authentication such as token refresh.
+
+#### Startup behavior
 
 On startup, Mastra Code connects to all configured servers and reports the status:
 
@@ -88,7 +113,13 @@ On startup, Mastra Code connects to all configured servers and reports the statu
 MCP: 2 server(s) connected, 15 tool(s)
 ```
 
-Tools from MCP servers are namespaced as `serverName_toolName` and appear in the agent's tool list alongside built-in tools.
+Invalid or ambiguous entries (for example, specifying both `command` and `url`, or providing an invalid URL) are skipped with a reason:
+
+```
+MCP: Skipped "bad-server": Missing required field: "command" (stdio) or "url" (http)
+```
+
+Tools from MCP servers are namespaced as `serverName_toolName` and appear in the agent's tool list alongside built-in tools. Use `/mcp` to see the status of all servers, including their transport type and any skipped entries.
 
 ## Hooks
 

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -52,6 +52,10 @@ async function main() {
     for (const s of failed) {
       console.info(`MCP: Failed to connect to "${s.name}": ${s.error}`);
     }
+    const skipped = mcpManager.getSkippedServers();
+    for (const s of skipped) {
+      console.info(`MCP: Skipped "${s.name}": ${s.reason}`);
+    }
   }
 
   const logFile = path.join(getAppDataDir(), 'debug.log');

--- a/mastracode/src/mcp/__tests__/config.test.ts
+++ b/mastracode/src/mcp/__tests__/config.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyServerEntry, validateConfig } from '../config.js';
+
+describe('classifyServerEntry', () => {
+  it('classifies stdio entry', () => {
+    expect(classifyServerEntry({ command: 'npx', args: ['-y', 'foo'] })).toEqual({ kind: 'stdio' });
+  });
+
+  it('classifies http entry', () => {
+    expect(classifyServerEntry({ url: 'https://mcp.example.com/sse' })).toEqual({ kind: 'http' });
+  });
+
+  it('skips entry with both command and url', () => {
+    const result = classifyServerEntry({ command: 'npx', url: 'https://example.com' });
+    expect(result.kind).toBe('skip');
+    expect(result.reason).toContain('Cannot specify both');
+  });
+
+  it('skips entry with neither command nor url', () => {
+    const result = classifyServerEntry({ args: ['foo'] });
+    expect(result.kind).toBe('skip');
+    expect(result.reason).toContain('Missing required field');
+  });
+
+  it('skips non-object entry', () => {
+    expect(classifyServerEntry('string')).toEqual({ kind: 'skip', reason: 'Invalid entry: expected an object' });
+    expect(classifyServerEntry(null)).toEqual({ kind: 'skip', reason: 'Invalid entry: expected an object' });
+    expect(classifyServerEntry(42)).toEqual({ kind: 'skip', reason: 'Invalid entry: expected an object' });
+  });
+
+  it('skips entry with invalid URL', () => {
+    const result = classifyServerEntry({ url: 'not a url' });
+    expect(result.kind).toBe('skip');
+    expect(result.reason).toContain('Invalid URL');
+  });
+
+  it('accepts http entry with various valid URL schemes', () => {
+    expect(classifyServerEntry({ url: 'http://localhost:8080/sse' }).kind).toBe('http');
+    expect(classifyServerEntry({ url: 'https://mcp.example.com/mcp' }).kind).toBe('http');
+  });
+});
+
+describe('validateConfig', () => {
+  it('returns empty for null/undefined input', () => {
+    expect(validateConfig(null)).toEqual({});
+    expect(validateConfig(undefined)).toEqual({});
+  });
+
+  it('returns empty when mcpServers is missing', () => {
+    expect(validateConfig({ other: 'field' })).toEqual({});
+  });
+
+  it('accepts stdio server entry', () => {
+    const result = validateConfig({
+      mcpServers: {
+        fs: { command: 'npx', args: ['-y', 'mcp-fs'], env: { HOME: '/tmp' } },
+      },
+    });
+    expect(result.mcpServers).toEqual({
+      fs: { command: 'npx', args: ['-y', 'mcp-fs'], env: { HOME: '/tmp' } },
+    });
+    expect(result.skippedServers).toBeUndefined();
+  });
+
+  it('accepts http server entry', () => {
+    const result = validateConfig({
+      mcpServers: {
+        remote: { url: 'https://mcp.example.com/sse' },
+      },
+    });
+    expect(result.mcpServers).toEqual({
+      remote: { url: 'https://mcp.example.com/sse', headers: undefined },
+    });
+  });
+
+  it('accepts http server entry with headers', () => {
+    const result = validateConfig({
+      mcpServers: {
+        remote: { url: 'https://mcp.example.com/sse', headers: { Authorization: 'Bearer tok' } },
+      },
+    });
+    expect(result.mcpServers!['remote']).toEqual({
+      url: 'https://mcp.example.com/sse',
+      headers: { Authorization: 'Bearer tok' },
+    });
+  });
+
+  it('skips invalid entries and collects reasons', () => {
+    const result = validateConfig({
+      mcpServers: {
+        good: { command: 'npx', args: [] },
+        bad: { args: ['orphan'] },
+        worse: { command: 'npx', url: 'https://example.com' },
+      },
+    });
+    expect(result.mcpServers).toEqual({
+      good: { command: 'npx', args: [], env: undefined },
+    });
+    expect(result.skippedServers).toHaveLength(2);
+    expect(result.skippedServers!.find(s => s.name === 'bad')!.reason).toContain('Missing required field');
+    expect(result.skippedServers!.find(s => s.name === 'worse')!.reason).toContain('Cannot specify both');
+  });
+
+  it('skips entry with invalid URL', () => {
+    const result = validateConfig({
+      mcpServers: {
+        broken: { url: 'not-a-url' },
+      },
+    });
+    expect(result.mcpServers).toBeUndefined();
+    expect(result.skippedServers).toHaveLength(1);
+    expect(result.skippedServers![0]!.reason).toContain('Invalid URL');
+  });
+
+  it('handles mixed valid stdio and http entries', () => {
+    const result = validateConfig({
+      mcpServers: {
+        local: { command: 'node', args: ['server.js'] },
+        remote: { url: 'https://api.example.com/mcp' },
+      },
+    });
+    expect(Object.keys(result.mcpServers!)).toEqual(['local', 'remote']);
+    expect(result.skippedServers).toBeUndefined();
+  });
+
+  it('strips invalid args and env gracefully', () => {
+    const result = validateConfig({
+      mcpServers: {
+        s: { command: 'cmd', args: 'not-an-array', env: 'not-an-object' },
+      },
+    });
+    expect(result.mcpServers!['s']).toEqual({
+      command: 'cmd',
+      args: undefined,
+      env: undefined,
+    });
+  });
+});

--- a/mastracode/src/mcp/__tests__/manager.test.ts
+++ b/mastracode/src/mcp/__tests__/manager.test.ts
@@ -1,4 +1,9 @@
+import { MCPClient } from '@mastra/mcp';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { loadMcpConfig } from '../config.js';
+import { createMcpManager } from '../manager.js';
+import type { McpConfig, McpHttpServerConfig, McpStdioServerConfig } from '../types.js';
 
 // Mock @mastra/mcp before importing manager
 vi.mock('@mastra/mcp', () => {
@@ -16,11 +21,6 @@ vi.mock('../config.js', async importOriginal => {
     loadMcpConfig: vi.fn(() => ({})),
   };
 });
-
-import { MCPClient } from '@mastra/mcp';
-import { loadMcpConfig } from '../config.js';
-import { createMcpManager } from '../manager.js';
-import type { McpConfig, McpHttpServerConfig, McpStdioServerConfig } from '../types.js';
 
 const mockedLoadMcpConfig = vi.mocked(loadMcpConfig);
 const MockedMCPClient = vi.mocked(MCPClient);

--- a/mastracode/src/mcp/__tests__/manager.test.ts
+++ b/mastracode/src/mcp/__tests__/manager.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock @mastra/mcp before importing manager
+vi.mock('@mastra/mcp', () => {
+  const MCPClient = vi.fn(function (this: any) {
+    // individual tests override listTools/disconnect via mockImplementation
+  });
+  return { MCPClient };
+});
+
+// Mock config module to control what loadMcpConfig returns
+vi.mock('../config.js', async importOriginal => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    loadMcpConfig: vi.fn(() => ({})),
+  };
+});
+
+import { MCPClient } from '@mastra/mcp';
+import { loadMcpConfig } from '../config.js';
+import { createMcpManager } from '../manager.js';
+import type { McpConfig, McpHttpServerConfig, McpStdioServerConfig } from '../types.js';
+
+const mockedLoadMcpConfig = vi.mocked(loadMcpConfig);
+const MockedMCPClient = vi.mocked(MCPClient);
+
+function setupConfig(config: McpConfig) {
+  mockedLoadMcpConfig.mockReturnValue(config);
+}
+
+describe('createMcpManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('hasServers', () => {
+    it('returns false when no servers configured', () => {
+      setupConfig({});
+      const manager = createMcpManager('/tmp/test');
+      expect(manager.hasServers()).toBe(false);
+    });
+
+    it('returns true when stdio servers configured', () => {
+      setupConfig({ mcpServers: { fs: { command: 'npx', args: [] } } });
+      const manager = createMcpManager('/tmp/test');
+      expect(manager.hasServers()).toBe(true);
+    });
+
+    it('returns true when http servers configured', () => {
+      setupConfig({ mcpServers: { remote: { url: 'https://example.com/mcp' } } });
+      const manager = createMcpManager('/tmp/test');
+      expect(manager.hasServers()).toBe(true);
+    });
+
+    it('returns true when only skipped servers exist', () => {
+      setupConfig({ skippedServers: [{ name: 'bad', reason: 'Invalid entry' }] });
+      const manager = createMcpManager('/tmp/test');
+      expect(manager.hasServers()).toBe(true);
+    });
+  });
+
+  describe('getSkippedServers', () => {
+    it('returns empty array when no skipped servers', () => {
+      setupConfig({ mcpServers: { fs: { command: 'npx' } } });
+      const manager = createMcpManager('/tmp/test');
+      expect(manager.getSkippedServers()).toEqual([]);
+    });
+
+    it('returns skipped servers from config', () => {
+      const skipped = [
+        { name: 'bad1', reason: 'Missing required field' },
+        { name: 'bad2', reason: 'Invalid URL' },
+      ];
+      setupConfig({ skippedServers: skipped });
+      const manager = createMcpManager('/tmp/test');
+      expect(manager.getSkippedServers()).toEqual(skipped);
+    });
+  });
+
+  describe('init with server defs', () => {
+    it('builds stdio server def correctly', async () => {
+      const stdioConfig: McpStdioServerConfig = { command: 'npx', args: ['-y', 'mcp-fs'], env: { HOME: '/tmp' } };
+      setupConfig({ mcpServers: { fs: stdioConfig } });
+
+      const mockListTools = vi.fn().mockResolvedValue({ fs_read: {} });
+      MockedMCPClient.mockImplementation(function (this: any) {
+        this.listTools = mockListTools;
+        this.disconnect = vi.fn();
+      } as any);
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      expect(MockedMCPClient).toHaveBeenCalledWith({
+        id: 'mastra-code-mcp',
+        servers: {
+          fs: { command: 'npx', args: ['-y', 'mcp-fs'], env: { HOME: '/tmp' } },
+        },
+      });
+    });
+
+    it('builds http server def with URL object and requestInit', async () => {
+      const httpConfig: McpHttpServerConfig = {
+        url: 'https://mcp.example.com/sse',
+        headers: { Authorization: 'Bearer tok' },
+      };
+      setupConfig({ mcpServers: { remote: httpConfig } });
+
+      const mockListTools = vi.fn().mockResolvedValue({ remote_weather: {} });
+      MockedMCPClient.mockImplementation(function (this: any) {
+        this.listTools = mockListTools;
+        this.disconnect = vi.fn();
+      } as any);
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      const call = MockedMCPClient.mock.calls[0]![0]!;
+      const serverDef = call.servers['remote'] as any;
+      expect(serverDef.url).toBeInstanceOf(URL);
+      expect(serverDef.url.href).toBe('https://mcp.example.com/sse');
+      expect(serverDef.requestInit).toEqual({ headers: { Authorization: 'Bearer tok' } });
+    });
+
+    it('builds http server def without headers', async () => {
+      const httpConfig: McpHttpServerConfig = { url: 'https://mcp.example.com/mcp' };
+      setupConfig({ mcpServers: { remote: httpConfig } });
+
+      const mockListTools = vi.fn().mockResolvedValue({});
+      MockedMCPClient.mockImplementation(function (this: any) {
+        this.listTools = mockListTools;
+        this.disconnect = vi.fn();
+      } as any);
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      const call = MockedMCPClient.mock.calls[0]![0]!;
+      const serverDef = call.servers['remote'] as any;
+      expect(serverDef.url).toBeInstanceOf(URL);
+      expect(serverDef.requestInit).toBeUndefined();
+    });
+  });
+
+  describe('server statuses include transport', () => {
+    it('sets transport to stdio for command-based servers', async () => {
+      setupConfig({ mcpServers: { fs: { command: 'npx' } } });
+      MockedMCPClient.mockImplementation(function (this: any) {
+        this.listTools = vi.fn().mockResolvedValue({ fs_tool: {} });
+        this.disconnect = vi.fn();
+      } as any);
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      const statuses = manager.getServerStatuses();
+      expect(statuses).toHaveLength(1);
+      expect(statuses[0]!.transport).toBe('stdio');
+    });
+
+    it('sets transport to http for url-based servers', async () => {
+      setupConfig({ mcpServers: { remote: { url: 'https://example.com/mcp' } } });
+      MockedMCPClient.mockImplementation(function (this: any) {
+        this.listTools = vi.fn().mockResolvedValue({ remote_tool: {} });
+        this.disconnect = vi.fn();
+      } as any);
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      const statuses = manager.getServerStatuses();
+      expect(statuses).toHaveLength(1);
+      expect(statuses[0]!.transport).toBe('http');
+    });
+
+    it('sets transport correctly on connection error', async () => {
+      setupConfig({
+        mcpServers: {
+          local: { command: 'npx' },
+          remote: { url: 'https://example.com/mcp' },
+        },
+      });
+      MockedMCPClient.mockImplementation(function (this: any) {
+        this.listTools = vi.fn().mockRejectedValue(new Error('Connection failed'));
+        this.disconnect = vi.fn();
+      } as any);
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      const statuses = manager.getServerStatuses();
+      const local = statuses.find(s => s.name === 'local')!;
+      const remote = statuses.find(s => s.name === 'remote')!;
+      expect(local.transport).toBe('stdio');
+      expect(remote.transport).toBe('http');
+      expect(local.connected).toBe(false);
+      expect(remote.connected).toBe(false);
+    });
+  });
+});

--- a/mastracode/src/mcp/config.ts
+++ b/mastracode/src/mcp/config.ts
@@ -115,7 +115,8 @@ export function validateConfig(raw: unknown): McpConfig {
       const e = entry as Record<string, unknown>;
       servers[name] = {
         url: e.url as string,
-        headers: typeof e.headers === 'object' && e.headers !== null ? (e.headers as Record<string, string>) : undefined,
+        headers:
+          typeof e.headers === 'object' && e.headers !== null ? (e.headers as Record<string, string>) : undefined,
       };
     } else {
       skippedServers.push({ name, reason: classification.reason! });

--- a/mastracode/src/mcp/config.ts
+++ b/mastracode/src/mcp/config.ts
@@ -11,7 +11,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import type { McpConfig, McpServerConfig } from './types.js';
+import type { McpConfig, McpServerConfig, McpSkippedServer } from './types.js';
 
 export function loadMcpConfig(projectDir: string): McpConfig {
   const claudeConfig = loadClaudeSettings(projectDir);
@@ -59,46 +59,88 @@ function loadClaudeSettings(projectDir: string): McpConfig {
   }
 }
 
-function validateConfig(raw: unknown): McpConfig {
+/**
+ * Classify a raw server entry as stdio, http, or skip (with reason).
+ */
+export function classifyServerEntry(raw: unknown): { kind: 'stdio' | 'http' | 'skip'; reason?: string } {
+  if (!raw || typeof raw !== 'object') {
+    return { kind: 'skip', reason: 'Invalid entry: expected an object' };
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const hasCommand = typeof obj.command === 'string';
+  const hasUrl = typeof obj.url === 'string';
+
+  if (hasCommand && hasUrl) {
+    return { kind: 'skip', reason: 'Cannot specify both "command" and "url"' };
+  }
+
+  if (hasCommand) {
+    return { kind: 'stdio' };
+  }
+
+  if (hasUrl) {
+    try {
+      new URL(obj.url as string);
+    } catch {
+      return { kind: 'skip', reason: `Invalid URL: "${obj.url}"` };
+    }
+    return { kind: 'http' };
+  }
+
+  return { kind: 'skip', reason: 'Missing required field: "command" (stdio) or "url" (http)' };
+}
+
+export function validateConfig(raw: unknown): McpConfig {
   if (!raw || typeof raw !== 'object') return {};
   const obj = raw as Record<string, unknown>;
 
   if (!obj.mcpServers || typeof obj.mcpServers !== 'object') return {};
 
   const servers: Record<string, McpServerConfig> = {};
+  const skippedServers: McpSkippedServer[] = [];
   const rawServers = obj.mcpServers as Record<string, unknown>;
 
   for (const [name, entry] of Object.entries(rawServers)) {
-    if (isValidServerConfig(entry)) {
+    const classification = classifyServerEntry(entry);
+
+    if (classification.kind === 'stdio') {
+      const e = entry as Record<string, unknown>;
       servers[name] = {
-        command: (entry as Record<string, unknown>).command as string,
-        args: Array.isArray((entry as Record<string, unknown>).args)
-          ? ((entry as Record<string, unknown>).args as string[])
-          : undefined,
-        env:
-          typeof (entry as Record<string, unknown>).env === 'object' && (entry as Record<string, unknown>).env !== null
-            ? ((entry as Record<string, unknown>).env as Record<string, string>)
-            : undefined,
+        command: e.command as string,
+        args: Array.isArray(e.args) ? (e.args as string[]) : undefined,
+        env: typeof e.env === 'object' && e.env !== null ? (e.env as Record<string, string>) : undefined,
       };
+    } else if (classification.kind === 'http') {
+      const e = entry as Record<string, unknown>;
+      servers[name] = {
+        url: e.url as string,
+        headers: typeof e.headers === 'object' && e.headers !== null ? (e.headers as Record<string, string>) : undefined,
+      };
+    } else {
+      skippedServers.push({ name, reason: classification.reason! });
     }
   }
 
-  if (Object.keys(servers).length === 0) return {};
-  return { mcpServers: servers };
-}
-
-function isValidServerConfig(raw: unknown): boolean {
-  if (!raw || typeof raw !== 'object') return false;
-  const obj = raw as Record<string, unknown>;
-  return typeof obj.command === 'string';
+  const result: McpConfig = {};
+  if (Object.keys(servers).length > 0) {
+    result.mcpServers = servers;
+  }
+  if (skippedServers.length > 0) {
+    result.skippedServers = skippedServers;
+  }
+  return result;
 }
 
 /**
  * Merge configs: claude (lowest priority) < global < project (highest).
  * Later configs override earlier by server name.
+ * Skipped entries are accumulated, but if a higher-priority config provides
+ * a valid entry for a skipped name, the skip is removed.
  */
 function mergeConfigs(...configs: McpConfig[]): McpConfig {
   const merged: Record<string, McpServerConfig> = {};
+  const allSkipped: McpSkippedServer[] = [];
 
   for (const config of configs) {
     if (config.mcpServers) {
@@ -106,8 +148,27 @@ function mergeConfigs(...configs: McpConfig[]): McpConfig {
         merged[name] = server;
       }
     }
+    if (config.skippedServers) {
+      allSkipped.push(...config.skippedServers);
+    }
   }
 
-  if (Object.keys(merged).length === 0) return {};
-  return { mcpServers: merged };
+  // Remove skipped entries that were resolved by a valid config at any priority
+  const validNames = new Set(Object.keys(merged));
+  const filteredSkipped = allSkipped.filter(s => !validNames.has(s.name));
+
+  // Deduplicate skipped entries by name (keep last occurrence — highest priority reason)
+  const skippedMap = new Map<string, McpSkippedServer>();
+  for (const s of filteredSkipped) {
+    skippedMap.set(s.name, s);
+  }
+
+  const result: McpConfig = {};
+  if (Object.keys(merged).length > 0) {
+    result.mcpServers = merged;
+  }
+  if (skippedMap.size > 0) {
+    result.skippedServers = Array.from(skippedMap.values());
+  }
+  return result;
 }

--- a/mastracode/src/mcp/index.ts
+++ b/mastracode/src/mcp/index.ts
@@ -1,4 +1,11 @@
 export { createMcpManager } from './manager.js';
 export type { McpManager } from './manager.js';
 export { loadMcpConfig, getProjectMcpPath, getGlobalMcpPath, getClaudeSettingsPath } from './config.js';
-export type { McpConfig, McpServerConfig, McpServerStatus } from './types.js';
+export type {
+  McpConfig,
+  McpServerConfig,
+  McpStdioServerConfig,
+  McpHttpServerConfig,
+  McpSkippedServer,
+  McpServerStatus,
+} from './types.js';

--- a/mastracode/src/mcp/manager.ts
+++ b/mastracode/src/mcp/manager.ts
@@ -4,8 +4,9 @@
  */
 
 import { MCPClient } from '@mastra/mcp';
+import type { MastraMCPServerDefinition } from '@mastra/mcp';
 import { loadMcpConfig, getProjectMcpPath, getGlobalMcpPath, getClaudeSettingsPath } from './config.js';
-import type { McpConfig, McpServerStatus } from './types.js';
+import type { McpConfig, McpHttpServerConfig, McpServerConfig, McpServerStatus, McpSkippedServer } from './types.js';
 
 /** Public interface for the MCP manager returned by createMcpManager(). */
 export interface McpManager {
@@ -17,14 +18,20 @@ export interface McpManager {
   disconnect(): Promise<void>;
   /** Get all tools from connected MCP servers (namespaced as serverName_toolName). */
   getTools(): Record<string, any>;
-  /** Check if any MCP servers are configured. */
+  /** Check if any MCP servers are configured (or skipped). */
   hasServers(): boolean;
   /** Get status of all servers. */
   getServerStatuses(): McpServerStatus[];
+  /** Get servers that were skipped during config loading. */
+  getSkippedServers(): McpSkippedServer[];
   /** Get config file paths for display. */
   getConfigPaths(): { project: string; global: string; claude: string };
   /** Get the merged config. */
   getConfig(): McpConfig;
+}
+
+function getTransport(cfg: McpServerConfig): 'stdio' | 'http' {
+  return 'url' in cfg ? 'http' : 'stdio';
 }
 
 /**
@@ -39,11 +46,19 @@ export function createMcpManager(projectDir: string): McpManager {
   let initialized = false;
 
   function buildServerDefs(
-    servers: Record<string, { command: string; args?: string[]; env?: Record<string, string> }>,
-  ) {
-    const defs: Record<string, { command: string; args?: string[]; env?: Record<string, string> }> = {};
+    servers: Record<string, McpServerConfig>,
+  ): Record<string, MastraMCPServerDefinition> {
+    const defs: Record<string, MastraMCPServerDefinition> = {};
     for (const [name, cfg] of Object.entries(servers)) {
-      defs[name] = { command: cfg.command, args: cfg.args, env: cfg.env };
+      if ('url' in cfg) {
+        const httpCfg = cfg as McpHttpServerConfig;
+        defs[name] = {
+          url: new URL(httpCfg.url),
+          requestInit: httpCfg.headers ? { headers: httpCfg.headers } : undefined,
+        };
+      } else {
+        defs[name] = { command: cfg.command, args: cfg.args, env: cfg.env };
+      }
     }
     return defs;
   }
@@ -75,6 +90,7 @@ export function createMcpManager(projectDir: string): McpManager {
           connected: true,
           toolCount: serverToolNames.length,
           toolNames: serverToolNames,
+          transport: getTransport(servers[name]!),
         });
       }
     } catch (error) {
@@ -86,6 +102,7 @@ export function createMcpManager(projectDir: string): McpManager {
           connected: false,
           toolCount: 0,
           toolNames: [],
+          transport: getTransport(servers[name]!),
           error: errMsg,
         });
       }
@@ -127,11 +144,17 @@ export function createMcpManager(projectDir: string): McpManager {
     },
 
     hasServers() {
-      return config.mcpServers !== undefined && Object.keys(config.mcpServers).length > 0;
+      const hasConfigured = config.mcpServers !== undefined && Object.keys(config.mcpServers).length > 0;
+      const hasSkipped = config.skippedServers !== undefined && config.skippedServers.length > 0;
+      return hasConfigured || hasSkipped;
     },
 
     getServerStatuses() {
       return Array.from(serverStatuses.values());
+    },
+
+    getSkippedServers() {
+      return config.skippedServers ?? [];
     },
 
     getConfigPaths() {

--- a/mastracode/src/mcp/manager.ts
+++ b/mastracode/src/mcp/manager.ts
@@ -45,9 +45,7 @@ export function createMcpManager(projectDir: string): McpManager {
   let serverStatuses = new Map<string, McpServerStatus>();
   let initialized = false;
 
-  function buildServerDefs(
-    servers: Record<string, McpServerConfig>,
-  ): Record<string, MastraMCPServerDefinition> {
+  function buildServerDefs(servers: Record<string, McpServerConfig>): Record<string, MastraMCPServerDefinition> {
     const defs: Record<string, MastraMCPServerDefinition> = {};
     for (const [name, cfg] of Object.entries(servers)) {
       if ('url' in cfg) {

--- a/mastracode/src/mcp/manager.ts
+++ b/mastracode/src/mcp/manager.ts
@@ -152,7 +152,7 @@ export function createMcpManager(projectDir: string): McpManager {
     },
 
     getSkippedServers() {
-      return config.skippedServers ?? [];
+      return [...(config.skippedServers ?? [])];
     },
 
     getConfigPaths() {

--- a/mastracode/src/mcp/types.ts
+++ b/mastracode/src/mcp/types.ts
@@ -4,10 +4,10 @@
  */
 
 /**
- * A single MCP server configuration entry.
- * Uses Claude Code's format for compatibility.
+ * A stdio-based MCP server configuration entry.
+ * Launches a local process that communicates via stdin/stdout.
  */
-export interface McpServerConfig {
+export interface McpStdioServerConfig {
   /** The command to launch the MCP server process */
   command: string;
   /** Arguments for the command */
@@ -17,11 +17,39 @@ export interface McpServerConfig {
 }
 
 /**
+ * An HTTP-based MCP server configuration entry.
+ * Connects to a remote server via Streamable HTTP or SSE.
+ */
+export interface McpHttpServerConfig {
+  /** The URL of the remote MCP server endpoint */
+  url: string;
+  /** Optional HTTP headers (e.g. for authentication) */
+  headers?: Record<string, string>;
+}
+
+/**
+ * A single MCP server configuration entry.
+ * Detected by the presence of `command` (stdio) or `url` (http).
+ */
+export type McpServerConfig = McpStdioServerConfig | McpHttpServerConfig;
+
+/**
+ * An MCP server entry that was skipped during config loading.
+ */
+export interface McpSkippedServer {
+  /** Server name (from config key) */
+  name: string;
+  /** Human-readable reason the server was skipped */
+  reason: string;
+}
+
+/**
  * The top-level config object from mcp.json or settings.local.json.
  * Maps server names to their config.
  */
 export interface McpConfig {
   mcpServers?: Record<string, McpServerConfig>;
+  skippedServers?: McpSkippedServer[];
 }
 
 /**
@@ -36,6 +64,8 @@ export interface McpServerStatus {
   toolCount: number;
   /** List of tool names provided */
   toolNames: string[];
+  /** Transport type used by the server */
+  transport: 'stdio' | 'http';
   /** Error message if connection failed */
   error?: string;
 }

--- a/mastracode/src/tui/commands/mcp.ts
+++ b/mastracode/src/tui/commands/mcp.ts
@@ -38,14 +38,21 @@ export async function handleMcpCommand(ctx: SlashCommandContext, args: string[])
         `        "command": "npx",\n` +
         `        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path"],\n` +
         `        "env": {}\n` +
+        `      },\n` +
+        `      "remote-api": {\n` +
+        `        "url": "https://mcp.example.com/sse",\n` +
+        `        "headers": { "Authorization": "Bearer <token>" }\n` +
         `      }\n` +
         `    }\n` +
-        `  }`,
+        `  }\n\n` +
+        `Note: For dynamic auth (token refresh), use a stdio wrapper.\n` +
+        `"headers" only supports static values.`,
     );
     return;
   }
 
   const statuses = mm.getServerStatuses();
+  const skipped = mm.getSkippedServers();
   const lines: string[] = [`MCP Servers:`];
   lines.push(`  Project: ${paths.project}`);
   lines.push(`  Global:  ${paths.global}`);
@@ -55,11 +62,19 @@ export async function handleMcpCommand(ctx: SlashCommandContext, args: string[])
   for (const status of statuses) {
     const icon = status.connected ? '\u2713' : '\u2717';
     const state = status.connected ? 'connected' : `error: ${status.error}`;
-    lines.push(`  ${icon} ${status.name} (${state})`);
+    lines.push(`  ${icon} ${status.name} [${status.transport}] (${state})`);
     if (status.toolNames.length > 0) {
       for (const toolName of status.toolNames) {
         lines.push(`      - ${toolName}`);
       }
+    }
+  }
+
+  if (skipped.length > 0) {
+    lines.push('');
+    lines.push('  Skipped:');
+    for (const s of skipped) {
+      lines.push(`    \u2717 ${s.name}: ${s.reason}`);
     }
   }
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

MCP server entries with a `url` field are now recognized as HTTP (Streamable HTTP / SSE) servers. Previously only stdio-based servers (with `command`)
were loaded from `mcp.json`; entries with `url` were silently dropped by `isValidServerConfig()`.

Changes:
- Expand `McpServerConfig` into a discriminated union (`McpStdioServerConfig | McpHttpServerConfig`)
- Replace `isValidServerConfig()` with `classifyServerEntry()` that detects stdio, http, or skip (with reason)
- Convert HTTP config `url` string to `URL` object and `headers` to `requestInit` for `MastraMCPServerDefinition`
- Track invalid/ambiguous entries as `McpSkippedServer` with human-readable reasons
- Show transport type (`[stdio]` / `[http]`) and skipped servers in `/mcp` TUI command
- Log skipped servers at startup

<img width="1303" height="849" alt="image" src="https://github.com/user-attachments/assets/057f8b10-3de4-42fd-a20a-e929dd976ffe" />

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #13583

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support HTTP-based MCP servers (url + optional headers) alongside stdio; startup logs and /mcp show each server's transport and list skipped servers with reasons; /mcp UI shows transport per server and a "Skipped" block.

* **Documentation**
  * Added MCP config docs with examples for stdio and HTTP, validation rules, and guidance to view statuses via /mcp.

* **Tests**
  * Added comprehensive tests for config validation and manager behavior across stdio, HTTP, and skipped-server scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->