### PR TITLE
fix: propagate tool lifecycle hooks through createTool pipeline

### DIFF
--- a/.changeset/fix-tool-lifecycle-hooks.md
+++ b/.changeset/fix-tool-lifecycle-hooks.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': patch
+---
+
+Fix tool lifecycle hooks (onInputStart, onInputDelta, onInputAvailable, onOutput) not firing during agent execution
+
+Tool lifecycle hooks defined in `createTool()` were silently dropped at two points in the propagation chain:
+1. The `Tool` constructor didn't assign hook properties from the options object
+2. `CoreToolBuilder.build()` didn't transfer hooks to the returned `CoreTool`
+
+Both breaks are now fixed, and hooks flow through the full `createTool → Tool → CoreToolBuilder → CoreTool` pipeline.

--- a/.changeset/fix-tool-lifecycle-hooks.md
+++ b/.changeset/fix-tool-lifecycle-hooks.md
@@ -2,10 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fix tool lifecycle hooks (onInputStart, onInputDelta, onInputAvailable, onOutput) not firing during agent execution
-
-Tool lifecycle hooks defined in `createTool()` were silently dropped at two points in the propagation chain:
-1. The `Tool` constructor didn't assign hook properties from the options object
-2. `CoreToolBuilder.build()` didn't transfer hooks to the returned `CoreTool`
-
-Both breaks are now fixed, and hooks flow through the full `createTool → Tool → CoreToolBuilder → CoreTool` pipeline.
+Tool lifecycle hooks (`onInputStart`, `onInputDelta`, `onInputAvailable`, `onOutput`) now fire correctly during agent execution for tools created via `createTool()`. Previously these hooks were silently ignored. Affected: `createTool`, `Tool`, `CoreToolBuilder.build`, `CoreTool`.

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -665,6 +665,10 @@ export class CoreToolBuilder extends MastraBase {
       providerOptions: 'providerOptions' in this.originalTool ? this.originalTool.providerOptions : undefined,
       mcp: 'mcp' in this.originalTool ? this.originalTool.mcp : undefined,
       toModelOutput: 'toModelOutput' in this.originalTool ? this.originalTool.toModelOutput : undefined,
+      onInputStart: 'onInputStart' in this.originalTool ? this.originalTool.onInputStart : undefined,
+      onInputDelta: 'onInputDelta' in this.originalTool ? this.originalTool.onInputDelta : undefined,
+      onInputAvailable: 'onInputAvailable' in this.originalTool ? this.originalTool.onInputAvailable : undefined,
+      onOutput: 'onOutput' in this.originalTool ? this.originalTool.onOutput : undefined,
     } as unknown as CoreTool;
   }
 }

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -163,6 +163,43 @@ export class Tool<
    */
   mcp?: MCPToolProperties;
 
+  onInputStart?: ToolAction<
+    TSchemaIn,
+    TSchemaOut,
+    TSuspendSchema,
+    TResumeSchema,
+    TContext,
+    TId,
+    TRequestContext
+  >['onInputStart'];
+  onInputDelta?: ToolAction<
+    TSchemaIn,
+    TSchemaOut,
+    TSuspendSchema,
+    TResumeSchema,
+    TContext,
+    TId,
+    TRequestContext
+  >['onInputDelta'];
+  onInputAvailable?: ToolAction<
+    TSchemaIn,
+    TSchemaOut,
+    TSuspendSchema,
+    TResumeSchema,
+    TContext,
+    TId,
+    TRequestContext
+  >['onInputAvailable'];
+  onOutput?: ToolAction<
+    TSchemaIn,
+    TSchemaOut,
+    TSuspendSchema,
+    TResumeSchema,
+    TContext,
+    TId,
+    TRequestContext
+  >['onOutput'];
+
   /**
    * Creates a new Tool instance with input validation wrapper.
    *
@@ -191,6 +228,10 @@ export class Tool<
     this.providerOptions = opts.providerOptions;
     this.toModelOutput = opts.toModelOutput;
     this.mcp = opts.mcp;
+    this.onInputStart = opts.onInputStart;
+    this.onInputDelta = opts.onInputDelta;
+    this.onInputAvailable = opts.onInputAvailable;
+    this.onOutput = opts.onOutput;
 
     // Tools receive two parameters:
     // 1. input - The raw, validated input data

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -207,6 +207,12 @@ export type CoreTool = {
    * Passed through from the original tool definition.
    */
   toModelOutput?: (output: unknown) => unknown;
+  onInputStart?: (options: ToolCallOptions) => void | PromiseLike<void>;
+  onInputDelta?: (options: { inputTextDelta: string } & ToolCallOptions) => void | PromiseLike<void>;
+  onInputAvailable?: (options: { input: any } & ToolCallOptions) => void | PromiseLike<void>;
+  onOutput?: (
+    options: { output: any; toolName: string } & Omit<ToolCallOptions, 'messages'>,
+  ) => void | PromiseLike<void>;
 } & (
   | {
       type?: 'function' | undefined;
@@ -245,6 +251,12 @@ export type InternalCoreTool = {
    * Passed through from the original tool definition.
    */
   toModelOutput?: (output: unknown) => unknown;
+  onInputStart?: (options: ToolCallOptions) => void | PromiseLike<void>;
+  onInputDelta?: (options: { inputTextDelta: string } & ToolCallOptions) => void | PromiseLike<void>;
+  onInputAvailable?: (options: { input: any } & ToolCallOptions) => void | PromiseLike<void>;
+  onOutput?: (
+    options: { output: any; toolName: string } & Omit<ToolCallOptions, 'messages'>,
+  ) => void | PromiseLike<void>;
 } & (
   | {
       type?: 'function' | undefined;

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -257,7 +257,7 @@ describe('makeCoreTool', () => {
     expect(coreTool.execute).toBeUndefined();
   });
 
-  it('should preserve lifecycle hooks through createTool → makeCoreTool pipeline', async () => {
+  it('should preserve lifecycle hooks through createTool → makeCoreTool pipeline', () => {
     const onInputStart = vi.fn();
     const onInputDelta = vi.fn();
     const onInputAvailable = vi.fn();
@@ -274,19 +274,21 @@ describe('makeCoreTool', () => {
       onOutput,
     });
 
-    const coreTool = makeCoreTool(tool, mockOptions);
+    // Break 1 fix: Tool instance preserves hooks from createTool options
+    expect(tool.onInputStart).toBe(onInputStart);
+    expect(tool.onInputDelta).toBe(onInputDelta);
+    expect(tool.onInputAvailable).toBe(onInputAvailable);
+    expect(tool.onOutput).toBe(onOutput);
 
-    expect('onInputStart' in coreTool).toBe(true);
-    expect('onInputDelta' in coreTool).toBe(true);
-    expect('onInputAvailable' in coreTool).toBe(true);
-    expect('onOutput' in coreTool).toBe(true);
+    // Break 2 fix: CoreToolBuilder.build() transfers hooks to CoreTool
+    const coreTool = makeCoreTool(tool, mockOptions);
     expect((coreTool as any).onInputStart).toBe(onInputStart);
     expect((coreTool as any).onInputDelta).toBe(onInputDelta);
     expect((coreTool as any).onInputAvailable).toBe(onInputAvailable);
     expect((coreTool as any).onOutput).toBe(onOutput);
   });
 
-  it('should work correctly for tools without lifecycle hooks', async () => {
+  it('should not add hook properties when tool has no hooks', () => {
     const tool = createTool({
       id: 'no-hooks',
       description: 'Tool without hooks',
@@ -296,38 +298,10 @@ describe('makeCoreTool', () => {
 
     const coreTool = makeCoreTool(tool, mockOptions);
 
-    expect(coreTool.description).toBe('Tool without hooks');
-    expect(typeof coreTool.execute).toBe('function');
     expect((coreTool as any).onInputStart).toBeUndefined();
     expect((coreTool as any).onInputDelta).toBeUndefined();
     expect((coreTool as any).onInputAvailable).toBeUndefined();
     expect((coreTool as any).onOutput).toBeUndefined();
-
-    const result = await coreTool.execute?.({ name: 'test' }, { toolCallId: 'test-id', messages: [] });
-    expect(result).toEqual({ ok: true });
-  });
-
-  it('should preserve lifecycle hooks on Tool instance from createTool', () => {
-    const onInputStart = vi.fn();
-    const onInputDelta = vi.fn();
-    const onInputAvailable = vi.fn();
-    const onOutput = vi.fn();
-
-    const tool = createTool({
-      id: 'instance-hooks',
-      description: 'Tool instance with hooks',
-      inputSchema: z.object({ value: z.number() }),
-      execute: async () => ({ done: true }),
-      onInputStart,
-      onInputDelta,
-      onInputAvailable,
-      onOutput,
-    });
-
-    expect(tool.onInputStart).toBe(onInputStart);
-    expect(tool.onInputDelta).toBe(onInputDelta);
-    expect(tool.onInputAvailable).toBe(onInputAvailable);
-    expect(tool.onOutput).toBe(onOutput);
   });
 
   it('should have default parameters if no parameters are provided for Vercel tool', () => {

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -257,6 +257,79 @@ describe('makeCoreTool', () => {
     expect(coreTool.execute).toBeUndefined();
   });
 
+  it('should preserve lifecycle hooks through createTool → makeCoreTool pipeline', async () => {
+    const onInputStart = vi.fn();
+    const onInputDelta = vi.fn();
+    const onInputAvailable = vi.fn();
+    const onOutput = vi.fn();
+
+    const tool = createTool({
+      id: 'hook-test',
+      description: 'Tool with hooks',
+      inputSchema: z.object({ name: z.string() }),
+      execute: async () => ({ ok: true }),
+      onInputStart,
+      onInputDelta,
+      onInputAvailable,
+      onOutput,
+    });
+
+    const coreTool = makeCoreTool(tool, mockOptions);
+
+    expect('onInputStart' in coreTool).toBe(true);
+    expect('onInputDelta' in coreTool).toBe(true);
+    expect('onInputAvailable' in coreTool).toBe(true);
+    expect('onOutput' in coreTool).toBe(true);
+    expect((coreTool as any).onInputStart).toBe(onInputStart);
+    expect((coreTool as any).onInputDelta).toBe(onInputDelta);
+    expect((coreTool as any).onInputAvailable).toBe(onInputAvailable);
+    expect((coreTool as any).onOutput).toBe(onOutput);
+  });
+
+  it('should work correctly for tools without lifecycle hooks', async () => {
+    const tool = createTool({
+      id: 'no-hooks',
+      description: 'Tool without hooks',
+      inputSchema: z.object({ name: z.string() }),
+      execute: async () => ({ ok: true }),
+    });
+
+    const coreTool = makeCoreTool(tool, mockOptions);
+
+    expect(coreTool.description).toBe('Tool without hooks');
+    expect(typeof coreTool.execute).toBe('function');
+    expect((coreTool as any).onInputStart).toBeUndefined();
+    expect((coreTool as any).onInputDelta).toBeUndefined();
+    expect((coreTool as any).onInputAvailable).toBeUndefined();
+    expect((coreTool as any).onOutput).toBeUndefined();
+
+    const result = await coreTool.execute?.({ name: 'test' }, { toolCallId: 'test-id', messages: [] });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('should preserve lifecycle hooks on Tool instance from createTool', () => {
+    const onInputStart = vi.fn();
+    const onInputDelta = vi.fn();
+    const onInputAvailable = vi.fn();
+    const onOutput = vi.fn();
+
+    const tool = createTool({
+      id: 'instance-hooks',
+      description: 'Tool instance with hooks',
+      inputSchema: z.object({ value: z.number() }),
+      execute: async () => ({ done: true }),
+      onInputStart,
+      onInputDelta,
+      onInputAvailable,
+      onOutput,
+    });
+
+    expect(tool.onInputStart).toBe(onInputStart);
+    expect(tool.onInputDelta).toBe(onInputDelta);
+    expect(tool.onInputAvailable).toBe(onInputAvailable);
+    expect(tool.onOutput).toBe(onOutput);
+  });
+
   it('should have default parameters if no parameters are provided for Vercel tool', () => {
     const coreTool = makeCoreTool(
       {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Tool lifecycle hooks (`onInputStart`, `onInputDelta`, `onInputAvailable`, `onOutput`) defined in `createTool()` were silently dropped and never fired during agent execution. Two breaks
in the propagation chain:

1. The `Tool` constructor assigned 12 properties but not the 4 hooks
2. `CoreToolBuilder.build()` didn't transfer hooks to the returned `CoreTool`

This patch adds the missing property declarations, constructor assignments, builder transfers, and type definitions so hooks flow through the full `createTool → Tool → CoreToolBuilder →
CoreTool` pipeline. The execution layer already correctly checks for and calls hooks — no changes needed there.

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #13665

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool lifecycle hooks (onInputStart, onInputDelta, onInputAvailable, onOutput) now propagate correctly through the tool creation pipeline and fire during agent execution, restoring expected observable behavior and enabling reliable monitoring of tool input/output events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->