### PR TITLE
fix(core): move llm-based output processors off stream chunks

### DIFF
--- a/.changeset/fix-llm-processors-stream.md
+++ b/.changeset/fix-llm-processors-stream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+fix(core): move llm-based output processors off stream chunks

--- a/packages/core/src/processor-provider/providers/index.ts
+++ b/packages/core/src/processor-provider/providers/index.ts
@@ -35,7 +35,7 @@ export const unicodeNormalizerProvider: ProcessorProvider = {
     collapseWhitespace: z.boolean().optional(),
     trim: z.boolean().optional(),
   }),
-  availablePhases: ['processInput', 'processOutputStep', 'processOutputResult'] as ProcessorPhase[],
+  availablePhases: ['processInput'] as ProcessorPhase[],
   createProcessor(config) {
     return new UnicodeNormalizer(config);
   },

--- a/packages/core/src/processor-provider/providers/index.ts
+++ b/packages/core/src/processor-provider/providers/index.ts
@@ -35,7 +35,7 @@ export const unicodeNormalizerProvider: ProcessorProvider = {
     collapseWhitespace: z.boolean().optional(),
     trim: z.boolean().optional(),
   }),
-  availablePhases: ['processInput'] as ProcessorPhase[],
+  availablePhases: ['processInput', 'processOutputStep', 'processOutputResult'] as ProcessorPhase[],
   createProcessor(config) {
     return new UnicodeNormalizer(config);
   },
@@ -121,7 +121,7 @@ export const moderationProvider: ProcessorProvider = {
     structuredOutputOptions: structuredOutputOptionsSchema,
     providerOptions: providerOptionsSchema,
   }),
-  availablePhases: ['processInput', 'processOutputResult', 'processOutputStream'] as ProcessorPhase[],
+  availablePhases: ['processInput', 'processOutputStep', 'processOutputResult'] as ProcessorPhase[],
   createProcessor(config) {
     return new ModerationProcessor(config as unknown as ModerationOptions);
   },
@@ -173,7 +173,7 @@ export const piiDetectorProvider: ProcessorProvider = {
     structuredOutputOptions: structuredOutputOptionsSchema,
     providerOptions: providerOptionsSchema,
   }),
-  availablePhases: ['processInput'] as ProcessorPhase[],
+  availablePhases: ['processInput', 'processOutputStep', 'processOutputResult'] as ProcessorPhase[],
   createProcessor(config) {
     return new PIIDetector(config as unknown as PIIDetectorOptions);
   },
@@ -225,7 +225,7 @@ export const systemPromptScrubberProvider: ProcessorProvider = {
     placeholderText: z.string().optional(),
     structuredOutputOptions: structuredOutputOptionsSchema,
   }),
-  availablePhases: ['processOutputStream', 'processOutputResult'] as ProcessorPhase[],
+  availablePhases: ['processOutputStep', 'processOutputResult'] as ProcessorPhase[],
   createProcessor(config) {
     return new SystemPromptScrubber(config as unknown as SystemPromptScrubberOptions);
   },

--- a/packages/core/src/processors/processors/moderation.test.ts
+++ b/packages/core/src/processors/processors/moderation.test.ts
@@ -603,6 +603,7 @@ describe('ModerationProcessor', () => {
   describe('processOutputStep', () => {
     it('should moderate the completed assistant step instead of each chunk', async () => {
       const model = setupMockModel({ object: createMockModerationResult(false) });
+      const generateSpy = vi.spyOn(model, 'doGenerate');
       const moderator = new ModerationProcessor({
         model,
         strategy: 'block',
@@ -617,6 +618,7 @@ describe('ModerationProcessor', () => {
       } as any);
 
       expect(result).toEqual(messages);
+      expect(generateSpy).toHaveBeenCalledTimes(1);
       expect(mockAbort).not.toHaveBeenCalled();
     });
   });

--- a/packages/core/src/processors/processors/moderation.test.ts
+++ b/packages/core/src/processors/processors/moderation.test.ts
@@ -548,17 +548,13 @@ describe('ModerationProcessor', () => {
   });
 
   describe('processOutputStream', () => {
-    it('should always moderate current part even when chunkWindow is 0', async () => {
+    it('should return streaming text chunks unchanged', async () => {
       const model = setupMockModel({ object: createMockModerationResult(true, ['hate']) });
       const moderator = new ModerationProcessor({
         model,
-        chunkWindow: 0, // No context window
         strategy: 'block',
       });
-
-      const mockAbort = vi.fn().mockImplementation(() => {
-        throw new TripWire('Content flagged');
-      });
+      const generateSpy = vi.spyOn(model, 'doGenerate');
 
       const part: ChunkType = {
         type: 'text-delta' as const,
@@ -566,62 +562,15 @@ describe('ModerationProcessor', () => {
         runId: '1',
         from: ChunkFrom.AGENT,
       };
-      const streamParts: any[] = []; // Empty context
-
-      // Should attempt to moderate the current part and abort
-      await expect(async () => {
-        await moderator.processOutputStream({
-          part,
-          streamParts,
-          state: {},
-          abort: mockAbort as any,
-        });
-      }).rejects.toThrow('Content flagged');
-
-      expect(mockAbort).toHaveBeenCalledWith(expect.stringContaining('Content flagged for moderation'));
-    });
-
-    it('should include context when chunkWindow is greater than 0', async () => {
-      const model = setupMockModel({ object: createMockModerationResult(false) });
-      const moderator = new ModerationProcessor({
-        model,
-        chunkWindow: 2, // Include 2 previous chunks
-        strategy: 'block',
-      });
-
-      const mockAbort = vi.fn();
-
-      const previousChunks: ChunkType[] = [
-        {
-          type: 'text-delta' as const,
-          payload: { text: 'Previous content ', id: 'text-1' },
-          runId: '1',
-          from: ChunkFrom.AGENT,
-        },
-        {
-          type: 'text-delta' as const,
-          payload: { text: 'more context ', id: 'text-1' },
-          runId: '1',
-          from: ChunkFrom.AGENT,
-        },
-      ];
-      const currentChunk: ChunkType = {
-        type: 'text-delta' as const,
-        payload: { text: 'current part', id: 'text-1' },
-        runId: '1',
-        from: ChunkFrom.AGENT,
-      };
-
       const result = await moderator.processOutputStream({
-        part: currentChunk,
-        streamParts: previousChunks,
+        part,
+        streamParts: [],
         state: {},
-        abort: mockAbort as any,
+        abort: vi.fn() as any,
       });
 
-      // Should return the part if moderation passes
-      expect(result).toEqual(currentChunk);
-      expect(mockAbort).not.toHaveBeenCalled();
+      expect(result).toEqual(part);
+      expect(generateSpy).not.toHaveBeenCalled();
     });
 
     it('should skip non-text-delta chunks', async () => {
@@ -630,8 +579,7 @@ describe('ModerationProcessor', () => {
         model,
         strategy: 'block',
       });
-
-      const mockAbort = vi.fn();
+      const generateSpy = vi.spyOn(model, 'doGenerate');
 
       const objectChunk: ChunkType = {
         type: 'object' as const,
@@ -644,41 +592,31 @@ describe('ModerationProcessor', () => {
         part: objectChunk,
         streamParts: [],
         state: {},
-        abort: mockAbort as any,
+        abort: vi.fn() as any,
       });
 
-      // Should return the part without moderation
       expect(result).toEqual(objectChunk);
-      expect(mockAbort).not.toHaveBeenCalled();
+      expect(generateSpy).not.toHaveBeenCalled();
     });
+  });
 
-    it('should properly handle chunkWindow=0 with current part in streamParts', async () => {
+  describe('processOutputStep', () => {
+    it('should moderate the completed assistant step instead of each chunk', async () => {
       const model = setupMockModel({ object: createMockModerationResult(false) });
       const moderator = new ModerationProcessor({
         model,
-        chunkWindow: 0, // No context window
         strategy: 'block',
       });
 
       const mockAbort = vi.fn();
+      const messages = [createTestMessage('Safe content', 'assistant')];
 
-      const currentChunk: ChunkType = {
-        type: 'text-delta' as const,
-        payload: { text: 'Safe content', id: 'text-1' },
-        runId: '1',
-        from: ChunkFrom.AGENT,
-      };
-      const streamParts = [currentChunk]; // streamParts includes the current part
-
-      const result = await moderator.processOutputStream({
-        part: currentChunk,
-        streamParts,
-        state: {},
+      const result = await moderator.processOutputStep({
+        messages,
         abort: mockAbort as any,
-      });
+      } as any);
 
-      // Should moderate the current part and return it if safe
-      expect(result).toEqual(currentChunk);
+      expect(result).toEqual(messages);
       expect(mockAbort).not.toHaveBeenCalled();
     });
   });

--- a/packages/core/src/processors/processors/moderation.ts
+++ b/packages/core/src/processors/processors/moderation.ts
@@ -8,7 +8,7 @@ import type { MastraModelConfig } from '../../llm/model/shared.types';
 import type { ObservabilityContext } from '../../observability';
 import { resolveObservabilityContext } from '../../observability';
 import type { ChunkType } from '../../stream';
-import type { Processor } from '../index';
+import type { ProcessOutputStepArgs, Processor } from '../index';
 
 /**
  * Individual moderation category score
@@ -71,9 +71,8 @@ export interface ModerationOptions {
   includeScores?: boolean;
 
   /**
-   * Number of previous chunks to include for context when moderating stream chunks.
-   * If set to 1, includes the previous part. If set to 2, includes the two previous chunks, etc.
-   * Default: 0 (no context window)
+   * Legacy streaming option retained for compatibility.
+   * LLM-based output moderation now runs at processOutputStep/result instead of per chunk.
    */
   chunkWindow?: number;
 
@@ -213,6 +212,13 @@ export class ModerationProcessor implements Processor<'moderation'> {
     return this.processInput(args);
   }
 
+  async processOutputStep(args: ProcessOutputStepArgs): Promise<MastraDBMessage[]> {
+    return this.processOutputResult(args);
+  }
+
+  /**
+   * Streaming is intentionally a passthrough. LLM-based moderation runs in processOutputStep/result.
+   */
   async processOutputStream(
     args: {
       part: ChunkType;
@@ -221,38 +227,7 @@ export class ModerationProcessor implements Processor<'moderation'> {
       abort: (reason?: string) => never;
     } & Partial<ObservabilityContext>,
   ): Promise<ChunkType | null | undefined> {
-    try {
-      const { part, streamParts, abort, ...rest } = args;
-      const observabilityContext = resolveObservabilityContext(rest);
-
-      // Only process text-delta chunks for moderation
-      if (part.type !== 'text-delta') {
-        return part;
-      }
-
-      // Build context from chunks based on chunkWindow (streamParts includes the current part)
-      const contentToModerate = this.buildContextFromChunks(streamParts);
-
-      const moderationResult = await this.moderateContent(contentToModerate, true, observabilityContext);
-
-      if (this.isModerationFlagged(moderationResult)) {
-        this.handleFlaggedContent(moderationResult, this.strategy, abort);
-
-        // If we reach here, strategy is 'warn' or 'filter'
-        if (this.strategy === 'filter') {
-          return null; // Don't emit this part
-        }
-      }
-
-      return part;
-    } catch (error) {
-      if (error instanceof TripWire) {
-        throw error; // Re-throw tripwire errors
-      }
-      // Log error but don't block the stream
-      console.warn('[ModerationProcessor] Stream moderation failed:', error);
-      return args.part;
-    }
+    return args.part;
   }
 
   /**

--- a/packages/core/src/processors/processors/pii-detector.test.ts
+++ b/packages/core/src/processors/processors/pii-detector.test.ts
@@ -862,7 +862,35 @@ describe('PIIDetector', () => {
       expect(result).toEqual(part);
     });
 
-    it('should detect and redact PII in text chunks', async () => {
+    it('should not run PII detection for streaming chunks', async () => {
+      const model = setupMockModel(createMockPIIResult(['email']));
+      const detector = new PIIDetector({ model });
+      const generateSpy = vi.spyOn(model, 'doGenerate');
+
+      const part: ChunkType = {
+        type: 'text-delta',
+        payload: {
+          id: 'test-id',
+          text: 'My email is test@example.com',
+        },
+        runId: 'test-run-id',
+        from: ChunkFrom.USER,
+      };
+
+      const result = await detector.processOutputStream({
+        part,
+        streamParts: [],
+        state: {},
+        abort: vi.fn() as any,
+      });
+
+      expect(result).toEqual(part);
+      expect(generateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('processOutputStep', () => {
+    it('should detect and redact PII after the step completes', async () => {
       const detections: PIIDetection[] = [
         {
           type: 'email',
@@ -876,148 +904,17 @@ describe('PIIDetector', () => {
       const model = setupMockModel(createMockPIIResult(['email'], detections, 'My email is j***.d**@e******.com'));
       const detector = new PIIDetector({ model });
 
-      const part: ChunkType = {
-        type: 'text-delta',
-        payload: {
-          id: 'test-id',
-          text: 'My email is test@example.com',
-        },
-        runId: 'test-run-id',
-        from: ChunkFrom.USER,
-      };
+      const messages = [createTestMessage('My email is test@example.com', 'assistant')];
 
-      const result = await detector.processOutputStream({
-        part,
-        streamParts: [],
-        state: {},
+      const result = await detector.processOutputStep({
+        messages,
         abort: vi.fn() as any,
+      } as any);
+
+      expect(result[0].content.parts[0]).toEqual({
+        type: 'text',
+        text: 'My email is j***.d**@e******.com',
       });
-
-      expect(result).toEqual({
-        type: 'text-delta',
-        payload: {
-          id: 'test-id',
-          text: 'My email is j***.d**@e******.com',
-        },
-        runId: 'test-run-id',
-        from: ChunkFrom.USER,
-      });
-    });
-
-    it('should block streaming content when strategy is block and PII is detected', async () => {
-      const model = setupMockModel(createMockPIIResult(['email']));
-      const detector = new PIIDetector({ model, strategy: 'block' });
-
-      const part: ChunkType = {
-        type: 'text-delta',
-        payload: {
-          id: 'test-id',
-          text: 'My email is test@example.com',
-          providerMetadata: {},
-        },
-        runId: 'test-run-id',
-        from: ChunkFrom.AGENT,
-      };
-
-      const mockAbort = vi.fn().mockImplementation(() => {
-        throw new TripWire('PII detected in streaming content');
-      });
-
-      await expect(
-        detector.processOutputStream({
-          part,
-          streamParts: [],
-          state: {},
-          abort: mockAbort as any,
-        }),
-      ).rejects.toThrow('PII detected in streaming content');
-
-      expect(mockAbort).toHaveBeenCalledWith(expect.stringContaining('PII detected in streaming content'));
-    });
-
-    it('should filter streaming chunks when strategy is filter and PII is detected', async () => {
-      const model = setupMockModel(createMockPIIResult(['email']));
-      const detector = new PIIDetector({ model, strategy: 'filter' });
-
-      const part: ChunkType = {
-        type: 'text-delta',
-        payload: {
-          id: 'test-id',
-          text: 'My email is test@example.com',
-          providerMetadata: {},
-        },
-        runId: 'test-run-id',
-        from: ChunkFrom.AGENT,
-      };
-
-      const result = await detector.processOutputStream({
-        part,
-        streamParts: [],
-        state: {},
-        abort: vi.fn() as any,
-      });
-
-      expect(result).toBeNull();
-    });
-
-    it('should warn but allow content when strategy is warn and PII is detected', async () => {
-      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-      const model = setupMockModel(createMockPIIResult(['email']));
-      const detector = new PIIDetector({ model, strategy: 'warn' });
-
-      const part: ChunkType = {
-        type: 'text-delta',
-        payload: {
-          id: 'test-id',
-          text: 'My email is test@example.com',
-          providerMetadata: {},
-        },
-        runId: 'test-run-id',
-        from: ChunkFrom.AGENT,
-      };
-
-      const result = await detector.processOutputStream({
-        part,
-        streamParts: [],
-        state: {},
-        abort: vi.fn() as any,
-      });
-
-      expect(result).toEqual(part);
-      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('PII detected in streaming content'));
-
-      consoleSpy.mockRestore();
-    });
-
-    it('should handle streaming detection failures gracefully', async () => {
-      const model = new MockLanguageModelV1({
-        defaultObjectGenerationMode: 'json',
-        doGenerate: async () => {
-          throw new Error('Detection failed');
-        },
-      });
-      const detector = new PIIDetector({ model });
-
-      const part: ChunkType = {
-        type: 'text-delta',
-        payload: {
-          id: 'test-id',
-          text: 'My email is test@example.com',
-          providerMetadata: {},
-        },
-        runId: 'test-run-id',
-        from: ChunkFrom.AGENT,
-      };
-
-      const result = await detector.processOutputStream({
-        part,
-        streamParts: [],
-        state: {},
-        abort: vi.fn() as any,
-      });
-
-      expect(result).toEqual(part); // Should return original part on failure
     });
   });
 

--- a/packages/core/src/processors/processors/pii-detector.ts
+++ b/packages/core/src/processors/processors/pii-detector.ts
@@ -9,7 +9,7 @@ import type { MastraModelConfig } from '../../llm/model/shared.types';
 import type { ObservabilityContext } from '../../observability';
 import { resolveObservabilityContext } from '../../observability';
 import type { ChunkType } from '../../stream';
-import type { Processor } from '../index';
+import type { ProcessOutputStepArgs, Processor } from '../index';
 
 /**
  * PII categories for detection and redaction
@@ -576,7 +576,7 @@ IMPORTANT: Only include PII types that are actually detected. If no PII is found
   }
 
   /**
-   * Process streaming output chunks for PII detection and redaction
+   * Streaming is intentionally a passthrough. LLM-based PII detection runs in processOutputStep/result.
    */
   async processOutputStream(
     args: {
@@ -586,68 +586,11 @@ IMPORTANT: Only include PII types that are actually detected. If no PII is found
       abort: (reason?: string) => never;
     } & Partial<ObservabilityContext>,
   ): Promise<ChunkType | null> {
-    const { part, abort, ...rest } = args;
-    const observabilityContext = resolveObservabilityContext(rest);
-    try {
-      // Only process text-delta chunks
-      if (part.type !== 'text-delta') {
-        return part;
-      }
+    return args.part;
+  }
 
-      const textContent = part.payload.text;
-      if (!textContent.trim()) {
-        return part;
-      }
-
-      const detectionResult = await this.detectPII(textContent, observabilityContext);
-
-      if (this.isPIIFlagged(detectionResult)) {
-        switch (this.strategy) {
-          case 'block':
-            abort(`PII detected in streaming content. Types: ${this.getDetectedTypes(detectionResult).join(', ')}`);
-
-          case 'warn':
-            console.warn(
-              `[PIIDetector] PII detected in streaming content: ${this.getDetectedTypes(detectionResult).join(', ')}`,
-            );
-            return part; // Allow content through with warning
-
-          case 'filter':
-            console.info(
-              `[PIIDetector] Filtered streaming part with PII: ${this.getDetectedTypes(detectionResult).join(', ')}`,
-            );
-            return null; // Don't emit this part
-
-          case 'redact':
-            if (detectionResult.redacted_content) {
-              console.info(
-                `[PIIDetector] Redacted PII in streaming content: ${this.getDetectedTypes(detectionResult).join(', ')}`,
-              );
-              return {
-                ...part,
-                payload: {
-                  ...part.payload,
-                  text: detectionResult.redacted_content,
-                },
-              };
-            } else {
-              console.warn(`[PIIDetector] No redaction available for streaming part, filtering`);
-              return null; // Fallback to filtering if no redaction available
-            }
-
-          default:
-            return part;
-        }
-      }
-
-      return part;
-    } catch (error) {
-      if (error instanceof TripWire) {
-        throw error; // Re-throw tripwire errors
-      }
-      console.warn('[PIIDetector] Streaming detection failed, allowing content:', error);
-      return part; // Fail open - allow content if detection fails
-    }
+  async processOutputStep(args: ProcessOutputStepArgs): Promise<MastraDBMessage[]> {
+    return this.processOutputResult(args);
   }
 
   /**

--- a/packages/core/src/processors/processors/system-prompt-scrubber.test.ts
+++ b/packages/core/src/processors/processors/system-prompt-scrubber.test.ts
@@ -272,10 +272,33 @@ describe('SystemPromptScrubber', () => {
       expect(result).toEqual(part);
     });
 
-    it('should redact system prompts in streaming chunks', async () => {
+    it('should not run detection on streaming chunks', async () => {
+      processor = new SystemPromptScrubber({ model: mockModel });
+      const generateSpy = vi.spyOn(mockModel, 'doGenerate');
+
+      const part: ChunkType = {
+        type: 'text-delta',
+        payload: { text: 'You are an AI. Hello there!', id: 'test-id' },
+        runId: 'test-run-id',
+        from: ChunkFrom.AGENT,
+      };
+
+      const result = await processor.processOutputStream({
+        part,
+        streamParts: [part],
+        state: {},
+        abort: vi.fn() as any,
+      });
+
+      expect(result).toEqual(part);
+      expect(generateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('processOutputStep', () => {
+    it('should redact system prompts after the step completes', async () => {
       processor = new SystemPromptScrubber({ model: mockModel });
 
-      // Mock the model to return detection results
       vi.spyOn(mockModel, 'doGenerate').mockResolvedValueOnce({
         rawCall: { rawPrompt: null, rawSettings: {} },
         text: JSON.stringify({
@@ -296,25 +319,16 @@ describe('SystemPromptScrubber', () => {
         usage: { completionTokens: 10, promptTokens: 5 },
       });
 
-      const part: ChunkType = {
-        type: 'text-delta',
-        payload: { text: 'You are an AI. Hello there!', id: 'test-id' },
-        runId: 'test-run-id',
-        from: ChunkFrom.AGENT,
-      };
+      const messages = [createTestMessage('You are an AI. Hello there!')];
 
-      const result = await processor.processOutputStream({
-        part,
-        streamParts: [part],
-        state: {},
+      const result = await processor.processOutputStep({
+        messages,
         abort: vi.fn() as any,
-      });
+      } as any);
 
-      expect(result).toEqual({
-        type: 'text-delta',
-        payload: { text: '*** [SYSTEM] ***. Hello there!', id: 'test-id' },
-        runId: 'test-run-id',
-        from: ChunkFrom.AGENT,
+      expect(result[0].content.parts[0]).toEqual({
+        type: 'text',
+        text: '*** [SYSTEM] ***. Hello there!',
       });
     });
   });

--- a/packages/core/src/processors/processors/system-prompt-scrubber.ts
+++ b/packages/core/src/processors/processors/system-prompt-scrubber.ts
@@ -5,7 +5,7 @@ import type { MastraModelConfig } from '../../llm/model/shared.types';
 import type { ObservabilityContext } from '../../observability';
 import { resolveObservabilityContext } from '../../observability';
 import type { ChunkType } from '../../stream';
-import type { Processor } from '../index';
+import type { ProcessOutputStepArgs, Processor } from '../index';
 
 export interface SystemPromptScrubberOptions {
   /** Strategy to use when system prompts are detected: 'block' | 'warn' | 'filter' | 'redact' */
@@ -98,7 +98,7 @@ export class SystemPromptScrubber implements Processor<'system-prompt-scrubber'>
   }
 
   /**
-   * Process streaming chunks to detect and handle system prompts
+   * Streaming is intentionally a passthrough. LLM-based detection runs in processOutputStep/result.
    */
   async processOutputStream(
     args: {
@@ -108,62 +108,11 @@ export class SystemPromptScrubber implements Processor<'system-prompt-scrubber'>
       abort: (reason?: string) => never;
     } & Partial<ObservabilityContext>,
   ): Promise<ChunkType | null> {
-    const { part, abort, ...rest } = args;
-    const observabilityContext = resolveObservabilityContext(rest);
+    return args.part;
+  }
 
-    // Only process text-delta chunks
-    if (part.type !== 'text-delta') {
-      return part;
-    }
-
-    const text = part.payload.text;
-    if (!text || text.trim() === '') {
-      return part;
-    }
-
-    try {
-      const detectionResult = await this.detectSystemPrompts(text, observabilityContext);
-
-      if (detectionResult.detections && detectionResult.detections.length > 0) {
-        const detectedTypes = detectionResult.detections.map(detection => detection.type);
-
-        switch (this.strategy) {
-          case 'block':
-            abort(`System prompt detected: ${detectedTypes.join(', ')}`);
-            break;
-
-          case 'filter':
-            return null; // Don't emit this part
-
-          case 'warn':
-            console.warn(
-              `[SystemPromptScrubber] System prompt detected in streaming content: ${detectedTypes.join(', ')}`,
-            );
-            if (this.includeDetections && detectionResult.detections) {
-              console.warn(`[SystemPromptScrubber] Detections: ${detectionResult.detections.length} items`);
-            }
-            return part; // Allow content through
-
-          case 'redact':
-          default:
-            const redactedText =
-              detectionResult.redacted_content || this.redactText(text, detectionResult.detections || []);
-            return {
-              ...part,
-              payload: {
-                ...part.payload,
-                text: redactedText,
-              },
-            };
-        }
-      }
-
-      return part;
-    } catch (error) {
-      // Fail open - allow content through if detection fails
-      console.warn('[SystemPromptScrubber] Detection failed, allowing content:', error);
-      return part;
-    }
+  async processOutputStep(args: ProcessOutputStepArgs): Promise<MastraDBMessage[]> {
+    return this.processOutputResult(args);
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an intermediate output-processing phase to handle completed steps for moderation, PII detection, and prompt scrubbing.

* **Refactor**
  * Moved processing from per-chunk streaming to step-based handling; streaming now passes through unchanged while finalization runs checks and transformations.

* **Tests**
  * Updated tests to validate step-based processing and streaming passthrough behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->