### PR TITLE
chore: suppress verbose lint-staged output in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,5 +4,5 @@ pnpm --version || {
 }
 
 # Formatting on staged files
-pnpm dlx lint-staged
+pnpm dlx lint-staged --quiet
 


### PR DESCRIPTION
Adds `--quiet` flag to the `lint-staged` call in the pre-commit hook. This suppresses the verbose `[STARTED]`/`[COMPLETED]` output for every task, while still showing errors if something fails.

Reduces noise in commit output, especially helpful for LLM-assisted workflows where the verbose output wastes tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced verbosity in the pre-commit hook to streamline development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->