### PR TITLE
TUI user experience

### DIFF
--- a/.changeset/young-gifts-agree.md
+++ b/.changeset/young-gifts-agree.md
@@ -1,0 +1,21 @@
+---
+'mastracode': patch
+---
+
+Improved TUI user experience with better visual hierarchy and information density
+
+**Role indicators**: User and assistant messages now have clear visual markers (❯ You / ◆ Assistant) making it easy to distinguish who said what in the conversation history.
+
+**Compact header**: Reduced the header from 10+ lines to a tighter layout by merging project info, branch, user, and shortcuts into a single context line below the banner.
+
+**Better thinking blocks**: When collapsed, thinking blocks now show a preview of the first line with line count instead of just "Thinking...", with a hint to expand (ctrl+t).
+
+**Improved diffs**: Edit tool diffs now show +/- prefixes on changed lines, matching the familiar unified diff format.
+
+**Elapsed time in status bar**: The status line now shows a live elapsed time counter (⏱) while the agent is processing, so you always know how long the current operation has been running.
+
+**Tighter spacing**: Reduced unnecessary blank lines and spacers throughout the UI for better information density, matching the compact feel of other coding TUIs.
+
+**Polished tool approval**: The tool approval dialog is more compact, showing the tool name and category on a single line with arguments below.
+
+**Consistent icons**: Task progress uses cleaner Unicode symbols (✓, ▸, ○) and error/info messages use consistent formatting.

--- a/mastracode/src/tui/components/assistant-message.ts
+++ b/mastracode/src/tui/components/assistant-message.ts
@@ -1,5 +1,6 @@
 /**
  * Component that renders an assistant message with streaming support.
+ * Includes a role indicator and improved thinking block presentation.
  */
 
 import fs from 'node:fs';
@@ -26,15 +27,21 @@ export class AssistantMessageComponent extends Container {
   private markdownTheme: MarkdownTheme;
   private lastMessage?: HarnessMessage;
   private _id: number;
+  private showRoleIndicator: boolean;
 
-  constructor(message?: HarnessMessage, hideThinkingBlock = false, markdownTheme: MarkdownTheme = getMarkdownTheme()) {
+  constructor(
+    message?: HarnessMessage,
+    hideThinkingBlock = false,
+    markdownTheme: MarkdownTheme = getMarkdownTheme(),
+    showRoleIndicator = false,
+  ) {
     super();
     this._id = ++_compId;
 
     this.hideThinkingBlock = hideThinkingBlock;
     this.markdownTheme = markdownTheme;
+    this.showRoleIndicator = showRoleIndicator;
 
-    // Container for text/thinking content
     this.contentContainer = new Container();
     this.addChild(this.contentContainer);
 
@@ -61,13 +68,11 @@ export class AssistantMessageComponent extends Container {
   }
 
   updateContent(message: HarnessMessage): void {
-    // Deep copy the message to prevent mutation from the harness's shared content array
     this.lastMessage = {
       ...message,
       content: message.content.map(c => ({ ...c })),
     };
 
-    // Clear content container
     this.contentContainer.clear();
 
     const hasVisibleContent = message.content.some(
@@ -76,28 +81,45 @@ export class AssistantMessageComponent extends Container {
 
     if (hasVisibleContent) {
       this.contentContainer.addChild(new Spacer(1));
+      if (this.showRoleIndicator) {
+        this.contentContainer.addChild(
+          new Text(theme.bold(theme.fg('accent', '◆')) + ' ' + theme.bold(theme.fg('text', 'Assistant')), 1, 0),
+        );
+      }
     }
-    // Render content in order
+
     for (let i = 0; i < message.content.length; i++) {
       const content = message.content[i]!;
 
       if (content.type === 'text' && (content as any).text.trim()) {
-        // Assistant text messages - trim the text
         this.contentContainer.addChild(new Markdown((content as any).text.trim(), 1, 0, this.markdownTheme));
       } else if (content.type === 'thinking' && (content as any).thinking.trim()) {
-        // Check if there's text content after this thinking block
         const hasTextAfter = message.content.slice(i + 1).some(c => c.type === 'text' && (c as any).text.trim());
+        const thinkingText = (content as any).thinking.trim();
+        const thinkingLines = thinkingText.split('\n').length;
 
         if (this.hideThinkingBlock) {
-          // Show static "Thinking..." label when hidden
-          this.contentContainer.addChild(new Text(theme.italic(theme.fg('thinkingText', 'Thinking...')), 1, 0));
+          const summary = thinkingText.length > 80 ? thinkingText.slice(0, 77) + '...' : thinkingText;
+          const firstLine = summary.split('\n')[0] || '';
+          const label = thinkingLines > 1
+            ? `${firstLine.slice(0, 60)}${firstLine.length > 60 ? '…' : ''} (+${thinkingLines - 1} lines)`
+            : firstLine;
+          this.contentContainer.addChild(
+            new Text(
+              theme.fg('dim', '  ') + theme.italic(theme.fg('thinkingText', `💭 ${label}`)) +
+              theme.fg('dim', '  ctrl+t to expand'),
+              1, 0,
+            ),
+          );
           if (hasTextAfter) {
             this.contentContainer.addChild(new Spacer(1));
           }
         } else {
-          // Thinking traces in thinkingText color, italic
           this.contentContainer.addChild(
-            new Markdown((content as any).thinking.trim(), 1, 0, this.markdownTheme, {
+            new Text(theme.fg('dim', '  ') + theme.italic(theme.fg('thinkingText', '💭 Thinking')), 1, 0),
+          );
+          this.contentContainer.addChild(
+            new Markdown(thinkingText, 1, 0, this.markdownTheme, {
               color: (text: string) => theme.fg('thinkingText', text),
               italic: true,
             }),
@@ -105,10 +127,8 @@ export class AssistantMessageComponent extends Container {
           this.contentContainer.addChild(new Spacer(1));
         }
       }
-      // Skip tool_call and tool_result - those are rendered by ToolExecutionComponent
     }
 
-    // Check if aborted or error - show after partial content
     if (message.stopReason === 'aborted') {
       const abortMessage = message.errorMessage || 'Interrupted';
       this.contentContainer.addChild(new Spacer(1));

--- a/mastracode/src/tui/components/banner.ts
+++ b/mastracode/src/tui/components/banner.ts
@@ -1,6 +1,6 @@
 /**
  * ASCII art banner for the Mastra Code TUI header.
- * Renders "MASTRA CODE" or "MASTRA" in block-letter art with a purple gradient.
+ * Compact single-line format with gradient diamond, or full block-letter art on wide terminals.
  */
 import chalk from 'chalk';
 
@@ -19,9 +19,6 @@ const FULL_ART = [
 // Short "MASTRA" banner (24 chars wide)
 const SHORT_ART = ['█▀▄▀█ ▄▀█ █▀ ▀█▀ █▀█ ▄▀█', '█ ▀ █ █▀█ ▀█  █  █▀▄ █▀█', '▀   ▀ ▀ ▀ ▀▀  ▀  ▀ ▀ ▀ ▀'];
 
-/**
- * Interpolate between two hex colors.
- */
 function lerpColor(hex1: string, hex2: string, t: number): [number, number, number] {
   const r1 = parseInt(hex1.slice(1, 3), 16);
   const g1 = parseInt(hex1.slice(3, 5), 16);
@@ -32,9 +29,6 @@ function lerpColor(hex1: string, hex2: string, t: number): [number, number, numb
   return [Math.round(r1 + (r2 - r1) * t), Math.round(g1 + (g2 - g1) * t), Math.round(b1 + (b2 - b1) * t)];
 }
 
-/**
- * Color a single character based on its horizontal position in the gradient.
- */
 function gradientChar(ch: string, colIdx: number, totalCols: number): string {
   if (ch === ' ') return ' ';
   const t = totalCols <= 1 ? 0.5 : colIdx / (totalCols - 1);
@@ -45,43 +39,43 @@ function gradientChar(ch: string, colIdx: number, totalCols: number): string {
   return chalk.rgb(r, g, b)(ch);
 }
 
-/**
- * Apply left-to-right purple gradient to a line of text.
- */
 function colorLine(line: string): string {
   const chars = [...line];
   return chars.map((ch, i) => gradientChar(ch, i, chars.length)).join('');
 }
 
 /**
+ * Render a compact single-line banner: ◆ Mastra Code v0.2.0
+ * Used on narrow terminals or as the default compact header.
+ */
+export function renderCompactBanner(version: string, appName?: string): string {
+  const name = appName || 'Mastra Code';
+  return theme.fg('accent', '◆') + ' ' + theme.bold(theme.fg('accent', name)) + theme.fg('dim', ` v${version}`);
+}
+
+/**
  * Render the banner header for the TUI.
  *
- * @param version - App version string (e.g. "0.2.0")
- * @param appName - App name. Block art is only used for "Mastra Code" (default).
- * @returns Styled multi-line string ready for display.
+ * Layout strategy:
+ * - Wide terminals (≥50 cols): full ASCII art
+ * - Medium (30-49): short ASCII art
+ * - Narrow (<30) or custom apps: compact single-line
  */
 export function renderBanner(version: string, appName?: string): string {
   const name = appName || 'Mastra Code';
 
-  // Custom app names get the simple text format (no Mastra branding)
   if (name !== 'Mastra Code') {
-    return theme.fg('accent', '◆') + ' ' + theme.bold(theme.fg('accent', name)) + theme.fg('dim', ` v${version}`);
+    return renderCompactBanner(version, name);
   }
 
   const cols = process.stdout.columns || 80;
 
-  // Narrow terminal — compact single line
   if (cols < 30) {
-    return (
-      theme.fg('accent', '◆') + ' ' + theme.bold(theme.fg('accent', 'Mastra Code')) + theme.fg('dim', ` v${version}`)
-    );
+    return renderCompactBanner(version);
   }
 
-  // Select art based on available width
   const art = cols >= 50 ? FULL_ART : SHORT_ART;
   const coloredLines = art.map(line => colorLine(line));
-
-  // Append version below the art
   coloredLines.push(theme.fg('dim', `v${version}`));
 
   return coloredLines.join('\n');

--- a/mastracode/src/tui/components/task-progress.ts
+++ b/mastracode/src/tui/components/task-progress.ts
@@ -60,17 +60,17 @@ export class TaskProgressComponent extends Container {
 
     switch (task.status) {
       case 'completed': {
-        const icon = theme.fg('success', '\u2713');
+        const icon = theme.fg('success', '✓');
         const text = chalk.hex(theme.getTheme().success).strikethrough(task.content);
         return `${indent}${icon} ${text}`;
       }
       case 'in_progress': {
-        const icon = theme.fg('warning', '\u25B6');
+        const icon = theme.fg('warning', '▸');
         const text = theme.bold(theme.fg('warning', task.activeForm));
         return `${indent}${icon} ${text}`;
       }
       case 'pending': {
-        const icon = theme.fg('dim', '\u25CB');
+        const icon = theme.fg('dim', '○');
         const text = theme.fg('dim', task.content);
         return `${indent}${icon} ${text}`;
       }

--- a/mastracode/src/tui/components/tool-approval-dialog.ts
+++ b/mastracode/src/tui/components/tool-approval-dialog.ts
@@ -55,47 +55,40 @@ export class ToolApprovalDialogComponent extends Box implements Focusable {
   }
 
   private buildUI(): void {
-    // Title
-    this.addChild(new Text(theme.fg('warning', '⚠ Tool Approval Required'), 0, 0));
-    this.addChild(new Spacer(1));
+    const t = theme.getTheme();
+    const dimColor = chalk.hex(t.dim);
+    const key = chalk.hex(t.text).bold;
 
-    // Tool name
-    this.addChild(new Text(theme.fg('accent', `Tool: `) + theme.fg('text', this.toolName), 0, 0));
-    if (this.categoryLabel) {
-      this.addChild(new Text(theme.fg('accent', `Category: `) + theme.fg('text', this.categoryLabel), 0, 0));
-    }
-    this.addChild(new Spacer(1));
+    this.addChild(
+      new Text(
+        theme.fg('warning', '⚠') + ' ' +
+        theme.bold(theme.fg('text', this.toolName)) +
+        (this.categoryLabel ? theme.fg('muted', ` [${this.categoryLabel}]`) : ''),
+        0, 0,
+      ),
+    );
 
-    // Arguments (formatted)
-    this.addChild(new Text(theme.fg('muted', 'Arguments:'), 0, 0));
     const argsText = this.formatArgs(this.args);
-    for (const line of argsText.split('\n').slice(0, 10)) {
-      this.addChild(new Text(theme.fg('text', '  ' + line), 0, 0));
+    const argsLines = argsText.split('\n').slice(0, 8);
+    for (const line of argsLines) {
+      this.addChild(new Text(theme.fg('muted', '  ' + line), 0, 0));
     }
-    if (argsText.split('\n').length > 10) {
-      this.addChild(new Text(theme.fg('muted', '  ... (truncated)'), 0, 0));
+    if (argsText.split('\n').length > 8) {
+      this.addChild(new Text(theme.fg('dim', '  ... (truncated)'), 0, 0));
     }
 
     this.addChild(new Spacer(1));
-    // Prompt text with keyboard shortcuts
     const categoryHint = this.categoryLabel
       ? `lways allow ${this.categoryLabel.toLowerCase()}`
       : 'lways allow category';
-    const dimColor = chalk.hex(theme.getTheme().dim);
-    const key = chalk.hex(theme.getTheme().text).bold;
     this.addChild(
       new Text(
         theme.fg('accent', 'Allow? ') +
-          key('y') +
-          dimColor('es  ') +
-          key('n') +
-          dimColor('o  ') +
-          key('a') +
-          dimColor(categoryHint + '  ') +
-          key('Y') +
-          dimColor('olo'),
-        0,
-        0,
+          key('y') + dimColor('es  ') +
+          key('n') + dimColor('o  ') +
+          key('a') + dimColor(categoryHint + '  ') +
+          key('Y') + dimColor('olo'),
+        0, 0,
       ),
     );
   }

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -723,26 +723,24 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const lines: string[] = [];
     let firstChangeIndex = -1;
 
-    // Use soft red for removed, green for added
-    const removedColor = chalk.hex(mastra.red); // soft red
-    const addedColor = chalk.hex(theme.getTheme().success); // soft green
+    const removedColor = chalk.hex(mastra.red);
+    const addedColor = chalk.hex(theme.getTheme().success);
 
     const maxLines = Math.max(oldLines.length, newLines.length);
 
     for (let i = 0; i < maxLines; i++) {
       if (i >= oldLines.length) {
         if (firstChangeIndex === -1) firstChangeIndex = lines.length;
-        lines.push(addedColor(newLines[i]));
+        lines.push(addedColor(`+ ${newLines[i]}`));
       } else if (i >= newLines.length) {
         if (firstChangeIndex === -1) firstChangeIndex = lines.length;
-        lines.push(removedColor(oldLines[i]));
+        lines.push(removedColor(`- ${oldLines[i]}`));
       } else if (oldLines[i] !== newLines[i]) {
         if (firstChangeIndex === -1) firstChangeIndex = lines.length;
-        lines.push(removedColor(oldLines[i]!));
-        lines.push(addedColor(newLines[i]!));
+        lines.push(removedColor(`- ${oldLines[i]!}`));
+        lines.push(addedColor(`+ ${newLines[i]!}`));
       } else {
-        // Context line
-        lines.push(theme.fg('muted', oldLines[i]!));
+        lines.push(theme.fg('muted', `  ${oldLines[i]!}`));
       }
     }
 

--- a/mastracode/src/tui/components/user-message.ts
+++ b/mastracode/src/tui/components/user-message.ts
@@ -1,8 +1,8 @@
 /**
- * Component that renders a user message.
+ * Component that renders a user message with a role indicator.
  */
 
-import { Container, Markdown, Spacer } from '@mariozechner/pi-tui';
+import { Container, Markdown, Spacer, Text } from '@mariozechner/pi-tui';
 import type { MarkdownTheme } from '@mariozechner/pi-tui';
 import { getMarkdownTheme, theme } from '../theme.js';
 
@@ -10,6 +10,7 @@ export class UserMessageComponent extends Container {
   constructor(text: string, markdownTheme: MarkdownTheme = getMarkdownTheme()) {
     super();
     this.addChild(new Spacer(1));
+    this.addChild(new Text(theme.bold(theme.fg('accent', '❯')) + ' ' + theme.bold(theme.fg('text', 'You')), 1, 0));
     this.addChild(
       new Markdown(text, 1, 1, markdownTheme, {
         bgColor: (text: string) => theme.bg('userMessageBg', text),

--- a/mastracode/src/tui/display.ts
+++ b/mastracode/src/tui/display.ts
@@ -10,14 +10,12 @@ import type { TUIState } from './state.js';
 import { theme } from './theme.js';
 
 export function showError(state: TUIState, message: string): void {
-  state.chatContainer.addChild(new Spacer(1));
-  state.chatContainer.addChild(new Text(theme.fg('error', `Error: ${message}`), 1, 0));
+  state.chatContainer.addChild(new Text(theme.fg('error', `✗ ${message}`), 1, 0));
   state.ui.requestRender();
 }
 
 export function showInfo(state: TUIState, message: string): void {
-  state.chatContainer.addChild(new Spacer(1));
-  state.chatContainer.addChild(new Text(theme.fg('muted', message), 1, 0));
+  state.chatContainer.addChild(new Text(theme.fg('dim', '  ') + theme.fg('muted', message), 1, 0));
   state.ui.requestRender();
 }
 

--- a/mastracode/src/tui/handlers/agent-lifecycle.ts
+++ b/mastracode/src/tui/handlers/agent-lifecycle.ts
@@ -13,7 +13,8 @@ import type { EventHandlerContext } from './types.js';
 export function handleAgentStart(ctx: EventHandlerContext): void {
   const { state } = ctx;
 
-  // Refresh git branch so status line reflects the current branch
+  state.agentStartTime = Date.now();
+
   const freshBranch = getCurrentGitBranch(state.projectInfo.rootPath);
   if (freshBranch) {
     state.projectInfo.gitBranch = freshBranch;
@@ -29,11 +30,12 @@ export function handleAgentStart(ctx: EventHandlerContext): void {
 
 export function handleAgentEnd(ctx: EventHandlerContext): void {
   const { state } = ctx;
+  state.agentStartTime = undefined;
+
   if (state.gradientAnimator) {
     state.gradientAnimator.fadeOut();
   }
 
-  // Refresh git branch — tool calls during this turn may have switched branches
   const freshBranch = getCurrentGitBranch(state.projectInfo.rootPath);
   if (freshBranch) {
     state.projectInfo.gitBranch = freshBranch;
@@ -62,6 +64,8 @@ export function handleAgentEnd(ctx: EventHandlerContext): void {
 
 export function handleAgentAborted(ctx: EventHandlerContext): void {
   const { state } = ctx;
+  state.agentStartTime = undefined;
+
   if (state.gradientAnimator) {
     state.gradientAnimator.fadeOut();
   }
@@ -89,6 +93,8 @@ export function handleAgentAborted(ctx: EventHandlerContext): void {
 
 export function handleAgentError(ctx: EventHandlerContext): void {
   const { state } = ctx;
+  state.agentStartTime = undefined;
+
   if (state.gradientAnimator) {
     state.gradientAnimator.fadeOut();
   }

--- a/mastracode/src/tui/handlers/message.ts
+++ b/mastracode/src/tui/handlers/message.ts
@@ -65,11 +65,15 @@ export function handleMessageStart(ctx: EventHandlerContext, message: HarnessMes
   if (message.role === 'user') {
     ctx.addUserMessage(message);
   } else if (message.role === 'assistant') {
-    // Clear tool component references when starting a new assistant message
     state.lastAskUserComponent = undefined;
     state.lastSubmitPlanComponent = undefined;
     if (!state.streamingComponent) {
-      state.streamingComponent = new AssistantMessageComponent(undefined, state.hideThinkingBlock, getMarkdownTheme());
+      state.streamingComponent = new AssistantMessageComponent(
+        undefined,
+        state.hideThinkingBlock,
+        getMarkdownTheme(),
+        true,
+      );
       ctx.addChildBeforeFollowUps(state.streamingComponent);
       state.streamingMessage = message;
       const trailingParts = getTrailingContentParts(message);

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -176,15 +176,13 @@ export async function renderExistingMessages(state: TUIState): Promise<void> {
     if (message.role === 'user') {
       addUserMessage(state, message);
     } else if (message.role === 'assistant') {
-      // Render content in order - interleaving text and tool calls
-      // Accumulate text/thinking until we hit a tool call, then render both
       let accumulatedContent: HarnessMessageContent[] = [];
+      let isFirstTextBlock = true;
 
       for (const content of message.content) {
         if (content.type === 'text' || content.type === 'thinking') {
           accumulatedContent.push(content);
         } else if (content.type === 'tool_call') {
-          // Render accumulated text first if any
           if (accumulatedContent.length > 0) {
             const textMessage: HarnessMessage = {
               ...message,
@@ -194,7 +192,9 @@ export async function renderExistingMessages(state: TUIState): Promise<void> {
               textMessage,
               state.hideThinkingBlock,
               getMarkdownTheme(),
+              isFirstTextBlock,
             );
+            isFirstTextBlock = false;
             state.chatContainer.addChild(textComponent);
             accumulatedContent = [];
           }
@@ -372,13 +372,17 @@ export async function renderExistingMessages(state: TUIState): Promise<void> {
         // Skip tool_result - it's handled with tool_call above
       }
 
-      // Render any remaining text after the last tool call
       if (accumulatedContent.length > 0) {
         const textMessage: HarnessMessage = {
           ...message,
           content: accumulatedContent,
         };
-        const textComponent = new AssistantMessageComponent(textMessage, state.hideThinkingBlock, getMarkdownTheme());
+        const textComponent = new AssistantMessageComponent(
+          textMessage,
+          state.hideThinkingBlock,
+          getMarkdownTheme(),
+          isFirstTextBlock,
+        );
         state.chatContainer.addChild(textComponent);
       }
     }

--- a/mastracode/src/tui/setup.ts
+++ b/mastracode/src/tui/setup.ts
@@ -181,48 +181,47 @@ export function setupKeyboardShortcuts(
 // =============================================================================
 
 export function buildLayout(state: TUIState, refreshModelAuthStatus: () => Promise<void>): void {
-  // Add header
   const appName = state.options.appName || 'Mastra Code';
   const version = state.options.version || '0.1.0';
 
   const banner = renderBanner(version, appName);
 
-  // Project frontmatter
-  const frontmatter = [
-    `Project: ${state.projectInfo.name}`,
-    `Resource ID: ${state.projectInfo.resourceId}`,
-    state.projectInfo.gitBranch ? `Branch: ${state.projectInfo.gitBranch}` : null,
-    state.projectInfo.isWorktree ? `Worktree of: ${state.projectInfo.mainRepoPath}` : null,
-    `User: ${getUserId(state.projectInfo.rootPath)}`,
-  ]
-    .filter(Boolean)
-    .map(line => theme.fg('muted', line as string))
-    .join('\n');
-
+  // Compact project context line: project · branch · user
   const sep = theme.fg('dim', ' · ');
+  const contextParts: string[] = [state.projectInfo.name];
+  if (state.projectInfo.gitBranch) {
+    contextParts.push(state.projectInfo.gitBranch);
+  }
+  if (state.projectInfo.isWorktree) {
+    contextParts.push(`worktree of ${state.projectInfo.mainRepoPath}`);
+  }
+  const userId = getUserId(state.projectInfo.rootPath);
+  if (userId) {
+    contextParts.push(userId);
+  }
+  const contextLine = theme.fg('muted', contextParts.join(theme.fg('dim', ' · ')));
+
+  // Hint line
   const hintParts: string[] = [];
   if (state.harness.listModes().length > 1) {
     hintParts.push(`${theme.fg('accent', '⇧+Tab')} ${theme.fg('muted', 'cycle modes')}`);
   }
-  hintParts.push(`${theme.fg('accent', '/help')} ${theme.fg('muted', 'info & shortcuts')}`);
-  const instructions = `  ${hintParts.join(sep)}`;
+  hintParts.push(`${theme.fg('accent', '/help')} ${theme.fg('muted', 'shortcuts')}`);
+  const hints = hintParts.join(sep);
 
   state.ui.addChild(new Spacer(1));
   state.ui.addChild(new Text(banner, 1, 0));
-  state.ui.addChild(new Text(frontmatter, 1, 0));
-  state.ui.addChild(new Spacer(1));
-  state.ui.addChild(new Text(instructions, 0, 0));
+  state.ui.addChild(new Text(`${contextLine}  ${hints}`, 1, 0));
   state.ui.addChild(new Spacer(1));
 
-  // Add main containers
+  // Main containers
   state.ui.addChild(state.chatContainer);
-  // Task progress (between chat and editor, visible only when tasks exist)
   state.taskProgress = new TaskProgressComponent();
   state.ui.addChild(state.taskProgress);
   state.ui.addChild(state.editorContainer);
   state.editorContainer.addChild(state.editor);
 
-  // Add footer with two-line status
+  // Footer with status
   state.statusLine = new Text('', 0, 0);
   state.memoryStatusLine = new Text('', 0, 0);
   state.footer.addChild(state.statusLine);
@@ -231,7 +230,6 @@ export function buildLayout(state: TUIState, refreshModelAuthStatus: () => Promi
   updateStatusLine(state);
   refreshModelAuthStatus();
 
-  // Set focus to editor
   state.ui.setFocus(state.editor);
 }
 

--- a/mastracode/src/tui/state.ts
+++ b/mastracode/src/tui/state.ts
@@ -155,6 +155,10 @@ export interface TUIState {
   /** Pending images from clipboard paste */
   pendingImages: Array<{ data: string; mimeType: string }>;
 
+  // ── Timing ──────────────────────────────────────────────────────────
+  /** Timestamp when the current agent turn started (for elapsed time display) */
+  agentStartTime?: number;
+
   // ── Abort tracking ────────────────────────────────────────────────────
   lastCtrlCTime: number;
   /** Track user-initiated aborts (Ctrl+C/Esc) vs system aborts */

--- a/mastracode/src/tui/status-line.ts
+++ b/mastracode/src/tui/status-line.ts
@@ -206,6 +206,24 @@ export function updateStatusLine(state: TUIState): void {
     shortModeBadgeWidth = shortName.length + 1;
   }
 
+  // --- Elapsed time (shown while agent is running) ---
+  let elapsedPart: { plain: string; styled: string } | null = null;
+  if (state.agentStartTime) {
+    const elapsedMs = Date.now() - state.agentStartTime;
+    let elapsedStr: string;
+    if (elapsedMs < 1000) {
+      elapsedStr = '<1s';
+    } else if (elapsedMs < 60_000) {
+      elapsedStr = `${Math.floor(elapsedMs / 1000)}s`;
+    } else {
+      const mins = Math.floor(elapsedMs / 60_000);
+      const secs = Math.floor((elapsedMs % 60_000) / 1000);
+      elapsedStr = `${mins}m${secs.toString().padStart(2, '0')}s`;
+    }
+    const plain = `⏱ ${elapsedStr}`;
+    elapsedPart = { plain, styled: theme.fg('muted', plain) };
+  }
+
   const buildLine = (opts: {
     modelId: string;
     memCompact?: 'percentOnly' | 'noBuffer' | 'full';
@@ -214,8 +232,6 @@ export function updateStatusLine(state: TUIState): void {
     badge?: 'full' | 'short';
   }): { plain: string; styled: string } | null => {
     const parts: Array<{ plain: string; styled: string }> = [];
-    // Model ID (always present) — styleModelId adds padding spaces
-    // When YOLO, append ⚒ box flush (no SEP gap)
     if (isYolo && modeColor) {
       const yBox = chalk.bgHex(tintHex(modeColor, 0.25)).hex(tintHex(modeColor, 0.9)).bold(' ⚒ ');
       parts.push({
@@ -227,6 +243,10 @@ export function updateStatusLine(state: TUIState): void {
         plain: ` ${opts.modelId} `,
         styled: styleModelId(opts.modelId),
       });
+    }
+
+    if (elapsedPart) {
+      parts.push(elapsedPart);
     }
     const useBadge = opts.badge === 'short' ? shortModeBadge : modeBadge;
     const useBadgeWidth = opts.badge === 'short' ? shortModeBadgeWidth : modeBadgeWidth;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR significantly enhances the Mastracode TUI user experience by improving clarity, compactness, and feedback mechanisms, addressing initial feedback that the UI was lacking compared to other coding assistants.

Key improvements include:
*   **Clarity & Attribution:** Introduced clear role indicators (`❯ You` / `◆ Assistant`) for messages and added `+/-` prefixes to diff displays.
*   **Compactness:** Drastically reduced the header/banner size and overall vertical spacing, and made the tool approval dialog more concise.
*   **Feedback:** Added an elapsed time counter to the status bar during agent activity and improved the visual consistency of task progress indicators.

## Related Issue(s)

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [x] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

---
<p><a href="https://cursor.com/agents/bc-29923a70-796d-4883-b6ec-f96689eb70ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29923a70-796d-4883-b6ec-f96689eb70ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->