### PR TITLE
feat(s3): support sessionToken for temporary AWS credentials

### DIFF
--- a/.changeset/clever-peas-fry.md
+++ b/.changeset/clever-peas-fry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/s3': patch
+---
+
+Added sessionToken option to S3Filesystem for temporary AWS credentials (e.g. STS AssumeRole)

--- a/docs/src/content/en/reference/workspace/s3-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/s3-filesystem.mdx
@@ -101,6 +101,12 @@ description: "AWS secret access key. Optional for public buckets (read-only acce
 isOptional: true,
 },
 {
+name: "sessionToken",
+type: "string",
+description: "AWS session token for temporary credentials (e.g. from STS AssumeRole). Only needed when using temporary security credentials. Ignored when accessKeyId and secretAccessKey are not provided.",
+isOptional: true,
+},
+{
 name: "endpoint",
 type: "string",
 description: "Custom endpoint URL for S3-compatible storage (R2, MinIO, etc.)",

--- a/workspaces/s3/src/filesystem/index.test.ts
+++ b/workspaces/s3/src/filesystem/index.test.ts
@@ -225,6 +225,32 @@ describe('S3Filesystem', () => {
       expect(config.secretAccessKey).toBe('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY');
     });
 
+    it('includes sessionToken if set with credentials', () => {
+      const fs = new S3Filesystem({
+        bucket: 'test',
+        region: 'us-east-1',
+        accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+        secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        sessionToken: 'FwoGZXIvYXdzEBYaDH7vz+example-session-token',
+      });
+
+      const config = fs.getMountConfig();
+
+      expect(config.sessionToken).toBe('FwoGZXIvYXdzEBYaDH7vz+example-session-token');
+    });
+
+    it('does not include sessionToken if credentials are not set', () => {
+      const fs = new S3Filesystem({
+        bucket: 'test',
+        region: 'us-east-1',
+        sessionToken: 'FwoGZXIvYXdzEBYaDH7vz+example-session-token',
+      });
+
+      const config = fs.getMountConfig();
+
+      expect(config.sessionToken).toBeUndefined();
+    });
+
     it('does not include credentials if not set', () => {
       const fs = new S3Filesystem({ bucket: 'test', region: 'us-east-1' });
 
@@ -417,6 +443,64 @@ describe('S3Filesystem', () => {
       expect(client1).toBe(fakeClient);
       expect(client2).toBe(fakeClient);
       expect(client1).toBe(client2);
+    });
+
+    it('passes sessionToken in credentials when provided', async () => {
+      const { S3Client } = await import('@aws-sdk/client-s3');
+      const MockS3Client = vi.mocked(S3Client);
+      MockS3Client.mockClear();
+
+      const fs = new S3Filesystem({
+        bucket: 'test',
+        region: 'us-east-1',
+        accessKeyId: 'AKID',
+        secretAccessKey: 'secret',
+        sessionToken: 'my-session-token',
+      });
+
+      try {
+        await fs.readFile('test.txt');
+      } catch {
+        // Expected to fail (mock), but client should be created
+      }
+
+      expect(MockS3Client).toHaveBeenCalledWith(
+        expect.objectContaining({
+          credentials: {
+            accessKeyId: 'AKID',
+            secretAccessKey: 'secret',
+            sessionToken: 'my-session-token',
+          },
+        }),
+      );
+    });
+
+    it('omits sessionToken from credentials when not provided', async () => {
+      const { S3Client } = await import('@aws-sdk/client-s3');
+      const MockS3Client = vi.mocked(S3Client);
+      MockS3Client.mockClear();
+
+      const fs = new S3Filesystem({
+        bucket: 'test',
+        region: 'us-east-1',
+        accessKeyId: 'AKID',
+        secretAccessKey: 'secret',
+      });
+
+      try {
+        await fs.readFile('test.txt');
+      } catch {
+        // Expected to fail (mock), but client should be created
+      }
+
+      expect(MockS3Client).toHaveBeenCalledWith(
+        expect.objectContaining({
+          credentials: {
+            accessKeyId: 'AKID',
+            secretAccessKey: 'secret',
+          },
+        }),
+      );
     });
 
     it('uses anonymous credentials for public buckets', async () => {

--- a/workspaces/s3/src/filesystem/index.ts
+++ b/workspaces/s3/src/filesystem/index.ts
@@ -43,6 +43,8 @@ export interface S3MountConfig extends FilesystemMountConfig {
   accessKeyId?: string;
   /** AWS secret access key */
   secretAccessKey?: string;
+  /** AWS session token (for temporary credentials) */
+  sessionToken?: string;
   /** Mount as read-only */
   readOnly?: boolean;
 }
@@ -138,6 +140,12 @@ export interface S3FilesystemOptions extends MastraFilesystemOptions {
    */
   secretAccessKey?: string;
   /**
+   * AWS session token for temporary credentials (e.g. from STS AssumeRole).
+   * Optional - only needed when using temporary security credentials.
+   * Ignored when accessKeyId and secretAccessKey are not provided.
+   */
+  sessionToken?: string;
+  /**
    * Custom endpoint URL for S3-compatible storage.
    * Examples:
    * - Cloudflare R2: 'https://{accountId}.r2.cloudflarestorage.com'
@@ -225,6 +233,7 @@ export class S3Filesystem extends MastraFilesystem {
   private readonly region: string;
   private readonly accessKeyId?: string;
   private readonly secretAccessKey?: string;
+  private readonly sessionToken?: string;
   private readonly endpoint?: string;
   private readonly forcePathStyle: boolean;
   private readonly prefix: string;
@@ -238,6 +247,7 @@ export class S3Filesystem extends MastraFilesystem {
     this.region = options.region;
     this.accessKeyId = options.accessKeyId;
     this.secretAccessKey = options.secretAccessKey;
+    this.sessionToken = options.sessionToken;
     this.endpoint = options.endpoint;
     this.forcePathStyle = options.forcePathStyle ?? !!options.endpoint; // Default true for custom endpoints
     // Trim leading/trailing slashes from prefix using iterative approach (avoids polynomial regex)
@@ -265,6 +275,7 @@ export class S3Filesystem extends MastraFilesystem {
     if (this.accessKeyId && this.secretAccessKey) {
       config.accessKeyId = this.accessKeyId;
       config.secretAccessKey = this.secretAccessKey;
+      if (this.sessionToken) config.sessionToken = this.sessionToken;
     }
 
     if (this.readOnly) {
@@ -413,6 +424,7 @@ export class S3Filesystem extends MastraFilesystem {
         ? {
             accessKeyId: this.accessKeyId!,
             secretAccessKey: this.secretAccessKey!,
+            ...(this.sessionToken && { sessionToken: this.sessionToken }),
           }
         : // Anonymous access for public buckets - use empty credentials
           // to prevent SDK from trying to find credentials elsewhere


### PR DESCRIPTION
## Description

When creating Workspaces with resource/thread-scoped credentials, it's common to use AWS STS to generate temporary, least-privilege credentials (via `AssumeRole`, `GetFederationToken`, etc.). These temporary credentials include a `sessionToken` in addition to the access key pair, but `S3Filesystem` had no way to pass it through. This PR plumbs `sessionToken` through to the AWS SDK credentials.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session token support to S3 storage, enabling temporary AWS credentials such as those from STS AssumeRole.

* **Documentation**
  * Updated S3 storage configuration reference with the new optional sessionToken parameter.

* **Tests**
  * Added test coverage for session token credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->