### PR TITLE
fix(workspace): update tool id when name is remapped

### DIFF
--- a/.changeset/common-lions-smoke.md
+++ b/.changeset/common-lions-smoke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workspace tools being callable by their old default names (e.g. mastra_workspace_edit_file) when renamed via tools config. The tool's internal id is now updated to match the remapped name, preventing fallback resolution from bypassing the rename.

--- a/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/tool-creation.test.ts
@@ -179,6 +179,25 @@ describe('createWorkspaceTools', () => {
       expect(tools['view'].requireApproval).toBe(true);
     });
 
+    it('should update tool id to match remapped name', () => {
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({ basePath: tempDir }),
+        tools: {
+          mastra_workspace_read_file: { name: 'view' },
+          mastra_workspace_edit_file: { name: 'string_replace_lsp' },
+        },
+      });
+      const tools = createWorkspaceTools(workspace);
+
+      // The tool id should be updated to match the exposed name so that
+      // fallback-by-id resolution doesn't allow calling by the old name
+      expect((tools['view'] as any).id).toBe('view');
+      expect((tools['string_replace_lsp'] as any).id).toBe('string_replace_lsp');
+
+      // Non-remapped tools should keep their default id
+      expect((tools[WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE] as any).id).toBe(WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE);
+    });
+
     it('should remap sandbox tools', () => {
       const workspace = new Workspace({
         sandbox: new LocalSandbox({ workingDirectory: tempDir }),

--- a/packages/core/src/workspace/tools/tools.ts
+++ b/packages/core/src/workspace/tools/tools.ts
@@ -225,6 +225,12 @@ export function createWorkspaceTools(workspace: Workspace) {
           `Check your tools config for duplicate "name" values.`,
       );
     }
+    // When the tool is renamed, update its id to match so fallback-by-id
+    // resolution (in tool-call-step, llm-execution-step, etc.) won't allow
+    // the model to call the tool using the old default name.
+    if (exposedName !== name && 'id' in wrapped) {
+      wrapped = { ...wrapped, id: exposedName };
+    }
     tools[exposedName] = wrapped;
   };
 


### PR DESCRIPTION
## Summary
- When workspace tools are renamed via `config.name`, the dictionary key was updated but the tool's `.id` property kept the old default name (e.g. `mastra_workspace_edit_file`)
- The agentic loop's fallback resolution (`tool-call-step`, `llm-execution-step`, `tool-search`) matches tools by `.id`, allowing the model to call tools by their old names even though those names aren't in the system prompt schema
- Updates `.id` to match the exposed name so fallback-by-id resolution no longer resolves old default names

## Test plan
- [x] Added test verifying remapped tools get updated `.id`
- [x] Added test verifying non-remapped tools keep default `.id`
- [x] All existing workspace tool tests pass (20/20)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool ID remapping so that when tools are exposed under different names in a workspace, their internal IDs are automatically updated to match the exposed names, preventing fallback resolution from referencing old names and ensuring correct tool invocation.

* **Tests**
  * Added test coverage confirming remapped tools receive updated IDs and that non-remapped tools retain their original IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->