### PR TITLE
fix: return auth disabled for dev playground requests in capabilities endpoint

### DIFF
--- a/.changeset/every-aliens-happen.md
+++ b/.changeset/every-aliens-happen.md
@@ -1,6 +1,0 @@
----
-'@mastra/playground-ui': patch
-'@mastra/server': patch
----
-
-Fixed MastraClient headers (including x-mastra-dev-playground) being passed to the auth capabilities endpoint, enabling proper dev playground detection on the server

--- a/.changeset/every-aliens-happen.md
+++ b/.changeset/every-aliens-happen.md
@@ -1,0 +1,6 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/server': patch
+---
+
+Fixed MastraClient headers (including x-mastra-dev-playground) being passed to the auth capabilities endpoint, enabling proper dev playground detection on the server

--- a/.changeset/wicked-hairs-film.md
+++ b/.changeset/wicked-hairs-film.md
@@ -1,0 +1,6 @@
+---
+'@mastra/playground-ui': patch
+'@mastra/server': patch
+---
+
+Fixed auth capabilities endpoint to return disabled state when dev playground header is present, preventing the login gate from appearing in dev playground mode

--- a/.changeset/wicked-hairs-film.md
+++ b/.changeset/wicked-hairs-film.md
@@ -3,4 +3,4 @@
 '@mastra/server': patch
 ---
 
-Fixed auth capabilities endpoint to return disabled state when dev playground header is present, preventing the login gate from appearing in dev playground mode
+Fixed dev playground auth bypass not working in capabilities endpoint. The client now passes MastraClient headers (including x-mastra-dev-playground) to the auth capabilities endpoint, and the server returns disabled state when this header is present. This prevents the login gate from appearing in dev playground mode.

--- a/packages/playground-ui/src/domains/auth/hooks/__tests__/use-auth-capabilities.test.ts
+++ b/packages/playground-ui/src/domains/auth/hooks/__tests__/use-auth-capabilities.test.ts
@@ -57,6 +57,7 @@ describe('useAuthCapabilities', () => {
       const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
 
       expect(url).toBe('http://localhost:3000/api/auth/capabilities');
+      expect(options.credentials).toBe('include');
       expect(options.headers).toEqual(
         expect.objectContaining({
           'Content-Type': 'application/json',
@@ -81,6 +82,7 @@ describe('useAuthCapabilities', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
       const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
 
+      expect(options.credentials).toBe('include');
       expect(options.headers).toEqual(
         expect.objectContaining({
           'Content-Type': 'application/json',
@@ -88,8 +90,10 @@ describe('useAuthCapabilities', () => {
       );
     });
 
-    it('should work when client options is undefined', async () => {
-      const mockClient = {};
+    it('should work when client options has no baseUrl or headers', async () => {
+      const mockClient = {
+        options: {},
+      };
 
       mockFetch.mockResolvedValue(createMockResponse({ enabled: false, login: null }));
 
@@ -101,6 +105,7 @@ describe('useAuthCapabilities', () => {
 
       // Should still work, just with empty base URL
       expect(url).toBe('/api/auth/capabilities');
+      expect(options.credentials).toBe('include');
       expect(options.headers).toEqual(
         expect.objectContaining({
           'Content-Type': 'application/json',

--- a/packages/playground-ui/src/domains/auth/hooks/__tests__/use-auth-capabilities.test.ts
+++ b/packages/playground-ui/src/domains/auth/hooks/__tests__/use-auth-capabilities.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Tests for useAuthCapabilities hook.
+ *
+ * The key regression this tests is that the hook must pass the MastraClient's
+ * headers (including x-mastra-dev-playground) to the auth capabilities endpoint.
+ * Without this, the UI would show a login gate even in dev playground mode
+ * where the server bypasses auth.
+ */
+
+// Helper to create a mock response
+const createMockResponse = (data: unknown): Response =>
+  ({
+    ok: true,
+    json: () => Promise.resolve(data),
+  }) as unknown as Response;
+
+describe('useAuthCapabilities', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    mockFetch = vi.fn();
+    globalThis.fetch = mockFetch as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  describe('client headers are passed to fetch', () => {
+    it('should include x-mastra-dev-playground header from client in fetch request', async () => {
+      // Mock the client with headers that include x-mastra-dev-playground
+      const mockClient = {
+        options: {
+          baseUrl: 'http://localhost:3000',
+          headers: {
+            'x-mastra-dev-playground': 'true',
+            'x-custom-header': 'custom-value',
+          },
+        },
+      };
+
+      // Mock response
+      mockFetch.mockResolvedValue(createMockResponse({ enabled: false, login: null }));
+
+      // We need to test the actual fetch call logic
+      // Since the hook uses react-query, we'll extract and test the queryFn directly
+      const { makeAuthCapabilitiesRequest } = await import('../use-auth-capabilities');
+      await makeAuthCapabilitiesRequest(mockClient as any);
+
+      // Verify fetch was called with the client's headers
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+
+      expect(url).toBe('http://localhost:3000/api/auth/capabilities');
+      expect(options.headers).toEqual(
+        expect.objectContaining({
+          'Content-Type': 'application/json',
+          'x-mastra-dev-playground': 'true',
+          'x-custom-header': 'custom-value',
+        }),
+      );
+    });
+
+    it('should work when client has no custom headers', async () => {
+      const mockClient = {
+        options: {
+          baseUrl: 'http://localhost:3000',
+        },
+      };
+
+      mockFetch.mockResolvedValue(createMockResponse({ enabled: false, login: null }));
+
+      const { makeAuthCapabilitiesRequest } = await import('../use-auth-capabilities');
+      await makeAuthCapabilitiesRequest(mockClient as any);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+
+      expect(options.headers).toEqual(
+        expect.objectContaining({
+          'Content-Type': 'application/json',
+        }),
+      );
+    });
+
+    it('should work when client options is undefined', async () => {
+      const mockClient = {};
+
+      mockFetch.mockResolvedValue(createMockResponse({ enabled: false, login: null }));
+
+      const { makeAuthCapabilitiesRequest } = await import('../use-auth-capabilities');
+      await makeAuthCapabilitiesRequest(mockClient as any);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+
+      // Should still work, just with empty base URL
+      expect(url).toBe('/api/auth/capabilities');
+      expect(options.headers).toEqual(
+        expect.objectContaining({
+          'Content-Type': 'application/json',
+        }),
+      );
+    });
+  });
+});

--- a/packages/playground-ui/src/domains/auth/hooks/use-auth-capabilities.ts
+++ b/packages/playground-ui/src/domains/auth/hooks/use-auth-capabilities.ts
@@ -11,9 +11,7 @@ import type { AuthCapabilities } from '../types';
  * @internal
  */
 export async function makeAuthCapabilitiesRequest(client: MastraClient): Promise<AuthCapabilities> {
-  const options = (client as any).options;
-  const baseUrl = options?.baseUrl || '';
-  const clientHeaders = options?.headers || {};
+  const { baseUrl = '', headers: clientHeaders = {} } = client.options;
 
   const response = await fetch(`${baseUrl}/api/auth/capabilities`, {
     credentials: 'include',

--- a/packages/playground-ui/src/domains/auth/hooks/use-auth-capabilities.ts
+++ b/packages/playground-ui/src/domains/auth/hooks/use-auth-capabilities.ts
@@ -1,7 +1,34 @@
+import type { MastraClient } from '@mastra/client-js';
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 
 import type { AuthCapabilities } from '../types';
+
+/**
+ * Makes a request to the auth capabilities endpoint.
+ * Exported for testing purposes.
+ *
+ * @internal
+ */
+export async function makeAuthCapabilitiesRequest(client: MastraClient): Promise<AuthCapabilities> {
+  const options = (client as any).options;
+  const baseUrl = options?.baseUrl || '';
+  const clientHeaders = options?.headers || {};
+
+  const response = await fetch(`${baseUrl}/api/auth/capabilities`, {
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...clientHeaders,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch auth capabilities: ${response.status}`);
+  }
+
+  return response.json();
+}
 
 /**
  * Hook to fetch authentication capabilities.
@@ -36,22 +63,7 @@ export function useAuthCapabilities() {
 
   return useQuery<AuthCapabilities>({
     queryKey: ['auth', 'capabilities'],
-    queryFn: async () => {
-      // Use the client's internal request method to call the auth endpoint
-      // This ensures proper base URL handling and headers
-      const response = await fetch(`${(client as any).options?.baseUrl || ''}/api/auth/capabilities`, {
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch auth capabilities: ${response.status}`);
-      }
-
-      return response.json();
-    },
+    queryFn: () => makeAuthCapabilitiesRequest(client),
     staleTime: 60 * 1000, // Cache for 1 minute
     retry: false, // Don't retry auth requests
   });

--- a/packages/server/src/server/handlers/auth.test.ts
+++ b/packages/server/src/server/handlers/auth.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { GET_AUTH_CAPABILITIES_ROUTE } from './auth';
+
+describe('Auth Handlers', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('GET_AUTH_CAPABILITIES_ROUTE', () => {
+    it('should return enabled: false when x-mastra-dev-playground header is set in dev mode', async () => {
+      // This is the regression test: in dev playground mode, the UI should not show auth gates
+      process.env.MASTRA_DEV = 'true';
+
+      const mockMastra = {
+        getServer: () => ({
+          auth: {
+            authenticateToken: vi.fn(),
+            protected: ['/api/*'],
+          },
+        }),
+      };
+
+      const mockRequest = {
+        headers: new Headers({
+          'x-mastra-dev-playground': 'true',
+        }),
+      };
+
+      const result = await GET_AUTH_CAPABILITIES_ROUTE.handler({
+        mastra: mockMastra,
+        request: mockRequest,
+      } as any);
+
+      expect(result).toEqual({ enabled: false, login: null });
+    });
+  });
+});

--- a/packages/server/src/server/handlers/auth.ts
+++ b/packages/server/src/server/handlers/auth.ts
@@ -18,6 +18,7 @@ import type {
 import type { IRBACProvider, EEUser } from '@mastra/core/auth/ee';
 import type { MastraAuthProvider } from '@mastra/core/server';
 
+import { isDevPlaygroundRequest } from '../auth/helpers';
 import { HTTPException } from '../http-exception';
 import {
   capabilitiesResponseSchema,
@@ -108,6 +109,17 @@ export const GET_AUTH_CAPABILITIES_ROUTE = createPublicRoute({
   handler: async ctx => {
     try {
       const { mastra, request } = ctx as any;
+
+      // In dev playground mode, return auth as disabled so the UI doesn't show login gates.
+      // The server already bypasses auth for dev playground requests, so the UI should match.
+      const serverConfig = mastra.getServer?.();
+      const authConfig = serverConfig?.auth || {};
+      const getHeader = (name: string) => request.headers.get(name) ?? undefined;
+
+      if (isDevPlaygroundRequest('/api/auth/capabilities', 'GET', getHeader, authConfig)) {
+        return { enabled: false, login: null };
+      }
+
       const auth = getAuthProvider(mastra);
       const rbac = getRBACProvider(mastra);
 


### PR DESCRIPTION
## Summary
- Server: Check `isDevPlaygroundRequest()` in capabilities endpoint and return `enabled: false` when in dev playground mode
- Client: Pass MastraClient headers (including `x-mastra-dev-playground`) to the capabilities endpoint fetch request

This fixes a regression where the playground UI was showing a login gate even in dev playground mode because the `/api/auth/capabilities` endpoint was returning `enabled: true` regardless of the dev playground context.

## Test plan
- [x] Added test for server capabilities endpoint dev playground bypass
- [x] Added test for client passing headers to capabilities endpoint
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication handling in development playground mode to prevent the login gate from appearing inappropriately.
  * Improved auth capabilities endpoint to properly respect development playground headers and return disabled state accordingly.

* **Tests**
  * Added comprehensive test coverage for authentication capabilities functionality across client and server components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->