### PR TITLE
fix(core): preserve single-model semantics for dynamic agent models

### DIFF
--- a/.changeset/vast-monkeys-taste.md
+++ b/.changeset/vast-monkeys-taste.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed dynamic model functions that return a single model so they no longer enter fallback-array mode. Request-context-based model selection now only exposes a model list when the function returns an array.

--- a/.changeset/vast-monkeys-taste.md
+++ b/.changeset/vast-monkeys-taste.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed dynamic model functions that return a single model so they no longer enter fallback-array mode. Request-context-based model selection now only exposes a model list when the function returns an array.
+Fixed a regression where dynamic `model` functions returning a single v1 model were treated as model arrays.

--- a/docs/src/content/en/docs/server/request-context.mdx
+++ b/docs/src/content/en/docs/server/request-context.mdx
@@ -117,13 +117,19 @@ export const weatherAgent = new Agent({
     if (userTier === 'enterprise') {
     }
   },
-  model: ({ requestContext }) => {},
+  model: ({ requestContext }) => {
+    const userTier = requestContext.get('user-tier') as UserTier['user-tier']
+
+    return userTier === 'enterprise' ? 'openai/gpt-5.1' : 'openai/gpt-4.1-nano'
+  },
   tools: ({ requestContext }) => {},
   memory: ({ requestContext }) => {},
 })
 ```
 
 You can also use `requestContext` with other options like `agents`, `workflows`, `scorers`, `inputProcessors`, and `outputProcessors`.
+
+The `model` function can return either a single model or a fallback array. Return an array only when you want multi-model fallback or load balancing behavior.
 
 ### Dynamic instructions
 

--- a/docs/src/content/en/docs/server/request-context.mdx
+++ b/docs/src/content/en/docs/server/request-context.mdx
@@ -117,19 +117,13 @@ export const weatherAgent = new Agent({
     if (userTier === 'enterprise') {
     }
   },
-  model: ({ requestContext }) => {
-    const userTier = requestContext.get('user-tier') as UserTier['user-tier']
-
-    return userTier === 'enterprise' ? 'openai/gpt-5.1' : 'openai/gpt-4.1-nano'
-  },
+  model: ({ requestContext }) => {},
   tools: ({ requestContext }) => {},
   memory: ({ requestContext }) => {},
 })
 ```
 
 You can also use `requestContext` with other options like `agents`, `workflows`, `scorers`, `inputProcessors`, and `outputProcessors`.
-
-The `model` function can return either a single model or a fallback array. Return an array only when you want multi-model fallback or load balancing behavior.
 
 ### Dynamic instructions
 

--- a/packages/core/src/agent/__tests__/dynamic-model-fallback.test.ts
+++ b/packages/core/src/agent/__tests__/dynamic-model-fallback.test.ts
@@ -1,9 +1,140 @@
+import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { describe, expect, it } from 'vitest';
 import { RequestContext } from '../../request-context';
 import { Agent } from '../agent';
 
 describe('Dynamic Model Selection with Fallback', () => {
+  it('should support a dynamic function returning a single v1 model', async () => {
+    const premiumModel = new MockLanguageModelV1({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { promptTokens: 5, completionTokens: 7 },
+        text: 'Premium v1 response',
+      }),
+    });
+
+    const standardModel = new MockLanguageModelV1({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { promptTokens: 4, completionTokens: 6 },
+        text: 'Standard v1 response',
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'dynamic-single-v1',
+      name: 'Dynamic Single V1 Test',
+      instructions: 'You are a test agent',
+      model: ({ requestContext }) => {
+        return requestContext.get('foo') ? premiumModel : standardModel;
+      },
+    });
+
+    const requestContext = new RequestContext();
+    requestContext.set('foo', true);
+
+    const result = await agent.generateLegacy('Test message', { requestContext });
+
+    expect(result.text).toBe('Premium v1 response');
+    await expect(agent.getModelList(requestContext)).resolves.toBeNull();
+  });
+
+  it('should support a dynamic function returning a single v2 model without exposing a model list', async () => {
+    const premiumModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+        text: 'Premium v2 response',
+        content: [
+          {
+            type: 'text',
+            text: 'Premium v2 response',
+          },
+        ],
+        warnings: [],
+      }),
+      doStream: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          {
+            type: 'response-metadata',
+            id: 'id-0',
+            modelId: 'premium-v2',
+            timestamp: new Date(0),
+          },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'Premium v2 response' },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          },
+        ]),
+      }),
+    });
+
+    const standardModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { inputTokens: 4, outputTokens: 8, totalTokens: 12 },
+        text: 'Standard v2 response',
+        content: [
+          {
+            type: 'text',
+            text: 'Standard v2 response',
+          },
+        ],
+        warnings: [],
+      }),
+      doStream: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          {
+            type: 'response-metadata',
+            id: 'id-1',
+            modelId: 'standard-v2',
+            timestamp: new Date(0),
+          },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'Standard v2 response' },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 4, outputTokens: 8, totalTokens: 12 },
+          },
+        ]),
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'dynamic-single-v2',
+      name: 'Dynamic Single V2 Test',
+      instructions: 'You are a test agent',
+      model: ({ requestContext }) => {
+        return requestContext.get('foo') ? premiumModel : standardModel;
+      },
+    });
+
+    const requestContext = new RequestContext();
+    requestContext.set('foo', true);
+
+    const result = await agent.stream('Test message', { requestContext });
+
+    expect(await result.text).toBe('Premium v2 response');
+    await expect(agent.getModelList(requestContext)).resolves.toBeNull();
+  });
+
   it('should support all models being dynamic in fallback array', async () => {
     const model1 = new MockLanguageModelV2({
       doGenerate: async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1500,6 +1500,29 @@ export class Agent<
   }
 
   /**
+   * Ensures a model can participate in prepared multi-model execution.
+   * @internal
+   */
+  private assertSupportsPreparedModels(
+    model: MastraLanguageModel | MastraLegacyLanguageModel,
+  ): asserts model is MastraLanguageModel {
+    if (!isSupportedLanguageModel(model)) {
+      const mastraError = new MastraError({
+        id: 'AGENT_PREPARE_MODELS_INCOMPATIBLE_WITH_MODEL_ARRAY_V1',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        details: {
+          agentName: this.name,
+        },
+        text: `[Agent:${this.name}] - Only v2/v3 models are allowed when an array of models is provided`,
+      });
+      this.logger.trackException(mastraError);
+      this.logger.error(mastraError.toString());
+      throw mastraError;
+    }
+  }
+
+  /**
    * Resolves model configuration that may be a dynamic function returning a single model or array of models.
    * Supports DynamicArgument for both MastraModelConfig and ModelWithRetries[].
    * Normalizes fallback arrays while preserving single-model semantics.
@@ -3935,21 +3958,7 @@ export class Agent<
 
     if (!Array.isArray(selection)) {
       const resolvedModel = await this.resolveModelConfig(selection, requestContext);
-
-      if (!isSupportedLanguageModel(resolvedModel)) {
-        const mastraError = new MastraError({
-          id: 'AGENT_PREPARE_MODELS_INCOMPATIBLE_WITH_MODEL_ARRAY_V1',
-          domain: ErrorDomain.AGENT,
-          category: ErrorCategory.USER,
-          details: {
-            agentName: this.name,
-          },
-          text: `[Agent:${this.name}] - Only v2/v3 models are allowed when an array of models is provided`,
-        });
-        this.logger.trackException(mastraError);
-        this.logger.error(mastraError.toString());
-        throw mastraError;
-      }
+      this.assertSupportsPreparedModels(resolvedModel);
 
       let headers: Record<string, string> | undefined;
       if (resolvedModel instanceof ModelRouterLanguageModel) {
@@ -3970,21 +3979,7 @@ export class Agent<
     const models = await Promise.all(
       selection.map(async modelConfig => {
         const model = await this.resolveModelConfig(modelConfig.model, requestContext);
-
-        if (!isSupportedLanguageModel(model)) {
-          const mastraError = new MastraError({
-            id: 'AGENT_PREPARE_MODELS_INCOMPATIBLE_WITH_MODEL_ARRAY_V1',
-            domain: ErrorDomain.AGENT,
-            category: ErrorCategory.USER,
-            details: {
-              agentName: this.name,
-            },
-            text: `[Agent:${this.name}] - Only v2/v3 models are allowed when an array of models is provided`,
-          });
-          this.logger.trackException(mastraError);
-          this.logger.error(mastraError.toString());
-          throw mastraError;
-        }
+        this.assertSupportsPreparedModels(model);
 
         const modelId = modelConfig.id || model.modelId;
         if (!modelId) {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -112,6 +112,8 @@ type ModelFallbacks = {
   enabled: boolean;
 }[];
 
+type ResolvedModelSelection = MastraModelConfig | ModelFallbacks;
+
 function resolveMaybePromise<T, R = void>(value: T | Promise<T> | PromiseLike<T>, cb: (value: T) => R): R | Promise<R> {
   if (value instanceof Promise || (value != null && typeof (value as PromiseLike<T>).then === 'function')) {
     return Promise.resolve(value).then(cb);
@@ -1378,14 +1380,15 @@ export class Agent<
     requestContext?: RequestContext;
     model?: DynamicArgument<MastraModelConfig>;
   } = {}): MastraLLM | Promise<MastraLLM> {
-    // Resolve model config to ModelFallbacks (always returns array now)
-    const modelFallbacksPromise = model
-      ? this.resolveModelFallbacks(model, requestContext)
-      : this.resolveModelFallbacks(this.model, requestContext);
+    const modelSelectionPromise = model
+      ? this.resolveModelSelection(model, requestContext)
+      : this.resolveModelSelection(this.model, requestContext);
 
-    return modelFallbacksPromise.then(modelFallbacks => {
-      // Get first enabled model to check if it's supported
-      const firstEnabledModel = modelFallbacks.find(m => m.enabled);
+    return modelSelectionPromise.then(modelSelection => {
+      const firstEnabledModel = Array.isArray(modelSelection)
+        ? modelSelection.find(m => m.enabled)?.model
+        : modelSelection;
+
       if (!firstEnabledModel) {
         const mastraError = new MastraError({
           id: 'AGENT_GET_LLM_NO_ENABLED_MODELS',
@@ -1399,13 +1402,12 @@ export class Agent<
         throw mastraError;
       }
 
-      const resolvedModel = this.resolveModelConfig(firstEnabledModel.model, requestContext);
+      const resolvedModel = this.resolveModelConfig(firstEnabledModel, requestContext);
 
       return resolveMaybePromise(resolvedModel, modelInfo => {
         let llm: MastraLLM | Promise<MastraLLM>;
         if (isSupportedLanguageModel(modelInfo)) {
-          // Prepare all models from the fallbacks
-          llm = this.prepareModels(requestContext, modelFallbacks).then(models => {
+          llm = this.prepareModels(requestContext, modelSelection).then(models => {
             const enabledModels = models.filter(model => model.enabled);
             return new MastraLLMVNext({
               models: enabledModels,
@@ -1481,19 +1483,33 @@ export class Agent<
   }
 
   /**
+   * Normalizes model arrays into the internal fallback shape.
+   * @internal
+   */
+  private normalizeModelFallbacks(models: ModelWithRetries[] | ModelFallbacks): ModelFallbacks {
+    if (this.isModelFallbacks(models)) {
+      return models;
+    }
+
+    return models.map(m => ({
+      id: m.id ?? randomUUID(),
+      model: m.model as DynamicArgument<MastraModelConfig>,
+      maxRetries: m.maxRetries ?? this.maxRetries,
+      enabled: m.enabled ?? true,
+    })) as ModelFallbacks;
+  }
+
+  /**
    * Resolves model configuration that may be a dynamic function returning a single model or array of models.
    * Supports DynamicArgument for both MastraModelConfig and ModelWithRetries[].
-   * Normalizes ModelWithRetries[] to ModelFallbacks by filling in defaults.
-   *
-   * Internal simplification: Always returns ModelFallbacks array, even for single models.
-   * This eliminates conditional Array.isArray() checks throughout the codebase.
+   * Normalizes fallback arrays while preserving single-model semantics.
    *
    * @internal
    */
-  private async resolveModelFallbacks(
+  private async resolveModelSelection(
     modelConfig: DynamicArgument<MastraModelConfig | ModelWithRetries[]> | ModelFallbacks,
     requestContext: RequestContext,
-  ): Promise<ModelFallbacks> {
+  ): Promise<ResolvedModelSelection> {
     // If it's a dynamic function, resolve it
     if (typeof modelConfig === 'function') {
       const resolved = await modelConfig({ requestContext, mastra: this.#mastra });
@@ -1513,23 +1529,10 @@ export class Agent<
           throw mastraError;
         }
 
-        return resolved.map(m => ({
-          id: m.id ?? randomUUID(),
-          model: m.model as DynamicArgument<MastraModelConfig>,
-          maxRetries: m.maxRetries ?? this.maxRetries,
-          enabled: m.enabled ?? true,
-        })) as ModelFallbacks;
+        return this.normalizeModelFallbacks(resolved);
       }
 
-      // Function returned single model - wrap in array
-      return [
-        {
-          id: randomUUID(),
-          model: resolved,
-          maxRetries: this.maxRetries,
-          enabled: true,
-        },
-      ] as ModelFallbacks;
+      return resolved;
     }
 
     // Already resolved - if it's a static array, check if already normalized
@@ -1548,29 +1551,10 @@ export class Agent<
         throw mastraError;
       }
 
-      // Skip normalization if already normalized (performance optimization)
-      if (this.isModelFallbacks(modelConfig)) {
-        return modelConfig;
-      }
-
-      // Normalize array
-      return modelConfig.map(m => ({
-        id: m.id ?? randomUUID(),
-        model: m.model as DynamicArgument<MastraModelConfig>,
-        maxRetries: m.maxRetries ?? this.maxRetries,
-        enabled: m.enabled ?? true,
-      })) as ModelFallbacks;
+      return this.normalizeModelFallbacks(modelConfig);
     }
 
-    // Static single model config - wrap in array
-    return [
-      {
-        id: randomUUID(),
-        model: modelConfig,
-        maxRetries: this.maxRetries,
-        enabled: true,
-      },
-    ] as ModelFallbacks;
+    return modelConfig;
   }
 
   /**
@@ -1593,9 +1577,11 @@ export class Agent<
     | MastraLanguageModel
     | MastraLegacyLanguageModel
     | Promise<MastraLanguageModel | MastraLegacyLanguageModel> {
-    // Resolve to array (always returns ModelFallbacks now)
-    return this.resolveModelFallbacks(modelConfig, requestContext).then(resolved => {
-      // Find first enabled model
+    return this.resolveModelSelection(modelConfig, requestContext).then(resolved => {
+      if (!Array.isArray(resolved)) {
+        return this.resolveModelConfig(resolved, requestContext);
+      }
+
       const enabledModel = resolved.find(entry => entry.enabled);
       if (!enabledModel) {
         const mastraError = new MastraError({
@@ -1629,10 +1615,11 @@ export class Agent<
   public async getModelList(
     requestContext: RequestContext = new RequestContext(),
   ): Promise<Array<AgentModelManagerConfig> | null> {
-    // Handle dynamic functions - always return prepared models for functions
-    // (functions that return arrays should expose model lists, even if single-element)
     if (typeof this.model === 'function') {
-      const resolved = await this.resolveModelFallbacks(this.model, requestContext);
+      const resolved = await this.resolveModelSelection(this.model, requestContext);
+      if (!Array.isArray(resolved)) {
+        return null;
+      }
       return this.prepareModels(requestContext, resolved);
     }
 
@@ -3937,21 +3924,51 @@ export class Agent<
    */
   private async prepareModels(
     requestContext: RequestContext,
-    model?: ModelFallbacks,
+    resolvedSelection?: ResolvedModelSelection,
   ): Promise<Array<AgentModelManagerConfig>> {
-    // Resolve dynamic functions if needed
-    let modelArray: ModelFallbacks;
-    if (typeof this.model === 'function' && !model) {
-      modelArray = await this.resolveModelFallbacks(this.model, requestContext);
-    } else if (model) {
-      modelArray = model;
-    } else {
-      modelArray = await this.resolveModelFallbacks(this.model, requestContext);
+    const selection =
+      resolvedSelection ??
+      (await this.resolveModelSelection(
+        this.model as DynamicArgument<MastraModelConfig | ModelWithRetries[]> | ModelFallbacks,
+        requestContext,
+      ));
+
+    if (!Array.isArray(selection)) {
+      const resolvedModel = await this.resolveModelConfig(selection, requestContext);
+
+      if (!isSupportedLanguageModel(resolvedModel)) {
+        const mastraError = new MastraError({
+          id: 'AGENT_PREPARE_MODELS_INCOMPATIBLE_WITH_MODEL_ARRAY_V1',
+          domain: ErrorDomain.AGENT,
+          category: ErrorCategory.USER,
+          details: {
+            agentName: this.name,
+          },
+          text: `[Agent:${this.name}] - Only v2/v3 models are allowed when an array of models is provided`,
+        });
+        this.logger.trackException(mastraError);
+        this.logger.error(mastraError.toString());
+        throw mastraError;
+      }
+
+      let headers: Record<string, string> | undefined;
+      if (resolvedModel instanceof ModelRouterLanguageModel) {
+        headers = (resolvedModel as any).config?.headers;
+      }
+
+      return [
+        {
+          id: 'main',
+          model: resolvedModel,
+          maxRetries: this.maxRetries ?? 0,
+          enabled: true,
+          headers,
+        },
+      ];
     }
 
-    // Process array (single models are now single-element arrays)
     const models = await Promise.all(
-      modelArray.map(async modelConfig => {
+      selection.map(async modelConfig => {
         const model = await this.resolveModelConfig(modelConfig.model, requestContext);
 
         if (!isSupportedLanguageModel(model)) {

--- a/packages/server/src/server/handlers/agent.test.ts
+++ b/packages/server/src/server/handlers/agent.test.ts
@@ -340,6 +340,37 @@ describe('Agent Handlers', () => {
       expect(typeof agent.tools.testTool.inputSchema).toBe('string');
       expect(typeof agent.tools.testTool.outputSchema).toBe('string');
     });
+
+    it('should not expose a model list for agents with dynamic single-model selection', async () => {
+      const dynamicSingleModelAgent = makeMockAgent({
+        name: 'dynamic-single-model-agent',
+        description: 'A test agent with dynamic single-model selection',
+        model: ({ requestContext }) => {
+          return requestContext.get('foo') ? openaiV5('gpt-4o-mini') : openaiV5('gpt-4.1');
+        },
+      });
+
+      const mastraWithDynamicSingleModel = makeMastraMock({
+        agents: { 'dynamic-single-model-agent': dynamicSingleModelAgent },
+      });
+
+      const dynamicRequestContext = new RequestContext();
+      dynamicRequestContext.set('foo', true);
+
+      const result = await LIST_AGENTS_ROUTE.handler({
+        ...createTestServerContext({ mastra: mastraWithDynamicSingleModel }),
+        requestContext: dynamicRequestContext,
+      });
+
+      expect(result['dynamic-single-model-agent']).toMatchObject({
+        name: 'dynamic-single-model-agent',
+        description: 'A test agent with dynamic single-model selection',
+        provider: 'openai.responses',
+        modelId: 'gpt-4o-mini',
+        modelVersion: 'v2',
+        modelList: undefined,
+      });
+    });
   });
 
   describe('getAgentByIdHandler', () => {
@@ -448,6 +479,38 @@ describe('Agent Handlers', () => {
           model: { modelId: 'gpt-4.1', provider: 'openai.responses', modelVersion: 'v2' },
         },
       ]);
+    });
+
+    it('should return serialized agent without a model list for dynamic single-model selection', async () => {
+      const dynamicSingleModelAgent = makeMockAgent({
+        name: 'dynamic-single-model-agent',
+        description: 'A test agent with dynamic single-model selection',
+        model: ({ requestContext }) => {
+          return requestContext.get('foo') ? openaiV5('gpt-4o-mini') : openaiV5('gpt-4.1');
+        },
+      });
+
+      const mastraWithDynamicSingleModel = makeMastraMock({
+        agents: { 'dynamic-single-model-agent': dynamicSingleModelAgent },
+      });
+
+      const dynamicRequestContext = new RequestContext();
+      dynamicRequestContext.set('foo', true);
+
+      const result = await GET_AGENT_BY_ID_ROUTE.handler({
+        ...createTestServerContext({ mastra: mastraWithDynamicSingleModel }),
+        agentId: 'dynamic-single-model-agent',
+        requestContext: dynamicRequestContext,
+      });
+
+      expect(result).toMatchObject({
+        name: 'dynamic-single-model-agent',
+        description: 'A test agent with dynamic single-model selection',
+        provider: 'openai.responses',
+        modelId: 'gpt-4o-mini',
+        modelVersion: 'v2',
+        modelList: undefined,
+      });
     });
 
     it('should throw 404 when agent not found', async () => {


### PR DESCRIPTION
## Summary
- fix the regression from #11975 where dynamic `model` functions returning a single model were treated like fallback arrays
- preserve runtime shape for resolved models so single-model selection stays single-model and only arrays enter fallback-list behavior
- add regression coverage in core and server so dynamic single-model agents no longer expose a one-item `modelList`

## Changes
- refactor agent model resolution to preserve single vs array shape instead of wrapping single results in a tagged fallback structure
- keep v1/v2 support for dynamic single-model selection while preserving the existing v2/v3-only restriction for actual model arrays
- add a patch changeset for `@mastra/core`

## Testing
- `pnpm exec tsc --noEmit -p tsconfig.build.json` in `packages/core`
- `pnpm vitest run src/agent/__tests__/dynamic-model-fallback.test.ts` in `packages/core`
- `pnpm vitest run src/agent/__tests__/model-list.test.ts` in `packages/core`
- `pnpm build:lib` in `packages/core`
- `pnpm vitest run src/server/handlers/agent.test.ts -t "dynamic single-model selection"` in `packages/server`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dynamic model selection now correctly treats a single resolved model as a single model (not a fallback array).
  * Model listing API now returns null for static single-model configurations.

* **Tests**
  * Added tests validating dynamic single-model behavior and that serialized agent responses do not expose a model list when a single model is selected.

* **Chores**
  * Added a changeset entry for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->