### PR TITLE
fix: count OM tool-result tokens from stored modelOutput

### DIFF
--- a/.changeset/large-paths-film.md
+++ b/.changeset/large-paths-film.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed observational memory token counting to use stored model output for tool results transformed with toModelOutput.

--- a/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
@@ -11,6 +11,37 @@ function createMessage(content: any) {
   } as any;
 }
 
+async function createToolResultPartFromExecutedTool({
+  toolName,
+  args,
+  execute,
+  toModelOutput,
+}: {
+  toolName: string;
+  args: Record<string, unknown>;
+  execute: (args: Record<string, unknown>) => unknown | Promise<unknown>;
+  toModelOutput: (output: unknown) => unknown | Promise<unknown>;
+}) {
+  const result = await execute(args);
+  const modelOutput = await toModelOutput(result);
+
+  return {
+    type: 'tool-invocation',
+    toolInvocation: {
+      state: 'result',
+      toolCallId: 'tool-1',
+      toolName,
+      args,
+      result,
+    },
+    providerMetadata: {
+      mastra: {
+        modelOutput,
+      },
+    },
+  } as const;
+}
+
 describe('TokenCounter', () => {
   describe('shared default encoder', () => {
     it('two default TokenCounter instances share the same encoder reference', () => {
@@ -258,12 +289,22 @@ describe('TokenCounter', () => {
       expect(withToolResultAgain).toBe(withToolResult);
     });
 
-    it('prefers stored mastra.modelOutput over raw tool results for token counting', () => {
+    it('prefers stored mastra.modelOutput over raw tool results for token counting', async () => {
       const counter = new TokenCounter();
+      const args = { q: 'weather in sf' };
       const rawResult = {
         longPayload: Array.from({ length: 200 }, (_, i) => `entry-${i}-${'very-large-result-'.repeat(5)}`),
       };
 
+      const weatherTool = {
+        execute: async (_args: Record<string, unknown>) => rawResult,
+        toModelOutput: async (output: unknown) => {
+          const entryCount = (output as { longPayload: string[] }).longPayload.length;
+          return { type: 'text', value: `sunny, 72°F (${entryCount} entries summarized)` };
+        },
+      };
+
+      const executedResult = await weatherTool.execute(args);
       const withoutModelOutput = createMessage({
         format: 2,
         parts: [
@@ -273,7 +314,8 @@ describe('TokenCounter', () => {
               state: 'result',
               toolCallId: 'tool-1',
               toolName: 'lookup',
-              result: rawResult,
+              args,
+              result: executedResult,
             },
           },
         ],
@@ -282,20 +324,12 @@ describe('TokenCounter', () => {
       const withModelOutput = createMessage({
         format: 2,
         parts: [
-          {
-            type: 'tool-invocation',
-            toolInvocation: {
-              state: 'result',
-              toolCallId: 'tool-1',
-              toolName: 'lookup',
-              result: rawResult,
-            },
-            providerMetadata: {
-              mastra: {
-                modelOutput: { type: 'text', value: 'sunny, 72°F' },
-              },
-            },
-          },
+          await createToolResultPartFromExecutedTool({
+            toolName: 'lookup',
+            args,
+            execute: weatherTool.execute,
+            toModelOutput: weatherTool.toModelOutput,
+          }),
         ],
       });
 
@@ -305,27 +339,25 @@ describe('TokenCounter', () => {
       expect(modelOutputTokens).toBeLessThan(rawResultTokens);
     });
 
-    it('recomputes tool-result estimates when stored modelOutput changes', () => {
+    it('recomputes tool-result estimates when stored modelOutput changes', async () => {
       const counter = new TokenCounter();
+      const args = { q: 'weather in sf' };
+      const weatherTool = {
+        execute: async (_args: Record<string, unknown>) => ({
+          longPayload: Array.from({ length: 200 }, (_, i) => `entry-${i}-${'very-large-result-'.repeat(5)}`),
+        }),
+        toModelOutput: async () => ({ type: 'text', value: 'brief output' }),
+      };
+
       const message = createMessage({
         format: 2,
         parts: [
-          {
-            type: 'tool-invocation',
-            toolInvocation: {
-              state: 'result',
-              toolCallId: 'tool-1',
-              toolName: 'lookup',
-              result: {
-                longPayload: Array.from({ length: 200 }, (_, i) => `entry-${i}-${'very-large-result-'.repeat(5)}`),
-              },
-            },
-            providerMetadata: {
-              mastra: {
-                modelOutput: { type: 'text', value: 'brief output' },
-              },
-            },
-          },
+          await createToolResultPartFromExecutedTool({
+            toolName: 'lookup',
+            args,
+            execute: weatherTool.execute,
+            toModelOutput: weatherTool.toModelOutput,
+          }),
         ],
       });
 

--- a/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
@@ -257,6 +257,92 @@ describe('TokenCounter', () => {
       expect(withToolResult).not.toBe(initial);
       expect(withToolResultAgain).toBe(withToolResult);
     });
+
+    it('prefers stored mastra.modelOutput over raw tool results for token counting', () => {
+      const counter = new TokenCounter();
+      const rawResult = {
+        longPayload: Array.from({ length: 200 }, (_, i) => `entry-${i}-${'very-large-result-'.repeat(5)}`),
+      };
+
+      const withoutModelOutput = createMessage({
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-1',
+              toolName: 'lookup',
+              result: rawResult,
+            },
+          },
+        ],
+      });
+
+      const withModelOutput = createMessage({
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-1',
+              toolName: 'lookup',
+              result: rawResult,
+            },
+            providerMetadata: {
+              mastra: {
+                modelOutput: { type: 'text', value: 'sunny, 72°F' },
+              },
+            },
+          },
+        ],
+      });
+
+      const rawResultTokens = counter.countMessage(withoutModelOutput);
+      const modelOutputTokens = counter.countMessage(withModelOutput);
+
+      expect(modelOutputTokens).toBeLessThan(rawResultTokens);
+    });
+
+    it('recomputes tool-result estimates when stored modelOutput changes', () => {
+      const counter = new TokenCounter();
+      const message = createMessage({
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-1',
+              toolName: 'lookup',
+              result: {
+                longPayload: Array.from({ length: 200 }, (_, i) => `entry-${i}-${'very-large-result-'.repeat(5)}`),
+              },
+            },
+            providerMetadata: {
+              mastra: {
+                modelOutput: { type: 'text', value: 'brief output' },
+              },
+            },
+          },
+        ],
+      });
+
+      const first = counter.countMessage(message);
+      const firstEstimate = message.content.parts[0].providerMetadata.mastra.tokenEstimate;
+
+      message.content.parts[0].providerMetadata.mastra.modelOutput = {
+        type: 'text',
+        value: 'expanded output '.repeat(40),
+      };
+
+      const second = counter.countMessage(message);
+      const secondEstimate = message.content.parts[0].providerMetadata.mastra.tokenEstimate;
+
+      expect(second).toBeGreaterThan(first);
+      expect(secondEstimate.key).not.toBe(firstEstimate.key);
+    });
   });
 
   describe('countObservations', () => {

--- a/packages/memory/src/processors/observational-memory/token-counter.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.ts
@@ -213,6 +213,24 @@ export class TokenCounter {
     return tokens;
   }
 
+  private resolveToolResultForTokenCounting(
+    part: CacheablePart,
+    invocationResult: unknown,
+  ): { value: unknown; usingStoredModelOutput: boolean } {
+    const mastraMetadata = (part as any)?.providerMetadata?.mastra;
+    if (mastraMetadata && typeof mastraMetadata === 'object' && 'modelOutput' in mastraMetadata) {
+      return {
+        value: (mastraMetadata as Record<string, unknown>).modelOutput,
+        usingStoredModelOutput: true,
+      };
+    }
+
+    return {
+      value: invocationResult,
+      usingStoredModelOutput: false,
+    };
+  }
+
   /**
    * Count tokens in a single message
    */
@@ -257,12 +275,26 @@ export class TokenCounter {
               }
             } else if (invocation.state === 'result') {
               toolResultCount++;
-              if (invocation.result !== undefined) {
-                if (typeof invocation.result === 'string') {
-                  payloadTokens += this.readOrPersistPartEstimate(part, 'tool-result', invocation.result);
+
+              const { value: resultForCounting, usingStoredModelOutput } = this.resolveToolResultForTokenCounting(
+                part,
+                invocation.result,
+              );
+
+              if (resultForCounting !== undefined) {
+                if (typeof resultForCounting === 'string') {
+                  payloadTokens += this.readOrPersistPartEstimate(
+                    part,
+                    usingStoredModelOutput ? 'tool-result-model-output' : 'tool-result',
+                    resultForCounting,
+                  );
                 } else {
-                  const resultJson = JSON.stringify(invocation.result);
-                  payloadTokens += this.readOrPersistPartEstimate(part, 'tool-result-json', resultJson);
+                  const resultJson = JSON.stringify(resultForCounting);
+                  payloadTokens += this.readOrPersistPartEstimate(
+                    part,
+                    usingStoredModelOutput ? 'tool-result-model-output-json' : 'tool-result-json',
+                    resultJson,
+                  );
                   overhead -= 12;
                 }
               }


### PR DESCRIPTION
This fixes observational memory token counting when a tool uses `toModelOutput`. We were counting `toolInvocation.result` even when the model prompt uses `providerMetadata.mastra.modelOutput`, so observation could trigger too early or too late.

Before:
```ts
const resultForCounting = invocation.result;
```

After:
```ts
const resultForCounting = part.providerMetadata?.mastra?.modelOutput ?? invocation.result;
```

Also added regression tests to confirm modelOutput is preferred and cache keys update when modelOutput changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Observational memory token counting now prefers stored model outputs for tool results, improving token estimate accuracy and labeling.

* **Tests**
  * Added tests verifying preference for stored model output in token counts.
  * Added tests ensuring token estimates are recomputed when the stored model output changes.

* **Chores**
  * Added a patch-level changeset for the memory package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->