### PR TITLE
fix(core): use execa for LocalProcessManager to fix spawn error handling and timeouts

### DIFF
--- a/.changeset/neat-crabs-warn.md
+++ b/.changeset/neat-crabs-warn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed spawn error handling in LocalSandbox by switching to execa. Previously, spawning a process with an invalid working directory or missing command could crash with an unhandled Node.js exception. Now returns descriptive error messages instead. Also fixed timeout handling to properly kill the entire process group for compound commands.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -222,6 +222,7 @@
     "@modelcontextprotocol/sdk": "^1.17.5",
     "@sindresorhus/slugify": "^2.2.1",
     "dotenv": "^17.2.3",
+    "execa": "^9.6.1",
     "gray-matter": "^4.0.3",
     "hono": "^4.11.9",
     "hono-openapi": "^1.1.1",

--- a/packages/core/src/workspace/sandbox/local-process-manager.ts
+++ b/packages/core/src/workspace/sandbox/local-process-manager.ts
@@ -36,16 +36,23 @@ class LocalProcessHandle extends ProcessHandle {
     this.startTime = startTime;
 
     let timedOut = false;
-    if (options?.timeout) {
-      // Track timeout state so we can distinguish timeout kills from manual kills
-      // in the close handler. Execa handles the actual SIGTERM → SIGKILL escalation.
-      setTimeout(() => {
-        timedOut = true;
-      }, options.timeout);
-    }
+    const timeoutId = options?.timeout
+      ? setTimeout(() => {
+          timedOut = true;
+          // Kill the entire process group so child processes are also terminated.
+          // We handle timeout ourselves rather than using execa's timeout option
+          // because execa only kills the direct subprocess, not the process group.
+          try {
+            process.kill(-this.pid, 'SIGTERM');
+          } catch {
+            subprocess.kill('SIGTERM');
+          }
+        }, options.timeout)
+      : undefined;
 
     this.waitPromise = new Promise<CommandResult>(resolve => {
       subprocess.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
+        if (timeoutId) clearTimeout(timeoutId);
         if (timedOut) {
           const timeoutMsg = `\nProcess timed out after ${options!.timeout}ms`;
           this.emitStderr(timeoutMsg);
@@ -65,6 +72,7 @@ class LocalProcessHandle extends ProcessHandle {
       });
 
       subprocess.on('error', (err: Error) => {
+        if (timeoutId) clearTimeout(timeoutId);
         this.emitStderr(err.message);
         this.exitCode = 1;
         resolve({
@@ -148,8 +156,6 @@ export class LocalProcessManager extends SandboxProcessManager<LocalSandbox> {
       stripFinalNewline: false,
       // Don't extend process.env — the sandbox controls the full environment via buildEnv().
       extendEnv: false,
-      // Timeout — execa sends SIGTERM then SIGKILL after forceKillAfterDelay.
-      timeout: options.timeout,
     };
 
     const subprocess = execa(wrapped.command, wrapped.args, execaOptions);

--- a/packages/core/src/workspace/sandbox/local-process-manager.ts
+++ b/packages/core/src/workspace/sandbox/local-process-manager.ts
@@ -1,12 +1,12 @@
 /**
  * Local Process Manager
  *
- * Local implementation of SandboxProcessManager using child_process.spawn.
+ * Local implementation of SandboxProcessManager using execa.
  * Tracks processes in-memory since there's no server to query.
  */
 
-import * as childProcess from 'node:child_process';
-import type { ChildProcess } from 'node:child_process';
+import { execa } from 'execa';
+import type { ResultPromise, Options as ExecaOptions } from 'execa';
 
 import type { LocalSandbox } from './local-sandbox';
 import { ProcessHandle, SandboxProcessManager } from './process-manager';
@@ -18,42 +18,34 @@ import type { CommandResult } from './types';
 // =============================================================================
 
 /**
- * Local implementation of ProcessHandle wrapping a node ChildProcess.
+ * Local implementation of ProcessHandle wrapping an execa subprocess.
  * Not exported — internal to this module.
  */
 class LocalProcessHandle extends ProcessHandle {
   readonly pid: number;
   exitCode: number | undefined;
 
-  private proc: ChildProcess;
+  private subprocess: ResultPromise;
   private readonly waitPromise: Promise<CommandResult>;
   private readonly startTime: number;
 
-  constructor(proc: ChildProcess, startTime: number, options?: SpawnProcessOptions) {
+  constructor(subprocess: ResultPromise, pid: number, startTime: number, options?: SpawnProcessOptions) {
     super(options);
-    if (!proc.pid) {
-      throw new Error('Process has no PID - it may have failed to spawn');
-    }
-    this.pid = proc.pid;
-    this.proc = proc;
+    this.pid = pid;
+    this.subprocess = subprocess;
     this.startTime = startTime;
 
     let timedOut = false;
-    const timeoutId = options?.timeout
-      ? setTimeout(() => {
-          timedOut = true;
-          // Kill the process group so child processes are also terminated
-          try {
-            process.kill(-this.pid, 'SIGTERM');
-          } catch {
-            proc.kill('SIGTERM');
-          }
-        }, options.timeout)
-      : undefined;
+    if (options?.timeout) {
+      // Track timeout state so we can distinguish timeout kills from manual kills
+      // in the close handler. Execa handles the actual SIGTERM → SIGKILL escalation.
+      setTimeout(() => {
+        timedOut = true;
+      }, options.timeout);
+    }
 
     this.waitPromise = new Promise<CommandResult>(resolve => {
-      proc.on('close', (code, signal) => {
-        if (timeoutId) clearTimeout(timeoutId);
+      subprocess.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
         if (timedOut) {
           const timeoutMsg = `\nProcess timed out after ${options!.timeout}ms`;
           this.emitStderr(timeoutMsg);
@@ -63,7 +55,7 @@ class LocalProcessHandle extends ProcessHandle {
         }
         resolve({
           success: this.exitCode === 0,
-          exitCode: this.exitCode,
+          exitCode: this.exitCode!,
           stdout: this.stdout,
           stderr: this.stderr,
           executionTimeMs: Date.now() - this.startTime,
@@ -72,8 +64,7 @@ class LocalProcessHandle extends ProcessHandle {
         });
       });
 
-      proc.on('error', err => {
-        if (timeoutId) clearTimeout(timeoutId);
+      subprocess.on('error', (err: Error) => {
         this.emitStderr(err.message);
         this.exitCode = 1;
         resolve({
@@ -86,11 +77,11 @@ class LocalProcessHandle extends ProcessHandle {
       });
     });
 
-    proc.stdout?.on('data', (data: Buffer) => {
+    subprocess.stdout?.on('data', (data: Buffer) => {
       this.emitStdout(data.toString());
     });
 
-    proc.stderr?.on('data', (data: Buffer) => {
+    subprocess.stderr?.on('data', (data: Buffer) => {
       this.emitStderr(data.toString());
     });
   }
@@ -104,12 +95,14 @@ class LocalProcessHandle extends ProcessHandle {
     // Kill the entire process group (negative PID) to ensure child processes
     // spawned by the shell are also terminated. Without this, commands like
     // "echo foo; sleep 60" would leave orphaned children holding stdio open.
+    // Execa doesn't handle process tree killing natively.
     try {
       process.kill(-this.pid, 'SIGKILL');
       return true;
     } catch {
       // Fallback to direct kill if process group kill fails
-      return this.proc.kill('SIGKILL');
+      this.subprocess.kill('SIGKILL');
+      return true;
     }
   }
 
@@ -117,11 +110,11 @@ class LocalProcessHandle extends ProcessHandle {
     if (this.exitCode !== undefined) {
       throw new Error(`Process ${this.pid} has already exited with code ${this.exitCode}`);
     }
-    if (!this.proc.stdin) {
+    if (!this.subprocess.stdin) {
       throw new Error(`Process ${this.pid} does not have stdin available`);
     }
     return new Promise<void>((resolve, reject) => {
-      this.proc.stdin!.write(data, err => (err ? reject(err) : resolve()));
+      this.subprocess.stdin!.write(data, (err: Error | null | undefined) => (err ? reject(err) : resolve()));
     });
   }
 }
@@ -132,7 +125,7 @@ class LocalProcessHandle extends ProcessHandle {
 
 /**
  * Local implementation of SandboxProcessManager.
- * Spawns processes via child_process.spawn and tracks them in-memory.
+ * Spawns processes via execa and tracks them in-memory.
  */
 export class LocalProcessManager extends SandboxProcessManager<LocalSandbox> {
   async spawn(command: string, options: SpawnProcessOptions = {}): Promise<ProcessHandle> {
@@ -140,18 +133,36 @@ export class LocalProcessManager extends SandboxProcessManager<LocalSandbox> {
     const env = this.sandbox.buildEnv(options.env);
     const wrapped = this.sandbox.wrapCommandForIsolation(command);
 
-    // detached: true creates a new process group so we can kill the entire tree.
-    // Non-isolated: use shell mode so the host shell interprets the command string.
-    // Isolated (seatbelt/bwrap): the wrapper already includes `sh -c` inside the
-    // sandbox, so we spawn the wrapper binary directly.
-    const proc = childProcess.spawn(wrapped.command, wrapped.args, {
+    const execaOptions: ExecaOptions = {
       cwd,
       env,
       shell: this.sandbox.isolation === 'none',
+      // detached: true creates a new process group so we can kill the entire tree.
       detached: true,
       stdio: 'pipe',
-    });
-    const handle = new LocalProcessHandle(proc, Date.now(), options);
+      // Don't throw on non-zero exit — we handle exit codes ourselves.
+      reject: false,
+      // Don't buffer output — we stream it via ProcessHandle callbacks.
+      buffer: false,
+      // Don't strip newlines — preserve raw output for ProcessHandle accumulation.
+      stripFinalNewline: false,
+      // Don't extend process.env — the sandbox controls the full environment via buildEnv().
+      extendEnv: false,
+      // Timeout — execa sends SIGTERM then SIGKILL after forceKillAfterDelay.
+      timeout: options.timeout,
+    };
+
+    const subprocess = execa(wrapped.command, wrapped.args, execaOptions);
+
+    // execa sets pid synchronously when the process spawns successfully.
+    // If pid is undefined, the spawn failed (bad cwd, missing command, etc.).
+    // Await the subprocess to get execa's detailed error message.
+    if (!subprocess.pid) {
+      const result = await subprocess;
+      throw new Error(result.message || 'Process failed to spawn');
+    }
+
+    const handle = new LocalProcessHandle(subprocess, subprocess.pid, Date.now(), options);
     this._tracked.set(handle.pid, handle);
     return handle;
   }

--- a/packages/core/src/workspace/sandbox/local-sandbox.test.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.test.ts
@@ -285,13 +285,25 @@ describe('LocalSandbox', () => {
 
     it('should respect custom timeout for command execution', async () => {
       if (os.platform() === 'win32') return; // Uses POSIX commands
-      // This should timeout quickly
       const result = await sandbox.executeCommand('sleep', ['5'], {
-        timeout: 100, // Very short timeout
+        timeout: 100,
       });
 
       expect(result.success).toBe(false);
-      // The error might be a timeout or killed signal
+      expect(result.exitCode).toBe(124);
+      expect(result.timedOut).toBe(true);
+    });
+
+    it('should timeout a compound command and kill the process group', async () => {
+      if (os.platform() === 'win32') return; // Uses POSIX commands
+      const result = await sandbox.executeCommand('sleep 2 && echo done', [], {
+        timeout: 100,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(124);
+      expect(result.timedOut).toBe(true);
+      expect(result.stdout).not.toContain('done');
     });
   });
 

--- a/packages/core/src/workspace/sandbox/local-sandbox.test.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.test.ts
@@ -250,6 +250,32 @@ describe('LocalSandbox', () => {
   });
 
   // ===========================================================================
+  // Spawn Failure Handling
+  // ===========================================================================
+  describe('spawn failure handling', () => {
+    beforeEach(async () => {
+      await sandbox._start();
+    });
+
+    it('should throw a descriptive error when cwd does not exist', async () => {
+      if (os.platform() === 'win32') return;
+      await expect(sandbox.executeCommand('pwd', [], { cwd: '/nonexistent/path/that/does/not/exist' })).rejects.toThrow(
+        /ENOENT|no such file or directory|cwd/i,
+      );
+    });
+
+    it('should return exit code 127 for nonexistent command', async () => {
+      if (os.platform() === 'win32') return;
+      // With shell: true (isolation: none), the shell spawns fine but reports
+      // "command not found" via stderr and exits with code 127.
+      const result = await sandbox.executeCommand('nonexistent-command-xyz-12345', []);
+      expect(result.success).toBe(false);
+      expect(result.exitCode).toBe(127);
+      expect(result.stderr).toMatch(/not found/i);
+    });
+  });
+
+  // ===========================================================================
   // Timeout Handling
   // ===========================================================================
   describe('timeout handling', () => {

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -25,11 +25,18 @@ const studioStandalonePlugin = (targetPort: string, targetHost: string): PluginO
 // stub them so Rollup can resolve the imports without erroring.
 // enforce: 'pre' ensures this runs before Vite's built-in vite:resolve which
 // would otherwise replace them with __vite-browser-external (no named exports).
+// Node-only npm packages imported by @mastra/core server-only code (e.g. sandbox).
+// These are never called in the browser — stub them alongside Node builtins.
+const nodeOnlyPackages = new Set(['execa']);
+
 const stubNodeBuiltinsPlugin: Plugin = {
   name: 'stub-node-builtins',
   enforce: 'pre',
   apply: 'build',
   resolveId(source) {
+    if (nodeOnlyPackages.has(source)) {
+      return { id: `\0node-stub:${source}`, moduleSideEffects: false };
+    }
     const mod = source.startsWith('node:') ? source.slice(5) : source;
     const baseMod = mod.split('/')[0];
     if (builtinModules.includes(baseMod)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2646,6 +2646,9 @@ importers:
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
+      execa:
+        specifier: ^9.6.1
+        version: 9.6.1
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3


### PR DESCRIPTION
## Summary

Replaces `child_process.spawn` with `execa` in `LocalProcessManager` for more reliable process spawning in the local sandbox.

### Problem

`child_process.spawn` could throw an unhandled Node.js exception when spawning failed (e.g. invalid `cwd`, missing command). The error handler was registered after the spawn attempt, so if the process failed to create, the error would crash instead of being caught.

### Fix

`execa` handles spawn failures gracefully — when a process fails to spawn, `subprocess.pid` is `undefined` and we await the result to get a descriptive error message instead of crashing.

The existing process-group timeout behavior (`setTimeout` + `process.kill(-pid, SIGTERM)`) is preserved, ensuring compound commands like `sleep 2 && echo done` are still fully terminated on timeout. Added test coverage for these timeout cases.

### Changes

- **`@mastra/core`**: Add `execa` dependency, refactor `LocalProcessManager`
  - `reject: false` — we handle exit codes ourselves
  - `extendEnv: false` — sandbox controls the full environment via `buildEnv()`
  - `detached: true` — enables process group killing to prevent orphaned children
  - Timeout handled via `setTimeout` + process-group kill (same as before)
  - Spawn failure detection via `subprocess.pid` check
- **`@internal/playground`**: Stub `execa` in Vite build (node-only package, never runs in browser)
- **Tests**: Added spawn failure tests and compound command timeout test

## Test plan

- [x] All 146 sandbox tests pass
- [x] `@mastra/core` builds successfully (both ESM and CJS)
- [x] `@internal/playground` builds successfully
- [x] `execa` is properly externalized in core's dist output\n- [x] Spawn with invalid cwd throws descriptive ENOENT error instead of crashing\n- [x] Spawn with nonexistent command returns exit code 127\n- [x] Compound command (`sleep 2 && echo done`) properly times out with exit code 124\n- [x] Manually verified in studio: `sleep 2` and `sleep 2 && echo done` both timeout correctly at configured timeout