### PR TITLE
fix(mastracode): fallback to package.json when running from source

### DIFF
--- a/.changeset/warm-clouds-rest.md
+++ b/.changeset/warm-clouds-rest.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fix fatal "MASTRACODE_VERSION is not defined" error when running from source with tsx. The version constant is now gracefully resolved from package.json at runtime when the build-time define is unavailable.

--- a/mastracode/src/utils/update-check.ts
+++ b/mastracode/src/utils/update-check.ts
@@ -5,7 +5,7 @@
 import { execFile } from 'node:child_process';
 import { realpathSync } from 'node:fs';
 
-declare const MASTRACODE_VERSION: string;
+declare const MASTRACODE_VERSION: string | undefined;
 
 const PACKAGE_NAME = 'mastracode';
 const NPM_REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
@@ -98,9 +98,16 @@ export function getInstallCommand(pm: PackageManager, version?: string): string 
 
 /**
  * Read the current version, injected at build time by tsup's `define` option.
+ * Falls back to reading package.json at runtime (e.g. when running from source with tsx).
  */
 export function getCurrentVersion(): string {
-  return MASTRACODE_VERSION;
+  if (typeof MASTRACODE_VERSION !== 'undefined') {
+    return MASTRACODE_VERSION;
+  }
+  // Fallback for running from source (e.g. pnpx tsx mastracode/src/main.ts)
+  const { createRequire } = require('node:module');
+  const req = createRequire(import.meta.url ?? __filename);
+  return req('../../package.json').version;
 }
 
 /**


### PR DESCRIPTION
## What

Fix fatal `MASTRACODE_VERSION is not defined` error when running mastracode from source (e.g. `pnpx tsx mastracode/src/main.ts`).

## Why

`MASTRACODE_VERSION` is injected at build time via tsup's `define` option. When running directly from TypeScript source with `tsx`, the constant doesn't exist, causing an immediate crash.

## How

`getCurrentVersion()` now checks `typeof MASTRACODE_VERSION` first:
- **Built version**: returns the inlined constant (no change in behavior)
- **Running from source**: falls back to reading `package.json` at runtime

## Test plan

- `pnpx tsx mastracode/src/main.ts` — no longer crashes, version resolves to package.json value
- `pnpm build:lib` — built output still inlines the version constant correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fatal "MASTRACODE_VERSION is not defined" error when running from source with tsx. The application now gracefully handles missing build-time version information by falling back to runtime resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->