### PR TITLE
fix: route data-* chunks through output processors (#13341)

### DIFF
--- a/.changeset/eight-months-refuse.md
+++ b/.changeset/eight-months-refuse.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed custom `data-*` chunks emitted by tools via `writer.custom()` bypassing output processors. These chunks are now routed through the output processor pipeline before being enqueued to the stream, so processors can inspect, modify, or block them.

--- a/.changeset/eight-months-refuse.md
+++ b/.changeset/eight-months-refuse.md
@@ -3,3 +3,16 @@
 ---
 
 Output processors can now inspect, modify, or block custom `data-*` chunks emitted by tools via `writer.custom()` during streaming. Processors must opt in by setting `processDataParts = true` to receive these chunks in `processOutputStream`.
+
+```ts
+class MyDataProcessor extends Processor {
+  processDataParts = true;
+
+  processOutputStream(part, { abort }) {
+    if (part.type === 'data-sensitive') {
+      abort('Blocked sensitive data');
+    }
+    return part;
+  }
+}
+```

--- a/.changeset/eight-months-refuse.md
+++ b/.changeset/eight-months-refuse.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed custom `data-*` chunks emitted by tools via `writer.custom()` bypassing output processors. These chunks are now routed through the output processor pipeline before being enqueued to the stream. Processors must opt in by setting `processDataParts = true` to receive `data-*` chunks in `processOutputStream`.
+Output processors can now inspect, modify, or block custom `data-*` chunks emitted by tools via `writer.custom()` during streaming. Processors must opt in by setting `processDataParts = true` to receive these chunks in `processOutputStream`.

--- a/.changeset/eight-months-refuse.md
+++ b/.changeset/eight-months-refuse.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed custom `data-*` chunks emitted by tools via `writer.custom()` bypassing output processors. These chunks are now routed through the output processor pipeline before being enqueued to the stream, so processors can inspect, modify, or block them.
+Fixed custom `data-*` chunks emitted by tools via `writer.custom()` bypassing output processors. These chunks are now routed through the output processor pipeline before being enqueued to the stream. Processors must opt in by setting `processDataParts = true` to receive `data-*` chunks in `processOutputStream`.

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -327,6 +327,8 @@ export class CustomOutputProcessor implements Processor {
 }
 ```
 
+The `processOutputStream` method receives all streaming chunks, including custom `data-*` chunks emitted by tools via `writer.custom()`. This means you can use output processors to inspect, modify, or block tool-emitted data chunks before they reach the client.
+
 #### Accessing generation result data
 
 The `processOutputResult` method receives a `result` object containing the resolved generation data — the same information available in the `onFinish` callback. This makes it easy to access token usage, generated text, finish reason, and step details.

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -327,7 +327,7 @@ export class CustomOutputProcessor implements Processor {
 }
 ```
 
-The `processOutputStream` method receives all streaming chunks, including custom `data-*` chunks emitted by tools via `writer.custom()`. This means you can use output processors to inspect, modify, or block tool-emitted data chunks before they reach the client.
+The `processOutputStream` method receives all streaming chunks. To also receive custom `data-*` chunks emitted by tools via `writer.custom()`, set `processDataParts = true` on your processor. This lets you inspect, modify, or block tool-emitted data chunks before they reach the client.
 
 #### Accessing generation result data
 

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -88,7 +88,13 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
             }
           }
 
-          if (messageId && !('transient' in processedChunk && processedChunk.transient)) {
+          // If a processor rewrote the chunk to a non-data type, skip persistence
+          if (
+            typeof processedChunk.type === 'string' &&
+            processedChunk.type.startsWith('data-') &&
+            messageId &&
+            !('transient' in processedChunk && processedChunk.transient)
+          ) {
             const dataPart = {
               type: processedChunk.type as `data-${string}`,
               data: 'data' in processedChunk ? processedChunk.data : undefined,

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -2,7 +2,10 @@ import { ReadableStream } from 'node:stream/web';
 import type { ToolSet } from '@internal/ai-sdk-v5';
 import type { MastraDBMessage } from '../../agent/message-list';
 import { getErrorFromUnknown } from '../../error';
+import { ConsoleLogger } from '../../logger';
 import { createObservabilityContext } from '../../observability';
+import { ProcessorRunner } from '../../processors/runner';
+import type { ProcessorState } from '../../processors/runner';
 import { RequestContext } from '../../request-context';
 import { safeClose, safeEnqueue } from '../../stream/base';
 import type { ChunkType } from '../../stream/types';
@@ -29,6 +32,18 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
 }: LoopRun<Tools, OUTPUT>) {
   return new ReadableStream<ChunkType<OUTPUT>>({
     start: async controller => {
+      // Create a ProcessorRunner for data-* chunks so they go through output processors
+      // instead of bypassing them (fixes #13341)
+      const hasOutputProcessors = rest.outputProcessors && rest.outputProcessors.length > 0;
+      const dataChunkProcessorRunner = hasOutputProcessors
+        ? new ProcessorRunner({
+            outputProcessors: rest.outputProcessors,
+            logger: rest.logger || new ConsoleLogger({ level: 'error' }),
+            agentName: agentId || 'unknown',
+          })
+        : undefined;
+      const dataChunkProcessorStates = hasOutputProcessors ? new Map<string, ProcessorState>() : undefined;
+
       const outputWriter = async (chunk: ChunkType<OUTPUT>) => {
         // Handle data-* chunks (custom data chunks from writer.custom())
         // These need to be persisted to storage, not just streamed
@@ -50,6 +65,28 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
             resourceId: _internal?.resourceId,
           };
           messageList.add(message, 'response');
+
+          // Run data-* chunks through output processors (fixes #13341)
+          if (dataChunkProcessorRunner) {
+            const streamWriter = {
+              custom: async (data: { type: string }) => {
+                safeEnqueue(controller, data as ChunkType<OUTPUT>);
+              },
+            };
+            const { part: processed, blocked } = await dataChunkProcessorRunner.processPart(
+              chunk,
+              dataChunkProcessorStates!,
+              undefined, // observabilityContext
+              rest.requestContext,
+              messageList,
+              0,
+              streamWriter,
+            );
+            if (!blocked && processed) {
+              safeEnqueue(controller, processed as ChunkType<OUTPUT>);
+            }
+            return;
+          }
         }
         safeEnqueue(controller, chunk);
       };

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -33,7 +33,6 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
   return new ReadableStream<ChunkType<OUTPUT>>({
     start: async controller => {
       // Create a ProcessorRunner for data-* chunks so they go through output processors
-      // instead of bypassing them (fixes #13341)
       const hasOutputProcessors = rest.outputProcessors && rest.outputProcessors.length > 0;
       const dataChunkProcessorRunner = hasOutputProcessors
         ? new ProcessorRunner({
@@ -49,7 +48,7 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
         // These need to be persisted to storage, not just streamed
         // Transient chunks are streamed to the client but not saved to the DB
         if (chunk.type.startsWith('data-')) {
-          // Run data-* chunks through output processors before persisting (fixes #13341)
+          // Run data-* chunks through output processors before persisting
           let processedChunk = chunk;
           if (dataChunkProcessorRunner) {
             const {

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -32,6 +32,9 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
 }: LoopRun<Tools, OUTPUT>) {
   return new ReadableStream<ChunkType<OUTPUT>>({
     start: async controller => {
+      // Normalize requestContext so data-chunk processors and the agentic loop share the same instance
+      const requestContext = rest.requestContext ?? new RequestContext();
+
       // Create a ProcessorRunner for data-* chunks so they go through output processors
       const hasOutputProcessors = rest.outputProcessors && rest.outputProcessors.length > 0;
       const dataChunkProcessorRunner = hasOutputProcessors
@@ -61,7 +64,7 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
               chunk,
               (rest.processorStates ?? dataChunkProcessorStates!) as Map<string, ProcessorState<OUTPUT>>,
               undefined, // observabilityContext
-              rest.requestContext,
+              requestContext,
               messageList,
               0,
             );
@@ -177,8 +180,6 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
       const run = await agenticLoopWorkflow.createRun({
         runId,
       });
-
-      const requestContext = rest.requestContext ?? new RequestContext();
 
       if (requireToolApproval) {
         requestContext.set('__mastra_requireToolApproval', true);

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -48,45 +48,68 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
         // Handle data-* chunks (custom data chunks from writer.custom())
         // These need to be persisted to storage, not just streamed
         // Transient chunks are streamed to the client but not saved to the DB
-        if (chunk.type.startsWith('data-') && messageId && !('transient' in chunk && chunk.transient)) {
-          const dataPart = {
-            type: chunk.type as `data-${string}`,
-            data: 'data' in chunk ? chunk.data : undefined,
-          };
-          const message: MastraDBMessage = {
-            id: messageId,
-            role: 'assistant',
-            content: {
-              format: 2,
-              parts: [dataPart],
-            },
-            createdAt: new Date(),
-            threadId: _internal?.threadId,
-            resourceId: _internal?.resourceId,
-          };
-          messageList.add(message, 'response');
-
-          // Run data-* chunks through output processors (fixes #13341)
+        if (chunk.type.startsWith('data-')) {
+          // Run data-* chunks through output processors before persisting (fixes #13341)
+          let processedChunk = chunk;
           if (dataChunkProcessorRunner) {
-            const streamWriter = {
-              custom: async (data: { type: string }) => {
-                safeEnqueue(controller, data as ChunkType<OUTPUT>);
-              },
-            };
-            const { part: processed, blocked } = await dataChunkProcessorRunner.processPart(
+            const {
+              part: processed,
+              blocked,
+              reason,
+              tripwireOptions,
+              processorId,
+            } = await dataChunkProcessorRunner.processPart(
               chunk,
-              dataChunkProcessorStates!,
+              (rest.processorStates ?? dataChunkProcessorStates!) as Map<string, ProcessorState<OUTPUT>>,
               undefined, // observabilityContext
               rest.requestContext,
               messageList,
               0,
-              streamWriter,
             );
-            if (!blocked && processed) {
-              safeEnqueue(controller, processed as ChunkType<OUTPUT>);
+
+            if (blocked) {
+              safeEnqueue(controller, {
+                type: 'tripwire',
+                runId,
+                from: ChunkFrom.AGENT,
+                payload: {
+                  reason: reason || 'Output processor blocked content',
+                  retry: tripwireOptions?.retry,
+                  metadata: tripwireOptions?.metadata,
+                  processorId,
+                },
+              } as ChunkType<OUTPUT>);
+              return;
             }
-            return;
+
+            if (processed) {
+              processedChunk = processed as ChunkType<OUTPUT>;
+            } else {
+              return;
+            }
           }
+
+          if (messageId && !('transient' in processedChunk && processedChunk.transient)) {
+            const dataPart = {
+              type: processedChunk.type as `data-${string}`,
+              data: 'data' in processedChunk ? processedChunk.data : undefined,
+            };
+            const message: MastraDBMessage = {
+              id: messageId,
+              role: 'assistant',
+              content: {
+                format: 2,
+                parts: [dataPart],
+              },
+              createdAt: new Date(),
+              threadId: _internal?.threadId,
+              resourceId: _internal?.resourceId,
+            };
+            messageList.add(message, 'response');
+          }
+
+          safeEnqueue(controller, processedChunk);
+          return;
         }
         safeEnqueue(controller, chunk);
       };

--- a/packages/core/src/processors/index.ts
+++ b/packages/core/src/processors/index.ts
@@ -272,6 +272,9 @@ export interface Processor<TId extends string = string, TTripwireMetadata = unkn
   /** Index of this processor in the workflow (set at runtime when combining processors) */
   processorIndex?: number;
 
+  /** When true, this processor will also receive `data-*` chunks in processOutputStream. Default: false. */
+  processDataParts?: boolean;
+
   /**
    * Process input messages before they are sent to the LLM
    *

--- a/packages/core/src/processors/output-processor-data-chunks.test.ts
+++ b/packages/core/src/processors/output-processor-data-chunks.test.ts
@@ -288,30 +288,32 @@ describe('Output Processor Data Chunks (#13341)', () => {
       outputProcessors: [new TransientMarkingProcessor()],
     });
 
-    const stream = await agent.stream('Call the tool with text "hello"', {
-      maxSteps: 5,
-    });
+    try {
+      const stream = await agent.stream('Call the tool with text "hello"', {
+        maxSteps: 5,
+      });
 
-    const dataChunks: any[] = [];
-    for await (const chunk of stream.fullStream) {
-      if (chunk.type === 'data-debug') {
-        dataChunks.push(chunk);
+      const dataChunks: any[] = [];
+      for await (const chunk of stream.fullStream) {
+        if (chunk.type === 'data-debug') {
+          dataChunks.push(chunk);
+        }
       }
+
+      // The chunk should still appear in the stream
+      expect(dataChunks).toHaveLength(1);
+      expect(dataChunks[0].data).toEqual({ step: 1, detail: 'internal state' });
+      expect(dataChunks[0].transient).toBe(true);
+
+      // messageList.add should NOT have been called with a data-debug part
+      const dataDebugAdds = addSpy.mock.calls.filter(([messages]) => {
+        const msgs = Array.isArray(messages) ? messages : [messages];
+        return msgs.some((m: any) => m.content?.parts?.some((p: any) => p.type === 'data-debug'));
+      });
+      expect(dataDebugAdds).toHaveLength(0);
+    } finally {
+      addSpy.mockRestore();
     }
-
-    // The chunk should still appear in the stream
-    expect(dataChunks).toHaveLength(1);
-    expect(dataChunks[0].data).toEqual({ step: 1, detail: 'internal state' });
-    expect(dataChunks[0].transient).toBe(true);
-
-    // messageList.add should NOT have been called with a data-debug part
-    const dataDebugAdds = addSpy.mock.calls.filter(([messages]) => {
-      const msgs = Array.isArray(messages) ? messages : [messages];
-      return msgs.some((m: any) => m.content?.parts?.some((p: any) => p.type === 'data-debug'));
-    });
-    expect(dataDebugAdds).toHaveLength(0);
-
-    addSpy.mockRestore();
   });
 
   it('should process multiple data-* chunks from a single tool execution', async () => {

--- a/packages/core/src/processors/output-processor-data-chunks.test.ts
+++ b/packages/core/src/processors/output-processor-data-chunks.test.ts
@@ -309,4 +309,58 @@ describe('Output Processor Data Chunks (#13341)', () => {
 
     addSpy.mockRestore();
   });
+
+  it('should process multiple data-* chunks from a single tool execution', async () => {
+    const capturedDataChunks: any[] = [];
+
+    class MultiChunkTracker implements Processor {
+      readonly id = 'multi-chunk-tracker';
+      readonly name = 'Multi Chunk Tracker';
+
+      async processOutputStream({ part }: any) {
+        if (part.type.startsWith('data-')) {
+          capturedDataChunks.push(part);
+        }
+        return part;
+      }
+    }
+
+    const toolWithMultipleChunks = createTool({
+      id: 'toolWithMultipleChunks',
+      description: 'A test tool that emits multiple data chunks',
+      inputSchema: z.object({ text: z.string() }),
+      execute: async (inputData, { writer }) => {
+        writer!.custom({ type: 'data-progress', data: { step: 1, status: 'started' } });
+        writer!.custom({ type: 'data-progress', data: { step: 2, status: 'processing' } });
+        writer!.custom({ type: 'data-metrics', data: { latency: 42 } });
+        return `Processed: ${inputData.text}`;
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent with tools',
+      model: createToolCallingModel('toolWithMultipleChunks') as any,
+      tools: { toolWithMultipleChunks },
+      outputProcessors: [new MultiChunkTracker()],
+    });
+
+    const stream = await agent.stream('Call the tool', { maxSteps: 5 });
+
+    const streamDataChunks: any[] = [];
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type.startsWith('data-')) {
+        streamDataChunks.push(chunk);
+      }
+    }
+
+    expect(streamDataChunks).toHaveLength(3);
+    expect(streamDataChunks[0]).toMatchObject({ type: 'data-progress', data: { step: 1, status: 'started' } });
+    expect(streamDataChunks[1]).toMatchObject({ type: 'data-progress', data: { step: 2, status: 'processing' } });
+    expect(streamDataChunks[2]).toMatchObject({ type: 'data-metrics', data: { latency: 42 } });
+
+    // Processor should have seen all 3 chunks
+    expect(capturedDataChunks).toHaveLength(3);
+  });
 });

--- a/packages/core/src/processors/output-processor-data-chunks.test.ts
+++ b/packages/core/src/processors/output-processor-data-chunks.test.ts
@@ -86,7 +86,7 @@ describe('Output Processor Data Chunks (#13341)', () => {
         text: z.string(),
       }),
       execute: async (inputData, { writer }) => {
-        writer!.custom({ type: 'data-moderation', data: { flagged: false, text: inputData.text } });
+        await writer!.custom({ type: 'data-moderation', data: { flagged: false, text: inputData.text } });
         return `Processed: ${inputData.text}`;
       },
     });
@@ -137,7 +137,7 @@ describe('Output Processor Data Chunks (#13341)', () => {
       description: 'A test tool that emits custom data chunks',
       inputSchema: z.object({ text: z.string() }),
       execute: async (inputData, { writer }) => {
-        writer!.custom({ type: 'data-moderation', data: { flagged: false } });
+        await writer!.custom({ type: 'data-moderation', data: { flagged: false } });
         return `Processed: ${inputData.text}`;
       },
     });
@@ -185,7 +185,7 @@ describe('Output Processor Data Chunks (#13341)', () => {
       description: 'A test tool that emits sensitive data chunks',
       inputSchema: z.object({ text: z.string() }),
       execute: async (inputData, { writer }) => {
-        writer!.custom({ type: 'data-sensitive', data: { secret: 'classified' } });
+        await writer!.custom({ type: 'data-sensitive', data: { secret: 'classified' } });
         return `Processed: ${inputData.text}`;
       },
     });
@@ -224,7 +224,7 @@ describe('Output Processor Data Chunks (#13341)', () => {
       description: 'A test tool that emits custom data chunks',
       inputSchema: z.object({ text: z.string() }),
       execute: async (inputData, { writer }) => {
-        writer!.custom({ type: 'data-metrics', data: { latency: 42 } });
+        await writer!.custom({ type: 'data-metrics', data: { latency: 42 } });
         return `Processed: ${inputData.text}`;
       },
     });
@@ -274,7 +274,7 @@ describe('Output Processor Data Chunks (#13341)', () => {
       description: 'A test tool that emits debug data chunks',
       inputSchema: z.object({ text: z.string() }),
       execute: async (inputData, { writer }) => {
-        writer!.custom({ type: 'data-debug', data: { step: 1, detail: 'internal state' } });
+        await writer!.custom({ type: 'data-debug', data: { step: 1, detail: 'internal state' } });
         return `Processed: ${inputData.text}`;
       },
     });
@@ -337,9 +337,9 @@ describe('Output Processor Data Chunks (#13341)', () => {
       description: 'A test tool that emits multiple data chunks',
       inputSchema: z.object({ text: z.string() }),
       execute: async (inputData, { writer }) => {
-        writer!.custom({ type: 'data-progress', data: { step: 1, status: 'started' } });
-        writer!.custom({ type: 'data-progress', data: { step: 2, status: 'processing' } });
-        writer!.custom({ type: 'data-metrics', data: { latency: 42 } });
+        await writer!.custom({ type: 'data-progress', data: { step: 1, status: 'started' } });
+        await writer!.custom({ type: 'data-progress', data: { step: 2, status: 'processing' } });
+        await writer!.custom({ type: 'data-metrics', data: { latency: 42 } });
         return `Processed: ${inputData.text}`;
       },
     });
@@ -390,7 +390,7 @@ describe('Output Processor Data Chunks (#13341)', () => {
       description: 'A test tool that emits custom data chunks',
       inputSchema: z.object({ text: z.string() }),
       execute: async (inputData, { writer }) => {
-        writer!.custom({ type: 'data-metrics', data: { latency: 42 } });
+        await writer!.custom({ type: 'data-metrics', data: { latency: 42 } });
         return `Processed: ${inputData.text}`;
       },
     });
@@ -459,7 +459,7 @@ describe('Output Processor Data Chunks (#13341)', () => {
       description: 'A test tool',
       inputSchema: z.object({ text: z.string() }),
       execute: async (inputData, { writer }) => {
-        writer!.custom({ type: 'data-pipeline', data: { original: true } });
+        await writer!.custom({ type: 'data-pipeline', data: { original: true } });
         return `Done: ${inputData.text}`;
       },
     });
@@ -524,7 +524,7 @@ describe('Output Processor Data Chunks (#13341)', () => {
       description: 'A test tool',
       inputSchema: z.object({ text: z.string() }),
       execute: async (inputData, { writer }) => {
-        writer!.custom({ type: 'data-info', data: { value: 1 } });
+        await writer!.custom({ type: 'data-info', data: { value: 1 } });
         return `Done: ${inputData.text}`;
       },
     });

--- a/packages/core/src/processors/output-processor-data-chunks.test.ts
+++ b/packages/core/src/processors/output-processor-data-chunks.test.ts
@@ -1,0 +1,321 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { Agent } from '../agent';
+import { createTool } from '../tools';
+import type { Processor } from './index';
+
+describe('Output Processor Data Chunks (#13341)', () => {
+  it('should receive data-* chunks from tool execute in processOutputStream', async () => {
+    const capturedChunkTypes: string[] = [];
+    const capturedDataChunks: any[] = [];
+
+    class DataChunkTrackingProcessor implements Processor {
+      readonly id = 'data-chunk-tracking-processor';
+      readonly name = 'Data Chunk Tracking Processor';
+
+      async processOutputStream({ part }: any) {
+        capturedChunkTypes.push(part.type);
+        if (part.type.startsWith('data-')) {
+          capturedDataChunks.push(part);
+        }
+        return part;
+      }
+    }
+
+    // Create a tool that emits a data-* chunk via writer.custom()
+    const toolWithCustomData = createTool({
+      id: 'toolWithCustomData',
+      description: 'A test tool that emits custom data chunks',
+      inputSchema: z.object({
+        text: z.string(),
+      }),
+      execute: async (inputData, { writer }) => {
+        writer!.custom({ type: 'data-moderation', data: { flagged: false, text: inputData.text } });
+        return `Processed: ${inputData.text}`;
+      },
+    });
+
+    // Create mock model that calls the tool
+    const mockModel = new MockLanguageModelV2({
+      doStream: async ({ prompt }) => {
+        const hasToolResults = prompt.some(
+          (msg: any) =>
+            msg.role === 'tool' ||
+            (Array.isArray(msg.content) && msg.content.some((c: any) => c.type === 'tool-result')),
+        );
+
+        if (!hasToolResults) {
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'toolWithCustomData',
+                input: JSON.stringify({ text: 'hello' }),
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              },
+            ]),
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        } else {
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+              { type: 'text-start', id: 'text-1' },
+              { type: 'text-delta', id: 'text-1', delta: 'Done!' },
+              { type: 'text-end', id: 'text-1' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 },
+              },
+            ]),
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        }
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent with tools',
+      model: mockModel as any,
+      tools: {
+        toolWithCustomData,
+      },
+      outputProcessors: [new DataChunkTrackingProcessor()],
+    });
+
+    const stream = await agent.stream('Call the tool with text "hello"', {
+      maxSteps: 5,
+    });
+
+    const streamChunkTypes: string[] = [];
+    for await (const chunk of stream.fullStream) {
+      streamChunkTypes.push(chunk.type);
+    }
+
+    // The stream should contain the data-moderation chunk
+    expect(streamChunkTypes).toContain('data-moderation');
+
+    // The key assertion: processOutputStream should have received the data-* chunk
+    expect(capturedChunkTypes).toContain('data-moderation');
+
+    // Verify the data was passed through correctly
+    expect(capturedDataChunks).toHaveLength(1);
+    expect(capturedDataChunks[0].data).toEqual({ flagged: false, text: 'hello' });
+  });
+
+  it('should allow output processor to modify data-* chunks', async () => {
+    class DataChunkModifyingProcessor implements Processor {
+      readonly id = 'data-chunk-modifying-processor';
+      readonly name = 'Data Chunk Modifying Processor';
+
+      async processOutputStream({ part }: any) {
+        if (part.type === 'data-moderation') {
+          return {
+            ...part,
+            data: { ...part.data, processed: true },
+          };
+        }
+        return part;
+      }
+    }
+
+    const toolWithCustomData = createTool({
+      id: 'toolWithCustomData',
+      description: 'A test tool that emits custom data chunks',
+      inputSchema: z.object({
+        text: z.string(),
+      }),
+      execute: async (inputData, { writer }) => {
+        writer!.custom({ type: 'data-moderation', data: { flagged: false } });
+        return `Processed: ${inputData.text}`;
+      },
+    });
+
+    const mockModel = new MockLanguageModelV2({
+      doStream: async ({ prompt }) => {
+        const hasToolResults = prompt.some(
+          (msg: any) =>
+            msg.role === 'tool' ||
+            (Array.isArray(msg.content) && msg.content.some((c: any) => c.type === 'tool-result')),
+        );
+
+        if (!hasToolResults) {
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'toolWithCustomData',
+                input: JSON.stringify({ text: 'hello' }),
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              },
+            ]),
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        } else {
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+              { type: 'text-start', id: 'text-1' },
+              { type: 'text-delta', id: 'text-1', delta: 'Done!' },
+              { type: 'text-end', id: 'text-1' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 },
+              },
+            ]),
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        }
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent with tools',
+      model: mockModel as any,
+      tools: {
+        toolWithCustomData,
+      },
+      outputProcessors: [new DataChunkModifyingProcessor()],
+    });
+
+    const stream = await agent.stream('Call the tool with text "hello"', {
+      maxSteps: 5,
+    });
+
+    const dataChunks: any[] = [];
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'data-moderation') {
+        dataChunks.push(chunk);
+      }
+    }
+
+    // The data chunk should have been modified by the processor
+    expect(dataChunks).toHaveLength(1);
+    expect(dataChunks[0].data).toEqual({ flagged: false, processed: true });
+  });
+
+  it('should allow output processor to block data-* chunks via abort', async () => {
+    class DataChunkBlockingProcessor implements Processor {
+      readonly id = 'data-chunk-blocking-processor';
+      readonly name = 'Data Chunk Blocking Processor';
+
+      async processOutputStream({ part, abort }: any) {
+        if (part.type === 'data-sensitive') {
+          abort('Sensitive data blocked');
+        }
+        return part;
+      }
+    }
+
+    const toolWithSensitiveData = createTool({
+      id: 'toolWithSensitiveData',
+      description: 'A test tool that emits sensitive data chunks',
+      inputSchema: z.object({
+        text: z.string(),
+      }),
+      execute: async (inputData, { writer }) => {
+        writer!.custom({ type: 'data-sensitive', data: { secret: 'classified' } });
+        return `Processed: ${inputData.text}`;
+      },
+    });
+
+    const mockModel = new MockLanguageModelV2({
+      doStream: async ({ prompt }) => {
+        const hasToolResults = prompt.some(
+          (msg: any) =>
+            msg.role === 'tool' ||
+            (Array.isArray(msg.content) && msg.content.some((c: any) => c.type === 'tool-result')),
+        );
+
+        if (!hasToolResults) {
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'toolWithSensitiveData',
+                input: JSON.stringify({ text: 'hello' }),
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              },
+            ]),
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        } else {
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+              { type: 'text-start', id: 'text-1' },
+              { type: 'text-delta', id: 'text-1', delta: 'Done!' },
+              { type: 'text-end', id: 'text-1' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 },
+              },
+            ]),
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        }
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent with tools',
+      model: mockModel as any,
+      tools: {
+        toolWithSensitiveData,
+      },
+      outputProcessors: [new DataChunkBlockingProcessor()],
+    });
+
+    const stream = await agent.stream('Call the tool with text "hello"', {
+      maxSteps: 5,
+    });
+
+    const streamChunkTypes: string[] = [];
+    for await (const chunk of stream.fullStream) {
+      streamChunkTypes.push(chunk.type);
+    }
+
+    // The data-sensitive chunk should NOT appear in the stream (blocked by processor)
+    expect(streamChunkTypes).not.toContain('data-sensitive');
+  });
+});

--- a/packages/core/src/processors/output-processor-data-chunks.test.ts
+++ b/packages/core/src/processors/output-processor-data-chunks.test.ts
@@ -1,9 +1,64 @@
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { Agent } from '../agent';
+import { MessageList } from '../agent/message-list';
 import { createTool } from '../tools';
 import type { Processor } from './index';
+
+/**
+ * Creates a mock model that calls `toolName` on the first turn,
+ * then replies with "Done!" after seeing the tool result.
+ */
+function createToolCallingModel(toolName: string) {
+  return new MockLanguageModelV2({
+    doStream: async ({ prompt }) => {
+      const hasToolResults = prompt.some(
+        (msg: any) =>
+          msg.role === 'tool' || (Array.isArray(msg.content) && msg.content.some((c: any) => c.type === 'tool-result')),
+      );
+
+      if (!hasToolResults) {
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName,
+              input: JSON.stringify({ text: 'hello' }),
+            },
+            {
+              type: 'finish',
+              finishReason: 'tool-calls',
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            },
+          ]),
+          rawCall: { rawPrompt: [], rawSettings: {} },
+          warnings: [],
+        };
+      } else {
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'Done!' },
+            { type: 'text-end', id: 'text-1' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 },
+            },
+          ]),
+          rawCall: { rawPrompt: [], rawSettings: {} },
+          warnings: [],
+        };
+      }
+    },
+  });
+}
 
 describe('Output Processor Data Chunks (#13341)', () => {
   it('should receive data-* chunks from tool execute in processOutputStream', async () => {
@@ -23,7 +78,6 @@ describe('Output Processor Data Chunks (#13341)', () => {
       }
     }
 
-    // Create a tool that emits a data-* chunk via writer.custom()
     const toolWithCustomData = createTool({
       id: 'toolWithCustomData',
       description: 'A test tool that emits custom data chunks',
@@ -36,64 +90,12 @@ describe('Output Processor Data Chunks (#13341)', () => {
       },
     });
 
-    // Create mock model that calls the tool
-    const mockModel = new MockLanguageModelV2({
-      doStream: async ({ prompt }) => {
-        const hasToolResults = prompt.some(
-          (msg: any) =>
-            msg.role === 'tool' ||
-            (Array.isArray(msg.content) && msg.content.some((c: any) => c.type === 'tool-result')),
-        );
-
-        if (!hasToolResults) {
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'stream-start', warnings: [] },
-              { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
-              {
-                type: 'tool-call',
-                toolCallId: 'call-1',
-                toolName: 'toolWithCustomData',
-                input: JSON.stringify({ text: 'hello' }),
-              },
-              {
-                type: 'finish',
-                finishReason: 'tool-calls',
-                usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
-              },
-            ]),
-            rawCall: { rawPrompt: [], rawSettings: {} },
-            warnings: [],
-          };
-        } else {
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'stream-start', warnings: [] },
-              { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
-              { type: 'text-start', id: 'text-1' },
-              { type: 'text-delta', id: 'text-1', delta: 'Done!' },
-              { type: 'text-end', id: 'text-1' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 },
-              },
-            ]),
-            rawCall: { rawPrompt: [], rawSettings: {} },
-            warnings: [],
-          };
-        }
-      },
-    });
-
     const agent = new Agent({
       id: 'test-agent',
       name: 'Test Agent',
       instructions: 'Test agent with tools',
-      model: mockModel as any,
-      tools: {
-        toolWithCustomData,
-      },
+      model: createToolCallingModel('toolWithCustomData') as any,
+      tools: { toolWithCustomData },
       outputProcessors: [new DataChunkTrackingProcessor()],
     });
 
@@ -106,13 +108,8 @@ describe('Output Processor Data Chunks (#13341)', () => {
       streamChunkTypes.push(chunk.type);
     }
 
-    // The stream should contain the data-moderation chunk
     expect(streamChunkTypes).toContain('data-moderation');
-
-    // The key assertion: processOutputStream should have received the data-* chunk
     expect(capturedChunkTypes).toContain('data-moderation');
-
-    // Verify the data was passed through correctly
     expect(capturedDataChunks).toHaveLength(1);
     expect(capturedDataChunks[0].data).toEqual({ flagged: false, text: 'hello' });
   });
@@ -136,61 +133,10 @@ describe('Output Processor Data Chunks (#13341)', () => {
     const toolWithCustomData = createTool({
       id: 'toolWithCustomData',
       description: 'A test tool that emits custom data chunks',
-      inputSchema: z.object({
-        text: z.string(),
-      }),
+      inputSchema: z.object({ text: z.string() }),
       execute: async (inputData, { writer }) => {
         writer!.custom({ type: 'data-moderation', data: { flagged: false } });
         return `Processed: ${inputData.text}`;
-      },
-    });
-
-    const mockModel = new MockLanguageModelV2({
-      doStream: async ({ prompt }) => {
-        const hasToolResults = prompt.some(
-          (msg: any) =>
-            msg.role === 'tool' ||
-            (Array.isArray(msg.content) && msg.content.some((c: any) => c.type === 'tool-result')),
-        );
-
-        if (!hasToolResults) {
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'stream-start', warnings: [] },
-              { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
-              {
-                type: 'tool-call',
-                toolCallId: 'call-1',
-                toolName: 'toolWithCustomData',
-                input: JSON.stringify({ text: 'hello' }),
-              },
-              {
-                type: 'finish',
-                finishReason: 'tool-calls',
-                usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
-              },
-            ]),
-            rawCall: { rawPrompt: [], rawSettings: {} },
-            warnings: [],
-          };
-        } else {
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'stream-start', warnings: [] },
-              { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
-              { type: 'text-start', id: 'text-1' },
-              { type: 'text-delta', id: 'text-1', delta: 'Done!' },
-              { type: 'text-end', id: 'text-1' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 },
-              },
-            ]),
-            rawCall: { rawPrompt: [], rawSettings: {} },
-            warnings: [],
-          };
-        }
       },
     });
 
@@ -198,10 +144,8 @@ describe('Output Processor Data Chunks (#13341)', () => {
       id: 'test-agent',
       name: 'Test Agent',
       instructions: 'Test agent with tools',
-      model: mockModel as any,
-      tools: {
-        toolWithCustomData,
-      },
+      model: createToolCallingModel('toolWithCustomData') as any,
+      tools: { toolWithCustomData },
       outputProcessors: [new DataChunkModifyingProcessor()],
     });
 
@@ -216,7 +160,6 @@ describe('Output Processor Data Chunks (#13341)', () => {
       }
     }
 
-    // The data chunk should have been modified by the processor
     expect(dataChunks).toHaveLength(1);
     expect(dataChunks[0].data).toEqual({ flagged: false, processed: true });
   });
@@ -237,61 +180,10 @@ describe('Output Processor Data Chunks (#13341)', () => {
     const toolWithSensitiveData = createTool({
       id: 'toolWithSensitiveData',
       description: 'A test tool that emits sensitive data chunks',
-      inputSchema: z.object({
-        text: z.string(),
-      }),
+      inputSchema: z.object({ text: z.string() }),
       execute: async (inputData, { writer }) => {
         writer!.custom({ type: 'data-sensitive', data: { secret: 'classified' } });
         return `Processed: ${inputData.text}`;
-      },
-    });
-
-    const mockModel = new MockLanguageModelV2({
-      doStream: async ({ prompt }) => {
-        const hasToolResults = prompt.some(
-          (msg: any) =>
-            msg.role === 'tool' ||
-            (Array.isArray(msg.content) && msg.content.some((c: any) => c.type === 'tool-result')),
-        );
-
-        if (!hasToolResults) {
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'stream-start', warnings: [] },
-              { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
-              {
-                type: 'tool-call',
-                toolCallId: 'call-1',
-                toolName: 'toolWithSensitiveData',
-                input: JSON.stringify({ text: 'hello' }),
-              },
-              {
-                type: 'finish',
-                finishReason: 'tool-calls',
-                usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
-              },
-            ]),
-            rawCall: { rawPrompt: [], rawSettings: {} },
-            warnings: [],
-          };
-        } else {
-          return {
-            stream: convertArrayToReadableStream([
-              { type: 'stream-start', warnings: [] },
-              { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
-              { type: 'text-start', id: 'text-1' },
-              { type: 'text-delta', id: 'text-1', delta: 'Done!' },
-              { type: 'text-end', id: 'text-1' },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 },
-              },
-            ]),
-            rawCall: { rawPrompt: [], rawSettings: {} },
-            warnings: [],
-          };
-        }
       },
     });
 
@@ -299,10 +191,8 @@ describe('Output Processor Data Chunks (#13341)', () => {
       id: 'test-agent',
       name: 'Test Agent',
       instructions: 'Test agent with tools',
-      model: mockModel as any,
-      tools: {
-        toolWithSensitiveData,
-      },
+      model: createToolCallingModel('toolWithSensitiveData') as any,
+      tools: { toolWithSensitiveData },
       outputProcessors: [new DataChunkBlockingProcessor()],
     });
 
@@ -311,11 +201,112 @@ describe('Output Processor Data Chunks (#13341)', () => {
     });
 
     const streamChunkTypes: string[] = [];
+    const tripwireChunks: any[] = [];
     for await (const chunk of stream.fullStream) {
       streamChunkTypes.push(chunk.type);
+      if (chunk.type === 'tripwire') {
+        tripwireChunks.push(chunk);
+      }
     }
 
-    // The data-sensitive chunk should NOT appear in the stream (blocked by processor)
     expect(streamChunkTypes).not.toContain('data-sensitive');
+    expect(tripwireChunks).toHaveLength(1);
+    expect(tripwireChunks[0].payload.reason).toBe('Sensitive data blocked');
+    expect(tripwireChunks[0].payload.processorId).toBe('data-chunk-blocking-processor');
+  });
+
+  it('should pass data-* chunks through unchanged when no output processors are configured', async () => {
+    const toolWithCustomData = createTool({
+      id: 'toolWithCustomData',
+      description: 'A test tool that emits custom data chunks',
+      inputSchema: z.object({ text: z.string() }),
+      execute: async (inputData, { writer }) => {
+        writer!.custom({ type: 'data-metrics', data: { latency: 42 } });
+        return `Processed: ${inputData.text}`;
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent with tools',
+      model: createToolCallingModel('toolWithCustomData') as any,
+      tools: { toolWithCustomData },
+      // No outputProcessors
+    });
+
+    const stream = await agent.stream('Call the tool with text "hello"', {
+      maxSteps: 5,
+    });
+
+    const dataChunks: any[] = [];
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'data-metrics') {
+        dataChunks.push(chunk);
+      }
+    }
+
+    expect(dataChunks).toHaveLength(1);
+    expect(dataChunks[0].data).toEqual({ latency: 42 });
+  });
+
+  it('should not persist data-* chunk when processor adds transient: true', async () => {
+    const addSpy = vi.spyOn(MessageList.prototype, 'add');
+
+    class TransientMarkingProcessor implements Processor {
+      readonly id = 'transient-marking-processor';
+      readonly name = 'Transient Marking Processor';
+
+      async processOutputStream({ part }: any) {
+        if (part.type === 'data-debug') {
+          return { ...part, transient: true };
+        }
+        return part;
+      }
+    }
+
+    const toolWithDebugData = createTool({
+      id: 'toolWithDebugData',
+      description: 'A test tool that emits debug data chunks',
+      inputSchema: z.object({ text: z.string() }),
+      execute: async (inputData, { writer }) => {
+        writer!.custom({ type: 'data-debug', data: { step: 1, detail: 'internal state' } });
+        return `Processed: ${inputData.text}`;
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent with tools',
+      model: createToolCallingModel('toolWithDebugData') as any,
+      tools: { toolWithDebugData },
+      outputProcessors: [new TransientMarkingProcessor()],
+    });
+
+    const stream = await agent.stream('Call the tool with text "hello"', {
+      maxSteps: 5,
+    });
+
+    const dataChunks: any[] = [];
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'data-debug') {
+        dataChunks.push(chunk);
+      }
+    }
+
+    // The chunk should still appear in the stream
+    expect(dataChunks).toHaveLength(1);
+    expect(dataChunks[0].data).toEqual({ step: 1, detail: 'internal state' });
+    expect(dataChunks[0].transient).toBe(true);
+
+    // messageList.add should NOT have been called with a data-debug part
+    const dataDebugAdds = addSpy.mock.calls.filter(([messages]) => {
+      const msgs = Array.isArray(messages) ? messages : [messages];
+      return msgs.some((m: any) => m.content?.parts?.some((p: any) => p.type === 'data-debug'));
+    });
+    expect(dataDebugAdds).toHaveLength(0);
+
+    addSpy.mockRestore();
   });
 });

--- a/packages/core/src/processors/output-processor-data-chunks.test.ts
+++ b/packages/core/src/processors/output-processor-data-chunks.test.ts
@@ -68,6 +68,7 @@ describe('Output Processor Data Chunks (#13341)', () => {
     class DataChunkTrackingProcessor implements Processor {
       readonly id = 'data-chunk-tracking-processor';
       readonly name = 'Data Chunk Tracking Processor';
+      readonly processDataParts = true;
 
       async processOutputStream({ part }: any) {
         capturedChunkTypes.push(part.type);
@@ -118,6 +119,7 @@ describe('Output Processor Data Chunks (#13341)', () => {
     class DataChunkModifyingProcessor implements Processor {
       readonly id = 'data-chunk-modifying-processor';
       readonly name = 'Data Chunk Modifying Processor';
+      readonly processDataParts = true;
 
       async processOutputStream({ part }: any) {
         if (part.type === 'data-moderation') {
@@ -168,6 +170,7 @@ describe('Output Processor Data Chunks (#13341)', () => {
     class DataChunkBlockingProcessor implements Processor {
       readonly id = 'data-chunk-blocking-processor';
       readonly name = 'Data Chunk Blocking Processor';
+      readonly processDataParts = true;
 
       async processOutputStream({ part, abort }: any) {
         if (part.type === 'data-sensitive') {
@@ -256,6 +259,7 @@ describe('Output Processor Data Chunks (#13341)', () => {
     class TransientMarkingProcessor implements Processor {
       readonly id = 'transient-marking-processor';
       readonly name = 'Transient Marking Processor';
+      readonly processDataParts = true;
 
       async processOutputStream({ part }: any) {
         if (part.type === 'data-debug') {
@@ -316,6 +320,7 @@ describe('Output Processor Data Chunks (#13341)', () => {
     class MultiChunkTracker implements Processor {
       readonly id = 'multi-chunk-tracker';
       readonly name = 'Multi Chunk Tracker';
+      readonly processDataParts = true;
 
       async processOutputStream({ part }: any) {
         if (part.type.startsWith('data-')) {
@@ -362,5 +367,57 @@ describe('Output Processor Data Chunks (#13341)', () => {
 
     // Processor should have seen all 3 chunks
     expect(capturedDataChunks).toHaveLength(3);
+  });
+
+  it('should skip data-* chunks for processors without processDataParts', async () => {
+    const capturedChunkTypes: string[] = [];
+
+    class RegularProcessor implements Processor {
+      readonly id = 'regular-processor';
+      readonly name = 'Regular Processor';
+      // processDataParts is NOT set (defaults to false)
+
+      async processOutputStream({ part }: any) {
+        capturedChunkTypes.push(part.type);
+        return part;
+      }
+    }
+
+    const toolWithCustomData = createTool({
+      id: 'toolWithCustomData',
+      description: 'A test tool that emits custom data chunks',
+      inputSchema: z.object({ text: z.string() }),
+      execute: async (inputData, { writer }) => {
+        writer!.custom({ type: 'data-metrics', data: { latency: 42 } });
+        return `Processed: ${inputData.text}`;
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent with tools',
+      model: createToolCallingModel('toolWithCustomData') as any,
+      tools: { toolWithCustomData },
+      outputProcessors: [new RegularProcessor()],
+    });
+
+    const stream = await agent.stream('Call the tool with text "hello"', {
+      maxSteps: 5,
+    });
+
+    const dataChunks: any[] = [];
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'data-metrics') {
+        dataChunks.push(chunk);
+      }
+    }
+
+    // The data chunk should still appear in the stream
+    expect(dataChunks).toHaveLength(1);
+    expect(dataChunks[0].data).toEqual({ latency: 42 });
+
+    // But the processor should NOT have seen any data-* chunks
+    expect(capturedChunkTypes.filter(t => t.startsWith('data-'))).toHaveLength(0);
   });
 });

--- a/packages/core/src/processors/output-processor-data-chunks.test.ts
+++ b/packages/core/src/processors/output-processor-data-chunks.test.ts
@@ -420,4 +420,139 @@ describe('Output Processor Data Chunks (#13341)', () => {
     // But the processor should NOT have seen any data-* chunks
     expect(capturedChunkTypes.filter(t => t.startsWith('data-'))).toHaveLength(0);
   });
+
+  it('should chain data-* chunks through multiple processors in order', async () => {
+    const processorOrder: string[] = [];
+
+    class FirstProcessor implements Processor {
+      readonly id = 'first-processor';
+      readonly name = 'First Processor';
+      readonly processDataParts = true;
+
+      async processOutputStream({ part }: any) {
+        if (part.type === 'data-pipeline') {
+          processorOrder.push('first');
+          return { ...part, data: { ...part.data, first: true } };
+        }
+        return part;
+      }
+    }
+
+    class SecondProcessor implements Processor {
+      readonly id = 'second-processor';
+      readonly name = 'Second Processor';
+      readonly processDataParts = true;
+
+      async processOutputStream({ part }: any) {
+        if (part.type === 'data-pipeline') {
+          processorOrder.push('second');
+          return { ...part, data: { ...part.data, second: true } };
+        }
+        return part;
+      }
+    }
+
+    const toolWithData = createTool({
+      id: 'toolWithData',
+      description: 'A test tool',
+      inputSchema: z.object({ text: z.string() }),
+      execute: async (inputData, { writer }) => {
+        writer!.custom({ type: 'data-pipeline', data: { original: true } });
+        return `Done: ${inputData.text}`;
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent',
+      model: createToolCallingModel('toolWithData') as any,
+      tools: { toolWithData },
+      outputProcessors: [new FirstProcessor(), new SecondProcessor()],
+    });
+
+    const stream = await agent.stream('Call the tool', { maxSteps: 5 });
+
+    const dataChunks: any[] = [];
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'data-pipeline') {
+        dataChunks.push(chunk);
+      }
+    }
+
+    // Both processors should have run in order
+    expect(processorOrder).toEqual(['first', 'second']);
+
+    // The final chunk should have mutations from both processors
+    expect(dataChunks).toHaveLength(1);
+    expect(dataChunks[0].data).toEqual({ original: true, first: true, second: true });
+  });
+
+  it('should only deliver data-* chunks to processors that opt in when mixed', async () => {
+    const optedInChunks: string[] = [];
+    const regularChunks: string[] = [];
+
+    class OptedInProcessor implements Processor {
+      readonly id = 'opted-in-processor';
+      readonly name = 'Opted In Processor';
+      readonly processDataParts = true;
+
+      async processOutputStream({ part }: any) {
+        optedInChunks.push(part.type);
+        if (part.type === 'data-info') {
+          return { ...part, data: { ...part.data, seen: true } };
+        }
+        return part;
+      }
+    }
+
+    class RegularProcessor implements Processor {
+      readonly id = 'regular-processor';
+      readonly name = 'Regular Processor';
+      // processDataParts NOT set — defaults to false
+
+      async processOutputStream({ part }: any) {
+        regularChunks.push(part.type);
+        return part;
+      }
+    }
+
+    const toolWithData = createTool({
+      id: 'toolWithData',
+      description: 'A test tool',
+      inputSchema: z.object({ text: z.string() }),
+      execute: async (inputData, { writer }) => {
+        writer!.custom({ type: 'data-info', data: { value: 1 } });
+        return `Done: ${inputData.text}`;
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent',
+      model: createToolCallingModel('toolWithData') as any,
+      tools: { toolWithData },
+      outputProcessors: [new OptedInProcessor(), new RegularProcessor()],
+    });
+
+    const stream = await agent.stream('Call the tool', { maxSteps: 5 });
+
+    const dataChunks: any[] = [];
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'data-info') {
+        dataChunks.push(chunk);
+      }
+    }
+
+    // The opted-in processor should have seen the data-* chunk
+    expect(optedInChunks.filter(t => t.startsWith('data-'))).toHaveLength(1);
+
+    // The regular processor should NOT have seen any data-* chunks
+    expect(regularChunks.filter(t => t.startsWith('data-'))).toHaveLength(0);
+
+    // The chunk should still appear in the stream with the opted-in processor's mutation
+    expect(dataChunks).toHaveLength(1);
+    expect(dataChunks[0].data).toEqual({ value: 1, seen: true });
+  });
 });

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -996,6 +996,10 @@ function createStepFromProcessor<TProcessorId extends string>(
           }
 
           case 'outputStream': {
+            // Skip data-* chunks for processors that haven't opted in
+            if (part && (part as ChunkType).type.startsWith('data-') && !processor.processDataParts) {
+              return { ...passThrough, part };
+            }
             if (processor.processOutputStream) {
               // Manage per-processor span lifecycle across stream chunks
               // Use unique key to store span on shared state object


### PR DESCRIPTION
## Problem

Custom `data-*` chunks emitted via `writer.custom()` in a tool's `execute` function were written directly to the stream, completely bypassing the output processor pipeline. This meant output processors (e.g. moderation filters, PII detectors) could not inspect, modify, or block these chunks.

Fixes #13341

## Solution

- Create a `ProcessorRunner` in `workflowLoopStream` when `outputProcessors` are configured. Route `data-*` chunks through `processPart()` before enqueuing them to the stream.
- Processing is **opt-in**: processors must set `processDataParts = true` to receive `data-*` chunks in `processOutputStream`. Built-in processors (token limiter, moderation, PII) are unaffected.
- Blocked chunks emit a `tripwire` chunk with processor ID and reason.
- Processors can mark chunks as `transient: true` to stream them to the client without persisting to storage.

### Changes

- **`packages/core/src/loop/workflows/stream.ts`** — Create a `ProcessorRunner` for data-* chunks, route through `processPart()`, emit `tripwire` on block, respect `transient` flag
- **`packages/core/src/processors/index.ts`** — Add `processDataParts?: boolean` to `Processor` interface
- **`packages/core/src/workflows/workflow.ts`** — Skip `data-*` chunks in `createStepFromProcessor` for processors without `processDataParts`
- **`docs/src/content/en/docs/agents/processors.mdx`** — Document `processDataParts` opt-in
- **`packages/core/src/processors/output-processor-data-chunks.test.ts`** (new) — 9 tests

## Test Plan

- 9/9 new tests pass: passthrough, modification, blocking+tripwire, no-processor, transient mutation, multi-chunk, opt-in skip, multi-processor chaining, mixed opt-in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom data-* chunks from tools now flow through the output processor pipeline so processors can inspect, modify, or block them.

* **New Features**
  * Processors can opt in to receive data-* chunks via a new flag.
  * Processors can block streams with tripwire events and mark chunks as transient to avoid persistence.

* **Documentation**
  * Docs updated to describe processor opt-in and handling of data-* chunks.

* **Tests**
  * Added tests covering emission, modification, blocking/tripwire, transient, and multi-chunk scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->