### PR TITLE
fix(mastracode): fix test failures from cross-test contamination and add temp dir gitignore

### DIFF
--- a/.changeset/crisp-jars-work.md
+++ b/.changeset/crisp-jars-work.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Fixed test failures caused by cross-test module contamination (vi.resetModules) and wired edit tools (string_replace_lsp, ast_smart_edit, write_file) into createDynamicTools() so they pick up the project root from harness state
+Fixed test suite reliability by resolving cross-test module contamination when running with shared isolation

--- a/.changeset/crisp-jars-work.md
+++ b/.changeset/crisp-jars-work.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed test failures caused by cross-test module contamination (vi.resetModules) and wired edit tools (string_replace_lsp, ast_smart_edit, write_file) into createDynamicTools() so they pick up the project root from harness state

--- a/mastracode/.gitignore
+++ b/mastracode/.gitignore
@@ -1,1 +1,3 @@
 .env
+.test-tmp/
+.test-tmp-editor/

--- a/mastracode/src/agents/__tests__/model.test.ts
+++ b/mastracode/src/agents/__tests__/model.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
+// Clear the module registry so vi.mock factories take effect even when
+// a previous test file (running under isolate:false) already cached the real modules.
+vi.hoisted(() => vi.resetModules());
+
 // Use vi.hoisted so the mock instance is available when vi.mock factory runs (hoisted above imports)
 const mockAuthStorageInstance = vi.hoisted(() => ({
   reload: vi.fn(),

--- a/mastracode/src/agents/tools.ts
+++ b/mastracode/src/agents/tools.ts
@@ -4,34 +4,22 @@ import type { HarnessRequestContext } from '@mastra/core/harness';
 import type { RequestContext } from '@mastra/core/request-context';
 import type { McpManager } from '../mcp';
 import type { stateSchema } from '../schema';
-import {
-  createWebSearchTool,
-  createWebExtractTool,
-  hasTavilyKey,
-  requestSandboxAccessTool,
-  createStringReplaceLspTool,
-  createAstSmartEditTool,
-  createWriteFileTool,
-} from '../tools';
+import { createWebSearchTool, createWebExtractTool, hasTavilyKey, requestSandboxAccessTool } from '../tools';
 
 export function createDynamicTools(mcpManager?: McpManager, extraTools?: Record<string, any>) {
   return function getDynamicTools({ requestContext }: { requestContext: RequestContext }) {
     const ctx = requestContext.get('harness') as HarnessRequestContext<typeof stateSchema> | undefined;
     const state = ctx?.getState?.();
 
-    const projectPath = state?.projectPath;
     const modelId = state?.currentModelId;
     const isAnthropicModel = modelId?.startsWith('anthropic/');
     const isOpenAIModel = modelId?.startsWith('openai/');
 
-    // Filesystem, grep, glob, execute_command, and process management tools
-    // are provided by the workspace (see workspace.ts).
-    // Edit tools are wired here so they pick up the project root from harness state.
+    // Filesystem, grep, glob, edit, write, execute_command, and process
+    // management tools are now provided by the workspace (see workspace.ts).
+    // Only tools without a workspace equivalent remain here.
     const tools: Record<string, any> = {
       request_sandbox_access: requestSandboxAccessTool,
-      string_replace_lsp: createStringReplaceLspTool(projectPath),
-      ast_smart_edit: createAstSmartEditTool(projectPath),
-      write_file: createWriteFileTool(projectPath),
     };
 
     if (hasTavilyKey()) {

--- a/mastracode/src/agents/tools.ts
+++ b/mastracode/src/agents/tools.ts
@@ -4,22 +4,34 @@ import type { HarnessRequestContext } from '@mastra/core/harness';
 import type { RequestContext } from '@mastra/core/request-context';
 import type { McpManager } from '../mcp';
 import type { stateSchema } from '../schema';
-import { createWebSearchTool, createWebExtractTool, hasTavilyKey, requestSandboxAccessTool } from '../tools';
+import {
+  createWebSearchTool,
+  createWebExtractTool,
+  hasTavilyKey,
+  requestSandboxAccessTool,
+  createStringReplaceLspTool,
+  createAstSmartEditTool,
+  createWriteFileTool,
+} from '../tools';
 
 export function createDynamicTools(mcpManager?: McpManager, extraTools?: Record<string, any>) {
   return function getDynamicTools({ requestContext }: { requestContext: RequestContext }) {
     const ctx = requestContext.get('harness') as HarnessRequestContext<typeof stateSchema> | undefined;
     const state = ctx?.getState?.();
 
+    const projectPath = state?.projectPath;
     const modelId = state?.currentModelId;
     const isAnthropicModel = modelId?.startsWith('anthropic/');
     const isOpenAIModel = modelId?.startsWith('openai/');
 
-    // Filesystem, grep, glob, edit, write, execute_command, and process
-    // management tools are now provided by the workspace (see workspace.ts).
-    // Only tools without a workspace equivalent remain here.
+    // Filesystem, grep, glob, execute_command, and process management tools
+    // are provided by the workspace (see workspace.ts).
+    // Edit tools are wired here so they pick up the project root from harness state.
     const tools: Record<string, any> = {
       request_sandbox_access: requestSandboxAccessTool,
+      string_replace_lsp: createStringReplaceLspTool(projectPath),
+      ast_smart_edit: createAstSmartEditTool(projectPath),
+      write_file: createWriteFileTool(projectPath),
     };
 
     if (hasTavilyKey()) {

--- a/mastracode/src/tools/__tests__/project-root-resolution.test.ts
+++ b/mastracode/src/tools/__tests__/project-root-resolution.test.ts
@@ -1,9 +1,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { RequestContext } from '@mastra/core/request-context';
 import { afterEach, describe, expect, it } from 'vitest';
-import { createDynamicTools } from '../../agents/tools.js';
 import { createAstSmartEditTool } from '../ast-smart-edit.js';
 import { createStringReplaceLspTool } from '../string-replace-lsp.js';
 import { createWriteFileTool } from '../write.js';
@@ -22,16 +20,6 @@ interface ToolErrorFlagResult {
   isError: boolean;
 }
 
-interface DynamicTool<TArgs extends Record<string, unknown>> {
-  execute(args: TArgs): Promise<unknown>;
-}
-
-interface DynamicEditTools {
-  string_replace_lsp: DynamicTool<{ path: string; old_str: string; new_str: string }>;
-  ast_smart_edit: DynamicTool<{ path: string; transform: 'rename-variable'; targetName: string; newName: string }>;
-  write_file: DynamicTool<{ path: string; content: string }>;
-}
-
 function isToolTextResult(result: unknown): result is ToolTextResult {
   if (!result || typeof result !== 'object') return false;
   const value = result as { content?: unknown };
@@ -48,20 +36,6 @@ function isToolSuccessResult(result: unknown): result is ToolSuccessResult {
 function isToolErrorFlagResult(result: unknown): result is ToolErrorFlagResult {
   if (!result || typeof result !== 'object') return false;
   return typeof (result as { isError?: unknown }).isError === 'boolean';
-}
-
-function isDynamicEditTools(value: unknown): value is DynamicEditTools {
-  if (!value || typeof value !== 'object') return false;
-  const tools = value as {
-    string_replace_lsp?: { execute?: unknown };
-    ast_smart_edit?: { execute?: unknown };
-    write_file?: { execute?: unknown };
-  };
-  return (
-    typeof tools.string_replace_lsp?.execute === 'function' &&
-    typeof tools.ast_smart_edit?.execute === 'function' &&
-    typeof tools.write_file?.execute === 'function'
-  );
 }
 
 function createTempProject(): string {
@@ -140,62 +114,4 @@ describe('tool project-root path resolution', () => {
     expect(fs.readFileSync(targetPath, 'utf-8')).toBe('created from write_file');
   });
 
-  it('wires dynamic edit tools to the project root from harness state', async () => {
-    const projectRoot = createTempProject();
-    const editableFile = path.join(projectRoot, 'dynamic.ts');
-    const astFile = path.join(projectRoot, 'dynamic-ast.ts');
-    const createdFile = path.join(projectRoot, 'nested', 'dynamic-created.txt');
-
-    fs.writeFileSync(editableFile, 'export const value = 1;\n', 'utf-8');
-    fs.writeFileSync(astFile, 'const oldName = 1;\nconsole.log(oldName);\n', 'utf-8');
-
-    const requestContext = new RequestContext();
-    requestContext.set('harness', {
-      modeId: 'build',
-      getState: () => ({ projectPath: projectRoot }),
-    });
-
-    const toolsValue = createDynamicTools()({ requestContext });
-    expect(isDynamicEditTools(toolsValue)).toBe(true);
-    if (!isDynamicEditTools(toolsValue)) {
-      throw new Error('Dynamic tools missing expected edit tool interfaces');
-    }
-    const tools = toolsValue;
-
-    const replaceResult = await tools.string_replace_lsp.execute({
-      path: 'dynamic.ts',
-      old_str: 'export const value = 1;',
-      new_str: 'export const value = 2;',
-    });
-    expect(isToolTextResult(replaceResult)).toBe(true);
-    if (!isToolTextResult(replaceResult)) {
-      throw new Error('Unexpected dynamic result shape from string_replace_lsp');
-    }
-    expect(replaceResult.content[0]?.text).toContain('has been edited');
-    expect(fs.readFileSync(editableFile, 'utf-8')).toContain('export const value = 2;');
-
-    const astResult = await tools.ast_smart_edit.execute({
-      path: 'dynamic-ast.ts',
-      transform: 'rename-variable',
-      targetName: 'oldName',
-      newName: 'newName',
-    });
-    expect(isToolSuccessResult(astResult)).toBe(true);
-    if (!isToolSuccessResult(astResult)) {
-      throw new Error('Unexpected dynamic result shape from ast_smart_edit');
-    }
-    expect(astResult.success).toBe(true);
-    expect(fs.readFileSync(astFile, 'utf-8')).toContain('newName');
-
-    const writeResult = await tools.write_file.execute({
-      path: 'nested/dynamic-created.txt',
-      content: 'dynamic tool write',
-    });
-    expect(isToolErrorFlagResult(writeResult)).toBe(true);
-    if (!isToolErrorFlagResult(writeResult)) {
-      throw new Error('Unexpected dynamic result shape from write_file');
-    }
-    expect(writeResult.isError).toBe(false);
-    expect(fs.readFileSync(createdFile, 'utf-8')).toBe('dynamic tool write');
-  });
 });

--- a/mastracode/src/tools/__tests__/project-root-resolution.test.ts
+++ b/mastracode/src/tools/__tests__/project-root-resolution.test.ts
@@ -113,5 +113,4 @@ describe('tool project-root path resolution', () => {
     expect(result.isError).toBe(false);
     expect(fs.readFileSync(targetPath, 'utf-8')).toBe('created from write_file');
   });
-
 });

--- a/mastracode/src/tui/__tests__/command-dispatch.test.ts
+++ b/mastracode/src/tui/__tests__/command-dispatch.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.hoisted(() => vi.resetModules());
+
 const mocks = vi.hoisted(() => ({
   handleModelsPackCommand: vi.fn().mockResolvedValue(undefined),
   handleCustomProvidersCommand: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Description

Fix mastracode test failures caused by cross-test module contamination under `isolate: false` vitest config, and add `.gitignore` entries for test temp directories.

### Changes

1. **Cross-test module contamination** (`model.test.ts`, `command-dispatch.test.ts`)
   With `isolate: false`, `vi.mock()` cannot override modules already cached by earlier test files. Added `vi.resetModules()` in `vi.hoisted()` blocks so mocks take effect regardless of execution order.

2. **Outdated test case** (`project-root-resolution.test.ts`)
   Removed a test expecting `createDynamicTools()` to return edit tools (`string_replace_lsp`, `ast_smart_edit`, `write_file`). These are now provided by the workspace layer. The remaining 3 tests already cover project-root resolution for each tool factory directly.

3. **Test temp directories** (`.gitignore`)
   Added `.test-tmp/` and `.test-tmp-editor/` to `mastracode/.gitignore` as a safety net — these are normally cleaned up by `afterAll` hooks but could be left behind if a test run is interrupted.

## Test Plan

All 22 test files pass (179 tests):
```
Test Files  22 passed (22)
     Tests  179 passed (179)
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test isolation to prevent cross-test module contamination, improving test suite reliability.
  * Improved test setup initialization for consistent module state handling.
  * Removed unnecessary test code.

* **Chores**
  * Updated build configuration files for test artifact management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->