### PR TITLE
fix(ci): add @internal/llm-recorder to Memory Tests build filter

### DIFF
--- a/.github/workflows/secrets.test-memory.yml
+++ b/.github/workflows/secrets.test-memory.yml
@@ -106,8 +106,8 @@ jobs:
       - name: Setup pnpm and Node.js
         uses: ./.github/actions/setup-pnpm-node
 
-      - name: Build vector+store packages
-        run: pnpm turbo build --filter "./stores/*" --filter "mastra" --filter "@mastra/memory" --filter "@mastra/fastembed"
+      - name: Build dependencies
+        run: pnpm turbo build --filter "./stores/*" --filter "mastra" --filter "@mastra/memory" --filter "@mastra/fastembed" --filter "@internal/llm-recorder"
         env:
           NODE_OPTIONS: '--max_old_space_size=6144'
 


### PR DESCRIPTION
## Problem

Memory Tests intermittently fail with:

```
Error: Failed to resolve entry for package "@internal/llm-recorder".
The package may have incorrect main/module/exports specified in its package.json.
```

This affects `agent-memory.test.ts`, `message-ordering.test.ts`, `streaming-memory.test.ts`, and `working-memory.test.ts`.

### Root cause

The memory integration tests (`packages/memory/integration-tests/`) are installed separately via `pnpm install --ignore-workspace` and reference `@internal/llm-recorder` through a link override (`link:../../_llm-recorder`). This means they depend on `@internal/llm-recorder` having a built `dist/` directory.

However, `@mastra/memory` itself does not list `@internal/llm-recorder` as a dependency, so turbo does not include it when building `--filter "@mastra/memory"`. Tests only pass when `@internal/llm-recorder` happens to have a Turbo remote cache hit from a previous run.

Introduced in #13298 which added `@internal/llm-recorder` as a test dependency but did not update the CI build filter.

## Fix

Added `--filter "@internal/llm-recorder"` to the turbo build command in `secrets.test-memory.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow: renamed a build step to "Build dependencies" and broadened the build scope to include an additional component.
  * Adjusted build filters used by the memory test workflow to ensure the new component is included.
  * No runtime, public API, or behavioral changes — only build configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->