### PR TITLE
feat: Add toolsets config to Harness for provider-defined tools

### DIFF
--- a/.changeset/fancy-gifts-peel.md
+++ b/.changeset/fancy-gifts-peel.md
@@ -1,0 +1,16 @@
+---
+'@mastra/core': minor
+---
+
+Added `toolsets` option to `HarnessConfig` for injecting provider-scoped tool groups (e.g., Anthropic native web search, OpenAI web search). The function receives the current model ID automatically, making it easy to return the right toolsets per provider.
+
+**Example usage:**
+
+```ts
+const harness = new Harness({
+  toolsets: modelId => {
+    if (modelId.startsWith('anthropic/')) return { anthropic: { web_search: anthropic.tools.webSearch_20250305() } };
+    if (modelId.startsWith('openai/')) return { openai: { web_search: openai.tools.webSearch() } };
+  },
+});
+```

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -2429,11 +2429,10 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
       }
     }
 
-    const result = resolvedHarnessTools
-      ? { harnessBuiltIn: builtInTools, harness: resolvedHarnessTools }
-      : { harnessBuiltIn: builtInTools };
-
-    return resolvedToolsets ? { ...result, ...resolvedToolsets } : result;
+    const result: ToolsetsInput = { harnessBuiltIn: builtInTools };
+    if (resolvedHarnessTools) result.harness = resolvedHarnessTools;
+    if (resolvedToolsets) Object.assign(result, resolvedToolsets);
+    return result;
   }
 
   /**

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -2417,10 +2417,23 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
       });
     }
 
-    if (resolvedHarnessTools) {
-      return { harnessBuiltIn: builtInTools, harness: resolvedHarnessTools };
+    // Resolve user-configured toolsets (provider-scoped tool groups)
+    let resolvedToolsets;
+    if (this.config.toolsets) {
+      const toolsets =
+        typeof this.config.toolsets === 'function'
+          ? await this.config.toolsets(this.getCurrentModelId(), requestContext)
+          : this.config.toolsets;
+      if (toolsets) {
+        resolvedToolsets = toolsets;
+      }
     }
-    return { harnessBuiltIn: builtInTools };
+
+    const result = resolvedHarnessTools
+      ? { harnessBuiltIn: builtInTools, harness: resolvedHarnessTools }
+      : { harnessBuiltIn: builtInTools };
+
+    return resolvedToolsets ? { ...result, ...resolvedToolsets } : result;
   }
 
   /**

--- a/packages/core/src/harness/toolsets-config.test.ts
+++ b/packages/core/src/harness/toolsets-config.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import { Agent } from '../agent';
+import type { ToolsInput, ToolsetsInput } from '../agent/types';
+import { RequestContext } from '../request-context';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+
+function createAgent() {
+  return new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+}
+
+function createRequestContext() {
+  return new RequestContext() as RequestContext;
+}
+
+/** Dummy tool that satisfies ToolsInput shape */
+const dummyTool = {
+  type: 'function' as const,
+  function: { name: 'dummy', parameters: {}, description: 'dummy' },
+};
+
+// ===========================================================================
+// Static toolsets
+// ===========================================================================
+
+describe('Harness toolsets config — static', () => {
+  it('spreads static toolsets into buildToolsets result', async () => {
+    const customToolsets: ToolsetsInput = {
+      anthropic: { web_search: dummyTool } as unknown as ToolsInput,
+    };
+
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+      toolsets: customToolsets,
+    });
+
+    const rc = createRequestContext();
+    const result: ToolsetsInput = await (harness as any).buildToolsets(rc);
+
+    // Should have the built-in toolset
+    expect(result.harnessBuiltIn).toBeDefined();
+    // Should have the user-provided toolset spread in
+    expect(result.anthropic).toBe(customToolsets.anthropic);
+  });
+
+  it('does not include extra keys when toolsets is undefined', async () => {
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+    });
+
+    const rc = createRequestContext();
+    const result: ToolsetsInput = await (harness as any).buildToolsets(rc);
+
+    expect(result.harnessBuiltIn).toBeDefined();
+    expect(Object.keys(result)).toEqual(['harnessBuiltIn']);
+  });
+});
+
+// ===========================================================================
+// Dynamic toolsets (function receives modelId)
+// ===========================================================================
+
+describe('Harness toolsets config — dynamic', () => {
+  it('passes current modelId to the toolsets function', async () => {
+    const anthropicToolset = { web_search: dummyTool } as unknown as ToolsInput;
+    const openaiToolset = { web_search: dummyTool } as unknown as ToolsInput;
+
+    const toolsetsFn = (modelId: string) => {
+      if (modelId.startsWith('anthropic/')) return { anthropic: anthropicToolset };
+      if (modelId.startsWith('openai/')) return { openai: openaiToolset };
+      return undefined;
+    };
+
+    // Harness with an Anthropic default model
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [
+        {
+          id: 'default',
+          name: 'Default',
+          default: true,
+          defaultModelId: 'anthropic/claude-sonnet-4-20250514',
+          agent: createAgent(),
+        },
+      ],
+      toolsets: toolsetsFn,
+    });
+
+    const rc = createRequestContext();
+    const result: ToolsetsInput = await (harness as any).buildToolsets(rc);
+
+    expect(result.harnessBuiltIn).toBeDefined();
+    expect(result.anthropic).toBe(anthropicToolset);
+    expect(result.openai).toBeUndefined();
+  });
+
+  it('returns openai toolset when model is openai', async () => {
+    const openaiToolset = { web_search: dummyTool } as unknown as ToolsInput;
+
+    const toolsetsFn = (modelId: string) => {
+      if (modelId.startsWith('openai/')) return { openai: openaiToolset };
+      return undefined;
+    };
+
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [
+        {
+          id: 'default',
+          name: 'Default',
+          default: true,
+          defaultModelId: 'openai/gpt-4o',
+          agent: createAgent(),
+        },
+      ],
+      toolsets: toolsetsFn,
+    });
+
+    const rc = createRequestContext();
+    const result: ToolsetsInput = await (harness as any).buildToolsets(rc);
+
+    expect(result.harnessBuiltIn).toBeDefined();
+    expect(result.openai).toBe(openaiToolset);
+  });
+
+  it('resolves async dynamic toolsets function', async () => {
+    const customToolsets: ToolsetsInput = {
+      anthropic: { web_search: dummyTool } as unknown as ToolsInput,
+    };
+
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [
+        {
+          id: 'default',
+          name: 'Default',
+          default: true,
+          defaultModelId: 'anthropic/claude-sonnet-4-20250514',
+          agent: createAgent(),
+        },
+      ],
+      toolsets: async () => customToolsets,
+    });
+
+    const rc = createRequestContext();
+    const result: ToolsetsInput = await (harness as any).buildToolsets(rc);
+
+    expect(result.harnessBuiltIn).toBeDefined();
+    expect(result.anthropic).toBe(customToolsets.anthropic);
+  });
+
+  it('handles dynamic toolsets returning undefined', async () => {
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+      toolsets: () => undefined,
+    });
+
+    const rc = createRequestContext();
+    const result: ToolsetsInput = await (harness as any).buildToolsets(rc);
+
+    expect(result.harnessBuiltIn).toBeDefined();
+    // No extra keys beyond built-in
+    expect(Object.keys(result)).toEqual(['harnessBuiltIn']);
+  });
+
+  it('returns no extra toolsets when modelId is empty and function returns undefined', async () => {
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+      toolsets: (modelId: string) => {
+        if (!modelId) return undefined;
+        return { some: { tool: dummyTool } as unknown as ToolsInput };
+      },
+    });
+
+    const rc = createRequestContext();
+    const result: ToolsetsInput = await (harness as any).buildToolsets(rc);
+
+    expect(Object.keys(result)).toEqual(['harnessBuiltIn']);
+  });
+});
+
+// ===========================================================================
+// Toolsets + tools combined
+// ===========================================================================
+
+describe('Harness toolsets config — combined with tools', () => {
+  it('includes both harness tools and custom toolsets', async () => {
+    const harnessTools: ToolsInput = {
+      my_tool: dummyTool as unknown as ToolsInput[string],
+    };
+    const customToolsets: ToolsetsInput = {
+      anthropic: { web_search: dummyTool } as unknown as ToolsInput,
+    };
+
+    const harness = new Harness({
+      id: 'test',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+      tools: harnessTools,
+      toolsets: customToolsets,
+    });
+
+    const rc = createRequestContext();
+    const result: ToolsetsInput = await (harness as any).buildToolsets(rc);
+
+    // Built-in tools
+    expect(result.harnessBuiltIn).toBeDefined();
+    // User-configured harness tools
+    expect(result.harness).toBe(harnessTools);
+    // Provider-scoped toolsets
+    expect(result.anthropic).toBe(customToolsets.anthropic);
+  });
+});

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -1,9 +1,10 @@
 import type { z } from 'zod';
 
 import type { Agent } from '../agent';
-import type { ToolsInput } from '../agent/types';
+import type { ToolsInput, ToolsetsInput } from '../agent/types';
 import type { MastraLanguageModel } from '../llm/model/shared.types';
 import type { MastraMemory } from '../memory/memory';
+import type { RequestContext } from '../request-context';
 import type { MastraCompositeStore } from '../storage/base';
 import type { DynamicArgument } from '../types';
 import type { Workspace, WorkspaceConfig, WorkspaceStatus } from '../workspace';
@@ -136,6 +137,32 @@ export interface HarnessConfig<TState extends HarnessStateSchema = HarnessStateS
    * the request context and returns tools per-request.
    */
   tools?: DynamicArgument<ToolsInput | undefined>;
+
+  /**
+   * Provider-scoped tool groups passed through to the AI SDK as toolsets.
+   * Use this for provider-defined tools like Anthropic's native web search
+   * (e.g., `{ anthropic: { web_search: webSearchTool } }`).
+   *
+   * Can be a static toolsets object or a function that receives the current
+   * model ID and request context, returning the appropriate toolsets for
+   * that provider.
+   *
+   * @example
+   * ```ts
+   * toolsets: (modelId) => {
+   *   if (modelId.startsWith('anthropic/'))
+   *     return { anthropic: { web_search: anthropic.tools.webSearch_20250305() } };
+   *   if (modelId.startsWith('openai/'))
+   *     return { openai: { web_search: openai.tools.webSearch() } };
+   * }
+   * ```
+   */
+  toolsets?:
+    | ToolsetsInput
+    | ((
+        modelId: string,
+        requestContext: RequestContext,
+      ) => ToolsetsInput | undefined | Promise<ToolsetsInput | undefined>);
 
   /**
    * Workspace configuration.


### PR DESCRIPTION
## Description

Adds a `toolsets` option to `HarnessConfig` for injecting provider-scoped tool groups. This is needed for provider-defined tools like Anthropic's native web search or OpenAI's web search, which the AI SDK requires to be passed as named toolsets rather than regular tools.

The `toolsets` function automatically receives the current `modelId` from harness state, so it resolves the correct provider toolsets on every `sendMessage` call — including when the user switches models mid-session.

### Usage

Apps that configure tools at the Harness level (like [mastra-code-ui](https://github.com/mastra-ai/mastra-code-ui)) can add `toolsets` alongside their existing `tools` config:

```ts
import { createAnthropic } from '@ai-sdk/anthropic';
import { createOpenAI } from '@ai-sdk/openai';

const anthropic = createAnthropic({});
const openai = createOpenAI({});

const harness = new Harness({
  id: 'my-app',
  modes: [/* ... */],
  tools: ({ requestContext }) => {
    // regular tools (file ops, grep, etc.)
  },
  toolsets: (modelId) => {
    if (hasTavilyKey()) return undefined;
    if (modelId.startsWith('anthropic/'))
      return { anthropic: { web_search: anthropic.tools.webSearch_20250305() } };
    if (modelId.startsWith('openai/'))
      return { openai: { web_search: openai.tools.webSearch() } };
  },
});
```

This unblocks mastra-code-ui where a `getToolsets` function was defined but never wired because `HarnessConfig` had no `toolsets` field (documented in `UPSTREAM_HARNESS_GAPS.md` item #11).

Note: the mastracode TUI currently configures tools on the Agent directly (via `createDynamicTools`) rather than on the Harness, and handles provider-native web search inline within that tools function. This `toolsets` config is for apps that configure tools at the Harness level.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have added tests that prove my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new toolsets configuration option to HarnessConfig for provider-scoped tool groups (e.g., web search capabilities).
  * Supports both static toolset definitions and dynamic configuration via a function receiving the current model ID.
  * Provider-scoped toolsets integrate seamlessly with existing tools.

* **Tests**
  * Added comprehensive unit tests for toolsets configuration covering static, dynamic, and edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->