### PR TITLE
fix(workspace): explicitly set stdio to pipe for detached spawn

### DIFF
--- a/.changeset/blue-symbols-unite.md
+++ b/.changeset/blue-symbols-unite.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed sandbox command execution crashing the parent process on some Node.js versions by explicitly setting stdio to pipe for detached child processes.

--- a/packages/core/src/workspace/sandbox/local-process-manager.ts
+++ b/packages/core/src/workspace/sandbox/local-process-manager.ts
@@ -149,6 +149,10 @@ export class LocalProcessManager extends SandboxProcessManager<LocalSandbox> {
       env,
       shell: this.sandbox.isolation === 'none',
       detached: true,
+      // Explicit 'pipe' prevents detached processes from inheriting parent
+      // stdio, which can cause the parent process to exit when the child
+      // closes its streams (observed on some Node.js versions).
+      stdio: 'pipe',
     });
     const handle = new LocalProcessHandle(proc, Date.now(), options);
     this._tracked.set(handle.pid, handle);

--- a/packages/core/src/workspace/sandbox/local-process-manager.ts
+++ b/packages/core/src/workspace/sandbox/local-process-manager.ts
@@ -149,9 +149,6 @@ export class LocalProcessManager extends SandboxProcessManager<LocalSandbox> {
       env,
       shell: this.sandbox.isolation === 'none',
       detached: true,
-      // Explicit 'pipe' prevents detached processes from inheriting parent
-      // stdio, which can cause the parent process to exit when the child
-      // closes its streams (observed on some Node.js versions).
       stdio: 'pipe',
     });
     const handle = new LocalProcessHandle(proc, Date.now(), options);


### PR DESCRIPTION
## Summary
- Detached child processes can inherit parent stdio on some Node.js versions, causing the parent process to exit when the child closes its streams
- Explicitly sets `stdio: 'pipe'` on `childProcess.spawn` to prevent this
- Observed on Node.js v22.21.1, not on v22.18.0

## Test plan
- [x] All 203 sandbox tests pass
- [x] All 23 execute-command tests pass
- [x] Tyler confirmed `stdio: 'pipe'` fixes the crash on his end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sandbox command execution crashing the parent process on certain Node.js versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->