### PR TITLE
fix(auth): support cookie-based and bearer token auth for better-auth

### DIFF
--- a/.changeset/fix-better-auth-cookie-bearer-auth.md
+++ b/.changeset/fix-better-auth-cookie-bearer-auth.md
@@ -1,6 +1,9 @@
 ---
 '@mastra/auth-better-auth': patch
 '@mastra/hono': patch
+'@mastra/express': patch
+'@mastra/fastify': patch
+'@mastra/koa': patch
 '@mastra/server': patch
 ---
 

--- a/.changeset/fix-better-auth-cookie-bearer-auth.md
+++ b/.changeset/fix-better-auth-cookie-bearer-auth.md
@@ -1,0 +1,12 @@
+---
+'@mastra/auth-better-auth': patch
+'@mastra/hono': patch
+'@mastra/server': patch
+---
+
+Fix cookie-based and bearer token authentication for better-auth integration.
+
+Requests using only cookies (e.g. `credentials: "include"` from a browser) were rejected with 401 before the auth provider could verify them. Bearer tokens passed via the `Authorization` header were also rejected because `better-auth` only reads session tokens from the `Cookie` header.
+
+- Auth middleware now allows requests with cookies (no `Authorization` header) to reach the auth provider
+- Bearer tokens are converted into a `better-auth.session_token` cookie so `better-auth` can verify them

--- a/auth/better-auth/src/index.test.ts
+++ b/auth/better-auth/src/index.test.ts
@@ -249,6 +249,29 @@ describe('MastraAuthBetterAuth', () => {
       // Should append the session cookie alongside existing non-session cookies
       expect(call.headers.get('Cookie')).toBe('other_cookie=value; better-auth.session_token=my-bearer-token');
     });
+
+    it('should add session cookie when session name appears only inside a cookie value (not as a key)', async () => {
+      mockAuth.api.getSession.mockResolvedValue({
+        session: mockSession,
+        user: mockUser,
+      });
+      // The session cookie name appears as part of another cookie's VALUE, not as a key
+      mockRequest.header.mockImplementation((name: string) => {
+        if (name === 'Cookie') return 'other_cookie=contains_better-auth.session_token=xyz';
+        return undefined;
+      });
+
+      const auth = new MastraAuthBetterAuth({
+        auth: mockAuth as any,
+      });
+      await auth.authenticateToken('my-bearer-token', mockRequest);
+
+      const call = mockAuth.api.getSession.mock.calls[0][0];
+      // The session cookie key is not present (only appears in a value), so the Bearer token must be injected
+      expect(call.headers.get('Cookie')).toBe(
+        'other_cookie=contains_better-auth.session_token=xyz; better-auth.session_token=my-bearer-token',
+      );
+    });
   });
 
   describe('authorizeUser', () => {

--- a/auth/better-auth/src/index.test.ts
+++ b/auth/better-auth/src/index.test.ts
@@ -141,32 +141,6 @@ describe('MastraAuthBetterAuth', () => {
       expect(result).toBeNull();
     });
 
-    it('should pass Authorization header when present', async () => {
-      mockAuth.api.getSession.mockResolvedValue({
-        session: mockSession,
-        user: mockUser,
-      });
-      mockRequest.header.mockImplementation((name: string) => {
-        if (name === 'Authorization') return 'Bearer existing-token';
-        return undefined;
-      });
-
-      const auth = new MastraAuthBetterAuth({
-        auth: mockAuth as any,
-      });
-      await auth.authenticateToken('test-token', mockRequest);
-
-      expect(mockAuth.api.getSession).toHaveBeenCalledWith(
-        expect.objectContaining({
-          headers: expect.any(Headers),
-        }),
-      );
-
-      // Verify the headers contain the Authorization
-      const call = mockAuth.api.getSession.mock.calls[0][0];
-      expect(call.headers.get('Authorization')).toBe('Bearer existing-token');
-    });
-
     it('should pass Cookie header when present for cookie-based sessions', async () => {
       mockAuth.api.getSession.mockResolvedValue({
         session: mockSession,
@@ -186,7 +160,7 @@ describe('MastraAuthBetterAuth', () => {
       expect(call.headers.get('Cookie')).toBe('better-auth.session_token=abc123');
     });
 
-    it('should set Authorization header from token when no existing header', async () => {
+    it('should convert Bearer token to cookie header when no session cookie exists', async () => {
       mockAuth.api.getSession.mockResolvedValue({
         session: mockSession,
         user: mockUser,
@@ -199,7 +173,49 @@ describe('MastraAuthBetterAuth', () => {
       await auth.authenticateToken('my-bearer-token', mockRequest);
 
       const call = mockAuth.api.getSession.mock.calls[0][0];
-      expect(call.headers.get('Authorization')).toBe('Bearer my-bearer-token');
+      // Bearer token should be converted to a cookie for Better Auth
+      expect(call.headers.get('Cookie')).toBe('better-auth.session_token=my-bearer-token');
+    });
+
+    it('should not overwrite existing session cookie when Bearer token is also present', async () => {
+      mockAuth.api.getSession.mockResolvedValue({
+        session: mockSession,
+        user: mockUser,
+      });
+      mockRequest.header.mockImplementation((name: string) => {
+        if (name === 'Authorization') return 'Bearer some-token';
+        if (name === 'Cookie') return 'better-auth.session_token=cookie-token';
+        return undefined;
+      });
+
+      const auth = new MastraAuthBetterAuth({
+        auth: mockAuth as any,
+      });
+      await auth.authenticateToken('some-token', mockRequest);
+
+      const call = mockAuth.api.getSession.mock.calls[0][0];
+      // Should use the existing cookie, not create a new one from the Bearer token
+      expect(call.headers.get('Cookie')).toBe('better-auth.session_token=cookie-token');
+    });
+
+    it('should add session cookie alongside other cookies when Bearer token provided', async () => {
+      mockAuth.api.getSession.mockResolvedValue({
+        session: mockSession,
+        user: mockUser,
+      });
+      mockRequest.header.mockImplementation((name: string) => {
+        if (name === 'Cookie') return 'other_cookie=value';
+        return undefined;
+      });
+
+      const auth = new MastraAuthBetterAuth({
+        auth: mockAuth as any,
+      });
+      await auth.authenticateToken('my-bearer-token', mockRequest);
+
+      const call = mockAuth.api.getSession.mock.calls[0][0];
+      // Should append the session cookie alongside existing non-session cookies
+      expect(call.headers.get('Cookie')).toBe('other_cookie=value; better-auth.session_token=my-bearer-token');
     });
   });
 

--- a/auth/better-auth/src/index.test.ts
+++ b/auth/better-auth/src/index.test.ts
@@ -62,6 +62,21 @@ describe('MastraAuthBetterAuth', () => {
       });
       expect(auth.name).toBe('custom-auth');
     });
+
+    it('should set default sessionCookieName to "better-auth.session_token"', () => {
+      const auth = new MastraAuthBetterAuth({
+        auth: mockAuth as any,
+      });
+      expect(auth.sessionCookieName).toBe('better-auth.session_token');
+    });
+
+    it('should use custom cookiePrefix from auth options', () => {
+      const customAuth = { ...mockAuth, options: { advanced: { cookiePrefix: 'myapp' } } };
+      const auth = new MastraAuthBetterAuth({
+        auth: customAuth as any,
+      });
+      expect(auth.sessionCookieName).toBe('myapp.session_token');
+    });
   });
 
   describe('authenticateToken', () => {
@@ -196,6 +211,23 @@ describe('MastraAuthBetterAuth', () => {
       const call = mockAuth.api.getSession.mock.calls[0][0];
       // Should use the existing cookie, not create a new one from the Bearer token
       expect(call.headers.get('Cookie')).toBe('better-auth.session_token=cookie-token');
+    });
+
+    it('should use custom cookiePrefix when converting Bearer token to cookie', async () => {
+      const customAuth = { ...mockAuth, options: { advanced: { cookiePrefix: 'myapp' } } };
+      mockAuth.api.getSession.mockResolvedValue({
+        session: mockSession,
+        user: mockUser,
+      });
+      mockRequest.header.mockReturnValue(undefined);
+
+      const auth = new MastraAuthBetterAuth({
+        auth: customAuth as any,
+      });
+      await auth.authenticateToken('my-bearer-token', mockRequest);
+
+      const call = mockAuth.api.getSession.mock.calls[0][0];
+      expect(call.headers.get('Cookie')).toBe('myapp.session_token=my-bearer-token');
     });
 
     it('should add session cookie alongside other cookies when Bearer token provided', async () => {

--- a/auth/better-auth/src/index.test.ts
+++ b/auth/better-auth/src/index.test.ts
@@ -215,7 +215,7 @@ describe('MastraAuthBetterAuth', () => {
 
     it('should use custom cookiePrefix when converting Bearer token to cookie', async () => {
       const customAuth = { ...mockAuth, options: { advanced: { cookiePrefix: 'myapp' } } };
-      mockAuth.api.getSession.mockResolvedValue({
+      customAuth.api.getSession.mockResolvedValue({
         session: mockSession,
         user: mockUser,
       });
@@ -226,7 +226,7 @@ describe('MastraAuthBetterAuth', () => {
       });
       await auth.authenticateToken('my-bearer-token', mockRequest);
 
-      const call = mockAuth.api.getSession.mock.calls[0][0];
+      const call = customAuth.api.getSession.mock.calls[0][0];
       expect(call.headers.get('Cookie')).toBe('myapp.session_token=my-bearer-token');
     });
 

--- a/auth/better-auth/src/index.ts
+++ b/auth/better-auth/src/index.ts
@@ -70,8 +70,7 @@ export class MastraAuthBetterAuth extends MastraAuthProvider<BetterAuthUser> {
     }
 
     this.auth = options.auth;
-    // Better Auth does not publicly export its options type, so we use a
-    // minimal inline interface instead of `as any` to document the assumed shape.
+    // options is not part of Better Auth's public API
     const authWithOptions = this.auth as unknown as { options?: { advanced?: { cookiePrefix?: string } } };
     const prefix = authWithOptions.options?.advanced?.cookiePrefix ?? 'better-auth';
     this.sessionCookieName = `${prefix}.session_token`;
@@ -99,9 +98,7 @@ export class MastraAuthBetterAuth extends MastraAuthProvider<BetterAuthUser> {
         headers.set('Cookie', cookieHeader);
       }
 
-      // Convert Bearer token to a session cookie so Better Auth can verify it.
-      // Use exact key matching (not substring) to avoid false positives when the
-      // cookie name appears inside another cookie's value.
+      // Convert Bearer token to a session cookie if not already present
       const hasSessionCookieInHeader = !!cookieHeader?.split(';').some(pair => {
         const [key] = pair.trim().split('=');
         return key?.trim() === this.sessionCookieName;
@@ -111,7 +108,6 @@ export class MastraAuthBetterAuth extends MastraAuthProvider<BetterAuthUser> {
         headers.set('Cookie', `${existingCookies}${this.sessionCookieName}=${token}`);
       }
 
-      // Use Better Auth's API to get the session
       const result = await this.auth.api.getSession({
         headers,
       });
@@ -125,7 +121,6 @@ export class MastraAuthBetterAuth extends MastraAuthProvider<BetterAuthUser> {
         user: result.user,
       };
     } catch {
-      // Session verification failed
       return null;
     }
   }

--- a/auth/better-auth/src/index.ts
+++ b/auth/better-auth/src/index.ts
@@ -70,7 +70,10 @@ export class MastraAuthBetterAuth extends MastraAuthProvider<BetterAuthUser> {
     }
 
     this.auth = options.auth;
-    const prefix = (this.auth as any).options?.advanced?.cookiePrefix || 'better-auth';
+    // Better Auth does not publicly export its options type, so we use a
+    // minimal inline interface instead of `as any` to document the assumed shape.
+    const authWithOptions = this.auth as unknown as { options?: { advanced?: { cookiePrefix?: string } } };
+    const prefix = authWithOptions.options?.advanced?.cookiePrefix ?? 'better-auth';
     this.sessionCookieName = `${prefix}.session_token`;
 
     this.registerOptions(options);

--- a/auth/better-auth/src/index.ts
+++ b/auth/better-auth/src/index.ts
@@ -86,23 +86,18 @@ export class MastraAuthBetterAuth extends MastraAuthProvider<BetterAuthUser> {
    */
   async authenticateToken(token: string, request: HonoRequest): Promise<BetterAuthUser | null> {
     try {
-      // Better Auth expects the token to be passed via headers
-      // We need to construct headers with the Authorization bearer token
+      // Better Auth's api.getSession() reads session tokens from the Cookie header
       const headers = new Headers();
 
-      // Copy relevant headers from the request
-      const authHeader = request.header('Authorization');
-      if (authHeader) {
-        headers.set('Authorization', authHeader);
-      } else if (token) {
-        // If no auth header but token is provided, set it
-        headers.set('Authorization', `Bearer ${token}`);
-      }
-
-      // Copy cookie header if present (Better Auth can use cookies for sessions)
-      const cookieHeader = request.header('Cookie');
+      const cookieHeader = request?.header('Cookie');
       if (cookieHeader) {
         headers.set('Cookie', cookieHeader);
+      }
+
+      // Convert Bearer token to a session cookie so Better Auth can verify it
+      if (token && (!cookieHeader || !cookieHeader.includes('better-auth.session_token='))) {
+        const existingCookies = cookieHeader ? `${cookieHeader}; ` : '';
+        headers.set('Cookie', `${existingCookies}better-auth.session_token=${token}`);
       }
 
       // Use Better Auth's API to get the session

--- a/auth/better-auth/src/index.ts
+++ b/auth/better-auth/src/index.ts
@@ -70,6 +70,8 @@ export class MastraAuthBetterAuth extends MastraAuthProvider<BetterAuthUser> {
     }
 
     this.auth = options.auth;
+    const prefix = (this.auth as any).options?.advanced?.cookiePrefix || 'better-auth';
+    this.sessionCookieName = `${prefix}.session_token`;
 
     this.registerOptions(options);
   }
@@ -95,9 +97,9 @@ export class MastraAuthBetterAuth extends MastraAuthProvider<BetterAuthUser> {
       }
 
       // Convert Bearer token to a session cookie so Better Auth can verify it
-      if (token && (!cookieHeader || !cookieHeader.includes('better-auth.session_token='))) {
+      if (token && (!cookieHeader || !cookieHeader.includes(`${this.sessionCookieName}=`))) {
         const existingCookies = cookieHeader ? `${cookieHeader}; ` : '';
-        headers.set('Cookie', `${existingCookies}better-auth.session_token=${token}`);
+        headers.set('Cookie', `${existingCookies}${this.sessionCookieName}=${token}`);
       }
 
       // Use Better Auth's API to get the session

--- a/auth/better-auth/src/index.ts
+++ b/auth/better-auth/src/index.ts
@@ -96,8 +96,14 @@ export class MastraAuthBetterAuth extends MastraAuthProvider<BetterAuthUser> {
         headers.set('Cookie', cookieHeader);
       }
 
-      // Convert Bearer token to a session cookie so Better Auth can verify it
-      if (token && (!cookieHeader || !cookieHeader.includes(`${this.sessionCookieName}=`))) {
+      // Convert Bearer token to a session cookie so Better Auth can verify it.
+      // Use exact key matching (not substring) to avoid false positives when the
+      // cookie name appears inside another cookie's value.
+      const hasSessionCookieInHeader = !!cookieHeader?.split(';').some(pair => {
+        const [key] = pair.trim().split('=');
+        return key?.trim() === this.sessionCookieName;
+      });
+      if (token && !hasSessionCookieInHeader) {
         const existingCookies = cookieHeader ? `${cookieHeader}; ` : '';
         headers.set('Cookie', `${existingCookies}${this.sessionCookieName}=${token}`);
       }

--- a/docs/src/content/en/docs/server/auth/better-auth.mdx
+++ b/docs/src/content/en/docs/server/auth/better-auth.mdx
@@ -118,7 +118,21 @@ When auth is enabled, requests to Mastra's built-in routes require authenticatio
 
 ### Cookie session (recommended)
 
-If your Better Auth setup uses cookies, configure the client to send credentials and ensure your Mastra server CORS allows credentials for cross-origin requests.
+If your Better Auth setup uses cookies, configure the client to send credentials. For cross-origin requests (e.g. Next.js on `:3000` calling Mastra on `:4111`), enable CORS credentials on the Mastra server:
+
+```ts title="src/mastra/index.ts"
+export const mastra = new Mastra({
+  server: {
+    auth: mastraAuth,
+    cors: {
+      origin: 'http://localhost:3000', // your frontend origin
+      credentials: true,
+    },
+  },
+})
+```
+
+Then configure the client to include credentials:
 
 ```ts
 import { MastraClient } from '@mastra/client-js'
@@ -144,15 +158,18 @@ await fetch('http://localhost:4111/api/agents/weatherAgent/generate', {
 
 ### Bearer token
 
-If your Better Auth setup issues bearer tokens, include them in the `Authorization` header:
+You can pass the signed session token as a Bearer token. Retrieve it from your Better Auth client session and include it in the `Authorization` header:
 
 ```ts
 import { MastraClient } from '@mastra/client-js'
+import { authClient } from './auth-client' // your Better Auth client
+
+const session = await authClient.getSession()
 
 export const mastraClient = new MastraClient({
   baseUrl: 'http://localhost:4111',
   headers: {
-    Authorization: `Bearer ${accessToken}`,
+    Authorization: `Bearer ${session.data?.session.token}`,
   },
 })
 ```
@@ -198,8 +215,8 @@ Visit [Mastra Client SDK](/docs/server/mastra-client) for more configuration opt
 
 ## Troubleshooting
 
-- **401/403 on every request**: confirm your Better Auth handler is mounted and your app can create a valid session/token.
-- **Cookies not sent**: set `credentials: "include"` in `MastraClient` and enable CORS credentials on the Mastra server.
-- **Authorization header missing**: ensure the client attaches `Authorization: Bearer <token>` when using bearer tokens.
+- **401 on every request**: confirm your Better Auth handler is mounted and your app can create a valid session. Check that your client sends either a session cookie or a `Authorization: Bearer <signed-token>` header.
+- **Cookies not sent cross-origin**: set `credentials: "include"` in `MastraClient` and configure `server.cors` with your frontend origin and `credentials: true`.
+- **Bearer token rejected**: ensure you pass the full signed session token (from `authClient.getSession()`), not a raw or unsigned token.
 - **Base URL issues**: set `baseURL` in `betterAuth({ ... })` or set `BETTER_AUTH_URL`.
 - **DB connection errors**: verify `DATABASE_URL` and database provider configuration.

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -19,6 +19,13 @@ export abstract class MastraAuthProvider<TUser = unknown> extends MastraBase {
   public protected?: MastraAuthConfig['protected'];
   public public?: MastraAuthConfig['public'];
 
+  /**
+   * The session cookie name this provider uses.
+   * When set, the auth middleware only treats requests with this specific cookie
+   * as having cookie-based credentials. Without it, any cookie header is accepted.
+   */
+  public sessionCookieName?: string;
+
   constructor(options?: MastraAuthProviderOptions<TUser>) {
     super({ component: 'AUTH', name: options?.name });
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -20,9 +20,8 @@ export abstract class MastraAuthProvider<TUser = unknown> extends MastraBase {
   public public?: MastraAuthConfig['public'];
 
   /**
-   * The session cookie name this provider uses.
-   * When set, the auth middleware only treats requests with this specific cookie
-   * as having cookie-based credentials. Without it, any cookie header is accepted.
+   * Session cookie name for cookie-based auth. When set, the middleware only
+   * passes requests that carry this specific cookie. Unset disables cookie auth.
    */
   public sessionCookieName?: string;
 

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -281,7 +281,11 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
       token = context.getQuery('apiKey') || null;
     }
 
-    if (!token) {
+    // Check for cookie-based credentials (e.g. better-auth session cookies)
+    const hasCookies = !!context.getHeader('cookie');
+
+    // No token AND no cookies — reject immediately
+    if (!token && !hasCookies) {
       return { status: 401, error: 'Authentication required' };
     }
 
@@ -290,7 +294,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
       if (typeof authConfig.authenticateToken === 'function') {
         // Note: We pass null as request since adapters have different request types
         // If specific request is needed, authenticateToken can use data from token
-        user = await authConfig.authenticateToken(token, null as any);
+        user = await authConfig.authenticateToken(token ?? '', null as any);
       } else {
         return { status: 401, error: 'No token verification method configured' };
       }

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -283,7 +283,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
 
     // Check for cookie-based credentials matching the provider's session cookie
     const cookieHeader = context.getHeader('cookie');
-    const sessionCookieName = 'sessionCookieName' in authConfig ? (authConfig as any).sessionCookieName : undefined;
+    const sessionCookieName = 'sessionCookieName' in authConfig ? authConfig.sessionCookieName : undefined;
     const hasSessionCookie = sessionCookieName
       ? !!cookieHeader?.split(';').some(pair => {
           const [key] = pair.trim().split('=');

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -281,11 +281,12 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
       token = context.getQuery('apiKey') || null;
     }
 
-    // Check for cookie-based credentials (e.g. better-auth session cookies)
-    const hasCookies = !!context.getHeader('cookie');
+    // Check for cookie-based credentials matching the provider's session cookie
+    const cookieHeader = context.getHeader('cookie');
+    const sessionCookieName = 'sessionCookieName' in authConfig ? (authConfig as any).sessionCookieName : undefined;
+    const hasSessionCookie = sessionCookieName ? !!cookieHeader?.includes(`${sessionCookieName}=`) : !!cookieHeader;
 
-    // No token AND no cookies — reject immediately
-    if (!token && !hasCookies) {
+    if (!token && !hasSessionCookie) {
       return { status: 401, error: 'Authentication required' };
     }
 

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -292,9 +292,9 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     let user: unknown;
     try {
       if (typeof authConfig.authenticateToken === 'function') {
-        // Note: We pass null as request since adapters have different request types
-        // If specific request is needed, authenticateToken can use data from token
-        user = await authConfig.authenticateToken(token ?? '', null as any);
+        // Create a minimal request-like object so auth providers can read headers (e.g. cookies)
+        const requestShim = { header: (name: string) => context.getHeader(name) };
+        user = await authConfig.authenticateToken(token ?? '', requestShim as any);
       } else {
         return { status: 401, error: 'No token verification method configured' };
       }

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -284,7 +284,12 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     // Check for cookie-based credentials matching the provider's session cookie
     const cookieHeader = context.getHeader('cookie');
     const sessionCookieName = 'sessionCookieName' in authConfig ? (authConfig as any).sessionCookieName : undefined;
-    const hasSessionCookie = sessionCookieName ? !!cookieHeader?.includes(`${sessionCookieName}=`) : !!cookieHeader;
+    const hasSessionCookie = sessionCookieName
+      ? !!cookieHeader?.split(';').some(pair => {
+          const [key] = pair.trim().split('=');
+          return key?.trim() === sessionCookieName;
+        })
+      : false;
 
     if (!token && !hasSessionCookie) {
       return { status: 401, error: 'Authentication required' };

--- a/server-adapters/express/src/auth-middleware.ts
+++ b/server-adapters/express/src/auth-middleware.ts
@@ -46,7 +46,12 @@ export const authenticationMiddleware = async (req: Request, res: Response, next
   // Check for cookie-based credentials matching the provider's session cookie
   const cookieHeader = req.headers.cookie;
   const sessionCookieName = 'sessionCookieName' in authConfig ? (authConfig as any).sessionCookieName : undefined;
-  const hasSessionCookie = sessionCookieName ? !!cookieHeader?.includes(`${sessionCookieName}=`) : !!cookieHeader;
+  const hasSessionCookie = sessionCookieName
+    ? !!cookieHeader?.split(';').some(pair => {
+        const [key] = pair.trim().split('=');
+        return key?.trim() === sessionCookieName;
+      })
+    : false;
 
   if (!token && !hasSessionCookie) {
     return res.status(401).json({ error: 'Authentication required' });

--- a/server-adapters/express/src/auth-middleware.ts
+++ b/server-adapters/express/src/auth-middleware.ts
@@ -43,8 +43,10 @@ export const authenticationMiddleware = async (req: Request, res: Response, next
     token = (req.query.apiKey as string) || null;
   }
 
-  // Handle missing token
-  if (!token) {
+  // Check for cookie-based credentials (e.g. better-auth session cookies)
+  const hasCookies = !!req.headers.cookie;
+
+  if (!token && !hasCookies) {
     return res.status(401).json({ error: 'Authentication required' });
   }
 
@@ -57,7 +59,7 @@ export const authenticationMiddleware = async (req: Request, res: Response, next
       // Note: Express doesn't have HonoRequest, so we pass the Express Request
       // The auth config function signature accepts HonoRequest, but in practice
       // it should work with any request object that has the necessary properties
-      user = await authConfig.authenticateToken(token, req as any);
+      user = await authConfig.authenticateToken(token ?? '', req as any);
     } else {
       throw new Error('No token verification method configured');
     }

--- a/server-adapters/express/src/auth-middleware.ts
+++ b/server-adapters/express/src/auth-middleware.ts
@@ -43,10 +43,12 @@ export const authenticationMiddleware = async (req: Request, res: Response, next
     token = (req.query.apiKey as string) || null;
   }
 
-  // Check for cookie-based credentials (e.g. better-auth session cookies)
-  const hasCookies = !!req.headers.cookie;
+  // Check for cookie-based credentials matching the provider's session cookie
+  const cookieHeader = req.headers.cookie;
+  const sessionCookieName = 'sessionCookieName' in authConfig ? (authConfig as any).sessionCookieName : undefined;
+  const hasSessionCookie = sessionCookieName ? !!cookieHeader?.includes(`${sessionCookieName}=`) : !!cookieHeader;
 
-  if (!token && !hasCookies) {
+  if (!token && !hasSessionCookie) {
     return res.status(401).json({ error: 'Authentication required' });
   }
 

--- a/server-adapters/express/src/auth-middleware.ts
+++ b/server-adapters/express/src/auth-middleware.ts
@@ -45,7 +45,7 @@ export const authenticationMiddleware = async (req: Request, res: Response, next
 
   // Check for cookie-based credentials matching the provider's session cookie
   const cookieHeader = req.headers.cookie;
-  const sessionCookieName = 'sessionCookieName' in authConfig ? (authConfig as any).sessionCookieName : undefined;
+  const sessionCookieName = 'sessionCookieName' in authConfig ? authConfig.sessionCookieName : undefined;
   const hasSessionCookie = sessionCookieName
     ? !!cookieHeader?.split(';').some(pair => {
         const [key] = pair.trim().split('=');

--- a/server-adapters/fastify/src/auth-middleware.ts
+++ b/server-adapters/fastify/src/auth-middleware.ts
@@ -46,7 +46,7 @@ export const authenticationMiddleware: preHandlerHookHandler = async (request: F
 
   // Check for cookie-based credentials matching the provider's session cookie
   const cookieHeader = request.headers.cookie;
-  const sessionCookieName = 'sessionCookieName' in authConfig ? (authConfig as any).sessionCookieName : undefined;
+  const sessionCookieName = 'sessionCookieName' in authConfig ? authConfig.sessionCookieName : undefined;
   const hasSessionCookie = sessionCookieName
     ? !!cookieHeader?.split(';').some(pair => {
         const [key] = pair.trim().split('=');

--- a/server-adapters/fastify/src/auth-middleware.ts
+++ b/server-adapters/fastify/src/auth-middleware.ts
@@ -44,10 +44,12 @@ export const authenticationMiddleware: preHandlerHookHandler = async (request: F
     token = query.apiKey || null;
   }
 
-  // Check for cookie-based credentials (e.g. better-auth session cookies)
-  const hasCookies = !!request.headers.cookie;
+  // Check for cookie-based credentials matching the provider's session cookie
+  const cookieHeader = request.headers.cookie;
+  const sessionCookieName = 'sessionCookieName' in authConfig ? (authConfig as any).sessionCookieName : undefined;
+  const hasSessionCookie = sessionCookieName ? !!cookieHeader?.includes(`${sessionCookieName}=`) : !!cookieHeader;
 
-  if (!token && !hasCookies) {
+  if (!token && !hasSessionCookie) {
     return reply.status(401).send({ error: 'Authentication required' });
   }
 

--- a/server-adapters/fastify/src/auth-middleware.ts
+++ b/server-adapters/fastify/src/auth-middleware.ts
@@ -47,7 +47,12 @@ export const authenticationMiddleware: preHandlerHookHandler = async (request: F
   // Check for cookie-based credentials matching the provider's session cookie
   const cookieHeader = request.headers.cookie;
   const sessionCookieName = 'sessionCookieName' in authConfig ? (authConfig as any).sessionCookieName : undefined;
-  const hasSessionCookie = sessionCookieName ? !!cookieHeader?.includes(`${sessionCookieName}=`) : !!cookieHeader;
+  const hasSessionCookie = sessionCookieName
+    ? !!cookieHeader?.split(';').some(pair => {
+        const [key] = pair.trim().split('=');
+        return key?.trim() === sessionCookieName;
+      })
+    : false;
 
   if (!token && !hasSessionCookie) {
     return reply.status(401).send({ error: 'Authentication required' });

--- a/server-adapters/fastify/src/auth-middleware.ts
+++ b/server-adapters/fastify/src/auth-middleware.ts
@@ -44,8 +44,10 @@ export const authenticationMiddleware: preHandlerHookHandler = async (request: F
     token = query.apiKey || null;
   }
 
-  // Handle missing token
-  if (!token) {
+  // Check for cookie-based credentials (e.g. better-auth session cookies)
+  const hasCookies = !!request.headers.cookie;
+
+  if (!token && !hasCookies) {
     return reply.status(401).send({ error: 'Authentication required' });
   }
 
@@ -57,7 +59,7 @@ export const authenticationMiddleware: preHandlerHookHandler = async (request: F
     if (typeof authConfig.authenticateToken === 'function') {
       // Note: The auth config function signature accepts HonoRequest, but in practice
       // it should work with any request object that has the necessary properties
-      user = await authConfig.authenticateToken(token, request as any);
+      user = await authConfig.authenticateToken(token ?? '', request as any);
     } else {
       throw new Error('No token verification method configured');
     }

--- a/server-adapters/hono/src/auth-middleware.ts
+++ b/server-adapters/hono/src/auth-middleware.ts
@@ -47,7 +47,12 @@ export const authenticationMiddleware = async (c: ContextWithMastra, next: Next)
   // Check for cookie-based credentials matching the provider's session cookie
   const cookieHeader = c.req.header('Cookie');
   const sessionCookieName = 'sessionCookieName' in authConfig ? (authConfig as any).sessionCookieName : undefined;
-  const hasSessionCookie = sessionCookieName ? !!cookieHeader?.includes(`${sessionCookieName}=`) : !!cookieHeader;
+  const hasSessionCookie = sessionCookieName
+    ? !!cookieHeader?.split(';').some(pair => {
+        const [key] = pair.trim().split('=');
+        return key?.trim() === sessionCookieName;
+      })
+    : false;
 
   if (!token && !hasSessionCookie) {
     return c.json({ error: 'Authentication required' }, 401);

--- a/server-adapters/hono/src/auth-middleware.ts
+++ b/server-adapters/hono/src/auth-middleware.ts
@@ -46,7 +46,7 @@ export const authenticationMiddleware = async (c: ContextWithMastra, next: Next)
 
   // Check for cookie-based credentials matching the provider's session cookie
   const cookieHeader = c.req.header('Cookie');
-  const sessionCookieName = 'sessionCookieName' in authConfig ? (authConfig as any).sessionCookieName : undefined;
+  const sessionCookieName = 'sessionCookieName' in authConfig ? authConfig.sessionCookieName : undefined;
   const hasSessionCookie = sessionCookieName
     ? !!cookieHeader?.split(';').some(pair => {
         const [key] = pair.trim().split('=');

--- a/server-adapters/hono/src/auth-middleware.ts
+++ b/server-adapters/hono/src/auth-middleware.ts
@@ -44,8 +44,11 @@ export const authenticationMiddleware = async (c: ContextWithMastra, next: Next)
     token = c.req.query('apiKey') || null;
   }
 
-  // Handle missing token
-  if (!token) {
+  // Check for cookie-based credentials (e.g. better-auth session cookies)
+  const hasCookies = !!c.req.header('Cookie');
+
+  // Handle missing credentials — no token AND no cookies
+  if (!token && !hasCookies) {
     return c.json({ error: 'Authentication required' }, 401);
   }
 
@@ -55,7 +58,7 @@ export const authenticationMiddleware = async (c: ContextWithMastra, next: Next)
 
     // Client provided verify function
     if (typeof authConfig.authenticateToken === 'function') {
-      user = await authConfig.authenticateToken(token, c.req);
+      user = await authConfig.authenticateToken(token ?? '', c.req);
     } else {
       throw new Error('No token verification method configured');
     }

--- a/server-adapters/hono/src/auth-middleware.ts
+++ b/server-adapters/hono/src/auth-middleware.ts
@@ -44,11 +44,12 @@ export const authenticationMiddleware = async (c: ContextWithMastra, next: Next)
     token = c.req.query('apiKey') || null;
   }
 
-  // Check for cookie-based credentials (e.g. better-auth session cookies)
-  const hasCookies = !!c.req.header('Cookie');
+  // Check for cookie-based credentials matching the provider's session cookie
+  const cookieHeader = c.req.header('Cookie');
+  const sessionCookieName = 'sessionCookieName' in authConfig ? (authConfig as any).sessionCookieName : undefined;
+  const hasSessionCookie = sessionCookieName ? !!cookieHeader?.includes(`${sessionCookieName}=`) : !!cookieHeader;
 
-  // Handle missing credentials — no token AND no cookies
-  if (!token && !hasCookies) {
+  if (!token && !hasSessionCookie) {
     return c.json({ error: 'Authentication required' }, 401);
   }
 

--- a/server-adapters/koa/src/auth-middleware.ts
+++ b/server-adapters/koa/src/auth-middleware.ts
@@ -44,8 +44,10 @@ export const authenticationMiddleware: Middleware = async (ctx: Context, next: N
     token = query.apiKey || null;
   }
 
-  // Handle missing token
-  if (!token) {
+  // Check for cookie-based credentials (e.g. better-auth session cookies)
+  const hasCookies = !!ctx.headers.cookie;
+
+  if (!token && !hasCookies) {
     ctx.status = 401;
     ctx.body = { error: 'Authentication required' };
     return;
@@ -59,7 +61,7 @@ export const authenticationMiddleware: Middleware = async (ctx: Context, next: N
     if (typeof authConfig.authenticateToken === 'function') {
       // Note: The auth config function signature accepts HonoRequest, but in practice
       // it should work with any request object that has the necessary properties
-      user = await authConfig.authenticateToken(token, ctx.request as any);
+      user = await authConfig.authenticateToken(token ?? '', ctx.request as any);
     } else {
       throw new Error('No token verification method configured');
     }

--- a/server-adapters/koa/src/auth-middleware.ts
+++ b/server-adapters/koa/src/auth-middleware.ts
@@ -44,10 +44,12 @@ export const authenticationMiddleware: Middleware = async (ctx: Context, next: N
     token = query.apiKey || null;
   }
 
-  // Check for cookie-based credentials (e.g. better-auth session cookies)
-  const hasCookies = !!ctx.headers.cookie;
+  // Check for cookie-based credentials matching the provider's session cookie
+  const cookieHeader = ctx.headers.cookie;
+  const sessionCookieName = 'sessionCookieName' in authConfig ? (authConfig as any).sessionCookieName : undefined;
+  const hasSessionCookie = sessionCookieName ? !!cookieHeader?.includes(`${sessionCookieName}=`) : !!cookieHeader;
 
-  if (!token && !hasCookies) {
+  if (!token && !hasSessionCookie) {
     ctx.status = 401;
     ctx.body = { error: 'Authentication required' };
     return;

--- a/server-adapters/koa/src/auth-middleware.ts
+++ b/server-adapters/koa/src/auth-middleware.ts
@@ -47,7 +47,12 @@ export const authenticationMiddleware: Middleware = async (ctx: Context, next: N
   // Check for cookie-based credentials matching the provider's session cookie
   const cookieHeader = ctx.headers.cookie;
   const sessionCookieName = 'sessionCookieName' in authConfig ? (authConfig as any).sessionCookieName : undefined;
-  const hasSessionCookie = sessionCookieName ? !!cookieHeader?.includes(`${sessionCookieName}=`) : !!cookieHeader;
+  const hasSessionCookie = sessionCookieName
+    ? !!cookieHeader?.split(';').some(pair => {
+        const [key] = pair.trim().split('=');
+        return key?.trim() === sessionCookieName;
+      })
+    : false;
 
   if (!token && !hasSessionCookie) {
     ctx.status = 401;

--- a/server-adapters/koa/src/auth-middleware.ts
+++ b/server-adapters/koa/src/auth-middleware.ts
@@ -46,7 +46,7 @@ export const authenticationMiddleware: Middleware = async (ctx: Context, next: N
 
   // Check for cookie-based credentials matching the provider's session cookie
   const cookieHeader = ctx.headers.cookie;
-  const sessionCookieName = 'sessionCookieName' in authConfig ? (authConfig as any).sessionCookieName : undefined;
+  const sessionCookieName = 'sessionCookieName' in authConfig ? authConfig.sessionCookieName : undefined;
   const hasSessionCookie = sessionCookieName
     ? !!cookieHeader?.split(';').some(pair => {
         const [key] = pair.trim().split('=');


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

better-auth integration was returning 401 for all requests due to two bugs:

1. The auth middleware in all server adapters and checkRouteAuth() rejected requests without an Authorization header — even when a valid session cookie
was present. This broke cookie-based auth (e.g. browsers using credentials: "include").
2. better-auth.api.getSession() only reads from the Cookie header, but the old code forwarded Bearer tokens via the Authorization header which better-auth
ignores.

Changes

- All auth middlewares (Hono, Express, Fastify, Koa) and checkRouteAuth() now allow requests through when cookies are present, even without a Bearer token
- checkRouteAuth() passes a request shim instead of null so auth providers can read headers like cookies
- MastraAuthBetterAuth.authenticateToken() converts the Bearer token into a better-auth.session_token cookie so getSession() can verify it
- Docs updated with CORS config for cross-origin cookie auth and correct bearer token source

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #13639

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supports cookie-based session authentication and accepts credentialed requests.
  * Converts Bearer tokens into a session cookie when no session cookie exists, preserving existing cookies.
  * Supports configurable session cookie name/prefix for provider-specific detection.

* **Documentation**
  * Added runnable examples for cookie and signed-token (Bearer) flows with explicit CORS/credentials guidance and troubleshooting.

* **Tests**
  * Added tests for cookie-session behavior, Bearer-to-cookie conversion, custom cookie prefixes, and cookie-preservation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->