### PR TITLE
feat(filesystem): add prefix scoping and STS session token support for S3/GCS mounts

### DIFF
--- a/workspaces/e2b/src/sandbox/mounts/gcs.ts
+++ b/workspaces/e2b/src/sandbox/mounts/gcs.ts
@@ -1,6 +1,6 @@
 import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
-import { LOG_PREFIX, validateBucketName } from './types';
+import { LOG_PREFIX, validateBucketName, validatePrefix } from './types';
 import type { MountContext } from './types';
 
 /**
@@ -15,16 +15,29 @@ export interface E2BGCSMountConfig extends FilesystemMountConfig {
   bucket: string;
   /** Service account key JSON (optional - omit for public buckets) */
   serviceAccountKey?: string;
+  /**
+   * GCS key prefix to scope the mount.
+   * When set, gcsfuse uses --only-dir to mount only this subdirectory,
+   * so sandbox paths map directly to prefixed GCS keys.
+   * Without trailing slash (e.g., 'workspace/user1/agents/abc').
+   */
+  prefix?: string;
 }
 
 /**
  * Mount a GCS bucket using gcsfuse.
+ *
+ * When `config.prefix` is set, the `--only-dir` flag is used to mount only
+ * the prefix subdirectory, aligning sandbox paths with GCS key prefixes.
  */
 export async function mountGCS(mountPath: string, config: E2BGCSMountConfig, ctx: MountContext): Promise<void> {
   const { sandbox, logger } = ctx;
 
   // Validate inputs before interpolating into shell commands
   validateBucketName(config.bucket);
+  if (config.prefix) {
+    validatePrefix(config.prefix);
+  }
 
   // Install gcsfuse if not present
   const checkResult = await sandbox.commands.run('which gcsfuse || echo "not found"');
@@ -50,6 +63,9 @@ export async function mountGCS(mountPath: string, config: E2BGCSMountConfig, ctx
   // Note: gcsfuse uses --uid/--gid flags, not -o uid=X style
   const uidGidFlags = uid && gid ? `--uid=${uid} --gid=${gid}` : '';
 
+  // Build --only-dir flag for prefix support
+  const onlyDirFlag = config.prefix ? `--only-dir="${config.prefix}"` : '';
+
   const hasCredentials = !!config.serviceAccountKey;
   let mountCmd: string;
 
@@ -64,15 +80,18 @@ export async function mountGCS(mountPath: string, config: E2BGCSMountConfig, ctx
     // Mount with credentials using --key-file flag
     // Use sudo for /dev/fuse access (same as s3fs)
     // -o allow_other lets non-root users access the FUSE mount
-    mountCmd = `sudo gcsfuse --key-file=${keyPath} -o allow_other ${uidGidFlags} ${config.bucket} ${mountPath}`;
+    mountCmd = `sudo gcsfuse --key-file=${keyPath} -o allow_other ${uidGidFlags} ${onlyDirFlag} ${config.bucket} ${mountPath}`;
   } else {
     // Public bucket mode - read-only access without credentials
     // Use --anonymous-access flag (not -o option)
     // Use sudo for /dev/fuse access (same as s3fs)
     logger.debug(`${LOG_PREFIX} No credentials provided, mounting GCS as public bucket (read-only)`);
 
-    mountCmd = `sudo gcsfuse --anonymous-access -o allow_other ${uidGidFlags} ${config.bucket} ${mountPath}`;
+    mountCmd = `sudo gcsfuse --anonymous-access -o allow_other ${uidGidFlags} ${onlyDirFlag} ${config.bucket} ${mountPath}`;
   }
+
+  // Clean up double spaces from optional flags
+  mountCmd = mountCmd.replace(/\s{2,}/g, ' ');
 
   logger.debug(`${LOG_PREFIX} Mounting GCS:`, mountCmd);
 
@@ -92,5 +111,9 @@ export async function mountGCS(mountPath: string, config: E2BGCSMountConfig, ctx
     const stdout = errorObj.result?.stdout || '';
     logger.error(`${LOG_PREFIX} gcsfuse error:`, { stderr, stdout, error: String(error) });
     throw new Error(`Failed to mount GCS bucket: ${stderr || stdout || error}`);
+  }
+
+  if (config.prefix) {
+    logger.debug(`${LOG_PREFIX} GCS prefix mount successful: sandbox "${mountPath}" → GCS "${config.prefix}/"`);
   }
 }

--- a/workspaces/e2b/src/sandbox/mounts/s3.ts
+++ b/workspaces/e2b/src/sandbox/mounts/s3.ts
@@ -1,6 +1,6 @@
 import type { FilesystemMountConfig } from '@mastra/core/workspace';
 
-import { LOG_PREFIX, validateBucketName, validateEndpoint } from './types';
+import { LOG_PREFIX, validateBucketName, validateEndpoint, validatePrefix } from './types';
 import type { MountContext } from './types';
 
 /**
@@ -23,12 +23,26 @@ export interface E2BS3MountConfig extends FilesystemMountConfig {
   accessKeyId?: string;
   /** AWS secret access key (optional - omit for public buckets) */
   secretAccessKey?: string;
+  /** AWS session token for temporary credentials (STS/AssumeRole/Federation) */
+  sessionToken?: string;
   /** Mount as read-only (even if credentials have write access) */
   readOnly?: boolean;
+  /**
+   * S3 key prefix to scope the mount.
+   * When set, s3fs uses `bucket:/prefix` syntax to mount only the prefix
+   * subdirectory, so sandbox paths map directly to prefixed S3 keys.
+   * Without trailing slash (e.g., 'workspace/user1/agents/abc').
+   */
+  prefix?: string;
 }
 
 /**
  * Mount an S3 bucket using s3fs-fuse.
+ *
+ * When `config.prefix` is set, s3fs uses `bucket:/prefix` syntax to mount only
+ * the prefix subdirectory directly to `mountPath`. This ensures that file operations
+ * within the sandbox at `mountPath` map directly to the prefixed S3 keys, aligning
+ * FUSE paths with the S3Filesystem API.
  */
 export async function mountS3(mountPath: string, config: E2BS3MountConfig, ctx: MountContext): Promise<void> {
   const { sandbox, logger } = ctx;
@@ -37,6 +51,9 @@ export async function mountS3(mountPath: string, config: E2BS3MountConfig, ctx: 
   validateBucketName(config.bucket);
   if (config.endpoint) {
     validateEndpoint(config.endpoint);
+  }
+  if (config.prefix) {
+    validatePrefix(config.prefix);
   }
 
   // Check if s3fs is installed
@@ -74,7 +91,10 @@ export async function mountS3(mountPath: string, config: E2BS3MountConfig, ctx: 
 
   // Determine if we have credentials or using public bucket mode
   const hasCredentials = config.accessKeyId && config.secretAccessKey;
-  const credentialsPath = '/tmp/.passwd-s3fs';
+  const passwdPath = '/tmp/.passwd-s3fs';
+  // s3fs reads AWS credentials from ~/.aws/credentials when run with sudo, ~ = /root
+  const awsCredentialsDir = '/root/.aws';
+  const awsCredentialsPath = `${awsCredentialsDir}/credentials`;
 
   // S3-compatible services (R2, MinIO, etc.) require credentials
   // public_bucket=1 only works for truly public AWS S3 buckets
@@ -87,18 +107,42 @@ export async function mountS3(mountPath: string, config: E2BS3MountConfig, ctx: 
   }
 
   if (hasCredentials) {
-    // Write credentials file (remove old one first to avoid permission issues)
-    const credentialsContent = `${config.accessKeyId}:${config.secretAccessKey}`;
-    await sandbox.commands.run(`sudo rm -f ${credentialsPath}`);
-    await sandbox.files.write(credentialsPath, credentialsContent);
-    await sandbox.commands.run(`chmod 600 ${credentialsPath}`);
+    if (config.sessionToken) {
+      // STS temporary credentials: must use standard AWS credentials file (INI format).
+      // The s3fs passwd file only supports "key:secret" — no session token support.
+      // s3fs automatically reads ~/.aws/credentials; with sudo, ~ resolves to /root.
+      // The -o use_session_token flag tells s3fs to look for aws_session_token in the file.
+      const awsCredsContent = [
+        '[default]',
+        `aws_access_key_id=${config.accessKeyId}`,
+        `aws_secret_access_key=${config.secretAccessKey}`,
+        `aws_session_token=${config.sessionToken}`,
+      ].join('\n');
+      // Write to temp file first (user-writable), then sudo mv to /root/.aws/
+      // This avoids shell-escaping issues with session tokens containing special chars
+      const tmpCredsPath = '/tmp/.aws-creds-staging';
+      await sandbox.files.write(tmpCredsPath, awsCredsContent);
+      await sandbox.commands.run(
+        `sudo mkdir -p ${awsCredentialsDir} && sudo mv ${tmpCredsPath} ${awsCredentialsPath} && sudo chmod 600 ${awsCredentialsPath}`,
+      );
+    } else {
+      // Long-lived IAM credentials: use simple passwd file (key:secret)
+      await sandbox.commands.run(`sudo rm -f ${passwdPath}`);
+      await sandbox.files.write(passwdPath, `${config.accessKeyId}:${config.secretAccessKey}`);
+      await sandbox.commands.run(`chmod 600 ${passwdPath}`);
+    }
   }
 
   // Build mount options
   const mountOptions: string[] = [];
 
   if (hasCredentials) {
-    mountOptions.push(`passwd_file=${credentialsPath}`);
+    if (config.sessionToken) {
+      // s3fs reads /root/.aws/credentials automatically when run as root (via sudo)
+      mountOptions.push('use_session_token');
+    } else {
+      mountOptions.push(`passwd_file=${passwdPath}`);
+    }
   } else {
     // Public bucket mode - read-only access without credentials
     mountOptions.push('public_bucket=1');
@@ -123,9 +167,16 @@ export async function mountS3(mountPath: string, config: E2BS3MountConfig, ctx: 
     logger.debug(`${LOG_PREFIX} Mounting as read-only`);
   }
 
+  // Build the s3fs bucket source:
+  // - Without prefix: just the bucket name (existing behavior)
+  // - With prefix: use `bucket:/prefix` syntax to mount only the subdirectory
+  const bucketSource = config.prefix ? `${config.bucket}:/${config.prefix}` : config.bucket;
+
   // Mount with sudo (required for /dev/fuse access)
-  const mountCmd = `sudo s3fs ${config.bucket} ${mountPath} -o ${mountOptions.join(' -o ')}`;
-  logger.debug(`${LOG_PREFIX} Mounting S3:`, hasCredentials ? mountCmd.replace(credentialsPath, '***') : mountCmd);
+  const mountCmd = `sudo s3fs ${bucketSource} ${mountPath} -o ${mountOptions.join(' -o ')}`;
+  // Redact credential file paths from logs
+  const logCmd = mountCmd.replace(passwdPath, '***');
+  logger.debug(`${LOG_PREFIX} Mounting S3:`, hasCredentials ? logCmd : mountCmd);
 
   try {
     const result = await sandbox.commands.run(mountCmd, { timeoutMs: 60_000 });
@@ -143,5 +194,9 @@ export async function mountS3(mountPath: string, config: E2BS3MountConfig, ctx: 
     const stdout = errorObj.result?.stdout || '';
     logger.error(`${LOG_PREFIX} s3fs error:`, { stderr, stdout, error: String(error) });
     throw new Error(`Failed to mount S3 bucket: ${stderr || stdout || error}`);
+  }
+
+  if (config.prefix) {
+    logger.debug(`${LOG_PREFIX} S3 prefix mount successful: sandbox "${mountPath}" → S3 "${config.prefix}/"`);
   }
 }

--- a/workspaces/e2b/src/sandbox/mounts/types.ts
+++ b/workspaces/e2b/src/sandbox/mounts/types.ts
@@ -59,3 +59,22 @@ export function validateEndpoint(endpoint: string): void {
     throw new Error(`Invalid endpoint URL: "${endpoint}"`);
   }
 }
+
+/**
+ * Validate a prefix path before interpolating into shell commands.
+ * Allows characters that are valid in S3 keys and safe in shell context:
+ * alphanumeric, hyphens, underscores, dots, forward slashes, @, and colons.
+ * Rejects empty strings, leading/trailing slashes, double slashes, and
+ * shell-unsafe characters (backticks, $, ;, &, |, <, >, quotes, spaces, etc.).
+ */
+const SAFE_PREFIX = /^[a-zA-Z0-9@][a-zA-Z0-9._\-/:@]*[a-zA-Z0-9.]$/;
+
+export function validatePrefix(prefix: string): void {
+  if (!prefix || prefix.includes('//') || !SAFE_PREFIX.test(prefix)) {
+    throw new Error(
+      `Invalid mount prefix: "${prefix}". ` +
+        `Prefix must contain only alphanumeric, hyphens, underscores, dots, forward slashes, @ and colons. ` +
+        `Must not start/end with a slash or contain consecutive slashes.`,
+    );
+  }
+}

--- a/workspaces/gcs/src/filesystem/index.test.ts
+++ b/workspaces/gcs/src/filesystem/index.test.ts
@@ -199,6 +199,36 @@ describe('GCSFilesystem', () => {
 
       expect(config.serviceAccountKey).toBeUndefined();
     });
+
+    it('includes prefix if set (without trailing slash)', () => {
+      const fs = new GCSFilesystem({
+        bucket: 'test',
+        prefix: 'workspace/user1/agents/abc',
+      });
+
+      const config = fs.getMountConfig();
+
+      expect(config.prefix).toBe('workspace/user1/agents/abc');
+    });
+
+    it('strips trailing slash from prefix in mount config', () => {
+      const fs = new GCSFilesystem({
+        bucket: 'test',
+        prefix: '/foo/bar/',
+      });
+
+      const config = fs.getMountConfig();
+
+      expect(config.prefix).toBe('foo/bar');
+    });
+
+    it('excludes prefix if not set', () => {
+      const fs = new GCSFilesystem({ bucket: 'test' });
+
+      const config = fs.getMountConfig();
+
+      expect(config.prefix).toBeUndefined();
+    });
   });
 
   describe('getInfo()', () => {

--- a/workspaces/gcs/src/filesystem/index.ts
+++ b/workspaces/gcs/src/filesystem/index.ts
@@ -34,6 +34,13 @@ export interface GCSMountConfig extends FilesystemMountConfig {
   bucket: string;
   /** Service account key JSON (optional - omit for public buckets or ADC) */
   serviceAccountKey?: string;
+  /**
+   * GCS key prefix to scope the mount.
+   * When set, gcsfuse uses --only-dir to mount only this subdirectory,
+   * so sandbox paths map directly to prefixed GCS keys.
+   * Without trailing slash (e.g., 'workspace/user1/agents/abc').
+   */
+  prefix?: string;
 }
 
 /**
@@ -229,6 +236,11 @@ export class GCSFilesystem extends MastraFilesystem {
     // Include service account key if credentials are an object
     if (this.credentials && typeof this.credentials === 'object') {
       config.serviceAccountKey = JSON.stringify(this.credentials);
+    }
+
+    // Include prefix so sandbox mounts can use --only-dir for path alignment
+    if (this.prefix) {
+      config.prefix = this.prefix.replace(/\/$/, ''); // Strip trailing slash
     }
 
     return config;

--- a/workspaces/s3/src/filesystem/index.test.ts
+++ b/workspaces/s3/src/filesystem/index.test.ts
@@ -279,6 +279,40 @@ describe('S3Filesystem', () => {
       expect(config1.readOnly).toBeUndefined();
       expect(config2.readOnly).toBeUndefined();
     });
+
+    it('includes prefix if set (without trailing slash)', () => {
+      const fs = new S3Filesystem({
+        bucket: 'test',
+        region: 'us-east-1',
+        prefix: 'workspace/user1/agents/abc',
+      });
+
+      const config = fs.getMountConfig();
+
+      expect(config.prefix).toBe('workspace/user1/agents/abc');
+    });
+
+    it('strips trailing slash from prefix in mount config', () => {
+      const fs = new S3Filesystem({
+        bucket: 'test',
+        region: 'us-east-1',
+        prefix: '/foo/bar/',
+      });
+
+      const config = fs.getMountConfig();
+
+      // S3Filesystem normalizes prefix to "foo/bar/" internally,
+      // getMountConfig strips the trailing slash for mount commands
+      expect(config.prefix).toBe('foo/bar');
+    });
+
+    it('excludes prefix if not set', () => {
+      const fs = new S3Filesystem({ bucket: 'test', region: 'us-east-1' });
+
+      const config = fs.getMountConfig();
+
+      expect(config.prefix).toBeUndefined();
+    });
   });
 
   describe('getInfo()', () => {

--- a/workspaces/s3/src/filesystem/index.ts
+++ b/workspaces/s3/src/filesystem/index.ts
@@ -47,6 +47,13 @@ export interface S3MountConfig extends FilesystemMountConfig {
   sessionToken?: string;
   /** Mount as read-only */
   readOnly?: boolean;
+  /**
+   * S3 key prefix to scope the mount.
+   * When set, the sandbox mount point will be aligned to this prefix subdirectory
+   * so that sandbox paths map directly to prefixed S3 keys.
+   * Without trailing slash (e.g., 'workspace/user1/agents/abc').
+   */
+  prefix?: string;
 }
 
 /**
@@ -282,6 +289,11 @@ export class S3Filesystem extends MastraFilesystem {
 
     if (this.readOnly) {
       config.readOnly = true;
+    }
+
+    // Include prefix so sandbox mounts can align paths to the correct subdirectory
+    if (this.prefix) {
+      config.prefix = this.prefix.replace(/\/$/, ''); // Strip trailing slash for mount commands
     }
 
     return config;


### PR DESCRIPTION
## Description

- Add prefix option to S3 and GCS mount configs to scope FUSE mounts to
  a subdirectory (s3fs bucket:/prefix syntax, gcsfuse --only-dir flag)
- Add sessionToken support to S3 mounts for STS/AssumeRole temporary credentials
  via AWS credentials file (INI format) rather than passwd file
- Add validatePrefix() to guard against shell injection in prefix paths
- Expose prefix from getMountConfig() in both S3Filesystem and GCSFilesystem
- Add tests for prefix inclusion, trailing-slash stripping, and omission

## Related Issue(s)


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- GCS mounts now support optional path-based scoping to limit access to specific directories
- S3 mounts now support optional path-based scoping to limit access to specific key prefixes
- S3 authentication now supports optional session tokens for temporary credential management
- Added validation for mount path prefixes to enforce safe configuration standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->