### PR TITLE
fix(memory): handle dynamic functions returning ModelWithRetries[] in observational memory

### DIFF
--- a/.changeset/memory-dynamic-model-fallback-fix.md
+++ b/.changeset/memory-dynamic-model-fallback-fix.md
@@ -1,0 +1,5 @@
+---
+"@mastra/memory": patch
+---
+
+fix(memory): handle dynamic functions returning ModelWithRetries[] in observational memory model resolution

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -2,6 +2,7 @@ import { appendFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { Agent } from '@mastra/core/agent';
 import type { AgentConfig, MastraDBMessage, MessageList } from '@mastra/core/agent';
+import type { MastraModelConfig } from '@mastra/core/llm';
 import { resolveModelConfig } from '@mastra/core/llm';
 import { getThreadOMMetadata, parseMemoryRequestContext, setThreadOMMetadata } from '@mastra/core/memory';
 import type {
@@ -932,9 +933,19 @@ export class ObservationalMemory implements Processor<'observational-memory'> {
     };
   }> {
     // Helper to get the model config to resolve (handles ModelWithRetries[] by taking first)
-    const getModelToResolve = (model: AgentConfig['model']) => {
+    const getModelToResolve = (model: AgentConfig['model']): Parameters<typeof resolveModelConfig>[0] => {
       if (Array.isArray(model)) {
-        return model[0]?.model ?? 'unknown';
+        return (model[0]?.model ?? 'unknown') as Parameters<typeof resolveModelConfig>[0];
+      }
+      if (typeof model === 'function') {
+        // Wrap to handle functions that may return ModelWithRetries[]
+        return async ctx => {
+          const result = await model(ctx);
+          if (Array.isArray(result)) {
+            return (result[0]?.model ?? 'unknown') as MastraModelConfig;
+          }
+          return result as MastraModelConfig;
+        };
       }
       return model;
     };


### PR DESCRIPTION
## Summary

- The commit `a07027766c` added support for dynamic functions returning `ModelWithRetries[]` arrays, but `observational-memory.ts` was not updated to handle this case
- `getModelToResolve` only handled the direct-array case; when a dynamic function was passed through unchanged, it caused:
  1. A TypeScript build error (`ModelWithRetries[]` is not assignable to `MastraModelConfig`)
  2. A runtime bug where `resolveModelConfig` would receive a function returning `ModelWithRetries[]` which it doesn't handle

**Fix:** Added a `typeof model === 'function'` branch in `getModelToResolve` that wraps the function and handles the `ModelWithRetries[]` return case by taking the first element's model — consistent with the existing direct-array behavior.

## Test plan

- [ ] `pnpm build:memory` passes without TypeScript errors
- [ ] Verify agents configured with `model: async () => [{ model: 'openai/gpt-4o' }, ...]` work correctly in observational memory context

🤖 Generated with [Claude Code](https://claude.com/claude-code)