### PR TITLE
fix: rename request_sandbox_access to request_access, fix tilde expansion and mid-turn setAllowedPaths

### DIFF
--- a/.changeset/smooth-donuts-work.md
+++ b/.changeset/smooth-donuts-work.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Fixed `request_sandbox_access` tool not expanding tilde paths (`~/.config/...`), which caused it to incorrectly report access as already granted. Also fixed newly approved paths not being accessible until the next turn by calling `setAllowedPaths` immediately after approval.
+Renamed `request_sandbox_access` tool to `request_access`. Fixed tilde paths (`~/.config/...`) not being expanded, which caused the tool to incorrectly report access as already granted. Fixed newly approved paths not being accessible until the next turn by calling `setAllowedPaths` immediately after approval.

--- a/.changeset/smooth-donuts-work.md
+++ b/.changeset/smooth-donuts-work.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed `request_sandbox_access` tool not expanding tilde paths (`~/.config/...`), which caused it to incorrectly report access as already granted. Also fixed newly approved paths not being accessible until the next turn by calling `setAllowedPaths` immediately after approval.

--- a/mastracode/src/agents/__tests__/extra-tools.test.ts
+++ b/mastracode/src/agents/__tests__/extra-tools.test.ts
@@ -45,22 +45,22 @@ describe('createDynamicTools – extraTools', () => {
     expect(tools.my_custom_tool).toBe(myCustomTool);
 
     // Built-in non-workspace tools should still be present
-    expect(tools).toHaveProperty('request_sandbox_access');
+    expect(tools).toHaveProperty('request_access');
   });
 
   it('should not overwrite built-in tools with extraTools of the same name', () => {
     const sneakyTool = createTool({
-      id: 'request_sandbox_access',
-      description: 'Trying to overwrite the built-in request_sandbox_access tool',
+      id: 'request_access',
+      description: 'Trying to overwrite the built-in request_access tool',
       inputSchema: z.object({}),
       execute: async () => ({ result: 'sneaky' }),
     });
 
-    const getDynamicTools = createDynamicTools(undefined, { request_sandbox_access: sneakyTool });
+    const getDynamicTools = createDynamicTools(undefined, { request_access: sneakyTool });
     const tools = getDynamicTools({ requestContext: makeRequestContext() });
 
-    // Built-in request_sandbox_access should NOT be replaced by the extra tool
-    expect(tools.request_sandbox_access).not.toBe(sneakyTool);
+    // Built-in request_access should NOT be replaced by the extra tool
+    expect(tools.request_access).not.toBe(sneakyTool);
   });
 
   it('should return extraTools even when no MCP manager is provided', () => {
@@ -129,7 +129,7 @@ describe('createDynamicTools – extraTools', () => {
 
     // Should have built-in non-workspace tools but nothing extra
     // Note: workspace tools (view, search_content, etc.) are provided by the workspace, not createDynamicTools
-    expect(tools).toHaveProperty('request_sandbox_access');
+    expect(tools).toHaveProperty('request_access');
     expect(tools).not.toHaveProperty('my_custom_tool');
   });
 });
@@ -160,11 +160,11 @@ describe('createDynamicTools – denied tool filtering', () => {
     const getDynamicTools = createDynamicTools();
     const tools = getDynamicTools({
       requestContext: makeRequestContext({
-        permissionRules: { categories: {}, tools: { request_sandbox_access: 'deny' } },
+        permissionRules: { categories: {}, tools: { request_access: 'deny' } },
       }),
     });
 
-    expect(tools).not.toHaveProperty('request_sandbox_access');
+    expect(tools).not.toHaveProperty('request_access');
   });
 
   it('should omit multiple denied tools', () => {
@@ -180,12 +180,12 @@ describe('createDynamicTools – denied tool filtering', () => {
       requestContext: makeRequestContext({
         permissionRules: {
           categories: {},
-          tools: { request_sandbox_access: 'deny', my_tool: 'deny' },
+          tools: { request_access: 'deny', my_tool: 'deny' },
         },
       }),
     });
 
-    expect(tools).not.toHaveProperty('request_sandbox_access');
+    expect(tools).not.toHaveProperty('request_access');
     expect(tools).not.toHaveProperty('my_tool');
   });
 
@@ -195,12 +195,12 @@ describe('createDynamicTools – denied tool filtering', () => {
       requestContext: makeRequestContext({
         permissionRules: {
           categories: {},
-          tools: { request_sandbox_access: 'allow' },
+          tools: { request_access: 'allow' },
         },
       }),
     });
 
-    expect(tools).toHaveProperty('request_sandbox_access');
+    expect(tools).toHaveProperty('request_access');
   });
 
   it('should also deny extraTools when they have a deny policy', () => {

--- a/mastracode/src/agents/tools.ts
+++ b/mastracode/src/agents/tools.ts
@@ -22,7 +22,7 @@ export function createDynamicTools(
     // management tools are now provided by the workspace (see workspace.ts).
     // Only tools without a workspace equivalent remain here.
     const tools: Record<string, any> = {
-      request_sandbox_access: requestSandboxAccessTool,
+      request_access: requestSandboxAccessTool,
     };
 
     if (hasTavilyKey()) {

--- a/mastracode/src/permissions.ts
+++ b/mastracode/src/permissions.ts
@@ -56,11 +56,11 @@ const TOOL_CATEGORY_MAP: Record<string, ToolCategory> = {
   [MC_TOOLS.EXECUTE_COMMAND]: 'execute',
 
   // Interactive / planning tools — always allowed (no category needed)
-  // ask_user, task_write, task_check, submit_plan, request_sandbox_access
+  // ask_user, task_write, task_check, submit_plan, request_access
 };
 
 // Tools that never need approval regardless of policy
-const ALWAYS_ALLOW_TOOLS = new Set(['ask_user', 'task_write', 'task_check', 'submit_plan', 'request_sandbox_access']);
+const ALWAYS_ALLOW_TOOLS = new Set(['ask_user', 'task_write', 'task_check', 'submit_plan', 'request_access']);
 
 /**
  * Get the category for a tool, or null if the tool is always-allowed.

--- a/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
+++ b/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
@@ -1,11 +1,20 @@
 import * as os from 'node:os';
+import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
+import { LocalFilesystem } from '@mastra/core/workspace';
 
 import { requestSandboxAccessTool } from '../request-sandbox-access.js';
 
+function createMockLocalFilesystem() {
+  const tmpDir = os.tmpdir();
+  const fs = new LocalFilesystem({ basePath: path.join(tmpDir, 'test-sandbox-access'), contained: true });
+  const spy = vi.spyOn(fs, 'setAllowedPaths');
+  return { fs, setAllowedPaths: spy };
+}
+
 describe('request_sandbox_access', () => {
   it('calls setAllowedPaths on workspace filesystem when access is approved', async () => {
-    const setAllowedPaths = vi.fn();
+    const { fs, setAllowedPaths } = createMockLocalFilesystem();
 
     const mockHarnessCtx = {
       emitEvent: vi.fn(),
@@ -22,7 +31,7 @@ describe('request_sandbox_access', () => {
         get: (key: string) => (key === 'harness' ? mockHarnessCtx : undefined),
       },
       workspace: {
-        filesystem: { setAllowedPaths },
+        filesystem: fs,
       },
     };
 
@@ -36,15 +45,16 @@ describe('request_sandbox_access', () => {
 
     // The key assertion: setAllowedPaths must be called mid-turn
     expect(setAllowedPaths).toHaveBeenCalledTimes(1);
-    const updater = setAllowedPaths.mock.calls[0][0];
-    expect(typeof updater).toBe('function');
+    const arg = setAllowedPaths.mock.calls[0]![0];
+    expect(typeof arg).toBe('function');
     // The updater should append the new path
+    const updater = arg as (current: readonly string[]) => string[];
     expect(updater([])).toEqual(['/outside/project/dir']);
     expect(updater(['/existing'])).toEqual(['/existing', '/outside/project/dir']);
   });
 
   it('does not call setAllowedPaths when access is denied', async () => {
-    const setAllowedPaths = vi.fn();
+    const { fs, setAllowedPaths } = createMockLocalFilesystem();
 
     const mockHarnessCtx = {
       emitEvent: vi.fn(),
@@ -60,7 +70,7 @@ describe('request_sandbox_access', () => {
         get: (key: string) => (key === 'harness' ? mockHarnessCtx : undefined),
       },
       workspace: {
-        filesystem: { setAllowedPaths },
+        filesystem: fs,
       },
     };
 
@@ -101,7 +111,7 @@ describe('request_sandbox_access', () => {
   });
 
   it('expands tilde paths instead of nesting under project root', async () => {
-    const setAllowedPaths = vi.fn();
+    const { fs, setAllowedPaths } = createMockLocalFilesystem();
 
     const mockHarnessCtx = {
       emitEvent: vi.fn(),
@@ -117,7 +127,7 @@ describe('request_sandbox_access', () => {
         get: (key: string) => (key === 'harness' ? mockHarnessCtx : undefined),
       },
       workspace: {
-        filesystem: { setAllowedPaths },
+        filesystem: fs,
       },
     };
 
@@ -135,7 +145,8 @@ describe('request_sandbox_access', () => {
 
     // setAllowedPaths should be called with the expanded path
     expect(setAllowedPaths).toHaveBeenCalledTimes(1);
-    const updater = setAllowedPaths.mock.calls[0][0];
+    const arg = setAllowedPaths.mock.calls[0]![0];
+    const updater = arg as (current: readonly string[]) => string[];
     expect(updater([])).toEqual([expectedPath]);
   });
 

--- a/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
+++ b/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
@@ -1,7 +1,7 @@
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
 import { LocalFilesystem } from '@mastra/core/workspace';
+import { describe, expect, it, vi } from 'vitest';
 
 import { requestSandboxAccessTool } from '../request-sandbox-access.js';
 

--- a/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
+++ b/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
@@ -1,0 +1,169 @@
+import * as os from 'node:os';
+import { describe, expect, it, vi } from 'vitest';
+
+import { requestSandboxAccessTool } from '../request-sandbox-access.js';
+
+describe('request_sandbox_access', () => {
+  it('calls setAllowedPaths on workspace filesystem when access is approved', async () => {
+    const setAllowedPaths = vi.fn();
+
+    const mockHarnessCtx = {
+      emitEvent: vi.fn(),
+      registerQuestion: vi.fn(({ resolve }: { questionId: string; resolve: (answer: string) => void }) => {
+        // Simulate immediate user approval
+        resolve('yes');
+      }),
+      getState: () => ({ sandboxAllowedPaths: [] }),
+      setState: vi.fn(),
+    };
+
+    const context = {
+      requestContext: {
+        get: (key: string) => (key === 'harness' ? mockHarnessCtx : undefined),
+      },
+      workspace: {
+        filesystem: { setAllowedPaths },
+      },
+    };
+
+    const result = await (requestSandboxAccessTool as any).execute(
+      { path: '/outside/project/dir', reason: 'need to read config' },
+      context,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Access granted');
+
+    // The key assertion: setAllowedPaths must be called mid-turn
+    expect(setAllowedPaths).toHaveBeenCalledTimes(1);
+    const updater = setAllowedPaths.mock.calls[0][0];
+    expect(typeof updater).toBe('function');
+    // The updater should append the new path
+    expect(updater([])).toEqual(['/outside/project/dir']);
+    expect(updater(['/existing'])).toEqual(['/existing', '/outside/project/dir']);
+  });
+
+  it('does not call setAllowedPaths when access is denied', async () => {
+    const setAllowedPaths = vi.fn();
+
+    const mockHarnessCtx = {
+      emitEvent: vi.fn(),
+      registerQuestion: vi.fn(({ resolve }: { questionId: string; resolve: (answer: string) => void }) => {
+        resolve('no');
+      }),
+      getState: () => ({ sandboxAllowedPaths: [] }),
+      setState: vi.fn(),
+    };
+
+    const context = {
+      requestContext: {
+        get: (key: string) => (key === 'harness' ? mockHarnessCtx : undefined),
+      },
+      workspace: {
+        filesystem: { setAllowedPaths },
+      },
+    };
+
+    const result = await (requestSandboxAccessTool as any).execute(
+      { path: '/outside/project/dir', reason: 'need to read config' },
+      context,
+    );
+
+    expect(result.content).toContain('Access denied');
+    expect(setAllowedPaths).not.toHaveBeenCalled();
+  });
+
+  it('works when workspace has no filesystem', async () => {
+    const mockHarnessCtx = {
+      emitEvent: vi.fn(),
+      registerQuestion: vi.fn(({ resolve }: { questionId: string; resolve: (answer: string) => void }) => {
+        resolve('yes');
+      }),
+      getState: () => ({ sandboxAllowedPaths: [] }),
+      setState: vi.fn(),
+    };
+
+    const context = {
+      requestContext: {
+        get: (key: string) => (key === 'harness' ? mockHarnessCtx : undefined),
+      },
+      workspace: {},
+    };
+
+    const result = await (requestSandboxAccessTool as any).execute(
+      { path: '/outside/project/dir', reason: 'testing' },
+      context,
+    );
+
+    // Should still succeed — just won't call setAllowedPaths
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Access granted');
+  });
+
+  it('expands tilde paths instead of nesting under project root', async () => {
+    const setAllowedPaths = vi.fn();
+
+    const mockHarnessCtx = {
+      emitEvent: vi.fn(),
+      registerQuestion: vi.fn(({ resolve }: { questionId: string; resolve: (answer: string) => void }) => {
+        resolve('yes');
+      }),
+      getState: () => ({ sandboxAllowedPaths: [] }),
+      setState: vi.fn(),
+    };
+
+    const context = {
+      requestContext: {
+        get: (key: string) => (key === 'harness' ? mockHarnessCtx : undefined),
+      },
+      workspace: {
+        filesystem: { setAllowedPaths },
+      },
+    };
+
+    const result = await (requestSandboxAccessTool as any).execute(
+      { path: '~/.config/opencode', reason: 'need config access' },
+      context,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Access granted');
+    // Must resolve to the real home dir, not nest under project root
+    const expectedPath = os.homedir() + '/.config/opencode';
+    expect(result.content).toContain(expectedPath);
+    expect(result.content).not.toContain('already granted');
+
+    // setAllowedPaths should be called with the expanded path
+    expect(setAllowedPaths).toHaveBeenCalledTimes(1);
+    const updater = setAllowedPaths.mock.calls[0][0];
+    expect(updater([])).toEqual([expectedPath]);
+  });
+
+  it('works when filesystem lacks setAllowedPaths method', async () => {
+    const mockHarnessCtx = {
+      emitEvent: vi.fn(),
+      registerQuestion: vi.fn(({ resolve }: { questionId: string; resolve: (answer: string) => void }) => {
+        resolve('yes');
+      }),
+      getState: () => ({ sandboxAllowedPaths: [] }),
+      setState: vi.fn(),
+    };
+
+    const context = {
+      requestContext: {
+        get: (key: string) => (key === 'harness' ? mockHarnessCtx : undefined),
+      },
+      workspace: {
+        filesystem: {}, // no setAllowedPaths
+      },
+    };
+
+    const result = await (requestSandboxAccessTool as any).execute(
+      { path: '/outside/project/dir', reason: 'testing' },
+      context,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Access granted');
+  });
+});

--- a/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
+++ b/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
@@ -12,7 +12,7 @@ function createMockLocalFilesystem() {
   return { fs, setAllowedPaths: spy };
 }
 
-describe('request_sandbox_access', () => {
+describe('request_access', () => {
   it('calls setAllowedPaths on workspace filesystem when access is approved', async () => {
     const { fs, setAllowedPaths } = createMockLocalFilesystem();
 

--- a/mastracode/src/tools/request-sandbox-access.ts
+++ b/mastracode/src/tools/request-sandbox-access.ts
@@ -3,11 +3,18 @@
  * The user can approve or deny the request via TUI dialog.
  */
 
+import * as os from 'node:os';
 import * as path from 'node:path';
 import type { HarnessRequestContext } from '@mastra/core/harness';
 import { createTool } from '@mastra/core/tools';
 import { z } from 'zod';
 import { isPathAllowed, getAllowedPathsFromContext } from './utils.js';
+
+function expandTilde(p: string): string {
+  if (p === '~') return os.homedir();
+  if (p.startsWith('~/') || p.startsWith('~\\')) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
 
 let requestCounter = 0;
 
@@ -22,8 +29,9 @@ export const requestSandboxAccessTool = createTool({
     try {
       const harnessCtx = context?.requestContext?.get('harness') as HarnessRequestContext | undefined;
 
-      // Resolve to absolute path
-      const absolutePath = path.isAbsolute(requestedPath) ? requestedPath : path.resolve(process.cwd(), requestedPath);
+      // Resolve to absolute path (expand ~ first since Node path APIs don't handle it)
+      const expanded = expandTilde(requestedPath);
+      const absolutePath = path.isAbsolute(expanded) ? expanded : path.resolve(process.cwd(), expanded);
 
       // Check if already allowed
       const projectRoot = process.cwd();
@@ -60,13 +68,21 @@ export const requestSandboxAccessTool = createTool({
 
       const approved = answer.toLowerCase().startsWith('y') || answer.toLowerCase() === 'approve';
       if (approved) {
-        // Add to allowed paths
+        // Add to allowed paths in harness state (persists across turns)
         const currentAllowed = (harnessCtx.getState?.()?.sandboxAllowedPaths as string[] | undefined) ?? [];
         if (!currentAllowed.includes(absolutePath)) {
           harnessCtx.setState?.({
             sandboxAllowedPaths: [...currentAllowed, absolutePath],
           });
         }
+
+        // Also update the workspace filesystem immediately so tools in the
+        // same turn can access the path without waiting for the next turn.
+        const fs = context?.workspace?.filesystem;
+        if (fs && 'setAllowedPaths' in fs && typeof (fs as any).setAllowedPaths === 'function') {
+          (fs as any).setAllowedPaths((prev: readonly string[]) => [...prev, absolutePath]);
+        }
+
         return {
           content: `Access granted: "${absolutePath}" has been added to allowed paths. You can now access files in this directory.`,
           isError: false,

--- a/mastracode/src/tools/request-sandbox-access.ts
+++ b/mastracode/src/tools/request-sandbox-access.ts
@@ -7,6 +7,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { HarnessRequestContext } from '@mastra/core/harness';
 import { createTool } from '@mastra/core/tools';
+import { LocalFilesystem } from '@mastra/core/workspace';
 import { z } from 'zod';
 import { isPathAllowed, getAllowedPathsFromContext } from './utils.js';
 
@@ -79,8 +80,8 @@ export const requestSandboxAccessTool = createTool({
         // Also update the workspace filesystem immediately so tools in the
         // same turn can access the path without waiting for the next turn.
         const fs = context?.workspace?.filesystem;
-        if (fs && 'setAllowedPaths' in fs && typeof (fs as any).setAllowedPaths === 'function') {
-          (fs as any).setAllowedPaths((prev: readonly string[]) => [...prev, absolutePath]);
+        if (fs instanceof LocalFilesystem) {
+          fs.setAllowedPaths((prev: readonly string[]) => [...prev, absolutePath]);
         }
 
         return {

--- a/mastracode/src/tools/request-sandbox-access.ts
+++ b/mastracode/src/tools/request-sandbox-access.ts
@@ -1,5 +1,5 @@
 /**
- * request_sandbox_access tool — requests permission to access a directory outside the project root.
+ * request_access tool — requests permission to access a directory outside the project root.
  * The user can approve or deny the request via TUI dialog.
  */
 
@@ -20,7 +20,7 @@ function expandTilde(p: string): string {
 let requestCounter = 0;
 
 export const requestSandboxAccessTool = createTool({
-  id: 'request_sandbox_access',
+  id: 'request_access',
   description: `Request permission to access a directory outside the current project. Use this when you need to read or write files in a directory that is not within the project root. The user will be prompted to approve or deny the request.`,
   inputSchema: z.object({
     path: z.string().min(1).describe('The absolute path to the directory you need access to.'),

--- a/mastracode/src/tui/__tests__/parallel-interactive-prompts.test.ts
+++ b/mastracode/src/tui/__tests__/parallel-interactive-prompts.test.ts
@@ -1,6 +1,6 @@
 /**
  * Test for GitHub issue #13642: Parallel interactive tool calls (ask_user,
- * request_sandbox_access) should all be answerable, not just the most recent.
+ * request_access) should all be answerable, not just the most recent.
  *
  * Root cause: state.activeInlineQuestion is a single property that gets
  * overwritten when multiple ask_question events arrive concurrently.

--- a/mastracode/src/tui/handlers/prompts.ts
+++ b/mastracode/src/tui/handlers/prompts.ts
@@ -145,7 +145,7 @@ export async function handleAskQuestion(
 }
 
 /**
- * Handle a sandbox_access_request event from the request_sandbox_access tool.
+ * Handle a sandbox_access_request event from the request_access tool.
  * Shows an inline prompt for the user to approve or deny directory access.
  *
  * If another inline question is already active, the new prompt is queued


### PR DESCRIPTION
## Problem

Two bugs in the `request_sandbox_access` tool:

1. **Tilde paths not expanded** — passing `~/.config/opencode` was resolved as a relative path (`/project/root/~/.config/opencode`) instead of expanding to the real home directory. This caused the tool to incorrectly report "Access already granted" since the nested path was within the project root.

2. **Mid-turn access not working** — after approval, `filesystem.setAllowedPaths()` was not called, so tools in the same turn could not access the newly allowed path until the next turn when `getDynamicWorkspace` re-resolved the workspace.

## Fix

- Renamed tool from `request_sandbox_access` to `request_access`
- Inline `expandTilde()` to expand `~` to `os.homedir()` before path resolution
- Call `workspace.filesystem.setAllowedPaths()` immediately after approval (`instanceof LocalFilesystem` check)

## Testing

- Added `request-sandbox-access.test.ts` with 5 tests covering: approval flow, denial, no filesystem, filesystem without `setAllowedPaths`, and tilde expansion
- Manually verified all three steps work in the same turn: permission denied → request access → read file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reason field to access requests for providing context about why access is needed.

* **Bug Fixes**
  * Fixed home directory path expansion (~/.config style paths) to expand correctly.
  * Approved sandbox paths are now immediately accessible after approval.

* **Chores**
  * Renamed access request tool identifier for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->