### PR TITLE
fix: handle malformed tool-call JSON from LLM providers

### DIFF
--- a/.changeset/twenty-kings-raise.md
+++ b/.changeset/twenty-kings-raise.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed tool-call input parsing crashing on malformed JSON from OpenRouter providers. The stream transform now applies progressive sanitization: stripping trailing LLM tokens (`<|call|>`, `<|endoftext|>`) and replacing invalid placeholder values (`?` → `null`). When all recovery attempts fail, a warning is logged instead of an error and the tool call proceeds with undefined args instead of throwing.

--- a/packages/core/src/stream/aisdk/v5/transform.test.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { ChunkFrom } from '../../types';
-import { convertFullStreamChunkToMastra } from './transform';
+import { convertFullStreamChunkToMastra, parseToolCallInput, stripTrailingLLMTokens } from './transform';
 import type { StreamPart } from './transform';
 
 describe('convertFullStreamChunkToMastra', () => {
@@ -182,6 +182,76 @@ describe('convertFullStreamChunkToMastra', () => {
     });
   });
 
+  describe('malformed tool-call arguments from OpenRouter (issue #13261)', () => {
+    it('should recover JSON with ? placeholder values by replacing with null', () => {
+      const chunk: StreamPart = {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'check_vehicle',
+        input: '{"vehicleType":"leopard","checkpointNumber":?}',
+        providerExecuted: false,
+      };
+
+      const result = convertFullStreamChunkToMastra(chunk, { runId: 'test-run-123' });
+
+      expect(result?.type).toBe('tool-call');
+      if (result?.type === 'tool-call') {
+        expect(result.payload.args).toEqual({ vehicleType: 'leopard', checkpointNumber: null });
+      }
+    });
+
+    it('should recover JSON with ? in the middle of an object', () => {
+      const chunk: StreamPart = {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'test_tool',
+        input: '{"a":?,"b":"hello"}',
+        providerExecuted: false,
+      };
+
+      const result = convertFullStreamChunkToMastra(chunk, { runId: 'test-run-123' });
+
+      expect(result?.type).toBe('tool-call');
+      if (result?.type === 'tool-call') {
+        expect(result.payload.args).toEqual({ a: null, b: 'hello' });
+      }
+    });
+
+    it('should recover JSON with ? in an array', () => {
+      const chunk: StreamPart = {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'test_tool',
+        input: '{"items":[?]}',
+        providerExecuted: false,
+      };
+
+      const result = convertFullStreamChunkToMastra(chunk, { runId: 'test-run-123' });
+
+      expect(result?.type).toBe('tool-call');
+      if (result?.type === 'tool-call') {
+        expect(result.payload.args).toEqual({ items: [null] });
+      }
+    });
+
+    it('should handle trailing LLM tokens combined with malformed JSON', () => {
+      const chunk: StreamPart = {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'test_tool',
+        input: '{"a":1}<|call|>',
+        providerExecuted: false,
+      };
+
+      const result = convertFullStreamChunkToMastra(chunk, { runId: 'test-run-123' });
+
+      expect(result?.type).toBe('tool-call');
+      if (result?.type === 'tool-call') {
+        expect(result.payload.args).toEqual({ a: 1 });
+      }
+    });
+  });
+
   describe('other chunk types', () => {
     it('should handle text-delta chunks correctly', () => {
       const chunk: StreamPart = {
@@ -228,5 +298,81 @@ describe('convertFullStreamChunkToMastra', () => {
         expect(result.payload.stepResult.reason).toBe('stop');
       }
     });
+  });
+});
+
+describe('parseToolCallInput', () => {
+  it('should parse valid JSON', () => {
+    expect(parseToolCallInput('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it('should return undefined for empty string', () => {
+    expect(parseToolCallInput('')).toBeUndefined();
+  });
+
+  it('should return undefined for null', () => {
+    expect(parseToolCallInput(null)).toBeUndefined();
+  });
+
+  it('should return undefined for undefined', () => {
+    expect(parseToolCallInput(undefined)).toBeUndefined();
+  });
+
+  it('should return undefined for non-string input', () => {
+    expect(parseToolCallInput(42)).toBeUndefined();
+    expect(parseToolCallInput({})).toBeUndefined();
+  });
+
+  it('should strip trailing LLM tokens and parse', () => {
+    expect(parseToolCallInput('{"a":1}<|call|>')).toEqual({ a: 1 });
+    expect(parseToolCallInput('{"a":1}  <|endoftext|>  ')).toEqual({ a: 1 });
+    expect(parseToolCallInput('{"a":1}\t<|call|>')).toEqual({ a: 1 });
+  });
+
+  it('should replace ? placeholder values with null', () => {
+    expect(parseToolCallInput('{"checkpointNumber":?}')).toEqual({ checkpointNumber: null });
+    expect(parseToolCallInput('{"a":?,"b":"hello"}')).toEqual({ a: null, b: 'hello' });
+  });
+
+  it('should handle combined trailing tokens and ? placeholders', () => {
+    expect(parseToolCallInput('{"a":?}<|call|>')).toEqual({ a: null });
+  });
+
+  it('should return undefined for completely unparseable input', () => {
+    expect(parseToolCallInput('{totally broken')).toBeUndefined();
+  });
+
+  it('should not modify valid JSON with ? inside string values', () => {
+    expect(parseToolCallInput('{"q":"what?"}')).toEqual({ q: 'what?' });
+  });
+});
+
+describe('stripTrailingLLMTokens', () => {
+  it('should strip a single trailing token', () => {
+    expect(stripTrailingLLMTokens('{"a":1}<|call|>')).toBe('{"a":1}');
+  });
+
+  it('should strip multiple trailing tokens', () => {
+    expect(stripTrailingLLMTokens('{"a":1}<|call|><|endoftext|>')).toBe('{"a":1}');
+  });
+
+  it('should strip tokens with surrounding whitespace', () => {
+    expect(stripTrailingLLMTokens('{"a":1}  <|call|>  ')).toBe('{"a":1}');
+  });
+
+  it('should not strip tokens inside JSON string values', () => {
+    expect(stripTrailingLLMTokens('{"prompt": "Use <|system|> token"}')).toBe('{"prompt": "Use <|system|> token"}');
+  });
+
+  it('should not strip leading tokens', () => {
+    expect(stripTrailingLLMTokens('<|im_start|>{"a":1}')).toBe('<|im_start|>{"a":1}');
+  });
+
+  it('should return input unchanged when no tokens present', () => {
+    expect(stripTrailingLLMTokens('{"a":1}')).toBe('{"a":1}');
+  });
+
+  it('should handle empty string', () => {
+    expect(stripTrailingLLMTokens('')).toBe('');
   });
 });

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -131,19 +131,7 @@ export function convertFullStreamChunkToMastra(value: StreamPart, ctx: { runId: 
       };
 
     case 'tool-call': {
-      let toolCallInput: Record<string, any> | undefined = undefined;
-
-      if (value.input) {
-        try {
-          toolCallInput = JSON.parse(value.input);
-        } catch (error) {
-          console.error('Error converting tool call input to JSON', {
-            error,
-            input: value.input,
-          });
-          toolCallInput = undefined;
-        }
-      }
+      const toolCallInput = parseToolCallInput(value.input);
 
       return {
         type: 'tool-call',
@@ -567,4 +555,69 @@ function normalizeFinishReason(
 
   // V2/V5 format - already a string, but normalize 'unknown' to 'other' for consistency with V6
   return finishReason === 'unknown' ? 'other' : finishReason;
+}
+
+/**
+ * Attempts to parse tool call input JSON, applying sanitization for common
+ * malformations produced by LLM providers (OpenRouter, OpenAI, etc.).
+ *
+ * Recovery strategies (in order):
+ * 1. Direct JSON.parse
+ * 2. Strip trailing LLM-internal tokens (`<|call|>`, `<|endoftext|>`, etc.)
+ * 3. Replace invalid placeholder values (`?` used instead of numbers/strings)
+ *
+ * @see https://github.com/mastra-ai/mastra/issues/13261
+ * @see https://github.com/mastra-ai/mastra/issues/13185
+ */
+export function parseToolCallInput(input: unknown): Record<string, any> | undefined {
+  if (!input || typeof input !== 'string') {
+    return undefined;
+  }
+
+  // 1. Try direct parse
+  try {
+    return JSON.parse(input);
+  } catch {
+    // continue to sanitization
+  }
+
+  // 2. Strip trailing LLM tokens (e.g. <|call|>, <|endoftext|>) and retry
+  const stripped = stripTrailingLLMTokens(input);
+  if (stripped !== input) {
+    try {
+      return JSON.parse(stripped);
+    } catch {
+      // continue to next strategy
+    }
+  }
+
+  // 3. Replace bare `?` values with null (OpenRouter/Novita malformation)
+  //    e.g. {"checkpointNumber":?} → {"checkpointNumber":null}
+  //    e.g. {"items":[?]} → {"items":[null]}
+  const withNulls = stripped.replace(/([:,\[]\s*)\?(\s*[,}\]])/g, '$1null$2');
+  if (withNulls !== stripped) {
+    try {
+      return JSON.parse(withNulls);
+    } catch {
+      // continue to fallback
+    }
+  }
+
+  console.warn('Failed to parse tool call input as JSON', { input });
+  return undefined;
+}
+
+/**
+ * Strips trailing LLM-internal special tokens from a string before JSON parsing.
+ *
+ * Some models (e.g. OpenAI gpt-4o-mini/gpt-4o) occasionally append internal tokens
+ * like `<|call|>` or `<|endoftext|>` to tool-call input JSON, which breaks JSON.parse.
+ *
+ * Only strips tokens that appear after the JSON content ends (trailing), so that
+ * legitimate `<|...|>` patterns inside JSON string values are preserved.
+ *
+ * @see https://github.com/mastra-ai/mastra/issues/13185
+ */
+export function stripTrailingLLMTokens(input: string): string {
+  return input.replace(/(\s*<\|[^|]*\|>)+\s*$/, '').trim();
 }


### PR DESCRIPTION
## Summary

Fixes #13261
Fixes #13185

LLM providers can produce malformed JSON in tool-call arguments during streaming:
- **OpenRouter/Novita** (e.g. `meta-llama/llama-4-maverick`): produces placeholder values like `{"checkpointNumber":?}`
- **OpenAI** (gpt-4o-mini, gpt-4o): appends internal tokens like `<|call|>` or `<|endoftext|>` to JSON strings

Both cases cause `JSON.parse` to fail, silently setting tool call args to `undefined`.

## Changes

- Replaced the inline `JSON.parse(value.input)` call with a new `parseToolCallInput()` function that applies progressive sanitization:
  1. Direct `JSON.parse` attempt
  2. Strip trailing LLM tokens (`<|call|>`, `<|endoftext|>`, etc.)
  3. Replace bare `?` placeholder values with `null`
- Downgraded the failure log from `console.error` to `console.warn` since the error is handled gracefully
- Added `stripTrailingLLMTokens()` utility that only removes `<|...|>` tokens appearing after JSON content (preserves tokens inside string values)

## Test Plan

- `pnpm vitest run src/stream/aisdk/v5/transform.test.ts` — 30 tests pass
- Integration tests: tool-call chunks with trailing tokens, `?` placeholders, combined malformations
- Unit tests for `parseToolCallInput` and `stripTrailingLLMTokens`
- All existing tests for valid/malformed/empty/undefined inputs continue to pass