### PR TITLE
Replace 4 dependencies with native Node.js 22+ alternatives

### DIFF
--- a/.changeset/brave-beds-admire.md
+++ b/.changeset/brave-beds-admire.md
@@ -1,0 +1,14 @@
+---
+'create-mastra': patch
+'@mastra/playground-ui': patch
+'@mastra/client-js': patch
+'@mastra/react': patch
+'@mastra/deployer-netlify': patch
+'@mastra/deployer': patch
+'@mastra/deployer-vercel': patch
+'@mastra/deployer-cloud': patch
+'@mastra/core': patch
+'mastra': patch
+---
+
+Replaced `@lukeed/uuid` with native `crypto.randomUUID()` to reduce bundle size and dependency count

--- a/.changeset/cozy-points-move.md
+++ b/.changeset/cozy-points-move.md
@@ -1,0 +1,14 @@
+---
+'create-mastra': patch
+'@mastra/playground-ui': patch
+'@mastra/client-js': patch
+'@mastra/react': patch
+'@mastra/deployer-netlify': patch
+'@mastra/deployer': patch
+'@mastra/deployer-vercel': patch
+'@mastra/deployer-cloud': patch
+'@mastra/core': patch
+'mastra': patch
+---
+
+Replaced `fs-extra`, `strip-json-comments`, and `tinyglobby` with native Node.js equivalents (`node:fs/promises`, `typescript`, `node:fs/promises` glob) to reduce bundle size and dependency count

--- a/.changeset/true-squids-doubt.md
+++ b/.changeset/true-squids-doubt.md
@@ -1,0 +1,10 @@
+---
+'@mastra/playground-ui': minor
+'@mastra/deployer-netlify': minor
+'@mastra/deployer': minor
+'@mastra/deployer-vercel': minor
+'@mastra/deployer-cloud': minor
+'mastra': minor
+---
+
+Update peer dependencies to match core package version bump (1.8.1)

--- a/.github/scripts/sync-templates.js
+++ b/.github/scripts/sync-templates.js
@@ -1,6 +1,5 @@
 import { Octokit } from '@octokit/rest';
 import fs from 'fs';
-import * as fsExtra from 'fs-extra/esm';
 import path from 'path';
 import { execSync } from 'child_process';
 import dotenv from 'dotenv';
@@ -129,7 +128,7 @@ async function pushToRepo(repoName) {
   try {
     // Create temp directory
     console.log(`Creating temp directory: ${tempRoot}`);
-    fsExtra.ensureDirSync(tempRoot);
+    fs.mkdirSync(tempRoot, { recursive: true });
 
     console.log(`Cloning repo into temp directory: ${tempRoot}`);
     execSync(
@@ -178,7 +177,7 @@ async function pushToRepo(repoName) {
     for (const fileOrDir of filesAndDirs) {
       if (fileOrDir !== '.git') {
         console.log(`Removing ${fileOrDir} in the temp directory: ${tempDir}`);
-        fsExtra.removeSync(path.join(tempDir, fileOrDir));
+        fs.rmSync(path.join(tempDir, fileOrDir), { recursive: true, force: true });
       }
     }
 
@@ -187,7 +186,7 @@ async function pushToRepo(repoName) {
 
     // Copy template content to temp directory
     console.log(`Copying template content to temp directory: ${tempDir}`);
-    fsExtra.copySync(templatePath, tempDir);
+    fs.cpSync(templatePath, tempDir, { recursive: true });
 
     // Initialize git and push to repo
     console.log(`Pushing to main branch`);
@@ -211,7 +210,7 @@ async function pushToRepo(repoName) {
   } finally {
     // Clean up temp directory
     console.log(`Cleaning up temp directory: ${tempDir}`);
-    fsExtra.removeSync(path.join(process.cwd(), '.temp'));
+    fs.rmSync(path.join(process.cwd(), '.temp'), { recursive: true, force: true });
   }
 }
 

--- a/client-sdks/client-js/package.json
+++ b/client-sdks/client-js/package.json
@@ -42,7 +42,6 @@
     "test:unit": "vitest run"
   },
   "dependencies": {
-    "@lukeed/uuid": "^2.0.1",
     "@mastra/core": "workspace:*",
     "@mastra/schema-compat": "workspace:*",
     "json-schema": "^0.4.0"

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -8,7 +8,7 @@ import type {
   UIMessage,
   UseChatOptions,
 } from '@ai-sdk/ui-utils';
-import { v4 as uuid } from '@lukeed/uuid';
+
 import type { SerializableStructuredOutputOptions } from '@mastra/core/agent';
 import type { MessageListInput } from '@mastra/core/agent/message-list';
 import { getErrorFromUnknown } from '@mastra/core/error';
@@ -396,7 +396,7 @@ export class Agent extends BaseResource {
     const message: UIMessage = replaceLastMessage
       ? structuredClone(lastMessage)
       : {
-          id: uuid(),
+          id: crypto.randomUUID(),
           createdAt: getCurrentDate(),
           role: 'assistant',
           content: '',
@@ -456,7 +456,7 @@ export class Agent extends BaseResource {
         // changes. This is why we need to add a revision id to ensure that the message
         // is updated with SWR (without it, the changes get stuck in SWR and are not
         // forwarded to rendering):
-        revisionId: uuid(),
+        revisionId: crypto.randomUUID(),
       } as UIMessage;
 
       update({
@@ -787,7 +787,7 @@ export class Agent extends BaseResource {
     const message: UIMessage = replaceLastMessage
       ? structuredClone(lastMessage)
       : {
-          id: uuid(),
+          id: crypto.randomUUID(),
           createdAt: getCurrentDate(),
           role: 'assistant',
           content: '',
@@ -847,7 +847,7 @@ export class Agent extends BaseResource {
         // changes. This is why we need to add a revision id to ensure that the message
         // is updated with SWR (without it, the changes get stuck in SWR and are not
         // forwarded to rendering):
-        revisionId: uuid(),
+        revisionId: crypto.randomUUID(),
       } as UIMessage;
 
       update({

--- a/client-sdks/react/package.json
+++ b/client-sdks/react/package.json
@@ -44,7 +44,6 @@
   ],
   "dependencies": {
     "@mastra/client-js": "workspace:*",
-    "@lukeed/uuid": "^2.0.1",
     "@radix-ui/react-tooltip": "^1.2.7",
     "hast-util-to-jsx-runtime": "^2.3.6",
     "lucide-react": "^0.522.0",

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -11,7 +11,7 @@ import { toUIMessage } from '@/lib/ai-sdk';
 import { AISdkNetworkTransformer } from '@/lib/ai-sdk/transformers/AISdkNetworkTransformer';
 import { resolveInitialMessages } from '@/lib/ai-sdk/memory/resolveInitialMessages';
 import { fromCoreUserMessageToUIMessage } from '@/lib/ai-sdk/utils/fromCoreUserMessageToUIMessage';
-import { v4 as uuid } from '@lukeed/uuid';
+
 import { type TracingOptions } from '@mastra/core/observability';
 
 export interface MastraChatProps {
@@ -115,7 +115,7 @@ export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProp
 
     const agent = clientWithAbort.getAgent(agentId);
 
-    const runId = uuid();
+    const runId = crypto.randomUUID();
     _currentRunId.current = runId;
 
     const response = await agent.generate(coreUserMessages, {
@@ -216,7 +216,7 @@ export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProp
 
     const agent = clientWithAbort.getAgent(agentId);
 
-    const runId = uuid();
+    const runId = crypto.randomUUID();
 
     const response = await agent.stream(coreUserMessages, {
       runId,
@@ -277,7 +277,7 @@ export const useChat = ({ agentId, resourceId, initialMessages }: MastraChatProp
 
     const agent = clientWithAbort.getAgent(agentId);
 
-    const runId = uuid();
+    const runId = crypto.randomUUID();
 
     const response = await agent.network(coreUserMessages, {
       maxSteps,

--- a/deployers/cloud/package.json
+++ b/deployers/cloud/package.json
@@ -36,7 +36,6 @@
     "@mastra/deployer": "workspace:^",
     "@mastra/loggers": "workspace:*",
     "execa": "^9.6.1",
-    "fs-extra": "^11.3.3",
     "pino": "^10.1.0",
     "redis": "^5.8.3"
   },
@@ -46,7 +45,6 @@
     "@internal/types-builder": "workspace:*",
     "@manypkg/get-packages": "^3.1.0",
     "@mastra/core": "workspace:*",
-    "@types/fs-extra": "^11.0.4",
     "@types/node": "22.19.7",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
@@ -56,7 +54,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.8.1-0 <2.0.0-0"
   },
   "repository": {
     "type": "git",

--- a/deployers/cloud/scripts/sync-versions.mjs
+++ b/deployers/cloud/scripts/sync-versions.mjs
@@ -1,7 +1,7 @@
+import { writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getPackages } from '@manypkg/get-packages';
-import { writeJson } from 'fs-extra/esm';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -18,4 +18,4 @@ packages.forEach(pkg => {
 
 console.log(`Writing versions to versions.json:\n${JSON.stringify(versionsToWrite, null, 2)}`);
 
-await writeJson(join(__dirname, '../versions.json'), versionsToWrite);
+await writeFile(join(__dirname, '../versions.json'), JSON.stringify(versionsToWrite, null, 2) + '\n', 'utf-8');

--- a/deployers/cloud/src/index.test.ts
+++ b/deployers/cloud/src/index.test.ts
@@ -8,7 +8,6 @@ import { getMastraEntryFile } from './utils/file.js';
 import { CloudDeployer } from './index.js';
 
 // Mock the dependencies
-vi.mock('fs-extra');
 vi.mock('./utils/file.js');
 vi.mock('./utils/deps.js');
 vi.mock('./utils/auth.js');

--- a/deployers/cloud/src/index.ts
+++ b/deployers/cloud/src/index.ts
@@ -1,8 +1,8 @@
+import { cp, readFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Config } from '@mastra/core/mastra';
 import { Deployer } from '@mastra/deployer';
-import { copy, readJSON } from 'fs-extra/esm';
 
 import { getAuthEntrypoint } from './utils/auth.js';
 import { MASTRA_DIRECTORY, BUILD_ID, PROJECT_ID, TEAM_ID } from './utils/constants.js';
@@ -46,15 +46,13 @@ export class CloudDeployer extends Deployer {
       const __dirname = dirname(__filename);
 
       const studioServePath = join(outputDirectory, this.outputDir, 'studio');
-      await copy(join(dirname(__dirname), join('dist', 'studio')), studioServePath, {
-        overwrite: true,
-      });
+      await cp(join(dirname(__dirname), join('dist', 'studio')), studioServePath, { recursive: true });
     }
   }
   async writePackageJson(outputDirectory: string, dependencies: Map<string, string>) {
-    const versions = (await readJSON(join(dirname(fileURLToPath(import.meta.url)), '../versions.json'))) as
-      | Record<string, string>
-      | undefined;
+    const versions = JSON.parse(
+      await readFile(join(dirname(fileURLToPath(import.meta.url)), '../versions.json'), 'utf-8'),
+    ) as Record<string, string> | undefined;
     for (const [pkgName, version] of Object.entries(versions || {})) {
       dependencies.set(pkgName, version);
     }

--- a/deployers/cloud/src/integration.test.ts
+++ b/deployers/cloud/src/integration.test.ts
@@ -1,10 +1,9 @@
 import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir, writeFile, readFile, cp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execa } from 'execa';
-import { ensureDir, writeFile, readFile } from 'fs-extra';
-import { copy } from 'fs-extra/esm';
 import { describe, it, expect, beforeEach, afterEach, vi, beforeAll } from 'vitest';
 
 import { CloudDeployer } from './index.js';
@@ -21,12 +20,12 @@ vi.mock('./utils/logger.js', () => ({
   },
 }));
 
-// Mock fs-extra/esm copy for studio tests
-vi.mock('fs-extra/esm', async () => {
-  const actual = await vi.importActual('fs-extra/esm');
+// Mock node:fs/promises cp for studio tests
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual('node:fs/promises');
   return {
     ...actual,
-    copy: vi.fn().mockResolvedValue(undefined),
+    cp: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -46,8 +45,8 @@ describe('CloudDeployer Integration Tests', () => {
     tempDir = mkdtempSync(join(tmpdir(), 'cloud-deployer-test-'));
     outputDir = join(tempDir, 'output');
 
-    await ensureDir(tempDir);
-    await ensureDir(outputDir);
+    await mkdir(tempDir, { recursive: true });
+    await mkdir(outputDir, { recursive: true });
   });
 
   afterEach(() => {
@@ -198,8 +197,8 @@ describe('CloudDeployer Integration Tests', () => {
   describe('Bundling Integration', () => {
     it('should handle bundle method with mocked parent implementation', async () => {
       const mastraDir = join(tempDir, 'mastra-project');
-      await ensureDir(mastraDir);
-      await ensureDir(join(mastraDir, 'src/mastra'));
+      await mkdir(mastraDir, { recursive: true });
+      await mkdir(join(mastraDir, 'src/mastra'), { recursive: true });
       await writeFile(join(mastraDir, 'src/mastra/index.ts'), 'export const mastra = {};');
 
       // Mock the parent _bundle method to avoid actual bundling
@@ -227,7 +226,7 @@ describe('CloudDeployer Integration Tests', () => {
 
   describe('Studio Bundling', () => {
     beforeEach(() => {
-      vi.mocked(copy).mockClear();
+      vi.mocked(cp).mockClear();
     });
 
     it('should copy studio assets when studio is true', async () => {
@@ -235,9 +234,9 @@ describe('CloudDeployer Integration Tests', () => {
 
       await studioDeployer.prepare(outputDir);
 
-      expect(copy).toHaveBeenCalledTimes(1);
-      expect(copy).toHaveBeenCalledWith(expect.stringContaining('dist/studio'), expect.stringContaining('studio'), {
-        overwrite: true,
+      expect(cp).toHaveBeenCalledTimes(1);
+      expect(cp).toHaveBeenCalledWith(expect.stringContaining('dist/studio'), expect.stringContaining('studio'), {
+        recursive: true,
       });
     });
 
@@ -246,7 +245,7 @@ describe('CloudDeployer Integration Tests', () => {
 
       await studioDeployer.prepare(outputDir);
 
-      expect(copy).not.toHaveBeenCalled();
+      expect(cp).not.toHaveBeenCalled();
     });
 
     it('should not copy studio assets when studio is not provided', async () => {
@@ -254,7 +253,7 @@ describe('CloudDeployer Integration Tests', () => {
 
       await studioDeployer.prepare(outputDir);
 
-      expect(copy).not.toHaveBeenCalled();
+      expect(cp).not.toHaveBeenCalled();
     });
 
     it('should copy studio to correct output path', async () => {
@@ -262,8 +261,8 @@ describe('CloudDeployer Integration Tests', () => {
 
       await studioDeployer.prepare(outputDir);
 
-      expect(copy).toHaveBeenCalledWith(expect.any(String), join(outputDir, 'output', 'studio'), {
-        overwrite: true,
+      expect(cp).toHaveBeenCalledWith(expect.any(String), join(outputDir, 'output', 'studio'), {
+        recursive: true,
       });
     });
   });

--- a/deployers/cloud/tsup.config.ts
+++ b/deployers/cloud/tsup.config.ts
@@ -1,7 +1,7 @@
+import { cp } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { generateTypes } from '@internal/types-builder';
-import { copy } from 'fs-extra';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
@@ -17,7 +17,7 @@ export default defineConfig({
   onSuccess: async () => {
     const studioPath = dirname(fileURLToPath(import.meta.resolve('@internal/playground/package.json')));
 
-    await copy(join(studioPath, 'dist'), join('dist', 'studio'));
+    await cp(join(studioPath, 'dist'), join('dist', 'studio'), { recursive: true });
     await generateTypes(process.cwd());
   },
 });

--- a/deployers/netlify/package.json
+++ b/deployers/netlify/package.json
@@ -32,14 +32,12 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@mastra/deployer": "workspace:^",
-    "fs-extra": "^11.3.3"
+    "@mastra/deployer": "workspace:^"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",
     "@internal/types-builder": "workspace:*",
     "@mastra/core": "workspace:*",
-    "@types/fs-extra": "^11.0.4",
     "@types/node": "22.19.7",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
@@ -58,7 +56,7 @@
     "url": "https://github.com/mastra-ai/mastra/issues"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/core": ">=1.8.1-0 <2.0.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "engines": {

--- a/deployers/netlify/src/index.ts
+++ b/deployers/netlify/src/index.ts
@@ -1,8 +1,8 @@
+import { rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import process from 'node:process';
 import { Deployer } from '@mastra/deployer';
 import { DepsService } from '@mastra/deployer/services';
-import { move, writeJson } from 'fs-extra/esm';
 
 export class NetlifyDeployer extends Deployer {
   constructor() {
@@ -47,25 +47,30 @@ export class NetlifyDeployer extends Deployer {
 
     // Use Netlify Frameworks API config.json
     // https://docs.netlify.com/build/frameworks/frameworks-api/
-    await writeJson(join(outputDirectory, '.netlify', 'v1', 'config.json'), {
-      functions: {
-        directory: '.netlify/v1/functions',
-        node_bundler: 'none', // Mastra pre-bundles, don't re-bundle
-        included_files: ['.netlify/v1/functions/**'],
-      },
-      redirects: [
+    await writeFile(
+      join(outputDirectory, '.netlify', 'v1', 'config.json'),
+      JSON.stringify(
         {
-          force: true,
-          from: '/*',
-          to: '/.netlify/functions/api/:splat',
-          status: 200,
+          functions: {
+            directory: '.netlify/v1/functions',
+            node_bundler: 'none', // Mastra pre-bundles, don't re-bundle
+            included_files: ['.netlify/v1/functions/**'],
+          },
+          redirects: [
+            {
+              force: true,
+              from: '/*',
+              to: '/.netlify/functions/api/:splat',
+              status: 200,
+            },
+          ],
         },
-      ],
-    });
+        null,
+        2,
+      ),
+    );
 
-    await move(join(outputDirectory, '.netlify', 'v1'), join(process.cwd(), '.netlify', 'v1'), {
-      overwrite: true,
-    });
+    await rename(join(outputDirectory, '.netlify', 'v1'), join(process.cwd(), '.netlify', 'v1'));
 
     return result;
   }

--- a/deployers/vercel/package.json
+++ b/deployers/vercel/package.json
@@ -32,15 +32,13 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@mastra/deployer": "workspace:^",
-    "fs-extra": "^11.3.3"
+    "@mastra/deployer": "workspace:^"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",
     "@internal/playground": "workspace:*",
     "@internal/types-builder": "workspace:*",
     "@mastra/core": "workspace:*",
-    "@types/fs-extra": "^11.0.4",
     "@types/node": "22.19.7",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
@@ -59,7 +57,7 @@
     "url": "https://github.com/mastra-ai/mastra/issues"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.8.1-0 <2.0.0-0"
   },
   "engines": {
     "node": ">=22.13.0"

--- a/deployers/vercel/src/index.ts
+++ b/deployers/vercel/src/index.ts
@@ -1,10 +1,10 @@
 import { readFileSync, writeFileSync } from 'node:fs';
+import { cp, rename } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { Deployer } from '@mastra/deployer';
 import { injectStudioHtmlConfig } from '@mastra/deployer/build';
-import { copy, move } from 'fs-extra/esm';
 import type { VcConfig, VcConfigOverrides, VercelDeployerOptions } from './types';
 
 export class VercelDeployer extends Deployer {
@@ -33,7 +33,7 @@ export class VercelDeployer extends Deployer {
       const staticDir = join(outputDirectory, '.vercel', 'output', 'static');
 
       try {
-        await copy(studioSource, staticDir, { overwrite: true });
+        await cp(studioSource, staticDir, { recursive: true });
       } catch (err) {
         throw new Error(
           `Failed to copy studio assets from "${studioSource}" to "${staticDir}": ${err instanceof Error ? err.message : err}`,
@@ -135,9 +135,7 @@ export const HEAD = handle(app);
 
     writeFileSync(join(outputDirectory, this.outputDir, '.vc-config.json'), JSON.stringify(vcConfig, null, 2));
 
-    await move(join(outputDirectory, '.vercel', 'output'), join(process.cwd(), '.vercel', 'output'), {
-      overwrite: true,
-    });
+    await rename(join(outputDirectory, '.vercel', 'output'), join(process.cwd(), '.vercel', 'output'));
 
     return result;
   }

--- a/deployers/vercel/tsup.config.ts
+++ b/deployers/vercel/tsup.config.ts
@@ -1,7 +1,7 @@
+import { cp } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { generateTypes } from '@internal/types-builder';
-import { copy } from 'fs-extra';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
@@ -17,7 +17,7 @@ export default defineConfig({
   onSuccess: async () => {
     const studioPath = dirname(fileURLToPath(import.meta.resolve('@internal/playground/package.json')));
 
-    await copy(join(studioPath, 'dist'), join('dist', 'studio'));
+    await cp(join(studioPath, 'dist'), join('dist', 'studio'), { recursive: true });
     await generateTypes(process.cwd());
   },
 });

--- a/docs/package.json
+++ b/docs/package.json
@@ -53,7 +53,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.0.0",
     "dotenv": "^17.2.3",
-    "fs-extra": "^11.3.3",
     "hast-util-select": "^6.0.4",
     "lucide-react": "^0.552.0",
     "node-forge": "^1.3.2",
@@ -66,7 +65,6 @@
     "rehype-parse": "^9.0.1",
     "rehype-remark": "^10.0.1",
     "remark-stringify": "^11.0.0",
-    "tinyglobby": "^0.2.15",
     "unified": "^11.0.5",
     "use-stick-to-bottom": "^1.1.1",
     "valibot": "^1.2.0"
@@ -77,7 +75,6 @@
     "@docusaurus/types": "^3.9.2",
     "@playwright/test": "^1.57.0",
     "@tailwindcss/postcss": "^4.1.18",
-    "@types/fs-extra": "^11.0.4",
     "@types/hast": "^3.0.4",
     "@types/mdast": "^4.0.4",
     "@types/node": "22.19.7",

--- a/docs/src/plugins/docusaurus-plugin-llms-txt/cache-manager.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/cache-manager.ts
@@ -3,7 +3,7 @@
  */
 
 import crypto from 'crypto'
-import fs from 'fs-extra'
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises'
 import path from 'path'
 
 interface CacheEntry {
@@ -41,10 +41,13 @@ export class CacheManager {
     if (!this.enabled) return
 
     try {
-      const exists = await fs.pathExists(this.cachePath)
+      const exists = await access(this.cachePath).then(
+        () => true,
+        () => false,
+      )
       if (!exists) return
 
-      const raw = await fs.readFile(this.cachePath, 'utf-8')
+      const raw = await readFile(this.cachePath, 'utf-8')
       const parsed = JSON.parse(raw) as CacheData
 
       // Version check - invalidate if version or plugin hash mismatch
@@ -86,8 +89,8 @@ export class CacheManager {
   async save(): Promise<void> {
     if (!this.enabled) return
 
-    await fs.ensureDir(this.cacheDir)
-    await fs.writeFile(this.cachePath, JSON.stringify(this.data, null, 2), 'utf-8')
+    await mkdir(this.cacheDir, { recursive: true })
+    await writeFile(this.cachePath, JSON.stringify(this.data, null, 2), 'utf-8')
   }
 
   getEntryCount(): number {

--- a/docs/src/plugins/docusaurus-plugin-llms-txt/index.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/index.ts
@@ -6,8 +6,7 @@
 
 import type { LoadContext, Plugin } from '@docusaurus/types'
 import path from 'path'
-import fs from 'fs-extra'
-import { glob } from 'tinyglobby'
+import { glob, readFile } from 'node:fs/promises'
 
 import { type LlmsTxtPluginOptions, resolveOptions, validateOptions } from './options'
 import { CacheManager, computeHash } from './cache-manager'
@@ -39,10 +38,9 @@ export default function pluginLlmsTxt(_context: LoadContext, userOptions: LlmsTx
       await cache.load()
 
       // Find all index.html files
-      const htmlFiles = await glob('**/index.html', {
-        cwd: outDir,
-        ignore: ['assets/**', '.llms-txt-cache/**'],
-      })
+      const htmlFiles = (await Array.fromAsync(glob('**/index.html', { cwd: outDir }))).filter(
+        f => !f.startsWith('assets/') && !f.startsWith('.llms-txt-cache/'),
+      )
 
       console.log(`[${PLUGIN_NAME}] Found ${htmlFiles.length} HTML files to process`)
 
@@ -67,7 +65,7 @@ export default function pluginLlmsTxt(_context: LoadContext, userOptions: LlmsTx
 
         try {
           // Read HTML content
-          const html = await fs.readFile(htmlPath, 'utf-8')
+          const html = await readFile(htmlPath, 'utf-8')
           const contentHash = computeHash(html)
 
           const llmsTxtPath = path.join(path.dirname(htmlPath), 'llms.txt')
@@ -161,12 +159,12 @@ async function mapConcurrent<T, R>(items: T[], concurrency: number, fn: (item: T
  * Compute a hash of all plugin source files to invalidate cache when plugin code changes
  */
 async function computePluginHash(): Promise<string> {
-  const pluginFiles = await glob('*.ts', { cwd: PLUGIN_DIR })
+  const pluginFiles = await Array.fromAsync(glob('*.ts', { cwd: PLUGIN_DIR }))
   const contents: string[] = []
 
   for (const file of pluginFiles.sort()) {
     const filePath = path.join(PLUGIN_DIR, file)
-    const content = await fs.readFile(filePath, 'utf-8')
+    const content = await readFile(filePath, 'utf-8')
     contents.push(content)
   }
 

--- a/docs/src/plugins/docusaurus-plugin-llms-txt/manifest-generator.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/manifest-generator.ts
@@ -2,8 +2,8 @@
  * Generate llms-manifest.json mapping packages to their documentation
  */
 
+import { readFile, writeFile } from 'node:fs/promises'
 import path from 'path'
-import fs from 'fs-extra'
 import { extractFrontMatter, getPackageNames } from '../../utils/frontmatter'
 import { resolveSourceFile, getCategoryFromRoute, getFolderPathFromRoute, isDocumentedRoute } from './source-resolver'
 
@@ -64,7 +64,7 @@ export async function generateManifest(routes: RouteInfo[], siteDir: string, out
 
     // Read and parse frontmatter
     try {
-      const content = await fs.readFile(sourceFile, 'utf-8')
+      const content = await readFile(sourceFile, 'utf-8')
       const frontmatter = extractFrontMatter(content)
       let packages = getPackageNames(frontmatter)
 
@@ -118,7 +118,7 @@ export async function generateManifest(routes: RouteInfo[], siteDir: string, out
  */
 export async function writeManifest(manifest: LlmsManifest, outDir: string): Promise<void> {
   const manifestPath = path.join(outDir, 'llms-manifest.json')
-  await fs.writeJson(manifestPath, manifest, { spaces: 2 })
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')
 
   const packageCount = Object.keys(manifest.packages).length
   const entryCount = Object.values(manifest.packages).reduce((sum, entries) => sum + entries.length, 0)

--- a/docs/src/plugins/docusaurus-plugin-llms-txt/output-generator.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/output-generator.ts
@@ -2,7 +2,7 @@
  * Output generation for root and individual llms.txt files
  */
 
-import fs from 'fs-extra'
+import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'path'
 import type { ResolvedOptions } from './options'
 import { generateMarkdownList, getBaseUrl, getSidebarLocations, parseSidebarFile } from './sidebars-handler'
@@ -33,15 +33,15 @@ export async function generateRootLlmsTxt(outDir: string, siteDir: string): Prom
     }
   }
 
-  await fs.writeFile(path.join(outDir, 'llms.txt'), output, 'utf-8')
+  await writeFile(path.join(outDir, 'llms.txt'), output, 'utf-8')
 }
 
 /**
  * Write an individual llms.txt file
  */
 export async function writeLlmsTxt(outputPath: string, content: string): Promise<void> {
-  await fs.ensureDir(path.dirname(outputPath))
-  await fs.writeFile(outputPath, content, 'utf-8')
+  await mkdir(path.dirname(outputPath), { recursive: true })
+  await writeFile(outputPath, content, 'utf-8')
 }
 
 const ROOT_LLMS_PREFIX_BLOCK = `# Mastra

--- a/docs/src/plugins/docusaurus-plugin-llms-txt/source-resolver.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/source-resolver.ts
@@ -4,8 +4,8 @@
  * Maps build routes to their source MDX files to extract frontmatter.
  */
 
+import { access } from 'node:fs/promises'
 import path from 'path'
-import fs from 'fs-extra'
 
 interface RouteMapping {
   routePrefix: string
@@ -42,7 +42,12 @@ export async function resolveSourceFile(route: string, siteDir: string): Promise
       ]
 
       for (const sourcePath of possiblePaths) {
-        if (await fs.pathExists(sourcePath)) {
+        if (
+          await access(sourcePath).then(
+            () => true,
+            () => false,
+          )
+        ) {
           return sourcePath
         }
       }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,6 @@
     "commander": "^14.0.3",
     "dotenv": "^17.2.3",
     "execa": "^9.6.1",
-    "fs-extra": "^11.3.3",
     "get-port": "^7.1.0",
     "local-pkg": "^1.1.2",
     "picocolors": "^1.1.1",
@@ -67,7 +66,6 @@
     "serve": "^14.2.5",
     "serve-handler": "^6.1.6",
     "shell-quote": "^1.8.3",
-    "strip-json-comments": "^5.0.3",
     "yocto-spinner": "^1.0.0"
   },
   "devDependencies": {
@@ -76,7 +74,6 @@
     "@internal/playground": "workspace:*",
     "@internal/types-builder": "workspace:*",
     "@mastra/core": "workspace:*",
-    "@types/fs-extra": "^11.0.4",
     "@types/node": "22.19.7",
     "@types/semver": "^7.7.0",
     "@types/serve-handler": "^6.1.4",
@@ -92,7 +89,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.1.0-0 <2.0.0-0",
+    "@mastra/core": ">=1.8.1-0 <2.0.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "homepage": "https://mastra.ai",

--- a/packages/cli/src/commands/build/BuildBundler.test.ts
+++ b/packages/cli/src/commands/build/BuildBundler.test.ts
@@ -1,18 +1,16 @@
-import { copy } from 'fs-extra';
+import { cp } from 'node:fs/promises';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// Mock fs-extra/esm - parent Bundler uses this import path
-vi.mock('fs-extra/esm', () => ({
-  copy: vi.fn(),
-  emptyDir: vi.fn().mockResolvedValue(undefined),
-  ensureDir: vi.fn().mockResolvedValue(undefined),
-  default: {},
-}));
-
-// Mock fs-extra - BuildBundler uses this import path
-vi.mock('fs-extra', () => ({
-  copy: vi.fn(),
-}));
+// Mock node:fs/promises - BuildBundler uses cp from this module
+vi.mock('node:fs/promises', async importOriginal => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    cp: vi.fn(),
+    mkdir: vi.fn(),
+    rm: vi.fn(),
+  };
+});
 
 vi.mock('@mastra/deployer/build', () => {
   class MockFileService {
@@ -104,9 +102,9 @@ describe('BuildBundler', () => {
 
       await bundler.prepare('/output/dir');
 
-      expect(copy).toHaveBeenCalledTimes(1);
-      expect(copy).toHaveBeenCalledWith(expect.stringContaining('dist/studio'), expect.stringContaining('studio'), {
-        overwrite: true,
+      expect(cp).toHaveBeenCalledTimes(1);
+      expect(cp).toHaveBeenCalledWith(expect.stringContaining('dist/studio'), expect.stringContaining('studio'), {
+        recursive: true,
       });
     });
 
@@ -116,7 +114,7 @@ describe('BuildBundler', () => {
 
       await bundler.prepare('/output/dir');
 
-      expect(copy).not.toHaveBeenCalled();
+      expect(cp).not.toHaveBeenCalled();
     });
 
     it('should not copy studio assets when studio is not provided', async () => {
@@ -125,7 +123,7 @@ describe('BuildBundler', () => {
 
       await bundler.prepare('/output/dir');
 
-      expect(copy).not.toHaveBeenCalled();
+      expect(cp).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/commands/build/BuildBundler.ts
+++ b/packages/cli/src/commands/build/BuildBundler.ts
@@ -1,9 +1,9 @@
+import { cp } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Config } from '@mastra/core/mastra';
 import { FileService } from '@mastra/deployer/build';
 import { Bundler, IS_DEFAULT } from '@mastra/deployer/bundler';
-import { copy } from 'fs-extra';
 import { shouldSkipDotenvLoading } from '../utils.js';
 
 export class BuildBundler extends Bundler {
@@ -60,8 +60,8 @@ export class BuildBundler extends Bundler {
       const __dirname = dirname(__filename);
 
       const studioServePath = join(outputDirectory, this.outputDir, 'studio');
-      await copy(join(dirname(__dirname), join('dist', 'studio')), studioServePath, {
-        overwrite: true,
+      await cp(join(dirname(__dirname), join('dist', 'studio')), studioServePath, {
+        recursive: true,
       });
     }
   }

--- a/packages/cli/src/commands/dev/DevBundler.test.ts
+++ b/packages/cli/src/commands/dev/DevBundler.test.ts
@@ -1,4 +1,4 @@
-import { remove } from 'fs-extra/esm';
+import { rm } from 'node:fs/promises';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DevBundler } from './DevBundler';
 
@@ -56,10 +56,12 @@ vi.mock('@mastra/deployer/build', () => {
   };
 });
 
-vi.mock('fs-extra', () => {
+vi.mock('node:fs/promises', async importOriginal => {
+  const original = await importOriginal();
   return {
-    pathExists: vi.fn().mockResolvedValue(false),
-    copy: vi.fn().mockResolvedValue(undefined),
+    ...original,
+    cp: vi.fn().mockResolvedValue(undefined),
+    rm: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -102,7 +104,7 @@ describe('DevBundler', () => {
           expect.objectContaining({ sourcemap: false }),
         );
       } finally {
-        await remove(tmpDir);
+        await rm(tmpDir, { recursive: true, force: true });
       }
     });
 
@@ -126,7 +128,7 @@ describe('DevBundler', () => {
           expect.objectContaining({ sourcemap: false }),
         );
       } finally {
-        await remove(tmpDir);
+        await rm(tmpDir, { recursive: true, force: true });
       }
     });
   });

--- a/packages/cli/src/commands/dev/DevBundler.ts
+++ b/packages/cli/src/commands/dev/DevBundler.ts
@@ -1,10 +1,9 @@
-import { writeFile } from 'node:fs/promises';
+import { cp, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { FileService } from '@mastra/deployer';
 import { createWatcher, getWatcherInputOptions } from '@mastra/deployer/build';
 import { Bundler } from '@mastra/deployer/bundler';
-import * as fsExtra from 'fs-extra';
 import type { InputPluginOption, RollupWatcherEvent } from 'rollup';
 
 import { devLogger } from '../../utils/dev-logger.js';
@@ -50,8 +49,8 @@ export class DevBundler extends Bundler {
     const __dirname = dirname(__filename);
 
     const studioServePath = join(outputDirectory, this.outputDir, 'studio');
-    await fsExtra.copy(join(dirname(__dirname), join('dist', 'studio')), studioServePath, {
-      overwrite: true,
+    await cp(join(dirname(__dirname), join('dist', 'studio')), studioServePath, {
+      recursive: true,
     });
   }
 

--- a/packages/cli/src/commands/init/mcp-docs-server-install.ts
+++ b/packages/cli/src/commands/init/mcp-docs-server-install.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { ensureFile, readJSON, writeJSON } from 'fs-extra/esm';
 
 const createArgs = (versionTag?: string) => {
   const packageName = versionTag ? `@mastra/mcp-docs-server@${versionTag}` : '@mastra/mcp-docs-server';
@@ -63,11 +63,9 @@ function makeConfig(
 
 async function writeMergedConfig(configPath: string, editor: Editor, versionTag?: string) {
   const configExists = existsSync(configPath);
-  const config = makeConfig(configExists ? await readJSON(configPath) : {}, editor, versionTag);
-  await ensureFile(configPath);
-  await writeJSON(configPath, config, {
-    spaces: 2,
-  });
+  const config = makeConfig(configExists ? JSON.parse(await readFile(configPath, 'utf-8')) : {}, editor, versionTag);
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(configPath, JSON.stringify(config, null, 2));
 }
 
 export const windsurfGlobalMCPConfigPath = path.join(os.homedir(), '.codeium', 'windsurf', 'mcp_config.json');
@@ -161,7 +159,7 @@ export async function globalMCPIsAlreadyInstalled(editor: Editor, versionTag?: s
   }
 
   try {
-    const configContents = await readJSON(configPath);
+    const configContents = JSON.parse(await readFile(configPath, 'utf-8'));
 
     if (!configContents) return false;
 

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -4,7 +4,6 @@ import path from 'node:path';
 import util from 'node:util';
 import * as p from '@clack/prompts';
 import type { ModelRouterModelId } from '@mastra/core/llm/model';
-import fsExtra from 'fs-extra/esm';
 import color from 'picocolors';
 import prettier from 'prettier';
 import shellQuote from 'shell-quote';
@@ -452,7 +451,7 @@ export async function writeCodeSampleForComponents(
 export const createComponentsDir = async (dirPath: string, component: string) => {
   const componentPath = dirPath + `/${component}`;
 
-  await fsExtra.ensureDir(componentPath);
+  await fs.mkdir(componentPath, { recursive: true });
 };
 
 export const writeIndexFile = async ({
@@ -632,7 +631,7 @@ export const createMastraDir = async (directory: string): Promise<{ ok: true; di
     await fs.access(dirPath);
     return { ok: false };
   } catch {
-    await fsExtra.ensureDir(dirPath);
+    await fs.mkdir(dirPath, { recursive: true });
     return { ok: true, dirPath };
   }
 };

--- a/packages/cli/src/commands/lint/rules/tsConfigRule.ts
+++ b/packages/cli/src/commands/lint/rules/tsConfigRule.ts
@@ -1,15 +1,14 @@
-import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import stripJsonComments from 'strip-json-comments';
+import ts from 'typescript';
 import { logger } from '../../../utils/logger.js';
 import type { LintContext, LintRule } from './types.js';
 
 function readTsConfig(dir: string) {
   const tsConfigPath = join(dir, 'tsconfig.json');
   try {
-    const tsConfigContent = readFileSync(tsConfigPath, 'utf-8');
-    const cleanTsConfigContent = stripJsonComments(tsConfigContent);
-    return JSON.parse(cleanTsConfigContent);
+    const { config, error } = ts.readConfigFile(tsConfigPath, ts.sys.readFile);
+    if (error) return null;
+    return config;
   } catch {
     return null;
   }

--- a/packages/cli/src/commands/utils.test.ts
+++ b/packages/cli/src/commands/utils.test.ts
@@ -1,14 +1,17 @@
+import { readFile } from 'node:fs/promises';
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 
 vi.mock('execa', () => ({
   execa: vi.fn(),
 }));
 
-vi.mock('fs-extra', () => ({
-  default: {
-    readJSON: vi.fn(),
-  },
-}));
+vi.mock('node:fs/promises', async importOriginal => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    readFile: vi.fn(),
+  };
+});
 
 vi.mock('node:url', () => ({
   fileURLToPath: vi.fn(() => '/mock/path/to/package.json'),
@@ -21,9 +24,8 @@ describe('getVersionTag', () => {
 
   test('returns "beta" when CLI version matches beta dist-tag', async () => {
     const { execa } = await import('execa');
-    const fsExtra = (await import('fs-extra')).default;
 
-    vi.mocked(fsExtra.readJSON).mockResolvedValue({ version: '1.0.0-beta.5' });
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ version: '1.0.0-beta.5' }) as any);
     vi.mocked(execa).mockResolvedValue({
       stdout: 'beta: 1.0.0-beta.5\nlatest: 0.18.6',
       stderr: '',
@@ -43,9 +45,8 @@ describe('getVersionTag', () => {
 
   test('returns "latest" when CLI version matches latest dist-tag', async () => {
     const { execa } = await import('execa');
-    const fsExtra = (await import('fs-extra')).default;
 
-    vi.mocked(fsExtra.readJSON).mockResolvedValue({ version: '0.18.6' });
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ version: '0.18.6' }) as any);
     vi.mocked(execa).mockResolvedValue({
       stdout: 'beta: 1.0.0-beta.5\nlatest: 0.18.6',
       stderr: '',
@@ -65,9 +66,8 @@ describe('getVersionTag', () => {
 
   test('returns undefined when version does not match any dist-tag', async () => {
     const { execa } = await import('execa');
-    const fsExtra = (await import('fs-extra')).default;
 
-    vi.mocked(fsExtra.readJSON).mockResolvedValue({ version: '0.0.0-local' });
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ version: '0.0.0-local' }) as any);
     vi.mocked(execa).mockResolvedValue({
       stdout: 'beta: 1.0.0-beta.5\nlatest: 0.18.6',
       stderr: '',
@@ -87,9 +87,8 @@ describe('getVersionTag', () => {
 
   test('returns undefined when npm command fails', async () => {
     const { execa } = await import('execa');
-    const fsExtra = (await import('fs-extra')).default;
 
-    vi.mocked(fsExtra.readJSON).mockResolvedValue({ version: '1.0.0-beta.5' });
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ version: '1.0.0-beta.5' }) as any);
     vi.mocked(execa).mockRejectedValue(new Error('npm command failed'));
 
     const { getVersionTag } = await import('./utils');
@@ -99,9 +98,7 @@ describe('getVersionTag', () => {
   });
 
   test('returns undefined when package.json cannot be read', async () => {
-    const fsExtra = (await import('fs-extra')).default;
-
-    vi.mocked(fsExtra.readJSON).mockRejectedValue(new Error('File not found'));
+    vi.mocked(readFile).mockRejectedValue(new Error('File not found'));
 
     const { getVersionTag } = await import('./utils');
     const tag = await getVersionTag();

--- a/packages/cli/src/commands/utils.ts
+++ b/packages/cli/src/commands/utils.ts
@@ -1,7 +1,7 @@
+import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { InvalidArgumentError } from 'commander';
 import { execa } from 'execa';
-import fsExtra from 'fs-extra';
 import type { PackageManager } from '../utils/package-manager';
 import { EDITOR, isValidEditor } from './init/mcp-docs-server-install';
 import { areValidComponents, COMPONENTS, isValidLLMProvider, LLMProvider } from './init/utils';
@@ -84,7 +84,7 @@ export function shouldSkipDotenvLoading(): boolean {
 export async function getVersionTag(): Promise<string | undefined> {
   try {
     const pkgPath = fileURLToPath(import.meta.resolve('mastra/package.json'));
-    const json = await fsExtra.readJSON(pkgPath);
+    const json = JSON.parse(await readFile(pkgPath, 'utf-8'));
     const currentVersion = json.version;
 
     const { stdout } = await execa('npm', ['dist-tag', 'ls', 'mastra'], {

--- a/packages/cli/src/services/service.file.ts
+++ b/packages/cli/src/services/service.file.ts
@@ -1,8 +1,7 @@
 import fs from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import fsExtra from 'fs-extra/esm';
 
 import { FileEnvService } from './service.fileEnv';
 
@@ -25,7 +24,8 @@ export class FileService {
       return false;
     }
 
-    await fsExtra.outputFile(outputFilePath, fileString);
+    await mkdir(path.dirname(outputFilePath), { recursive: true });
+    await writeFile(outputFilePath, fileString);
 
     return true;
   }
@@ -33,7 +33,8 @@ export class FileService {
   public async setupEnvFile({ dbUrl }: { dbUrl: string }) {
     const envPath = path.join(process.cwd(), '.env.development');
 
-    await fsExtra.ensureFile(envPath);
+    await mkdir(path.dirname(envPath), { recursive: true });
+    await writeFile(envPath, '', { flag: 'a' });
 
     const fileEnvService = new FileEnvService(envPath);
     await fileEnvService.setEnvValue('DB_URL', dbUrl);

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,7 +1,7 @@
+import { cp } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { generateTypes } from '@internal/types-builder';
-import { copy } from 'fs-extra';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
@@ -15,7 +15,7 @@ export default defineConfig({
   onSuccess: async () => {
     const studioPath = dirname(fileURLToPath(import.meta.resolve('@internal/playground/package.json')));
 
-    await copy(join(studioPath, 'dist'), join('dist', 'studio'));
+    await cp(join(studioPath, 'dist'), join('dist', 'studio'), { recursive: true });
     await generateTypes(process.cwd());
   },
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -217,7 +217,6 @@
     "@ai-sdk/provider-v6": "npm:@ai-sdk/provider@3.0.0",
     "@ai-sdk/ui-utils-v5": "npm:@ai-sdk/ui-utils@1.2.11",
     "@isaacs/ttlcache": "^2.1.4",
-    "@lukeed/uuid": "^2.0.1",
     "@mastra/schema-compat": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.17.5",
     "@sindresorhus/slugify": "^2.2.1",

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1,7 +1,6 @@
 import type { LanguageModelV2Prompt } from '@ai-sdk/provider-v5';
 import type { LanguageModelV1Prompt, CoreMessage as CoreMessageV4 } from '@internal/ai-sdk-v4';
 import type * as AIV4Type from '@internal/ai-sdk-v4';
-import { v4 as randomUUID } from '@lukeed/uuid';
 
 import { MastraError, ErrorDomain, ErrorCategory } from '../../error';
 import type { IdGeneratorContext } from '../../types';
@@ -883,7 +882,7 @@ export class MessageList {
           // Only create a new message if there are actually new parts
           if (newParts.length > 0) {
             // Generate a new ID for the incoming message
-            messageV2.id = this.generateMessageId?.({ idType: 'message', source: 'memory' }) ?? randomUUID();
+            messageV2.id = this.generateMessageId?.({ idType: 'message', source: 'memory' }) ?? crypto.randomUUID();
             // Replace the parts with only the new ones
             messageV2.content.parts = newParts;
             // Ensure the new message has a timestamp after the sealed message
@@ -980,7 +979,7 @@ export class MessageList {
         role,
       });
     }
-    return randomUUID();
+    return crypto.randomUUID();
   }
 
   private createAdapterContext() {

--- a/packages/create-mastra/package.json
+++ b/packages/create-mastra/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "commander": "^14.0.3",
     "execa": "^9.6.1",
-    "fs-extra": "^11.3.3",
     "pino": "^10.1.0",
     "pino-pretty": "^13.1.3",
     "posthog-node": "^5.17.2",
@@ -48,7 +47,6 @@
     "@rollup/plugin-commonjs": "29.0.0",
     "@rollup/plugin-json": "6.1.0",
     "@rollup/plugin-node-resolve": "16.0.3",
-    "@types/fs-extra": "^11.0.4",
     "@types/node": "22.19.7",
     "esbuild": "^0.27.1",
     "eslint": "^9.39.2",

--- a/packages/create-mastra/rollup.config.js
+++ b/packages/create-mastra/rollup.config.js
@@ -1,15 +1,15 @@
+import { cp } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';
-import fsExtra from 'fs-extra/esm';
 import { defineConfig } from 'rollup';
 import esbuild from 'rollup-plugin-esbuild';
 import nodeExternals from 'rollup-plugin-node-externals';
 import pkgJson from './package.json' with { type: 'json' };
 
-const external = ['commander', 'fs-extra', 'execa', 'prettier', 'posthog-node', 'pino', 'pino-pretty'];
+const external = ['commander', 'execa', 'prettier', 'posthog-node', 'pino', 'pino-pretty'];
 external.forEach(pkg => {
   if (!pkgJson.dependencies[pkg]) {
     throw new Error(`${pkg} is not in the dependencies of create-mastra`);
@@ -42,8 +42,8 @@ export default defineConfig({
         const mastraPath = path.dirname(fileURLToPath(import.meta.resolve('mastra/package.json')));
 
         // Copy to dist directory instead of root
-        await fsExtra.copy(path.join(mastraPath, 'dist', 'starter-files'), './dist/starter-files');
-        await fsExtra.copy(path.join(mastraPath, 'dist', 'templates'), './dist/templates');
+        await cp(path.join(mastraPath, 'dist', 'starter-files'), './dist/starter-files', { recursive: true });
+        await cp(path.join(mastraPath, 'dist', 'templates'), './dist/templates', { recursive: true });
       },
     },
   ],

--- a/packages/create-mastra/src/utils.ts
+++ b/packages/create-mastra/src/utils.ts
@@ -1,21 +1,21 @@
+import { readFile } from 'node:fs/promises';
 import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execa } from 'execa';
-import fsExtra from 'fs-extra';
 
 export async function getPackageVersion() {
   const __filename = fileURLToPath(import.meta.url);
   const __dirname = dirname(__filename);
   const pkgJsonPath = path.join(__dirname, '..', 'package.json');
 
-  const content = await fsExtra.readJSON(pkgJsonPath);
+  const content = JSON.parse(await readFile(pkgJsonPath, 'utf-8'));
   return content.version;
 }
 
 export async function getCreateVersionTag(): Promise<string | undefined> {
   try {
     const pkgPath = fileURLToPath(import.meta.resolve('create-mastra/package.json'));
-    const json = await fsExtra.readJSON(pkgPath);
+    const json = JSON.parse(await readFile(pkgPath, 'utf-8'));
 
     const { stdout } = await execa('npm', ['dist-tag', 'create-mastra']);
     const tagLine = stdout.split('\n').find(distLine => distLine.endsWith(`: ${json.version}`));

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -108,15 +108,12 @@
     "empathic": "^2.0.0",
     "esbuild": "^0.25.10",
     "find-workspaces": "^0.3.1",
-    "fs-extra": "^11.3.3",
     "hono": "^4.11.9",
     "local-pkg": "^1.1.2",
     "resolve-from": "^5.0.0",
     "resolve.exports": "^2.0.3",
     "rollup": "~4.55.1",
     "rollup-plugin-esbuild": "^6.2.1",
-    "strip-json-comments": "^5.0.3",
-    "tinyglobby": "^0.2.15",
     "typescript-paths": "^1.5.1"
   },
   "devDependencies": {
@@ -129,7 +126,6 @@
     "@mastra/hono": "workspace:*",
     "@mastra/mcp": "workspace:^",
     "@types/babel__core": "^7.20.5",
-    "@types/fs-extra": "^11.0.4",
     "@types/node": "22.19.7",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
@@ -144,7 +140,7 @@
     "zod": "^3.25.76"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "@mastra/core": ">=1.8.1-0 <2.0.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "homepage": "https://mastra.ai",

--- a/packages/deployer/src/build/analyze/analyzeEntry.test.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.test.ts
@@ -1,6 +1,6 @@
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { noopLogger } from '@mastra/core/logger';
-import { readFile } from 'fs-extra';
 import { resolveModule } from 'local-pkg';
 import type * as LocalPkgModule from 'local-pkg';
 import { rollup } from 'rollup';

--- a/packages/deployer/src/build/analyze/analyzeEntry.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.ts
@@ -1,10 +1,10 @@
+import { readFile } from 'node:fs/promises';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { noopLogger } from '@mastra/core/logger';
 import type { IMastraLogger } from '@mastra/core/logger';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import virtual from '@rollup/plugin-virtual';
-import { readJSON } from 'fs-extra/esm';
 import { resolveModule } from 'local-pkg';
 import { rollup } from 'rollup';
 import type { OutputChunk, Plugin, SourceMap } from 'rollup';
@@ -125,7 +125,7 @@ async function captureDependenciesToOptimize(
       // Read version from package.json when we have a valid rootPath
       if (rootPath) {
         try {
-          const pkgJson = await readJSON(`${rootPath}/package.json`);
+          const pkgJson = JSON.parse(await readFile(`${rootPath}/package.json`, 'utf-8'));
           version = pkgJson.version;
         } catch {
           // Failed to read package.json, version will remain undefined
@@ -234,7 +234,7 @@ async function captureDependenciesToOptimize(
           rootPath = await getPackageRootPath(dynamicImport, entryRootPath);
           if (rootPath) {
             try {
-              const pkgJson = await readJSON(`${rootPath}/package.json`);
+              const pkgJson = JSON.parse(await readFile(`${rootPath}/package.json`, 'utf-8'));
               version = pkgJson.version;
             } catch {
               // Failed to read package.json

--- a/packages/deployer/src/build/analyze/bundleExternals.test.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.test.ts
@@ -1,6 +1,6 @@
+import { access, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { ensureDir, remove, pathExists, writeFile } from 'fs-extra';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
 import type { DependencyMetadata } from '../types';
@@ -371,17 +371,22 @@ describe('bundleExternals', () => {
 
   beforeEach(async () => {
     testDir = join(tmpdir(), 'bundleExternals-test-' + Date.now());
-    await ensureDir(testDir);
+    await mkdir(testDir, { recursive: true });
   });
 
   afterEach(async () => {
-    if (await pathExists(testDir)) {
-      await remove(testDir);
+    if (
+      await access(testDir).then(
+        () => true,
+        () => false,
+      )
+    ) {
+      await rm(testDir, { recursive: true, force: true });
     }
   });
 
   async function createWorkspacePackageJson(packagePath: string, packageName: string) {
-    await ensureDir(packagePath);
+    await mkdir(packagePath, { recursive: true });
     await writeFile(
       join(packagePath, 'package.json'),
       JSON.stringify({

--- a/packages/deployer/src/build/plugins/tsconfig-paths.ts
+++ b/packages/deployer/src/build/plugins/tsconfig-paths.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path, { normalize } from 'node:path';
 import type { Plugin } from 'rollup';
-import stripJsonComments from 'strip-json-comments';
+import ts from 'typescript';
 import type { RegisterOptions } from 'typescript-paths';
 import { createHandler } from 'typescript-paths';
 
@@ -18,8 +18,8 @@ export type PluginOptions = Omit<RegisterOptions, 'loggerID'> & { localResolve?:
  */
 export function hasPaths(tsConfigPath: string): boolean {
   try {
-    const content = fs.readFileSync(tsConfigPath, 'utf8');
-    const config = JSON.parse(stripJsonComments(content));
+    const { config } = ts.readConfigFile(tsConfigPath, ts.sys.readFile);
+    if (!config) return false;
     return !!(
       (config.compilerOptions?.paths && Object.keys(config.compilerOptions.paths).length > 0) ||
       (typeof config.extends === 'string' && config.extends.length > 0) ||

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -1,14 +1,13 @@
 import { existsSync } from 'node:fs';
-import { stat, writeFile } from 'node:fs/promises';
-import { dirname, join, posix } from 'node:path';
+import { access, cp, glob, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { dirname, join, posix, resolve } from 'node:path';
 import { MastraBundler } from '@mastra/core/bundler';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
 import type { Config } from '@mastra/core/mastra';
 import virtual from '@rollup/plugin-virtual';
 import * as pkg from 'empathic/package';
-import fsExtra, { copy, ensureDir, readJSON, emptyDir } from 'fs-extra/esm';
 import type { InputOptions, OutputOptions } from 'rollup';
-import { glob } from 'tinyglobby';
+
 import { analyzeBundle } from '../build/analyze';
 import { createBundler as createBundlerUtil, getInputOptions } from '../build/bundler';
 import { getBundlerOptions } from '../build/bundlerOptions';
@@ -36,10 +35,11 @@ export abstract class Bundler extends MastraBundler {
 
   async prepare(outputDirectory: string): Promise<void> {
     // Clean up the output directory first
-    await emptyDir(outputDirectory);
+    await rm(outputDirectory, { recursive: true, force: true });
+    await mkdir(outputDirectory, { recursive: true });
 
-    await ensureDir(join(outputDirectory, this.analyzeOutputDir));
-    await ensureDir(join(outputDirectory, this.outputDir));
+    await mkdir(join(outputDirectory, this.analyzeOutputDir), { recursive: true });
+    await mkdir(join(outputDirectory, this.outputDir), { recursive: true });
   }
 
   async writePackageJson(
@@ -49,7 +49,7 @@ export abstract class Bundler extends MastraBundler {
   ) {
     this.logger.debug(`Writing project's package.json`);
 
-    await ensureDir(outputDirectory);
+    await mkdir(outputDirectory, { recursive: true });
     const pkgPath = join(outputDirectory, 'package.json');
 
     const dependenciesMap = new Map();
@@ -146,7 +146,7 @@ export abstract class Bundler extends MastraBundler {
       return;
     }
 
-    await copy(publicDir, join(outputDirectory, this.outputDir));
+    await cp(publicDir, join(outputDirectory, this.outputDir), { recursive: true });
   }
 
   protected async copyDOTNPMRC({
@@ -161,7 +161,7 @@ export abstract class Bundler extends MastraBundler {
 
     try {
       await stat(sourceDotNpmRcPath);
-      await copy(sourceDotNpmRcPath, targetDotNpmRcPath);
+      await cp(sourceDotNpmRcPath, targetDotNpmRcPath, { recursive: true });
     } catch {
       return;
     }
@@ -233,13 +233,15 @@ export abstract class Bundler extends MastraBundler {
     const inputs: Record<string, string> = {};
 
     for (const toolPath of toolsPaths) {
-      const expandedPaths = await glob(toolPath, {
-        absolute: true,
-        expandDirectories: false,
-      });
+      const expandedPaths = (await Array.fromAsync(glob(toolPath))).map(p => resolve(p));
 
       for (const path of expandedPaths) {
-        if (await fsExtra.pathExists(path)) {
+        if (
+          await access(path).then(
+            () => true,
+            () => false,
+          )
+        ) {
           const fileService = new FileService();
           const entryFile = fileService.getFirstExistingFile([
             join(path, 'index.ts'),
@@ -343,7 +345,7 @@ export abstract class Bundler extends MastraBundler {
         }
 
         if (rootPath) {
-          const pkg = await readJSON(`${rootPath}/package.json`);
+          const pkg = JSON.parse(await readFile(`${rootPath}/package.json`, 'utf-8'));
           actualPackageName = pkg.name;
           // Use pre-resolved version if available, otherwise use from package.json
           if (!version) {

--- a/packages/deployer/src/bundler/workspaceDependencies.test.ts
+++ b/packages/deployer/src/bundler/workspaceDependencies.test.ts
@@ -19,8 +19,8 @@ vi.mock('empathic/package', () => ({
   up: vi.fn().mockReturnValue('/workspace/packages/pkg-a/package.json'),
 }));
 
-vi.mock('fs-extra', () => ({
-  ensureDir: vi.fn().mockResolvedValue(undefined),
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Create shared mock methods that can be accessed in tests

--- a/packages/deployer/src/bundler/workspaceDependencies.ts
+++ b/packages/deployer/src/bundler/workspaceDependencies.ts
@@ -1,9 +1,9 @@
+import { mkdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import type { IMastraLogger } from '@mastra/core/logger';
 import slugify from '@sindresorhus/slugify';
 import * as pkg from 'empathic/package';
 import { findWorkspaces, findWorkspacesRoot, createWorkspacesCache } from 'find-workspaces';
-import { ensureDir } from 'fs-extra';
 import { slash } from '../build/utils';
 import { DepsService } from '../services';
 
@@ -151,7 +151,7 @@ export const packWorkspaceDependencies = async ({
   // package all workspace dependencies
   if (usedWorkspacePackages.size > 0) {
     const workspaceDirPath = join(bundleOutputDir, 'workspace-module');
-    await ensureDir(workspaceDirPath);
+    await mkdir(workspaceDirPath, { recursive: true });
 
     logger.info(`Packaging ${usedWorkspacePackages.size} workspace dependencies...`);
 

--- a/packages/deployer/src/services/deps.ts
+++ b/packages/deployer/src/services/deps.ts
@@ -3,7 +3,6 @@ import fsPromises from 'node:fs/promises';
 import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { MastraBase } from '@mastra/core/base';
-import { readJSON, writeJSON, ensureFile } from 'fs-extra/esm';
 import type { PackageJson } from 'type-fest';
 
 import { createChildProcessLogger } from '../deploy/log.js';
@@ -92,7 +91,7 @@ export class Deps extends MastraBase {
 
   private async writePnpmConfig(dir: string, options: ArchitectureOptions) {
     const packageJsonPath = path.join(dir, 'package.json');
-    const packageJson = await readJSON(packageJsonPath);
+    const packageJson = JSON.parse(await fsPromises.readFile(packageJsonPath, 'utf-8'));
 
     packageJson.pnpm = {
       ...packageJson.pnpm,
@@ -103,7 +102,7 @@ export class Deps extends MastraBase {
       },
     };
 
-    await writeJSON(packageJsonPath, packageJson, { spaces: 2 });
+    await fsPromises.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
   }
 
   private async writeYarnConfig(dir: string, options: ArchitectureOptions) {
@@ -169,7 +168,8 @@ export class Deps extends MastraBase {
         break;
       case 'yarn':
         // similar to --ignore-workspace but for yarn
-        await ensureFile(path.join(dir, 'yarn.lock'));
+        await fsPromises.mkdir(dirname(path.join(dir, 'yarn.lock')), { recursive: true });
+        await fsPromises.writeFile(path.join(dir, 'yarn.lock'), '', { flag: 'a' });
         if (architecture) {
           await this.writeYarnConfig(dir, architecture);
         }
@@ -229,7 +229,7 @@ export class Deps extends MastraBase {
         return 'No package.json file found in the current directory';
       }
 
-      const packageJson = await readJSON(packageJsonPath);
+      const packageJson = JSON.parse(await fsPromises.readFile(packageJsonPath, 'utf-8'));
       for (const dependency of dependencies) {
         if (!packageJson.dependencies || !packageJson.dependencies[dependency]) {
           return `Please install ${dependency} before running this command (${this.packageManager} install ${dependency})`;
@@ -246,7 +246,7 @@ export class Deps extends MastraBase {
   public async getProjectName() {
     try {
       const packageJsonPath = path.join(this.rootDir, 'package.json');
-      const pkg = await readJSON(packageJsonPath);
+      const pkg = JSON.parse(await fsPromises.readFile(packageJsonPath, 'utf-8'));
       return pkg.name;
     } catch (err) {
       throw err;
@@ -258,17 +258,17 @@ export class Deps extends MastraBase {
     const __dirname = dirname(__filename);
     const pkgJsonPath = path.join(__dirname, '..', '..', 'package.json');
 
-    const content = (await readJSON(pkgJsonPath)) as PackageJson;
+    const content = JSON.parse(await fsPromises.readFile(pkgJsonPath, 'utf-8')) as PackageJson;
     return content.version;
   }
 
   public async addScriptsToPackageJson(scripts: Record<string, string>) {
-    const packageJson = await readJSON('package.json');
+    const packageJson = JSON.parse(await fsPromises.readFile('package.json', 'utf-8'));
     packageJson.scripts = {
       ...packageJson.scripts,
       ...scripts,
     };
-    await writeJSON('package.json', packageJson, { spaces: 2 });
+    await fsPromises.writeFile('package.json', JSON.stringify(packageJson, null, 2));
   }
 }
 

--- a/packages/deployer/src/services/fs.ts
+++ b/packages/deployer/src/services/fs.ts
@@ -1,8 +1,7 @@
 import fs from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import fsExtra from 'fs-extra/esm';
 
 import { FileEnvService } from './env.js';
 
@@ -25,7 +24,8 @@ export class FileService {
       return false;
     }
 
-    await fsExtra.outputFile(outputFilePath, fileString);
+    await mkdir(path.dirname(outputFilePath), { recursive: true });
+    await writeFile(outputFilePath, fileString);
 
     return true;
   }
@@ -33,7 +33,8 @@ export class FileService {
   public async setupEnvFile({ dbUrl }: { dbUrl: string }) {
     const envPath = path.join(process.cwd(), '.env.development');
 
-    await fsExtra.ensureFile(envPath);
+    await mkdir(path.dirname(envPath), { recursive: true });
+    await writeFile(envPath, '', { flag: 'a' });
 
     const fileEnvService = new FileEnvService(envPath);
     await fileEnvService.setEnvValue('DB_URL', dbUrl);

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -86,7 +86,6 @@
     "@hello-pangea/dnd": "^18.0.1",
     "@hookform/resolvers": "^3.10.0",
     "@lezer/highlight": "^1.2.3",
-    "@lukeed/uuid": "^2.0.1",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-collapsible": "^1.1.11",
@@ -132,7 +131,7 @@
   "peerDependencies": {
     "@mastra/ai-sdk": "workspace:^",
     "@mastra/client-js": "workspace:^",
-    "@mastra/core": ">=1.5.0-0 <2.0.0-0",
+    "@mastra/core": ">=1.8.1-0 <2.0.0-0",
     "@mastra/react": "workspace:*",
     "@mastra/schema-compat": "workspace:*",
     "@tanstack/react-query": "^5.81.5",

--- a/packages/playground-ui/src/domains/agents/components/agent-cms-pages/skill-file-tree.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-cms-pages/skill-file-tree.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { useCallback, useRef, useState } from 'react';
-import { v4 as uuid } from '@lukeed/uuid';
+
 import { File, FileCode, FileJson, FileText, Folder, FolderOpen, FolderPlus, Image, Plus, Trash2 } from 'lucide-react';
 
 import { Tree } from '@/ds/components/Tree/tree';
@@ -333,7 +333,7 @@ export function SkillFileTree({ files, onChange, selectedFileId, onSelectFile, r
       reader.onload = () => {
         const base64 = reader.result as string;
         const newNode: InMemoryFileNode = {
-          id: uuid(),
+          id: crypto.randomUUID(),
           name: file.name,
           type: 'file',
           content: base64,
@@ -352,7 +352,7 @@ export function SkillFileTree({ files, onChange, selectedFileId, onSelectFile, r
   const handleInputSubmit = useCallback(
     (name: string) => {
       if (!pendingInput) return;
-      const newId = uuid();
+      const newId = crypto.randomUUID();
       const newNode: InMemoryFileNode =
         pendingInput.type === 'folder'
           ? { id: newId, name, type: 'folder', children: [] }

--- a/packages/playground-ui/src/domains/agents/components/agent-edit-page/utils/form-validation.ts
+++ b/packages/playground-ui/src/domains/agents/components/agent-edit-page/utils/form-validation.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { v4 as uuid } from '@lukeed/uuid';
+
 import type { JsonSchema } from '@/lib/json-schema';
 import type { RuleGroup, RuleGroupDepth1, RuleGroupDepth2 } from '@mastra/core/storage';
 
@@ -84,14 +84,14 @@ const refInstructionBlockSchema = z.object({
 const instructionBlockSchema = z.discriminatedUnion('type', [inlineInstructionBlockSchema, refInstructionBlockSchema]);
 
 export const createInstructionBlock = (content = '', rules?: RuleGroup): InlineInstructionBlock => ({
-  id: uuid(),
+  id: crypto.randomUUID(),
   type: 'prompt_block',
   content,
   rules,
 });
 
 export const createRefInstructionBlock = (promptBlockId: string): RefInstructionBlock => ({
-  id: uuid(),
+  id: crypto.randomUUID(),
   type: 'prompt_block_ref',
   promptBlockId,
 });

--- a/packages/playground-ui/src/ds/components/ContentBlocks/content-blocks.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ContentBlocks/content-blocks.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { v4 as uuid } from '@lukeed/uuid';
 
 import { ContentBlocks } from './content-blocks';
 import { ContentBlock } from './content-block';
@@ -39,7 +38,7 @@ const Components = () => {
   const [items, setItems] = useState<Array<Item>>([]);
 
   const addButton = () => {
-    setItems(state => [...state, { id: uuid(), content: `item content number ${state.length + 1}` }]);
+    setItems(state => [...state, { id: crypto.randomUUID(), content: `item content number ${state.length + 1}` }]);
   };
 
   const handleItemChange = (index: number, newValue: Item) => {

--- a/packages/playground-ui/src/lib/form/components/record-field.tsx
+++ b/packages/playground-ui/src/lib/form/components/record-field.tsx
@@ -1,5 +1,5 @@
 import { AutoFormFieldProps } from '@autoform/react';
-import { v4 as uuid } from '@lukeed/uuid';
+
 import { Plus, TrashIcon } from 'lucide-react';
 import * as React from 'react';
 import { Button } from '@/ds/components/Button';
@@ -15,7 +15,7 @@ export const RecordField: React.FC<AutoFormFieldProps> = ({ inputProps, field, e
   const { key, onChange, ...props } = inputProps;
   const [pairs, setPairs] = React.useState<KeyValuePair[]>(() =>
     Object.entries(field.default || {}).map(([key, val]) => ({
-      id: key || uuid(),
+      id: key || crypto.randomUUID(),
       key,
       value: val as string,
     })),
@@ -23,7 +23,7 @@ export const RecordField: React.FC<AutoFormFieldProps> = ({ inputProps, field, e
 
   React.useEffect(() => {
     if (pairs.length === 0) {
-      setPairs([{ id: uuid(), key: '', value: '' }]);
+      setPairs([{ id: crypto.randomUUID(), key: '', value: '' }]);
     }
   }, [pairs]);
 
@@ -55,7 +55,7 @@ export const RecordField: React.FC<AutoFormFieldProps> = ({ inputProps, field, e
   };
 
   const addPair = () => {
-    const newPairs = [...pairs, { id: uuid(), key: '', value: '' }];
+    const newPairs = [...pairs, { id: crypto.randomUUID(), key: '', value: '' }];
     setPairs(newPairs);
     updateForm(newPairs);
   };
@@ -63,7 +63,7 @@ export const RecordField: React.FC<AutoFormFieldProps> = ({ inputProps, field, e
   const removePair = (id: string) => {
     const newPairs = pairs.filter(p => p.id !== id);
     if (newPairs.length === 0) {
-      newPairs.push({ id: uuid(), key: '', value: '' });
+      newPairs.push({ id: crypto.randomUUID(), key: '', value: '' });
     }
     setPairs(newPairs);
     updateForm(newPairs);

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -29,7 +29,6 @@
     "test:e2e:setup": "node ./e2e/scripts/info.js && pnpm install --ignore-workspace --dir ./e2e/kitchen-sink && playwright install chromium"
   },
   "dependencies": {
-    "@lukeed/uuid": "^2.0.1",
     "@mastra/client-js": "workspace:*",
     "date-fns": "^4.1.0",
     "@mastra/core": "workspace:*",

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -1,5 +1,5 @@
 import { coreFeatures } from '@mastra/core/features';
-import { v4 as uuid } from '@lukeed/uuid';
+
 import { createBrowserRouter, RouterProvider, Outlet, useNavigate, redirect } from 'react-router';
 
 import { Layout } from '@/components/layout';
@@ -95,7 +95,7 @@ const paths: LinkComponentProviderProps['paths'] = {
   workflowsLink: () => `/workflows`,
   workflowLink: (workflowId: string) => `/workflows/${workflowId}`,
   networkLink: (networkId: string) => `/networks/v-next/${networkId}/chat`,
-  networkNewThreadLink: (networkId: string) => `/networks/v-next/${networkId}/chat/${uuid()}`,
+  networkNewThreadLink: (networkId: string) => `/networks/v-next/${networkId}/chat/${crypto.randomUUID()}`,
   networkThreadLink: (networkId: string, threadId: string) => `/networks/v-next/${networkId}/chat/${threadId}`,
   scorerLink: (scorerId: string) => `/scorers/${scorerId}`,
   cmsScorersCreateLink: () => '/cms/scorers/create',

--- a/packages/playground/src/pages/agents/agent/index.tsx
+++ b/packages/playground/src/pages/agents/agent/index.tsx
@@ -16,7 +16,7 @@ import {
   type AgentSettingsType,
 } from '@mastra/playground-ui';
 import { useEffect, useMemo } from 'react';
-import { v4 as uuid } from '@lukeed/uuid';
+
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 
 import { AgentSidebar } from '@/domains/agents/agent-sidebar';
@@ -32,7 +32,7 @@ function Agent() {
   // Generate a stable thread ID for new threads. Regenerate when threadId
   // changes (e.g., clicking "New Chat" navigates back to /chat/new).
   // eslint-disable-next-line react-hooks/exhaustive-deps -- threadId is intentional: we need a new UUID per thread
-  const newThreadId = useMemo(() => uuid(), [threadId]);
+  const newThreadId = useMemo(() => crypto.randomUUID(), [threadId]);
 
   const hasMemory = Boolean(memory?.result);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,7 +236,7 @@ importers:
     dependencies:
       firebase-admin:
         specifier: ^13.4.0
-        version: 13.5.0(encoding@0.1.13)
+        version: 13.5.0
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -396,9 +396,6 @@ importers:
 
   client-sdks/client-js:
     dependencies:
-      '@lukeed/uuid':
-        specifier: ^2.0.1
-        version: 2.0.1
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -454,9 +451,6 @@ importers:
 
   client-sdks/react:
     dependencies:
-      '@lukeed/uuid':
-        specifier: ^2.0.1
-        version: 2.0.1
       '@mastra/client-js':
         specifier: workspace:*
         version: link:../client-js
@@ -554,9 +548,6 @@ importers:
       execa:
         specifier: ^9.6.1
         version: 9.6.1
-      fs-extra:
-        specifier: ^11.3.3
-        version: 11.3.3
       pino:
         specifier: ^10.1.0
         version: 10.1.0
@@ -579,9 +570,6 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
-      '@types/fs-extra':
-        specifier: ^11.0.4
-        version: 11.0.4
       '@types/node':
         specifier: 22.19.7
         version: 22.19.7
@@ -673,9 +661,6 @@ importers:
       '@mastra/deployer':
         specifier: workspace:^
         version: link:../../packages/deployer
-      fs-extra:
-        specifier: ^11.3.3
-        version: 11.3.3
       zod:
         specifier: ^3.25.0 || ^4.0.0
         version: 3.25.76
@@ -689,9 +674,6 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
-      '@types/fs-extra':
-        specifier: ^11.0.4
-        version: 11.0.4
       '@types/node':
         specifier: 22.19.7
         version: 22.19.7
@@ -719,9 +701,6 @@ importers:
       '@mastra/deployer':
         specifier: workspace:^
         version: link:../../packages/deployer
-      fs-extra:
-        specifier: ^11.3.3
-        version: 11.3.3
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -735,9 +714,6 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
-      '@types/fs-extra':
-        specifier: ^11.0.4
-        version: 11.0.4
       '@types/node':
         specifier: 22.19.7
         version: 22.19.7
@@ -831,9 +807,6 @@ importers:
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
-      fs-extra:
-        specifier: ^11.3.3
-        version: 11.3.3
       hast-util-select:
         specifier: ^6.0.4
         version: 6.0.4
@@ -870,9 +843,6 @@ importers:
       remark-stringify:
         specifier: ^11.0.0
         version: 11.0.0
-      tinyglobby:
-        specifier: ^0.2.15
-        version: 0.2.15
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -898,9 +868,6 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.1.18
-      '@types/fs-extra':
-        specifier: ^11.0.4
-        version: 11.0.4
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
@@ -2455,9 +2422,6 @@ importers:
       execa:
         specifier: ^9.6.1
         version: 9.6.1
-      fs-extra:
-        specifier: ^11.3.3
-        version: 11.3.3
       get-port:
         specifier: ^7.1.0
         version: 7.1.0
@@ -2485,9 +2449,6 @@ importers:
       shell-quote:
         specifier: ^1.8.3
         version: 1.8.3
-      strip-json-comments:
-        specifier: ^5.0.3
-        version: 5.0.3
       yocto-spinner:
         specifier: ^1.0.0
         version: 1.0.0
@@ -2510,9 +2471,6 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../core
-      '@types/fs-extra':
-        specifier: ^11.0.4
-        version: 11.0.4
       '@types/node':
         specifier: 22.19.7
         version: 22.19.7
@@ -2625,9 +2583,6 @@ importers:
       '@isaacs/ttlcache':
         specifier: ^2.1.4
         version: 2.1.4
-      '@lukeed/uuid':
-        specifier: ^2.0.1
-        version: 2.0.1
       '@mastra/schema-compat':
         specifier: workspace:*
         version: link:../schema-compat
@@ -2821,9 +2776,6 @@ importers:
       execa:
         specifier: ^9.6.1
         version: 9.6.1
-      fs-extra:
-        specifier: ^11.3.3
-        version: 11.3.3
       pino:
         specifier: ^10.1.0
         version: 10.1.0
@@ -2849,9 +2801,6 @@ importers:
       '@rollup/plugin-node-resolve':
         specifier: 16.0.3
         version: 16.0.3(rollup@4.55.3)
-      '@types/fs-extra':
-        specifier: ^11.0.4
-        version: 11.0.4
       '@types/node':
         specifier: 22.19.7
         version: 22.19.7
@@ -2921,9 +2870,6 @@ importers:
       find-workspaces:
         specifier: ^0.3.1
         version: 0.3.1
-      fs-extra:
-        specifier: ^11.3.3
-        version: 11.3.3
       hono:
         specifier: ^4.11.9
         version: 4.11.9
@@ -2942,12 +2888,6 @@ importers:
       rollup-plugin-esbuild:
         specifier: ^6.2.1
         version: 6.2.1(esbuild@0.25.11)(rollup@4.55.3)
-      strip-json-comments:
-        specifier: ^5.0.3
-        version: 5.0.3
-      tinyglobby:
-        specifier: ^0.2.15
-        version: 0.2.15
       typescript-paths:
         specifier: ^1.5.1
         version: 1.5.1(typescript@5.9.3)
@@ -2979,9 +2919,6 @@ importers:
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
-      '@types/fs-extra':
-        specifier: ^11.0.4
-        version: 11.0.4
       '@types/node':
         specifier: 22.19.7
         version: 22.19.7
@@ -3512,9 +3449,6 @@ importers:
 
   packages/playground:
     dependencies:
-      '@lukeed/uuid':
-        specifier: ^2.0.1
-        version: 2.0.1
       '@mastra/client-js':
         specifier: workspace:*
         version: link:../../client-sdks/client-js
@@ -3660,9 +3594,6 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
-      '@lukeed/uuid':
-        specifier: ^2.0.1
-        version: 2.0.1
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.14
         version: 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -14103,9 +14034,6 @@ packages:
   '@types/express@5.0.5':
     resolution: {integrity: sha512-LuIQOcb6UmnF7C1PCFmEU1u2hmiHL43fgFQX67sN3H4Z+0Yk0Neo++mFsBjhOAuLzvlQeqAAkeDOZrJs9rzumQ==}
 
-  '@types/fs-extra@11.0.4':
-    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
-
   '@types/gtag.js@0.0.12':
     resolution: {integrity: sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==}
 
@@ -14156,9 +14084,6 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-
-  '@types/jsonfile@6.1.4':
-    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
@@ -29146,7 +29071,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google-cloud/firestore@7.11.6(encoding@0.1.13)':
+  '@google-cloud/firestore@7.11.6':
     dependencies:
       '@opentelemetry/api': 1.9.0
       fast-deep-equal: 3.1.3
@@ -34564,11 +34489,6 @@ snapshots:
       '@types/express-serve-static-core': 5.1.0
       '@types/serve-static': 1.15.9
 
-  '@types/fs-extra@11.0.4':
-    dependencies:
-      '@types/jsonfile': 6.1.4
-      '@types/node': 22.19.7
-
   '@types/gtag.js@0.0.12': {}
 
   '@types/hast@2.3.10':
@@ -34619,10 +34539,6 @@ snapshots:
       parse5: 7.3.0
 
   '@types/json-schema@7.0.15': {}
-
-  '@types/jsonfile@6.1.4':
-    dependencies:
-      '@types/node': 22.19.7
 
   '@types/jsonwebtoken@9.0.10':
     dependencies:
@@ -38654,7 +38570,7 @@ snapshots:
       pkg-types: 1.3.1
       yaml: 2.8.1
 
-  firebase-admin@13.5.0(encoding@0.1.13):
+  firebase-admin@13.5.0:
     dependencies:
       '@fastify/busboy': 3.2.0
       '@firebase/database-compat': 2.1.0
@@ -38668,7 +38584,7 @@ snapshots:
       node-forge: 1.3.3
       uuid: 11.1.0
     optionalDependencies:
-      '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
+      '@google-cloud/firestore': 7.11.6
       '@google-cloud/storage': 7.19.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding


### PR DESCRIPTION
## Description

Replace 4 third-party dependencies with native Node.js 22+ alternatives to reduce bundle size and dependency count:

- `@lukeed/uuid` → `crypto.randomUUID()` (9 files)
- `strip-json-comments` → `ts.readConfigFile()` (2 files)
- `tinyglobby` → `node:fs/promises` glob (2 files)
- `fs-extra` → `node:fs/promises` (25+ files across 7 packages)

Also fixed 3 ESLint errors in test files by removing forbidden `import()` type annotations.

## Related Issue(s)

Fixes #12995

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced third-party UUID generation with native `crypto.randomUUID()` across SDKs and packages.
  * Replaced file system operations with native Node.js APIs, removing `fs-extra` and related dependencies.

* **Chores**
  * Updated peer dependency requirement for `@mastra/core` to `>=1.8.1-0 <2.0.0-0`.
  * Reduced bundle size by eliminating external dependencies in favor of native platform APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->