### PR TITLE
fix(workspace): accept execute_command timeout in seconds instead of ms

### DIFF
--- a/.changeset/better-owls-thank.md
+++ b/.changeset/better-owls-thank.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed execute_command tool timeout parameter to accept seconds instead of milliseconds, preventing agents from accidentally setting extremely short timeouts

--- a/packages/core/src/workspace/tools/execute-command.ts
+++ b/packages/core/src/workspace/tools/execute-command.ts
@@ -13,7 +13,7 @@ export const executeCommandInputSchema = z.object({
   command: z
     .string()
     .describe('The shell command to execute (e.g., "npm install", "ls -la src/", "cat file.txt | grep error")'),
-  timeout: z.number().nullish().describe('Maximum execution time in milliseconds. Example: 60000 for 1 minute.'),
+  timeout: z.number().nullish().describe('Maximum execution time in seconds. Example: 60 for 1 minute.'),
   cwd: z.string().nullish().describe('Working directory for the command'),
   tail: z
     .number()
@@ -58,7 +58,8 @@ function extractTailPipe(command: string): { command: string; tail?: number } {
 
 /** Shared execute function used by both foreground-only and background-capable tool variants. */
 async function executeCommand(input: Record<string, any>, context: any) {
-  let { command, timeout, cwd, tail } = input;
+  let { command, cwd, tail } = input;
+  const timeout = input.timeout != null ? (input.timeout as number) * 1000 : undefined;
   const background = input.background as boolean | undefined;
   const { workspace, sandbox } = requireSandbox(context);
 
@@ -201,7 +202,7 @@ Examples:
 Usage:
 - Commands run in a shell, so pipes, redirects, and chaining (&&, ||, ;) all work.
 - Always quote file paths that contain spaces (e.g., cd "/path/with spaces").
-- Use the timeout parameter to limit execution time. Behavior when omitted depends on the sandbox provider.
+- Use the timeout parameter (in seconds) to limit execution time. Behavior when omitted depends on the sandbox provider.
 - Optionally use cwd to override the working directory. Commands run from the sandbox default if omitted.`;
 
 /** Foreground-only tool (no background param in schema). */


### PR DESCRIPTION
## Problem

Agents naturally pass timeout values in seconds (e.g. `timeout: 60` for 1 minute), but the `mastra_workspace_execute_command` tool was passing the value straight through to the sandbox which expects milliseconds. This caused processes to be killed almost instantly — a timeout of `60` was interpreted as 60ms.

## Fix

- Changed the tool schema description from milliseconds to seconds
- Convert seconds → ms in the tool before passing to the sandbox
- Updated the tool guidance text to mention seconds

## Test plan

- All existing tests pass (82 tool tests + 147 local-sandbox tests)
- Manually verified: `sleep 2` with `timeout: 60` now completes instead of being killed after 60ms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed execute-command timeout unit: accepts seconds (not milliseconds) and is now handled correctly to avoid unexpectedly short timeouts.
* **Documentation**
  * Updated usage text and changelog to reflect the timeout parameter is specified in seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->