### PR TITLE
fix(playground-ui): fix Enter key not reliably submitting messages in chat input

### DIFF
--- a/.changeset/true-stars-turn.md
+++ b/.changeset/true-stars-turn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed Enter key not reliably submitting messages in the playground chat input

--- a/packages/playground-ui/src/lib/ai-ui/thread.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/thread.tsx
@@ -4,6 +4,7 @@ import {
   ThreadPrimitive,
   ToolCallMessagePartComponent,
   useComposerRuntime,
+  useThread,
 } from '@assistant-ui/react';
 import { ArrowUp, Mic, PlusIcon } from 'lucide-react';
 
@@ -100,10 +101,11 @@ const Composer = ({ hasMemory, agentId, hasModelList }: ComposerProps) => {
   const { canExecute } = usePermissions();
   const canExecuteAgent = canExecute('agents');
   const composerRuntime = useComposerRuntime();
+  const isRunning = useThread(s => s.isRunning);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.nativeEvent.isComposing) return;
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !isRunning) {
       e.preventDefault();
       composerRuntime.send();
     }

--- a/packages/playground-ui/src/lib/ai-ui/thread.tsx
+++ b/packages/playground-ui/src/lib/ai-ui/thread.tsx
@@ -99,6 +99,15 @@ const Composer = ({ hasMemory, agentId, hasModelList }: ComposerProps) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { canExecute } = usePermissions();
   const canExecuteAgent = canExecute('agents');
+  const composerRuntime = useComposerRuntime();
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.nativeEvent.isComposing) return;
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      composerRuntime.send();
+    }
+  };
 
   return (
     <div className="mx-4">
@@ -117,6 +126,7 @@ const Composer = ({ hasMemory, agentId, hasModelList }: ComposerProps) => {
               name=""
               id=""
               onChange={e => setThreadInput?.(e.target.value)}
+              onKeyDown={handleKeyDown}
               disabled={!canExecuteAgent}
             />
           </ComposerPrimitive.Input>


### PR DESCRIPTION
## Summary
- Fixed Enter key not reliably submitting messages in the playground chat input (had to press Enter multiple times)
- Added explicit `onKeyDown` handler that calls `composerRuntime.send()` directly, bypassing the library's form submission chain which relied on a stale React render closure

## Root Cause
The `ComposerPrimitive.Root`'s form submit handler captured a `send` function from `useComposerSend()` during render. This hook returns `null` when `s.composer.isEmpty` is true. Due to React 18's automatic batching, when the user typed text and pressed Enter quickly, the `send` closure could still be `null` from a previous render where the composer was empty, causing the submission to silently fail.

## Fix
Added an `onKeyDown` handler on the textarea that calls `composerRuntime.send()` directly on Enter. This reads the current state from the runtime at the time of the key press rather than depending on a render-time closure. Calling `preventDefault()` also prevents the library's internal handler from double-firing (Radix's `composeEventHandlers` skips when `defaultPrevented` is true).

## Test plan
- [ ] Open a fresh thread in the playground, type a message, press Enter once — message should submit immediately
- [ ] Verify Shift+Enter still inserts a newline
- [ ] Verify IME composition (e.g. CJK input) doesn't prematurely submit
- [ ] Verify the send button still works when clicked

Closes #13878

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enter now reliably submits messages in the playground chat input; Shift+Enter still inserts newlines.
  * Prevents duplicate sends while a message send is already in progress.
  * Respects IME composition so Enter during composition won't trigger send.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->