### PR TITLE
fix(convex): use existing indexes for queryTable instead of full table scans

### DIFF
--- a/.changeset/fix-convex-querytable-index-scan.md
+++ b/.changeset/fix-convex-querytable-index-scan.md
@@ -1,0 +1,16 @@
+---
+'@mastra/convex': patch
+---
+
+fix: use existing indexes for queryTable operations instead of full table scans
+
+The `queryTable` handler in the Convex storage mutation now automatically
+selects the best matching index based on equality filters. Previously, all
+`queryTable` operations performed a full table scan (up to 10,000 documents)
+and filtered in JavaScript, which hit Convex's 16MB/32K document read limit
+when enough records accumulated across threads.
+
+Now, when equality filters are provided (e.g., `thread_id` for message queries
+or `resourceId` for thread queries), the handler matches them against the
+existing schema indexes (`by_thread`, `by_thread_created`, `by_resource`, etc.)
+and uses `.withIndex()` for efficient indexed queries.

--- a/stores/convex/src/server/index-map.test.ts
+++ b/stores/convex/src/server/index-map.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+
+import { findBestIndex, TABLE_INDEX_MAP } from './index-map';
+
+describe('findBestIndex', () => {
+  describe('mastra_messages', () => {
+    it('should use an index with thread_id prefix for thread_id filter', () => {
+      const result = findBestIndex('mastra_messages', [{ field: 'thread_id', value: 'thread-1' }]);
+      expect(result).not.toBeNull();
+      // by_thread_created and by_thread both match; either is correct since both
+      // use thread_id as a prefix field. by_thread_created also provides createdAt sort.
+      expect(['by_thread', 'by_thread_created']).toContain(result!.indexName);
+      expect(result!.indexedFilters).toEqual([{ field: 'thread_id', value: 'thread-1' }]);
+    });
+
+    it('should prefer by_thread_created over by_thread when both thread_id and createdAt filters present', () => {
+      const result = findBestIndex('mastra_messages', [
+        { field: 'thread_id', value: 'thread-1' },
+        { field: 'createdAt', value: '2024-01-01' },
+      ]);
+      expect(result).not.toBeNull();
+      expect(result!.indexName).toBe('by_thread_created');
+      expect(result!.indexedFilters).toHaveLength(2);
+      expect(result!.indexedFilters[0]).toEqual({ field: 'thread_id', value: 'thread-1' });
+      expect(result!.indexedFilters[1]).toEqual({ field: 'createdAt', value: '2024-01-01' });
+    });
+
+    it('should match by_resource for resourceId filter', () => {
+      const result = findBestIndex('mastra_messages', [{ field: 'resourceId', value: 'res-1' }]);
+      expect(result).not.toBeNull();
+      expect(result!.indexName).toBe('by_resource');
+    });
+
+    it('should match by_record_id for id filter', () => {
+      const result = findBestIndex('mastra_messages', [{ field: 'id', value: 'msg-1' }]);
+      expect(result).not.toBeNull();
+      expect(result!.indexName).toBe('by_record_id');
+    });
+
+    it('should use thread_id index when combined with non-indexed field', () => {
+      const result = findBestIndex('mastra_messages', [
+        { field: 'thread_id', value: 'thread-1' },
+        { field: 'role', value: 'user' },
+      ]);
+      expect(result).not.toBeNull();
+      expect(['by_thread', 'by_thread_created']).toContain(result!.indexName);
+      expect(result!.indexedFilters).toEqual([{ field: 'thread_id', value: 'thread-1' }]);
+    });
+  });
+
+  describe('mastra_threads', () => {
+    it('should match by_resource for resourceId filter', () => {
+      const result = findBestIndex('mastra_threads', [{ field: 'resourceId', value: 'res-1' }]);
+      expect(result).not.toBeNull();
+      expect(result!.indexName).toBe('by_resource');
+    });
+
+    it('should match by_record_id for id filter', () => {
+      const result = findBestIndex('mastra_threads', [{ field: 'id', value: 'thread-1' }]);
+      expect(result).not.toBeNull();
+      expect(result!.indexName).toBe('by_record_id');
+    });
+  });
+
+  describe('mastra_workflow_snapshots', () => {
+    it('should prefer by_workflow_run over by_workflow when both fields present', () => {
+      const result = findBestIndex('mastra_workflow_snapshots', [
+        { field: 'workflow_name', value: 'my-workflow' },
+        { field: 'run_id', value: 'run-1' },
+      ]);
+      expect(result).not.toBeNull();
+      expect(result!.indexName).toBe('by_workflow_run');
+      expect(result!.indexedFilters).toHaveLength(2);
+    });
+
+    it('should use workflow_name index for workflow_name only', () => {
+      const result = findBestIndex('mastra_workflow_snapshots', [{ field: 'workflow_name', value: 'my-workflow' }]);
+      expect(result).not.toBeNull();
+      // by_workflow_run and by_workflow both match with prefix length 1; either is correct
+      expect(['by_workflow', 'by_workflow_run']).toContain(result!.indexName);
+      expect(result!.indexedFilters).toEqual([{ field: 'workflow_name', value: 'my-workflow' }]);
+    });
+
+    it('should return null for run_id only (not a prefix of any index)', () => {
+      const result = findBestIndex('mastra_workflow_snapshots', [{ field: 'run_id', value: 'run-1' }]);
+      // run_id is never the first field in any index
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('mastra_scorers', () => {
+    it('should match by_scorer for scorerId filter', () => {
+      const result = findBestIndex('mastra_scorers', [{ field: 'scorerId', value: 'scorer-1' }]);
+      expect(result).not.toBeNull();
+      expect(result!.indexName).toBe('by_scorer');
+    });
+
+    it('should prefer by_entity for entityId + entityType', () => {
+      const result = findBestIndex('mastra_scorers', [
+        { field: 'entityId', value: 'entity-1' },
+        { field: 'entityType', value: 'agent' },
+      ]);
+      expect(result).not.toBeNull();
+      expect(result!.indexName).toBe('by_entity');
+      expect(result!.indexedFilters).toHaveLength(2);
+    });
+
+    it('should match by_entity for entityId only (prefix of composite)', () => {
+      const result = findBestIndex('mastra_scorers', [{ field: 'entityId', value: 'entity-1' }]);
+      expect(result).not.toBeNull();
+      expect(result!.indexName).toBe('by_entity');
+      expect(result!.indexedFilters).toHaveLength(1);
+    });
+
+    it('should match by_run for runId filter', () => {
+      const result = findBestIndex('mastra_scorers', [{ field: 'runId', value: 'run-1' }]);
+      expect(result).not.toBeNull();
+      expect(result!.indexName).toBe('by_run');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return null for empty filters', () => {
+      const result = findBestIndex('mastra_messages', []);
+      expect(result).toBeNull();
+    });
+
+    it('should return null for unknown table', () => {
+      const result = findBestIndex('unknown_table', [{ field: 'id', value: '1' }]);
+      expect(result).toBeNull();
+    });
+
+    it('should return null when no filter matches any index prefix', () => {
+      const result = findBestIndex('mastra_messages', [{ field: 'nonexistent_field', value: 'val' }]);
+      expect(result).toBeNull();
+    });
+
+    it('should not match composite index when only second field is filtered', () => {
+      // by_thread_created has fields: [thread_id, createdAt]
+      // Filtering only by createdAt should NOT match by_thread_created (not a prefix)
+      const result = findBestIndex('mastra_messages', [{ field: 'createdAt', value: '2024-01-01' }]);
+      // Should not be by_thread_created
+      expect(result).toBeNull();
+    });
+
+    it('should handle duplicate filter fields gracefully', () => {
+      const result = findBestIndex('mastra_messages', [
+        { field: 'thread_id', value: 'thread-1' },
+        { field: 'thread_id', value: 'thread-2' },
+      ]);
+      expect(result).not.toBeNull();
+      expect(['by_thread', 'by_thread_created']).toContain(result!.indexName);
+    });
+  });
+
+  describe('TABLE_INDEX_MAP sync with schema', () => {
+    it('should have entries for all typed tables', () => {
+      expect(TABLE_INDEX_MAP).toHaveProperty('mastra_messages');
+      expect(TABLE_INDEX_MAP).toHaveProperty('mastra_threads');
+      expect(TABLE_INDEX_MAP).toHaveProperty('mastra_resources');
+      expect(TABLE_INDEX_MAP).toHaveProperty('mastra_workflow_snapshots');
+      expect(TABLE_INDEX_MAP).toHaveProperty('mastra_scorers');
+      expect(TABLE_INDEX_MAP).toHaveProperty('mastra_vector_indexes');
+    });
+
+    it('mastra_messages indexes should include by_thread and by_thread_created', () => {
+      const names = TABLE_INDEX_MAP['mastra_messages']!.map(i => i.name);
+      expect(names).toContain('by_thread');
+      expect(names).toContain('by_thread_created');
+      expect(names).toContain('by_resource');
+      expect(names).toContain('by_record_id');
+    });
+
+    it('composite indexes should list fields in correct order', () => {
+      const threadCreated = TABLE_INDEX_MAP['mastra_messages']!.find(i => i.name === 'by_thread_created');
+      expect(threadCreated!.fields).toEqual(['thread_id', 'createdAt']);
+
+      const workflowRun = TABLE_INDEX_MAP['mastra_workflow_snapshots']!.find(i => i.name === 'by_workflow_run');
+      expect(workflowRun!.fields).toEqual(['workflow_name', 'run_id']);
+
+      const entity = TABLE_INDEX_MAP['mastra_scorers']!.find(i => i.name === 'by_entity');
+      expect(entity!.fields).toEqual(['entityId', 'entityType']);
+    });
+  });
+});

--- a/stores/convex/src/server/index-map.ts
+++ b/stores/convex/src/server/index-map.ts
@@ -1,0 +1,94 @@
+/**
+ * Index definitions for automatic query optimization.
+ *
+ * Maps each typed Convex table to its available indexes and their field lists.
+ * Indexes with more fields are listed first so the best (most specific) match
+ * is preferred during selection.
+ *
+ * These must stay in sync with the index definitions in schema.ts.
+ */
+export const TABLE_INDEX_MAP: Record<string, Array<{ name: string; fields: string[] }>> = {
+  mastra_messages: [
+    { name: 'by_thread_created', fields: ['thread_id', 'createdAt'] },
+    { name: 'by_thread', fields: ['thread_id'] },
+    { name: 'by_resource', fields: ['resourceId'] },
+    { name: 'by_record_id', fields: ['id'] },
+  ],
+  mastra_threads: [
+    { name: 'by_resource', fields: ['resourceId'] },
+    { name: 'by_created', fields: ['createdAt'] },
+    { name: 'by_updated', fields: ['updatedAt'] },
+    { name: 'by_record_id', fields: ['id'] },
+  ],
+  mastra_resources: [
+    { name: 'by_updated', fields: ['updatedAt'] },
+    { name: 'by_record_id', fields: ['id'] },
+  ],
+  mastra_workflow_snapshots: [
+    { name: 'by_workflow_run', fields: ['workflow_name', 'run_id'] },
+    { name: 'by_workflow', fields: ['workflow_name'] },
+    { name: 'by_resource', fields: ['resourceId'] },
+    { name: 'by_created', fields: ['createdAt'] },
+    { name: 'by_record_id', fields: ['id'] },
+  ],
+  mastra_scorers: [
+    { name: 'by_entity', fields: ['entityId', 'entityType'] },
+    { name: 'by_scorer', fields: ['scorerId'] },
+    { name: 'by_run', fields: ['runId'] },
+    { name: 'by_created', fields: ['createdAt'] },
+    { name: 'by_record_id', fields: ['id'] },
+  ],
+  mastra_vector_indexes: [
+    { name: 'by_name', fields: ['indexName'] },
+    { name: 'by_record_id', fields: ['id'] },
+  ],
+};
+
+type EqualityFilter = { field: string; value: unknown };
+
+/**
+ * Finds the best matching index for the given equality filters on a Convex table.
+ *
+ * Returns the index name and the subset of filters that form the index prefix,
+ * or null when no index matches.
+ *
+ * The "best" index is the one whose prefix has the most consecutive fields
+ * covered by the provided filters. For example, given filters for `thread_id`
+ * and `createdAt` on mastra_messages, the composite `by_thread_created` index
+ * (fields: [thread_id, createdAt]) is preferred over `by_thread` (fields: [thread_id]).
+ */
+export function findBestIndex(
+  convexTable: string,
+  filters: EqualityFilter[],
+): { indexName: string; indexedFilters: EqualityFilter[] } | null {
+  const indexes = TABLE_INDEX_MAP[convexTable];
+  if (!indexes || filters.length === 0) return null;
+
+  const filtersByField = new Map<string, EqualityFilter>();
+  for (const f of filters) {
+    filtersByField.set(f.field, f);
+  }
+
+  let best: { indexName: string; indexedFilters: EqualityFilter[]; prefixLength: number } | null = null;
+
+  for (const index of indexes) {
+    let prefixLength = 0;
+    const indexedFilters: EqualityFilter[] = [];
+
+    for (const field of index.fields) {
+      const filter = filtersByField.get(field);
+      if (filter) {
+        prefixLength++;
+        indexedFilters.push(filter);
+      } else {
+        break;
+      }
+    }
+
+    if (prefixLength > 0 && (!best || prefixLength > best.prefixLength)) {
+      best = { indexName: index.name, indexedFilters, prefixLength };
+    }
+  }
+
+  return best ? { indexName: best.indexName, indexedFilters: best.indexedFilters } : null;
+}

--- a/stores/convex/src/server/index-map.ts
+++ b/stores/convex/src/server/index-map.ts
@@ -7,6 +7,8 @@
  *
  * These must stay in sync with the index definitions in schema.ts.
  */
+import type { EqualityFilter } from '../storage/types';
+
 export const TABLE_INDEX_MAP: Record<string, Array<{ name: string; fields: string[] }>> = {
   mastra_messages: [
     { name: 'by_thread_created', fields: ['thread_id', 'createdAt'] },
@@ -43,8 +45,6 @@ export const TABLE_INDEX_MAP: Record<string, Array<{ name: string; fields: strin
     { name: 'by_record_id', fields: ['id'] },
   ],
 };
-
-type EqualityFilter = { field: string; value: unknown };
 
 /**
  * Finds the best matching index for the given equality filters on a Convex table.

--- a/stores/convex/src/server/storage.ts
+++ b/stores/convex/src/server/storage.ts
@@ -9,6 +9,7 @@ import type { GenericMutationCtx as MutationCtx } from 'convex/server';
 import { mutationGeneric } from 'convex/server';
 
 import type { StorageRequest, StorageResponse } from '../storage/types';
+import { findBestIndex } from './index-map';
 
 // Vector-specific table names (not in @mastra/core)
 const TABLE_VECTOR_INDEXES = 'mastra_vector_indexes';
@@ -160,6 +161,22 @@ async function handleTypedOperation(
           docs = await ctx.db
             .query(convexTable)
             .withIndex('by_workflow_run', (q: any) => q.eq('workflow_name', hint.workflowName).eq('run_id', hint.runId))
+            .take(maxDocs);
+        } else {
+          docs = await ctx.db.query(convexTable).take(maxDocs);
+        }
+      } else if (request.filters && request.filters.length > 0) {
+        const match = findBestIndex(convexTable, request.filters);
+        if (match) {
+          docs = await ctx.db
+            .query(convexTable)
+            .withIndex(match.indexName, (q: any) => {
+              let builder = q;
+              for (const filter of match.indexedFilters) {
+                builder = builder.eq(filter.field, filter.value);
+              }
+              return builder;
+            })
             .take(maxDocs);
         } else {
           docs = await ctx.db.query(convexTable).take(maxDocs);


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

The `queryTable` handler in the Convex storage mutation performed full table scans (up to 10,000 documents) for all typed tables, filtering in JavaScript
afterward. This hit Convex's 16MB/32K document read limit when enough messages accumulated across threads.

This PR adds automatic index selection based on equality filters. A new `findBestIndex` function matches provided filters against existing schema indexes
(e.g., `by_thread_created`, `by_resource`, `by_scorer`) using longest-prefix matching. When a match is found, the query uses `.withIndex()` for an
efficient indexed read. The in-memory filter is still applied as a safety net for any non-indexed fields.

**Changes:**
- New `index-map.ts` module with `TABLE_INDEX_MAP` and `findBestIndex()` pure function
- Updated `queryTable` case in `handleTypedOperation` to use automatic index selection when filters are present and no explicit `indexHint` is provided
- 22 unit tests covering all tables, composite indexes, prefix matching, and edge cases

## Before 
<img width="508" height="695" alt="Screenshot 2026-03-01 110245" src="https://github.com/user-attachments/assets/67955303-54a1-4e4a-9f37-4bd7438a5cca" />

## After
<img width="508" height="698" alt="Screenshot 2026-03-01 110814" src="https://github.com/user-attachments/assets/97d2fa15-5720-4e0a-96be-0ee4386a374f" />

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #13626

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query optimization now selects and uses the best matching index for filtered queries, avoiding full table scans and reducing read volume and limits-related failures.

* **Tests**
  * Added comprehensive tests validating index-selection behavior across tables, composite indexes, edge cases, and filter combinations.

* **Chores**
  * Updated changelog documenting the storage/query performance improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->