### PR TITLE
fix: experiment results viewing issues in studio

### DIFF
--- a/.changeset/bold-falcons-melt.md
+++ b/.changeset/bold-falcons-melt.md
@@ -1,6 +1,5 @@
 ---
 '@mastra/playground-ui': patch
-'mastra': patch
 ---
 
 Fixed experiment results page showing only 10 items, empty summary tab with no scorers, and scores not updating during experiment runs.

--- a/.changeset/bold-falcons-melt.md
+++ b/.changeset/bold-falcons-melt.md
@@ -1,0 +1,6 @@
+---
+'@mastra/playground-ui': patch
+'mastra': patch
+---
+
+Fixed experiment results page showing only 10 items, empty summary tab with no scorers, and scores not updating during experiment runs.

--- a/.changeset/rich-masks-work.md
+++ b/.changeset/rich-masks-work.md
@@ -4,4 +4,5 @@
 '@mastra/pg': patch
 ---
 
-Fixed negative pending count for async experiments and scorer prompt metadata being lost during experiment score persistence.
+- Fixed experiment pending count showing negative values when experiments are triggered from the Studio
+- Fixed scorer prompt metadata (analysis context, generated prompts) being lost when saving experiment scores

--- a/.changeset/rich-masks-work.md
+++ b/.changeset/rich-masks-work.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/pg': patch
+---
+
+Fixed negative pending count for async experiments and scorer prompt metadata being lost during experiment score persistence.

--- a/packages/core/src/datasets/experiment/index.ts
+++ b/packages/core/src/datasets/experiment/index.ts
@@ -186,9 +186,12 @@ export async function runExperiment(mastra: Mastra, config: ExperimentConfig): P
       });
     }
     // Update status to running (both sync and async paths)
+    // Also set totalItems — needed for the async path where the experiment
+    // was created with totalItems: 0 before items were resolved.
     await experimentsStore.updateExperiment({
       id: experimentId,
       status: 'running',
+      totalItems: items.length,
       startedAt,
     });
   }

--- a/packages/core/src/datasets/experiment/scorer.ts
+++ b/packages/core/src/datasets/experiment/scorer.ts
@@ -120,33 +120,47 @@ async function runScorerSafe(
   scorerOutput?: ScorerRunOutputForAgent,
 ): Promise<{ result: ScorerResult; promptMetadata: ScorerPromptMetadata }> {
   try {
-    const scoreResult = await scorer.run({
+    const scoreResult: unknown = await scorer.run({
       input: scorerInput ?? item.input,
       output: scorerOutput ?? output,
       groundTruth: item.groundTruth,
     });
 
-    // Extract score and reason with proper null handling
-    // Scorer run result types are complex generics, so we cast through any
-    const raw = scoreResult as any;
-    const score = raw.score;
-    const reason = raw.reason;
+    // Extract fields with typeof guards — scorer run result types use complex
+    // conditional generics that don't resolve cleanly with MastraScorer<any,…>.
+    if (typeof scoreResult !== 'object' || scoreResult === null) {
+      return {
+        result: { scorerId: scorer.id, scorerName: scorer.name, score: null, reason: null, error: null },
+        promptMetadata: {},
+      };
+    }
+
+    const fields = scoreResult as Record<string, unknown>;
+    const score = typeof fields.score === 'number' ? fields.score : null;
+    const reason = typeof fields.reason === 'string' ? fields.reason : null;
+
+    const str = (key: string): string | undefined =>
+      typeof fields[key] === 'string' ? (fields[key] as string) : undefined;
+    const obj = (key: string): Record<string, unknown> | undefined => {
+      const val = fields[key];
+      return typeof val === 'object' && val !== null ? (val as Record<string, unknown>) : undefined;
+    };
 
     return {
       result: {
         scorerId: scorer.id,
         scorerName: scorer.name,
-        score: typeof score === 'number' ? score : null,
-        reason: typeof reason === 'string' ? reason : null,
+        score,
+        reason,
         error: null,
       },
       promptMetadata: {
-        generateScorePrompt: raw.generateScorePrompt,
-        generateReasonPrompt: raw.generateReasonPrompt,
-        preprocessStepResult: raw.preprocessStepResult,
-        preprocessPrompt: raw.preprocessPrompt,
-        analyzeStepResult: raw.analyzeStepResult,
-        analyzePrompt: raw.analyzePrompt,
+        generateScorePrompt: str('generateScorePrompt'),
+        generateReasonPrompt: str('generateReasonPrompt'),
+        preprocessStepResult: obj('preprocessStepResult'),
+        preprocessPrompt: str('preprocessPrompt'),
+        analyzeStepResult: obj('analyzeStepResult'),
+        analyzePrompt: str('analyzePrompt'),
       },
     };
   } catch (error) {

--- a/packages/core/src/datasets/experiment/scorer.ts
+++ b/packages/core/src/datasets/experiment/scorer.ts
@@ -52,7 +52,7 @@ export async function runScorersForItem(
 
   const settled = await Promise.allSettled(
     scorers.map(async scorer => {
-      const result = await runScorerSafe(scorer, item, output, scorerInput, scorerOutput);
+      const { result, promptMetadata } = await runScorerSafe(scorer, item, output, scorerInput, scorerOutput);
 
       // Persist score if storage available and score was computed
       if (storage && result.score !== null) {
@@ -79,6 +79,7 @@ export async function runScorersForItem(
               id: targetId,
               name: targetId,
             },
+            ...promptMetadata,
           });
         } catch (saveError) {
           // Log but don't fail - score persistence is best-effort
@@ -97,8 +98,19 @@ export async function runScorersForItem(
   );
 }
 
+/** Prompt/step metadata returned by scorer.run() for DB persistence. */
+interface ScorerPromptMetadata {
+  generateScorePrompt?: string;
+  generateReasonPrompt?: string;
+  preprocessStepResult?: Record<string, unknown>;
+  preprocessPrompt?: string;
+  analyzeStepResult?: Record<string, unknown>;
+  analyzePrompt?: string;
+}
+
 /**
  * Run a single scorer safely, catching any errors.
+ * Returns both the ScorerResult and prompt metadata for DB persistence.
  */
 async function runScorerSafe(
   scorer: MastraScorer<any, any, any, any>,
@@ -106,7 +118,7 @@ async function runScorerSafe(
   output: unknown,
   scorerInput?: ScorerRunInputForAgent,
   scorerOutput?: ScorerRunOutputForAgent,
-): Promise<ScorerResult> {
+): Promise<{ result: ScorerResult; promptMetadata: ScorerPromptMetadata }> {
   try {
     const scoreResult = await scorer.run({
       input: scorerInput ?? item.input,
@@ -116,23 +128,37 @@ async function runScorerSafe(
 
     // Extract score and reason with proper null handling
     // Scorer run result types are complex generics, so we cast through any
-    const score = (scoreResult as any).score;
-    const reason = (scoreResult as any).reason;
+    const raw = scoreResult as any;
+    const score = raw.score;
+    const reason = raw.reason;
 
     return {
-      scorerId: scorer.id,
-      scorerName: scorer.name,
-      score: typeof score === 'number' ? score : null,
-      reason: typeof reason === 'string' ? reason : null,
-      error: null,
+      result: {
+        scorerId: scorer.id,
+        scorerName: scorer.name,
+        score: typeof score === 'number' ? score : null,
+        reason: typeof reason === 'string' ? reason : null,
+        error: null,
+      },
+      promptMetadata: {
+        generateScorePrompt: raw.generateScorePrompt,
+        generateReasonPrompt: raw.generateReasonPrompt,
+        preprocessStepResult: raw.preprocessStepResult,
+        preprocessPrompt: raw.preprocessPrompt,
+        analyzeStepResult: raw.analyzeStepResult,
+        analyzePrompt: raw.analyzePrompt,
+      },
     };
   } catch (error) {
     return {
-      scorerId: scorer.id,
-      scorerName: scorer.name,
-      score: null,
-      reason: null,
-      error: error instanceof Error ? error.message : String(error),
+      result: {
+        scorerId: scorer.id,
+        scorerName: scorer.name,
+        score: null,
+        reason: null,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      promptMetadata: {},
     };
   }
 }

--- a/packages/core/src/datasets/experiment/scorer.ts
+++ b/packages/core/src/datasets/experiment/scorer.ts
@@ -130,7 +130,13 @@ async function runScorerSafe(
     // conditional generics that don't resolve cleanly with MastraScorer<any,…>.
     if (typeof scoreResult !== 'object' || scoreResult === null) {
       return {
-        result: { scorerId: scorer.id, scorerName: scorer.name, score: null, reason: null, error: null },
+        result: {
+          scorerId: scorer.id,
+          scorerName: scorer.name,
+          score: null,
+          reason: null,
+          error: `Scorer ${scorer.name} (${scorer.id}) returned invalid result: expected object, got ${scoreResult === null ? 'null' : typeof scoreResult} (${String(scoreResult)})`,
+        },
         promptMetadata: {},
       };
     }

--- a/packages/core/src/storage/domains/experiments/inmemory.ts
+++ b/packages/core/src/storage/domains/experiments/inmemory.ts
@@ -60,6 +60,7 @@ export class ExperimentsInMemory extends ExperimentsStorage {
     const updated: Experiment = {
       ...existing,
       status: input.status ?? existing.status,
+      totalItems: input.totalItems ?? existing.totalItems,
       succeededCount: input.succeededCount ?? existing.succeededCount,
       failedCount: input.failedCount ?? existing.failedCount,
       skippedCount: input.skippedCount ?? existing.skippedCount,

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -2267,6 +2267,7 @@ export interface UpdateExperimentInput {
   description?: string;
   metadata?: Record<string, unknown>;
   status?: ExperimentStatus;
+  totalItems?: number;
   succeededCount?: number;
   failedCount?: number;
   skippedCount?: number;

--- a/packages/playground-ui/src/domains/datasets/hooks/use-dataset-experiments.ts
+++ b/packages/playground-ui/src/domains/datasets/hooks/use-dataset-experiments.ts
@@ -3,6 +3,7 @@ import { useMastraClient } from '@mastra/react';
 import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useInView } from '@/hooks/use-in-view';
+import type { ExperimentStatus } from '@mastra/core/storage';
 
 export interface DatasetExperimentsFilters {
   status?: string;
@@ -62,7 +63,7 @@ const RESULTS_PER_PAGE = 100;
 interface UseDatasetExperimentResultsParams {
   datasetId: string;
   experimentId: string;
-  experimentStatus?: string;
+  experimentStatus?: ExperimentStatus;
 }
 
 /**
@@ -117,7 +118,7 @@ export const useDatasetExperimentResults = ({
  * Hook to fetch all scores for an experiment, transformed to Record<entityId, ClientScoreRowData[]>
  * Paginates through all pages to ensure no scores are silently dropped.
  */
-export const useScoresByExperimentId = (experimentId: string, experimentStatus?: string) => {
+export const useScoresByExperimentId = (experimentId: string, experimentStatus?: ExperimentStatus) => {
   const client = useMastraClient();
   return useQuery({
     queryKey: ['dataset-experiment-scores', experimentId, experimentStatus],

--- a/packages/playground-ui/src/domains/datasets/hooks/use-dataset-experiments.ts
+++ b/packages/playground-ui/src/domains/datasets/hooks/use-dataset-experiments.ts
@@ -1,6 +1,8 @@
 import type { ClientScoreRowData } from '@mastra/client-js';
 import { useMastraClient } from '@mastra/react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { useInView } from '@/hooks/use-in-view';
 
 export interface DatasetExperimentsFilters {
   status?: string;
@@ -55,40 +57,73 @@ export const useDatasetExperiment = (datasetId: string, experimentId: string) =>
   });
 };
 
+const RESULTS_PER_PAGE = 100;
+
 interface UseDatasetExperimentResultsParams {
   datasetId: string;
   experimentId: string;
-  pagination?: { page?: number; perPage?: number };
   experimentStatus?: string;
 }
 
 /**
- * Hook to list results for a dataset experiment with optional pagination
- * Polls every 2 seconds while experiment status is 'pending' or 'running'
+ * Hook to list results for a dataset experiment with infinite scroll pagination.
+ * Polls every 2 seconds while experiment status is 'pending' or 'running'.
  */
 export const useDatasetExperimentResults = ({
   datasetId,
   experimentId,
-  pagination,
   experimentStatus,
 }: UseDatasetExperimentResultsParams) => {
   const client = useMastraClient();
-  return useQuery({
-    queryKey: ['dataset-experiment-results', datasetId, experimentId, pagination],
-    queryFn: () => client.listDatasetExperimentResults(datasetId, experimentId, pagination),
+  const { inView: isEndOfListInView, setRef: setEndOfListElement } = useInView();
+
+  const query = useInfiniteQuery({
+    queryKey: ['dataset-experiment-results', datasetId, experimentId, experimentStatus],
+    queryFn: async ({ pageParam }) => {
+      return client.listDatasetExperimentResults(datasetId, experimentId, {
+        page: pageParam,
+        perPage: RESULTS_PER_PAGE,
+      });
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _, lastPageParam) => {
+      if (!lastPage?.results?.length) {
+        return undefined;
+      }
+      const totalFetched = (lastPageParam + 1) * RESULTS_PER_PAGE;
+      const total = lastPage?.pagination?.total ?? 0;
+      if (totalFetched >= total) {
+        return undefined;
+      }
+      return lastPageParam + 1;
+    },
     enabled: Boolean(datasetId) && Boolean(experimentId),
     refetchInterval: experimentStatus === 'running' || experimentStatus === 'pending' ? 2000 : false,
+    select: data => {
+      return data.pages.flatMap(page => page?.results ?? []);
+    },
   });
+
+  useEffect(() => {
+    if (isEndOfListInView && query.hasNextPage && !query.isFetchingNextPage) {
+      query.fetchNextPage();
+    }
+  }, [isEndOfListInView, query.hasNextPage, query.isFetchingNextPage]);
+
+  return { ...query, setEndOfListElement };
 };
 
 /**
  * Hook to fetch all scores for an experiment, transformed to Record<entityId, ClientScoreRowData[]>
  * Paginates through all pages to ensure no scores are silently dropped.
  */
-export const useScoresByExperimentId = (experimentId: string) => {
+export const useScoresByExperimentId = (
+  experimentId: string,
+  experimentStatus?: string,
+) => {
   const client = useMastraClient();
   return useQuery({
-    queryKey: ['dataset-experiment-scores', experimentId],
+    queryKey: ['dataset-experiment-scores', experimentId, experimentStatus],
     queryFn: async () => {
       const allScores: ClientScoreRowData[] = [];
       let page = 0;
@@ -112,5 +147,6 @@ export const useScoresByExperimentId = (experimentId: string) => {
       return grouped;
     },
     enabled: Boolean(experimentId),
+    refetchInterval: experimentStatus === 'running' || experimentStatus === 'pending' ? 2000 : false,
   });
 };

--- a/packages/playground-ui/src/domains/datasets/hooks/use-dataset-experiments.ts
+++ b/packages/playground-ui/src/domains/datasets/hooks/use-dataset-experiments.ts
@@ -117,10 +117,7 @@ export const useDatasetExperimentResults = ({
  * Hook to fetch all scores for an experiment, transformed to Record<entityId, ClientScoreRowData[]>
  * Paginates through all pages to ensure no scores are silently dropped.
  */
-export const useScoresByExperimentId = (
-  experimentId: string,
-  experimentStatus?: string,
-) => {
+export const useScoresByExperimentId = (experimentId: string, experimentStatus?: string) => {
   const client = useMastraClient();
   return useQuery({
     queryKey: ['dataset-experiment-scores', experimentId, experimentStatus],

--- a/packages/playground-ui/src/domains/experiments/components/experiment-page-content.tsx
+++ b/packages/playground-ui/src/domains/experiments/components/experiment-page-content.tsx
@@ -160,7 +160,7 @@ export function ExperimentPageContent({
       </TabList>
 
       <TabContent value="summary" className="overflow-y-auto mt-5">
-        <ExperimentScorerSummary scoresByItemId={scoresByExperimentId} />
+        <ExperimentScorerSummary scoresByItemId={scoresByExperimentId} experimentStatus={experimentStatus} />
       </TabContent>
 
       <TabContent value="results" className="grid overflow-hidden mt-5">

--- a/packages/playground-ui/src/domains/experiments/components/experiment-page-content.tsx
+++ b/packages/playground-ui/src/domains/experiments/components/experiment-page-content.tsx
@@ -15,10 +15,11 @@ import { ExperimentResultTracePanel } from './experiment-result-trace-panel';
 import { ExperimentScorePanel } from './experiment-score-panel';
 import { ExperimentResultsList } from './experiment-results-list';
 import { ExperimentScorerSummary } from './experiment-scorer-summary';
+import type { ExperimentStatus } from '@mastra/core/storage';
 
 export type ExperimentPageContentProps = {
   experimentId: string;
-  experimentStatus?: string;
+  experimentStatus?: ExperimentStatus;
   results: DatasetExperimentResult[];
   isLoading: boolean;
   setEndOfListElement?: (element: HTMLDivElement | null) => void;

--- a/packages/playground-ui/src/domains/experiments/components/experiment-page-content.tsx
+++ b/packages/playground-ui/src/domains/experiments/components/experiment-page-content.tsx
@@ -18,15 +18,27 @@ import { ExperimentScorerSummary } from './experiment-scorer-summary';
 
 export type ExperimentPageContentProps = {
   experimentId: string;
+  experimentStatus?: string;
   results: DatasetExperimentResult[];
   isLoading: boolean;
+  setEndOfListElement?: (element: HTMLDivElement | null) => void;
+  isFetchingNextPage?: boolean;
+  hasNextPage?: boolean;
 };
 
 /**
  * Master-detail layout for experiment results.
  * Shows results list on left, result detail panel on right when a result is selected.
  */
-export function ExperimentPageContent({ experimentId, results, isLoading }: ExperimentPageContentProps) {
+export function ExperimentPageContent({
+  experimentId,
+  experimentStatus,
+  results,
+  isLoading,
+  setEndOfListElement,
+  isFetchingNextPage,
+  hasNextPage,
+}: ExperimentPageContentProps) {
   const [featuredResultId, setSelectedResultId] = useState<string | null>(null);
   const [featuredTraceId, setFeaturedTraceId] = useState<string | null>(null);
   const [featuredSpanId, setFeaturedSpanId] = useState<string | undefined>(undefined);
@@ -34,7 +46,7 @@ export function ExperimentPageContent({ experimentId, results, isLoading }: Expe
 
   const featuredResult = results.find(r => r.id === featuredResultId) ?? null;
 
-  const { data: scoresByExperimentId } = useScoresByExperimentId(experimentId);
+  const { data: scoresByExperimentId } = useScoresByExperimentId(experimentId, experimentStatus);
 
   const scorerIds = useMemo(() => {
     if (!scoresByExperimentId) return [];
@@ -163,6 +175,9 @@ export function ExperimentPageContent({ experimentId, results, isLoading }: Expe
               columns={resultsListColumns}
               scoresByItemId={scoresByExperimentId}
               scorerIds={!featuredResultId ? scorerIds : undefined}
+              setEndOfListElement={setEndOfListElement}
+              isFetchingNextPage={isFetchingNextPage}
+              hasNextPage={hasNextPage}
             />
           </Column>
 

--- a/packages/playground-ui/src/domains/experiments/components/experiment-results-list.tsx
+++ b/packages/playground-ui/src/domains/experiments/components/experiment-results-list.tsx
@@ -9,6 +9,9 @@ export type ExperimentResultsListProps = {
   columns: { name: string; label: string; size: string }[];
   scoresByItemId?: Record<string, ClientScoreRowData[]>;
   scorerIds?: string[];
+  setEndOfListElement?: (element: HTMLDivElement | null) => void;
+  isFetchingNextPage?: boolean;
+  hasNextPage?: boolean;
 };
 
 /**
@@ -22,6 +25,9 @@ export function ExperimentResultsList({
   columns,
   scoresByItemId,
   scorerIds,
+  setEndOfListElement,
+  isFetchingNextPage,
+  hasNextPage,
 }: ExperimentResultsListProps) {
   if (isLoading) {
     return <ExperimentResultsListSkeleton columns={columns} />;
@@ -76,6 +82,13 @@ export function ExperimentResultsList({
             );
           })}
         </ItemList.Items>
+        <ItemList.NextPageLoading
+          setEndOfListElement={setEndOfListElement}
+          isLoading={isFetchingNextPage}
+          hasMore={hasNextPage}
+          loadingText="Loading more results..."
+          noMoreDataText="All results loaded"
+        />
       </ItemList.Scroller>
     </ItemList>
   );

--- a/packages/playground-ui/src/domains/experiments/components/experiment-scorer-summary.tsx
+++ b/packages/playground-ui/src/domains/experiments/components/experiment-scorer-summary.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 import type { ClientScoreRowData } from '@mastra/client-js';
+import { GaugeIcon } from 'lucide-react';
+import { EmptyState } from '@/ds/components/EmptyState';
 import { ItemList } from '@/ds/components/ItemList';
 
 export type ExperimentScorerSummaryProps = {
@@ -37,7 +39,17 @@ export function ExperimentScorerSummary({ scoresByItemId }: ExperimentScorerSumm
       .sort((a, b) => a.scorerId.localeCompare(b.scorerId));
   }, [scoresByItemId]);
 
-  if (scorerSummaries.length === 0) return null;
+  if (scorerSummaries.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center py-12">
+        <EmptyState
+          iconSlot={<GaugeIcon className="w-8 h-8 text-neutral3" />}
+          titleSlot="No scorers configured"
+          descriptionSlot="Add scorers when triggering an experiment to evaluate results and see summary metrics here."
+        />
+      </div>
+    );
+  }
 
   return (
     <ItemList>

--- a/packages/playground-ui/src/domains/experiments/components/experiment-scorer-summary.tsx
+++ b/packages/playground-ui/src/domains/experiments/components/experiment-scorer-summary.tsx
@@ -3,10 +3,11 @@ import type { ClientScoreRowData } from '@mastra/client-js';
 import { GaugeIcon } from 'lucide-react';
 import { EmptyState } from '@/ds/components/EmptyState';
 import { ItemList } from '@/ds/components/ItemList';
+import type { ExperimentStatus } from '@mastra/core/storage';
 
 export type ExperimentScorerSummaryProps = {
   scoresByItemId?: Record<string, ClientScoreRowData[]>;
-  experimentStatus?: string;
+  experimentStatus?: ExperimentStatus;
 };
 
 const columns = [

--- a/packages/playground-ui/src/domains/experiments/components/experiment-scorer-summary.tsx
+++ b/packages/playground-ui/src/domains/experiments/components/experiment-scorer-summary.tsx
@@ -6,6 +6,7 @@ import { ItemList } from '@/ds/components/ItemList';
 
 export type ExperimentScorerSummaryProps = {
   scoresByItemId?: Record<string, ClientScoreRowData[]>;
+  experimentStatus?: string;
 };
 
 const columns = [
@@ -14,7 +15,7 @@ const columns = [
   { name: 'count', label: 'Items Scored', size: '1fr' },
 ];
 
-export function ExperimentScorerSummary({ scoresByItemId }: ExperimentScorerSummaryProps) {
+export function ExperimentScorerSummary({ scoresByItemId, experimentStatus }: ExperimentScorerSummaryProps) {
   const scorerSummaries = useMemo(() => {
     if (!scoresByItemId) return [];
 
@@ -40,12 +41,17 @@ export function ExperimentScorerSummary({ scoresByItemId }: ExperimentScorerSumm
   }, [scoresByItemId]);
 
   if (scorerSummaries.length === 0) {
+    const isRunning = experimentStatus === 'running' || experimentStatus === 'pending';
     return (
       <div className="flex h-full items-center justify-center py-12">
         <EmptyState
           iconSlot={<GaugeIcon className="w-8 h-8 text-neutral3" />}
-          titleSlot="No scorers configured"
-          descriptionSlot="Add scorers when triggering an experiment to evaluate results and see summary metrics here."
+          titleSlot={isRunning ? 'Experiment in progress' : 'No scorers configured'}
+          descriptionSlot={
+            isRunning
+              ? 'Summary metrics will appear here once the experiment completes.'
+              : 'Add scorers when triggering an experiment to evaluate results and see summary metrics here.'
+          }
         />
       </div>
     );

--- a/packages/playground-ui/src/domains/experiments/components/experiment-scorer-summary.tsx
+++ b/packages/playground-ui/src/domains/experiments/components/experiment-scorer-summary.tsx
@@ -42,16 +42,28 @@ export function ExperimentScorerSummary({ scoresByItemId, experimentStatus }: Ex
 
   if (scorerSummaries.length === 0) {
     const isRunning = experimentStatus === 'running' || experimentStatus === 'pending';
+    const hasLoadedScores = scoresByItemId !== undefined;
+
+    let title: string;
+    let description: string;
+
+    if (isRunning) {
+      title = 'Experiment in progress';
+      description = 'Summary metrics will appear here once the experiment completes.';
+    } else if (!hasLoadedScores) {
+      title = 'Loading scores';
+      description = 'Fetching scorer results…';
+    } else {
+      title = 'No scorers configured';
+      description = 'Add scorers when triggering an experiment to evaluate results and see summary metrics here.';
+    }
+
     return (
       <div className="flex h-full items-center justify-center py-12">
         <EmptyState
           iconSlot={<GaugeIcon className="w-8 h-8 text-neutral3" />}
-          titleSlot={isRunning ? 'Experiment in progress' : 'No scorers configured'}
-          descriptionSlot={
-            isRunning
-              ? 'Summary metrics will appear here once the experiment completes.'
-              : 'Add scorers when triggering an experiment to evaluate results and see summary metrics here.'
-          }
+          titleSlot={title}
+          descriptionSlot={description}
         />
       </div>
     );

--- a/packages/playground/src/pages/datasets/dataset/experiment/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/experiment/index.tsx
@@ -25,7 +25,13 @@ function DatasetExperimentPage() {
     error: experimentError,
   } = useDatasetExperiment(datasetId!, experimentId!);
 
-  const { data: resultsData, isLoading: resultsLoading } = useDatasetExperimentResults({
+  const {
+    data: results,
+    isLoading: resultsLoading,
+    setEndOfListElement,
+    isFetchingNextPage,
+    hasNextPage,
+  } = useDatasetExperimentResults({
     datasetId: datasetId!,
     experimentId: experimentId!,
     experimentStatus: experiment?.status,
@@ -55,8 +61,6 @@ function DatasetExperimentPage() {
     );
   }
 
-  const results = resultsData?.results ?? [];
-
   return (
     <MainContentLayout>
       <Header>
@@ -79,7 +83,15 @@ function DatasetExperimentPage() {
       <div className="h-full overflow-hidden px-[3vw] pb-4">
         <div className="grid gap-1 max-w-[140rem] mx-auto grid-rows-[auto_1fr] h-full">
           <ExperimentPageHeader experimentId={experimentId!} experiment={experiment} />
-          <ExperimentPageContent experimentId={experimentId!} results={results} isLoading={resultsLoading} />
+          <ExperimentPageContent
+            experimentId={experimentId!}
+            experimentStatus={experiment?.status}
+            results={results ?? []}
+            isLoading={resultsLoading}
+            setEndOfListElement={setEndOfListElement}
+            isFetchingNextPage={isFetchingNextPage}
+            hasNextPage={hasNextPage}
+          />
         </div>
       </div>
     </MainContentLayout>

--- a/stores/_test-utils/src/domains/experiments/index.ts
+++ b/stores/_test-utils/src/domains/experiments/index.ts
@@ -157,25 +157,7 @@ export function createExperimentsTests({ storage }: { storage: MastraStorage }) 
         expect(updated.skippedCount).toBe(1);
       });
 
-      it('updateExperiment updates totalItems', async () => {
-        const exp = await experimentsStorage.createExperiment({
-          name: 'totalItems-exp',
-          datasetId: null,
-          datasetVersion: null,
-          targetType: 'agent',
-          targetId: 'agent-1',
-          totalItems: 0,
-        });
-
-        const updated = await experimentsStorage.updateExperiment({
-          id: exp.id,
-          totalItems: 10,
-        });
-
-        expect(updated.totalItems).toBe(10);
-      });
-
-      it('updateExperiment updates totalItems', async () => {
+      it('createExperiment sets initial totalItems and updateExperiment persists change', async () => {
         const exp = await experimentsStorage.createExperiment({
           name: 'total-items-exp',
           datasetId: null,

--- a/stores/_test-utils/src/domains/experiments/index.ts
+++ b/stores/_test-utils/src/domains/experiments/index.ts
@@ -157,6 +157,44 @@ export function createExperimentsTests({ storage }: { storage: MastraStorage }) 
         expect(updated.skippedCount).toBe(1);
       });
 
+      it('updateExperiment updates totalItems', async () => {
+        const exp = await experimentsStorage.createExperiment({
+          name: 'totalItems-exp',
+          datasetId: null,
+          datasetVersion: null,
+          targetType: 'agent',
+          targetId: 'agent-1',
+          totalItems: 0,
+        });
+
+        const updated = await experimentsStorage.updateExperiment({
+          id: exp.id,
+          totalItems: 10,
+        });
+
+        expect(updated.totalItems).toBe(10);
+      });
+
+      it('updateExperiment updates totalItems', async () => {
+        const exp = await experimentsStorage.createExperiment({
+          name: 'total-items-exp',
+          datasetId: null,
+          datasetVersion: null,
+          targetType: 'agent',
+          targetId: 'agent-1',
+          totalItems: 0,
+        });
+
+        expect(exp.totalItems).toBe(0);
+
+        const updated = await experimentsStorage.updateExperiment({
+          id: exp.id,
+          totalItems: 10,
+        });
+
+        expect(updated.totalItems).toBe(10);
+      });
+
       it('updateExperiment throws for non-existent experiment', async () => {
         await expect(experimentsStorage.updateExperiment({ id: 'non-existent', status: 'running' })).rejects.toThrow();
       });

--- a/stores/libsql/src/storage/domains/experiments/index.ts
+++ b/stores/libsql/src/storage/domains/experiments/index.ts
@@ -208,10 +208,6 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
         updates.push('completedAt = ?');
         values.push(input.completedAt?.toISOString() ?? null);
       }
-      if (input.totalItems !== undefined) {
-        updates.push('totalItems = ?');
-        values.push(input.totalItems);
-      }
       if (input.skippedCount !== undefined) {
         updates.push('skippedCount = ?');
         values.push(input.skippedCount);

--- a/stores/libsql/src/storage/domains/experiments/index.ts
+++ b/stores/libsql/src/storage/domains/experiments/index.ts
@@ -196,6 +196,10 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
         updates.push('failedCount = ?');
         values.push(input.failedCount);
       }
+      if (input.totalItems !== undefined) {
+        updates.push('totalItems = ?');
+        values.push(input.totalItems);
+      }
       if (input.startedAt !== undefined) {
         updates.push('startedAt = ?');
         values.push(input.startedAt?.toISOString() ?? null);
@@ -203,6 +207,10 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
       if (input.completedAt !== undefined) {
         updates.push('completedAt = ?');
         values.push(input.completedAt?.toISOString() ?? null);
+      }
+      if (input.totalItems !== undefined) {
+        updates.push('totalItems = ?');
+        values.push(input.totalItems);
       }
       if (input.skippedCount !== undefined) {
         updates.push('skippedCount = ?');

--- a/stores/pg/src/storage/domains/experiments/index.ts
+++ b/stores/pg/src/storage/domains/experiments/index.ts
@@ -249,11 +249,11 @@ export class ExperimentsPG extends ExperimentsStorage {
         values.push(input.failedCount);
       }
       if (input.totalItems !== undefined) {
-        setClauses.push(`"totalItems" = ${paramIndex++}`);
+        setClauses.push(`"totalItems" = $${paramIndex++}`);
         values.push(input.totalItems);
       }
       if (input.skippedCount !== undefined) {
-        setClauses.push(`"skippedCount" = ${paramIndex++}`);
+        setClauses.push(`"skippedCount" = $${paramIndex++}`);
         values.push(input.skippedCount);
       }
       if (input.startedAt !== undefined) {

--- a/stores/pg/src/storage/domains/experiments/index.ts
+++ b/stores/pg/src/storage/domains/experiments/index.ts
@@ -248,8 +248,12 @@ export class ExperimentsPG extends ExperimentsStorage {
         setClauses.push(`"failedCount" = $${paramIndex++}`);
         values.push(input.failedCount);
       }
+      if (input.totalItems !== undefined) {
+        setClauses.push(`"totalItems" = ${paramIndex++}`);
+        values.push(input.totalItems);
+      }
       if (input.skippedCount !== undefined) {
-        setClauses.push(`"skippedCount" = $${paramIndex++}`);
+        setClauses.push(`"skippedCount" = ${paramIndex++}`);
         values.push(input.skippedCount);
       }
       if (input.startedAt !== undefined) {


### PR DESCRIPTION
Fixes several issues when viewing experiment results in the Studio:

**Negative pending count** — async experiments created with `totalItems: 0` and never updated it. Now `totalItems` is set when the experiment enters `running` state. Added `totalItems` to `UpdateExperimentInput` and updated all three storage adapters (in-memory, pg, libsql).

**Results capped at 10** — server defaults to `perPage: 10` and the UI wasn't paginating. Converted `useDatasetExperimentResults` to `useInfiniteQuery` with auto-loading infinite scroll, matching the existing dataset items pattern.

**Empty summary tab** — `ExperimentScorerSummary` returned `null` when no scorers were configured. Now shows an `EmptyState` with a hint to add scorers.

**Scores not updating during runs** — `useScoresByExperimentId` had no polling. Added `refetchInterval` while experiment is `running`/`pending`.

**Stale data on completion** — scores and results didn't refresh when experiment finished. Added `experimentStatus` to query keys so status transitions trigger refetches.

**Scorer prompt metadata lost** — `runScorerSafe` only extracted `score` and `reason` from `scorer.run()`, dropping `generateScorePrompt`, `generateReasonPrompt`, `preprocessStepResult`, `preprocessPrompt`, `analyzeStepResult`, and `analyzePrompt`. These are now passed through to `validateAndSaveScore`.

All 42 experiment tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed experiment results pagination, stale score updates during runs, negative pending counts, and empty scorer summary UX.

* **New Features**
  * Infinite pagination for experiment results with auto-load on scroll and live refresh while experiments run.

* **Improvements**
  * Scorer prompt metadata is now persisted with scores; experiment total item counts are tracked and updated reliably.

* **Tests**
  * Added tests verifying experiment totalItems updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->