### PR TITLE
feat: Add requestContext support to MCP Client custom fetch

### DIFF
--- a/.changeset/dull-heads-wonder.md
+++ b/.changeset/dull-heads-wonder.md
@@ -1,0 +1,27 @@
+---
+'@mastra/mcp': minor
+---
+
+Added requestContext support to the custom fetch option in MCP client HTTP server definitions. The fetch function now receives the current request context as an optional third argument, enabling users to forward authentication cookies, bearer tokens, and other request-scoped data from the incoming request to remote MCP servers during tool execution.
+
+**Example usage:**
+
+```typescript
+const mcp = new MCPClient({
+  servers: {
+    myServer: {
+      url: new URL('https://api.example.com/mcp'),
+      fetch: async (url, init, requestContext) => {
+        const headers = new Headers(init?.headers);
+        const cookie = requestContext?.get('cookie');
+        if (cookie) {
+          headers.set('cookie', cookie);
+        }
+        return fetch(url, { ...init, headers });
+      },
+    },
+  },
+});
+```
+
+This change is fully backward-compatible — existing fetch functions with `(url, init)` signatures continue to work unchanged. Closes #13769.

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -104,10 +104,10 @@ description:
 },
 {
 name: "fetch",
-type: "FetchLike",
+type: "MastraFetchLike",
 isOptional: true,
 description:
-"For HTTP servers: Custom fetch implementation used for all network requests. When provided, this function will be used for all HTTP requests, allowing you to add dynamic authentication headers (e.g., refreshing bearer tokens), customize request behavior per-request, or intercept and modify requests/responses. When `fetch` is provided, `requestInit`, `eventSourceInit`, and `authProvider` become optional, as you can handle these concerns within your custom fetch function.",
+"For HTTP servers: Custom fetch implementation used for all network requests. Receives an optional third `requestContext` parameter containing request-scoped data (e.g., authentication cookies, bearer tokens) from the incoming request. When provided, this function will be used for all HTTP requests, allowing you to add dynamic authentication headers, forward request-scoped credentials to the MCP server, customize request behavior per-request, or intercept and modify requests/responses. When `fetch` is provided, `requestInit`, `eventSourceInit`, and `authProvider` become optional, as you can handle these concerns within your custom fetch function.",
 },
 {
 name: "logger",
@@ -964,7 +964,9 @@ MCPClient handles server connections gracefully:
 
 ## Using Custom Fetch for Dynamic Authentication
 
-For HTTP servers, you can provide a custom `fetch` function to handle dynamic authentication, request interception, or other custom behavior. This is particularly useful when you need to refresh tokens on each request or customize request behavior.
+For HTTP servers, you can provide a custom `fetch` function to handle dynamic authentication, request interception, or other custom behavior. This is particularly useful when you need to refresh tokens on each request or forward user credentials from the incoming request to the MCP server.
+
+The custom `fetch` function receives an optional third `requestContext` parameter, which provides access to request-scoped data (e.g., authentication cookies, bearer tokens) set by middleware or passed during agent/tool execution. The `requestContext` is `null` during the initial connection handshake.
 
 When `fetch` is provided, `requestInit`, `eventSourceInit`, and `authProvider` become optional, as you can handle these concerns within your custom fetch function.
 
@@ -973,20 +975,29 @@ const mcpClient = new MCPClient({
   servers: {
     apiServer: {
       url: new URL('https://api.example.com/mcp'),
-      fetch: async (url, init) => {
-        // Refresh token on each request
-        const token = await getAuthToken() // Your token refresh logic
-
-        return fetch(url, {
-          ...init,
-          headers: {
-            ...init?.headers,
-            Authorization: `Bearer ${token}`,
-          },
-        })
+      fetch: async (url, init, requestContext) => {
+        const headers = new Headers(init?.headers)
+        // Forward auth cookie from the incoming request
+        const cookie = requestContext?.get('cookie')
+        if (cookie) {
+          headers.set('cookie', cookie)
+        }
+        return fetch(url, { ...init, headers })
       },
     },
   },
+})
+
+// Use with an agent — requestContext is automatically forwarded
+const agent = new Agent({
+  name: 'My Agent',
+  instructions: 'You are a helpful assistant.',
+  model: openai('gpt-4o'),
+  tools: await mcpClient.listTools(),
+})
+
+await agent.generate('Hello!', {
+  requestContext: myRequestContext, // forwarded to the custom fetch
 })
 ```
 

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -1771,12 +1771,10 @@ describe('MastraMCPClient fetch with requestContext', () => {
   let client: InternalMastraMCPClient;
 
   afterEach(async () => {
-    if (client) {
-      await client.disconnect();
-    }
-    if (testServer) {
-      testServer.httpServer.close();
-    }
+    await client?.disconnect().catch(() => {});
+    await testServer?.mcpServer.close().catch(() => {});
+    await testServer?.serverTransport.close().catch(() => {});
+    testServer?.httpServer.close();
   });
 
   it('should pass requestContext to the custom fetch function during tool execution', async () => {

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { createServer } from 'node:http';
 import type { Server as HttpServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
+import { RequestContext } from '@mastra/core/di';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -1758,4 +1759,146 @@ describe('MastraMCPClient - Filesystem Server Integration (Issue #8660)', () => 
 
     await client.disconnect();
   }, 30000);
+});
+
+describe('MastraMCPClient fetch with requestContext', () => {
+  let testServer: {
+    httpServer: HttpServer;
+    mcpServer: McpServer;
+    serverTransport: StreamableHTTPServerTransport;
+    baseUrl: URL;
+  };
+  let client: InternalMastraMCPClient;
+
+  afterEach(async () => {
+    if (client) {
+      await client.disconnect();
+    }
+    if (testServer) {
+      testServer.httpServer.close();
+    }
+  });
+
+  it('should pass requestContext to the custom fetch function during tool execution', async () => {
+    testServer = await setupTestServer(false);
+    const fetchSpy = vi.fn((url: string | URL, init?: RequestInit, _requestContext?: RequestContext | null) => {
+      return fetch(url, init);
+    });
+
+    client = new InternalMastraMCPClient({
+      name: 'fetch-context-test',
+      server: {
+        url: testServer.baseUrl,
+        fetch: fetchSpy,
+      },
+    });
+
+    await client.connect();
+    const tools = await client.tools();
+    const greetTool = tools['greet'];
+    expect(greetTool).toBeDefined();
+
+    type TestContext = { userId: string; authToken: string };
+    const requestContext = new RequestContext<TestContext>();
+    requestContext.set('userId', 'user-123');
+    requestContext.set('authToken', 'bearer-abc');
+
+    await greetTool.execute({ name: 'Test' }, { requestContext });
+
+    // Find a fetch call that was made with the requestContext (during tool execution)
+    const callsWithContext = fetchSpy.mock.calls.filter(call => {
+      const ctx = call[2];
+      return ctx && typeof ctx.get === 'function' && ctx.get('userId') === 'user-123';
+    });
+
+    expect(callsWithContext.length).toBeGreaterThan(0);
+    const capturedContext = callsWithContext[0]![2]!;
+    expect(capturedContext.get('userId')).toBe('user-123');
+    expect(capturedContext.get('authToken')).toBe('bearer-abc');
+  }, 15000);
+
+  it('should pass different requestContexts for sequential tool calls', async () => {
+    testServer = await setupTestServer(false);
+    const fetchSpy = vi.fn((url: string | URL, init?: RequestInit, _requestContext?: RequestContext | null) => {
+      return fetch(url, init);
+    });
+
+    client = new InternalMastraMCPClient({
+      name: 'fetch-seq-context-test',
+      server: {
+        url: testServer.baseUrl,
+        fetch: fetchSpy,
+      },
+    });
+
+    await client.connect();
+    const tools = await client.tools();
+    const greetTool = tools['greet'];
+
+    // First call with context A
+    type ContextA = { sessionId: string };
+    const contextA = new RequestContext<ContextA>();
+    contextA.set('sessionId', 'session-A');
+    await greetTool.execute({ name: 'Alice' }, { requestContext: contextA });
+
+    const callsWithA = fetchSpy.mock.calls.filter(call => {
+      const ctx = call[2];
+      return ctx && typeof ctx.get === 'function' && ctx.get('sessionId') === 'session-A';
+    });
+    expect(callsWithA.length).toBeGreaterThan(0);
+
+    fetchSpy.mockClear();
+
+    // Second call with context B
+    type ContextB = { sessionId: string };
+    const contextB = new RequestContext<ContextB>();
+    contextB.set('sessionId', 'session-B');
+    await greetTool.execute({ name: 'Bob' }, { requestContext: contextB });
+
+    const callsWithB = fetchSpy.mock.calls.filter(call => {
+      const ctx = call[2];
+      return ctx && typeof ctx.get === 'function' && ctx.get('sessionId') === 'session-B';
+    });
+    expect(callsWithB.length).toBeGreaterThan(0);
+
+    // Ensure context A didn't leak into context B's calls
+    const contextALeak = fetchSpy.mock.calls.some(call => {
+      const ctx = call[2];
+      return ctx && typeof ctx.get === 'function' && ctx.get('sessionId') === 'session-A';
+    });
+    expect(contextALeak).toBe(false);
+  }, 15000);
+
+  it('should pass requestContext to fetch even when an empty context is auto-created', async () => {
+    testServer = await setupTestServer(false);
+    const fetchSpy = vi.fn((url: string | URL, init?: RequestInit, _requestContext?: RequestContext | null) => {
+      return fetch(url, init);
+    });
+
+    client = new InternalMastraMCPClient({
+      name: 'fetch-no-context-test',
+      server: {
+        url: testServer.baseUrl,
+        fetch: fetchSpy,
+      },
+    });
+
+    await client.connect();
+
+    // Clear fetch calls from the connection phase
+    fetchSpy.mockClear();
+
+    const tools = await client.tools();
+    const greetTool = tools['greet'];
+
+    // Call without explicit requestContext — the tool framework auto-creates an empty one
+    await greetTool.execute({ name: 'NoContext' });
+
+    // Fetch should still have been called with the third argument (requestContext)
+    const callsDuringToolExec = fetchSpy.mock.calls;
+    expect(callsDuringToolExec.length).toBeGreaterThan(0);
+    // The third argument should be defined (either null or an empty RequestContext)
+    const lastToolCallFetch = callsDuringToolExec[callsDuringToolExec.length - 1];
+    expect(lastToolCallFetch!.length).toBeGreaterThanOrEqual(3);
+  }, 15000);
 });

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import $RefParser from '@apidevtools/json-schema-ref-parser';
 import { MastraBase } from '@mastra/core/base';
 import type { RequestContext } from '@mastra/core/di';
@@ -104,7 +105,7 @@ export class InternalMastraMCPClient extends MastraBase {
   private enableProgressTracking?: boolean;
   private serverConfig: MastraMCPServerDefinition;
   private transport?: Transport;
-  private currentOperationContext: RequestContext | null = null;
+  private operationContextStore = new AsyncLocalStorage<RequestContext | null>();
   private exitHookUnsubscribe?: () => void;
   private sigTermHandler?: () => void;
   private _roots: Root[];
@@ -195,7 +196,7 @@ export class InternalMastraMCPClient extends MastraBase {
         timestamp: new Date(),
         serverName: this.name,
         details,
-        requestContext: this.currentOperationContext,
+        requestContext: this.operationContextStore.getStore() ?? null,
       });
     }
   }
@@ -303,7 +304,7 @@ export class InternalMastraMCPClient extends MastraBase {
     // The transport calls fetch with standard (url, init) signature, but we forward
     // the current operation context so users can access request-scoped data (e.g., auth cookies).
     const fetch: FetchLike | undefined = userFetch
-      ? (url: string | URL, init?: RequestInit) => userFetch(url, init, this.currentOperationContext)
+      ? (url: string | URL, init?: RequestInit) => userFetch(url, init, this.operationContextStore.getStore() ?? null)
       : undefined;
 
     this.log('debug', `Attempting to connect to URL: ${url}`);
@@ -789,90 +790,94 @@ export class InternalMastraMCPClient extends MastraBase {
           inputSchema: await this.convertInputSchema(tool.inputSchema),
           outputSchema: await this.convertOutputSchema(tool.outputSchema),
           execute: async (input: any, context?: { requestContext?: RequestContext | null; runId?: string }) => {
-            const previousContext = this.currentOperationContext;
-            this.currentOperationContext = context?.requestContext || null; // Set current context
+            const operationContext = context?.requestContext ?? null;
 
-            const executeToolCall = async () => {
-              this.log('debug', `Executing tool: ${tool.name}`, { toolArgs: input, runId: context?.runId });
-              const res = await this.client.callTool(
-                {
-                  name: tool.name,
-                  arguments: input,
-                  // Use runId as progress token if available, otherwise generate a random UUID
-                  ...(this.enableProgressTracking
-                    ? { _meta: { progressToken: context?.runId || crypto.randomUUID() } }
-                    : {}),
-                },
-                CallToolResultSchema,
-                {
-                  timeout: this.timeout,
-                },
-              );
+            return this.operationContextStore.run(operationContext, async () => {
+              const executeToolCall = async () => {
+                this.log('debug', `Executing tool: ${tool.name}`, { toolArgs: input, runId: context?.runId });
+                const res = await this.client.callTool(
+                  {
+                    name: tool.name,
+                    arguments: input,
+                    // Use runId as progress token if available, otherwise generate a random UUID
+                    ...(this.enableProgressTracking
+                      ? { _meta: { progressToken: context?.runId || crypto.randomUUID() } }
+                      : {}),
+                  },
+                  CallToolResultSchema,
+                  {
+                    timeout: this.timeout,
+                  },
+                );
 
-              this.log('debug', `Tool executed successfully: ${tool.name}`);
+                this.log('debug', `Tool executed successfully: ${tool.name}`);
 
-              // When a tool has an outputSchema, return the structuredContent directly
-              // so that output validation works correctly
-              if (res.structuredContent !== undefined) {
-                return res.structuredContent;
-              }
+                // When a tool has an outputSchema, return the structuredContent directly
+                // so that output validation works correctly
+                if (res.structuredContent !== undefined) {
+                  return res.structuredContent;
+                }
 
-              // When the tool has an outputSchema but the server didn't return
-              // structuredContent (e.g. older MCP protocol versions that predate the
-              // structuredContent spec), extract the result from the content array.
-              // Without this, the raw CallToolResult envelope ({ content, isError,
-              // _meta }) gets validated against the outputSchema and Zod strips all
-              // unrecognised keys, producing {}.
-              if (tool.outputSchema && !res.isError) {
-                const content = res.content as Array<{ type: string; text?: string }> | undefined;
-                if (content && content.length === 1 && content[0]!.type === 'text' && content[0]!.text !== undefined) {
-                  try {
-                    return JSON.parse(content[0]!.text);
-                  } catch {
-                    return content[0]!.text;
+                // When the tool has an outputSchema but the server didn't return
+                // structuredContent (e.g. older MCP protocol versions that predate the
+                // structuredContent spec), extract the result from the content array.
+                // Without this, the raw CallToolResult envelope ({ content, isError,
+                // _meta }) gets validated against the outputSchema and Zod strips all
+                // unrecognised keys, producing {}.
+                if (tool.outputSchema && !res.isError) {
+                  const content = res.content as Array<{ type: string; text?: string }> | undefined;
+                  if (
+                    content &&
+                    content.length === 1 &&
+                    content[0]!.type === 'text' &&
+                    content[0]!.text !== undefined
+                  ) {
+                    try {
+                      return JSON.parse(content[0]!.text);
+                    } catch {
+                      return content[0]!.text;
+                    }
                   }
                 }
-              }
 
-              return res;
-            };
+                return res;
+              };
 
-            try {
-              return await executeToolCall();
-            } catch (e) {
-              // Check if this is a session-related error that requires reconnection
-              if (this.isSessionError(e)) {
-                this.log('debug', `Session error detected for tool ${tool.name}, attempting reconnection...`, {
-                  error: e instanceof Error ? e.message : String(e),
-                });
-
-                try {
-                  // Force reconnection
-                  await this.forceReconnect();
-
-                  // Retry the tool call with fresh connection
-                  this.log('debug', `Retrying tool ${tool.name} after reconnection...`);
-                  return await executeToolCall();
-                } catch (reconnectError) {
-                  this.log('error', `Reconnection or retry failed for tool ${tool.name}`, {
-                    originalError: e instanceof Error ? e.message : String(e),
-                    reconnectError: reconnectError instanceof Error ? reconnectError.stack : String(reconnectError),
-                    toolArgs: input,
+              try {
+                return await executeToolCall();
+              } catch (e) {
+                // Check if this is a session-related error that requires reconnection
+                if (this.isSessionError(e)) {
+                  this.log('debug', `Session error detected for tool ${tool.name}, attempting reconnection...`, {
+                    error: e instanceof Error ? e.message : String(e),
                   });
-                  // Throw the original error if reconnection/retry fails
-                  throw e;
-                }
-              }
 
-              // For non-session errors, log and rethrow
-              this.log('error', `Error calling tool: ${tool.name}`, {
-                error: e instanceof Error ? e.stack : JSON.stringify(e, null, 2),
-                toolArgs: input,
-              });
-              throw e;
-            } finally {
-              this.currentOperationContext = previousContext; // Restore previous context
-            }
+                  try {
+                    // Force reconnection
+                    await this.forceReconnect();
+
+                    // Retry the tool call with fresh connection
+                    this.log('debug', `Retrying tool ${tool.name} after reconnection...`);
+                    return await executeToolCall();
+                  } catch (reconnectError) {
+                    this.log('error', `Reconnection or retry failed for tool ${tool.name}`, {
+                      originalError: e instanceof Error ? e.message : String(e),
+                      reconnectError: reconnectError instanceof Error ? reconnectError.stack : String(reconnectError),
+                      toolArgs: input,
+                    });
+                    // Throw the original error if reconnection/retry fails
+                    throw e;
+                  }
+                }
+
+                // For non-session errors, log and rethrow
+                this.log('error', `Error calling tool: ${tool.name}`, {
+                  error: e instanceof Error ? e.stack : JSON.stringify(e, null, 2),
+                  toolArgs: input,
+                });
+                throw e;
+              }
+            });
           },
         });
 

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -37,6 +37,7 @@ import { ProgressClientActions } from './actions/progress';
 import { PromptClientActions } from './actions/prompt';
 import { ResourceClientActions } from './actions/resource';
 import type {
+  FetchLike,
   LogHandler,
   ElicitationHandler,
   ProgressHandler,
@@ -52,6 +53,7 @@ export type {
   LogHandler,
   ElicitationHandler,
   ProgressHandler,
+  MastraFetchLike,
   MastraMCPServerDefinition,
   InternalMastraMCPClientOptions,
   Root,
@@ -295,7 +297,14 @@ export class InternalMastraMCPClient extends MastraBase {
   }
 
   private async connectHttp(url: URL) {
-    const { requestInit, eventSourceInit, authProvider, connectTimeout, fetch } = this.serverConfig;
+    const { requestInit, eventSourceInit, authProvider, connectTimeout, fetch: userFetch } = this.serverConfig;
+
+    // Wrap the user's fetch function to inject requestContext as the third argument.
+    // The transport calls fetch with standard (url, init) signature, but we forward
+    // the current operation context so users can access request-scoped data (e.g., auth cookies).
+    const fetch: FetchLike | undefined = userFetch
+      ? (url: string | URL, init?: RequestInit) => userFetch(url, init, this.currentOperationContext)
+      : undefined;
 
     this.log('debug', `Attempting to connect to URL: ${url}`);
 

--- a/packages/mcp/src/client/types.ts
+++ b/packages/mcp/src/client/types.ts
@@ -1,7 +1,8 @@
 import type { RequestContext } from '@mastra/core/di';
 import type { SSEClientTransportOptions } from '@modelcontextprotocol/sdk/client/sse.js';
 import type { StreamableHTTPClientTransportOptions } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
+// FetchLike is used internally when wrapping MastraFetchLike for transport compatibility
+export type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type {
   ClientCapabilities,
   ElicitRequest,
@@ -9,6 +10,40 @@ import type {
   LoggingLevel,
   ProgressNotification,
 } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * Extended fetch function type that receives the current request context as a third argument.
+ *
+ * This allows custom fetch implementations to access request-scoped data (e.g., authentication
+ * cookies, bearer tokens) from the incoming request and forward them to the MCP server.
+ *
+ * The `requestContext` parameter is `null` when no context is available (e.g., during
+ * initial connection or when a tool is called without a request context).
+ *
+ * @example
+ * ```typescript
+ * const mcp = new MCPClient({
+ *   servers: {
+ *     myServer: {
+ *       url: new URL('https://api.example.com/mcp'),
+ *       fetch: (url, init, requestContext) => {
+ *         const headers = new Headers(init?.headers);
+ *         const cookie = requestContext?.get('cookie');
+ *         if (cookie) {
+ *           headers.set('cookie', cookie);
+ *         }
+ *         return fetch(url, { ...init, headers });
+ *       },
+ *     },
+ *   },
+ * });
+ * ```
+ */
+export type MastraFetchLike = (
+  url: string | URL,
+  init?: RequestInit,
+  requestContext?: RequestContext | null,
+) => Promise<Response>;
 
 // Re-export MCP SDK LoggingLevel for convenience
 export type { LoggingLevel } from '@modelcontextprotocol/sdk/types.js';
@@ -156,8 +191,13 @@ export type HttpServerDefinition = BaseServerOptions & {
    *
    * When provided, this function will be used for all HTTP requests, allowing you to:
    * - Add dynamic authentication headers (e.g., refreshing bearer tokens)
+   * - Forward request-scoped data (cookies, tokens) from the incoming request to the MCP server
    * - Customize request behavior per-request
    * - Intercept and modify requests/responses
+   *
+   * The third `requestContext` parameter provides access to request-scoped data set by middleware
+   * or passed during agent/tool execution. It is `null` when no context is available (e.g.,
+   * during the initial connection handshake).
    *
    * When `fetch` is provided, `requestInit`, `eventSourceInit`, and `authProvider` become optional,
    * as you can handle these concerns within your custom fetch function.
@@ -166,20 +206,19 @@ export type HttpServerDefinition = BaseServerOptions & {
    * ```typescript
    * {
    *   url: new URL('https://api.example.com/mcp'),
-   *   fetch: async (url, init) => {
-   *     const token = await getAuthToken(); // Your token refresh logic
-   *     return fetch(url, {
-   *       ...init,
-   *       headers: {
-   *         ...init?.headers,
-   *         Authorization: `Bearer ${token}`,
-   *       },
-   *     });
+   *   fetch: async (url, init, requestContext) => {
+   *     const headers = new Headers(init?.headers);
+   *     // Forward auth cookie from the incoming request
+   *     const cookie = requestContext?.get('cookie');
+   *     if (cookie) {
+   *       headers.set('cookie', cookie);
+   *     }
+   *     return fetch(url, { ...init, headers });
    *   },
    * }
    * ```
    */
-  fetch?: FetchLike;
+  fetch?: MastraFetchLike;
   /** Optional request configuration for HTTP requests (optional when `fetch` is provided) */
   requestInit?: StreamableHTTPClientTransportOptions['requestInit'];
   /** Optional configuration for SSE fallback (required when using custom headers with SSE, optional when `fetch` is provided) */
@@ -255,4 +294,3 @@ export type InternalMastraMCPClientOptions = {
   /** Optional timeout in milliseconds */
   timeout?: number;
 };
-


### PR DESCRIPTION
## Description

Added support for passing request context to MCP server connections through custom fetch functions. Users can now access request-scoped data (authentication cookies, bearer tokens) from incoming requests and forward them to remote MCP servers. The `requestContext` is provided as an optional third argument to the custom fetch function, enabling secure multi-user authentication scenarios.

## Related Issue(s)

Fixes #13769

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom fetch handlers for MCP servers can now receive an optional requestContext (cookies, bearer tokens, other request-scoped data) and forward it to remote servers during tool execution; existing fetch usage remains compatible.
  * Public fetch type updated to expose the optional requestContext parameter.

* **Documentation**
  * API reference updated with examples showing how to read and forward request-scoped credentials and notes on requestContext lifecycle.

* **Tests**
  * Added tests validating requestContext propagation, isolation across calls, and automatic creation when absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->