### PR TITLE
fix(mcp): forward AbortSignal to callTool

### DIFF
--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -40,6 +40,20 @@ async function setupTestServer(withSessionManagement: boolean) {
     },
   );
 
+  mcpServer.tool(
+    'slow_tool',
+    'A slow tool for testing abort behavior',
+    {
+      input: z.string().describe('Input to simulate work').default('test'),
+    },
+    async (): Promise<CallToolResult> => {
+      await new Promise(resolve => setTimeout(resolve, 60000));
+      return {
+        content: [{ type: 'text', text: 'Done' }],
+      };
+    },
+  );
+
   mcpServer.resource('test-resource', 'resource://test', () => {
     return {
       contents: [
@@ -1536,6 +1550,78 @@ describe('MastraMCPClient - Session Reconnection (Issue #7675)', () => {
     } finally {
       forceReconnectSpy.mockRestore();
       callToolSpy.mockRestore();
+      await client.disconnect().catch(() => {});
+      await testServer.mcpServer.close().catch(() => {});
+      await testServer.serverTransport.close().catch(() => {});
+      testServer.httpServer.close();
+    }
+  });
+});
+
+describe('MastraMCPClient - AbortSignal forwarding', () => {
+  it('should forward abortSignal to callTool options', async () => {
+    const testServer = await setupTestServer(true);
+    const client = new InternalMastraMCPClient({
+      name: 'abort-signal-forwarding-test-client',
+      server: { url: testServer.baseUrl },
+    });
+
+    await client.connect();
+
+    const tools = await client.tools();
+    const greetTool = tools['greet'];
+    expect(greetTool).toBeDefined();
+
+    const sdkClient = (client as any).client as Client;
+    const callToolSpy = vi.spyOn(sdkClient, 'callTool');
+
+    const abortController = new AbortController();
+
+    try {
+      await greetTool.execute?.({ name: 'AbortTest' }, { abortSignal: abortController.signal });
+
+      expect(callToolSpy).toHaveBeenCalled();
+      const [, , options] = callToolSpy.mock.calls[0]!;
+      expect(options).toMatchObject({ signal: abortController.signal });
+    } finally {
+      callToolSpy.mockRestore();
+      await client.disconnect().catch(() => {});
+      await testServer.mcpServer.close().catch(() => {});
+      await testServer.serverTransport.close().catch(() => {});
+      testServer.httpServer.close();
+    }
+  });
+
+  it('should abort a slow tool call when abortSignal is triggered', async () => {
+    const testServer = await setupTestServer(true);
+    const client = new InternalMastraMCPClient({
+      name: 'abort-slow-tool-test-client',
+      server: { url: testServer.baseUrl },
+    });
+
+    await client.connect();
+
+    try {
+      const tools = await client.tools();
+      const slowTool = tools['slow_tool'];
+      expect(slowTool).toBeDefined();
+
+      const abortController = new AbortController();
+      const timeoutId = setTimeout(() => abortController.abort(), 100);
+
+      const start = Date.now();
+      try {
+        await expect(
+          slowTool.execute?.({ input: 'test' }, { abortSignal: abortController.signal }),
+        ).rejects.toThrow();
+      } finally {
+        clearTimeout(timeoutId);
+      }
+      const elapsed = Date.now() - start;
+
+      // The abort signal should cancel the request well before the full 60s sleep
+      expect(elapsed).toBeLessThan(5000);
+    } finally {
       await client.disconnect().catch(() => {});
       await testServer.mcpServer.close().catch(() => {});
       await testServer.serverTransport.close().catch(() => {});

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -47,7 +47,10 @@ async function setupTestServer(withSessionManagement: boolean) {
       input: z.string().describe('Input to simulate work').default('test'),
     },
     async (): Promise<CallToolResult> => {
-      await new Promise(resolve => setTimeout(resolve, 60000));
+      await new Promise<void>(resolve => {
+        const t = setTimeout(resolve, 10000);
+        t.unref();
+      });
       return {
         content: [{ type: 'text', text: 'Done' }],
       };
@@ -1610,16 +1613,21 @@ describe('MastraMCPClient - AbortSignal forwarding', () => {
       const timeoutId = setTimeout(() => abortController.abort(), 100);
 
       const start = Date.now();
+      let error: unknown;
       try {
-        await expect(
-          slowTool.execute?.({ input: 'test' }, { abortSignal: abortController.signal }),
-        ).rejects.toThrow();
+        await slowTool.execute?.({ input: 'test' }, { abortSignal: abortController.signal });
+      } catch (err) {
+        error = err;
       } finally {
         clearTimeout(timeoutId);
       }
       const elapsed = Date.now() - start;
 
-      // The abort signal should cancel the request well before the full 60s sleep
+      expect(abortController.signal.aborted).toBe(true);
+      expect(error).toBeDefined();
+      expect(error).toBeInstanceOf(DOMException);
+      expect((error as DOMException).name).toBe('AbortError');
+      // The abort signal should cancel the request well before the full sleep
       expect(elapsed).toBeLessThan(5000);
     } finally {
       await client.disconnect().catch(() => {});

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -4,7 +4,7 @@ import { MastraBase } from '@mastra/core/base';
 import type { RequestContext } from '@mastra/core/di';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import { createTool } from '@mastra/core/tools';
-import type { Tool } from '@mastra/core/tools';
+import type { Tool, ToolExecutionContext } from '@mastra/core/tools';
 import { isZodType } from '@mastra/core/utils';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
@@ -791,7 +791,7 @@ export class InternalMastraMCPClient extends MastraBase {
           outputSchema: await this.convertOutputSchema(tool.outputSchema),
           execute: async (
             input: any,
-            context?: { requestContext?: RequestContext | null; runId?: string; abortSignal?: AbortSignal },
+            context?: Partial<ToolExecutionContext> & { runId?: string },
           ) => {
             const operationContext = context?.requestContext ?? null;
 

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -789,7 +789,10 @@ export class InternalMastraMCPClient extends MastraBase {
           description: tool.description || '',
           inputSchema: await this.convertInputSchema(tool.inputSchema),
           outputSchema: await this.convertOutputSchema(tool.outputSchema),
-          execute: async (input: any, context?: { requestContext?: RequestContext | null; runId?: string }) => {
+          execute: async (
+            input: any,
+            context?: { requestContext?: RequestContext | null; runId?: string; abortSignal?: AbortSignal },
+          ) => {
             const operationContext = context?.requestContext ?? null;
 
             return this.operationContextStore.run(operationContext, async () => {
@@ -807,6 +810,7 @@ export class InternalMastraMCPClient extends MastraBase {
                   CallToolResultSchema,
                   {
                     timeout: this.timeout,
+                    signal: context?.abortSignal,
                   },
                 );
 


### PR DESCRIPTION
## What does this PR do?
Forwards the AI SDK’s abortSignal into the MCP client’s callTool options so MCP tool calls can be cancelled, and adds tests to verify AbortSignal forwarding and cancellation behavior.

## Root Cause
The InternalMastraMCPClient.tools() execute wrapper received an execution context from the AI SDK but did not include abortSignal in the context type nor forward it to this.client.callTool(); as a result, Harness.abort() never reached the underlying MCP HTTP request and long-running tool calls could not be cancelled.

## Changes Made
- packages/mcp/src/client/client.ts
  - Extended the execute context type to include abortSignal?: AbortSignal.
  - Passed signal: context?.abortSignal into the Client.callTool options alongside the existing timeout and progress metadata.
- packages/mcp/src/client/client.test.ts
  - Added a slow_tool to the shared test MCP server for simulating long-running tool calls.
  - Added a unit-style test that spies on Client.callTool and asserts that signal is set to the provided AbortController signal when a tool is executed with abortSignal in its context.
  - Added an integration-style test that calls slow_tool with an AbortController, aborts shortly after starting, and asserts the call rejects and completes in well under the full 60-second sleep.

## Testing
- Automated
  - New unit test verifying abortSignal is forwarded to Client.callTool options.
  - New integration test verifying that a slow MCP tool call is cancelled quickly when the abort signal is triggered.
- Local
  - Attempted to run `pnpm test --filter "@mastra/mcp" -- --runInBand`, but the run failed because vitest and dependencies are not yet installed in this clone. Once `pnpm install` is run, the new tests should execute as part of the MCP test suite.

## Related Issues
Closes #13646


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool execution now accepts AbortSignal to cancel long-running MCP tool calls.
  * Dynamic HTTP authentication for MCP servers: env- or command-sourced bearer tokens, optional caching/TTL, and merged headers.

* **Documentation**
  * Added README guidance on MCP servers and dynamic HTTP auth configuration and examples.

* **Tests**
  * Added tests for AbortSignal behavior and for dynamic auth token sourcing, caching, and header composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->