### PR TITLE
fix(mastracode): gate debug.log behind MASTRA_DEBUG env var and cap file size

### DIFF
--- a/.changeset/whole-peaches-act.md
+++ b/.changeset/whole-peaches-act.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Added MASTRA_DEBUG environment variable to gate debug.log file writing. When MASTRA_DEBUG=true is set, console.error and console.warn output is captured to a debug.log file in the app data directory. The log file is automatically truncated to ~4 MB on startup if it exceeds 5 MB, preventing unbounded disk usage over time.

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -2,15 +2,12 @@
 /**
  * Main entry point for Mastra Code TUI.
  */
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-
 import { isStreamDestroyedError } from './error-classification.js';
 import { loadSettings } from './onboarding/settings.js';
 import { detectTerminalTheme } from './tui/detect-theme.js';
 import { MastraTUI } from './tui/index.js';
 import { applyThemeMode } from './tui/theme.js';
-import { getAppDataDir } from './utils/project.js';
+import { setupDebugLogging } from './utils/debug-log.js';
 import { releaseAllThreadLocks } from './utils/thread-lock.js';
 import { createMastraCode } from './index.js';
 
@@ -54,52 +51,7 @@ async function main() {
     }
   }
 
-  const debugEnabled = process.env.MASTRA_DEBUG === 'true';
-
-  if (debugEnabled) {
-    const logFile = path.join(getAppDataDir(), 'debug.log');
-
-    // Cap the log file: if it exceeds 5 MB, keep only the last ~4 MB
-    const MAX_LOG_SIZE = 5 * 1024 * 1024;
-    const KEEP_SIZE = 4 * 1024 * 1024;
-    try {
-      const stat = fs.statSync(logFile);
-      if (stat.size > MAX_LOG_SIZE) {
-        const buf = Buffer.alloc(KEEP_SIZE);
-        const fd = fs.openSync(logFile, 'r');
-        fs.readSync(fd, buf, 0, KEEP_SIZE, stat.size - KEEP_SIZE);
-        fs.closeSync(fd);
-        // Find the first newline so we don't start mid-line
-        const firstNewline = buf.indexOf(10);
-        const trimmed = firstNewline >= 0 ? buf.subarray(firstNewline + 1) : buf;
-        fs.writeFileSync(logFile, trimmed);
-      }
-    } catch {
-      // File may not exist yet — that's fine
-    }
-
-    const logStream = fs.createWriteStream(logFile, { flags: 'a' });
-    const fmt = (a: unknown): string => {
-      if (typeof a === 'string') return a;
-      if (a instanceof Error) return `${a.name}: ${a.message}`;
-      try {
-        return JSON.stringify(a);
-      } catch {
-        return String(a);
-      }
-    };
-    console.error = (...args: unknown[]) => {
-      logStream.write(`[ERROR] ${new Date().toISOString()} ${args.map(fmt).join(' ')}\n`);
-    };
-    console.warn = (...args: unknown[]) => {
-      logStream.write(`[WARN] ${new Date().toISOString()} ${args.map(fmt).join(' ')}\n`);
-    };
-  } else {
-    // Silence console.error/warn to avoid corrupting the TUI
-    const noop = () => {};
-    console.error = noop;
-    console.warn = noop;
-  }
+  setupDebugLogging();
 
   // Detect and apply terminal theme
   // MASTRA_THEME env var is the highest-priority override

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -54,23 +54,52 @@ async function main() {
     }
   }
 
-  const logFile = path.join(getAppDataDir(), 'debug.log');
-  const logStream = fs.createWriteStream(logFile, { flags: 'a' });
-  const fmt = (a: unknown): string => {
-    if (typeof a === 'string') return a;
-    if (a instanceof Error) return `${a.name}: ${a.message}`;
+  const debugEnabled = process.env.MASTRA_DEBUG === 'true';
+
+  if (debugEnabled) {
+    const logFile = path.join(getAppDataDir(), 'debug.log');
+
+    // Cap the log file: if it exceeds 5 MB, keep only the last ~4 MB
+    const MAX_LOG_SIZE = 5 * 1024 * 1024;
+    const KEEP_SIZE = 4 * 1024 * 1024;
     try {
-      return JSON.stringify(a);
+      const stat = fs.statSync(logFile);
+      if (stat.size > MAX_LOG_SIZE) {
+        const buf = Buffer.alloc(KEEP_SIZE);
+        const fd = fs.openSync(logFile, 'r');
+        fs.readSync(fd, buf, 0, KEEP_SIZE, stat.size - KEEP_SIZE);
+        fs.closeSync(fd);
+        // Find the first newline so we don't start mid-line
+        const firstNewline = buf.indexOf(10);
+        const trimmed = firstNewline >= 0 ? buf.subarray(firstNewline + 1) : buf;
+        fs.writeFileSync(logFile, trimmed);
+      }
     } catch {
-      return String(a);
+      // File may not exist yet — that's fine
     }
-  };
-  console.error = (...args: unknown[]) => {
-    logStream.write(`[ERROR] ${new Date().toISOString()} ${args.map(fmt).join(' ')}\n`);
-  };
-  console.warn = (...args: unknown[]) => {
-    logStream.write(`[WARN] ${new Date().toISOString()} ${args.map(fmt).join(' ')}\n`);
-  };
+
+    const logStream = fs.createWriteStream(logFile, { flags: 'a' });
+    const fmt = (a: unknown): string => {
+      if (typeof a === 'string') return a;
+      if (a instanceof Error) return `${a.name}: ${a.message}`;
+      try {
+        return JSON.stringify(a);
+      } catch {
+        return String(a);
+      }
+    };
+    console.error = (...args: unknown[]) => {
+      logStream.write(`[ERROR] ${new Date().toISOString()} ${args.map(fmt).join(' ')}\n`);
+    };
+    console.warn = (...args: unknown[]) => {
+      logStream.write(`[WARN] ${new Date().toISOString()} ${args.map(fmt).join(' ')}\n`);
+    };
+  } else {
+    // Silence console.error/warn to avoid corrupting the TUI
+    const noop = () => {};
+    console.error = noop;
+    console.warn = noop;
+  }
 
   // Detect and apply terminal theme
   // MASTRA_THEME env var is the highest-priority override

--- a/mastracode/src/tui/components/assistant-message.ts
+++ b/mastracode/src/tui/components/assistant-message.ts
@@ -11,7 +11,7 @@ import { getMarkdownTheme, theme } from '../theme.js';
 
 let _compId = 0;
 function asmDebugLog(...args: unknown[]) {
-  if (process.env.MASTRA_DEBUG !== `true`) {
+  if (!['true', '1'].includes(process.env.MASTRA_DEBUG!)) {
     return;
   }
   const line = `[ASM ${new Date().toISOString()}] ${args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')}\n`;

--- a/mastracode/src/tui/components/assistant-message.ts
+++ b/mastracode/src/tui/components/assistant-message.ts
@@ -11,7 +11,7 @@ import { getMarkdownTheme, theme } from '../theme.js';
 
 let _compId = 0;
 function asmDebugLog(...args: unknown[]) {
-  if (process.env.DEBUG_MASTRA_CODE !== `true`) {
+  if (process.env.MASTRA_DEBUG !== `true`) {
     return;
   }
   const line = `[ASM ${new Date().toISOString()}] ${args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ')}\n`;

--- a/mastracode/src/utils/__tests__/debug-log.test.ts
+++ b/mastracode/src/utils/__tests__/debug-log.test.ts
@@ -93,6 +93,13 @@ describe('setupDebugLogging', () => {
     expect(console.warn).not.toBe(originalWarn);
   });
 
+  it('should silence console when MASTRA_DEBUG=false', () => {
+    vi.stubEnv('MASTRA_DEBUG', 'false');
+    setupDebugLogging();
+    expect(console.error).not.toBe(originalError);
+    expect(console.warn).not.toBe(originalWarn);
+  });
+
   it('should redirect console.error and console.warn to file when MASTRA_DEBUG=true', async () => {
     vi.stubEnv('MASTRA_DEBUG', 'true');
     // Point getAppDataDir to our tmp dir

--- a/mastracode/src/utils/__tests__/debug-log.test.ts
+++ b/mastracode/src/utils/__tests__/debug-log.test.ts
@@ -116,4 +116,23 @@ describe('setupDebugLogging', () => {
 
     spy.mockRestore();
   });
+
+  it('should redirect console.error and console.warn to file when MASTRA_DEBUG=1', async () => {
+    vi.stubEnv('MASTRA_DEBUG', '1');
+    const projectMod = await import('../project.js');
+    const spy = vi.spyOn(projectMod, 'getAppDataDir').mockReturnValue(tmpDir);
+
+    setupDebugLogging();
+
+    console.error('test error via 1');
+
+    await new Promise(r => setTimeout(r, 100));
+
+    const logFile = path.join(tmpDir, 'debug.log');
+    const content = fs.readFileSync(logFile, 'utf-8');
+    expect(content).toContain('[ERROR]');
+    expect(content).toContain('test error via 1');
+
+    spy.mockRestore();
+  });
 });

--- a/mastracode/src/utils/__tests__/debug-log.test.ts
+++ b/mastracode/src/utils/__tests__/debug-log.test.ts
@@ -1,0 +1,119 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { truncateLogFile, setupDebugLogging } from '../debug-log.js';
+
+describe('truncateLogFile', () => {
+  let tmpDir: string;
+  let logFile: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug-log-test-'));
+    logFile = path.join(tmpDir, 'debug.log');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should not touch a file under 5 MB', () => {
+    const content = 'line one\nline two\nline three\n';
+    fs.writeFileSync(logFile, content);
+    truncateLogFile(logFile);
+    expect(fs.readFileSync(logFile, 'utf-8')).toBe(content);
+  });
+
+  it('should truncate a file over 5 MB to roughly 4 MB', () => {
+    // Write ~6 MB of log lines
+    const line = '[ERROR] 2026-01-01T00:00:00.000Z some error message here\n';
+    const repeatCount = Math.ceil((6 * 1024 * 1024) / line.length);
+    const content = line.repeat(repeatCount);
+    fs.writeFileSync(logFile, content);
+
+    const sizeBefore = fs.statSync(logFile).size;
+    expect(sizeBefore).toBeGreaterThan(5 * 1024 * 1024);
+
+    truncateLogFile(logFile);
+
+    const sizeAfter = fs.statSync(logFile).size;
+    expect(sizeAfter).toBeLessThanOrEqual(4 * 1024 * 1024);
+    expect(sizeAfter).toBeGreaterThan(3 * 1024 * 1024);
+  });
+
+  it('should cut at a newline boundary', () => {
+    const line = 'A'.repeat(100) + '\n';
+    const repeatCount = Math.ceil((6 * 1024 * 1024) / line.length);
+    fs.writeFileSync(logFile, line.repeat(repeatCount));
+
+    truncateLogFile(logFile);
+
+    const result = fs.readFileSync(logFile, 'utf-8');
+    // Should not start mid-line
+    expect(result.startsWith('A')).toBe(true);
+    // Every line should be intact
+    const lines = result.split('\n').filter(l => l.length > 0);
+    for (const l of lines) {
+      expect(l).toBe('A'.repeat(100));
+    }
+  });
+
+  it('should handle a non-existent file without throwing', () => {
+    expect(() => truncateLogFile(path.join(tmpDir, 'does-not-exist.log'))).not.toThrow();
+  });
+});
+
+describe('setupDebugLogging', () => {
+  let tmpDir: string;
+  const originalError = console.error;
+  const originalWarn = console.warn;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug-log-test-'));
+    vi.stubEnv('MASTRA_DEBUG', '');
+  });
+
+  afterEach(() => {
+    console.error = originalError;
+    console.warn = originalWarn;
+    vi.unstubAllEnvs();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should silence console.error and console.warn when MASTRA_DEBUG is not set', () => {
+    setupDebugLogging();
+
+    // They should be no-ops — calling them should not throw
+    expect(() => console.error('test')).not.toThrow();
+    expect(() => console.warn('test')).not.toThrow();
+
+    // Verify they are no longer the originals
+    expect(console.error).not.toBe(originalError);
+    expect(console.warn).not.toBe(originalWarn);
+  });
+
+  it('should redirect console.error and console.warn to file when MASTRA_DEBUG=true', async () => {
+    vi.stubEnv('MASTRA_DEBUG', 'true');
+    // Point getAppDataDir to our tmp dir
+    const projectMod = await import('../project.js');
+    const spy = vi.spyOn(projectMod, 'getAppDataDir').mockReturnValue(tmpDir);
+
+    setupDebugLogging();
+
+    console.error('test error message');
+    console.warn('test warn message');
+
+    // Give the write stream a moment to flush
+    await new Promise(r => setTimeout(r, 100));
+
+    const logFile = path.join(tmpDir, 'debug.log');
+    const content = fs.readFileSync(logFile, 'utf-8');
+    expect(content).toContain('[ERROR]');
+    expect(content).toContain('test error message');
+    expect(content).toContain('[WARN]');
+    expect(content).toContain('test warn message');
+
+    spy.mockRestore();
+  });
+});

--- a/mastracode/src/utils/__tests__/debug-log.test.ts
+++ b/mastracode/src/utils/__tests__/debug-log.test.ts
@@ -75,6 +75,7 @@ describe('setupDebugLogging', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     console.error = originalError;
     console.warn = originalWarn;
     vi.unstubAllEnvs();
@@ -104,11 +105,12 @@ describe('setupDebugLogging', () => {
     vi.stubEnv('MASTRA_DEBUG', 'true');
     // Point getAppDataDir to our tmp dir
     const projectMod = await import('../project.js');
-    const spy = vi.spyOn(projectMod, 'getAppDataDir').mockReturnValue(tmpDir);
+    vi.spyOn(projectMod, 'getAppDataDir').mockReturnValue(tmpDir);
 
     setupDebugLogging();
 
     console.error('test error message');
+    console.error(new Error('test stack path'));
     console.warn('test warn message');
 
     // Give the write stream a moment to flush
@@ -118,16 +120,15 @@ describe('setupDebugLogging', () => {
     const content = fs.readFileSync(logFile, 'utf-8');
     expect(content).toContain('[ERROR]');
     expect(content).toContain('test error message');
+    expect(content).toContain('Error: test stack path');
     expect(content).toContain('[WARN]');
     expect(content).toContain('test warn message');
-
-    spy.mockRestore();
   });
 
   it('should redirect console.error and console.warn to file when MASTRA_DEBUG=1', async () => {
     vi.stubEnv('MASTRA_DEBUG', '1');
     const projectMod = await import('../project.js');
-    const spy = vi.spyOn(projectMod, 'getAppDataDir').mockReturnValue(tmpDir);
+    vi.spyOn(projectMod, 'getAppDataDir').mockReturnValue(tmpDir);
 
     setupDebugLogging();
 
@@ -139,7 +140,5 @@ describe('setupDebugLogging', () => {
     const content = fs.readFileSync(logFile, 'utf-8');
     expect(content).toContain('[ERROR]');
     expect(content).toContain('test error via 1');
-
-    spy.mockRestore();
   });
 });

--- a/mastracode/src/utils/debug-log.ts
+++ b/mastracode/src/utils/debug-log.ts
@@ -33,7 +33,7 @@ export function truncateLogFile(logFile: string): void {
  * oversized). Otherwise silences them to avoid corrupting the TUI.
  */
 export function setupDebugLogging(): void {
-  const debugEnabled = process.env.MASTRA_DEBUG === 'true';
+  const debugEnabled = ['true', '1'].includes(process.env.MASTRA_DEBUG!);
 
   if (debugEnabled) {
     const logFile = path.join(getAppDataDir(), 'debug.log');

--- a/mastracode/src/utils/debug-log.ts
+++ b/mastracode/src/utils/debug-log.ts
@@ -1,0 +1,63 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { getAppDataDir } from './project.js';
+
+const MAX_LOG_SIZE = 5 * 1024 * 1024; // 5 MB
+const KEEP_SIZE = 4 * 1024 * 1024; // 4 MB
+
+/**
+ * Truncate a log file to roughly {@link KEEP_SIZE} bytes if it exceeds
+ * {@link MAX_LOG_SIZE}, cutting at the first newline so we don't start mid-line.
+ */
+export function truncateLogFile(logFile: string): void {
+  try {
+    const stat = fs.statSync(logFile);
+    if (stat.size > MAX_LOG_SIZE) {
+      const buf = Buffer.alloc(KEEP_SIZE);
+      const fd = fs.openSync(logFile, 'r');
+      fs.readSync(fd, buf, 0, KEEP_SIZE, stat.size - KEEP_SIZE);
+      fs.closeSync(fd);
+      const firstNewline = buf.indexOf(10);
+      const trimmed = firstNewline >= 0 ? buf.subarray(firstNewline + 1) : buf;
+      fs.writeFileSync(logFile, trimmed);
+    }
+  } catch {
+    // File may not exist yet — that's fine
+  }
+}
+
+/**
+ * Set up debug logging. When {@link MASTRA_DEBUG} is `"true"`, redirects
+ * `console.error` and `console.warn` to a log file (truncating it first if
+ * oversized). Otherwise silences them to avoid corrupting the TUI.
+ */
+export function setupDebugLogging(): void {
+  const debugEnabled = process.env.MASTRA_DEBUG === 'true';
+
+  if (debugEnabled) {
+    const logFile = path.join(getAppDataDir(), 'debug.log');
+    truncateLogFile(logFile);
+
+    const logStream = fs.createWriteStream(logFile, { flags: 'a' });
+    const fmt = (a: unknown): string => {
+      if (typeof a === 'string') return a;
+      if (a instanceof Error) return `${a.name}: ${a.message}`;
+      try {
+        return JSON.stringify(a);
+      } catch {
+        return String(a);
+      }
+    };
+    console.error = (...args: unknown[]) => {
+      logStream.write(`[ERROR] ${new Date().toISOString()} ${args.map(fmt).join(' ')}\n`);
+    };
+    console.warn = (...args: unknown[]) => {
+      logStream.write(`[WARN] ${new Date().toISOString()} ${args.map(fmt).join(' ')}\n`);
+    };
+  } else {
+    const noop = () => {};
+    console.error = noop;
+    console.warn = noop;
+  }
+}

--- a/mastracode/src/utils/debug-log.ts
+++ b/mastracode/src/utils/debug-log.ts
@@ -33,7 +33,7 @@ export function truncateLogFile(logFile: string): void {
  * oversized). Otherwise silences them to avoid corrupting the TUI.
  */
 export function setupDebugLogging(): void {
-  const debugEnabled = ['true', '1'].includes(process.env.MASTRA_DEBUG!);
+  const debugEnabled = ['true', '1'].includes(process.env.MASTRA_DEBUG ?? '');
 
   if (debugEnabled) {
     const logFile = path.join(getAppDataDir(), 'debug.log');
@@ -42,7 +42,7 @@ export function setupDebugLogging(): void {
     const logStream = fs.createWriteStream(logFile, { flags: 'a' });
     const fmt = (a: unknown): string => {
       if (typeof a === 'string') return a;
-      if (a instanceof Error) return `${a.name}: ${a.message}`;
+      if (a instanceof Error) return a.stack ?? `${a.name}: ${a.message}`;
       try {
         return JSON.stringify(a);
       } catch {


### PR DESCRIPTION
## Description

The `debug.log` file in mastra-code grows unbounded over time, consuming significant disk space. This PR adds two fixes:

1. **Env var gate** — Debug logging to file only happens when `MASTRA_DEBUG=true` is set. When disabled, `console.error`/`console.warn` become no-ops (they can't write to stdout/stderr without corrupting the TUI).

2. **Size cap** — On startup (when debug is enabled), if `debug.log` exceeds 5 MB, it's truncated to the last ~4 MB at a newline boundary so log lines stay intact.

## Related Issue(s)

N/A (reported internally via Slack)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MASTRA_DEBUG env var to capture console.error/warn to a debug.log when enabled.
  * Startup truncates oversized logs to keep them around 4 MB if they exceed 5 MB.

* **Chores**
  * Centralized debug logging initialization into a dedicated setup.

* **Tests**
  * Added tests for log truncation and for enabling/disabling debug logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->