### PR TITLE
fix(core): widen TrailingAssistantGuard to block all trailing assistant messages for Claude 4.6

### DIFF
--- a/.changeset/fix-trailing-assistant-guard.md
+++ b/.changeset/fix-trailing-assistant-guard.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed TrailingAssistantGuard to protect against trailing assistant messages in all cases, not just structured output. Claude 4.6 rejects all trailing assistant messages (prefilling is no longer supported), but the guard was only active when structured output was enabled. This caused errors during thread resumption, agent handoffs, and tool-call rounds. Fixes #13969.

--- a/.changeset/fix-trailing-assistant-guard.md
+++ b/.changeset/fix-trailing-assistant-guard.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed TrailingAssistantGuard to protect against trailing assistant messages in all cases, not just structured output. Claude 4.6 rejects all trailing assistant messages (prefilling is no longer supported), but the guard was only active when structured output was enabled. This caused errors during thread resumption, agent handoffs, and tool-call rounds. Fixes #13969.
+Fixed Claude 4.6 agents failing with "does not support assistant message prefill" during thread resumption, agent handoffs, and tool-call rounds. Previously, only structured output calls were guarded against trailing assistant messages — now all cases are covered. Fixes #13969.

--- a/packages/core/src/processors/trailing-assistant-guard.test.ts
+++ b/packages/core/src/processors/trailing-assistant-guard.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+
+import { MessageList } from '../agent/message-list';
+import type { MastraDBMessage } from '../memory/types';
+
+import { isMaybeClaude46, TrailingAssistantGuard } from './trailing-assistant-guard';
+
+function makeMessages(...roles: Array<'user' | 'assistant'>): MastraDBMessage[] {
+  return roles.map((role, i) => ({
+    id: `msg-${i}`,
+    role,
+    content: {
+      format: 2 as const,
+      parts: [{ type: 'text' as const, text: `${role} message ${i}` }],
+    },
+    createdAt: new Date(Date.now() + i),
+  }));
+}
+
+function makeArgs(messages: MastraDBMessage[], structuredOutput?: any) {
+  const mockAbort = ((reason?: string) => {
+    throw new Error(reason || 'Aborted');
+  }) as (reason?: string) => never;
+
+  return {
+    messages,
+    messageList: new MessageList({ messages: [] }),
+    abort: mockAbort,
+    stepNumber: 0,
+    steps: [],
+    systemMessages: [],
+    state: {},
+    ...(structuredOutput !== undefined ? { structuredOutput } : {}),
+  };
+}
+
+describe('TrailingAssistantGuard', () => {
+  const guard = new TrailingAssistantGuard();
+
+  describe('without structured output (#13969)', () => {
+    it('should append a user message when last message is assistant without structured output', () => {
+      const messages = makeMessages('user', 'assistant');
+      const result = guard.processInputStep(makeArgs(messages));
+
+      expect(result).toBeDefined();
+      expect(result!.messages).toHaveLength(3);
+      const appended = result!.messages[2]!;
+      expect(appended.role).toBe('user');
+      expect(appended.content.parts[0].text).toBe('Continue.');
+    });
+
+    it('should not modify messages when last message is user without structured output', () => {
+      const messages = makeMessages('user', 'assistant', 'user');
+      const result = guard.processInputStep(makeArgs(messages));
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle single assistant message without structured output', () => {
+      const messages = makeMessages('assistant');
+      const result = guard.processInputStep(makeArgs(messages));
+
+      expect(result).toBeDefined();
+      expect(result!.messages).toHaveLength(2);
+      expect(result!.messages[1]!.role).toBe('user');
+      expect(result!.messages[1]!.content.parts[0].text).toBe('Continue.');
+    });
+  });
+
+  describe('with structured output (#12800)', () => {
+    const structuredOutput = {
+      schema: { type: 'object' },
+    };
+
+    it('should append a user message with structured output text when last message is assistant', () => {
+      const messages = makeMessages('user', 'assistant');
+      const result = guard.processInputStep(makeArgs(messages, structuredOutput));
+
+      expect(result).toBeDefined();
+      expect(result!.messages).toHaveLength(3);
+      const appended = result!.messages[2]!;
+      expect(appended.role).toBe('user');
+      expect(appended.content.parts[0].text).toBe('Generate the structured response.');
+    });
+
+    it('should not modify messages when last message is user with structured output', () => {
+      const messages = makeMessages('user');
+      const result = guard.processInputStep(makeArgs(messages, structuredOutput));
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should use "Continue." when structuredOutput has its own model (no responseFormat)', () => {
+      const messages = makeMessages('user', 'assistant');
+      const result = guard.processInputStep(makeArgs(messages, { schema: { type: 'object' }, model: 'some-model' }));
+
+      expect(result).toBeDefined();
+      expect(result!.messages[2]!.content.parts[0].text).toBe('Continue.');
+    });
+
+    it('should use "Continue." when structuredOutput uses jsonPromptInjection (no responseFormat)', () => {
+      const messages = makeMessages('user', 'assistant');
+      const result = guard.processInputStep(
+        makeArgs(messages, { schema: { type: 'object' }, jsonPromptInjection: true }),
+      );
+
+      expect(result).toBeDefined();
+      expect(result!.messages[2]!.content.parts[0].text).toBe('Continue.');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return undefined for empty messages array', () => {
+      const result = guard.processInputStep(makeArgs([]));
+      expect(result).toBeUndefined();
+    });
+
+    it('should preserve all original messages in the returned array', () => {
+      const messages = makeMessages('user', 'assistant', 'user', 'assistant');
+      const result = guard.processInputStep(makeArgs(messages));
+
+      expect(result).toBeDefined();
+      expect(result!.messages).toHaveLength(5);
+      // Original messages preserved
+      for (let i = 0; i < 4; i++) {
+        expect(result!.messages[i]).toBe(messages[i]);
+      }
+    });
+
+    it('should generate a unique id for each appended message', () => {
+      const messages = makeMessages('user', 'assistant');
+      const result1 = guard.processInputStep(makeArgs(messages));
+      const result2 = guard.processInputStep(makeArgs(messages));
+
+      expect(result1!.messages[2]!.id).not.toBe(result2!.messages[2]!.id);
+    });
+  });
+});
+
+describe('isMaybeClaude46', () => {
+  it('should return true for anthropic claude 4.6 string', () => {
+    expect(isMaybeClaude46('anthropic/claude-opus-4-6')).toBe(true);
+    expect(isMaybeClaude46('anthropic/claude-sonnet-4-6')).toBe(true);
+  });
+
+  it('should return false for non-4.6 anthropic models', () => {
+    expect(isMaybeClaude46('anthropic/claude-haiku-4-5-20251001')).toBe(false);
+    expect(isMaybeClaude46('anthropic/claude-sonnet-3-5')).toBe(false);
+  });
+
+  it('should return false for non-anthropic providers', () => {
+    expect(isMaybeClaude46('openai/gpt-4o')).toBe(false);
+  });
+
+  it('should return true for functions (safe default)', () => {
+    expect(isMaybeClaude46(() => 'some-model')).toBe(true);
+  });
+
+  it('should return true for unknown types (safe default)', () => {
+    expect(isMaybeClaude46(undefined)).toBe(true);
+    expect(isMaybeClaude46(null)).toBe(true);
+  });
+
+  it('should handle model objects with provider and modelId', () => {
+    expect(isMaybeClaude46({ provider: 'anthropic.messages', modelId: 'claude-opus-4-6' })).toBe(true);
+    expect(isMaybeClaude46({ provider: 'anthropic.messages', modelId: 'claude-haiku-4-5' })).toBe(false);
+    expect(isMaybeClaude46({ provider: 'openai.chat', modelId: 'gpt-4o' })).toBe(false);
+  });
+
+  it('should handle model fallback arrays', () => {
+    expect(
+      isMaybeClaude46([
+        { model: 'openai/gpt-4o', enabled: true },
+        { model: 'anthropic/claude-opus-4-6', enabled: true },
+      ]),
+    ).toBe(true);
+
+    expect(
+      isMaybeClaude46([
+        { model: 'openai/gpt-4o', enabled: true },
+        { model: 'anthropic/claude-haiku-4-5', enabled: true },
+      ]),
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/processors/trailing-assistant-guard.ts
+++ b/packages/core/src/processors/trailing-assistant-guard.ts
@@ -38,30 +38,29 @@ export function isMaybeClaude46(
 }
 
 /**
- * Guards against trailing assistant messages when using native structured output
- * with Anthropic Claude 4.6.
+ * Guards against trailing assistant messages for Anthropic Claude 4.6.
  *
- * Claude 4.6 rejects requests where the last message is an assistant message when
- * using output format (structured output), interpreting it as pre-filling the response.
+ * Claude 4.6 does not support assistant message prefilling and rejects all
+ * requests where the last message has role `assistant`. This affects thread
+ * resumption, agent handoffs, tool-call rounds, and structured output calls.
  * This processor appends a user message to prevent that error.
  *
  * This processor should only be added when the agent uses a Claude 4.6 model.
  * Use {@link isMaybeClaude46} to check before adding.
  *
  * @see https://github.com/mastra-ai/mastra/issues/12800
+ * @see https://github.com/mastra-ai/mastra/issues/13969
  */
 export class TrailingAssistantGuard implements Processor<'trailing-assistant-guard'> {
   readonly id = 'trailing-assistant-guard' as const;
   readonly name = 'Trailing Assistant Guard';
 
   processInputStep({ messages, structuredOutput }: ProcessInputStepArgs): ProcessInputStepResult | undefined {
-    const willUseResponseFormat =
-      structuredOutput?.schema && !structuredOutput?.model && !structuredOutput?.jsonPromptInjection;
-
-    if (!willUseResponseFormat) return;
-
     const lastMessage = messages[messages.length - 1];
     if (!lastMessage || lastMessage.role !== 'assistant') return;
+
+    const willUseResponseFormat =
+      structuredOutput?.schema && !structuredOutput?.model && !structuredOutput?.jsonPromptInjection;
 
     return {
       messages: [
@@ -71,7 +70,12 @@ export class TrailingAssistantGuard implements Processor<'trailing-assistant-gua
           role: 'user' as const,
           content: {
             format: 2 as const,
-            parts: [{ type: 'text' as const, text: 'Generate the structured response.' }],
+            parts: [
+              {
+                type: 'text' as const,
+                text: willUseResponseFormat ? 'Generate the structured response.' : 'Continue.',
+              },
+            ],
           },
           createdAt: new Date(),
         },


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

The `TrailingAssistantGuard` processor only appended a user message when structured output (`willUseResponseFormat`) was active.
Claude 4.6 removed assistant message prefilling entirely, so any trailing assistant message — during thread resumption, agent handoffs, or tool-call rounds — causes a 400 error. This PR removes the `willUseResponseFormat` early return so the guard fires for all trailing assistant messages when the model is Claude 4.6. The injected text is contextual: "Generate the structured response." for structured output, "Continue." otherwise.

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #13969

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issues where trailing assistant messages could disrupt thread resumption, agent handoffs, and tool-call rounds by ensuring a continuation prompt is injected when needed.

* **Tests**
  * Added extensive tests covering trailing-assistant behavior and model-detection logic to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->