### PR TITLE
fix: apply TrailingAssistantGuard to all requests, not just structured output

### DIFF
--- a/packages/core/src/processors/trailing-assistant-guard.ts
+++ b/packages/core/src/processors/trailing-assistant-guard.ts
@@ -38,28 +38,24 @@ export function isMaybeClaude46(
 }
 
 /**
- * Guards against trailing assistant messages when using native structured output
- * with Anthropic Claude 4.6.
+ * Guards against trailing assistant messages when using Anthropic Claude 4.6.
  *
- * Claude 4.6 rejects requests where the last message is an assistant message when
- * using output format (structured output), interpreting it as pre-filling the response.
- * This processor appends a user message to prevent that error.
+ * Claude 4.6 rejects requests where the last message is an assistant message,
+ * interpreting it as pre-filling the response. This applies to all requests,
+ * not just structured output. This processor appends a user message to prevent
+ * that error.
  *
  * This processor should only be added when the agent uses a Claude 4.6 model.
  * Use {@link isMaybeClaude46} to check before adding.
  *
  * @see https://github.com/mastra-ai/mastra/issues/12800
+ * @see https://github.com/mastra-ai/mastra/issues/13969
  */
 export class TrailingAssistantGuard implements Processor<'trailing-assistant-guard'> {
   readonly id = 'trailing-assistant-guard' as const;
   readonly name = 'Trailing Assistant Guard';
 
-  processInputStep({ messages, structuredOutput }: ProcessInputStepArgs): ProcessInputStepResult | undefined {
-    const willUseResponseFormat =
-      structuredOutput?.schema && !structuredOutput?.model && !structuredOutput?.jsonPromptInjection;
-
-    if (!willUseResponseFormat) return;
-
+  processInputStep({ messages }: ProcessInputStepArgs): ProcessInputStepResult | undefined {
     const lastMessage = messages[messages.length - 1];
     if (!lastMessage || lastMessage.role !== 'assistant') return;
 
@@ -71,7 +67,7 @@ export class TrailingAssistantGuard implements Processor<'trailing-assistant-gua
           role: 'user' as const,
           content: {
             format: 2 as const,
-            parts: [{ type: 'text' as const, text: 'Generate the structured response.' }],
+            parts: [{ type: 'text' as const, text: 'Continue.' }],
           },
           createdAt: new Date(),
         },


### PR DESCRIPTION
## Summary

Fix `TrailingAssistantGuard` to guard against trailing assistant messages in **all** requests, not just structured output.

Fixes #13969.

## Problem

The current guard only fires when `willUseResponseFormat` is true (structured output). But Claude 4.6 rejects trailing assistant messages in **all** cases, causing:

```
Error: Invalid request: This model does not support assistant message prefill.
The conversation must end with a user message.
```

This breaks thread resumption, tool-call rounds, and agent handoffs — any scenario where the last saved message was from the assistant.

## Fix

Remove the `willUseResponseFormat` early return so the guard fires whenever the last message has `role: 'assistant'`, regardless of whether structured output is used.

The `structuredOutput` parameter is no longer needed in the destructured args since the guard applies universally for Claude 4.6.

## Changes

- `packages/core/src/processors/trailing-assistant-guard.ts`: Remove `willUseResponseFormat` check, update JSDoc to reflect broader scope

> This PR was authored by Claude Opus 4.6 (AI). Human partner: @MaxwellCalkin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced handling of trailing assistant messages in Claude 4.6 scenarios—now applied consistently across all requests instead of selectively.
  * Simplified prompt guidance for improved message continuation.
  * Streamlined configuration by removing unnecessary parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->