### PR TITLE
fix(core): fix Windows shell command spawning

### DIFF
--- a/.changeset/crisp-owls-hope.md
+++ b/.changeset/crisp-owls-hope.md
@@ -2,4 +2,4 @@
 "@mastra/core": patch
 ---
 
-Fixed Windows shell command execution to avoid visible cmd.exe window popups and broken stdout/stderr piping. On Windows, `LocalProcessManager` no longer uses `detached: true` (which caused console window popups), and process tree killing uses `taskkill /T` via execa instead of Unix process groups.
+Fixed Windows shell command execution to avoid visible cmd.exe popups and broken output piping.

--- a/.changeset/crisp-owls-hope.md
+++ b/.changeset/crisp-owls-hope.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed Windows shell command execution to avoid visible cmd.exe window popups and broken stdout/stderr piping. On Windows, `LocalProcessManager` no longer uses `detached: true` (which caused console window popups), and process tree killing uses `taskkill /T` via execa instead of Unix process groups.

--- a/packages/core/src/workspace/sandbox/local-process-manager.ts
+++ b/packages/core/src/workspace/sandbox/local-process-manager.ts
@@ -5,6 +5,8 @@
  * Tracks processes in-memory since there's no server to query.
  */
 
+import { execSync } from 'node:child_process';
+
 import type { ResultPromise, Options as ExecaOptions } from 'execa';
 
 import { getExeca } from './execa';
@@ -12,6 +14,8 @@ import type { LocalSandbox } from './local-sandbox';
 import { ProcessHandle, SandboxProcessManager } from './process-manager';
 import type { ProcessInfo, SpawnProcessOptions } from './process-manager';
 import type { CommandResult } from './types';
+
+const isWindows = process.platform === 'win32';
 
 // =============================================================================
 // Local Process Handle
@@ -39,14 +43,10 @@ class LocalProcessHandle extends ProcessHandle {
     const timeoutId = options?.timeout
       ? setTimeout(() => {
           timedOut = true;
-          // Kill the entire process group so child processes are also terminated.
+          // Kill the entire process tree so child processes are also terminated.
           // We handle timeout ourselves rather than using execa's timeout option
-          // because execa only kills the direct subprocess, not the process group.
-          try {
-            process.kill(-this.pid, 'SIGTERM');
-          } catch {
-            subprocess.kill('SIGTERM');
-          }
+          // because execa only kills the direct subprocess, not the process tree.
+          killProcessTree(this.pid, subprocess, 'SIGTERM');
         }, options.timeout)
       : undefined;
 
@@ -100,18 +100,11 @@ class LocalProcessHandle extends ProcessHandle {
 
   async kill(): Promise<boolean> {
     if (this.exitCode !== undefined) return false;
-    // Kill the entire process group (negative PID) to ensure child processes
-    // spawned by the shell are also terminated. Without this, commands like
+    // Kill the entire process tree to ensure child processes spawned by the
+    // shell are also terminated. Without this, commands like
     // "echo foo; sleep 60" would leave orphaned children holding stdio open.
-    // Execa doesn't handle process tree killing natively.
-    try {
-      process.kill(-this.pid, 'SIGKILL');
-      return true;
-    } catch {
-      // Fallback to direct kill if process group kill fails
-      this.subprocess.kill('SIGKILL');
-      return true;
-    }
+    killProcessTree(this.pid, this.subprocess, 'SIGKILL');
+    return true;
   }
 
   async sendStdin(data: string): Promise<void> {
@@ -124,6 +117,38 @@ class LocalProcessHandle extends ProcessHandle {
     return new Promise<void>((resolve, reject) => {
       this.subprocess.stdin!.write(data, (err: Error | null | undefined) => (err ? reject(err) : resolve()));
     });
+  }
+}
+
+// =============================================================================
+// Process Tree Killing
+// =============================================================================
+
+/**
+ * Kill a process and all its children.
+ *
+ * On Unix, we use process groups (negative PID) since processes are spawned
+ * with `detached: true` which creates a new process group.
+ *
+ * On Windows, `process.kill(-pid)` doesn't work (no process groups), and
+ * `detached: true` opens a new console window. Instead we use `taskkill /T`
+ * which recursively kills the process tree by PID.
+ */
+function killProcessTree(pid: number, subprocess: ResultPromise, signal: NodeJS.Signals): void {
+  if (isWindows) {
+    try {
+      // /T = kill child processes, /F = force, /PID = target process
+      execSync(`taskkill /T /F /PID ${pid}`, { stdio: 'ignore' });
+    } catch {
+      // Process may have already exited
+      subprocess.kill(signal);
+    }
+  } else {
+    try {
+      process.kill(-pid, signal);
+    } catch {
+      subprocess.kill(signal);
+    }
   }
 }
 
@@ -141,13 +166,11 @@ export class LocalProcessManager extends SandboxProcessManager<LocalSandbox> {
     const env = this.sandbox.buildEnv(options.env);
     const wrapped = this.sandbox.wrapCommandForIsolation(command);
 
-    const execaOptions: ExecaOptions = {
+    // Base options shared across all platforms.
+    const baseOptions = {
       cwd,
       env,
-      shell: this.sandbox.isolation === 'none',
-      // detached: true creates a new process group so we can kill the entire tree.
-      detached: true,
-      stdio: 'pipe',
+      stdio: 'pipe' as const,
       // Don't throw on non-zero exit — we handle exit codes ourselves.
       reject: false,
       // Don't buffer output — we stream it via ProcessHandle callbacks.
@@ -157,6 +180,36 @@ export class LocalProcessManager extends SandboxProcessManager<LocalSandbox> {
       // Don't extend process.env — the sandbox controls the full environment via buildEnv().
       extendEnv: false,
     };
+
+    let execaOptions: ExecaOptions;
+
+    if (isWindows) {
+      // On Windows, `detached: true` opens a new console window (visible cmd.exe
+      // popup) and breaks stdout/stderr piping. Instead we spawn without detached
+      // and use `taskkill /T` for process tree killing.
+      //
+      // For shell interpretation (isolation=none), we explicitly invoke cmd.exe
+      // rather than using execa's `shell: true` which also triggers the console
+      // window issue when combined with detached.
+      if (this.sandbox.isolation === 'none') {
+        // Wrap the command for cmd.exe: /d disables AutoRun, /s /c handles quoting
+        wrapped.command = process.env.COMSPEC || 'cmd.exe';
+        wrapped.args = ['/d', '/s', '/c', `"${command}"`];
+      }
+      execaOptions = baseOptions;
+    } else {
+      // On Unix, `detached: true` creates a new process group so we can kill the
+      // entire tree via `process.kill(-pid, signal)`.
+      //
+      // Non-isolated: use shell mode so the host shell interprets the command string
+      // (pipes, redirects, chaining, etc.). Isolated (seatbelt/bwrap): the wrapper
+      // already includes `sh -c` inside the sandbox, so we spawn the wrapper directly.
+      execaOptions = {
+        ...baseOptions,
+        detached: true,
+        shell: this.sandbox.isolation === 'none',
+      };
+    }
 
     const execa = await getExeca();
     const subprocess = execa(wrapped.command, wrapped.args, execaOptions);

--- a/packages/core/src/workspace/sandbox/local-process-manager.ts
+++ b/packages/core/src/workspace/sandbox/local-process-manager.ts
@@ -5,8 +5,6 @@
  * Tracks processes in-memory since there's no server to query.
  */
 
-import { execSync } from 'node:child_process';
-
 import type { ResultPromise, Options as ExecaOptions } from 'execa';
 
 import { getExeca } from './execa';
@@ -46,7 +44,7 @@ class LocalProcessHandle extends ProcessHandle {
           // Kill the entire process tree so child processes are also terminated.
           // We handle timeout ourselves rather than using execa's timeout option
           // because execa only kills the direct subprocess, not the process tree.
-          killProcessTree(this.pid, subprocess, 'SIGTERM');
+          void killProcessTree(this.pid, subprocess, 'SIGTERM');
         }, options.timeout)
       : undefined;
 
@@ -103,7 +101,7 @@ class LocalProcessHandle extends ProcessHandle {
     // Kill the entire process tree to ensure child processes spawned by the
     // shell are also terminated. Without this, commands like
     // "echo foo; sleep 60" would leave orphaned children holding stdio open.
-    killProcessTree(this.pid, this.subprocess, 'SIGKILL');
+    await killProcessTree(this.pid, this.subprocess, 'SIGKILL');
     return true;
   }
 
@@ -134,11 +132,12 @@ class LocalProcessHandle extends ProcessHandle {
  * `detached: true` opens a new console window. Instead we use `taskkill /T`
  * which recursively kills the process tree by PID.
  */
-function killProcessTree(pid: number, subprocess: ResultPromise, signal: NodeJS.Signals): void {
+async function killProcessTree(pid: number, subprocess: ResultPromise, signal: NodeJS.Signals): Promise<void> {
   if (isWindows) {
     try {
       // /T = kill child processes, /F = force, /PID = target process
-      execSync(`taskkill /T /F /PID ${pid}`, { stdio: 'ignore' });
+      const execa = await getExeca();
+      await execa('taskkill', ['/T', '/F', '/PID', String(pid)], { reject: false, stdio: 'ignore' });
     } catch {
       // Process may have already exited
       subprocess.kill(signal);
@@ -185,18 +184,15 @@ export class LocalProcessManager extends SandboxProcessManager<LocalSandbox> {
 
     if (isWindows) {
       // On Windows, `detached: true` opens a new console window (visible cmd.exe
-      // popup) and breaks stdout/stderr piping. Instead we spawn without detached
-      // and use `taskkill /T` for process tree killing.
+      // popup) and breaks stdout/stderr piping. `shell: true` without `detached`
+      // works correctly — it uses cmd.exe for shell interpretation and pipes
+      // stdout/stderr back to the parent process without any visible window.
       //
-      // For shell interpretation (isolation=none), we explicitly invoke cmd.exe
-      // rather than using execa's `shell: true` which also triggers the console
-      // window issue when combined with detached.
-      if (this.sandbox.isolation === 'none') {
-        // Wrap the command for cmd.exe: /d disables AutoRun, /s /c handles quoting
-        wrapped.command = process.env.COMSPEC || 'cmd.exe';
-        wrapped.args = ['/d', '/s', '/c', `"${command}"`];
-      }
-      execaOptions = baseOptions;
+      // Process tree killing uses `taskkill /T` instead of Unix process groups.
+      execaOptions = {
+        ...baseOptions,
+        shell: this.sandbox.isolation === 'none',
+      };
     } else {
       // On Unix, `detached: true` creates a new process group so we can kill the
       // entire tree via `process.kill(-pid, signal)`.

--- a/packages/core/src/workspace/sandbox/local-process-manager.ts
+++ b/packages/core/src/workspace/sandbox/local-process-manager.ts
@@ -139,7 +139,7 @@ async function killProcessTree(pid: number, subprocess: ResultPromise, signal: N
       const execa = await getExeca();
       await execa('taskkill', ['/T', '/F', '/PID', String(pid)], { reject: false, stdio: 'ignore' });
     } catch {
-      // Process may have already exited
+      // taskkill binary not found — fall back to direct kill
       subprocess.kill(signal);
     }
   } else {


### PR DESCRIPTION
## Problem

On Windows, `LocalProcessManager` uses `shell: true` + `detached: true` when spawning commands via execa. The `detached: true` option causes:

1. **Visible cmd.exe window popup** — a new console window opens for each spawned process
2. **Broken stdout/stderr piping** — output goes to the new console window instead of back to the parent process

Additionally, process tree killing uses `process.kill(-pid)` (Unix process groups) which doesn't work on Windows.

## Fix

On Windows, `LocalProcessManager` no longer uses `detached: true`. The `shell: true` option (for `isolation === 'none'`) works correctly on its own — it routes through `cmd.exe` for shell interpretation and pipes stdout/stderr back without any visible window.

Process tree killing uses `taskkill /T /F /PID` via execa instead of Unix process groups.

| Concern | Unix (unchanged) | Windows (fixed) |
|---------|------------------|-----------------|
| Shell interpretation | `shell: true` | `shell: true` (same) |
| Process groups | `detached: true` | Not used |
| Tree killing | `process.kill(-pid, signal)` | `taskkill /T /F /PID` via execa |

## Test plan

- [x] All 233 tests pass (147 LocalSandbox + 62 sandbox-tools + 24 execute-command)
- [x] Manually tested on Windows — commands execute correctly, no window popup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented visible console popups on Windows and restored reliable stdout/stderr piping when running shell commands.
  * Improved cross-platform process termination so timeouts, cancellations, and normal exits consistently terminate entire process trees (children included) on both Windows and Unix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->