### PR TITLE
fix(core): expand tilde (~) to home directory in LocalFilesystem and LocalSandbox

### DIFF
--- a/.changeset/upset-comics-follow.md
+++ b/.changeset/upset-comics-follow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed tilde (~) paths not expanding to the home directory in LocalFilesystem and LocalSandbox. Paths like `~/my-project` were silently treated as relative paths, creating a literal `~/` directory instead of resolving to `$HOME`. This affects `basePath`, `allowedPaths`, `setAllowedPaths()`, all file operations in LocalFilesystem, and `workingDirectory` in LocalSandbox.

--- a/packages/core/src/workspace/filesystem/fs-utils.ts
+++ b/packages/core/src/workspace/filesystem/fs-utils.ts
@@ -5,9 +5,26 @@
  */
 
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { FileNotFoundError } from '../errors';
+
+// =============================================================================
+// Tilde Expansion
+// =============================================================================
+
+/**
+ * Expand a leading `~` or `~/` to the user's home directory.
+ * Shell commands handle this automatically, but Node.js path APIs do not.
+ */
+export function expandTilde(p: string): string {
+  if (p === '~') return os.homedir();
+  if (p.startsWith('~/') || p.startsWith('~\\')) {
+    return path.join(os.homedir(), p.slice(2));
+  }
+  return p;
+}
 
 // =============================================================================
 // Types

--- a/packages/core/src/workspace/filesystem/local-filesystem.test.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.test.ts
@@ -817,6 +817,117 @@ describe('LocalFilesystem', () => {
   });
 
   // ===========================================================================
+  // Tilde (~) expansion
+  // ===========================================================================
+  describe('tilde expansion', () => {
+    let homeDir: string;
+    let tildeTargetDir: string;
+
+    beforeEach(async () => {
+      homeDir = os.homedir();
+      // Create a temp directory inside the real home dir for tilde tests
+      tildeTargetDir = await fs.mkdtemp(path.join(homeDir, '.mastra-tilde-test-'));
+    });
+
+    afterEach(async () => {
+      try {
+        await fs.rm(tildeTargetDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    });
+
+    it('should expand ~ in basePath', () => {
+      const tildeFs = new LocalFilesystem({ basePath: '~/my-project' });
+      expect(tildeFs.basePath).toBe(path.join(homeDir, 'my-project'));
+    });
+
+    it('should expand ~ in allowedPaths constructor option', () => {
+      const tildeFs = new LocalFilesystem({
+        basePath: tempDir,
+        allowedPaths: ['~/allowed-dir'],
+      });
+      expect(tildeFs.allowedPaths).toEqual([path.join(homeDir, 'allowed-dir')]);
+    });
+
+    it('should expand ~ to home directory when contained is false', async () => {
+      const uncontainedFs = new LocalFilesystem({
+        basePath: tempDir,
+        contained: false,
+      });
+      const relativeTildePath = tildeTargetDir.replace(homeDir, '~');
+      const filePath = `${relativeTildePath}/tilde-test.txt`;
+
+      await uncontainedFs.writeFile(filePath, 'tilde works');
+
+      const absoluteExpected = path.join(tildeTargetDir, 'tilde-test.txt');
+      const content = await fs.readFile(absoluteExpected, 'utf-8');
+      expect(content).toBe('tilde works');
+    });
+
+    it('should expand ~ to home directory when path is in allowedPaths', async () => {
+      const relativeTildeDir = tildeTargetDir.replace(homeDir, '~');
+      const fsWithAllowed = new LocalFilesystem({
+        basePath: tempDir,
+        contained: true,
+        allowedPaths: [relativeTildeDir],
+      });
+      const filePath = `${relativeTildeDir}/tilde-allowed.txt`;
+
+      await fsWithAllowed.writeFile(filePath, 'tilde allowed works');
+
+      const absoluteExpected = path.join(tildeTargetDir, 'tilde-allowed.txt');
+      const content = await fs.readFile(absoluteExpected, 'utf-8');
+      expect(content).toBe('tilde allowed works');
+    });
+
+    it('should expand ~ in setAllowedPaths', async () => {
+      const relativeTildeDir = tildeTargetDir.replace(homeDir, '~');
+      localFs.setAllowedPaths([relativeTildeDir]);
+
+      const filePath = `${relativeTildeDir}/tilde-set-allowed.txt`;
+      await localFs.writeFile(filePath, 'tilde set allowed works');
+
+      const absoluteExpected = path.join(tildeTargetDir, 'tilde-set-allowed.txt');
+      const content = await fs.readFile(absoluteExpected, 'utf-8');
+      expect(content).toBe('tilde set allowed works');
+    });
+
+    it('should contain tilde paths inside basePath when not in allowedPaths', async () => {
+      const relativeTildeDir = tildeTargetDir.replace(homeDir, '~');
+      const filePath = `${relativeTildeDir}/contained.txt`;
+
+      // Default contained: true, no allowedPaths — should write inside basePath
+      await localFs.writeFile(filePath, 'should be contained');
+
+      // File should NOT exist at the real home dir location
+      const realPath = path.join(tildeTargetDir, 'contained.txt');
+      await expect(fs.access(realPath)).rejects.toThrow();
+
+      // File should exist inside basePath instead (tilde expands, then containment
+      // strips leading / and joins the full absolute path under basePath)
+      const containedPath = path.join(tempDir, tildeTargetDir, 'contained.txt');
+      const content = await fs.readFile(containedPath, 'utf-8');
+      expect(content).toBe('should be contained');
+    });
+
+    it('should read files written via tilde path', async () => {
+      const uncontainedFs = new LocalFilesystem({
+        basePath: tempDir,
+        contained: false,
+      });
+      const relativeTildePath = tildeTargetDir.replace(homeDir, '~');
+
+      // Write directly to disk
+      await fs.writeFile(path.join(tildeTargetDir, 'read-test.txt'), 'read via tilde');
+
+      // Read via tilde path
+      const content = await uncontainedFs.readFile(`${relativeTildePath}/read-test.txt`);
+      expect(content.toString()).toBe('read via tilde');
+    });
+  });
+
+  // ===========================================================================
   // MIME Type Detection
   // ===========================================================================
   describe('mime type detection', () => {

--- a/packages/core/src/workspace/filesystem/local-filesystem.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.ts
@@ -33,7 +33,7 @@ import type {
   RemoveOptions,
   CopyOptions,
 } from './filesystem';
-import { fsExists, fsStat, isEnoentError, isEexistError, resolveWorkspacePath } from './fs-utils';
+import { expandTilde, fsExists, fsStat, isEnoentError, isEexistError, resolveWorkspacePath } from './fs-utils';
 import { MastraFilesystem } from './mastra-filesystem';
 import type { MastraFilesystemOptions } from './mastra-filesystem';
 import type { FilesystemMountConfig } from './mount';
@@ -195,16 +195,16 @@ export class LocalFilesystem extends MastraFilesystem {
    */
   setAllowedPaths(pathsOrUpdater: string[] | ((current: readonly string[]) => string[])): void {
     const newPaths = typeof pathsOrUpdater === 'function' ? pathsOrUpdater(this._allowedPaths) : pathsOrUpdater;
-    this._allowedPaths = newPaths.map(p => nodePath.resolve(p));
+    this._allowedPaths = newPaths.map(p => nodePath.resolve(expandTilde(p)));
   }
 
   constructor(options: LocalFilesystemOptions) {
     super({ ...options, name: 'LocalFilesystem' });
     this.id = options.id ?? this.generateId();
-    this._basePath = nodePath.resolve(options.basePath);
+    this._basePath = nodePath.resolve(expandTilde(options.basePath));
     this._contained = options.contained ?? true;
     this.readOnly = options.readOnly;
-    this._allowedPaths = (options.allowedPaths ?? []).map(p => nodePath.resolve(p));
+    this._allowedPaths = (options.allowedPaths ?? []).map(p => nodePath.resolve(expandTilde(p)));
     this._instructionsOverride = options.instructions;
   }
 
@@ -239,6 +239,7 @@ export class LocalFilesystem extends MastraFilesystem {
 
   private resolvePath(inputPath: string): string {
     let absolutePath: string;
+    inputPath = expandTilde(inputPath);
 
     if (!this._contained && nodePath.isAbsolute(inputPath)) {
       // Containment disabled — absolute paths are real filesystem paths

--- a/packages/core/src/workspace/sandbox/local-sandbox.test.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.test.ts
@@ -58,8 +58,12 @@ describe('LocalSandbox', () => {
 
     it('should accept custom working directory', () => {
       const customSandbox = new LocalSandbox({ workingDirectory: '/tmp/custom' });
-      // We can't directly check the working directory, but we can verify it's set by running a command
-      expect(customSandbox).toBeDefined();
+      expect(customSandbox.workingDirectory).toBe('/tmp/custom');
+    });
+
+    it('should expand ~ in working directory', () => {
+      const customSandbox = new LocalSandbox({ workingDirectory: '~/my-sandbox' });
+      expect(customSandbox.workingDirectory).toBe(path.join(os.homedir(), 'my-sandbox'));
     });
   });
 

--- a/packages/core/src/workspace/sandbox/local-sandbox.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.ts
@@ -16,6 +16,7 @@ import * as path from 'node:path';
 import type { RequestContext } from '../../request-context';
 
 import type { WorkspaceFilesystem } from '../filesystem/filesystem';
+import { expandTilde } from '../filesystem/fs-utils';
 import type { FilesystemMountConfig, MountResult } from '../filesystem/mount';
 import type { ProviderStatus } from '../lifecycle';
 import type { InstructionsOption } from '../types';
@@ -174,7 +175,7 @@ export class LocalSandbox extends MastraSandbox {
 
     this.id = options.id ?? this.generateId();
     this._createdAt = new Date();
-    this.workingDirectory = options.workingDirectory ?? path.join(process.cwd(), '.sandbox');
+    this.workingDirectory = expandTilde(options.workingDirectory ?? path.join(process.cwd(), '.sandbox'));
     this.env = options.env ?? {};
     this._nativeSandboxConfig = {
       ...options.nativeSandbox,


### PR DESCRIPTION
## Problem

Node.js `path.isAbsolute('~/foo')` returns `false`, so paths starting with `~` were silently treated as relative — creating a literal `~/` directory inside `basePath` instead of resolving to `$HOME`.

This affected `LocalFilesystem` (all file operations, `basePath`, `allowedPaths`) and `LocalSandbox` (`workingDirectory`).

## Fix

Added a shared `expandTilde()` utility in `fs-utils.ts` that converts `~` and `~/...` to `os.homedir()`. Applied in:

- **LocalFilesystem**: `resolvePath()`, constructor (`basePath`, `allowedPaths`), `setAllowedPaths()`
- **LocalSandbox**: `workingDirectory`

## Tests

- 7 new tests in `local-filesystem.test.ts` covering `basePath`, `allowedPaths`, `setAllowedPaths`, contained/uncontained writes, and reads via tilde paths
- 1 new test in `local-sandbox.test.ts` for `workingDirectory` tilde expansion
- Verified tests fail without the fix (literal `~/` dir created inside basePath)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paths beginning with tilde (~) are now expanded to the user’s home directory for resolution, containment checks, allowed-path updates, and sandbox working directories.

* **Tests**
  * Added comprehensive tests validating tilde expansion across containment semantics, updating allowed paths, and read/write behavior using tilde paths (including files created directly on disk).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->