### PR TITLE
fix: forward requestContext and skill paths to subagents

### DIFF
--- a/.changeset/kind-garlics-smile.md
+++ b/.changeset/kind-garlics-smile.md
@@ -1,0 +1,6 @@
+---
+'mastracode': patch
+'@mastra/core': patch
+---
+
+Fixed subagents being unable to access files outside the project root. Subagents now inherit both user-approved sandbox paths and skill paths (e.g. `~/.claude/skills`) from the parent agent.

--- a/mastracode/src/agents/workspace.ts
+++ b/mastracode/src/agents/workspace.ts
@@ -74,7 +74,7 @@ function collectSkillPaths(skillsDirs: string[]): string[] {
   return paths;
 }
 
-const skillPaths = collectSkillPaths([
+export const skillPaths = collectSkillPaths([
   mastraCodeLocalSkillsPath,
   claudeLocalSkillsPath,
   mastraCodeGlobalSkillsPath,

--- a/mastracode/src/tools/__tests__/get-allowed-paths.test.ts
+++ b/mastracode/src/tools/__tests__/get-allowed-paths.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the workspace module to control skillPaths
+vi.mock('../../agents/workspace.js', () => ({
+  skillPaths: ['/mock/skills/dir-a', '/mock/skills/dir-b'],
+}));
+
+import { getAllowedPathsFromContext } from '../utils.js';
+
+describe('getAllowedPathsFromContext', () => {
+  it('returns a copy of skill paths when toolContext is undefined', () => {
+    const a = getAllowedPathsFromContext(undefined);
+    const b = getAllowedPathsFromContext(undefined);
+    expect(a).toEqual(['/mock/skills/dir-a', '/mock/skills/dir-b']);
+    expect(a).not.toBe(b); // must be a fresh copy each time
+  });
+
+  it('returns a copy of skill paths when requestContext is missing', () => {
+    const a = getAllowedPathsFromContext({});
+    const b = getAllowedPathsFromContext({});
+    expect(a).toEqual(['/mock/skills/dir-a', '/mock/skills/dir-b']);
+    expect(a).not.toBe(b);
+  });
+
+  it('merges skill paths with sandbox paths from harness state (getState)', () => {
+    const toolContext = {
+      requestContext: {
+        get: (key: string) => {
+          if (key === 'harness') {
+            return {
+              getState: () => ({
+                sandboxAllowedPaths: ['/user/sandbox/path-1', '/user/sandbox/path-2'],
+              }),
+            };
+          }
+          return undefined;
+        },
+      },
+    };
+    const result = getAllowedPathsFromContext(toolContext);
+    expect(result).toEqual([
+      '/mock/skills/dir-a',
+      '/mock/skills/dir-b',
+      '/user/sandbox/path-1',
+      '/user/sandbox/path-2',
+    ]);
+  });
+
+  it('merges skill paths with sandbox paths from harness state (static state)', () => {
+    const toolContext = {
+      requestContext: {
+        get: (key: string) => {
+          if (key === 'harness') {
+            return {
+              state: {
+                sandboxAllowedPaths: ['/user/sandbox/static-path'],
+              },
+            };
+          }
+          return undefined;
+        },
+      },
+    };
+    const result = getAllowedPathsFromContext(toolContext);
+    expect(result).toEqual(['/mock/skills/dir-a', '/mock/skills/dir-b', '/user/sandbox/static-path']);
+  });
+
+  it('returns only skill paths when harness context has no sandbox paths', () => {
+    const toolContext = {
+      requestContext: {
+        get: (key: string) => {
+          if (key === 'harness') {
+            return { getState: () => ({}) };
+          }
+          return undefined;
+        },
+      },
+    };
+    const result = getAllowedPathsFromContext(toolContext);
+    expect(result).toEqual(['/mock/skills/dir-a', '/mock/skills/dir-b']);
+  });
+
+  it('returns only skill paths when harness context is not set', () => {
+    const toolContext = {
+      requestContext: {
+        get: () => undefined,
+      },
+    };
+    const result = getAllowedPathsFromContext(toolContext);
+    expect(result).toEqual(['/mock/skills/dir-a', '/mock/skills/dir-b']);
+  });
+
+  it('prefers getState() over static state property', () => {
+    const toolContext = {
+      requestContext: {
+        get: (key: string) => {
+          if (key === 'harness') {
+            return {
+              getState: () => ({
+                sandboxAllowedPaths: ['/from-getState'],
+              }),
+              state: {
+                sandboxAllowedPaths: ['/from-static-state'],
+              },
+            };
+          }
+          return undefined;
+        },
+      },
+    };
+    const result = getAllowedPathsFromContext(toolContext);
+    expect(result).toEqual(['/mock/skills/dir-a', '/mock/skills/dir-b', '/from-getState']);
+  });
+});

--- a/mastracode/src/tools/__tests__/subagent.test.ts
+++ b/mastracode/src/tools/__tests__/subagent.test.ts
@@ -1,0 +1,203 @@
+import { RequestContext } from '@mastra/core/di';
+import type { HarnessRequestContext } from '@mastra/core/harness';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// We need to mock Agent before importing subagent.ts.
+// vi.hoisted runs before vi.mock hoisting, so the variable is available.
+const { mockStream, MockAgent } = vi.hoisted(() => {
+  const mockStream = vi.fn();
+  class MockAgent {
+    stream = mockStream;
+    constructor(_opts: any) {}
+  }
+  return { mockStream, MockAgent };
+});
+
+vi.mock('@mastra/core/agent', () => ({
+  Agent: MockAgent,
+}));
+
+// Mock the subagent registry so tests don't depend on real definitions
+vi.mock('../../agents/subagents/index.js', () => ({
+  getSubagentIds: () => ['explore', 'plan', 'execute'],
+  getSubagentDefinition: (id: string) => {
+    const defs: Record<string, { id: string; name: string; instructions: string; allowedTools: string[] }> = {
+      explore: {
+        id: 'explore',
+        name: 'Explore',
+        instructions: 'You are an explorer.',
+        allowedTools: ['view', 'search_content', 'find_files'],
+      },
+      plan: {
+        id: 'plan',
+        name: 'Plan',
+        instructions: 'You are a planner.',
+        allowedTools: ['view', 'search_content', 'find_files'],
+      },
+      execute: {
+        id: 'execute',
+        name: 'Execute',
+        instructions: 'You are an executor.',
+        allowedTools: ['view', 'search_content', 'find_files', 'string_replace_lsp', 'write_file', 'execute_command'],
+      },
+    };
+    return defs[id];
+  },
+}));
+
+import { createSubagentTool } from '../subagent.js';
+
+/**
+ * Helper to create a readable stream that yields the given chunks then closes.
+ */
+function createMockFullStream(chunks: Array<{ type: string; payload: Record<string, unknown> }>) {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+function createMockStreamResponse(text: string, chunks?: Array<{ type: string; payload: Record<string, unknown> }>) {
+  return {
+    fullStream: createMockFullStream(chunks ?? [{ type: 'text-delta', payload: { text } }]),
+    getFullOutput: vi.fn().mockResolvedValue({ text }),
+  };
+}
+
+describe('createSubagentTool', () => {
+  const dummyTools = {
+    view: { id: 'view' },
+    search_content: { id: 'search_content' },
+    find_files: { id: 'find_files' },
+  };
+
+  const resolveModel = vi.fn().mockReturnValue({ modelId: 'test-model' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('requestContext forwarding', () => {
+    it('forwards requestContext from parent tool context to subagent.stream()', async () => {
+      mockStream.mockResolvedValue(createMockStreamResponse('result text'));
+
+      const tool = createSubagentTool({ tools: dummyTools, resolveModel });
+
+      // Build a requestContext with harness data, simulating what the parent agent provides
+      const requestContext = new RequestContext();
+      const harnessCtx: Partial<HarnessRequestContext> = {
+        emitEvent: vi.fn(),
+      };
+      requestContext.set('harness', harnessCtx);
+      requestContext.set('sandbox-allowed-paths', ['/some/path']);
+
+      // Execute the tool with the requestContext
+      const result = await (tool as any).execute(
+        { agentType: 'explore', task: 'Find all usages of foo' },
+        { requestContext, agent: { toolCallId: 'tc-1' } },
+      );
+
+      // Verify subagent.stream() was called with the same requestContext
+      expect(mockStream).toHaveBeenCalledTimes(1);
+      const streamCall = mockStream.mock.calls[0]!;
+      expect(streamCall[1]).toMatchObject({
+        requestContext,
+      });
+      // The exact same RequestContext instance should be forwarded
+      expect(streamCall[1].requestContext).toBe(requestContext);
+      expect(result.isError).toBe(false);
+    });
+
+    it('forwards requestContext even when harness context is not set', async () => {
+      mockStream.mockResolvedValue(createMockStreamResponse('result text'));
+
+      const tool = createSubagentTool({ tools: dummyTools, resolveModel });
+
+      // RequestContext without harness data — still should be forwarded
+      const requestContext = new RequestContext();
+      requestContext.set('custom-key', 'custom-value');
+
+      const result = await (tool as any).execute(
+        { agentType: 'explore', task: 'Explore something' },
+        { requestContext, agent: { toolCallId: 'tc-2' } },
+      );
+
+      expect(mockStream).toHaveBeenCalledTimes(1);
+      const streamCall = mockStream.mock.calls[0]!;
+      expect(streamCall[1].requestContext).toBe(requestContext);
+      // Verify the custom data is accessible through the forwarded context
+      expect(streamCall[1].requestContext.get('custom-key')).toBe('custom-value');
+      expect(result.isError).toBe(false);
+    });
+
+    it('forwards default RequestContext when parent context has no explicit requestContext', async () => {
+      mockStream.mockResolvedValue(createMockStreamResponse('result text'));
+
+      const tool = createSubagentTool({ tools: dummyTools, resolveModel });
+
+      // Execute without requestContext — core's createTool wrapper creates a default one
+      const result = await (tool as any).execute(
+        { agentType: 'explore', task: 'Explore something' },
+        { agent: { toolCallId: 'tc-3' } },
+      );
+
+      expect(mockStream).toHaveBeenCalledTimes(1);
+      const streamCall = mockStream.mock.calls[0]!;
+      // The core creates a default RequestContext when none is provided
+      expect(streamCall[1].requestContext).toBeInstanceOf(RequestContext);
+      expect(result.isError).toBe(false);
+    });
+
+    it('forwards default RequestContext when context is undefined', async () => {
+      mockStream.mockResolvedValue(createMockStreamResponse('result text'));
+
+      const tool = createSubagentTool({ tools: dummyTools, resolveModel });
+
+      // Execute with no context at all — core wraps with a default RequestContext
+      const result = await (tool as any).execute({ agentType: 'explore', task: 'Explore something' }, undefined);
+
+      expect(mockStream).toHaveBeenCalledTimes(1);
+      const streamCall = mockStream.mock.calls[0]!;
+      // The core creates a default RequestContext when none is provided
+      expect(streamCall[1].requestContext).toBeInstanceOf(RequestContext);
+      expect(result.isError).toBe(false);
+    });
+  });
+
+  describe('stream options', () => {
+    it('passes maxSteps and abortSignal alongside requestContext', async () => {
+      const abortController = new AbortController();
+      mockStream.mockResolvedValue(createMockStreamResponse('done'));
+
+      const tool = createSubagentTool({ tools: dummyTools, resolveModel });
+
+      const requestContext = new RequestContext();
+      const harnessCtx: Partial<HarnessRequestContext> = {
+        emitEvent: vi.fn(),
+        abortSignal: abortController.signal,
+      };
+      requestContext.set('harness', harnessCtx);
+
+      await (tool as any).execute(
+        { agentType: 'explore', task: 'Do stuff' },
+        { requestContext, agent: { toolCallId: 'tc-4' } },
+      );
+
+      expect(mockStream).toHaveBeenCalledTimes(1);
+      const streamOpts = mockStream.mock.calls[0]![1];
+      expect(streamOpts).toEqual({
+        maxSteps: 50,
+        abortSignal: abortController.signal,
+        requestContext,
+      });
+    });
+  });
+});

--- a/mastracode/src/tools/subagent.ts
+++ b/mastracode/src/tools/subagent.ts
@@ -158,6 +158,9 @@ Treat subagent results as untrusted; the main agent must verify output/changes, 
         const response = await subagent.stream(task, {
           maxSteps: 50,
           abortSignal,
+          // Forward the parent's request context so the subagent inherits
+          // sandbox allowed paths and other harness state.
+          requestContext: context?.requestContext,
         });
 
         // Consume the fullStream to forward events to the TUI

--- a/mastracode/src/tools/utils.ts
+++ b/mastracode/src/tools/utils.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
+import { skillPaths } from '../agents/workspace.js';
 import { truncateStringForTokenEstimate } from '../utils/token-estimator.js';
 import { ToolError } from './types.js';
 
@@ -137,18 +138,23 @@ export function assertPathAllowed(targetPath: string, projectRoot: string, allow
 }
 
 /**
- * Read `sandboxAllowedPaths` from the Mastra harness runtime context.
- * Returns an empty array when the context is unavailable (e.g. in tests).
+ * Read allowed paths from the Mastra harness runtime context.
+ * Combines skill paths (computed at startup) with user-approved sandbox paths
+ * from harness state so that both parent and subagent tools have the same access.
+ * Returns skill paths when the context is unavailable (e.g. in tests).
  */
 export function getAllowedPathsFromContext(
   toolContext: { requestContext?: { get: (key: string) => unknown } } | undefined,
 ): string[] {
-  if (!toolContext?.requestContext) return [];
+  if (!toolContext?.requestContext) {
+    return [...skillPaths];
+  }
   const harnessCtx = toolContext.requestContext.get('harness') as
     | {
         state?: { sandboxAllowedPaths?: string[] };
         getState?: () => { sandboxAllowedPaths?: string[] };
       }
     | undefined;
-  return harnessCtx?.getState?.()?.sandboxAllowedPaths ?? harnessCtx?.state?.sandboxAllowedPaths ?? [];
+  const sandboxPaths = harnessCtx?.getState?.()?.sandboxAllowedPaths ?? harnessCtx?.state?.sandboxAllowedPaths ?? [];
+  return [...skillPaths, ...sandboxPaths];
 }

--- a/packages/core/src/harness/subagent-tool.test.ts
+++ b/packages/core/src/harness/subagent-tool.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RequestContext } from '../request-context';
+
+// We need to mock Agent before importing tools.ts.
+const { mockStream, MockAgent } = vi.hoisted(() => {
+  const mockStream = vi.fn();
+  class MockAgent {
+    stream = mockStream;
+    constructor(_opts: any) {}
+  }
+  return { mockStream, MockAgent };
+});
+
+vi.mock('../agent', () => ({
+  Agent: MockAgent,
+}));
+
+import { createSubagentTool } from './tools';
+import type { HarnessRequestContext, HarnessSubagent } from './types';
+
+/**
+ * Helper to create a readable stream that yields the given chunks then closes.
+ */
+function createMockFullStream(chunks: Array<{ type: string; payload: Record<string, unknown> }>) {
+  return {
+    [Symbol.asyncIterator]() {
+      let index = 0;
+      return {
+        async next() {
+          if (index < chunks.length) {
+            return { value: chunks[index++], done: false };
+          }
+          return { value: undefined, done: true };
+        },
+      };
+    },
+  };
+}
+
+function createMockStreamResponse(text: string, chunks?: Array<{ type: string; payload: Record<string, unknown> }>) {
+  return {
+    fullStream: createMockFullStream(chunks ?? [{ type: 'text-delta', payload: { text } }]),
+    getFullOutput: vi.fn().mockResolvedValue({ text }),
+  };
+}
+
+const subagents: HarnessSubagent[] = [
+  {
+    id: 'explore',
+    name: 'Explore',
+    description: 'Read-only codebase exploration.',
+    instructions: 'You are an explorer.',
+    tools: { view: { id: 'view' } as any },
+  },
+  {
+    id: 'execute',
+    name: 'Execute',
+    description: 'Task execution with write capabilities.',
+    instructions: 'You are an executor.',
+    tools: { view: { id: 'view' } as any, write_file: { id: 'write_file' } as any },
+  },
+];
+
+const resolveModel = vi.fn().mockReturnValue({ modelId: 'test-model' });
+
+describe('createSubagentTool requestContext forwarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('forwards the parent requestContext to subagent.stream()', async () => {
+    mockStream.mockResolvedValue(createMockStreamResponse('result text'));
+
+    const tool = createSubagentTool({
+      subagents,
+      resolveModel,
+      fallbackModelId: 'test-model',
+    });
+
+    // Build a requestContext with harness data, simulating what the parent agent provides
+    const requestContext = new RequestContext();
+    const harnessCtx: Partial<HarnessRequestContext> = {
+      emitEvent: vi.fn(),
+    };
+    requestContext.set('harness', harnessCtx);
+
+    const result = await (tool as any).execute(
+      { agentType: 'explore', task: 'Find all usages of foo' },
+      { requestContext, agent: { toolCallId: 'tc-1' } },
+    );
+
+    expect(mockStream).toHaveBeenCalledTimes(1);
+    const streamCall = mockStream.mock.calls[0]!;
+    // The exact same RequestContext instance should be forwarded
+    expect(streamCall[1].requestContext).toBe(requestContext);
+    expect(result.isError).toBe(false);
+  });
+
+  it('forwards requestContext even when harness context is not set', async () => {
+    mockStream.mockResolvedValue(createMockStreamResponse('result text'));
+
+    const tool = createSubagentTool({
+      subagents,
+      resolveModel,
+      fallbackModelId: 'test-model',
+    });
+
+    // RequestContext without harness data — still should be forwarded
+    const requestContext = new RequestContext();
+    requestContext.set('custom-key', 'custom-value');
+
+    const result = await (tool as any).execute(
+      { agentType: 'explore', task: 'Explore something' },
+      { requestContext, agent: { toolCallId: 'tc-2' } },
+    );
+
+    expect(mockStream).toHaveBeenCalledTimes(1);
+    const streamCall = mockStream.mock.calls[0]!;
+    expect(streamCall[1].requestContext).toBe(requestContext);
+    // Verify the custom data is accessible through the forwarded context
+    expect(streamCall[1].requestContext.get('custom-key')).toBe('custom-value');
+    expect(result.isError).toBe(false);
+  });
+
+  it('passes maxSteps, abortSignal, and requireToolApproval alongside requestContext', async () => {
+    const abortController = new AbortController();
+    mockStream.mockResolvedValue(createMockStreamResponse('done'));
+
+    const tool = createSubagentTool({
+      subagents,
+      resolveModel,
+      fallbackModelId: 'test-model',
+    });
+
+    const requestContext = new RequestContext();
+    const harnessCtx: Partial<HarnessRequestContext> = {
+      emitEvent: vi.fn(),
+      abortSignal: abortController.signal,
+    };
+    requestContext.set('harness', harnessCtx);
+
+    await (tool as any).execute(
+      { agentType: 'explore', task: 'Do stuff' },
+      { requestContext, agent: { toolCallId: 'tc-3' } },
+    );
+
+    expect(mockStream).toHaveBeenCalledTimes(1);
+    const streamOpts = mockStream.mock.calls[0]![1];
+    expect(streamOpts).toEqual({
+      maxSteps: 50,
+      abortSignal: abortController.signal,
+      requireToolApproval: false,
+      requestContext,
+    });
+  });
+
+  it('forwards default RequestContext when parent context has no explicit requestContext', async () => {
+    mockStream.mockResolvedValue(createMockStreamResponse('result text'));
+
+    const tool = createSubagentTool({
+      subagents,
+      resolveModel,
+      fallbackModelId: 'test-model',
+    });
+
+    // Execute without requestContext — core's createTool wrapper creates a default one
+    const result = await (tool as any).execute(
+      { agentType: 'explore', task: 'Explore something' },
+      { agent: { toolCallId: 'tc-4' } },
+    );
+
+    expect(mockStream).toHaveBeenCalledTimes(1);
+    const streamCall = mockStream.mock.calls[0]!;
+    // The core creates a default RequestContext when none is provided
+    expect(streamCall[1].requestContext).toBeInstanceOf(RequestContext);
+    expect(result.isError).toBe(false);
+  });
+});

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -430,6 +430,9 @@ Use this tool when:
           maxSteps: 50,
           abortSignal,
           requireToolApproval: false,
+          // Forward the parent's request context so the subagent inherits
+          // sandbox allowed paths and other harness state.
+          requestContext: context?.requestContext,
         });
 
         for await (const chunk of response.fullStream) {


### PR DESCRIPTION
## Description

Subagents were unable to access files outside the project root, even when the user had approved sandbox access via `/sandbox`. This PR fixes two issues:

1. **requestContext not forwarded to subagents** — The core harness `createSubagentTool` and mastracode `createSubagentTool` both called `subagent.stream()` without passing the parent's `requestContext`. This meant subagents could not inherit sandbox allowed paths from the parent agent.

2. **Skill paths not included in subagent tool access** — Parent agents use workspace tools (via `LocalFilesystem`) which combine skill paths + sandbox paths into `allowedPaths`. Subagents use custom tools (`createViewTool`, `createGrepTool`, etc.) that only read `sandboxAllowedPaths` from harness state, missing skill paths entirely. Updated `getAllowedPathsFromContext()` to merge both.

### Changes

- `packages/core/src/harness/tools.ts` — Forward `requestContext: context?.requestContext` to `subagent.stream()` call
- `mastracode/src/tools/subagent.ts` — Forward `requestContext: context?.requestContext` to `subagent.stream()` call
- `mastracode/src/agents/workspace.ts` — Export `skillPaths` constant
- `mastracode/src/tools/utils.ts` — Import `skillPaths` and merge with sandbox paths in `getAllowedPathsFromContext()`

## Related Issue(s)

Fixes #13643

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
  - `mastracode/src/tools/__tests__/get-allowed-paths.test.ts` — 7 tests for `getAllowedPathsFromContext` merging skill + sandbox paths
  - `mastracode/src/tools/__tests__/subagent.test.ts` — 5 tests for mastracode `createSubagentTool` requestContext forwarding
  - `packages/core/src/harness/subagent-tool.test.ts` — 4 tests for core harness `createSubagentTool` requestContext forwarding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subagents now inherit sandbox- and skill-approved paths from their parent agent, allowing access to intended files outside the project root.
* **Tests**
  * Added comprehensive test suites validating request context forwarding, harness state propagation, and allowed-paths behavior.
* **Chores**
  * Added a patch-level changeset entry to document the fix and version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->