### PR TITLE
feat(template): add Slack coding agent template

### DIFF
--- a/templates/template-slack-coding-agent/.dockerignore
+++ b/templates/template-slack-coding-agent/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.env
+*.test.ts
+__tests__
+pnpm-lock.yaml
+.git

--- a/templates/template-slack-coding-agent/.env.example
+++ b/templates/template-slack-coding-agent/.env.example
@@ -1,0 +1,18 @@
+# Slack App Credentials
+SLACK_BOT_TOKEN=xoxb-your-bot-token
+SLACK_SIGNING_SECRET=your-signing-secret
+
+# AI Model
+ANTHROPIC_API_KEY=sk-ant-your-api-key
+
+# E2B Cloud Sandbox
+E2B_API_KEY=e2b_your-api-key
+
+# GitHub (for git operations in sandbox)
+GITHUB_TOKEN=ghp_your-github-token
+GIT_USER_NAME=Your Name
+GIT_USER_EMAIL=you@example.com
+
+# Optional: Default repo to clone when a sandbox starts
+# DEFAULT_REPO_URL=https://github.com/your-org/your-repo.git
+# DEFAULT_REPO_BRANCH=main

--- a/templates/template-slack-coding-agent/.gitignore
+++ b/templates/template-slack-coding-agent/.gitignore
@@ -1,0 +1,8 @@
+output.txt
+node_modules
+dist
+.mastra
+.env.development
+.env
+*.db
+*.db-*

--- a/templates/template-slack-coding-agent/.railwayignore
+++ b/templates/template-slack-coding-agent/.railwayignore
@@ -1,0 +1,6 @@
+node_modules
+.mastra
+.env
+__tests__
+*.test.ts
+.git

--- a/templates/template-slack-coding-agent/Dockerfile
+++ b/templates/template-slack-coding-agent/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:22-slim
+
+# Install procps (provides ps, needed by tree-kill)
+RUN apt-get update && apt-get install -y --no-install-recommends procps && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy package files and install (need devDeps for tsx)
+COPY package.json ./
+RUN npm install
+
+# Copy source
+COPY tsconfig.json ./
+COPY src/ src/
+
+ENV NODE_ENV=production
+
+CMD ["npx", "tsx", "src/server.ts"]

--- a/templates/template-slack-coding-agent/README.md
+++ b/templates/template-slack-coding-agent/README.md
@@ -1,0 +1,135 @@
+# Slack Coding Agent Template
+
+A Mastra template for a Slack-based coding agent powered by the **MastraCode Harness** and **E2B cloud sandboxes**. Send messages in Slack and get a fully autonomous coding assistant that can read, write, and execute code in an isolated sandbox.
+
+## Features
+
+- **E2B Cloud Sandboxes** — Each Slack thread gets its own isolated cloud sandbox
+- **Template-based Repo Cloning** — Repos are baked into E2B templates for instant cold starts
+- **Real-time Streaming** — Tool usage and agent responses stream to Slack in real-time
+- **Git Operations** — Commit, push, create PRs directly from Slack
+- **Session Management** — Auto-pause, reconnect, and cleanup of idle sandboxes
+- **Thread-scoped Sessions** — Each Slack thread is an independent coding session
+
+## Setup
+
+### 1. Install dependencies
+
+```bash
+npm install
+# or
+pnpm install
+```
+
+### 2. Create a Slack App
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → **From Scratch**
+2. Under **OAuth & Permissions**, add these **Bot Token Scopes**:
+   - `app_mentions:read`
+   - `chat:write`
+   - `channels:history` (for reading messages in public channels)
+   - `groups:history` (for reading messages in private channels)
+   - `im:history` (for reading direct messages)
+3. **Install to Workspace** and copy the **Bot User OAuth Token** (`xoxb-...`)
+4. Under **Basic Information**, copy the **Signing Secret**
+5. Under **Event Subscriptions**:
+   - Enable Events
+   - Set the Request URL to: `https://your-server.com/api/slack/coding/events`
+   - Subscribe to bot events: `app_mention`, `message.im`
+
+### 3. Get API Keys
+
+- **Anthropic API Key**: [console.anthropic.com](https://console.anthropic.com)
+- **E2B API Key**: [e2b.dev](https://e2b.dev) (sign up for cloud sandboxes)
+- **GitHub Token**: [github.com/settings/tokens](https://github.com/settings/tokens) (needs `repo` scope for private repos)
+
+### 4. Configure environment
+
+```bash
+cp .env.example .env
+```
+
+Fill in all the values in `.env`.
+
+### 5. Start the server
+
+```bash
+npm run dev
+```
+
+## Usage
+
+### Basic Coding
+
+Mention the bot in a Slack channel or DM it:
+
+> @coding-agent Read the README.md and explain what this project does
+
+> @coding-agent Fix the TypeScript errors in src/utils.ts
+
+> @coding-agent Add a new API endpoint for user registration
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `clone <repo-url> [branch]` | Set up a sandbox with a specific repo |
+| `status` | Show current session status and tasks |
+| `summary` | Ask the agent to summarize work done |
+| `commit [message]` | Commit and push changes |
+| `pr [title]` | Create a pull request |
+| `destroy` | Tear down the sandbox |
+
+### Example Workflow
+
+```
+User: clone https://github.com/myorg/myapp.git main
+Bot:  🚀 Setting up sandbox with myorg/myapp...
+Bot:  ✅ Sandbox ready! Send me a coding task.
+
+User: Fix the failing tests in src/auth/
+Bot:  📂 Reading src/auth/...
+      🔍 Searching for test files...
+      ⚡ Running npm test...
+      🔧 Editing src/auth/middleware.ts...
+      ⚡ Running npm test...
+      ✅ All 12 tests passing. Fixed the JWT validation...
+
+User: commit fix auth middleware validation
+Bot:  ⚡ git add -A && git commit && git push
+      ✅ Committed and pushed: "fix: auth middleware validation"
+
+User: pr Fix auth middleware JWT validation
+Bot:  ⚡ gh pr create...
+      ✅ PR created: https://github.com/myorg/myapp/pull/42
+```
+
+## Architecture
+
+```
+Slack Event → Route Handler → Harness.sendMessage() → Agent in E2B Sandbox
+                                    ↓
+                              Harness Events → Slack Message Updates
+```
+
+- **One Harness per Slack thread** — each thread is an isolated coding session
+- **E2B sandbox per Harness** — isolated cloud environment with the repo pre-cloned
+- **Template caching** — E2B builds the template once, reuses it for subsequent sessions
+- **Auto-pause** — Sandboxes pause after 30 min idle, reconnect on next message
+- **Cleanup** — Sessions destroyed after 2 hours of inactivity
+
+## File Structure
+
+```
+src/mastra/
+├── index.ts                      # Mastra instance
+├── coding/
+│   ├── harness-factory.ts        # Harness creation & caching
+│   ├── workspace-config.ts       # E2B sandbox + template config
+│   ├── sandbox-manager.ts        # Lifecycle management
+│   └── system-prompt.ts          # Agent system prompt
+└── slack/
+    ├── routes.ts                 # Slack event handling + commands
+    ├── harness-streaming.ts      # Harness events → Slack updates
+    └── verify.ts                 # Slack request verification
+```

--- a/templates/template-slack-coding-agent/package.json
+++ b/templates/template-slack-coding-agent/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "template-slack-coding-agent",
+  "version": "1.0.0",
+  "description": "A Slack-based coding agent powered by MastraCode Harness and E2B cloud sandboxes",
+  "main": "index.js",
+  "scripts": {
+    "start": "tsx src/server.ts",
+    "dev": "tsx --watch src/server.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "Apache-2.0",
+  "type": "module",
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "dependencies": {
+    "@mastra/core": "latest",
+    "@mastra/deployer": "latest",
+    "@mastra/e2b": "latest",
+    "@slack/web-api": "^7.13.0",
+    "mastracode": "latest",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/templates/template-slack-coding-agent/railway.toml
+++ b/templates/template-slack-coding-agent/railway.toml
@@ -1,0 +1,8 @@
+[build]
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 60
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3

--- a/templates/template-slack-coding-agent/src/__tests__/integration.test.ts
+++ b/templates/template-slack-coding-agent/src/__tests__/integration.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Integration tests for the Slack Coding Agent.
+ *
+ * Level 1: Unit tests — verify Harness creation, event flow, streaming adapter
+ *          (no external services needed)
+ *
+ * Level 2: E2B integration — real sandbox with E2B API key
+ *          (skipped if E2B_API_KEY is not set)
+ *
+ * Run with: npx vitest run src/__tests__/integration.test.ts
+ */
+
+import { Agent } from '@mastra/core/agent';
+import { Harness } from '@mastra/core/harness';
+import type { HarnessEvent, HarnessEventListener, HarnessMode } from '@mastra/core/harness';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createTestAgent() {
+  return new Agent({
+    name: 'test-coding-agent',
+    instructions: 'You are a test coding agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+}
+
+function createTestHarness(overrides?: Partial<Parameters<typeof Harness>[0]>) {
+  const agent = createTestAgent();
+  const modes: HarnessMode[] = [
+    { id: 'build', name: 'Build', default: true, agent },
+  ];
+  return new Harness({
+    id: 'test-slack-coding',
+    modes,
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Level 1: Unit Tests (no external services)
+// ---------------------------------------------------------------------------
+
+describe('Harness creation', () => {
+  it('creates a Harness with minimal config', () => {
+    const harness = createTestHarness();
+    expect(harness).toBeDefined();
+    expect(harness.id).toBe('test-slack-coding');
+  });
+
+  it('starts with isRunning = false', () => {
+    const harness = createTestHarness();
+    const ds = harness.getDisplayState();
+    expect(ds.isRunning).toBe(false);
+  });
+
+  it('can init without storage or workspace', async () => {
+    const harness = createTestHarness();
+    await harness.init();
+    // Should not throw
+  });
+});
+
+describe('Harness event subscription', () => {
+  it('receives events via subscribe', () => {
+    const harness = createTestHarness();
+    const events: HarnessEvent[] = [];
+    const listener: HarnessEventListener = (event) => {
+      events.push(event);
+    };
+    harness.subscribe(listener);
+
+    // Emit an event via the private emit method
+    (harness as any).emit({ type: 'agent_start' });
+
+    // Should receive agent_start + display_state_changed
+    expect(events.length).toBe(2);
+    expect(events[0]!.type).toBe('agent_start');
+    expect(events[1]!.type).toBe('display_state_changed');
+  });
+
+  it('updates display state on agent_start', () => {
+    const harness = createTestHarness();
+    harness.subscribe(() => {}); // activate listener
+
+    (harness as any).emit({ type: 'agent_start' });
+
+    const ds = harness.getDisplayState();
+    expect(ds.isRunning).toBe(true);
+  });
+
+  it('resets isRunning on agent_end', () => {
+    const harness = createTestHarness();
+    harness.subscribe(() => {});
+
+    (harness as any).emit({ type: 'agent_start' });
+    expect(harness.getDisplayState().isRunning).toBe(true);
+
+    (harness as any).emit({ type: 'agent_end', reason: 'complete' });
+    expect(harness.getDisplayState().isRunning).toBe(false);
+  });
+
+  it('tracks tool activity through events', () => {
+    const harness = createTestHarness();
+    const events: HarnessEvent[] = [];
+    harness.subscribe((e) => events.push(e));
+
+    (harness as any).emit({
+      type: 'tool_start',
+      toolCallId: 'tc1',
+      toolName: 'execute_command',
+      args: { command: 'echo hello' },
+    });
+
+    const toolEvents = events.filter((e) => e.type === 'tool_start');
+    expect(toolEvents.length).toBe(1);
+    expect((toolEvents[0] as any).toolName).toBe('execute_command');
+  });
+
+  it('tracks task updates', () => {
+    const harness = createTestHarness();
+    const events: HarnessEvent[] = [];
+    harness.subscribe((e) => events.push(e));
+
+    (harness as any).emit({
+      type: 'task_updated',
+      tasks: [
+        { content: 'Fix bug', status: 'in_progress', activeForm: 'Fixing bug' },
+        { content: 'Write tests', status: 'pending', activeForm: 'Writing tests' },
+      ],
+    });
+
+    const taskEvents = events.filter((e) => e.type === 'task_updated');
+    expect(taskEvents.length).toBe(1);
+    expect((taskEvents[0] as any).tasks).toHaveLength(2);
+  });
+});
+
+describe('Streaming adapter event mapping', () => {
+  // Import the streaming module dynamically so we can test its helpers
+  // For now, test the event patterns that the adapter handles
+
+  it('handles message_update with text content', () => {
+    const harness = createTestHarness();
+    const events: HarnessEvent[] = [];
+    harness.subscribe((e) => events.push(e));
+
+    (harness as any).emit({
+      type: 'message_update',
+      message: {
+        id: 'msg1',
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Hello from the agent' },
+        ],
+        createdAt: new Date(),
+      },
+    });
+
+    const msgEvents = events.filter((e) => e.type === 'message_update');
+    expect(msgEvents.length).toBe(1);
+    const msg = (msgEvents[0] as any).message;
+    const textParts = msg.content
+      .filter((c: any) => c.type === 'text')
+      .map((c: any) => c.text);
+    expect(textParts.join('')).toBe('Hello from the agent');
+  });
+
+  it('handles error events', () => {
+    const harness = createTestHarness();
+    const events: HarnessEvent[] = [];
+    harness.subscribe((e) => events.push(e));
+
+    const error = new Error('Something went wrong');
+    (harness as any).emit({ type: 'error', error });
+
+    const errorEvents = events.filter((e) => e.type === 'error');
+    expect(errorEvents.length).toBe(1);
+    expect((errorEvents[0] as any).error.message).toBe('Something went wrong');
+  });
+
+  it('handles subagent lifecycle events', () => {
+    const harness = createTestHarness();
+    const events: HarnessEvent[] = [];
+    harness.subscribe((e) => events.push(e));
+
+    (harness as any).emit({
+      type: 'subagent_start',
+      toolCallId: 'tc1',
+      agentType: 'explore',
+      task: 'Find all usages of X',
+      modelId: 'anthropic/claude-sonnet-4-20250514',
+    });
+
+    (harness as any).emit({
+      type: 'subagent_end',
+      toolCallId: 'tc1',
+      agentType: 'explore',
+      result: 'Found 3 usages',
+      isError: false,
+      durationMs: 5000,
+    });
+
+    const startEvents = events.filter((e) => e.type === 'subagent_start');
+    const endEvents = events.filter((e) => e.type === 'subagent_end');
+    expect(startEvents.length).toBe(1);
+    expect(endEvents.length).toBe(1);
+    expect((endEvents[0] as any).durationMs).toBe(5000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Level 2: E2B Integration Tests (requires E2B_API_KEY)
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!process.env.E2B_API_KEY)('E2B Sandbox Integration', () => {
+  // Dynamic imports since @mastra/e2b may not be installed in all environments
+  let E2BSandbox: any;
+  let Workspace: any;
+
+  beforeEach(async () => {
+    const e2bModule = await import('@mastra/e2b');
+    E2BSandbox = e2bModule.E2BSandbox;
+    const wsModule = await import('@mastra/core/workspace');
+    Workspace = wsModule.Workspace;
+  });
+
+  it('creates and starts an E2B sandbox', async () => {
+    const sandbox = new E2BSandbox({
+      id: `test-slack-${Date.now()}`,
+      timeout: 60_000,
+    });
+
+    try {
+      await sandbox._start();
+      const result = await sandbox.executeCommand('echo', ['Hello from E2B']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('Hello from E2B');
+    } finally {
+      await sandbox._destroy().catch(() => {});
+    }
+  }, 120_000);
+
+  it('creates a sandbox with git installed via template', async () => {
+    const sandbox = new E2BSandbox({
+      id: `test-git-${Date.now()}`,
+      template: (base: any) => base.aptInstall(['git']),
+      timeout: 60_000,
+    });
+
+    try {
+      await sandbox._start();
+      const result = await sandbox.executeCommand('git', ['--version']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('git version');
+    } finally {
+      await sandbox._destroy().catch(() => {});
+    }
+  }, 180_000);
+
+  it('creates a Workspace wrapping an E2B sandbox', async () => {
+    const sandbox = new E2BSandbox({
+      id: `test-ws-${Date.now()}`,
+      timeout: 60_000,
+    });
+
+    const workspace = new Workspace({ sandbox });
+
+    try {
+      await workspace.init();
+      // Workspace should have a running sandbox
+      expect(sandbox.status).toBe('running');
+    } finally {
+      await sandbox._destroy().catch(() => {});
+    }
+  }, 120_000);
+
+  it('creates a Harness with E2B workspace and initializes it', async () => {
+    const sandbox = new E2BSandbox({
+      id: `test-harness-${Date.now()}`,
+      timeout: 60_000,
+    });
+
+    const workspace = new Workspace({ sandbox });
+    const harness = createTestHarness({ workspace });
+
+    const events: HarnessEvent[] = [];
+    harness.subscribe((e) => events.push(e));
+
+    try {
+      await harness.init();
+
+      // Should have received workspace events
+      const wsEvents = events.filter(
+        (e) => e.type === 'workspace_status_changed' || e.type === 'workspace_ready',
+      );
+      expect(wsEvents.length).toBeGreaterThan(0);
+    } finally {
+      await sandbox._destroy().catch(() => {});
+    }
+  }, 120_000);
+});

--- a/templates/template-slack-coding-agent/src/__tests__/mastracode-e2e.test.ts
+++ b/templates/template-slack-coding-agent/src/__tests__/mastracode-e2e.test.ts
@@ -1,0 +1,291 @@
+/**
+ * End-to-end test: Agent + E2B sandbox exploring the real Mastra repo.
+ *
+ * Requires: ANTHROPIC_API_KEY and E2B_API_KEY environment variables.
+ *
+ * Run with:
+ *   E2B_API_KEY=... npx vitest run src/__tests__/mastracode-e2e.test.ts
+ */
+
+import { anthropic } from '@ai-sdk/anthropic';
+import { Agent } from '@mastra/core/agent';
+import { Harness } from '@mastra/core/harness';
+import type { HarnessEvent, HarnessMode } from '@mastra/core/harness';
+import { Workspace } from '@mastra/core/workspace';
+import { E2BSandbox } from '@mastra/e2b';
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+const stateSchema = z.object({
+  yolo: z.boolean().default(true),
+});
+
+const hasKeys = process.env.ANTHROPIC_API_KEY && process.env.E2B_API_KEY;
+
+describe.skipIf(!hasKeys)('MastraCode E2E', () => {
+  // =========================================================================
+  // Test 1: Sanity check — raw sandbox works
+  // =========================================================================
+  it('raw sandbox: echo command works after healthcheck', async () => {
+    console.log('\n--- raw sandbox test ---');
+    const sandbox = new E2BSandbox({
+      id: `raw-${Date.now()}`,
+      timeout: 120_000,
+    });
+    try {
+      await sandbox._start();
+      console.log(`sandbox status: ${sandbox.status}`);
+
+      // Poll until echo works
+      for (let i = 0; i < 15; i++) {
+        try {
+          const r = await sandbox.executeCommand('echo ok');
+          if (r?.exitCode === 0) {
+            console.log(`echo ok after ${i + 1} attempts`);
+            break;
+          }
+        } catch (e: any) {
+          console.log(`attempt ${i + 1} failed: ${e.message?.slice(0, 80)}`);
+        }
+        await new Promise(r => setTimeout(r, 2000));
+      }
+
+      const result = await sandbox.executeCommand('echo hello');
+      console.log(`result: exitCode=${result.exitCode} stdout="${result.stdout.trim()}"`);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('hello');
+    } finally {
+      await sandbox._destroy().catch(() => {});
+    }
+  }, 120_000);
+
+  // =========================================================================
+  // Test 2: Harness + E2B + Agent — minimal
+  // =========================================================================
+  it('harness + agent: simple echo via execute_command', async () => {
+    console.log('\n--- harness + agent test ---');
+    const t0 = Date.now();
+    const elapsed = () => `${((Date.now() - t0) / 1000).toFixed(1)}s`;
+
+    // 1. Sandbox — bare, no repo
+    const sandbox = new E2BSandbox({
+      id: `harness-${Date.now()}`,
+      timeout: 120_000,
+    });
+    const workspace = new Workspace({ sandbox });
+
+    // 2. Agent — minimal instructions
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: `You have one tool: execute_command. Use it to run shell commands.
+When asked a question, use execute_command to answer it. Be concise (1-2 sentences).`,
+      model: anthropic('claude-sonnet-4-20250514'),
+    });
+
+    // 3. Harness
+    const modes: HarnessMode[] = [
+      { id: 'build', name: 'Build', default: true, agent },
+    ];
+    const harness = new Harness({ id: 'e2e-test', modes, workspace, stateSchema, initialState: { yolo: true } });
+
+    // 4. Event logging
+    const events: HarnessEvent[] = [];
+    let fullText = '';
+    harness.subscribe((event: HarnessEvent) => {
+      events.push(event);
+      switch (event.type) {
+        case 'agent_start':
+          console.log(`[${elapsed()}] agent_start`);
+          break;
+        case 'agent_end':
+          console.log(`[${elapsed()}] agent_end (${event.reason})`);
+          break;
+        case 'tool_start':
+          console.log(`[${elapsed()}] tool_start: ${event.toolName}(${JSON.stringify(event.args).slice(0, 100)})`);
+          break;
+        case 'tool_end':
+          console.log(`[${elapsed()}] tool_end: ${event.toolCallId} ${event.isError ? 'ERROR' : 'ok'}`);
+          break;
+        case 'error':
+          console.log(`[${elapsed()}] ERROR: ${event.error?.message || event.error}`);
+          break;
+        case 'message_update': {
+          const textParts = event.message.content
+            .filter((c: any) => c.type === 'text')
+            .map((c: any) => c.text);
+          fullText = textParts.join('');
+          break;
+        }
+        case 'workspace_status_changed':
+          console.log(`[${elapsed()}] workspace: ${event.status}`);
+          break;
+        case 'workspace_ready':
+          console.log(`[${elapsed()}] workspace_ready`);
+          break;
+      }
+    });
+
+    try {
+      // 5. Init — starts sandbox
+      console.log(`[${elapsed()}] Initializing harness...`);
+      await harness.init();
+      console.log(`[${elapsed()}] Harness initialized`);
+
+      // 6. Wait for sandbox to be healthy
+      console.log(`[${elapsed()}] Waiting for sandbox healthcheck...`);
+      for (let i = 0; i < 15; i++) {
+        try {
+          const r = await sandbox.executeCommand('echo ready');
+          if (r?.exitCode === 0) {
+            console.log(`[${elapsed()}] Sandbox healthy after ${i + 1} attempts`);
+            break;
+          }
+        } catch {
+          console.log(`[${elapsed()}] Healthcheck attempt ${i + 1} failed`);
+        }
+        await new Promise(r => setTimeout(r, 2000));
+      }
+
+      // 7. Send a simple message
+      console.log(`[${elapsed()}] Sending message...`);
+      await harness.sendMessage({
+        content: 'What Linux distro is this? Run: cat /etc/os-release | head -5',
+      });
+      console.log(`[${elapsed()}] Agent finished`);
+
+      // 8. Results
+      console.log('\n--- AGENT RESPONSE ---');
+      console.log(fullText);
+      console.log('--- END ---\n');
+
+      expect(fullText.length).toBeGreaterThan(10);
+      expect(events.some(e => e.type === 'agent_start')).toBe(true);
+      expect(events.some(e => e.type === 'agent_end')).toBe(true);
+    } finally {
+      console.log(`[${elapsed()}] Cleaning up...`);
+      await sandbox._destroy().catch(() => {});
+      console.log(`[${elapsed()}] Done`);
+    }
+  }, 300_000);
+
+  // =========================================================================
+  // Test 3: Full test — clone repo + explore
+  // =========================================================================
+  it('harness + agent: clone mastra repo and explore', async () => {
+    console.log('\n--- full clone test ---');
+    const t0 = Date.now();
+    const elapsed = () => `${((Date.now() - t0) / 1000).toFixed(1)}s`;
+
+    const sandbox = new E2BSandbox({
+      id: `e2e-full-${Date.now()}`,
+      template: base =>
+        base
+          .aptInstall(['git'])
+          .gitClone('https://github.com/mastra-ai/mastra.git', '/home/user/mastra', {
+            branch: 'main',
+            depth: 1,
+          })
+          .setWorkdir('/home/user/mastra'),
+      timeout: 600_000,
+    });
+    const workspace = new Workspace({ sandbox });
+
+    const agent = new Agent({
+      id: 'explore-agent',
+      name: 'explore-agent',
+      instructions: `You are a code explorer inside an E2B cloud sandbox.
+The Mastra repository is cloned at /home/user/mastra.
+
+You have one tool: execute_command. Use it to run shell commands like:
+- ls /home/user/mastra
+- head -80 /home/user/mastra/README.md
+- cat /home/user/mastra/package.json
+
+Be concise — answer in 3-5 sentences max. Do NOT install anything or run builds.`,
+      model: anthropic('claude-sonnet-4-20250514'),
+    });
+
+    const modes: HarnessMode[] = [
+      { id: 'explore', name: 'Explore', default: true, agent },
+    ];
+    const harness = new Harness({ id: 'e2e-explore', modes, workspace, stateSchema, initialState: { yolo: true } });
+
+    const events: HarnessEvent[] = [];
+    let fullText = '';
+    harness.subscribe((event: HarnessEvent) => {
+      events.push(event);
+      switch (event.type) {
+        case 'agent_start':
+          console.log(`[${elapsed()}] agent_start`);
+          break;
+        case 'agent_end':
+          console.log(`[${elapsed()}] agent_end (${event.reason})`);
+          break;
+        case 'tool_start':
+          console.log(`[${elapsed()}] tool_start: ${event.toolName}(${JSON.stringify(event.args).slice(0, 100)})`);
+          break;
+        case 'tool_end':
+          console.log(`[${elapsed()}] tool_end: ${event.toolCallId} ${event.isError ? 'ERROR' : 'ok'}`);
+          break;
+        case 'error':
+          console.log(`[${elapsed()}] ERROR: ${event.error?.message || event.error}`);
+          break;
+        case 'message_update': {
+          const textParts = event.message.content
+            .filter((c: any) => c.type === 'text')
+            .map((c: any) => c.text);
+          fullText = textParts.join('');
+          break;
+        }
+      }
+    });
+
+    try {
+      console.log(`[${elapsed()}] Initializing harness (template build + sandbox start)...`);
+      await harness.init();
+      console.log(`[${elapsed()}] Harness initialized`);
+
+      // Wait for healthcheck
+      console.log(`[${elapsed()}] Waiting for sandbox healthcheck...`);
+      for (let i = 0; i < 30; i++) {
+        try {
+          const r = await sandbox.executeCommand('echo ready');
+          if (r?.exitCode === 0) {
+            console.log(`[${elapsed()}] Sandbox healthy`);
+            break;
+          }
+        } catch {
+          if (i % 5 === 0) console.log(`[${elapsed()}] Still waiting... (attempt ${i + 1})`);
+        }
+        await new Promise(r => setTimeout(r, 2000));
+      }
+
+      // Verify repo is actually there
+      const lsResult = await sandbox.executeCommand('ls /home/user/mastra/package.json');
+      console.log(`[${elapsed()}] Repo check: ${lsResult.stdout.trim()}`);
+
+      console.log(`[${elapsed()}] Sending message to agent...`);
+      await harness.sendMessage({
+        content:
+          'Quickly explore this codebase. Run: ls /home/user/mastra, then head -80 /home/user/mastra/README.md, then cat /home/user/mastra/package.json. Tell me what Mastra is in 3-5 sentences.',
+      });
+      console.log(`[${elapsed()}] Agent finished`);
+
+      console.log('\n========================================');
+      console.log('AGENT RESPONSE:');
+      console.log('========================================');
+      console.log(fullText);
+      console.log('========================================\n');
+
+      expect(fullText.length).toBeGreaterThan(50);
+      expect(fullText.toLowerCase()).toContain('mastra');
+      expect(events.some(e => e.type === 'agent_start')).toBe(true);
+      expect(events.some(e => e.type === 'agent_end')).toBe(true);
+    } finally {
+      console.log(`[${elapsed()}] Cleaning up...`);
+      await sandbox._destroy().catch(() => {});
+      console.log(`[${elapsed()}] Done`);
+    }
+  }, 600_000);
+});

--- a/templates/template-slack-coding-agent/src/__tests__/slack-e2e.test.ts
+++ b/templates/template-slack-coding-agent/src/__tests__/slack-e2e.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Simulated Slack E2E test using createMastraCode
+ *
+ * Tests the full pipeline: Slack webhook → Harness (MastraCode) → E2B sandbox → Slack API
+ *
+ * - Real: Anthropic API, E2B sandbox, MastraCode agent + tools
+ * - Mocked: Slack WebClient (captures all API calls)
+ * - Skipped if ANTHROPIC_API_KEY or E2B_API_KEY is not set
+ */
+import crypto from 'node:crypto';
+import { Workspace } from '@mastra/core/workspace';
+import { E2BSandbox } from '@mastra/e2b';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+
+import { createMastraCode } from 'mastracode';
+import { streamHarnessToSlack } from '../mastra/slack/harness-streaming.js';
+import { verifySlackRequest } from '../mastra/slack/verify.js';
+
+const hasKeys = !!(process.env.ANTHROPIC_API_KEY && process.env.E2B_API_KEY);
+
+// ---------------------------------------------------------------------------
+// Mock Slack WebClient
+// ---------------------------------------------------------------------------
+
+interface SlackCall {
+  method: 'postMessage' | 'update';
+  args: Record<string, unknown>;
+  ts: number;
+}
+
+function createMockSlackClient() {
+  const calls: SlackCall[] = [];
+  let messageCounter = 0;
+
+  const postMessage = vi.fn().mockImplementation(async (args: Record<string, unknown>) => {
+    const ts = `${Date.now()}.${++messageCounter}`;
+    calls.push({ method: 'postMessage', args, ts: Date.now() });
+    return { ok: true, ts, channel: args.channel };
+  });
+
+  const update = vi.fn().mockImplementation(async (args: Record<string, unknown>) => {
+    calls.push({ method: 'update', args, ts: Date.now() });
+    return { ok: true, ts: args.ts, channel: args.channel };
+  });
+
+  const client = {
+    chat: { postMessage, update },
+  } as any;
+
+  return { client, calls, postMessage, update };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function computeSlackSignature(signingSecret: string, timestamp: string, body: string): string {
+  const sigBaseString = `v0:${timestamp}:${body}`;
+  const hmac = crypto.createHmac('sha256', signingSecret).update(sigBaseString).digest('hex');
+  return `v0=${hmac}`;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!hasKeys)('Slack E2E (simulated) — createMastraCode', () => {
+  let sandbox: E2BSandbox;
+  let harness: any;
+
+  beforeAll(async () => {
+    const t0 = Date.now();
+    const elapsed = () => `${((Date.now() - t0) / 1000).toFixed(1)}s`;
+
+    // Create a bare E2B sandbox
+    console.log(`[${elapsed()}] Creating E2B sandbox...`);
+    sandbox = new E2BSandbox({
+      id: `slack-e2e-${Date.now()}`,
+      timeout: 300_000,
+    });
+
+    const workspace = new Workspace({ sandbox });
+
+    // Create MastraCode with E2B workspace override
+    console.log(`[${elapsed()}] Creating MastraCode instance...`);
+    const result = await createMastraCode({
+      workspace,
+      disableMcp: true,
+      disableHooks: true,
+      initialState: {
+        projectPath: '/home/user',
+      },
+    });
+    harness = result.harness;
+
+    // Initialize harness (starts the sandbox)
+    console.log(`[${elapsed()}] Initializing harness...`);
+    await harness.init();
+
+    // Wait for sandbox healthcheck
+    console.log(`[${elapsed()}] Waiting for sandbox healthcheck...`);
+    for (let i = 0; i < 30; i++) {
+      try {
+        const r = await sandbox.executeCommand!('echo ready');
+        if (r?.exitCode === 0) {
+          console.log(`[${elapsed()}] Sandbox healthy`);
+          break;
+        }
+      } catch {
+        // retry
+      }
+      await new Promise(r => setTimeout(r, 2000));
+    }
+
+    console.log(`[${elapsed()}] Setup complete`);
+  }, 120_000);
+
+  afterAll(async () => {
+    await sandbox._destroy().catch(() => {});
+  }, 30_000);
+
+  // =========================================================================
+  // Test 1: Slack signature verification
+  // =========================================================================
+  it('verifies Slack request signatures', () => {
+    const signingSecret = 'test-secret-123';
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const body = '{"type":"event_callback","event":{"type":"app_mention"}}';
+
+    const signature = computeSlackSignature(signingSecret, timestamp, body);
+
+    expect(verifySlackRequest(signingSecret, signature, timestamp, body)).toBe(true);
+    expect(verifySlackRequest(signingSecret, 'v0=invalid', timestamp, body)).toBe(false);
+
+    const oldTimestamp = String(Math.floor(Date.now() / 1000) - 600);
+    const oldSig = computeSlackSignature(signingSecret, oldTimestamp, body);
+    expect(verifySlackRequest(signingSecret, oldSig, oldTimestamp, body)).toBe(false);
+  });
+
+  // =========================================================================
+  // Test 2: Full pipeline — MastraCode agent explores E2B sandbox
+  // =========================================================================
+  it('streams MastraCode agent responses to Slack via Harness events', async () => {
+    const t0 = Date.now();
+    const elapsed = () => `${((Date.now() - t0) / 1000).toFixed(1)}s`;
+
+    const { client, calls, postMessage, update } = createMockSlackClient();
+
+    console.log(`[${elapsed()}] Starting streamHarnessToSlack...`);
+
+    const streamPromise = streamHarnessToSlack({
+      slackClient: client,
+      channel: 'C_TEST_CHANNEL',
+      threadTs: '1234567890.000001',
+      harness,
+    });
+
+    console.log(`[${elapsed()}] Sending message to agent...`);
+
+    // Subscribe to events for progress logging
+    harness.subscribe(event => {
+      if (event.type === 'tool_start') {
+        const args = JSON.stringify(event.args).slice(0, 100);
+        console.log(`[${elapsed()}] tool_start: ${event.toolName}(${args})`);
+      } else if (event.type === 'tool_end') {
+        console.log(`[${elapsed()}] tool_end: ${event.toolCallId}`);
+      } else if (event.type === 'agent_end') {
+        console.log(`[${elapsed()}] agent_end`);
+      }
+    });
+
+    await harness.sendMessage({
+      content: 'Run: echo "Hello from MastraCode E2E" — then tell me what you see.',
+    });
+
+    console.log(`[${elapsed()}] Waiting for stream to finish...`);
+    await streamPromise;
+    console.log(`[${elapsed()}] Stream complete`);
+
+    // --- Assertions ---
+
+    // 1. Initial "thinking" message was posted
+    const thinkingCall = calls.find(
+      c => c.method === 'postMessage' && String(c.args.text).includes('Thinking'),
+    );
+    expect(thinkingCall).toBeDefined();
+    console.log(`  ✓ Initial "Thinking..." message posted`);
+
+    // 2. Progress updates
+    const updateCalls = calls.filter(c => c.method === 'update');
+    expect(updateCalls.length).toBeGreaterThan(0);
+    console.log(`  ✓ ${updateCalls.length} progress update(s)`);
+
+    // 3. Final response posted
+    const responseCalls = calls.filter(
+      c =>
+        c.method === 'postMessage' &&
+        !String(c.args.text).includes('Thinking') &&
+        String(c.args.text).length > 10,
+    );
+    expect(responseCalls.length).toBeGreaterThanOrEqual(1);
+    const responseText = String(responseCalls[0]?.args.text || '');
+    console.log(`  ✓ Final response posted (${responseText.length} chars)`);
+    console.log(`  Response preview: ${responseText.slice(0, 200)}...`);
+
+    // 4. Status updated to "Done"
+    const doneUpdate = calls.find(
+      c => c.method === 'update' && String(c.args.text).includes('Done'),
+    );
+    expect(doneUpdate).toBeDefined();
+    console.log(`  ✓ Status updated to "Done"`);
+
+    // 5. Response references the echo output
+    expect(responseText.toLowerCase()).toMatch(/hello|mastracode|e2e/i);
+    console.log(`  ✓ Response content references echo output`);
+
+    // 6. All Slack calls targeted the right channel
+    for (const call of calls.filter(c => c.method === 'postMessage')) {
+      expect(call.args.channel).toBe('C_TEST_CHANNEL');
+    }
+    console.log(`  ✓ All messages sent to correct channel`);
+
+    console.log(`\n  Total Slack API calls: ${calls.length}`);
+    console.log(`    postMessage: ${postMessage.mock.calls.length}`);
+    console.log(`    update: ${update.mock.calls.length}`);
+  }, 120_000);
+
+  // =========================================================================
+  // Test 3: Multi-turn conversation
+  // =========================================================================
+  it('handles sequential messages reusing the same Harness', async () => {
+    const { client, calls } = createMockSlackClient();
+
+    // First message
+    const stream1 = streamHarnessToSlack({
+      slackClient: client,
+      channel: 'C_REUSE_TEST',
+      threadTs: '9999.000001',
+      harness,
+    });
+    await harness.sendMessage({ content: 'What is 2 + 2? Just say the number.' });
+    await stream1;
+
+    const firstCalls = calls.length;
+    console.log(`  First message: ${firstCalls} Slack API calls`);
+
+    // Second message
+    const stream2 = streamHarnessToSlack({
+      slackClient: client,
+      channel: 'C_REUSE_TEST',
+      threadTs: '9999.000001',
+      harness,
+    });
+    await harness.sendMessage({ content: 'Now multiply that result by 10. Just say the number.' });
+    await stream2;
+
+    const secondCalls = calls.length - firstCalls;
+    console.log(`  Second message: ${secondCalls} Slack API calls`);
+
+    // Both rounds should have produced responses
+    const responseMsgs = calls.filter(
+      c =>
+        c.method === 'postMessage' &&
+        !String(c.args.text).includes('Thinking') &&
+        String(c.args.text).length > 1,
+    );
+    expect(responseMsgs.length).toBeGreaterThanOrEqual(2);
+
+    for (const msg of responseMsgs) {
+      console.log(`  Response: ${String(msg.args.text).slice(0, 100)}`);
+    }
+  }, 120_000);
+});

--- a/templates/template-slack-coding-agent/src/mastra/coding/e2b-filesystem.ts
+++ b/templates/template-slack-coding-agent/src/mastra/coding/e2b-filesystem.ts
@@ -1,0 +1,138 @@
+/**
+ * E2BFilesystem — MastraFilesystem backed by E2B sandbox file operations.
+ *
+ * Uses sandbox.e2b.files (the raw E2B SDK) for all file I/O, giving the agent
+ * proper read_file / write_file / list_files / grep tools via the workspace.
+ */
+
+import { MastraFilesystem } from '@mastra/core/workspace';
+import type {
+  FileContent,
+  FileStat,
+  FileEntry,
+  ReadOptions,
+  WriteOptions,
+  ListOptions,
+  RemoveOptions,
+  CopyOptions,
+} from '@mastra/core/workspace';
+import type { ProviderStatus } from '@mastra/core/workspace';
+import type { E2BSandbox } from '@mastra/e2b';
+
+export class E2BFilesystem extends MastraFilesystem {
+  readonly id: string;
+  readonly name = 'E2BFilesystem';
+  readonly provider = 'e2b';
+  status: ProviderStatus = 'pending';
+
+  private readonly sandbox: E2BSandbox;
+
+  constructor(sandbox: E2BSandbox) {
+    super({ name: 'E2BFilesystem' });
+    this.id = `e2b-fs-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    this.sandbox = sandbox;
+  }
+
+  private get files() {
+    return this.sandbox.e2b.files;
+  }
+
+  // Lifecycle
+  async init(): Promise<void> {
+    // The E2B sandbox handles its own lifecycle — nothing extra needed here.
+  }
+
+  async destroy(): Promise<void> {
+    // Sandbox cleanup is handled by E2BSandbox.stop()
+  }
+
+  // File Operations
+
+  async readFile(path: string, options?: ReadOptions): Promise<string | Buffer> {
+    await this.ensureReady();
+    if (options?.encoding) {
+      return await this.files.read(path, { format: 'text' });
+    }
+    const bytes = await this.files.read(path, { format: 'bytes' });
+    return Buffer.from(bytes);
+  }
+
+  async writeFile(path: string, content: FileContent, _options?: WriteOptions): Promise<void> {
+    await this.ensureReady();
+    const data = typeof content === 'string' ? content : Buffer.from(content).toString();
+    await this.files.write(path, data);
+  }
+
+  async appendFile(path: string, content: FileContent): Promise<void> {
+    await this.ensureReady();
+    // E2B doesn't have native append — read + write
+    let existing = '';
+    try {
+      existing = await this.files.read(path, { format: 'text' });
+    } catch {
+      // File doesn't exist yet — that's fine
+    }
+    const appendData = typeof content === 'string' ? content : Buffer.from(content).toString();
+    await this.files.write(path, existing + appendData);
+  }
+
+  async deleteFile(path: string, _options?: RemoveOptions): Promise<void> {
+    await this.ensureReady();
+    await this.files.remove(path);
+  }
+
+  async copyFile(src: string, dest: string, _options?: CopyOptions): Promise<void> {
+    await this.ensureReady();
+    const content = await this.files.read(src, { format: 'bytes' });
+    await this.files.write(dest, content);
+  }
+
+  async moveFile(src: string, dest: string, _options?: CopyOptions): Promise<void> {
+    await this.ensureReady();
+    await this.files.rename(src, dest);
+  }
+
+  // Directory Operations
+
+  async mkdir(path: string, _options?: { recursive?: boolean }): Promise<void> {
+    await this.ensureReady();
+    await this.files.makeDir(path);
+  }
+
+  async rmdir(path: string, _options?: RemoveOptions): Promise<void> {
+    await this.ensureReady();
+    await this.files.remove(path);
+  }
+
+  async readdir(path: string, _options?: ListOptions): Promise<FileEntry[]> {
+    await this.ensureReady();
+    const entries = await this.files.list(path);
+    return entries.map(e => ({
+      name: e.name,
+      type: e.type === 'dir' ? 'directory' as const : 'file' as const,
+      size: e.size,
+      isSymlink: !!e.symlinkTarget,
+      symlinkTarget: e.symlinkTarget,
+    }));
+  }
+
+  // Path Operations
+
+  async exists(path: string): Promise<boolean> {
+    await this.ensureReady();
+    return await this.files.exists(path);
+  }
+
+  async stat(path: string): Promise<FileStat> {
+    await this.ensureReady();
+    const info = await this.files.getInfo(path);
+    return {
+      name: info.name,
+      path: info.path,
+      type: info.type === 'dir' ? 'directory' : 'file',
+      size: info.size,
+      createdAt: info.modifiedTime ?? new Date(),
+      modifiedAt: info.modifiedTime ?? new Date(),
+    };
+  }
+}

--- a/templates/template-slack-coding-agent/src/mastra/coding/harness-factory.ts
+++ b/templates/template-slack-coding-agent/src/mastra/coding/harness-factory.ts
@@ -1,0 +1,195 @@
+/**
+ * Harness factory — creates MastraCode instances backed by E2B sandboxes.
+ * Each Slack thread gets its own Harness + sandbox session.
+ */
+import type { HarnessEventListener } from '@mastra/core/harness';
+
+import { createMastraCode } from 'mastracode';
+import { createCodingSandbox, createBareSandbox, createCodingWorkspace } from './workspace-config.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CodingSessionConfig {
+  repoUrl?: string;
+  branch?: string;
+  githubToken: string;
+  gitUserName: string;
+  gitUserEmail: string;
+}
+
+interface CachedSession {
+  harness: Awaited<ReturnType<typeof createMastraCode>>['harness'];
+  threadKey: string;
+  lastActivity: number;
+}
+
+// ---------------------------------------------------------------------------
+// Session Cache
+// ---------------------------------------------------------------------------
+
+const sessions = new Map<string, CachedSession>();
+
+// ---------------------------------------------------------------------------
+// Harness Creation
+// ---------------------------------------------------------------------------
+
+async function createHarnessForSession(
+  threadKey: string,
+  config: CodingSessionConfig,
+) {
+  // Create E2B sandbox — with repo pre-cloned if repoUrl is provided
+  const sandboxId = `slack-coding-${threadKey}`;
+  const sandbox = config.repoUrl
+    ? createCodingSandbox({
+        repoUrl: config.repoUrl,
+        branch: config.branch,
+        githubToken: config.githubToken,
+        gitUserName: config.gitUserName,
+        gitUserEmail: config.gitUserEmail,
+        sandboxId,
+      })
+    : createBareSandbox({
+        sandboxId,
+        githubToken: config.githubToken,
+        gitUserName: config.gitUserName,
+        gitUserEmail: config.gitUserEmail,
+      });
+
+  const workspace = createCodingWorkspace(sandbox);
+
+  console.log('[harness-factory] workspace created:', {
+    id: workspace.id,
+    hasSandbox: !!workspace.sandbox,
+    hasFilesystem: !!workspace.filesystem,
+    constructorName: workspace.constructor.name,
+  });
+
+  const { harness } = await createMastraCode({
+    workspace,
+    disableMcp: true,
+    disableHooks: true,
+    initialState: {
+      projectPath: '/home/user/project',
+      yolo: true,
+      permissionRules: {
+        categories: {},
+        tools: {
+          // request_sandbox_access is a local TUI tool that waits for terminal input.
+          // In Slack/E2B context it hangs forever, so deny it entirely.
+          request_sandbox_access: 'deny',
+        },
+      },
+    },
+  });
+
+  // Debug: log workspace state after harness creation
+  console.log('[harness-factory] harness created, workspace state:', {
+    hasSandbox: !!workspace.sandbox,
+    sandboxHasExecCmd: !!workspace.sandbox?.executeCommand,
+    sandboxStatus: workspace.status,
+  });
+
+  return harness;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Get an existing Harness for a Slack thread, or create a new one.
+ * Returns `isNew: true` when a fresh session was created.
+ */
+export async function getOrCreateHarness(
+  threadKey: string,
+  config: CodingSessionConfig,
+): Promise<{ harness: CachedSession['harness']; isNew: boolean }> {
+  const existing = sessions.get(threadKey);
+  if (existing) {
+    existing.lastActivity = Date.now();
+    return { harness: existing.harness, isNew: false };
+  }
+
+  const harness = await createHarnessForSession(threadKey, config);
+
+  // Subscribe to workspace events during init
+  harness.subscribe((event: any) => {
+    if (event.type === 'workspace_status_changed' || event.type === 'workspace_ready' || event.type === 'workspace_error') {
+      console.log('[harness-factory] workspace event:', JSON.stringify(event));
+    }
+  });
+
+  await harness.init();
+
+  console.log('[harness-factory] harness.init() completed for thread:', threadKey);
+
+  // Check if the workspace is ready and has tools
+  try {
+    const ws = harness.getWorkspace();
+    console.log('[harness-factory] post-init workspace:', {
+      hasWorkspace: !!ws,
+      status: ws?.status,
+      hasSandbox: !!ws?.sandbox,
+      sandboxHasExecCmd: !!ws?.sandbox?.executeCommand,
+      hasFilesystem: !!ws?.filesystem,
+    });
+  } catch (e) {
+    console.log('[harness-factory] post-init workspace check failed:', e);
+  }
+
+  sessions.set(threadKey, {
+    harness,
+    threadKey,
+    lastActivity: Date.now(),
+  });
+
+  return { harness, isNew: true };
+}
+
+/**
+ * Destroy a session and its sandbox.
+ */
+export async function destroySession(threadKey: string): Promise<boolean> {
+  const session = sessions.get(threadKey);
+  if (!session) return false;
+
+  try {
+    await session.harness.destroyWorkspace();
+  } catch {
+    // Best-effort cleanup
+  }
+  sessions.delete(threadKey);
+  return true;
+}
+
+/**
+ * Get an existing session without creating a new one.
+ */
+export function getSession(threadKey: string): CachedSession | undefined {
+  return sessions.get(threadKey);
+}
+
+/**
+ * Subscribe to Harness events for a session.
+ */
+export function subscribeToSession(
+  threadKey: string,
+  listener: HarnessEventListener,
+): boolean {
+  const session = sessions.get(threadKey);
+  if (!session) return false;
+  session.harness.subscribe(listener);
+  return true;
+}
+
+/**
+ * List all active sessions.
+ */
+export function listSessions(): Array<{ threadKey: string; lastActivity: number }> {
+  return Array.from(sessions.entries()).map(([key, s]) => ({
+    threadKey: key,
+    lastActivity: s.lastActivity,
+  }));
+}

--- a/templates/template-slack-coding-agent/src/mastra/coding/sandbox-manager.ts
+++ b/templates/template-slack-coding-agent/src/mastra/coding/sandbox-manager.ts
@@ -1,0 +1,89 @@
+import { destroySession, listSessions, getSession } from './harness-factory.js';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Maximum idle time before a session is destroyed (2 hours) */
+const MAX_IDLE_MS = 2 * 60 * 60 * 1000;
+
+/** How often to check for idle sessions (5 minutes) */
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+
+let cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+// ---------------------------------------------------------------------------
+// Idle Cleanup
+// ---------------------------------------------------------------------------
+
+/**
+ * Start the periodic cleanup of idle sessions.
+ * E2B's autoPause handles sandbox-level idle detection (pauses after timeout).
+ * This manager handles session-level cleanup (destroys sessions after extended idle).
+ */
+export function startSessionCleanup(): void {
+  if (cleanupTimer) return;
+
+  cleanupTimer = setInterval(async () => {
+    const now = Date.now();
+    const sessions = listSessions();
+
+    for (const session of sessions) {
+      const idleMs = now - session.lastActivity;
+      if (idleMs > MAX_IDLE_MS) {
+        console.log(
+          `🗑️ Destroying idle session ${session.threadKey} (idle for ${Math.round(idleMs / 60000)}m)`,
+        );
+        await destroySession(session.threadKey);
+      }
+    }
+  }, CLEANUP_INTERVAL_MS);
+}
+
+/**
+ * Stop the periodic cleanup.
+ */
+export function stopSessionCleanup(): void {
+  if (cleanupTimer) {
+    clearInterval(cleanupTimer);
+    cleanupTimer = null;
+  }
+}
+
+/**
+ * Destroy all active sessions. Call this on server shutdown.
+ */
+export async function destroyAllSessions(): Promise<void> {
+  const sessions = listSessions();
+  for (const session of sessions) {
+    try {
+      await destroySession(session.threadKey);
+    } catch {
+      // Best-effort cleanup
+    }
+  }
+}
+
+/**
+ * Get a summary of active sessions for monitoring.
+ */
+export function getSessionsSummary(): {
+  totalSessions: number;
+  sessions: Array<{
+    threadKey: string;
+    lastActivity: number;
+    idleMinutes: number;
+  }>;
+} {
+  const now = Date.now();
+  const sessions = listSessions();
+
+  return {
+    totalSessions: sessions.length,
+    sessions: sessions.map(s => ({
+      threadKey: s.threadKey,
+      lastActivity: s.lastActivity,
+      idleMinutes: Math.round((now - s.lastActivity) / 60000),
+    })),
+  };
+}

--- a/templates/template-slack-coding-agent/src/mastra/coding/system-prompt.ts
+++ b/templates/template-slack-coding-agent/src/mastra/coding/system-prompt.ts
@@ -1,0 +1,51 @@
+/**
+ * System prompt for the Slack coding agent.
+ * Tailored for autonomous coding in an E2B sandbox with Slack-compatible output.
+ */
+export function getSystemPrompt(projectPath: string): string {
+  return `You are a coding assistant running in a cloud sandbox. Users interact with you through Slack.
+
+# Environment
+Working directory: ${projectPath}
+Platform: linux (E2B cloud sandbox)
+Tools: You have file system access, command execution, and search tools.
+
+# How You Work
+- You run autonomously — make changes, run tests, and verify your work.
+- Use tools to read files before editing. Never guess file contents.
+- After making changes, verify they work (run tests, check for errors).
+- Work incrementally: one change at a time, verify, then move on.
+
+# Git & GitHub
+- The sandbox has git and gh (GitHub CLI) pre-configured.
+- To commit: \`git add -A && git commit -m "your message"\`
+- To push: \`git push origin HEAD\`
+- To create a PR: \`gh pr create --title "Title" --body "Description"\`
+- Always commit with descriptive messages explaining WHY, not just WHAT.
+
+# Slack Output Guidelines
+- Keep responses concise — they appear in Slack threads.
+- Use simple formatting: *bold*, _italic_, \`code\`, \`\`\`code blocks\`\`\`.
+- Avoid complex markdown (no tables, no nested lists deeper than 2 levels).
+- For long outputs, summarize the key points rather than dumping everything.
+- Use bullet points for lists.
+
+# Task Tracking
+- Use task_write for multi-step work to show progress in Slack.
+- Mark tasks in_progress before starting, completed when done.
+- Only one task should be in_progress at a time.
+
+# Coding Guidelines
+- Follow existing code conventions in the project.
+- Don't add unnecessary comments, docstrings, or error handling.
+- Don't over-engineer — make the minimal change needed.
+- Clean up dead code. If something is unused, delete it.
+- Run relevant tests after changes to verify correctness.
+
+# When You're Done
+Provide a brief summary of what you did:
+- What files were changed/created
+- What the changes accomplish
+- Any tests that were run and their results
+- Next steps if applicable`;
+}

--- a/templates/template-slack-coding-agent/src/mastra/coding/workspace-config.ts
+++ b/templates/template-slack-coding-agent/src/mastra/coding/workspace-config.ts
@@ -1,0 +1,145 @@
+import { Workspace } from '@mastra/core/workspace';
+import { E2BSandbox } from '@mastra/e2b';
+import { E2BFilesystem } from './e2b-filesystem';
+
+export interface CodingWorkspaceConfig {
+  repoUrl: string;
+  branch?: string;
+  githubToken: string;
+  gitUserName: string;
+  gitUserEmail: string;
+  sandboxId: string;
+}
+
+/**
+ * Create an E2B sandbox with a repo pre-cloned via template.
+ *
+ * Uses E2B's TemplateBuilder.gitClone() to bake the repo into
+ * the sandbox template at build time. Subsequent sandboxes for
+ * the same repo start from that snapshot instantly.
+ */
+// Install gh CLI: download the pre-built binary to avoid apt repo setup issues in E2B template builds
+const INSTALL_GH_CLI = [
+  'curl -fsSL https://github.com/cli/cli/releases/download/v2.74.1/gh_2.74.1_linux_amd64.tar.gz -o /tmp/gh.tar.gz',
+  'tar -xzf /tmp/gh.tar.gz -C /tmp',
+  'mv /tmp/gh_2.74.1_linux_amd64/bin/gh /usr/local/bin/gh',
+  'chmod +x /usr/local/bin/gh',
+  'rm -rf /tmp/gh.tar.gz /tmp/gh_2.74.1_linux_amd64',
+].join(' && ');
+
+export function createCodingSandbox(config: CodingWorkspaceConfig): E2BSandbox {
+  const authUrl = config.repoUrl.replace(
+    'https://',
+    `https://x-access-token:${config.githubToken}@`,
+  );
+
+  return new E2BSandbox({
+    id: config.sandboxId,
+    template: base =>
+      base
+        .aptInstall(['git', 'curl', 'wget', 'jq', 'ripgrep', 'tree', 'gnupg'])
+        .runCmd(INSTALL_GH_CLI)
+        .runCmd('curl -fsSL https://get.pnpm.io/install.sh | sh -')
+        .runCmd('echo "export PNPM_HOME=\"$HOME/.local/share/pnpm\"" >> ~/.bashrc && echo "export PATH=\"$PNPM_HOME:$PATH\"" >> ~/.bashrc')
+        .gitClone(authUrl, '/home/user/project', {
+          branch: config.branch ?? 'main',
+          depth: 1,
+        })
+        .setWorkdir('/home/user/project'),
+    timeout: 1_800_000, // 30 min
+    env: {
+      GITHUB_TOKEN: config.githubToken,
+      GH_TOKEN: config.githubToken,
+      GIT_AUTHOR_NAME: config.gitUserName,
+      GIT_AUTHOR_EMAIL: config.gitUserEmail,
+      FORCE_COLOR: '1',
+      CLICOLOR_FORCE: '1',
+      TERM: 'xterm-256color',
+      CI: 'true',
+      NONINTERACTIVE: '1',
+      DEBIAN_FRONTEND: 'noninteractive',
+    },
+    onStart: async ({ sandbox }) => {
+      await sandbox.executeCommand?.(
+        `git config --global user.name "${config.gitUserName}"`,
+      );
+      await sandbox.executeCommand?.(
+        `git config --global user.email "${config.gitUserEmail}"`,
+      );
+      // Credential helper that uses GITHUB_TOKEN env var for push/PR
+      await sandbox.executeCommand?.(
+        'git config --global credential.helper "!f() { echo username=x-access-token; echo password=$GITHUB_TOKEN; }; f"',
+      );
+      // Configure gh CLI to use git protocol https (needed for push via token)
+      await sandbox.executeCommand?.('gh auth setup-git');
+      // Install dependencies and build the project
+      await sandbox.executeCommand?.(
+        'export PNPM_HOME="$HOME/.local/share/pnpm" && export PATH="$PNPM_HOME:$PATH" && pnpm install && pnpm build',
+      );
+      // Create a working branch for this coding session
+      await sandbox.executeCommand?.(
+        `git checkout -b slack-session-${Date.now()}`,
+      );
+    },
+  });
+}
+
+/**
+ * Create a bare E2B sandbox without a pre-cloned repo.
+ * The agent can clone a repo later via execute_command.
+ */
+export function createBareSandbox(config: {
+  sandboxId: string;
+  githubToken: string;
+  gitUserName: string;
+  gitUserEmail: string;
+}): E2BSandbox {
+  return new E2BSandbox({
+    id: config.sandboxId,
+    template: base =>
+      base
+        .aptInstall(['git', 'curl', 'wget', 'jq', 'ripgrep', 'tree', 'gnupg'])
+        .runCmd(INSTALL_GH_CLI)
+        .runCmd('curl -fsSL https://get.pnpm.io/install.sh | sh -')
+        .runCmd('echo "export PNPM_HOME=\"$HOME/.local/share/pnpm\"" >> ~/.bashrc && echo "export PATH=\"$PNPM_HOME:$PATH\"" >> ~/.bashrc'),
+    timeout: 1_800_000,
+    env: {
+      GITHUB_TOKEN: config.githubToken,
+      GH_TOKEN: config.githubToken,
+      GIT_AUTHOR_NAME: config.gitUserName,
+      GIT_AUTHOR_EMAIL: config.gitUserEmail,
+      FORCE_COLOR: '1',
+      CLICOLOR_FORCE: '1',
+      TERM: 'xterm-256color',
+      CI: 'true',
+      NONINTERACTIVE: '1',
+      DEBIAN_FRONTEND: 'noninteractive',
+    },
+    onStart: async ({ sandbox }) => {
+      await sandbox.executeCommand?.(
+        `git config --global user.name "${config.gitUserName}"`,
+      );
+      await sandbox.executeCommand?.(
+        `git config --global user.email "${config.gitUserEmail}"`,
+      );
+      await sandbox.executeCommand?.(
+        'git config --global credential.helper "!f() { echo username=x-access-token; echo password=$GITHUB_TOKEN; }; f"',
+      );
+      // Configure gh CLI to use git protocol https
+      await sandbox.executeCommand?.('gh auth setup-git');
+    },
+  });
+}
+
+/**
+ * Create a Workspace wrapping an E2B sandbox with filesystem tools.
+ *
+ * The E2BFilesystem bridges the E2B SDK's file API to MastraFilesystem,
+ * enabling the agent to use read_file, write_file, list_files, etc.
+ */
+export function createCodingWorkspace(sandbox: E2BSandbox): Workspace {
+  return new Workspace({
+    sandbox,
+    filesystem: new E2BFilesystem(sandbox),
+  });
+}

--- a/templates/template-slack-coding-agent/src/mastra/index.ts
+++ b/templates/template-slack-coding-agent/src/mastra/index.ts
@@ -1,0 +1,13 @@
+import { Mastra } from '@mastra/core';
+
+import { slackRoutes } from './slack/routes.js';
+
+const PORT = Number(process.env.PORT) || 4211;
+
+export const mastra = new Mastra({
+  server: {
+    host: '0.0.0.0',
+    port: PORT,
+    apiRoutes: slackRoutes,
+  },
+});

--- a/templates/template-slack-coding-agent/src/mastra/slack/harness-streaming.ts
+++ b/templates/template-slack-coding-agent/src/mastra/slack/harness-streaming.ts
@@ -1,0 +1,606 @@
+import type { WebClient } from '@slack/web-api';
+import type { HarnessEvent, HarnessEventListener } from '@mastra/core/harness';
+import type { Harness } from '@mastra/core/harness';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SLACK_MAX_LENGTH = 3900;
+const UPDATE_THROTTLE_MS = 1000;
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const GIST_SYNC_INTERVAL = 10; // Sync gist every N new log entries
+const GIST_FILENAME = 'activity-log.md';
+
+const TOOL_EMOJI: Record<string, string> = {
+  view: '📂',
+  search_content: '🔍',
+  find_files: '📁',
+  execute_command: '⚡',
+  string_replace_lsp: '🔧',
+  write_file: '✏️',
+  web_search: '🌐',
+  web_extract: '🌐',
+  task_write: '📋',
+  task_check: '✅',
+  subagent: '🤖',
+  mastra_workspace_execute_command: '⚡',
+  mastra_workspace_read_file: '📂',
+  mastra_workspace_write_file: '✏️',
+  mastra_workspace_edit_file: '🔧',
+  mastra_workspace_list_files: '📁',
+  mastra_workspace_grep: '🔍',
+  mastra_workspace_ast_edit: '🔧',
+  mastra_workspace_delete: '🗑️',
+  mastra_workspace_mkdir: '📁',
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface StreamingState {
+  messageTs: string;
+  text: string;
+  statusText: string;
+  spinnerIdx: number;
+  lastUpdateTime: number;
+  updatePending: boolean;
+  updateTimer: ReturnType<typeof setTimeout> | null;
+  finished: boolean;
+  toolActivities: string[]; // Last N lines for Slack display
+  gistLog: string;           // Append-only string buffer for gist (avoids array + join overhead)
+  gistLogCount: number;      // Number of entries appended to gistLog
+  activeSubagents: Map<string, { agentType: string; task: string }>;
+  toolCount: number;
+  startTime: number;
+  // Gist
+  gistId: string | null;
+  gistUrl: string | null;
+  lastGistSyncCount: number;
+  gistSyncing: boolean;       // Lock to prevent concurrent PATCH calls
+  gistPendingForce: boolean;  // If a forced sync was requested while locked
+}
+
+export interface StreamHarnessOptions {
+  slackClient: WebClient;
+  channel: string;
+  threadTs: string;
+  harness: Harness;
+  onAskQuestion?: (event: {
+    questionId: string;
+    question: string;
+    options?: Array<{ label: string; description?: string }>;
+  }) => void;
+  onPlanApproval?: (event: {
+    planId: string;
+    title?: string;
+    plan: string;
+  }) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Main streaming function
+// ---------------------------------------------------------------------------
+
+export function streamHarnessToSlack(options: StreamHarnessOptions): Promise<void> {
+  const { slackClient, channel, threadTs, harness, onAskQuestion, onPlanApproval } = options;
+
+  const state: StreamingState = {
+    messageTs: '',
+    text: '',
+    statusText: 'Thinking...',
+    spinnerIdx: 0,
+    lastUpdateTime: Date.now(),
+    updatePending: false,
+    updateTimer: null,
+    finished: false,
+    toolActivities: [],
+    gistLog: '',
+    gistLogCount: 0,
+    activeSubagents: new Map(),
+    toolCount: 0,
+    startTime: Date.now(),
+    gistId: null,
+    gistUrl: null,
+    lastGistSyncCount: 0,
+    gistSyncing: false,
+    gistPendingForce: false,
+  };
+
+  // Subscribe to events BEFORE any async work so we don't miss early events
+  const listener: HarnessEventListener = (event: HarnessEvent) => {
+    if (event.type === 'ask_question' && onAskQuestion) {
+      onAskQuestion(event);
+      return;
+    }
+    if (event.type === 'plan_approval_required' && onPlanApproval) {
+      onPlanApproval(event);
+      return;
+    }
+    handleHarnessEvent(event, state, slackClient, channel);
+  };
+  harness.subscribe(listener);
+
+  // Post initial "thinking" message
+  const initPromise = slackClient.chat
+    .postMessage({ channel, thread_ts: threadTs, text: `${SPINNER_FRAMES[0]} Thinking...` })
+    .then((msg: any) => { state.messageTs = msg.ts!; })
+    .catch((err: any) => { console.error('Failed to post initial Slack message:', err); });
+
+  const spinnerInterval = setInterval(() => {
+    if (state.finished || !state.messageTs) return;
+    state.spinnerIdx = (state.spinnerIdx + 1) % SPINNER_FRAMES.length;
+    scheduleSlackUpdate(slackClient, channel, state);
+  }, 500);
+
+  return new Promise<void>(resolve => {
+    const checkFinished: HarnessEventListener = async (event: HarnessEvent) => {
+      if (event.type === 'agent_end') {
+        state.finished = true;
+        clearInterval(spinnerInterval);
+        if (state.updateTimer) clearTimeout(state.updateTimer);
+
+        await initPromise;
+        await postFinalResponse(slackClient, channel, threadTs, state);
+
+        // Final gist update with response
+        await syncGist(state, true).catch(() => {});
+
+        if (state.messageTs) {
+          const elapsed = ((Date.now() - state.startTime) / 1000).toFixed(1);
+          const gistLink = state.gistUrl ? ` | <${state.gistUrl}|📄 Full log>` : '';
+          const summary = state.toolCount > 0
+            ? `✅ Done — ${state.toolCount} tool calls in ${elapsed}s${gistLink}`
+            : `✅ Done (${elapsed}s)${gistLink}`;
+          try {
+            await slackClient.chat.update({ channel, ts: state.messageTs, text: summary });
+          } catch { /* best effort */ }
+        }
+
+        resolve();
+      } else if (event.type === 'error') {
+        state.finished = true;
+        clearInterval(spinnerInterval);
+        if (state.updateTimer) clearTimeout(state.updateTimer);
+
+        await initPromise;
+
+        const errorMsg = event.error?.message || 'An unknown error occurred';
+        const elapsed = ((Date.now() - state.startTime) / 1000).toFixed(1);
+        const errorDetail = state.toolCount > 0
+          ? `❌ Error after ${state.toolCount} tool calls (${elapsed}s):\n${truncate(errorMsg, 500)}`
+          : `❌ Error: ${truncate(errorMsg, 500)}`;
+
+        // Final gist update
+        pushLog(state, `❌ Error: ${truncate(errorMsg, 300)}`);
+        await syncGist(state, true).catch(() => {});
+
+        if (state.messageTs) {
+          const gistLink = state.gistUrl ? ` | <${state.gistUrl}|📄 Full log>` : '';
+          await slackClient.chat.update({
+            channel, ts: state.messageTs, text: `❌ Failed (${elapsed}s)${gistLink}`,
+          }).catch(() => {});
+        }
+
+        await slackClient.chat.postMessage({
+          channel, thread_ts: threadTs, text: errorDetail,
+        }).catch(() => {});
+
+        resolve();
+      }
+    };
+    harness.subscribe(checkFinished);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Event Handling
+// ---------------------------------------------------------------------------
+
+function handleHarnessEvent(
+  event: HarnessEvent,
+  state: StreamingState,
+  slackClient: WebClient,
+  channel: string,
+): void {
+  switch (event.type) {
+    case 'message_start':
+      state.statusText = 'Writing response...';
+      break;
+
+    case 'message_update': {
+      const msg = event.message;
+      if (msg.content) {
+        const textParts = msg.content
+          .filter((c: { type: string }) => c.type === 'text')
+          .map((c: { type: string; text?: string }) => c.text ?? '');
+        state.text = textParts.join('');
+      }
+      state.statusText = 'Writing response...';
+      break;
+    }
+
+    case 'tool_start': {
+      state.toolCount++;
+      const toolName = stripPrefix(event.toolName);
+      const emoji = TOOL_EMOJI[event.toolName] ?? TOOL_EMOJI[toolName] ?? '🔧';
+      const summary = fmtToolStart(toolName, event.args);
+      // Verbose detail for gist: include full args
+      const argsStr = event.args ? JSON.stringify(event.args, null, 2) : '';
+      const detail = argsStr ? `**Tool:** \`${toolName}\`\n\`\`\`json\n${truncate(argsStr, 2000)}\n\`\`\`` : `**Tool:** \`${toolName}\``;
+      pushActivity(state, `${emoji} ${summary}`, detail);
+      state.statusText = summary;
+      break;
+    }
+
+    case 'tool_end': {
+      const resultStr = typeof event.result === 'string' ? event.result : JSON.stringify(event.result ?? '', null, 2);
+      if (event.isError) {
+        const preview = truncate(resultStr, 100);
+        pushActivity(state, `❌ Tool error: ${preview}`, `**Error output:**\n\`\`\`\n${truncate(resultStr, 3000)}\n\`\`\``);
+      } else {
+        // Log successful tool results to gist (not to Slack)
+        pushLog(state, `✅ Tool result`, `\`\`\`\n${truncate(resultStr, 3000)}\n\`\`\``);
+      }
+      break;
+    }
+
+    case 'shell_output': {
+      const out = truncate(event.output, 200);
+      if (out.trim()) pushActivity(state, `\`\`\`\n${out}\n\`\`\``, `**Full output:**\n\`\`\`\n${truncate(event.output, 5000)}\n\`\`\``);
+      break;
+    }
+
+    case 'task_updated': {
+      const taskSummary = fmtTasks(event.tasks);
+      let lastIdx = -1;
+      for (let i = state.toolActivities.length - 1; i >= 0; i--) {
+        if (state.toolActivities[i]!.includes('✅') || state.toolActivities[i]!.includes('🔄') || state.toolActivities[i]!.includes('⬜')) {
+          lastIdx = i;
+          break;
+        }
+      }
+      if (lastIdx >= 0) state.toolActivities[lastIdx] = taskSummary;
+      else pushActivity(state, taskSummary);
+      state.statusText = 'Working on tasks...';
+      break;
+    }
+
+    case 'subagent_start':
+      state.activeSubagents.set(event.toolCallId, { agentType: event.agentType, task: event.task });
+      state.statusText = `🤖 Running ${event.agentType} subagent...`;
+      pushActivity(state, `🤖 *${event.agentType}* subagent: ${truncate(event.task, 120)}`, `**Full task:**\n${event.task}`);
+      break;
+
+    case 'subagent_tool_start': {
+      const sub = state.activeSubagents.get(event.toolCallId);
+      const subName = sub ? sub.agentType : 'subagent';
+      const subTool = stripPrefix(event.subToolName);
+      const subEmoji = TOOL_EMOJI[event.subToolName] ?? TOOL_EMOJI[subTool] ?? '🔧';
+      const subArgsStr = event.subToolArgs ? JSON.stringify(event.subToolArgs, null, 2) : '';
+      state.statusText = `🤖 ${subName} → ${fmtToolStart(subTool, event.subToolArgs)}`;
+      pushActivity(
+        state,
+        `  ${subEmoji} _${subName}_ → ${fmtToolStart(subTool, event.subToolArgs)}`,
+        subArgsStr ? `**${subName} → ${subTool}:**\n\`\`\`json\n${truncate(subArgsStr, 2000)}\n\`\`\`` : undefined,
+      );
+      break;
+    }
+
+    case 'subagent_tool_end': {
+      const sub = state.activeSubagents.get(event.toolCallId);
+      const subName = sub?.agentType ?? 'subagent';
+      const subResultStr = typeof event.result === 'string' ? event.result : JSON.stringify(event.result ?? '', null, 2);
+      if (event.isError) {
+        pushActivity(state, `  ❌ _${subName}_ tool error`, `**${subName} error:**\n\`\`\`\n${truncate(subResultStr, 3000)}\n\`\`\``);
+      } else {
+        pushLog(state, `  ✅ _${subName}_ tool result`, `\`\`\`\n${truncate(subResultStr, 3000)}\n\`\`\``);
+      }
+      break;
+    }
+
+    case 'subagent_end': {
+      state.activeSubagents.delete(event.toolCallId);
+      const status = event.isError ? '❌ failed' : '✅ done';
+      pushActivity(state, `🤖 *${event.agentType}* ${status} (${(event.durationMs / 1000).toFixed(1)}s)`);
+      if (state.activeSubagents.size > 0) {
+        const remaining = Array.from(state.activeSubagents.values()).map(s => s.agentType).join(', ');
+        state.statusText = `🤖 Still running: ${remaining}`;
+      } else {
+        state.statusText = 'Processing...';
+      }
+      break;
+    }
+
+    case 'error':
+      pushActivity(state, `❌ Error: ${truncate(event.error?.message || 'Unknown error', 150)}`);
+      state.statusText = 'Error occurred';
+      break;
+
+    case 'info':
+      pushActivity(state, `ℹ️ ${truncate(event.message, 150)}`);
+      break;
+
+    default:
+      return; // Don't trigger Slack update for unhandled events
+  }
+
+  scheduleSlackUpdate(slackClient, channel, state);
+}
+
+// ---------------------------------------------------------------------------
+// Slack Updates
+// ---------------------------------------------------------------------------
+
+function scheduleSlackUpdate(slackClient: WebClient, channel: string, state: StreamingState): void {
+  if (state.finished) return;
+  const elapsed = Date.now() - state.lastUpdateTime;
+  if (elapsed >= UPDATE_THROTTLE_MS) {
+    void doSlackUpdate(slackClient, channel, state);
+  } else if (!state.updateTimer) {
+    state.updateTimer = setTimeout(() => {
+      state.updateTimer = null;
+      void doSlackUpdate(slackClient, channel, state);
+    }, UPDATE_THROTTLE_MS - elapsed);
+  }
+}
+
+async function doSlackUpdate(slackClient: WebClient, channel: string, state: StreamingState): Promise<void> {
+  if (!state.messageTs) return;
+  state.lastUpdateTime = Date.now();
+
+  const spinner = SPINNER_FRAMES[state.spinnerIdx]!;
+  const elapsed = ((Date.now() - state.startTime) / 1000).toFixed(0);
+  const toolInfo = state.toolCount > 0 ? ` | ${state.toolCount} tool calls | ${elapsed}s` : '';
+  const gistLink = state.gistUrl ? ` | <${state.gistUrl}|📄 Full log>` : '';
+  const lines: string[] = [`${spinner} ${state.statusText}${toolInfo}${gistLink}`];
+
+  if (state.toolActivities.length > 0) {
+    lines.push('');
+    lines.push(...state.toolActivities.slice(-5));
+  }
+
+  if (state.activeSubagents.size > 0) {
+    lines.push('');
+    for (const [, sub] of state.activeSubagents) {
+      lines.push(`🤖 _${sub.agentType}_ running: ${truncate(sub.task, 80)}`);
+    }
+  }
+
+  try {
+    await slackClient.chat.update({
+      channel,
+      ts: state.messageTs,
+      text: truncate(lines.join('\n'), SLACK_MAX_LENGTH),
+    });
+  } catch { /* rate limiting etc */ }
+}
+
+async function postFinalResponse(
+  slackClient: WebClient, channel: string, threadTs: string, state: StreamingState,
+): Promise<void> {
+  const responseText = state.text.trim();
+  if (!responseText) return;
+
+  const chunks = splitMessage(responseText, SLACK_MAX_LENGTH);
+  for (const chunk of chunks) {
+    try {
+      await slackClient.chat.postMessage({ channel, thread_ts: threadTs, text: chunk });
+    } catch (err) {
+      console.error('Failed to post response chunk to Slack:', err);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Activity Log
+// ---------------------------------------------------------------------------
+
+function pushActivity(state: StreamingState, activity: string, detail?: string): void {
+  // Slack display (capped)
+  state.toolActivities.push(activity);
+  if (state.toolActivities.length > 8) state.toolActivities.shift();
+
+  // Append to gist log buffer (pushLog triggers gist sync internally)
+  pushLog(state, activity, detail);
+}
+
+function pushLog(state: StreamingState, line: string, detail?: string): void {
+  const elapsed = ((Date.now() - state.startTime) / 1000).toFixed(1);
+  state.gistLog += `\n---\n\n#### [${elapsed}s] ${line}\n\n`;
+  if (detail) {
+    state.gistLog += `${detail}\n\n`;
+  }
+  state.gistLogCount++;
+  // Trigger gist sync (fire-and-forget)
+  syncGist(state).catch((err: unknown) => console.error('[gist] Sync error:', err));
+}
+
+// ---------------------------------------------------------------------------
+// Gist Helpers
+// ---------------------------------------------------------------------------
+
+function buildGistContent(state: StreamingState, final?: boolean): string {
+  const elapsed = ((Date.now() - state.startTime) / 1000).toFixed(1);
+  const status = final ? '✅ Complete' : '🔄 Running...';
+
+  let content = `# Agent Activity Log
+
+**Status:** ${status} | **Tool calls:** ${state.toolCount} | **Elapsed:** ${elapsed}s
+_Started: ${new Date(state.startTime).toISOString()}_
+
+---
+${state.gistLog || '\n_No activity yet_\n'}`;
+
+  if (final && state.text.trim()) {
+    content += `\n---\n\n## Final Response\n\n${state.text.trim()}\n`;
+  }
+
+  return content;
+}
+
+async function createGistForLog(state: StreamingState): Promise<void> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) return;
+
+  try {
+    const res = await fetch('https://api.github.com/gists', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/vnd.github+json',
+      },
+      body: JSON.stringify({
+        description: `MastraCode activity — ${new Date().toISOString()}`,
+        public: false,
+        files: { [GIST_FILENAME]: { content: buildGistContent(state) } },
+      }),
+    });
+
+    if (!res.ok) {
+      console.error('[gist] Create failed:', res.status, await res.text());
+      return;
+    }
+
+    const data = (await res.json()) as { id: string; html_url: string };
+    state.gistId = data.id;
+    state.gistUrl = data.html_url;
+    state.lastGistSyncCount = state.gistLogCount;
+    console.log('[gist] Created:', state.gistUrl);
+  } catch (err) {
+    console.error('[gist] Create error:', err);
+  }
+}
+
+async function updateGistLog(state: StreamingState, final = false): Promise<void> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token || !state.gistId) return;
+
+  try {
+    const res = await fetch(`https://api.github.com/gists/${state.gistId}`, {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/vnd.github+json',
+      },
+      body: JSON.stringify({
+        files: { [GIST_FILENAME]: { content: buildGistContent(state, final) } },
+      }),
+    });
+
+    if (!res.ok) console.error('[gist] Update failed:', res.status);
+    state.lastGistSyncCount = state.gistLogCount;
+  } catch (err) {
+    console.error('[gist] Update error:', err);
+  }
+}
+
+async function syncGist(state: StreamingState, force?: boolean): Promise<void> {
+  const newEntries = state.gistLogCount - state.lastGistSyncCount;
+  if (!force && newEntries < GIST_SYNC_INTERVAL) return;
+
+  // Serialize gist updates to avoid concurrent PATCH → 409 conflicts
+  if (state.gistSyncing) {
+    if (force) state.gistPendingForce = true;
+    return;
+  }
+
+  state.gistSyncing = true;
+  try {
+    if (!state.gistId) {
+      await createGistForLog(state);
+    } else {
+      await updateGistLog(state, force);
+    }
+  } finally {
+    state.gistSyncing = false;
+    // If a forced sync was requested while we were busy, do it now
+    if (state.gistPendingForce) {
+      state.gistPendingForce = false;
+      await syncGist(state, true);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Formatting Helpers
+// ---------------------------------------------------------------------------
+
+function stripPrefix(name: string): string {
+  return name.replace(/^mastra_workspace_/, '');
+}
+
+function fmtToolStart(toolName: string, args: unknown): string {
+  switch (toolName) {
+    case 'view':
+    case 'read_file':
+      return `Reading \`${getArg(args, 'path', 'file')}\``;
+    case 'search_content':
+    case 'grep':
+      return `Searching for \`${getArg(args, 'pattern', 'pattern')}\``;
+    case 'find_files':
+    case 'list_files':
+      return `Listing \`${getArg(args, 'path', '.')}\``;
+    case 'execute_command':
+      return `Running \`${truncate(getArg(args, 'command', 'command'), 80)}\``;
+    case 'string_replace_lsp':
+    case 'edit_file':
+      return `Editing \`${getArg(args, 'path', 'file')}\``;
+    case 'write_file':
+      return `Writing \`${getArg(args, 'path', 'file')}\``;
+    case 'ast_edit':
+      return `AST editing \`${getArg(args, 'path', 'file')}\``;
+    case 'web_search':
+      return `Searching web for \`${getArg(args, 'query', 'query')}\``;
+    case 'task_write':
+      return 'Updating task list';
+    case 'task_check':
+      return 'Checking task status';
+    case 'delete':
+      return `Deleting \`${getArg(args, 'path', 'file')}\``;
+    case 'mkdir':
+      return `Creating directory \`${getArg(args, 'path', 'dir')}\``;
+    case 'file_stat':
+      return `Checking \`${getArg(args, 'path', 'file')}\``;
+    default:
+      return `Running ${toolName}`;
+  }
+}
+
+function fmtTasks(tasks: Array<{ content: string; status: string; activeForm: string }>): string {
+  return tasks
+    .map(t => {
+      const icon = t.status === 'completed' ? '✅' : t.status === 'in_progress' ? '🔄' : '⬜';
+      return `${icon} ${t.content}`;
+    })
+    .join('\n');
+}
+
+function getArg(args: unknown, key: string, fallback: string): string {
+  if (args && typeof args === 'object' && key in args) {
+    return String((args as Record<string, unknown>)[key]);
+  }
+  return fallback;
+}
+
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength - 3) + '...';
+}
+
+function splitMessage(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) return [text];
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLength) { chunks.push(remaining); break; }
+    let idx = remaining.lastIndexOf('\n', maxLength);
+    if (idx < maxLength / 2) idx = maxLength;
+    chunks.push(remaining.slice(0, idx));
+    remaining = remaining.slice(idx).trimStart();
+  }
+  return chunks;
+}

--- a/templates/template-slack-coding-agent/src/mastra/slack/routes.ts
+++ b/templates/template-slack-coding-agent/src/mastra/slack/routes.ts
@@ -1,0 +1,655 @@
+/**
+ * Slack events route for the coding agent.
+ * Routes Slack messages to a Harness instance per thread.
+ */
+import { registerApiRoute } from '@mastra/core/server';
+import { WebClient } from '@slack/web-api';
+
+import {
+  getOrCreateHarness,
+  destroySession,
+  getSession,
+  listSessions,
+} from '../coding/harness-factory.js';
+import type { CodingSessionConfig } from '../coding/harness-factory.js';
+import { streamHarnessToSlack } from './harness-streaming.js';
+import { verifySlackRequest } from './verify.js';
+
+// ---------------------------------------------------------------------------
+// Pending interactive prompts (ask_user / submit_plan)
+// ---------------------------------------------------------------------------
+
+interface PendingQuestion {
+  questionId: string;
+  question: string;
+  options?: Array<{ label: string; description?: string }>;
+}
+
+interface PendingPlan {
+  planId: string;
+  title?: string;
+  plan: string;
+}
+
+const pendingQuestions = new Map<string, PendingQuestion>();
+const pendingPlans = new Map<string, PendingPlan>();
+
+// ---------------------------------------------------------------------------
+// GitHub Gist helper
+// ---------------------------------------------------------------------------
+
+const SLACK_MAX_LENGTH = 3900;
+
+async function createGist(
+  title: string,
+  content: string,
+): Promise<string | null> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) return null;
+
+  try {
+    const filename = `${title.replace(/[^a-zA-Z0-9-_ ]/g, '').replace(/\s+/g, '-').slice(0, 60) || 'plan'}.md`;
+    const res = await fetch('https://api.github.com/gists', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/vnd.github+json',
+      },
+      body: JSON.stringify({
+        description: title,
+        public: false,
+        files: { [filename]: { content } },
+      }),
+    });
+
+    if (!res.ok) {
+      console.error('Failed to create gist:', res.status, await res.text());
+      return null;
+    }
+
+    const data = await res.json();
+    return data.html_url as string;
+  } catch (err) {
+    console.error('Failed to create gist:', err);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Config from environment
+// ---------------------------------------------------------------------------
+
+function getSessionConfig(overrides?: { repoUrl?: string; branch?: string }): CodingSessionConfig {
+  return {
+    repoUrl: overrides?.repoUrl ?? process.env.DEFAULT_REPO_URL,
+    branch: overrides?.branch ?? process.env.DEFAULT_REPO_BRANCH,
+    githubToken: process.env.GITHUB_TOKEN!,
+    gitUserName: process.env.GIT_USER_NAME!,
+    gitUserEmail: process.env.GIT_USER_EMAIL!,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Session context — injected into the first message of every new session
+// ---------------------------------------------------------------------------
+
+const SESSION_CONTEXT = `
+<environment_context>
+You are running inside an E2B cloud sandbox (Debian Linux). Your working directory is /home/user/project.
+All shell commands run inside the sandbox via execute_command.
+
+## CLI tools available in the sandbox
+The following are available via execute_command — use them directly:
+- **gh** (GitHub CLI) — pre-installed and authenticated via GH_TOKEN. Use for ALL GitHub operations.
+- **git** — pre-configured with credentials. You can push, pull, and commit directly.
+- **jq** — JSON processing
+- **rg** (ripgrep) — fast code search
+- **tree** — directory visualization
+- **pnpm** — Node.js package management
+
+## CRITICAL: GitHub operations
+- To view an issue: \`execute_command\` with \`gh issue view <number>\`
+- To list issues: \`execute_command\` with \`gh issue list\`
+- To create a PR: \`execute_command\` with \`gh pr create --title "..." --body "..."\`
+- To view a PR: \`execute_command\` with \`gh pr view <number>\`
+- Do NOT use web_search to look up GitHub issues or PRs — use \`gh\` via execute_command instead.
+- Do NOT use raw GitHub API calls — use the \`gh\` CLI.
+
+## Slack formatting
+Keep responses concise. Use *bold*, \`code\`, and bullet points for readability.
+</environment_context>
+`.trim();
+
+// ---------------------------------------------------------------------------
+// Thread history
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch prior messages in a Slack thread to give the agent context
+ * when joining an existing conversation.
+ */
+async function fetchThreadHistory(
+  slackClient: WebClient,
+  channel: string,
+  threadTs: string,
+  currentMessageTs: string,
+): Promise<string | null> {
+  try {
+    const result = await slackClient.conversations.replies({
+      channel,
+      ts: threadTs,
+      limit: 50,
+    });
+
+    const messages = result.messages ?? [];
+
+    // Filter out the current message and bot messages
+    const prior = messages.filter(
+      m => m.ts !== currentMessageTs && !m.bot_id,
+    );
+
+    if (prior.length === 0) return null;
+
+    const formatted = prior
+      .map(m => {
+        const user = m.user ? `<@${m.user}>` : 'unknown';
+        const text = (m.text ?? '').replace(/<@[A-Z0-9]+>/g, '@user').trim();
+        return `${user}: ${text}`;
+      })
+      .join('\n');
+
+    return formatted;
+  } catch (err) {
+    console.error('Failed to fetch thread history:', err);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Slack command parsing
+// ---------------------------------------------------------------------------
+
+interface ParsedCommand {
+  type: 'command';
+  command: string;
+  args: string[];
+}
+
+interface ParsedMessage {
+  type: 'message';
+  text: string;
+}
+
+function parseSlackMessage(text: string): ParsedCommand | ParsedMessage {
+  const trimmed = text.trim();
+
+  // Check for slash-style commands (without the slash, since Slack strips mentions)
+  const commands = ['clone', 'status', 'summary', 'commit', 'pr', 'destroy'];
+  for (const cmd of commands) {
+    if (trimmed.toLowerCase().startsWith(cmd + ' ') || trimmed.toLowerCase() === cmd) {
+      const rest = trimmed.slice(cmd.length).trim();
+      return {
+        type: 'command',
+        command: cmd,
+        args: rest ? rest.split(/\s+/) : [],
+      };
+    }
+  }
+
+  return { type: 'message', text: trimmed };
+}
+
+// ---------------------------------------------------------------------------
+// Command handlers
+// ---------------------------------------------------------------------------
+
+async function handleCommand(
+  parsed: ParsedCommand,
+  slackClient: WebClient,
+  channel: string,
+  threadTs: string,
+  threadKey: string,
+): Promise<void> {
+  switch (parsed.command) {
+    case 'clone': {
+      const repoUrl = parsed.args[0];
+      const branch = parsed.args[1];
+      if (!repoUrl) {
+        await slackClient.chat.postMessage({
+          channel,
+          thread_ts: threadTs,
+          text: '⚠️ Usage: `clone <repo-url> [branch]`',
+        });
+        return;
+      }
+
+      // Destroy existing session if any
+      await destroySession(threadKey);
+
+      await slackClient.chat.postMessage({
+        channel,
+        thread_ts: threadTs,
+        text: `🚀 Setting up sandbox with \`${repoUrl}\`${branch ? ` (branch: ${branch})` : ''}...`,
+      });
+
+      try {
+        const config = getSessionConfig({ repoUrl, branch });
+        await getOrCreateHarness(threadKey, config);
+        await slackClient.chat.postMessage({
+          channel,
+          thread_ts: threadTs,
+          text: '✅ Sandbox ready! The repo is cloned and ready for work. Send me a coding task.',
+        });
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        await slackClient.chat.postMessage({
+          channel,
+          thread_ts: threadTs,
+          text: `❌ Failed to set up sandbox: ${errorMsg}`,
+        });
+      }
+      return;
+    }
+
+    case 'status': {
+      const session = getSession(threadKey);
+      if (!session) {
+        await slackClient.chat.postMessage({
+          channel,
+          thread_ts: threadTs,
+          text: '💤 No active session for this thread. Send a message or use `clone <repo-url>` to start.',
+        });
+        return;
+      }
+      const elapsed = Math.round((Date.now() - session.lastActivity) / 1000);
+      const allSessions = listSessions();
+      await slackClient.chat.postMessage({
+        channel,
+        thread_ts: threadTs,
+        text: [
+          `📊 *Session Status*`,
+          `• Thread: ${threadKey}`,
+          `• Last activity: ${elapsed}s ago`,
+          `• Active sessions: ${allSessions.length}`,
+        ].join('\n'),
+      });
+      return;
+    }
+
+    case 'summary': {
+      const session = getSession(threadKey);
+      if (!session) {
+        await slackClient.chat.postMessage({
+          channel,
+          thread_ts: threadTs,
+          text: '💤 No active session to summarize.',
+        });
+        return;
+      }
+      // Start streaming before sending message to catch all events
+      const summaryStreamPromise = streamHarnessToSlack({
+        slackClient,
+        channel,
+        threadTs,
+        harness: session.harness,
+      });
+      await session.harness.sendMessage({
+        content:
+          'Please provide a brief summary of all the work done in this session so far. ' +
+          'Include: files changed, what was accomplished, and any pending items.',
+      });
+      await summaryStreamPromise;
+      return;
+    }
+
+    case 'commit': {
+      const message = parsed.args.join(' ') || 'Update from Slack coding session';
+      const session = getSession(threadKey);
+      if (!session) {
+        await slackClient.chat.postMessage({
+          channel,
+          thread_ts: threadTs,
+          text: '💤 No active session. Start one first.',
+        });
+        return;
+      }
+      const commitStreamPromise = streamHarnessToSlack({
+        slackClient,
+        channel,
+        threadTs,
+        harness: session.harness,
+      });
+      await session.harness.sendMessage({
+        content: `Please commit all changes with message: "${message}", then push to the remote.`,
+      });
+      await commitStreamPromise;
+      return;
+    }
+
+    case 'pr': {
+      const title = parsed.args.join(' ') || 'Changes from Slack coding session';
+      const session = getSession(threadKey);
+      if (!session) {
+        await slackClient.chat.postMessage({
+          channel,
+          thread_ts: threadTs,
+          text: '💤 No active session. Start one first.',
+        });
+        return;
+      }
+      const prStreamPromise = streamHarnessToSlack({
+        slackClient,
+        channel,
+        threadTs,
+        harness: session.harness,
+      });
+      await session.harness.sendMessage({
+        content:
+          `Please commit all changes, push, and create a PR with title: "${title}". ` +
+          'Include a description of all changes made in the PR body.',
+      });
+      await prStreamPromise;
+      return;
+    }
+
+    case 'destroy': {
+      const destroyed = await destroySession(threadKey);
+      await slackClient.chat.postMessage({
+        channel,
+        thread_ts: threadTs,
+        text: destroyed
+          ? '🗑️ Session and sandbox destroyed.'
+          : '💤 No active session to destroy.',
+      });
+      return;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main route
+// ---------------------------------------------------------------------------
+
+const slackEventsRoute = registerApiRoute('/slack/coding/events', {
+  method: 'POST',
+  handler: async c => {
+    try {
+      const body = await c.req.text();
+      const payload = JSON.parse(body);
+
+      // Handle URL verification challenge
+      if (payload.type === 'url_verification') {
+        console.log('✅ URL verification challenge received');
+        return c.json({ challenge: payload.challenge });
+      }
+
+      const botToken = process.env.SLACK_BOT_TOKEN;
+      const signingSecret = process.env.SLACK_SIGNING_SECRET;
+
+      if (!botToken || !signingSecret) {
+        console.error('❌ Missing SLACK_BOT_TOKEN or SLACK_SIGNING_SECRET');
+        return c.json({ error: 'Server misconfigured' }, 500);
+      }
+
+      // Verify Slack signature
+      const slackSignature = c.req.header('x-slack-signature');
+      const slackTimestamp = c.req.header('x-slack-request-timestamp');
+
+      if (!slackSignature || !slackTimestamp) {
+        return c.json({ error: 'Missing Slack signature headers' }, 401);
+      }
+
+      if (!verifySlackRequest(signingSecret, slackSignature, slackTimestamp, body)) {
+        console.error('❌ Invalid Slack signature');
+        return c.json({ error: 'Invalid signature' }, 401);
+      }
+
+      // Handle event
+      if (payload.event) {
+        const event = payload.event;
+
+        // Ignore bot messages and message edits
+        if (event.bot_id || event.subtype) {
+          return c.json({ ok: true });
+        }
+
+        // Handle app mentions and direct messages
+        if (event.type === 'app_mention' || event.type === 'message') {
+          let messageText: string = event.text || '';
+          const channelId: string = event.channel;
+          const threadTs: string = event.thread_ts || event.ts;
+
+          console.log('📨 Message received:', {
+            text: messageText,
+            user: event.user,
+            channel: channelId,
+          });
+
+          // Strip bot mentions
+          messageText = messageText.replace(/<@[A-Z0-9]+>/g, '').trim();
+
+          if (!messageText) {
+            return c.json({ ok: true });
+          }
+
+          const slackClient = new WebClient(botToken);
+          const threadKey = `${channelId}-${threadTs}`;
+
+          // React immediately so the user knows we received it
+          slackClient.reactions.add({
+            channel: channelId,
+            timestamp: event.ts,
+            name: 'eyes',
+          }).catch(() => {});
+
+          // Process asynchronously (don't block Slack's 3s timeout)
+          (async () => {
+            try {
+              const parsed = parseSlackMessage(messageText);
+
+              if (parsed.type === 'command') {
+                await handleCommand(parsed, slackClient, channelId, threadTs, threadKey);
+                return;
+              }
+
+              // Check if there's a pending question or plan for this thread.
+              // After resolving, start a new streaming session so we get a fresh
+              // status message instead of editing the old (stale) one.
+              const pendingQ = pendingQuestions.get(threadKey);
+              if (pendingQ) {
+                pendingQuestions.delete(threadKey);
+                const session = getSession(threadKey);
+                if (session) {
+                  let answer = parsed.text;
+                  if (pendingQ.options?.length) {
+                    const idx = parseInt(answer, 10);
+                    if (!isNaN(idx) && idx >= 1 && idx <= pendingQ.options.length) {
+                      answer = pendingQ.options[idx - 1].label;
+                    }
+                  }
+
+                  // Start fresh streaming BEFORE resolving, so events are captured
+                  const resumeStream = streamHarnessToSlack({
+                    slackClient,
+                    channel: channelId,
+                    threadTs,
+                    harness: session.harness,
+                    onAskQuestion: (evt) => {
+                      pendingQuestions.set(threadKey, evt);
+                      const optionsText = evt.options?.length
+                        ? '\n' + evt.options.map((o, i) => `  ${i + 1}. *${o.label}*${o.description ? ` — ${o.description}` : ''}`).join('\n') + '\n\n_Reply with a number or type your answer._'
+                        : '';
+                      slackClient.chat.postMessage({
+                        channel: channelId,
+                        thread_ts: threadTs,
+                        text: `❓ *Question from the agent:*\n${evt.question}${optionsText}`,
+                      }).catch(err => console.error('Failed to post question to Slack:', err));
+                    },
+                    onPlanApproval: async (evt) => {
+                      pendingPlans.set(threadKey, evt);
+                      const header = `📋 *Plan submitted for review${evt.title ? `: ${evt.title}` : ''}*`;
+                      const footer = `\n\n_Reply *approve* to proceed or describe changes to reject._`;
+                      if (evt.plan.length <= SLACK_MAX_LENGTH - header.length - footer.length - 10) {
+                        slackClient.chat.postMessage({ channel: channelId, thread_ts: threadTs, text: `${header}\n\n${evt.plan}${footer}` })
+                          .catch(err => console.error('Failed to post plan to Slack:', err));
+                      } else {
+                        const gistUrl = await createGist(evt.title || 'Implementation Plan', evt.plan);
+                        const planPreview = evt.plan.slice(0, 1500) + '\n\n_(truncated)_';
+                        const linkText = gistUrl ? `\n\n<${gistUrl}|📄 View full plan on GitHub>` : '';
+                        slackClient.chat.postMessage({ channel: channelId, thread_ts: threadTs, text: `${header}${linkText}\n\n${planPreview}${footer}` })
+                          .catch(err => console.error('Failed to post plan to Slack:', err));
+                      }
+                    },
+                  });
+
+                  // Now resolve — the agent resumes and events flow to the new stream
+                  session.harness.respondToQuestion({ questionId: pendingQ.questionId, answer });
+                  console.log(`✅ Resolved pending question ${pendingQ.questionId} with: ${answer}`);
+                  await resumeStream;
+                }
+                return;
+              }
+
+              const pendingP = pendingPlans.get(threadKey);
+              if (pendingP) {
+                pendingPlans.delete(threadKey);
+                const session = getSession(threadKey);
+                if (session) {
+                  const lower = parsed.text.toLowerCase();
+                  const approved = lower.startsWith('approve') || lower.startsWith('yes') || lower === 'lgtm' || lower === 'ok' || lower === 'go';
+
+                  // Start fresh streaming before resolving
+                  const resumeStream = streamHarnessToSlack({
+                    slackClient,
+                    channel: channelId,
+                    threadTs,
+                    harness: session.harness,
+                    onAskQuestion: (evt) => {
+                      pendingQuestions.set(threadKey, evt);
+                      const optionsText = evt.options?.length
+                        ? '\n' + evt.options.map((o, i) => `  ${i + 1}. *${o.label}*${o.description ? ` — ${o.description}` : ''}`).join('\n') + '\n\n_Reply with a number or type your answer._'
+                        : '';
+                      slackClient.chat.postMessage({ channel: channelId, thread_ts: threadTs, text: `❓ *Question from the agent:*\n${evt.question}${optionsText}` })
+                        .catch(err => console.error('Failed to post question to Slack:', err));
+                    },
+                    onPlanApproval: async (evt) => {
+                      pendingPlans.set(threadKey, evt);
+                      const header = `📋 *Plan submitted for review${evt.title ? `: ${evt.title}` : ''}*`;
+                      const footer = `\n\n_Reply *approve* to proceed or describe changes to reject._`;
+                      if (evt.plan.length <= SLACK_MAX_LENGTH - header.length - footer.length - 10) {
+                        slackClient.chat.postMessage({ channel: channelId, thread_ts: threadTs, text: `${header}\n\n${evt.plan}${footer}` })
+                          .catch(err => console.error('Failed to post plan to Slack:', err));
+                      } else {
+                        const gistUrl = await createGist(evt.title || 'Implementation Plan', evt.plan);
+                        const planPreview = evt.plan.slice(0, 1500) + '\n\n_(truncated)_';
+                        const linkText = gistUrl ? `\n\n<${gistUrl}|📄 View full plan on GitHub>` : '';
+                        slackClient.chat.postMessage({ channel: channelId, thread_ts: threadTs, text: `${header}${linkText}\n\n${planPreview}${footer}` })
+                          .catch(err => console.error('Failed to post plan to Slack:', err));
+                      }
+                    },
+                  });
+
+                  await session.harness.respondToPlanApproval({
+                    planId: pendingP.planId,
+                    response: approved
+                      ? { action: 'approved' }
+                      : { action: 'rejected', feedback: parsed.text },
+                  });
+                  console.log(`✅ Resolved pending plan ${pendingP.planId}: ${approved ? 'approved' : 'rejected'}`);
+                  await resumeStream;
+                }
+                return;
+              }
+
+              // Regular message — route to Harness
+              const config = getSessionConfig();
+              const { harness, isNew } = await getOrCreateHarness(threadKey, config);
+
+              // Always include environment context so the agent knows about gh, git, etc.
+              let messageContent = `${SESSION_CONTEXT}\n\n`;
+              if (isNew) {
+                const history = await fetchThreadHistory(slackClient, channelId, threadTs, event.ts);
+                if (history) {
+                  messageContent +=
+                    `Here is the prior conversation in this Slack thread for context:\n\n` +
+                    `<thread_history>\n${history}\n</thread_history>\n\n`;
+                }
+              }
+              messageContent += parsed.text;
+
+              // Send message and stream events to Slack
+              const streamPromise = streamHarnessToSlack({
+                slackClient,
+                channel: channelId,
+                threadTs,
+                harness,
+                onAskQuestion: (evt) => {
+                  pendingQuestions.set(threadKey, evt);
+                  const optionsText = evt.options?.length
+                    ? '\n' + evt.options.map((o, i) => `  ${i + 1}. *${o.label}*${o.description ? ` — ${o.description}` : ''}`).join('\n') + '\n\n_Reply with a number or type your answer._'
+                    : '';
+                  slackClient.chat.postMessage({
+                    channel: channelId,
+                    thread_ts: threadTs,
+                    text: `❓ *Question from the agent:*\n${evt.question}${optionsText}`,
+                  }).catch(err => console.error('Failed to post question to Slack:', err));
+                },
+                onPlanApproval: async (evt) => {
+                  pendingPlans.set(threadKey, evt);
+                  const header = `📋 *Plan submitted for review${evt.title ? `: ${evt.title}` : ''}*`;
+                  const footer = `\n\n_Reply *approve* to proceed or describe changes to reject._`;
+
+                  if (evt.plan.length <= SLACK_MAX_LENGTH - header.length - footer.length - 10) {
+                    // Short enough to post inline
+                    slackClient.chat.postMessage({
+                      channel: channelId,
+                      thread_ts: threadTs,
+                      text: `${header}\n\n${evt.plan}${footer}`,
+                    }).catch(err => console.error('Failed to post plan to Slack:', err));
+                  } else {
+                    // Too long — create a gist
+                    const gistUrl = await createGist(
+                      evt.title || 'Implementation Plan',
+                      evt.plan,
+                    );
+                    const planPreview = evt.plan.slice(0, 1500) + '\n\n_(truncated)_';
+                    const linkText = gistUrl
+                      ? `\n\n<${gistUrl}|📄 View full plan on GitHub>`
+                      : '';
+                    slackClient.chat.postMessage({
+                      channel: channelId,
+                      thread_ts: threadTs,
+                      text: `${header}${linkText}\n\n${planPreview}${footer}`,
+                    }).catch(err => console.error('Failed to post plan to Slack:', err));
+                  }
+                },
+              });
+
+              await harness.sendMessage({ content: messageContent });
+              await streamPromise;
+            } catch (error) {
+              console.error('❌ Error processing message:', error);
+              try {
+                await slackClient.chat.postMessage({
+                  channel: channelId,
+                  thread_ts: threadTs,
+                  text: `❌ Error: ${error instanceof Error ? error.message : String(error)}`,
+                });
+              } catch {
+                // Best-effort error reporting
+              }
+            }
+          })();
+        }
+      }
+
+      return c.json({ ok: true });
+    } catch (error) {
+      console.error('Error handling Slack event:', error);
+      return c.json({ error: 'Failed to handle event' }, 500);
+    }
+  },
+});
+
+export const slackRoutes = [slackEventsRoute];

--- a/templates/template-slack-coding-agent/src/mastra/slack/verify.ts
+++ b/templates/template-slack-coding-agent/src/mastra/slack/verify.ts
@@ -1,0 +1,32 @@
+import * as crypto from 'crypto';
+
+/**
+ * Verify that a request came from Slack
+ */
+export function verifySlackRequest(
+  signingSecret: string,
+  requestSignature: string,
+  timestamp: string,
+  body: string,
+): boolean {
+  // Reject old requests (more than 5 minutes old)
+  const fiveMinutesAgo = Math.floor(Date.now() / 1000) - 60 * 5;
+  if (parseInt(timestamp) < fiveMinutesAgo) {
+    return false;
+  }
+
+  // Compute the expected signature
+  const sigBasestring = `v0:${timestamp}:${body}`;
+  const mySignature = 'v0=' + crypto.createHmac('sha256', signingSecret).update(sigBasestring, 'utf8').digest('hex');
+
+  // Guard: ensure requestSignature is valid and lengths match before timingSafeEqual
+  if (
+    typeof requestSignature !== 'string' ||
+    Buffer.byteLength(requestSignature, 'utf8') !== Buffer.byteLength(mySignature, 'utf8')
+  ) {
+    return false;
+  }
+
+  // Compare signatures
+  return crypto.timingSafeEqual(Buffer.from(mySignature, 'utf8'), Buffer.from(requestSignature, 'utf8'));
+}

--- a/templates/template-slack-coding-agent/src/server.ts
+++ b/templates/template-slack-coding-agent/src/server.ts
@@ -1,0 +1,31 @@
+/**
+ * Standalone server entry point.
+ * Run with: npx tsx --env-file=.env src/server.ts
+ */
+import { createNodeServer } from '@mastra/deployer/server';
+import { mastra } from './mastra/index.js';
+
+// Catch crashes so they appear in Railway logs instead of silently dying
+process.on('uncaughtException', (err) => {
+  console.error('[FATAL] Uncaught exception:', err);
+});
+process.on('unhandledRejection', (reason) => {
+  console.error('[FATAL] Unhandled rejection:', reason);
+});
+
+async function main() {
+  const PORT = Number(process.env.PORT) || 4211;
+  console.log('Starting Slack coding agent server...');
+  console.log(`SLACK_BOT_TOKEN: ${process.env.SLACK_BOT_TOKEN ? 'set' : 'MISSING'}`);
+  console.log(`SLACK_SIGNING_SECRET: ${process.env.SLACK_SIGNING_SECRET ? 'set' : 'MISSING'}`);
+  console.log(`ANTHROPIC_API_KEY: ${process.env.ANTHROPIC_API_KEY ? 'set' : 'MISSING'}`);
+  console.log(`E2B_API_KEY: ${process.env.E2B_API_KEY ? 'set' : 'MISSING'}`);
+  await createNodeServer(mastra, { tools: {} });
+  console.log(`Server listening on http://0.0.0.0:${PORT}`);
+  console.log(`Slack events endpoint: http://0.0.0.0:${PORT}/slack/coding/events`);
+}
+
+main().catch(err => {
+  console.error('Failed to start server:', err);
+  process.exit(1);
+});

--- a/templates/template-slack-coding-agent/tsconfig.json
+++ b/templates/template-slack-coding-agent/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/templates/template-slack-coding-agent/vitest.config.ts
+++ b/templates/template-slack-coding-agent/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
Standalone template that wires MastraCode + E2B sandboxes into a Slack bot. Each Slack thread gets its own E2B sandbox with the repo pre-cloned, and the agent streams tool activity back to Slack in real time.

Key pieces:
- Slack event handler with signature verification and thread-per-sandbox isolation
- E2BFilesystem extending MastraFilesystem so the agent gets proper file tools (read, write, edit, grep, etc.) not just `execute_command`
- Harness streaming → Slack with live status updates, spinner, tool activity feed
- Interactive prompt bridging — `ask_user` and plan approvals get posted to Slack, user replies resolve them
- Thread history injection when the bot is tagged in an existing thread
- Gist-based activity logging (append-only buffer, syncs every 10 entries)
- Docker + Railway deployment config with auto-pause/resume via E2B

Deployed and tested end-to-end on Railway talking to a real Slack workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New Slack Coding Agent Template enabling per-thread sandbox sessions with real-time streaming to Slack
  * Git repository management with template-based cloning capabilities
  * Session management with automatic idle cleanup

* **Documentation**
  * Comprehensive README with setup, usage examples, and architecture overview

* **Tests**
  * Integration and end-to-end test suites for agent and Slack functionality

* **Chores**
  * Docker, Railway, and project configuration files added

<!-- end of auto-generated comment: release notes by coderabbit.ai -->