### PR TITLE
fix(harness): use mediaType instead of mimeType in sendMessage file parts

### DIFF
--- a/.changeset/fix-harness-file-mediatype.md
+++ b/.changeset/fix-harness-file-mediatype.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix `mimeType` → `mediaType` typo in `sendMessage` file part construction. This caused file attachments to be routed through the V4 adapter instead of V5, preventing them from being correctly processed by AI SDK v5 providers.

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1305,7 +1305,7 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
           return {
             type: 'file' as const,
             data: f.data,
-            mimeType: f.mediaType,
+            mediaType: f.mediaType,
             filename: f.filename,
           };
         });


### PR DESCRIPTION
## Summary

Fixes a typo in `Harness.sendMessage()` where file parts were constructed with `mimeType` instead of `mediaType`. This caused file attachments to be routed through the V4 adapter instead of V5, preventing them from being correctly processed by AI SDK v5 providers.

## Change

**`packages/core/src/harness/harness.ts`**

```diff
- return { type: 'file' as const, data: f.data, mimeType: f.mediaType, filename: f.filename };
+ return { type: 'file' as const, data: f.data, mediaType: f.mediaType, filename: f.filename };
```

## Context

The `files` parameter was added in #13574, but the file part construction used `mimeType` (V4 format) instead of `mediaType` (V5 format). The AI SDK v5 `FilePart` type expects `mediaType`, so using `mimeType` causes the part to not match the expected shape and fall through to the legacy adapter path.

This bug is present in `@mastra/core@1.9.0` on npm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected file attachment metadata naming in the message system to ensure files are properly routed and processed by supported AI SDK providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->