### PR TITLE
fix(docs): preserve property nesting context in llms.txt PropertiesTable handler

### DIFF
--- a/docs/src/plugins/docusaurus-plugin-llms-txt/component-handlers.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/component-handlers.ts
@@ -2,7 +2,7 @@
  * Custom handlers for Docusaurus components (tabs, details, etc.)
  */
 
-import type { Element, ElementContent } from 'hast'
+import type { Element, ElementContent, Parents } from 'hast'
 import type { BlockContent, DefinitionContent, Paragraph, Text, Strong } from 'mdast'
 import type { State } from 'hast-util-to-mdast'
 
@@ -361,13 +361,54 @@ export function isPropertiesTable(node: Element): boolean {
 }
 
 /**
- * Handle PropertiesTable - format as definition-style list
+ * Find the nearest preceding heading sibling of a node within its parent.
+ * Walks backwards through parent's children to find the closest h1-h6.
+ * Returns the heading text and level, or undefined if none found.
+ */
+function findPrecedingHeading(node: Element, parent: Parents | undefined): { text: string; level: number } | undefined {
+  if (!parent) return undefined
+
+  const siblings = parent.children
+  const nodeIndex = siblings.indexOf(node)
+  if (nodeIndex <= 0) return undefined
+
+  for (let i = nodeIndex - 1; i >= 0; i--) {
+    const sibling = siblings[i]
+    if (sibling.type === 'element' && /^h[1-6]$/.test(sibling.tagName)) {
+      const level = parseInt(sibling.tagName[1], 10)
+      return { text: getTextContent(sibling).trim(), level }
+    }
+  }
+  return undefined
+}
+
+/**
+ * Extract a parent property name from a sub-heading like "### X parameters".
+ * Only applies to h3+ (sub-headings), not h1/h2 (main section headings),
+ * since top-level properties don't need a prefix.
+ * e.g. "### Options parameters" → "options", "### Config properties" → "config"
+ */
+function extractParentPropertyFromHeading(heading: { text: string; level: number } | undefined): string | undefined {
+  if (!heading || heading.level <= 2) return undefined
+  const match = heading.text.match(/^(\w+)\s+(?:parameters|properties|options|config)\s*$/i)
+  if (!match) return undefined
+  return match[1].charAt(0).toLowerCase() + match[1].slice(1)
+}
+
+/**
+ * Handle PropertiesTable - format as definition-style list.
+ * When preceded by a heading like "X parameters", properties are prefixed
+ * with the parent name (e.g. "options.generateTitle") so the nesting is clear.
  */
 export function handlePropertiesTable(
   _state: State,
   node: Element,
+  parent?: Parents,
 ): BlockContent | Array<BlockContent | DefinitionContent> {
   const result: Array<BlockContent | DefinitionContent> = []
+
+  const heading = findPrecedingHeading(node, parent)
+  const parentProp = extractParentPropertyFromHeading(heading)
 
   for (const child of node.children) {
     if (child.type !== 'element') continue
@@ -377,7 +418,8 @@ export function handlePropertiesTable(
 
     // Find the h3 with property name
     const h3 = findElementByTag(child, 'h3')
-    const propName = h3 ? getTextContent(h3).trim() : propId
+    const rawPropName = h3 ? getTextContent(h3).trim() : propId
+    const propName = parentProp ? `${parentProp}.${rawPropName}` : rawPropName
 
     // Find type and default value in the first row div
     let propType = ''

--- a/docs/src/plugins/docusaurus-plugin-llms-txt/html-processor.ts
+++ b/docs/src/plugins/docusaurus-plugin-llms-txt/html-processor.ts
@@ -7,7 +7,7 @@ import rehypeParse from 'rehype-parse'
 import rehypeRemark from 'rehype-remark'
 import remarkStringify from 'remark-stringify'
 import remarkGfm from 'remark-gfm'
-import type { Root as HastRoot, Element, Text, Comment, ElementContent } from 'hast'
+import type { Root as HastRoot, Element, Text, Comment, ElementContent, Parents } from 'hast'
 import type { Root as MdastRoot } from 'mdast'
 
 import { handleCodeBlock } from './code-block-handler'
@@ -43,7 +43,11 @@ const htmlParser = unified().use(rehypeParse, { fragment: false })
  * Custom handler for div elements
  * Checks for special div types (admonitions, tabs, card grids, properties tables) and handles them appropriately
  */
-function handleDiv(state: State, node: Element): BlockContent | Array<BlockContent | DefinitionContent> | undefined {
+function handleDiv(
+  state: State,
+  node: Element,
+  parent: Parents | undefined,
+): BlockContent | Array<BlockContent | DefinitionContent> | undefined {
   // Check if this is an admonition
   if (isAdmonition(node)) {
     return handleAdmonition(state, node)
@@ -66,7 +70,7 @@ function handleDiv(state: State, node: Element): BlockContent | Array<BlockConte
 
   // Check if this is a PropertiesTable
   if (isPropertiesTable(node)) {
-    return handlePropertiesTable(state, node)
+    return handlePropertiesTable(state, node, parent)
   }
 
   // For regular divs, process children and return them (default behavior)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

The `docusaurus-plugin-llms-txt` plugin's `handlePropertiesTable` handler was flattening all `<PropertiesTable>` blocks into a plain list without parent
context. This caused the embedded docs shipped in npm packages (`dist/docs/references/`) to render nested properties like `options.generateTitle` as if
they were top-level constructor params — misleading users and AI tools into writing `new Memory({ generateTitle: true })` instead of `new Memory({
options: { generateTitle: true } })`.

The fix makes `handlePropertiesTable` look at the preceding heading to determine nesting. For h3+ sub-headings matching "X parameters/properties" (e.g.
`### Options parameters`), each property is prefixed with the parent name (e.g. `options.generateTitle`). Top-level h2 headings are left unprefixed. This
affects 24 reference pages across the docs.

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #13830

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced property documentation to display hierarchical relationships, showing parent-child property contexts in generated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->