### PR TITLE
fix: correct documentation link in empty datasets page

### DIFF
--- a/.changeset/tidy-nights-like.md
+++ b/.changeset/tidy-nights-like.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed documentation link in empty datasets page pointing to the correct datasets docs instead of evals

--- a/packages/playground-ui/src/domains/datasets/components/empty-datasets-table.tsx
+++ b/packages/playground-ui/src/domains/datasets/components/empty-datasets-table.tsx
@@ -28,7 +28,7 @@ export function EmptyDatasetsTable({ onCreateClick }: EmptyDatasetsTableProps) {
               size="lg"
               variant="outline"
               as="a"
-              href="https://mastra.ai/docs/evals"
+              href="https://mastra.ai/docs/observability/datasets/overview"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
The documentation link on the empty datasets page was pointing to `/docs/evals`. Updated it to point to `/docs/observability/datasets/overview`.

Before:
```
href="https://mastra.ai/docs/evals"
```

After:
```
href="https://mastra.ai/docs/observability/datasets/overview"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the documentation link on the empty datasets page to reference the correct datasets documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->