### PR TITLE
fix: handle SIGHUP to prevent stdio child process leaks

### DIFF
--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -108,6 +108,7 @@ export class InternalMastraMCPClient extends MastraBase {
   private operationContextStore = new AsyncLocalStorage<RequestContext | null>();
   private exitHookUnsubscribe?: () => void;
   private sigTermHandler?: () => void;
+  private sigHupHandler?: () => void;
   private _roots: Root[];
 
   /** Provides access to resource operations (list, read, subscribe, etc.) */
@@ -430,6 +431,11 @@ export class InternalMastraMCPClient extends MastraBase {
       process.on('SIGTERM', this.sigTermHandler);
     }
 
+    if (!this.sigHupHandler) {
+      this.sigHupHandler = () => gracefulExit();
+      process.on('SIGHUP', this.sigHupHandler);
+    }
+
     this.log('debug', `Successfully connected to MCP server`);
     return this.isConnected;
   }
@@ -476,6 +482,10 @@ export class InternalMastraMCPClient extends MastraBase {
       if (this.sigTermHandler) {
         process.off('SIGTERM', this.sigTermHandler);
         this.sigTermHandler = undefined;
+      }
+      if (this.sigHupHandler) {
+        process.off('SIGHUP', this.sigHupHandler);
+        this.sigHupHandler = undefined;
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #13973

MCPClient registers cleanup via `exit-hook` which handles `beforeExit`, `SIGINT`, `SIGTERM`, and `exit`. It also has an explicit `SIGTERM` handler that calls `gracefulExit()`. However, `SIGHUP` is not handled.

When a terminal window closes (or an SSH session drops), the OS sends `SIGHUP` to the process group. Since MCPClient has no handler for this signal, the Node.js process exits without running the cleanup hooks, leaving stdio child processes (MCP servers) running as orphaned processes.

## Changes

- Add `sigHupHandler` property alongside existing `sigTermHandler`
- Register a `SIGHUP` handler in `connect()` that calls `gracefulExit()`, matching the existing `SIGTERM` pattern
- Clean up the handler in `disconnect()` via `process.off('SIGHUP', ...)` to prevent memory leaks

The fix follows the exact same pattern as the existing SIGTERM handler — when SIGHUP is received, `gracefulExit()` is called, which triggers the `asyncExitHook` that runs `disconnect()` and closes the transport/child process.

## Test plan

- Verify stdio MCP child processes are cleaned up when terminal sends SIGHUP
- Verify existing SIGTERM handling still works
- Verify `disconnect()` properly removes the SIGHUP listener

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced graceful shutdown handling for improved application stability and resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->