### PR TITLE
fix(playground-ui): pass maxTokens without premature rename to maxOutputTokens

### DIFF
--- a/.changeset/fix-studio-max-tokens.md
+++ b/.changeset/fix-studio-max-tokens.md
@@ -1,0 +1,7 @@
+---
+'@mastra/playground-ui': patch
+---
+
+fix: maxTokens from Studio Advanced Settings now correctly limits model output
+
+The `modelSettingsArgs` object was prematurely renaming `maxTokens` to `maxOutputTokens`. The React hook (`useChat`) destructures `maxTokens` from this object, so the rename caused it to receive `undefined`, and the value was silently dropped from the API request body.

--- a/packages/playground-ui/src/services/mastra-runtime-provider.tsx
+++ b/packages/playground-ui/src/services/mastra-runtime-provider.tsx
@@ -654,7 +654,7 @@ export function MastraRuntimeProvider({
     topK,
     topP,
     seed,
-    maxOutputTokens: maxTokens, // AI SDK v5 uses maxOutputTokens
+    maxTokens,
     providerOptions,
     maxSteps,
     requireToolApproval,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

The `modelSettingsArgs` object in `MastraRuntimeProvider` was renaming `maxTokens` to `maxOutputTokens` before passing it to the React hooks. The `useChat` hook
destructures `maxTokens` from this object, so the premature rename caused it to receive `undefined`, and the value was silently dropped from the API request body.

Fix: pass `maxTokens` as-is from playground-ui. The React hooks already handle the `maxTokens` → `maxOutputTokens` mapping when building the API request.

## Before
<img width="1919" height="962" alt="Screenshot 2026-03-06 185812" src="https://github.com/user-attachments/assets/43f7a9f4-1a44-48ac-afc2-d16768506ecd" />

## After
<img width="1918" height="964" alt="Screenshot 2026-03-06 190200" src="https://github.com/user-attachments/assets/e5da408e-5abd-4fe0-8f15-d9e82b84294a" />

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #13893

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the max tokens setting was not being correctly applied in model requests, ensuring token limit configurations now work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->