### PR TITLE
refactor(memory): extract message part filtering into message-parts.ts

### DIFF
--- a/.changeset/bright-foxes-glow.md
+++ b/.changeset/bright-foxes-glow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Improved observational memory threshold calculation testability by extracting pure threshold functions into a dedicated module. No public API changes.

--- a/.changeset/bright-foxes-glow.md
+++ b/.changeset/bright-foxes-glow.md
@@ -2,4 +2,4 @@
 '@mastra/memory': patch
 ---
 
-Improved observational memory threshold calculation testability by extracting pure threshold functions into a dedicated module. No public API changes.
+Improved confidence in observational memory threshold behavior through expanded automated test coverage. No public API changes.

--- a/.changeset/thin-parrots-act.md
+++ b/.changeset/thin-parrots-act.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Improved observational memory code organization by extracting message part filtering, sealing, and boundary detection logic into a dedicated module with comprehensive test coverage. No public API changes.

--- a/packages/memory/src/processors/observational-memory/__tests__/message-parts.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/message-parts.test.ts
@@ -1,0 +1,430 @@
+import type { MastraDBMessage, MastraMessageContentV2 } from '@mastra/core/agent';
+import type { ObservationalMemoryRecord } from '@mastra/core/storage';
+import { describe, it, expect } from 'vitest';
+
+import {
+  findLastCompletedObservationBoundary,
+  hasInProgressObservation,
+  sealMessagesForBuffering,
+  getUnobservedParts,
+  hasUnobservedParts,
+  createUnobservedMessage,
+  getUnobservedMessages,
+  getBufferedChunks,
+} from '../message-parts';
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+function createMsg(
+  parts: MastraMessageContentV2['parts'],
+  opts?: { id?: string; role?: 'user' | 'assistant'; createdAt?: Date },
+): MastraDBMessage {
+  return {
+    id: opts?.id ?? 'msg-1',
+    threadId: 'thread-1',
+    role: opts?.role ?? 'user',
+    type: 'text',
+    content: { format: 2, parts },
+    createdAt: opts?.createdAt ?? new Date('2026-01-01'),
+  } as MastraDBMessage;
+}
+
+function textPart(text: string) {
+  return { type: 'text' as const, text };
+}
+
+function markerPart(type: string) {
+  return { type };
+}
+
+// =============================================================================
+// findLastCompletedObservationBoundary
+// =============================================================================
+
+describe('findLastCompletedObservationBoundary', () => {
+  it('returns -1 for message with no parts', () => {
+    const msg = createMsg([]);
+    expect(findLastCompletedObservationBoundary(msg)).toBe(-1);
+  });
+
+  it('returns -1 for message with only text parts', () => {
+    const msg = createMsg([textPart('hello'), textPart('world')]);
+    expect(findLastCompletedObservationBoundary(msg)).toBe(-1);
+  });
+
+  it('returns -1 for message with only start marker', () => {
+    const msg = createMsg([textPart('hello'), markerPart('data-om-observation-start')]);
+    expect(findLastCompletedObservationBoundary(msg)).toBe(-1);
+  });
+
+  it('returns index of end marker', () => {
+    const msg = createMsg([
+      textPart('hello'),
+      markerPart('data-om-observation-start'),
+      markerPart('data-om-observation-end'),
+    ]);
+    expect(findLastCompletedObservationBoundary(msg)).toBe(2);
+  });
+
+  it('returns last end marker index when multiple exist', () => {
+    const msg = createMsg([
+      markerPart('data-om-observation-start'),
+      markerPart('data-om-observation-end'),
+      textPart('new content'),
+      markerPart('data-om-observation-start'),
+      markerPart('data-om-observation-end'),
+    ]);
+    expect(findLastCompletedObservationBoundary(msg)).toBe(4);
+  });
+
+  it('handles null/undefined content', () => {
+    const msg = { id: 'x', content: null } as unknown as MastraDBMessage;
+    expect(findLastCompletedObservationBoundary(msg)).toBe(-1);
+  });
+});
+
+// =============================================================================
+// hasInProgressObservation
+// =============================================================================
+
+describe('hasInProgressObservation', () => {
+  it('returns false for message with no parts', () => {
+    expect(hasInProgressObservation(createMsg([]))).toBe(false);
+  });
+
+  it('returns false when no markers exist', () => {
+    expect(hasInProgressObservation(createMsg([textPart('hello')]))).toBe(false);
+  });
+
+  it('returns true when start marker has no matching end', () => {
+    const msg = createMsg([textPart('hello'), markerPart('data-om-observation-start')]);
+    expect(hasInProgressObservation(msg)).toBe(true);
+  });
+
+  it('returns false when start + end both present', () => {
+    const msg = createMsg([
+      textPart('hello'),
+      markerPart('data-om-observation-start'),
+      markerPart('data-om-observation-end'),
+    ]);
+    expect(hasInProgressObservation(msg)).toBe(false);
+  });
+
+  it('returns false when start + failed both present', () => {
+    const msg = createMsg([
+      textPart('hello'),
+      markerPart('data-om-observation-start'),
+      markerPart('data-om-observation-failed'),
+    ]);
+    expect(hasInProgressObservation(msg)).toBe(false);
+  });
+
+  it('returns true when second observation is in progress', () => {
+    const msg = createMsg([
+      markerPart('data-om-observation-start'),
+      markerPart('data-om-observation-end'),
+      textPart('new content'),
+      markerPart('data-om-observation-start'),
+    ]);
+    expect(hasInProgressObservation(msg)).toBe(true);
+  });
+});
+
+// =============================================================================
+// sealMessagesForBuffering
+// =============================================================================
+
+describe('sealMessagesForBuffering', () => {
+  it('sets sealed metadata on messages', () => {
+    const messages = [createMsg([textPart('hello')]), createMsg([textPart('world')], { id: 'msg-2' })];
+
+    sealMessagesForBuffering(messages);
+
+    for (const msg of messages) {
+      const meta = msg.content.metadata as { mastra?: { sealed?: boolean } };
+      expect(meta?.mastra?.sealed).toBe(true);
+
+      const lastPart = msg.content.parts[msg.content.parts.length - 1] as {
+        metadata?: { mastra?: { sealedAt?: number } };
+      };
+      expect(lastPart.metadata?.mastra?.sealedAt).toBeTypeOf('number');
+    }
+  });
+
+  it('skips messages with empty parts', () => {
+    const msg = createMsg([]);
+    sealMessagesForBuffering([msg]);
+    expect(msg.content.metadata).toBeUndefined();
+  });
+
+  it('uses consistent timestamp across all messages', () => {
+    const messages = [createMsg([textPart('a')]), createMsg([textPart('b')], { id: 'msg-2' })];
+
+    sealMessagesForBuffering(messages);
+
+    const ts1 = (messages[0].content.parts[0] as any).metadata?.mastra?.sealedAt;
+    const ts2 = (messages[1].content.parts[0] as any).metadata?.mastra?.sealedAt;
+    expect(ts1).toBe(ts2);
+  });
+});
+
+// =============================================================================
+// getUnobservedParts
+// =============================================================================
+
+describe('getUnobservedParts', () => {
+  it('returns all parts when no markers exist', () => {
+    const msg = createMsg([textPart('hello'), textPart('world')]);
+    expect(getUnobservedParts(msg)).toHaveLength(2);
+  });
+
+  it('excludes start markers when observation is in progress', () => {
+    const msg = createMsg([textPart('hello'), markerPart('data-om-observation-start')]);
+    const parts = getUnobservedParts(msg);
+    expect(parts).toHaveLength(1);
+    expect((parts[0] as any).text).toBe('hello');
+  });
+
+  it('returns parts after end marker', () => {
+    const msg = createMsg([
+      textPart('observed'),
+      markerPart('data-om-observation-start'),
+      markerPart('data-om-observation-end'),
+      textPart('unobserved'),
+    ]);
+    const parts = getUnobservedParts(msg);
+    expect(parts).toHaveLength(1);
+    expect((parts[0] as any).text).toBe('unobserved');
+  });
+
+  it('returns empty for fully observed message', () => {
+    const msg = createMsg([
+      textPart('observed'),
+      markerPart('data-om-observation-start'),
+      markerPart('data-om-observation-end'),
+    ]);
+    expect(getUnobservedParts(msg)).toHaveLength(0);
+  });
+
+  it('returns empty array for null content', () => {
+    const msg = { id: 'x', content: null } as unknown as MastraDBMessage;
+    expect(getUnobservedParts(msg)).toEqual([]);
+  });
+});
+
+// =============================================================================
+// hasUnobservedParts
+// =============================================================================
+
+describe('hasUnobservedParts', () => {
+  it('returns true when unobserved parts exist', () => {
+    expect(hasUnobservedParts(createMsg([textPart('hello')]))).toBe(true);
+  });
+
+  it('returns false when all parts are observed', () => {
+    const msg = createMsg([
+      textPart('observed'),
+      markerPart('data-om-observation-start'),
+      markerPart('data-om-observation-end'),
+    ]);
+    expect(hasUnobservedParts(msg)).toBe(false);
+  });
+});
+
+// =============================================================================
+// createUnobservedMessage
+// =============================================================================
+
+describe('createUnobservedMessage', () => {
+  it('returns null when no unobserved parts', () => {
+    const msg = createMsg([
+      textPart('observed'),
+      markerPart('data-om-observation-start'),
+      markerPart('data-om-observation-end'),
+    ]);
+    expect(createUnobservedMessage(msg)).toBeNull();
+  });
+
+  it('returns virtual message with only unobserved parts', () => {
+    const msg = createMsg([
+      textPart('observed'),
+      markerPart('data-om-observation-start'),
+      markerPart('data-om-observation-end'),
+      textPart('new stuff'),
+    ]);
+    const virtual = createUnobservedMessage(msg);
+    expect(virtual).not.toBeNull();
+    expect(virtual!.id).toBe(msg.id);
+    expect(virtual!.content.parts).toHaveLength(1);
+    expect((virtual!.content.parts[0] as any).text).toBe('new stuff');
+  });
+
+  it('preserves message metadata', () => {
+    const msg = createMsg([textPart('hello')], { id: 'custom-id', role: 'assistant' });
+    const virtual = createUnobservedMessage(msg);
+    expect(virtual!.id).toBe('custom-id');
+    expect(virtual!.role).toBe('assistant');
+  });
+});
+
+// =============================================================================
+// getUnobservedMessages
+// =============================================================================
+
+describe('getUnobservedMessages', () => {
+  const baseRecord: ObservationalMemoryRecord = {
+    id: 'rec-1',
+    threadId: 'thread-1',
+    resourceId: 'resource-1',
+    scope: 'thread',
+    observations: '',
+    observationTokens: 0,
+    lastObservedAt: null,
+    observedMessageIds: [],
+    config: {},
+    isObserving: false,
+    isReflecting: false,
+    isBufferingObservation: false,
+    isBufferingReflection: false,
+    pendingMessageTokens: 0,
+    reflectionGeneration: 0,
+    bufferedObservationChunks: [],
+    bufferedReflection: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as unknown as ObservationalMemoryRecord;
+
+  it('returns all messages when no observations exist', () => {
+    const messages = [createMsg([textPart('a')], { id: 'a' }), createMsg([textPart('b')], { id: 'b' })];
+    const result = getUnobservedMessages(messages, baseRecord);
+    expect(result).toHaveLength(2);
+  });
+
+  it('filters by lastObservedAt timestamp', () => {
+    const record = {
+      ...baseRecord,
+      lastObservedAt: new Date('2026-01-15'),
+    };
+    const messages = [
+      createMsg([textPart('old')], { id: 'old', createdAt: new Date('2026-01-10') }),
+      createMsg([textPart('new')], { id: 'new', createdAt: new Date('2026-01-20') }),
+    ];
+    const result = getUnobservedMessages(messages, record);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('new');
+  });
+
+  it('filters by observedMessageIds', () => {
+    const record = {
+      ...baseRecord,
+      lastObservedAt: new Date('2026-01-01'),
+      observedMessageIds: ['msg-a'],
+    };
+    const messages = [
+      createMsg([textPart('a')], { id: 'msg-a', createdAt: new Date('2026-01-20') }),
+      createMsg([textPart('b')], { id: 'msg-b', createdAt: new Date('2026-01-20') }),
+    ];
+    const result = getUnobservedMessages(messages, record);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('msg-b');
+  });
+
+  it('excludes buffered chunk messages when excludeBuffered is true', () => {
+    const record = {
+      ...baseRecord,
+      bufferedObservationChunks: [
+        {
+          id: 'chunk-1',
+          cycleId: 'cycle-1',
+          observations: 'test',
+          tokenCount: 10,
+          messageIds: ['msg-a'],
+          messageTokens: 100,
+          lastObservedAt: new Date(),
+          createdAt: new Date(),
+        },
+      ],
+    };
+    const messages = [createMsg([textPart('a')], { id: 'msg-a' }), createMsg([textPart('b')], { id: 'msg-b' })];
+
+    // Without excludeBuffered — all visible
+    const all = getUnobservedMessages(messages, record);
+    expect(all).toHaveLength(2);
+
+    // With excludeBuffered — buffered msg excluded
+    const filtered = getUnobservedMessages(messages, record, { excludeBuffered: true });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].id).toBe('msg-b');
+  });
+
+  it('uses part-level filtering for messages with completed observation', () => {
+    const record = {
+      ...baseRecord,
+      lastObservedAt: new Date('2026-01-01'),
+    };
+    const msg = createMsg(
+      [
+        textPart('observed'),
+        markerPart('data-om-observation-start'),
+        markerPart('data-om-observation-end'),
+        textPart('new content'),
+      ],
+      { id: 'msg-1', createdAt: new Date('2026-01-20') },
+    );
+    const result = getUnobservedMessages([msg], record);
+    expect(result).toHaveLength(1);
+    expect(result[0].content.parts).toHaveLength(1);
+    expect((result[0].content.parts[0] as any).text).toBe('new content');
+  });
+
+  it('includes full message for in-progress observation', () => {
+    const record = {
+      ...baseRecord,
+      lastObservedAt: new Date('2026-01-01'),
+    };
+    const msg = createMsg([textPart('hello'), markerPart('data-om-observation-start')], {
+      id: 'msg-1',
+      createdAt: new Date('2026-01-20'),
+    });
+    const result = getUnobservedMessages([msg], record);
+    expect(result).toHaveLength(1);
+    expect(result[0].content.parts).toHaveLength(2);
+  });
+});
+
+// =============================================================================
+// getBufferedChunks
+// =============================================================================
+
+describe('getBufferedChunks', () => {
+  it('returns empty array for null/undefined record', () => {
+    expect(getBufferedChunks(null)).toEqual([]);
+    expect(getBufferedChunks(undefined)).toEqual([]);
+  });
+
+  it('returns empty array for missing field', () => {
+    expect(getBufferedChunks({} as any)).toEqual([]);
+    expect(getBufferedChunks({ bufferedObservationChunks: undefined } as any)).toEqual([]);
+  });
+
+  it('returns array directly when already an array', () => {
+    const chunks = [{ id: 'c1' }];
+    expect(getBufferedChunks({ bufferedObservationChunks: chunks } as any)).toBe(chunks);
+  });
+
+  it('parses JSON string into array', () => {
+    const chunks = [{ id: 'c1', observations: 'test' }];
+    const result = getBufferedChunks({ bufferedObservationChunks: JSON.stringify(chunks) } as any);
+    expect(result).toEqual(chunks);
+  });
+
+  it('returns empty for invalid JSON', () => {
+    expect(getBufferedChunks({ bufferedObservationChunks: 'not-json' } as any)).toEqual([]);
+  });
+
+  it('returns empty for non-array JSON', () => {
+    expect(getBufferedChunks({ bufferedObservationChunks: '42' } as any)).toEqual([]);
+  });
+});

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -3,6 +3,7 @@ import type { MastraDBMessage, MastraMessageContentV2 } from '@mastra/core/agent
 import { InMemoryMemory, InMemoryDB } from '@mastra/core/storage';
 import { describe, it, expect, beforeEach } from 'vitest';
 
+import { getBufferedChunks, getUnobservedMessages, sealMessagesForBuffering } from '../message-parts';
 import { ObservationalMemory } from '../observational-memory';
 import {
   buildObserverPrompt,
@@ -4561,14 +4562,6 @@ describe('Async Buffering Processor Logic', () => {
   describe('getUnobservedMessages filtering with buffered chunks', () => {
     it('should exclude messages already in buffered chunks from unobserved list', async () => {
       const storage = createInMemoryStorage();
-      const om = new ObservationalMemory({
-        storage,
-        scope: 'thread',
-        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
-        observation: { messageTokens: 50000 },
-        reflection: { observationTokens: 20000 },
-      });
-
       const record = await storage.initializeObservationalMemory({
         threadId: 'thread-1',
         resourceId: 'resource-1',
@@ -4599,11 +4592,11 @@ describe('Async Buffering Processor Logic', () => {
       ];
 
       // Default: buffered messages are NOT excluded (main agent still sees them)
-      const unobserved = (om as any).getUnobservedMessages(allMessages, updatedRecord!);
+      const unobserved = getUnobservedMessages(allMessages, updatedRecord!);
       expect(unobserved).toHaveLength(3);
 
       // With excludeBuffered: buffered messages ARE excluded (buffering path only)
-      const unobservedForBuffering = (om as any).getUnobservedMessages(allMessages, updatedRecord!, {
+      const unobservedForBuffering = getUnobservedMessages(allMessages, updatedRecord!, {
         excludeBuffered: true,
       });
       expect(unobservedForBuffering).toHaveLength(1);
@@ -4612,14 +4605,6 @@ describe('Async Buffering Processor Logic', () => {
 
     it('should include all messages when no buffered chunks exist', async () => {
       const storage = createInMemoryStorage();
-      const om = new ObservationalMemory({
-        storage,
-        scope: 'thread',
-        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
-        observation: { messageTokens: 50000 },
-        reflection: { observationTokens: 20000 },
-      });
-
       const record = await storage.initializeObservationalMemory({
         threadId: 'thread-1',
         resourceId: 'resource-1',
@@ -4628,21 +4613,13 @@ describe('Async Buffering Processor Logic', () => {
       });
 
       const allMessages = createTestMessages(3);
-      const unobserved = (om as any).getUnobservedMessages(allMessages, record);
+      const unobserved = getUnobservedMessages(allMessages, record);
 
       expect(unobserved).toHaveLength(3);
     });
 
     it('should exclude messages in both observedMessageIds and buffered chunks', async () => {
       const storage = createInMemoryStorage();
-      const om = new ObservationalMemory({
-        storage,
-        scope: 'thread',
-        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
-        observation: { messageTokens: 50000 },
-        reflection: { observationTokens: 20000 },
-      });
-
       const record = await storage.initializeObservationalMemory({
         threadId: 'thread-1',
         resourceId: 'resource-1',
@@ -4682,12 +4659,12 @@ describe('Async Buffering Processor Logic', () => {
       ];
 
       // Default (excludeBuffered=false): only observedMessageIds are excluded, buffered messages still visible
-      const unobservedDefault = (om as any).getUnobservedMessages(allMessages, updatedRecord!);
+      const unobservedDefault = getUnobservedMessages(allMessages, updatedRecord!);
       expect(unobservedDefault).toHaveLength(3);
       expect(unobservedDefault.map((m: MastraDBMessage) => m.id)).toEqual(['msg-1', 'msg-2', 'msg-3']);
 
       // With excludeBuffered=true: both observedMessageIds AND buffered chunks are excluded
-      const unobservedExcluded = (om as any).getUnobservedMessages(allMessages, updatedRecord!, {
+      const unobservedExcluded = getUnobservedMessages(allMessages, updatedRecord!, {
         excludeBuffered: true,
       });
       expect(unobservedExcluded).toHaveLength(2);
@@ -4697,42 +4674,18 @@ describe('Async Buffering Processor Logic', () => {
 
   describe('getBufferedChunks defensive parsing', () => {
     it('should return empty array for null record', () => {
-      const om = new ObservationalMemory({
-        storage: createInMemoryStorage(),
-        scope: 'thread',
-        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
-        observation: { messageTokens: 50000 },
-        reflection: { observationTokens: 20000 },
-      });
-
-      expect((om as any).getBufferedChunks(null)).toEqual([]);
-      expect((om as any).getBufferedChunks(undefined)).toEqual([]);
+      expect(getBufferedChunks(null)).toEqual([]);
+      expect(getBufferedChunks(undefined)).toEqual([]);
     });
 
     it('should return empty array for record without chunks', () => {
-      const om = new ObservationalMemory({
-        storage: createInMemoryStorage(),
-        scope: 'thread',
-        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
-        observation: { messageTokens: 50000 },
-        reflection: { observationTokens: 20000 },
-      });
-
-      expect((om as any).getBufferedChunks({})).toEqual([]);
-      expect((om as any).getBufferedChunks({ bufferedObservationChunks: undefined })).toEqual([]);
+      expect(getBufferedChunks({})).toEqual([]);
+      expect(getBufferedChunks({ bufferedObservationChunks: undefined })).toEqual([]);
     });
 
     it('should parse JSON string chunks', () => {
-      const om = new ObservationalMemory({
-        storage: createInMemoryStorage(),
-        scope: 'thread',
-        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
-        observation: { messageTokens: 50000 },
-        reflection: { observationTokens: 20000 },
-      });
-
       const chunks = [{ observations: '- test', tokenCount: 10, messageIds: ['msg-1'], cycleId: 'c1' }];
-      const result = (om as any).getBufferedChunks({
+      const result = getBufferedChunks({
         bufferedObservationChunks: JSON.stringify(chunks),
       });
 
@@ -4741,29 +4694,13 @@ describe('Async Buffering Processor Logic', () => {
     });
 
     it('should return empty array for invalid JSON string', () => {
-      const om = new ObservationalMemory({
-        storage: createInMemoryStorage(),
-        scope: 'thread',
-        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
-        observation: { messageTokens: 50000 },
-        reflection: { observationTokens: 20000 },
-      });
-
-      expect((om as any).getBufferedChunks({ bufferedObservationChunks: 'not-json' })).toEqual([]);
-      expect((om as any).getBufferedChunks({ bufferedObservationChunks: '42' })).toEqual([]);
+      expect(getBufferedChunks({ bufferedObservationChunks: 'not-json' })).toEqual([]);
+      expect(getBufferedChunks({ bufferedObservationChunks: '42' })).toEqual([]);
     });
 
     it('should pass through array chunks directly', () => {
-      const om = new ObservationalMemory({
-        storage: createInMemoryStorage(),
-        scope: 'thread',
-        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
-        observation: { messageTokens: 50000 },
-        reflection: { observationTokens: 20000 },
-      });
-
       const chunks = [{ observations: '- test', tokenCount: 10, messageIds: ['msg-1'], cycleId: 'c1' }];
-      expect((om as any).getBufferedChunks({ bufferedObservationChunks: chunks })).toBe(chunks);
+      expect(getBufferedChunks({ bufferedObservationChunks: chunks })).toBe(chunks);
     });
   });
 
@@ -5133,20 +5070,12 @@ describe('Async Buffering Processor Logic', () => {
 
   describe('sealMessagesForBuffering', () => {
     it('should set sealed metadata on messages', () => {
-      const om = new ObservationalMemory({
-        storage: createInMemoryStorage(),
-        scope: 'thread',
-        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
-        observation: { messageTokens: 50000 },
-        reflection: { observationTokens: 20000 },
-      });
-
       const messages = [
         createTestMessage('Message 1', 'user', 'msg-1'),
         createTestMessage('Message 2', 'assistant', 'msg-2'),
       ];
 
-      (om as any).sealMessagesForBuffering(messages);
+      sealMessagesForBuffering(messages);
 
       for (const msg of messages) {
         const metadata = msg.content.metadata as { mastra?: { sealed?: boolean } };
@@ -5160,19 +5089,11 @@ describe('Async Buffering Processor Logic', () => {
     });
 
     it('should skip messages without parts', () => {
-      const om = new ObservationalMemory({
-        storage: createInMemoryStorage(),
-        scope: 'thread',
-        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
-        observation: { messageTokens: 50000 },
-        reflection: { observationTokens: 20000 },
-      });
-
       const msg = createTestMessage('Test', 'user', 'msg-1');
       msg.content.parts = [];
 
       // Should not throw
-      (om as any).sealMessagesForBuffering([msg]);
+      sealMessagesForBuffering([msg]);
       expect(msg.content.metadata).toBeUndefined();
     });
   });

--- a/packages/memory/src/processors/observational-memory/__tests__/thresholds.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/thresholds.test.ts
@@ -1,0 +1,246 @@
+import type { BufferedObservationChunk } from '@mastra/core/storage';
+import { describe, it, expect } from 'vitest';
+
+import {
+  getMaxThreshold,
+  calculateDynamicThreshold,
+  resolveBufferTokens,
+  resolveBlockAfter,
+  resolveRetentionFloor,
+  resolveActivationRatio,
+  calculateProjectedMessageRemoval,
+} from '../thresholds';
+
+function makeChunk(messageTokens: number): BufferedObservationChunk {
+  return {
+    id: `chunk-${Math.random().toString(36).slice(2, 8)}`,
+    cycleId: 'cycle-1',
+    observations: '',
+    tokenCount: messageTokens,
+    messageIds: [],
+    messageTokens,
+    lastObservedAt: new Date(),
+    createdAt: new Date(),
+  };
+}
+
+describe('thresholds', () => {
+  describe('getMaxThreshold', () => {
+    it('returns the number for simple thresholds', () => {
+      expect(getMaxThreshold(30000)).toBe(30000);
+    });
+
+    it('returns max for range thresholds', () => {
+      expect(getMaxThreshold({ min: 8000, max: 70000 })).toBe(70000);
+    });
+
+    it('handles zero', () => {
+      expect(getMaxThreshold(0)).toBe(0);
+    });
+  });
+
+  describe('calculateDynamicThreshold', () => {
+    it('returns the number as-is for simple thresholds', () => {
+      expect(calculateDynamicThreshold(30000, 10000)).toBe(30000);
+      expect(calculateDynamicThreshold(30000, 0)).toBe(30000);
+    });
+
+    it('expands into unused observation space for range thresholds', () => {
+      // 30k:40k → total budget 70k
+      // 0 observations → can use full 70k
+      expect(calculateDynamicThreshold({ min: 30000, max: 70000 }, 0)).toBe(70000);
+    });
+
+    it('shrinks as observations grow', () => {
+      // 10k observations → 70k - 10k = 60k
+      expect(calculateDynamicThreshold({ min: 30000, max: 70000 }, 10000)).toBe(60000);
+    });
+
+    it('never goes below the base threshold (min)', () => {
+      // 50k observations → 70k - 50k = 20k, but min is 30k
+      expect(calculateDynamicThreshold({ min: 30000, max: 70000 }, 50000)).toBe(30000);
+    });
+
+    it('returns min when observations exceed the total budget', () => {
+      expect(calculateDynamicThreshold({ min: 30000, max: 70000 }, 100000)).toBe(30000);
+    });
+
+    it('rounds the result', () => {
+      // 33333 observations → 70000 - 33333 = 36667
+      expect(calculateDynamicThreshold({ min: 30000, max: 70000 }, 33333)).toBe(36667);
+    });
+  });
+
+  describe('resolveBufferTokens', () => {
+    it('returns undefined for false', () => {
+      expect(resolveBufferTokens(false, 30000)).toBeUndefined();
+    });
+
+    it('returns undefined for undefined', () => {
+      expect(resolveBufferTokens(undefined, 30000)).toBeUndefined();
+    });
+
+    it('converts fractional values to absolute using simple threshold', () => {
+      // 0.25 * 20000 = 5000
+      expect(resolveBufferTokens(0.25, 20000)).toBe(5000);
+    });
+
+    it('converts fractional values using range threshold max', () => {
+      // 0.1 * 70000 = 7000
+      expect(resolveBufferTokens(0.1, { min: 30000, max: 70000 })).toBe(7000);
+    });
+
+    it('returns absolute values as-is', () => {
+      expect(resolveBufferTokens(5000, 30000)).toBe(5000);
+    });
+
+    it('returns 1 as-is (not fractional — boundary)', () => {
+      // 1 is not in (0, 1) so it's treated as absolute
+      expect(resolveBufferTokens(1, 30000)).toBe(1);
+    });
+
+    it('handles very small fractions', () => {
+      expect(resolveBufferTokens(0.01, 100000)).toBe(1000);
+    });
+  });
+
+  describe('resolveBlockAfter', () => {
+    it('returns undefined for undefined', () => {
+      expect(resolveBlockAfter(undefined, 30000)).toBeUndefined();
+    });
+
+    it('converts multipliers to absolute values', () => {
+      // 1.5 * 20000 = 30000
+      expect(resolveBlockAfter(1.5, 20000)).toBe(30000);
+    });
+
+    it('treats 1.0 as a multiplier (exactly at threshold)', () => {
+      expect(resolveBlockAfter(1.0, 20000)).toBe(20000);
+    });
+
+    it('uses range max for multiplier resolution', () => {
+      // 1.2 * 70000 = 84000
+      expect(resolveBlockAfter(1.2, { min: 30000, max: 70000 })).toBe(84000);
+    });
+
+    it('treats values >= 100 as absolute token counts', () => {
+      expect(resolveBlockAfter(50000, 20000)).toBe(50000);
+      expect(resolveBlockAfter(100, 20000)).toBe(100); // 100 is >= 100, so absolute
+    });
+
+    it('rounds the result', () => {
+      // 1.3 * 33333 = 43332.9
+      expect(resolveBlockAfter(1.3, 33333)).toBe(43333);
+    });
+  });
+
+  describe('resolveRetentionFloor', () => {
+    it('uses ratio when bufferActivation < 1000', () => {
+      // 0.7 ratio → retentionFloor = 30000 * (1 - 0.7) = 9000
+      expect(resolveRetentionFloor(0.7, 30000)).toBeCloseTo(9000, 0);
+    });
+
+    it('returns absolute value when bufferActivation >= 1000', () => {
+      expect(resolveRetentionFloor(5000, 30000)).toBe(5000);
+      expect(resolveRetentionFloor(1000, 30000)).toBe(1000);
+    });
+
+    it('ratio of 1.0 means zero retention', () => {
+      expect(resolveRetentionFloor(1.0, 30000)).toBe(0);
+    });
+
+    it('ratio of 0.0 means full retention', () => {
+      expect(resolveRetentionFloor(0.0, 30000)).toBe(30000);
+    });
+  });
+
+  describe('resolveActivationRatio', () => {
+    it('returns ratio as-is when < 1000', () => {
+      expect(resolveActivationRatio(0.7, 30000)).toBe(0.7);
+    });
+
+    it('converts absolute to equivalent ratio when >= 1000', () => {
+      // 5000 absolute, 30000 threshold → 1 - (5000 / 30000) ≈ 0.833
+      const result = resolveActivationRatio(5000, 30000);
+      expect(result).toBeCloseTo(0.8333, 3);
+    });
+
+    it('clamps to [0, 1]', () => {
+      // bufferActivation > threshold → ratio would be negative, clamped to 0
+      expect(resolveActivationRatio(50000, 30000)).toBe(0);
+      // bufferActivation = 0 (>= 1000 is false) — handled by ratio path
+    });
+
+    it('exact match returns 0', () => {
+      // 30000 / 30000 = 1, 1 - 1 = 0
+      expect(resolveActivationRatio(30000, 30000)).toBe(0);
+    });
+  });
+
+  describe('calculateProjectedMessageRemoval', () => {
+    it('returns 0 for empty chunks', () => {
+      expect(calculateProjectedMessageRemoval([], 0.7, 30000, 25000)).toBe(0);
+    });
+
+    it('selects the best over-boundary when within safeguards', () => {
+      const chunks = [makeChunk(5000), makeChunk(5000), makeChunk(5000)];
+      // bufferActivation 0.7, threshold 30000 → retentionFloor = 9000
+      // pendingTokens 25000 → target = 25000 - 9000 = 16000
+      // Chunk boundaries: 5000, 10000, 15000
+      // All under target, so best under = 15000
+      const result = calculateProjectedMessageRemoval(chunks, 0.7, 30000, 25000);
+      expect(result).toBe(15000);
+    });
+
+    it('prefers over-boundary when close to target', () => {
+      const chunks = [makeChunk(8000), makeChunk(9000)];
+      // bufferActivation 0.7, threshold 30000 → retentionFloor = 9000
+      // pendingTokens 25000 → target = 16000
+      // Boundaries: 8000 (under), 17000 (over)
+      // overshoot = 17000 - 16000 = 1000, maxOvershoot = 9000 * 0.95 = 8550
+      // remaining = 25000 - 17000 = 8000 >= min(1000, 9000) = 1000
+      const result = calculateProjectedMessageRemoval(chunks, 0.7, 30000, 25000);
+      expect(result).toBe(17000);
+    });
+
+    it('falls back to under-boundary when over would overshoot too much', () => {
+      const chunks = [makeChunk(3000), makeChunk(25000)];
+      // bufferActivation 0.7, threshold 30000 → retentionFloor = 9000
+      // pendingTokens 25000 → target = 16000
+      // Boundaries: 3000 (under), 28000 (over)
+      // overshoot = 28000 - 16000 = 12000 > maxOvershoot = 8550
+      // Falls back to under-boundary = 3000 (remaining = 22000 >= 1000)
+      const result = calculateProjectedMessageRemoval(chunks, 0.7, 30000, 25000);
+      expect(result).toBe(3000);
+    });
+
+    it('returns first chunk for single chunk', () => {
+      const chunks = [makeChunk(10000)];
+      // retentionFloor = 30000 * (1 - 0.7) = 9000
+      // target = 25000 - 9000 = 16000
+      // Only boundary at 10000, under target
+      const result = calculateProjectedMessageRemoval(chunks, 0.7, 30000, 25000);
+      expect(result).toBe(10000);
+    });
+
+    it('handles activation ratio of 1.0 (remove everything)', () => {
+      const chunks = [makeChunk(5000), makeChunk(5000)];
+      // retentionFloor = 30000 * (1 - 1.0) = 0
+      // target = 10000 - 0 = 10000
+      // Boundary at 10000 exactly matches target
+      const result = calculateProjectedMessageRemoval(chunks, 1.0, 30000, 10000);
+      expect(result).toBe(10000);
+    });
+
+    it('handles absolute retention floor (>= 1000)', () => {
+      const chunks = [makeChunk(4000), makeChunk(4000), makeChunk(4000)];
+      // bufferActivation = 5000 (absolute), retentionFloor = 5000
+      // pendingTokens 15000 → target = 15000 - 5000 = 10000
+      // Boundaries: 4000 (under), 8000 (under), 12000 (over)
+      // overshoot = 12000 - 10000 = 2000, maxOvershoot = 4750
+      // remaining = 15000 - 12000 = 3000 >= min(1000, 5000) = 1000
+      const result = calculateProjectedMessageRemoval(chunks, 5000, 30000, 15000);
+      expect(result).toBe(12000);
+    });
+  });
+});

--- a/packages/memory/src/processors/observational-memory/message-parts.ts
+++ b/packages/memory/src/processors/observational-memory/message-parts.ts
@@ -1,0 +1,245 @@
+import type { MastraDBMessage } from '@mastra/core/agent';
+import type { BufferedObservationChunk, ObservationalMemoryRecord } from '@mastra/core/storage';
+
+/**
+ * Parse buffered observation chunks from a record, handling both array and
+ * stringified JSON forms.
+ */
+export function getBufferedChunks(record: ObservationalMemoryRecord | null | undefined): BufferedObservationChunk[] {
+  if (!record?.bufferedObservationChunks) return [];
+  if (Array.isArray(record.bufferedObservationChunks)) return record.bufferedObservationChunks;
+  if (typeof record.bufferedObservationChunks === 'string') {
+    try {
+      const parsed = JSON.parse(record.bufferedObservationChunks);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+/**
+ * Find the last completed observation boundary in a message's parts.
+ * A completed observation is a start marker followed by an end marker.
+ *
+ * Returns the index of the END marker (which is the observation boundary),
+ * or -1 if no completed observation is found.
+ */
+export function findLastCompletedObservationBoundary(message: MastraDBMessage): number {
+  const parts = message.content?.parts;
+  if (!parts || !Array.isArray(parts)) return -1;
+
+  // Search from the end to find the most recent end marker
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const part = parts[i] as { type?: string };
+    if (part?.type === 'data-om-observation-end') {
+      // Found an end marker - this is the observation boundary
+      return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Check if a message has an in-progress observation (start without end).
+ */
+export function hasInProgressObservation(message: MastraDBMessage): boolean {
+  const parts = message.content?.parts;
+  if (!parts || !Array.isArray(parts)) return false;
+
+  let lastStartIndex = -1;
+  let lastEndOrFailedIndex = -1;
+
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const part = parts[i] as { type?: string };
+    if (part?.type === 'data-om-observation-start' && lastStartIndex === -1) {
+      lastStartIndex = i;
+    }
+    if (
+      (part?.type === 'data-om-observation-end' || part?.type === 'data-om-observation-failed') &&
+      lastEndOrFailedIndex === -1
+    ) {
+      lastEndOrFailedIndex = i;
+    }
+  }
+
+  // In progress if we have a start that comes after any end/failed
+  return lastStartIndex !== -1 && lastStartIndex > lastEndOrFailedIndex;
+}
+
+/**
+ * Seal messages to prevent new parts from being merged into them.
+ * This is used when starting buffering to capture the current content state.
+ *
+ * Sealing works by:
+ * 1. Setting `message.content.metadata.mastra.sealed = true` (message-level flag)
+ * 2. Adding `metadata.mastra.sealedAt` to the last part (boundary marker)
+ *
+ * When MessageList.add() receives a message with the same ID as a sealed message,
+ * it creates a new message with only the parts beyond the seal boundary.
+ *
+ * The messages are mutated in place - since they're references to the same objects
+ * in the MessageList, the seal will be recognized immediately.
+ *
+ * @param messages - Messages to seal (mutated in place)
+ */
+export function sealMessagesForBuffering(messages: MastraDBMessage[]): void {
+  const sealedAt = Date.now();
+
+  for (const msg of messages) {
+    if (!msg.content?.parts?.length) continue;
+
+    // Set message-level sealed flag
+    if (!msg.content.metadata) {
+      msg.content.metadata = {};
+    }
+    const metadata = msg.content.metadata as { mastra?: { sealed?: boolean } };
+    if (!metadata.mastra) {
+      metadata.mastra = {};
+    }
+    metadata.mastra.sealed = true;
+
+    // Add sealedAt to the last part
+    const lastPart = msg.content.parts[msg.content.parts.length - 1] as {
+      metadata?: { mastra?: { sealedAt?: number } };
+    };
+    if (!lastPart.metadata) {
+      lastPart.metadata = {};
+    }
+    if (!lastPart.metadata.mastra) {
+      lastPart.metadata.mastra = {};
+    }
+    lastPart.metadata.mastra.sealedAt = sealedAt;
+  }
+}
+
+/**
+ * Get unobserved parts from a message.
+ * If the message has a completed observation (start + end), only return parts after the end.
+ * If observation is in progress (start without end), include parts before the start.
+ * Otherwise, return all parts.
+ */
+export function getUnobservedParts(message: MastraDBMessage): MastraDBMessage['content']['parts'] {
+  const parts = message.content?.parts;
+  if (!parts || !Array.isArray(parts)) return [];
+
+  const endMarkerIndex = findLastCompletedObservationBoundary(message);
+  if (endMarkerIndex === -1) {
+    // No completed observation - all parts are unobserved
+    // (This includes the case where observation is in progress)
+    return parts.filter(p => {
+      const part = p as { type?: string };
+      // Exclude start markers that are in progress
+      return part?.type !== 'data-om-observation-start';
+    });
+  }
+
+  // Return only parts after the end marker (excluding start/end/failed markers)
+  return parts.slice(endMarkerIndex + 1).filter(p => {
+    const part = p as { type?: string };
+    return !part?.type?.startsWith('data-om-observation-');
+  });
+}
+
+/**
+ * Check if a message has any unobserved parts.
+ */
+export function hasUnobservedParts(message: MastraDBMessage): boolean {
+  return getUnobservedParts(message).length > 0;
+}
+
+/**
+ * Create a virtual message containing only the unobserved parts.
+ * This is used for token counting and observation.
+ */
+export function createUnobservedMessage(message: MastraDBMessage): MastraDBMessage | null {
+  const unobservedParts = getUnobservedParts(message);
+  if (unobservedParts.length === 0) return null;
+
+  return {
+    ...message,
+    content: {
+      ...message.content,
+      parts: unobservedParts,
+    },
+  };
+}
+
+/**
+ * Get unobserved messages with part-level filtering.
+ *
+ * This method uses data-om-observation-end markers to filter at the part level:
+ * 1. For messages WITH a completed observation: only return parts AFTER the end marker
+ * 2. For messages WITHOUT completed observation: check timestamp against lastObservedAt
+ *
+ * This handles the case where a single message accumulates many parts
+ * (like tool calls) during an agentic loop - we only observe the new parts.
+ */
+export function getUnobservedMessages(
+  allMessages: MastraDBMessage[],
+  record: ObservationalMemoryRecord,
+  opts?: { excludeBuffered?: boolean },
+): MastraDBMessage[] {
+  const lastObservedAt = record.lastObservedAt;
+  // Safeguard: track message IDs that were already observed to prevent re-observation
+  // This handles edge cases like process restarts where lastObservedAt might not capture all messages
+  const observedMessageIds = new Set<string>(Array.isArray(record.observedMessageIds) ? record.observedMessageIds : []);
+
+  // Only exclude buffered chunk message IDs when called from the buffering path.
+  // The main agent context should still see buffered messages until activation.
+  if (opts?.excludeBuffered) {
+    const bufferedChunks = getBufferedChunks(record);
+    for (const chunk of bufferedChunks) {
+      if (Array.isArray(chunk.messageIds)) {
+        for (const id of chunk.messageIds) {
+          observedMessageIds.add(id);
+        }
+      }
+    }
+  }
+
+  if (!lastObservedAt && observedMessageIds.size === 0) {
+    // No observations yet - all messages are unobserved
+    return allMessages;
+  }
+
+  const result: MastraDBMessage[] = [];
+
+  for (const msg of allMessages) {
+    // First check: skip if this message ID was already observed (safeguard against re-observation)
+    if (observedMessageIds?.has(msg.id)) {
+      continue;
+    }
+
+    // Check if this message has a completed observation
+    const endMarkerIndex = findLastCompletedObservationBoundary(msg);
+    const inProgress = hasInProgressObservation(msg);
+
+    if (inProgress) {
+      // Include the full message for in-progress observations
+      // The Observer is currently working on this
+      result.push(msg);
+    } else if (endMarkerIndex !== -1) {
+      // Message has a completed observation - only include parts after it
+      const virtualMsg = createUnobservedMessage(msg);
+      if (virtualMsg) {
+        result.push(virtualMsg);
+      }
+    } else {
+      // No observation markers - fall back to timestamp-based filtering
+      if (!msg.createdAt || !lastObservedAt) {
+        // Messages without timestamps are always included
+        // Also include messages when there's no lastObservedAt timestamp
+        result.push(msg);
+      } else {
+        const msgDate = new Date(msg.createdAt);
+        if (msgDate > lastObservedAt) {
+          result.push(msg);
+        }
+      }
+    }
+  }
+
+  return result;
+}

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -13,7 +13,7 @@ import type {
 } from '@mastra/core/processors';
 import { MessageHistory } from '@mastra/core/processors';
 import type { RequestContext } from '@mastra/core/request-context';
-import type { MemoryStorage, ObservationalMemoryRecord, BufferedObservationChunk } from '@mastra/core/storage';
+import type { MemoryStorage, ObservationalMemoryRecord } from '@mastra/core/storage';
 import xxhash from 'xxhash-wasm';
 
 const OM_DEBUG_LOG = process.env.OM_DEBUG ? join(process.cwd(), 'om-debug.log') : null;
@@ -54,6 +54,14 @@ import {
   createObservationFailedMarker,
   createObservationStartMarker,
 } from './markers';
+import {
+  findLastCompletedObservationBoundary,
+  getBufferedChunks,
+  getUnobservedMessages,
+  getUnobservedParts,
+  hasUnobservedParts,
+  sealMessagesForBuffering,
+} from './message-parts';
 import {
   buildObserverSystemPrompt,
   buildObserverPrompt,
@@ -537,24 +545,6 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     } catch {
       // Timeout or error - continue silently
     }
-  }
-
-  /**
-   * Safely get bufferedObservationChunks as an array.
-   * Handles cases where it might be a JSON string or undefined.
-   */
-  private getBufferedChunks(record: ObservationalMemoryRecord | null | undefined): BufferedObservationChunk[] {
-    if (!record?.bufferedObservationChunks) return [];
-    if (Array.isArray(record.bufferedObservationChunks)) return record.bufferedObservationChunks;
-    if (typeof record.bufferedObservationChunks === 'string') {
-      try {
-        const parsed = JSON.parse(record.bufferedObservationChunks);
-        return Array.isArray(parsed) ? parsed : [];
-      } catch {
-        return [];
-      }
-    }
-    return [];
   }
 
   /**
@@ -1293,250 +1283,6 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
   }
 
   /**
-   * Find the last completed observation boundary in a message's parts.
-   * A completed observation is a start marker followed by an end marker.
-   *
-   * Returns the index of the END marker (which is the observation boundary),
-   * or -1 if no completed observation is found.
-   */
-  private findLastCompletedObservationBoundary(message: MastraDBMessage): number {
-    const parts = message.content?.parts;
-    if (!parts || !Array.isArray(parts)) return -1;
-
-    // Search from the end to find the most recent end marker
-    for (let i = parts.length - 1; i >= 0; i--) {
-      const part = parts[i] as { type?: string };
-      if (part?.type === 'data-om-observation-end') {
-        // Found an end marker - this is the observation boundary
-        return i;
-      }
-    }
-    return -1;
-  }
-
-  /**
-   * Check if a message has an in-progress observation (start without end).
-   */
-  private hasInProgressObservation(message: MastraDBMessage): boolean {
-    const parts = message.content?.parts;
-    if (!parts || !Array.isArray(parts)) return false;
-
-    let lastStartIndex = -1;
-    let lastEndOrFailedIndex = -1;
-
-    for (let i = parts.length - 1; i >= 0; i--) {
-      const part = parts[i] as { type?: string };
-      if (part?.type === 'data-om-observation-start' && lastStartIndex === -1) {
-        lastStartIndex = i;
-      }
-      if (
-        (part?.type === 'data-om-observation-end' || part?.type === 'data-om-observation-failed') &&
-        lastEndOrFailedIndex === -1
-      ) {
-        lastEndOrFailedIndex = i;
-      }
-    }
-
-    // In progress if we have a start that comes after any end/failed
-    return lastStartIndex !== -1 && lastStartIndex > lastEndOrFailedIndex;
-  }
-
-  /**
-   * Seal messages to prevent new parts from being merged into them.
-   * This is used when starting buffering to capture the current content state.
-   *
-   * Sealing works by:
-   * 1. Setting `message.content.metadata.mastra.sealed = true` (message-level flag)
-   * 2. Adding `metadata.mastra.sealedAt` to the last part (boundary marker)
-   *
-   * When MessageList.add() receives a message with the same ID as a sealed message,
-   * it creates a new message with only the parts beyond the seal boundary.
-   *
-   * The messages are mutated in place - since they're references to the same objects
-   * in the MessageList, the seal will be recognized immediately.
-   *
-   * @param messages - Messages to seal (mutated in place)
-   */
-  private sealMessagesForBuffering(messages: MastraDBMessage[]): void {
-    const sealedAt = Date.now();
-
-    for (const msg of messages) {
-      if (!msg.content?.parts?.length) continue;
-
-      // Set message-level sealed flag
-      if (!msg.content.metadata) {
-        msg.content.metadata = {};
-      }
-      const metadata = msg.content.metadata as { mastra?: { sealed?: boolean } };
-      if (!metadata.mastra) {
-        metadata.mastra = {};
-      }
-      metadata.mastra.sealed = true;
-
-      // Add sealedAt to the last part
-      const lastPart = msg.content.parts[msg.content.parts.length - 1] as {
-        metadata?: { mastra?: { sealedAt?: number } };
-      };
-      if (!lastPart.metadata) {
-        lastPart.metadata = {};
-      }
-      if (!lastPart.metadata.mastra) {
-        lastPart.metadata.mastra = {};
-      }
-      lastPart.metadata.mastra.sealedAt = sealedAt;
-    }
-  }
-
-  /**
-   * Insert an observation marker into a message.
-   * The marker is appended directly to the message's parts array (mutating in place).
-   * Also persists the change to storage so markers survive page refresh.
-   *
-   * For end/failed markers, the message is also "sealed" to prevent future content
-   * from being merged into it. This ensures observation markers are preserved.
-   */
-  /**
-   * Insert an observation marker into a message.
-   * For start markers, this pushes the part directly.
-   * For end/failed markers, this should be called AFTER writer.custom() has added the part,
-   * so we just find the part and add sealing metadata.
-   */
-
-  /**
-   * Get unobserved parts from a message.
-   * If the message has a completed observation (start + end), only return parts after the end.
-   * If observation is in progress (start without end), include parts before the start.
-   * Otherwise, return all parts.
-   */
-  private getUnobservedParts(message: MastraDBMessage): MastraDBMessage['content']['parts'] {
-    const parts = message.content?.parts;
-    if (!parts || !Array.isArray(parts)) return [];
-
-    const endMarkerIndex = this.findLastCompletedObservationBoundary(message);
-    if (endMarkerIndex === -1) {
-      // No completed observation - all parts are unobserved
-      // (This includes the case where observation is in progress)
-      return parts.filter(p => {
-        const part = p as { type?: string };
-        // Exclude start markers that are in progress
-        return part?.type !== 'data-om-observation-start';
-      });
-    }
-
-    // Return only parts after the end marker (excluding start/end/failed markers)
-    return parts.slice(endMarkerIndex + 1).filter(p => {
-      const part = p as { type?: string };
-      return !part?.type?.startsWith('data-om-observation-');
-    });
-  }
-
-  /**
-   * Check if a message has any unobserved parts.
-   */
-  private hasUnobservedParts(message: MastraDBMessage): boolean {
-    return this.getUnobservedParts(message).length > 0;
-  }
-
-  /**
-   * Create a virtual message containing only the unobserved parts.
-   * This is used for token counting and observation.
-   */
-  private createUnobservedMessage(message: MastraDBMessage): MastraDBMessage | null {
-    const unobservedParts = this.getUnobservedParts(message);
-    if (unobservedParts.length === 0) return null;
-
-    return {
-      ...message,
-      content: {
-        ...message.content,
-        parts: unobservedParts,
-      },
-    };
-  }
-
-  /**
-   * Get unobserved messages with part-level filtering.
-   *
-   * This method uses data-om-observation-end markers to filter at the part level:
-   * 1. For messages WITH a completed observation: only return parts AFTER the end marker
-   * 2. For messages WITHOUT completed observation: check timestamp against lastObservedAt
-   *
-   * This handles the case where a single message accumulates many parts
-   * (like tool calls) during an agentic loop - we only observe the new parts.
-   */
-  private getUnobservedMessages(
-    allMessages: MastraDBMessage[],
-    record: ObservationalMemoryRecord,
-    opts?: { excludeBuffered?: boolean },
-  ): MastraDBMessage[] {
-    const lastObservedAt = record.lastObservedAt;
-    // Safeguard: track message IDs that were already observed to prevent re-observation
-    // This handles edge cases like process restarts where lastObservedAt might not capture all messages
-    const observedMessageIds = new Set<string>(
-      Array.isArray(record.observedMessageIds) ? record.observedMessageIds : [],
-    );
-
-    // Only exclude buffered chunk message IDs when called from the buffering path.
-    // The main agent context should still see buffered messages until activation.
-    if (opts?.excludeBuffered) {
-      const bufferedChunks = this.getBufferedChunks(record);
-      for (const chunk of bufferedChunks) {
-        if (Array.isArray(chunk.messageIds)) {
-          for (const id of chunk.messageIds) {
-            observedMessageIds.add(id);
-          }
-        }
-      }
-    }
-
-    if (!lastObservedAt && observedMessageIds.size === 0) {
-      // No observations yet - all messages are unobserved
-      return allMessages;
-    }
-
-    const result: MastraDBMessage[] = [];
-
-    for (const msg of allMessages) {
-      // First check: skip if this message ID was already observed (safeguard against re-observation)
-      if (observedMessageIds?.has(msg.id)) {
-        continue;
-      }
-
-      // Check if this message has a completed observation
-      const endMarkerIndex = this.findLastCompletedObservationBoundary(msg);
-      const inProgress = this.hasInProgressObservation(msg);
-
-      if (inProgress) {
-        // Include the full message for in-progress observations
-        // The Observer is currently working on this
-        result.push(msg);
-      } else if (endMarkerIndex !== -1) {
-        // Message has a completed observation - only include parts after it
-        const virtualMsg = this.createUnobservedMessage(msg);
-        if (virtualMsg) {
-          result.push(virtualMsg);
-        } else {
-        }
-      } else {
-        // No observation markers - fall back to timestamp-based filtering
-        if (!msg.createdAt || !lastObservedAt) {
-          // Messages without timestamps are always included
-          // Also include messages when there's no lastObservedAt timestamp
-          result.push(msg);
-        } else {
-          const msgDate = new Date(msg.createdAt);
-          if (msgDate > lastObservedAt) {
-            result.push(msg);
-          } else {
-          }
-        }
-      }
-    }
-
-    return result;
-  }
-
-  /**
    * Wrapper for observer/reflector agent.generate() calls that checks for abort.
    * agent.generate() returns an empty result on abort instead of throwing,
    * so we must check the signal before and after the call.
@@ -2038,7 +1784,7 @@ ${suggestedResponse}
 
       for (const msg of currentThreadMessages) {
         if (msg.role !== 'system') {
-          if (!this.hasUnobservedParts(msg) && this.findLastCompletedObservationBoundary(msg) !== -1) {
+          if (!hasUnobservedParts(msg) && findLastCompletedObservationBoundary(msg) !== -1) {
             continue;
           }
           messageList.add(msg, 'memory');
@@ -2051,7 +1797,7 @@ ${suggestedResponse}
       if (historicalMessages.length > 0) {
         for (const msg of historicalMessages) {
           if (msg.role !== 'system') {
-            if (!this.hasUnobservedParts(msg) && this.findLastCompletedObservationBoundary(msg) !== -1) {
+            if (!hasUnobservedParts(msg) && findLastCompletedObservationBoundary(msg) !== -1) {
               continue;
             }
             messageList.add(msg, 'memory');
@@ -2138,7 +1884,7 @@ ${suggestedResponse}
 
     if (writer) {
       // Calculate buffered chunk totals for UI
-      const bufferedChunks = this.getBufferedChunks(record);
+      const bufferedChunks = getBufferedChunks(record);
       const bufferedObservationTokens = bufferedChunks.reduce((sum, chunk) => sum + (chunk.tokenCount ?? 0), 0);
 
       // chunk.messageTokens represents the token count of raw messages that will be
@@ -2244,7 +1990,7 @@ ${suggestedResponse}
     await this.withLock(lockKey, async () => {
       let freshRecord = await this.getOrCreateRecord(threadId, resourceId);
       const freshAllMessages = messageList.get.all.db();
-      let freshUnobservedMessages = this.getUnobservedMessages(freshAllMessages, freshRecord);
+      let freshUnobservedMessages = getUnobservedMessages(freshAllMessages, freshRecord);
 
       // Re-check threshold inside the lock using only unobserved messages.
       // Already-observed messages may still be in the messageList but shouldn't
@@ -2294,7 +2040,7 @@ ${suggestedResponse}
 
         // Re-fetch record after waiting for async op
         const recordAfterWait = await this.getOrCreateRecord(threadId, resourceId);
-        const chunksAfterWait = this.getBufferedChunks(recordAfterWait);
+        const chunksAfterWait = getBufferedChunks(recordAfterWait);
         omDebug(
           `[OM:threshold] tryActivation: chunksAvailable=${chunksAfterWait.length}, isBufferingObs=${recordAfterWait.isBufferingObservation}`,
         );
@@ -2360,7 +2106,7 @@ ${suggestedResponse}
           // Re-fetch unobserved messages since activation may have changed things.
           freshRecord = await this.getOrCreateRecord(threadId, resourceId);
           const refreshedAll = messageList.get.all.db();
-          freshUnobservedMessages = this.getUnobservedMessages(refreshedAll, freshRecord);
+          freshUnobservedMessages = getUnobservedMessages(refreshedAll, freshRecord);
         } else {
           omDebug(`[OM:threshold] activation failed, no blockAfter or below it — letting async buffering catch up`);
           // Below blockAfter (or no blockAfter set) — let async buffering catch up.
@@ -2431,7 +2177,7 @@ ${suggestedResponse}
     for (let i = allMsgs.length - 1; i >= 0; i--) {
       const msg = allMsgs[i];
       if (!msg) continue;
-      if (this.findLastCompletedObservationBoundary(msg) !== -1) {
+      if (findLastCompletedObservationBoundary(msg) !== -1) {
         markerIdx = i;
         markerMsg = msg;
         break;
@@ -2459,7 +2205,7 @@ ${suggestedResponse}
       messagesToSave.push(markerMsg);
 
       // Filter marker message to only unobserved parts
-      const unobservedParts = this.getUnobservedParts(markerMsg);
+      const unobservedParts = getUnobservedParts(markerMsg);
       if (unobservedParts.length === 0) {
         // Marker message is fully observed — remove it too
         if (markerMsg.id) {
@@ -2638,7 +2384,7 @@ ${suggestedResponse}
     for (let i = allMessages.length - 1; i >= 0; i--) {
       const msg = allMessages[i];
       if (!msg) continue;
-      if (this.findLastCompletedObservationBoundary(msg) !== -1) {
+      if (findLastCompletedObservationBoundary(msg) !== -1) {
         markerMessageIndex = i;
         markerMessage = msg;
         break;
@@ -2659,7 +2405,7 @@ ${suggestedResponse}
       }
 
       // Filter marker message to only unobserved parts
-      const unobservedParts = this.getUnobservedParts(markerMessage);
+      const unobservedParts = getUnobservedParts(markerMessage);
       if (unobservedParts.length === 0) {
         if (markerMessage.id) {
           messageList.removeByIds([markerMessage.id]);
@@ -2762,7 +2508,7 @@ ${suggestedResponse}
     // ════════════════════════════════════════════════════════════════════════
     if (stepNumber === 0 && !readOnly && this.isAsyncObservationEnabled()) {
       const lockKey = this.getLockKey(threadId, resourceId);
-      const bufferedChunks = this.getBufferedChunks(record);
+      const bufferedChunks = getBufferedChunks(record);
       omDebug(
         `[OM:step0-activation] asyncObsEnabled=true, bufferedChunks=${bufferedChunks.length}, isBufferingObs=${record.isBufferingObservation}`,
       );
@@ -2788,7 +2534,7 @@ ${suggestedResponse}
       if (bufferedChunks.length > 0) {
         // Compute threshold to check if activation is warranted
         const allMsgsForCheck = messageList.get.all.db();
-        const unobservedMsgsForCheck = this.getUnobservedMessages(allMsgsForCheck, record);
+        const unobservedMsgsForCheck = getUnobservedMessages(allMsgsForCheck, record);
         const otherThreadTokensForCheck = unobservedContextBlocks
           ? this.tokenCounter.countString(unobservedContextBlocks)
           : 0;
@@ -2924,7 +2670,7 @@ ${suggestedResponse}
     // ════════════════════════════════════════════════════════════════════════
     if (!readOnly) {
       const allMessages = messageList.get.all.db();
-      const unobservedMessages = this.getUnobservedMessages(allMessages, record);
+      const unobservedMessages = getUnobservedMessages(allMessages, record);
       const otherThreadTokens = unobservedContextBlocks ? this.tokenCounter.countString(unobservedContextBlocks) : 0;
       const currentObservationTokens = record.observationTokenCount ?? 0;
 
@@ -2943,7 +2689,7 @@ ${suggestedResponse}
       // sent to the observer — counting them would cause redundant buffering ops, especially
       // after activation resets lastBufferedBoundary to 0.
       // IMPORTANT: Use messageTokens (message tokens being removed), NOT tokenCount (observation tokens).
-      const bufferedChunkTokens = this.getBufferedChunks(record).reduce((sum, c) => sum + (c.messageTokens ?? 0), 0);
+      const bufferedChunkTokens = getBufferedChunks(record).reduce((sum, c) => sum + (c.messageTokens ?? 0), 0);
       const unbufferedPendingTokens = Math.max(0, totalPendingTokens - bufferedChunkTokens);
 
       // Merge per-state sealedIds with static sealedMessageIds (survives across OM instances)
@@ -3213,7 +2959,7 @@ ${suggestedResponse}
     const filteredMessages: MastraDBMessage[] = [];
     for (const msg of messagesToSave) {
       if (sealedIds.has(msg.id)) {
-        if (this.findLastCompletedObservationBoundary(msg) !== -1) {
+        if (findLastCompletedObservationBoundary(msg) !== -1) {
           filteredMessages.push(msg);
         }
         // else: sealed for buffering only, already persisted — skip to avoid duplication
@@ -3233,7 +2979,7 @@ ${suggestedResponse}
     // After successful save, track IDs of messages that now have observation markers (sealed)
     // These IDs cannot be reused in future cycles
     for (const msg of filteredMessages) {
-      if (this.findLastCompletedObservationBoundary(msg) !== -1) {
+      if (findLastCompletedObservationBoundary(msg) !== -1) {
         sealedIds.add(msg.id);
       }
     }
@@ -3595,7 +3341,7 @@ ${formattedMessages}
       if (bufferActivation && bufferActivation < 1 && unobservedMessages.length >= 1) {
         const newestMsg = unobservedMessages[unobservedMessages.length - 1];
         if (newestMsg?.content?.parts?.length) {
-          this.sealMessagesForBuffering([newestMsg]);
+          sealMessagesForBuffering([newestMsg]);
           omDebug(
             `[OM:sync-obs] sealed newest message (${newestMsg.role}, ${newestMsg.content.parts.length} parts) for ratio-aware observation`,
           );
@@ -3853,7 +3599,7 @@ ${formattedMessages}
     // Filter messages to only those newer than the buffer cursor.
     // This prevents re-buffering messages that were already included in a previous chunk,
     // even if their IDs were mutated by saveMessagesWithSealedIdTracking.
-    let candidateMessages = this.getUnobservedMessages(unobservedMessages, freshRecord, {
+    let candidateMessages = getUnobservedMessages(unobservedMessages, freshRecord, {
       excludeBuffered: true,
     });
     const preFilterCount = candidateMessages.length;
@@ -3882,7 +3628,7 @@ ${formattedMessages}
     // Seal the messages being buffered to prevent new parts from being added.
     // This ensures that any streaming content after this point goes to new messages,
     // preserving the boundary of what we're buffering.
-    this.sealMessagesForBuffering(messagesToBuffer);
+    sealMessagesForBuffering(messagesToBuffer);
 
     // CRITICAL: Persist the sealed messages to storage immediately.
     // This ensures that:
@@ -3983,7 +3729,7 @@ ${formattedMessages}
     requestContext?: RequestContext,
   ): Promise<void> {
     // Build combined context for the observer: active + buffered chunk observations
-    const bufferedChunks = this.getBufferedChunks(record);
+    const bufferedChunks = getBufferedChunks(record);
     const bufferedChunksText = bufferedChunks.map(c => c.observations).join('\n\n');
     const combinedObservations = this.combineObservationsForBuffering(record.activeObservations, bufferedChunksText);
 
@@ -4044,7 +3790,7 @@ ${formattedMessages}
       const tokensBuffered = this.tokenCounter.countMessages(messagesToBuffer);
       // Re-fetch record to get total buffered tokens after storage update
       const updatedRecord = await this.storage.getObservationalMemory(record.threadId, record.resourceId);
-      const updatedChunks = this.getBufferedChunks(updatedRecord);
+      const updatedChunks = getBufferedChunks(updatedRecord);
       const totalBufferedTokens = updatedChunks.reduce((sum, c) => sum + (c.tokenCount ?? 0), 0) || newTokenCount;
       const endMarker = createBufferingEndMarker({
         cycleId,
@@ -4106,7 +3852,7 @@ ${formattedMessages}
     currentTask?: string;
   }> {
     // Check if there's buffered content to activate
-    const chunks = this.getBufferedChunks(record);
+    const chunks = getBufferedChunks(record);
     omDebug(`[OM:tryActivate] chunks=${chunks.length}, recordId=${record.id}`);
     if (!chunks.length) {
       omDebug(`[OM:tryActivate] no chunks, returning false`);
@@ -4134,7 +3880,7 @@ ${formattedMessages}
     if (!freshRecord) {
       return { success: false };
     }
-    const freshChunks = this.getBufferedChunks(freshRecord);
+    const freshChunks = getBufferedChunks(freshRecord);
     if (!freshChunks.length) {
       return { success: false };
     }
@@ -5351,7 +5097,7 @@ ${formattedMessages}
       } else {
         // Thread scope: use provided messages or load from storage
         const unobservedMessages = messages
-          ? this.getUnobservedMessages(messages, freshRecord)
+          ? getUnobservedMessages(messages, freshRecord)
           : await this.loadUnobservedMessages(
               threadId,
               resourceId,

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -70,6 +70,15 @@ import {
   parseReflectorOutput,
   validateCompression,
 } from './reflector-agent';
+import {
+  calculateDynamicThreshold,
+  calculateProjectedMessageRemoval,
+  getMaxThreshold,
+  resolveActivationRatio,
+  resolveBlockAfter,
+  resolveBufferTokens,
+  resolveRetentionFloor,
+} from './thresholds';
 import { TokenCounter } from './token-counter';
 import type {
   ObservationConfig,
@@ -549,102 +558,6 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
   }
 
   /**
-   * Resolve bufferActivation config into an absolute retention floor (tokens to keep).
-   * - Value in (0, 1]: ratio → retentionFloor = threshold * (1 - value)
-   * - Value >= 1000: absolute token count → retentionFloor = value
-   */
-  private resolveRetentionFloor(bufferActivation: number, messageTokensThreshold: number): number {
-    if (bufferActivation >= 1000) return bufferActivation;
-    return messageTokensThreshold * (1 - bufferActivation);
-  }
-
-  /**
-   * Convert bufferActivation to the equivalent ratio (0-1) for the storage layer.
-   * When bufferActivation >= 1000, it's an absolute retention target, so we compute
-   * the equivalent ratio: 1 - (bufferActivation / threshold).
-   */
-  private resolveActivationRatio(bufferActivation: number, messageTokensThreshold: number): number {
-    if (bufferActivation >= 1000) {
-      return Math.max(0, Math.min(1, 1 - bufferActivation / messageTokensThreshold));
-    }
-    return bufferActivation;
-  }
-
-  /**
-   * Calculate the projected message tokens that would be removed if activation happened now.
-   * This replicates the chunk boundary logic in swapBufferedToActive without actually activating.
-   */
-  private calculateProjectedMessageRemoval(
-    chunks: BufferedObservationChunk[],
-    bufferActivation: number,
-    messageTokensThreshold: number,
-    currentPendingTokens: number,
-  ): number {
-    if (chunks.length === 0) return 0;
-
-    const retentionFloor = this.resolveRetentionFloor(bufferActivation, messageTokensThreshold);
-    const targetMessageTokens = Math.max(0, currentPendingTokens - retentionFloor);
-
-    // Find the closest chunk boundary to the target, biased over (prefer removing
-    // slightly more than the target so remaining context lands at or below retentionFloor).
-    // Track both best-over and best-under boundaries so we can fall back to under
-    // if the over boundary would overshoot by too much.
-    let cumulativeMessageTokens = 0;
-    let bestOverBoundary = 0;
-    let bestOverTokens = 0;
-    let bestUnderBoundary = 0;
-    let bestUnderTokens = 0;
-
-    for (let i = 0; i < chunks.length; i++) {
-      cumulativeMessageTokens += chunks[i]!.messageTokens ?? 0;
-      const boundary = i + 1;
-
-      if (cumulativeMessageTokens >= targetMessageTokens) {
-        // Over or equal — track the closest (lowest) over boundary
-        if (bestOverBoundary === 0 || cumulativeMessageTokens < bestOverTokens) {
-          bestOverBoundary = boundary;
-          bestOverTokens = cumulativeMessageTokens;
-        }
-      } else {
-        // Under — track the closest (highest) under boundary
-        if (cumulativeMessageTokens > bestUnderTokens) {
-          bestUnderBoundary = boundary;
-          bestUnderTokens = cumulativeMessageTokens;
-        }
-      }
-    }
-
-    // Safeguard: if the over boundary would eat into more than 95% of the
-    // retention floor, fall back to the best under boundary instead.
-    // This prevents edge cases where a large chunk overshoots dramatically.
-    // Additionally, never bias over if it would leave fewer than the smaller of
-    // 1000 tokens or the retention floor — at that level the agent may lose
-    // all meaningful context.
-    const maxOvershoot = retentionFloor * 0.95;
-    const overshoot = bestOverTokens - targetMessageTokens;
-    const remainingAfterOver = currentPendingTokens - bestOverTokens;
-    const remainingAfterUnder = currentPendingTokens - bestUnderTokens;
-    // When activationRatio ≈ 1.0, retentionFloor is 0 and minRemaining becomes 0 — intentional for "activate everything" configs.
-    const minRemaining = Math.min(1000, retentionFloor);
-
-    let bestBoundaryMessageTokens: number;
-
-    if (bestOverBoundary > 0 && overshoot <= maxOvershoot && remainingAfterOver >= minRemaining) {
-      bestBoundaryMessageTokens = bestOverTokens;
-    } else if (bestUnderBoundary > 0 && remainingAfterUnder >= minRemaining) {
-      bestBoundaryMessageTokens = bestUnderTokens;
-    } else if (bestOverBoundary > 0) {
-      // All boundaries are over and exceed the safeguard — still activate
-      // the closest over boundary (better than nothing)
-      bestBoundaryMessageTokens = bestOverTokens;
-    } else {
-      return chunks[0]?.messageTokens ?? 0;
-    }
-
-    return bestBoundaryMessageTokens;
-  }
-
-  /**
    * Check if we've crossed a new bufferTokens interval boundary.
    * Returns true if async buffering should be triggered.
    *
@@ -728,7 +641,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     if (record.bufferedReflection) return false;
 
     // Check if we've crossed the activation threshold
-    const reflectThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+    const reflectThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
     const activationPoint = reflectThreshold * this.reflectionConfig.bufferActivation!;
 
     const shouldTrigger = currentObservationTokens >= activationPoint;
@@ -903,7 +816,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
         config.observation?.maxTokensPerBatch ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.maxTokensPerBatch,
       bufferTokens: asyncBufferingDisabled
         ? undefined
-        : this.resolveBufferTokens(
+        : resolveBufferTokens(
             config.observation?.bufferTokens ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.bufferTokens,
             config.observation?.messageTokens ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.messageTokens,
           ),
@@ -912,7 +825,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
         : (config.observation?.bufferActivation ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.bufferActivation),
       blockAfter: asyncBufferingDisabled
         ? undefined
-        : this.resolveBlockAfter(
+        : resolveBlockAfter(
             config.observation?.blockAfter ??
               ((config.observation?.bufferTokens ?? OBSERVATIONAL_MEMORY_DEFAULTS.observation.bufferTokens)
                 ? 1.2
@@ -941,7 +854,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
         : (config?.reflection?.bufferActivation ?? OBSERVATIONAL_MEMORY_DEFAULTS.reflection.bufferActivation),
       blockAfter: asyncBufferingDisabled
         ? undefined
-        : this.resolveBlockAfter(
+        : resolveBlockAfter(
             config.reflection?.blockAfter ??
               ((config.reflection?.bufferActivation ?? OBSERVATIONAL_MEMORY_DEFAULTS.reflection.bufferActivation)
                 ? 1.2
@@ -1091,7 +1004,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     }
 
     // Validate observation bufferTokens
-    const observationThreshold = this.getMaxThreshold(this.observationConfig.messageTokens);
+    const observationThreshold = getMaxThreshold(this.observationConfig.messageTokens);
     if (this.observationConfig.bufferTokens !== undefined) {
       if (this.observationConfig.bufferTokens <= 0) {
         throw new Error(`observation.bufferTokens must be > 0, got ${this.observationConfig.bufferTokens}`);
@@ -1148,7 +1061,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
 
     // Validate reflection blockAfter
     if (this.reflectionConfig.blockAfter !== undefined) {
-      const reflectionThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+      const reflectionThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
       if (this.reflectionConfig.blockAfter < reflectionThreshold) {
         throw new Error(
           `reflection.blockAfter (${this.reflectionConfig.blockAfter}) must be >= reflection.observationTokens (${reflectionThreshold})`,
@@ -1163,87 +1076,6 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
   }
 
   /**
-   * Resolve bufferTokens: if it's a fraction (0 < value < 1), multiply by messageTokens threshold.
-   * Otherwise return the absolute token count.
-   */
-  private resolveBufferTokens(
-    bufferTokens: number | false | undefined,
-    messageTokens: number | ThresholdRange,
-  ): number | undefined {
-    if (bufferTokens === false) return undefined;
-    if (bufferTokens === undefined) return undefined;
-    if (bufferTokens > 0 && bufferTokens < 1) {
-      const threshold = typeof messageTokens === 'number' ? messageTokens : messageTokens.max;
-      return Math.round(threshold * bufferTokens);
-    }
-    return bufferTokens;
-  }
-
-  /**
-   * Resolve blockAfter config value.
-   * Values in [1, 100) are treated as multipliers of the threshold.
-   * e.g. blockAfter: 1.5 with messageTokens: 20_000 → 30_000
-   * Values >= 100 are treated as absolute token counts.
-   * Defaults to 1.2 (120% of threshold) when async buffering is enabled but blockAfter is omitted.
-   */
-  private resolveBlockAfter(
-    blockAfter: number | undefined,
-    messageTokens: number | ThresholdRange,
-  ): number | undefined {
-    if (blockAfter === undefined) return undefined;
-    // Values between 1 (inclusive) and 2 (exclusive) are treated as multipliers of the threshold.
-    // e.g. blockAfter: 1.5 means 1.5x the threshold. blockAfter: 1 means exactly at threshold.
-    // Values >= 100 are treated as absolute token counts.
-    if (blockAfter >= 1 && blockAfter < 100) {
-      const threshold = typeof messageTokens === 'number' ? messageTokens : messageTokens.max;
-      return Math.round(threshold * blockAfter);
-    }
-    return blockAfter;
-  }
-
-  /**
-   * Get the maximum value from a threshold (simple number or range)
-   */
-  private getMaxThreshold(threshold: number | ThresholdRange): number {
-    if (typeof threshold === 'number') {
-      return threshold;
-    }
-    return threshold.max;
-  }
-
-  /**
-   * Calculate dynamic threshold based on observation space.
-   * When shareTokenBudget is enabled, the message threshold can expand
-   * into unused observation space, up to the total context budget.
-   *
-   * Total budget = messageTokens + observationTokens
-   * Effective threshold = totalBudget - currentObservationTokens
-   *
-   * Example with 30k:40k thresholds (70k total):
-   * - 0 observations → messages can use ~70k
-   * - 10k observations → messages can use ~60k
-   * - 40k observations → messages back to ~30k
-   */
-  private calculateDynamicThreshold(threshold: number | ThresholdRange, currentObservationTokens: number): number {
-    // If not using adaptive threshold (simple number), return as-is
-    if (typeof threshold === 'number') {
-      return threshold;
-    }
-
-    // Adaptive threshold: use remaining space in total budget
-    // Total budget is stored as threshold.max (base + reflection threshold)
-    // Base threshold is stored as threshold.min
-    const totalBudget = threshold.max;
-    const baseThreshold = threshold.min;
-
-    // Effective threshold = total budget minus current observations
-    // But never go below the base threshold
-    const effectiveThreshold = Math.max(totalBudget - currentObservationTokens, baseThreshold);
-
-    return Math.round(effectiveThreshold);
-  }
-
-  /**
    * Check whether the unobserved message tokens meet the observation threshold.
    */
   private meetsObservationThreshold(opts: {
@@ -1254,7 +1086,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     const { record, unobservedTokens, extraTokens = 0 } = opts;
     const pendingTokens = (record.pendingMessageTokens ?? 0) + unobservedTokens + extraTokens;
     const currentObservationTokens = record.observationTokenCount ?? 0;
-    const threshold = this.calculateDynamicThreshold(this.observationConfig.messageTokens, currentObservationTokens);
+    const threshold = calculateDynamicThreshold(this.observationConfig.messageTokens, currentObservationTokens);
     return pendingTokens >= threshold;
   }
 
@@ -1346,7 +1178,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
    * Check if we need to trigger reflection.
    */
   private shouldReflect(observationTokens: number): boolean {
-    const threshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+    const threshold = getMaxThreshold(this.reflectionConfig.observationTokens);
     return observationTokens > threshold;
   }
 
@@ -1369,8 +1201,8 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
    */
   private getObservationMarkerConfig(): ObservationMarkerConfig {
     return {
-      messageTokens: this.getMaxThreshold(this.observationConfig.messageTokens),
-      observationTokens: this.getMaxThreshold(this.reflectionConfig.observationTokens),
+      messageTokens: getMaxThreshold(this.observationConfig.messageTokens),
+      observationTokens: getMaxThreshold(this.reflectionConfig.observationTokens),
       scope: this.scope,
     };
   }
@@ -1931,7 +1763,7 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     const originalTokens = this.tokenCounter.countObservations(observations);
 
     // Get the target threshold - use provided value or fall back to config
-    const targetThreshold = observationTokensThreshold ?? this.getMaxThreshold(this.reflectionConfig.observationTokens);
+    const targetThreshold = observationTokensThreshold ?? getMaxThreshold(this.reflectionConfig.observationTokens);
 
     // Track total usage across attempts
     let totalUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
@@ -2254,11 +2086,11 @@ ${suggestedResponse}
     // Total pending = unobserved in-context tokens + other threads
     const totalPendingTokens = Math.max(0, contextWindowTokens + otherThreadTokens);
 
-    const threshold = this.calculateDynamicThreshold(this.observationConfig.messageTokens, currentObservationTokens);
+    const threshold = calculateDynamicThreshold(this.observationConfig.messageTokens, currentObservationTokens);
 
     // Calculate effective reflection threshold for UI display
     // When adaptive threshold is enabled, both thresholds share a budget
-    const baseReflectionThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+    const baseReflectionThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
     const isSharedBudget = typeof this.observationConfig.messageTokens !== 'number';
     const totalBudget = isSharedBudget ? (this.observationConfig.messageTokens as { min: number; max: number }).max : 0;
     const effectiveObservationTokensThreshold = isSharedBudget
@@ -2317,10 +2149,10 @@ ${suggestedResponse}
 
       // Calculate projected message removal based on activation ratio and chunk boundaries
       // This replicates the logic in swapBufferedToActive without actually activating
-      const projectedMessageRemoval = this.calculateProjectedMessageRemoval(
+      const projectedMessageRemoval = calculateProjectedMessageRemoval(
         bufferedChunks,
         this.observationConfig.bufferActivation ?? 1,
-        this.getMaxThreshold(this.observationConfig.messageTokens),
+        getMaxThreshold(this.observationConfig.messageTokens),
         totalPendingTokens,
       );
 
@@ -3202,7 +3034,7 @@ ${suggestedResponse}
               : undefined;
           const minRemaining =
             typeof this.observationConfig.bufferActivation === 'number'
-              ? Math.min(1000, this.resolveRetentionFloor(this.observationConfig.bufferActivation, threshold))
+              ? Math.min(1000, resolveRetentionFloor(this.observationConfig.bufferActivation, threshold))
               : undefined;
           omDebug(
             `[OM:cleanup] observedIds=${observedIds?.length ?? 'undefined'}, ids=${observedIds?.join(',') ?? 'none'}, updatedRecord.observedMessageIds=${JSON.stringify(updatedRecord.observedMessageIds)}, minRemaining=${minRemaining ?? 'n/a'}`,
@@ -3274,8 +3106,8 @@ ${suggestedResponse}
       const otherThreadTokens = unobservedContextBlocks ? this.tokenCounter.countString(unobservedContextBlocks) : 0;
       const currentObservationTokens = freshRecord.observationTokenCount ?? 0;
 
-      const threshold = this.calculateDynamicThreshold(this.observationConfig.messageTokens, currentObservationTokens);
-      const baseReflectionThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+      const threshold = calculateDynamicThreshold(this.observationConfig.messageTokens, currentObservationTokens);
+      const baseReflectionThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
       const isSharedBudget = typeof this.observationConfig.messageTokens !== 'number';
       const totalBudget = isSharedBudget
         ? (this.observationConfig.messageTokens as { min: number; max: number }).max
@@ -4311,7 +4143,7 @@ ${formattedMessages}
     // turn (or an in-flight buffering op that just completed) may have already
     // brought us well below the threshold. Activating unnecessarily invalidates
     // the prompt cache, so we skip if we're already under the threshold.
-    const messageTokensThreshold = this.getMaxThreshold(this.observationConfig.messageTokens);
+    const messageTokensThreshold = getMaxThreshold(this.observationConfig.messageTokens);
     let effectivePendingTokens = currentPendingTokens;
     if (messageList) {
       effectivePendingTokens = this.tokenCounter.countMessages(messageList.get.all.db());
@@ -4325,7 +4157,7 @@ ${formattedMessages}
 
     // Perform partial swap with bufferActivation
     const bufferActivation = this.observationConfig.bufferActivation ?? 0.7;
-    const activationRatio = this.resolveActivationRatio(bufferActivation, messageTokensThreshold);
+    const activationRatio = resolveActivationRatio(bufferActivation, messageTokensThreshold);
 
     // When above blockAfter, prefer the over boundary to reduce context, while still
     // respecting the minimum remaining tokens safeguard.
@@ -4334,8 +4166,8 @@ ${formattedMessages}
     );
 
     const bufferTokens = this.observationConfig.bufferTokens ?? 0;
-    const retentionFloor = this.resolveRetentionFloor(bufferActivation, messageTokensThreshold);
-    const projectedMessageRemoval = this.calculateProjectedMessageRemoval(
+    const retentionFloor = resolveRetentionFloor(bufferActivation, messageTokensThreshold);
+    const projectedMessageRemoval = calculateProjectedMessageRemoval(
       freshChunks,
       bufferActivation,
       messageTokensThreshold,
@@ -4494,7 +4326,7 @@ ${formattedMessages}
     const freshRecord = await this.storage.getObservationalMemory(record.threadId, record.resourceId);
     const currentRecord = freshRecord ?? record;
     const observationTokens = currentRecord.observationTokenCount ?? 0;
-    const reflectThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+    const reflectThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
     const bufferActivation = this.reflectionConfig.bufferActivation ?? 0.5;
     const startedAt = new Date().toISOString();
     const cycleId = `reflect-buf-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
@@ -4822,7 +4654,7 @@ ${formattedMessages}
     // - Accumulate until we hit the threshold
     // - This prevents making many small Observer calls for 1-message threads
     // ════════════════════════════════════════════════════════════
-    const threshold = this.getMaxThreshold(this.observationConfig.messageTokens);
+    const threshold = getMaxThreshold(this.observationConfig.messageTokens);
 
     // Calculate tokens per thread and sort by size (largest first)
     const threadTokenCounts = new Map<string, number>();
@@ -5232,7 +5064,7 @@ ${formattedMessages}
     if (!this.isAsyncReflectionEnabled()) return;
 
     const lockKey = this.getLockKey(record.threadId, record.resourceId);
-    const reflectThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+    const reflectThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
 
     omDebug(
       `[OM:reflect] maybeAsyncReflect: observationTokens=${observationTokens}, reflectThreshold=${reflectThreshold}, isReflecting=${record.isReflecting}, bufferedReflection=${record.bufferedReflection ? 'present (' + record.bufferedReflection.length + ' chars)' : 'empty'}, recordId=${record.id}, genCount=${record.generationCount}`,
@@ -5288,7 +5120,7 @@ ${formattedMessages}
   }): Promise<void> {
     const { record, observationTokens, writer, abortSignal, messageList, reflectionHooks, requestContext } = opts;
     const lockKey = this.getLockKey(record.threadId, record.resourceId);
-    const reflectThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+    const reflectThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
 
     // ════════════════════════════════════════════════════════════════════════
     // ASYNC BUFFERING: Trigger background reflection at bufferActivation ratio
@@ -5583,7 +5415,7 @@ ${formattedMessages}
     registerOp(record.id, 'reflecting');
 
     try {
-      const reflectThreshold = this.getMaxThreshold(this.reflectionConfig.observationTokens);
+      const reflectThreshold = getMaxThreshold(this.reflectionConfig.observationTokens);
       const reflectResult = await this.callReflector(
         record.activeObservations,
         prompt,

--- a/packages/memory/src/processors/observational-memory/thresholds.ts
+++ b/packages/memory/src/processors/observational-memory/thresholds.ts
@@ -1,0 +1,184 @@
+import type { BufferedObservationChunk } from '@mastra/core/storage';
+
+import type { ThresholdRange } from './types';
+
+/**
+ * Get the maximum value from a threshold (simple number or range).
+ */
+export function getMaxThreshold(threshold: number | ThresholdRange): number {
+  if (typeof threshold === 'number') {
+    return threshold;
+  }
+  return threshold.max;
+}
+
+/**
+ * Calculate dynamic threshold based on observation space.
+ * When shareTokenBudget is enabled, the message threshold can expand
+ * into unused observation space, up to the total context budget.
+ *
+ * Total budget = messageTokens + observationTokens
+ * Effective threshold = totalBudget - currentObservationTokens
+ *
+ * Example with 30k:40k thresholds (70k total):
+ * - 0 observations → messages can use ~70k
+ * - 10k observations → messages can use ~60k
+ * - 40k observations → messages back to ~30k
+ */
+export function calculateDynamicThreshold(
+  threshold: number | ThresholdRange,
+  currentObservationTokens: number,
+): number {
+  // If not using adaptive threshold (simple number), return as-is
+  if (typeof threshold === 'number') {
+    return threshold;
+  }
+
+  // Adaptive threshold: use remaining space in total budget
+  // Total budget is stored as threshold.max (base + reflection threshold)
+  // Base threshold is stored as threshold.min
+  const totalBudget = threshold.max;
+  const baseThreshold = threshold.min;
+
+  // Effective threshold = total budget minus current observations
+  // But never go below the base threshold
+  const effectiveThreshold = Math.max(totalBudget - currentObservationTokens, baseThreshold);
+
+  return Math.round(effectiveThreshold);
+}
+
+/**
+ * Resolve bufferTokens config value.
+ * Values in (0, 1) are treated as ratios of the message threshold.
+ * e.g. bufferTokens: 0.25 with messageTokens: 20_000 → 5_000
+ */
+export function resolveBufferTokens(
+  bufferTokens: number | false | undefined,
+  messageTokens: number | ThresholdRange,
+): number | undefined {
+  if (bufferTokens === false) return undefined;
+  if (bufferTokens === undefined) return undefined;
+  if (bufferTokens > 0 && bufferTokens < 1) {
+    const threshold = typeof messageTokens === 'number' ? messageTokens : messageTokens.max;
+    return Math.round(threshold * bufferTokens);
+  }
+  return bufferTokens;
+}
+
+/**
+ * Resolve blockAfter config value.
+ * Values in [1, 100) are treated as multipliers of the threshold.
+ * e.g. blockAfter: 1.5 with messageTokens: 20_000 → 30_000
+ * Values >= 100 are treated as absolute token counts.
+ * Defaults to 1.2 (120% of threshold) when async buffering is enabled but blockAfter is omitted.
+ */
+export function resolveBlockAfter(
+  blockAfter: number | undefined,
+  messageTokens: number | ThresholdRange,
+): number | undefined {
+  if (blockAfter === undefined) return undefined;
+  // Values between 1 (inclusive) and 2 (exclusive) are treated as multipliers of the threshold.
+  // e.g. blockAfter: 1.5 means 1.5x the threshold. blockAfter: 1 means exactly at threshold.
+  // Values >= 100 are treated as absolute token counts.
+  if (blockAfter >= 1 && blockAfter < 100) {
+    const threshold = typeof messageTokens === 'number' ? messageTokens : messageTokens.max;
+    return Math.round(threshold * blockAfter);
+  }
+  return blockAfter;
+}
+
+/**
+ * Convert bufferActivation to an absolute retention floor (tokens to keep after activation).
+ * When bufferActivation >= 1000, it's an absolute retention target.
+ * Otherwise it's a ratio: retentionFloor = threshold * (1 - ratio).
+ */
+export function resolveRetentionFloor(bufferActivation: number, messageTokensThreshold: number): number {
+  if (bufferActivation >= 1000) return bufferActivation;
+  return messageTokensThreshold * (1 - bufferActivation);
+}
+
+/**
+ * Convert bufferActivation to the equivalent ratio (0-1) for the storage layer.
+ * When bufferActivation >= 1000, it's an absolute retention target, so we compute
+ * the equivalent ratio: 1 - (bufferActivation / threshold).
+ */
+export function resolveActivationRatio(bufferActivation: number, messageTokensThreshold: number): number {
+  if (bufferActivation >= 1000) {
+    return Math.max(0, Math.min(1, 1 - bufferActivation / messageTokensThreshold));
+  }
+  return bufferActivation;
+}
+
+/**
+ * Calculate the projected message tokens that would be removed if activation happened now.
+ * This replicates the chunk boundary logic in swapBufferedToActive without actually activating.
+ */
+export function calculateProjectedMessageRemoval(
+  chunks: BufferedObservationChunk[],
+  bufferActivation: number,
+  messageTokensThreshold: number,
+  currentPendingTokens: number,
+): number {
+  if (chunks.length === 0) return 0;
+
+  const retentionFloor = resolveRetentionFloor(bufferActivation, messageTokensThreshold);
+  const targetMessageTokens = Math.max(0, currentPendingTokens - retentionFloor);
+
+  // Find the closest chunk boundary to the target, biased over (prefer removing
+  // slightly more than the target so remaining context lands at or below retentionFloor).
+  // Track both best-over and best-under boundaries so we can fall back to under
+  // if the over boundary would overshoot by too much.
+  let cumulativeMessageTokens = 0;
+  let bestOverBoundary = 0;
+  let bestOverTokens = 0;
+  let bestUnderBoundary = 0;
+  let bestUnderTokens = 0;
+
+  for (let i = 0; i < chunks.length; i++) {
+    cumulativeMessageTokens += chunks[i]!.messageTokens ?? 0;
+    const boundary = i + 1;
+
+    if (cumulativeMessageTokens >= targetMessageTokens) {
+      // Over or equal — track the closest (lowest) over boundary
+      if (bestOverBoundary === 0 || cumulativeMessageTokens < bestOverTokens) {
+        bestOverBoundary = boundary;
+        bestOverTokens = cumulativeMessageTokens;
+      }
+    } else {
+      // Under — track the closest (highest) under boundary
+      if (cumulativeMessageTokens > bestUnderTokens) {
+        bestUnderBoundary = boundary;
+        bestUnderTokens = cumulativeMessageTokens;
+      }
+    }
+  }
+
+  // Safeguard: if the over boundary would eat into more than 95% of the
+  // retention floor, fall back to the best under boundary instead.
+  // This prevents edge cases where a large chunk overshoots dramatically.
+  // Additionally, never bias over if it would leave fewer than the smaller of
+  // 1000 tokens or the retention floor — at that level the agent may lose
+  // all meaningful context.
+  const maxOvershoot = retentionFloor * 0.95;
+  const overshoot = bestOverTokens - targetMessageTokens;
+  const remainingAfterOver = currentPendingTokens - bestOverTokens;
+  const remainingAfterUnder = currentPendingTokens - bestUnderTokens;
+  // When activationRatio ≈ 1.0, retentionFloor is 0 and minRemaining becomes 0 — intentional for "activate everything" configs.
+  const minRemaining = Math.min(1000, retentionFloor);
+
+  let bestBoundaryMessageTokens: number;
+
+  if (bestOverBoundary > 0 && overshoot <= maxOvershoot && remainingAfterOver >= minRemaining) {
+    bestBoundaryMessageTokens = bestOverTokens;
+  } else if (bestUnderBoundary > 0 && remainingAfterUnder >= minRemaining) {
+    bestBoundaryMessageTokens = bestUnderTokens;
+  } else if (bestOverBoundary > 0) {
+    // All boundaries are over and exceed the safeguard — still activate
+    // the closest over boundary (better than nothing)
+    bestBoundaryMessageTokens = bestOverTokens;
+  } else {
+    return chunks[0]?.messageTokens ?? 0;
+  }
+
+  return bestBoundaryMessageTokens;
+}

--- a/packages/memory/src/processors/observational-memory/thresholds.ts
+++ b/packages/memory/src/processors/observational-memory/thresholds.ts
@@ -77,7 +77,7 @@ export function resolveBlockAfter(
   messageTokens: number | ThresholdRange,
 ): number | undefined {
   if (blockAfter === undefined) return undefined;
-  // Values between 1 (inclusive) and 2 (exclusive) are treated as multipliers of the threshold.
+  // Values between 1 (inclusive) and 100 (exclusive) are treated as multipliers of the threshold.
   // e.g. blockAfter: 1.5 means 1.5x the threshold. blockAfter: 1 means exactly at threshold.
   // Values >= 100 are treated as absolute token counts.
   if (blockAfter >= 1 && blockAfter < 100) {


### PR DESCRIPTION
## Summary

Extracts 8 functions from the `ObservationalMemory` class into a standalone `message-parts.ts` module:

- `findLastCompletedObservationBoundary` — finds the last completed observation end marker in a message
- `hasInProgressObservation` — detects start markers without matching end
- `sealMessagesForBuffering` — seals messages to preserve buffering boundaries
- `getUnobservedParts` / `hasUnobservedParts` / `createUnobservedMessage` — part-level filtering
- `getUnobservedMessages` — message-level filtering with timestamp and buffered chunk awareness
- `getBufferedChunks` — defensive parsing of buffered observation chunks

All functions are pure (no class state dependency), making them independently testable.

## Changes

- **New file**: `packages/memory/src/processors/observational-memory/message-parts.ts` (248 lines)
- **New tests**: `packages/memory/src/processors/observational-memory/__tests__/message-parts.test.ts` (37 tests)
- **Updated**: `observational-memory.ts` — removed extracted methods, imports standalone functions
- **Updated**: `observational-memory.test.ts` — uses standalone functions directly, removed unused `om` instances

Reduces `observational-memory.ts` from ~5,509 to ~5,253 lines.

## Test Plan

- 541 unit tests pass (37 new + 504 existing)
- Build passes
- Lint passes