### PR TITLE
refactor(memory): extract threshold calculation functions

### DIFF
--- a/.changeset/bright-foxes-glow.md
+++ b/.changeset/bright-foxes-glow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Improved observational memory threshold calculation testability by extracting pure threshold functions into a dedicated module. No public API changes.

--- a/.changeset/bright-foxes-glow.md
+++ b/.changeset/bright-foxes-glow.md
@@ -2,4 +2,4 @@
 '@mastra/memory': patch
 ---
 
-Improved observational memory threshold calculation testability by extracting pure threshold functions into a dedicated module. No public API changes.
+Improved confidence in observational memory threshold behavior through expanded automated test coverage. No public API changes.

--- a/packages/memory/src/processors/observational-memory/__tests__/thresholds.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/thresholds.test.ts
@@ -1,0 +1,246 @@
+import type { BufferedObservationChunk } from '@mastra/core/storage';
+import { describe, it, expect } from 'vitest';
+
+import {
+  getMaxThreshold,
+  calculateDynamicThreshold,
+  resolveBufferTokens,
+  resolveBlockAfter,
+  resolveRetentionFloor,
+  resolveActivationRatio,
+  calculateProjectedMessageRemoval,
+} from '../thresholds';
+
+function makeChunk(messageTokens: number): BufferedObservationChunk {
+  return {
+    id: `chunk-${Math.random().toString(36).slice(2, 8)}`,
+    cycleId: 'cycle-1',
+    observations: '',
+    tokenCount: messageTokens,
+    messageIds: [],
+    messageTokens,
+    lastObservedAt: new Date(),
+    createdAt: new Date(),
+  };
+}
+
+describe('thresholds', () => {
+  describe('getMaxThreshold', () => {
+    it('returns the number for simple thresholds', () => {
+      expect(getMaxThreshold(30000)).toBe(30000);
+    });
+
+    it('returns max for range thresholds', () => {
+      expect(getMaxThreshold({ min: 8000, max: 70000 })).toBe(70000);
+    });
+
+    it('handles zero', () => {
+      expect(getMaxThreshold(0)).toBe(0);
+    });
+  });
+
+  describe('calculateDynamicThreshold', () => {
+    it('returns the number as-is for simple thresholds', () => {
+      expect(calculateDynamicThreshold(30000, 10000)).toBe(30000);
+      expect(calculateDynamicThreshold(30000, 0)).toBe(30000);
+    });
+
+    it('expands into unused observation space for range thresholds', () => {
+      // 30k:40k → total budget 70k
+      // 0 observations → can use full 70k
+      expect(calculateDynamicThreshold({ min: 30000, max: 70000 }, 0)).toBe(70000);
+    });
+
+    it('shrinks as observations grow', () => {
+      // 10k observations → 70k - 10k = 60k
+      expect(calculateDynamicThreshold({ min: 30000, max: 70000 }, 10000)).toBe(60000);
+    });
+
+    it('never goes below the base threshold (min)', () => {
+      // 50k observations → 70k - 50k = 20k, but min is 30k
+      expect(calculateDynamicThreshold({ min: 30000, max: 70000 }, 50000)).toBe(30000);
+    });
+
+    it('returns min when observations exceed the total budget', () => {
+      expect(calculateDynamicThreshold({ min: 30000, max: 70000 }, 100000)).toBe(30000);
+    });
+
+    it('rounds the result', () => {
+      // 33333 observations → 70000 - 33333 = 36667
+      expect(calculateDynamicThreshold({ min: 30000, max: 70000 }, 33333)).toBe(36667);
+    });
+  });
+
+  describe('resolveBufferTokens', () => {
+    it('returns undefined for false', () => {
+      expect(resolveBufferTokens(false, 30000)).toBeUndefined();
+    });
+
+    it('returns undefined for undefined', () => {
+      expect(resolveBufferTokens(undefined, 30000)).toBeUndefined();
+    });
+
+    it('converts fractional values to absolute using simple threshold', () => {
+      // 0.25 * 20000 = 5000
+      expect(resolveBufferTokens(0.25, 20000)).toBe(5000);
+    });
+
+    it('converts fractional values using range threshold max', () => {
+      // 0.1 * 70000 = 7000
+      expect(resolveBufferTokens(0.1, { min: 30000, max: 70000 })).toBe(7000);
+    });
+
+    it('returns absolute values as-is', () => {
+      expect(resolveBufferTokens(5000, 30000)).toBe(5000);
+    });
+
+    it('returns 1 as-is (not fractional — boundary)', () => {
+      // 1 is not in (0, 1) so it's treated as absolute
+      expect(resolveBufferTokens(1, 30000)).toBe(1);
+    });
+
+    it('handles very small fractions', () => {
+      expect(resolveBufferTokens(0.01, 100000)).toBe(1000);
+    });
+  });
+
+  describe('resolveBlockAfter', () => {
+    it('returns undefined for undefined', () => {
+      expect(resolveBlockAfter(undefined, 30000)).toBeUndefined();
+    });
+
+    it('converts multipliers to absolute values', () => {
+      // 1.5 * 20000 = 30000
+      expect(resolveBlockAfter(1.5, 20000)).toBe(30000);
+    });
+
+    it('treats 1.0 as a multiplier (exactly at threshold)', () => {
+      expect(resolveBlockAfter(1.0, 20000)).toBe(20000);
+    });
+
+    it('uses range max for multiplier resolution', () => {
+      // 1.2 * 70000 = 84000
+      expect(resolveBlockAfter(1.2, { min: 30000, max: 70000 })).toBe(84000);
+    });
+
+    it('treats values >= 100 as absolute token counts', () => {
+      expect(resolveBlockAfter(50000, 20000)).toBe(50000);
+      expect(resolveBlockAfter(100, 20000)).toBe(100); // 100 is >= 100, so absolute
+    });
+
+    it('rounds the result', () => {
+      // 1.3 * 33333 = 43332.9
+      expect(resolveBlockAfter(1.3, 33333)).toBe(43333);
+    });
+  });
+
+  describe('resolveRetentionFloor', () => {
+    it('uses ratio when bufferActivation < 1000', () => {
+      // 0.7 ratio → retentionFloor = 30000 * (1 - 0.7) = 9000
+      expect(resolveRetentionFloor(0.7, 30000)).toBeCloseTo(9000, 0);
+    });
+
+    it('returns absolute value when bufferActivation >= 1000', () => {
+      expect(resolveRetentionFloor(5000, 30000)).toBe(5000);
+      expect(resolveRetentionFloor(1000, 30000)).toBe(1000);
+    });
+
+    it('ratio of 1.0 means zero retention', () => {
+      expect(resolveRetentionFloor(1.0, 30000)).toBe(0);
+    });
+
+    it('ratio of 0.0 means full retention', () => {
+      expect(resolveRetentionFloor(0.0, 30000)).toBe(30000);
+    });
+  });
+
+  describe('resolveActivationRatio', () => {
+    it('returns ratio as-is when < 1000', () => {
+      expect(resolveActivationRatio(0.7, 30000)).toBe(0.7);
+    });
+
+    it('converts absolute to equivalent ratio when >= 1000', () => {
+      // 5000 absolute, 30000 threshold → 1 - (5000 / 30000) ≈ 0.833
+      const result = resolveActivationRatio(5000, 30000);
+      expect(result).toBeCloseTo(0.8333, 3);
+    });
+
+    it('clamps to [0, 1]', () => {
+      // bufferActivation > threshold → ratio would be negative, clamped to 0
+      expect(resolveActivationRatio(50000, 30000)).toBe(0);
+      // bufferActivation = 0 (>= 1000 is false) — handled by ratio path
+    });
+
+    it('exact match returns 0', () => {
+      // 30000 / 30000 = 1, 1 - 1 = 0
+      expect(resolveActivationRatio(30000, 30000)).toBe(0);
+    });
+  });
+
+  describe('calculateProjectedMessageRemoval', () => {
+    it('returns 0 for empty chunks', () => {
+      expect(calculateProjectedMessageRemoval([], 0.7, 30000, 25000)).toBe(0);
+    });
+
+    it('selects the best over-boundary when within safeguards', () => {
+      const chunks = [makeChunk(5000), makeChunk(5000), makeChunk(5000)];
+      // bufferActivation 0.7, threshold 30000 → retentionFloor = 9000
+      // pendingTokens 25000 → target = 25000 - 9000 = 16000
+      // Chunk boundaries: 5000, 10000, 15000
+      // All under target, so best under = 15000
+      const result = calculateProjectedMessageRemoval(chunks, 0.7, 30000, 25000);
+      expect(result).toBe(15000);
+    });
+
+    it('prefers over-boundary when close to target', () => {
+      const chunks = [makeChunk(8000), makeChunk(9000)];
+      // bufferActivation 0.7, threshold 30000 → retentionFloor = 9000
+      // pendingTokens 25000 → target = 16000
+      // Boundaries: 8000 (under), 17000 (over)
+      // overshoot = 17000 - 16000 = 1000, maxOvershoot = 9000 * 0.95 = 8550
+      // remaining = 25000 - 17000 = 8000 >= min(1000, 9000) = 1000
+      const result = calculateProjectedMessageRemoval(chunks, 0.7, 30000, 25000);
+      expect(result).toBe(17000);
+    });
+
+    it('falls back to under-boundary when over would overshoot too much', () => {
+      const chunks = [makeChunk(3000), makeChunk(25000)];
+      // bufferActivation 0.7, threshold 30000 → retentionFloor = 9000
+      // pendingTokens 25000 → target = 16000
+      // Boundaries: 3000 (under), 28000 (over)
+      // overshoot = 28000 - 16000 = 12000 > maxOvershoot = 8550
+      // Falls back to under-boundary = 3000 (remaining = 22000 >= 1000)
+      const result = calculateProjectedMessageRemoval(chunks, 0.7, 30000, 25000);
+      expect(result).toBe(3000);
+    });
+
+    it('returns first chunk for single chunk', () => {
+      const chunks = [makeChunk(10000)];
+      // retentionFloor = 30000 * (1 - 0.7) = 9000
+      // target = 25000 - 9000 = 16000
+      // Only boundary at 10000, under target
+      const result = calculateProjectedMessageRemoval(chunks, 0.7, 30000, 25000);
+      expect(result).toBe(10000);
+    });
+
+    it('handles activation ratio of 1.0 (remove everything)', () => {
+      const chunks = [makeChunk(5000), makeChunk(5000)];
+      // retentionFloor = 30000 * (1 - 1.0) = 0
+      // target = 10000 - 0 = 10000
+      // Boundary at 10000 exactly matches target
+      const result = calculateProjectedMessageRemoval(chunks, 1.0, 30000, 10000);
+      expect(result).toBe(10000);
+    });
+
+    it('handles absolute retention floor (>= 1000)', () => {
+      const chunks = [makeChunk(4000), makeChunk(4000), makeChunk(4000)];
+      // bufferActivation = 5000 (absolute), retentionFloor = 5000
+      // pendingTokens 15000 → target = 15000 - 5000 = 10000
+      // Boundaries: 4000 (under), 8000 (under), 12000 (over)
+      // overshoot = 12000 - 10000 = 2000, maxOvershoot = 4750
+      // remaining = 15000 - 12000 = 3000 >= min(1000, 5000) = 1000
+      const result = calculateProjectedMessageRemoval(chunks, 5000, 30000, 15000);
+      expect(result).toBe(12000);
+    });
+  });
+});

--- a/packages/memory/src/processors/observational-memory/__tests__/thresholds.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/thresholds.test.ts
@@ -152,6 +152,14 @@ describe('thresholds', () => {
     it('ratio of 0.0 means full retention', () => {
       expect(resolveRetentionFloor(0.0, 30000)).toBe(30000);
     });
+
+    it('clamps negative ratio to 0', () => {
+      expect(resolveRetentionFloor(-0.5, 30000)).toBe(30000);
+    });
+
+    it('clamps ratio > 1 to 1', () => {
+      expect(resolveRetentionFloor(1.5, 30000)).toBe(0);
+    });
   });
 
   describe('resolveActivationRatio', () => {
@@ -175,11 +183,26 @@ describe('thresholds', () => {
       // 30000 / 30000 = 1, 1 - 1 = 0
       expect(resolveActivationRatio(30000, 30000)).toBe(0);
     });
+
+    it('clamps negative ratio to 0', () => {
+      expect(resolveActivationRatio(-0.5, 30000)).toBe(0);
+    });
+
+    it('clamps ratio > 1 to 1', () => {
+      expect(resolveActivationRatio(1.5, 30000)).toBe(1);
+    });
   });
 
   describe('calculateProjectedMessageRemoval', () => {
     it('returns 0 for empty chunks', () => {
       expect(calculateProjectedMessageRemoval([], 0.7, 30000, 25000)).toBe(0);
+    });
+
+    it('returns 0 when already within retention floor', () => {
+      // retentionFloor = 30000 * (1 - 0.7) = 9000
+      // pendingTokens 5000 < retentionFloor → target = 0 → short-circuit
+      const chunks = [makeChunk(5000), makeChunk(5000)];
+      expect(calculateProjectedMessageRemoval(chunks, 0.7, 30000, 5000)).toBe(0);
     });
 
     it('selects the best over-boundary when within safeguards', () => {

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -70,6 +70,15 @@ import {
   parseReflectorOutput,
   validateCompression,
 } from './reflector-agent';
+import {
+  calculateDynamicThreshold,
+  calculateProjectedMessageRemoval,
+  getMaxThreshold,
+  resolveActivationRatio,
+  resolveBlockAfter,
+  resolveBufferTokens,
+  resolveRetentionFloor,
+} from './thresholds';
 import { TokenCounter } from './token-counter';
 import type {
   ObservationConfig,
@@ -549,102 +558,6 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
   }
 
   /**
-   * Resolve bufferActivation config into an absolute retention floor (tokens to keep).
-   * - Value in (0, 1]: ratio → retentionFloor = threshold * (1 - value)
-   * - Value >= 1000: absolute token count → retentionFloor = value
-   */
-  private resolveRetentionFloor(bufferActivation: number, messageTokensThreshold: number): number {
-    if (bufferActivation >= 1000) return bufferActivation;
-    return messageTokensThreshold * (1 - bufferActivation);
-  }
-
-  /**
-   * Convert bufferActivation to the equivalent ratio (0-1) for the storage layer.
-   * When bufferActivation >= 1000, it's an absolute retention target, so we compute
-   * the equivalent ratio: 1 - (bufferActivation / threshold).
-   */
-  private resolveActivationRatio(bufferActivation: number, messageTokensThreshold: number): number {
-    if (bufferActivation >= 1000) {
-      return Math.max(0, Math.min(1, 1 - bufferActivation / messageTokensThreshold));
-    }
-    return bufferActivation;
-  }
-
-  /**
-   * Calculate the projected message tokens that would be removed if activation happened now.
-   * This replicates the chunk boundary logic in swapBufferedToActive without actually activating.
-   */
-  private calculateProjectedMessageRemoval(
-    chunks: BufferedObservationChunk[],
-    bufferActivation: number,
-    messageTokensThreshold: number,
-    currentPendingTokens: number,
-  ): number {
-    if (chunks.length === 0) return 0;
-
-    const retentionFloor = this.resolveRetentionFloor(bufferActivation, messageTokensThreshold);
-    const targetMessageTokens = Math.max(0, currentPendingTokens - retentionFloor);
-
-    // Find the closest chunk boundary to the target, biased over (prefer removing
-    // slightly more than the target so remaining context lands at or below retentionFloor).
-    // Track both best-over and best-under boundaries so we can fall back to under
-    // if the over boundary would overshoot by too much.
-    let cumulativeMessageTokens = 0;
-    let bestOverBoundary = 0;
-    let bestOverTokens = 0;
-    let bestUnderBoundary = 0;
-    let bestUnderTokens = 0;
-
-    for (let i = 0; i < chunks.length; i++) {
-      cumulativeMessageTokens += chunks[i]!.messageTokens ?? 0;
-      const boundary = i + 1;
-
-      if (cumulativeMessageTokens >= targetMessageTokens) {
-        // Over or equal — track the closest (lowest) over boundary
-        if (bestOverBoundary === 0 || cumulativeMessageTokens < bestOverTokens) {
-          bestOverBoundary = boundary;
-          bestOverTokens = cumulativeMessageTokens;
-        }
-      } else {
-        // Under — track the closest (highest) under boundary
-        if (cumulativeMessageTokens > bestUnderTokens) {
-          bestUnderBoundary = boundary;
-          bestUnderTokens = cumulativeMessageTokens;
-        }
-      }
-    }
-
-    // Safeguard: if the over boundary would eat into more than 95% of the
-    // retention floor, fall back to the best under boundary instead.
-    // This prevents edge cases where a large chunk overshoots dramatically.
-    // Additionally, never bias over if it would leave fewer than the smaller of
-    // 1000 tokens or the retention floor — at that level the agent may lose
-    // all meaningful context.
-    const maxOvershoot = retentionFloor * 0.95;
-    const overshoot = bestOverTokens - targetMessageTokens;
-    const remainingAfterOver = currentPendingTokens - bestOverTokens;
-    const remainingAfterUnder = currentPendingTokens - bestUnderTokens;
-    // When activationRatio ≈ 1.0, retentionFloor is 0 and minRemaining becomes 0 — intentional for "activate everything" configs.
-    const minRemaining = Math.min(1000, retentionFloor);
-
-    let bestBoundaryMessageTokens: number;
-
-    if (bestOverBoundary > 0 && overshoot <= maxOvershoot && remainingAfterOver >= minRemaining) {
-      bestBoundaryMessageTokens = bestOverTokens;
-    } else if (bestUnderBoundary > 0 && remainingAfterUnder >= minRemaining) {
-      bestBoundaryMessageTokens = bestUnderTokens;
-    } else if (bestOverBoundary > 0) {
-      // All boundaries are over and exceed the safeguard — still activate
-      // the closest over boundary (better than nothing)
-      bestBoundaryMessageTokens = bestOverTokens;
-    } else {
-      return chunks[0]?.messageTokens ?? 0;
-    }
-
-    return bestBoundaryMessageTokens;
-  }
-
-  /**
    * Check if we've crossed a new bufferTokens interval boundary.
    * Returns true if async buffering should be triggered.
    *
@@ -728,7 +641,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     if (record.bufferedReflection) return false;
 
     // Check if we've crossed the activation threshold
-    const reflectThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+    const reflectThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
     const activationPoint = reflectThreshold * this.reflectionConfig.bufferActivation!;
 
     const shouldTrigger = currentObservationTokens >= activationPoint;
@@ -903,7 +816,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
         config.observation?.maxTokensPerBatch ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.maxTokensPerBatch,
       bufferTokens: asyncBufferingDisabled
         ? undefined
-        : this.resolveBufferTokens(
+        : resolveBufferTokens(
             config.observation?.bufferTokens ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.bufferTokens,
             config.observation?.messageTokens ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.messageTokens,
           ),
@@ -912,7 +825,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
         : (config.observation?.bufferActivation ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.bufferActivation),
       blockAfter: asyncBufferingDisabled
         ? undefined
-        : this.resolveBlockAfter(
+        : resolveBlockAfter(
             config.observation?.blockAfter ??
               ((config.observation?.bufferTokens ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.bufferTokens)
                 ? 1.2
@@ -941,7 +854,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
         : (config?.reflection?.bufferActivation ?? OBSERVATIONAL_MEMORY_DEFAULTS.reflection.bufferActivation),
       blockAfter: asyncBufferingDisabled
         ? undefined
-        : this.resolveBlockAfter(
+        : resolveBlockAfter(
             config.reflection?.blockAfter ??
               ((config.reflection?.bufferActivation ?? OBSERVATIONAL_MEMORY_DEFAULTS.reflection.bufferActivation)
                 ? 1.2
@@ -1091,7 +1004,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     }
 
     // Validate observation bufferTokens
-    const observationThreshold = this.getMaxThreshold(this.observationConfig.messageTokens);
+    const observationThreshold = getMaxThreshold(this.observationConfig.messageTokens);
     if (this.observationConfig.bufferTokens !== undefined) {
       if (this.observationConfig.bufferTokens <= 0) {
         throw new Error(`observation.bufferTokens must be > 0, got ${this.observationConfig.bufferTokens}`);
@@ -1148,7 +1061,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
 
     // Validate reflection blockAfter
     if (this.reflectionConfig.blockAfter !== undefined) {
-      const reflectionThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+      const reflectionThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
       if (this.reflectionConfig.blockAfter < reflectionThreshold) {
         throw new Error(
           `reflection.blockAfter (${this.reflectionConfig.blockAfter}) must be >= reflection.observationTokens (${reflectionThreshold})`,
@@ -1163,87 +1076,6 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
   }
 
   /**
-   * Resolve bufferTokens: if it's a fraction (0 < value < 1), multiply by messageTokens threshold.
-   * Otherwise return the absolute token count.
-   */
-  private resolveBufferTokens(
-    bufferTokens: number | false | undefined,
-    messageTokens: number | ThresholdRange,
-  ): number | undefined {
-    if (bufferTokens === false) return undefined;
-    if (bufferTokens === undefined) return undefined;
-    if (bufferTokens > 0 && bufferTokens < 1) {
-      const threshold = typeof messageTokens === 'number' ? messageTokens : messageTokens.max;
-      return Math.round(threshold * bufferTokens);
-    }
-    return bufferTokens;
-  }
-
-  /**
-   * Resolve blockAfter config value.
-   * Values in [1, 100) are treated as multipliers of the threshold.
-   * e.g. blockAfter: 1.5 with messageTokens: 20_000 → 30_000
-   * Values >= 100 are treated as absolute token counts.
-   * Defaults to 1.2 (120% of threshold) when async buffering is enabled but blockAfter is omitted.
-   */
-  private resolveBlockAfter(
-    blockAfter: number | undefined,
-    messageTokens: number | ThresholdRange,
-  ): number | undefined {
-    if (blockAfter === undefined) return undefined;
-    // Values between 1 (inclusive) and 2 (exclusive) are treated as multipliers of the threshold.
-    // e.g. blockAfter: 1.5 means 1.5x the threshold. blockAfter: 1 means exactly at threshold.
-    // Values >= 100 are treated as absolute token counts.
-    if (blockAfter >= 1 && blockAfter < 100) {
-      const threshold = typeof messageTokens === 'number' ? messageTokens : messageTokens.max;
-      return Math.round(threshold * blockAfter);
-    }
-    return blockAfter;
-  }
-
-  /**
-   * Get the maximum value from a threshold (simple number or range)
-   */
-  private getMaxThreshold(threshold: number | ThresholdRange): number {
-    if (typeof threshold === 'number') {
-      return threshold;
-    }
-    return threshold.max;
-  }
-
-  /**
-   * Calculate dynamic threshold based on observation space.
-   * When shareTokenBudget is enabled, the message threshold can expand
-   * into unused observation space, up to the total context budget.
-   *
-   * Total budget = messageTokens + observationTokens
-   * Effective threshold = totalBudget - currentObservationTokens
-   *
-   * Example with 30k:40k thresholds (70k total):
-   * - 0 observations → messages can use ~70k
-   * - 10k observations → messages can use ~60k
-   * - 40k observations → messages back to ~30k
-   */
-  private calculateDynamicThreshold(threshold: number | ThresholdRange, currentObservationTokens: number): number {
-    // If not using adaptive threshold (simple number), return as-is
-    if (typeof threshold === 'number') {
-      return threshold;
-    }
-
-    // Adaptive threshold: use remaining space in total budget
-    // Total budget is stored as threshold.max (base + reflection threshold)
-    // Base threshold is stored as threshold.min
-    const totalBudget = threshold.max;
-    const baseThreshold = threshold.min;
-
-    // Effective threshold = total budget minus current observations
-    // But never go below the base threshold
-    const effectiveThreshold = Math.max(totalBudget - currentObservationTokens, baseThreshold);
-
-    return Math.round(effectiveThreshold);
-  }
-
-  /**
    * Check whether the unobserved message tokens meet the observation threshold.
    */
   private meetsObservationThreshold(opts: {
@@ -1254,7 +1086,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     const { record, unobservedTokens, extraTokens = 0 } = opts;
     const pendingTokens = (record.pendingMessageTokens ?? 0) + unobservedTokens + extraTokens;
     const currentObservationTokens = record.observationTokenCount ?? 0;
-    const threshold = this.calculateDynamicThreshold(this.observationConfig.messageTokens, currentObservationTokens);
+    const threshold = calculateDynamicThreshold(this.observationConfig.messageTokens, currentObservationTokens);
     return pendingTokens >= threshold;
   }
 
@@ -1346,7 +1178,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
    * Check if we need to trigger reflection.
    */
   private shouldReflect(observationTokens: number): boolean {
-    const threshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+    const threshold = getMaxThreshold(this.reflectionConfig.observationTokens);
     return observationTokens > threshold;
   }
 
@@ -1369,8 +1201,8 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
    */
   private getObservationMarkerConfig(): ObservationMarkerConfig {
     return {
-      messageTokens: this.getMaxThreshold(this.observationConfig.messageTokens),
-      observationTokens: this.getMaxThreshold(this.reflectionConfig.observationTokens),
+      messageTokens: getMaxThreshold(this.observationConfig.messageTokens),
+      observationTokens: getMaxThreshold(this.reflectionConfig.observationTokens),
       scope: this.scope,
     };
   }
@@ -1931,7 +1763,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     const originalTokens = this.tokenCounter.countObservations(observations);
 
     // Get the target threshold - use provided value or fall back to config
-    const targetThreshold = observationTokensThreshold ?? this.getMaxThreshold(this.reflectionConfig.observationTokens);
+    const targetThreshold = observationTokensThreshold ?? getMaxThreshold(this.reflectionConfig.observationTokens);
 
     // Track total usage across attempts
     let totalUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
@@ -2254,11 +2086,11 @@ ${suggestedResponse}
     // Total pending = unobserved in-context tokens + other threads
     const totalPendingTokens = Math.max(0, contextWindowTokens + otherThreadTokens);
 
-    const threshold = this.calculateDynamicThreshold(this.observationConfig.messageTokens, currentObservationTokens);
+    const threshold = calculateDynamicThreshold(this.observationConfig.messageTokens, currentObservationTokens);
 
     // Calculate effective reflection threshold for UI display
     // When adaptive threshold is enabled, both thresholds share a budget
-    const baseReflectionThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+    const baseReflectionThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
     const isSharedBudget = typeof this.observationConfig.messageTokens !== 'number';
     const totalBudget = isSharedBudget ? (this.observationConfig.messageTokens as { min: number; max: number }).max : 0;
     const effectiveObservationTokensThreshold = isSharedBudget
@@ -2317,10 +2149,10 @@ ${suggestedResponse}
 
       // Calculate projected message removal based on activation ratio and chunk boundaries
       // This replicates the logic in swapBufferedToActive without actually activating
-      const projectedMessageRemoval = this.calculateProjectedMessageRemoval(
+      const projectedMessageRemoval = calculateProjectedMessageRemoval(
         bufferedChunks,
         this.observationConfig.bufferActivation ?? 1,
-        this.getMaxThreshold(this.observationConfig.messageTokens),
+        getMaxThreshold(this.observationConfig.messageTokens),
         totalPendingTokens,
       );
 
@@ -3202,7 +3034,7 @@ ${suggestedResponse}
               : undefined;
           const minRemaining =
             typeof this.observationConfig.bufferActivation === 'number'
-              ? Math.min(1000, this.resolveRetentionFloor(this.observationConfig.bufferActivation, threshold))
+              ? Math.min(1000, resolveRetentionFloor(this.observationConfig.bufferActivation, threshold))
               : undefined;
           omDebug(
             `[OM:cleanup] observedIds=${observedIds?.length ?? 'undefined'}, ids=${observedIds?.join(',') ?? 'none'}, updatedRecord.observedMessageIds=${JSON.stringify(updatedRecord.observedMessageIds)}, minRemaining=${minRemaining ?? 'n/a'}`,
@@ -3274,8 +3106,8 @@ ${suggestedResponse}
       const otherThreadTokens = unobservedContextBlocks ? this.tokenCounter.countString(unobservedContextBlocks) : 0;
       const currentObservationTokens = freshRecord.observationTokenCount ?? 0;
 
-      const threshold = this.calculateDynamicThreshold(this.observationConfig.messageTokens, currentObservationTokens);
-      const baseReflectionThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+      const threshold = calculateDynamicThreshold(this.observationConfig.messageTokens, currentObservationTokens);
+      const baseReflectionThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
       const isSharedBudget = typeof this.observationConfig.messageTokens !== 'number';
       const totalBudget = isSharedBudget
         ? (this.observationConfig.messageTokens as { min: number; max: number }).max
@@ -4311,7 +4143,7 @@ ${formattedMessages}
     // turn (or an in-flight buffering op that just completed) may have already
     // brought us well below the threshold. Activating unnecessarily invalidates
     // the prompt cache, so we skip if we're already under the threshold.
-    const messageTokensThreshold = this.getMaxThreshold(this.observationConfig.messageTokens);
+    const messageTokensThreshold = getMaxThreshold(this.observationConfig.messageTokens);
     let effectivePendingTokens = currentPendingTokens;
     if (messageList) {
       effectivePendingTokens = this.tokenCounter.countMessages(messageList.get.all.db());
@@ -4325,7 +4157,7 @@ ${formattedMessages}
 
     // Perform partial swap with bufferActivation
     const bufferActivation = this.observationConfig.bufferActivation ?? 0.7;
-    const activationRatio = this.resolveActivationRatio(bufferActivation, messageTokensThreshold);
+    const activationRatio = resolveActivationRatio(bufferActivation, messageTokensThreshold);
 
     // When above blockAfter, prefer the over boundary to reduce context, while still
     // respecting the minimum remaining tokens safeguard.
@@ -4334,8 +4166,8 @@ ${formattedMessages}
     );
 
     const bufferTokens = this.observationConfig.bufferTokens ?? 0;
-    const retentionFloor = this.resolveRetentionFloor(bufferActivation, messageTokensThreshold);
-    const projectedMessageRemoval = this.calculateProjectedMessageRemoval(
+    const retentionFloor = resolveRetentionFloor(bufferActivation, messageTokensThreshold);
+    const projectedMessageRemoval = calculateProjectedMessageRemoval(
       freshChunks,
       bufferActivation,
       messageTokensThreshold,
@@ -4494,7 +4326,7 @@ ${formattedMessages}
     const freshRecord = await this.storage.getObservationalMemory(record.threadId, record.resourceId);
     const currentRecord = freshRecord ?? record;
     const observationTokens = currentRecord.observationTokenCount ?? 0;
-    const reflectThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+    const reflectThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
     const bufferActivation = this.reflectionConfig.bufferActivation ?? 0.5;
     const startedAt = new Date().toISOString();
     const cycleId = `reflect-buf-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
@@ -4822,7 +4654,7 @@ ${formattedMessages}
     // - Accumulate until we hit the threshold
     // - This prevents making many small Observer calls for 1-message threads
     // ════════════════════════════════════════════════════════════
-    const threshold = this.getMaxThreshold(this.observationConfig.messageTokens);
+    const threshold = getMaxThreshold(this.observationConfig.messageTokens);
 
     // Calculate tokens per thread and sort by size (largest first)
     const threadTokenCounts = new Map<string, number>();
@@ -5232,7 +5064,7 @@ ${formattedMessages}
     if (!this.isAsyncReflectionEnabled()) return;
 
     const lockKey = this.getLockKey(record.threadId, record.resourceId);
-    const reflectThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+    const reflectThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
 
     omDebug(
       `[OM:reflect] maybeAsyncReflect: observationTokens=${observationTokens}, reflectThreshold=${reflectThreshold}, isReflecting=${record.isReflecting}, bufferedReflection=${record.bufferedReflection ? 'present (' + record.bufferedReflection.length + ' chars)' : 'empty'}, recordId=${record.id}, genCount=${record.generationCount}`,
@@ -5288,7 +5120,7 @@ ${formattedMessages}
   }): Promise<void> {
     const { record, observationTokens, writer, abortSignal, messageList, reflectionHooks, requestContext } = opts;
     const lockKey = this.getLockKey(record.threadId, record.resourceId);
-    const reflectThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+    const reflectThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
 
     // ════════════════════════════════════════════════════════════════════════
     // ASYNC BUFFERING: Trigger background reflection at bufferActivation ratio
@@ -5583,7 +5415,7 @@ ${formattedMessages}
     registerOp(record.id, 'reflecting');
 
     try {
-      const reflectThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+      const reflectThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
       const reflectResult = await this.callReflector(
         record.activeObservations,
         prompt,

--- a/packages/memory/src/processors/observational-memory/thresholds.ts
+++ b/packages/memory/src/processors/observational-memory/thresholds.ts
@@ -1,0 +1,184 @@
+import type { BufferedObservationChunk } from '@mastra/core/storage';
+
+import type { ThresholdRange } from './types';
+
+/**
+ * Get the maximum value from a threshold (simple number or range).
+ */
+export function getMaxThreshold(threshold: number | ThresholdRange): number {
+  if (typeof threshold === 'number') {
+    return threshold;
+  }
+  return threshold.max;
+}
+
+/**
+ * Calculate dynamic threshold based on observation space.
+ * When shareTokenBudget is enabled, the message threshold can expand
+ * into unused observation space, up to the total context budget.
+ *
+ * Total budget = messageTokens + observationTokens
+ * Effective threshold = totalBudget - currentObservationTokens
+ *
+ * Example with 30k:40k thresholds (70k total):
+ * - 0 observations → messages can use ~70k
+ * - 10k observations → messages can use ~60k
+ * - 40k observations → messages back to ~30k
+ */
+export function calculateDynamicThreshold(
+  threshold: number | ThresholdRange,
+  currentObservationTokens: number,
+): number {
+  // If not using adaptive threshold (simple number), return as-is
+  if (typeof threshold === 'number') {
+    return threshold;
+  }
+
+  // Adaptive threshold: use remaining space in total budget
+  // Total budget is stored as threshold.max (base + reflection threshold)
+  // Base threshold is stored as threshold.min
+  const totalBudget = threshold.max;
+  const baseThreshold = threshold.min;
+
+  // Effective threshold = total budget minus current observations
+  // But never go below the base threshold
+  const effectiveThreshold = Math.max(totalBudget - currentObservationTokens, baseThreshold);
+
+  return Math.round(effectiveThreshold);
+}
+
+/**
+ * Resolve bufferTokens config value.
+ * Values in (0, 1) are treated as ratios of the message threshold.
+ * e.g. bufferTokens: 0.25 with messageTokens: 20_000 → 5_000
+ */
+export function resolveBufferTokens(
+  bufferTokens: number | false | undefined,
+  messageTokens: number | ThresholdRange,
+): number | undefined {
+  if (bufferTokens === false) return undefined;
+  if (bufferTokens === undefined) return undefined;
+  if (bufferTokens > 0 && bufferTokens < 1) {
+    const threshold = typeof messageTokens === 'number' ? messageTokens : messageTokens.max;
+    return Math.round(threshold * bufferTokens);
+  }
+  return bufferTokens;
+}
+
+/**
+ * Resolve blockAfter config value.
+ * Values in [1, 100) are treated as multipliers of the threshold.
+ * e.g. blockAfter: 1.5 with messageTokens: 20_000 → 30_000
+ * Values >= 100 are treated as absolute token counts.
+ * Defaults to 1.2 (120% of threshold) when async buffering is enabled but blockAfter is omitted.
+ */
+export function resolveBlockAfter(
+  blockAfter: number | undefined,
+  messageTokens: number | ThresholdRange,
+): number | undefined {
+  if (blockAfter === undefined) return undefined;
+  // Values between 1 (inclusive) and 2 (exclusive) are treated as multipliers of the threshold.
+  // e.g. blockAfter: 1.5 means 1.5x the threshold. blockAfter: 1 means exactly at threshold.
+  // Values >= 100 are treated as absolute token counts.
+  if (blockAfter >= 1 && blockAfter < 100) {
+    const threshold = typeof messageTokens === 'number' ? messageTokens : messageTokens.max;
+    return Math.round(threshold * blockAfter);
+  }
+  return blockAfter;
+}
+
+/**
+ * Convert bufferActivation to an absolute retention floor (tokens to keep after activation).
+ * When bufferActivation >= 1000, it's an absolute retention target.
+ * Otherwise it's a ratio: retentionFloor = threshold * (1 - ratio).
+ */
+export function resolveRetentionFloor(bufferActivation: number, messageTokensThreshold: number): number {
+  if (bufferActivation >= 1000) return bufferActivation;
+  return messageTokensThreshold * (1 - bufferActivation);
+}
+
+/**
+ * Convert bufferActivation to the equivalent ratio (0-1) for the storage layer.
+ * When bufferActivation >= 1000, it's an absolute retention target, so we compute
+ * the equivalent ratio: 1 - (bufferActivation / threshold).
+ */
+export function resolveActivationRatio(bufferActivation: number, messageTokensThreshold: number): number {
+  if (bufferActivation >= 1000) {
+    return Math.max(0, Math.min(1, 1 - bufferActivation / messageTokensThreshold));
+  }
+  return bufferActivation;
+}
+
+/**
+ * Calculate the projected message tokens that would be removed if activation happened now.
+ * This replicates the chunk boundary logic in swapBufferedToActive without actually activating.
+ */
+export function calculateProjectedMessageRemoval(
+  chunks: BufferedObservationChunk[],
+  bufferActivation: number,
+  messageTokensThreshold: number,
+  currentPendingTokens: number,
+): number {
+  if (chunks.length === 0) return 0;
+
+  const retentionFloor = resolveRetentionFloor(bufferActivation, messageTokensThreshold);
+  const targetMessageTokens = Math.max(0, currentPendingTokens - retentionFloor);
+
+  // Find the closest chunk boundary to the target, biased over (prefer removing
+  // slightly more than the target so remaining context lands at or below retentionFloor).
+  // Track both best-over and best-under boundaries so we can fall back to under
+  // if the over boundary would overshoot by too much.
+  let cumulativeMessageTokens = 0;
+  let bestOverBoundary = 0;
+  let bestOverTokens = 0;
+  let bestUnderBoundary = 0;
+  let bestUnderTokens = 0;
+
+  for (let i = 0; i < chunks.length; i++) {
+    cumulativeMessageTokens += chunks[i]!.messageTokens ?? 0;
+    const boundary = i + 1;
+
+    if (cumulativeMessageTokens >= targetMessageTokens) {
+      // Over or equal — track the closest (lowest) over boundary
+      if (bestOverBoundary === 0 || cumulativeMessageTokens < bestOverTokens) {
+        bestOverBoundary = boundary;
+        bestOverTokens = cumulativeMessageTokens;
+      }
+    } else {
+      // Under — track the closest (highest) under boundary
+      if (cumulativeMessageTokens > bestUnderTokens) {
+        bestUnderBoundary = boundary;
+        bestUnderTokens = cumulativeMessageTokens;
+      }
+    }
+  }
+
+  // Safeguard: if the over boundary would eat into more than 95% of the
+  // retention floor, fall back to the best under boundary instead.
+  // This prevents edge cases where a large chunk overshoots dramatically.
+  // Additionally, never bias over if it would leave fewer than the smaller of
+  // 1000 tokens or the retention floor — at that level the agent may lose
+  // all meaningful context.
+  const maxOvershoot = retentionFloor * 0.95;
+  const overshoot = bestOverTokens - targetMessageTokens;
+  const remainingAfterOver = currentPendingTokens - bestOverTokens;
+  const remainingAfterUnder = currentPendingTokens - bestUnderTokens;
+  // When activationRatio ≈ 1.0, retentionFloor is 0 and minRemaining becomes 0 — intentional for "activate everything" configs.
+  const minRemaining = Math.min(1000, retentionFloor);
+
+  let bestBoundaryMessageTokens: number;
+
+  if (bestOverBoundary > 0 && overshoot <= maxOvershoot && remainingAfterOver >= minRemaining) {
+    bestBoundaryMessageTokens = bestOverTokens;
+  } else if (bestUnderBoundary > 0 && remainingAfterUnder >= minRemaining) {
+    bestBoundaryMessageTokens = bestUnderTokens;
+  } else if (bestOverBoundary > 0) {
+    // All boundaries are over and exceed the safeguard — still activate
+    // the closest over boundary (better than nothing)
+    bestBoundaryMessageTokens = bestOverTokens;
+  } else {
+    return chunks[0]?.messageTokens ?? 0;
+  }
+
+  return bestBoundaryMessageTokens;
+}

--- a/packages/memory/src/processors/observational-memory/thresholds.ts
+++ b/packages/memory/src/processors/observational-memory/thresholds.ts
@@ -59,8 +59,7 @@ export function resolveBufferTokens(
   if (bufferTokens === false) return undefined;
   if (bufferTokens === undefined) return undefined;
   if (bufferTokens > 0 && bufferTokens < 1) {
-    const threshold = typeof messageTokens === 'number' ? messageTokens : messageTokens.max;
-    return Math.round(threshold * bufferTokens);
+    return Math.round(getMaxThreshold(messageTokens) * bufferTokens);
   }
   return bufferTokens;
 }
@@ -81,8 +80,7 @@ export function resolveBlockAfter(
   // e.g. blockAfter: 1.5 means 1.5x the threshold. blockAfter: 1 means exactly at threshold.
   // Values >= 100 are treated as absolute token counts.
   if (blockAfter >= 1 && blockAfter < 100) {
-    const threshold = typeof messageTokens === 'number' ? messageTokens : messageTokens.max;
-    return Math.round(threshold * blockAfter);
+    return Math.round(getMaxThreshold(messageTokens) * blockAfter);
   }
   return blockAfter;
 }
@@ -94,7 +92,8 @@ export function resolveBlockAfter(
  */
 export function resolveRetentionFloor(bufferActivation: number, messageTokensThreshold: number): number {
   if (bufferActivation >= 1000) return bufferActivation;
-  return messageTokensThreshold * (1 - bufferActivation);
+  const ratio = Math.max(0, Math.min(1, bufferActivation));
+  return messageTokensThreshold * (1 - ratio);
 }
 
 /**
@@ -106,7 +105,7 @@ export function resolveActivationRatio(bufferActivation: number, messageTokensTh
   if (bufferActivation >= 1000) {
     return Math.max(0, Math.min(1, 1 - bufferActivation / messageTokensThreshold));
   }
-  return bufferActivation;
+  return Math.max(0, Math.min(1, bufferActivation));
 }
 
 /**
@@ -123,6 +122,9 @@ export function calculateProjectedMessageRemoval(
 
   const retentionFloor = resolveRetentionFloor(bufferActivation, messageTokensThreshold);
   const targetMessageTokens = Math.max(0, currentPendingTokens - retentionFloor);
+
+  // Already within retention floor — no removal needed
+  if (targetMessageTokens === 0) return 0;
 
   // Find the closest chunk boundary to the target, biased over (prefer removing
   // slightly more than the target so remaining context lands at or below retentionFloor).

--- a/packages/memory/src/processors/observational-memory/thresholds.ts
+++ b/packages/memory/src/processors/observational-memory/thresholds.ts
@@ -77,7 +77,7 @@ export function resolveBlockAfter(
   messageTokens: number | ThresholdRange,
 ): number | undefined {
   if (blockAfter === undefined) return undefined;
-  // Values between 1 (inclusive) and 2 (exclusive) are treated as multipliers of the threshold.
+  // Values between 1 (inclusive) and 100 (exclusive) are treated as multipliers of the threshold.
   // e.g. blockAfter: 1.5 means 1.5x the threshold. blockAfter: 1 means exactly at threshold.
   // Values >= 100 are treated as absolute token counts.
   if (blockAfter >= 1 && blockAfter < 100) {


### PR DESCRIPTION
## Summary

Extracts 7 pure threshold/config resolution functions from the `ObservationalMemory` class into a dedicated `thresholds.ts` module:

- `getMaxThreshold` — resolve simple or range thresholds
- `calculateDynamicThreshold` — adaptive threshold with shared token budget
- `resolveBufferTokens` — fractional to absolute buffer token conversion
- `resolveBlockAfter` — multiplier to absolute block-after conversion
- `resolveRetentionFloor` — activation ratio to retention floor conversion
- `resolveActivationRatio` — absolute retention to ratio conversion
- `calculateProjectedMessageRemoval` — chunk boundary selection simulation

These are all pure functions (no `this` dependency), making them independently testable.

## Changes

- Created `thresholds.ts` (181 lines) with 7 extracted functions
- Removed corresponding private methods from `ObservationalMemory` class
- Updated all call sites (removed `this.` prefix)
- Added `thresholds.test.ts` with 37 unit tests covering all functions
- `observational-memory.ts` reduced from 5675 → 5509 lines

## Verification

- Build passes (`pnpm build:memory`)
- All 504 tests pass across 16 test files
- No public API changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal threshold calculation logic in the memory processor into standalone helpers for clearer structure and maintainability.

* **Tests**
  * Added a comprehensive test suite covering threshold behaviors, edge cases, activation/buffering logic, and projected message removal scenarios.

* **Chores**
  * Added a changeset entry documenting a patch release for the memory package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->