### PR TITLE
fix(mastracode): inline version at build time instead of requiring package.json

### DIFF
--- a/.changeset/dry-suns-mate.md
+++ b/.changeset/dry-suns-mate.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed fatal 'Cannot find module ../../package.json' error when running mastracode after installing from npm. The version is now inlined at build time instead of requiring the package.json file at runtime.

--- a/mastracode/src/utils/update-check.ts
+++ b/mastracode/src/utils/update-check.ts
@@ -4,7 +4,8 @@
 
 import { execFile } from 'node:child_process';
 import { realpathSync } from 'node:fs';
-import { createRequire } from 'node:module';
+
+declare const MASTRACODE_VERSION: string;
 
 const PACKAGE_NAME = 'mastracode';
 const NPM_REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
@@ -96,12 +97,10 @@ export function getInstallCommand(pm: PackageManager, version?: string): string 
 }
 
 /**
- * Read the current version from our own package.json.
+ * Read the current version, injected at build time by tsup's `define` option.
  */
 export function getCurrentVersion(): string {
-  const require = createRequire(import.meta.url);
-  const pkg = require('../../package.json') as { version: string };
-  return pkg.version;
+  return MASTRACODE_VERSION;
 }
 
 /**

--- a/mastracode/tsup.config.ts
+++ b/mastracode/tsup.config.ts
@@ -1,5 +1,9 @@
+import { readFileSync } from 'node:fs';
+
 import { generateTypes } from '@internal/types-builder';
 import { defineConfig } from 'tsup';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 export default defineConfig({
   entry: {
@@ -13,6 +17,9 @@ export default defineConfig({
   splitting: true,
   treeshake: {
     preset: 'smallest',
+  },
+  define: {
+    MASTRACODE_VERSION: JSON.stringify(pkg.version),
   },
   sourcemap: true,
   onSuccess: async () => {


### PR DESCRIPTION
## Summary

The published npm package did not include `package.json` in its `files` field, causing a fatal `Cannot find module '../../package.json'` error on startup when installed from npm.

### Changes

- **`mastracode/src/utils/update-check.ts`**: Replaced `require('../../package.json')` with a build-time constant `MASTRACODE_VERSION`
- **`mastracode/tsup.config.ts`**: Added `define` option to inline the version from `package.json` at build time

### Test Plan

1. `cd mastracode && pnpm build:lib`
2. `node dist/cli.js` — version displays in the TUI header, no fatal error
3. Verified `"0.5.0"` is inlined in the bundle output and no `require('../../package.json')` references remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical fatal error that prevented the application from starting after npm install. Module resolution failures have been resolved by switching to build-time version embedding. Version information is now injected at build time rather than loaded dynamically at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->