### PR TITLE
add user-agent tracking header to ES client

### DIFF
--- a/.changeset/brave-elk-track.md
+++ b/.changeset/brave-elk-track.md
@@ -1,0 +1,5 @@
+---
+'@mastra/elasticsearch': patch
+---
+
+Added custom `user-agent` header to all Elasticsearch requests. Every request now identifies itself as `mastra-elasticsearch/<version>` via the `user-agent` header, enabling usage tracking in Elasticsearch server logs and analytics tools.

--- a/stores/elasticsearch/src/vector/index.ts
+++ b/stores/elasticsearch/src/vector/index.ts
@@ -50,7 +50,7 @@ export class ElasticSearchVector extends MastraVector<ElasticSearchVectorFilter>
       node: url,
       ...(auth && { auth }),
       name: 'mastra-elasticsearch',
-      headers: { 'user-agent': `mastra-elasticsearch/${packageJson.version}` },
+      headers: { 'user-agent': `mastra-es/${packageJson.version}` },
     });
   }
 

--- a/stores/elasticsearch/src/vector/index.ts
+++ b/stores/elasticsearch/src/vector/index.ts
@@ -14,6 +14,8 @@ import type {
   DeleteVectorsParams,
 } from '@mastra/core/vector';
 import { MastraVector, validateUpsert, validateTopK } from '@mastra/core/vector';
+
+import packageJson from '../../package.json';
 import { ElasticSearchFilterTranslator } from './filter';
 import type { ElasticSearchVectorFilter } from './filter';
 
@@ -44,7 +46,12 @@ export class ElasticSearchVector extends MastraVector<ElasticSearchVectorFilter>
    */
   constructor({ url, id, auth }: { url: string } & { id: string } & { auth?: ElasticSearchAuth }) {
     super({ id });
-    this.client = new ElasticSearchClient({ node: url, ...(auth && { auth }) });
+    this.client = new ElasticSearchClient({
+      node: url,
+      ...(auth && { auth }),
+      name: 'mastra-elasticsearch',
+      headers: { 'user-agent': `mastra-elasticsearch/${packageJson.version}` },
+    });
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

[Elastic](https://www.elastic.co/) wants to provide a great developer experience with 3rd party integrations. In order to be able to prioritize maintenance and feature development efforts, we keep track of which integrations are popular by setting the user-agent header. We can then see usage statistics in the [Elastic Cloud](https://cloud.elastic.co/) metrics.

We want to gauge the usage of the Mastra integration and hence add a user-agent header here.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


Notes:
Currently the info in the request sent is like this 
```
host: localhost:9200
connection: keep-alive
user-agent: elasticsearch-js/8.19.1 (darwin 24.6.0-arm64; Node.js 24.12.0; Transport 8.10.0)
x-elastic-client-meta: es=8.19.1,js=24.12.0,t=8.10.0,un=24.12.0
authorization: ApiKey <redacted>==
accept: application/vnd.elasticsearch+json; compatible-with=8,text/plain
```
After this change it looks like this 

```
host: localhost:9200
connection: keep-alive
user-agent: mastra-elasticsearch/1.1.1
x-elastic-client-meta: es=8.19.1,js=24.12.0,t=8.10.0,un=24.12.0
authorization: ApiKey <redacted>==
accept: application/vnd.elasticsearch+json; compatible-with=8,text/plain
```
This means that since we overwrite user-agent set by the client we lose the OS/Platform info. The other info is still present in `x-elastic-client-meta`. This is inline with how we are tracking other integrations however

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Patch update: added a custom User-Agent header to all Elasticsearch requests identifying as mastra-elasticsearch/<version> to enable usage tracking in server logs and analytics. This change only augments request metadata and does not alter functional behavior or user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->