### PR TITLE
fix(observability): update peer dependency to require @mastra/core >= 1.9.0

### DIFF
--- a/.changeset/strong-laws-train.md
+++ b/.changeset/strong-laws-train.md
@@ -2,4 +2,9 @@
 '@mastra/observability': patch
 ---
 
-Fixed peer dependency constraint to require @mastra/core >= 1.9.0. The 1.3.0 release introduced imports (DEFAULT_BLOCKED_LABELS, CardinalityConfig, MetricsContext, and other metrics/logging types) that only exist in @mastra/core 1.9.0+, but the peer dependency still allowed versions as low as 1.1.0, causing runtime errors for users on older core versions.
+---
+`@mastra/observability`: patch
+---
+
+Fixed compatibility checks for `@mastra/observability` by requiring `@mastra/core >= 1.9.0`.
+This prevents installs with older core versions that can cause runtime errors.

--- a/.changeset/strong-laws-train.md
+++ b/.changeset/strong-laws-train.md
@@ -2,9 +2,5 @@
 '@mastra/observability': patch
 ---
 
----
-`@mastra/observability`: patch
----
-
 Fixed compatibility checks for `@mastra/observability` by requiring `@mastra/core >= 1.9.0`.
 This prevents installs with older core versions that can cause runtime errors.

--- a/.changeset/strong-laws-train.md
+++ b/.changeset/strong-laws-train.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed peer dependency constraint to require @mastra/core >= 1.9.0. The 1.3.0 release introduced imports (DEFAULT_BLOCKED_LABELS, CardinalityConfig, MetricsContext, and other metrics/logging types) that only exist in @mastra/core 1.9.0+, but the peer dependency still allowed versions as low as 1.1.0, causing runtime errors for users on older core versions.

--- a/observability/mastra/package.json
+++ b/observability/mastra/package.json
@@ -46,7 +46,7 @@
     "zod": "^3.25.76"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.1.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.9.0-0 <2.0.0-0"
   },
   "homepage": "https://mastra.ai",
   "repository": {


### PR DESCRIPTION
## Summary

- Fixed `@mastra/observability` peer dependency constraint from `>=1.1.0-0` to `>=1.9.0-0` to match the actual minimum required `@mastra/core` version
- The 1.3.0 release (#13612) introduced imports (`DEFAULT_BLOCKED_LABELS`, `CardinalityConfig`, `MetricsContext`, `ObservabilityEventBus`, and other metrics/logging types) that only exist in `@mastra/core@1.9.0+`, causing runtime errors for users on older core versions

## Context

The `feat(observability): add ObservabilityBus, metrics, and structured logging` change in v1.3.0 added new runtime and type imports from `@mastra/core/observability` that were introduced simultaneously in `@mastra/core@1.9.0`. However, the peer dependency was never updated and still allowed `@mastra/core` versions as low as 1.1.0, which don't export these symbols.

**New imports requiring @mastra/core >= 1.9.0:**
- **Runtime**: `DEFAULT_BLOCKED_LABELS` (in `metrics/cardinality.ts`)
- **Types**: `CardinalityConfig`, `MetricsContext`, `Counter`, `Gauge`, `Histogram`, `MetricType`, `ExportedMetric`, `MetricEvent`, `LogEvent`, `LogLevel`, `ExportedLog`, `LoggerContext`, `ObservabilityEventBus`, `ObservabilityEvent`, `ScoreEvent`, `FeedbackEvent`, `MetricsConfig`

## Test plan

- [ ] Verify `pnpm build` succeeds with the updated peer dependency
- [ ] Verify `pnpm test` passes for the observability package
- [ ] Confirm npm/pnpm warns when installing `@mastra/observability@1.3.1` with `@mastra/core` < 1.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a release entry for the observability package.
  * Raised the minimum required core package version to 1.9.0 to ensure compatibility and avoid runtime issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->