### PR TITLE
fix: merge providerOptions in handleChatStream (#12572)

### DIFF
--- a/.changeset/fresh-foxes-build.md
+++ b/.changeset/fresh-foxes-build.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed `handleChatStream` not merging `providerOptions` from `params` and `defaultOptions`. Previously, `params.providerOptions` would completely replace `defaultOptions.providerOptions` instead of merging them. Now provider-specific keys from both sources are merged, with `params.providerOptions` taking precedence for the same provider.

--- a/client-sdks/ai-sdk/src/__tests__/provider-options.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/provider-options.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for issue #12572: handleChatStream should properly merge providerOptions.
+ */
+import type { UIMessage } from '@internal/ai-sdk-v5';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { Agent } from '@mastra/core/agent';
+import { Mastra } from '@mastra/core/mastra';
+import { describe, expect, it, vi } from 'vitest';
+
+import { handleChatStream } from '../chat-route';
+
+function createMockModel() {
+  return new MockLanguageModelV2({
+    doStream: async () => ({
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'msg-1', modelId: 'mock-model', timestamp: new Date() },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Hello world' },
+        { type: 'text-end', id: 'text-1' },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+        },
+      ] as any),
+      rawCall: { rawPrompt: [], rawSettings: {} },
+      warnings: [],
+    }),
+  });
+}
+
+function createTestAgent() {
+  return new Agent({
+    id: 'test-agent',
+    name: 'Test Agent',
+    instructions: 'You are a helpful assistant.',
+    model: createMockModel(),
+  });
+}
+
+function createTestMastra(agent: Agent) {
+  return new Mastra({
+    agents: { [agent.id]: agent },
+  });
+}
+
+async function drainStream(stream: ReadableStream) {
+  const reader = stream.getReader();
+  while (true) {
+    const { done } = await reader.read();
+    if (done) break;
+  }
+}
+
+const messages: UIMessage[] = [{ id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] }];
+
+describe('providerOptions forwarding (issue #12572)', () => {
+  it('should forward params.providerOptions to agent.stream()', async () => {
+    const agent = createTestAgent();
+    const mastra = createTestMastra(agent);
+    const streamSpy = vi.spyOn(agent, 'stream');
+
+    const stream = await handleChatStream({
+      mastra,
+      agentId: 'test-agent',
+      params: {
+        messages,
+        providerOptions: { openai: { reasoningEffort: 'high' } },
+      },
+    });
+    await drainStream(stream);
+
+    expect(streamSpy).toHaveBeenCalledTimes(1);
+    const options = streamSpy.mock.calls[0]![1];
+    expect(options?.providerOptions).toEqual({ openai: { reasoningEffort: 'high' } });
+
+    streamSpy.mockRestore();
+  });
+
+  it('should merge params.providerOptions with defaultOptions.providerOptions', async () => {
+    const agent = createTestAgent();
+    const mastra = createTestMastra(agent);
+    const streamSpy = vi.spyOn(agent, 'stream');
+
+    const stream = await handleChatStream({
+      mastra,
+      agentId: 'test-agent',
+      defaultOptions: {
+        providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+      },
+      params: {
+        messages,
+        providerOptions: { openai: { reasoningEffort: 'high' } },
+      },
+    });
+    await drainStream(stream);
+
+    expect(streamSpy).toHaveBeenCalledTimes(1);
+    const options = streamSpy.mock.calls[0]![1];
+    expect(options?.providerOptions).toEqual({
+      anthropic: { cacheControl: { type: 'ephemeral' } },
+      openai: { reasoningEffort: 'high' },
+    });
+
+    streamSpy.mockRestore();
+  });
+
+  it('should let params.providerOptions override defaultOptions.providerOptions for the same provider', async () => {
+    const agent = createTestAgent();
+    const mastra = createTestMastra(agent);
+    const streamSpy = vi.spyOn(agent, 'stream');
+
+    const stream = await handleChatStream({
+      mastra,
+      agentId: 'test-agent',
+      defaultOptions: {
+        providerOptions: { openai: { reasoningEffort: 'low' } },
+      },
+      params: {
+        messages,
+        providerOptions: { openai: { reasoningEffort: 'high' } },
+      },
+    });
+    await drainStream(stream);
+
+    expect(streamSpy).toHaveBeenCalledTimes(1);
+    const options = streamSpy.mock.calls[0]![1];
+    expect(options?.providerOptions).toEqual({ openai: { reasoningEffort: 'high' } });
+
+    streamSpy.mockRestore();
+  });
+
+  it('should replace the entire provider block when params overrides the same provider', async () => {
+    const agent = createTestAgent();
+    const mastra = createTestMastra(agent);
+    const streamSpy = vi.spyOn(agent, 'stream');
+
+    const stream = await handleChatStream({
+      mastra,
+      agentId: 'test-agent',
+      defaultOptions: {
+        providerOptions: { openai: { reasoningEffort: 'low', someOtherSetting: true } },
+      },
+      params: {
+        messages,
+        providerOptions: { openai: { reasoningEffort: 'high' } },
+      },
+    });
+    await drainStream(stream);
+
+    expect(streamSpy).toHaveBeenCalledTimes(1);
+    const options = streamSpy.mock.calls[0]![1];
+    // params.providerOptions.openai replaces defaultOptions.providerOptions.openai entirely
+    expect(options?.providerOptions).toEqual({ openai: { reasoningEffort: 'high' } });
+
+    streamSpy.mockRestore();
+  });
+
+  it('should not include providerOptions when none are provided', async () => {
+    const agent = createTestAgent();
+    const mastra = createTestMastra(agent);
+    const streamSpy = vi.spyOn(agent, 'stream');
+
+    const stream = await handleChatStream({
+      mastra,
+      agentId: 'test-agent',
+      params: { messages },
+    });
+    await drainStream(stream);
+
+    expect(streamSpy).toHaveBeenCalledTimes(1);
+    const options = streamSpy.mock.calls[0]![1];
+    expect(options?.providerOptions).toBeUndefined();
+
+    streamSpy.mockRestore();
+  });
+});

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -91,11 +91,17 @@ export async function handleChatStream<UI_MESSAGE extends UIMessage, OUTPUT = un
     }
   }
 
+  const mergedProviderOptions = {
+    ...defaultOptions?.providerOptions,
+    ...rest.providerOptions,
+  };
+
   const mergedOptions = {
     ...defaultOptions,
     ...rest,
     ...(runId && { runId }),
     requestContext: requestContext || defaultOptions?.requestContext,
+    ...(Object.keys(mergedProviderOptions).length > 0 && { providerOptions: mergedProviderOptions }),
   };
 
   const result = resumeData

--- a/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/handle-chat-stream.mdx
@@ -76,6 +76,13 @@ export async function POST(req: Request) {
     isOptional: true,
   },
   {
+    name: 'params.providerOptions',
+    type: 'Record<string, Record<string, unknown>>',
+    description:
+      'Provider-specific options passed to the language model (e.g. `{ openai: { reasoningEffort: "high" } }`). Merged with `defaultOptions.providerOptions`, with `params` taking precedence.',
+    isOptional: true,
+  },
+  {
     name: 'params.requestContext',
     type: 'RequestContext',
     description: 'Request context to pass to the agent execution.',


### PR DESCRIPTION
## Summary

Fixes #12572

`params.providerOptions` was already supported for passing provider-specific options (e.g. OpenAI `reasoningEffort`) to `handleChatStream`, but wasn't documented. Additionally, if both `defaultOptions.providerOptions` and `params.providerOptions` were set, `params` would completely replace `defaultOptions` instead of merging them.

## Changes

- Merge `defaultOptions.providerOptions` and `params.providerOptions` instead of replacing. Precedence: `defaultOptions` < `params`
- Only include `providerOptions` in merged options when at least one source provides it
- Added `params.providerOptions` to the `handleChatStream` reference docs with usage example

## Test Plan

Added 4 tests in `provider-options.test.ts`:
- `params.providerOptions` forwarded to `agent.stream()`
- Merges `params.providerOptions` with `defaultOptions.providerOptions`
- `params.providerOptions` overrides `defaultOptions` for the same provider
- No `providerOptions` when none provided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider-specific options now merge correctly: parameter-level options override defaults and are applied only when present.

* **Tests**
  * Added tests validating forwarding, merging, overrides, replacement, and omission behaviors for provider options.

* **Documentation**
  * Updated examples and parameter docs demonstrating how to pass provider-specific options and describing merge/precedence behavior.

* **Changelog**
  * Added a patch changelog entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->