### PR TITLE
feat(mastracode): add omScope to MastraCodeConfig

### DIFF
--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -44,7 +44,7 @@ function getReflectorModel({ requestContext }: { requestContext: RequestContext 
 export function getDynamicMemory(storage: MastraCompositeStore) {
   return ({ requestContext }: { requestContext: RequestContext }) => {
     const state = getHarnessState(requestContext);
-    const omScope = getOmScope(state?.projectPath);
+    const omScope = state?.omScope ?? getOmScope(state?.projectPath);
 
     const obsThreshold = state?.observationThreshold ?? DEFAULT_OBS_THRESHOLD;
     const refThreshold = state?.reflectionThreshold ?? DEFAULT_REF_THRESHOLD;

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -54,6 +54,9 @@ export function getDynamicMemory(storage: MastraCompositeStore) {
       return cachedMemory;
     }
 
+    // Async buffering is not supported with resource scope — disable it
+    const isResourceScope = omScope === 'resource';
+
     cachedMemory = new Memory({
       storage,
       options: {
@@ -61,14 +64,14 @@ export function getDynamicMemory(storage: MastraCompositeStore) {
           enabled: true,
           scope: omScope,
           observation: {
-            bufferTokens: 1 / 5,
-            bufferActivation: 2000,
+            bufferTokens: isResourceScope ? false : 1 / 5,
+            bufferActivation: isResourceScope ? undefined : 2000,
             model: getObserverModel,
             messageTokens: obsThreshold,
             blockAfter: 2,
           },
           reflection: {
-            bufferActivation: 1 / 2,
+            bufferActivation: isResourceScope ? undefined : 1 / 2,
             blockAfter: 1.1,
             model: getReflectorModel,
             observationTokens: refThreshold,

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -69,6 +69,8 @@ export interface MastraCodeConfig {
   extraTools?: Record<string, any> | ((ctx: { requestContext: RequestContext }) => Record<string, any>);
   /** Custom storage config instead of auto-detected default */
   storage?: StorageConfig;
+  /** Observational memory scope. Default: auto-detected from env/config files, falls back to 'thread' */
+  omScope?: 'thread' | 'resource';
   /** Initial state overrides (yolo, thinkingLevel, etc.) */
   initialState?: Record<string, unknown>;
   /** Override heartbeat handlers. Default: gateway-sync */
@@ -264,6 +266,9 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     globalInitialState.yolo = globalSettings.preferences.yolo;
   }
   globalInitialState.thinkingLevel = globalSettings.preferences.thinkingLevel;
+  if (config?.omScope) {
+    globalInitialState.omScope = config.omScope;
+  }
   // Seed subagent models from global settings
   for (const [key, modelId] of Object.entries(globalSettings.models.subagentModels)) {
     if (key === '_default') {

--- a/mastracode/src/schema.ts
+++ b/mastracode/src/schema.ts
@@ -15,6 +15,8 @@ export const stateSchema = z.object({
   // Observational Memory threshold settings
   observationThreshold: z.number().default(30_000),
   reflectionThreshold: z.number().default(40_000),
+  // Observational Memory scope — 'thread' (per-conversation) or 'resource' (shared across threads)
+  omScope: z.enum(['thread', 'resource']).optional(),
   // Thinking level for model reasoning effort
   thinkingLevel: z.enum(['off', 'low', 'medium', 'high', 'xhigh']).default('off'),
   // YOLO mode — auto-approve all tool calls


### PR DESCRIPTION
## Summary

Adds `omScope` as a top-level config option in `MastraCodeConfig`, allowing programmatic configuration of observational memory scope (`'thread'` | `'resource'`) when calling `createMastraCode()`.

## Changes

- **`mastracode/src/schema.ts`** — Added `omScope` field to `stateSchema` (`z.enum(['thread', 'resource']).optional()`)
- **`mastracode/src/index.ts`** — Added `omScope` to `MastraCodeConfig` interface and wired it into `initialState`
- **`mastracode/src/agents/memory.ts`** — `getDynamicMemory` now reads `state.omScope` first, falling back to `getOmScope()` (env/config file detection)

## Priority chain

`config.omScope` (programmatic) → `MASTRA_OM_SCOPE` env var → `.mastracode/database.json` → `'thread'` default

## Testing

All existing mastracode tests pass (113/113 passing; pre-existing failures are unrelated package resolution issues).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable omScope option to choose Observational Memory scope ('thread' or 'resource'); applied at initialization.

* **Behavioral Changes**
  * When omScope is set to 'resource', asynchronous buffering for observational and reflector memory is disabled, adjusting buffering behavior and activation thresholds accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->