### PR TITLE
fix(playground): change import type to value import for runtime components

### DIFF
--- a/.changeset/fix-playground-import-type.md
+++ b/.changeset/fix-playground-import-type.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed studio crash caused by runtime components being erased from the sidebar import. Icons, layout components, and hooks were incorrectly imported as type-only, which TypeScript strips at compile time.

--- a/.changeset/fix-playground-import-type.md
+++ b/.changeset/fix-playground-import-type.md
@@ -1,5 +1,0 @@
----
-'@internal/playground': patch
----
-
-Fixed studio crash caused by runtime components being erased from the sidebar import. Icons, layout components, and hooks were incorrectly imported as type-only, which TypeScript strips at compile time.

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -1,5 +1,4 @@
-import type {
-  NavLink,
+import {
   AgentIcon,
   GithubIcon,
   McpServerIcon,
@@ -7,13 +6,13 @@ import type {
   WorkflowIcon,
   MainSidebar,
   useMainSidebar,
-  type NavSection,
   LogoWithoutText,
   SettingsIcon,
   MastraVersionFooter,
   useMastraPlatform,
   useIsCmsAvailable,
 } from '@mastra/playground-ui';
+import type { NavLink, NavSection } from '@mastra/playground-ui';
 import {
   GaugeIcon,
   EyeIcon,


### PR DESCRIPTION
## Summary

The `@mastra/playground-ui` import in `app-sidebar.tsx` was incorrectly using `import type { ... }`, which TypeScript erases at compile time. This caused a runtime error in the studio:

```
Uncaught (in promise) ReferenceError: AgentIcon is not defined
```

React components (`AgentIcon`, `MainSidebar`, `ToolsIcon`, etc.) and hooks (`useMainSidebar`, `useMastraPlatform`, `useIsCmsAvailable`) were all being erased because of the `import type` keyword.

### Fix
Changed `import type { ... }` → `import { ... }` while keeping `NavLink` and `NavSection` as inline `type` imports since those are actual TypeScript types.

### Root cause
Introduced in #13703 — a Prettier formatting pass incorrectly converted the value import to a type-only import.

## Test plan
- [ ] Studio loads without `AgentIcon is not defined` error
- [ ] Sidebar renders correctly with all icons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->