### PR TITLE
feat(mastracode): export resolveModel from createMastraCode

### DIFF
--- a/.changeset/fresh-lizards-refuse.md
+++ b/.changeset/fresh-lizards-refuse.md
@@ -1,0 +1,5 @@
+---
+'mastracode': minor
+---
+
+Added `resolveModel` to the return value of `createMastraCode`, allowing consumers to use the fully-authenticated model resolver instead of having to reimplement provider logic locally.

--- a/.changeset/fresh-lizards-refuse.md
+++ b/.changeset/fresh-lizards-refuse.md
@@ -3,3 +3,8 @@
 ---
 
 Added `resolveModel` to the return value of `createMastraCode`, allowing consumers to use the fully-authenticated model resolver instead of having to reimplement provider logic locally.
+
+```typescript
+const { harness, resolveModel } = await createMastraCode({ cwd: projectPath });
+const model = resolveModel('anthropic/claude-sonnet-4-20250514');
+```

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -351,5 +351,5 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     });
   }
 
-  return { harness, mcpManager, hookManager, authStorage, storageWarning };
+  return { harness, mcpManager, hookManager, authStorage, resolveModel, storageWarning };
 }


### PR DESCRIPTION
## Description

Export the authenticated `resolveModel` function from the `createMastraCode` return value. Consumers like the Electron UI can now use the fully-authenticated model resolver instead of reimplementing provider logic locally.

```typescript
const { harness, mcpManager, hookManager, resolveModel, storageWarning } =
    await createMastraCode({ cwd: projectPath })
```

## Related Issue(s)

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The public API now exposes a new resolveModel property on createMastraCode, giving callers direct access to a fully authenticated model resolver without additional wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->