### PR TITLE
feat(mastracode): add /update slash command

### DIFF
--- a/.changeset/tough-streets-send.md
+++ b/.changeset/tough-streets-send.md
@@ -1,0 +1,5 @@
+---
+'mastracode': minor
+---
+
+Added /update slash command to check for and install updates directly from the TUI. Fixed update notifications logging repeatedly in the terminal — now only shown once per session. Update messages now reference /update instead of shell commands.

--- a/mastracode/src/tui/command-dispatch.ts
+++ b/mastracode/src/tui/command-dispatch.ts
@@ -31,6 +31,7 @@ import {
   handleReportIssueCommand as handleReportIssueCmd,
   handleSetupCommand,
   handleThemeCommand,
+  handleUpdateCommand,
 } from './commands/index.js';
 import type { SlashCommandContext } from './commands/types.js';
 import { SlashCommandComponent } from './components/slash-command.js';
@@ -150,6 +151,9 @@ export async function dispatchSlashCommand(
       return true;
     case 'theme':
       await handleThemeCommand(buildCtx(), args);
+      return true;
+    case 'update':
+      await handleUpdateCommand(buildCtx());
       return true;
     default: {
       const customCommand = state.customSlashCommands.find(cmd => cmd.name === command);

--- a/mastracode/src/tui/commands/index.ts
+++ b/mastracode/src/tui/commands/index.ts
@@ -28,3 +28,4 @@ export { handleReviewCommand } from './review.js';
 export { handleReportIssueCommand } from './report-issue.js';
 export { handleSetupCommand } from './setup.js';
 export { handleThemeCommand } from './theme.js';
+export { handleUpdateCommand } from './update.js';

--- a/mastracode/src/tui/commands/update.ts
+++ b/mastracode/src/tui/commands/update.ts
@@ -1,0 +1,88 @@
+import { Spacer } from '@mariozechner/pi-tui';
+
+import { loadSettings, saveSettings } from '../../onboarding/settings.js';
+import {
+  detectPackageManager,
+  fetchLatestVersion,
+  getInstallCommand,
+  isNewerVersion,
+  runUpdate,
+} from '../../utils/update-check.js';
+import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
+import type { SlashCommandContext } from './types.js';
+
+export async function handleUpdateCommand(ctx: SlashCommandContext): Promise<void> {
+  const currentVersion = ctx.state.options.version;
+  if (!currentVersion) {
+    ctx.showError('Could not determine the current version.');
+    return;
+  }
+
+  ctx.showInfo('Checking for updates…');
+
+  const latestVersion = await fetchLatestVersion();
+  if (!latestVersion) {
+    ctx.showError('Could not reach the npm registry. Check your network connection.');
+    return;
+  }
+
+  if (!isNewerVersion(currentVersion, latestVersion)) {
+    ctx.showInfo(`You are already on the latest version (v${currentVersion}).`);
+    return;
+  }
+
+  const pm = await detectPackageManager();
+
+  // Clear any previously dismissed version so the prompt always shows
+  const settings = loadSettings();
+  if (settings.updateDismissedVersion) {
+    settings.updateDismissedVersion = null;
+    saveSettings(settings);
+  }
+
+  // Show interactive prompt
+  return new Promise<void>(resolve => {
+    const questionComponent = new AskQuestionInlineComponent(
+      {
+        question: `A new version is available: v${latestVersion} (current: v${currentVersion}). Would you like to update now?`,
+        options: [
+          { label: 'Yes', description: 'Update and restart' },
+          { label: 'No', description: 'Skip this version' },
+        ],
+        formatResult: answer => (answer === 'Yes' ? 'Updating…' : 'Update skipped.'),
+        onSubmit: async answer => {
+          ctx.state.activeInlineQuestion = undefined;
+          if (answer === 'Yes') {
+            ctx.showInfo(`Updating to v${latestVersion}…`);
+            const ok = await runUpdate(pm, latestVersion);
+            if (ok) {
+              ctx.showInfo(`Updated to v${latestVersion}. Please restart Mastra Code.`);
+              ctx.stop();
+              process.exit(0);
+            } else {
+              const cmd = getInstallCommand(pm, latestVersion);
+              ctx.showError(`Auto-update failed. Run \`${cmd}\` manually.`);
+            }
+          } else {
+            const s = loadSettings();
+            s.updateDismissedVersion = latestVersion;
+            saveSettings(s);
+            ctx.showInfo('Update skipped.');
+          }
+          resolve();
+        },
+        onCancel: () => {
+          ctx.state.activeInlineQuestion = undefined;
+          resolve();
+        },
+      },
+      ctx.state.ui,
+    );
+
+    ctx.state.activeInlineQuestion = questionComponent;
+    ctx.state.chatContainer.addChild(questionComponent);
+    ctx.state.chatContainer.addChild(new Spacer(1));
+    ctx.state.ui.requestRender();
+    ctx.state.chatContainer.invalidate();
+  });
+}

--- a/mastracode/src/tui/components/help-overlay.ts
+++ b/mastracode/src/tui/components/help-overlay.ts
@@ -45,6 +45,7 @@ function getCommands(modes: number): HelpEntry[] {
     { key: '/logout', description: 'Logout from OAuth provider' },
     { key: '/setup', description: 'Run the setup wizard' },
     { key: '/theme', description: 'Switch color theme (auto/dark/light)' },
+    { key: '/update', description: 'Check for and install updates' },
   ];
 
   if (modes > 1) {

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -75,6 +75,7 @@ const UPDATE_RECHECK_INTERVAL_MS = 45 * 60 * 1_000; // 45 minutes
 export class MastraTUI {
   private state: TUIState;
   private updateCheckTimer: ReturnType<typeof setInterval> | null = null;
+  private hasShownUpdateBanner = false;
 
   private static readonly DOUBLE_CTRL_C_MS = 500;
 
@@ -868,31 +869,36 @@ export class MastraTUI {
     const latestVersion = await fetchLatestVersion();
     if (!latestVersion || !isNewerVersion(currentVersion, latestVersion)) return;
 
-    const pm = await detectPackageManager();
-
-    // Passive mode or previously dismissed — show info message only
+    // Passive mode or previously dismissed — show info message only once
     if (passive) {
-      const cmd = getInstallCommand(pm);
-      showInfo(
-        this.state,
-        `Update available: v${latestVersion} (current: v${currentVersion}). Run \`${cmd}\` to update.`,
-      );
+      if (!this.hasShownUpdateBanner) {
+        this.hasShownUpdateBanner = true;
+        showInfo(
+          this.state,
+          `Update available: v${latestVersion} (current: v${currentVersion}). Run /update to update.`,
+        );
+      }
       return;
     }
 
     const settings = loadSettings();
 
-    // User previously dismissed this exact version — show passive banner note only
+    // User previously dismissed this exact version — show passive banner note only once
     if (settings.updateDismissedVersion && !isNewerVersion(settings.updateDismissedVersion, latestVersion)) {
-      const cmd = getInstallCommand(pm);
-      showInfo(
-        this.state,
-        `Update available: v${latestVersion} (current: v${currentVersion}). Run \`${cmd}\` to update.`,
-      );
+      if (!this.hasShownUpdateBanner) {
+        this.hasShownUpdateBanner = true;
+        showInfo(
+          this.state,
+          `Update available: v${latestVersion} (current: v${currentVersion}). Run /update to update.`,
+        );
+      }
       return;
     }
 
-    // Prompt the user
+    const pm = await detectPackageManager();
+
+    // Prompt the user (and mark banner as shown so periodic checks don't repeat it)
+    this.hasShownUpdateBanner = true;
     await this.showUpdatePrompt(currentVersion, latestVersion, pm);
   }
 
@@ -931,8 +937,7 @@ export class MastraTUI {
               const settings = loadSettings();
               settings.updateDismissedVersion = latestVersion;
               saveSettings(settings);
-              const cmd = getInstallCommand(pm);
-              showInfo(this.state, `Update skipped. Run \`${cmd}\` to update manually.`);
+              showInfo(this.state, `Update skipped. Run /update to update later.`);
             }
             resolve();
           },

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -301,6 +301,7 @@ export function setupAutocomplete(state: TUIState): void {
     { name: 'report-issue', description: 'Open or browse mastracode issues' },
     { name: 'setup', description: 'Re-run the setup wizard' },
     { name: 'theme', description: 'Switch color theme (auto/dark/light)' },
+    { name: 'update', description: 'Check for and install updates' },
     { name: 'exit', description: 'Exit the TUI' },
     { name: 'help', description: 'Show available commands' },
   ];


### PR DESCRIPTION
Adds a new `/update` slash command so users can check for and install updates directly from the TUI instead of being told to run shell commands.

Also fixes the update notification logging repeatedly every 45 minutes — it now only shows once per session.

```
/update
```

Checks npm for the latest version, prompts to update, and restarts on success. Passive update banners now say `Run /update to update` instead of `Run \`npm install -g mastracode@latest\``.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `/update` slash command to check for and install updates directly within the TUI.
  * Update notifications now appear only once per session, reducing notification fatigue.
  * Help menu and autocomplete expanded to include the new `/update` command for easy discovery.
  * All update-related messaging updated to guide users toward the slash command for streamlined update management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->