### PR TITLE
fix: remove GPT-5 temperature auto-default in playground agent settings

### DIFF
--- a/.changeset/quiet-lions-rest.md
+++ b/.changeset/quiet-lions-rest.md
@@ -2,8 +2,4 @@
 "@mastra/playground-ui": patch
 ---
 
----
-"@mastra/playground-ui": patch
----
-
 Fixed Playground UI agent settings so temperature is no longer reset to `1` on refresh. Temperature now stays unset unless saved settings or code defaults provide a value.

--- a/.changeset/quiet-lions-rest.md
+++ b/.changeset/quiet-lions-rest.md
@@ -1,0 +1,5 @@
+---
+"@mastra/playground-ui": patch
+---
+
+Remove the Playground UI GPT-5 temperature auto-default workaround in agent settings. Temperature now remains unset unless explicitly provided by saved settings or code defaults, preventing refresh-time resets to `1`.

--- a/.changeset/quiet-lions-rest.md
+++ b/.changeset/quiet-lions-rest.md
@@ -2,4 +2,8 @@
 "@mastra/playground-ui": patch
 ---
 
-Remove the Playground UI GPT-5 temperature auto-default workaround in agent settings. Temperature now remains unset unless explicitly provided by saved settings or code defaults, preventing refresh-time resets to `1`.
+---
+"@mastra/playground-ui": patch
+---
+
+Fixed Playground UI agent settings so temperature is no longer reset to `1` on refresh. Temperature now stays unset unless saved settings or code defaults provide a value.

--- a/packages/playground-ui/src/domains/agents/components/agent-information/agent-information.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-information/agent-information.tsx
@@ -5,11 +5,9 @@ import { Tabs, Tab, TabContent, TabList } from '@/ds/components/Tabs';
 import { AgentMetadata } from '../agent-metadata';
 import { useAgent } from '../../hooks/use-agent';
 import { useMemory } from '@/domains/memory/hooks';
-import { useAgentSettings } from '../../context/agent-context';
 import { AgentSettings } from '../agent-settings';
 import { TracingRunOptions } from '@/domains/observability/components/tracing-run-options';
 import { RequestContextSchemaForm } from '@/domains/request-context';
-import { cn } from '@/lib/utils';
 
 export interface AgentInformationProps {
   agentId: string;
@@ -27,7 +25,7 @@ export function AgentInformation({ agentId, threadId }: AgentInformationProps) {
   });
 
   return (
-    <AgentInformationLayout agentId={agentId}>
+    <AgentInformationLayout>
       <AgentEntityHeader agentId={agentId} />
 
       <div className="flex-1 overflow-hidden border-t border-border1 flex flex-col">
@@ -100,40 +98,11 @@ export const useAgentInformationTab = ({ isMemoryLoading, hasMemory }: UseAgentI
   };
 };
 
-export interface UseAgentInformationSettingsArgs {
-  modelId: string;
-}
-
-export const useAgentInformationSettings = ({ modelId }: UseAgentInformationSettingsArgs) => {
-  const { settings, setSettings } = useAgentSettings();
-
-  useEffect(() => {
-    if (modelId?.includes('gpt-5')) {
-      setSettings({
-        ...(settings || {}),
-        modelSettings: {
-          ...(settings?.modelSettings || {}),
-          temperature: 1,
-        },
-      });
-    }
-  }, [modelId]);
-
-  return {
-    settings,
-    setSettings,
-  };
-};
-
 export interface AgentInformationLayoutProps {
   children: React.ReactNode;
-  agentId?: string;
 }
 
-export const AgentInformationLayout = ({ children, agentId }: AgentInformationLayoutProps) => {
-  const { data: agent } = useAgent(agentId);
-  useAgentInformationSettings({ modelId: agent?.modelId || '' });
-
+export const AgentInformationLayout = ({ children }: AgentInformationLayoutProps) => {
   return (
     <div className="grid grid-rows-[auto_1fr] h-full items-start overflow-y-auto overflow-x-hidden min-w-0 w-full">
       {children}


### PR DESCRIPTION
This removes the GPT-5-specific temperature override in agent settings so the UI no longer forces temperature back to  after refresh.

Before:


After:


I also added a patch changeset for  describing this bug fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent temperature settings now persist correctly across page refreshes instead of unexpectedly resetting to default values.
  * Temperature will remain unset on refresh unless explicitly provided by saved settings or application defaults, preventing inadvertent changes to agent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->