### PR TITLE
fix(core): prevent tilde paths from nesting under basePath in contained LocalFilesystem

### DIFF
--- a/.changeset/yellow-shirts-drum.md
+++ b/.changeset/yellow-shirts-drum.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed tilde paths (`~/foo`) in contained `LocalFilesystem` silently writing to the wrong location. Previously, `~/foo` would expand and then nest under basePath (e.g. `basePath/home/user/foo`). Tilde paths are now treated as real absolute paths, and throw `PermissionError` when the expanded path is outside `basePath` and `allowedPaths`.

--- a/packages/core/src/workspace/filesystem/local-filesystem.test.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.test.ts
@@ -893,22 +893,13 @@ describe('LocalFilesystem', () => {
       expect(content).toBe('tilde set allowed works');
     });
 
-    it('should contain tilde paths inside basePath when not in allowedPaths', async () => {
+    it('should throw PermissionError for tilde path outside basePath in contained mode', async () => {
       const relativeTildeDir = tildeTargetDir.replace(homeDir, '~');
       const filePath = `${relativeTildeDir}/contained.txt`;
 
-      // Default contained: true, no allowedPaths — should write inside basePath
-      await localFs.writeFile(filePath, 'should be contained');
-
-      // File should NOT exist at the real home dir location
-      const realPath = path.join(tildeTargetDir, 'contained.txt');
-      await expect(fs.access(realPath)).rejects.toThrow();
-
-      // File should exist inside basePath instead (tilde expands, then containment
-      // strips leading / and joins the full absolute path under basePath)
-      const containedPath = path.join(tempDir, tildeTargetDir, 'contained.txt');
-      const content = await fs.readFile(containedPath, 'utf-8');
-      expect(content).toBe('should be contained');
+      // contained: true, no allowedPaths — tilde expands to a real absolute path
+      // outside basePath, so it should throw PermissionError (not nest under basePath)
+      await expect(localFs.writeFile(filePath, 'should not be here')).rejects.toThrow('Permission');
     });
 
     it('should read files written via tilde path', async () => {

--- a/packages/core/src/workspace/filesystem/local-filesystem.ts
+++ b/packages/core/src/workspace/filesystem/local-filesystem.ts
@@ -239,6 +239,7 @@ export class LocalFilesystem extends MastraFilesystem {
 
   private resolvePath(inputPath: string): string {
     let absolutePath: string;
+    const wasTilde = inputPath.startsWith('~');
     inputPath = expandTilde(inputPath);
 
     if (!this._contained && nodePath.isAbsolute(inputPath)) {
@@ -250,6 +251,12 @@ export class LocalFilesystem extends MastraFilesystem {
       // convention (e.g. "/file.txt" meaning "basePath/file.txt")
       const normalized = nodePath.normalize(inputPath);
       if (this._isWithinAnyRoot(normalized)) {
+        absolutePath = normalized;
+      } else if (wasTilde) {
+        // Path started with ~ so the user meant a real filesystem path,
+        // not a virtual-root path. Treat as a real absolute path — the
+        // containment check below will throw PermissionError if it's not
+        // within basePath or allowedPaths.
         absolutePath = normalized;
       } else {
         absolutePath = resolveWorkspacePath(this._basePath, inputPath);
@@ -774,7 +781,7 @@ export class LocalFilesystem extends MastraFilesystem {
     };
   }
 
-  getInstructions(opts?: { requestContext?: RequestContext }): string {
+  getInstructions(opts?: { requestContext?: RequestContext<any> }): string {
     return resolveInstructions(this._instructionsOverride, () => this._getDefaultInstructions(), opts?.requestContext);
   }
 


### PR DESCRIPTION
## Follow-up to #13739

After #13739 added tilde expansion, `~/foo` correctly expands to an absolute path. However in contained mode, the expanded path was silently nested under basePath (e.g. `basePath/home/user/foo`) instead of being rejected — because the containment logic treated it as a virtual-root path.

Since the user explicitly typed `~`, they meant a real filesystem path. Tilde paths are now treated as real absolute paths, and throw `PermissionError` when the expanded path is outside `basePath` and `allowedPaths`.

## Changes

- **`resolvePath`**: Track whether the original input started with `~` and treat expanded tilde paths as real absolute paths, not virtual-root paths
- **Test**: Replace the nesting assertion with a `PermissionError` assertion
- **Type fix**: `RequestContext` → `RequestContext<any>` in `getInstructions` to fix generic variance error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed tilde path (~) resolution in file access. Tilde paths are now treated as absolute paths and must respect configured access boundaries; attempts to access paths outside allowed locations will raise a PermissionError instead of being implicitly nested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->