### PR TITLE
fix(mcp): clean up stdio clients on sighup

### DIFF
--- a/.changeset/fix-mcp-sighup.md
+++ b/.changeset/fix-mcp-sighup.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+fix(mcp): clean up stdio clients on sighup

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -1122,6 +1122,7 @@ describe('MastraMCPClient - Resource Cleanup Tests', () => {
 
   it('should not accumulate SIGTERM listeners across multiple connect/disconnect cycles', async () => {
     const initialListenerCount = process.listenerCount('SIGTERM');
+    const initialSighupListenerCount = process.listenerCount('SIGHUP');
 
     // Perform multiple connect/disconnect cycles
     for (let i = 0; i < 15; i++) {
@@ -1137,14 +1138,17 @@ describe('MastraMCPClient - Resource Cleanup Tests', () => {
     }
 
     const finalListenerCount = process.listenerCount('SIGTERM');
+    const finalSighupListenerCount = process.listenerCount('SIGHUP');
 
     // The listener count should not have increased significantly
     // (allowing for some tolerance in case other parts of the test framework add listeners)
     expect(finalListenerCount).toBeLessThanOrEqual(initialListenerCount + 1);
+    expect(finalSighupListenerCount).toBeLessThanOrEqual(initialSighupListenerCount + 1);
   });
 
-  it('should clean up exit hooks and SIGTERM listeners on disconnect', async () => {
+  it('should clean up exit hooks and signal listeners on disconnect', async () => {
     const initialListenerCount = process.listenerCount('SIGTERM');
+    const initialSighupListenerCount = process.listenerCount('SIGHUP');
 
     const client = new InternalMastraMCPClient({
       name: 'cleanup-single-test-client',
@@ -1155,19 +1159,24 @@ describe('MastraMCPClient - Resource Cleanup Tests', () => {
 
     await client.connect();
 
-    // After connect, there should be at most one additional SIGTERM listener
+    // After connect, there should be at most one additional signal listener per signal
     const afterConnectCount = process.listenerCount('SIGTERM');
+    const afterConnectSighupCount = process.listenerCount('SIGHUP');
     expect(afterConnectCount).toBeLessThanOrEqual(initialListenerCount + 1);
+    expect(afterConnectSighupCount).toBeLessThanOrEqual(initialSighupListenerCount + 1);
 
     await client.disconnect();
 
-    // After disconnect, the listener count should return to the initial value
+    // After disconnect, the listener counts should return to the initial values
     const afterDisconnectCount = process.listenerCount('SIGTERM');
+    const afterDisconnectSighupCount = process.listenerCount('SIGHUP');
     expect(afterDisconnectCount).toBe(initialListenerCount);
+    expect(afterDisconnectSighupCount).toBe(initialSighupListenerCount);
   });
 
-  it('should not add duplicate listeners when connect is called multiple times on the same client', async () => {
+  it('should not add duplicate signal listeners when connect is called multiple times on the same client', async () => {
     const initialListenerCount = process.listenerCount('SIGTERM');
+    const initialSighupListenerCount = process.listenerCount('SIGHUP');
 
     const client = new InternalMastraMCPClient({
       name: 'duplicate-connect-test-client',
@@ -1182,14 +1191,18 @@ describe('MastraMCPClient - Resource Cleanup Tests', () => {
     await client.connect();
 
     const afterMultipleConnects = process.listenerCount('SIGTERM');
+    const afterMultipleConnectsSighup = process.listenerCount('SIGHUP');
 
-    // Should only have added one listener, not three
+    // Should only have added one listener per signal, not three
     expect(afterMultipleConnects).toBeLessThanOrEqual(initialListenerCount + 1);
+    expect(afterMultipleConnectsSighup).toBeLessThanOrEqual(initialSighupListenerCount + 1);
 
     await client.disconnect();
 
     const afterDisconnectCount = process.listenerCount('SIGTERM');
+    const afterDisconnectSighupCount = process.listenerCount('SIGHUP');
     expect(afterDisconnectCount).toBe(initialListenerCount);
+    expect(afterDisconnectSighupCount).toBe(initialSighupListenerCount);
   });
 
   it('should not create duplicate connections when connect is called concurrently', async () => {

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -1174,6 +1174,45 @@ describe('MastraMCPClient - Resource Cleanup Tests', () => {
     expect(afterDisconnectSighupCount).toBe(initialSighupListenerCount);
   });
 
+  it('should not leave a SIGHUP listener behind when connect fails', async () => {
+    const { StreamableHTTPClientTransport } = await import('@modelcontextprotocol/sdk/client/streamableHttp.js');
+    const originalStart = StreamableHTTPClientTransport.prototype.start;
+    const initialSighupListenerCount = process.listenerCount('SIGHUP');
+
+    StreamableHTTPClientTransport.prototype.start = async function () {
+      throw new MockStreamableHTTPError(401, 'Unauthorized');
+    };
+
+    const httpServer = createServer((req, res) => {
+      res.writeHead(401, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Unauthorized' }));
+    });
+
+    const baseUrl = await new Promise<URL>(resolve => {
+      httpServer.listen(0, '127.0.0.1', () => {
+        const addr = httpServer.address() as { port: number };
+        resolve(new URL(`http://127.0.0.1:${addr.port}/mcp`));
+      });
+    });
+
+    const client = new InternalMastraMCPClient({
+      name: 'failed-connect-cleanup-test',
+      server: {
+        url: baseUrl,
+        connectTimeout: 1000,
+      },
+    });
+
+    try {
+      await expect(client.connect()).rejects.toThrow('Streamable HTTP error: Unauthorized');
+      expect(process.listenerCount('SIGHUP')).toBe(initialSighupListenerCount);
+    } finally {
+      StreamableHTTPClientTransport.prototype.start = originalStart;
+      await client.disconnect().catch(() => {});
+      httpServer.close();
+    }
+  });
+
   it('should not add duplicate signal listeners when connect is called multiple times on the same client', async () => {
     const initialListenerCount = process.listenerCount('SIGTERM');
     const initialSighupListenerCount = process.listenerCount('SIGHUP');

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -398,8 +398,6 @@ export class InternalMastraMCPClient extends MastraBase {
           throw new Error('Server configuration must include either a command or a url.');
         }
 
-        resolve(true);
-
         // Set up disconnect handler to reset state.
         const originalOnClose = this.client.onclose;
         this.client.onclose = () => {
@@ -409,6 +407,13 @@ export class InternalMastraMCPClient extends MastraBase {
             originalOnClose();
           }
         };
+
+        if (!this.sigHupHandler) {
+          this.sigHupHandler = () => gracefulExit();
+          process.on('SIGHUP', this.sigHupHandler);
+        }
+
+        resolve(true);
       } catch (e) {
         this.isConnected = null;
         reject(e);
@@ -429,11 +434,6 @@ export class InternalMastraMCPClient extends MastraBase {
     if (!this.sigTermHandler) {
       this.sigTermHandler = () => gracefulExit();
       process.on('SIGTERM', this.sigTermHandler);
-    }
-
-    if (!this.sigHupHandler) {
-      this.sigHupHandler = () => gracefulExit();
-      process.on('SIGHUP', this.sigHupHandler);
     }
 
     this.log('debug', `Successfully connected to MCP server`);

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -108,6 +108,7 @@ export class InternalMastraMCPClient extends MastraBase {
   private operationContextStore = new AsyncLocalStorage<RequestContext | null>();
   private exitHookUnsubscribe?: () => void;
   private sigTermHandler?: () => void;
+  private sigHupHandler?: () => void;
   private _roots: Root[];
 
   /** Provides access to resource operations (list, read, subscribe, etc.) */
@@ -430,6 +431,11 @@ export class InternalMastraMCPClient extends MastraBase {
       process.on('SIGTERM', this.sigTermHandler);
     }
 
+    if (!this.sigHupHandler) {
+      this.sigHupHandler = () => gracefulExit();
+      process.on('SIGHUP', this.sigHupHandler);
+    }
+
     this.log('debug', `Successfully connected to MCP server`);
     return this.isConnected;
   }
@@ -476,6 +482,10 @@ export class InternalMastraMCPClient extends MastraBase {
       if (this.sigTermHandler) {
         process.off('SIGTERM', this.sigTermHandler);
         this.sigTermHandler = undefined;
+      }
+      if (this.sigHupHandler) {
+        process.off('SIGHUP', this.sigHupHandler);
+        this.sigHupHandler = undefined;
       }
     }
   }


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signal handling to ensure graceful cleanup when receiving SIGHUP, complementing existing SIGTERM handling for more reliable resource management during client state changes.
* **Tests**
  * Expanded test coverage to verify SIGHUP listener behavior across connect/disconnect scenarios.
* **Chores**
  * Added release metadata entry preparing a patch release that documents the SIGHUP cleanup fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->