### PR TITLE
fix(@mastra/mongo): handle null bufferedObservationChunks in MongoDB OM

### DIFF
--- a/.changeset/fair-bags-march.md
+++ b/.changeset/fair-bags-march.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mongodb': patch
+---
+
+Fixed MongoDB observational memory buffering so legacy records with `bufferedObservationChunks: null` can append chunks safely and continue storing chunk buffers as arrays after activation.

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -1314,7 +1314,9 @@ export class MemoryStorageMongoDB extends MemoryStorage {
       generationCount: Number(doc.generationCount || 0),
       activeObservations: doc.activeObservations || '',
       // Handle new chunk-based structure
-      bufferedObservationChunks: doc.bufferedObservationChunks || undefined,
+      bufferedObservationChunks: Array.isArray(doc.bufferedObservationChunks)
+        ? doc.bufferedObservationChunks
+        : undefined,
       // Deprecated fields (for backward compatibility)
       bufferedObservations: doc.activeObservationsPendingUpdate || undefined,
       bufferedObservationTokens: doc.bufferedObservationTokens ? Number(doc.bufferedObservationTokens) : undefined,
@@ -1482,7 +1484,9 @@ export class MemoryStorageMongoDB extends MemoryStorage {
         totalTokensObserved: record.totalTokensObserved || 0,
         observationTokenCount: record.observationTokenCount || 0,
         observedMessageIds: record.observedMessageIds || null,
-        bufferedObservationChunks: record.bufferedObservationChunks || null,
+        bufferedObservationChunks: Array.isArray(record.bufferedObservationChunks)
+          ? record.bufferedObservationChunks
+          : [],
         bufferedReflection: record.bufferedReflection || null,
         bufferedReflectionTokens: record.bufferedReflectionTokens ?? null,
         bufferedReflectionInputTokens: record.bufferedReflectionInputTokens ?? null,
@@ -1851,18 +1855,19 @@ export class MemoryStorageMongoDB extends MemoryStorage {
         currentTask: input.chunk.currentTask,
       };
 
-      // Use $push to append chunk to array atomically
-      const $set: Record<string, any> = { updatedAt: new Date() };
-      if (input.lastBufferedAtTime) {
-        $set.lastBufferedAtTime = input.lastBufferedAtTime;
-      }
-      const result = await collection.updateOne(
-        { id: input.id },
-        {
-          $push: { bufferedObservationChunks: newChunk as any },
-          $set,
+      // Use an update pipeline so legacy null/missing fields are coerced to arrays atomically
+      const now = new Date();
+      const setStage: Record<string, any> = {
+        updatedAt: now,
+        bufferedObservationChunks: {
+          $concatArrays: [{ $ifNull: ['$bufferedObservationChunks', []] }, [newChunk as any]],
         },
-      );
+      };
+      if (input.lastBufferedAtTime) {
+        setStage.lastBufferedAtTime = input.lastBufferedAtTime;
+      }
+
+      const result = await collection.updateOne({ id: input.id }, [{ $set: setStage }]);
 
       if (result.matchedCount === 0) {
         throw new MastraError({
@@ -2025,7 +2030,7 @@ export class MemoryStorageMongoDB extends MemoryStorage {
             activeObservations: newActive,
             observationTokenCount: newTokenCount,
             pendingMessageTokens: newPending,
-            bufferedObservationChunks: remainingChunks.length > 0 ? remainingChunks : null,
+            bufferedObservationChunks: remainingChunks,
             lastObservedAt,
             updatedAt: new Date(),
           },

--- a/stores/mongodb/src/storage/index.test.ts
+++ b/stores/mongodb/src/storage/index.test.ts
@@ -543,6 +543,69 @@ describe('MongoDB Specific Tests', () => {
     });
   });
 
+  describe('MongoDB OM Regression: bufferedObservationChunks null handling', () => {
+    beforeEach(async () => {
+      const memoryStore = await store.getStore('memory');
+      expect(memoryStore).toBeDefined();
+      await memoryStore?.dangerouslyClearAll();
+    });
+
+    it('should append buffered observation chunks when legacy docs store null and keep array shape after swap', async () => {
+      const memoryStore = await store.getStore('memory');
+      expect(memoryStore).toBeDefined();
+
+      const resourceId = `resource-om-regression-${Date.now()}`;
+      const record = await memoryStore!.initializeObservationalMemory({
+        threadId: null,
+        resourceId,
+        scope: 'resource',
+        config: {
+          observationThreshold: 5000,
+          reflectionThreshold: 40000,
+        },
+      });
+
+      const client = new MongoClient(TEST_CONFIG.uri!);
+      await client.connect();
+      try {
+        const omCollection = client.db(TEST_CONFIG.dbName).collection('mastra_observational_memory');
+
+        await omCollection.updateOne({ id: record.id }, { $set: { bufferedObservationChunks: null } });
+
+        await expect(
+          memoryStore!.updateBufferedObservations({
+            id: record.id,
+            chunk: {
+              cycleId: `cycle-${Date.now()}`,
+              observations: 'Buffered from regression test',
+              tokenCount: 100,
+              messageIds: [`msg-${Date.now()}`],
+              messageTokens: 200,
+              lastObservedAt: new Date(),
+            },
+          }),
+        ).resolves.not.toThrow();
+
+        const afterBuffer = await omCollection.findOne({ id: record.id });
+        expect(Array.isArray(afterBuffer?.bufferedObservationChunks)).toBe(true);
+        expect(afterBuffer?.bufferedObservationChunks).toHaveLength(1);
+
+        await memoryStore!.swapBufferedToActive({
+          id: record.id,
+          activationRatio: 1,
+          messageTokensThreshold: 1000,
+          currentPendingTokens: 200,
+        });
+
+        const afterSwap = await omCollection.findOne({ id: record.id });
+        expect(Array.isArray(afterSwap?.bufferedObservationChunks)).toBe(true);
+        expect(afterSwap?.bufferedObservationChunks).toEqual([]);
+      } finally {
+        await client.close();
+      }
+    });
+  });
+
   describe('MongoDB Span Operations with Complex Data', () => {
     beforeEach(async () => {
       const observabilityStore = await store.getStore('observability');


### PR DESCRIPTION
This fixes a MongoDB observational memory edge case where legacy records with bufferedObservationChunks: null failed on append.

The MongoDB OM write path now keeps bufferedObservationChunks array-shaped (including empty arrays), and the regression test covers null -> append -> swap with the expected array state throughout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed observational memory handling so that legacy records with null buffered chunks can safely append new chunks and properly initialize chunk buffers as arrays.

* **Tests**
  * Added regression test suite validating observational memory chunk buffering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->