### PR TITLE
fix: implement Harness resource ID methods and improve /resource command

### DIFF
--- a/.changeset/lazy-otters-relax.md
+++ b/.changeset/lazy-otters-relax.md
@@ -3,3 +3,8 @@
 ---
 
 Improved the `/resource` command. Switching resources now resumes the most recent thread for that resource instead of always creating a new one. If no threads exist for the resource, a new thread is created. Also added help text clarifying how resource switching works.
+
+Example:
+```bash
+/resource my-resource-id
+```

--- a/.changeset/lazy-otters-relax.md
+++ b/.changeset/lazy-otters-relax.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved the `/resource` command. Switching resources now resumes the most recent thread for that resource instead of always creating a new one. If no threads exist for the resource, a new thread is created. Also added help text clarifying how resource switching works.

--- a/.changeset/spicy-jokes-read.md
+++ b/.changeset/spicy-jokes-read.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added `getDefaultResourceId()` and `getKnownResourceIds()` methods to the Harness class. `getDefaultResourceId()` returns the original resource ID from config, while `getKnownResourceIds()` returns all unique resource IDs found across stored threads.

--- a/.changeset/spicy-jokes-read.md
+++ b/.changeset/spicy-jokes-read.md
@@ -2,4 +2,11 @@
 '@mastra/core': patch
 ---
 
-Added `getDefaultResourceId()` and `getKnownResourceIds()` methods to the Harness class. `getDefaultResourceId()` returns the original resource ID from config, while `getKnownResourceIds()` returns all unique resource IDs found across stored threads.
+Added support for reading resource IDs from `Harness`.
+
+You can now get the default resource ID and list known resource IDs from stored threads.
+
+```ts
+const defaultId = harness.getDefaultResourceId();
+const knownIds = await harness.getKnownResourceIds();
+```

--- a/mastracode/src/tui/commands/__tests__/resource.test.ts
+++ b/mastracode/src/tui/commands/__tests__/resource.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleResourceCommand } from '../resource.js';
+import type { SlashCommandContext } from '../types.js';
+
+/**
+ * Minimal mock harness that satisfies what handleResourceCommand calls.
+ * Threads are stored in-memory so we can test the "resume latest thread"
+ * vs "no threads → pendingNewThread" paths.
+ */
+function createMockHarness(opts?: { id?: string; resourceId?: string }) {
+  const id = opts?.id ?? 'test-harness';
+  const defaultResourceId = opts?.resourceId ?? id;
+  let currentResourceId = defaultResourceId;
+  let currentThreadId: string | null = null;
+
+  const threads: Array<{
+    id: string;
+    resourceId: string;
+    title: string;
+    createdAt: Date;
+    updatedAt: Date;
+  }> = [];
+
+  return {
+    getResourceId: vi.fn(() => currentResourceId),
+    getDefaultResourceId: vi.fn(() => defaultResourceId),
+    getKnownResourceIds: vi.fn(async () => [...new Set(threads.map(t => t.resourceId))]),
+    setResourceId: vi.fn(({ resourceId }: { resourceId: string }) => {
+      currentResourceId = resourceId;
+      currentThreadId = null;
+    }),
+    listThreads: vi.fn(async () => threads.filter(t => t.resourceId === currentResourceId)),
+    switchThread: vi.fn(async ({ threadId }: { threadId: string }) => {
+      currentThreadId = threadId;
+    }),
+    getCurrentThreadId: vi.fn(() => currentThreadId),
+
+    // Test helpers
+    _addThread(resourceId: string, title: string, updatedAt: Date) {
+      const id = `thread-${threads.length + 1}`;
+      threads.push({
+        id,
+        resourceId,
+        title,
+        createdAt: updatedAt,
+        updatedAt,
+      });
+      return id;
+    },
+  };
+}
+
+function createMockCtx(harness: ReturnType<typeof createMockHarness>) {
+  const infoMessages: string[] = [];
+  const errorMessages: string[] = [];
+
+  return {
+    ctx: {
+      state: {
+        pendingNewThread: false,
+        chatContainer: { clear: vi.fn() },
+        pendingTools: { clear: vi.fn() },
+        allToolComponents: [] as any[],
+        ui: { requestRender: vi.fn() },
+      },
+      harness: harness as any,
+      showInfo: vi.fn((msg: string) => infoMessages.push(msg)),
+      showError: vi.fn((msg: string) => errorMessages.push(msg)),
+      updateStatusLine: vi.fn(),
+      renderExistingMessages: vi.fn(async () => {}),
+      stop: vi.fn(),
+      getResolvedWorkspace: vi.fn(),
+      addUserMessage: vi.fn(),
+      showOnboarding: vi.fn(async () => {}),
+      customSlashCommands: [],
+    } as unknown as SlashCommandContext,
+    infoMessages,
+    errorMessages,
+  };
+}
+
+describe('handleResourceCommand', () => {
+  let harness: ReturnType<typeof createMockHarness>;
+  let ctx: SlashCommandContext;
+  let infoMessages: string[];
+
+  beforeEach(() => {
+    harness = createMockHarness();
+    const mock = createMockCtx(harness);
+    ctx = mock.ctx;
+    infoMessages = mock.infoMessages;
+  });
+
+  describe('no args (info display)', () => {
+    it('shows current resource ID and known IDs', async () => {
+      harness._addThread('test-harness', 'thread-a', new Date());
+      await handleResourceCommand(ctx, []);
+
+      expect(harness.getKnownResourceIds).toHaveBeenCalled();
+      expect(infoMessages[0]).toContain('Current: test-harness');
+      expect(infoMessages[0]).toContain('Known resource IDs:');
+    });
+
+    it('shows auto-detected note when resource has been overridden', async () => {
+      harness.setResourceId({ resourceId: 'custom-id' });
+      await handleResourceCommand(ctx, []);
+
+      expect(infoMessages[0]).toContain('auto-detected: test-harness');
+    });
+  });
+
+  describe('switching to same resource', () => {
+    it('shows already-on message and does not switch', async () => {
+      await handleResourceCommand(ctx, ['test-harness']);
+
+      expect(infoMessages[0]).toBe('Already on resource: test-harness');
+      expect(harness.switchThread).not.toHaveBeenCalled();
+      expect(ctx.state.pendingNewThread).toBe(false);
+    });
+  });
+
+  describe('switching to a resource with existing threads', () => {
+    it('resumes the most recently updated thread', async () => {
+      const oldDate = new Date('2025-01-01');
+      const newDate = new Date('2025-06-01');
+      harness._addThread('other-resource', 'old-thread', oldDate);
+      const latestId = harness._addThread('other-resource', 'latest-thread', newDate);
+
+      await handleResourceCommand(ctx, ['other-resource']);
+
+      expect(harness.setResourceId).toHaveBeenCalledWith({ resourceId: 'other-resource' });
+      expect(harness.switchThread).toHaveBeenCalledWith({ threadId: latestId });
+      expect(ctx.state.pendingNewThread).toBe(false);
+      expect(ctx.renderExistingMessages).toHaveBeenCalled();
+      expect(infoMessages[0]).toContain('resumed thread: latest-thread');
+    });
+
+    it('clears UI state before switching', async () => {
+      harness._addThread('other-resource', 'a-thread', new Date());
+
+      await handleResourceCommand(ctx, ['other-resource']);
+
+      expect(ctx.state.chatContainer.clear).toHaveBeenCalled();
+      expect(ctx.state.pendingTools.clear).toHaveBeenCalled();
+      expect(ctx.state.allToolComponents).toEqual([]);
+    });
+  });
+
+  describe('switching to a resource with no threads', () => {
+    it('sets pendingNewThread and does not call switchThread', async () => {
+      await handleResourceCommand(ctx, ['brand-new-resource']);
+
+      expect(harness.setResourceId).toHaveBeenCalledWith({ resourceId: 'brand-new-resource' });
+      expect(harness.switchThread).not.toHaveBeenCalled();
+      expect(ctx.state.pendingNewThread).toBe(true);
+      expect(infoMessages[0]).toContain('no existing threads');
+      expect(infoMessages[0]).toContain('brand-new-resource');
+    });
+  });
+
+  describe('reset', () => {
+    it('resets to the default resource ID and resumes latest thread', async () => {
+      harness._addThread('test-harness', 'default-thread', new Date());
+      harness.setResourceId({ resourceId: 'some-other' });
+
+      await handleResourceCommand(ctx, ['reset']);
+
+      expect(harness.setResourceId).toHaveBeenLastCalledWith({ resourceId: 'test-harness' });
+      expect(harness.switchThread).toHaveBeenCalled();
+      expect(infoMessages[0]).toContain('Resource ID reset to: test-harness');
+      expect(infoMessages[0]).toContain('resumed thread: default-thread');
+    });
+
+    it('resets to default with no threads available', async () => {
+      harness.setResourceId({ resourceId: 'some-other' });
+
+      await handleResourceCommand(ctx, ['reset']);
+
+      expect(ctx.state.pendingNewThread).toBe(true);
+      expect(infoMessages[0]).toContain('Resource ID reset to: test-harness');
+      expect(infoMessages[0]).toContain('no existing threads');
+    });
+  });
+});

--- a/mastracode/src/tui/commands/resource.ts
+++ b/mastracode/src/tui/commands/resource.ts
@@ -16,7 +16,7 @@ export async function handleResourceCommand(ctx: SlashCommandContext, args: stri
       ...knownIds.map((id: string) => `  ${id === current ? '* ' : '  '}${id}`),
       '',
       'Usage:',
-      '  /resource <id>    - Switch to a resource ID',
+      '  /resource <id>    - Switch to a resource ID (resumes latest thread)',
       '  /resource reset   - Reset to auto-detected ID',
     ];
     ctx.showInfo(lines.join('\n'));
@@ -24,14 +24,40 @@ export async function handleResourceCommand(ctx: SlashCommandContext, args: stri
   }
 
   const newId = sub === 'reset' ? defaultId : args.join(' ').trim();
+
+  if (newId === current) {
+    ctx.showInfo(`Already on resource: ${current}`);
+    return;
+  }
+
   harness.setResourceId({ resourceId: newId });
 
-  state.pendingNewThread = true;
+  // Try to resume the most recent thread for this resource
+  const threads = await harness.listThreads();
+  const latest = threads.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
+
   state.chatContainer.clear();
   state.pendingTools.clear();
   state.allToolComponents = [];
+
+  if (latest) {
+    await harness.switchThread({ threadId: latest.id });
+    state.pendingNewThread = false;
+    await ctx.renderExistingMessages();
+    ctx.showInfo(
+      sub === 'reset'
+        ? `Resource ID reset to: ${defaultId} — resumed thread: ${latest.title || latest.id}`
+        : `Switched to resource: ${newId} — resumed thread: ${latest.title || latest.id}`,
+    );
+  } else {
+    state.pendingNewThread = true;
+    ctx.showInfo(
+      sub === 'reset'
+        ? `Resource ID reset to: ${defaultId} (no existing threads, a new one will be created)`
+        : `Switched to resource: ${newId} (no existing threads, a new one will be created)`,
+    );
+  }
+
   ctx.updateStatusLine();
   state.ui.requestRender();
-
-  ctx.showInfo(sub === 'reset' ? `Resource ID reset to: ${defaultId}` : `Switched to resource: ${newId}`);
 }

--- a/mastracode/src/tui/commands/resource.ts
+++ b/mastracode/src/tui/commands/resource.ts
@@ -37,12 +37,11 @@ export async function handleResourceCommand(ctx: SlashCommandContext, args: stri
   const threads = await harness.listThreads();
   const latest = [...threads].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
 
-  state.chatContainer.clear();
-  state.pendingTools.clear();
-  state.allToolComponents = [];
-
   if (latest) {
     await harness.switchThread({ threadId: latest.id });
+    state.chatContainer.clear();
+    state.pendingTools.clear();
+    state.allToolComponents = [];
     state.pendingNewThread = false;
     await ctx.renderExistingMessages();
     ctx.showInfo(
@@ -51,6 +50,9 @@ export async function handleResourceCommand(ctx: SlashCommandContext, args: stri
         : `Switched to resource: ${newId} — resumed thread: ${latest.title || latest.id}`,
     );
   } else {
+    state.chatContainer.clear();
+    state.pendingTools.clear();
+    state.allToolComponents = [];
     state.pendingNewThread = true;
     ctx.showInfo(
       sub === 'reset'

--- a/mastracode/src/tui/commands/resource.ts
+++ b/mastracode/src/tui/commands/resource.ts
@@ -16,8 +16,9 @@ export async function handleResourceCommand(ctx: SlashCommandContext, args: stri
       ...knownIds.map((id: string) => `  ${id === current ? '* ' : '  '}${id}`),
       '',
       'Usage:',
-      '  /resource <id>    - Switch to a resource ID (resumes latest thread)',
-      '  /resource reset   - Reset to auto-detected ID',
+      '  /resource          - Show current resource and known IDs',
+      '  /resource <id>     - Switch to a resource ID (resumes latest thread)',
+      '  /resource reset    - Reset to auto-detected ID',
     ];
     ctx.showInfo(lines.join('\n'));
     return;

--- a/mastracode/src/tui/commands/resource.ts
+++ b/mastracode/src/tui/commands/resource.ts
@@ -35,7 +35,7 @@ export async function handleResourceCommand(ctx: SlashCommandContext, args: stri
 
   // Try to resume the most recent thread for this resource
   const threads = await harness.listThreads();
-  const latest = threads.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
+  const latest = [...threads].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
 
   state.chatContainer.clear();
   state.pendingTools.clear();

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -67,6 +67,7 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
   private currentModeId: string;
   private currentThreadId: string | null = null;
   private resourceId: string;
+  private defaultResourceId: string;
   private listeners: HarnessEventListener[] = [];
   private abortController: AbortController | null = null;
   private abortRequested: boolean = false;
@@ -100,6 +101,7 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
     this.id = config.id;
     this.config = config;
     this.resourceId = config.resourceId ?? config.id;
+    this.defaultResourceId = this.resourceId;
 
     // Initialize state from schema defaults + initial state
     this.state = {
@@ -533,6 +535,16 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
   setResourceId({ resourceId }: { resourceId: string }): void {
     this.resourceId = resourceId;
     this.currentThreadId = null;
+  }
+
+  getDefaultResourceId(): string {
+    return this.defaultResourceId;
+  }
+
+  async getKnownResourceIds(): Promise<string[]> {
+    const threads = await this.listThreads({ allResources: true });
+    const ids = new Set(threads.map(t => t.resourceId));
+    return [...ids];
   }
 
   async createThread({ title }: { title?: string } = {}): Promise<HarnessThread> {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -544,7 +544,7 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
   async getKnownResourceIds(): Promise<string[]> {
     const threads = await this.listThreads({ allResources: true });
     const ids = new Set(threads.map(t => t.resourceId));
-    return [...ids];
+    return [...ids].sort();
   }
 
   async createThread({ title }: { title?: string } = {}): Promise<HarnessThread> {

--- a/packages/core/src/harness/resource-id.test.ts
+++ b/packages/core/src/harness/resource-id.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+
+function createAgent() {
+  return new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+}
+
+function createHarness(opts?: { resourceId?: string; storage?: InMemoryStore }) {
+  const agent = createAgent();
+  return new Harness({
+    id: 'test-harness',
+    storage: opts?.storage ?? new InMemoryStore(),
+    modes: [{ id: 'default', name: 'Default', default: true, agent }],
+    ...(opts?.resourceId ? { resourceId: opts.resourceId } : {}),
+  });
+}
+
+describe('Harness resource ID', () => {
+  describe('getDefaultResourceId', () => {
+    it('returns the harness id when no explicit resourceId is configured', () => {
+      const harness = createHarness();
+      expect(harness.getDefaultResourceId()).toBe('test-harness');
+    });
+
+    it('returns the configured resourceId when one is provided', () => {
+      const harness = createHarness({ resourceId: 'custom-resource' });
+      expect(harness.getDefaultResourceId()).toBe('custom-resource');
+    });
+
+    it('still returns the original default after setResourceId is called', () => {
+      const harness = createHarness({ resourceId: 'original' });
+      harness.setResourceId({ resourceId: 'changed' });
+      expect(harness.getResourceId()).toBe('changed');
+      expect(harness.getDefaultResourceId()).toBe('original');
+    });
+  });
+
+  describe('getKnownResourceIds', () => {
+    let storage: InMemoryStore;
+    let harness: Harness;
+
+    beforeEach(() => {
+      storage = new InMemoryStore();
+      harness = createHarness({ storage });
+    });
+
+    it('returns an empty array when no threads exist', async () => {
+      const ids = await harness.getKnownResourceIds();
+      expect(ids).toEqual([]);
+    });
+
+    it('returns unique resource IDs from threads', async () => {
+      // Create threads under different resource IDs
+      await harness.createThread({ title: 'thread-1' });
+
+      harness.setResourceId({ resourceId: 'user-2' });
+      await harness.createThread({ title: 'thread-2' });
+
+      harness.setResourceId({ resourceId: 'user-3' });
+      await harness.createThread({ title: 'thread-3' });
+
+      const ids = await harness.getKnownResourceIds();
+      expect(ids.sort()).toEqual(['test-harness', 'user-2', 'user-3'].sort());
+    });
+
+    it('does not return duplicate resource IDs', async () => {
+      await harness.createThread({ title: 'thread-1' });
+      await harness.createThread({ title: 'thread-2' });
+
+      const ids = await harness.getKnownResourceIds();
+      expect(ids).toEqual(['test-harness']);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Fix the `/resource` command which was broken due to unimplemented `getDefaultResourceId()` and `getKnownResourceIds()` methods on the Harness class. Also improved the `/resource` command UX so that switching resources resumes the most recent thread for that resource instead of always creating a new one.

**Changes:**

- **`@mastra/core`**: Added `getDefaultResourceId()` (returns the original resource ID from config) and `getKnownResourceIds()` (returns all unique resource IDs found across stored threads) to the Harness class.
- **`mastracode`**: Improved `/resource` command to resume the most recent thread when switching resources. If no threads exist for the target resource, a new thread is created. Added help text clarifying resource switching behavior.

Closes #13660 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - /resource now resumes the most recently used thread for a resource (creates a new thread only if none exist)
  - Clarified help text for resource-switching and reset behavior
  - Added public ways to get the default resource and list known resource IDs

* **Tests**
  - Added comprehensive tests covering /resource resume, reset, and no-thread scenarios and resource-ID utilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->