### PR TITLE
docs(workspace): add tool name remapping, output truncation, and setToolsConfig docs

### DIFF
--- a/.changeset/consistent-token-limits.md
+++ b/.changeset/consistent-token-limits.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+fix(workspace): Use consistent default token limit for `list_files` tool
+
+The `list_files` workspace tool now defaults to a 2,000-token output limit, matching all other workspace tools.

--- a/.changeset/consistent-token-limits.md
+++ b/.changeset/consistent-token-limits.md
@@ -2,6 +2,4 @@
 '@mastra/core': patch
 ---
 
-fix(workspace): Use consistent default token limit for `list_files` tool
-
 The `list_files` workspace tool now defaults to a 2,000-token output limit, matching all other workspace tools.

--- a/.changeset/consistent-token-limits.md
+++ b/.changeset/consistent-token-limits.md
@@ -1,5 +1,0 @@
----
-'@mastra/core': patch
----
-
-The `list_files` workspace tool now defaults to a 2,000-token output limit, matching all other workspace tools.

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -214,10 +214,11 @@ const workspace = new Workspace({
 Rename workspace tools to match the conventions your agent expects. The config key remains the original `WORKSPACE_TOOLS` constant — only the exposed name changes.
 
 ```typescript title="src/mastra/workspaces.ts"
-import { Workspace, LocalFilesystem, WORKSPACE_TOOLS } from '@mastra/core/workspace'
+import { Workspace, LocalFilesystem, LocalSandbox, WORKSPACE_TOOLS } from '@mastra/core/workspace'
 
 const workspace = new Workspace({
   filesystem: new LocalFilesystem({ basePath: './workspace' }),
+  sandbox: new LocalSandbox({ workingDirectory: './workspace' }),
   tools: {
     [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { name: 'view' },
     [WORKSPACE_TOOLS.FILESYSTEM.GREP]: { name: 'search_content' },

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -235,7 +235,7 @@ The agent sees `view`, `search_content`, `find_files`, and `execute_command` ins
 Workspace tools automatically truncate large outputs to avoid exceeding LLM context limits. Two layers of truncation apply:
 
 1. **Line-based tail**: Command output is limited to the last 200 lines by default (configurable per-command via the `tail` parameter)
-1. **Token-based limit**: All tool output is capped at 2,000 tokens by default using tiktoken
+1. **Token-based limit**: Tool output is capped at 2,000 tokens by default using tiktoken
 
 Set `maxOutputTokens` per tool to adjust the token limit:
 

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -235,7 +235,7 @@ The agent sees `view`, `search_content`, `find_files`, and `execute_command` ins
 Workspace tools automatically truncate large outputs to avoid exceeding LLM context limits. Two layers of truncation apply:
 
 1. **Line-based tail**: Command output is limited to the last 200 lines by default (configurable per-command via the `tail` parameter)
-1. **Token-based limit**: Tool output is capped at 2,000 tokens by default using tiktoken
+1. **Token-based limit**: Tool output is capped at 2000 tokens by default using tiktoken
 
 Set `maxOutputTokens` per tool to adjust the token limit:
 

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -206,6 +206,50 @@ const workspace = new Workspace({
 | `enabled` | `boolean` | Whether the tool is available (default: `true`) |
 | `requireApproval` | `boolean` | Whether the tool requires user approval before execution (default: `false`) |
 | `requireReadBeforeWrite` | `boolean` | For write tools: require reading the file first (default: `false`) |
+| `name` | `string` | Custom name for the tool. Replaces the default `mastra_workspace_*` name. |
+| `maxOutputTokens` | `number` | Maximum tokens for tool output (default: `2000`). Output exceeding this limit is truncated using tiktoken. |
+
+### Tool name remapping
+
+Rename workspace tools to match the conventions your agent expects. The config key remains the original `WORKSPACE_TOOLS` constant — only the exposed name changes.
+
+```typescript title="src/mastra/workspaces.ts"
+import { Workspace, LocalFilesystem, WORKSPACE_TOOLS } from '@mastra/core/workspace'
+
+const workspace = new Workspace({
+  filesystem: new LocalFilesystem({ basePath: './workspace' }),
+  tools: {
+    [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { name: 'view' },
+    [WORKSPACE_TOOLS.FILESYSTEM.GREP]: { name: 'search_content' },
+    [WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES]: { name: 'find_files' },
+    [WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]: { name: 'execute_command' },
+  },
+})
+```
+
+The agent sees `view`, `search_content`, `find_files`, and `execute_command` instead of the default `mastra_workspace_*` names. Tool names must be unique — duplicate names or conflicts with other default names throw an error.
+
+### Output truncation
+
+Workspace tools automatically truncate large outputs to avoid exceeding LLM context limits. Two layers of truncation apply:
+
+1. **Line-based tail**: Command output is limited to the last 200 lines by default (configurable per-command via the `tail` parameter)
+1. **Token-based limit**: All tool output is capped at 2,000 tokens by default using tiktoken
+
+Set `maxOutputTokens` per tool to adjust the token limit:
+
+```typescript
+const workspace = new Workspace({
+  // ...
+  tools: {
+    [WORKSPACE_TOOLS.SANDBOX.EXECUTE_COMMAND]: {
+      maxOutputTokens: 5000,
+    },
+  },
+})
+```
+
+ANSI escape codes (colors, cursor sequences) are automatically stripped from command output before it reaches the model.
 
 ### Read-before-write
 

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -235,7 +235,7 @@ The agent sees `view`, `search_content`, `find_files`, and `execute_command` ins
 Workspace tools automatically truncate large outputs to avoid exceeding LLM context limits. Two layers of truncation apply:
 
 1. **Line-based tail**: Command output is limited to the last 200 lines by default (configurable per-command via the `tail` parameter)
-1. **Token-based limit**: Tool output is capped at 2000 tokens by default using tiktoken
+1. **Token-based limit**: Tool output is capped at 2000 tokens by default
 
 Set `maxOutputTokens` per tool to adjust the token limit:
 

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -138,11 +138,25 @@ const workspace = new Workspace({
             defaultValue: 'false',
           },
           {
+            name: 'name',
+            type: 'string',
+            description:
+              'Custom name to expose this tool as. Replaces the default `mastra_workspace_*` name. The config key must still use the original `WORKSPACE_TOOLS` constant.',
+            isOptional: true,
+          },
+          {
             name: 'requireReadBeforeWrite',
             type: 'boolean',
             description: 'For write tools: require reading the file first to prevent overwrites',
             isOptional: true,
             defaultValue: 'false',
+          },
+          {
+            name: 'maxOutputTokens',
+            type: 'number',
+            description: 'Maximum tokens for tool output. Output exceeding this limit is truncated using tiktoken.',
+            isOptional: true,
+            defaultValue: '2000',
           },
         ],
       },
@@ -161,19 +175,24 @@ const workspace = new Workspace({
 
 The `tools` option accepts a `WorkspaceToolsConfig` object that controls which workspace tools are enabled and their safety settings.
 
-```typescript prettier:false
-import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+```typescript {2,7-16}
+import { Workspace } from '@mastra/core/workspace'
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace'
 
-tools: {
-  // Global defaults (apply to all tools)
-  enabled: true,
-  requireApproval: false,
+const workspace = new Workspace({
+  id: 'my-workspace',
+  name: 'My Workspace',
+  tools: {
+    // Global defaults (apply to all tools)
+    enabled: true,
+    requireApproval: false,
 
-  // Per-tool overrides using WORKSPACE_TOOLS constants
-  [WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]: {
-    requireApproval: true,
+    // Per-tool overrides using WORKSPACE_TOOLS constants
+    [WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]: {
+      requireApproval: true,
+    },
   },
-}
+})
 ```
 
 The config object has two parts:
@@ -183,61 +202,22 @@ The config object has two parts:
 
 See [workspace overview](/docs/workspace/overview#tool-configuration) for more examples.
 
-### Per-tool options
-
-Each tool can be configured with these options:
-
-<PropertiesTable
-  content={[
-  {
-    name: 'enabled',
-    type: 'boolean',
-    description: 'Whether the tool is available to agents',
-    isOptional: true,
-    defaultValue: 'true',
-  },
-  {
-    name: 'requireApproval',
-    type: 'boolean',
-    description: 'Whether the tool requires user approval before execution',
-    isOptional: true,
-    defaultValue: 'false',
-  },
-  {
-    name: 'name',
-    type: 'string',
-    description:
-      'Custom name to expose this tool as. Replaces the default mastra_workspace_* name. The config key must still use the original WORKSPACE_TOOLS constant.',
-    isOptional: true,
-  },
-  {
-    name: 'requireReadBeforeWrite',
-    type: 'boolean',
-    description: 'For write tools: require reading the file first to prevent overwrites',
-    isOptional: true,
-    defaultValue: 'false',
-  },
-  {
-    name: 'maxOutputTokens',
-    type: 'number',
-    description: 'Maximum tokens for tool output. Output exceeding this limit is truncated using tiktoken.',
-    isOptional: true,
-    defaultValue: '2000',
-  },
-]}
-/>
-
 ### Tool name remapping
 
 Rename workspace tools by setting the `name` property on individual tool configs. The config key remains the original constant — only the name exposed to the agent changes.
 
-```typescript prettier:false
-import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+```typescript {8,9}
+import { Workspace } from '@mastra/core/workspace'
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace'
 
-tools: {
-  [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { name: 'view' },
-  [WORKSPACE_TOOLS.FILESYSTEM.GREP]: { name: 'search_content' },
-}
+const workspace = new Workspace({
+  id: 'my-workspace',
+  name: 'My Workspace',
+  tools: {
+    [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { name: 'view' },
+    [WORKSPACE_TOOLS.FILESYSTEM.GREP]: { name: 'search_content' },
+  },
+})
 ```
 
 Tool names must be unique across all workspace tools. Setting a custom name that conflicts with another tool's default or custom name throws an error.

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -424,6 +424,7 @@ workspace.setToolsConfig(undefined)
   {
     name: 'config',
     type: 'WorkspaceToolsConfig | undefined',
+    isOptional: true,
     description: 'New tool configuration to apply. Pass undefined to reset to defaults.',
   },
 ]}

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -467,17 +467,3 @@ Added when BM25 or vector search is configured:
 | `mastra_workspace_index` | Index content for search. Associates content with a path for later retrieval. |
 
 The `index` tool is excluded when the filesystem is in read-only mode.
-
-## Types
-
-### `AnyWorkspace`
-
-A type alias that accepts a workspace with any combination of filesystem and sandbox providers. Use this when writing functions or generics that accept any workspace configuration.
-
-```typescript
-import type { AnyWorkspace } from '@mastra/core/workspace'
-
-function processWorkspace(workspace: AnyWorkspace) {
-  // Works with any workspace configuration
-}
-```

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -183,6 +183,64 @@ The config object has two parts:
 
 See [workspace overview](/docs/workspace/overview#tool-configuration) for more examples.
 
+### Per-tool options
+
+Each tool can be configured with these options:
+
+<PropertiesTable
+  content={[
+{
+name: "enabled",
+type: "boolean",
+description: "Whether the tool is available to agents",
+isOptional: true,
+defaultValue: "true",
+},
+{
+name: "requireApproval",
+type: "boolean",
+description: "Whether the tool requires user approval before execution",
+isOptional: true,
+defaultValue: "false",
+},
+{
+name: "name",
+type: "string",
+description: "Custom name to expose this tool as. Replaces the default mastra_workspace_* name. The config key must still use the original WORKSPACE_TOOLS constant.",
+isOptional: true,
+},
+{
+name: "requireReadBeforeWrite",
+type: "boolean",
+description: "For write tools: require reading the file first to prevent overwrites",
+isOptional: true,
+defaultValue: "false",
+},
+{
+name: "maxOutputTokens",
+type: "number",
+description: "Maximum tokens for tool output. Output exceeding this limit is truncated using tiktoken.",
+isOptional: true,
+defaultValue: "2000",
+},
+]}
+/>
+
+### Tool name remapping
+
+Rename workspace tools by setting the `name` property on individual tool configs. The config key remains the original constant — only the name exposed to the agent changes.
+
+```typescript prettier:false
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace';
+
+tools: {
+  [WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]: { name: 'view' },
+  [WORKSPACE_TOOLS.FILESYSTEM.GREP]: { name: 'search_content' },
+}
+```
+
+Tool names must be unique across all workspace tools. Setting a custom name that conflicts with another tool's default or custom name throws an error.
+
 ## Properties
 
 <PropertiesTable
@@ -333,11 +391,42 @@ To override the default output, pass an `instructions` option to [LocalFilesyste
 
 #### `getToolsConfig()`
 
-Get the tools configuration.
+Get the current tools configuration.
 
 ```typescript
 const config = workspace.getToolsConfig()
 ```
+
+**Returns:** `WorkspaceToolsConfig | undefined`
+
+#### `setToolsConfig()`
+
+Update the per-tool configuration at runtime. Changes take effect on the next agent interaction (the next `createWorkspaceTools()` call).
+
+```typescript
+import { WORKSPACE_TOOLS } from '@mastra/core/workspace'
+
+// Disable write tools for read-only mode
+workspace.setToolsConfig({
+  [WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE]: { enabled: false },
+  [WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE]: { enabled: false },
+})
+
+// Reset to defaults
+workspace.setToolsConfig(undefined)
+```
+
+**Parameters:**
+
+<PropertiesTable
+  content={[
+{
+name: "config",
+type: "WorkspaceToolsConfig | undefined",
+description: "New tool configuration to apply. Pass undefined to reset to defaults.",
+},
+]}
+/>
 
 ## Agent tools
 
@@ -352,7 +441,7 @@ Added when a filesystem is configured:
 | `mastra_workspace_read_file` | Read file contents. Supports optional line range for reading specific portions of large files. |
 | `mastra_workspace_write_file` | Create or overwrite a file with new content. Creates parent directories automatically. |
 | `mastra_workspace_edit_file` | Edit an existing file by finding and replacing text. Useful for targeted changes without rewriting the entire file. |
-| `mastra_workspace_list_files` | List directory contents as a tree structure. Supports recursive listing with depth limits. |
+| `mastra_workspace_list_files` | List directory contents as a tree structure. Supports recursive listing with depth limits, glob patterns, and `.gitignore` filtering (enabled by default). |
 | `mastra_workspace_delete` | Delete a file or directory. Supports recursive deletion for directories. |
 | `mastra_workspace_file_stat` | Get metadata about a file or directory including size, type, and modification time. |
 | `mastra_workspace_mkdir` | Create a directory. Creates parent directories automatically if they don't exist. |
@@ -378,3 +467,17 @@ Added when BM25 or vector search is configured:
 | `mastra_workspace_index` | Index content for search. Associates content with a path for later retrieval. |
 
 The `index` tool is excluded when the filesystem is in read-only mode.
+
+## Types
+
+### `AnyWorkspace`
+
+A type alias that accepts a workspace with any combination of filesystem and sandbox providers. Use this when writing functions or generics that accept any workspace configuration.
+
+```typescript
+import type { AnyWorkspace } from '@mastra/core/workspace'
+
+function processWorkspace(workspace: AnyWorkspace) {
+  // Works with any workspace configuration
+}
+```

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -401,7 +401,7 @@ const config = workspace.getToolsConfig()
 
 #### `setToolsConfig()`
 
-Update the per-tool configuration at runtime. Changes take effect on the next agent interaction (the next `createWorkspaceTools()` call).
+Replace the per-tool configuration at runtime. This performs a full replacement — it does not merge with the previous config. Pass `undefined` to reset to defaults. Changes take effect on the next agent interaction (the next `createWorkspaceTools()` call).
 
 ```typescript
 import { WORKSPACE_TOOLS } from '@mastra/core/workspace'

--- a/docs/src/content/en/reference/workspace/workspace-class.mdx
+++ b/docs/src/content/en/reference/workspace/workspace-class.mdx
@@ -189,40 +189,41 @@ Each tool can be configured with these options:
 
 <PropertiesTable
   content={[
-{
-name: "enabled",
-type: "boolean",
-description: "Whether the tool is available to agents",
-isOptional: true,
-defaultValue: "true",
-},
-{
-name: "requireApproval",
-type: "boolean",
-description: "Whether the tool requires user approval before execution",
-isOptional: true,
-defaultValue: "false",
-},
-{
-name: "name",
-type: "string",
-description: "Custom name to expose this tool as. Replaces the default mastra_workspace_* name. The config key must still use the original WORKSPACE_TOOLS constant.",
-isOptional: true,
-},
-{
-name: "requireReadBeforeWrite",
-type: "boolean",
-description: "For write tools: require reading the file first to prevent overwrites",
-isOptional: true,
-defaultValue: "false",
-},
-{
-name: "maxOutputTokens",
-type: "number",
-description: "Maximum tokens for tool output. Output exceeding this limit is truncated using tiktoken.",
-isOptional: true,
-defaultValue: "2000",
-},
+  {
+    name: 'enabled',
+    type: 'boolean',
+    description: 'Whether the tool is available to agents',
+    isOptional: true,
+    defaultValue: 'true',
+  },
+  {
+    name: 'requireApproval',
+    type: 'boolean',
+    description: 'Whether the tool requires user approval before execution',
+    isOptional: true,
+    defaultValue: 'false',
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description:
+      'Custom name to expose this tool as. Replaces the default mastra_workspace_* name. The config key must still use the original WORKSPACE_TOOLS constant.',
+    isOptional: true,
+  },
+  {
+    name: 'requireReadBeforeWrite',
+    type: 'boolean',
+    description: 'For write tools: require reading the file first to prevent overwrites',
+    isOptional: true,
+    defaultValue: 'false',
+  },
+  {
+    name: 'maxOutputTokens',
+    type: 'number',
+    description: 'Maximum tokens for tool output. Output exceeding this limit is truncated using tiktoken.',
+    isOptional: true,
+    defaultValue: '2000',
+  },
 ]}
 />
 
@@ -399,7 +400,7 @@ const config = workspace.getToolsConfig()
 
 **Returns:** `WorkspaceToolsConfig | undefined`
 
-#### `setToolsConfig()`
+#### `setToolsConfig(config?)`
 
 Replace the per-tool configuration at runtime. This performs a full replacement — it does not merge with the previous config. Pass `undefined` to reset to defaults. Changes take effect on the next agent interaction (the next `createWorkspaceTools()` call).
 
@@ -420,11 +421,11 @@ workspace.setToolsConfig(undefined)
 
 <PropertiesTable
   content={[
-{
-name: "config",
-type: "WorkspaceToolsConfig | undefined",
-description: "New tool configuration to apply. Pass undefined to reset to defaults.",
-},
+  {
+    name: 'config',
+    type: 'WorkspaceToolsConfig | undefined',
+    description: 'New tool configuration to apply. Pass undefined to reset to defaults.',
+  },
 ]}
 />
 


### PR DESCRIPTION
## Summary

Documents several recent workspace features that were missing from the docs:

- **Tool name remapping** (`name` property on per-tool config) — conceptual guide + reference
- **Output truncation** (line-based tail, token-based limits, ANSI stripping) — conceptual guide
- **`maxOutputTokens`** per-tool option — conceptual guide + reference
- **`setToolsConfig()`** method — reference with code example
- **`respectGitignore`** on `list_files` — updated tool table description

## Changed files

- `docs/src/content/en/docs/workspace/overview.mdx` — added Tool name remapping, Output truncation sections; added `name` and `maxOutputTokens` to tool options table
- `docs/src/content/en/reference/workspace/workspace-class.mdx` — added `name`, `maxOutputTokens` to PropertiesTable; added Tool name remapping subsection; added `setToolsConfig()` method; updated `list_files` description

## Related PRs

- feat(workspace): support tool name remapping (#13687, #13694)
- feat(workspace): ANSI stripping, tail pipe extraction, tiktoken output limits (#13440)
- feat(core): add setToolsConfig to Workspace (#13439)
- feat(workspace): gitignore support, lower tree depth, fix tool guidance (#13724)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-tool display names and per-tool output limits (default 2,000 tokens)
  * Runtime tool configuration: replace or reset per-tool settings via new runtime API

* **Improvements**
  * Two-stage output truncation (line-based tail — default last 200 lines — + token cap); ANSI codes stripped
  * Per-tool name remapping with uniqueness enforcement and conflict errors
  * Filesystem listing enhancements (depth, glob patterns, .gitignore handling)
  * Clarified read-before-write behavior

* **Documentation**
  * Expanded workspace tool configuration guide with examples and usage notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->