### PR TITLE
fix(ci): add @internal/test-utils to Memory Tests build filter

### DIFF
--- a/.github/workflows/secrets.test-memory.yml
+++ b/.github/workflows/secrets.test-memory.yml
@@ -107,7 +107,7 @@ jobs:
         uses: ./.github/actions/setup-pnpm-node
 
       - name: Build dependencies
-        run: pnpm turbo build --filter "./stores/*" --filter "mastra" --filter "@mastra/memory" --filter "@mastra/fastembed" --filter "@internal/llm-recorder"
+        run: pnpm turbo build --filter "./stores/*" --filter "mastra" --filter "@mastra/memory" --filter "@mastra/fastembed" --filter "@internal/llm-recorder" --filter "@internal/test-utils"
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'
 


### PR DESCRIPTION
## Problem

Memory integration tests fail with:
```
Error: Failed to resolve entry for package "@internal/test-utils". The package may have incorrect main/module/exports specified in its package.json.
```

Same root cause as #13736 (`@internal/llm-recorder`). The memory integration tests run `pnpm install --ignore-workspace` with `link:` overrides pointing to `../../_test-utils`. Since Turbo doesn't know about this out-of-workspace dependency chain, `@internal/test-utils` needs to be explicitly included in the build filter so its `dist/` exists before tests run.

## Fix

Add `--filter "@internal/test-utils"` to the Memory Tests build step in `secrets.test-memory.yml`.

## Verification

- The build filter already works for `@internal/llm-recorder` (confirmed in #13736 CI run)
- Same pattern, same fix