### PR TITLE
Fix harness getTokenUsage() returning zeros with AI SDK v5/v6

### DIFF
--- a/.changeset/slow-tips-deny.md
+++ b/.changeset/slow-tips-deny.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed harness getTokenUsage() returning zeros when using AI SDK v5/v6. The token usage extraction now correctly reads both inputTokens/outputTokens (v5/v6) and promptTokens/completionTokens (v4) field names from the usage object.

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1490,8 +1490,8 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
         case 'step-finish': {
           const usage = chunk.payload?.output?.usage;
           if (usage) {
-            const promptTokens = usage.promptTokens ?? 0;
-            const completionTokens = usage.completionTokens ?? 0;
+            const promptTokens = usage.promptTokens ?? usage.inputTokens ?? 0;
+            const completionTokens = usage.completionTokens ?? usage.outputTokens ?? 0;
             const totalTokens = promptTokens + completionTokens;
 
             this.tokenUsage.promptTokens += promptTokens;

--- a/packages/core/src/harness/token-usage.test.ts
+++ b/packages/core/src/harness/token-usage.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+
+function createHarness() {
+  const agent = new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+
+  return new Harness({
+    id: 'test-harness',
+    storage: new InMemoryStore(),
+    modes: [{ id: 'default', name: 'Default', default: true, agent }],
+  });
+}
+
+/**
+ * Creates a mock async iterable simulating a fullStream with a step-finish chunk
+ * containing the given usage data, followed by a finish chunk.
+ */
+async function* mockStream(usage: Record<string, unknown>) {
+  yield {
+    type: 'step-finish',
+    runId: 'run-1',
+    from: 'AGENT',
+    payload: {
+      output: { usage },
+      stepResult: { reason: 'stop' },
+      metadata: {},
+    },
+  };
+  yield {
+    type: 'finish',
+    runId: 'run-1',
+    from: 'AGENT',
+    payload: {
+      stepResult: { reason: 'stop' },
+      output: { usage },
+      metadata: {},
+    },
+  };
+}
+
+describe('step-finish token usage extraction', () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    harness = createHarness();
+  });
+
+  it('extracts token usage from AI SDK v5/v6 format (inputTokens/outputTokens)', async () => {
+    const usage = { inputTokens: 100, outputTokens: 50, totalTokens: 150 };
+
+    await (harness as any).processStream({ fullStream: mockStream(usage) });
+
+    const tokenUsage = harness.getTokenUsage();
+    expect(tokenUsage.promptTokens).toBe(100);
+    expect(tokenUsage.completionTokens).toBe(50);
+    expect(tokenUsage.totalTokens).toBe(150);
+  });
+
+  it('extracts token usage from legacy v4 format (promptTokens/completionTokens)', async () => {
+    const usage = { promptTokens: 200, completionTokens: 80, totalTokens: 280 };
+
+    await (harness as any).processStream({ fullStream: mockStream(usage) });
+
+    const tokenUsage = harness.getTokenUsage();
+    expect(tokenUsage.promptTokens).toBe(200);
+    expect(tokenUsage.completionTokens).toBe(80);
+    expect(tokenUsage.totalTokens).toBe(280);
+  });
+
+  it('accumulates token usage across multiple step-finish chunks', async () => {
+    const usage1 = { inputTokens: 100, outputTokens: 50 };
+    const usage2 = { inputTokens: 150, outputTokens: 70 };
+
+    async function* multiStepStream() {
+      yield {
+        type: 'step-finish',
+        runId: 'run-1',
+        from: 'AGENT',
+        payload: {
+          output: { usage: usage1 },
+          stepResult: { reason: 'tool-calls' },
+          metadata: {},
+        },
+      };
+      yield {
+        type: 'step-finish',
+        runId: 'run-1',
+        from: 'AGENT',
+        payload: {
+          output: { usage: usage2 },
+          stepResult: { reason: 'stop' },
+          metadata: {},
+        },
+      };
+      yield {
+        type: 'finish',
+        runId: 'run-1',
+        from: 'AGENT',
+        payload: {
+          stepResult: { reason: 'stop' },
+          output: { usage: usage2 },
+          metadata: {},
+        },
+      };
+    }
+
+    await (harness as any).processStream({ fullStream: multiStepStream() });
+
+    const tokenUsage = harness.getTokenUsage();
+    expect(tokenUsage.promptTokens).toBe(250);
+    expect(tokenUsage.completionTokens).toBe(120);
+    expect(tokenUsage.totalTokens).toBe(370);
+  });
+});


### PR DESCRIPTION
## Description

Fixed harness `getTokenUsage()` returning all zeros when using AI SDK v5/v6. The token usage extraction now supports both field name versions: `inputTokens`/`outputTokens` (v5/v6) and `promptTokens`/`completionTokens` (v4 legacy).

## Related Issue(s)

Fixes mastra-ai/mastra-code-ui#17

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token usage reporting to correctly extract token counts instead of returning zeros when using AI SDK v5/v6 and v4 formats, with proper field mapping across SDK versions.

* **Tests**
  * Added comprehensive test suite for token usage extraction, validating correct handling across multiple AI SDK versions and multi-chunk scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->