### PR TITLE
fix: preserve embedded json fences in structured output

### DIFF
--- a/.changeset/big-rats-smoke.md
+++ b/.changeset/big-rats-smoke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed structured output parsing when JSON string fields include fenced JSON examples.

--- a/packages/core/src/stream/base/output-format-handlers.test.ts
+++ b/packages/core/src/stream/base/output-format-handlers.test.ts
@@ -851,6 +851,50 @@ describe('output-format-handlers', () => {
       expect(objectResultChunk).toBeDefined();
       expect(objectResultChunk?.object).toEqual({ title: 'Test', count: 5 });
     });
+
+    it('should preserve ```json fences inside valid JSON string values', async () => {
+      const schema = z.object({
+        response: z.string(),
+        status: z.string(),
+      });
+
+      const transformer = createObjectStreamTransformer({
+        structuredOutput: { schema },
+      });
+
+      const response = 'API example:\n```json\nPOST /v1/payments\n{\n  "customerId": "cust_123"\n}\n```';
+
+      const streamParts: ChunkType<typeof schema>[] = [
+        {
+          type: 'text-delta',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: {
+            id: '1',
+            text: JSON.stringify({ response, status: 'ok' }),
+          },
+        },
+        {
+          type: 'finish',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: {
+            stepResult: { reason: 'stop' },
+            output: { usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+            metadata: {},
+            messages: { all: [], user: [], nonUser: [] },
+          },
+        },
+      ];
+
+      // @ts-expect-error - web/stream readable stream type error
+      const stream = convertArrayToReadableStream(streamParts).pipeThrough(transformer);
+      const chunks = await convertAsyncIterableToArray(stream);
+
+      const objectResultChunk = chunks.find(c => c?.type === 'object-result');
+      expect(objectResultChunk).toBeDefined();
+      expect(objectResultChunk?.object).toEqual({ response, status: 'ok' });
+    });
   });
 
   describe('unescaped newlines in JSON strings', () => {

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -258,16 +258,18 @@ abstract class BaseFormatHandler<OUTPUT = undefined> {
       }
     }
 
-    // Some LLMs wrap the JSON response in code blocks.
-    // In that case, first try to extract content from complete code blocks
-    if (processedText.includes('```json')) {
-      const match = processedText.match(/```json\s*\n?([\s\S]*?)\n?\s*```/);
+    // Some LLMs wrap the entire JSON response in a ```json code block.
+    // Only unwrap when the accumulated text itself starts with that fence so
+    // embedded examples inside valid JSON string values are preserved.
+    const trimmedStart = processedText.trimStart();
+    if (/^```json\b/.test(trimmedStart)) {
+      const match = trimmedStart.match(/^```json\s*\n?([\s\S]*?)\n?\s*```\s*$/);
       if (match && match[1]) {
         // Complete code block found - use content between tags
         processedText = match[1].trim();
       } else {
-        // No complete code block - just remove the opening ```json
-        processedText = processedText.replace(/^```json\s*\n?/, '');
+        // No complete code block yet - just remove the opening ```json prefix
+        processedText = trimmedStart.replace(/^```json\s*\n?/, '');
       }
     }
 

--- a/packages/playground/e2e/kitchen-sink/pnpm-lock.yaml
+++ b/packages/playground/e2e/kitchen-sink/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         version: 3.25.76
     devDependencies:
       '@types/node':
-        specifier: 22.19.7
-        version: 22.19.7
+        specifier: 22.19.13
+        version: 22.19.13
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -107,9 +107,9 @@ packages:
     resolution:
       { integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w== }
 
-  '@types/node@22.19.7':
+  '@types/node@22.19.13':
     resolution:
-      { integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw== }
+      { integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw== }
 
   ai@5.1.0-beta.13:
     resolution:
@@ -182,7 +182,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@types/node@22.19.7':
+  '@types/node@22.19.13':
     dependencies:
       undici-types: 6.21.0
 


### PR DESCRIPTION
This keeps structured output parsing from unwrapping ` ```json ` fences that appear inside valid JSON string values, while still handling responses that are fully wrapped in a top-level JSON fence.

Before:
```ts
if (processedText.includes('```json')) {
  const match = processedText.match(/```json\s*\n?([\s\S]*?)\n?\s*```/);
}
```

After:
```ts
const trimmedStart = processedText.trimStart();
if (/^```json\b/.test(trimmedStart)) {
  const match = trimmedStart.match(/^```json\s*\n?([\s\S]*?)\n?\s*```\s*$/);
}
```

Also added a regression test for a valid JSON response whose string field contains an embedded fenced JSON example.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured output parsing to correctly preserve JSON string fields containing fenced code examples, ensuring complex nested content is handled properly.

* **Tests**
  * Added test case verifying JSON code blocks within string values remain intact during stream transformation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->