### PR TITLE
Add input message preview column to trace list

### DIFF
--- a/.changeset/rich-shirts-nail.md
+++ b/.changeset/rich-shirts-nail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added input message preview column to the observability trace list. You can now see a truncated preview of user input messages directly in the trace table, making it easier to find specific traces without clicking into each one.

--- a/packages/playground-ui/src/domains/observability/components/traces-list.tsx
+++ b/packages/playground-ui/src/domains/observability/components/traces-list.tsx
@@ -2,18 +2,21 @@ import { EntryList } from '@/ds/components/EntryList';
 import { getShortId } from '@/ds/components/Text';
 import { SpanRecord } from '@mastra/core/storage';
 import { format, isToday } from 'date-fns';
+import { getInputPreview } from '../utils/span-utils';
 
 export const tracesListColumns = [
   { name: 'shortId', label: 'ID', size: '6rem' },
   { name: 'date', label: 'Date', size: '4.5rem' },
   { name: 'time', label: 'Time', size: '6.5rem' },
   { name: 'name', label: 'Name', size: '1fr' },
+  { name: 'input', label: 'Input', size: '1fr' },
   { name: 'entityId', label: 'Entity', size: '10rem' },
   { name: 'status', label: 'Status', size: '3rem' },
 ];
 
 type Trace = Pick<SpanRecord, 'traceId' | 'name' | 'entityType' | 'entityId' | 'entityName'> & {
   attributes?: Record<string, any> | null;
+  input?: unknown;
   createdAt: Date | string;
 };
 
@@ -62,6 +65,7 @@ export function TracesList({
                     date: isTodayDate ? 'Today' : format(createdAtDate, 'MMM dd'),
                     time: format(createdAtDate, 'h:mm:ss aaa'),
                     name: trace?.name,
+                    input: getInputPreview(trace?.input),
                     entityId:
                       trace?.entityName ||
                       trace?.entityId ||

--- a/packages/playground-ui/src/domains/observability/utils/__tests__/span-utils.test.ts
+++ b/packages/playground-ui/src/domains/observability/utils/__tests__/span-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isTokenLimitExceeded, getTokenLimitMessage } from '../span-utils';
+import { isTokenLimitExceeded, getTokenLimitMessage, getInputPreview } from '../span-utils';
 import { SpanRecord } from '@mastra/core/storage';
 
 describe('span-utils', () => {
@@ -140,6 +140,88 @@ describe('span-utils', () => {
       });
       const message = getTokenLimitMessage(span);
       expect(message).toContain('\n\n');
+    });
+  });
+
+  describe('getInputPreview', () => {
+    it('should return empty string for null input', () => {
+      expect(getInputPreview(null)).toBe('');
+    });
+
+    it('should return empty string for undefined input', () => {
+      expect(getInputPreview(undefined)).toBe('');
+    });
+
+    it('should extract user message content from message array', () => {
+      const input = [
+        { role: 'system', content: 'You are a helpful assistant' },
+        { role: 'user', content: 'Hello, how are you?' },
+      ];
+      expect(getInputPreview(input)).toBe('Hello, how are you?');
+    });
+
+    it('should join multiple user messages with pipe separator', () => {
+      const input = [
+        { role: 'user', content: 'First message' },
+        { role: 'assistant', content: 'Response' },
+        { role: 'user', content: 'Second message' },
+      ];
+      expect(getInputPreview(input)).toBe('First message | Second message');
+    });
+
+    it('should truncate long text to maxLength with ellipsis', () => {
+      const longContent = 'a'.repeat(150);
+      const input = [{ role: 'user', content: longContent }];
+      const result = getInputPreview(input, 100);
+      expect(result).toHaveLength(101); // 100 chars + ellipsis
+      expect(result.endsWith('…')).toBe(true);
+    });
+
+    it('should handle multipart content arrays', () => {
+      const input = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is in this image?' },
+            { type: 'image', image_url: 'http://example.com/img.png' },
+          ],
+        },
+      ];
+      expect(getInputPreview(input)).toBe('What is in this image?');
+    });
+
+    it('should handle plain string input', () => {
+      expect(getInputPreview('Hello world')).toBe('Hello world');
+    });
+
+    it('should truncate long string input', () => {
+      const longStr = 'b'.repeat(150);
+      const result = getInputPreview(longStr, 100);
+      expect(result).toHaveLength(101);
+      expect(result.endsWith('…')).toBe(true);
+    });
+
+    it('should fallback to JSON.stringify for object input', () => {
+      const input = { key: 'value' };
+      expect(getInputPreview(input)).toBe('{"key":"value"}');
+    });
+
+    it('should handle empty message array', () => {
+      expect(getInputPreview([])).toBe('');
+    });
+
+    it('should skip messages without user role', () => {
+      const input = [
+        { role: 'system', content: 'System prompt' },
+        { role: 'assistant', content: 'Assistant response' },
+      ];
+      expect(getInputPreview(input)).toBe('');
+    });
+
+    it('should use custom maxLength', () => {
+      const input = [{ role: 'user', content: 'Hello world, this is a test message' }];
+      const result = getInputPreview(input, 10);
+      expect(result).toBe('Hello worl…');
     });
   });
 });

--- a/packages/playground-ui/src/domains/observability/utils/span-utils.ts
+++ b/packages/playground-ui/src/domains/observability/utils/span-utils.ts
@@ -1,5 +1,56 @@
 import { SpanRecord } from '@mastra/core/storage';
 
+type MessageLike = { role?: string; content?: unknown };
+
+/**
+ * Extract a truncated text preview from a span's input field.
+ * Agent traces store `input` as an array of message objects.
+ * Returns the text content of all user messages joined, truncated to maxLength.
+ */
+export function getInputPreview(input: unknown, maxLength = 100): string {
+  if (input == null) return '';
+
+  if (Array.isArray(input)) {
+    const messages = input as MessageLike[];
+    const userMessages = messages
+      .filter(m => m?.role === 'user')
+      .map(m => {
+        if (typeof m.content === 'string') return m.content;
+        if (Array.isArray(m.content)) {
+          return m.content
+            .map((part: any) => {
+              if (typeof part === 'string') return part;
+              if (part?.type === 'text' && typeof part.text === 'string') return part.text;
+              return '';
+            })
+            .filter(Boolean)
+            .join(' ');
+        }
+        return '';
+      })
+      .filter(Boolean);
+
+    const joined = userMessages.join(' | ');
+    if (joined.length > maxLength) {
+      return joined.slice(0, maxLength) + '…';
+    }
+    return joined;
+  }
+
+  if (typeof input === 'string') {
+    if (input.length > maxLength) {
+      return input.slice(0, maxLength) + '…';
+    }
+    return input;
+  }
+
+  const str = JSON.stringify(input);
+  if (str.length > maxLength) {
+    return str.slice(0, maxLength) + '…';
+  }
+  return str;
+}
+
 type TokenUsage = {
   inputTokens?: number;
   outputTokens?: number;


### PR DESCRIPTION
## Description

Added an "Input" column to the observability trace list showing a truncated preview of user input messages. This enables developers to visually scan traces and find specific ones based on user input without clicking into each trace individually.

The implementation includes a new `getInputPreview()` utility that extracts user message content from agent traces, handles multipart content arrays, and truncates long text to 100 characters with an ellipsis.

<img width="1606" height="426" alt="image" src="https://github.com/user-attachments/assets/0b7dd6b3-2f56-43b3-8b36-9a23b72ddfe5" />


## Related Issue(s)

Fixes #14006

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an input message preview column to the observability trace list, allowing users to view truncated previews of user input messages directly within the trace table for better debugging and monitoring visibility.

* **Tests**
  * Added comprehensive test coverage for input preview functionality, including edge cases such as null inputs, multiple messages, content truncation, and various input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->