### PR TITLE
docs: add capsule tools reference for safe python/JS execution in wasm sandboxes

### DIFF
--- a/docs/scripts/validate-frontmatter.ts
+++ b/docs/scripts/validate-frontmatter.ts
@@ -25,8 +25,8 @@ const DEFAULT_CONFIG: ValidationConfig = {
     'models/',
     'docs/build-with-ai/skills.mdx',
   ],
-  // Allow for @mastra/* packages + mastra + create-mastra + mastracode
-  packagePattern: /^(@mastra\/[\w-]+|mastra|create-mastra|mastracode)$/,
+  // Allow for @mastra/* packages + mastra + create-mastra + mastracode + @capsule-run/* (third-party integrations)
+  packagePattern: /^(@mastra\/[\w-]+|mastra|create-mastra|mastracode|@capsule-run\/[\w-]+)$/,
   concurrency: 50,
 }
 

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -425,6 +425,7 @@ const sidebars = {
       label: 'Tools & MCP',
       collapsed: true,
       items: [
+        { type: 'doc', id: 'tools/capsule', label: 'Capsule tools' },
         { type: 'doc', id: 'tools/document-chunker-tool', label: 'createDocumentChunkerTool()' },
         { type: 'doc', id: 'tools/graph-rag-tool', label: 'createGraphRAGTool()' },
         { type: 'doc', id: 'tools/create-tool', label: 'createTool()' },

--- a/docs/src/content/en/reference/tools/capsule.mdx
+++ b/docs/src/content/en/reference/tools/capsule.mdx
@@ -1,0 +1,48 @@
+---
+title: "Reference: Capsule tools | Tools & MCP"
+description: "Use Capsule to safely execute Python and JavaScript code from Mastra agents in isolated WebAssembly sandboxes."
+packages:
+  - "@capsule-run/mastra"
+---
+
+# Capsule tools
+
+Capsule runs untrusted code in isolated WebAssembly sandboxes. The `@capsule-run/mastra` package exposes two Mastra tools that execute Python and JavaScript code through Capsule.
+
+## Installation
+
+```bash npm2yarn
+npm install @capsule-run/mastra
+```
+
+## Tools
+
+- `capsulePythonTool` — id: `python_repl`, input: `{ code: string }`, output: `string`
+- `capsuleJsTool` — id: `javascript_repl`, input: `{ code: string }`, output: `string`
+
+Both tools return the last evaluated expression or returned value as a string.
+
+## Usage
+
+```typescript
+import { Agent } from '@mastra/core/agent'
+import { capsulePythonTool, capsuleJsTool } from '@capsule-run/mastra'
+
+export const simpleAgent = new Agent({
+  id: 'simple-agent',
+  name: 'Simple Agent',
+  instructions:
+    'You can safely execute Python and JavaScript code using the available tools. End your code with an expression or return statement so the result is captured.',
+  model: 'openai/gpt-4o',
+  tools: {
+    capsulePythonTool,
+    capsuleJsTool,
+  },
+})
+```
+
+## Related
+
+- [Capsule](https://github.com/mavdol/capsule)
+- [Mastra Capsule integration](https://github.com/mavdol/mastra-capsule)
+- [createTool()](./create-tool)


### PR DESCRIPTION
### description

- Adds docs for the Capsule integration (@capsule-run/mastra), which runs Python and JavaScript in isolated WebAssembly sandboxes.

### Related Issue(s)

- <!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

### Type of Change

- [x] Documentation update

### Checklist
- [x] I have made corresponding changes to the documentation (if applicable)

fix : #13711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for Capsule tools integration, including installation instructions and TypeScript code examples for agent integration.
  * Updated documentation sidebar navigation to include Capsule tools reference section.

* **Chores**
  * Extended package validation configuration to support @capsule-run/* packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->