### PR TITLE
fix(harness): use type 'image' and mimeType for image parts in convertToHarnessMessage

### DIFF
--- a/.changeset/tiny-poems-open.md
+++ b/.changeset/tiny-poems-open.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+fix(harness): use type 'image' and mimeType for image parts in convertToHarnessMessage to fix Gemini image recognition
+
+# Please enter your changeset message above this line.

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1529,9 +1529,9 @@ export class Harness<TState extends HarnessStateSchema = HarnessStateSchema> {
                 ? (part as { image?: string }).image!
                 : '';
           content.push({
-            type: 'file',
+            type: 'image',
             data: imgData,
-            mediaType:
+            mimeType:
               (part as { mimeType?: string }).mimeType ?? (part as { mediaType?: string }).mediaType ?? 'image/png',
           });
           break;

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -379,7 +379,7 @@ async function processOutputStream<OUTPUT = undefined>({
 
       case 'finish':
         runState.setState({
-          providerOptions: chunk.payload.metadata.providerMetadata,
+          providerOptions: chunk.payload.metadata?.providerMetadata ?? chunk.payload.providerMetadata,
           stepResult: {
             reason: chunk.payload.reason,
             logprobs: chunk.payload.logprobs,

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -220,6 +220,7 @@ interface FinishPayload<Tools extends ToolSet = ToolSet, OUTPUT extends OutputSc
     request?: LanguageModelRequestMetadata;
     [key: string]: unknown;
   };
+  providerMetadata?: ProviderMetadata;
   messages: {
     all: ModelMessage[];
     user: ModelMessage[];


### PR DESCRIPTION
## Description
In `convertToHarnessMessage()`, the `case 'image':` block was pushing a content part with `type: 'file'` and `mediaType` instead of `type: 'image'` and `mimeType`. Gemini (via the AI SDK Google provider) requires image content parts to have `type: 'image'` to recognize them — `type: 'file'` is silently ignored, causing Gemini to not see any images sent via `harness.sendMessage({ files })`.

**Change:**
```diff
- type: 'file',
- mediaType: ...
+ type: 'image',
+ mimeType: ...
```

## Related Issue
Fixes #13913

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR