### PR TITLE
fix(server): support Zod v4 in query parameter type detection

### DIFF
--- a/.changeset/fix-zod4-query-param-detection.md
+++ b/.changeset/fix-zod4-query-param-detection.md
@@ -1,0 +1,7 @@
+---
+'@mastra/server': patch
+---
+
+fix(server): support Zod v4 in query parameter type detection
+
+`wrapSchemaForQueryParams` relied on `_def.typeName` to detect complex schema types (objects, arrays, records) that need JSON parsing from query strings. Zod v4 uses `_def.type` with lowercase values instead, causing all complex fields to be treated as simple strings. This broke date range filters, tags, and metadata filters in the Studio Observability UI when users had Zod v4 installed.

--- a/.changeset/fix-zod4-query-param-detection.md
+++ b/.changeset/fix-zod4-query-param-detection.md
@@ -2,6 +2,4 @@
 '@mastra/server': patch
 ---
 
-fix(server): fix complex query parameter parsing for Zod v4 projects
-
-Projects using Zod v4 would get "Invalid query parameters" errors when using date-range filters, tag filters, or metadata filters in the Studio Observability UI and server API. Complex query parameters (objects, arrays, records) are now correctly detected and parsed regardless of whether the project uses Zod v3 or v4.
+Fixed "Invalid query parameters" errors that occurred in projects using Zod v4 when filtering by date ranges, tags, or metadata. Complex query parameters (objects, arrays, records) are now correctly detected and parsed for both Zod v3 and v4.

--- a/.changeset/fix-zod4-query-param-detection.md
+++ b/.changeset/fix-zod4-query-param-detection.md
@@ -2,6 +2,6 @@
 '@mastra/server': patch
 ---
 
-fix(server): support Zod v4 in query parameter type detection
+fix(server): fix complex query parameter parsing for Zod v4 projects
 
-`wrapSchemaForQueryParams` relied on `_def.typeName` to detect complex schema types (objects, arrays, records) that need JSON parsing from query strings. Zod v4 uses `_def.type` with lowercase values instead, causing all complex fields to be treated as simple strings. This broke date range filters, tags, and metadata filters in the Studio Observability UI when users had Zod v4 installed.
+Projects using Zod v4 would get "Invalid query parameters" errors when using date-range filters, tag filters, or metadata filters in the Studio Observability UI and server API. Complex query parameters (objects, arrays, records) are now correctly detected and parsed regardless of whether the project uses Zod v3 or v4.

--- a/packages/server/src/server/server-adapter/routes/route-builder.ts
+++ b/packages/server/src/server/server-adapter/routes/route-builder.ts
@@ -78,51 +78,26 @@ export function jsonQueryParam<T extends ZodTypeAny>(schema: T): z.ZodType<z.inf
   ]) as z.ZodType<z.infer<T>>;
 }
 
-/**
- * Gets the type name from a Zod schema's internal definition.
- * Works across zod v3 and v4 by checking _def.typeName (v3) and _def.type (v4).
- */
 function getZodTypeName(schema: ZodTypeAny): string | undefined {
-  const schemaAny = schema as any;
-  const def = schemaAny?._def ?? schemaAny?.def;
+  const def = (schema as any)?._def;
+  // Zod v3 uses _def.typeName ("ZodObject"), Zod v4 uses _def.type ("object")
   return def?.typeName ?? def?.type;
 }
 
-/**
- * Checks if a Zod schema represents a complex type that needs JSON parsing from query strings.
- * Complex types: arrays, objects, records (these can't be represented as simple strings)
- * Simple types: strings, numbers, booleans, enums (can use z.coerce for conversion)
- *
- * Uses _def.typeName string comparison instead of instanceof to support both zod v3 and v4,
- * since instanceof checks fail across different zod versions in bundled code.
- */
+const OPTIONAL_TYPES = new Set(['ZodOptional', 'optional', 'ZodNullable', 'nullable']);
+const COMPLEX_TYPES = new Set(['ZodArray', 'array', 'ZodRecord', 'record', 'ZodObject', 'object']);
+
 function isComplexType(schema: ZodTypeAny): boolean {
-  // Unwrap all optional/nullable layers to check the inner type
-  // Note: .partial() can create nested optionals (e.g., ZodOptional<ZodOptional<ZodObject>>)
   let inner: ZodTypeAny = schema;
   let typeName = getZodTypeName(inner);
 
-  while (
-    typeName === 'ZodOptional' ||
-    typeName === 'ZodNullable' ||
-    typeName === 'optional' ||
-    typeName === 'nullable'
-  ) {
-    // Access innerType from internals to avoid version-specific method differences
+  while (typeName && OPTIONAL_TYPES.has(typeName)) {
     const innerDef = (inner as any)._def ?? (inner as any).def;
     inner = innerDef.innerType;
     typeName = getZodTypeName(inner);
   }
 
-  // Complex types that need JSON parsing
-  return (
-    typeName === 'ZodArray' ||
-    typeName === 'ZodRecord' ||
-    typeName === 'ZodObject' ||
-    typeName === 'array' ||
-    typeName === 'record' ||
-    typeName === 'object'
-  );
+  return typeName != null && COMPLEX_TYPES.has(typeName);
 }
 
 /**


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

`wrapSchemaForQueryParams` relied on `_def.typeName` to detect complex schema types (objects, arrays, records) that need JSON parsing from query strings.
Zod v4 uses `_def.type` with lowercase values (`"object"`, `"optional"`, `"array"`, `"record"`) instead of Zod v3's `_def.typeName` (`"ZodObject"`, `"ZodOptional"`, `"ZodArray"`, `"ZodRecord"`). This caused `isComplexType()` to return `false` for all fields, so complex query params like date ranges were never wrapped with `jsonQueryParam()` — the raw JSON string failed validation with "Invalid query parameters".

The fix updates `getZodTypeName()` to check both `_def.typeName` (v3) and `_def.type` (v4), and uses `Set` lookups for both naming conventions in `isComplexType()`.

## Before
<img width="1919" height="1027" alt="image" src="https://github.com/user-attachments/assets/67d7f985-2593-44ce-9519-5e5b1a5b18cb" />

## After
<img width="1918" height="1035" alt="image" src="https://github.com/user-attachments/assets/04097d81-f4e9-44b0-a4bc-98fa69571a04" />

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #13962

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing and detection of complex query parameters (objects, arrays, records) so date-range, tag, and metadata filters no longer trigger "Invalid query parameters" errors.
  * Ensured consistent filter behavior between the Studio Observability UI and the server API across different schema tooling versions, improving stability for affected queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->