### PR TITLE
fix: Anthropic cache tokens missing from Langfuse traces in streaming mode

### DIFF
--- a/.changeset/bright-squids-share.md
+++ b/.changeset/bright-squids-share.md
@@ -1,0 +1,7 @@
+---
+"@mastra/core": patch
+---
+
+**Fixed streamed finish metadata being dropped from final model results**
+
+Provider-specific metadata from streamed `finish` events is now preserved consistently across final output results, buffered steps, and `onFinish` callbacks. This improves compatibility with providers like Anthropic and Google/Gemini when they attach cache, reasoning, or other finish-time metadata during streaming.

--- a/.changeset/fair-ladybugs-jog.md
+++ b/.changeset/fair-ladybugs-jog.md
@@ -1,0 +1,7 @@
+---
+"@mastra/observability": patch
+---
+
+**Fixed Anthropic cache tokens being double-counted in observability metrics**
+
+Anthropic cache token usage is now normalized correctly for AI SDK v6-style usage payloads, so input token metrics and tracing output no longer overcount cached tokens when the total already includes them.

--- a/observability/mastra/src/usage.test.ts
+++ b/observability/mastra/src/usage.test.ts
@@ -150,6 +150,42 @@ describe('extractUsageMetrics', () => {
       expect(result.inputDetails?.cacheRead).toBeUndefined();
       expect(result.outputDetails?.text).toBe(50);
     });
+
+    it('should not double count Anthropic cache tokens when v6 usage already includes them', () => {
+      const usage: LanguageModelUsage = {
+        inputTokens: 106,
+        outputTokens: 20,
+        cachedInputTokens: 94,
+        raw: {
+          inputTokens: {
+            total: 106,
+            noCache: 6,
+            cacheRead: 94,
+            cacheWrite: 6,
+          },
+          outputTokens: {
+            total: 20,
+            text: 20,
+            reasoning: undefined,
+          },
+        },
+      };
+
+      const providerMetadata: ProviderMetadata = {
+        anthropic: {
+          cacheReadInputTokens: 94,
+          cacheCreationInputTokens: 6,
+        },
+      };
+
+      const result = extractUsageMetrics(usage, providerMetadata);
+
+      expect(result.inputTokens).toBe(106);
+      expect(result.outputTokens).toBe(20);
+      expect(result.inputDetails?.text).toBe(6);
+      expect(result.inputDetails?.cacheRead).toBe(94);
+      expect(result.inputDetails?.cacheWrite).toBe(6);
+    });
   });
 
   describe('Google/Gemini cache and thought tokens', () => {

--- a/observability/mastra/src/usage.ts
+++ b/observability/mastra/src/usage.ts
@@ -23,6 +23,21 @@ interface GoogleMetadata {
   usageMetadata?: GoogleUsageMetadata;
 }
 
+interface V3InputUsage {
+  total?: number;
+  noCache?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+}
+
+interface V3RawUsage {
+  inputTokens?: V3InputUsage;
+}
+
+function isV3RawUsage(raw: unknown): raw is V3RawUsage {
+  return typeof raw === 'object' && raw !== null && 'inputTokens' in raw;
+}
+
 /**
  * AI SDK aggregated input token details.
  * Available on totalUsage in multi-step runs — properly summed across all steps.
@@ -100,6 +115,11 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
   const anthropic = providerMetadata?.anthropic as AnthropicMetadata | undefined;
 
   if (anthropic) {
+    const rawV3InputUsage = isV3RawUsage(usage.raw) ? usage.raw.inputTokens : undefined;
+    const hasV3CachedTotals =
+      rawV3InputUsage?.total !== undefined &&
+      (rawV3InputUsage.cacheRead !== undefined || rawV3InputUsage.cacheWrite !== undefined);
+
     if (!isDefined(inputDetails.cacheRead) && isDefined(anthropic.cacheReadInputTokens)) {
       inputDetails.cacheRead = anthropic.cacheReadInputTokens;
     }
@@ -107,10 +127,9 @@ export function extractUsageMetrics(usage?: LanguageModelUsage, providerMetadata
       inputDetails.cacheWrite = anthropic.cacheCreationInputTokens;
     }
 
-    // For Anthropic, adjust inputTokens to include cache tokens
-    // Per Anthropic docs: "Total input tokens is the summation of input_tokens,
-    // cache_creation_input_tokens, and cache_read_input_tokens"
-    if (isDefined(inputDetails.cacheRead) || isDefined(inputDetails.cacheWrite)) {
+    // AI SDK v6-style usage already provides total input tokens including cache details,
+    // so avoid adding cache tokens on top of an already-totaled input count.
+    if (!hasV3CachedTotals && (isDefined(inputDetails.cacheRead) || isDefined(inputDetails.cacheWrite))) {
       inputTokens = (usage.inputTokens ?? 0) + (inputDetails.cacheRead ?? 0) + (inputDetails.cacheWrite ?? 0);
     }
   }

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -439,7 +439,7 @@ async function processOutputStream<OUTPUT = undefined>({
 
       case 'finish':
         runState.setState({
-          providerOptions: chunk.payload.metadata.providerMetadata,
+          providerOptions: chunk.payload.metadata?.providerMetadata ?? chunk.payload.providerMetadata,
           stepResult: {
             reason: chunk.payload.reason,
             logprobs: chunk.payload.logprobs,

--- a/packages/core/src/stream/aisdk/v5/input.test.ts
+++ b/packages/core/src/stream/aisdk/v5/input.test.ts
@@ -297,6 +297,11 @@ describe('AISDKV5InputStream', () => {
             },
           },
         },
+        providerMetadata: {
+          testProvider: {
+            testKey: 'testValue',
+          },
+        },
         type: 'finish',
       },
     });

--- a/packages/core/src/stream/aisdk/v5/input.test.ts
+++ b/packages/core/src/stream/aisdk/v5/input.test.ts
@@ -297,6 +297,11 @@ describe('AISDKV5InputStream', () => {
             },
           },
         },
+        messages: {
+          all: [],
+          user: [],
+          nonUser: [],
+        },
         providerMetadata: {
           testProvider: {
             testKey: 'testValue',

--- a/packages/core/src/stream/aisdk/v5/transform.test.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.test.ts
@@ -562,6 +562,80 @@ describe('convertFullStreamChunkToMastra', () => {
       expect(result?.type).toBe('finish');
       if (result?.type === 'finish') {
         expect(result.payload.stepResult.reason).toBe('stop');
+        expect(result.payload.providerMetadata).toEqual({});
+        expect(result.payload.metadata.providerMetadata).toEqual({});
+      }
+    });
+
+    it('should preserve providerMetadata for AI SDK v6 finish chunks', () => {
+      const providerMetadata = {
+        anthropic: {
+          cacheReadInputTokens: 94,
+          cacheCreationInputTokens: 6,
+        },
+      };
+      const chunk: StreamPart = {
+        type: 'finish',
+        finishReason: { unified: 'stop', raw: 'end_turn' },
+        usage: {
+          inputTokens: { total: 100, noCache: 6, cacheRead: 94, cacheWrite: 6 },
+          outputTokens: { total: 20, text: 20, reasoning: undefined },
+        },
+        providerMetadata,
+        messages: {
+          all: [],
+          user: [],
+          nonUser: [],
+        },
+      };
+
+      const result = convertFullStreamChunkToMastra(chunk, { runId: 'test-run-123' });
+
+      expect(result?.type).toBe('finish');
+      if (result?.type === 'finish') {
+        expect(result.payload.stepResult.reason).toBe('stop');
+        expect(result.payload.output.usage.cachedInputTokens).toBe(94);
+        expect(result.payload.providerMetadata).toEqual(providerMetadata);
+        expect(result.payload.metadata.providerMetadata).toEqual(providerMetadata);
+      }
+    });
+
+    it('should preserve Google/Gemini providerMetadata for finish chunks', () => {
+      const providerMetadata = {
+        google: {
+          usageMetadata: {
+            cachedContentTokenCount: 150,
+            thoughtsTokenCount: 250,
+          },
+          groundingMetadata: {
+            webSearchQueries: ['mastra ai'],
+          },
+        },
+      };
+      const chunk: StreamPart = {
+        type: 'finish',
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage: {
+          inputTokens: { total: 200, noCache: 50, cacheRead: 150 },
+          outputTokens: { total: 400, text: 150, reasoning: 250 },
+        },
+        providerMetadata,
+        messages: {
+          all: [],
+          user: [],
+          nonUser: [],
+        },
+      };
+
+      const result = convertFullStreamChunkToMastra(chunk, { runId: 'test-run-123' });
+
+      expect(result?.type).toBe('finish');
+      if (result?.type === 'finish') {
+        expect(result.payload.stepResult.reason).toBe('stop');
+        expect(result.payload.output.usage.cachedInputTokens).toBe(150);
+        expect(result.payload.output.usage.reasoningTokens).toBe(250);
+        expect(result.payload.providerMetadata).toEqual(providerMetadata);
+        expect(result.payload.metadata.providerMetadata).toEqual(providerMetadata);
       }
     });
   });

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -323,7 +323,11 @@ export function convertFullStreamChunkToMastra(value: StreamPart, ctx: { runId: 
           metadata: {
             providerMetadata: value.providerMetadata,
           },
-          ...(messages !== undefined && { messages }),
+          messages: messages ?? {
+            all: [],
+            user: [],
+            nonUser: [],
+          },
           ...rest,
         },
       };

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -323,7 +323,7 @@ export function convertFullStreamChunkToMastra(value: StreamPart, ctx: { runId: 
           metadata: {
             providerMetadata: value.providerMetadata,
           },
-          messages,
+          ...(messages !== undefined && { messages }),
           ...rest,
         },
       };

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -312,6 +312,7 @@ export function convertFullStreamChunkToMastra(value: StreamPart, ctx: { runId: 
         runId: ctx.runId,
         from: ChunkFrom.AGENT,
         payload: {
+          providerMetadata: value.providerMetadata,
           stepResult: {
             reason: normalizeFinishReason(value.finishReason),
           },
@@ -479,7 +480,7 @@ export function convertMastraChunkToAISDKv5<OUTPUT = undefined>({
         providerMetadata: chunk.payload.providerMetadata,
       };
     case 'step-finish': {
-      const { request: _request, providerMetadata, ...rest } = chunk.payload.metadata;
+      const { request: _request, providerMetadata: metadataProviderMetadata, ...rest } = chunk.payload.metadata;
       return {
         type: 'finish-step',
         response: {
@@ -490,7 +491,7 @@ export function convertMastraChunkToAISDKv5<OUTPUT = undefined>({
         },
         usage: chunk.payload.output.usage,
         finishReason: chunk.payload.stepResult.reason,
-        providerMetadata,
+        providerMetadata: metadataProviderMetadata ?? chunk.payload.providerMetadata,
       };
     }
     case 'text-delta':

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -23,7 +23,7 @@ function createChunkStream<OUTPUT = undefined>(chunks: ChunkType<OUTPUT>[]): Rea
 /**
  * Minimal step-finish chunk to populate bufferedSteps before the finish chunk.
  */
-function createStepFinishChunk(runId: string): ChunkType {
+function createStepFinishChunk(runId: string, providerMetadata?: Record<string, unknown>): ChunkType {
   return {
     type: 'step-finish',
     runId,
@@ -39,8 +39,9 @@ function createStepFinishChunk(runId: string): ChunkType {
         warnings: [],
         isContinued: false,
       },
-      metadata: {},
+      metadata: providerMetadata ? { providerMetadata } : {},
       messages: { nonUser: [], all: [] },
+      providerMetadata,
     },
   } as ChunkType;
 }
@@ -48,7 +49,7 @@ function createStepFinishChunk(runId: string): ChunkType {
 /**
  * Minimal finish chunk for the outer MastraModelOutput.
  */
-function createFinishChunk(runId: string): ChunkType {
+function createFinishChunk(runId: string, providerMetadata?: Record<string, unknown>): ChunkType {
   return {
     type: 'finish',
     runId,
@@ -65,6 +66,7 @@ function createFinishChunk(runId: string): ChunkType {
         isContinued: false,
       },
       metadata: {},
+      providerMetadata,
       messages: { nonUser: [], all: [] },
     },
   } as ChunkType;
@@ -221,6 +223,89 @@ describe('MastraModelOutput', () => {
 
       expect(result.traceId).toBe('mastra-trace-id');
       expect(result.spanId).toBe('mastra-agent-span-id');
+    });
+
+    it('should resolve top-level finish providerMetadata on the final output', async () => {
+      const runId = 'test-run';
+      const providerMetadata = {
+        anthropic: {
+          cacheReadInputTokens: 94,
+          cacheCreationInputTokens: 6,
+        },
+      };
+      const messageList = new MessageList({ threadId: 'test-thread' });
+
+      messageList.add(
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          content: { format: 2 as const, parts: [{ type: 'text' as const, text: 'hello' }] },
+          createdAt: new Date(),
+        },
+        'response',
+      );
+
+      const stream = createChunkStream([createStepFinishChunk(runId), createFinishChunk(runId, providerMetadata)]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: {
+          runId,
+        },
+      });
+
+      await output.consumeStream();
+
+      expect(await output.providerMetadata).toEqual(providerMetadata);
+    });
+
+    it('should propagate arbitrary finish providerMetadata to steps and onFinish', async () => {
+      const runId = 'test-run';
+      const providerMetadata = {
+        customProvider: {
+          route: 'priority',
+          finishMetrics: {
+            latencyMs: 42,
+            region: 'us-central1',
+          },
+        },
+      };
+      let onFinishPayload: any;
+      const messageList = new MessageList({ threadId: 'test-thread' });
+
+      messageList.add(
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          content: { format: 2 as const, parts: [{ type: 'text' as const, text: 'hello' }] },
+          createdAt: new Date(),
+        },
+        'response',
+      );
+
+      const stream = createChunkStream([createStepFinishChunk(runId), createFinishChunk(runId, providerMetadata)]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: {
+          runId,
+          onFinish: async payload => {
+            onFinishPayload = payload;
+          },
+        },
+      });
+
+      await output.consumeStream();
+
+      expect(await output.providerMetadata).toEqual(providerMetadata);
+      expect((await output.steps).at(-1)?.providerMetadata).toEqual(providerMetadata);
+      expect(onFinishPayload?.providerMetadata).toEqual(providerMetadata);
     });
   });
 });

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -654,7 +654,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                   // complicated to do this in this PR, it will require a much bigger change.
                   uiMessages: messageList.get.response.aiV5.ui() as LLMStepResult<OUTPUT>['response']['uiMessages'],
                 },
-                providerMetadata: providerMetadata,
+                providerMetadata: providerMetadata ?? chunk.payload.providerMetadata,
               };
 
               await options?.onStepFinish?.({
@@ -746,6 +746,10 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               if (chunk.payload.stepResult.reason) {
                 self.#finishReason = chunk.payload.stepResult.reason;
               }
+
+              // We can preserve finish metadata from whichever shape the upstream SDK emitted,
+              // but we cannot reconstruct providerMetadata if the provider omitted it entirely.
+              const finalProviderMetadata = chunk.payload.metadata?.providerMetadata ?? chunk.payload.providerMetadata;
 
               // Check if this is a tripwire case - set tripwire data
               // This can happen when max retries is exceeded or a processor triggers a tripwire
@@ -901,11 +905,21 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 self.#bufferedReasoning.length > 0
                   ? self.#bufferedReasoning.map(reasoningPart => reasoningPart.payload.text).join('')
                   : undefined;
+
+              const baseFinishStep = self.#bufferedSteps[self.#bufferedSteps.length - 1];
+              if (
+                baseFinishStep &&
+                baseFinishStep.providerMetadata === undefined &&
+                finalProviderMetadata !== undefined
+              ) {
+                baseFinishStep.providerMetadata = finalProviderMetadata;
+              }
+
               // Resolve all delayed promises with final values
               this.resolvePromises({
                 usage: self.#usageCount,
                 warnings: self.#warnings,
-                providerMetadata: chunk.payload.metadata?.providerMetadata,
+                providerMetadata: finalProviderMetadata,
                 response: { ...response, dbMessages: self.messageList.get.response.db() },
                 request: self.#request || {},
                 reasoningText,
@@ -921,12 +935,10 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 resumeSchema: undefined,
               });
 
-              const baseFinishStep = self.#bufferedSteps[self.#bufferedSteps.length - 1];
-
               if (baseFinishStep) {
                 const onFinishPayload: MastraOnFinishCallbackArgs<OUTPUT> = {
                   // StepResult properties from baseFinishStep
-                  providerMetadata: baseFinishStep.providerMetadata,
+                  providerMetadata: baseFinishStep.providerMetadata ?? finalProviderMetadata,
                   text: self.#bufferedText.join(''),
                   warnings: baseFinishStep.warnings ?? [],
                   finishReason: chunk.payload.stepResult.reason,

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -220,6 +220,7 @@ interface FinishPayload<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSc
     request?: LanguageModelRequestMetadata;
     [key: string]: unknown;
   };
+  providerMetadata?: ProviderMetadata;
   messages: {
     all: ModelMessage[];
     user: ModelMessage[];


### PR DESCRIPTION
## Description
In streaming mode, Anthropic places cache token counts (`cacheReadInputTokens`, 
`cacheCreationInputTokens`) at the top level of the finish chunk 
(`chunk.payload.providerMetadata`). We were only reading from 
`chunk.payload.metadata.providerMetadata`, so it was always `undefined` for Anthropic 
and cache metrics never reached Langfuse traces.

Fixed by falling back to the top-level field:
`chunk.payload.metadata?.providerMetadata ?? chunk.payload.providerMetadata`

## Related Issue
Fixes #13848

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Finish events now include an optional top-level providerMetadata field, exposing provider-specific details in final outputs and callbacks.

* **Bug Fixes**
  * Preserve provider metadata emitted during streamed finish events so it appears on final results, last steps, and in onFinish payloads.
  * Prevent double-counting of cached tokens in observability metrics for certain provider usage formats.

* **Tests**
  * Added/updated tests to validate providerMetadata propagation and corrected cache token handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->