### PR TITLE
fix(core): truncate workspace tool output at token level instead of line boundaries

### DIFF
--- a/.changeset/tasty-otters-tan.md
+++ b/.changeset/tasty-otters-tan.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workspace tool output truncation so it no longer gets prematurely cut off when short lines precede a very long line (e.g. minified JSON). Output now uses the full token budget instead of stopping at line boundaries, resulting in more complete tool results.

--- a/packages/core/src/workspace/tools/__tests__/sandbox-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/sandbox-tools.test.ts
@@ -609,13 +609,6 @@ describe('output-helpers', () => {
       expect(await applyTokenLimit('', 100)).toBe('');
     });
 
-    it('handles output with punctuation and symbols', async () => {
-      const output = 'alpha | beta ~ gamma\nline 1\nline 2\nline 3';
-      const result = await applyTokenLimit(output, 5);
-      expect(result).toBeDefined();
-      expect(result).toContain('[output truncated');
-    });
-
     it('truncates from the start by default (keeps the end)', async () => {
       const lines = Array.from({ length: 100 }, (_, i) => `line number ${i + 1}`);
       const output = lines.join('\n');
@@ -647,10 +640,19 @@ describe('output-helpers', () => {
       expect(result).toContain('[output truncated');
     });
 
-    it('keeps at least one line even if it exceeds limit', async () => {
-      const longLine = 'word '.repeat(500);
-      const result = await applyTokenLimit(longLine, 10);
-      expect(result).toContain('word');
+    it('fills the token budget even with a single long line', async () => {
+      // This is the bug Tyler hit: a file with one huge line should still use the full budget
+      const longLine = 'word '.repeat(500); // 500 tokens of "word "
+      const limit = 50;
+      const result = await applyTokenLimit(longLine, limit);
+      expect(result).toContain('[output truncated');
+      // The kept portion (minus the notice) should be close to the budget
+      const notice = result.match(/\[output truncated[^\]]*\]\n?/)?.[0] ?? '';
+      const keptText = result.replace(notice, '');
+      // "word " is 1 token each, so we should have ~50 words
+      const wordCount = keptText.trim().split(/\s+/).length;
+      expect(wordCount).toBeGreaterThanOrEqual(limit - 5);
+      expect(wordCount).toBeLessThanOrEqual(limit + 5);
     });
   });
 
@@ -663,34 +665,62 @@ describe('output-helpers', () => {
       expect(await applyTokenLimitSandwich('', 100)).toBe('');
     });
 
-    it('keeps lines from both start and end', async () => {
+    it('keeps tokens from both start and end', async () => {
       const lines = Array.from({ length: 200 }, (_, i) => `line number ${i + 1}`);
       const output = lines.join('\n');
       const result = await applyTokenLimitSandwich(output, 50, 0.2);
-      // Should contain early lines (head)
       expect(result).toContain('line number 1');
-      // Should contain late lines (tail)
       expect(result).toContain('line number 200');
-      // Should have truncation notice in the middle
-      expect(result).toContain('lines truncated');
-      // Middle lines should be gone
+      expect(result).toContain('output truncated');
       expect(result).not.toContain('line number 100\n');
     });
 
-    it('head ratio controls how much of the budget goes to the start', async () => {
+    it('respects head ratio — higher ratio keeps more from the start', async () => {
       const lines = Array.from({ length: 200 }, (_, i) => `line number ${i + 1}`);
       const output = lines.join('\n');
-      // With headRatio 0.5, roughly equal head and tail
-      const result = await applyTokenLimitSandwich(output, 50, 0.5);
-      expect(result).toContain('line number 1');
-      expect(result).toContain('line number 200');
-      expect(result).toContain('lines truncated');
+      const small = await applyTokenLimitSandwich(output, 50, 0.1);
+      const large = await applyTokenLimitSandwich(output, 50, 0.9);
+      // Both should have start and end
+      expect(small).toContain('line number 1');
+      expect(large).toContain('line number 1');
+      // With 90% head ratio, the head portion should contain more lines from the start
+      const smallHead = small.split('output truncated')[0]!;
+      const largeHead = large.split('output truncated')[0]!;
+      expect(largeHead.length).toBeGreaterThan(smallHead.length);
+    });
+
+    it('fills the token budget even with a single long line', async () => {
+      const longLine = 'word '.repeat(500);
+      const limit = 50;
+      const result = await applyTokenLimitSandwich(longLine, limit, 0.2);
+      expect(result).toContain('output truncated');
+      const notice = result.match(/\[\.\.\.output truncated[^\]]*\.\.\.\]\n?/)?.[0] ?? '';
+      const keptText = result.replace(notice, '');
+      const wordCount = keptText.trim().split(/\s+/).length;
+      expect(wordCount).toBeGreaterThanOrEqual(limit - 5);
+    });
+
+    it('does not leak full output when tail budget is zero', async () => {
+      const longLine = 'word '.repeat(500);
+      const result = await applyTokenLimitSandwich(longLine, 10, 1.0);
+      expect(result).toContain('output truncated');
+      const notice = result.match(/\[\.\.\.output truncated[^\]]*\.\.\.\]\n?/)?.[0] ?? '';
+      const keptText = result.replace(notice, '');
+      expect(keptText.trim().split(/\s+/).length).toBeLessThanOrEqual(15);
+    });
+
+    it('does not leak full output when head budget is zero', async () => {
+      const longLine = 'word '.repeat(500);
+      const result = await applyTokenLimitSandwich(longLine, 10, 0);
+      expect(result).toContain('output truncated');
+      const notice = result.match(/\[\.\.\.output truncated[^\]]*\.\.\.\]\n?/)?.[0] ?? '';
+      const keptText = result.replace(notice, '');
+      expect(keptText.trim().split(/\s+/).length).toBeLessThanOrEqual(15);
     });
   });
 
   describe('truncateOutput', () => {
     it('applies tail then token limit', async () => {
-      // tail: 0 = no line limit, so only token limit applies
       const lines = Array.from({ length: 5000 }, (_, i) => `line number ${String(i).padStart(4, '0')}`);
       const output = lines.join('\n');
 
@@ -705,6 +735,16 @@ describe('output-helpers', () => {
       const result = await truncateOutput(output, 5);
       expect(result).not.toContain('[output truncated');
       expect(result).toContain('[showing last 5 of 500 lines]');
+    });
+
+    it('routes to sandwich mode when tokenFrom is sandwich', async () => {
+      const lines = Array.from({ length: 5000 }, (_, i) => `line number ${i + 1}`);
+      const output = lines.join('\n');
+
+      const result = await truncateOutput(output, 0, undefined, 'sandwich');
+      expect(result).toContain('line number 1');
+      expect(result).toContain('line number 5000');
+      expect(result).toContain('output truncated');
     });
   });
 });
@@ -773,7 +813,7 @@ describe('token limit integration', () => {
     const ctx = createContext(sandbox);
     const result = await executeCommandTool.execute({ command: 'cat big.log', tail: 0 }, ctx);
     // execute_command uses sandwich truncation — head + [...truncated...] + tail
-    expect(result).toContain('lines truncated');
+    expect(result).toContain('output truncated');
     // Should contain both start and end of output
     expect(result).toContain('output line number 1');
     expect(result).toContain('output line number 5000');
@@ -798,7 +838,7 @@ describe('token limit integration', () => {
       tools: { mastra_workspace_execute_command: { maxOutputTokens: 100 } },
     });
     const result = await executeCommandTool.execute({ command: 'cat big.log', tail: 0 }, { workspace });
-    expect(result).toContain('lines truncated');
+    expect(result).toContain('output truncated');
     // With only 100 tokens, result should be much shorter than default 3k limit
     const defaultResult = await executeCommandTool.execute({ command: 'cat big.log', tail: 0 }, createContext(sandbox));
     expect((result as string).length).toBeLessThan((defaultResult as string).length);
@@ -821,7 +861,7 @@ describe('token limit integration', () => {
     const ctx = createContext(sandbox);
     const result = await getProcessOutputTool.execute({ pid: 30, tail: 0 }, ctx);
     // get_process_output uses sandwich truncation
-    expect(result).toContain('lines truncated');
+    expect(result).toContain('output truncated');
     expect(result).toContain('log entry number 1');
     expect(result).toContain('log entry number 5000');
   });

--- a/packages/core/src/workspace/tools/output-helpers.ts
+++ b/packages/core/src/workspace/tools/output-helpers.ts
@@ -67,22 +67,15 @@ export function applyTail(output: string, tail: number | null | undefined): stri
 // ---------------------------------------------------------------------------
 
 /**
- * Count tokens while allowing tokenizer special tokens.
- */
-async function countTokens(output: string): Promise<number> {
-  const tiktoken = await getTiktoken();
-  return tiktoken.encode(output, 'all').length;
-}
-
-/**
  * Token-based output limit. Truncates output to fit within a token budget.
- * Uses tiktoken for accurate token counting.
+ * Uses tiktoken for accurate token counting and truncates at the token level
+ * (not line boundaries) to maximise use of the budget.
  *
  * @param output - The text to truncate
  * @param limit - Maximum tokens (default: DEFAULT_MAX_OUTPUT_TOKENS)
  * @param from - Which end to truncate from:
- *   - `'start'` (default): Remove lines from the start, keep the end
- *   - `'end'`: Remove lines from the end, keep the start
+ *   - `'start'` (default): Remove tokens from the start, keep the end
+ *   - `'end'`: Remove tokens from the end, keep the start
  */
 export async function applyTokenLimit(
   output: string,
@@ -91,39 +84,16 @@ export async function applyTokenLimit(
 ): Promise<string> {
   if (!output) return output;
 
-  const tokens = await countTokens(output);
-  if (tokens <= limit) return output;
+  const tiktoken = await getTiktoken();
+  const allTokens = tiktoken.encode(output, 'all');
+  if (allTokens.length <= limit) return output;
 
-  const trailingNewline = output.endsWith('\n');
-  const lines = (trailingNewline ? output.slice(0, -1) : output).split('\n');
+  const kept = from === 'start' ? tiktoken.decode(allTokens.slice(-limit)) : tiktoken.decode(allTokens.slice(0, limit));
 
-  const kept: string[] = [];
-  let keptTokens = 0;
-
-  if (from === 'start') {
-    // Keep the end — iterate backwards
-    for (let i = lines.length - 1; i >= 0; i--) {
-      const lineTokens = await countTokens(lines[i]!);
-      if (keptTokens + lineTokens > limit && kept.length > 0) break;
-      kept.unshift(lines[i]!);
-      keptTokens += lineTokens;
-    }
-  } else {
-    // Keep the start — iterate forwards
-    for (let i = 0; i < lines.length; i++) {
-      const lineTokens = await countTokens(lines[i]!);
-      if (keptTokens + lineTokens > limit && kept.length > 0) break;
-      kept.push(lines[i]!);
-      keptTokens += lineTokens;
-    }
-  }
-
-  if (kept.length >= lines.length) return output; // nothing to truncate
-  const body = kept.join('\n') + (trailingNewline && from === 'start' ? '\n' : '');
   const position = from === 'start' ? 'last' : 'first';
   return from === 'start'
-    ? `[output truncated: showing ${position} ~${keptTokens} of ~${tokens} tokens]\n${body}`
-    : `${body}\n[output truncated: showing ${position} ~${keptTokens} of ~${tokens} tokens]`;
+    ? `[output truncated: showing ${position} ~${limit} of ~${allTokens.length} tokens]\n${kept}`
+    : `${kept}\n[output truncated: showing ${position} ~${limit} of ~${allTokens.length} tokens]`;
 }
 
 /**
@@ -142,41 +112,17 @@ export async function applyTokenLimitSandwich(
 ): Promise<string> {
   if (!output) return output;
 
-  const tokens = await countTokens(output);
-  if (tokens <= limit) return output;
-
-  const trailingNewline = output.endsWith('\n');
-  const lines = (trailingNewline ? output.slice(0, -1) : output).split('\n');
-
+  const tiktoken = await getTiktoken();
+  const allTokens = tiktoken.encode(output, 'all');
+  if (allTokens.length <= limit) return output;
   const headBudget = Math.floor(limit * headRatio);
   const tailBudget = limit - headBudget;
 
-  // Collect head lines (from the start)
-  const headLines: string[] = [];
-  let headTokens = 0;
-  for (let i = 0; i < lines.length; i++) {
-    const lineTokens = await countTokens(lines[i]!);
-    if (headTokens + lineTokens > headBudget && headLines.length > 0) break;
-    headLines.push(lines[i]!);
-    headTokens += lineTokens;
-  }
+  const head = headBudget > 0 ? tiktoken.decode(allTokens.slice(0, headBudget)) : '';
+  const tail = tailBudget > 0 ? tiktoken.decode(allTokens.slice(-tailBudget)) : '';
 
-  // Collect tail lines (from the end, not overlapping with head)
-  const tailLines: string[] = [];
-  let tailTokens = 0;
-  for (let i = lines.length - 1; i >= headLines.length; i--) {
-    const lineTokens = await countTokens(lines[i]!);
-    if (tailTokens + lineTokens > tailBudget && tailLines.length > 0) break;
-    tailLines.unshift(lines[i]!);
-    tailTokens += lineTokens;
-  }
-
-  if (headLines.length + tailLines.length >= lines.length) return output;
-
-  const omitted = lines.length - headLines.length - tailLines.length;
-  const head = headLines.join('\n');
-  const tail = tailLines.join('\n') + (trailingNewline ? '\n' : '');
-  return `${head}\n[...${omitted} lines truncated — showing first ~${headTokens} + last ~${tailTokens} of ~${tokens} tokens...]\n${tail}`;
+  const notice = `[...output truncated — showing first ~${headBudget} + last ~${tailBudget} of ~${allTokens.length} tokens...]`;
+  return [head, notice, tail].filter(Boolean).join('\n');
 }
 
 /**


### PR DESCRIPTION
## Problem

Workspace tool output truncation (`applyTokenLimit`, `applyTokenLimitSandwich`) worked at **line boundaries**. When a file had a few short lines followed by a very long line (e.g. minified JSON, base64 blobs), the truncation stopped before the long line — wasting most of the token budget. Tyler observed a file showing only ~295 of the 2000 token budget.

## Fix

Changed both `applyTokenLimit` and `applyTokenLimitSandwich` to truncate at the **exact token level** using tiktoken's `encode`/`decode`. The full token budget is now always utilized regardless of line length distribution.

## Changes

- `packages/core/src/workspace/tools/output-helpers.ts` — Rewrote `applyTokenLimit` and `applyTokenLimitSandwich` to use token-level truncation via tiktoken encode → slice → decode
- Removed unused `countTokens` helper
- Updated tests to match new truncation message format

## Test Plan

- `pnpm vitest run src/workspace/tools/__tests__/sandbox-tools.test.ts` — 59/59 passing
- `pnpm tsc --noEmit` in packages/core — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace tool output truncation to use token-level limits for more accurate trimming (prevents premature cutoff when short lines precede very long ones).
  * Updated truncation notice to a clearer "[output truncated]" message and ensured preserved start/end content respects the configured token budget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->