### PR TITLE
feat: show accurate tiktoken output count in shell tool footers

### DIFF
--- a/.changeset/calm-pots-cheat.md
+++ b/.changeset/calm-pots-cheat.md
@@ -1,0 +1,6 @@
+---
+'@mastra/playground-ui': patch
+'mastracode': patch
+---
+
+Added output token count display to shell tool footers. Shows the tiktoken-based token estimate (e.g. "1.5k tokens") in the command footer when output exceeds 1k tokens, giving visibility into how much context each shell command consumes.

--- a/.changeset/twelve-parents-think.md
+++ b/.changeset/twelve-parents-think.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added `outputTokensEstimate` to shell tool exit data. Workspace tools (execute_command, get_process_output, kill_process) now emit a tiktoken-based token count in the `data-sandbox-exit` chunk, and a new `shell_exit` harness event surfaces this to consumers.

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -111,6 +111,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   private collapsible?: CollapsibleComponent;
   private startTime = Date.now();
   private streamingOutput = ''; // Buffer for streaming shell output
+  private shellExit?: { exitCode: number; success: boolean; executionTimeMs: number; outputTokensEstimate: number };
 
   constructor(toolName: string, args: unknown, options: ToolExecutionOptions = {}, ui: TUI) {
     super();
@@ -158,6 +159,14 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       return;
     }
     this.streamingOutput += output;
+    this.rebuild();
+  }
+
+  /**
+   * Store shell exit metadata (exit code, duration, output token count).
+   */
+  setShellExit(data: { exitCode: number; success: boolean; executionTimeMs: number; outputTokensEstimate: number }): void {
+    this.shellExit = data;
     this.rebuild();
   }
 
@@ -338,11 +347,12 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const timeoutSuffix = timeout ? theme.fg('muted', ` (timeout ${timeout}s)`) : '';
     const cwdSuffix = cwd ? theme.fg('muted', ` in ${cwd}`) : '';
     const timeSuffix = this.isPartial ? timeoutSuffix : this.getDurationSuffix();
+    const tokenSuffix = this.getTokenEstimateSuffix();
 
     // Helper to render shell command with bordered box
     const renderBorderedShell = (status: string, outputLines: string[]) => {
       const border = (char: string) => theme.bold(theme.fg('accent', char));
-      const footerText = `${theme.bold(theme.fg('toolTitle', '$'))} ${theme.fg('accent', command)}${cwdSuffix}${timeSuffix}${status}`;
+      const footerText = `${theme.bold(theme.fg('toolTitle', '$'))} ${theme.fg('accent', command)}${cwdSuffix}${timeSuffix}${tokenSuffix}${status}`;
 
       // Top border
       this.contentBox.addChild(new Text(border('┌──'), 0, 0));
@@ -432,11 +442,12 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const isWait = !isKill && argsObj?.wait === true;
 
     const timeSuffix = this.isPartial ? '' : this.getDurationSuffix();
+    const tokenSuffix = this.getTokenEstimateSuffix();
     const label = isKill ? 'kill' : isWait ? 'wait' : 'output';
 
     const renderBorderedProcess = (status: string, outputLines: string[]) => {
       const border = (char: string) => theme.bold(theme.fg('accent', char));
-      const footerText = `${theme.fg('toolTitle', label)} ${theme.fg('accent', `PID ${pid}`)}${timeSuffix}${status}`;
+      const footerText = `${theme.fg('toolTitle', label)} ${theme.fg('accent', `PID ${pid}`)}${timeSuffix}${tokenSuffix}${status}`;
 
       this.contentBox.addChild(new Text(border('┌──'), 0, 0));
 
@@ -1021,6 +1032,22 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const ms = Date.now() - this.startTime;
     if (ms < 1000) return theme.fg('muted', ` ${ms}ms`);
     return theme.fg('muted', ` ${(ms / 1000).toFixed(1)}s`);
+  }
+
+  private getTokenEstimateSuffix(): string {
+    if (this.isPartial || !this.result) return '';
+    // Prefer accurate tiktoken count from shell exit data when available
+    if (this.shellExit && this.shellExit.outputTokensEstimate > 1000) {
+      const tokens = this.shellExit.outputTokensEstimate;
+      const label = `${(tokens / 1000).toFixed(1)}k`;
+      return theme.fg('muted', ` ${label} tokens`);
+    }
+    const output = this.getFormattedOutput();
+    if (!output) return '';
+    const tokens = Math.ceil(output.length / 4);
+    if (tokens <= 1000) return '';
+    const label = `${(tokens / 1000).toFixed(1)}k`;
+    return theme.fg('muted', ` ~${label} tokens`);
   }
 
   private getFormattedOutput(): string {

--- a/mastracode/src/tui/components/tool-execution-interface.ts
+++ b/mastracode/src/tui/components/tool-execution-interface.ts
@@ -18,4 +18,6 @@ export interface IToolExecutionComponent {
   setExpanded(expanded: boolean): void;
   /** Append streaming output for shell commands */
   appendStreamingOutput?(output: string): void;
+  /** Store shell exit metadata (exit code, duration, output token count) */
+  setShellExit?(data: { exitCode: number; success: boolean; executionTimeMs: number; outputTokensEstimate: number }): void;
 }

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -32,6 +32,7 @@ import {
   handleToolStart,
   handleToolUpdate,
   handleShellOutput,
+  handleShellExit,
   handleToolInputStart,
   handleToolInputDelta,
   handleToolInputEnd,
@@ -85,6 +86,10 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
 
     case 'shell_output':
       handleShellOutput(ectx, event.toolCallId, event.output, event.stream);
+      break;
+
+    case 'shell_exit':
+      handleShellExit(ectx, event.toolCallId, event.exitCode, event.success, event.executionTimeMs, event.outputTokensEstimate);
       break;
 
     case 'tool_input_start':

--- a/mastracode/src/tui/handlers/index.ts
+++ b/mastracode/src/tui/handlers/index.ts
@@ -20,6 +20,7 @@ export {
   handleToolStart,
   handleToolUpdate,
   handleShellOutput,
+  handleShellExit,
   handleToolInputStart,
   handleToolInputDelta,
   handleToolInputEnd,

--- a/mastracode/src/tui/handlers/tool.ts
+++ b/mastracode/src/tui/handlers/tool.ts
@@ -190,6 +190,22 @@ export function handleShellOutput(
   }
 }
 
+export function handleShellExit(
+  ctx: EventHandlerContext,
+  toolCallId: string,
+  exitCode: number,
+  success: boolean,
+  executionTimeMs: number,
+  outputTokensEstimate: number,
+): void {
+  const { state } = ctx;
+  const component = state.pendingTools.get(toolCallId);
+  if (component?.setShellExit) {
+    component.setShellExit({ exitCode, success, executionTimeMs, outputTokensEstimate });
+    state.ui.requestRender();
+  }
+}
+
 /**
  * Handle the start of streaming tool call input arguments.
  * Creates the tool component early so partial args can render as they arrive.

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1958,6 +1958,20 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
           }
           break;
         }
+        case 'data-sandbox-exit': {
+          const d = (chunk as any).data as Record<string, any> | undefined;
+          if (d?.toolCallId) {
+            this.emit({
+              type: 'shell_exit',
+              toolCallId: d.toolCallId,
+              exitCode: d.exitCode ?? -1,
+              success: d.success ?? false,
+              executionTimeMs: d.executionTimeMs ?? 0,
+              outputTokensEstimate: d.outputTokensEstimate ?? 0,
+            });
+          }
+          break;
+        }
 
         default:
           break;
@@ -2385,6 +2399,10 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
         }
         break;
       }
+
+      case 'shell_exit':
+        // Consumed by TUI subscribers; no display state update needed.
+        break;
 
       case 'tool_approval_required':
         ds.pendingApproval = {

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -623,6 +623,14 @@ export type HarnessEvent =
   | { type: 'tool_input_delta'; toolCallId: string; argsTextDelta: string; toolName?: string }
   | { type: 'tool_input_end'; toolCallId: string }
   | { type: 'shell_output'; toolCallId: string; output: string; stream: 'stdout' | 'stderr' }
+  | {
+      type: 'shell_exit';
+      toolCallId: string;
+      exitCode: number;
+      success: boolean;
+      executionTimeMs: number;
+      outputTokensEstimate: number;
+    }
   | { type: 'usage_update'; usage: TokenUsage }
   | { type: 'info'; message: string }
   | { type: 'error'; error: Error; errorType?: string; retryable?: boolean; retryDelay?: number }

--- a/packages/core/src/workspace/tools/__tests__/sandbox-tools.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/sandbox-tools.test.ts
@@ -602,53 +602,61 @@ describe('output-helpers', () => {
 
   describe('applyTokenLimit', () => {
     it('returns output unchanged when under limit', async () => {
-      expect(await applyTokenLimit('short text', 100)).toBe('short text');
+      const r = await applyTokenLimit('short text', 100);
+      expect(r.text).toBe('short text');
+      expect(r.tokens).toBeGreaterThan(0);
     });
 
     it('returns empty string for empty input', async () => {
-      expect(await applyTokenLimit('', 100)).toBe('');
+      const r = await applyTokenLimit('', 100);
+      expect(r.text).toBe('');
+      expect(r.tokens).toBe(0);
     });
 
     it('truncates from the start by default (keeps the end)', async () => {
       const lines = Array.from({ length: 100 }, (_, i) => `line number ${i + 1}`);
       const output = lines.join('\n');
-      const result = await applyTokenLimit(output, 20);
-      expect(result).toContain('[output truncated: showing last');
-      expect(result).toContain('tokens]');
-      expect(result).toContain('line number 100');
-      expect(result).not.toContain('line number 1\n');
+      const r = await applyTokenLimit(output, 20);
+      expect(r.text).toContain('[output truncated: showing last');
+      expect(r.text).toContain('tokens]');
+      expect(r.text).toContain('line number 100');
+      expect(r.text).not.toContain('line number 1\n');
+      expect(r.tokens).toBe(20);
     });
 
     it('truncates from the end when from="end" (keeps the start)', async () => {
       const lines = Array.from({ length: 100 }, (_, i) => `line number ${i + 1}`);
       const output = lines.join('\n');
-      const result = await applyTokenLimit(output, 20, 'end');
-      expect(result).toContain('[output truncated: showing first');
-      expect(result).toContain('tokens]');
-      expect(result).toContain('line number 1');
-      expect(result).not.toContain('line number 100');
+      const r = await applyTokenLimit(output, 20, 'end');
+      expect(r.text).toContain('[output truncated: showing first');
+      expect(r.text).toContain('tokens]');
+      expect(r.text).toContain('line number 1');
+      expect(r.text).not.toContain('line number 100');
       // Notice should be at the end
-      expect(result.indexOf('[output truncated')).toBeGreaterThan(result.indexOf('line number 1'));
+      expect(r.text.indexOf('[output truncated')).toBeGreaterThan(r.text.indexOf('line number 1'));
+      expect(r.tokens).toBe(20);
     });
 
     it('uses DEFAULT_MAX_OUTPUT_TOKENS as default limit', async () => {
-      expect(await applyTokenLimit('hello world')).toBe('hello world');
+      const r = await applyTokenLimit('hello world');
+      expect(r.text).toBe('hello world');
 
       const hugeLines = Array.from({ length: 5000 }, (_, i) => `output line number ${i + 1}`);
       const hugeOutput = hugeLines.join('\n');
-      const result = await applyTokenLimit(hugeOutput);
-      expect(result).toContain('[output truncated');
+      const r2 = await applyTokenLimit(hugeOutput);
+      expect(r2.text).toContain('[output truncated');
     });
 
     it('fills the token budget even with a single long line', async () => {
       // This is the bug Tyler hit: a file with one huge line should still use the full budget
       const longLine = 'word '.repeat(500); // 500 tokens of "word "
       const limit = 50;
-      const result = await applyTokenLimit(longLine, limit);
-      expect(result).toContain('[output truncated');
+      const r = await applyTokenLimit(longLine, limit);
+      expect(r.text).toContain('[output truncated');
+      expect(r.tokens).toBe(limit);
       // The kept portion (minus the notice) should be close to the budget
-      const notice = result.match(/\[output truncated[^\]]*\]\n?/)?.[0] ?? '';
-      const keptText = result.replace(notice, '');
+      const notice = r.text.match(/\[output truncated[^\]]*\]\n?/)?.[0] ?? '';
+      const keptText = r.text.replace(notice, '');
       // "word " is 1 token each, so we should have ~50 words
       const wordCount = keptText.trim().split(/\s+/).length;
       expect(wordCount).toBeGreaterThanOrEqual(limit - 5);
@@ -658,21 +666,26 @@ describe('output-helpers', () => {
 
   describe('applyTokenLimitSandwich', () => {
     it('returns output unchanged when under limit', async () => {
-      expect(await applyTokenLimitSandwich('short text', 100)).toBe('short text');
+      const r = await applyTokenLimitSandwich('short text', 100);
+      expect(r.text).toBe('short text');
+      expect(r.tokens).toBeGreaterThan(0);
     });
 
     it('returns empty string for empty input', async () => {
-      expect(await applyTokenLimitSandwich('', 100)).toBe('');
+      const r = await applyTokenLimitSandwich('', 100);
+      expect(r.text).toBe('');
+      expect(r.tokens).toBe(0);
     });
 
     it('keeps tokens from both start and end', async () => {
       const lines = Array.from({ length: 200 }, (_, i) => `line number ${i + 1}`);
       const output = lines.join('\n');
-      const result = await applyTokenLimitSandwich(output, 50, 0.2);
-      expect(result).toContain('line number 1');
-      expect(result).toContain('line number 200');
-      expect(result).toContain('output truncated');
-      expect(result).not.toContain('line number 100\n');
+      const r = await applyTokenLimitSandwich(output, 50, 0.2);
+      expect(r.text).toContain('line number 1');
+      expect(r.text).toContain('line number 200');
+      expect(r.text).toContain('output truncated');
+      expect(r.text).not.toContain('line number 100\n');
+      expect(r.tokens).toBe(50);
     });
 
     it('respects head ratio — higher ratio keeps more from the start', async () => {
@@ -681,40 +694,41 @@ describe('output-helpers', () => {
       const small = await applyTokenLimitSandwich(output, 50, 0.1);
       const large = await applyTokenLimitSandwich(output, 50, 0.9);
       // Both should have start and end
-      expect(small).toContain('line number 1');
-      expect(large).toContain('line number 1');
+      expect(small.text).toContain('line number 1');
+      expect(large.text).toContain('line number 1');
       // With 90% head ratio, the head portion should contain more lines from the start
-      const smallHead = small.split('output truncated')[0]!;
-      const largeHead = large.split('output truncated')[0]!;
+      const smallHead = small.text.split('output truncated')[0]!;
+      const largeHead = large.text.split('output truncated')[0]!;
       expect(largeHead.length).toBeGreaterThan(smallHead.length);
     });
 
     it('fills the token budget even with a single long line', async () => {
       const longLine = 'word '.repeat(500);
       const limit = 50;
-      const result = await applyTokenLimitSandwich(longLine, limit, 0.2);
-      expect(result).toContain('output truncated');
-      const notice = result.match(/\[\.\.\.output truncated[^\]]*\.\.\.\]\n?/)?.[0] ?? '';
-      const keptText = result.replace(notice, '');
+      const r = await applyTokenLimitSandwich(longLine, limit, 0.2);
+      expect(r.text).toContain('output truncated');
+      expect(r.tokens).toBe(limit);
+      const notice = r.text.match(/\[\.\.\.output truncated[^\]]*\.\.\.\]\n?/)?.[0] ?? '';
+      const keptText = r.text.replace(notice, '');
       const wordCount = keptText.trim().split(/\s+/).length;
       expect(wordCount).toBeGreaterThanOrEqual(limit - 5);
     });
 
     it('does not leak full output when tail budget is zero', async () => {
       const longLine = 'word '.repeat(500);
-      const result = await applyTokenLimitSandwich(longLine, 10, 1.0);
-      expect(result).toContain('output truncated');
-      const notice = result.match(/\[\.\.\.output truncated[^\]]*\.\.\.\]\n?/)?.[0] ?? '';
-      const keptText = result.replace(notice, '');
+      const r = await applyTokenLimitSandwich(longLine, 10, 1.0);
+      expect(r.text).toContain('output truncated');
+      const notice = r.text.match(/\[\.\.\.output truncated[^\]]*\.\.\.\]\n?/)?.[0] ?? '';
+      const keptText = r.text.replace(notice, '');
       expect(keptText.trim().split(/\s+/).length).toBeLessThanOrEqual(15);
     });
 
     it('does not leak full output when head budget is zero', async () => {
       const longLine = 'word '.repeat(500);
-      const result = await applyTokenLimitSandwich(longLine, 10, 0);
-      expect(result).toContain('output truncated');
-      const notice = result.match(/\[\.\.\.output truncated[^\]]*\.\.\.\]\n?/)?.[0] ?? '';
-      const keptText = result.replace(notice, '');
+      const r = await applyTokenLimitSandwich(longLine, 10, 0);
+      expect(r.text).toContain('output truncated');
+      const notice = r.text.match(/\[\.\.\.output truncated[^\]]*\.\.\.\]\n?/)?.[0] ?? '';
+      const keptText = r.text.replace(notice, '');
       expect(keptText.trim().split(/\s+/).length).toBeLessThanOrEqual(15);
     });
   });
@@ -724,27 +738,30 @@ describe('output-helpers', () => {
       const lines = Array.from({ length: 5000 }, (_, i) => `line number ${String(i).padStart(4, '0')}`);
       const output = lines.join('\n');
 
-      const result = await truncateOutput(output, 0);
-      expect(result).toContain('[output truncated');
+      const r = await truncateOutput(output, 0);
+      expect(r.text).toContain('[output truncated');
+      expect(r.tokens).toBeGreaterThan(0);
     });
 
     it('tail reduces output enough to skip token limit', async () => {
       const lines = Array.from({ length: 500 }, (_, i) => `line ${i + 1}`);
       const output = lines.join('\n');
 
-      const result = await truncateOutput(output, 5);
-      expect(result).not.toContain('[output truncated');
-      expect(result).toContain('[showing last 5 of 500 lines]');
+      const r = await truncateOutput(output, 5);
+      expect(r.text).not.toContain('[output truncated');
+      expect(r.text).toContain('[showing last 5 of 500 lines]');
+      expect(r.tokens).toBeGreaterThan(0);
     });
 
     it('routes to sandwich mode when tokenFrom is sandwich', async () => {
       const lines = Array.from({ length: 5000 }, (_, i) => `line number ${i + 1}`);
       const output = lines.join('\n');
 
-      const result = await truncateOutput(output, 0, undefined, 'sandwich');
-      expect(result).toContain('line number 1');
-      expect(result).toContain('line number 5000');
-      expect(result).toContain('output truncated');
+      const r = await truncateOutput(output, 0, undefined, 'sandwich');
+      expect(r.text).toContain('line number 1');
+      expect(r.text).toContain('line number 5000');
+      expect(r.text).toContain('output truncated');
+      expect(r.tokens).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/core/src/workspace/tools/execute-command.ts
+++ b/packages/core/src/workspace/tools/execute-command.ts
@@ -151,43 +151,54 @@ async function executeCommand(input: Record<string, any>, context: any) {
       },
     });
 
+    let output: string;
+    let outputTokensEstimate = 0;
+    if (!result.success) {
+      const stdoutResult = await truncateOutput(result.stdout, tail, tokenLimit, tokenFrom);
+      const stderrResult = await truncateOutput(result.stderr, tail, tokenLimit, tokenFrom);
+      outputTokensEstimate = stdoutResult.tokens + stderrResult.tokens;
+      const parts = [stdoutResult.text, stderrResult.text].filter(Boolean);
+      parts.push(`Exit code: ${result.exitCode}`);
+      output = parts.join('\n');
+    } else {
+      const result_ = await truncateOutput(result.stdout, tail, tokenLimit, tokenFrom);
+      outputTokensEstimate = result_.tokens;
+      output = result_.text || '(no output)';
+    }
+
     await context?.writer?.custom({
       type: 'data-sandbox-exit',
       data: {
         exitCode: result.exitCode,
         success: result.success,
         executionTimeMs: result.executionTimeMs,
+        outputTokensEstimate,
         toolCallId,
       },
     });
 
-    if (!result.success) {
-      const parts = [
-        await truncateOutput(result.stdout, tail, tokenLimit, tokenFrom),
-        await truncateOutput(result.stderr, tail, tokenLimit, tokenFrom),
-      ].filter(Boolean);
-      parts.push(`Exit code: ${result.exitCode}`);
-      return parts.join('\n');
-    }
-
-    return (await truncateOutput(result.stdout, tail, tokenLimit, tokenFrom)) || '(no output)';
+    return output;
   } catch (error) {
+    const stdoutResult = await truncateOutput(stdout, tail, tokenLimit, tokenFrom);
+    const stderrResult = await truncateOutput(stderr, tail, tokenLimit, tokenFrom);
+    const outputTokensEstimate = stdoutResult.tokens + stderrResult.tokens;
+    const parts = [stdoutResult.text, stderrResult.text].filter(Boolean);
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    parts.push(`Error: ${errorMessage}`);
+    const output = parts.join('\n');
+
     await context?.writer?.custom({
       type: 'data-sandbox-exit',
       data: {
         exitCode: -1,
         success: false,
         executionTimeMs: Date.now() - startedAt,
+        outputTokensEstimate,
         toolCallId,
       },
     });
-    const parts = [
-      await truncateOutput(stdout, tail, tokenLimit, tokenFrom),
-      await truncateOutput(stderr, tail, tokenLimit, tokenFrom),
-    ].filter(Boolean);
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    parts.push(`Error: ${errorMessage}`);
-    return parts.join('\n');
+
+    return output;
   }
 }
 

--- a/packages/core/src/workspace/tools/get-process-output.ts
+++ b/packages/core/src/workspace/tools/get-process-output.ts
@@ -51,8 +51,9 @@ Use this after starting a background command with execute_command (background: t
     }
 
     // If wait requested, block until process exits with streaming callbacks
+    let waitResult: { exitCode: number; success: boolean; executionTimeMs?: number } | undefined;
     if (shouldWait && handle.exitCode === undefined) {
-      const result = await handle.wait({
+      waitResult = await handle.wait({
         onStdout: context?.writer
           ? async (data: string) => {
               await context.writer!.custom({
@@ -70,43 +71,48 @@ Use this after starting a background command with execute_command (background: t
             }
           : undefined,
       });
-
-      await context?.writer?.custom({
-        type: 'data-sandbox-exit',
-        data: {
-          exitCode: result.exitCode,
-          success: result.success,
-          executionTimeMs: result.executionTimeMs,
-          toolCallId,
-        },
-      });
     }
 
     const running = handle.exitCode === undefined;
 
     const tokenLimit = workspace.getToolsConfig()?.[WORKSPACE_TOOLS.SANDBOX.GET_PROCESS_OUTPUT]?.maxOutputTokens;
-    const stdout = await truncateOutput(handle.stdout, tail, tokenLimit, 'sandwich');
-    const stderr = await truncateOutput(handle.stderr, tail, tokenLimit, 'sandwich');
+    const stdoutResult = await truncateOutput(handle.stdout, tail, tokenLimit, 'sandwich');
+    const stderrResult = await truncateOutput(handle.stderr, tail, tokenLimit, 'sandwich');
 
-    if (!stdout && !stderr) {
+    if (!stdoutResult.text && !stderrResult.text) {
       return '(no output yet)';
     }
 
     const parts: string[] = [];
 
     // Only label stdout/stderr when both are present
-    if (stdout && stderr) {
-      parts.push('stdout:', stdout, '', 'stderr:', stderr);
-    } else if (stdout) {
-      parts.push(stdout);
+    if (stdoutResult.text && stderrResult.text) {
+      parts.push('stdout:', stdoutResult.text, '', 'stderr:', stderrResult.text);
+    } else if (stdoutResult.text) {
+      parts.push(stdoutResult.text);
     } else {
-      parts.push('stderr:', stderr);
+      parts.push('stderr:', stderrResult.text);
     }
 
     if (!running) {
       parts.push('', `Exit code: ${handle.exitCode}`);
     }
 
-    return parts.join('\n');
+    const output = parts.join('\n');
+
+    if (waitResult) {
+      await context?.writer?.custom({
+        type: 'data-sandbox-exit',
+        data: {
+          exitCode: waitResult.exitCode,
+          success: waitResult.success,
+          executionTimeMs: waitResult.executionTimeMs,
+          outputTokensEstimate: stdoutResult.tokens + stderrResult.tokens,
+          toolCallId,
+        },
+      });
+    }
+
+    return output;
   },
 });

--- a/packages/core/src/workspace/tools/grep.ts
+++ b/packages/core/src/workspace/tools/grep.ts
@@ -229,10 +229,11 @@ Usage:
     const summary = summaryParts.join(' ');
     outputLines.unshift(summary, '---');
 
-    return await applyTokenLimit(
+    const result = await applyTokenLimit(
       outputLines.join('\n'),
       workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.GREP]?.maxOutputTokens,
       'end',
     );
+    return result.text;
   },
 });

--- a/packages/core/src/workspace/tools/kill-process.ts
+++ b/packages/core/src/workspace/tools/kill-process.ts
@@ -40,33 +40,42 @@ Use this to stop a long-running background process that was started with execute
     const killed = await sandbox.processes.kill(pid);
 
     if (!killed) {
+      const output = `Process ${pid} was not found or had already exited.`;
       await context?.writer?.custom({
         type: 'data-sandbox-exit',
-        data: { exitCode: handle?.exitCode ?? -1, success: false, killed: false, toolCallId },
+        data: { exitCode: handle?.exitCode ?? -1, success: false, killed: false, outputTokensEstimate: 0, toolCallId },
       });
-      return `Process ${pid} was not found or had already exited.`;
+      return output;
     }
 
-    await context?.writer?.custom({
-      type: 'data-sandbox-exit',
-      data: { exitCode: handle?.exitCode ?? 137, success: false, killed: true, toolCallId },
-    });
-
     const parts: string[] = [`Process ${pid} has been killed.`];
+    let outputTokensEstimate = 0;
 
     if (handle) {
       const tokenLimit = workspace.getToolsConfig()?.[WORKSPACE_TOOLS.SANDBOX.KILL_PROCESS]?.maxOutputTokens;
-      const stdout = handle.stdout ? await truncateOutput(handle.stdout, KILL_TAIL_LINES, tokenLimit, 'sandwich') : '';
-      const stderr = handle.stderr ? await truncateOutput(handle.stderr, KILL_TAIL_LINES, tokenLimit, 'sandwich') : '';
+      const stdoutResult = handle.stdout
+        ? await truncateOutput(handle.stdout, KILL_TAIL_LINES, tokenLimit, 'sandwich')
+        : { text: '', tokens: 0 };
+      const stderrResult = handle.stderr
+        ? await truncateOutput(handle.stderr, KILL_TAIL_LINES, tokenLimit, 'sandwich')
+        : { text: '', tokens: 0 };
+      outputTokensEstimate = stdoutResult.tokens + stderrResult.tokens;
 
-      if (stdout) {
-        parts.push('', '--- stdout (last output) ---', stdout);
+      if (stdoutResult.text) {
+        parts.push('', '--- stdout (last output) ---', stdoutResult.text);
       }
-      if (stderr) {
-        parts.push('', '--- stderr (last output) ---', stderr);
+      if (stderrResult.text) {
+        parts.push('', '--- stderr (last output) ---', stderrResult.text);
       }
     }
 
-    return parts.join('\n');
+    const output = parts.join('\n');
+
+    await context?.writer?.custom({
+      type: 'data-sandbox-exit',
+      data: { exitCode: handle?.exitCode ?? 137, success: false, killed: true, outputTokensEstimate, toolCallId },
+    });
+
+    return output;
   },
 });

--- a/packages/core/src/workspace/tools/list-files.ts
+++ b/packages/core/src/workspace/tools/list-files.ts
@@ -67,10 +67,11 @@ Examples:
       respectGitignore,
     });
 
-    return await applyTokenLimit(
+    const truncated = await applyTokenLimit(
       `${result.tree}\n\n${result.summary}`,
       workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES]?.maxOutputTokens ?? 1_000,
       'end',
     );
+    return truncated.text;
   },
 });

--- a/packages/core/src/workspace/tools/output-helpers.ts
+++ b/packages/core/src/workspace/tools/output-helpers.ts
@@ -77,23 +77,30 @@ export function applyTail(output: string, tail: number | null | undefined): stri
  *   - `'start'` (default): Remove tokens from the start, keep the end
  *   - `'end'`: Remove tokens from the end, keep the start
  */
+export interface TruncationResult {
+  text: string;
+  tokens: number;
+}
+
 export async function applyTokenLimit(
   output: string,
   limit: number = DEFAULT_MAX_OUTPUT_TOKENS,
   from: 'start' | 'end' = 'start',
-): Promise<string> {
-  if (!output) return output;
+): Promise<TruncationResult> {
+  if (!output) return { text: output, tokens: 0 };
 
   const tiktoken = await getTiktoken();
   const allTokens = tiktoken.encode(output, 'all');
-  if (allTokens.length <= limit) return output;
+  if (allTokens.length <= limit) return { text: output, tokens: allTokens.length };
 
   const kept = from === 'start' ? tiktoken.decode(allTokens.slice(-limit)) : tiktoken.decode(allTokens.slice(0, limit));
 
   const position = from === 'start' ? 'last' : 'first';
-  return from === 'start'
-    ? `[output truncated: showing ${position} ~${limit} of ~${allTokens.length} tokens]\n${kept}`
-    : `${kept}\n[output truncated: showing ${position} ~${limit} of ~${allTokens.length} tokens]`;
+  const text =
+    from === 'start'
+      ? `[output truncated: showing ${position} ~${limit} of ~${allTokens.length} tokens]\n${kept}`
+      : `${kept}\n[output truncated: showing ${position} ~${limit} of ~${allTokens.length} tokens]`;
+  return { text, tokens: limit };
 }
 
 /**
@@ -109,12 +116,12 @@ export async function applyTokenLimitSandwich(
   output: string,
   limit: number = DEFAULT_MAX_OUTPUT_TOKENS,
   headRatio: number = 0.1,
-): Promise<string> {
-  if (!output) return output;
+): Promise<TruncationResult> {
+  if (!output) return { text: output, tokens: 0 };
 
   const tiktoken = await getTiktoken();
   const allTokens = tiktoken.encode(output, 'all');
-  if (allTokens.length <= limit) return output;
+  if (allTokens.length <= limit) return { text: output, tokens: allTokens.length };
   const headBudget = Math.floor(limit * headRatio);
   const tailBudget = limit - headBudget;
 
@@ -122,7 +129,7 @@ export async function applyTokenLimitSandwich(
   const tail = tailBudget > 0 ? tiktoken.decode(allTokens.slice(-tailBudget)) : '';
 
   const notice = `[...output truncated — showing first ~${headBudget} + last ~${tailBudget} of ~${allTokens.length} tokens...]`;
-  return [head, notice, tail].filter(Boolean).join('\n');
+  return { text: [head, notice, tail].filter(Boolean).join('\n'), tokens: limit };
 }
 
 /**
@@ -133,7 +140,7 @@ export async function truncateOutput(
   tail?: number | null,
   tokenLimit?: number,
   tokenFrom?: 'start' | 'end' | 'sandwich',
-): Promise<string> {
+): Promise<TruncationResult> {
   const tailed = applyTail(output, tail);
   if (tokenFrom === 'sandwich') {
     return applyTokenLimitSandwich(tailed, tokenLimit);

--- a/packages/core/src/workspace/tools/read-file.ts
+++ b/packages/core/src/workspace/tools/read-file.ts
@@ -39,19 +39,23 @@ export const readFileTool = createTool({
     const tokenLimit = workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.READ_FILE]?.maxOutputTokens;
 
     if (!isTextEncoding) {
-      return await applyTokenLimit(
-        `${stat.path} (${stat.size} bytes, ${effectiveEncoding})\n${fullContent}`,
-        tokenLimit,
-        'end',
-      );
+      return (
+        await applyTokenLimit(
+          `${stat.path} (${stat.size} bytes, ${effectiveEncoding})\n${fullContent}`,
+          tokenLimit,
+          'end',
+        )
+      ).text;
     }
 
     if (typeof fullContent !== 'string') {
-      return await applyTokenLimit(
-        `${stat.path} (${stat.size} bytes, base64)\n${fullContent.toString('base64')}`,
-        tokenLimit,
-        'end',
-      );
+      return (
+        await applyTokenLimit(
+          `${stat.path} (${stat.size} bytes, base64)\n${fullContent.toString('base64')}`,
+          tokenLimit,
+          'end',
+        )
+      ).text;
     }
 
     const hasLineRange = offset !== undefined || limit !== undefined;
@@ -69,6 +73,6 @@ export const readFileTool = createTool({
       header = `${stat.path} (${stat.size} bytes)`;
     }
 
-    return await applyTokenLimit(`${header}\n${formattedContent}`, tokenLimit, 'end');
+    return (await applyTokenLimit(`${header}\n${formattedContent}`, tokenLimit, 'end')).text;
   },
 });

--- a/packages/playground-ui/package.json
+++ b/packages/playground-ui/package.json
@@ -132,7 +132,7 @@
   "peerDependencies": {
     "@mastra/ai-sdk": "workspace:^",
     "@mastra/client-js": "workspace:^",
-    "@mastra/core": ">=1.7.1-0 <2.0.0-0",
+    "@mastra/core": ">=1.9.1-0 <2.0.0-0",
     "@mastra/react": "workspace:*",
     "@mastra/schema-compat": "workspace:*",
     "@tanstack/react-query": "^5.81.5",

--- a/packages/playground-ui/src/lib/ai-ui/tools/badges/sandbox-execution-badge.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/tools/badges/sandbox-execution-badge.tsx
@@ -198,7 +198,7 @@ export const SandboxExecutionBadge = ({
 
   // Exit chunk scoped to this tool call
   const exitChunk = dataParts.find(chunk => chunk.name === 'sandbox-exit' && chunk.data?.toolCallId === toolCallId) as
-    | { name: string; data: { exitCode: number; success: boolean; executionTimeMs?: number; killed?: boolean } }
+    | { name: string; data: { exitCode: number; success: boolean; executionTimeMs?: number; killed?: boolean; outputTokensEstimate?: number } }
     | undefined;
 
   // Streaming is complete if we have exit chunk or a final result
@@ -213,6 +213,7 @@ export const SandboxExecutionBadge = ({
   const exitSuccess = exitChunk?.data?.success;
   const executionTime = exitChunk?.data?.executionTimeMs;
   const wasKilled = exitChunk?.data?.killed;
+  const outputTokensEstimate = exitChunk?.data?.outputTokensEstimate;
 
   // Combine streaming output into a single string
   const streamingContent = sandboxChunks.map(chunk => chunk.data?.output || '').join('');
@@ -285,6 +286,11 @@ export const SandboxExecutionBadge = ({
                   </span>
                 ))}
               {executionTime !== undefined && <span className="text-neutral6 text-xs">{executionTime}ms</span>}
+              {outputTokensEstimate !== undefined && outputTokensEstimate > 1000 && (
+                <span className="text-neutral6 text-xs">
+                  {(outputTokensEstimate / 1000).toFixed(1)}k tokens
+                </span>
+              )}
             </>
           )}
         </div>


### PR DESCRIPTION
## Summary

Workspace tools now emit the actual tiktoken token count in the `data-sandbox-exit` chunk, giving visibility into how many tokens each shell tool call sends to the model.

### Changes

**Server-side (workspace tools)**
- `output-helpers.ts`: `applyTokenLimit`, `applyTokenLimitSandwich`, and `truncateOutput` now return `TruncationResult` (`{ text, tokens }`) — reusing the tiktoken count already computed during truncation
- `execute-command.ts`, `get-process-output.ts`, `kill-process.ts`: emit token count in `data-sandbox-exit` chunk
- `grep.ts`, `list-files.ts`, `read-file.ts`: updated to use `.text` from new return type

**Harness (event plumbing)**
- New `shell_exit` event type added to `HarnessEvent` union
- Harness converts `data-sandbox-exit` chunks into `shell_exit` events (mirrors existing `shell_output` pattern)

**mc TUI**
- `ToolExecutionComponentEnhanced` receives `shell_exit` via new `setShellExit()` method
- Token count shown in footer only when > 1k tokens
- Accurate count shown without `~` prefix; fallback `chars/4` estimate keeps `~` for non-shell tools

**Playground UI**
- `sandbox-execution-badge.tsx` extracts and displays `outputTokens` from exit chunk (> 1k only)

### Test plan
- All 62 sandbox-tools tests pass (updated assertions for new return type)
- Manually verified in mc TUI: small commands show no token count, large outputs show e.g. `1.5k tokens`
