### PR TITLE
fix(mcp): forward AbortSignal from AI SDK context to callTool()

### DIFF
--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -451,10 +451,14 @@ describe('MastraMCPClient - AbortSignal forwarding', () => {
     const abortController = new AbortController();
 
     // Abort after 100ms
-    setTimeout(() => abortController.abort(), 100);
+    const timeoutId = setTimeout(() => abortController.abort(), 100);
 
     const start = Date.now();
-    await expect(slowTool.execute?.({ input: 'test' }, { abortSignal: abortController.signal })).rejects.toThrow();
+    try {
+      await expect(slowTool.execute?.({ input: 'test' }, { abortSignal: abortController.signal })).rejects.toThrow();
+    } finally {
+      clearTimeout(timeoutId);
+    }
     const elapsed = Date.now() - start;
 
     // Should abort quickly (< 5s), not wait the full 60s tool duration

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -411,6 +411,77 @@ describe('MastraMCPClient - outputSchema Zod stripping', () => {
   });
 });
 
+describe('MastraMCPClient - AbortSignal forwarding', () => {
+  let testServer: {
+    httpServer: HttpServer;
+    mcpServer: McpServer;
+    serverTransport: StreamableHTTPServerTransport;
+    baseUrl: URL;
+  };
+  let client: InternalMastraMCPClient;
+
+  beforeEach(async () => {
+    testServer = await setupTestServer(false);
+
+    // Add a slow tool that takes 60s
+    testServer.mcpServer.tool('slow_tool', 'A slow tool', { input: z.string() }, async () => {
+      await new Promise(resolve => setTimeout(resolve, 60_000));
+      return { content: [{ type: 'text' as const, text: 'done' }] };
+    });
+
+    client = new InternalMastraMCPClient({
+      name: 'abort-signal-test-client',
+      server: { url: testServer.baseUrl },
+    });
+    await client.connect();
+  });
+
+  afterEach(async () => {
+    await client?.disconnect().catch(() => {});
+    await testServer?.mcpServer.close().catch(() => {});
+    await testServer?.serverTransport.close().catch(() => {});
+    testServer?.httpServer.close();
+  });
+
+  it('should forward abortSignal to callTool and reject when aborted', async () => {
+    const tools = await client.tools();
+    const slowTool = tools['slow_tool'];
+    expect(slowTool).toBeDefined();
+
+    const abortController = new AbortController();
+
+    // Abort after 100ms
+    setTimeout(() => abortController.abort(), 100);
+
+    const start = Date.now();
+    await expect(slowTool.execute?.({ input: 'test' }, { abortSignal: abortController.signal })).rejects.toThrow();
+    const elapsed = Date.now() - start;
+
+    // Should abort quickly (< 5s), not wait the full 60s tool duration
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
+  it('should pass abortSignal through to the MCP SDK client', async () => {
+    const sdkClient = (client as any).client as Client;
+    const callToolSpy = vi.spyOn(sdkClient, 'callTool').mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+      isError: false,
+    });
+
+    const tools = await client.tools();
+    const slowTool = tools['slow_tool'];
+
+    const abortController = new AbortController();
+    await slowTool.execute?.({ input: 'test' }, { abortSignal: abortController.signal });
+
+    expect(callToolSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'slow_tool' }),
+      expect.anything(),
+      expect.objectContaining({ signal: abortController.signal }),
+    );
+  });
+});
+
 describe('MastraMCPClient - Elicitation Tests', () => {
   let testServer: {
     httpServer: HttpServer;

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -789,7 +789,10 @@ export class InternalMastraMCPClient extends MastraBase {
           description: tool.description || '',
           inputSchema: await this.convertInputSchema(tool.inputSchema),
           outputSchema: await this.convertOutputSchema(tool.outputSchema),
-          execute: async (input: any, context?: { requestContext?: RequestContext | null; runId?: string }) => {
+          execute: async (
+            input: any,
+            context?: { requestContext?: RequestContext | null; runId?: string; abortSignal?: AbortSignal },
+          ) => {
             const operationContext = context?.requestContext ?? null;
 
             return this.operationContextStore.run(operationContext, async () => {
@@ -807,6 +810,7 @@ export class InternalMastraMCPClient extends MastraBase {
                   CallToolResultSchema,
                   {
                     timeout: this.timeout,
+                    signal: context?.abortSignal,
                   },
                 );
 


### PR DESCRIPTION
## Summary

`MCPClient`'s tool execute wrapper receives `context.abortSignal` from the AI SDK but was not forwarding it to `this.client.callTool()`. This meant `Harness.abort()` had no effect during MCP tool execution — the in-flight HTTP request continued running until timeout.

The MCP SDK (`@modelcontextprotocol/sdk`) already supports `signal?: AbortSignal` in its `RequestOptions` type. This PR adds the one-line forwarding.

Fixes #13646

## Changes

**`packages/mcp/src/client/client.ts`**
- Added `abortSignal?: AbortSignal` to the execute context type
- Forward `context?.abortSignal` as `signal` to `this.client.callTool()` options

**`packages/mcp/src/client/client.test.ts`**
- Added test verifying abort signal is forwarded to callTool options
- Added integration test verifying a slow tool call rejects quickly when aborted

## The broken signal chain (before)

```
Harness.abort()
  → AbortController.abort()                               ✅
    → agent.stream({ abortSignal })                        ✅
      → AI SDK executeToolCall({ abortSignal })             ✅
        → tool.execute(input, context)                      ✅ context.abortSignal available
          → this.client.callTool(..., { timeout })          ❌ signal not forwarded
```

## After this fix

```
Harness.abort()
  → AbortController.abort()                               ✅
    → agent.stream({ abortSignal })                        ✅
      → AI SDK executeToolCall({ abortSignal })             ✅
        → tool.execute(input, context)                      ✅
          → this.client.callTool(..., { timeout, signal })  ✅ signal forwarded
```

## Test Plan

- All 39 existing MCP client tests pass
- New test: verifies `callTool` receives the abort signal in options
- New test: verifies a 60s slow tool call rejects in < 5s when aborted after 100ms

## Minimal Reproduction

https://github.com/iulspop/mastra-mcp-abort-signal-repro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for cancelling in-flight tool calls via AbortSignal.
  * Tool execution now accepts and forwards cancellation signals to the underlying MCP client.

* **Tests**
  * Added test coverage verifying AbortSignal forwarding and that aborting cancels long-running tool calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->