### PR TITLE
fix(memory): ignore binary payload size in observational token counts

### DIFF
--- a/.changeset/fix-binary-token-count.md
+++ b/.changeset/fix-binary-token-count.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+fix(memory): ignore binary payload size in observational token counts

--- a/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
@@ -241,6 +241,63 @@ describe('TokenCounter', () => {
       expect(message.content.parts[2].providerMetadata?.mastra?.tokenEstimate).toBeUndefined();
     });
 
+    it('does not let image base64 payload size dominate token counts', () => {
+      const counter = new TokenCounter();
+      const smallImage = createMessage({
+        format: 2,
+        parts: [
+          { type: 'text', text: 'Look at this image' },
+          { type: 'image', mimeType: 'image/png', image: 'a'.repeat(80) },
+        ],
+      });
+      const largeImage = createMessage({
+        format: 2,
+        parts: [
+          { type: 'text', text: 'Look at this image' },
+          { type: 'image', mimeType: 'image/png', image: 'a'.repeat(80_000) },
+        ],
+      });
+
+      const smallTokens = counter.countMessage(smallImage);
+      const largeTokens = counter.countMessage(largeImage);
+
+      expect(largeTokens - smallTokens).toBeLessThanOrEqual(5);
+    });
+
+    it('does not let binary file base64 payload size dominate token counts', () => {
+      const counter = new TokenCounter();
+      const shortFile = createMessage({
+        format: 2,
+        parts: [{ type: 'file', mediaType: 'image/png', data: 'A'.repeat(80), filename: 'tiny.png' }],
+      });
+      const largeFile = createMessage({
+        format: 2,
+        parts: [{ type: 'file', mediaType: 'image/png', data: 'A'.repeat(120_000), filename: 'huge.png' }],
+      });
+
+      const shortTokens = counter.countMessage(shortFile);
+      const largeTokens = counter.countMessage(largeFile);
+
+      expect(largeTokens - shortTokens).toBeLessThanOrEqual(5);
+    });
+
+    it('still counts text-like file contents', () => {
+      const counter = new TokenCounter();
+      const shortTextFile = createMessage({
+        format: 2,
+        parts: [{ type: 'file', mediaType: 'text/plain', data: 'short note', filename: 'note.txt' }],
+      });
+      const longTextFile = createMessage({
+        format: 2,
+        parts: [{ type: 'file', mediaType: 'text/plain', data: 'long note '.repeat(200), filename: 'note.txt' }],
+      });
+
+      const shortTokens = counter.countMessage(shortTextFile);
+      const longTokens = counter.countMessage(longTextFile);
+
+      expect(longTokens).toBeGreaterThan(shortTokens);
+    });
+
     it('caches string-content fallback on content.metadata.mastra', () => {
       const counter = new TokenCounter();
       const message = createMessage({

--- a/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/token-counter.test.ts
@@ -281,6 +281,23 @@ describe('TokenCounter', () => {
       expect(largeTokens - shortTokens).toBeLessThanOrEqual(5);
     });
 
+    it('does not let mimeType-based binary file payload size dominate token counts', () => {
+      const counter = new TokenCounter();
+      const shortFile = createMessage({
+        format: 2,
+        parts: [{ type: 'file', mimeType: 'image/png', data: 'A'.repeat(80), filename: 'tiny.png' }],
+      });
+      const largeFile = createMessage({
+        format: 2,
+        parts: [{ type: 'file', mimeType: 'image/png', data: 'A'.repeat(120_000), filename: 'huge.png' }],
+      });
+
+      const shortTokens = counter.countMessage(shortFile);
+      const largeTokens = counter.countMessage(largeFile);
+
+      expect(largeTokens - shortTokens).toBeLessThanOrEqual(5);
+    });
+
     it('still counts text-like file contents', () => {
       const counter = new TokenCounter();
       const shortTextFile = createMessage({

--- a/packages/memory/src/processors/observational-memory/token-counter.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.ts
@@ -31,6 +31,15 @@ const TOKEN_ESTIMATE_CACHE_VERSION = 1;
 
 type CacheablePart = any;
 
+const TEXT_LIKE_FILE_MEDIA_TYPES = new Set([
+  'application/json',
+  'application/ld+json',
+  'application/xml',
+  'application/javascript',
+  'application/typescript',
+  'application/x-typescript',
+]);
+
 function buildEstimateKey(kind: string, text: string): string {
   const payloadHash = createHash('sha1').update(text).digest('hex');
   return `${kind}:${payloadHash}`;
@@ -105,6 +114,43 @@ function setMessageCacheEntry(message: MastraDBMessage, _key: string, entry: Tok
 }
 
 function serializePartForTokenCounting(part: CacheablePart): string {
+  if (part?.type === 'image') {
+    return JSON.stringify({
+      type: 'image',
+      mimeType: typeof part.mimeType === 'string' ? part.mimeType : undefined,
+      source: summarizeMediaReference(part.image),
+    });
+  }
+
+  if (part?.type === 'file') {
+    const mediaType = typeof part.mediaType === 'string' ? part.mediaType : undefined;
+    const filename = typeof part.filename === 'string' ? part.filename : undefined;
+    const filePayload =
+      typeof part.data === 'string'
+        ? part.data
+        : typeof part.url === 'string'
+          ? part.url
+          : typeof part.base64 === 'string'
+            ? part.base64
+            : undefined;
+
+    if (isTextLikeFileMediaType(mediaType)) {
+      return JSON.stringify({
+        type: 'file',
+        mediaType,
+        filename,
+        data: filePayload ?? '',
+      });
+    }
+
+    return JSON.stringify({
+      type: 'file',
+      mediaType,
+      filename,
+      source: summarizeMediaReference(filePayload),
+    });
+  }
+
   const hasTokenEstimate = Boolean((part as any)?.providerMetadata?.mastra?.tokenEstimate);
   if (!hasTokenEstimate) {
     return JSON.stringify(part);
@@ -131,6 +177,35 @@ function serializePartForTokenCounting(part: CacheablePart): string {
   }
 
   return JSON.stringify(clonedPart);
+}
+
+function isTextLikeFileMediaType(mediaType: unknown): mediaType is string {
+  return typeof mediaType === 'string' && (mediaType.startsWith('text/') || TEXT_LIKE_FILE_MEDIA_TYPES.has(mediaType));
+}
+
+function summarizeMediaReference(value: unknown): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    return '[binary]';
+  }
+
+  if (/^data:[^;]+;base64,/i.test(value)) {
+    const mediaType = value.slice(5, value.indexOf(';')) || 'unknown';
+    return `[data-uri:${mediaType}]`;
+  }
+
+  if (/^(https?|file|blob):/i.test(value)) {
+    return '[url]';
+  }
+
+  if (looksLikeBase64(value)) {
+    return '[base64]';
+  }
+
+  return value;
+}
+
+function looksLikeBase64(value: string): boolean {
+  return value.length >= 64 && /^[A-Za-z0-9+/=\s]+$/.test(value);
 }
 
 function isValidCacheEntry(

--- a/packages/memory/src/processors/observational-memory/token-counter.ts
+++ b/packages/memory/src/processors/observational-memory/token-counter.ts
@@ -123,7 +123,8 @@ function serializePartForTokenCounting(part: CacheablePart): string {
   }
 
   if (part?.type === 'file') {
-    const mediaType = typeof part.mediaType === 'string' ? part.mediaType : undefined;
+    const mediaType =
+      typeof part.mediaType === 'string' ? part.mediaType : typeof part.mimeType === 'string' ? part.mimeType : undefined;
     const filename = typeof part.filename === 'string' ? part.filename : undefined;
     const filePayload =
       typeof part.data === 'string'


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Token counting now ignores raw binary payload size and uses summarized media references for images and files, improving accuracy and consistency.

* **Tests**
  * Added coverage validating token estimates for images, binary files, and text-like file contents to ensure bounded and meaningful counts.

* **Chores**
  * Added a patch-level changelog entry documenting the binary payload handling fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->