### PR TITLE
docs(mastracode): mention OpenAI web search support for web_search tool

### DIFF
--- a/docs/src/mastra-code/tools.mdx
+++ b/docs/src/mastra-code/tools.mdx
@@ -144,10 +144,11 @@ Request access to directories outside the project root. The user is prompted to 
 
 Search the web for documentation, error messages, package APIs, and other information.
 
-This tool is available through two providers:
+This tool is available through three providers:
 
-- **Tavily**: When the `TAVILY_API_KEY` environment variable is set.
-- **Anthropic web search**: Built into Anthropic models, used as a fallback when no Tavily key is configured.
+- **Tavily**: When the `TAVILY_API_KEY` environment variable is set (takes priority).
+- **Anthropic web search**: Built into Anthropic models, used when no Tavily key is configured.
+- **OpenAI web search**: Built into OpenAI models, used when no Tavily key is configured.
 
 | Parameter | Type | Required | Description |
 | - | - | - | - |


### PR DESCRIPTION
The web_search tool docs only mentioned Tavily and Anthropic as providers, but it also supports OpenAI's built-in web search. Updated the docs to list all three providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated web search tool documentation to clarify available search provider options and their precedence for users configuring search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->