### PR TITLE
fix: handle pre-converted JSON Schemas in getSerializedAgentTools

### DIFF
--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -11,6 +11,23 @@ import type {
 } from '@mastra/core/processors';
 import type { RequestContext } from '@mastra/core/request-context';
 import { zodToJsonSchema } from '@mastra/core/utils/zod-to-json';
+
+function isPlainJsonSchema(schema: unknown): schema is Record<string, unknown> {
+  return (
+    schema != null &&
+    typeof schema === 'object' &&
+    !Array.isArray(schema) &&
+    ('type' in schema || 'properties' in schema || '$schema' in schema || 'anyOf' in schema || 'oneOf' in schema)
+  );
+}
+
+function safeZodToJsonSchema(schema: unknown): unknown {
+  if (isPlainJsonSchema(schema)) {
+    return schema;
+  }
+  return zodToJsonSchema(schema as Parameters<typeof zodToJsonSchema>[0]);
+}
+
 import { stringify } from 'superjson';
 
 import { z } from 'zod';
@@ -208,7 +225,7 @@ export async function getSerializedAgentTools(
             }
           } else if (tool.inputSchema) {
             inputSchemaForReturn = stringify(
-              zodToJsonSchema(tool.inputSchema as Parameters<typeof zodToJsonSchema>[0]),
+              safeZodToJsonSchema(tool.inputSchema),
             );
           }
         }
@@ -223,7 +240,7 @@ export async function getSerializedAgentTools(
             }
           } else if (tool.outputSchema) {
             outputSchemaForReturn = stringify(
-              zodToJsonSchema(tool.outputSchema as Parameters<typeof zodToJsonSchema>[0]),
+              safeZodToJsonSchema(tool.outputSchema),
             );
           }
         }
@@ -242,7 +259,7 @@ export async function getSerializedAgentTools(
             }
           } else if (tool.requestContextSchema) {
             requestContextSchemaForReturn = stringify(
-              zodToJsonSchema(tool.requestContextSchema as Parameters<typeof zodToJsonSchema>[0]),
+              safeZodToJsonSchema(tool.requestContextSchema),
             );
           }
         }


### PR DESCRIPTION
## Summary

Fix `zodToJsonSchema()` crashing on pre-converted JSON Schema objects in `getSerializedAgentTools`.

Fixes #13909.

## Problem

When tools from providers like Composio use `applyCompatLayer` with `mode: "jsonSchema"`, their schemas are already plain JSON Schema objects. `zodToJsonSchema()` crashes on these with:

```
Cannot read properties of undefined (reading 'typeName')
```

The outer try-catch catches this error but the schema is lost (stays `undefined`), making tools silently disappear from Mastra Studio.

## Fix

Add a `safeZodToJsonSchema()` wrapper that checks if a schema is already a plain JSON Schema (has `type`, `properties`, `$schema`, `anyOf`, or `oneOf`) and returns it directly, only calling `zodToJsonSchema()` for actual Zod schemas.

Applied to all three schema serialization points: `inputSchema`, `outputSchema`, `requestContextSchema`.

## Changes

- `packages/server/src/server/handlers/agents.ts`: Add `isPlainJsonSchema` and `safeZodToJsonSchema` helpers, replace 3 `zodToJsonSchema` calls

> This PR was authored by Claude Opus 4.6 (AI). Human partner: @MaxwellCalkin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of schema handling for agent tools to ensure correct processing across different schema formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->