### PR TITLE
chore(create-mastra): update default OpenAI model from gpt-4o to gpt-5-mini

### DIFF
--- a/.changeset/breezy-turkeys-pick.md
+++ b/.changeset/breezy-turkeys-pick.md
@@ -1,0 +1,6 @@
+---
+'mastra': patch
+'create-mastra': patch
+---
+
+Updated default OpenAI model from gpt-4o to gpt-5-mini for new projects.

--- a/packages/cli/src/commands/create/create.test.ts
+++ b/packages/cli/src/commands/create/create.test.ts
@@ -51,7 +51,7 @@ vi.mock('../init/utils', () => ({
   interactivePrompt: vi.fn(),
   getModelIdentifier: vi.fn((provider: string) => {
     const models: Record<string, string> = {
-      openai: "'openai/gpt-4o-mini'",
+      openai: "'openai/gpt-5-mini'",
       anthropic: "'anthropic/claude-sonnet-4-5-20250929'",
       groq: "'groq/llama-3.3-70b-versatile'",
       google: "'google/gemini-2.5-pro'",

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -42,7 +42,7 @@ export function areValidComponents(values: string[]): values is Component[] {
 }
 
 export const getModelIdentifier = (llmProvider: LLMProvider): ModelRouterModelId => {
-  let model: ModelRouterModelId = 'openai/gpt-4o';
+  let model: ModelRouterModelId = 'openai/gpt-5-mini';
 
   if (llmProvider === 'anthropic') {
     model = 'anthropic/claude-sonnet-4-5';


### PR DESCRIPTION
## Summary

Updates the default OpenAI model in the `create-mastra` CLI from `gpt-4o` to `gpt-5-mini`. When users scaffold a new project with OpenAI as their provider, the generated weather agent now uses a cheaper, faster model that is more appropriate for getting started.

## Changes

- `packages/cli/src/commands/init/utils.ts` — Updated `getModelIdentifier()` default from `openai/gpt-4o` to `openai/gpt-5-mini`
- `packages/cli/src/commands/create/create.test.ts` — Updated test mock to match

## Test plan

```
cd packages/cli && pnpm vitest run src/commands/create/create.test.ts src/commands/init/init.test.ts
```

All 17 tests pass.