### PR TITLE
fix(core): default maxSteps to 50 for subagent tool

### DIFF
--- a/.changeset/perky-roses-lay.md
+++ b/.changeset/perky-roses-lay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed subagent tool defaulting maxSteps to 50 when no stop condition is configured, preventing unbounded execution loops. When stopWhen is set, maxSteps is left to the caller.

--- a/.changeset/wicked-lemons-change.md
+++ b/.changeset/wicked-lemons-change.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed subagent tool to default maxSteps to 50 when no stopWhen condition is configured, preventing unbounded agent loops. When stopWhen is set, maxSteps remains unset so the stop condition controls termination.

--- a/packages/core/src/harness/subagent-tool.test.ts
+++ b/packages/core/src/harness/subagent-tool.test.ts
@@ -153,10 +153,46 @@ describe('createSubagentTool requestContext forwarding', () => {
     const streamOpts = mockStream.mock.calls[0]![1];
     expect(streamOpts).toEqual({
       maxSteps: 50,
+      stopWhen: undefined,
       abortSignal: abortController.signal,
       requireToolApproval: false,
       requestContext,
     });
+  });
+
+  it('does not default maxSteps when stopWhen is configured', async () => {
+    const stopFn = vi.fn().mockReturnValue({ continue: true });
+    mockStream.mockResolvedValue(createMockStreamResponse('done'));
+
+    const subagentsWithStopWhen: HarnessSubagent[] = [
+      {
+        id: 'custom',
+        name: 'Custom',
+        description: 'Subagent with stopWhen.',
+        instructions: 'You are custom.',
+        tools: { view: { id: 'view' } as any },
+        stopWhen: stopFn,
+      },
+    ];
+
+    const tool = createSubagentTool({
+      subagents: subagentsWithStopWhen,
+      resolveModel,
+      fallbackModelId: 'test-model',
+    });
+
+    const requestContext = new RequestContext();
+    requestContext.set('harness', { emitEvent: vi.fn() });
+
+    await (tool as any).execute(
+      { agentType: 'custom', task: 'Do stuff' },
+      { requestContext, agent: { toolCallId: 'tc-5' } },
+    );
+
+    expect(mockStream).toHaveBeenCalledTimes(1);
+    const streamOpts = mockStream.mock.calls[0]![1];
+    expect(streamOpts.maxSteps).toBeUndefined();
+    expect(streamOpts.stopWhen).toBe(stopFn);
   });
 
   it('forwards default RequestContext when parent context has no explicit requestContext', async () => {

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -427,7 +427,7 @@ Use this tool when:
 
       try {
         const response = await subagent.stream(task, {
-          maxSteps: definition.maxSteps,
+          maxSteps: definition.maxSteps ?? (definition.stopWhen ? undefined : 50),
           stopWhen: definition.stopWhen,
           abortSignal,
           requireToolApproval: false,


### PR DESCRIPTION
## Summary

Subagent tool previously passed `undefined` for `maxSteps` when the subagent definition didn't specify one, allowing unbounded agent loops.

Now defaults to `50` unless `stopWhen` is configured — in which case `maxSteps` stays `undefined` so the stop condition controls termination.

## Changes

- **`packages/core/src/harness/tools.ts`** — Default `maxSteps` to `50` only when `stopWhen` is not set
- **`packages/core/src/harness/subagent-tool.test.ts`** — Fixed existing test expectations, added test for `stopWhen` case

## Test Plan

- `pnpm vitest run packages/core/src/harness/subagent-tool.test.ts` — 5/5 tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed subagent tool default behavior: maxSteps now defaults to 50 when no stop condition is configured, preventing unbounded execution loops. When a stop condition is provided, maxSteps remains controlled by caller configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->