### PR TITLE
fix(playground): split vendor deps into parallel-loadable chunks

### DIFF
--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -64,6 +64,26 @@ export default defineConfig(({ mode }) => {
     },
     build: {
       cssCodeSplit: false,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (
+              id.includes('@codemirror/') ||
+              id.includes('@lezer/') ||
+              id.includes('@uiw/react-codemirror') ||
+              id.includes('@uiw/codemirror-theme')
+            ) {
+              return 'vendor-codemirror';
+            }
+            if (id.includes('@xyflow/') || id.includes('@dagrejs/')) {
+              return 'vendor-xyflow';
+            }
+            if (id.includes('posthog')) {
+              return 'vendor-posthog';
+            }
+          },
+        },
+      },
     },
     server: {
       fs: {


### PR DESCRIPTION
## Summary

Add `manualChunks` configuration to the playground Vite build to split heavy vendor dependencies into separate parallel-loadable chunks. This enables the browser to download vendor chunks in parallel with the main bundle, improving perceived load time.

**Stacked on #13942** (barrel split) → **#13939** (route splitting) → **#13934** (prettier lazy-loading)

## What changed

1 file changed: `packages/playground/vite.config.ts`

Added `manualChunks` function that splits:
- **`vendor-codemirror`** (1,694 KB) — CodeMirror editor, Lezer parsers, themes
- **`vendor-xyflow`** (230 KB) — React Flow / XYFlow for workflow graphs
- **`vendor-posthog`** (165 KB) — PostHog analytics SDK

## Bundle impact

Combined with all optimizations in the stack:

| Metric | Original | After all PRs | Change |
|--------|----------|--------------|--------|
| Main bundle | 5,834 KB | 2,062 KB | **-65%** |
| Main gzipped | 1,736 KB | 594 KB | **-66%** |

The vendor chunks load in parallel and are only needed when their respective features render (code editors, workflow graph, analytics).

## Test plan
- `pnpm build` in playground — main chunk 2,062 KB ✅
- Vendor chunks created: codemirror (1,694 KB), xyflow (230 KB), posthog (165 KB) ✅
- `tsc --noEmit` passes ✅