### PR TITLE
Harness primitive rationale

### DIFF
--- a/.changeset/cuddly-days-draw.md
+++ b/.changeset/cuddly-days-draw.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': minor
+---
+
+Update peer dependencies to match core package version bump (1.11.0)

--- a/.changeset/five-pots-arrive.md
+++ b/.changeset/five-pots-arrive.md
@@ -1,0 +1,14 @@
+---
+'@mastra/server': minor
+'@mastra/core': patch
+---
+
+Added server routes for Agent orchestration features:
+
+- `GET /api/agents/:agentId/modes` — list configured modes and current mode
+- `POST /api/agents/:agentId/modes/switch` — switch to a different mode
+- `GET /api/agents/:agentId/state` — get agent state
+- `POST /api/agents/:agentId/state` — update agent state
+- `POST /api/agents/:agentId/send` — send a message and stream lifecycle events via SSE
+
+The `/send` endpoint streams agent events (`send_start`, `message_start`, `message_update`, `tool_start`, `tool_end`, `send_end`, etc.) as Server-Sent Events, enabling real-time UI updates.

--- a/.changeset/public-places-occur.md
+++ b/.changeset/public-places-occur.md
@@ -1,0 +1,24 @@
+---
+'@mastra/core': minor
+---
+
+Added `.send()` method to the Agent class — a higher-level orchestration method that wraps `stream()` with event emission, abort handling, and error recovery.
+
+`.send()` emits lifecycle events (`send_start`, `send_end`), message events (`message_start`, `message_update`, `message_end`), tool events (`tool_start`, `tool_end`, `tool_approval_required`), and usage events (`usage_update`) so UIs can subscribe and react.
+
+Also adds `abort()` to cancel in-progress sends and `respondToToolApproval()` for interactive tool approval flows.
+
+```typescript
+agent.subscribe(event => {
+  if (event.type === 'message_update') console.log(event.message);
+});
+
+const { message } = await agent.send({
+  messages: 'Hello!',
+  threadId: 'thread-1',
+  resourceId: 'user-1',
+});
+
+// Cancel:
+agent.abort();
+```

--- a/.changeset/silly-ravens-strive.md
+++ b/.changeset/silly-ravens-strive.md
@@ -1,0 +1,37 @@
+---
+'@mastra/core': minor
+---
+
+Added optional orchestration capabilities to the Agent class: event system (subscribe/on), modes (named presets of instructions/model/tools), and shared state (Zod-validated). These are the foundation for folding Harness capabilities into Agent, reducing the number of concepts users need to learn.
+
+**Events** - Subscribe to agent lifecycle events with `subscribe()` or `on()`:
+
+```typescript
+agent.on('mode_changed', event => {
+  console.log(`Switched to ${event.modeId}`);
+});
+```
+
+**Modes** - Define named presets and switch between them at runtime:
+
+```typescript
+const agent = new Agent({
+  modes: [
+    { id: 'plan', name: 'Plan', default: true, model: 'anthropic/claude-sonnet-4-20250514' },
+    { id: 'build', name: 'Build', model: 'anthropic/claude-sonnet-4-20250514', tools: buildTools },
+  ],
+});
+
+agent.switchMode('build');
+```
+
+**State** - Shared, Zod-validated state that persists across mode switches:
+
+```typescript
+const agent = new Agent({
+  stateSchema: z.object({ counter: z.number().default(0) }),
+});
+
+agent.setState({ counter: 1 });
+console.log(agent.getState()); // { counter: 1 }
+```

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -223,62 +223,25 @@ SystemMessage types: string | string[] | CoreSystemMessage | CoreSystemMessage[]
       'Zod schema for validating request context values. When provided, the context is validated at the start of generate() or stream(), throwing a MastraError if validation fails.',
   },
   {
-    name: 'modes',
-    type: 'AgentMode[]',
+    name: 'harness',
+    type: 'AgentHarnessConfig',
     isOptional: true,
     description:
-      "Named presets of instructions, model, and tools that can be switched at runtime. When configured, the current mode's overrides are applied on top of the agent's base configuration. Use `switchMode()` to change between modes.",
+      'Per-session orchestration config. Defines modes and state schema available per `.send()` operation. Values are NOT stored on the Agent singleton — they are passed per-operation for session isolation.',
     properties: [
       {
-        name: 'id',
-        type: 'string',
-        description: 'Unique identifier for this mode (e.g., "plan", "build", "review").',
+        name: 'modes',
+        type: 'AgentMode[]',
+        isOptional: true,
+        description: 'Named presets. Select a mode per `.send()` via `modeId`.',
       },
       {
-        name: 'name',
-        type: 'string',
+        name: 'stateSchema',
+        type: 'z.ZodObject',
         isOptional: true,
-        description: 'Human-readable name for display.',
-      },
-      {
-        name: 'default',
-        type: 'boolean',
-        isOptional: true,
-        description:
-          'Whether this is the default mode when the agent starts. If no mode is marked default, the first mode is used.',
-      },
-      {
-        name: 'instructions',
-        type: 'SystemMessage | ({ requestContext }) => SystemMessage',
-        isOptional: true,
-        description: 'Instructions override for this mode.',
-      },
-      {
-        name: 'model',
-        type: 'MastraModelConfig | ({ requestContext }) => MastraModelConfig',
-        isOptional: true,
-        description: 'Model override for this mode.',
-      },
-      {
-        name: 'tools',
-        type: 'ToolsInput | ({ requestContext }) => ToolsInput',
-        isOptional: true,
-        description: 'Tools override for this mode (merged with agent-level tools).',
+        description: 'Zod schema for per-session state. Validated per `.send()` operation.',
       },
     ],
-  },
-  {
-    name: 'stateSchema',
-    type: 'z.ZodObject',
-    isOptional: true,
-    description:
-      'Zod object schema defining the shape of shared agent state. State persists across mode switches and is accessible via `getState()` / `setState()`. If the schema includes defaults, they are applied automatically.',
-  },
-  {
-    name: 'initialState',
-    type: 'Record<string, unknown>',
-    isOptional: true,
-    description: 'Initial state values. Must conform to `stateSchema` if provided. Overrides schema defaults.',
   },
 ]}
 />
@@ -322,21 +285,21 @@ agent.on('mode_changed', event => {
 })
 ```
 
-### Modes
+### Harness
 
 #### `hasModes()`
 
-Returns `true` if the agent has modes configured.
+Returns `true` if the agent has modes configured in its `harness` config.
 
 ```typescript
 if (agent.hasModes()) {
-  console.log('Current mode:', agent.getCurrentModeId())
+  console.log('Default mode:', agent.getDefaultMode()?.id)
 }
 ```
 
 #### `listModes()`
 
-Returns all configured modes, or an empty array if modes are not configured.
+Returns all configured modes from the harness config.
 
 ```typescript
 const modes = agent.listModes()
@@ -344,53 +307,25 @@ const modes = agent.listModes()
 
 **Returns:** `AgentMode[]`
 
-#### `getCurrentModeId()`
+#### `getDefaultMode()`
 
-Returns the current mode ID, or `undefined` if modes are not configured.
-
-```typescript
-const modeId = agent.getCurrentModeId()
-```
-
-**Returns:** `string | undefined`
-
-#### `getCurrentMode()`
-
-Returns the current mode object, or `undefined` if modes are not configured.
+Returns the default mode (marked `default: true`, or the first mode).
 
 ```typescript
-const mode = agent.getCurrentMode()
+const defaultMode = agent.getDefaultMode()
 ```
 
 **Returns:** `AgentMode | undefined`
 
-#### `switchMode(modeId)`
+#### `getStateSchema()`
 
-Switch to a different mode. Throws if modes are not configured or the mode ID is not found.
-
-```typescript
-agent.switchMode('build')
-```
-
-### State
-
-#### `getState()`
-
-Returns a read-only snapshot of the current agent state. Returns an empty object if state is not configured.
+Returns the Zod state schema from the harness config, if configured.
 
 ```typescript
-const state = agent.getState()
+const schema = agent.getStateSchema()
 ```
 
-**Returns:** `Readonly<Record<string, unknown>>`
-
-#### `setState(updates)`
-
-Update agent state with a partial update. Validates against `stateSchema` if provided and emits a `state_changed` event.
-
-```typescript
-agent.setState({ counter: agent.getState().counter + 1 })
-```
+**Returns:** `z.ZodObject | undefined`
 
 ### Orchestration
 
@@ -405,6 +340,8 @@ const op = agent.send({
   messages: 'Hello!',
   threadId: 'thread-1',
   resourceId: 'user-1',
+  modeId: 'plan',
+  state: { counter: 0 },
 })
 
 // Consume events as an async iterable
@@ -432,6 +369,20 @@ const { message } = await op.result
     name: 'resourceId',
     type: 'string',
     description: 'The resource ID for memory persistence.',
+  },
+  {
+    name: 'modeId',
+    type: 'string',
+    isOptional: true,
+    description:
+      'Mode to use for this operation. Must match an id from `harness.modes`. Falls back to the default mode.',
+  },
+  {
+    name: 'state',
+    type: 'Record<string, unknown>',
+    isOptional: true,
+    description:
+      'Per-operation state. Validated against `harness.stateSchema` if configured. Accessible by tools via `requestContext.get("agentState")`.',
   },
   {
     name: 'maxSteps',

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -396,22 +396,24 @@ agent.setState({ counter: agent.getState().counter + 1 })
 
 #### `send({ messages, threadId, resourceId, ... })`
 
-Send a message and stream the response, emitting events for the full lifecycle. This is a higher-level method that wraps `stream()` with event emission, abort handling, and error recovery.
+Send a message and get back a self-contained `SendOperation`. Each call has its own isolated event stream, abort handle, and tool-approval resolver — multiple concurrent sends to the same Agent do not interfere with each other.
 
 Requires `memory` to be configured on the agent.
 
 ```typescript
-agent.subscribe(event => {
-  if (event.type === 'message_update') {
-    console.log(event.message.content)
-  }
-})
-
-const { message } = await agent.send({
+const op = agent.send({
   messages: 'Hello!',
   threadId: 'thread-1',
   resourceId: 'user-1',
 })
+
+// Consume events as an async iterable
+for await (const event of op.events) {
+  if (event.type === 'message_update') console.log(event.message.content)
+}
+
+// Or await the final message directly
+const { message } = await op.result
 ```
 
 <PropertiesTable
@@ -459,28 +461,34 @@ const { message } = await agent.send({
 ]}
 />
 
-**Returns:** `Promise<{ message: AgentMessage }>`
+**Returns:** `SendOperation`
 
-#### `abort()`
+The returned `SendOperation` has the following properties:
 
-Abort the current `.send()` operation. The in-progress stream is cancelled and a `send_end` event with reason `'aborted'` is emitted.
-
-```typescript
-agent.abort()
-```
-
-#### `respondToToolApproval(decision, requestContext?)`
-
-Respond to a pending tool approval request. Only meaningful when a `tool_approval_required` event has been emitted.
-
-```typescript
-agent.on('tool_approval_required', event => {
-  // Auto-approve read tools, ask for others
-  if (event.toolName.startsWith('read')) {
-    agent.respondToToolApproval('approve')
-  }
-})
-```
+<PropertiesTable
+  content={[
+  {
+    name: 'result',
+    type: 'Promise<{ message: AgentMessage }>',
+    description: 'Resolves when the send completes, with the assembled assistant message.',
+  },
+  {
+    name: 'events',
+    type: 'AsyncIterable<AgentEvent>',
+    description: 'Async iterable of events emitted during this send. Use with `for await`.',
+  },
+  {
+    name: 'abort()',
+    type: '() => void',
+    description: 'Abort this specific send operation.',
+  },
+  {
+    name: 'respondToToolApproval(decision, requestContext?)',
+    type: '(decision: "approve" | "decline", requestContext?: RequestContext) => void',
+    description: 'Respond to a tool approval request within this send operation.',
+  },
+]}
+/>
 
 ## Related
 

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -392,6 +392,96 @@ Update agent state with a partial update. Validates against `stateSchema` if pro
 agent.setState({ counter: agent.getState().counter + 1 })
 ```
 
+### Orchestration
+
+#### `send({ messages, threadId, resourceId, ... })`
+
+Send a message and stream the response, emitting events for the full lifecycle. This is a higher-level method that wraps `stream()` with event emission, abort handling, and error recovery.
+
+Requires `memory` to be configured on the agent.
+
+```typescript
+agent.subscribe(event => {
+  if (event.type === 'message_update') {
+    console.log(event.message.content)
+  }
+})
+
+const { message } = await agent.send({
+  messages: 'Hello!',
+  threadId: 'thread-1',
+  resourceId: 'user-1',
+})
+```
+
+<PropertiesTable
+  content={[
+  {
+    name: 'messages',
+    type: 'MessageListInput',
+    description: 'The message(s) to send. Can be a string or structured message input.',
+  },
+  {
+    name: 'threadId',
+    type: 'string',
+    description: 'The thread ID for memory persistence.',
+  },
+  {
+    name: 'resourceId',
+    type: 'string',
+    description: 'The resource ID for memory persistence.',
+  },
+  {
+    name: 'maxSteps',
+    type: 'number',
+    isOptional: true,
+    defaultValue: '100',
+    description: 'Maximum number of LLM steps allowed.',
+  },
+  {
+    name: 'requestContext',
+    type: 'RequestContext',
+    isOptional: true,
+    description: 'Request context for dependency injection.',
+  },
+  {
+    name: 'toolsets',
+    type: 'ToolsetsInput',
+    isOptional: true,
+    description: 'Additional tool sets available during this send.',
+  },
+  {
+    name: 'abortSignal',
+    type: 'AbortSignal',
+    isOptional: true,
+    description: 'External abort signal. When aborted, cancels the stream.',
+  },
+]}
+/>
+
+**Returns:** `Promise<{ message: AgentMessage }>`
+
+#### `abort()`
+
+Abort the current `.send()` operation. The in-progress stream is cancelled and a `send_end` event with reason `'aborted'` is emitted.
+
+```typescript
+agent.abort()
+```
+
+#### `respondToToolApproval(decision, requestContext?)`
+
+Respond to a pending tool approval request. Only meaningful when a `tool_approval_required` event has been emitted.
+
+```typescript
+agent.on('tool_approval_required', event => {
+  // Auto-approve read tools, ask for others
+  if (event.toolName.startsWith('read')) {
+    agent.respondToToolApproval('approve')
+  }
+})
+```
+
 ## Related
 
 - [Agents overview](/docs/agents/overview)

--- a/docs/src/content/en/reference/agents/agent.mdx
+++ b/docs/src/content/en/reference/agents/agent.mdx
@@ -222,6 +222,64 @@ SystemMessage types: string | string[] | CoreSystemMessage | CoreSystemMessage[]
     description:
       'Zod schema for validating request context values. When provided, the context is validated at the start of generate() or stream(), throwing a MastraError if validation fails.',
   },
+  {
+    name: 'modes',
+    type: 'AgentMode[]',
+    isOptional: true,
+    description:
+      "Named presets of instructions, model, and tools that can be switched at runtime. When configured, the current mode's overrides are applied on top of the agent's base configuration. Use `switchMode()` to change between modes.",
+    properties: [
+      {
+        name: 'id',
+        type: 'string',
+        description: 'Unique identifier for this mode (e.g., "plan", "build", "review").',
+      },
+      {
+        name: 'name',
+        type: 'string',
+        isOptional: true,
+        description: 'Human-readable name for display.',
+      },
+      {
+        name: 'default',
+        type: 'boolean',
+        isOptional: true,
+        description:
+          'Whether this is the default mode when the agent starts. If no mode is marked default, the first mode is used.',
+      },
+      {
+        name: 'instructions',
+        type: 'SystemMessage | ({ requestContext }) => SystemMessage',
+        isOptional: true,
+        description: 'Instructions override for this mode.',
+      },
+      {
+        name: 'model',
+        type: 'MastraModelConfig | ({ requestContext }) => MastraModelConfig',
+        isOptional: true,
+        description: 'Model override for this mode.',
+      },
+      {
+        name: 'tools',
+        type: 'ToolsInput | ({ requestContext }) => ToolsInput',
+        isOptional: true,
+        description: 'Tools override for this mode (merged with agent-level tools).',
+      },
+    ],
+  },
+  {
+    name: 'stateSchema',
+    type: 'z.ZodObject',
+    isOptional: true,
+    description:
+      'Zod object schema defining the shape of shared agent state. State persists across mode switches and is accessible via `getState()` / `setState()`. If the schema includes defaults, they are applied automatically.',
+  },
+  {
+    name: 'initialState',
+    type: 'Record<string, unknown>',
+    isOptional: true,
+    description: 'Initial state values. Must conform to `stateSchema` if provided. Overrides schema defaults.',
+  },
 ]}
 />
 
@@ -236,6 +294,103 @@ SystemMessage types: string | string[] | CoreSystemMessage | CoreSystemMessage[]
   },
 ]}
 />
+
+## Methods
+
+### Events
+
+#### `subscribe(listener)`
+
+Subscribe to all agent events. Returns an unsubscribe function.
+
+```typescript
+const unsub = agent.subscribe(event => {
+  console.log(event.type, event)
+})
+
+// later:
+unsub()
+```
+
+#### `on(type, handler)`
+
+Subscribe to a specific event type. Returns an unsubscribe function.
+
+```typescript
+agent.on('mode_changed', event => {
+  console.log(`Switched to mode: ${event.modeId}`)
+})
+```
+
+### Modes
+
+#### `hasModes()`
+
+Returns `true` if the agent has modes configured.
+
+```typescript
+if (agent.hasModes()) {
+  console.log('Current mode:', agent.getCurrentModeId())
+}
+```
+
+#### `listModes()`
+
+Returns all configured modes, or an empty array if modes are not configured.
+
+```typescript
+const modes = agent.listModes()
+```
+
+**Returns:** `AgentMode[]`
+
+#### `getCurrentModeId()`
+
+Returns the current mode ID, or `undefined` if modes are not configured.
+
+```typescript
+const modeId = agent.getCurrentModeId()
+```
+
+**Returns:** `string | undefined`
+
+#### `getCurrentMode()`
+
+Returns the current mode object, or `undefined` if modes are not configured.
+
+```typescript
+const mode = agent.getCurrentMode()
+```
+
+**Returns:** `AgentMode | undefined`
+
+#### `switchMode(modeId)`
+
+Switch to a different mode. Throws if modes are not configured or the mode ID is not found.
+
+```typescript
+agent.switchMode('build')
+```
+
+### State
+
+#### `getState()`
+
+Returns a read-only snapshot of the current agent state. Returns an empty object if state is not configured.
+
+```typescript
+const state = agent.getState()
+```
+
+**Returns:** `Readonly<Record<string, unknown>>`
+
+#### `setState(updates)`
+
+Update agent state with a partial update. Validates against `stateSchema` if provided and emits a `state_changed` event.
+
+```typescript
+agent.setState({ counter: agent.getState().counter + 1 })
+```
 
 ## Related
 

--- a/docs/src/content/en/reference/server/routes.mdx
+++ b/docs/src/content/en/reference/server/routes.mdx
@@ -17,6 +17,11 @@ Server adapters register these routes when you call `server.init()`. All routes 
 | `GET` | `/api/agents/:agentId` | Get agent by ID |
 | `POST` | `/api/agents/:agentId/generate` | Generate agent response |
 | `POST` | `/api/agents/:agentId/stream` | Stream agent response |
+| `POST` | `/api/agents/:agentId/send` | Send message with event streaming (SSE) |
+| `GET` | `/api/agents/:agentId/modes` | List agent modes and current mode |
+| `POST` | `/api/agents/:agentId/modes/switch` | Switch agent mode |
+| `GET` | `/api/agents/:agentId/state` | Get agent state |
+| `POST` | `/api/agents/:agentId/state` | Update agent state |
 | `GET` | `/api/agents/:agentId/tools` | List agent tools |
 | `POST` | `/api/agents/:agentId/tools/:toolId/execute` | Execute agent tool |
 
@@ -51,6 +56,53 @@ Server adapters register these routes when you call `server.init()`. All routes 
     promptTokens: number;
     completionTokens: number;
   };
+}
+```
+
+### Send request body
+
+```typescript prettier:false
+{
+  messages: string | CoreMessage[];   // Required
+  threadId: string;                   // Required — thread for memory
+  resourceId: string;                 // Required — resource for memory
+  maxSteps?: number;                  // Max tool steps (default: 100)
+  bodyRequestContext?: Record<string, unknown>; // Additional request context
+}
+```
+
+The response is an SSE stream of agent events (`send_start`, `message_start`, `message_update`, `message_end`, `tool_start`, `tool_end`, `usage_update`, `error`, `send_end`).
+
+### Modes response
+
+```typescript prettier:false
+{
+  modes: Array<{ id: string; name?: string; default?: boolean }>;
+  currentModeId?: string;
+}
+```
+
+### Switch mode request body
+
+```typescript prettier:false
+{
+  modeId: string;   // The mode ID to switch to
+}
+```
+
+### State response
+
+```typescript prettier:false
+{
+  state: Record<string, unknown>;
+}
+```
+
+### Update state request body
+
+```typescript prettier:false
+{
+  state: Record<string, unknown>;   // Partial state update to merge
 }
 ```
 

--- a/docs/src/content/en/reference/server/routes.mdx
+++ b/docs/src/content/en/reference/server/routes.mdx
@@ -18,10 +18,8 @@ Server adapters register these routes when you call `server.init()`. All routes 
 | `POST` | `/api/agents/:agentId/generate` | Generate agent response |
 | `POST` | `/api/agents/:agentId/stream` | Stream agent response |
 | `POST` | `/api/agents/:agentId/send` | Send message with event streaming (SSE) |
-| `GET` | `/api/agents/:agentId/modes` | List agent modes and current mode |
-| `POST` | `/api/agents/:agentId/modes/switch` | Switch agent mode |
-| `GET` | `/api/agents/:agentId/state` | Get agent state |
-| `POST` | `/api/agents/:agentId/state` | Update agent state |
+| `GET` | `/api/agents/:agentId/modes` | List available agent modes |
+| `GET` | `/api/agents/:agentId/state` | Get agent state (read-only) |
 | `GET` | `/api/agents/:agentId/tools` | List agent tools |
 | `POST` | `/api/agents/:agentId/tools/:toolId/execute` | Execute agent tool |
 
@@ -66,12 +64,15 @@ Server adapters register these routes when you call `server.init()`. All routes 
   messages: string | CoreMessage[];   // Required
   threadId: string;                   // Required — thread for memory
   resourceId: string;                 // Required — resource for memory
+  modeId?: string;                    // Mode to use for this request
   maxSteps?: number;                  // Max tool steps (default: 100)
   bodyRequestContext?: Record<string, unknown>; // Additional request context
 }
 ```
 
 The response is an SSE stream of agent events (`send_start`, `message_start`, `message_update`, `message_end`, `tool_start`, `tool_end`, `usage_update`, `error`, `send_end`).
+
+Pass `modeId` to select which mode's instructions, model, and tools to use for this specific request. Each request is isolated — selecting a mode does not affect other concurrent requests.
 
 ### Modes response
 
@@ -82,27 +83,11 @@ The response is an SSE stream of agent events (`send_start`, `message_start`, `m
 }
 ```
 
-### Switch mode request body
-
-```typescript prettier:false
-{
-  modeId: string;   // The mode ID to switch to
-}
-```
-
 ### State response
 
 ```typescript prettier:false
 {
   state: Record<string, unknown>;
-}
-```
-
-### Update state request body
-
-```typescript prettier:false
-{
-  state: Record<string, unknown>;   // Partial state update to merge
 }
 ```
 

--- a/docs/src/content/en/reference/server/routes.mdx
+++ b/docs/src/content/en/reference/server/routes.mdx
@@ -18,8 +18,7 @@ Server adapters register these routes when you call `server.init()`. All routes 
 | `POST` | `/api/agents/:agentId/generate` | Generate agent response |
 | `POST` | `/api/agents/:agentId/stream` | Stream agent response |
 | `POST` | `/api/agents/:agentId/send` | Send message with event streaming (SSE) |
-| `GET` | `/api/agents/:agentId/modes` | List available agent modes |
-| `GET` | `/api/agents/:agentId/state` | Get agent state (read-only) |
+| `GET` | `/api/agents/:agentId/modes` | List available modes from harness config |
 | `GET` | `/api/agents/:agentId/tools` | List agent tools |
 | `POST` | `/api/agents/:agentId/tools/:toolId/execute` | Execute agent tool |
 
@@ -80,14 +79,6 @@ Pass `modeId` to select which mode's instructions, model, and tools to use for t
 {
   modes: Array<{ id: string; name?: string; default?: boolean }>;
   currentModeId?: string;
-}
-```
-
-### State response
-
-```typescript prettier:false
-{
-  state: Record<string, unknown>;
 }
 ```
 

--- a/packages/core/src/agent/agent-orchestration.test.ts
+++ b/packages/core/src/agent/agent-orchestration.test.ts
@@ -1,6 +1,9 @@
 import { MockLanguageModelV1, simulateReadableStream } from '@internal/ai-sdk-v4/test';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
+
+import { MockMemory } from '../memory/mock';
 
 import type { AgentEvent } from './events';
 import { Agent } from './index';
@@ -18,6 +21,33 @@ function createDummyModel() {
         chunks: [{ type: 'text-delta' as const, textDelta: 'Dummy response' }],
       }),
       rawCall: { rawPrompt: null, rawSettings: {} },
+    }),
+  });
+}
+
+function createV2StreamModel(text = 'Hello from send') {
+  return new MockLanguageModelV2({
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop' as const,
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      content: [{ type: 'text' as const, text }],
+      warnings: [],
+    }),
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: text },
+        { type: 'text-end', id: 'text-1' },
+        {
+          type: 'finish',
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        },
+      ]),
     }),
   });
 }
@@ -380,5 +410,198 @@ describe('Agent Orchestration Integration', () => {
     expect(events).toHaveLength(2);
     expect(events[0]!.type).toBe('mode_changed');
     expect(events[1]!.type).toBe('state_changed');
+  });
+});
+
+describe('Agent .send()', () => {
+  it('emits send_start, message events, and send_end', async () => {
+    const mockMemory = new MockMemory();
+    const agent = new Agent({
+      id: 'send-agent',
+      name: 'Send Agent',
+      instructions: 'You are helpful.',
+      model: createV2StreamModel('Hello world'),
+      memory: mockMemory,
+    });
+
+    const events: AgentEvent[] = [];
+    agent.subscribe(e => events.push(e));
+
+    await agent.send({
+      messages: 'Hi there',
+      threadId: 'thread-1',
+      resourceId: 'user-1',
+    });
+
+    const eventTypes = events.map(e => e.type);
+    expect(eventTypes).toContain('send_start');
+    expect(eventTypes).toContain('message_start');
+    expect(eventTypes).toContain('message_update');
+    expect(eventTypes).toContain('message_end');
+    expect(eventTypes).toContain('send_end');
+
+    const sendEnd = events.find(e => e.type === 'send_end');
+    expect(sendEnd).toBeDefined();
+    if (sendEnd && sendEnd.type === 'send_end') {
+      expect(sendEnd.reason).toBe('complete');
+    }
+  });
+
+  it('returns the assembled message', async () => {
+    const mockMemory = new MockMemory();
+    const agent = new Agent({
+      id: 'send-agent',
+      name: 'Send Agent',
+      instructions: 'You are helpful.',
+      model: createV2StreamModel('Test response'),
+      memory: mockMemory,
+    });
+
+    const { message } = await agent.send({
+      messages: 'Hello',
+      threadId: 'thread-1',
+      resourceId: 'user-1',
+    });
+
+    expect(message.role).toBe('assistant');
+    expect(message.content.length).toBeGreaterThan(0);
+    const textContent = message.content.find(c => c.type === 'text');
+    expect(textContent).toBeDefined();
+    expect(textContent!.text).toContain('Test response');
+  });
+
+  it('abort() cancels the stream and emits aborted', async () => {
+    const mockMemory = new MockMemory();
+    const agent = new Agent({
+      id: 'abort-agent',
+      name: 'Abort Agent',
+      instructions: 'You are helpful.',
+      model: new MockLanguageModelV2({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          content: [{ type: 'text' as const, text: 'response' }],
+          warnings: [],
+        }),
+        doStream: async () => {
+          await new Promise(resolve => setTimeout(resolve, 100));
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'text-start', id: 'text-1' },
+              { type: 'text-delta', id: 'text-1', delta: 'slow' },
+              { type: 'text-end', id: 'text-1' },
+              {
+                type: 'finish',
+                finishReason: 'stop' as const,
+                usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+              },
+            ]),
+          };
+        },
+      }),
+      memory: mockMemory,
+    });
+
+    const events: AgentEvent[] = [];
+    agent.subscribe(e => events.push(e));
+
+    setTimeout(() => agent.abort(), 10);
+
+    await agent.send({
+      messages: 'Hello',
+      threadId: 'thread-1',
+      resourceId: 'user-1',
+    });
+
+    const eventTypes = events.map(e => e.type);
+    expect(eventTypes).toContain('send_start');
+    expect(eventTypes).toContain('send_end');
+    const sendEnd = events.find(e => e.type === 'send_end');
+    if (sendEnd && sendEnd.type === 'send_end') {
+      expect(sendEnd.reason).toBe('aborted');
+    }
+  });
+
+  it('emits error event when stream contains an error chunk', async () => {
+    const mockMemory = new MockMemory();
+    const agent = new Agent({
+      id: 'error-agent',
+      name: 'Error Agent',
+      instructions: 'You are helpful.',
+      model: new MockLanguageModelV2({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+          content: [{ type: 'text' as const, text: '' }],
+          warnings: [],
+        }),
+        doStream: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'error', error: new Error('Stream error') },
+            {
+              type: 'finish',
+              finishReason: 'error' as const,
+              usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+            },
+          ]),
+        }),
+      }),
+      memory: mockMemory,
+    });
+
+    const events: AgentEvent[] = [];
+    agent.subscribe(e => events.push(e));
+
+    await agent.send({
+      messages: 'Hello',
+      threadId: 'thread-1',
+      resourceId: 'user-1',
+    });
+
+    const eventTypes = events.map(e => e.type);
+    expect(eventTypes).toContain('send_start');
+    expect(eventTypes).toContain('error');
+    expect(eventTypes).toContain('send_end');
+
+    const errorEvent = events.find(e => e.type === 'error');
+    if (errorEvent && errorEvent.type === 'error') {
+      expect(errorEvent.error.message).toBe('Stream error');
+    }
+  });
+
+  it('emits usage_update event with token counts', async () => {
+    const mockMemory = new MockMemory();
+    const agent = new Agent({
+      id: 'usage-agent',
+      name: 'Usage Agent',
+      instructions: 'You are helpful.',
+      model: createV2StreamModel('Token test'),
+      memory: mockMemory,
+    });
+
+    const events: AgentEvent[] = [];
+    agent.subscribe(e => events.push(e));
+
+    await agent.send({
+      messages: 'Hello',
+      threadId: 'thread-1',
+      resourceId: 'user-1',
+    });
+
+    const usageEvents = events.filter(e => e.type === 'usage_update');
+    expect(usageEvents.length).toBeGreaterThanOrEqual(1);
+
+    const usage = usageEvents[0]!;
+    if (usage.type === 'usage_update') {
+      expect(usage.usage.totalTokens).toBeGreaterThan(0);
+    }
   });
 });

--- a/packages/core/src/agent/agent-orchestration.test.ts
+++ b/packages/core/src/agent/agent-orchestration.test.ts
@@ -1,0 +1,384 @@
+import { MockLanguageModelV1, simulateReadableStream } from '@internal/ai-sdk-v4/test';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import type { AgentEvent } from './events';
+import { Agent } from './index';
+
+function createDummyModel() {
+  return new MockLanguageModelV1({
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop' as const,
+      usage: { promptTokens: 10, completionTokens: 20 },
+      text: 'Dummy response',
+    }),
+    doStream: async () => ({
+      stream: simulateReadableStream({
+        chunks: [{ type: 'text-delta' as const, textDelta: 'Dummy response' }],
+      }),
+      rawCall: { rawPrompt: null, rawSettings: {} },
+    }),
+  });
+}
+
+describe('Agent Events', () => {
+  it('subscribe receives events and returns unsubscribe function', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      stateSchema: z.object({ counter: z.number().default(0) }),
+    });
+
+    const events: AgentEvent[] = [];
+    const unsub = agent.subscribe(event => events.push(event));
+
+    agent.setState({ counter: 1 });
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('state_changed');
+
+    unsub();
+    agent.setState({ counter: 2 });
+    expect(events).toHaveLength(1); // no new event after unsub
+  });
+
+  it('on() filters by event type', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      modes: [
+        { id: 'plan', name: 'Plan', default: true },
+        { id: 'build', name: 'Build' },
+      ],
+      stateSchema: z.object({ counter: z.number().default(0) }),
+    });
+
+    const modeEvents: AgentEvent[] = [];
+    const stateEvents: AgentEvent[] = [];
+
+    agent.on('mode_changed', event => modeEvents.push(event));
+    agent.on('state_changed', event => stateEvents.push(event));
+
+    agent.switchMode('build');
+    agent.setState({ counter: 42 });
+
+    expect(modeEvents).toHaveLength(1);
+    expect(stateEvents).toHaveLength(1);
+    expect(modeEvents[0]!.type).toBe('mode_changed');
+    expect(stateEvents[0]!.type).toBe('state_changed');
+  });
+
+  it('listener errors do not propagate', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      stateSchema: z.object({ x: z.number().default(0) }),
+    });
+
+    const events: AgentEvent[] = [];
+    agent.subscribe(() => {
+      throw new Error('boom');
+    });
+    agent.subscribe(event => events.push(event));
+
+    agent.setState({ x: 1 });
+    expect(events).toHaveLength(1);
+  });
+
+  it('multiple subscribers all receive events', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      stateSchema: z.object({ x: z.number().default(0) }),
+    });
+
+    const a: AgentEvent[] = [];
+    const b: AgentEvent[] = [];
+
+    agent.subscribe(e => a.push(e));
+    agent.subscribe(e => b.push(e));
+
+    agent.setState({ x: 5 });
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+  });
+});
+
+describe('Agent Modes', () => {
+  it('hasModes returns false when no modes configured', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+    });
+
+    expect(agent.hasModes()).toBe(false);
+    expect(agent.listModes()).toEqual([]);
+    expect(agent.getCurrentModeId()).toBeUndefined();
+    expect(agent.getCurrentMode()).toBeUndefined();
+  });
+
+  it('defaults to the mode marked default', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      modes: [
+        { id: 'alpha', name: 'Alpha' },
+        { id: 'beta', name: 'Beta', default: true },
+      ],
+    });
+
+    expect(agent.hasModes()).toBe(true);
+    expect(agent.getCurrentModeId()).toBe('beta');
+    expect(agent.getCurrentMode()!.id).toBe('beta');
+  });
+
+  it('defaults to first mode when none marked default', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      modes: [
+        { id: 'first', name: 'First' },
+        { id: 'second', name: 'Second' },
+      ],
+    });
+
+    expect(agent.getCurrentModeId()).toBe('first');
+  });
+
+  it('switchMode changes the current mode and emits event', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      modes: [
+        { id: 'plan', name: 'Plan', default: true },
+        { id: 'build', name: 'Build' },
+      ],
+    });
+
+    const events: AgentEvent[] = [];
+    agent.subscribe(e => events.push(e));
+
+    agent.switchMode('build');
+    expect(agent.getCurrentModeId()).toBe('build');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: 'mode_changed',
+      modeId: 'build',
+      previousModeId: 'plan',
+    });
+  });
+
+  it('switchMode to same mode is a no-op', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      modes: [{ id: 'plan', name: 'Plan', default: true }],
+    });
+
+    const events: AgentEvent[] = [];
+    agent.subscribe(e => events.push(e));
+
+    agent.switchMode('plan');
+    expect(events).toHaveLength(0);
+  });
+
+  it('switchMode throws for unknown mode', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      modes: [{ id: 'plan', name: 'Plan', default: true }],
+    });
+
+    expect(() => agent.switchMode('nonexistent')).toThrow('Mode not found: nonexistent');
+  });
+
+  it('switchMode throws when modes not configured', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+    });
+
+    expect(() => agent.switchMode('plan')).toThrow('Cannot switch modes: no modes configured on this agent');
+  });
+
+  it('listModes returns all configured modes', () => {
+    const modes = [
+      { id: 'plan', name: 'Plan', default: true },
+      { id: 'build', name: 'Build' },
+      { id: 'review', name: 'Review' },
+    ];
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      modes,
+    });
+
+    expect(agent.listModes()).toEqual(modes);
+  });
+});
+
+describe('Agent State', () => {
+  it('getState returns empty object when no state configured', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+    });
+
+    expect(agent.getState()).toEqual({});
+  });
+
+  it('initializes state from schema defaults', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      stateSchema: z.object({
+        counter: z.number().default(0),
+        label: z.string().default('untitled'),
+      }),
+    });
+
+    expect(agent.getState()).toEqual({ counter: 0, label: 'untitled' });
+  });
+
+  it('initialState overrides schema defaults', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      stateSchema: z.object({
+        counter: z.number().default(0),
+        label: z.string().default('untitled'),
+      }),
+      initialState: { counter: 10 },
+    });
+
+    expect(agent.getState()).toEqual({ counter: 10, label: 'untitled' });
+  });
+
+  it('setState updates state and emits event', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      stateSchema: z.object({
+        counter: z.number().default(0),
+      }),
+    });
+
+    const events: AgentEvent[] = [];
+    agent.subscribe(e => events.push(e));
+
+    agent.setState({ counter: 42 });
+    expect(agent.getState()).toEqual({ counter: 42 });
+    expect(events).toHaveLength(1);
+
+    const event = events[0]!;
+    expect(event.type).toBe('state_changed');
+    if (event.type === 'state_changed') {
+      expect(event.changedKeys).toEqual(['counter']);
+      expect(event.state).toEqual({ counter: 42 });
+    }
+  });
+
+  it('setState validates against schema', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      stateSchema: z.object({
+        counter: z.number(),
+      }),
+      initialState: { counter: 0 },
+    });
+
+    expect(() => agent.setState({ counter: 'not a number' as any })).toThrow('Invalid state update');
+  });
+
+  it('setState works without schema (unvalidated)', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      initialState: { foo: 'bar' },
+    });
+
+    agent.setState({ foo: 'baz', extra: true });
+    expect(agent.getState()).toEqual({ foo: 'baz', extra: true });
+  });
+
+  it('getState returns a snapshot (not a reference)', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      initialState: { counter: 0 },
+    });
+
+    const snapshot = agent.getState();
+    (snapshot as any).counter = 999;
+    expect(agent.getState().counter).toBe(0);
+  });
+});
+
+describe('Agent Orchestration Integration', () => {
+  it('modes and state work together', () => {
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'You are helpful.',
+      model: createDummyModel(),
+      modes: [
+        { id: 'plan', name: 'Plan', default: true },
+        { id: 'build', name: 'Build' },
+      ],
+      stateSchema: z.object({
+        currentModelId: z.string().optional(),
+      }),
+    });
+
+    const events: AgentEvent[] = [];
+    agent.subscribe(e => events.push(e));
+
+    agent.switchMode('build');
+    agent.setState({ currentModelId: 'anthropic/claude-sonnet-4-20250514' });
+
+    expect(agent.getCurrentModeId()).toBe('build');
+    expect(agent.getState()).toEqual({ currentModelId: 'anthropic/claude-sonnet-4-20250514' });
+    expect(events).toHaveLength(2);
+    expect(events[0]!.type).toBe('mode_changed');
+    expect(events[1]!.type).toBe('state_changed');
+  });
+});

--- a/packages/core/src/agent/agent-orchestration.test.ts
+++ b/packages/core/src/agent/agent-orchestration.test.ts
@@ -414,7 +414,7 @@ describe('Agent Orchestration Integration', () => {
 });
 
 describe('Agent .send()', () => {
-  it('emits send_start, message events, and send_end', async () => {
+  it('operation events stream contains lifecycle events', async () => {
     const mockMemory = new MockMemory();
     const agent = new Agent({
       id: 'send-agent',
@@ -424,14 +424,16 @@ describe('Agent .send()', () => {
       memory: mockMemory,
     });
 
-    const events: AgentEvent[] = [];
-    agent.subscribe(e => events.push(e));
-
-    await agent.send({
+    const op = agent.send({
       messages: 'Hi there',
       threadId: 'thread-1',
       resourceId: 'user-1',
     });
+
+    const events: AgentEvent[] = [];
+    for await (const event of op.events) {
+      events.push(event);
+    }
 
     const eventTypes = events.map(e => e.type);
     expect(eventTypes).toContain('send_start');
@@ -447,7 +449,33 @@ describe('Agent .send()', () => {
     }
   });
 
-  it('returns the assembled message', async () => {
+  it('global subscribers also receive events from send operations', async () => {
+    const mockMemory = new MockMemory();
+    const agent = new Agent({
+      id: 'send-agent',
+      name: 'Send Agent',
+      instructions: 'You are helpful.',
+      model: createV2StreamModel('Hello world'),
+      memory: mockMemory,
+    });
+
+    const globalEvents: AgentEvent[] = [];
+    agent.subscribe(e => globalEvents.push(e));
+
+    const op = agent.send({
+      messages: 'Hi there',
+      threadId: 'thread-1',
+      resourceId: 'user-1',
+    });
+
+    await op.result;
+
+    const eventTypes = globalEvents.map(e => e.type);
+    expect(eventTypes).toContain('send_start');
+    expect(eventTypes).toContain('send_end');
+  });
+
+  it('result resolves with the assembled message', async () => {
     const mockMemory = new MockMemory();
     const agent = new Agent({
       id: 'send-agent',
@@ -457,11 +485,13 @@ describe('Agent .send()', () => {
       memory: mockMemory,
     });
 
-    const { message } = await agent.send({
+    const op = agent.send({
       messages: 'Hello',
       threadId: 'thread-1',
       resourceId: 'user-1',
     });
+
+    const { message } = await op.result;
 
     expect(message.role).toBe('assistant');
     expect(message.content.length).toBeGreaterThan(0);
@@ -470,7 +500,7 @@ describe('Agent .send()', () => {
     expect(textContent!.text).toContain('Test response');
   });
 
-  it('abort() cancels the stream and emits aborted', async () => {
+  it('op.abort() cancels this specific send', async () => {
     const mockMemory = new MockMemory();
     const agent = new Agent({
       id: 'abort-agent',
@@ -506,16 +536,18 @@ describe('Agent .send()', () => {
       memory: mockMemory,
     });
 
-    const events: AgentEvent[] = [];
-    agent.subscribe(e => events.push(e));
-
-    setTimeout(() => agent.abort(), 10);
-
-    await agent.send({
+    const op = agent.send({
       messages: 'Hello',
       threadId: 'thread-1',
       resourceId: 'user-1',
     });
+
+    setTimeout(() => op.abort(), 10);
+
+    const events: AgentEvent[] = [];
+    for await (const event of op.events) {
+      events.push(event);
+    }
 
     const eventTypes = events.map(e => e.type);
     expect(eventTypes).toContain('send_start');
@@ -557,14 +589,16 @@ describe('Agent .send()', () => {
       memory: mockMemory,
     });
 
-    const events: AgentEvent[] = [];
-    agent.subscribe(e => events.push(e));
-
-    await agent.send({
+    const op = agent.send({
       messages: 'Hello',
       threadId: 'thread-1',
       resourceId: 'user-1',
     });
+
+    const events: AgentEvent[] = [];
+    for await (const event of op.events) {
+      events.push(event);
+    }
 
     const eventTypes = events.map(e => e.type);
     expect(eventTypes).toContain('send_start');
@@ -587,14 +621,16 @@ describe('Agent .send()', () => {
       memory: mockMemory,
     });
 
-    const events: AgentEvent[] = [];
-    agent.subscribe(e => events.push(e));
-
-    await agent.send({
+    const op = agent.send({
       messages: 'Hello',
       threadId: 'thread-1',
       resourceId: 'user-1',
     });
+
+    const events: AgentEvent[] = [];
+    for await (const event of op.events) {
+      events.push(event);
+    }
 
     const usageEvents = events.filter(e => e.type === 'usage_update');
     expect(usageEvents.length).toBeGreaterThanOrEqual(1);
@@ -603,5 +639,36 @@ describe('Agent .send()', () => {
     if (usage.type === 'usage_update') {
       expect(usage.usage.totalTokens).toBeGreaterThan(0);
     }
+  });
+
+  it('concurrent sends have isolated event streams', async () => {
+    const mockMemory = new MockMemory();
+    const agent = new Agent({
+      id: 'concurrent-agent',
+      name: 'Concurrent Agent',
+      instructions: 'You are helpful.',
+      model: createV2StreamModel('Response'),
+      memory: mockMemory,
+    });
+
+    const op1 = agent.send({ messages: 'First', threadId: 't-1', resourceId: 'u-1' });
+    const op2 = agent.send({ messages: 'Second', threadId: 't-2', resourceId: 'u-2' });
+
+    const events1: AgentEvent[] = [];
+    const events2: AgentEvent[] = [];
+
+    await Promise.all([
+      (async () => {
+        for await (const e of op1.events) events1.push(e);
+      })(),
+      (async () => {
+        for await (const e of op2.events) events2.push(e);
+      })(),
+    ]);
+
+    expect(events1.some(e => e.type === 'send_start')).toBe(true);
+    expect(events2.some(e => e.type === 'send_start')).toBe(true);
+    expect(events1.some(e => e.type === 'send_end')).toBe(true);
+    expect(events2.some(e => e.type === 'send_end')).toBe(true);
   });
 });

--- a/packages/core/src/agent/agent-orchestration.test.ts
+++ b/packages/core/src/agent/agent-orchestration.test.ts
@@ -53,62 +53,61 @@ function createV2StreamModel(text = 'Hello from send') {
 }
 
 describe('Agent Events', () => {
-  it('subscribe receives events and returns unsubscribe function', () => {
+  it('subscribe receives events and returns unsubscribe function', async () => {
+    const mockMemory = new MockMemory();
     const agent = new Agent({
       id: 'test-agent',
       name: 'Test Agent',
       instructions: 'You are helpful.',
-      model: createDummyModel(),
-      stateSchema: z.object({ counter: z.number().default(0) }),
+      model: createV2StreamModel(),
+      memory: mockMemory,
     });
 
     const events: AgentEvent[] = [];
     const unsub = agent.subscribe(event => events.push(event));
 
-    agent.setState({ counter: 1 });
-    expect(events).toHaveLength(1);
-    expect(events[0]!.type).toBe('state_changed');
+    const op = agent.send({ messages: 'hi', threadId: 't1', resourceId: 'r1' });
+    await op.result;
 
+    expect(events.length).toBeGreaterThan(0);
+
+    const countBefore = events.length;
     unsub();
-    agent.setState({ counter: 2 });
-    expect(events).toHaveLength(1); // no new event after unsub
+
+    const op2 = agent.send({ messages: 'hi again', threadId: 't1', resourceId: 'r1' });
+    await op2.result;
+
+    expect(events.length).toBe(countBefore);
   });
 
-  it('on() filters by event type', () => {
+  it('on() filters by event type', async () => {
+    const mockMemory = new MockMemory();
     const agent = new Agent({
       id: 'test-agent',
       name: 'Test Agent',
       instructions: 'You are helpful.',
-      model: createDummyModel(),
-      modes: [
-        { id: 'plan', name: 'Plan', default: true },
-        { id: 'build', name: 'Build' },
-      ],
-      stateSchema: z.object({ counter: z.number().default(0) }),
+      model: createV2StreamModel(),
+      memory: mockMemory,
     });
 
-    const modeEvents: AgentEvent[] = [];
-    const stateEvents: AgentEvent[] = [];
+    const sendEvents: AgentEvent[] = [];
+    agent.on('send_start', event => sendEvents.push(event));
 
-    agent.on('mode_changed', event => modeEvents.push(event));
-    agent.on('state_changed', event => stateEvents.push(event));
+    const op = agent.send({ messages: 'hi', threadId: 't1', resourceId: 'r1' });
+    await op.result;
 
-    agent.switchMode('build');
-    agent.setState({ counter: 42 });
-
-    expect(modeEvents).toHaveLength(1);
-    expect(stateEvents).toHaveLength(1);
-    expect(modeEvents[0]!.type).toBe('mode_changed');
-    expect(stateEvents[0]!.type).toBe('state_changed');
+    expect(sendEvents).toHaveLength(1);
+    expect(sendEvents[0]!.type).toBe('send_start');
   });
 
-  it('listener errors do not propagate', () => {
+  it('listener errors do not propagate', async () => {
+    const mockMemory = new MockMemory();
     const agent = new Agent({
       id: 'test-agent',
       name: 'Test Agent',
       instructions: 'You are helpful.',
-      model: createDummyModel(),
-      stateSchema: z.object({ x: z.number().default(0) }),
+      model: createV2StreamModel(),
+      memory: mockMemory,
     });
 
     const events: AgentEvent[] = [];
@@ -117,33 +116,15 @@ describe('Agent Events', () => {
     });
     agent.subscribe(event => events.push(event));
 
-    agent.setState({ x: 1 });
-    expect(events).toHaveLength(1);
-  });
+    const op = agent.send({ messages: 'hi', threadId: 't1', resourceId: 'r1' });
+    await op.result;
 
-  it('multiple subscribers all receive events', () => {
-    const agent = new Agent({
-      id: 'test-agent',
-      name: 'Test Agent',
-      instructions: 'You are helpful.',
-      model: createDummyModel(),
-      stateSchema: z.object({ x: z.number().default(0) }),
-    });
-
-    const a: AgentEvent[] = [];
-    const b: AgentEvent[] = [];
-
-    agent.subscribe(e => a.push(e));
-    agent.subscribe(e => b.push(e));
-
-    agent.setState({ x: 5 });
-    expect(a).toHaveLength(1);
-    expect(b).toHaveLength(1);
+    expect(events.length).toBeGreaterThan(0);
   });
 });
 
-describe('Agent Modes', () => {
-  it('hasModes returns false when no modes configured', () => {
+describe('Agent Harness Config', () => {
+  it('hasModes returns false when no harness configured', () => {
     const agent = new Agent({
       id: 'test-agent',
       name: 'Test Agent',
@@ -153,109 +134,64 @@ describe('Agent Modes', () => {
 
     expect(agent.hasModes()).toBe(false);
     expect(agent.listModes()).toEqual([]);
-    expect(agent.getCurrentModeId()).toBeUndefined();
-    expect(agent.getCurrentMode()).toBeUndefined();
+    expect(agent.getDefaultMode()).toBeUndefined();
   });
 
-  it('defaults to the mode marked default', () => {
+  it('hasModes returns true when harness has modes', () => {
     const agent = new Agent({
       id: 'test-agent',
       name: 'Test Agent',
       instructions: 'You are helpful.',
       model: createDummyModel(),
-      modes: [
-        { id: 'alpha', name: 'Alpha' },
-        { id: 'beta', name: 'Beta', default: true },
-      ],
+      harness: {
+        modes: [
+          { id: 'plan', name: 'Plan', default: true },
+          { id: 'build', name: 'Build' },
+        ],
+      },
     });
 
     expect(agent.hasModes()).toBe(true);
-    expect(agent.getCurrentModeId()).toBe('beta');
-    expect(agent.getCurrentMode()!.id).toBe('beta');
+    expect(agent.listModes()).toHaveLength(2);
   });
 
-  it('defaults to first mode when none marked default', () => {
+  it('getDefaultMode returns the mode marked default', () => {
     const agent = new Agent({
       id: 'test-agent',
       name: 'Test Agent',
       instructions: 'You are helpful.',
       model: createDummyModel(),
-      modes: [
-        { id: 'first', name: 'First' },
-        { id: 'second', name: 'Second' },
-      ],
+      harness: {
+        modes: [
+          { id: 'alpha', name: 'Alpha' },
+          { id: 'beta', name: 'Beta', default: true },
+        ],
+      },
     });
 
-    expect(agent.getCurrentModeId()).toBe('first');
+    expect(agent.getDefaultMode()!.id).toBe('beta');
   });
 
-  it('switchMode changes the current mode and emits event', () => {
+  it('getDefaultMode falls back to first mode', () => {
     const agent = new Agent({
       id: 'test-agent',
       name: 'Test Agent',
       instructions: 'You are helpful.',
       model: createDummyModel(),
-      modes: [
-        { id: 'plan', name: 'Plan', default: true },
-        { id: 'build', name: 'Build' },
-      ],
+      harness: {
+        modes: [
+          { id: 'first', name: 'First' },
+          { id: 'second', name: 'Second' },
+        ],
+      },
     });
 
-    const events: AgentEvent[] = [];
-    agent.subscribe(e => events.push(e));
-
-    agent.switchMode('build');
-    expect(agent.getCurrentModeId()).toBe('build');
-    expect(events).toHaveLength(1);
-    expect(events[0]).toEqual({
-      type: 'mode_changed',
-      modeId: 'build',
-      previousModeId: 'plan',
-    });
-  });
-
-  it('switchMode to same mode is a no-op', () => {
-    const agent = new Agent({
-      id: 'test-agent',
-      name: 'Test Agent',
-      instructions: 'You are helpful.',
-      model: createDummyModel(),
-      modes: [{ id: 'plan', name: 'Plan', default: true }],
-    });
-
-    const events: AgentEvent[] = [];
-    agent.subscribe(e => events.push(e));
-
-    agent.switchMode('plan');
-    expect(events).toHaveLength(0);
-  });
-
-  it('switchMode throws for unknown mode', () => {
-    const agent = new Agent({
-      id: 'test-agent',
-      name: 'Test Agent',
-      instructions: 'You are helpful.',
-      model: createDummyModel(),
-      modes: [{ id: 'plan', name: 'Plan', default: true }],
-    });
-
-    expect(() => agent.switchMode('nonexistent')).toThrow('Mode not found: nonexistent');
-  });
-
-  it('switchMode throws when modes not configured', () => {
-    const agent = new Agent({
-      id: 'test-agent',
-      name: 'Test Agent',
-      instructions: 'You are helpful.',
-      model: createDummyModel(),
-    });
-
-    expect(() => agent.switchMode('plan')).toThrow('Cannot switch modes: no modes configured on this agent');
+    expect(agent.getDefaultMode()!.id).toBe('first');
   });
 
   it('listModes returns all configured modes', () => {
     const modes = [
-      { id: 'plan', name: 'Plan', default: true },
+      { id: 'plan', name: 'Plan', default: true as const },
       { id: 'build', name: 'Build' },
       { id: 'review', name: 'Review' },
     ];
@@ -264,152 +200,34 @@ describe('Agent Modes', () => {
       name: 'Test Agent',
       instructions: 'You are helpful.',
       model: createDummyModel(),
-      modes,
+      harness: { modes },
     });
 
     expect(agent.listModes()).toEqual(modes);
   });
-});
 
-describe('Agent State', () => {
-  it('getState returns empty object when no state configured', () => {
+  it('getStateSchema returns the schema from harness config', () => {
+    const schema = z.object({ counter: z.number().default(0) });
     const agent = new Agent({
       id: 'test-agent',
       name: 'Test Agent',
       instructions: 'You are helpful.',
       model: createDummyModel(),
+      harness: { stateSchema: schema },
     });
 
-    expect(agent.getState()).toEqual({});
+    expect(agent.getStateSchema()).toBe(schema);
   });
 
-  it('initializes state from schema defaults', () => {
+  it('getStateSchema returns undefined when no harness', () => {
     const agent = new Agent({
       id: 'test-agent',
       name: 'Test Agent',
       instructions: 'You are helpful.',
       model: createDummyModel(),
-      stateSchema: z.object({
-        counter: z.number().default(0),
-        label: z.string().default('untitled'),
-      }),
     });
 
-    expect(agent.getState()).toEqual({ counter: 0, label: 'untitled' });
-  });
-
-  it('initialState overrides schema defaults', () => {
-    const agent = new Agent({
-      id: 'test-agent',
-      name: 'Test Agent',
-      instructions: 'You are helpful.',
-      model: createDummyModel(),
-      stateSchema: z.object({
-        counter: z.number().default(0),
-        label: z.string().default('untitled'),
-      }),
-      initialState: { counter: 10 },
-    });
-
-    expect(agent.getState()).toEqual({ counter: 10, label: 'untitled' });
-  });
-
-  it('setState updates state and emits event', () => {
-    const agent = new Agent({
-      id: 'test-agent',
-      name: 'Test Agent',
-      instructions: 'You are helpful.',
-      model: createDummyModel(),
-      stateSchema: z.object({
-        counter: z.number().default(0),
-      }),
-    });
-
-    const events: AgentEvent[] = [];
-    agent.subscribe(e => events.push(e));
-
-    agent.setState({ counter: 42 });
-    expect(agent.getState()).toEqual({ counter: 42 });
-    expect(events).toHaveLength(1);
-
-    const event = events[0]!;
-    expect(event.type).toBe('state_changed');
-    if (event.type === 'state_changed') {
-      expect(event.changedKeys).toEqual(['counter']);
-      expect(event.state).toEqual({ counter: 42 });
-    }
-  });
-
-  it('setState validates against schema', () => {
-    const agent = new Agent({
-      id: 'test-agent',
-      name: 'Test Agent',
-      instructions: 'You are helpful.',
-      model: createDummyModel(),
-      stateSchema: z.object({
-        counter: z.number(),
-      }),
-      initialState: { counter: 0 },
-    });
-
-    expect(() => agent.setState({ counter: 'not a number' as any })).toThrow('Invalid state update');
-  });
-
-  it('setState works without schema (unvalidated)', () => {
-    const agent = new Agent({
-      id: 'test-agent',
-      name: 'Test Agent',
-      instructions: 'You are helpful.',
-      model: createDummyModel(),
-      initialState: { foo: 'bar' },
-    });
-
-    agent.setState({ foo: 'baz', extra: true });
-    expect(agent.getState()).toEqual({ foo: 'baz', extra: true });
-  });
-
-  it('getState returns a snapshot (not a reference)', () => {
-    const agent = new Agent({
-      id: 'test-agent',
-      name: 'Test Agent',
-      instructions: 'You are helpful.',
-      model: createDummyModel(),
-      initialState: { counter: 0 },
-    });
-
-    const snapshot = agent.getState();
-    (snapshot as any).counter = 999;
-    expect(agent.getState().counter).toBe(0);
-  });
-});
-
-describe('Agent Orchestration Integration', () => {
-  it('modes and state work together', () => {
-    const agent = new Agent({
-      id: 'test-agent',
-      name: 'Test Agent',
-      instructions: 'You are helpful.',
-      model: createDummyModel(),
-      modes: [
-        { id: 'plan', name: 'Plan', default: true },
-        { id: 'build', name: 'Build' },
-      ],
-      stateSchema: z.object({
-        currentModelId: z.string().optional(),
-      }),
-    });
-
-    const events: AgentEvent[] = [];
-    agent.subscribe(e => events.push(e));
-
-    agent.switchMode('build');
-    agent.setState({ currentModelId: 'anthropic/claude-sonnet-4-20250514' });
-
-    expect(agent.getCurrentModeId()).toBe('build');
-    expect(agent.getState()).toEqual({ currentModelId: 'anthropic/claude-sonnet-4-20250514' });
-    expect(events).toHaveLength(2);
-    expect(events[0]!.type).toBe('mode_changed');
-    expect(events[1]!.type).toBe('state_changed');
+    expect(agent.getStateSchema()).toBeUndefined();
   });
 });
 
@@ -441,38 +259,6 @@ describe('Agent .send()', () => {
     expect(eventTypes).toContain('message_update');
     expect(eventTypes).toContain('message_end');
     expect(eventTypes).toContain('send_end');
-
-    const sendEnd = events.find(e => e.type === 'send_end');
-    expect(sendEnd).toBeDefined();
-    if (sendEnd && sendEnd.type === 'send_end') {
-      expect(sendEnd.reason).toBe('complete');
-    }
-  });
-
-  it('global subscribers also receive events from send operations', async () => {
-    const mockMemory = new MockMemory();
-    const agent = new Agent({
-      id: 'send-agent',
-      name: 'Send Agent',
-      instructions: 'You are helpful.',
-      model: createV2StreamModel('Hello world'),
-      memory: mockMemory,
-    });
-
-    const globalEvents: AgentEvent[] = [];
-    agent.subscribe(e => globalEvents.push(e));
-
-    const op = agent.send({
-      messages: 'Hi there',
-      threadId: 'thread-1',
-      resourceId: 'user-1',
-    });
-
-    await op.result;
-
-    const eventTypes = globalEvents.map(e => e.type);
-    expect(eventTypes).toContain('send_start');
-    expect(eventTypes).toContain('send_end');
   });
 
   it('result resolves with the assembled message', async () => {
@@ -494,10 +280,118 @@ describe('Agent .send()', () => {
     const { message } = await op.result;
 
     expect(message.role).toBe('assistant');
-    expect(message.content.length).toBeGreaterThan(0);
     const textContent = message.content.find(c => c.type === 'text');
     expect(textContent).toBeDefined();
     expect(textContent!.text).toContain('Test response');
+  });
+
+  it('accepts modeId per-operation', async () => {
+    const mockMemory = new MockMemory();
+    const agent = new Agent({
+      id: 'mode-agent',
+      name: 'Mode Agent',
+      instructions: 'You are helpful.',
+      model: createV2StreamModel('mode response'),
+      memory: mockMemory,
+      harness: {
+        modes: [
+          { id: 'plan', name: 'Plan', default: true },
+          { id: 'build', name: 'Build' },
+        ],
+      },
+    });
+
+    const op = agent.send({
+      messages: 'Hello',
+      threadId: 'thread-1',
+      resourceId: 'user-1',
+      modeId: 'build',
+    });
+
+    const { message } = await op.result;
+    expect(message.role).toBe('assistant');
+  });
+
+  it('throws for unknown modeId', async () => {
+    const mockMemory = new MockMemory();
+    const agent = new Agent({
+      id: 'mode-agent',
+      name: 'Mode Agent',
+      instructions: 'You are helpful.',
+      model: createV2StreamModel(),
+      memory: mockMemory,
+      harness: {
+        modes: [{ id: 'plan', name: 'Plan' }],
+      },
+    });
+
+    const op = agent.send({
+      messages: 'Hello',
+      threadId: 'thread-1',
+      resourceId: 'user-1',
+      modeId: 'nonexistent',
+    });
+
+    const events: AgentEvent[] = [];
+    for await (const event of op.events) {
+      events.push(event);
+    }
+
+    const errorEvent = events.find(e => e.type === 'error');
+    expect(errorEvent).toBeDefined();
+  });
+
+  it('validates state against harness stateSchema', async () => {
+    const mockMemory = new MockMemory();
+    const agent = new Agent({
+      id: 'state-agent',
+      name: 'State Agent',
+      instructions: 'You are helpful.',
+      model: createV2StreamModel(),
+      memory: mockMemory,
+      harness: {
+        stateSchema: z.object({ counter: z.number() }),
+      },
+    });
+
+    const op = agent.send({
+      messages: 'Hello',
+      threadId: 'thread-1',
+      resourceId: 'user-1',
+      state: { counter: 'not a number' as any },
+    });
+
+    const events: AgentEvent[] = [];
+    for await (const event of op.events) {
+      events.push(event);
+    }
+
+    const errorEvent = events.find(e => e.type === 'error');
+    expect(errorEvent).toBeDefined();
+  });
+
+  it('accepts valid state per-operation', async () => {
+    const mockMemory = new MockMemory();
+    const agent = new Agent({
+      id: 'state-agent',
+      name: 'State Agent',
+      instructions: 'You are helpful.',
+      model: createV2StreamModel(),
+      memory: mockMemory,
+      harness: {
+        stateSchema: z.object({ counter: z.number() }),
+      },
+    });
+
+    const op = agent.send({
+      messages: 'Hello',
+      threadId: 'thread-1',
+      resourceId: 'user-1',
+      state: { counter: 42 },
+    });
+
+    const { message } = await op.result;
+    expect(message.role).toBe('assistant');
   });
 
   it('op.abort() cancels this specific send', async () => {
@@ -555,89 +449,6 @@ describe('Agent .send()', () => {
     const sendEnd = events.find(e => e.type === 'send_end');
     if (sendEnd && sendEnd.type === 'send_end') {
       expect(sendEnd.reason).toBe('aborted');
-    }
-  });
-
-  it('emits error event when stream contains an error chunk', async () => {
-    const mockMemory = new MockMemory();
-    const agent = new Agent({
-      id: 'error-agent',
-      name: 'Error Agent',
-      instructions: 'You are helpful.',
-      model: new MockLanguageModelV2({
-        doGenerate: async () => ({
-          rawCall: { rawPrompt: null, rawSettings: {} },
-          finishReason: 'stop' as const,
-          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-          content: [{ type: 'text' as const, text: '' }],
-          warnings: [],
-        }),
-        doStream: async () => ({
-          rawCall: { rawPrompt: null, rawSettings: {} },
-          warnings: [],
-          stream: convertArrayToReadableStream([
-            { type: 'stream-start', warnings: [] },
-            { type: 'error', error: new Error('Stream error') },
-            {
-              type: 'finish',
-              finishReason: 'error' as const,
-              usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-            },
-          ]),
-        }),
-      }),
-      memory: mockMemory,
-    });
-
-    const op = agent.send({
-      messages: 'Hello',
-      threadId: 'thread-1',
-      resourceId: 'user-1',
-    });
-
-    const events: AgentEvent[] = [];
-    for await (const event of op.events) {
-      events.push(event);
-    }
-
-    const eventTypes = events.map(e => e.type);
-    expect(eventTypes).toContain('send_start');
-    expect(eventTypes).toContain('error');
-    expect(eventTypes).toContain('send_end');
-
-    const errorEvent = events.find(e => e.type === 'error');
-    if (errorEvent && errorEvent.type === 'error') {
-      expect(errorEvent.error.message).toBe('Stream error');
-    }
-  });
-
-  it('emits usage_update event with token counts', async () => {
-    const mockMemory = new MockMemory();
-    const agent = new Agent({
-      id: 'usage-agent',
-      name: 'Usage Agent',
-      instructions: 'You are helpful.',
-      model: createV2StreamModel('Token test'),
-      memory: mockMemory,
-    });
-
-    const op = agent.send({
-      messages: 'Hello',
-      threadId: 'thread-1',
-      resourceId: 'user-1',
-    });
-
-    const events: AgentEvent[] = [];
-    for await (const event of op.events) {
-      events.push(event);
-    }
-
-    const usageEvents = events.filter(e => e.type === 'usage_update');
-    expect(usageEvents.length).toBeGreaterThanOrEqual(1);
-
-    const usage = usageEvents[0]!;
-    if (usage.type === 'usage_update') {
-      expect(usage.usage.totalTokens).toBeGreaterThan(0);
     }
   });
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -82,7 +82,7 @@ import type {
   DelegationStartContext,
   DelegationCompleteContext,
 } from './agent.types';
-import type { AgentEvent, AgentEventListener, AgentEventMap, AgentMessage } from './events';
+import type { AgentEvent, AgentEventListener, AgentEventMap, AgentMessage, SendOperation } from './events';
 import { MessageList } from './message-list';
 import type { MessageInput, MessageListInput, UIMessageWithMetadata, MastraDBMessage } from './message-list';
 import type { AgentMode } from './modes';
@@ -183,13 +183,6 @@ export class Agent<
   #stateSchema?: z.ZodObject<z.ZodRawShape>;
   #state: Record<string, unknown> = {};
   #eventListeners: AgentEventListener[] = [];
-  #abortController: AbortController | null = null;
-  #abortRequested = false;
-  #sendOperationId = 0;
-  #followUpQueue: Array<{ content: string; requestContext?: RequestContext }> = [];
-  #pendingApprovalResolve:
-    | ((params: { decision: 'approve' | 'decline'; requestContext?: RequestContext }) => void)
-    | null = null;
 
   // This flag is for agent network messages. We should change the agent network formatting and remove this flag after.
   private _agentNetworkAppend = false;
@@ -518,27 +511,28 @@ export class Agent<
   // ===========================================================================
 
   /**
-   * Send a message to the agent and stream the response, emitting events
-   * for the full lifecycle (text deltas, tool calls, tool results, errors).
+   * Send a message to the agent and get back a self-contained operation handle.
    *
-   * Requires `memory` to be configured on the agent. The thread and resource
-   * are specified via `memory` on each call, or you can let it use the
-   * existing memory configuration.
+   * Each `.send()` call returns a `SendOperation` with its own isolated event
+   * stream, abort handle, and tool-approval resolver. Multiple concurrent sends
+   * to the same Agent instance do not interfere with each other.
    *
    * @example
    * ```typescript
-   * agent.subscribe((event) => {
-   *   if (event.type === 'message_update') console.log(event.message);
-   * });
-   *
-   * await agent.send({
+   * const op = agent.send({
    *   messages: 'Hello!',
    *   threadId: 'thread-1',
    *   resourceId: 'user-1',
    * });
+   *
+   * for await (const event of op.events) {
+   *   if (event.type === 'message_update') console.log(event.message);
+   * }
+   *
+   * const { message } = await op.result;
    * ```
    */
-  async send({
+  send({
     messages,
     threadId,
     resourceId,
@@ -556,301 +550,312 @@ export class Agent<
     toolsets?: ToolsetsInput;
     onStepFinish?: (step: unknown) => void | Promise<void>;
     abortSignal?: AbortSignal;
-  }): Promise<{ message: AgentMessage }> {
-    const operationId = ++this.#sendOperationId;
-    this.#abortController = new AbortController();
-    this.#abortRequested = false;
+  }): SendOperation {
+    const abortController = new AbortController();
+    let abortRequested = false;
+    const listeners: AgentEventListener[] = [];
+    let pendingApprovalResolve:
+      | ((params: { decision: 'approve' | 'decline'; requestContext?: RequestContext }) => void)
+      | null = null;
 
-    if (abortSignal) {
-      abortSignal.addEventListener('abort', () => this.abort(), { once: true });
-    }
-
-    this.emitEvent({ type: 'send_start' });
-
-    try {
-      const streamOptions: Record<string, unknown> = {
-        memory: { thread: threadId, resource: resourceId },
-        abortSignal: this.#abortController.signal,
-        maxSteps,
-        ...(requestContext && { requestContext }),
-        ...(toolsets && { toolsets }),
-        ...(onStepFinish && { onStepFinish }),
-      };
-
-      const response = await this.stream(messages, streamOptions as any);
-      const result = await this.#processStreamEvents(response);
-
-      if (this.#sendOperationId === operationId) {
-        const reason = this.#abortRequested ? 'aborted' : 'complete';
-        this.emitEvent({ type: 'send_end', reason });
+    const emit = (event: AgentEvent): void => {
+      for (const listener of listeners) {
+        try {
+          void listener(event);
+        } catch {
+          // Listener errors don't break the operation
+        }
       }
-
-      return result;
-    } catch (error) {
-      if (this.#sendOperationId !== operationId) {
-        return { message: this.#emptyMessage() };
-      }
-
-      if (error instanceof Error && error.name === 'AbortError') {
-        this.emitEvent({ type: 'send_end', reason: 'aborted' });
-      } else if (error instanceof Error && error.message.match(/^Tool .+ not found$/)) {
-        const badTool = error.message.replace('Tool ', '').replace(' not found', '');
-        this.emitEvent({
-          type: 'error',
-          error: new Error(`Unknown tool "${badTool}".`),
-          retryable: true,
-        });
-        this.#followUpQueue.push({
-          content: `[System] Your previous tool call used "${badTool}" which is not a valid tool. Please retry with the correct tool name.`,
-          requestContext,
-        });
-        this.emitEvent({ type: 'send_end', reason: 'error' });
-      } else {
-        const err = error instanceof Error ? error : new Error(String(error));
-        this.emitEvent({ type: 'error', error: err });
-        this.emitEvent({ type: 'send_end', reason: 'error' });
-      }
-
-      return { message: this.#emptyMessage() };
-    } finally {
-      if (this.#sendOperationId === operationId) {
-        this.#abortController = null;
-        this.#abortRequested = false;
-      }
-
-      if (this.#sendOperationId === operationId && this.#followUpQueue.length > 0) {
-        const next = this.#followUpQueue.shift()!;
-        await this.send({
-          messages: next.content,
-          threadId,
-          resourceId,
-          maxSteps,
-          requestContext: next.requestContext,
-          toolsets,
-        });
-      }
-    }
-  }
-
-  /**
-   * Abort the current `.send()` operation.
-   * The in-progress stream will be cancelled and a `send_end` event with
-   * reason `'aborted'` will be emitted.
-   */
-  abort(): void {
-    if (this.#abortController) {
-      this.#abortRequested = true;
-      this.#abortController.abort();
-    }
-  }
-
-  /**
-   * Respond to a pending tool approval request.
-   * Only meaningful when a `tool_approval_required` event has been emitted.
-   */
-  respondToToolApproval(decision: 'approve' | 'decline', requestContext?: RequestContext): void {
-    if (this.#pendingApprovalResolve) {
-      this.#pendingApprovalResolve({ decision, requestContext });
-      this.#pendingApprovalResolve = null;
-    }
-  }
-
-  /**
-   * Process the full stream from a `stream()` call, emitting events for
-   * each chunk type (text, reasoning, tool calls, tool results, etc.).
-   */
-  async #processStreamEvents(response: { fullStream: AsyncIterable<any> }): Promise<{ message: AgentMessage }> {
-    const currentMessage: AgentMessage = {
-      id: randomUUID(),
-      role: 'assistant',
-      content: [],
-      createdAt: new Date(),
+      this.emitEvent(event);
     };
 
-    const textContentById = new Map<string, { index: number; text: string }>();
-    const thinkingContentById = new Map<string, { index: number; text: string }>();
-
-    for await (const chunk of response.fullStream) {
-      switch (chunk.type) {
-        case 'text-start': {
-          const textIndex = currentMessage.content.length;
-          currentMessage.content.push({ type: 'text', text: '' });
-          textContentById.set(chunk.payload.id, { index: textIndex, text: '' });
-          this.emitEvent({ type: 'message_start', message: { ...currentMessage } });
-          break;
-        }
-
-        case 'text-delta': {
-          const textState = textContentById.get(chunk.payload.id);
-          if (textState) {
-            textState.text += chunk.payload.text;
-            const textContent = currentMessage.content[textState.index];
-            if (textContent && textContent.type === 'text') {
-              textContent.text = textState.text;
-            }
-            this.emitEvent({ type: 'message_update', message: { ...currentMessage } });
-          }
-          break;
-        }
-
-        case 'reasoning-start': {
-          const thinkingIndex = currentMessage.content.length;
-          currentMessage.content.push({ type: 'thinking', thinking: '' });
-          thinkingContentById.set(chunk.payload.id, { index: thinkingIndex, text: '' });
-          this.emitEvent({ type: 'message_update', message: { ...currentMessage } });
-          break;
-        }
-
-        case 'reasoning-delta': {
-          const thinkingState = thinkingContentById.get(chunk.payload.id);
-          if (thinkingState) {
-            thinkingState.text += chunk.payload.text;
-            const thinkingContent = currentMessage.content[thinkingState.index];
-            if (thinkingContent && thinkingContent.type === 'thinking') {
-              thinkingContent.thinking = thinkingState.text;
-            }
-            this.emitEvent({ type: 'message_update', message: { ...currentMessage } });
-          }
-          break;
-        }
-
-        case 'tool-call-input-streaming-start': {
-          const { toolCallId, toolName } = chunk.payload;
-          this.emitEvent({ type: 'tool_input_start', toolCallId, toolName });
-          break;
-        }
-
-        case 'tool-call-delta': {
-          const { toolCallId, argsTextDelta, toolName } = chunk.payload;
-          this.emitEvent({ type: 'tool_input_delta', toolCallId, argsTextDelta, toolName });
-          break;
-        }
-
-        case 'tool-call-input-streaming-end': {
-          const { toolCallId } = chunk.payload;
-          this.emitEvent({ type: 'tool_input_end', toolCallId });
-          break;
-        }
-
-        case 'tool-call': {
-          const toolCall = chunk.payload;
-          currentMessage.content.push({
-            type: 'tool_call',
-            id: toolCall.toolCallId,
-            name: toolCall.toolName,
-            args: toolCall.args,
-          });
-          this.emitEvent({
-            type: 'tool_start',
-            toolCallId: toolCall.toolCallId,
-            toolName: toolCall.toolName,
-            args: toolCall.args,
-          });
-          this.emitEvent({ type: 'message_update', message: { ...currentMessage } });
-          break;
-        }
-
-        case 'tool-result': {
-          const toolResult = chunk.payload;
-          currentMessage.content.push({
-            type: 'tool_result',
-            id: toolResult.toolCallId,
-            name: toolResult.toolName,
-            result: toolResult.result,
-            isError: toolResult.isError ?? false,
-          });
-          this.emitEvent({
-            type: 'tool_end',
-            toolCallId: toolResult.toolCallId,
-            result: toolResult.result,
-            isError: toolResult.isError ?? false,
-          });
-          this.emitEvent({ type: 'message_update', message: { ...currentMessage } });
-          break;
-        }
-
-        case 'tool-error': {
-          const toolError = chunk.payload;
-          this.emitEvent({
-            type: 'tool_end',
-            toolCallId: toolError.toolCallId,
-            result: toolError.error,
-            isError: true,
-          });
-          break;
-        }
-
-        case 'tool-call-approval': {
-          const { toolCallId, toolName, args: toolArgs } = chunk.payload;
-          this.emitEvent({ type: 'tool_approval_required', toolCallId, toolName, args: toolArgs });
-
-          const approval = await new Promise<{ decision: 'approve' | 'decline'; requestContext?: RequestContext }>(
-            resolve => {
-              this.#pendingApprovalResolve = resolve;
-            },
-          );
-          this.#pendingApprovalResolve = null;
-
-          if (approval.decision === 'approve') {
-            const approveResult = await (response as any).approveToolExecution(toolCallId);
-            if (approveResult?.fullStream) {
-              const subResult = await this.#processStreamEvents(approveResult);
-              currentMessage.content.push(...subResult.message.content);
-            }
-          } else {
-            const declineResult = await (response as any).declineToolExecution(toolCallId);
-            if (declineResult?.fullStream) {
-              const subResult = await this.#processStreamEvents(declineResult);
-              currentMessage.content.push(...subResult.message.content);
-            }
-          }
-          return { message: currentMessage };
-        }
-
-        case 'error': {
-          const streamError =
-            chunk.payload.error instanceof Error ? chunk.payload.error : new Error(String(chunk.payload.error));
-          this.emitEvent({ type: 'error', error: streamError });
-          break;
-        }
-
-        case 'step-finish': {
-          const usage = chunk.payload?.output?.usage;
-          if (usage) {
-            const promptTokens = usage.promptTokens ?? usage.inputTokens ?? 0;
-            const completionTokens = usage.completionTokens ?? usage.outputTokens ?? 0;
-            const totalTokens = promptTokens + completionTokens;
-            this.emitEvent({ type: 'usage_update', usage: { promptTokens, completionTokens, totalTokens } });
-          }
-          break;
-        }
-
-        case 'finish': {
-          const finishReason = chunk.payload.stepResult?.reason;
-          if (finishReason === 'stop' || finishReason === 'end-turn') {
-            currentMessage.stopReason = 'complete';
-          } else if (finishReason === 'tool-calls') {
-            currentMessage.stopReason = 'tool_use';
-          } else {
-            currentMessage.stopReason = 'complete';
-          }
-          break;
-        }
-
-        // Skip data parts we don't handle yet — future phases will add OM events etc.
-      }
+    if (abortSignal) {
+      abortSignal.addEventListener(
+        'abort',
+        () => {
+          abortRequested = true;
+          abortController.abort();
+        },
+        { once: true },
+      );
     }
 
-    this.emitEvent({ type: 'message_end', message: { ...currentMessage } });
-    return { message: currentMessage };
-  }
+    const processStream = async (response: { fullStream: AsyncIterable<any> }): Promise<{ message: AgentMessage }> => {
+      const currentMessage: AgentMessage = {
+        id: randomUUID(),
+        role: 'assistant',
+        content: [],
+        createdAt: new Date(),
+      };
 
-  #emptyMessage(): AgentMessage {
-    return {
+      const textContentById = new Map<string, { index: number; text: string }>();
+      const thinkingContentById = new Map<string, { index: number; text: string }>();
+
+      for await (const chunk of response.fullStream) {
+        switch (chunk.type) {
+          case 'text-start': {
+            const textIndex = currentMessage.content.length;
+            currentMessage.content.push({ type: 'text', text: '' });
+            textContentById.set(chunk.payload.id, { index: textIndex, text: '' });
+            emit({ type: 'message_start', message: { ...currentMessage } });
+            break;
+          }
+
+          case 'text-delta': {
+            const textState = textContentById.get(chunk.payload.id);
+            if (textState) {
+              textState.text += chunk.payload.text;
+              const textContent = currentMessage.content[textState.index];
+              if (textContent && textContent.type === 'text') {
+                textContent.text = textState.text;
+              }
+              emit({ type: 'message_update', message: { ...currentMessage } });
+            }
+            break;
+          }
+
+          case 'reasoning-start': {
+            const thinkingIndex = currentMessage.content.length;
+            currentMessage.content.push({ type: 'thinking', thinking: '' });
+            thinkingContentById.set(chunk.payload.id, { index: thinkingIndex, text: '' });
+            emit({ type: 'message_update', message: { ...currentMessage } });
+            break;
+          }
+
+          case 'reasoning-delta': {
+            const thinkingState = thinkingContentById.get(chunk.payload.id);
+            if (thinkingState) {
+              thinkingState.text += chunk.payload.text;
+              const thinkingContent = currentMessage.content[thinkingState.index];
+              if (thinkingContent && thinkingContent.type === 'thinking') {
+                thinkingContent.thinking = thinkingState.text;
+              }
+              emit({ type: 'message_update', message: { ...currentMessage } });
+            }
+            break;
+          }
+
+          case 'tool-call-input-streaming-start': {
+            const { toolCallId, toolName } = chunk.payload;
+            emit({ type: 'tool_input_start', toolCallId, toolName });
+            break;
+          }
+
+          case 'tool-call-delta': {
+            const { toolCallId, argsTextDelta, toolName } = chunk.payload;
+            emit({ type: 'tool_input_delta', toolCallId, argsTextDelta, toolName });
+            break;
+          }
+
+          case 'tool-call-input-streaming-end': {
+            const { toolCallId } = chunk.payload;
+            emit({ type: 'tool_input_end', toolCallId });
+            break;
+          }
+
+          case 'tool-call': {
+            const toolCall = chunk.payload;
+            currentMessage.content.push({
+              type: 'tool_call',
+              id: toolCall.toolCallId,
+              name: toolCall.toolName,
+              args: toolCall.args,
+            });
+            emit({
+              type: 'tool_start',
+              toolCallId: toolCall.toolCallId,
+              toolName: toolCall.toolName,
+              args: toolCall.args,
+            });
+            emit({ type: 'message_update', message: { ...currentMessage } });
+            break;
+          }
+
+          case 'tool-result': {
+            const toolResult = chunk.payload;
+            currentMessage.content.push({
+              type: 'tool_result',
+              id: toolResult.toolCallId,
+              name: toolResult.toolName,
+              result: toolResult.result,
+              isError: toolResult.isError ?? false,
+            });
+            emit({
+              type: 'tool_end',
+              toolCallId: toolResult.toolCallId,
+              result: toolResult.result,
+              isError: toolResult.isError ?? false,
+            });
+            emit({ type: 'message_update', message: { ...currentMessage } });
+            break;
+          }
+
+          case 'tool-error': {
+            const toolError = chunk.payload;
+            emit({ type: 'tool_end', toolCallId: toolError.toolCallId, result: toolError.error, isError: true });
+            break;
+          }
+
+          case 'tool-call-approval': {
+            const { toolCallId, toolName, args: toolArgs } = chunk.payload;
+            emit({ type: 'tool_approval_required', toolCallId, toolName, args: toolArgs });
+
+            const approval = await new Promise<{ decision: 'approve' | 'decline'; requestContext?: RequestContext }>(
+              resolve => {
+                pendingApprovalResolve = resolve;
+              },
+            );
+            pendingApprovalResolve = null;
+
+            if (approval.decision === 'approve') {
+              const approveResult = await (response as any).approveToolExecution(toolCallId);
+              if (approveResult?.fullStream) {
+                const subResult = await processStream(approveResult);
+                currentMessage.content.push(...subResult.message.content);
+              }
+            } else {
+              const declineResult = await (response as any).declineToolExecution(toolCallId);
+              if (declineResult?.fullStream) {
+                const subResult = await processStream(declineResult);
+                currentMessage.content.push(...subResult.message.content);
+              }
+            }
+            return { message: currentMessage };
+          }
+
+          case 'error': {
+            const streamError =
+              chunk.payload.error instanceof Error ? chunk.payload.error : new Error(String(chunk.payload.error));
+            emit({ type: 'error', error: streamError });
+            break;
+          }
+
+          case 'step-finish': {
+            const usage = chunk.payload?.output?.usage;
+            if (usage) {
+              const promptTokens = usage.promptTokens ?? usage.inputTokens ?? 0;
+              const completionTokens = usage.completionTokens ?? usage.outputTokens ?? 0;
+              const totalTokens = promptTokens + completionTokens;
+              emit({ type: 'usage_update', usage: { promptTokens, completionTokens, totalTokens } });
+            }
+            break;
+          }
+
+          case 'finish': {
+            const finishReason = chunk.payload.stepResult?.reason;
+            if (finishReason === 'stop' || finishReason === 'end-turn') {
+              currentMessage.stopReason = 'complete';
+            } else if (finishReason === 'tool-calls') {
+              currentMessage.stopReason = 'tool_use';
+            } else {
+              currentMessage.stopReason = 'complete';
+            }
+            break;
+          }
+        }
+      }
+
+      emit({ type: 'message_end', message: { ...currentMessage } });
+      return { message: currentMessage };
+    };
+
+    const emptyMessage = (): AgentMessage => ({
       id: randomUUID(),
       role: 'assistant',
       content: [],
       createdAt: new Date(),
+    });
+
+    // Set up the event queue eagerly so events are captured from the start,
+    // even before the consumer calls `for await (const event of op.events)`.
+    const eventQueue: AgentEvent[] = [];
+    type EventResolver = (value: IteratorResult<AgentEvent, undefined>) => void;
+    let eventResolve: EventResolver | null = null;
+    let eventsDone = false;
+
+    function flushResolve(result: IteratorResult<AgentEvent, undefined>): void {
+      if (eventResolve) {
+        const fn: EventResolver = eventResolve;
+        eventResolve = null;
+        fn(result);
+      }
+    }
+
+    const queueListener: AgentEventListener = (event: AgentEvent) => {
+      if (eventResolve) {
+        flushResolve({ value: event, done: false });
+      } else {
+        eventQueue.push(event);
+      }
+    };
+    listeners.push(queueListener);
+
+    const resultPromise = (async (): Promise<{ message: AgentMessage }> => {
+      emit({ type: 'send_start' });
+
+      try {
+        const streamOptions: Record<string, unknown> = {
+          memory: { thread: threadId, resource: resourceId },
+          abortSignal: abortController.signal,
+          maxSteps,
+          ...(requestContext && { requestContext }),
+          ...(toolsets && { toolsets }),
+          ...(onStepFinish && { onStepFinish }),
+        };
+
+        const response = await this.stream(messages, streamOptions as any);
+        const result = await processStream(response);
+
+        emit({ type: 'send_end', reason: abortRequested ? 'aborted' : 'complete' });
+        return result;
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') {
+          emit({ type: 'send_end', reason: 'aborted' });
+        } else {
+          const err = error instanceof Error ? error : new Error(String(error));
+          emit({ type: 'error', error: err });
+          emit({ type: 'send_end', reason: 'error' });
+        }
+        return { message: emptyMessage() };
+      } finally {
+        eventsDone = true;
+        flushResolve({ value: undefined, done: true as const });
+      }
+    })();
+
+    const events: AsyncIterable<AgentEvent> = {
+      [Symbol.asyncIterator]() {
+        return {
+          next(): Promise<IteratorResult<AgentEvent, undefined>> {
+            if (eventQueue.length > 0) {
+              return Promise.resolve({ value: eventQueue.shift()!, done: false });
+            }
+            if (eventsDone) {
+              return Promise.resolve({ value: undefined, done: true as const });
+            }
+            return new Promise<IteratorResult<AgentEvent, undefined>>(resolver => {
+              eventResolve = resolver;
+            });
+          },
+        };
+      },
+    };
+
+    return {
+      result: resultPromise,
+      events,
+
+      abort() {
+        abortRequested = true;
+        abortController.abort();
+      },
+
+      respondToToolApproval(decision: 'approve' | 'decline', reqContext?: RequestContext) {
+        if (pendingApprovalResolve) {
+          pendingApprovalResolve({ decision, requestContext: reqContext });
+          pendingApprovalResolve = null;
+        }
+      },
     };
   }
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -82,8 +82,10 @@ import type {
   DelegationStartContext,
   DelegationCompleteContext,
 } from './agent.types';
+import type { AgentEvent, AgentEventListener, AgentEventMap } from './events';
 import { MessageList } from './message-list';
 import type { MessageInput, MessageListInput, UIMessageWithMetadata, MastraDBMessage } from './message-list';
+import type { AgentMode } from './modes';
 import { SaveQueueManager } from './save-queue';
 import { TripWire } from './trip-wire';
 import type {
@@ -174,6 +176,13 @@ export class Agent<
   #requestContextSchema?: ZodSchema<TRequestContext>;
   readonly #options?: AgentCreateOptions;
   #legacyHandler?: AgentLegacyHandler;
+
+  // -- Orchestration (optional) -----------------------------------------------
+  #modes?: AgentMode[];
+  #currentModeId?: string;
+  #stateSchema?: z.ZodObject<z.ZodRawShape>;
+  #state: Record<string, unknown> = {};
+  #eventListeners: AgentEventListener[] = [];
 
   // This flag is for agent network messages. We should change the agent network formatting and remove this flag after.
   private _agentNetworkAppend = false;
@@ -314,12 +323,187 @@ export class Agent<
       this.#requestContextSchema = config.requestContextSchema;
     }
 
+    if (config.modes?.length) {
+      this.#modes = config.modes;
+      const defaultMode = config.modes.find(m => m.default) ?? config.modes[0]!;
+      this.#currentModeId = defaultMode.id;
+    }
+
+    if (config.stateSchema) {
+      this.#stateSchema = config.stateSchema;
+      this.#state = {
+        ...this.#getSchemaDefaults(config.stateSchema),
+        ...config.initialState,
+      };
+    } else if (config.initialState) {
+      this.#state = { ...config.initialState };
+    }
+
     // @ts-expect-error Flag for agent network messages
     this._agentNetworkAppend = config._agentNetworkAppend || false;
   }
 
   getMastraInstance() {
     return this.#mastra;
+  }
+
+  // ===========================================================================
+  // Events
+  // ===========================================================================
+
+  /**
+   * Subscribe to all agent events. Returns an unsubscribe function.
+   *
+   * @example
+   * ```typescript
+   * const unsub = agent.subscribe((event) => {
+   *   if (event.type === 'mode_changed') console.log(event.modeId);
+   * });
+   * // later:
+   * unsub();
+   * ```
+   */
+  subscribe(listener: AgentEventListener): () => void {
+    this.#eventListeners.push(listener);
+    return () => {
+      const idx = this.#eventListeners.indexOf(listener);
+      if (idx >= 0) this.#eventListeners.splice(idx, 1);
+    };
+  }
+
+  /**
+   * Subscribe to a specific event type. Returns an unsubscribe function.
+   *
+   * @example
+   * ```typescript
+   * agent.on('mode_changed', (event) => {
+   *   console.log(`Switched to ${event.modeId}`);
+   * });
+   * ```
+   */
+  on<K extends keyof AgentEventMap>(type: K, handler: (event: AgentEventMap[K]) => void | Promise<void>): () => void {
+    const wrappedListener: AgentEventListener = event => {
+      if (event.type === type) return handler(event as AgentEventMap[K]);
+    };
+    return this.subscribe(wrappedListener);
+  }
+
+  /**
+   * Emit an event to all subscribers.
+   * @internal — used by Agent internals and future orchestration methods.
+   */
+  protected emitEvent(event: AgentEvent): void {
+    for (const listener of this.#eventListeners) {
+      try {
+        void listener(event);
+      } catch {
+        // Don't let listener errors break the agent
+      }
+    }
+  }
+
+  // ===========================================================================
+  // Modes
+  // ===========================================================================
+
+  /**
+   * Whether this agent has modes configured.
+   */
+  hasModes(): boolean {
+    return !!this.#modes?.length;
+  }
+
+  /**
+   * List all configured modes.
+   * Returns an empty array if modes are not configured.
+   */
+  listModes(): AgentMode[] {
+    return this.#modes ?? [];
+  }
+
+  /**
+   * Get the current mode ID. Returns undefined if modes are not configured.
+   */
+  getCurrentModeId(): string | undefined {
+    return this.#currentModeId;
+  }
+
+  /**
+   * Get the current mode. Returns undefined if modes are not configured.
+   */
+  getCurrentMode(): AgentMode | undefined {
+    if (!this.#modes || !this.#currentModeId) return undefined;
+    return this.#modes.find(m => m.id === this.#currentModeId);
+  }
+
+  /**
+   * Switch to a different mode.
+   * Throws if modes are not configured or the mode ID is not found.
+   */
+  switchMode(modeId: string): void {
+    if (!this.#modes) {
+      throw new Error('Cannot switch modes: no modes configured on this agent');
+    }
+    const mode = this.#modes.find(m => m.id === modeId);
+    if (!mode) {
+      throw new Error(`Mode not found: ${modeId}`);
+    }
+    const previousModeId = this.#currentModeId!;
+    if (previousModeId === modeId) return;
+
+    this.#currentModeId = modeId;
+    this.emitEvent({ type: 'mode_changed', modeId, previousModeId });
+  }
+
+  // ===========================================================================
+  // State
+  // ===========================================================================
+
+  /**
+   * Get the current agent state (read-only snapshot).
+   * Returns an empty object if state is not configured.
+   */
+  getState(): Readonly<Record<string, unknown>> {
+    return { ...this.#state };
+  }
+
+  /**
+   * Update agent state. Validates against stateSchema if provided.
+   * Emits a state_changed event.
+   */
+  setState(updates: Record<string, unknown>): void {
+    const changedKeys = Object.keys(updates);
+    const newState = { ...this.#state, ...updates };
+
+    if (this.#stateSchema) {
+      const result = this.#stateSchema.safeParse(newState);
+      if (!result.success) {
+        throw new Error(`Invalid state update: ${result.error.message}`);
+      }
+      this.#state = result.data as Record<string, unknown>;
+    } else {
+      this.#state = newState;
+    }
+
+    this.emitEvent({ type: 'state_changed', state: this.#state, changedKeys });
+  }
+
+  #getSchemaDefaults(schema: z.ZodObject<z.ZodRawShape>): Record<string, unknown> {
+    const shape = schema.shape;
+    const defaults: Record<string, unknown> = {};
+
+    for (const [key, field] of Object.entries(shape)) {
+      try {
+        const result = (field as any).safeParse(undefined);
+        if (result.success && result.data !== undefined) {
+          defaults[key] = result.data;
+        }
+      } catch {
+        // field has no default — skip
+      }
+    }
+
+    return defaults;
   }
 
   /**

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -82,7 +82,7 @@ import type {
   DelegationStartContext,
   DelegationCompleteContext,
 } from './agent.types';
-import type { AgentEvent, AgentEventListener, AgentEventMap } from './events';
+import type { AgentEvent, AgentEventListener, AgentEventMap, AgentMessage } from './events';
 import { MessageList } from './message-list';
 import type { MessageInput, MessageListInput, UIMessageWithMetadata, MastraDBMessage } from './message-list';
 import type { AgentMode } from './modes';
@@ -183,6 +183,13 @@ export class Agent<
   #stateSchema?: z.ZodObject<z.ZodRawShape>;
   #state: Record<string, unknown> = {};
   #eventListeners: AgentEventListener[] = [];
+  #abortController: AbortController | null = null;
+  #abortRequested = false;
+  #sendOperationId = 0;
+  #followUpQueue: Array<{ content: string; requestContext?: RequestContext }> = [];
+  #pendingApprovalResolve:
+    | ((params: { decision: 'approve' | 'decline'; requestContext?: RequestContext }) => void)
+    | null = null;
 
   // This flag is for agent network messages. We should change the agent network formatting and remove this flag after.
   private _agentNetworkAppend = false;
@@ -504,6 +511,347 @@ export class Agent<
     }
 
     return defaults;
+  }
+
+  // ===========================================================================
+  // Send (orchestration loop)
+  // ===========================================================================
+
+  /**
+   * Send a message to the agent and stream the response, emitting events
+   * for the full lifecycle (text deltas, tool calls, tool results, errors).
+   *
+   * Requires `memory` to be configured on the agent. The thread and resource
+   * are specified via `memory` on each call, or you can let it use the
+   * existing memory configuration.
+   *
+   * @example
+   * ```typescript
+   * agent.subscribe((event) => {
+   *   if (event.type === 'message_update') console.log(event.message);
+   * });
+   *
+   * await agent.send({
+   *   messages: 'Hello!',
+   *   threadId: 'thread-1',
+   *   resourceId: 'user-1',
+   * });
+   * ```
+   */
+  async send({
+    messages,
+    threadId,
+    resourceId,
+    maxSteps = 100,
+    requestContext,
+    toolsets,
+    onStepFinish,
+    abortSignal,
+  }: {
+    messages: MessageListInput;
+    threadId: string;
+    resourceId: string;
+    maxSteps?: number;
+    requestContext?: RequestContext;
+    toolsets?: ToolsetsInput;
+    onStepFinish?: (step: unknown) => void | Promise<void>;
+    abortSignal?: AbortSignal;
+  }): Promise<{ message: AgentMessage }> {
+    const operationId = ++this.#sendOperationId;
+    this.#abortController = new AbortController();
+    this.#abortRequested = false;
+
+    if (abortSignal) {
+      abortSignal.addEventListener('abort', () => this.abort(), { once: true });
+    }
+
+    this.emitEvent({ type: 'send_start' });
+
+    try {
+      const streamOptions: Record<string, unknown> = {
+        memory: { thread: threadId, resource: resourceId },
+        abortSignal: this.#abortController.signal,
+        maxSteps,
+        ...(requestContext && { requestContext }),
+        ...(toolsets && { toolsets }),
+        ...(onStepFinish && { onStepFinish }),
+      };
+
+      const response = await this.stream(messages, streamOptions as any);
+      const result = await this.#processStreamEvents(response);
+
+      if (this.#sendOperationId === operationId) {
+        const reason = this.#abortRequested ? 'aborted' : 'complete';
+        this.emitEvent({ type: 'send_end', reason });
+      }
+
+      return result;
+    } catch (error) {
+      if (this.#sendOperationId !== operationId) {
+        return { message: this.#emptyMessage() };
+      }
+
+      if (error instanceof Error && error.name === 'AbortError') {
+        this.emitEvent({ type: 'send_end', reason: 'aborted' });
+      } else if (error instanceof Error && error.message.match(/^Tool .+ not found$/)) {
+        const badTool = error.message.replace('Tool ', '').replace(' not found', '');
+        this.emitEvent({
+          type: 'error',
+          error: new Error(`Unknown tool "${badTool}".`),
+          retryable: true,
+        });
+        this.#followUpQueue.push({
+          content: `[System] Your previous tool call used "${badTool}" which is not a valid tool. Please retry with the correct tool name.`,
+          requestContext,
+        });
+        this.emitEvent({ type: 'send_end', reason: 'error' });
+      } else {
+        const err = error instanceof Error ? error : new Error(String(error));
+        this.emitEvent({ type: 'error', error: err });
+        this.emitEvent({ type: 'send_end', reason: 'error' });
+      }
+
+      return { message: this.#emptyMessage() };
+    } finally {
+      if (this.#sendOperationId === operationId) {
+        this.#abortController = null;
+        this.#abortRequested = false;
+      }
+
+      if (this.#sendOperationId === operationId && this.#followUpQueue.length > 0) {
+        const next = this.#followUpQueue.shift()!;
+        await this.send({
+          messages: next.content,
+          threadId,
+          resourceId,
+          maxSteps,
+          requestContext: next.requestContext,
+          toolsets,
+        });
+      }
+    }
+  }
+
+  /**
+   * Abort the current `.send()` operation.
+   * The in-progress stream will be cancelled and a `send_end` event with
+   * reason `'aborted'` will be emitted.
+   */
+  abort(): void {
+    if (this.#abortController) {
+      this.#abortRequested = true;
+      this.#abortController.abort();
+    }
+  }
+
+  /**
+   * Respond to a pending tool approval request.
+   * Only meaningful when a `tool_approval_required` event has been emitted.
+   */
+  respondToToolApproval(decision: 'approve' | 'decline', requestContext?: RequestContext): void {
+    if (this.#pendingApprovalResolve) {
+      this.#pendingApprovalResolve({ decision, requestContext });
+      this.#pendingApprovalResolve = null;
+    }
+  }
+
+  /**
+   * Process the full stream from a `stream()` call, emitting events for
+   * each chunk type (text, reasoning, tool calls, tool results, etc.).
+   */
+  async #processStreamEvents(response: { fullStream: AsyncIterable<any> }): Promise<{ message: AgentMessage }> {
+    const currentMessage: AgentMessage = {
+      id: randomUUID(),
+      role: 'assistant',
+      content: [],
+      createdAt: new Date(),
+    };
+
+    const textContentById = new Map<string, { index: number; text: string }>();
+    const thinkingContentById = new Map<string, { index: number; text: string }>();
+
+    for await (const chunk of response.fullStream) {
+      switch (chunk.type) {
+        case 'text-start': {
+          const textIndex = currentMessage.content.length;
+          currentMessage.content.push({ type: 'text', text: '' });
+          textContentById.set(chunk.payload.id, { index: textIndex, text: '' });
+          this.emitEvent({ type: 'message_start', message: { ...currentMessage } });
+          break;
+        }
+
+        case 'text-delta': {
+          const textState = textContentById.get(chunk.payload.id);
+          if (textState) {
+            textState.text += chunk.payload.text;
+            const textContent = currentMessage.content[textState.index];
+            if (textContent && textContent.type === 'text') {
+              textContent.text = textState.text;
+            }
+            this.emitEvent({ type: 'message_update', message: { ...currentMessage } });
+          }
+          break;
+        }
+
+        case 'reasoning-start': {
+          const thinkingIndex = currentMessage.content.length;
+          currentMessage.content.push({ type: 'thinking', thinking: '' });
+          thinkingContentById.set(chunk.payload.id, { index: thinkingIndex, text: '' });
+          this.emitEvent({ type: 'message_update', message: { ...currentMessage } });
+          break;
+        }
+
+        case 'reasoning-delta': {
+          const thinkingState = thinkingContentById.get(chunk.payload.id);
+          if (thinkingState) {
+            thinkingState.text += chunk.payload.text;
+            const thinkingContent = currentMessage.content[thinkingState.index];
+            if (thinkingContent && thinkingContent.type === 'thinking') {
+              thinkingContent.thinking = thinkingState.text;
+            }
+            this.emitEvent({ type: 'message_update', message: { ...currentMessage } });
+          }
+          break;
+        }
+
+        case 'tool-call-input-streaming-start': {
+          const { toolCallId, toolName } = chunk.payload;
+          this.emitEvent({ type: 'tool_input_start', toolCallId, toolName });
+          break;
+        }
+
+        case 'tool-call-delta': {
+          const { toolCallId, argsTextDelta, toolName } = chunk.payload;
+          this.emitEvent({ type: 'tool_input_delta', toolCallId, argsTextDelta, toolName });
+          break;
+        }
+
+        case 'tool-call-input-streaming-end': {
+          const { toolCallId } = chunk.payload;
+          this.emitEvent({ type: 'tool_input_end', toolCallId });
+          break;
+        }
+
+        case 'tool-call': {
+          const toolCall = chunk.payload;
+          currentMessage.content.push({
+            type: 'tool_call',
+            id: toolCall.toolCallId,
+            name: toolCall.toolName,
+            args: toolCall.args,
+          });
+          this.emitEvent({
+            type: 'tool_start',
+            toolCallId: toolCall.toolCallId,
+            toolName: toolCall.toolName,
+            args: toolCall.args,
+          });
+          this.emitEvent({ type: 'message_update', message: { ...currentMessage } });
+          break;
+        }
+
+        case 'tool-result': {
+          const toolResult = chunk.payload;
+          currentMessage.content.push({
+            type: 'tool_result',
+            id: toolResult.toolCallId,
+            name: toolResult.toolName,
+            result: toolResult.result,
+            isError: toolResult.isError ?? false,
+          });
+          this.emitEvent({
+            type: 'tool_end',
+            toolCallId: toolResult.toolCallId,
+            result: toolResult.result,
+            isError: toolResult.isError ?? false,
+          });
+          this.emitEvent({ type: 'message_update', message: { ...currentMessage } });
+          break;
+        }
+
+        case 'tool-error': {
+          const toolError = chunk.payload;
+          this.emitEvent({
+            type: 'tool_end',
+            toolCallId: toolError.toolCallId,
+            result: toolError.error,
+            isError: true,
+          });
+          break;
+        }
+
+        case 'tool-call-approval': {
+          const { toolCallId, toolName, args: toolArgs } = chunk.payload;
+          this.emitEvent({ type: 'tool_approval_required', toolCallId, toolName, args: toolArgs });
+
+          const approval = await new Promise<{ decision: 'approve' | 'decline'; requestContext?: RequestContext }>(
+            resolve => {
+              this.#pendingApprovalResolve = resolve;
+            },
+          );
+          this.#pendingApprovalResolve = null;
+
+          if (approval.decision === 'approve') {
+            const approveResult = await (response as any).approveToolExecution(toolCallId);
+            if (approveResult?.fullStream) {
+              const subResult = await this.#processStreamEvents(approveResult);
+              currentMessage.content.push(...subResult.message.content);
+            }
+          } else {
+            const declineResult = await (response as any).declineToolExecution(toolCallId);
+            if (declineResult?.fullStream) {
+              const subResult = await this.#processStreamEvents(declineResult);
+              currentMessage.content.push(...subResult.message.content);
+            }
+          }
+          return { message: currentMessage };
+        }
+
+        case 'error': {
+          const streamError =
+            chunk.payload.error instanceof Error ? chunk.payload.error : new Error(String(chunk.payload.error));
+          this.emitEvent({ type: 'error', error: streamError });
+          break;
+        }
+
+        case 'step-finish': {
+          const usage = chunk.payload?.output?.usage;
+          if (usage) {
+            const promptTokens = usage.promptTokens ?? usage.inputTokens ?? 0;
+            const completionTokens = usage.completionTokens ?? usage.outputTokens ?? 0;
+            const totalTokens = promptTokens + completionTokens;
+            this.emitEvent({ type: 'usage_update', usage: { promptTokens, completionTokens, totalTokens } });
+          }
+          break;
+        }
+
+        case 'finish': {
+          const finishReason = chunk.payload.stepResult?.reason;
+          if (finishReason === 'stop' || finishReason === 'end-turn') {
+            currentMessage.stopReason = 'complete';
+          } else if (finishReason === 'tool-calls') {
+            currentMessage.stopReason = 'tool_use';
+          } else {
+            currentMessage.stopReason = 'complete';
+          }
+          break;
+        }
+
+        // Skip data parts we don't handle yet — future phases will add OM events etc.
+      }
+    }
+
+    this.emitEvent({ type: 'message_end', message: { ...currentMessage } });
+    return { message: currentMessage };
+  }
+
+  #emptyMessage(): AgentMessage {
+    return {
+      id: randomUUID(),
+      role: 'assistant',
+      content: [],
+      createdAt: new Date(),
+    };
   }
 
   /**

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -536,6 +536,7 @@ export class Agent<
     messages,
     threadId,
     resourceId,
+    modeId,
     maxSteps = 100,
     requestContext,
     toolsets,
@@ -545,6 +546,8 @@ export class Agent<
     messages: MessageListInput;
     threadId: string;
     resourceId: string;
+    /** Mode to use for this operation. Overrides the instance-level current mode. */
+    modeId?: string;
     maxSteps?: number;
     requestContext?: RequestContext;
     toolsets?: ToolsetsInput;
@@ -794,6 +797,9 @@ export class Agent<
       emit({ type: 'send_start' });
 
       try {
+        const effectiveModeId = modeId ?? this.#currentModeId;
+        const mode = effectiveModeId ? this.#modes?.find(m => m.id === effectiveModeId) : undefined;
+
         const streamOptions: Record<string, unknown> = {
           memory: { thread: threadId, resource: resourceId },
           abortSignal: abortController.signal,
@@ -801,6 +807,7 @@ export class Agent<
           ...(requestContext && { requestContext }),
           ...(toolsets && { toolsets }),
           ...(onStepFinish && { onStepFinish }),
+          ...(mode?.instructions && { instructions: mode.instructions }),
         };
 
         const response = await this.stream(messages, streamOptions as any);

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -85,7 +85,7 @@ import type {
 import type { AgentEvent, AgentEventListener, AgentEventMap, AgentMessage, SendOperation } from './events';
 import { MessageList } from './message-list';
 import type { MessageInput, MessageListInput, UIMessageWithMetadata, MastraDBMessage } from './message-list';
-import type { AgentMode } from './modes';
+import type { AgentHarnessConfig, AgentMode } from './modes';
 import { SaveQueueManager } from './save-queue';
 import { TripWire } from './trip-wire';
 import type {
@@ -177,11 +177,8 @@ export class Agent<
   readonly #options?: AgentCreateOptions;
   #legacyHandler?: AgentLegacyHandler;
 
-  // -- Orchestration (optional) -----------------------------------------------
-  #modes?: AgentMode[];
-  #currentModeId?: string;
-  #stateSchema?: z.ZodObject<z.ZodRawShape>;
-  #state: Record<string, unknown> = {};
+  // -- Harness (optional per-session orchestration) ----------------------------
+  #harness?: AgentHarnessConfig;
   #eventListeners: AgentEventListener[] = [];
 
   // This flag is for agent network messages. We should change the agent network formatting and remove this flag after.
@@ -323,20 +320,8 @@ export class Agent<
       this.#requestContextSchema = config.requestContextSchema;
     }
 
-    if (config.modes?.length) {
-      this.#modes = config.modes;
-      const defaultMode = config.modes.find(m => m.default) ?? config.modes[0]!;
-      this.#currentModeId = defaultMode.id;
-    }
-
-    if (config.stateSchema) {
-      this.#stateSchema = config.stateSchema;
-      this.#state = {
-        ...this.#getSchemaDefaults(config.stateSchema),
-        ...config.initialState,
-      };
-    } else if (config.initialState) {
-      this.#state = { ...config.initialState };
+    if (config.harness) {
+      this.#harness = config.harness;
     }
 
     // @ts-expect-error Flag for agent network messages
@@ -403,107 +388,39 @@ export class Agent<
   }
 
   // ===========================================================================
-  // Modes
+  // Harness (read-only config accessors)
   // ===========================================================================
 
   /**
-   * Whether this agent has modes configured.
+   * Whether this agent has modes configured in its harness config.
    */
   hasModes(): boolean {
-    return !!this.#modes?.length;
+    return !!this.#harness?.modes?.length;
   }
 
   /**
-   * List all configured modes.
-   * Returns an empty array if modes are not configured.
+   * List all configured modes from the harness config.
+   * Returns an empty array if no harness or modes are configured.
    */
   listModes(): AgentMode[] {
-    return this.#modes ?? [];
+    return this.#harness?.modes ?? [];
   }
 
   /**
-   * Get the current mode ID. Returns undefined if modes are not configured.
+   * Get the default mode from the harness config.
+   * Returns the mode marked `default: true`, or the first mode if none is marked.
    */
-  getCurrentModeId(): string | undefined {
-    return this.#currentModeId;
+  getDefaultMode(): AgentMode | undefined {
+    const modes = this.#harness?.modes;
+    if (!modes?.length) return undefined;
+    return modes.find(m => m.default) ?? modes[0];
   }
 
   /**
-   * Get the current mode. Returns undefined if modes are not configured.
+   * Get the harness state schema, if configured.
    */
-  getCurrentMode(): AgentMode | undefined {
-    if (!this.#modes || !this.#currentModeId) return undefined;
-    return this.#modes.find(m => m.id === this.#currentModeId);
-  }
-
-  /**
-   * Switch to a different mode.
-   * Throws if modes are not configured or the mode ID is not found.
-   */
-  switchMode(modeId: string): void {
-    if (!this.#modes) {
-      throw new Error('Cannot switch modes: no modes configured on this agent');
-    }
-    const mode = this.#modes.find(m => m.id === modeId);
-    if (!mode) {
-      throw new Error(`Mode not found: ${modeId}`);
-    }
-    const previousModeId = this.#currentModeId!;
-    if (previousModeId === modeId) return;
-
-    this.#currentModeId = modeId;
-    this.emitEvent({ type: 'mode_changed', modeId, previousModeId });
-  }
-
-  // ===========================================================================
-  // State
-  // ===========================================================================
-
-  /**
-   * Get the current agent state (read-only snapshot).
-   * Returns an empty object if state is not configured.
-   */
-  getState(): Readonly<Record<string, unknown>> {
-    return { ...this.#state };
-  }
-
-  /**
-   * Update agent state. Validates against stateSchema if provided.
-   * Emits a state_changed event.
-   */
-  setState(updates: Record<string, unknown>): void {
-    const changedKeys = Object.keys(updates);
-    const newState = { ...this.#state, ...updates };
-
-    if (this.#stateSchema) {
-      const result = this.#stateSchema.safeParse(newState);
-      if (!result.success) {
-        throw new Error(`Invalid state update: ${result.error.message}`);
-      }
-      this.#state = result.data as Record<string, unknown>;
-    } else {
-      this.#state = newState;
-    }
-
-    this.emitEvent({ type: 'state_changed', state: this.#state, changedKeys });
-  }
-
-  #getSchemaDefaults(schema: z.ZodObject<z.ZodRawShape>): Record<string, unknown> {
-    const shape = schema.shape;
-    const defaults: Record<string, unknown> = {};
-
-    for (const [key, field] of Object.entries(shape)) {
-      try {
-        const result = (field as any).safeParse(undefined);
-        if (result.success && result.data !== undefined) {
-          defaults[key] = result.data;
-        }
-      } catch {
-        // field has no default — skip
-      }
-    }
-
-    return defaults;
+  getStateSchema(): z.ZodObject<z.ZodRawShape> | undefined {
+    return this.#harness?.stateSchema;
   }
 
   // ===========================================================================
@@ -537,6 +454,7 @@ export class Agent<
     threadId,
     resourceId,
     modeId,
+    state,
     maxSteps = 100,
     requestContext,
     toolsets,
@@ -548,6 +466,8 @@ export class Agent<
     resourceId: string;
     /** Mode to use for this operation. Overrides the instance-level current mode. */
     modeId?: string;
+    /** Per-operation state. Overrides the instance-level state for this operation only. */
+    state?: Record<string, unknown>;
     maxSteps?: number;
     requestContext?: RequestContext;
     toolsets?: ToolsetsInput;
@@ -797,14 +717,35 @@ export class Agent<
       emit({ type: 'send_start' });
 
       try {
-        const effectiveModeId = modeId ?? this.#currentModeId;
-        const mode = effectiveModeId ? this.#modes?.find(m => m.id === effectiveModeId) : undefined;
+        const modes = this.#harness?.modes;
+        const defaultMode = modes?.find(m => m.default) ?? modes?.[0];
+        const effectiveModeId = modeId ?? defaultMode?.id;
+        const mode = effectiveModeId ? modes?.find(m => m.id === effectiveModeId) : undefined;
+
+        if (modeId && modes?.length && !mode) {
+          throw new Error(`Mode not found: ${modeId}. Available: ${modes.map(m => m.id).join(', ')}`);
+        }
+
+        if (state && this.#harness?.stateSchema) {
+          const result = this.#harness.stateSchema.safeParse(state);
+          if (!result.success) {
+            throw new Error(`Invalid state: ${result.error.message}`);
+          }
+        }
+
+        const effectiveRequestContext = requestContext ?? new RequestContext();
+        if (state) {
+          effectiveRequestContext.set('agentState', state);
+        }
+        if (effectiveModeId) {
+          effectiveRequestContext.set('agentModeId', effectiveModeId);
+        }
 
         const streamOptions: Record<string, unknown> = {
           memory: { thread: threadId, resource: resourceId },
           abortSignal: abortController.signal,
           maxSteps,
-          ...(requestContext && { requestContext }),
+          requestContext: effectiveRequestContext,
           ...(toolsets && { toolsets }),
           ...(onStepFinish && { onStepFinish }),
           ...(mode?.instructions && { instructions: mode.instructions }),

--- a/packages/core/src/agent/events.ts
+++ b/packages/core/src/agent/events.ts
@@ -1,3 +1,5 @@
+import type { RequestContext } from '../request-context';
+
 /**
  * Event listener that receives agent events.
  */
@@ -171,6 +173,29 @@ export interface AgentErrorEvent {
   error: Error;
   errorType?: string;
   retryable?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// SendOperation
+// ---------------------------------------------------------------------------
+
+/**
+ * A self-contained send operation returned by `agent.send()`.
+ * Each operation has its own event stream, abort handle, and tool-approval
+ * resolver — multiple concurrent sends to the same Agent do not interfere.
+ */
+export interface SendOperation {
+  /** Resolves when the send completes, with the assembled assistant message. */
+  result: Promise<{ message: AgentMessage }>;
+
+  /** Async iterable of events emitted during this send. */
+  events: AsyncIterable<AgentEvent>;
+
+  /** Abort this specific send operation. */
+  abort(): void;
+
+  /** Respond to a tool approval request within this send operation. */
+  respondToToolApproval(decision: 'approve' | 'decline', requestContext?: RequestContext): void;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/agent/events.ts
+++ b/packages/core/src/agent/events.ts
@@ -1,0 +1,49 @@
+/**
+ * Event listener that receives agent events.
+ */
+export type AgentEventListener = (event: AgentEvent) => void | Promise<void>;
+
+/**
+ * Map of event type to its payload, used for typed `on()` overloads.
+ */
+export interface AgentEventMap {
+  mode_changed: AgentModeChangedEvent;
+  model_changed: AgentModelChangedEvent;
+  state_changed: AgentStateChangedEvent;
+  error: AgentErrorEvent;
+}
+
+// ---------------------------------------------------------------------------
+// Individual event types
+// ---------------------------------------------------------------------------
+
+export interface AgentModeChangedEvent {
+  type: 'mode_changed';
+  modeId: string;
+  previousModeId: string;
+}
+
+export interface AgentModelChangedEvent {
+  type: 'model_changed';
+  modelId: string;
+  scope?: 'global' | 'mode';
+  modeId?: string;
+}
+
+export interface AgentStateChangedEvent {
+  type: 'state_changed';
+  state: Record<string, unknown>;
+  changedKeys: string[];
+}
+
+export interface AgentErrorEvent {
+  type: 'error';
+  error: Error;
+  errorType?: string;
+}
+
+/**
+ * Union of all events the Agent can emit.
+ * This set will grow as more orchestration features are added.
+ */
+export type AgentEvent = AgentModeChangedEvent | AgentModelChangedEvent | AgentStateChangedEvent | AgentErrorEvent;

--- a/packages/core/src/agent/events.ts
+++ b/packages/core/src/agent/events.ts
@@ -7,14 +7,37 @@ export type AgentEventListener = (event: AgentEvent) => void | Promise<void>;
  * Map of event type to its payload, used for typed `on()` overloads.
  */
 export interface AgentEventMap {
+  // Orchestration
   mode_changed: AgentModeChangedEvent;
   model_changed: AgentModelChangedEvent;
   state_changed: AgentStateChangedEvent;
+
+  // Streaming lifecycle
+  send_start: AgentSendStartEvent;
+  send_end: AgentSendEndEvent;
+
+  // Message
+  message_start: AgentMessageStartEvent;
+  message_update: AgentMessageUpdateEvent;
+  message_end: AgentMessageEndEvent;
+
+  // Tool
+  tool_start: AgentToolStartEvent;
+  tool_end: AgentToolEndEvent;
+  tool_input_start: AgentToolInputStartEvent;
+  tool_input_delta: AgentToolInputDeltaEvent;
+  tool_input_end: AgentToolInputEndEvent;
+  tool_approval_required: AgentToolApprovalRequiredEvent;
+
+  // Usage
+  usage_update: AgentUsageUpdateEvent;
+
+  // Error
   error: AgentErrorEvent;
 }
 
 // ---------------------------------------------------------------------------
-// Individual event types
+// Orchestration events
 // ---------------------------------------------------------------------------
 
 export interface AgentModeChangedEvent {
@@ -36,14 +59,141 @@ export interface AgentStateChangedEvent {
   changedKeys: string[];
 }
 
+// ---------------------------------------------------------------------------
+// Streaming lifecycle events
+// ---------------------------------------------------------------------------
+
+export interface AgentSendStartEvent {
+  type: 'send_start';
+}
+
+export interface AgentSendEndEvent {
+  type: 'send_end';
+  reason: 'complete' | 'aborted' | 'error';
+}
+
+// ---------------------------------------------------------------------------
+// Message events
+// ---------------------------------------------------------------------------
+
+export interface AgentMessageContent {
+  type: 'text' | 'thinking' | 'tool_call' | 'tool_result';
+  text?: string;
+  thinking?: string;
+  id?: string;
+  name?: string;
+  args?: unknown;
+  result?: unknown;
+  isError?: boolean;
+}
+
+export interface AgentMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: AgentMessageContent[];
+  createdAt: Date;
+  stopReason?: 'complete' | 'tool_use' | 'aborted' | 'error';
+}
+
+export interface AgentMessageStartEvent {
+  type: 'message_start';
+  message: AgentMessage;
+}
+
+export interface AgentMessageUpdateEvent {
+  type: 'message_update';
+  message: AgentMessage;
+}
+
+export interface AgentMessageEndEvent {
+  type: 'message_end';
+  message: AgentMessage;
+}
+
+// ---------------------------------------------------------------------------
+// Tool events
+// ---------------------------------------------------------------------------
+
+export interface AgentToolStartEvent {
+  type: 'tool_start';
+  toolCallId: string;
+  toolName: string;
+  args: unknown;
+}
+
+export interface AgentToolEndEvent {
+  type: 'tool_end';
+  toolCallId: string;
+  result: unknown;
+  isError: boolean;
+}
+
+export interface AgentToolInputStartEvent {
+  type: 'tool_input_start';
+  toolCallId: string;
+  toolName: string;
+}
+
+export interface AgentToolInputDeltaEvent {
+  type: 'tool_input_delta';
+  toolCallId: string;
+  argsTextDelta: string;
+  toolName?: string;
+}
+
+export interface AgentToolInputEndEvent {
+  type: 'tool_input_end';
+  toolCallId: string;
+}
+
+export interface AgentToolApprovalRequiredEvent {
+  type: 'tool_approval_required';
+  toolCallId: string;
+  toolName: string;
+  args: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Usage events
+// ---------------------------------------------------------------------------
+
+export interface AgentUsageUpdateEvent {
+  type: 'usage_update';
+  usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+}
+
+// ---------------------------------------------------------------------------
+// Error events
+// ---------------------------------------------------------------------------
+
 export interface AgentErrorEvent {
   type: 'error';
   error: Error;
   errorType?: string;
+  retryable?: boolean;
 }
+
+// ---------------------------------------------------------------------------
+// Union
+// ---------------------------------------------------------------------------
 
 /**
  * Union of all events the Agent can emit.
- * This set will grow as more orchestration features are added.
  */
-export type AgentEvent = AgentModeChangedEvent | AgentModelChangedEvent | AgentStateChangedEvent | AgentErrorEvent;
+export type AgentEvent =
+  | AgentModeChangedEvent
+  | AgentModelChangedEvent
+  | AgentStateChangedEvent
+  | AgentSendStartEvent
+  | AgentSendEndEvent
+  | AgentMessageStartEvent
+  | AgentMessageUpdateEvent
+  | AgentMessageEndEvent
+  | AgentToolStartEvent
+  | AgentToolEndEvent
+  | AgentToolInputStartEvent
+  | AgentToolInputDeltaEvent
+  | AgentToolInputEndEvent
+  | AgentToolApprovalRequiredEvent
+  | AgentUsageUpdateEvent
+  | AgentErrorEvent;

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -4,7 +4,14 @@ export type { OutputFormat } from './message-list';
 export * from './types';
 export * from './agent';
 export * from './utils';
-export type { AgentEvent, AgentEventListener, AgentEventMap, AgentMessage, AgentMessageContent } from './events';
+export type {
+  AgentEvent,
+  AgentEventListener,
+  AgentEventMap,
+  AgentMessage,
+  AgentMessageContent,
+  SendOperation,
+} from './events';
 export type { AgentMode } from './modes';
 
 export type {

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -4,6 +4,8 @@ export type { OutputFormat } from './message-list';
 export * from './types';
 export * from './agent';
 export * from './utils';
+export type { AgentEvent, AgentEventListener, AgentEventMap } from './events';
+export type { AgentMode } from './modes';
 
 export type {
   AgentExecutionOptions,

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -4,7 +4,7 @@ export type { OutputFormat } from './message-list';
 export * from './types';
 export * from './agent';
 export * from './utils';
-export type { AgentEvent, AgentEventListener, AgentEventMap } from './events';
+export type { AgentEvent, AgentEventListener, AgentEventMap, AgentMessage, AgentMessageContent } from './events';
 export type { AgentMode } from './modes';
 
 export type {

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -12,7 +12,7 @@ export type {
   AgentMessageContent,
   SendOperation,
 } from './events';
-export type { AgentMode } from './modes';
+export type { AgentMode, AgentHarnessConfig } from './modes';
 
 export type {
   AgentExecutionOptions,

--- a/packages/core/src/agent/modes.ts
+++ b/packages/core/src/agent/modes.ts
@@ -1,3 +1,5 @@
+import type { z } from 'zod';
+
 import type { MastraModelConfig } from '../llm/model/shared.types';
 import type { DynamicArgument } from '../types';
 
@@ -5,8 +7,8 @@ import type { AgentInstructions, ToolsInput } from './types';
 
 /**
  * A mode is a named preset of instructions, model, and tools.
- * When an Agent has modes configured, you can switch between them
- * at runtime without creating a new Agent.
+ * When an Agent has harness config with modes, callers can select
+ * a mode per `.send()` operation.
  */
 export interface AgentMode {
   /** Unique identifier for this mode (e.g., "plan", "build", "review") */
@@ -15,7 +17,7 @@ export interface AgentMode {
   /** Human-readable name for display */
   name?: string;
 
-  /** Whether this is the default mode when the agent starts */
+  /** Whether this is the default mode when no modeId is specified */
   default?: boolean;
 
   /** Instructions override for this mode */
@@ -26,4 +28,26 @@ export interface AgentMode {
 
   /** Tools override for this mode (merged with agent-level tools) */
   tools?: DynamicArgument<ToolsInput>;
+}
+
+/**
+ * Harness configuration for per-session orchestration capabilities.
+ *
+ * The `harness` config on an Agent defines what modes and state shape
+ * are available. The actual mode selection and state values are per-operation
+ * (passed to `.send()`), not stored on the Agent singleton.
+ */
+export interface AgentHarnessConfig {
+  /**
+   * Named presets of instructions, model, and tools.
+   * Callers select a mode per `.send()` operation via `modeId`.
+   */
+  modes?: AgentMode[];
+
+  /**
+   * Zod object schema defining the shape of per-session state.
+   * State values are passed to `.send()` per-operation and validated
+   * against this schema. Tools can access state via `requestContext.get('agentState')`.
+   */
+  stateSchema?: z.ZodObject<z.ZodRawShape>;
 }

--- a/packages/core/src/agent/modes.ts
+++ b/packages/core/src/agent/modes.ts
@@ -1,0 +1,29 @@
+import type { MastraModelConfig } from '../llm/model/shared.types';
+import type { DynamicArgument } from '../types';
+
+import type { AgentInstructions, ToolsInput } from './types';
+
+/**
+ * A mode is a named preset of instructions, model, and tools.
+ * When an Agent has modes configured, you can switch between them
+ * at runtime without creating a new Agent.
+ */
+export interface AgentMode {
+  /** Unique identifier for this mode (e.g., "plan", "build", "review") */
+  id: string;
+
+  /** Human-readable name for display */
+  name?: string;
+
+  /** Whether this is the default mode when the agent starts */
+  default?: boolean;
+
+  /** Instructions override for this mode */
+  instructions?: DynamicArgument<AgentInstructions>;
+
+  /** Model override for this mode */
+  model?: DynamicArgument<MastraModelConfig>;
+
+  /** Tools override for this mode (merged with agent-level tools) */
+  tools?: DynamicArgument<ToolsInput>;
+}

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1,7 +1,7 @@
 import type { GenerateTextOnStepFinishCallback } from '@internal/ai-sdk-v4';
 import type { ProviderDefinedTool } from '@internal/external-types';
 import type { JSONSchema7 } from 'json-schema';
-import type { ZodSchema } from 'zod';
+import type { z, ZodSchema } from 'zod';
 import type { MastraScorer, MastraScorers, ScoringSamplingConfig } from '../evals';
 import type {
   CoreMessage,
@@ -39,6 +39,7 @@ import type { SkillFormat } from '../workspace/skills';
 import type { Agent } from './agent';
 import type { AgentExecutionOptions, NetworkOptions } from './agent.types';
 import type { MessageList } from './message-list/index';
+import type { AgentMode } from './modes';
 
 export type {
   MastraDBMessage,
@@ -329,6 +330,32 @@ export interface AgentConfig<
    * If validation fails, an error is thrown.
    */
   requestContextSchema?: ZodSchema<TRequestContext>;
+
+  /**
+   * Named presets of instructions, model, and tools that can be switched at runtime.
+   * When configured, the current mode's overrides are applied on top of the
+   * agent's base configuration during `stream()` and `generate()`.
+   *
+   * @example
+   * ```typescript
+   * modes: [
+   *   { id: 'plan', name: 'Plan', default: true, model: 'anthropic/claude-sonnet-4-20250514' },
+   *   { id: 'build', name: 'Build', model: 'anthropic/claude-sonnet-4-20250514', tools: buildTools },
+   * ]
+   * ```
+   */
+  modes?: AgentMode[];
+
+  /**
+   * Zod object schema defining the shape of shared agent state.
+   * State persists across mode switches and is accessible via `getState()` / `setState()`.
+   */
+  stateSchema?: z.ZodObject<z.ZodRawShape>;
+
+  /**
+   * Initial state values. Must conform to `stateSchema` if provided.
+   */
+  initialState?: Record<string, unknown>;
 }
 
 export type AgentMemoryOption = {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1,7 +1,7 @@
 import type { GenerateTextOnStepFinishCallback } from '@internal/ai-sdk-v4';
 import type { ProviderDefinedTool } from '@internal/external-types';
 import type { JSONSchema7 } from 'json-schema';
-import type { z, ZodSchema } from 'zod';
+import type { ZodSchema } from 'zod';
 import type { MastraScorer, MastraScorers, ScoringSamplingConfig } from '../evals';
 import type {
   CoreMessage,
@@ -39,7 +39,7 @@ import type { SkillFormat } from '../workspace/skills';
 import type { Agent } from './agent';
 import type { AgentExecutionOptions, NetworkOptions } from './agent.types';
 import type { MessageList } from './message-list/index';
-import type { AgentMode } from './modes';
+import type { AgentHarnessConfig } from './modes';
 
 export type {
   MastraDBMessage,
@@ -332,30 +332,23 @@ export interface AgentConfig<
   requestContextSchema?: ZodSchema<TRequestContext>;
 
   /**
-   * Named presets of instructions, model, and tools that can be switched at runtime.
-   * When configured, the current mode's overrides are applied on top of the
-   * agent's base configuration during `stream()` and `generate()`.
+   * Harness configuration for per-session orchestration capabilities.
+   * Defines modes (named presets) and state schema that callers can use
+   * per `.send()` operation. These values are NOT stored on the Agent
+   * singleton — they are passed per-operation to ensure session isolation.
    *
    * @example
    * ```typescript
-   * modes: [
-   *   { id: 'plan', name: 'Plan', default: true, model: 'anthropic/claude-sonnet-4-20250514' },
-   *   { id: 'build', name: 'Build', model: 'anthropic/claude-sonnet-4-20250514', tools: buildTools },
-   * ]
+   * harness: {
+   *   modes: [
+   *     { id: 'plan', name: 'Plan', default: true, instructions: '...' },
+   *     { id: 'build', name: 'Build', tools: buildTools },
+   *   ],
+   *   stateSchema: z.object({ counter: z.number().default(0) }),
+   * }
    * ```
    */
-  modes?: AgentMode[];
-
-  /**
-   * Zod object schema defining the shape of shared agent state.
-   * State persists across mode switches and is accessible via `getState()` / `setState()`.
-   */
-  stateSchema?: z.ZodObject<z.ZodRawShape>;
-
-  /**
-   * Initial state values. Must conform to `stateSchema` if provided.
-   */
-  initialState?: Record<string, unknown>;
+  harness?: AgentHarnessConfig;
 }
 
 export type AgentMemoryOption = {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -88,7 +88,7 @@
   "author": "",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@mastra/core": ">=1.7.1-0 <2.0.0-0",
+    "@mastra/core": ">=1.11.0-0 <2.0.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -2050,7 +2050,7 @@ export const SEND_MESSAGE_ROUTE = createRoute({
   handler: async ({ mastra, agentId, abortSignal, requestContext: serverRequestContext, ...params }) => {
     try {
       const agent = await getAgentFromSystem({ mastra, agentId });
-      const { messages, threadId, resourceId, maxSteps, bodyRequestContext } = params;
+      const { messages, threadId, resourceId, modeId, maxSteps, bodyRequestContext } = params;
 
       if (bodyRequestContext && typeof bodyRequestContext === 'object') {
         for (const [key, value] of Object.entries(bodyRequestContext as Record<string, unknown>)) {
@@ -2075,6 +2075,7 @@ export const SEND_MESSAGE_ROUTE = createRoute({
         messages,
         threadId: effectiveThreadId,
         resourceId: effectiveResourceId,
+        modeId,
         maxSteps,
         requestContext: serverRequestContext,
         abortSignal,

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -40,6 +40,13 @@ import {
   enhanceInstructionsResponseSchema,
   approveNetworkToolCallBodySchema,
   declineNetworkToolCallBodySchema,
+  listModesResponseSchema,
+  switchModeBodySchema,
+  switchModeResponseSchema,
+  agentStateResponseSchema,
+  updateStateBodySchema,
+  agentSendBodySchema,
+  sendEventSchema,
 } from '../schemas/agents';
 import { createStoredAgentResponseSchema } from '../schemas/stored-agents';
 import { getAgentSkillResponseSchema } from '../schemas/workspace';
@@ -1930,6 +1937,181 @@ export const GET_AGENT_SKILL_ROUTE = createRoute({
       };
     } catch (error) {
       return handleError(error, 'Error getting agent skill');
+    }
+  },
+});
+
+// ============================================================================
+// Orchestration Routes (Modes, State, Send)
+// ============================================================================
+
+export const LIST_MODES_ROUTE = createRoute({
+  method: 'GET',
+  path: '/agents/:agentId/modes',
+  responseType: 'json' as const,
+  pathParamSchema: agentIdPathParams,
+  responseSchema: listModesResponseSchema,
+  summary: 'List agent modes',
+  description: 'Returns the configured modes for an agent and the current active mode',
+  tags: ['Agents', 'Orchestration'],
+  requiresAuth: true,
+  handler: async ({ mastra, agentId }) => {
+    try {
+      const agent = await getAgentFromSystem({ mastra, agentId });
+      return {
+        modes: agent.listModes().map(m => ({ id: m.id, name: m.name, default: m.default })),
+        currentModeId: agent.getCurrentModeId(),
+      };
+    } catch (error) {
+      return handleError(error, 'Error listing agent modes');
+    }
+  },
+});
+
+export const SWITCH_MODE_ROUTE = createRoute({
+  method: 'POST',
+  path: '/agents/:agentId/modes/switch',
+  responseType: 'json' as const,
+  pathParamSchema: agentIdPathParams,
+  bodySchema: switchModeBodySchema,
+  responseSchema: switchModeResponseSchema,
+  summary: 'Switch agent mode',
+  description: 'Switch the agent to a different mode',
+  tags: ['Agents', 'Orchestration'],
+  requiresAuth: true,
+  handler: async ({ mastra, agentId, modeId }) => {
+    try {
+      const agent = await getAgentFromSystem({ mastra, agentId });
+      const previousModeId = agent.getCurrentModeId();
+      agent.switchMode(modeId);
+      return { modeId, previousModeId };
+    } catch (error) {
+      return handleError(error, 'Error switching agent mode');
+    }
+  },
+});
+
+export const GET_STATE_ROUTE = createRoute({
+  method: 'GET',
+  path: '/agents/:agentId/state',
+  responseType: 'json' as const,
+  pathParamSchema: agentIdPathParams,
+  responseSchema: agentStateResponseSchema,
+  summary: 'Get agent state',
+  description: 'Returns the current shared state of the agent',
+  tags: ['Agents', 'Orchestration'],
+  requiresAuth: true,
+  handler: async ({ mastra, agentId }) => {
+    try {
+      const agent = await getAgentFromSystem({ mastra, agentId });
+      return { state: agent.getState() };
+    } catch (error) {
+      return handleError(error, 'Error getting agent state');
+    }
+  },
+});
+
+export const UPDATE_STATE_ROUTE = createRoute({
+  method: 'POST',
+  path: '/agents/:agentId/state',
+  responseType: 'json' as const,
+  pathParamSchema: agentIdPathParams,
+  bodySchema: updateStateBodySchema,
+  responseSchema: agentStateResponseSchema,
+  summary: 'Update agent state',
+  description: 'Merge partial updates into the agent state. Validates against stateSchema if configured.',
+  tags: ['Agents', 'Orchestration'],
+  requiresAuth: true,
+  handler: async ({ mastra, agentId, state: updates }) => {
+    try {
+      const agent = await getAgentFromSystem({ mastra, agentId });
+      agent.setState(updates);
+      return { state: agent.getState() };
+    } catch (error) {
+      return handleError(error, 'Error updating agent state');
+    }
+  },
+});
+
+export const SEND_MESSAGE_ROUTE = createRoute({
+  method: 'POST',
+  path: '/agents/:agentId/send',
+  responseType: 'stream' as const,
+  streamFormat: 'sse' as const,
+  pathParamSchema: agentIdPathParams,
+  bodySchema: agentSendBodySchema,
+  responseSchema: sendEventSchema,
+  summary: 'Send message with event streaming',
+  description:
+    'Send a message to the agent and receive a stream of lifecycle events (message deltas, tool calls, errors, etc.)',
+  tags: ['Agents', 'Orchestration'],
+  requiresAuth: true,
+  requiresPermission: 'agents:execute',
+  handler: async ({ mastra, agentId, abortSignal, requestContext: serverRequestContext, ...params }) => {
+    try {
+      const agent = await getAgentFromSystem({ mastra, agentId });
+      const { messages, threadId, resourceId, maxSteps, bodyRequestContext } = params;
+
+      if (bodyRequestContext && typeof bodyRequestContext === 'object') {
+        for (const [key, value] of Object.entries(bodyRequestContext as Record<string, unknown>)) {
+          if (serverRequestContext.get(key) === undefined) {
+            serverRequestContext.set(key, value);
+          }
+        }
+      }
+
+      const effectiveResourceId = getEffectiveResourceId(serverRequestContext, resourceId) ?? resourceId;
+      const effectiveThreadId = getEffectiveThreadId(serverRequestContext, threadId) ?? threadId;
+
+      if (effectiveThreadId && effectiveResourceId) {
+        const memoryInstance = await agent.getMemory({ requestContext: serverRequestContext });
+        if (memoryInstance) {
+          const thread = await memoryInstance.getThreadById({ threadId: effectiveThreadId });
+          await validateThreadOwnership(thread, effectiveResourceId);
+        }
+      }
+
+      const eventStream = new ReadableStream({
+        start(controller) {
+          const unsub = agent.subscribe(event => {
+            try {
+              controller.enqueue(event);
+            } catch {
+              // Stream may be closed
+            }
+          });
+
+          agent
+            .send({
+              messages,
+              threadId: effectiveThreadId,
+              resourceId: effectiveResourceId,
+              maxSteps,
+              requestContext: serverRequestContext,
+              abortSignal,
+            })
+            .then(() => {
+              unsub();
+              try {
+                controller.close();
+              } catch {
+                // Already closed
+              }
+            })
+            .catch((err: unknown) => {
+              unsub();
+              try {
+                controller.error(err);
+              } catch {
+                // Already closed
+              }
+            });
+        },
+      });
+
+      return eventStream;
+    } catch (error) {
+      return handleError(error, 'Error sending agent message');
     }
   },
 });

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -41,10 +41,6 @@ import {
   approveNetworkToolCallBodySchema,
   declineNetworkToolCallBodySchema,
   listModesResponseSchema,
-  switchModeBodySchema,
-  switchModeResponseSchema,
-  agentStateResponseSchema,
-  updateStateBodySchema,
   agentSendBodySchema,
   sendEventSchema,
 } from '../schemas/agents';
@@ -1952,83 +1948,19 @@ export const LIST_MODES_ROUTE = createRoute({
   pathParamSchema: agentIdPathParams,
   responseSchema: listModesResponseSchema,
   summary: 'List agent modes',
-  description: 'Returns the configured modes for an agent and the current active mode',
+  description: 'Returns the available modes from the agent harness config and the default mode',
   tags: ['Agents', 'Orchestration'],
   requiresAuth: true,
   handler: async ({ mastra, agentId }) => {
     try {
       const agent = await getAgentFromSystem({ mastra, agentId });
+      const defaultMode = agent.getDefaultMode();
       return {
         modes: agent.listModes().map(m => ({ id: m.id, name: m.name, default: m.default })),
-        currentModeId: agent.getCurrentModeId(),
+        currentModeId: defaultMode?.id,
       };
     } catch (error) {
       return handleError(error, 'Error listing agent modes');
-    }
-  },
-});
-
-export const SWITCH_MODE_ROUTE = createRoute({
-  method: 'POST',
-  path: '/agents/:agentId/modes/switch',
-  responseType: 'json' as const,
-  pathParamSchema: agentIdPathParams,
-  bodySchema: switchModeBodySchema,
-  responseSchema: switchModeResponseSchema,
-  summary: 'Switch agent mode',
-  description: 'Switch the agent to a different mode',
-  tags: ['Agents', 'Orchestration'],
-  requiresAuth: true,
-  handler: async ({ mastra, agentId, modeId }) => {
-    try {
-      const agent = await getAgentFromSystem({ mastra, agentId });
-      const previousModeId = agent.getCurrentModeId();
-      agent.switchMode(modeId);
-      return { modeId, previousModeId };
-    } catch (error) {
-      return handleError(error, 'Error switching agent mode');
-    }
-  },
-});
-
-export const GET_STATE_ROUTE = createRoute({
-  method: 'GET',
-  path: '/agents/:agentId/state',
-  responseType: 'json' as const,
-  pathParamSchema: agentIdPathParams,
-  responseSchema: agentStateResponseSchema,
-  summary: 'Get agent state',
-  description: 'Returns the current shared state of the agent',
-  tags: ['Agents', 'Orchestration'],
-  requiresAuth: true,
-  handler: async ({ mastra, agentId }) => {
-    try {
-      const agent = await getAgentFromSystem({ mastra, agentId });
-      return { state: agent.getState() };
-    } catch (error) {
-      return handleError(error, 'Error getting agent state');
-    }
-  },
-});
-
-export const UPDATE_STATE_ROUTE = createRoute({
-  method: 'POST',
-  path: '/agents/:agentId/state',
-  responseType: 'json' as const,
-  pathParamSchema: agentIdPathParams,
-  bodySchema: updateStateBodySchema,
-  responseSchema: agentStateResponseSchema,
-  summary: 'Update agent state',
-  description: 'Merge partial updates into the agent state. Validates against stateSchema if configured.',
-  tags: ['Agents', 'Orchestration'],
-  requiresAuth: true,
-  handler: async ({ mastra, agentId, state: updates }) => {
-    try {
-      const agent = await getAgentFromSystem({ mastra, agentId });
-      agent.setState(updates);
-      return { state: agent.getState() };
-    } catch (error) {
-      return handleError(error, 'Error updating agent state');
     }
   },
 });
@@ -2050,7 +1982,7 @@ export const SEND_MESSAGE_ROUTE = createRoute({
   handler: async ({ mastra, agentId, abortSignal, requestContext: serverRequestContext, ...params }) => {
     try {
       const agent = await getAgentFromSystem({ mastra, agentId });
-      const { messages, threadId, resourceId, modeId, maxSteps, bodyRequestContext } = params;
+      const { messages, threadId, resourceId, modeId, state, maxSteps, bodyRequestContext } = params;
 
       if (bodyRequestContext && typeof bodyRequestContext === 'object') {
         for (const [key, value] of Object.entries(bodyRequestContext as Record<string, unknown>)) {
@@ -2076,6 +2008,7 @@ export const SEND_MESSAGE_ROUTE = createRoute({
         threadId: effectiveThreadId,
         resourceId: effectiveResourceId,
         modeId,
+        state: state as Record<string, unknown> | undefined,
         maxSteps,
         requestContext: serverRequestContext,
         abortSignal,

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -2071,41 +2071,33 @@ export const SEND_MESSAGE_ROUTE = createRoute({
         }
       }
 
-      const eventStream = new ReadableStream({
-        start(controller) {
-          const unsub = agent.subscribe(event => {
-            try {
-              controller.enqueue(event);
-            } catch {
-              // Stream may be closed
-            }
-          });
+      const op = agent.send({
+        messages,
+        threadId: effectiveThreadId,
+        resourceId: effectiveResourceId,
+        maxSteps,
+        requestContext: serverRequestContext,
+        abortSignal,
+      });
 
-          agent
-            .send({
-              messages,
-              threadId: effectiveThreadId,
-              resourceId: effectiveResourceId,
-              maxSteps,
-              requestContext: serverRequestContext,
-              abortSignal,
-            })
-            .then(() => {
-              unsub();
+      const eventStream = new ReadableStream({
+        async start(controller) {
+          try {
+            for await (const event of op.events) {
               try {
-                controller.close();
+                controller.enqueue(event);
               } catch {
-                // Already closed
+                break;
               }
-            })
-            .catch((err: unknown) => {
-              unsub();
-              try {
-                controller.error(err);
-              } catch {
-                // Already closed
-              }
-            });
+            }
+            controller.close();
+          } catch (err) {
+            try {
+              controller.error(err);
+            } catch {
+              // Already closed
+            }
+          }
         },
       });
 

--- a/packages/server/src/server/schemas/agents.ts
+++ b/packages/server/src/server/schemas/agents.ts
@@ -494,6 +494,7 @@ export const agentSendBodySchema = z.object({
   messages: z.union([z.string(), z.array(z.any())]).describe('Message(s) to send to the agent'),
   threadId: z.string().describe('Thread ID for memory persistence'),
   resourceId: z.string().describe('Resource ID for memory persistence'),
+  modeId: z.string().optional().describe('Mode to use for this operation (overrides instance default)'),
   maxSteps: z.number().optional().describe('Maximum number of LLM steps'),
   bodyRequestContext: z.record(z.unknown()).optional().describe('Additional request context values'),
 });

--- a/packages/server/src/server/schemas/agents.ts
+++ b/packages/server/src/server/schemas/agents.ts
@@ -442,3 +442,67 @@ export const enhanceInstructionsResponseSchema = z.object({
   explanation: z.string().describe('Explanation of the changes made'),
   new_prompt: z.string().describe('The enhanced instructions'),
 });
+
+// ============================================================================
+// Orchestration Schemas (Modes, State, Send)
+// ============================================================================
+
+/**
+ * Response schema for listing agent modes
+ */
+export const agentModeSchema = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+  default: z.boolean().optional(),
+});
+
+export const listModesResponseSchema = z.object({
+  modes: z.array(agentModeSchema),
+  currentModeId: z.string().optional(),
+});
+
+/**
+ * Body schema for switching agent mode
+ */
+export const switchModeBodySchema = z.object({
+  modeId: z.string().describe('The mode ID to switch to'),
+});
+
+export const switchModeResponseSchema = z.object({
+  modeId: z.string(),
+  previousModeId: z.string().optional(),
+});
+
+/**
+ * Response schema for agent state
+ */
+export const agentStateResponseSchema = z.object({
+  state: z.record(z.unknown()),
+});
+
+/**
+ * Body schema for updating agent state
+ */
+export const updateStateBodySchema = z.object({
+  state: z.record(z.unknown()).describe('Partial state update to merge'),
+});
+
+/**
+ * Body schema for agent send
+ */
+export const agentSendBodySchema = z.object({
+  messages: z.union([z.string(), z.array(z.any())]).describe('Message(s) to send to the agent'),
+  threadId: z.string().describe('Thread ID for memory persistence'),
+  resourceId: z.string().describe('Resource ID for memory persistence'),
+  maxSteps: z.number().optional().describe('Maximum number of LLM steps'),
+  bodyRequestContext: z.record(z.unknown()).optional().describe('Additional request context values'),
+});
+
+/**
+ * Response schema for send events (SSE)
+ */
+export const sendEventSchema = z
+  .object({
+    type: z.string(),
+  })
+  .passthrough();

--- a/packages/server/src/server/schemas/agents.ts
+++ b/packages/server/src/server/schemas/agents.ts
@@ -495,6 +495,7 @@ export const agentSendBodySchema = z.object({
   threadId: z.string().describe('Thread ID for memory persistence'),
   resourceId: z.string().describe('Resource ID for memory persistence'),
   modeId: z.string().optional().describe('Mode to use for this operation (overrides instance default)'),
+  state: z.record(z.unknown()).optional().describe('Per-operation state (overrides instance default)'),
   maxSteps: z.number().optional().describe('Maximum number of LLM steps'),
   bodyRequestContext: z.record(z.unknown()).optional().describe('Additional request context values'),
 });

--- a/packages/server/src/server/server-adapter/routes/agents.ts
+++ b/packages/server/src/server/server-adapter/routes/agents.ts
@@ -24,6 +24,11 @@ import {
   APPROVE_NETWORK_TOOL_CALL_ROUTE,
   DECLINE_NETWORK_TOOL_CALL_ROUTE,
   GET_AGENT_SKILL_ROUTE,
+  LIST_MODES_ROUTE,
+  SWITCH_MODE_ROUTE,
+  GET_STATE_ROUTE,
+  UPDATE_STATE_ROUTE,
+  SEND_MESSAGE_ROUTE,
 } from '../../handlers/agents';
 import { GET_AGENT_TOOL_ROUTE, EXECUTE_AGENT_TOOL_ROUTE } from '../../handlers/tools';
 import {
@@ -107,6 +112,15 @@ export const AGENTS_ROUTES: ServerRoute<any, any, any>[] = [
   TRANSCRIBE_SPEECH_ROUTE,
   TRANSCRIBE_SPEECH_DEPRECATED_ROUTE,
   GET_LISTENER_ROUTE,
+
+  // ============================================================================
+  // Orchestration Routes (Modes, State, Send)
+  // ============================================================================
+  LIST_MODES_ROUTE,
+  SWITCH_MODE_ROUTE,
+  GET_STATE_ROUTE,
+  UPDATE_STATE_ROUTE,
+  SEND_MESSAGE_ROUTE,
 
   // ============================================================================
   // Deprecated Routes

--- a/packages/server/src/server/server-adapter/routes/agents.ts
+++ b/packages/server/src/server/server-adapter/routes/agents.ts
@@ -25,9 +25,7 @@ import {
   DECLINE_NETWORK_TOOL_CALL_ROUTE,
   GET_AGENT_SKILL_ROUTE,
   LIST_MODES_ROUTE,
-  SWITCH_MODE_ROUTE,
   GET_STATE_ROUTE,
-  UPDATE_STATE_ROUTE,
   SEND_MESSAGE_ROUTE,
 } from '../../handlers/agents';
 import { GET_AGENT_TOOL_ROUTE, EXECUTE_AGENT_TOOL_ROUTE } from '../../handlers/tools';
@@ -114,12 +112,10 @@ export const AGENTS_ROUTES: ServerRoute<any, any, any>[] = [
   GET_LISTENER_ROUTE,
 
   // ============================================================================
-  // Orchestration Routes (Modes, State, Send)
+  // Orchestration Routes (Modes, Send)
   // ============================================================================
   LIST_MODES_ROUTE,
-  SWITCH_MODE_ROUTE,
   GET_STATE_ROUTE,
-  UPDATE_STATE_ROUTE,
   SEND_MESSAGE_ROUTE,
 
   // ============================================================================

--- a/packages/server/src/server/server-adapter/routes/agents.ts
+++ b/packages/server/src/server/server-adapter/routes/agents.ts
@@ -25,7 +25,6 @@ import {
   DECLINE_NETWORK_TOOL_CALL_ROUTE,
   GET_AGENT_SKILL_ROUTE,
   LIST_MODES_ROUTE,
-  GET_STATE_ROUTE,
   SEND_MESSAGE_ROUTE,
 } from '../../handlers/agents';
 import { GET_AGENT_TOOL_ROUTE, EXECUTE_AGENT_TOOL_ROUTE } from '../../handlers/tools';
@@ -115,7 +114,6 @@ export const AGENTS_ROUTES: ServerRoute<any, any, any>[] = [
   // Orchestration Routes (Modes, Send)
   // ============================================================================
   LIST_MODES_ROUTE,
-  GET_STATE_ROUTE,
   SEND_MESSAGE_ROUTE,
 
   // ============================================================================


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR initiates the refactoring effort to integrate the capabilities of the `Harness` primitive directly into the `Agent` class. The primary goal is to reduce cognitive overhead and simplify the architecture by making `Agent` a more comprehensive and flexible primitive for building interactive agent applications, thereby eliminating the need for a separate, application-level orchestration layer.

This first phase introduces three foundational, optional features to the `Agent` class:

1.  **Event System:** Adds `subscribe()`, `on()`, and `emitEvent()` methods for internal and external event handling.
2.  **Modes:** Enables defining and switching between named agent configurations (`instructions`, `model`, `tools`) within a single `Agent` instance.
3.  **Shared State:** Provides Zod-validated, mutable state that can persist across mode switches, accessible via `getState()` and `setState()`.

These changes lay the groundwork for future phases to migrate more `Harness` functionality into `Agent` and eventually deprecate `Harness`.

## Related Issue(s)

<!-- No specific issue linked, but this addresses the architectural question of Harness vs. Agent discussed in the conversation. -->

## Type of Change

-   [ ] Bug fix (non-breaking change that fixes an issue)
-   [x] New feature (non-breaking change that adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Documentation update
-   [x] Code refactoring
-   [ ] Performance improvement
-   [x] Test update

## Checklist

-   [x] I have made corresponding changes to the documentation (if applicable)
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have addressed all Coderabbit comments on this PR

---
<p><a href="https://cursor.com/agents/bc-c2c1ba7f-0091-4d26-bb54-521a75faff75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2c1ba7f-0091-4d26-bb54-521a75faff75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->