### PR TITLE
fix: strip trailing LLM tokens from tool-call input before JSON.parse

### DIFF
--- a/.changeset/grumpy-cities-judge.md
+++ b/.changeset/grumpy-cities-judge.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed JSON.parse failing on tool-call inputs when LLM models append internal tokens like `<|call|>` or `<|endoftext|>` to the JSON string. These trailing tokens are now stripped before parsing, so tool calls correctly receive their input parameters instead of silently losing them.

--- a/packages/core/src/stream/aisdk/v5/transform.test.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { ChunkFrom } from '../../types';
-import { convertFullStreamChunkToMastra } from './transform';
+import { convertFullStreamChunkToMastra, stripTrailingLLMTokens } from './transform';
 import type { StreamPart } from './transform';
 
 describe('convertFullStreamChunkToMastra', () => {
@@ -182,6 +182,93 @@ describe('convertFullStreamChunkToMastra', () => {
     });
   });
 
+  describe('trailing LLM token stripping (issue #13185)', () => {
+    it('should parse JSON with trailing <|call|> token', () => {
+      const chunk: StreamPart = {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'get_weather',
+        input: '{}<|call|>',
+        providerExecuted: false,
+      };
+
+      const result = convertFullStreamChunkToMastra(chunk, { runId: 'test-run-123' });
+
+      expect(result?.type).toBe('tool-call');
+      if (result?.type === 'tool-call') {
+        expect(result.payload.args).toEqual({});
+      }
+    });
+
+    it('should parse JSON with tab + trailing <|call|> token', () => {
+      const chunk: StreamPart = {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'get_weather',
+        input: '{\n"checkpointNumber": 1,\n"vehicleType": "leopard"\n}\t<|call|>',
+        providerExecuted: false,
+      };
+
+      const result = convertFullStreamChunkToMastra(chunk, { runId: 'test-run-123' });
+
+      expect(result?.type).toBe('tool-call');
+      if (result?.type === 'tool-call') {
+        expect(result.payload.args).toEqual({ checkpointNumber: 1, vehicleType: 'leopard' });
+      }
+    });
+
+    it('should parse JSON with trailing <|endoftext|> token', () => {
+      const chunk: StreamPart = {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'get_weather',
+        input: '{"location": "NYC"}<|endoftext|>',
+        providerExecuted: false,
+      };
+
+      const result = convertFullStreamChunkToMastra(chunk, { runId: 'test-run-123' });
+
+      expect(result?.type).toBe('tool-call');
+      if (result?.type === 'tool-call') {
+        expect(result.payload.args).toEqual({ location: 'NYC' });
+      }
+    });
+
+    it('should parse JSON with multiple trailing tokens', () => {
+      const chunk: StreamPart = {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'get_weather',
+        input: '{"a": 1}<|call|><|endoftext|>',
+        providerExecuted: false,
+      };
+
+      const result = convertFullStreamChunkToMastra(chunk, { runId: 'test-run-123' });
+
+      expect(result?.type).toBe('tool-call');
+      if (result?.type === 'tool-call') {
+        expect(result.payload.args).toEqual({ a: 1 });
+      }
+    });
+
+    it('should not modify valid JSON without trailing tokens', () => {
+      const chunk: StreamPart = {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'get_weather',
+        input: '{"location": "New York"}',
+        providerExecuted: false,
+      };
+
+      const result = convertFullStreamChunkToMastra(chunk, { runId: 'test-run-123' });
+
+      expect(result?.type).toBe('tool-call');
+      if (result?.type === 'tool-call') {
+        expect(result.payload.args).toEqual({ location: 'New York' });
+      }
+    });
+  });
+
   describe('other chunk types', () => {
     it('should handle text-delta chunks correctly', () => {
       const chunk: StreamPart = {
@@ -228,5 +315,43 @@ describe('convertFullStreamChunkToMastra', () => {
         expect(result.payload.stepResult.reason).toBe('stop');
       }
     });
+  });
+});
+
+describe('stripTrailingLLMTokens', () => {
+  it('should strip <|call|> token', () => {
+    expect(stripTrailingLLMTokens('{}<|call|>')).toBe('{}');
+  });
+
+  it('should strip <|call|> with preceding tab', () => {
+    expect(stripTrailingLLMTokens('{}\t<|call|>')).toBe('{}');
+  });
+
+  it('should strip <|endoftext|> token', () => {
+    expect(stripTrailingLLMTokens('{"a":1}<|endoftext|>')).toBe('{"a":1}');
+  });
+
+  it('should strip multiple tokens', () => {
+    expect(stripTrailingLLMTokens('{"a":1}<|call|> <|endoftext|>')).toBe('{"a":1}');
+  });
+
+  it('should return input unchanged when no tokens present', () => {
+    expect(stripTrailingLLMTokens('{"a":1}')).toBe('{"a":1}');
+  });
+
+  it('should handle empty string', () => {
+    expect(stripTrailingLLMTokens('')).toBe('');
+  });
+
+  it('should strip tokens with surrounding whitespace', () => {
+    expect(stripTrailingLLMTokens('{"a":1}  <|call|>  ')).toBe('{"a":1}');
+  });
+
+  it('should not strip tokens inside JSON string values', () => {
+    expect(stripTrailingLLMTokens('{"prompt": "Use <|system|> token"}')).toBe('{"prompt": "Use <|system|> token"}');
+  });
+
+  it('should not strip leading tokens', () => {
+    expect(stripTrailingLLMTokens('<|im_start|>{"a":1}')).toBe('<|im_start|>{"a":1}');
   });
 });

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -135,7 +135,7 @@ export function convertFullStreamChunkToMastra(value: StreamPart, ctx: { runId: 
 
       if (value.input) {
         try {
-          toolCallInput = JSON.parse(value.input);
+          toolCallInput = JSON.parse(stripTrailingLLMTokens(value.input));
         } catch (error) {
           console.error('Error converting tool call input to JSON', {
             error,
@@ -567,4 +567,19 @@ function normalizeFinishReason(
 
   // V2/V5 format - already a string, but normalize 'unknown' to 'other' for consistency with V6
   return finishReason === 'unknown' ? 'other' : finishReason;
+}
+
+/**
+ * Strips trailing LLM-internal special tokens from a string before JSON parsing.
+ *
+ * Some models (e.g. OpenAI gpt-4o-mini/gpt-4o) occasionally append internal tokens
+ * like `<|call|>` or `<|endoftext|>` to tool-call input JSON, which breaks JSON.parse.
+ *
+ * Only strips tokens that appear after the JSON content ends (trailing), so that
+ * legitimate `<|...|>` patterns inside JSON string values are preserved.
+ *
+ * @see https://github.com/mastra-ai/mastra/issues/13185
+ */
+export function stripTrailingLLMTokens(input: string): string {
+  return input.replace(/(\s*<\|[^|]*\|>)+\s*$/, '').trim();
 }


### PR DESCRIPTION
## Summary

Fixes #13185

Some OpenAI models (gpt-4o-mini, gpt-4o) occasionally append internal tokens like `<|call|>` or `<|endoftext|>` to tool-call input JSON strings. This caused `JSON.parse` to fail with a `SyntaxError`, silently setting tool call args to `undefined` instead of the correct parsed object.

## Changes

- Added `stripTrailingLLMTokens()` utility in `packages/core/src/stream/aisdk/v5/transform.ts` that strips `<|...|>` tokens and surrounding whitespace from input strings
- Applied the sanitization before `JSON.parse` in the `tool-call` case of `convertFullStreamChunkToMastra()`
- Added tests for the utility function and integration tests verifying tool-call inputs with trailing tokens are parsed correctly

## Test Plan

- `pnpm vitest run src/stream/aisdk/v5/transform.test.ts` — 21 tests pass
- New tests cover: `<|call|>`, `<|endoftext|>`, multiple tokens, tab + token, whitespace-surrounded tokens
- Existing tests for valid JSON, malformed JSON, and empty/undefined inputs continue to pass