### PR TITLE
feat(cli): Add clipboard image and text paste support via Ctrl+V

### DIFF
--- a/.changeset/hungry-times-admire.md
+++ b/.changeset/hungry-times-admire.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Added Ctrl+V clipboard paste support for both images and text. Images from the clipboard are detected and sent to the AI agent. Text pastes flow through the editor's paste handling, which condenses large pastes (>10 lines) into a compact `[paste #N +X lines]` marker instead of dumping raw content.

--- a/mastracode/src/clipboard/index.ts
+++ b/mastracode/src/clipboard/index.ts
@@ -16,6 +16,44 @@ export interface ClipboardImage {
 }
 
 /**
+ * Read plain text from the system clipboard.
+ * Returns null if clipboard is empty or reading fails.
+ */
+export function getClipboardText(): string | null {
+  try {
+    if (process.platform === 'darwin') {
+      const text = execSync('pbpaste', {
+        encoding: 'utf-8',
+        timeout: 3000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      return text.length > 0 ? text : null;
+    }
+    if (process.platform === 'linux') {
+      // Try xclip first, then wl-paste
+      try {
+        const text = execSync('xclip -selection clipboard -o', {
+          encoding: 'utf-8',
+          timeout: 3000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        return text.length > 0 ? text : null;
+      } catch {
+        const text = execSync('wl-paste', {
+          encoding: 'utf-8',
+          timeout: 3000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        return text.length > 0 ? text : null;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Check the system clipboard for image data and return it as base64.
  * Returns null if no image data is found or extraction fails.
  */

--- a/mastracode/src/tui/components/custom-editor.ts
+++ b/mastracode/src/tui/components/custom-editor.ts
@@ -4,7 +4,7 @@
 
 import { Editor, matchesKey } from '@mariozechner/pi-tui';
 import type { EditorTheme, TUI } from '@mariozechner/pi-tui';
-import { getClipboardImage } from '../../clipboard/index.js';
+import { getClipboardImage, getClipboardText } from '../../clipboard/index.js';
 import type { ClipboardImage } from '../../clipboard/index.js';
 
 const PASTE_START = '\x1b[200~';
@@ -74,6 +74,28 @@ export class CustomEditor extends Editor {
         }
         return;
       }
+    }
+
+    // Ctrl+V - explicit paste (handles image-only clipboard where terminals
+    // don't generate a bracketed paste event, and text clipboard)
+    if (matchesKey(data, 'ctrl+v')) {
+      // Check for image first
+      if (this.onImagePaste) {
+        const clipboardImage = getClipboardImage();
+        if (clipboardImage) {
+          this.onImagePaste(clipboardImage);
+          return;
+        }
+      }
+      // No image — read text and synthesize a bracketed paste so the parent
+      // Editor.handlePaste() logic kicks in (large paste condensation, etc.)
+      const clipboardText = getClipboardText();
+      if (clipboardText) {
+        const syntheticPaste = `${PASTE_START}${clipboardText}${PASTE_END}`;
+        super.handleInput(syntheticPaste);
+        return;
+      }
+      return;
     }
 
     // Ctrl+C - interrupt


### PR DESCRIPTION
## Summary

Fixes #13589

Adds Ctrl+V keybinding to the mastracode TUI for clipboard pasting:

- **Image paste**: Detects image data on the clipboard (macOS PNGf/TIFF, Linux PNG), inserts an `📎` marker in the editor, and sends the base64 image data to the AI agent.
- **Text paste**: Reads clipboard text via `pbpaste` (macOS) / `xclip` / `wl-paste` (Linux), synthesizes a bracketed paste event so large pastes (>10 lines or >1000 chars) are condensed into `[paste #N +X lines]` markers instead of dumping raw content.

### Changes

- **`mastracode/src/clipboard/index.ts`**: Added `getClipboardText()` for platform-specific text clipboard reading.
- **`mastracode/src/tui/components/custom-editor.ts`**: Unified Ctrl+V handler that checks for image first, then falls back to text paste with bracketed paste synthesis.

### Test Plan

1. Copy a screenshot → Ctrl+V in mastracode → should show `📎` marker and send image to AI
2. Copy a small text block (<10 lines) → Ctrl+V → should paste inline
3. Copy a large text block (>10 lines) → Ctrl+V → should show `[paste #1 +X lines]`
4. Cmd+V (native terminal paste) → continues to work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ctrl+V clipboard paste support for both images and text.
  * Images from clipboard are automatically sent to the AI agent.
  * Text pastes are processed through the editor's paste handling.
  * Large text pastes (10+ lines) display as a compact marker instead of raw content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->