### PR TITLE
fix gemini resume data schema issue

### DIFF
--- a/.changeset/modern-animals-own.md
+++ b/.changeset/modern-animals-own.md
@@ -2,4 +2,5 @@
 '@mastra/core': patch
 ---
 
-Fixed Gemini rejecting tool schemas for agent-as-tools. The `resumeData` field (auto-injected for suspend/resume support) used `z.any()` which produced an invalid JSON Schema with `items: {}` on a non-array type. Gemini requires `items` only when the type is exclusively `ARRAY`. The fallback type union for typeless properties no longer includes `array`, preventing the invalid schema from being sent to the model.
+Fixed agent-as-tools schema generation so Gemini accepts tool definitions for suspend/resume flows.
+This prevents schema validation failures when `resumeData` is present.

--- a/.changeset/modern-animals-own.md
+++ b/.changeset/modern-animals-own.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Gemini rejecting tool schemas for agent-as-tools. The `resumeData` field (auto-injected for suspend/resume support) used `z.any()` which produced an invalid JSON Schema with `items: {}` on a non-array type. Gemini requires `items` only when the type is exclusively `ARRAY`. The fallback type union for typeless properties no longer includes `array`, preventing the invalid schema from being sent to the model.

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
@@ -395,12 +395,17 @@ describe('prepareToolsAndToolChoice', () => {
           `Property '${propName}' in agent tool schema must have a 'type', '$ref', 'anyOf', 'oneOf', or 'allOf' key. Got: ${JSON.stringify(schema)}`,
         ).toBe(true);
 
-        // OpenAI requires 'items' when 'array' is in the type union
-        if (Array.isArray(schema.type) && schema.type.includes('array')) {
+        // Typeless fallback must NOT include 'array' — an array without a meaningful
+        // items schema is unusable, and it breaks Gemini which rejects items on non-ARRAY types.
+        if (Array.isArray(schema.type)) {
+          expect(
+            schema.type,
+            `Property '${propName}' fallback type should not include 'array'. Got: ${JSON.stringify(schema)}`,
+          ).not.toContain('array');
           expect(
             schema.items,
-            `Property '${propName}' includes 'array' in type but is missing 'items'. OpenAI requires 'items' for array types. Got: ${JSON.stringify(schema)}`,
-          ).toBeDefined();
+            `Property '${propName}' should not have 'items' in the fallback. Got: ${JSON.stringify(schema)}`,
+          ).toBeUndefined();
         }
       }
     });

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
@@ -71,10 +71,11 @@ function fixTypelessProperties(schema: Record<string, unknown>): Record<string, 
         const hasAllOf = 'allOf' in propSchema;
 
         if (!hasType && !hasRef && !hasAnyOf && !hasOneOf && !hasAllOf) {
-          return [
-            key,
-            { ...propSchema, type: ['string', 'number', 'integer', 'boolean', 'object', 'array', 'null'], items: {} },
-          ];
+          // Exclude 'array' from the fallback: an array without a meaningful items schema
+          // is unusable by the LLM, and including it with items: {} causes Gemini to reject
+          // the schema (items is only valid when type is exclusively ARRAY).
+          const { items: _items, ...rest } = propSchema;
+          return [key, { ...rest, type: ['string', 'number', 'integer', 'boolean', 'object', 'null'] }];
         }
         // Recurse into nested object schemas
         return [key, fixTypelessProperties(propSchema)];


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
Fixed Gemini rejecting tool schemas for agent-as-tools. The `resumeData` field (auto-injected for suspend/resume support) used `z.any()` which produced an invalid JSON Schema with `items: {}` on a non-array type. Gemini requires `items` only when the type is exclusively `ARRAY`. The fallback type union for typeless properties no longer includes `array`, preventing the invalid schema from being sent to the model.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
#13649 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved tool-schema rejection issues with agent-as-tools so tool definitions with resume data are accepted by models.
  * Improved JSON Schema generation to avoid producing invalid array fallbacks, fixing validation failures and improving compatibility with AI model requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->