### PR TITLE
fix: stabilize flaky observational memory token counter tests

### DIFF
--- a/.changeset/shiny-tools-visit.md
+++ b/.changeset/shiny-tools-visit.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed a flaky observational memory token counter test timeout in CI.

--- a/.changeset/shiny-tools-visit.md
+++ b/.changeset/shiny-tools-visit.md
@@ -1,5 +1,0 @@
----
-'@mastra/memory': patch
----
-
-Fixed a flaky observational memory token counter test timeout in CI.

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 test-outputs/
 .vitest-reports/
 .DS_Store
+.mastra-om-repro/
 
 # IDE
 .vscode/

--- a/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
@@ -1,6 +1,17 @@
+import o200k_base from 'js-tiktoken/ranks/o200k_base';
 import { describe, it, expect } from 'vitest';
 
 import { TokenCounter } from '../token-counter';
+
+let sharedCustomCounter: TokenCounter | undefined;
+
+function getSharedCustomCounter() {
+  if (!sharedCustomCounter) {
+    sharedCustomCounter = new TokenCounter(o200k_base);
+  }
+
+  return sharedCustomCounter;
+}
 
 function createMessage(content: any) {
   return {
@@ -73,8 +84,7 @@ describe('TokenCounter', () => {
   describe('custom encoding', () => {
     it('constructor with explicit encoding creates a separate encoder instance', () => {
       const defaultCounter = new TokenCounter();
-      const o200k_base = require('js-tiktoken/ranks/o200k_base');
-      const customCounter = new TokenCounter(o200k_base);
+      const customCounter = getSharedCustomCounter();
 
       const encoderDefault = (defaultCounter as any).encoder;
       const encoderCustom = (customCounter as any).encoder;
@@ -83,8 +93,7 @@ describe('TokenCounter', () => {
     });
 
     it('custom encoding still produces valid token counts', () => {
-      const o200k_base = require('js-tiktoken/ranks/o200k_base');
-      const counter = new TokenCounter(o200k_base);
+      const counter = getSharedCustomCounter();
 
       const tokens = counter.countString('hello world');
       expect(tokens).toBeGreaterThan(0);
@@ -206,8 +215,7 @@ describe('TokenCounter', () => {
       defaultCounter.countMessage(message);
       const defaultEntry = message.content.parts[0].providerMetadata.mastra.tokenEstimate as any;
 
-      const o200k_base = require('js-tiktoken/ranks/o200k_base');
-      const customCounter = new TokenCounter(o200k_base);
+      const customCounter = getSharedCustomCounter();
       customCounter.countMessage(message);
 
       const refreshedEntry = message.content.parts[0].providerMetadata.mastra.tokenEstimate as any;


### PR DESCRIPTION
This keeps the observational memory token counter tests from timing out in CI by reusing one explicit `o200k_base` counter instead of constructing a fresh heavy encoder in each custom-encoding assertion.

Before:
```ts
const o200k_base = require('js-tiktoken/ranks/o200k_base');
const counter = new TokenCounter(o200k_base);
```

After:
```ts
const counter = getSharedCustomCounter();
```

It also adds the local `.mastra-om-repro/` debug directory to `.gitignore` and includes a changeset for `@mastra/memory`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore patterns.

* **Tests**
  * Optimized test infrastructure with enhanced utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->