### PR TITLE
fix(docs): use /api/og/blog endpoint for learn section OG images

### DIFF
--- a/docs/src/learn/pages/LearnLandingPage.tsx
+++ b/docs/src/learn/pages/LearnLandingPage.tsx
@@ -32,7 +32,10 @@ function LandingContent() {
         <meta property="og:title" content={`${course.title} - Free Full Course`} />
         <meta property="og:description" content={course.description} />
         <meta property="og:type" content="website" />
-        <meta property="og:image" content="https://mastra.ai/img/guil-hernandez.jpg" />
+        <meta
+          property="og:image"
+          content={`https://mastra.ai/api/og/blog?title=${encodeURIComponent(course.title)}&author=${encodeURIComponent('Free Full Course')}`}
+        />
         <meta name="author" content="Guil Hernandez" />
         <script type="application/ld+json">
           {JSON.stringify({
@@ -103,7 +106,7 @@ function LandingContent() {
 
 export default function LearnLandingPage() {
   return (
-    <LearnLayout title={`${course.title} - Free Full Course`} description={course.description}>
+    <LearnLayout title={course.title} description={course.description}>
       <LandingContent />
     </LearnLayout>
   )

--- a/docs/src/learn/pages/LessonPage.tsx
+++ b/docs/src/learn/pages/LessonPage.tsx
@@ -117,23 +117,27 @@ export default function LessonPage() {
   const seoTitle = lesson.seo?.title ?? `${lesson.title} | Mastra`
   const seoDescription = lesson.seo?.description ?? lesson.preview.intro
 
+  const ogImageUrl = new URL('https://mastra.ai/api/og/blog')
+  ogImageUrl.searchParams.set('title', lesson.title)
+  ogImageUrl.searchParams.set('author', 'Build Your First AI Agent in TypeScript with Guil')
+
   return (
     <LearnLayout title={seoTitle} description={seoDescription}>
       <Head>
         <meta property="og:title" content={seoTitle} />
         <meta property="og:description" content={seoDescription} />
+        <meta property="og:image" content={ogImageUrl.toString()} />
         {lesson.youtubeId && (
           <>
             <meta property="og:type" content="video.other" />
             <meta property="og:video" content={`https://www.youtube.com/embed/${lesson.youtubeId}`} />
-            <meta property="og:image" content={`https://img.youtube.com/vi/${lesson.youtubeId}/maxresdefault.jpg`} />
             <script type="application/ld+json">
               {JSON.stringify({
                 '@context': 'https://schema.org',
                 '@type': 'VideoObject',
                 name: lesson.title,
                 description: seoDescription,
-                thumbnailUrl: `https://img.youtube.com/vi/${lesson.youtubeId}/maxresdefault.jpg`,
+                thumbnailUrl: ogImageUrl.toString(),
                 embedUrl: `https://www.youtube.com/embed/${lesson.youtubeId}`,
                 contentUrl: `https://www.youtube.com/watch?v=${lesson.youtubeId}`,
                 duration: `PT${lesson.durationMin}M`,


### PR DESCRIPTION
## Summary

Replace static/YouTube-based OG images in the learn section with dynamic OG images generated via the `/api/og/blog` endpoint, consistent with the rest of the site.

### Changes

- **Lesson pages**: OG image now uses `/api/og/blog?title={lesson.title}&author=Build Your First AI Agent in TypeScript with Guil`
- **Landing page**: OG image now uses `/api/og/blog?title={course.title}&author=Free Full Course`

### Before
- Lesson pages used YouTube thumbnails (`img.youtube.com/vi/.../maxresdefault.jpg`)
- Landing page used a static instructor photo (`/img/guil-hernandez.jpg`)

### Test plan
- Verify OG images render correctly by inspecting the meta tags on lesson and landing pages
- Check with an OG image debugger (e.g. opengraph.xyz) that the generated images look correct

## `mastra.ai/learn`
![](https://mastra.ai/api/og/blog?title=Build%20Your%20First%20AI%20Agent%20in%20TypeScript&author=Free%20Full%20Course)


## `mastra.ai/learn/what-is-an-agent`
![](https://mastra.ai/api/og/blog?title=What+is+an+Agent%3F&author=Build+Your+First+AI+Agent+in+TypeScript+with+Guil)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced preview images for course and lesson pages with dynamic, course-specific content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->