### PR TITLE
fix(core): guard trailing assistant prompts for Claude 4.6

### DIFF
--- a/.changeset/fix-trailing-assistant-guard.md
+++ b/.changeset/fix-trailing-assistant-guard.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+fix(core): guard trailing assistant prompts for Claude 4.6

--- a/packages/core/src/processors/process-input-step.test.ts
+++ b/packages/core/src/processors/process-input-step.test.ts
@@ -2082,4 +2082,33 @@ describe('processInputStep', () => {
       expect(allMessages[1].id).toBe('result-msg');
     });
   });
+
+  describe('TrailingAssistantGuard auto-injection for Claude 4.6', () => {
+    it('should append a trailing user continuation even without structured output', async () => {
+      const runner = new ProcessorRunner({
+        inputProcessors: [],
+        outputProcessors: [],
+        logger: mockLogger,
+        agentName: 'test-agent',
+      });
+
+      const messageList = new MessageList({ threadId: 'test-thread' });
+      messageList.add([createMessage('Assistant reply', 'assistant')], 'response');
+
+      await runner.runProcessInputStep({
+        messageList,
+        stepNumber: 0,
+        model: {
+          ...createMockModel('claude-opus-4-6'),
+          provider: 'anthropic',
+        },
+        steps: [],
+      });
+
+      const allMessages = messageList.get.all.db();
+      expect(allMessages).toHaveLength(2);
+      expect(allMessages[1]?.role).toBe('user');
+      expect(allMessages[1]?.content.parts).toEqual([{ type: 'text', text: 'Continue.' }]);
+    });
+  });
 });

--- a/packages/core/src/processors/trailing-assistant-guard.test.ts
+++ b/packages/core/src/processors/trailing-assistant-guard.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import type { MastraDBMessage } from '../agent/message-list';
+import { TrailingAssistantGuard, isMaybeClaude46 } from './trailing-assistant-guard';
+
+function createMessage(text: string, role: 'user' | 'assistant'): MastraDBMessage {
+  return {
+    id: `msg-${Math.random()}`,
+    role,
+    content: {
+      format: 2 as const,
+      parts: [{ type: 'text' as const, text }],
+    },
+    createdAt: new Date(),
+    threadId: 'test-thread',
+  };
+}
+
+describe('TrailingAssistantGuard', () => {
+  it('should append a generic continuation for Claude 4.6 prompts that end with assistant without structured output', () => {
+    const guard = new TrailingAssistantGuard();
+    const messages = [createMessage('Previous assistant reply', 'assistant')];
+
+    const result = guard.processInputStep({
+      messages,
+      structuredOutput: undefined,
+    } as any);
+
+    expect(result?.messages).toHaveLength(2);
+    expect(result?.messages?.[1]?.role).toBe('user');
+    expect(result?.messages?.[1]?.content.parts).toEqual([{ type: 'text', text: 'Continue.' }]);
+  });
+
+  it('should preserve the structured-output continuation when structured output is active', () => {
+    const guard = new TrailingAssistantGuard();
+    const messages = [createMessage('Previous assistant reply', 'assistant')];
+
+    const result = guard.processInputStep({
+      messages,
+      structuredOutput: {
+        schema: z.object({ ok: z.boolean() }),
+      },
+    } as any);
+
+    expect(result?.messages).toHaveLength(2);
+    expect(result?.messages?.[1]?.content.parts).toEqual([
+      { type: 'text', text: 'Generate the structured response.' },
+    ]);
+  });
+
+  it('should not modify prompts that already end with a user message', () => {
+    const guard = new TrailingAssistantGuard();
+    const messages = [createMessage('User prompt', 'user')];
+
+    const result = guard.processInputStep({
+      messages,
+      structuredOutput: undefined,
+    } as any);
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('isMaybeClaude46', () => {
+  it('should detect anthropic Claude 4.6 string configs', () => {
+    expect(isMaybeClaude46('anthropic/claude-opus-4-6')).toBe(true);
+    expect(isMaybeClaude46('anthropic/claude-sonnet-4.6')).toBe(true);
+    expect(isMaybeClaude46('openai/gpt-5')).toBe(false);
+  });
+});

--- a/packages/core/src/processors/trailing-assistant-guard.ts
+++ b/packages/core/src/processors/trailing-assistant-guard.ts
@@ -38,17 +38,21 @@ export function isMaybeClaude46(
 }
 
 /**
- * Guards against trailing assistant messages when using native structured output
- * with Anthropic Claude 4.6.
+ * Guards against trailing assistant messages with Anthropic Claude 4.6.
  *
- * Claude 4.6 rejects requests where the last message is an assistant message when
- * using output format (structured output), interpreting it as pre-filling the response.
- * This processor appends a user message to prevent that error.
+ * Claude 4.6 rejects requests where the last message is an assistant message,
+ * treating it as assistant prefill. Native structured output is one trigger,
+ * but the same rejection also happens in normal turns (thread resumption,
+ * handoffs, and tool-call continuations).
+ *
+ * This processor appends a minimal user continuation message whenever the
+ * prompt would otherwise end with an assistant message.
  *
  * This processor should only be added when the agent uses a Claude 4.6 model.
  * Use {@link isMaybeClaude46} to check before adding.
  *
  * @see https://github.com/mastra-ai/mastra/issues/12800
+ * @see https://github.com/mastra-ai/mastra/issues/13969
  */
 export class TrailingAssistantGuard implements Processor<'trailing-assistant-guard'> {
   readonly id = 'trailing-assistant-guard' as const;
@@ -58,10 +62,10 @@ export class TrailingAssistantGuard implements Processor<'trailing-assistant-gua
     const willUseResponseFormat =
       structuredOutput?.schema && !structuredOutput?.model && !structuredOutput?.jsonPromptInjection;
 
-    if (!willUseResponseFormat) return;
-
     const lastMessage = messages[messages.length - 1];
     if (!lastMessage || lastMessage.role !== 'assistant') return;
+
+    const continuationText = willUseResponseFormat ? 'Generate the structured response.' : 'Continue.';
 
     return {
       messages: [
@@ -71,7 +75,7 @@ export class TrailingAssistantGuard implements Processor<'trailing-assistant-gua
           role: 'user' as const,
           content: {
             format: 2 as const,
-            parts: [{ type: 'text' as const, text: 'Generate the structured response.' }],
+            parts: [{ type: 'text' as const, text: continuationText }],
           },
           createdAt: new Date(),
         },


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering trailing-assistant behavior and Claude 4.6 detection, verifying automatic continuation messages in varied conversation scenarios.

* **Improvements**
  * Processor now appends an appropriate user continuation more broadly when conversations end with an assistant, and selects continuation text based on output mode.

* **Documentation**
  * Clarified processor description to reflect broader trailing-assistant handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->