### PR TITLE
Fix observability flush in Inngest workflow finalization

### DIFF
--- a/.changeset/fix-inngest-observability-flush.md
+++ b/.changeset/fix-inngest-observability-flush.md
@@ -1,0 +1,5 @@
+---
+'@mastra/inngest': patch
+---
+
+Flush observability after Inngest workflow finalize step to ensure span export promises resolve before the function completes. Fixes #13388 where fire-and-forget export promises were abandoned in durable execution contexts.

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -431,6 +431,15 @@ export class InngestWorkflow<
           return result;
         });
 
+        // Flush observability OUTSIDE step.run() so it executes on every invocation
+        // (not memoized) and ensures all span export promises resolve before the
+        // Inngest function completes. This fixes #13388 where fire-and-forget export
+        // promises were abandoned when step.run() completed.
+        const observability = mastra?.observability?.getSelectedInstance({ requestContext });
+        if (observability) {
+          await observability.flush();
+        }
+
         return { result, runId };
       },
     );


### PR DESCRIPTION
## Description

This PR fixes an issue where observability span export promises were being abandoned in durable execution contexts. The fix moves the observability flush operation outside of `step.run()` to ensure it executes on every invocation (not memoized) and that all span export promises resolve before the Inngest function completes.

Previously, fire-and-forget export promises were not being awaited when `step.run()` completed, causing spans to be lost in durable execution environments.

https://github.com/mastra-ai/mastra/pull/13612 implemented most of the work to fix this issue. This PR is the final piece. 

## Related Issue(s)

Fixes #13388

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

https://claude.ai/code/session_01GSUjhYByGCRNfKKPhxbwtf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where observability and telemetry data exports from Inngest workflows could be abandoned before completion. Observability data now properly exports before the workflow finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->