### PR TITLE
types(agent): infer requestContext from schema in dynamic model

### DIFF
--- a/.changeset/fine-crabs-cheer.md
+++ b/.changeset/fine-crabs-cheer.md
@@ -2,4 +2,6 @@
 '@mastra/core': patch
 ---
 
-types(agent): infer requestContext from schema in dynamic model
+`@mastra/core`: patch
+
+Improved type inference for agent's `requestContext` parameter. When defining a `requestContextSchema` on an agent, the `requestContext` type is now automatically inferred in dynamic model functions.

--- a/.changeset/fine-crabs-cheer.md
+++ b/.changeset/fine-crabs-cheer.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+types(agent): infer requestContext from schema in dynamic model

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4929,11 +4929,11 @@ export class Agent<
   resolveTitleGenerationConfig(
     generateTitleConfig:
       | boolean
-      | { model: DynamicArgument<MastraModelConfig>; instructions?: DynamicArgument<string> }
+      | { model: DynamicArgument<MastraModelConfig, TRequestContext>; instructions?: DynamicArgument<string> }
       | undefined,
   ): {
     shouldGenerate: boolean;
-    model?: DynamicArgument<MastraModelConfig>;
+    model?: DynamicArgument<MastraModelConfig, TRequestContext>;
     instructions?: DynamicArgument<string>;
   } {
     if (typeof generateTitleConfig === 'boolean') {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -121,17 +121,17 @@ export interface AgentCreateOptions {
 
 // This is used in place of DynamicArgument so that model router IDE autocomplete works.
 // Without this TS doesn't understand the function/string union type from DynamicArgument
-type DynamicModel = ({
+type DynamicModel<TRequestContext extends Record<string, any> | unknown = unknown> = ({
   requestContext,
   mastra,
 }: {
-  requestContext: RequestContext;
+  requestContext: TRequestContext;
   mastra?: Mastra;
 }) => Promise<MastraModelConfig> | MastraModelConfig;
 
-type ModelWithRetries = {
+type ModelWithRetries<TRequestContext extends Record<string, any> | unknown = unknown> = {
   id?: string;
-  model: MastraModelConfig | DynamicModel;
+  model: MastraModelConfig | DynamicModel<TRequestContext>;
   maxRetries?: number; //defaults to 0
   enabled?: boolean; //defaults to true
 };
@@ -162,7 +162,7 @@ export interface AgentConfig<
   /**
    * The language model used by the agent. Can be provided statically or resolved at runtime.
    */
-  model: MastraModelConfig | DynamicModel | ModelWithRetries[];
+  model: MastraModelConfig | DynamicModel<TRequestContext> | ModelWithRetries<TRequestContext>[];
   /**
    * Maximum number of retries for model calls in case of failure.
    * @defaultValue 0

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -121,7 +121,7 @@ export interface AgentCreateOptions {
 
 // This is used in place of DynamicArgument so that model router IDE autocomplete works.
 // Without this TS doesn't understand the function/string union type from DynamicArgument
-type DynamicModel<TRequestContext extends Record<string, any> | unknown = unknown> = ({
+type DynamicModel<TRequestContext = unknown> = ({
   requestContext,
   mastra,
 }: {
@@ -129,7 +129,7 @@ type DynamicModel<TRequestContext extends Record<string, any> | unknown = unknow
   mastra?: Mastra;
 }) => Promise<MastraModelConfig> | MastraModelConfig;
 
-type ModelWithRetries<TRequestContext extends Record<string, any> | unknown = unknown> = {
+type ModelWithRetries<TRequestContext = unknown> = {
   id?: string;
   model: MastraModelConfig | DynamicModel<TRequestContext>;
   maxRetries?: number; //defaults to 0


### PR DESCRIPTION
## Description

Infers the requestContext type from the agent’s requestContextSchema within the dynamic model function.

This change only touches the type defs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5: This PR makes TypeScript smarter so that when an agent defines a requestContextSchema, functions that build models automatically get the right requestContext type. It's a types-only, non-breaking bugfix to improve developer ergonomics and type safety.

* **What changed**
  * Parameterized dynamic model and related types by request-context so the `requestContext` parameter is inferred from an agent's `requestContextSchema`.
  * Key type updates:
    - DynamicModel -> DynamicModel<TRequestContext = unknown> with requestContext: TRequestContext
    - ModelWithRetries -> ModelWithRetries<TRequestContext = unknown> and its `model` accepts DynamicModel<TRequestContext>
    - AgentConfig.model now accepts MastraModelConfig | DynamicModel<TRequestContext> | ModelWithRetries<TRequestContext>[]
    - resolveTitleGenerationConfig signatures updated to propagate the TRequestContext generic for DynamicArgument<MastraModelConfig, TRequestContext>
  * Files inspected/modified (types-only): packages/core/src/agent/types.ts, packages/core/src/agent/agent.ts, and .changeset/fine-crabs-cheer.md (changeset entry).

* **Impact**
  * Types-only change; non-breaking bug fix improving type inference for dynamic model functions and models-with-retries.
  * No runtime code changes.
  * Documentation was updated per the author; tests were not added.
  * Coderabbit comments were addressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->