### PR TITLE
feat(workspace): support tool name remapping in workspace tools config

### DIFF
--- a/.changeset/open-crews-lie.md
+++ b/.changeset/open-crews-lie.md
@@ -1,0 +1,18 @@
+---
+'@mastra/core': minor
+---
+
+Added `name` property to `WorkspaceToolConfig` for remapping workspace tool names. Tools can now be exposed under custom names to the LLM while keeping the original constant as the config key.
+
+```typescript
+const workspace = new Workspace({
+  filesystem: new LocalFilesystem({ basePath: './project' }),
+  tools: {
+    mastra_workspace_read_file: { name: 'view' },
+    mastra_workspace_grep: { name: 'search_content' },
+    mastra_workspace_edit_file: { name: 'string_replace_lsp' },
+  },
+});
+```
+
+Also removed hardcoded tool-name cross-references from edit-file and ast-edit tool descriptions, since tools can be renamed or disabled.

--- a/.changeset/perky-glasses-make.md
+++ b/.changeset/perky-glasses-make.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Use workspace tool name remapping to restore original tool names (view, search_content, string_replace_lsp, etc.) so they match the tool guidance prompts.

--- a/.changeset/perky-glasses-make.md
+++ b/.changeset/perky-glasses-make.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Use workspace tool name remapping to restore original tool names (view, search_content, string_replace_lsp, etc.) so they match the tool guidance prompts. Extracted tool names into `MC_TOOLS` constants for reuse across permissions, TUI, subagents, and tool guidance.
+Workspace tool names are now remapped to canonical names (`view`, `search_content`, `string_replace_lsp`, etc.) so they match tool guidance prompts, permissions, and TUI rendering.

--- a/.changeset/perky-glasses-make.md
+++ b/.changeset/perky-glasses-make.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Use workspace tool name remapping to restore original tool names (view, search_content, string_replace_lsp, etc.) so they match the tool guidance prompts.
+Use workspace tool name remapping to restore original tool names (view, search_content, string_replace_lsp, etc.) so they match the tool guidance prompts. Extracted tool names into `MC_TOOLS` constants for reuse across permissions, TUI, subagents, and tool guidance.

--- a/mastracode/src/agents/__tests__/extra-tools.test.ts
+++ b/mastracode/src/agents/__tests__/extra-tools.test.ts
@@ -43,26 +43,23 @@ describe('createDynamicTools – extraTools', () => {
     expect(tools).toHaveProperty('my_custom_tool');
     expect(tools.my_custom_tool).toBe(myCustomTool);
 
-    // Built-in tools should still be present
-    expect(tools).toHaveProperty('view');
-    expect(tools).toHaveProperty('search_content');
-    expect(tools).toHaveProperty('find_files');
-    expect(tools).toHaveProperty('execute_command');
+    // Built-in non-workspace tools should still be present
+    expect(tools).toHaveProperty('request_sandbox_access');
   });
 
   it('should not overwrite built-in tools with extraTools of the same name', () => {
     const sneakyTool = createTool({
-      id: 'view',
-      description: 'Trying to overwrite the built-in view tool',
+      id: 'request_sandbox_access',
+      description: 'Trying to overwrite the built-in request_sandbox_access tool',
       inputSchema: z.object({}),
       execute: async () => ({ result: 'sneaky' }),
     });
 
-    const getDynamicTools = createDynamicTools(undefined, { view: sneakyTool });
+    const getDynamicTools = createDynamicTools(undefined, { request_sandbox_access: sneakyTool });
     const tools = getDynamicTools({ requestContext: makeRequestContext() });
 
-    // Built-in view should NOT be replaced by the extra tool
-    expect(tools.view).not.toBe(sneakyTool);
+    // Built-in request_sandbox_access should NOT be replaced by the extra tool
+    expect(tools.request_sandbox_access).not.toBe(sneakyTool);
   });
 
   it('should return extraTools even when no MCP manager is provided', () => {
@@ -90,9 +87,9 @@ describe('createDynamicTools – extraTools', () => {
     const getDynamicTools = createDynamicTools(undefined, undefined);
     const tools = getDynamicTools({ requestContext: makeRequestContext() });
 
-    // Should have built-in tools but nothing extra
-    expect(tools).toHaveProperty('view');
-    expect(tools).toHaveProperty('search_content');
+    // Should have built-in non-workspace tools but nothing extra
+    // Note: workspace tools (view, search_content, etc.) are provided by the workspace, not createDynamicTools
+    expect(tools).toHaveProperty('request_sandbox_access');
     expect(tools).not.toHaveProperty('my_custom_tool');
   });
 });
@@ -123,31 +120,33 @@ describe('createDynamicTools – denied tool filtering', () => {
     const getDynamicTools = createDynamicTools();
     const tools = getDynamicTools({
       requestContext: makeRequestContext({
-        permissionRules: { categories: {}, tools: { execute_command: 'deny' } },
+        permissionRules: { categories: {}, tools: { request_sandbox_access: 'deny' } },
       }),
     });
 
-    expect(tools).not.toHaveProperty('execute_command');
-    // Other tools should still be present
-    expect(tools).toHaveProperty('view');
-    expect(tools).toHaveProperty('search_content');
+    expect(tools).not.toHaveProperty('request_sandbox_access');
   });
 
   it('should omit multiple denied tools', () => {
-    const getDynamicTools = createDynamicTools();
+    const myTool = createTool({
+      id: 'my_tool',
+      description: 'A custom tool',
+      inputSchema: z.object({}),
+      execute: async () => ({ result: 'custom' }),
+    });
+
+    const getDynamicTools = createDynamicTools(undefined, { my_tool: myTool });
     const tools = getDynamicTools({
       requestContext: makeRequestContext({
         permissionRules: {
           categories: {},
-          tools: { execute_command: 'deny', view: 'deny', find_files: 'deny' },
+          tools: { request_sandbox_access: 'deny', my_tool: 'deny' },
         },
       }),
     });
 
-    expect(tools).not.toHaveProperty('execute_command');
-    expect(tools).not.toHaveProperty('view');
-    expect(tools).not.toHaveProperty('find_files');
-    expect(tools).toHaveProperty('search_content');
+    expect(tools).not.toHaveProperty('request_sandbox_access');
+    expect(tools).not.toHaveProperty('my_tool');
   });
 
   it('should keep tools with allow or ask policies', () => {
@@ -156,13 +155,12 @@ describe('createDynamicTools – denied tool filtering', () => {
       requestContext: makeRequestContext({
         permissionRules: {
           categories: {},
-          tools: { execute_command: 'allow', view: 'ask' },
+          tools: { request_sandbox_access: 'allow' },
         },
       }),
     });
 
-    expect(tools).toHaveProperty('execute_command');
-    expect(tools).toHaveProperty('view');
+    expect(tools).toHaveProperty('request_sandbox_access');
   });
 
   it('should also deny extraTools when they have a deny policy', () => {

--- a/mastracode/src/agents/__tests__/extra-tools.test.ts
+++ b/mastracode/src/agents/__tests__/extra-tools.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect } from 'vitest';
 import z from 'zod';
 
 import { getToolCategory } from '../../permissions.js';
+import { MC_TOOLS } from '../../tool-names.js';
 import { buildToolGuidance } from '../prompts/tool-guidance.js';
 import { createDynamicTools } from '../tools.js';
 
@@ -102,10 +103,10 @@ describe('getToolCategory – extra tools', () => {
   });
 
   it('should still categorize built-in tools correctly', () => {
-    expect(getToolCategory('view')).toBe('read');
-    expect(getToolCategory('search_content')).toBe('read');
-    expect(getToolCategory('string_replace_lsp')).toBe('edit');
-    expect(getToolCategory('execute_command')).toBe('execute');
+    expect(getToolCategory(MC_TOOLS.VIEW)).toBe('read');
+    expect(getToolCategory(MC_TOOLS.SEARCH_CONTENT)).toBe('read');
+    expect(getToolCategory(MC_TOOLS.STRING_REPLACE_LSP)).toBe('edit');
+    expect(getToolCategory(MC_TOOLS.EXECUTE_COMMAND)).toBe('execute');
   });
 
   it('should return null for always-allowed tools', () => {
@@ -185,32 +186,32 @@ describe('createDynamicTools – denied tool filtering', () => {
 describe('buildToolGuidance – denied tool filtering', () => {
   it('should omit guidance for denied tools', () => {
     const guidance = buildToolGuidance('build', {
-      deniedTools: new Set(['execute_command']),
+      deniedTools: new Set([MC_TOOLS.EXECUTE_COMMAND]),
     });
 
-    expect(guidance).not.toContain('**execute_command**');
-    expect(guidance).toContain('**view**');
-    expect(guidance).toContain('**search_content**');
+    expect(guidance).not.toContain(`**${MC_TOOLS.EXECUTE_COMMAND}**`);
+    expect(guidance).toContain(`**${MC_TOOLS.VIEW}**`);
+    expect(guidance).toContain(`**${MC_TOOLS.SEARCH_CONTENT}**`);
   });
 
   it('should omit multiple denied tools from guidance', () => {
     const guidance = buildToolGuidance('build', {
-      deniedTools: new Set(['execute_command', 'write_file', 'subagent']),
+      deniedTools: new Set([MC_TOOLS.EXECUTE_COMMAND, MC_TOOLS.WRITE_FILE, 'subagent']),
     });
 
-    expect(guidance).not.toContain('**execute_command**');
-    expect(guidance).not.toContain('**write_file**');
+    expect(guidance).not.toContain(`**${MC_TOOLS.EXECUTE_COMMAND}**`);
+    expect(guidance).not.toContain(`**${MC_TOOLS.WRITE_FILE}**`);
     expect(guidance).not.toContain('**subagent**');
-    expect(guidance).toContain('**view**');
-    expect(guidance).toContain('**string_replace_lsp**');
+    expect(guidance).toContain(`**${MC_TOOLS.VIEW}**`);
+    expect(guidance).toContain(`**${MC_TOOLS.STRING_REPLACE_LSP}**`);
   });
 
   it('should include all tools when no denied set is provided', () => {
     const guidance = buildToolGuidance('build');
 
-    expect(guidance).toContain('**execute_command**');
-    expect(guidance).toContain('**view**');
-    expect(guidance).toContain('**string_replace_lsp**');
+    expect(guidance).toContain(`**${MC_TOOLS.EXECUTE_COMMAND}**`);
+    expect(guidance).toContain(`**${MC_TOOLS.VIEW}**`);
+    expect(guidance).toContain(`**${MC_TOOLS.STRING_REPLACE_LSP}**`);
     expect(guidance).toContain('**subagent**');
   });
 });

--- a/mastracode/src/agents/prompts/tool-guidance.ts
+++ b/mastracode/src/agents/prompts/tool-guidance.ts
@@ -4,6 +4,8 @@
  * and are scoped to what's available in the current mode.
  */
 
+import { MC_TOOLS } from '../../tool-names.js';
+
 interface ToolGuidanceOptions {
   hasWebSearch?: boolean;
   /** Tool names that have been denied — omit their guidance sections. */
@@ -24,18 +26,18 @@ You have access to the following tools. Use the RIGHT tool for the job:`);
 
   const readTools: string[] = [];
 
-  if (!denied.has('view')) {
+  if (!denied.has(MC_TOOLS.VIEW)) {
     readTools.push(`
-**view** — Read file contents or list directories
+**${MC_TOOLS.VIEW}** — Read file contents or list directories
 - Use this to read files before editing them. NEVER propose changes to code you haven't read.
 - Use \`view_range\` for large files to read specific sections.
 - For directory listings, this shows 2 levels deep.
 - Example: To check lines 50-100 of a large file: \`view("src/big-file.ts", { view_range: [50, 100] })\``);
   }
 
-  if (!denied.has('search_content')) {
+  if (!denied.has(MC_TOOLS.SEARCH_CONTENT)) {
     readTools.push(`
-**search_content** — Search file contents using regex
+**${MC_TOOLS.SEARCH_CONTENT}** — Search file contents using regex
 - Use this for ALL content search (finding functions, variables, error messages, imports, etc.)
 - NEVER use \`execute_command\` with grep, rg, or ag. Always use the search_content tool.
 - Supports regex patterns, file type filtering, and context lines.
@@ -43,9 +45,9 @@ You have access to the following tools. Use the RIGHT tool for the job:`);
 - Example: Find all imports of a module: \`search_content("from ['\\"\\]express['\\"\\]", { glob: "**/*.ts" })\``);
   }
 
-  if (!denied.has('find_files')) {
+  if (!denied.has(MC_TOOLS.FIND_FILES)) {
     readTools.push(`
-**find_files** — Find files by name pattern
+**${MC_TOOLS.FIND_FILES}** — Find files by name pattern
 - Use this to find files matching a pattern (e.g., "**/*.ts", "src/**/test*").
 - NEVER use \`execute_command\` with find or ls for file search. Always use find_files.
 - Respects .gitignore automatically.
@@ -53,15 +55,15 @@ You have access to the following tools. Use the RIGHT tool for the job:`);
 - Example: Find config files: \`find_files("**/config.{js,ts,json}")\``);
   }
 
-  if (!denied.has('execute_command')) {
+  if (!denied.has(MC_TOOLS.EXECUTE_COMMAND)) {
     readTools.push(`
-**execute_command** — Run shell commands
+**${MC_TOOLS.EXECUTE_COMMAND}** — Run shell commands
 - Use for: git, npm/pnpm, docker, build tools, test runners, and other terminal operations.
-- Do NOT use for: file reading (use view), file search (use search_content/find_files), file editing (use string_replace_lsp/write_file).
+- Do NOT use for: file reading (use ${MC_TOOLS.VIEW}), file search (use ${MC_TOOLS.SEARCH_CONTENT}/${MC_TOOLS.FIND_FILES}), file editing (use ${MC_TOOLS.STRING_REPLACE_LSP}/${MC_TOOLS.WRITE_FILE}).
 - Commands have a 30-second default timeout. Use the \`timeout\` parameter for longer-running commands.
 - Pipe to \`| tail -N\` for commands with long output — the full output streams to the user, only the last N lines are returned to you. If you're building any kind of package you should be tailing.
 - Good: Run independent commands in parallel when possible.
-- Bad: Running \`cat file.txt\` — use the view tool instead.`);
+- Bad: Running \`cat file.txt\` — use the ${MC_TOOLS.VIEW} tool instead.`);
   }
 
   if (readTools.length > 0) {
@@ -73,22 +75,22 @@ You have access to the following tools. Use the RIGHT tool for the job:`);
   if (modeId !== 'plan') {
     const writeTools: string[] = [];
 
-    if (!denied.has('string_replace_lsp')) {
+    if (!denied.has(MC_TOOLS.STRING_REPLACE_LSP)) {
       writeTools.push(`
-**string_replace_lsp** — Edit files by replacing exact text
-- You MUST read a file with \`view\` before editing it.
+**${MC_TOOLS.STRING_REPLACE_LSP}** — Edit files by replacing exact text
+- You MUST read a file with \`${MC_TOOLS.VIEW}\` before editing it.
 - \`old_str\` must be an exact match of existing text in the file.
 - Provide enough surrounding context in \`old_str\` to make it unique.
-- For creating new files, use \`write_file\` instead.
+- For creating new files, use \`${MC_TOOLS.WRITE_FILE}\` instead.
 - Good: Include 2-3 lines of surrounding context to ensure uniqueness.
 - Bad: Using just \`return true;\` — too common, will match multiple places.`);
     }
 
-    if (!denied.has('write_file')) {
+    if (!denied.has(MC_TOOLS.WRITE_FILE)) {
       writeTools.push(`
-**write_file** — Create new files or overwrite existing ones
+**${MC_TOOLS.WRITE_FILE}** — Create new files or overwrite existing ones
 - Use this to create new files.
-- If overwriting an existing file, you MUST have read it first with \`view\`.
+- If overwriting an existing file, you MUST have read it first with \`${MC_TOOLS.VIEW}\`.
 - NEVER create files unless necessary. Prefer editing existing files.`);
     }
 

--- a/mastracode/src/agents/subagents/audit-tests.ts
+++ b/mastracode/src/agents/subagents/audit-tests.ts
@@ -5,6 +5,7 @@
  * explores the repo's existing testing conventions, and produces
  * a detailed audit report with actionable improvement recommendations.
  */
+import { MC_TOOLS } from '../../tool-names.js';
 import type { SubagentDefinition } from './types.js';
 
 export const auditTestsSubagent: SubagentDefinition = {
@@ -117,5 +118,5 @@ Prioritized, actionable list. Most impactful improvements first. Be specific —
 - Ground all feedback in the repo's actual conventions, not generic best practices.
 - Be direct. If tests are sloppy, say so. If they're good, say that too.
 - Focus on **actionable feedback** — every finding should have a clear "do this instead" recommendation.`,
-  allowedTools: ['view', 'search_content', 'find_files'],
+  allowedTools: [MC_TOOLS.VIEW, MC_TOOLS.SEARCH_CONTENT, MC_TOOLS.FIND_FILES],
 };

--- a/mastracode/src/agents/subagents/execute.ts
+++ b/mastracode/src/agents/subagents/execute.ts
@@ -5,6 +5,7 @@
  * read and write tools to complete it. It can modify files, run commands,
  * and perform actual development work within a constrained scope.
  */
+import { MC_TOOLS } from '../../tool-names.js';
 import type { SubagentDefinition } from './types.js';
 
 export const executeSubagent: SubagentDefinition = {
@@ -45,14 +46,14 @@ End with a structured summary:
 . **Notes**: Follow-up needed (if any)`,
   allowedTools: [
     // Read tools
-    'view',
-    'search_content',
-    'find_files',
+    MC_TOOLS.VIEW,
+    MC_TOOLS.SEARCH_CONTENT,
+    MC_TOOLS.FIND_FILES,
     // Write tools
-    'string_replace_lsp',
-    'write_file',
+    MC_TOOLS.STRING_REPLACE_LSP,
+    MC_TOOLS.WRITE_FILE,
     // Execution tool
-    'execute_command',
+    MC_TOOLS.EXECUTE_COMMAND,
     // Task tracking (built-in harness tools)
     'task_write',
     'task_check',

--- a/mastracode/src/agents/subagents/explore.ts
+++ b/mastracode/src/agents/subagents/explore.ts
@@ -5,6 +5,7 @@
  * "understand how module Y works") and uses read-only tools to explore
  * the codebase, then returns a concise summary of its findings.
  */
+import { MC_TOOLS } from '../../tool-names.js';
 import type { SubagentDefinition } from './types.js';
 
 export const exploreSubagent: SubagentDefinition = {
@@ -36,5 +37,5 @@ End with a structured summary:
 . **Details**: Additional context if needed
 
 Keep your summary under 300 words.`,
-  allowedTools: ['view', 'search_content', 'find_files'],
+  allowedTools: [MC_TOOLS.VIEW, MC_TOOLS.SEARCH_CONTENT, MC_TOOLS.FIND_FILES],
 };

--- a/mastracode/src/agents/subagents/plan.ts
+++ b/mastracode/src/agents/subagents/plan.ts
@@ -5,6 +5,7 @@
  * implementation plan. It can read the codebase to understand existing
  * patterns and architecture, but cannot modify anything.
  */
+import { MC_TOOLS } from '../../tool-names.js';
 import type { SubagentDefinition } from './types.js';
 
 export const planSubagent: SubagentDefinition = {
@@ -38,5 +39,5 @@ Structure your plan as:
 . **Risks**: Potential issues or edge cases (if any)
 
 Be specific about code locations (file paths, function names, line numbers). Keep the plan actionable and under 500 words.`,
-  allowedTools: ['view', 'search_content', 'find_files'],
+  allowedTools: [MC_TOOLS.VIEW, MC_TOOLS.SEARCH_CONTENT, MC_TOOLS.FIND_FILES],
 };

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -9,7 +9,7 @@ import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace
 import type { LSPConfig } from '@mastra/core/workspace';
 import { loadSettings } from '../onboarding/settings.js';
 import type { stateSchema } from '../schema';
-import { MC_TOOLS, TOOL_NAME_OVERRIDES } from '../tool-names.js';
+import { TOOL_NAME_OVERRIDES } from '../tool-names.js';
 
 // =============================================================================
 // Create Workspace with Skills

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -109,10 +109,27 @@ export function getDynamicWorkspace({ requestContext, mastra }: { requestContext
   const sandboxPaths = state?.sandboxAllowedPaths ?? [];
   const allowedPaths = [...skillPaths, ...sandboxPaths.map((p: string) => path.resolve(p))];
   const isPlanMode = modeId === 'plan';
+
+  // Remap workspace tool names to match mastracode's tool guidance and prompts
+  const toolNameOverrides = {
+    mastra_workspace_read_file: { name: 'view' },
+    mastra_workspace_write_file: { name: 'write_file' },
+    mastra_workspace_edit_file: { name: 'string_replace_lsp' },
+    mastra_workspace_list_files: { name: 'find_files' },
+    mastra_workspace_delete: { name: 'delete_file' },
+    mastra_workspace_file_stat: { name: 'file_stat' },
+    mastra_workspace_mkdir: { name: 'mkdir' },
+    mastra_workspace_grep: { name: 'search_content' },
+    mastra_workspace_ast_edit: { name: 'ast_smart_edit' },
+    mastra_workspace_execute_command: { name: 'execute_command' },
+    mastra_workspace_get_process_output: { name: 'get_process_output' },
+    mastra_workspace_kill_process: { name: 'kill_process' },
+  };
+
   const planModeTools = {
-    mastra_workspace_write_file: { enabled: false },
-    mastra_workspace_edit_file: { enabled: false },
-    mastra_workspace_ast_edit: { enabled: false },
+    mastra_workspace_write_file: { ...toolNameOverrides.mastra_workspace_write_file, enabled: false },
+    mastra_workspace_edit_file: { ...toolNameOverrides.mastra_workspace_edit_file, enabled: false },
+    mastra_workspace_ast_edit: { ...toolNameOverrides.mastra_workspace_ast_edit, enabled: false },
   };
 
   // Reuse existing workspace if already registered (preserves ProcessManager state)
@@ -125,7 +142,7 @@ export function getDynamicWorkspace({ requestContext, mastra }: { requestContext
 
   if (existing) {
     existing.filesystem.setAllowedPaths(allowedPaths);
-    existing.setToolsConfig(isPlanMode ? planModeTools : undefined);
+    existing.setToolsConfig(isPlanMode ? { ...toolNameOverrides, ...planModeTools } : toolNameOverrides);
     return existing;
   }
 
@@ -157,7 +174,7 @@ export function getDynamicWorkspace({ requestContext, mastra }: { requestContext
         DEBIAN_FRONTEND: 'noninteractive',
       },
     }),
-    ...(isPlanMode ? { tools: planModeTools } : {}),
+    tools: isPlanMode ? { ...toolNameOverrides, ...planModeTools } : toolNameOverrides,
     ...(skillPaths.length > 0 ? { skills: skillPaths } : {}),
     lsp: lspConfig,
   });

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -9,6 +9,7 @@ import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace
 import type { LSPConfig } from '@mastra/core/workspace';
 import { loadSettings } from '../onboarding/settings.js';
 import type { stateSchema } from '../schema';
+import { MC_TOOLS, TOOL_NAME_OVERRIDES } from '../tool-names.js';
 
 // =============================================================================
 // Create Workspace with Skills
@@ -110,26 +111,10 @@ export function getDynamicWorkspace({ requestContext, mastra }: { requestContext
   const allowedPaths = [...skillPaths, ...sandboxPaths.map((p: string) => path.resolve(p))];
   const isPlanMode = modeId === 'plan';
 
-  // Remap workspace tool names to match mastracode's tool guidance and prompts
-  const toolNameOverrides = {
-    mastra_workspace_read_file: { name: 'view' },
-    mastra_workspace_write_file: { name: 'write_file' },
-    mastra_workspace_edit_file: { name: 'string_replace_lsp' },
-    mastra_workspace_list_files: { name: 'find_files' },
-    mastra_workspace_delete: { name: 'delete_file' },
-    mastra_workspace_file_stat: { name: 'file_stat' },
-    mastra_workspace_mkdir: { name: 'mkdir' },
-    mastra_workspace_grep: { name: 'search_content' },
-    mastra_workspace_ast_edit: { name: 'ast_smart_edit' },
-    mastra_workspace_execute_command: { name: 'execute_command' },
-    mastra_workspace_get_process_output: { name: 'get_process_output' },
-    mastra_workspace_kill_process: { name: 'kill_process' },
-  };
-
   const planModeTools = {
-    mastra_workspace_write_file: { ...toolNameOverrides.mastra_workspace_write_file, enabled: false },
-    mastra_workspace_edit_file: { ...toolNameOverrides.mastra_workspace_edit_file, enabled: false },
-    mastra_workspace_ast_edit: { ...toolNameOverrides.mastra_workspace_ast_edit, enabled: false },
+    mastra_workspace_write_file: { ...TOOL_NAME_OVERRIDES.mastra_workspace_write_file, enabled: false },
+    mastra_workspace_edit_file: { ...TOOL_NAME_OVERRIDES.mastra_workspace_edit_file, enabled: false },
+    mastra_workspace_ast_edit: { ...TOOL_NAME_OVERRIDES.mastra_workspace_ast_edit, enabled: false },
   };
 
   // Reuse existing workspace if already registered (preserves ProcessManager state)
@@ -142,7 +127,7 @@ export function getDynamicWorkspace({ requestContext, mastra }: { requestContext
 
   if (existing) {
     existing.filesystem.setAllowedPaths(allowedPaths);
-    existing.setToolsConfig(isPlanMode ? { ...toolNameOverrides, ...planModeTools } : toolNameOverrides);
+    existing.setToolsConfig(isPlanMode ? { ...TOOL_NAME_OVERRIDES, ...planModeTools } : TOOL_NAME_OVERRIDES);
     return existing;
   }
 
@@ -174,7 +159,7 @@ export function getDynamicWorkspace({ requestContext, mastra }: { requestContext
         DEBIAN_FRONTEND: 'noninteractive',
       },
     }),
-    tools: isPlanMode ? { ...toolNameOverrides, ...planModeTools } : toolNameOverrides,
+    tools: isPlanMode ? { ...TOOL_NAME_OVERRIDES, ...planModeTools } : TOOL_NAME_OVERRIDES,
     ...(skillPaths.length > 0 ? { skills: skillPaths } : {}),
     lsp: lspConfig,
   });

--- a/mastracode/src/permissions.ts
+++ b/mastracode/src/permissions.ts
@@ -6,6 +6,8 @@
  * Session-scoped grants let the user approve a category once per session.
  */
 
+import { MC_TOOLS } from './tool-names.js';
+
 // ---------------------------------------------------------------------------
 // Categories
 // ---------------------------------------------------------------------------
@@ -37,21 +39,21 @@ export const TOOL_CATEGORIES: Record<ToolCategory, { label: string; description:
 
 const TOOL_CATEGORY_MAP: Record<string, ToolCategory> = {
   // Read-only tools — always safe
-  view: 'read',
-  search_content: 'read',
-  find_files: 'read',
+  [MC_TOOLS.VIEW]: 'read',
+  [MC_TOOLS.SEARCH_CONTENT]: 'read',
+  [MC_TOOLS.FIND_FILES]: 'read',
   web_search: 'read',
   'web-search': 'read',
   web_extract: 'read',
   'web-extract': 'read',
   // Edit tools — modify files
-  string_replace_lsp: 'edit',
-  ast_smart_edit: 'edit',
-  write_file: 'edit',
+  [MC_TOOLS.STRING_REPLACE_LSP]: 'edit',
+  [MC_TOOLS.AST_SMART_EDIT]: 'edit',
+  [MC_TOOLS.WRITE_FILE]: 'edit',
   subagent: 'edit',
 
   // Execute tools — run arbitrary commands
-  execute_command: 'execute',
+  [MC_TOOLS.EXECUTE_COMMAND]: 'execute',
 
   // Interactive / planning tools — always allowed (no category needed)
   // ask_user, task_write, task_check, submit_plan, request_sandbox_access

--- a/mastracode/src/tool-names.ts
+++ b/mastracode/src/tool-names.ts
@@ -1,0 +1,54 @@
+/**
+ * Mastracode tool name constants.
+ *
+ * These are the names exposed to the LLM via workspace tool name remapping.
+ * Used throughout mastracode for permissions, TUI rendering, tool guidance,
+ * subagent allowedTools, etc.
+ *
+ * The workspace tools get remapped from their core names (e.g. `mastra_workspace_read_file`)
+ * to these names (e.g. `view`) via the `name` property in workspace tool config.
+ */
+
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+
+export const MC_TOOLS = {
+  // Filesystem
+  VIEW: 'view',
+  WRITE_FILE: 'write_file',
+  STRING_REPLACE_LSP: 'string_replace_lsp',
+  FIND_FILES: 'find_files',
+  DELETE_FILE: 'delete_file',
+  FILE_STAT: 'file_stat',
+  MKDIR: 'mkdir',
+
+  // Search
+  SEARCH_CONTENT: 'search_content',
+
+  // Code intelligence
+  AST_SMART_EDIT: 'ast_smart_edit',
+
+  // Sandbox
+  EXECUTE_COMMAND: 'execute_command',
+  GET_PROCESS_OUTPUT: 'get_process_output',
+  KILL_PROCESS: 'kill_process',
+} as const;
+
+/**
+ * Workspace tool name remapping config.
+ * Maps core workspace tool constants to mastracode's tool names.
+ * Pass this (or spread it) into `Workspace({ tools: ... })`.
+ */
+export const TOOL_NAME_OVERRIDES = {
+  [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { name: MC_TOOLS.VIEW },
+  [WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]: { name: MC_TOOLS.WRITE_FILE },
+  [WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE]: { name: MC_TOOLS.STRING_REPLACE_LSP },
+  [WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES]: { name: MC_TOOLS.FIND_FILES },
+  [WORKSPACE_TOOLS.FILESYSTEM.DELETE]: { name: MC_TOOLS.DELETE_FILE },
+  [WORKSPACE_TOOLS.FILESYSTEM.FILE_STAT]: { name: MC_TOOLS.FILE_STAT },
+  [WORKSPACE_TOOLS.FILESYSTEM.MKDIR]: { name: MC_TOOLS.MKDIR },
+  [WORKSPACE_TOOLS.FILESYSTEM.GREP]: { name: MC_TOOLS.SEARCH_CONTENT },
+  [WORKSPACE_TOOLS.FILESYSTEM.AST_EDIT]: { name: MC_TOOLS.AST_SMART_EDIT },
+  [WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]: { name: MC_TOOLS.EXECUTE_COMMAND },
+  [WORKSPACE_TOOLS.SANDBOX.GET_PROCESS_OUTPUT]: { name: MC_TOOLS.GET_PROCESS_OUTPUT },
+  [WORKSPACE_TOOLS.SANDBOX.KILL_PROCESS]: { name: MC_TOOLS.KILL_PROCESS },
+} as const;

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -152,7 +152,9 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     if (
       this.toolName !== 'execute_command' &&
       this.toolName !== 'mastra_workspace_execute_command' &&
+      this.toolName !== 'get_process_output' &&
       this.toolName !== 'mastra_workspace_get_process_output' &&
+      this.toolName !== 'kill_process' &&
       this.toolName !== 'mastra_workspace_kill_process'
     ) {
       return;
@@ -190,7 +192,10 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const isEditCommand = this.toolName === 'string_replace_lsp' || this.toolName === 'mastra_workspace_edit_file';
     const isWriteCommand = this.toolName === 'write_file' || this.toolName === 'mastra_workspace_write_file';
     const isProcessCommand =
-      this.toolName === 'mastra_workspace_get_process_output' || this.toolName === 'mastra_workspace_kill_process';
+      this.toolName === 'get_process_output' ||
+      this.toolName === 'mastra_workspace_get_process_output' ||
+      this.toolName === 'kill_process' ||
+      this.toolName === 'mastra_workspace_kill_process';
     const isTaskWrite = this.toolName === 'task_write';
 
     if (isShellCommand || isViewCommand || isEditCommand || isWriteCommand || isProcessCommand || isTaskWrite) {
@@ -236,7 +241,9 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       case 'mastra_workspace_list_files':
         this.renderListFilesEnhanced();
         break;
+      case 'get_process_output':
       case 'mastra_workspace_get_process_output':
+      case 'kill_process':
       case 'mastra_workspace_kill_process':
         this.renderProcessToolEnhanced();
         break;
@@ -434,7 +441,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   private renderProcessToolEnhanced(): void {
     const argsObj = this.args as Record<string, unknown> | undefined;
     const pid = argsObj?.pid ? Number(argsObj.pid) : 0;
-    const isKill = this.toolName === 'mastra_workspace_kill_process';
+    const isKill = this.toolName === 'kill_process' || this.toolName === 'mastra_workspace_kill_process';
     const isWait = !isKill && argsObj?.wait === true;
 
     const timeSuffix = this.isPartial ? '' : this.getDurationSuffix();

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -9,6 +9,7 @@ import type { TUI } from '@mariozechner/pi-tui';
 import type { TaskItem } from '@mastra/core/harness';
 import chalk from 'chalk';
 import { highlight } from 'cli-highlight';
+import { MC_TOOLS } from '../../tool-names.js';
 import { theme, mastra } from '../theme.js';
 import { CollapsibleComponent } from './collapsible.js';
 import { ErrorDisplayComponent } from './error-display.js';
@@ -150,12 +151,9 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
    */
   appendStreamingOutput(output: string): void {
     if (
-      this.toolName !== 'execute_command' &&
-      this.toolName !== 'mastra_workspace_execute_command' &&
-      this.toolName !== 'get_process_output' &&
-      this.toolName !== 'mastra_workspace_get_process_output' &&
-      this.toolName !== 'kill_process' &&
-      this.toolName !== 'mastra_workspace_kill_process'
+      this.toolName !== MC_TOOLS.EXECUTE_COMMAND &&
+      this.toolName !== MC_TOOLS.GET_PROCESS_OUTPUT &&
+      this.toolName !== MC_TOOLS.KILL_PROCESS
     ) {
       return;
     }
@@ -187,15 +185,11 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
 
   private updateBgColor(): void {
     // For shell, view, edit, and process commands, skip background - we use bordered box style instead
-    const isShellCommand = this.toolName === 'execute_command' || this.toolName === 'mastra_workspace_execute_command';
-    const isViewCommand = this.toolName === 'view' || this.toolName === 'mastra_workspace_read_file';
-    const isEditCommand = this.toolName === 'string_replace_lsp' || this.toolName === 'mastra_workspace_edit_file';
-    const isWriteCommand = this.toolName === 'write_file' || this.toolName === 'mastra_workspace_write_file';
-    const isProcessCommand =
-      this.toolName === 'get_process_output' ||
-      this.toolName === 'mastra_workspace_get_process_output' ||
-      this.toolName === 'kill_process' ||
-      this.toolName === 'mastra_workspace_kill_process';
+    const isShellCommand = this.toolName === MC_TOOLS.EXECUTE_COMMAND;
+    const isViewCommand = this.toolName === MC_TOOLS.VIEW;
+    const isEditCommand = this.toolName === MC_TOOLS.STRING_REPLACE_LSP;
+    const isWriteCommand = this.toolName === MC_TOOLS.WRITE_FILE;
+    const isProcessCommand = this.toolName === MC_TOOLS.GET_PROCESS_OUTPUT || this.toolName === MC_TOOLS.KILL_PROCESS;
     const isTaskWrite = this.toolName === 'task_write';
 
     if (isShellCommand || isViewCommand || isEditCommand || isWriteCommand || isProcessCommand || isTaskWrite) {
@@ -221,30 +215,23 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     this.collapsible = undefined;
 
     switch (this.toolName) {
-      case 'view':
-      case 'mastra_workspace_read_file':
+      case MC_TOOLS.VIEW:
         this.renderViewToolEnhanced();
         break;
-      case 'execute_command':
-      case 'mastra_workspace_execute_command':
+      case MC_TOOLS.EXECUTE_COMMAND:
         this.renderBashToolEnhanced();
         break;
-      case 'string_replace_lsp':
-      case 'mastra_workspace_edit_file':
+      case MC_TOOLS.STRING_REPLACE_LSP:
         this.renderEditToolEnhanced();
         break;
-      case 'write_file':
-      case 'mastra_workspace_write_file':
+      case MC_TOOLS.WRITE_FILE:
         this.renderWriteToolEnhanced();
         break;
-      case 'find_files':
-      case 'mastra_workspace_list_files':
+      case MC_TOOLS.FIND_FILES:
         this.renderListFilesEnhanced();
         break;
-      case 'get_process_output':
-      case 'mastra_workspace_get_process_output':
-      case 'kill_process':
-      case 'mastra_workspace_kill_process':
+      case MC_TOOLS.GET_PROCESS_OUTPUT:
+      case MC_TOOLS.KILL_PROCESS:
         this.renderProcessToolEnhanced();
         break;
       case 'task_write':
@@ -441,7 +428,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   private renderProcessToolEnhanced(): void {
     const argsObj = this.args as Record<string, unknown> | undefined;
     const pid = argsObj?.pid ? Number(argsObj.pid) : 0;
-    const isKill = this.toolName === 'kill_process' || this.toolName === 'mastra_workspace_kill_process';
+    const isKill = this.toolName === MC_TOOLS.KILL_PROCESS;
     const isWait = !isKill && argsObj?.wait === true;
 
     const timeSuffix = this.isPartial ? '' : this.getDurationSuffix();

--- a/mastracode/src/tui/components/tool-validation-error.ts
+++ b/mastracode/src/tui/components/tool-validation-error.ts
@@ -5,6 +5,7 @@
 
 import { Container, Text } from '@mariozechner/pi-tui';
 import type { TUI } from '@mariozechner/pi-tui';
+import { MC_TOOLS } from '../../tool-names.js';
 import { theme } from '../theme.js';
 
 export interface ValidationError {
@@ -203,11 +204,11 @@ export class ToolValidationErrorComponent extends Container {
       suggestions.push('Make sure to provide a "question" parameter with your question text');
     }
 
-    if (toolName === 'execute_command' && errors.some(e => e.field === 'command')) {
+    if (toolName === MC_TOOLS.EXECUTE_COMMAND && errors.some(e => e.field === 'command')) {
       suggestions.push('Provide a "command" parameter with the command to execute');
     }
 
-    if (toolName === 'view' && errors.some(e => e.field === 'path')) {
+    if (toolName === MC_TOOLS.VIEW && errors.some(e => e.field === 'path')) {
       suggestions.push('Provide a "path" parameter with the file or directory path');
     }
 

--- a/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
@@ -134,6 +134,89 @@ describe('createWorkspaceTools', () => {
     expect(WORKSPACE_TOOLS.SANDBOX.KILL_PROCESS).toBe('mastra_workspace_kill_process');
   });
 
+  describe('tool name remapping', () => {
+    it('should use custom name as dictionary key when name is provided', () => {
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({ basePath: tempDir }),
+        tools: {
+          mastra_workspace_read_file: { name: 'view' },
+          mastra_workspace_grep: { name: 'search_content' },
+        },
+      });
+      const tools = createWorkspaceTools(workspace);
+
+      expect(tools).toHaveProperty('view');
+      expect(tools).toHaveProperty('search_content');
+      expect(tools).not.toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.READ_FILE);
+      expect(tools).not.toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.GREP);
+    });
+
+    it('should keep default names for non-remapped tools', () => {
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({ basePath: tempDir }),
+        tools: {
+          mastra_workspace_read_file: { name: 'view' },
+        },
+      });
+      const tools = createWorkspaceTools(workspace);
+
+      expect(tools).toHaveProperty('view');
+      expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE);
+      expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES);
+      expect(tools).toHaveProperty(WORKSPACE_TOOLS.FILESYSTEM.GREP);
+    });
+
+    it('should preserve config options when name is remapped', () => {
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({ basePath: tempDir }),
+        tools: {
+          mastra_workspace_read_file: { name: 'view', requireApproval: true },
+        },
+      });
+      const tools = createWorkspaceTools(workspace);
+
+      expect(tools).toHaveProperty('view');
+      expect(tools['view'].requireApproval).toBe(true);
+    });
+
+    it('should remap sandbox tools', () => {
+      const workspace = new Workspace({
+        sandbox: new LocalSandbox({ workingDirectory: tempDir }),
+        tools: {
+          mastra_workspace_execute_command: { name: 'execute_command' },
+        },
+      });
+      const tools = createWorkspaceTools(workspace);
+
+      expect(tools).toHaveProperty('execute_command');
+      expect(tools).not.toHaveProperty(WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND);
+    });
+
+    it('should throw on duplicate custom names', () => {
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({ basePath: tempDir }),
+        tools: {
+          mastra_workspace_read_file: { name: 'my_tool' },
+          mastra_workspace_grep: { name: 'my_tool' },
+        },
+      });
+
+      expect(() => createWorkspaceTools(workspace)).toThrow(/Duplicate workspace tool name "my_tool"/);
+    });
+
+    it('should throw when custom name conflicts with a default name', () => {
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({ basePath: tempDir }),
+        tools: {
+          // Remap read_file to the default name of grep — conflict
+          mastra_workspace_read_file: { name: WORKSPACE_TOOLS.FILESYSTEM.GREP },
+        },
+      });
+
+      expect(() => createWorkspaceTools(workspace)).toThrow(/Duplicate workspace tool name/);
+    });
+  });
+
   describe('background process tools', () => {
     it('should register process tools when sandbox has processes (LocalSandbox)', () => {
       const workspace = new Workspace({

--- a/packages/core/src/workspace/tools/ast-edit.ts
+++ b/packages/core/src/workspace/tools/ast-edit.ts
@@ -448,13 +448,13 @@ Pattern replace (for everything else):
       content = await filesystem.readFile(path, { encoding: 'utf-8' });
     } catch (error) {
       if (error instanceof FileNotFoundError) {
-        return `File not found: ${path}. Use ${WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE} to create it first.`;
+        return `File not found: ${path}. Use the write file tool to create it first.`;
       }
       throw error;
     }
 
     if (typeof content !== 'string') {
-      return `Cannot perform AST edits on binary files. Use ${WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE} instead.`;
+      return `Cannot perform AST edits on binary files. Use the write file tool instead.`;
     }
 
     // Parse AST

--- a/packages/core/src/workspace/tools/edit-file.ts
+++ b/packages/core/src/workspace/tools/edit-file.ts
@@ -11,7 +11,7 @@ export const editFileTool = createTool({
 
 Usage:
 - Read the file first to get the exact text to replace.
-- By default, ${WORKSPACE_TOOLS.FILESYSTEM.READ_FILE} output includes line number prefixes (e.g., "     1→"). Ensure you preserve the exact indentation as it appears AFTER the arrow. Never include any part of the line number prefix in old_string or new_string.
+- By default, read file output includes line number prefixes (e.g., "     1→"). Ensure you preserve the exact indentation as it appears AFTER the arrow. Never include any part of the line number prefix in old_string or new_string.
 - Include enough surrounding context (multiple lines) to make old_string unique. If it still isn't unique, include more lines.
 - Use replace_all only when intentionally replacing all occurrences.`,
   inputSchema: z.object({
@@ -36,7 +36,7 @@ Usage:
       const content = await filesystem.readFile(path, { encoding: 'utf-8' });
 
       if (typeof content !== 'string') {
-        return `Cannot edit binary files. Use ${WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE} instead.`;
+        return `Cannot edit binary files. Use the write file tool instead.`;
       }
 
       const result = replaceString(content, old_string, new_string, replace_all);

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -48,11 +48,18 @@ import { writeFileTool } from './write-file';
 export function resolveToolConfig(
   toolsConfig: WorkspaceToolsConfig | undefined,
   toolName: WorkspaceToolName,
-): { enabled: boolean; requireApproval: boolean; requireReadBeforeWrite?: boolean; maxOutputTokens?: number } {
+): {
+  enabled: boolean;
+  requireApproval: boolean;
+  requireReadBeforeWrite?: boolean;
+  maxOutputTokens?: number;
+  name?: string;
+} {
   let enabled = true;
   let requireApproval = false;
   let requireReadBeforeWrite: boolean | undefined;
   let maxOutputTokens: number | undefined;
+  let name: string | undefined;
 
   if (toolsConfig) {
     if (toolsConfig.enabled !== undefined) {
@@ -76,10 +83,13 @@ export function resolveToolConfig(
       if (perToolConfig.maxOutputTokens !== undefined) {
         maxOutputTokens = perToolConfig.maxOutputTokens;
       }
+      if (perToolConfig.name !== undefined) {
+        name = perToolConfig.name;
+      }
     }
   }
 
-  return { enabled, requireApproval, requireReadBeforeWrite, maxOutputTokens };
+  return { enabled, requireApproval, requireReadBeforeWrite, maxOutputTokens, name };
 }
 
 // ---------------------------------------------------------------------------
@@ -207,7 +217,15 @@ export function createWorkspaceTools(workspace: Workspace) {
       wrapped = wrapWithWriteLock(wrapped, writeLock);
     }
 
-    tools[name] = wrapped;
+    // Use custom name if provided, otherwise use the default constant name
+    const exposedName = config.name ?? name;
+    if (tools[exposedName]) {
+      throw new Error(
+        `Duplicate workspace tool name "${exposedName}": tool "${name}" conflicts with an already-registered tool. ` +
+          `Check your tools config for duplicate "name" values.`,
+      );
+    }
+    tools[exposedName] = wrapped;
   };
 
   // Filesystem tools

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -25,6 +25,22 @@ export interface WorkspaceToolConfig {
   requireApproval?: boolean;
 
   /**
+   * Custom name to expose this tool as to the LLM.
+   * When set, the tool is registered under this name instead of the default
+   * `mastra_workspace_*` name. The config key must still be the original
+   * WorkspaceToolName constant — only the exposed name changes.
+   *
+   * @example
+   * ```typescript
+   * tools: {
+   *   mastra_workspace_read_file: { name: 'view' },
+   *   mastra_workspace_grep: { name: 'search_content' },
+   * }
+   * ```
+   */
+  name?: string;
+
+  /**
    * For write tools only: require reading a file before writing to it.
    * Prevents accidental overwrites when the agent hasn't seen the current content.
    */


### PR DESCRIPTION
## Summary

- Adds a `name` property to `WorkspaceToolConfig` so workspace tools can be exposed under custom names to the LLM
- Mastracode uses this to remap workspace tools back to its original names (`view`, `search_content`, `string_replace_lsp`, etc.) so they match the tool guidance prompts
- Removes hardcoded tool-name cross-references from `edit-file` and `ast-edit` descriptions/output, since tools can be renamed or disabled
- Extracts tool names into `MC_TOOLS` constants and `TOOL_NAME_OVERRIDES` mapping in `mastracode/src/tool-names.ts` for reuse across permissions, TUI, subagents, and tool guidance
- Fixes pre-existing test failures in mastracode's `extra-tools.test.ts` that still expected workspace tools in `createDynamicTools()` output

## Test plan

- [x] All 19 core workspace tool creation tests pass (including 6 new name remapping tests)
- [x] All 14 mastracode extra-tools tests pass
- [x] Core and mastracode packages build cleanly
- [x] Verify mastracode works end-to-end with remapped tool names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools can be exposed under custom display names while keeping original config keys.

* **Documentation**
  * Guidance and usage text updated to reference remappable tool names and avoid implementation-specific placeholders.

* **Refactor**
  * Centralized canonical tool name constants and standardized name usage across UI, prompts, and permission logic.

* **Bug Fixes**
  * Clarified error messages to use generic guidance instead of hard-coded tool identifiers.

* **Tests**
  * Added tests covering custom tool name remapping, conflicts, and preservation of config options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->