### PR TITLE
fix(memory): skip continuation hints during async buffered observations

### DIFF
--- a/.changeset/old-teeth-happen.md
+++ b/.changeset/old-teeth-happen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed a bug where async buffered observations generated stale continuation hints (suggested response and current task) that would be injected into the agent's context on the next turn, causing the agent to reply to old messages or work on already-completed tasks.

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -4614,13 +4614,13 @@ ${formattedMessages}
     const combinedObservations = this.combineObservationsForBuffering(record.activeObservations, bufferedChunksText);
 
     // Call observer with combined context
-    // Allow the observer to produce suggestedResponse/currentTask so they survive
-    // activation and maintain continuity when the context window shrinks
+    // Skip continuation hints during async buffering — they reflect the observer's
+    // understanding at buffering time and become stale by activation.
     const result = await this.callObserver(
       combinedObservations,
       messagesToBuffer,
       undefined, // No abort signal for background ops
-      { requestContext },
+      { skipContinuationHints: true, requestContext },
     );
 
     // If the observer returned empty observations, skip buffering


### PR DESCRIPTION
Async buffered observations were generating `suggestedContinuation` and `currentTask` hints at buffering time. By the time these got activated on the next turn, they were stale (or could be applied in the wrong order maybe?) — causing the agent to reply to old messages or work on already-completed tasks.

The buffered reflection path already passed `skipContinuationHints: true`, but the buffered observation path didn't. This fixes the inconsistency:

```ts
// before
const result = await this.callObserver(
  combinedObservations,
  messagesToBuffer,
  undefined,
  { requestContext },
);

// after
const result = await this.callObserver(
  combinedObservations,
  messagesToBuffer,
  undefined,
  { skipContinuationHints: true, requestContext },
);
```

The hint fields are still passed through to `updateBufferedObservations()` so that the latest chunk's explicit `undefined` overwrites any stale hints from older chunks during activation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where asynchronous buffered observations could produce stale continuation hints, causing the agent to respond to outdated messages or work on already-completed tasks. The agent now correctly processes background buffered observations without carrying forward irrelevant context from previous turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->