### PR TITLE
fix: persist final OM pending tokens before repro capture

### DIFF
--- a/.changeset/fresh-ducks-check.md
+++ b/.changeset/fresh-ducks-check.md
@@ -1,0 +1,5 @@
+---
+"@mastra/memory": patch
+---
+
+Improved observational memory repro captures so post-step pending token counts reflect the final persisted state after cleanup or activation.

--- a/.changeset/fresh-ducks-check.md
+++ b/.changeset/fresh-ducks-check.md
@@ -1,5 +1,0 @@
----
-"@mastra/memory": patch
----
-
-Improved observational memory repro captures so post-step pending token counts reflect the final persisted state after cleanup or activation.

--- a/packages/memory/scripts/sanitize-om-repro.mjs
+++ b/packages/memory/scripts/sanitize-om-repro.mjs
@@ -200,6 +200,10 @@ function sanitizeUnknown(value, label) {
       clone[key] = sanitizeScalarString(child, `${label}:${key}`);
       continue;
     }
+    if (typeof child === 'string') {
+      clone[key] = sanitizeScalarString(child, `${label}:${key}`);
+      continue;
+    }
 
     clone[key] = sanitizeNode(child, `${label}:${key}`);
   }

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -3187,11 +3187,15 @@ ${suggestedResponse}
       // Persist the computed token count so the UI can display it on page load
       await this.storage.setPendingMessageTokens(freshRecord.id, totalPendingTokens);
 
-      const captureStorageIds = this.getStorageIds(threadId, resourceId);
-      const postCaptureRecord = reproCaptureEnabled
-        ? ((await this.storage.getObservationalMemory(captureStorageIds.threadId, captureStorageIds.resourceId)) ??
-          freshRecord)
-        : freshRecord;
+      let postCaptureRecord = freshRecord;
+      if (reproCaptureEnabled) {
+        const captureStorageIds = this.getStorageIds(threadId, resourceId);
+        const captureRecordHistory = await this.storage.getObservationalMemoryHistory(
+          captureStorageIds.threadId,
+          captureStorageIds.resourceId,
+        );
+        postCaptureRecord = captureRecordHistory.find(record => record.id === freshRecord.id) ?? freshRecord;
+      }
 
       if (reproCaptureEnabled && preRecordSnapshot && preMessagesSnapshot && preSerializedMessageList) {
         writeProcessInputStepReproCapture({

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -3185,7 +3185,13 @@ ${suggestedResponse}
       );
 
       // Persist the computed token count so the UI can display it on page load
-      this.storage.setPendingMessageTokens(freshRecord.id, totalPendingTokens).catch(() => {});
+      await this.storage.setPendingMessageTokens(freshRecord.id, totalPendingTokens);
+
+      const captureStorageIds = this.getStorageIds(threadId, resourceId);
+      const postCaptureRecord = reproCaptureEnabled
+        ? ((await this.storage.getObservationalMemory(captureStorageIds.threadId, captureStorageIds.resourceId)) ??
+          freshRecord)
+        : freshRecord;
 
       if (reproCaptureEnabled && preRecordSnapshot && preMessagesSnapshot && preSerializedMessageList) {
         writeProcessInputStepReproCapture({
@@ -3194,12 +3200,12 @@ ${suggestedResponse}
           stepNumber,
           args,
           preRecord: preRecordSnapshot,
-          postRecord: freshRecord,
+          postRecord: postCaptureRecord,
           preMessages: preMessagesSnapshot,
           preBufferedChunks: this.getBufferedChunks(preRecordSnapshot),
           preContextTokenCount: this.tokenCounter.countMessages(preMessagesSnapshot),
           preSerializedMessageList,
-          postBufferedChunks: this.getBufferedChunks(freshRecord),
+          postBufferedChunks: this.getBufferedChunks(postCaptureRecord),
           postContextTokenCount: this.tokenCounter.countMessages(contextMessages),
           messageList,
           details: {


### PR DESCRIPTION
## Summary
- await the final OM pending-token persistence write before recording post-step repro state
- reload the OM record after that write so captures reflect the stored pending token count
- keep repro output aligned with the real persisted state after cleanup/activation

## Test plan
- pnpm build:core
- cd packages/memory && pnpm check
- cd packages/memory && pnpm vitest run src/processors/observational-memory/__tests__/observational-memory.test.ts --bail 1 --reporter=dot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured pending memory writes complete before continuing so persisted state is reliable.
  * Improved post-capture memory accuracy so diagnostic captures reflect persisted memory rather than transient state.
  * Broadened sanitization to handle all string values within objects, reducing unexpected or unsafe string artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->