### PR TITLE
 fix(core): trim trailing whitespace in agent network routing prompt

### DIFF
--- a/.changeset/fix-agent-network-routing-whitespace.md
+++ b/.changeset/fix-agent-network-routing-whitespace.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed trailing whitespace in Agent Network routing prompt that caused failures with Bedrock-backed Claude models. The routing step's assistant message had a newline and spaces from template literal indentation, which strict providers (AWS Bedrock) rejected with a 400 error. Simple agents were unaffected — only Agent Networks hit this issue.

--- a/.changeset/fix-agent-network-routing-whitespace.md
+++ b/.changeset/fix-agent-network-routing-whitespace.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed trailing whitespace in Agent Network routing prompt that caused failures with Bedrock-backed Claude models. The routing step's assistant message had a newline and spaces from template literal indentation, which strict providers (AWS Bedrock) rejected with a 400 error. Simple agents were unaffected — only Agent Networks hit this issue.
+Fixed Agent Network routing failures for users running Claude models through AWS Bedrock by removing trailing whitespace from the routing assistant message.

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -602,7 +602,7 @@ export async function createNetworkLoop({
                     }
 
                     The 'selectionReason' property should explain why you picked the primitive${inputData.verboseIntrospection ? ', as well as why the other primitives were not picked.' : '.'}
-                    `,
+                    `.trim(),
         },
       ];
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

The Agent Network routing step constructs an assistant message using a template literal (`packages/core/src/loop/network/index.ts`, line 576-605). Due to code indentation, the string ends with `\n` + 20 spaces of trailing whitespace.

Providers with strict message validation (Anthropic Claude via AWS Bedrock) reject this with: `"final assistant content cannot end with trailing whitespace" (400)`.

The fix adds `.trim()` to the template literal, consistent with the existing pattern in `message-history.ts` (lines 143, 162) where Mastra already trims assistant
message content.

Simple agents are unaffected (they don't use the routing step). Only Agent Networks routed through Bedrock-backed providers hit this issue.

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #13554

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed trailing whitespace in agent routing prompts to prevent occasional request errors and improve reliability.
  * Cleaned up selection-reason formatting so extraneous spacing/newlines are removed for more consistent display across integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->