### PR TITLE
feat(mastracode): support dynamic extraTools functions

### DIFF
--- a/.changeset/bright-old-full.md
+++ b/.changeset/bright-old-full.md
@@ -1,0 +1,5 @@
+---
+'mastracode': minor
+---
+
+Added support for dynamic `extraTools` in `createMastraCode`. The `extraTools` option now accepts a function `({ requestContext }) => Record<string, any>` in addition to a static record, enabling conditional tool registration based on the current request context (e.g. model, mode).

--- a/mastracode/src/agents/__tests__/extra-tools.test.ts
+++ b/mastracode/src/agents/__tests__/extra-tools.test.ts
@@ -84,6 +84,45 @@ describe('createDynamicTools – extraTools', () => {
     expect(tools).toHaveProperty('tool_b');
   });
 
+  it('should support extraTools as a function that receives requestContext', () => {
+    const myCustomTool = createTool({
+      id: 'dynamic_tool',
+      description: 'A dynamically provided tool',
+      inputSchema: z.object({}),
+      execute: async () => ({ result: 'dynamic' }),
+    });
+
+    const getDynamicTools = createDynamicTools(undefined, ({ requestContext }) => {
+      // Verify requestContext is usable
+      const ctx = requestContext.get('harness') as any;
+      if (!ctx) return {};
+      return { dynamic_tool: myCustomTool };
+    });
+
+    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+    expect(tools).toHaveProperty('dynamic_tool');
+    expect(tools.dynamic_tool).toBe(myCustomTool);
+  });
+
+  it('should support extraTools function that conditionally returns empty', () => {
+    const myCustomTool = createTool({
+      id: 'conditional_tool',
+      description: 'A conditionally provided tool',
+      inputSchema: z.object({}),
+      execute: async () => ({ result: 'conditional' }),
+    });
+
+    const getDynamicTools = createDynamicTools(undefined, ({ requestContext }) => {
+      // Condition that won't match — harness context has no 'featureFlag' key
+      const flag = requestContext.get('featureFlag') as string | undefined;
+      if (!flag) return {};
+      return { conditional_tool: myCustomTool };
+    });
+
+    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+    expect(tools).not.toHaveProperty('conditional_tool');
+  });
+
   it('should return only built-in tools when extraTools is undefined', () => {
     const getDynamicTools = createDynamicTools(undefined, undefined);
     const tools = getDynamicTools({ requestContext: makeRequestContext() });

--- a/mastracode/src/agents/tools.ts
+++ b/mastracode/src/agents/tools.ts
@@ -6,7 +6,10 @@ import type { McpManager } from '../mcp';
 import type { stateSchema } from '../schema';
 import { createWebSearchTool, createWebExtractTool, hasTavilyKey, requestSandboxAccessTool } from '../tools';
 
-export function createDynamicTools(mcpManager?: McpManager, extraTools?: Record<string, any>) {
+export function createDynamicTools(
+  mcpManager?: McpManager,
+  extraTools?: Record<string, any> | ((ctx: { requestContext: RequestContext }) => Record<string, any>),
+) {
   return function getDynamicTools({ requestContext }: { requestContext: RequestContext }) {
     const ctx = requestContext.get('harness') as HarnessRequestContext<typeof stateSchema> | undefined;
     const state = ctx?.getState?.();
@@ -39,7 +42,8 @@ export function createDynamicTools(mcpManager?: McpManager, extraTools?: Record<
     }
 
     if (extraTools) {
-      for (const [name, tool] of Object.entries(extraTools)) {
+      const resolved = typeof extraTools === 'function' ? extraTools({ requestContext }) : extraTools;
+      for (const [name, tool] of Object.entries(resolved)) {
         if (!(name in tools)) {
           tools[name] = tool;
         }

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -2,8 +2,8 @@ import { Agent } from '@mastra/core/agent';
 import { Harness, taskWriteTool, taskCheckTool } from '@mastra/core/harness';
 import type { CustomAvailableModel, HeartbeatHandler, HarnessMode, HarnessSubagent } from '@mastra/core/harness';
 import { PROVIDER_REGISTRY } from '@mastra/core/llm';
-import type { RequestContext } from '@mastra/core/request-context';
 import type { ProviderConfig } from '@mastra/core/llm';
+import type { RequestContext } from '@mastra/core/request-context';
 
 import { getDynamicInstructions } from './agents/instructions.js';
 import { getDynamicMemory } from './agents/memory.js';

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -2,6 +2,7 @@ import { Agent } from '@mastra/core/agent';
 import { Harness, taskWriteTool, taskCheckTool } from '@mastra/core/harness';
 import type { CustomAvailableModel, HeartbeatHandler, HarnessMode, HarnessSubagent } from '@mastra/core/harness';
 import { PROVIDER_REGISTRY } from '@mastra/core/llm';
+import type { RequestContext } from '@mastra/core/request-context';
 import type { ProviderConfig } from '@mastra/core/llm';
 
 import { getDynamicInstructions } from './agents/instructions.js';
@@ -58,8 +59,8 @@ export interface MastraCodeConfig {
   modes?: HarnessMode[];
   /** Override or extend subagent definitions. Default: explore/plan/execute */
   subagents?: HarnessSubagent[];
-  /** Extra tools merged into the dynamic tool set */
-  extraTools?: Record<string, any>;
+  /** Extra tools merged into the dynamic tool set. Can be a static record or a function that receives requestContext. */
+  extraTools?: Record<string, any> | ((ctx: { requestContext: RequestContext }) => Record<string, any>);
   /** Custom storage config instead of auto-detected default */
   storage?: StorageConfig;
   /** Initial state overrides (yolo, thinkingLevel, etc.) */


### PR DESCRIPTION
## Description

Extended `extraTools` in `createMastraCode` to accept both a static record and a dynamic function. The `extraTools` option now accepts `({ requestContext }) => Record<string, any>` in addition to a static record, enabling conditional tool registration based on the current request context (e.g. model, mode).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have added tests that prove my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * extraTools now supports both static configuration and dynamic functions that return tools based on request context, enabling conditional tool registration.

* **Tests**
  * Added tests verifying function-based extraTools receives request context and conditionally returns tools as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->