### PR TITLE
fix(mcp): retry after streamable SSE termination disconnects

### DIFF
--- a/.changeset/wacky-tips-lick.md
+++ b/.changeset/wacky-tips-lick.md
@@ -2,4 +2,4 @@
 '@mastra/mcp': patch
 ---
 
-Fixed MCP tool execution to retry after Streamable HTTP SSE disconnect termination errors.
+Fixed MCP tool calls to retry automatically after a stream disconnect, instead of failing on the first attempt.

--- a/.changeset/wacky-tips-lick.md
+++ b/.changeset/wacky-tips-lick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed MCP tool execution to retry after Streamable HTTP SSE disconnect termination errors.

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -1375,6 +1375,46 @@ describe('MastraMCPClient - Session Reconnection (Issue #7675)', () => {
     await serverTransport.close().catch(() => {});
     httpServer.close();
   });
+
+  it('should reconnect and retry when streamable SSE stream is terminated', async () => {
+    const testServer = await setupTestServer(true);
+    const client = new InternalMastraMCPClient({
+      name: 'sse-terminated-retry-test',
+      server: { url: testServer.baseUrl },
+    });
+
+    await client.connect();
+
+    const tools = await client.tools();
+    const greetTool = tools['greet'];
+    expect(greetTool).toBeDefined();
+
+    const sdkClient = (client as any).client as Client;
+    const originalCallTool = sdkClient.callTool.bind(sdkClient);
+
+    const callToolSpy = vi
+      .spyOn(sdkClient, 'callTool')
+      .mockImplementationOnce(async () => {
+        throw new Error('SSE stream disconnected: TypeError: terminated');
+      })
+      .mockImplementation(originalCallTool);
+
+    const forceReconnectSpy = vi.spyOn(client as any, 'forceReconnect').mockResolvedValue(undefined);
+
+    try {
+      const result = await greetTool.execute?.({ name: 'Recovered' });
+      expect(result).toEqual({ content: [{ type: 'text', text: 'Hello, Recovered!' }] });
+      expect(forceReconnectSpy).toHaveBeenCalledTimes(1);
+      expect(callToolSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      forceReconnectSpy.mockRestore();
+      callToolSpy.mockRestore();
+      await client.disconnect().catch(() => {});
+      await testServer.mcpServer.close().catch(() => {});
+      await testServer.serverTransport.close().catch(() => {});
+      testServer.httpServer.close();
+    }
+  });
 });
 
 describe('MastraMCPClient - Filesystem Server Integration (Issue #8660)', () => {

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -502,7 +502,9 @@ export class InternalMastraMCPClient extends MastraBase {
       errorMessage.includes('http 403') ||
       errorMessage.includes('econnrefused') ||
       errorMessage.includes('fetch failed') ||
-      errorMessage.includes('connection refused')
+      errorMessage.includes('connection refused') ||
+      errorMessage.includes('sse stream disconnected') ||
+      errorMessage.includes('typeerror: terminated')
     );
   }
 


### PR DESCRIPTION
This updates @mastra/mcp to treat Streamable HTTP SSE termination disconnects as reconnectable so tool execution retries instead of failing on the first error.

Before: `SSE stream disconnected: TypeError: terminated` could bubble out of `execute` without triggering reconnect/retry.
After: that error path is classified as reconnectable, `forceReconnect()` runs, and the tool call is retried automatically.

It also adds a regression test for this exact message and includes a patch changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP tool execution reliability by treating additional session error conditions as reconnect-worthy, enabling automatic reconnection and retry after SSE stream disconnections.

* **Tests**
  * Added tests verifying automatic reconnection and retry behavior for session recovery scenarios.

* **Chores**
  * Added a release changeset documenting the patch bump and fix description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->