### PR TITLE
fix(core): use consistent default token limit for workspace list_files tool

### DIFF
--- a/.changeset/consistent-token-limits.md
+++ b/.changeset/consistent-token-limits.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+fix(workspace): Use consistent default token limit for `list_files` tool
+
+The `list_files` tool was hardcoded to a 1,000-token output limit while all other workspace tools use `DEFAULT_MAX_OUTPUT_TOKENS` (2,000). Updated `list_files` to use the shared constant for consistency.
+
+Also corrected the `maxOutputTokens` JSDoc comment which incorrectly stated the default was 3,000.

--- a/.changeset/consistent-token-limits.md
+++ b/.changeset/consistent-token-limits.md
@@ -2,8 +2,4 @@
 '@mastra/core': patch
 ---
 
-fix(workspace): Use consistent default token limit for `list_files` tool
-
-The `list_files` tool was hardcoded to a 1,000-token output limit while all other workspace tools use `DEFAULT_MAX_OUTPUT_TOKENS` (2,000). Updated `list_files` to use the shared constant for consistency.
-
-Also corrected the `maxOutputTokens` JSDoc comment which incorrectly stated the default was 3,000.
+The `list_files` workspace tool now defaults to a 2,000-token output limit, matching all other workspace tools.

--- a/packages/core/src/workspace/tools/list-files.ts
+++ b/packages/core/src/workspace/tools/list-files.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { createTool } from '../../tools';
 import { WORKSPACE_TOOLS } from '../constants';
 import { emitWorkspaceMetadata, requireFilesystem } from './helpers';
-import { applyTokenLimit } from './output-helpers';
+import { applyTokenLimit, DEFAULT_MAX_OUTPUT_TOKENS } from './output-helpers';
 import { formatAsTree } from './tree-formatter';
 
 export const listFilesTool = createTool({
@@ -69,7 +69,7 @@ Examples:
 
     return await applyTokenLimit(
       `${result.tree}\n\n${result.summary}`,
-      workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES]?.maxOutputTokens ?? 1_000,
+      workspace.getToolsConfig()?.[WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES]?.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
       'end',
     );
   },

--- a/packages/core/src/workspace/tools/types.ts
+++ b/packages/core/src/workspace/tools/types.ts
@@ -47,7 +47,7 @@ export interface WorkspaceToolConfig {
   requireReadBeforeWrite?: boolean;
 
   /**
-   * Maximum tokens for tool output (default: 3000).
+   * Maximum tokens for tool output (default: 2000).
    * Output exceeding this limit is truncated. Uses tiktoken for accurate counting.
    */
   maxOutputTokens?: number;


### PR DESCRIPTION
## Summary

The `list_files` workspace tool was hardcoded to a 1,000-token output limit while all other workspace tools default to `DEFAULT_MAX_OUTPUT_TOKENS` (2,000). This PR makes it consistent.

## Changes

- **`list-files.ts`**: Import and use `DEFAULT_MAX_OUTPUT_TOKENS` instead of hardcoded `1_000`
- **`types.ts`**: Fix `maxOutputTokens` JSDoc comment — stated default was 3,000, actual default is 2,000

## Test plan

- All 62 sandbox tool tests pass
- All 20 tool creation tests pass
- TypeScript compiles with no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the workspace file-listing output token limit to 2000 for consistent results.
  * Corrected documentation to reflect the 2000-token default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->