### PR TITLE
Fixed observability flush to run when the finalize step throws an error.

### DIFF
--- a/.changeset/wet-bananas-rhyme.md
+++ b/.changeset/wet-bananas-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@mastra/inngest': patch
+---
+
+Fixed observability flush to run on all code paths, including when the finalize step throws an error. Previously, if the workflow failed inside step.run, the flush call was skipped because it was placed after the await.

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -322,122 +322,128 @@ export class InngestWorkflow<
 
         // Final step to invoke lifecycle callbacks and end workflow span.
         // This step is memoized by step.run.
-        await step.run(`workflow.${this.id}.finalize`, async () => {
-          if (result.status !== 'paused') {
-            // Invoke lifecycle callbacks (onFinish and onError)
-            await engine.invokeLifecycleCallbacksInternal({
-              status: result.status,
-              result: 'result' in result ? result.result : undefined,
-              error: 'error' in result ? result.error : undefined,
-              steps: result.steps,
-              tripwire: 'tripwire' in result ? result.tripwire : undefined,
-              runId,
-              workflowId: this.id,
-              resourceId,
-              input: inputData,
-              requestContext,
-              state: result.state ?? initialState ?? {},
-            });
-          }
-
-          // End the workflow span with appropriate status
-          // The workflow span was already created and SPAN_STARTED was exported in the span.start step
-          if (workflowSpanData) {
-            const observability = mastra?.observability?.getSelectedInstance({ requestContext });
-            if (observability) {
-              // Rebuild the span from cached data to call end/error
-              const workflowSpan = observability.rebuildSpan(workflowSpanData);
-
-              if (result.status === 'failed') {
-                workflowSpan.error({
-                  error: result.error instanceof Error ? result.error : new Error(String(result.error)),
-                  attributes: { status: 'failed' },
-                });
-              } else {
-                workflowSpan.end({
-                  output: result.status === 'success' ? result.result : undefined,
-                  attributes: { status: result.status },
-                });
-              }
-            }
-          }
-
-          // Ensure final snapshot is persisted BEFORE publishing workflow-finish
-          // This fixes a race condition where getRunOutput reads the snapshot before it's fully written
-          const shouldPersistFinalSnapshot = this.options.shouldPersistSnapshot({
-            workflowStatus: result.status as any,
-            stepResults: result.steps,
-          });
-          if (shouldPersistFinalSnapshot) {
-            const workflowsStore = await mastra?.getStorage()?.getStore('workflows');
-            if (workflowsStore) {
-              // For suspended workflows, read existing snapshot to preserve suspendedPaths and resumeLabels
-              // which were set correctly by the handlers during execution
-              let existingSnapshot:
-                | { suspendedPaths?: Record<string, number[]>; resumeLabels?: Record<string, any> }
-                | undefined;
-              if (result.status === 'suspended') {
-                existingSnapshot =
-                  (await workflowsStore.loadWorkflowSnapshot({
-                    workflowName: this.id,
-                    runId,
-                  })) ?? undefined;
-              }
-
-              await workflowsStore.persistWorkflowSnapshot({
-                workflowName: this.id,
+        let finalizeError: unknown;
+        try {
+          await step.run(`workflow.${this.id}.finalize`, async () => {
+            if (result.status !== 'paused') {
+              // Invoke lifecycle callbacks (onFinish and onError)
+              await engine.invokeLifecycleCallbacksInternal({
+                status: result.status,
+                result: 'result' in result ? result.result : undefined,
+                error: 'error' in result ? result.error : undefined,
+                steps: result.steps,
+                tripwire: 'tripwire' in result ? result.tripwire : undefined,
                 runId,
+                workflowId: this.id,
                 resourceId,
-                snapshot: {
-                  runId,
-                  status: result.status,
-                  value: result.state ?? initialState ?? {},
-                  context: result.steps as any,
-                  activePaths: [],
-                  activeStepsPath: {},
-                  serializedStepGraph: this.serializedStepGraph,
-                  suspendedPaths: existingSnapshot?.suspendedPaths ?? {},
-                  waitingPaths: {},
-                  resumeLabels: existingSnapshot?.resumeLabels ?? result.resumeLabels ?? {},
-                  result: result.status === 'success' ? (result.result as any) : undefined,
-                  error: result.status === 'failed' ? result.error : undefined,
-                  timestamp: Date.now(),
-                },
+                input: inputData,
+                requestContext,
+                state: result.state ?? initialState ?? {},
               });
             }
-          }
 
-          // Publish workflow-finish event for realtime subscribers
-          await pubsub.publish(`workflow.events.v2.${runId}`, {
-            type: 'watch',
-            runId,
-            data: {
-              type: 'workflow-finish',
-              payload: {
-                status: result.status,
-                result: result.status === 'success' ? result.result : undefined,
-                error: result.status === 'failed' ? result.error : undefined,
-              },
-            },
-          });
+            // End the workflow span with appropriate status
+            // The workflow span was already created and SPAN_STARTED was exported in the span.start step
+            if (workflowSpanData) {
+              const observability = mastra?.observability?.getSelectedInstance({ requestContext });
+              if (observability) {
+                // Rebuild the span from cached data to call end/error
+                const workflowSpan = observability.rebuildSpan(workflowSpanData);
 
-          // Throw after span ended for failed workflows
-          if (result.status === 'failed') {
-            throw new NonRetriableError(`Workflow failed`, {
-              cause: result,
+                if (result.status === 'failed') {
+                  workflowSpan.error({
+                    error: result.error instanceof Error ? result.error : new Error(String(result.error)),
+                    attributes: { status: 'failed' },
+                  });
+                } else {
+                  workflowSpan.end({
+                    output: result.status === 'success' ? result.result : undefined,
+                    attributes: { status: result.status },
+                  });
+                }
+              }
+            }
+
+            // Ensure final snapshot is persisted BEFORE publishing workflow-finish
+            // This fixes a race condition where getRunOutput reads the snapshot before it's fully written
+            const shouldPersistFinalSnapshot = this.options.shouldPersistSnapshot({
+              workflowStatus: result.status as any,
+              stepResults: result.steps,
             });
+            if (shouldPersistFinalSnapshot) {
+              const workflowsStore = await mastra?.getStorage()?.getStore('workflows');
+              if (workflowsStore) {
+                // For suspended workflows, read existing snapshot to preserve suspendedPaths and resumeLabels
+                // which were set correctly by the handlers during execution
+                let existingSnapshot:
+                  | { suspendedPaths?: Record<string, number[]>; resumeLabels?: Record<string, any> }
+                  | undefined;
+                if (result.status === 'suspended') {
+                  existingSnapshot =
+                    (await workflowsStore.loadWorkflowSnapshot({
+                      workflowName: this.id,
+                      runId,
+                    })) ?? undefined;
+                }
+
+                await workflowsStore.persistWorkflowSnapshot({
+                  workflowName: this.id,
+                  runId,
+                  resourceId,
+                  snapshot: {
+                    runId,
+                    status: result.status,
+                    value: result.state ?? initialState ?? {},
+                    context: result.steps as any,
+                    activePaths: [],
+                    activeStepsPath: {},
+                    serializedStepGraph: this.serializedStepGraph,
+                    suspendedPaths: existingSnapshot?.suspendedPaths ?? {},
+                    waitingPaths: {},
+                    resumeLabels: existingSnapshot?.resumeLabels ?? result.resumeLabels ?? {},
+                    result: result.status === 'success' ? (result.result as any) : undefined,
+                    error: result.status === 'failed' ? result.error : undefined,
+                    timestamp: Date.now(),
+                  },
+                });
+              }
+            }
+
+            // Publish workflow-finish event for realtime subscribers
+            await pubsub.publish(`workflow.events.v2.${runId}`, {
+              type: 'watch',
+              runId,
+              data: {
+                type: 'workflow-finish',
+                payload: {
+                  status: result.status,
+                  result: result.status === 'success' ? result.result : undefined,
+                  error: result.status === 'failed' ? result.error : undefined,
+                },
+              },
+            });
+
+            // Throw after span ended for failed workflows
+            if (result.status === 'failed') {
+              throw new NonRetriableError(`Workflow failed`, {
+                cause: result,
+              });
+            }
+
+            return result;
+          });
+        } catch (error) {
+          finalizeError = error;
+        } finally {
+          // Keep this outside step.run memoization, but guaranteed on all paths.
+          const observability = mastra?.observability?.getSelectedInstance({ requestContext });
+          if (observability) {
+            await observability.flush();
           }
+        }
 
-          return result;
-        });
-
-        // Flush observability OUTSIDE step.run() so it executes on every invocation
-        // (not memoized) and ensures all span export promises resolve before the
-        // Inngest function completes. This fixes #13388 where fire-and-forget export
-        // promises were abandoned when step.run() completed.
-        const observability = mastra?.observability?.getSelectedInstance({ requestContext });
-        if (observability) {
-          await observability.flush();
+        if (finalizeError) {
+          throw finalizeError;
         }
 
         return { result, runId };

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -9,6 +9,7 @@ import type {
   WorkflowConfig,
   StepFlowEntry,
   WorkflowResult,
+  WorkflowRunStatus,
   WorkflowStreamEvent,
   Run,
 } from '@mastra/core/workflows';
@@ -323,6 +324,7 @@ export class InngestWorkflow<
         // Final step to invoke lifecycle callbacks and end workflow span.
         // This step is memoized by step.run.
         let finalizeError: unknown;
+        let finalizeErrored = false;
         try {
           await step.run(`workflow.${this.id}.finalize`, async () => {
             if (result.status !== 'paused') {
@@ -367,7 +369,7 @@ export class InngestWorkflow<
             // Ensure final snapshot is persisted BEFORE publishing workflow-finish
             // This fixes a race condition where getRunOutput reads the snapshot before it's fully written
             const shouldPersistFinalSnapshot = this.options.shouldPersistSnapshot({
-              workflowStatus: result.status as any,
+              workflowStatus: result.status as WorkflowRunStatus,
               stepResults: result.steps,
             });
             if (shouldPersistFinalSnapshot) {
@@ -394,6 +396,7 @@ export class InngestWorkflow<
                     runId,
                     status: result.status,
                     value: result.state ?? initialState ?? {},
+                    // StepResult is a structural subset of SerializedStepResult; cast needed due to generics
                     context: result.steps as any,
                     activePaths: [],
                     activeStepsPath: {},
@@ -401,7 +404,7 @@ export class InngestWorkflow<
                     suspendedPaths: existingSnapshot?.suspendedPaths ?? {},
                     waitingPaths: {},
                     resumeLabels: existingSnapshot?.resumeLabels ?? result.resumeLabels ?? {},
-                    result: result.status === 'success' ? (result.result as any) : undefined,
+                    result: result.status === 'success' ? (result.result as Record<string, any>) : undefined,
                     error: result.status === 'failed' ? result.error : undefined,
                     timestamp: Date.now(),
                   },
@@ -409,19 +412,23 @@ export class InngestWorkflow<
               }
             }
 
-            // Publish workflow-finish event for realtime subscribers
-            await pubsub.publish(`workflow.events.v2.${runId}`, {
-              type: 'watch',
-              runId,
-              data: {
-                type: 'workflow-finish',
-                payload: {
-                  status: result.status,
-                  result: result.status === 'success' ? result.result : undefined,
-                  error: result.status === 'failed' ? result.error : undefined,
+            // Publish workflow-finish event for realtime subscribers (best-effort)
+            try {
+              await pubsub.publish(`workflow.events.v2.${runId}`, {
+                type: 'watch',
+                runId,
+                data: {
+                  type: 'workflow-finish',
+                  payload: {
+                    status: result.status,
+                    result: result.status === 'success' ? result.result : undefined,
+                    error: result.status === 'failed' ? result.error : undefined,
+                  },
                 },
-              },
-            });
+              });
+            } catch (publishError) {
+              this.logger.debug?.('Failed to publish workflow-finish event:', publishError);
+            }
 
             // Throw after span ended for failed workflows
             if (result.status === 'failed') {
@@ -433,6 +440,7 @@ export class InngestWorkflow<
             return result;
           });
         } catch (error) {
+          finalizeErrored = true;
           finalizeError = error;
         } finally {
           // Keep this outside step.run memoization, but guaranteed on all paths.
@@ -446,7 +454,7 @@ export class InngestWorkflow<
           }
         }
 
-        if (finalizeError) {
+        if (finalizeErrored) {
           throw finalizeError;
         }
 

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -438,7 +438,11 @@ export class InngestWorkflow<
           // Keep this outside step.run memoization, but guaranteed on all paths.
           const observability = mastra?.observability?.getSelectedInstance({ requestContext });
           if (observability) {
-            await observability.flush();
+            try {
+              await observability.flush();
+            } catch (flushError) {
+              this.logger.debug?.('Failed to flush observability:', flushError);
+            }
           }
         }
 

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -6,10 +6,11 @@ import type { WorkflowRuns } from '@mastra/core/storage';
 import { Workflow } from '@mastra/core/workflows';
 import type {
   Step,
+  StepResult,
   WorkflowConfig,
   StepFlowEntry,
   WorkflowResult,
-  WorkflowRunStatus,
+  WorkflowRunState,
   WorkflowStreamEvent,
   Run,
 } from '@mastra/core/workflows';
@@ -369,7 +370,7 @@ export class InngestWorkflow<
             // Ensure final snapshot is persisted BEFORE publishing workflow-finish
             // This fixes a race condition where getRunOutput reads the snapshot before it's fully written
             const shouldPersistFinalSnapshot = this.options.shouldPersistSnapshot({
-              workflowStatus: result.status as WorkflowRunStatus,
+              workflowStatus: result.status,
               stepResults: result.steps,
             });
             if (shouldPersistFinalSnapshot) {
@@ -396,15 +397,14 @@ export class InngestWorkflow<
                     runId,
                     status: result.status,
                     value: result.state ?? initialState ?? {},
-                    // StepResult is a structural subset of SerializedStepResult; cast needed due to generics
-                    context: result.steps as any,
+                    context: toSnapshotContext(result.steps),
                     activePaths: [],
                     activeStepsPath: {},
                     serializedStepGraph: this.serializedStepGraph,
                     suspendedPaths: existingSnapshot?.suspendedPaths ?? {},
                     waitingPaths: {},
                     resumeLabels: existingSnapshot?.resumeLabels ?? result.resumeLabels ?? {},
-                    result: result.status === 'success' ? (result.result as Record<string, any>) : undefined,
+                    result: result.status === 'success' ? toSnapshotResult(result.result) : undefined,
                     error: result.status === 'failed' ? result.error : undefined,
                     timestamp: Date.now(),
                   },
@@ -486,4 +486,21 @@ export class InngestWorkflow<
       ...this.getNestedFunctions(this.executionGraph.steps),
     ];
   }
+}
+
+/**
+ * Converts runtime step results to the serialized context shape expected by WorkflowRunState.
+ * StepResult is a structural subset of SerializedStepResult (widening), so no data
+ * transformation is needed — this bridges the generic type mismatch at the persistence boundary.
+ */
+function toSnapshotContext(steps: Record<string, StepResult<any, any, any, any>>): WorkflowRunState['context'] {
+  return steps as unknown as WorkflowRunState['context'];
+}
+
+/**
+ * Converts a workflow output value to the record shape expected by WorkflowRunState.result.
+ * Workflow outputs are generic (TOutput) but the snapshot schema stores them as Record<string, any>.
+ */
+function toSnapshotResult(output: unknown): WorkflowRunState['result'] {
+  return output as WorkflowRunState['result'];
 }


### PR DESCRIPTION
## Description

Fixes issue introduced in #13717 

## Related Issue(s)

https://github.com/mastra-ai/mastra/issues/13388

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Observability flush now reliably runs on all execution paths, including when finalization errors occur, ensuring consistent telemetry.

* **Improvements**
  * Finalization and end-of-workflow signals are deterministic: final snapshots and publish events occur in a reliable sequence.
  * More robust handling and propagation for failed and suspended runs, with improved snapshot loading and publish sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->