### PR TITLE
fix: handle absent optional fields in OpenAI processed schemas

### DIFF
--- a/.changeset/fix-absent-nullable-fields.md
+++ b/.changeset/fix-absent-nullable-fields.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed an infinite tool-call loop when using OpenAI models with optional fields in nested objects. When the LLM omits inner fields of a nested object (sends `{}` instead of `{ "field": null }`), validation would reject the input with "Required" errors, causing the agent to retry endlessly. Tool input validation now detects absent nullable fields and fills them with `null` before validation, allowing the existing transform pipeline to restore the original optional semantics.
+Fixed an issue where agents would enter an infinite retry loop when LLMs omit optional fields inside nested objects. Tool inputs with missing nested fields are now handled gracefully.

--- a/.changeset/fix-absent-nullable-fields.md
+++ b/.changeset/fix-absent-nullable-fields.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed an infinite tool-call loop when using OpenAI models with optional fields in nested objects. When the LLM omits inner fields of a nested object (sends `{}` instead of `{ "field": null }`), validation would reject the input with "Required" errors, causing the agent to retry endlessly. Tool input validation now detects absent nullable fields and fills them with `null` before validation, allowing the existing transform pipeline to restore the original optional semantics.

--- a/packages/core/src/tools/validation.test.ts
+++ b/packages/core/src/tools/validation.test.ts
@@ -1823,3 +1823,121 @@ describe('validateToolInput - Stringified JSON Coercion (GitHub #12757)', () => 
     });
   });
 });
+
+describe('validateToolInput - Absent Optional Fields in OpenAI Processed Schemas', () => {
+  it('should handle absent optional fields in nested objects after OpenAI schema processing', () => {
+    const processedSchema = z.object({
+      name: z
+        .string()
+        .nullable()
+        .transform((val: string | null) => (val === null ? undefined : val)),
+      story: z
+        .object({
+          whyTheyCreate: z
+            .string()
+            .nullable()
+            .transform((val: string | null) => (val === null ? undefined : val)),
+          howLong: z
+            .string()
+            .nullable()
+            .transform((val: string | null) => (val === null ? undefined : val)),
+        })
+        .nullable()
+        .transform((val: any) => (val === null ? undefined : val)),
+    });
+
+    const input = { name: 'Rafael', story: {} };
+
+    const result = validateToolInput(processedSchema, input);
+
+    expect(result.error).toBeUndefined();
+    expect(result.data).toEqual({
+      name: 'Rafael',
+      story: { whyTheyCreate: undefined, howLong: undefined },
+    });
+  });
+
+  it('should handle deeply nested absent optional fields', () => {
+    const processedSchema = z.object({
+      user: z.object({
+        profile: z.object({
+          bio: z
+            .string()
+            .nullable()
+            .transform((val: string | null) => (val === null ? undefined : val)),
+          settings: z.object({
+            theme: z
+              .string()
+              .nullable()
+              .transform((val: string | null) => (val === null ? undefined : val)),
+            notifications: z.boolean(),
+          }),
+        }),
+      }),
+    });
+
+    const input = {
+      user: {
+        profile: {
+          settings: { notifications: true },
+        },
+      },
+    };
+
+    const result = validateToolInput(processedSchema, input);
+
+    expect(result.error).toBeUndefined();
+    expect(result.data).toEqual({
+      user: {
+        profile: {
+          bio: undefined,
+          settings: { theme: undefined, notifications: true },
+        },
+      },
+    });
+  });
+
+  it('should not fill absent truly required fields with null', () => {
+    const processedSchema = z.object({
+      name: z.string(),
+      age: z
+        .number()
+        .nullable()
+        .transform((val: number | null) => (val === null ? undefined : val)),
+    });
+
+    const input = { age: null };
+
+    const result = validateToolInput(processedSchema, input);
+
+    expect(result.error).toBeDefined();
+  });
+
+  it('should handle arrays of objects with absent optional fields', () => {
+    const processedSchema = z.object({
+      items: z.array(
+        z.object({
+          id: z.string(),
+          label: z
+            .string()
+            .nullable()
+            .transform((val: string | null) => (val === null ? undefined : val)),
+        }),
+      ),
+    });
+
+    const input = {
+      items: [{ id: '1' }, { id: '2', label: 'present' }],
+    };
+
+    const result = validateToolInput(processedSchema, input);
+
+    expect(result.error).toBeUndefined();
+    expect(result.data).toEqual({
+      items: [
+        { id: '1', label: undefined },
+        { id: '2', label: 'present' },
+      ],
+    });
+  });
+});

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -2,7 +2,15 @@ import type { z } from 'zod';
 import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../request-context';
 import type { RequestContext } from '../request-context';
 import type { SchemaWithValidation } from '../stream/base/schema';
-import { getZodTypeName, isZodArray, isZodObject, unwrapZodType } from '../utils/zod-utils';
+import {
+  getZodDef,
+  getZodInnerType,
+  getZodTypeName,
+  isZodArray,
+  isZodObject,
+  isZodType,
+  unwrapZodType,
+} from '../utils/zod-utils';
 
 /**
  * Keys that should be redacted from error messages to prevent sensitive data leakage.
@@ -192,19 +200,72 @@ function stripNullishValues(input: unknown): unknown {
 }
 
 /**
+ * Gets the object shape from a Zod schema, unwrapping any wrapper types.
+ * Returns undefined if the schema is not a ZodObject after unwrapping.
+ */
+function getObjectShape(schema: unknown): Record<string, unknown> | undefined {
+  if (!schema || !isZodType(schema)) return undefined;
+  const unwrapped = unwrapZodType(schema as z.ZodTypeAny);
+  if (!isZodObject(unwrapped)) return undefined;
+  const shape = (unwrapped as any).shape;
+  if (!shape || typeof shape !== 'object') return undefined;
+  return shape;
+}
+
+/**
+ * Checks if a Zod schema has ZodNullable but NOT ZodOptional in its type chain.
+ * This targets the OpenAI compat pattern: .optional() → .nullable().transform(...)
+ * Fields with ZodOptional already accept absent values and should not be filled.
+ */
+function hasNullableButNotOptionalInChain(schema: unknown): boolean {
+  if (!schema || !isZodType(schema)) return false;
+  let hasNullable = false;
+  let current = schema as z.ZodTypeAny;
+  while (true) {
+    const typeName = getZodTypeName(current);
+    if (!typeName) break;
+    if (typeName === 'ZodOptional') return false;
+    if (typeName === 'ZodNullable') hasNullable = true;
+    if (typeName === 'ZodAny') return true;
+    const inner = getZodInnerType(current, typeName);
+    if (!inner) break;
+    current = inner;
+  }
+  return hasNullable;
+}
+
+/**
+ * Gets the array element schema from a Zod schema, unwrapping any wrapper types.
+ * Returns undefined if the schema is not a ZodArray after unwrapping.
+ */
+function getArrayItemSchema(schema: unknown): unknown {
+  if (!schema || !isZodType(schema)) return undefined;
+  const unwrapped = unwrapZodType(schema as z.ZodTypeAny);
+  if (!isZodArray(unwrapped)) return undefined;
+  const def = getZodDef(unwrapped as z.ZodTypeAny);
+  // Zod v3 uses _def.type, Zod v4 uses _def.element
+  return def?.type ?? def?.element;
+}
+
+/**
  * Recursively converts undefined values to null in an object.
  * This is needed for OpenAI compat layers which convert .optional() to .nullable()
  * for strict mode compliance. When fields are omitted (undefined), we convert them
  * to null so the schema validation passes, and the transform then converts null back
  * to undefined. (GitHub #11457)
  *
+ * When a schema is provided, also fills in absent nullable properties with null.
+ * This handles OpenAI compat layers where .optional() → .nullable() and the LLM
+ * omits fields from nested objects.
+ *
  * Only recurses into plain objects to preserve class instances and built-in objects
  * like Date, Map, URL, etc. (GitHub #11502)
  *
  * @param input The input to process
+ * @param schema Optional Zod schema to fill absent properties from
  * @returns The processed input with undefined values converted to null
  */
-function convertUndefinedToNull(input: unknown): unknown {
+function convertUndefinedToNull(input: unknown, schema?: unknown): unknown {
   if (input === undefined) {
     return null;
   }
@@ -214,7 +275,8 @@ function convertUndefinedToNull(input: unknown): unknown {
   }
 
   if (Array.isArray(input)) {
-    return input.map(convertUndefinedToNull);
+    const itemSchema = getArrayItemSchema(schema);
+    return input.map(item => convertUndefinedToNull(item, itemSchema));
   }
 
   // Only recurse into plain objects - preserve class instances, built-in objects
@@ -223,11 +285,23 @@ function convertUndefinedToNull(input: unknown): unknown {
     return input;
   }
 
+  const shape = getObjectShape(schema);
+
   // It's a plain object - recursively process all properties
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(input)) {
-    result[key] = convertUndefinedToNull(value);
+    result[key] = convertUndefinedToNull(value, shape?.[key]);
   }
+
+  // Fill absent nullable properties with null
+  if (shape) {
+    for (const key of Object.keys(shape)) {
+      if (!(key in result) && hasNullableButNotOptionalInChain(shape[key])) {
+        result[key] = null;
+      }
+    }
+  }
+
   return result;
 }
 
@@ -352,7 +426,7 @@ export function validateToolInput<T = any>(
   let normalizedInput = normalizeNullishInput(schema, input);
 
   // Step 2: Convert undefined values to null recursively (GitHub #11457)
-  normalizedInput = convertUndefinedToNull(normalizedInput);
+  normalizedInput = convertUndefinedToNull(normalizedInput, schema);
 
   // Step 3: Try validation with null values preserved
   const validation = schema.safeParse(normalizedInput);

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -226,7 +226,7 @@ function hasNullableButNotOptionalInChain(schema: unknown): boolean {
     if (!typeName) break;
     if (typeName === 'ZodOptional') return false;
     if (typeName === 'ZodNullable') hasNullable = true;
-    if (typeName === 'ZodAny') return true;
+    if (typeName === 'ZodAny') return hasNullable;
     const inner = getZodInnerType(current, typeName);
     if (!inner) break;
     current = inner;


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

When using OpenAI models, `OpenAISchemaCompatLayer.processZodType()` converts `.optional()` fields to `.nullable().transform(null →
undefined)` for strict mode compliance. If the LLM omits inner fields of a nested object (sends `{}` instead of `{ "field": null
}`), validation fails with "Required" errors causing an infinite tool-call retry loop.

This fix makes `convertUndefinedToNull` schema-aware — it inspects the Zod schema shape, detects absent fields that have the
`.nullable()` (but not `.optional()`) pattern, and fills them with `null` before validation. The existing `.transform(null →
undefined)` then restores the original `.optional()` semantics.

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #13518

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests verifying handling of absent optional fields in nested objects, arrays, and deep structures after schema processing.

* **Bug Fixes**
  * Validation now correctly treats missing optional/nullable fields (avoiding false required-field errors) and prevents infinite retry loops when models omit nested fields.

* **Chores**
  * Added a changelog entry documenting the patch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->