### PR TITLE
fix(mastracode): use ESM-compatible fallback for version detection

### DIFF
--- a/mastracode/src/utils/update-check.ts
+++ b/mastracode/src/utils/update-check.ts
@@ -3,7 +3,9 @@
  */
 
 import { execFile } from 'node:child_process';
-import { realpathSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 declare const MASTRACODE_VERSION: string | undefined;
 
@@ -105,9 +107,10 @@ export function getCurrentVersion(): string {
     return MASTRACODE_VERSION;
   }
   // Fallback for running from source (e.g. pnpx tsx mastracode/src/main.ts)
-  const { createRequire } = require('node:module');
-  const req = createRequire(import.meta.url ?? __filename);
-  return req('../../package.json').version;
+  const dir = dirname(fileURLToPath(import.meta.url));
+  const pkgPath = resolve(dir, '../../package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  return pkg.version;
 }
 
 /**


### PR DESCRIPTION
## What

The dev fallback in `getCurrentVersion()` used `require('node:module')` which doesn't exist in ESM context (`"type": "module"`), causing:

```
Fatal error: require is not defined
```

## Fix

Replaced with ESM-compatible `readFileSync` + `fileURLToPath` to read `package.json`.

Note: This only affects running from source (e.g. `pnpx tsx mastracode/src/main.ts`). The built bundle inlines the version via tsup's `define` and tree-shakes the fallback away.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version detection reliability by implementing an automatic fallback mechanism when the standard environment configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->