### PR TITLE
fix: improve gh-debug-issue command to preserve issue context

### DIFF
--- a/.claude/commands/gh-debug-issue.md
+++ b/.claude/commands/gh-debug-issue.md
@@ -29,7 +29,7 @@ Debugging Github issues has 3 stages. Each stage must be fully completed before 
 
 Once you've analyzed the issue:
 
-1. Create an ISSUE_SUMMARY$1.md file in the project root and add a summary of what you've analyzed so far. Do not begin to fix the issue, that isn't our goal.
+1. Update the existing ISSUE_SUMMARY$1.md file in the project root with a summary of what you've analyzed so far. Do not begin to fix the issue; that isn't our goal.
 2. Deeply explore and think about the issue. Find relevant tests and files, and docs/info about how the feature works and how it should work. Add this info to the issue summary file. Especially add info about what you think is happening and how the issue can be reproduced in a test.
 3. Ask the user for feedback on your issue summary document. Do you have any misconceptions? Is your theory plausible? Did you miss anything?
 4. Now that the user agrees with your findings, write a test (in the appropriate package and test file) that reproduces the issue. The test MUST fail and clearly show the problem. The test should make sense in the context of the repo, do not make the test specific to the issue (ie with references to the issue and the specific reproduction if provided in the issue). Tests should be generalized and fit into the broader testing ecosystem in the repo.

--- a/.claude/commands/gh-debug-issue.md
+++ b/.claude/commands/gh-debug-issue.md
@@ -1,14 +1,19 @@
-# Debug GitHub Issue $ISSUE
+# Debug GitHub Issue $1
 
 Use the GH CLI to examine the GitHub issue for the current repository.
 
-RUN gh issue view $ISSUE --json title,body,comments,labels,assignees,milestone
+RUN gh issue view $1 --json title,body,comments,labels,assignees,milestone
 
 If the Github issue has a discord link in the first message, ie https://discord.com/channels/GUILD_ID/<THREAD_ID>, grab the THREAD_ID off the URL to apply to the next command.
 
 RUN curl -s -X GET -H "Authorization: Bot $MASTRA_DISCORD_BOT_TOKEN" "https://discord.com/api/v10/channels/<THREAD_ID>/messages?limit=100" > /tmp/discord_out.json && jq '[.[] | {timestamp, author: {username: .author.username, display_name: .author.global_name}, content, attachments: [.attachments[]? | {filename, url}], embeds: [.embeds[]? | {title, description, url}]}]' /tmp/discord_out.json ; rm -f /tmp/discord_out.json
 
 If discord returns a 401, ignore it, the user hasn't set up the token yet, continue on without the discord messages.
+
+**IMPORTANT — Capture issue details immediately.** After fetching the issue, before doing anything else:
+
+1. Record the issue number, title, and a 2-3 sentence summary of the problem as your first task (e.g., "Debug issue #$1: <title> — <brief summary>"). This ensures the issue context survives in your task state even if conversation history is compressed.
+2. Create an ISSUE_SUMMARY$1.md file in the project root with the issue number, title, labels, and a summary of the issue body and key comments. This file is your persistent reference — you can re-read it at any point if you need to recall the issue details.
 
 Debugging Github issues has 3 stages. Each stage must be fully completed before moving on to the next.
 
@@ -18,12 +23,13 @@ Debugging Github issues has 3 stages. Each stage must be fully completed before 
 2. Any linked PRs or related issues
 3. Comments and discussion threads
 4. Labels and metadata
+5. Update your ISSUE_SUMMARY$1.md with your analysis findings
 
 ## Stage 2 "Reproduce"
 
 Once you've analyzed the issue:
 
-1. Create an ISSUE_SUMMARY${ISSUE_NUMBER}.md file in the project root and add a summary of what you've analyzed so far. Do not begin to fix the issue, that isn't our goal.
+1. Create an ISSUE_SUMMARY$1.md file in the project root and add a summary of what you've analyzed so far. Do not begin to fix the issue, that isn't our goal.
 2. Deeply explore and think about the issue. Find relevant tests and files, and docs/info about how the feature works and how it should work. Add this info to the issue summary file. Especially add info about what you think is happening and how the issue can be reproduced in a test.
 3. Ask the user for feedback on your issue summary document. Do you have any misconceptions? Is your theory plausible? Did you miss anything?
 4. Now that the user agrees with your findings, write a test (in the appropriate package and test file) that reproduces the issue. The test MUST fail and clearly show the problem. The test should make sense in the context of the repo, do not make the test specific to the issue (ie with references to the issue and the specific reproduction if provided in the issue). Tests should be generalized and fit into the broader testing ecosystem in the repo.
@@ -39,6 +45,7 @@ Now that we have a failing test, a summary of our findings, and you and the user
 3. Write code to fix the issue. Run the failing test while you make changes and debug the issue so you know when it's fixed.
 4. If you get stuck, ask the user for help! They might know something you don't, or they might have an idea you didn't have.
 5. Once it's fixed, explain your fix to the user. They must agree that it's the correct fix for the issue at hand.
+6. When creating commits or PRs, reference the issue number (#$1) and title. If you've lost track of the details, re-read the ISSUE_SUMMARY$1.md file.
 
 You MUST first reproduce the issue in a test file, make sure the new test is failing (IMPORTANT!) then finally add a code fix.
 If we don't first reproduce in a unit or integration test then we can't be sure we fixed the problem.

--- a/.claude/commands/make-moves.md
+++ b/.claude/commands/make-moves.md
@@ -1,10 +1,10 @@
-# Make Moves Issue $ISSUE
+# Make Moves Issue $1
 
 You are a highly respected and valued engineer working on the Mastra framework.
 
 Use the GH CLI to examine the GitHub issue for the current repository.
 
-RUN gh issue view $ISSUE --json title,body,comments,labels,assignees,milestone
+RUN gh issue view $1 --json title,body,comments,labels,assignees,milestone
 
 Use the following workflow:
 

--- a/.cursor/commands/gh-debug-issue.md
+++ b/.cursor/commands/gh-debug-issue.md
@@ -29,7 +29,7 @@ Debugging Github issues has 3 stages. Each stage must be fully completed before 
 
 Once you've analyzed the issue:
 
-1. Create an ISSUE_SUMMARY$1.md file in the project root and add a summary of what you've analyzed so far. Do not begin to fix the issue, that isn't our goal.
+1. Update the existing ISSUE_SUMMARY$1.md file in the project root with a summary of what you've analyzed so far. Do not begin to fix the issue; that isn't our goal.
 2. Deeply explore and think about the issue. Find relevant tests and files, and docs/info about how the feature works and how it should work. Add this info to the issue summary file. Especially add info about what you think is happening and how the issue can be reproduced in a test.
 3. Ask the user for feedback on your issue summary document. Do you have any misconceptions? Is your theory plausible? Did you miss anything?
 4. Now that the user agrees with your findings, write a test (in the appropriate package and test file) that reproduces the issue. The test MUST fail and clearly show the problem. The test should make sense in the context of the repo, do not make the test specific to the issue (ie with references to the issue and the specific reproduction if provided in the issue). Tests should be generalized and fit into the broader testing ecosystem in the repo.

--- a/.cursor/commands/gh-debug-issue.md
+++ b/.cursor/commands/gh-debug-issue.md
@@ -1,14 +1,19 @@
-# Debug GitHub Issue $ISSUE
+# Debug GitHub Issue $1
 
 Use the GH CLI to examine the GitHub issue for the current repository.
 
-RUN gh issue view $ISSUE --json title,body,comments,labels,assignees,milestone
+RUN gh issue view $1 --json title,body,comments,labels,assignees,milestone
 
 If the Github issue has a discord link in the first message, ie https://discord.com/channels/GUILD_ID/<THREAD_ID>, grab the THREAD_ID off the URL to apply to the next command.
 
 RUN curl -s -X GET -H "Authorization: Bot $MASTRA_DISCORD_BOT_TOKEN" "https://discord.com/api/v10/channels/<THREAD_ID>/messages?limit=100" > /tmp/discord_out.json && jq '[.[] | {timestamp, author: {username: .author.username, display_name: .author.global_name}, content, attachments: [.attachments[]? | {filename, url}], embeds: [.embeds[]? | {title, description, url}]}]' /tmp/discord_out.json ; rm -f /tmp/discord_out.json
 
 If discord returns a 401, ignore it, the user hasn't set up the token yet, continue on without the discord messages.
+
+**IMPORTANT — Capture issue details immediately.** After fetching the issue, before doing anything else:
+
+1. Record the issue number, title, and a 2-3 sentence summary of the problem as your first task (e.g., "Debug issue #$1: <title> — <brief summary>"). This ensures the issue context survives in your task state even if conversation history is compressed.
+2. Create an ISSUE_SUMMARY$1.md file in the project root with the issue number, title, labels, and a summary of the issue body and key comments. This file is your persistent reference — you can re-read it at any point if you need to recall the issue details.
 
 Debugging Github issues has 3 stages. Each stage must be fully completed before moving on to the next.
 
@@ -18,12 +23,13 @@ Debugging Github issues has 3 stages. Each stage must be fully completed before 
 2. Any linked PRs or related issues
 3. Comments and discussion threads
 4. Labels and metadata
+5. Update your ISSUE_SUMMARY$1.md with your analysis findings
 
 ## Stage 2 "Reproduce"
 
 Once you've analyzed the issue:
 
-1. Create an ISSUE_SUMMARY${ISSUE_NUMBER}.md file in the project root and add a summary of what you've analyzed so far. Do not begin to fix the issue, that isn't our goal.
+1. Create an ISSUE_SUMMARY$1.md file in the project root and add a summary of what you've analyzed so far. Do not begin to fix the issue, that isn't our goal.
 2. Deeply explore and think about the issue. Find relevant tests and files, and docs/info about how the feature works and how it should work. Add this info to the issue summary file. Especially add info about what you think is happening and how the issue can be reproduced in a test.
 3. Ask the user for feedback on your issue summary document. Do you have any misconceptions? Is your theory plausible? Did you miss anything?
 4. Now that the user agrees with your findings, write a test (in the appropriate package and test file) that reproduces the issue. The test MUST fail and clearly show the problem. The test should make sense in the context of the repo, do not make the test specific to the issue (ie with references to the issue and the specific reproduction if provided in the issue). Tests should be generalized and fit into the broader testing ecosystem in the repo.
@@ -39,6 +45,7 @@ Now that we have a failing test, a summary of our findings, and you and the user
 3. Write code to fix the issue. Run the failing test while you make changes and debug the issue so you know when it's fixed.
 4. If you get stuck, ask the user for help! They might know something you don't, or they might have an idea you didn't have.
 5. Once it's fixed, explain your fix to the user. They must agree that it's the correct fix for the issue at hand.
+6. When creating commits or PRs, reference the issue number (#$1) and title. If you've lost track of the details, re-read the ISSUE_SUMMARY$1.md file.
 
 You MUST first reproduce the issue in a test file, make sure the new test is failing (IMPORTANT!) then finally add a code fix.
 If we don't first reproduce in a unit or integration test then we can't be sure we fixed the problem.

--- a/.github/prompts/gh-debug-issue.prompt.md
+++ b/.github/prompts/gh-debug-issue.prompt.md
@@ -34,7 +34,7 @@ Debugging Github issues has 3 stages. Each stage must be fully completed before 
 
 Once you've analyzed the issue:
 
-1. Create an ISSUE_SUMMARY${input:issue}.md file in the project root and add a summary of what you've analyzed so far. Do not begin to fix the issue, that isn't our goal.
+1. Update the existing ISSUE_SUMMARY${input:issue}.md file in the project root with a summary of what you've analyzed so far. Do not begin to fix the issue; that isn't our goal.
 2. Deeply explore and think about the issue. Find relevant tests and files, and docs/info about how the feature works and how it should work. Add this info to the issue summary file. Especially add info about what you think is happening and how the issue can be reproduced in a test.
 3. Ask the user for feedback on your issue summary document. Do you have any misconceptions? Is your theory plausible? Did you miss anything?
 4. Now that the user agrees with your findings, write a test (in the appropriate package and test file) that reproduces the issue. The test MUST fail and clearly show the problem. The test should make sense in the context of the repo, do not make the test specific to the issue (ie with references to the issue and the specific reproduction if provided in the issue). Tests should be generalized and fit into the broader testing ecosystem in the repo.

--- a/.github/prompts/gh-debug-issue.prompt.md
+++ b/.github/prompts/gh-debug-issue.prompt.md
@@ -15,6 +15,11 @@ RUN curl -s -X GET -H "Authorization: Bot $MASTRA_DISCORD_BOT_TOKEN" "https://di
 
 If discord returns a 401, ignore it, the user hasn't set up the token yet, continue on without the discord messages.
 
+**IMPORTANT — Capture issue details immediately.** After fetching the issue, before doing anything else:
+
+1. Record the issue number, title, and a 2-3 sentence summary of the problem as your first task (e.g., "Debug issue #${input:issue}: <title> — <brief summary>"). This ensures the issue context survives in your task state even if conversation history is compressed.
+2. Create an ISSUE_SUMMARY${input:issue}.md file in the project root with the issue number, title, labels, and a summary of the issue body and key comments. This file is your persistent reference — you can re-read it at any point if you need to recall the issue details.
+
 Debugging Github issues has 3 stages. Each stage must be fully completed before moving on to the next.
 
 ## Stage 1 "Analyze"
@@ -23,12 +28,13 @@ Debugging Github issues has 3 stages. Each stage must be fully completed before 
 2. Any linked PRs or related issues
 3. Comments and discussion threads
 4. Labels and metadata
+5. Update your ISSUE_SUMMARY${input:issue}.md with your analysis findings
 
 ## Stage 2 "Reproduce"
 
 Once you've analyzed the issue:
 
-1. Create an ISSUE_SUMMARY${ISSUE_NUMBER}.md file in the project root and add a summary of what you've analyzed so far. Do not begin to fix the issue, that isn't our goal.
+1. Create an ISSUE_SUMMARY${input:issue}.md file in the project root and add a summary of what you've analyzed so far. Do not begin to fix the issue, that isn't our goal.
 2. Deeply explore and think about the issue. Find relevant tests and files, and docs/info about how the feature works and how it should work. Add this info to the issue summary file. Especially add info about what you think is happening and how the issue can be reproduced in a test.
 3. Ask the user for feedback on your issue summary document. Do you have any misconceptions? Is your theory plausible? Did you miss anything?
 4. Now that the user agrees with your findings, write a test (in the appropriate package and test file) that reproduces the issue. The test MUST fail and clearly show the problem. The test should make sense in the context of the repo, do not make the test specific to the issue (ie with references to the issue and the specific reproduction if provided in the issue). Tests should be generalized and fit into the broader testing ecosystem in the repo.
@@ -44,6 +50,7 @@ Now that we have a failing test, a summary of our findings, and you and the user
 3. Write code to fix the issue. Run the failing test while you make changes and debug the issue so you know when it's fixed.
 4. If you get stuck, ask the user for help! They might know something you don't, or they might have an idea you didn't have.
 5. Once it's fixed, explain your fix to the user. They must agree that it's the correct fix for the issue at hand.
+6. When creating commits or PRs, reference the issue number (#${input:issue}) and title. If you've lost track of the details, re-read the ISSUE_SUMMARY${input:issue}.md file.
 
 You MUST first reproduce the issue in a test file, make sure the new test is failing (IMPORTANT!) then finally add a code fix.
 If we don't first reproduce in a unit or integration test then we can't be sure we fixed the problem.


### PR DESCRIPTION
Fixes a problem where MastraCode agents lose track of issue details after memory compaction, making it hard to create good PRs at the end of a debugging session.

**Changes:**

`$ISSUE` → `$1` across all command files so MastraCode can substitute the argument properly. Also fixes `$\{ISSUE_NUMBER\}` references.

Adds durable context strategies to the gh-debug-issue command: agents now record the issue number/title in task state immediately, create an ISSUE_SUMMARY file early as an on-disk reference, and get a reminder in Stage 3 to re-read the summary if they've lost track.

Same $ISSUE fix applied to make-moves.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Debugging workflow now requires capturing and persisting issue details (number, title, short summary and key comments) so context is retained across stages.
  * Workflow updates ensure issue summaries are maintained and that commits/PRs reference the related issue number and title for clearer traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->