### PR TITLE
fix(core): enforce activeTools at tool execution time

### DIFF
--- a/.changeset/enforce-active-tools-execution.md
+++ b/.changeset/enforce-active-tools-execution.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `activeTools` to also enforce at execution time, not just at the model prompt. Tool calls to tools not in the active set are now rejected with a `ToolNotFoundError`.

--- a/packages/core/src/agent/__tests__/active-tools-enforcement.test.ts
+++ b/packages/core/src/agent/__tests__/active-tools-enforcement.test.ts
@@ -1,0 +1,223 @@
+import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { createTool } from '../../tools';
+import { Agent } from '../agent';
+
+/**
+ * Tests that activeTools filtering is enforced at tool execution time,
+ * not just at the model prompt level. This prevents models from executing
+ * tools they shouldn't have access to (e.g. from conversation history).
+ */
+describe('activeTools enforcement at execution time', () => {
+  it('rejects tool calls for tools not in activeTools', async () => {
+    const allowedExecute = vi.fn().mockResolvedValue('allowed result');
+    const hiddenExecute = vi.fn().mockResolvedValue('hidden result');
+
+    let callCount = 0;
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async () => {
+        callCount++;
+        if (callCount === 1) {
+          // Model calls a tool that is NOT in activeTools
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            finishReason: 'tool-calls' as const,
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            text: '',
+            content: [
+              {
+                type: 'tool-call' as const,
+                toolCallId: 'call-1',
+                toolName: 'hiddenTool',
+                input: JSON.stringify({ value: 'test' }),
+              },
+            ],
+            warnings: [],
+          };
+        }
+        // Second call: model gives up and returns text
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          text: 'Done.',
+          content: [{ type: 'text' as const, text: 'Done.' }],
+          warnings: [],
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'You are a helpful assistant.',
+      model: mockModel,
+      tools: {
+        allowedTool: createTool({
+          id: 'allowedTool',
+          description: 'An allowed tool',
+          inputSchema: z.object({ value: z.string() }),
+          execute: allowedExecute,
+        }),
+        hiddenTool: createTool({
+          id: 'hiddenTool',
+          description: 'A hidden tool',
+          inputSchema: z.object({ value: z.string() }),
+          execute: hiddenExecute,
+        }),
+      },
+    });
+
+    const result = await agent.generate('Hello', {
+      maxSteps: 3,
+      prepareStep: () => ({
+        activeTools: ['allowedTool'],
+      }),
+    });
+
+    // The hidden tool should NOT have been executed
+    expect(hiddenExecute).not.toHaveBeenCalled();
+
+    // Model was called twice: first with hidden tool call (rejected), then text response
+    expect(callCount).toBe(2);
+    expect(result.text).toBe('Done.');
+  });
+
+  it('allows tool calls for tools in activeTools', async () => {
+    const allowedExecute = vi.fn().mockResolvedValue('allowed result');
+
+    let callCount = 0;
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            finishReason: 'tool-calls' as const,
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            text: '',
+            content: [
+              {
+                type: 'tool-call' as const,
+                toolCallId: 'call-1',
+                toolName: 'allowedTool',
+                input: JSON.stringify({ value: 'test' }),
+              },
+            ],
+            warnings: [],
+          };
+        }
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          text: 'Done.',
+          content: [{ type: 'text' as const, text: 'Done.' }],
+          warnings: [],
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'You are a helpful assistant.',
+      model: mockModel,
+      tools: {
+        allowedTool: createTool({
+          id: 'allowedTool',
+          description: 'An allowed tool',
+          inputSchema: z.object({ value: z.string() }),
+          execute: allowedExecute,
+        }),
+        hiddenTool: createTool({
+          id: 'hiddenTool',
+          description: 'A hidden tool',
+          inputSchema: z.object({ value: z.string() }),
+          execute: vi.fn().mockResolvedValue('hidden result'),
+        }),
+      },
+    });
+
+    await agent.generate('Hello', {
+      maxSteps: 3,
+      prepareStep: () => ({
+        activeTools: ['allowedTool'],
+      }),
+    });
+
+    // The allowed tool should have been executed
+    expect(allowedExecute).toHaveBeenCalledOnce();
+  });
+
+  it('does not restrict tools when activeTools is not set', async () => {
+    const tool1Execute = vi.fn().mockResolvedValue('result1');
+    const tool2Execute = vi.fn().mockResolvedValue('result2');
+
+    let callCount = 0;
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            finishReason: 'tool-calls' as const,
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            text: '',
+            content: [
+              {
+                type: 'tool-call' as const,
+                toolCallId: 'call-1',
+                toolName: 'tool1',
+                input: JSON.stringify({ value: 'test' }),
+              },
+              {
+                type: 'tool-call' as const,
+                toolCallId: 'call-2',
+                toolName: 'tool2',
+                input: JSON.stringify({ value: 'test' }),
+              },
+            ],
+            warnings: [],
+          };
+        }
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          text: 'Done.',
+          content: [{ type: 'text' as const, text: 'Done.' }],
+          warnings: [],
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'You are a helpful assistant.',
+      model: mockModel,
+      tools: {
+        tool1: createTool({
+          id: 'tool1',
+          description: 'Tool 1',
+          inputSchema: z.object({ value: z.string() }),
+          execute: tool1Execute,
+        }),
+        tool2: createTool({
+          id: 'tool2',
+          description: 'Tool 2',
+          inputSchema: z.object({ value: z.string() }),
+          execute: tool2Execute,
+        }),
+      },
+    });
+
+    // No prepareStep = no activeTools restriction
+    await agent.generate('Hello', { maxSteps: 3 });
+
+    expect(tool1Execute).toHaveBeenCalledOnce();
+    expect(tool2Execute).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/loop/types.ts
+++ b/packages/core/src/loop/types.ts
@@ -52,6 +52,8 @@ export type StreamInternal = {
   threadExists?: boolean;
   // Tools modified by prepareStep/processInputStep - stored here to avoid workflow serialization
   stepTools?: ToolSet;
+  // Active tools from prepareStep - used by toolCallStep to reject calls to hidden tools
+  stepActiveTools?: string[];
   // Workspace from prepareStep/processInputStep - stored here to avoid workflow serialization
   stepWorkspace?: Workspace;
   // Set to true when a delegation hook calls ctx.bail() to signal the loop should stop

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -699,6 +699,11 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
           }
         }
 
+        // Store activeTools on _internal so toolCallStep can enforce them
+        if (_internal) {
+          _internal.stepActiveTools = currentStep.activeTools as string[] | undefined;
+        }
+
         const runState = new AgenticRunState({
           _internal: _internal!,
           model: currentStep.model,

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -48,6 +48,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
       // This avoids serialization issues - _internal is a mutable object that preserves execute functions
       // Fall back to the original tools from the closure if not set
       const stepTools = (_internal?.stepTools as Tools) || tools;
+      const stepActiveTools = _internal?.stepActiveTools;
 
       const tool =
         stepTools?.[inputData.toolName] ||
@@ -221,8 +222,15 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         };
       }
 
-      if (!tool) {
-        const availableToolNames = Object.keys(stepTools || {});
+      // Resolve the tool key for activeTools enforcement (may differ from toolName when matched by id)
+      const toolKey = stepTools?.[inputData.toolName]
+        ? inputData.toolName
+        : Object.entries(stepTools || {}).find(([_, t]: [string, any]) => t === tool)?.[0];
+
+      // Reject if tool doesn't exist or isn't in the active set for this step
+      const isHiddenByActiveTools = stepActiveTools && toolKey && !stepActiveTools.includes(toolKey);
+      if (!tool || isHiddenByActiveTools) {
+        const availableToolNames = stepActiveTools ?? Object.keys(stepTools || {});
         const availableToolsStr =
           availableToolNames.length > 0 ? ` Available tools: ${availableToolNames.join(', ')}` : '';
         return {


### PR DESCRIPTION
## Problem

`activeTools` (from `prepareStep`) only filtered which tools were sent to the model's prompt via `prepareToolsAndToolChoice`. However, `tool-call-step.ts` resolved tools from the full `stepTools` set without checking `activeTools`.

This means if a model hallucinated a tool call for a tool it shouldn't have access to (e.g. because it saw the tool in conversation history), the tool would still execute successfully.

## Fix

1. Added `stepActiveTools?: string[]` to `_internal` type (`loop/types.ts`)
2. `llm-execution-step.ts` now stores `currentStep.activeTools` on `_internal.stepActiveTools`
3. `tool-call-step.ts` checks `_internal.stepActiveTools` before executing — if the tool is not in the active set, it returns a `ToolNotFoundError`

## Tests

3 new tests in `active-tools-enforcement.test.ts`:
- Rejects tool calls for tools not in `activeTools`
- Allows tool calls for tools in `activeTools`
- Does not restrict tools when `activeTools` is not set

## Related

This was discovered while working on subagent workspace tool inheritance (#13940), where `prepareStep` + `activeTools` is used to restrict which workspace tools subagents can use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool execution now enforces the configured active tools at runtime: attempts to call tools outside the active set are rejected with a clear error listing available tools.

* **Tests**
  * Added end-to-end tests verifying enforcement behavior for allowed, disallowed, and unspecified active-tools scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->