### PR TITLE
fix: correlate provider-executed tool results back to tool calls

### DIFF
--- a/.changeset/fix-tool-result-correlation.md
+++ b/.changeset/fix-tool-result-correlation.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+fix: correlate provider-executed tool results back to tool calls by matching toolCallId

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1010,6 +1010,21 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
         return chunk.payload;
       });
 
+      // Correlate provider-executed tool results back to their tool calls.
+      // Without this, provider-executed tools lose their results in tool-call-step
+      // because inputData.output is undefined and falls back to a sentinel value.
+      const toolResults = outputStream._getImmediateToolResults();
+      if (toolResults && toolResults.length > 0) {
+        const resultsByCallId = new Map(
+          toolResults.map(r => [r.payload.toolCallId, r.payload.result]),
+        );
+        for (const tc of toolCalls) {
+          if (tc.providerExecuted && resultsByCallId.has(tc.toolCallId)) {
+            tc.output = resultsByCallId.get(tc.toolCallId);
+          }
+        }
+      }
+
       if (toolCalls.length > 0) {
         const message: MastraDBMessage = {
           id: messageId,


### PR DESCRIPTION
## Summary

Fixes #13846

- Provider-executed tools (e.g., Anthropic's `code_execution_20260120`) emit `tool-result` chunks with real output data (stdout, stderr, file_id, etc.), but `_getImmediateToolCalls()` only captures `tool-call` chunks which lack result data
- When these tool calls reach `tool-call-step`, `inputData.output` is always `undefined`, so the step falls back to `{ providerExecuted: true, toolName }` — discarding the actual result
- After building the `toolCalls` array, this PR correlates `_getImmediateToolResults()` back by `toolCallId` and attaches the real result to each provider-executed tool call's `output` field

## Details

The root cause is in `llm-execution-step.ts` where `toolCalls` are built from `_getImmediateToolCalls()` (line 1009). These chunks only contain `{ toolCallId, toolName, args, providerExecuted }`. The matching tool-result data exists in `_getImmediateToolResults()` but was never used to enrich the tool calls before passing them downstream.

The fix adds a correlation step that:
1. Gets tool results via `outputStream._getImmediateToolResults()`
2. Builds a `toolCallId → result` lookup map
3. For each provider-executed tool call, sets `tc.output` to the matching result

This way when `tool-call-step.ts:220` evaluates `inputData.output ?? { providerExecuted: true, toolName }`, it finds the actual result instead of falling through to the sentinel.

## Test plan

- [ ] Existing `tool-call-step.test.ts` tests for provider-executed tools continue to pass (both with and without output)
- [ ] Verify with Anthropic's `code_execution_20260120` tool that `ToolUIPart.output` on the client receives real result data
- [ ] Confirm non-provider-executed tools are unaffected (the correlation only targets `tc.providerExecuted === true`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where provider-executed tool results could be lost in certain cases, ensuring results are correctly matched back to their corresponding tool calls even when outputs are undefined.

* **Chores**
  * Prepared a patch release entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->