### PR TITLE
fix: memory-usage mock embedder and working-memory model upgrade

### DIFF
--- a/packages/memory/integration-tests/src/working-memory.test.ts
+++ b/packages/memory/integration-tests/src/working-memory.test.ts
@@ -6,18 +6,18 @@ import { getWorkingMemoryAdditiveTests } from './shared/working-memory-additive'
 
 // v4
 describe('V4', () => {
-  getWorkingMemoryTests(openai('gpt-4o'));
-  getWorkingMemoryAdditiveTests(openai('gpt-4o'));
+  getWorkingMemoryTests(openai('gpt-4.1'));
+  getWorkingMemoryAdditiveTests(openai('gpt-4.1'));
 });
 
 // v5
 describe('V5', () => {
-  getWorkingMemoryTests('openai/gpt-4o');
-  getWorkingMemoryAdditiveTests('openai/gpt-4o');
+  getWorkingMemoryTests('openai/gpt-4.1');
+  getWorkingMemoryAdditiveTests('openai/gpt-4.1');
 });
 
 // v6
 describe('V6', () => {
-  getWorkingMemoryTests(openaiV6('gpt-4o'));
-  getWorkingMemoryAdditiveTests(openaiV6('gpt-4o'));
+  getWorkingMemoryTests(openaiV6('gpt-4.1'));
+  getWorkingMemoryAdditiveTests(openaiV6('gpt-4.1'));
 });

--- a/packages/memory/src/memory-usage.test.ts
+++ b/packages/memory/src/memory-usage.test.ts
@@ -28,8 +28,13 @@ vi.mock('@internal/ai-sdk-v4', () => ({
   }),
 }));
 
+// Token counts must match the vi.mock return values above so tests pass
+// even when vi.mock doesn't intercept (e.g. CI sharded runs with isolate: false)
+const TOKEN_COUNTS: Record<string, number> = { v1: 33, v2: 55, v3: 42 };
+
 // Helper to create a Memory instance with specific embedder version
 function createMemoryWithEmbedder(specVersion: 'v1' | 'v2' | 'v3') {
+  const tokens = TOKEN_COUNTS[specVersion]!;
   return new Memory({
     storage: new InMemoryStore(),
     vector: {
@@ -42,7 +47,7 @@ function createMemoryWithEmbedder(specVersion: 'v1' | 'v2' | 'v3') {
       specificationVersion: specVersion,
       provider: 'test',
       modelId: 'test-model',
-      doEmbed: vi.fn(),
+      doEmbed: vi.fn().mockResolvedValue({ embeddings: [[0.1, 0.2]], usage: { tokens } }),
     } as any,
     options: {
       semanticRecall: true,


### PR DESCRIPTION
## Summary

Two test reliability fixes for memory tests failing in CI:

### 1. memory-usage.test.ts — mock embedder fix
The `doEmbed: vi.fn()` mock had no return value, so when `vi.mock('@internal/ai-v6')` didn't intercept (due to `isolate: false` + sharding in CI), the real `embedMany` called `doEmbed` which returned `undefined`, crashing on `modelResponse.embeddings`.

Fix: make `doEmbed` return a proper response shape (`{ embeddings, usage }`) so the test works whether or not `vi.mock` intercepts.

### 2. working-memory.test.ts — model upgrade
"Large Real-World Schema" additive update tests were flaky with `gpt-4o` — `getWorkingMemory()` returned `null` in 4 test cases. Upgraded to `gpt-4.1` across all 3 SDK versions (V4, V5, V6) for more reliable structured output handling.

## Test Plan
- CI memory integration tests (`secrets.test-memory.yml`)
- CI vitest-changed workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configurations to use gpt-4.1 model identifiers across multiple test blocks.
  * Enhanced embedder token mocking to maintain consistency across different spec versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->