### PR TITLE
fix(core): dynamic import execa to fix Cloudflare Workers builds

### DIFF
--- a/.changeset/fix-cloudflare-execa-dynamic-import.md
+++ b/.changeset/fix-cloudflare-execa-dynamic-import.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Cloudflare Workers build failures when using `@mastra/core`. Local process execution now loads its runtime dependency lazily, preventing incompatible Node-only modules from being bundled during worker builds.

--- a/packages/core/src/workspace/sandbox/execa.ts
+++ b/packages/core/src/workspace/sandbox/execa.ts
@@ -1,0 +1,33 @@
+import type { execa as execaType } from 'execa';
+
+let cached: typeof execaType | undefined;
+let loading: Promise<typeof execaType> | undefined;
+
+/**
+ * Lazily imports execa using a runtime-constructed module specifier.
+ * This prevents bundlers (Vite/Rollup/esbuild) from resolving execa at build time,
+ * which is necessary for Cloudflare Workers where execa's transitive deps
+ * (npm-run-path → unicorn-magic) use Node-only conditional exports.
+ */
+export async function getExeca(): Promise<typeof execaType> {
+  if (cached) {
+    return cached;
+  }
+  if (!loading) {
+    loading = (async () => {
+      try {
+        const mod = 'execa';
+        const execa = (await import(/* @vite-ignore */ /* webpackIgnore: true */ mod)).execa;
+        cached = execa;
+        return execa;
+      } catch (err) {
+        throw new Error(
+          'execa is required for local process execution but is not available in this environment. ' +
+            'LocalProcessManager is not supported in Cloudflare Workers or other non-Node runtimes.',
+          { cause: err },
+        );
+      }
+    })();
+  }
+  return loading;
+}

--- a/packages/core/src/workspace/sandbox/local-process-manager.ts
+++ b/packages/core/src/workspace/sandbox/local-process-manager.ts
@@ -5,9 +5,9 @@
  * Tracks processes in-memory since there's no server to query.
  */
 
-import { execa } from 'execa';
 import type { ResultPromise, Options as ExecaOptions } from 'execa';
 
+import { getExeca } from './execa';
 import type { LocalSandbox } from './local-sandbox';
 import { ProcessHandle, SandboxProcessManager } from './process-manager';
 import type { ProcessInfo, SpawnProcessOptions } from './process-manager';
@@ -158,6 +158,7 @@ export class LocalProcessManager extends SandboxProcessManager<LocalSandbox> {
       extendEnv: false,
     };
 
+    const execa = await getExeca();
     const subprocess = execa(wrapped.command, wrapped.args, execaOptions);
 
     // execa sets pid synchronously when the process spawns successfully.

--- a/packages/core/src/workspace/tools/ast-edit.ts
+++ b/packages/core/src/workspace/tools/ast-edit.ts
@@ -80,7 +80,7 @@ export async function loadAstGrep(): Promise<AstGrepModule | null> {
       try {
         // Dynamic import with string concatenation to prevent bundlers from resolving at build time
         const moduleName = '@ast-grep' + '/napi';
-        const mod = await import(/* webpackIgnore: true */ moduleName);
+        const mod = await import(/* @vite-ignore */ /* webpackIgnore: true */ moduleName);
         astGrepModule = { parse: mod.parse, Lang: mod.Lang };
         return astGrepModule;
       } catch {


### PR DESCRIPTION
## Problem

`@mastra/core@1.9.0` added `execa` as a dependency for `LocalProcessManager`. The static top-level `import { execa } from 'execa'` in `local-process-manager.ts` gets pulled into the bundle for any consumer of `@mastra/core` or `@mastra/core/workspace`, even if `LocalProcessManager` is never used.

This breaks Cloudflare Workers builds because execa's transitive dependency chain (`execa` → `npm-run-path` → `unicorn-magic`) uses Node-only conditional exports (`"node"` condition for `toPath`/`traversePathUp`). Cloudflare's esbuild bundler resolves the `"default"` condition instead, which doesn't export those functions:

```
✘ [ERROR] No matching export in "unicorn-magic/default.js" for import "toPath"
```

PR #13746 added an `execa` stub alias in the Cloudflare deployer's wrangler config, but this only helps users building through the Mastra deployer — not those using `@cloudflare/vite-plugin` or other bundlers directly.

## Fix

- Extracted `execa` loading into a `getExeca()` utility (`packages/core/src/workspace/sandbox/execa.ts`) that uses a lazy dynamic import with a runtime-constructed module specifier to prevent static analysis by bundlers (Rollup/Vite/esbuild).
- Uses a shared promise pattern to prevent race conditions when multiple callers invoke `getExeca()` concurrently.
- Includes a `try/catch` with a clear error message when `execa` is unavailable (e.g. in Cloudflare Workers), with the original error preserved as `cause`.
- Added `@vite-ignore` comments to the dynamic imports for both `execa` and `ast-grep` to suppress Vite dev server warnings.

## Verification

- `pnpm build:lib` — builds clean, compiled output uses dynamic `import(mod)` with no static `execa` imports
- No static `from "execa"` imports in `dist/`
- All 207 unit tests pass
- No type errors, no lint errors
- Tested with a minimal Cloudflare Workers project using `@cloudflare/vite-plugin`:
  - `vite build` succeeds (previously failed with `unicorn-magic` error)
  - `vite dev` starts cleanly with no dynamic import warnings
  - Calling `LocalProcessManager.spawn()` at runtime returns the friendly error message with original cause

## Test plan

1. Build `@mastra/core`
2. Verify `grep -rn "from 'execa'" packages/core/dist/ --include="*.js"` returns no results
3. Verify `LocalProcessManager` still works by running sandbox tests
4. Create a minimal Cloudflare Workers project with `@cloudflare/vite-plugin` that imports from `@mastra/core` and verify both `vite build` and `vite dev` succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed Cloudflare Workers build failures by preventing incompatible Node-only modules from being bundled during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->