### PR TITLE
fix(mastracode): queue parallel interactive tool calls to prevent input corruption

### DIFF
--- a/.changeset/dark-beers-send.md
+++ b/.changeset/dark-beers-send.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Fixed parallel interactive tool calls (ask_user, request_sandbox_access) corrupting TUI input. When the agent fires multiple interactive tool calls simultaneously, they are now queued and shown one at a time instead of overwriting each other.
+Fixed an issue where multiple interactive prompts could appear at once and make earlier prompts unresponsive. Prompts are now shown one at a time so each can be answered reliably.

--- a/.changeset/dark-beers-send.md
+++ b/.changeset/dark-beers-send.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed parallel interactive tool calls (ask_user, request_sandbox_access) corrupting TUI input. When the agent fires multiple interactive tool calls simultaneously, they are now queued and shown one at a time instead of overwriting each other.

--- a/mastracode/src/tui/__tests__/parallel-interactive-prompts.test.ts
+++ b/mastracode/src/tui/__tests__/parallel-interactive-prompts.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Test for GitHub issue #13642: Parallel interactive tool calls (ask_user,
+ * request_sandbox_access) should all be answerable, not just the most recent.
+ *
+ * Root cause: state.activeInlineQuestion is a single property that gets
+ * overwritten when multiple ask_question events arrive concurrently.
+ * The Harness dispatches events fire-and-forget (no await), so multiple
+ * interactive handlers run concurrently, and the last one wins — earlier
+ * prompts become unreachable.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { handleAskQuestion, handleSandboxAccessRequest } from '../handlers/prompts.js';
+import type { EventHandlerContext } from '../handlers/types.js';
+import type { TUIState } from '../state.js';
+
+/**
+ * Create a minimal mock state for testing interactive prompts.
+ */
+function createMockState(): TUIState {
+  const chatContainer = {
+    children: [] as any[],
+    addChild: vi.fn(function (this: any, child: any) {
+      this.children.push(child);
+    }),
+    clear: vi.fn(function (this: any) {
+      this.children = [];
+    }),
+    invalidate: vi.fn(),
+  };
+  chatContainer.addChild = chatContainer.addChild.bind(chatContainer);
+  chatContainer.clear = chatContainer.clear.bind(chatContainer);
+
+  return {
+    options: { inlineQuestions: true, harness: {} as any },
+    harness: {
+      respondToQuestion: vi.fn(),
+      respondToPlanApproval: vi.fn(),
+    },
+    chatContainer,
+    ui: {
+      requestRender: vi.fn(),
+    },
+    activeInlineQuestion: undefined,
+    activeInlinePlanApproval: undefined,
+    pendingInlineQuestions: [],
+    lastAskUserComponent: undefined,
+    pendingApprovalDismiss: null,
+  } as unknown as TUIState;
+}
+
+function createMockContext(state: TUIState): EventHandlerContext {
+  return {
+    state,
+    showInfo: vi.fn(),
+    showError: vi.fn(),
+    showFormattedError: vi.fn(),
+    updateStatusLine: vi.fn(),
+    notify: vi.fn(),
+    handleSlashCommand: vi.fn(),
+    addUserMessage: vi.fn(),
+    addChildBeforeFollowUps: vi.fn(),
+    fireMessage: vi.fn(),
+    renderExistingMessages: vi.fn(),
+    renderCompletedTasksInline: vi.fn(),
+    renderClearedTasksInline: vi.fn(),
+    refreshModelAuthStatus: vi.fn(),
+  };
+}
+
+describe('Parallel interactive tool calls (issue #13642)', () => {
+  let state: TUIState;
+  let ctx: EventHandlerContext;
+
+  beforeEach(() => {
+    state = createMockState();
+    ctx = createMockContext(state);
+  });
+
+  describe('multiple concurrent ask_user calls', () => {
+    it('should not overwrite activeInlineQuestion when a second ask_question arrives while first is pending', async () => {
+      // Start first question - this sets state.activeInlineQuestion
+      handleAskQuestion(ctx, 'q1', 'First question?');
+
+      const firstComponent = state.activeInlineQuestion;
+      expect(firstComponent).toBeDefined();
+
+      // Start second question while first is still pending
+      // In the buggy code, this overwrites activeInlineQuestion
+      handleAskQuestion(ctx, 'q2', 'Second question?');
+
+      // CRITICAL: The first component should still be the active one
+      // (second should be queued), OR both should be tracked
+      expect(state.activeInlineQuestion).toBe(firstComponent);
+    });
+
+    it('should allow answering all parallel questions sequentially', async () => {
+      const respondToQuestion = state.harness.respondToQuestion as ReturnType<typeof vi.fn>;
+
+      // Fire 3 concurrent ask_question events (simulating parallel tool calls)
+      const p1 = handleAskQuestion(ctx, 'q1', 'Question 1?');
+      const p2 = handleAskQuestion(ctx, 'q2', 'Question 2?');
+      const p3 = handleAskQuestion(ctx, 'q3', 'Question 3?');
+
+      // First question should be active
+      expect(state.activeInlineQuestion).toBeDefined();
+
+      // Simulate answering first question via its select/input
+      // The onSubmit callback should call respondToQuestion and resolve the promise
+      // We need to trigger the component's internal submission mechanism
+      // Since AskQuestionInlineComponent uses Input with onSubmit,
+      // we simulate by directly triggering the select list or sending Enter
+      const comp1 = state.activeInlineQuestion!;
+
+      // For free-text input questions, type text and press Enter
+      comp1.handleInput('a');
+      comp1.handleInput('n');
+      comp1.handleInput('s');
+      comp1.handleInput('1');
+      comp1.handleInput('\r'); // Enter to submit
+
+      // Wait for the first promise to resolve
+      await p1;
+
+      expect(respondToQuestion).toHaveBeenCalledWith({
+        questionId: 'q1',
+        answer: 'ans1',
+      });
+
+      // Second question should now be active
+      expect(state.activeInlineQuestion).toBeDefined();
+      const comp2 = state.activeInlineQuestion!;
+      expect(comp2).not.toBe(comp1);
+
+      comp2.handleInput('a');
+      comp2.handleInput('n');
+      comp2.handleInput('s');
+      comp2.handleInput('2');
+      comp2.handleInput('\r');
+
+      await p2;
+
+      expect(respondToQuestion).toHaveBeenCalledWith({
+        questionId: 'q2',
+        answer: 'ans2',
+      });
+
+      // Third question should now be active
+      expect(state.activeInlineQuestion).toBeDefined();
+      const comp3 = state.activeInlineQuestion!;
+
+      comp3.handleInput('a');
+      comp3.handleInput('n');
+      comp3.handleInput('s');
+      comp3.handleInput('3');
+      comp3.handleInput('\r');
+
+      await p3;
+
+      expect(respondToQuestion).toHaveBeenCalledWith({
+        questionId: 'q3',
+        answer: 'ans3',
+      });
+    });
+
+    it('should resolve all promises even when questions arrive concurrently', async () => {
+      const respondToQuestion = state.harness.respondToQuestion as ReturnType<typeof vi.fn>;
+
+      // Fire concurrent questions
+      const p1 = handleAskQuestion(ctx, 'q1', 'Q1?');
+      const p2 = handleAskQuestion(ctx, 'q2', 'Q2?');
+
+      // Answer first
+      const comp1 = state.activeInlineQuestion!;
+      comp1.handleInput('y');
+      comp1.handleInput('\r');
+      await p1;
+
+      // Answer second
+      const comp2 = state.activeInlineQuestion!;
+      comp2.handleInput('n');
+      comp2.handleInput('\r');
+      await p2;
+
+      // Both should have been answered
+      expect(respondToQuestion).toHaveBeenCalledTimes(2);
+      expect(respondToQuestion).toHaveBeenCalledWith({ questionId: 'q1', answer: 'y' });
+      expect(respondToQuestion).toHaveBeenCalledWith({ questionId: 'q2', answer: 'n' });
+    });
+  });
+
+  describe('concurrent sandbox_access_request calls', () => {
+    it('should queue parallel sandbox access requests', async () => {
+      const respondToQuestion = state.harness.respondToQuestion as ReturnType<typeof vi.fn>;
+
+      const p1 = handleSandboxAccessRequest(ctx, 'sa1', '/path/a', 'reason A');
+      const p2 = handleSandboxAccessRequest(ctx, 'sa2', '/path/b', 'reason B');
+
+      // First should be active (it has select options: Yes/No)
+      expect(state.activeInlineQuestion).toBeDefined();
+      const comp1 = state.activeInlineQuestion!;
+
+      // Select "Yes" via Enter on the first item in select list
+      comp1.handleInput('\r'); // Enter selects first option ("Yes")
+      await p1;
+
+      expect(respondToQuestion).toHaveBeenCalledWith({ questionId: 'sa1', answer: 'Yes' });
+
+      // Second should now be active
+      expect(state.activeInlineQuestion).toBeDefined();
+      const comp2 = state.activeInlineQuestion!;
+      expect(comp2).not.toBe(comp1);
+
+      // Select "No" by pressing down then Enter
+      comp2.handleInput('\x1b[B'); // Down arrow
+      comp2.handleInput('\r'); // Enter selects "No"
+      await p2;
+
+      expect(respondToQuestion).toHaveBeenCalledWith({ questionId: 'sa2', answer: 'No' });
+    });
+  });
+
+  describe('mixed interactive tool calls', () => {
+    it('should handle ask_question and sandbox_access_request arriving concurrently', async () => {
+      const respondToQuestion = state.harness.respondToQuestion as ReturnType<typeof vi.fn>;
+
+      const p1 = handleAskQuestion(ctx, 'q1', 'Pick one', [
+        { label: 'A' },
+        { label: 'B' },
+      ]);
+      const p2 = handleSandboxAccessRequest(ctx, 'sa1', '/some/path', 'need access');
+
+      // First should be the ask_question
+      expect(state.activeInlineQuestion).toBeDefined();
+      const comp1 = state.activeInlineQuestion!;
+
+      // Select first option
+      comp1.handleInput('\r');
+      await p1;
+      expect(respondToQuestion).toHaveBeenCalledWith({ questionId: 'q1', answer: 'A' });
+
+      // Sandbox request should now be active
+      expect(state.activeInlineQuestion).toBeDefined();
+      state.activeInlineQuestion!.handleInput('\r'); // Yes
+      await p2;
+      expect(respondToQuestion).toHaveBeenCalledWith({ questionId: 'sa1', answer: 'Yes' });
+    });
+  });
+});

--- a/mastracode/src/tui/__tests__/parallel-interactive-prompts.test.ts
+++ b/mastracode/src/tui/__tests__/parallel-interactive-prompts.test.ts
@@ -80,18 +80,26 @@ describe('Parallel interactive tool calls (issue #13642)', () => {
   describe('multiple concurrent ask_user calls', () => {
     it('should not overwrite activeInlineQuestion when a second ask_question arrives while first is pending', async () => {
       // Start first question - this sets state.activeInlineQuestion
-      handleAskQuestion(ctx, 'q1', 'First question?');
+      const p1 = handleAskQuestion(ctx, 'q1', 'First question?');
 
       const firstComponent = state.activeInlineQuestion;
       expect(firstComponent).toBeDefined();
 
       // Start second question while first is still pending
       // In the buggy code, this overwrites activeInlineQuestion
-      handleAskQuestion(ctx, 'q2', 'Second question?');
+      const p2 = handleAskQuestion(ctx, 'q2', 'Second question?');
 
       // CRITICAL: The first component should still be the active one
       // (second should be queued), OR both should be tracked
       expect(state.activeInlineQuestion).toBe(firstComponent);
+
+      // Cleanup: resolve both pending prompts
+      state.activeInlineQuestion!.handleInput('y');
+      state.activeInlineQuestion!.handleInput('\r');
+      await p1;
+      state.activeInlineQuestion!.handleInput('y');
+      state.activeInlineQuestion!.handleInput('\r');
+      await p2;
     });
 
     it('should allow answering all parallel questions sequentially', async () => {

--- a/mastracode/src/tui/__tests__/parallel-interactive-prompts.test.ts
+++ b/mastracode/src/tui/__tests__/parallel-interactive-prompts.test.ts
@@ -220,6 +220,51 @@ describe('Parallel interactive tool calls (issue #13642)', () => {
     });
   });
 
+  describe('abort clears queued prompts', () => {
+    it('should clear the queue and not activate pending questions after abort', async () => {
+      const respondToQuestion = state.harness.respondToQuestion as ReturnType<typeof vi.fn>;
+
+      // Fire two concurrent questions: first is active, second is queued
+      handleAskQuestion(ctx, 'q1', 'Active question?');
+      handleAskQuestion(ctx, 'q2', 'Queued question?');
+
+      expect(state.activeInlineQuestion).toBeDefined();
+      expect(state.pendingInlineQuestions).toHaveLength(1);
+
+      // Simulate abort: clear state the same way setup.ts does on Ctrl+C
+      state.activeInlineQuestion = undefined;
+      state.pendingInlineQuestions.length = 0;
+
+      // The queue should stay empty and no new question should activate
+      expect(state.activeInlineQuestion).toBeUndefined();
+      expect(state.pendingInlineQuestions).toHaveLength(0);
+
+      // respondToQuestion should not have been called (nothing was answered)
+      expect(respondToQuestion).not.toHaveBeenCalled();
+    });
+
+    it('should not activate queued questions if the active one is cancelled after abort', async () => {
+      // Fire two concurrent questions
+      handleAskQuestion(ctx, 'q1', 'First?');
+      handleAskQuestion(ctx, 'q2', 'Second?');
+
+      const comp1 = state.activeInlineQuestion!;
+      expect(state.pendingInlineQuestions).toHaveLength(1);
+
+      // Abort: clear everything
+      state.activeInlineQuestion = undefined;
+      state.pendingInlineQuestions.length = 0;
+
+      // Even if comp1's onCancel fires after abort (e.g. cleanup), the queue is empty
+      // so processNextInlineQuestion should be a no-op
+      comp1.handleInput('\x1b'); // Esc to cancel
+
+      // Queue should still be empty, no new active question
+      expect(state.activeInlineQuestion).toBeUndefined();
+      expect(state.pendingInlineQuestions).toHaveLength(0);
+    });
+  });
+
   describe('mixed interactive tool calls', () => {
     it('should handle ask_question and sandbox_access_request arriving concurrently', async () => {
       const respondToQuestion = state.harness.respondToQuestion as ReturnType<typeof vi.fn>;

--- a/mastracode/src/tui/__tests__/parallel-interactive-prompts.test.ts
+++ b/mastracode/src/tui/__tests__/parallel-interactive-prompts.test.ts
@@ -224,10 +224,7 @@ describe('Parallel interactive tool calls (issue #13642)', () => {
     it('should handle ask_question and sandbox_access_request arriving concurrently', async () => {
       const respondToQuestion = state.harness.respondToQuestion as ReturnType<typeof vi.fn>;
 
-      const p1 = handleAskQuestion(ctx, 'q1', 'Pick one', [
-        { label: 'A' },
-        { label: 'B' },
-      ]);
+      const p1 = handleAskQuestion(ctx, 'q1', 'Pick one', [{ label: 'A' }, { label: 'B' }]);
       const p2 = handleSandboxAccessRequest(ctx, 'sa1', '/some/path', 'need access');
 
       // First should be the ask_question

--- a/mastracode/src/tui/handlers/prompts.ts
+++ b/mastracode/src/tui/handlers/prompts.ts
@@ -8,13 +8,28 @@ import { savePlanToDisk } from '../../utils/plans.js';
 import { AskQuestionDialogComponent } from '../components/ask-question-dialog.js';
 import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
 import { PlanApprovalInlineComponent } from '../components/plan-approval-inline.js';
+import type { TUIState } from '../state.js';
 import { theme } from '../theme.js';
 
 import type { EventHandlerContext } from './types.js';
 
 /**
+ * Process the next pending inline question from the queue.
+ * Called when the current active question is resolved (submitted or cancelled).
+ */
+function processNextInlineQuestion(state: TUIState): void {
+  const next = state.pendingInlineQuestions.shift();
+  if (next) {
+    next();
+  }
+}
+
+/**
  * Handle an ask_question event from the ask_user tool.
  * Shows a dialog overlay and resolves the tool's pending promise.
+ *
+ * If another inline question is already active, the new question is queued
+ * and will be shown once the current one is answered.
  */
 export async function handleAskQuestion(
   ctx: EventHandlerContext,
@@ -25,71 +40,82 @@ export async function handleAskQuestion(
   const { state } = ctx;
   return new Promise(resolve => {
     if (state.options.inlineQuestions) {
-      // Inline mode: Add question component to chat
-      const questionComponent = new AskQuestionInlineComponent(
-        {
-          question,
-          options,
-          onSubmit: answer => {
-            state.activeInlineQuestion = undefined;
-            state.harness.respondToQuestion({ questionId, answer });
-            resolve();
+      const activate = () => {
+        // Inline mode: Add question component to chat
+        const questionComponent = new AskQuestionInlineComponent(
+          {
+            question,
+            options,
+            onSubmit: answer => {
+              state.activeInlineQuestion = undefined;
+              state.harness.respondToQuestion({ questionId, answer });
+              resolve();
+              processNextInlineQuestion(state);
+            },
+            onCancel: () => {
+              state.activeInlineQuestion = undefined;
+              state.harness.respondToQuestion({ questionId, answer: '(skipped)' });
+              resolve();
+              processNextInlineQuestion(state);
+            },
           },
-          onCancel: () => {
-            state.activeInlineQuestion = undefined;
-            state.harness.respondToQuestion({ questionId, answer: '(skipped)' });
-            resolve();
-          },
-        },
-        state.ui,
-      );
+          state.ui,
+        );
 
-      // Store as active question
-      state.activeInlineQuestion = questionComponent;
+        // Store as active question
+        state.activeInlineQuestion = questionComponent;
 
-      // Insert the question right after the ask_user tool component
-      if (state.lastAskUserComponent) {
-        // Find the position of the ask_user component
-        const children = [...state.chatContainer.children];
-        const askUserIndex = children.indexOf(state.lastAskUserComponent as any);
+        // Insert the question right after the ask_user tool component
+        if (state.lastAskUserComponent) {
+          // Find the position of the ask_user component
+          const children = [...state.chatContainer.children];
+          const askUserIndex = children.indexOf(state.lastAskUserComponent as any);
 
-        if (askUserIndex >= 0) {
-          // Clear and rebuild with question in the right place
-          state.chatContainer.clear();
-          // Add all children up to and including the ask_user tool
-          for (let i = 0; i <= askUserIndex; i++) {
-            state.chatContainer.addChild(children[i]!);
-          }
+          if (askUserIndex >= 0) {
+            // Clear and rebuild with question in the right place
+            state.chatContainer.clear();
+            // Add all children up to and including the ask_user tool
+            for (let i = 0; i <= askUserIndex; i++) {
+              state.chatContainer.addChild(children[i]!);
+            }
 
-          // Add the question component with spacing
-          state.chatContainer.addChild(new Spacer(1));
-          state.chatContainer.addChild(questionComponent);
-          state.chatContainer.addChild(new Spacer(1));
+            // Add the question component with spacing
+            state.chatContainer.addChild(new Spacer(1));
+            state.chatContainer.addChild(questionComponent);
+            state.chatContainer.addChild(new Spacer(1));
 
-          // Add remaining children
-          for (let i = askUserIndex + 1; i < children.length; i++) {
-            state.chatContainer.addChild(children[i]!);
+            // Add remaining children
+            for (let i = askUserIndex + 1; i < children.length; i++) {
+              state.chatContainer.addChild(children[i]!);
+            }
+          } else {
+            // Fallback: add at the end
+            state.chatContainer.addChild(new Spacer(1));
+            state.chatContainer.addChild(questionComponent);
+            state.chatContainer.addChild(new Spacer(1));
           }
         } else {
-          // Fallback: add at the end
+          // Fallback: add at the end if no ask_user component tracked
           state.chatContainer.addChild(new Spacer(1));
           state.chatContainer.addChild(questionComponent);
           state.chatContainer.addChild(new Spacer(1));
         }
+
+        state.ui.requestRender();
+
+        // Ensure the chat scrolls to show the question
+        state.chatContainer.invalidate();
+
+        // Focus the question component
+        questionComponent.focused = true;
+      };
+
+      // If another inline question is already active, queue this one
+      if (state.activeInlineQuestion) {
+        state.pendingInlineQuestions.push(activate);
       } else {
-        // Fallback: add at the end if no ask_user component tracked
-        state.chatContainer.addChild(new Spacer(1));
-        state.chatContainer.addChild(questionComponent);
-        state.chatContainer.addChild(new Spacer(1));
+        activate();
       }
-
-      state.ui.requestRender();
-
-      // Ensure the chat scrolls to show the question
-      state.chatContainer.invalidate();
-
-      // Focus the question component
-      questionComponent.focused = true;
     } else {
       // Dialog mode: Show overlay
       const dialog = new AskQuestionDialogComponent({
@@ -117,6 +143,9 @@ export async function handleAskQuestion(
 /**
  * Handle a sandbox_access_request event from the request_sandbox_access tool.
  * Shows an inline prompt for the user to approve or deny directory access.
+ *
+ * If another inline question is already active, the new prompt is queued
+ * and will be shown once the current one is answered.
  */
 export async function handleSandboxAccessRequest(
   ctx: EventHandlerContext,
@@ -126,42 +155,53 @@ export async function handleSandboxAccessRequest(
 ): Promise<void> {
   const { state } = ctx;
   return new Promise(resolve => {
-    const questionComponent = new AskQuestionInlineComponent(
-      {
-        question: `Grant sandbox access to "${requestedPath}"?\n${theme.fg('dim', `Reason: ${reason}`)}`,
-        options: [
-          { label: 'Yes', description: 'Allow access to this directory' },
-          { label: 'No', description: 'Deny access' },
-        ],
-        onSubmit: answer => {
-          state.activeInlineQuestion = undefined;
-          state.harness.respondToQuestion({ questionId, answer });
-          resolve();
+    const activate = () => {
+      const questionComponent = new AskQuestionInlineComponent(
+        {
+          question: `Grant sandbox access to "${requestedPath}"?\n${theme.fg('dim', `Reason: ${reason}`)}`,
+          options: [
+            { label: 'Yes', description: 'Allow access to this directory' },
+            { label: 'No', description: 'Deny access' },
+          ],
+          onSubmit: answer => {
+            state.activeInlineQuestion = undefined;
+            state.harness.respondToQuestion({ questionId, answer });
+            resolve();
+            processNextInlineQuestion(state);
+          },
+          onCancel: () => {
+            state.activeInlineQuestion = undefined;
+            state.harness.respondToQuestion({ questionId, answer: 'No' });
+            resolve();
+            processNextInlineQuestion(state);
+          },
+          formatResult: answer => {
+            const approved = answer.toLowerCase().startsWith('y');
+            return approved ? `Granted access to ${requestedPath}` : `Denied access to ${requestedPath}`;
+          },
+          isNegativeAnswer: answer => !answer.toLowerCase().startsWith('y'),
         },
-        onCancel: () => {
-          state.activeInlineQuestion = undefined;
-          state.harness.respondToQuestion({ questionId, answer: 'No' });
-          resolve();
-        },
-        formatResult: answer => {
-          const approved = answer.toLowerCase().startsWith('y');
-          return approved ? `Granted access to ${requestedPath}` : `Denied access to ${requestedPath}`;
-        },
-        isNegativeAnswer: answer => !answer.toLowerCase().startsWith('y'),
-      },
-      state.ui,
-    );
+        state.ui,
+      );
 
-    // Store as active question so input routing works
-    state.activeInlineQuestion = questionComponent;
+      // Store as active question so input routing works
+      state.activeInlineQuestion = questionComponent;
 
-    // Add to chat
-    state.chatContainer.addChild(new Spacer(1));
-    state.chatContainer.addChild(questionComponent);
-    state.chatContainer.addChild(new Spacer(1));
-    questionComponent.focused = true;
-    state.ui.requestRender();
-    state.chatContainer.invalidate();
+      // Add to chat
+      state.chatContainer.addChild(new Spacer(1));
+      state.chatContainer.addChild(questionComponent);
+      state.chatContainer.addChild(new Spacer(1));
+      questionComponent.focused = true;
+      state.ui.requestRender();
+      state.chatContainer.invalidate();
+    };
+
+    // If another inline question is already active, queue this one
+    if (state.activeInlineQuestion) {
+      state.pendingInlineQuestions.push(activate);
+    } else {
+      activate();
+    }
 
     ctx.notify('sandbox_access', `Sandbox access requested: ${requestedPath}`);
   });

--- a/mastracode/src/tui/handlers/prompts.ts
+++ b/mastracode/src/tui/handlers/prompts.ts
@@ -40,6 +40,10 @@ export async function handleAskQuestion(
   const { state } = ctx;
   return new Promise(resolve => {
     if (state.options.inlineQuestions) {
+      // Capture the current ask_user component reference now, before it can be
+      // overwritten by a subsequent parallel tool call.
+      const askUserComponent = state.lastAskUserComponent;
+
       const activate = () => {
         // Inline mode: Add question component to chat
         const questionComponent = new AskQuestionInlineComponent(
@@ -66,10 +70,10 @@ export async function handleAskQuestion(
         state.activeInlineQuestion = questionComponent;
 
         // Insert the question right after the ask_user tool component
-        if (state.lastAskUserComponent) {
+        if (askUserComponent) {
           // Find the position of the ask_user component
           const children = [...state.chatContainer.children];
-          const askUserIndex = children.indexOf(state.lastAskUserComponent as any);
+          const askUserIndex = children.indexOf(askUserComponent as any);
 
           if (askUserIndex >= 0) {
             // Clear and rebuild with question in the right place

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -353,6 +353,9 @@ export function setupKeyHandlers(
     if (state.pendingApprovalDismiss) {
       state.pendingApprovalDismiss();
     }
+    state.activeInlinePlanApproval = undefined;
+    state.activeInlineQuestion = undefined;
+    state.pendingInlineQuestions.length = 0;
     state.userInitiatedAbort = true;
     state.harness.abort();
   });

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -45,12 +45,14 @@ export function setupKeyboardShortcuts(
       state.pendingApprovalDismiss();
       state.activeInlinePlanApproval = undefined;
       state.activeInlineQuestion = undefined;
+      state.pendingInlineQuestions.length = 0;
       state.userInitiatedAbort = true;
       state.harness.abort();
     } else if (state.harness.isRunning()) {
       // Clean up active inline components on abort
       state.activeInlinePlanApproval = undefined;
       state.activeInlineQuestion = undefined;
+      state.pendingInlineQuestions.length = 0;
       state.userInitiatedAbort = true;
       state.harness.abort();
     } else {

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -122,6 +122,8 @@ export interface TUIState {
   /** Saved editor text for Ctrl+Z undo */
   lastClearedText: string;
   activeInlineQuestion?: AskQuestionInlineComponent;
+  /** Queue of pending inline questions waiting to be shown (when one is already active) */
+  pendingInlineQuestions: Array<() => void>;
   activeInlinePlanApproval?: PlanApprovalInlineComponent;
   activeOnboarding?: OnboardingInlineComponent;
   lastSubmitPlanComponent?: IToolExecutionComponent;
@@ -214,6 +216,7 @@ export function createTUIState(options: MastraTUIOptions): TUIState {
 
     // Inline interaction
     lastClearedText: '',
+    pendingInlineQuestions: [],
     followUpComponents: [],
     pendingSlashCommands: [],
     pendingApprovalDismiss: null,


### PR DESCRIPTION
## Description

When the agent fires multiple `ask_user` or `request_sandbox_access` tool calls in parallel, the second inline question component overwrites the first in `state.activeInlineQuestion`. This breaks input routing for the first question and corrupts the TUI — the first question renders but is unresponsive, and answering the second one aborts the first.

This PR adds a `pendingInlineQuestions` queue so only one inline question is shown at a time. When the active question is answered or cancelled, the next queued question is activated. The queue is cleared on Ctrl+C abort.

Fixes #13642 
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive prompts (ask user / sandbox requests) are now queued and shown one at a time to avoid input corruption; queued prompts preserve order and insertion position.
  * Pending inline prompts are cleared when an operation is aborted or interrupted to avoid stale in-flight prompts.

* **Tests**
  * Added comprehensive tests validating concurrent prompt queuing, sequential handling, mixed-call sequencing, abort behavior, and correct response payloads.

* **Changelog**
  * Added a patch-level changelog entry describing the prompt-queueing fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->