### PR TITLE
docs(workflows): add parallel failure handling pattern

### DIFF
--- a/docs/src/content/en/docs/workflows/control-flow.mdx
+++ b/docs/src/content/en/docs/workflows/control-flow.mdx
@@ -173,6 +173,48 @@ export const testWorkflow = createWorkflow({
 - The next step receives an object containing all parallel step outputs
 - You must define the `inputSchema` of the following step to match this structure
 
+### Handling step failures
+
+If any parallel step throws an error, the entire parallel block fails. To build resilient parallel workflows where some steps may fail — for example, multiple research agents where one might have an expired auth token — handle errors inside the step itself using try/catch:
+
+```typescript title="src/mastra/workflows/test-workflow.ts"
+const resilientStep = createStep({
+  id: 'researcher',
+  inputSchema: z.object({ query: z.string() }),
+  outputSchema: z.object({
+    brief: z.string().nullable(),
+    failed: z.boolean(),
+  }),
+  execute: async ({ inputData }) => {
+    try {
+      const result = await fetchExternalData(inputData.query)
+      return { brief: result, failed: false }
+    } catch {
+      return { brief: null, failed: true }
+    }
+  },
+})
+```
+
+This way the step always succeeds with a typed result, and the downstream step can filter out failed results:
+
+```typescript title="src/mastra/workflows/test-workflow.ts"
+const writerStep = createStep({
+  id: 'writer',
+  inputSchema: z.object({
+    'researcher-a': z.object({ brief: z.string().nullable(), failed: z.boolean() }),
+    'researcher-b': z.object({ brief: z.string().nullable(), failed: z.boolean() }),
+  }),
+  outputSchema: z.object({ synthesis: z.string() }),
+  execute: async ({ inputData }) => {
+    const briefs = Object.values(inputData)
+      .filter(v => !v.failed && v.brief)
+      .map(v => v.brief)
+    return { synthesis: briefs.join('; ') }
+  },
+})
+```
+
 :::info
 
 Visit [Choosing the right pattern](#choosing-the-right-pattern) to understand when to use `.parallel()` vs `.foreach()`.


### PR DESCRIPTION
## Description

Added documentation explaining how to handle failures in parallel workflow steps using try/catch and typed error results instead of letting steps throw. This guides users toward the recommended pattern: steps should handle their own errors and return typed results that downstream steps can filter/process.

Includes a practical example showing a resilient researcher step that catches errors and returns a result shape with a `failed` flag, and a downstream writer step that filters out failed results.

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new section on handling step failures in parallel workflows, including best practices and examples for implementing error handling to ensure robust and resilient workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->