### PR TITLE
fix(harness) - remove default maxSteps which is interfering with stopWhen

### DIFF
--- a/.changeset/good-ends-lay.md
+++ b/.changeset/good-ends-lay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Remove the default maxSteps limit so stopWhen can control sub-agent execution

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -427,7 +427,7 @@ Use this tool when:
 
       try {
         const response = await subagent.stream(task, {
-          maxSteps: definition.maxSteps ?? 50,
+          maxSteps: definition.maxSteps,
           stopWhen: definition.stopWhen,
           abortSignal,
           requireToolApproval: false,


### PR DESCRIPTION
## Description

In a previous PR I exposed the stopWhen and maxSteps options for harness sub-agents. However, the harness still applies a default maxSteps value of 50.

Because maxSteps is always set, it effectively overrides stopWhen, which makes the stopWhen option unusable in practice.

This PR removes the default maxSteps value now that callers can explicitly pass their own limits. This allows stopWhen to function as intended and aligns the harness behavior more closely with how Agent behaves when used directly.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed default execution step limit for sub-agents, allowing the `stopWhen` condition to properly control sub-agent execution flow without hardcoded constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->