### PR TITLE
chore(harness): Update instructions type to be dynamic

### DIFF
--- a/.changeset/strong-ghosts-wink.md
+++ b/.changeset/strong-ghosts-wink.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+chore(harness): Update harness sub-agent instructions type to be dynamic

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -1,7 +1,7 @@
 import type { z } from 'zod';
 
 import type { Agent } from '../agent';
-import type { ToolsInput } from '../agent/types';
+import type { AgentInstructions, ToolsInput } from '../agent/types';
 import type { MastraLanguageModel } from '../llm/model/shared.types';
 import type { LoopOptions } from '../loop/types';
 import type { MastraMemory } from '../memory/memory';
@@ -82,8 +82,11 @@ export interface HarnessSubagent {
   /** Description of what this subagent does (used in auto-generated tool description) */
   description: string;
 
-  /** System prompt for this subagent */
-  instructions: string;
+  /**
+   * Instructions that guide the agent's behavior. Can be a string, array of strings, system message object,
+   * array of system messages, or a function that returns any of these types dynamically.
+   */
+  instructions: DynamicArgument<AgentInstructions>;
 
   /** Tools this subagent has direct access to */
   tools?: ToolsInput;


### PR DESCRIPTION
## Description

Nice and simple, matching the agents instruction type with the harness configs type.

We're already directly passing the instruction to the sub-agent so no actual code outside of types needs to change.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subagent instructions now accept multiple formats — single strings, arrays of strings, message objects, or callables returning those — enabling more flexible and dynamic configuration.
* **Chores**
  * Internal update to support the new dynamic instruction handling for harness sub-agents (patch-level change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->