### PR TITLE
feat(playground-ui): add group-by-thread utility for observability traces

### DIFF
--- a/.changeset/spotty-groups-make.md
+++ b/.changeset/spotty-groups-make.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added group-by-thread utility for the Observability tab. Traces can now be grouped by their conversation thread ID, making it easier to follow multi-turn agent conversations in Studio. See [#14004](https://github.com/mastra-ai/mastra/issues/14004).

--- a/packages/playground-ui/src/domains/observability/components/traces-list.tsx
+++ b/packages/playground-ui/src/domains/observability/components/traces-list.tsx
@@ -32,6 +32,8 @@ type TracesListProps = {
   isFetchingNextPage?: boolean;
   hasNextPage?: boolean;
   groupByThread?: boolean;
+  threadTitles?: Record<string, string>;
+  columns?: typeof tracesListColumns;
 };
 
 function traceToEntry(trace: Trace, selectedTraceId?: string) {
@@ -92,11 +94,13 @@ function GroupedTracesList({
   selectedTraceId,
   onTraceClick,
   filtersApplied,
+  threadTitles,
 }: {
   traces: Trace[];
   selectedTraceId?: string;
   onTraceClick?: (id: string) => void;
   filtersApplied?: boolean;
+  threadTitles?: Record<string, string>;
 }) {
   const { groups, ungrouped } = groupTracesByThread(traces as SpanRecord[]);
 
@@ -122,7 +126,11 @@ function GroupedTracesList({
               )}
             >
               <ChevronRightIcon className="h-3.5 w-3.5 shrink-0" />
-              <span className="truncate">Thread {getShortId(group.threadId) || group.threadId}</span>
+              <span className="truncate">
+                {threadTitles?.[group.threadId]
+                  ? <>Thread '{threadTitles[group.threadId]}' ({getShortId(group.threadId) || group.threadId})</>
+                  : <>Thread {getShortId(group.threadId) || group.threadId}</>}
+              </span>
               <span className="text-neutral3">({group.traces.length})</span>
             </CollapsibleTrigger>
             <CollapsibleContent>
@@ -173,6 +181,8 @@ export function TracesList({
   isFetchingNextPage,
   hasNextPage,
   groupByThread,
+  threadTitles,
+  columns = tracesListColumns,
 }: TracesListProps) {
   if (!traces) {
     return null;
@@ -192,6 +202,7 @@ export function TracesList({
             selectedTraceId={selectedTraceId}
             onTraceClick={onTraceClick}
             filtersApplied={filtersApplied}
+            threadTitles={threadTitles}
           />
         )}
         <EntryList.NextPageLoading

--- a/packages/playground-ui/src/domains/observability/components/traces-list.tsx
+++ b/packages/playground-ui/src/domains/observability/components/traces-list.tsx
@@ -1,7 +1,11 @@
 import { EntryList } from '@/ds/components/EntryList';
 import { getShortId } from '@/ds/components/Text';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/ds/components/Collapsible';
+import { cn } from '@/lib/utils';
 import { SpanRecord } from '@mastra/core/storage';
 import { format, isToday } from 'date-fns';
+import { ChevronRightIcon } from 'lucide-react';
+import { groupTracesByThread } from '../utils/group-traces-by-thread';
 
 export const tracesListColumns = [
   { name: 'shortId', label: 'ID', size: '6rem' },
@@ -15,6 +19,7 @@ export const tracesListColumns = [
 type Trace = Pick<SpanRecord, 'traceId' | 'name' | 'entityType' | 'entityId' | 'entityName'> & {
   attributes?: Record<string, any> | null;
   createdAt: Date | string;
+  threadId?: string | null;
 };
 
 type TracesListProps = {
@@ -26,7 +31,137 @@ type TracesListProps = {
   filtersApplied?: boolean;
   isFetchingNextPage?: boolean;
   hasNextPage?: boolean;
+  groupByThread?: boolean;
 };
+
+function traceToEntry(trace: Trace, selectedTraceId?: string) {
+  const createdAtDate = new Date(trace.createdAt);
+  const isTodayDate = isToday(createdAtDate);
+
+  return {
+    id: trace.traceId,
+    shortId: getShortId(trace?.traceId) || 'n/a',
+    date: isTodayDate ? 'Today' : format(createdAtDate, 'MMM dd'),
+    time: format(createdAtDate, 'h:mm:ss aaa'),
+    name: trace?.name,
+    entityId:
+      trace?.entityName || trace?.entityId || trace?.attributes?.agentId || trace?.attributes?.workflowId,
+    status: trace?.attributes?.status,
+    isSelected: selectedTraceId === trace.traceId,
+  };
+}
+
+function TraceEntries({
+  traces,
+  selectedTraceId,
+  onTraceClick,
+}: {
+  traces: Trace[];
+  selectedTraceId?: string;
+  onTraceClick?: (id: string) => void;
+}) {
+  return (
+    <EntryList.Entries>
+      {traces.map(trace => {
+        const entry = traceToEntry(trace, selectedTraceId);
+        return (
+          <EntryList.Entry
+            key={entry.id}
+            entry={entry}
+            isSelected={entry.isSelected}
+            columns={tracesListColumns}
+            onClick={onTraceClick}
+          >
+            {tracesListColumns.map((col, index) => {
+              const key = `${index}-${trace.traceId}`;
+              return col.name === 'status' ? (
+                <EntryList.EntryStatus key={key} status={entry?.[col.name as keyof typeof entry]} />
+              ) : (
+                <EntryList.EntryText key={key}>{entry?.[col.name as keyof typeof entry]}</EntryList.EntryText>
+              );
+            })}
+          </EntryList.Entry>
+        );
+      })}
+    </EntryList.Entries>
+  );
+}
+
+function GroupedTracesList({
+  traces,
+  selectedTraceId,
+  onTraceClick,
+  filtersApplied,
+}: {
+  traces: Trace[];
+  selectedTraceId?: string;
+  onTraceClick?: (id: string) => void;
+  filtersApplied?: boolean;
+}) {
+  const { groups, ungrouped } = groupTracesByThread(traces as SpanRecord[]);
+
+  if (groups.length === 0 && ungrouped.length === 0) {
+    return (
+      <EntryList.Trim>
+        <EntryList.Header columns={tracesListColumns} />
+        <EntryList.Message
+          message={filtersApplied ? 'No traces found for applied filters' : 'No traces found yet'}
+        />
+      </EntryList.Trim>
+    );
+  }
+
+  return (
+    <div className={cn('grid gap-2')}>
+      {groups.map(group => (
+        <Collapsible key={group.threadId} defaultOpen>
+          <div className={cn('rounded-lg border border-border1 overflow-clip')}>
+            <CollapsibleTrigger
+              className={cn(
+                'flex w-full items-center gap-2 px-4 py-2 bg-surface2 hover:bg-surface3 text-ui-md text-neutral4',
+              )}
+            >
+              <ChevronRightIcon className="h-3.5 w-3.5 shrink-0" />
+              <span className="truncate">Thread {getShortId(group.threadId) || group.threadId}</span>
+              <span className="text-neutral3">({group.traces.length})</span>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <EntryList.Header columns={tracesListColumns} />
+              <TraceEntries
+                traces={group.traces as Trace[]}
+                selectedTraceId={selectedTraceId}
+                onTraceClick={onTraceClick}
+              />
+            </CollapsibleContent>
+          </div>
+        </Collapsible>
+      ))}
+      {ungrouped.length > 0 && (
+        <Collapsible defaultOpen>
+          <div className={cn('rounded-lg border border-border1 overflow-clip')}>
+            <CollapsibleTrigger
+              className={cn(
+                'flex w-full items-center gap-2 px-4 py-2 bg-surface2 hover:bg-surface3 text-ui-md text-neutral4',
+              )}
+            >
+              <ChevronRightIcon className="h-3.5 w-3.5 shrink-0" />
+              <span>No thread</span>
+              <span className="text-neutral3">({ungrouped.length})</span>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <EntryList.Header columns={tracesListColumns} />
+              <TraceEntries
+                traces={ungrouped as Trace[]}
+                selectedTraceId={selectedTraceId}
+                onTraceClick={onTraceClick}
+              />
+            </CollapsibleContent>
+          </div>
+        </Collapsible>
+      )}
+    </div>
+  );
+}
 
 export function TracesList({
   traces,
@@ -37,9 +172,37 @@ export function TracesList({
   filtersApplied,
   isFetchingNextPage,
   hasNextPage,
+  groupByThread,
 }: TracesListProps) {
   if (!traces) {
     return null;
+  }
+
+  if (groupByThread) {
+    return (
+      <EntryList>
+        {errorMsg ? (
+          <EntryList.Trim>
+            <EntryList.Header columns={tracesListColumns} />
+            <EntryList.Message message={errorMsg} type="error" />
+          </EntryList.Trim>
+        ) : (
+          <GroupedTracesList
+            traces={traces}
+            selectedTraceId={selectedTraceId}
+            onTraceClick={onTraceClick}
+            filtersApplied={filtersApplied}
+          />
+        )}
+        <EntryList.NextPageLoading
+          setEndOfListElement={setEndOfListElement}
+          loadingText="Loading more traces..."
+          noMoreDataText="All traces loaded"
+          isLoading={isFetchingNextPage}
+          hasMore={hasNextPage}
+        />
+      </EntryList>
+    );
   }
 
   return (
@@ -51,45 +214,7 @@ export function TracesList({
         ) : (
           <>
             {traces.length > 0 ? (
-              <EntryList.Entries>
-                {traces.map(trace => {
-                  const createdAtDate = new Date(trace.createdAt);
-                  const isTodayDate = isToday(createdAtDate);
-
-                  const entry = {
-                    id: trace.traceId,
-                    shortId: getShortId(trace?.traceId) || 'n/a',
-                    date: isTodayDate ? 'Today' : format(createdAtDate, 'MMM dd'),
-                    time: format(createdAtDate, 'h:mm:ss aaa'),
-                    name: trace?.name,
-                    entityId:
-                      trace?.entityName ||
-                      trace?.entityId ||
-                      trace?.attributes?.agentId ||
-                      trace?.attributes?.workflowId,
-                    status: trace?.attributes?.status,
-                  };
-
-                  return (
-                    <EntryList.Entry
-                      key={entry.id}
-                      entry={entry}
-                      isSelected={selectedTraceId === trace.traceId}
-                      columns={tracesListColumns}
-                      onClick={onTraceClick}
-                    >
-                      {tracesListColumns.map((col, index) => {
-                        const key = `${index}-${trace.traceId}`;
-                        return col.name === 'status' ? (
-                          <EntryList.EntryStatus key={key} status={entry?.[col.name as keyof typeof entry]} />
-                        ) : (
-                          <EntryList.EntryText key={key}>{entry?.[col.name as keyof typeof entry]}</EntryList.EntryText>
-                        );
-                      })}
-                    </EntryList.Entry>
-                  );
-                })}
-              </EntryList.Entries>
+              <TraceEntries traces={traces} selectedTraceId={selectedTraceId} onTraceClick={onTraceClick} />
             ) : (
               <EntryList.Message
                 message={filtersApplied ? 'No traces found for applied filters' : 'No traces found yet'}

--- a/packages/playground-ui/src/domains/observability/components/traces-tools.tsx
+++ b/packages/playground-ui/src/domains/observability/components/traces-tools.tsx
@@ -1,6 +1,7 @@
 import { SelectField } from '@/ds/components/FormFields';
 import { DateTimePicker } from '@/ds/components/DateTimePicker';
 import { Button } from '@/ds/components/Button/Button';
+import { Switch } from '@/ds/components/Switch/switch';
 import { cn } from '@/lib/utils';
 import { XIcon } from 'lucide-react';
 import { EntityType } from '@mastra/core/observability';
@@ -22,6 +23,8 @@ type TracesToolsProps = {
   onReset?: () => void;
   onDateChange?: (value: Date | undefined, type: 'from' | 'to') => void;
   isLoading?: boolean;
+  groupByThread?: boolean;
+  onGroupByThreadChange?: (value: boolean) => void;
 };
 
 export function TracesTools({
@@ -33,6 +36,8 @@ export function TracesTools({
   selectedDateFrom,
   selectedDateTo,
   isLoading,
+  groupByThread,
+  onGroupByThreadChange,
 }: TracesToolsProps) {
   return (
     <div className={cn('flex flex-wrap gap-x-8 gap-y-4')}>
@@ -71,6 +76,15 @@ export function TracesTools({
           defaultTimeStrValue="11:59 PM"
           disabled={isLoading}
         />
+
+        <label className={cn('flex gap-2 items-center shrink-0 cursor-pointer')}>
+          <Switch
+            checked={groupByThread}
+            onCheckedChange={onGroupByThreadChange}
+            disabled={isLoading}
+          />
+          <span className={cn('text-ui-md text-neutral3')}>Group by thread</span>
+        </label>
 
         <Button variant="light" size="lg" className="min-w-32" onClick={onReset} disabled={isLoading}>
           <Icon>

--- a/packages/playground-ui/src/domains/observability/index.ts
+++ b/packages/playground-ui/src/domains/observability/index.ts
@@ -1,4 +1,5 @@
 export * from './utils/format-hierarchical-spans';
+export * from './utils/group-traces-by-thread';
 export * from './types';
 export * from './components';
 export * from './context/tracing-settings-context';

--- a/packages/playground-ui/src/domains/observability/utils/__tests__/group-traces-by-thread.test.ts
+++ b/packages/playground-ui/src/domains/observability/utils/__tests__/group-traces-by-thread.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import { groupTracesByThread } from '../group-traces-by-thread';
+import { SpanRecord } from '@mastra/core/storage';
+
+const createMockTrace = (overrides: Partial<SpanRecord> = {}): SpanRecord => ({
+  traceId: `trace-${Math.random().toString(36).slice(2, 8)}`,
+  spanId: `span-${Math.random().toString(36).slice(2, 8)}`,
+  parentSpanId: null,
+  name: 'Test Span',
+  scope: null,
+  spanType: 'AGENT_RUN' as any,
+  attributes: null,
+  metadata: null,
+  links: null,
+  tags: null,
+  startedAt: new Date('2025-01-01T00:00:00Z'),
+  endedAt: new Date('2025-01-01T00:00:01Z'),
+  input: null,
+  output: null,
+  error: null,
+  createdAt: new Date('2025-01-01T00:00:00Z'),
+  updatedAt: new Date('2025-01-01T00:00:01Z'),
+  isEvent: false,
+  entityType: null,
+  entityId: null,
+  entityName: null,
+  userId: null,
+  organizationId: null,
+  resourceId: null,
+  runId: null,
+  sessionId: null,
+  threadId: null,
+  requestId: null,
+  environment: null,
+  source: null,
+  serviceName: null,
+  ...overrides,
+});
+
+describe('groupTracesByThread', () => {
+  it('should return empty groups and ungrouped for empty input', () => {
+    const result = groupTracesByThread([]);
+    expect(result.groups).toEqual([]);
+    expect(result.ungrouped).toEqual([]);
+  });
+
+  it('should place traces without threadId in ungrouped', () => {
+    const trace1 = createMockTrace({ traceId: 'trace-1' });
+    const trace2 = createMockTrace({ traceId: 'trace-2' });
+
+    const result = groupTracesByThread([trace1, trace2]);
+
+    expect(result.groups).toEqual([]);
+    expect(result.ungrouped).toHaveLength(2);
+    expect(result.ungrouped[0].traceId).toBe('trace-1');
+    expect(result.ungrouped[1].traceId).toBe('trace-2');
+  });
+
+  it('should group traces by threadId', () => {
+    const trace1 = createMockTrace({ traceId: 'trace-1', threadId: 'thread-A' });
+    const trace2 = createMockTrace({ traceId: 'trace-2', threadId: 'thread-A' });
+    const trace3 = createMockTrace({ traceId: 'trace-3', threadId: 'thread-B' });
+
+    const result = groupTracesByThread([trace1, trace2, trace3]);
+
+    expect(result.groups).toHaveLength(2);
+    expect(result.ungrouped).toHaveLength(0);
+
+    const threadA = result.groups.find(g => g.threadId === 'thread-A');
+    const threadB = result.groups.find(g => g.threadId === 'thread-B');
+
+    expect(threadA).toBeDefined();
+    expect(threadA!.traces).toHaveLength(2);
+    expect(threadA!.traces.map(t => t.traceId)).toEqual(['trace-1', 'trace-2']);
+
+    expect(threadB).toBeDefined();
+    expect(threadB!.traces).toHaveLength(1);
+    expect(threadB!.traces[0].traceId).toBe('trace-3');
+  });
+
+  it('should separate grouped and ungrouped traces', () => {
+    const trace1 = createMockTrace({ traceId: 'trace-1', threadId: 'thread-A' });
+    const trace2 = createMockTrace({ traceId: 'trace-2', threadId: null });
+    const trace3 = createMockTrace({ traceId: 'trace-3', threadId: 'thread-A' });
+
+    const result = groupTracesByThread([trace1, trace2, trace3]);
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0].threadId).toBe('thread-A');
+    expect(result.groups[0].traces).toHaveLength(2);
+    expect(result.ungrouped).toHaveLength(1);
+    expect(result.ungrouped[0].traceId).toBe('trace-2');
+  });
+
+  it('should sort groups by most recent trace (descending)', () => {
+    const trace1 = createMockTrace({
+      traceId: 'trace-1',
+      threadId: 'thread-old',
+      startedAt: new Date('2025-01-01T00:00:00Z'),
+    });
+    const trace2 = createMockTrace({
+      traceId: 'trace-2',
+      threadId: 'thread-new',
+      startedAt: new Date('2025-01-03T00:00:00Z'),
+    });
+    const trace3 = createMockTrace({
+      traceId: 'trace-3',
+      threadId: 'thread-mid',
+      startedAt: new Date('2025-01-02T00:00:00Z'),
+    });
+
+    const result = groupTracesByThread([trace1, trace2, trace3]);
+
+    expect(result.groups).toHaveLength(3);
+    expect(result.groups[0].threadId).toBe('thread-new');
+    expect(result.groups[1].threadId).toBe('thread-mid');
+    expect(result.groups[2].threadId).toBe('thread-old');
+  });
+
+  it('should sort groups by the latest trace within a group, not the earliest', () => {
+    const traceOldGroup1 = createMockTrace({
+      traceId: 'trace-1',
+      threadId: 'thread-A',
+      startedAt: new Date('2025-01-01T00:00:00Z'),
+    });
+    const traceNewGroup1 = createMockTrace({
+      traceId: 'trace-2',
+      threadId: 'thread-A',
+      startedAt: new Date('2025-01-05T00:00:00Z'),
+    });
+    const traceMidGroup2 = createMockTrace({
+      traceId: 'trace-3',
+      threadId: 'thread-B',
+      startedAt: new Date('2025-01-03T00:00:00Z'),
+    });
+
+    const result = groupTracesByThread([traceOldGroup1, traceNewGroup1, traceMidGroup2]);
+
+    expect(result.groups).toHaveLength(2);
+    // thread-A has the latest trace (Jan 5), so it should be first
+    expect(result.groups[0].threadId).toBe('thread-A');
+    expect(result.groups[1].threadId).toBe('thread-B');
+  });
+
+  it('should preserve trace order within each group', () => {
+    const trace1 = createMockTrace({ traceId: 'trace-1', threadId: 'thread-A' });
+    const trace2 = createMockTrace({ traceId: 'trace-2', threadId: 'thread-A' });
+    const trace3 = createMockTrace({ traceId: 'trace-3', threadId: 'thread-A' });
+
+    const result = groupTracesByThread([trace1, trace2, trace3]);
+
+    expect(result.groups[0].traces.map(t => t.traceId)).toEqual(['trace-1', 'trace-2', 'trace-3']);
+  });
+
+  it('should handle a single trace with a threadId', () => {
+    const trace = createMockTrace({ traceId: 'trace-1', threadId: 'thread-only' });
+
+    const result = groupTracesByThread([trace]);
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0].threadId).toBe('thread-only');
+    expect(result.groups[0].traces).toHaveLength(1);
+    expect(result.ungrouped).toHaveLength(0);
+  });
+});

--- a/packages/playground-ui/src/domains/observability/utils/group-traces-by-thread.ts
+++ b/packages/playground-ui/src/domains/observability/utils/group-traces-by-thread.ts
@@ -1,0 +1,49 @@
+import { SpanRecord } from '@mastra/core/storage';
+
+export type ThreadGroup = {
+  threadId: string;
+  traces: SpanRecord[];
+};
+
+export type GroupedTraces = {
+  groups: ThreadGroup[];
+  ungrouped: SpanRecord[];
+};
+
+/**
+ * Groups traces by their threadId field.
+ * Traces without a threadId are placed in the `ungrouped` bucket.
+ * Groups are ordered by the most recent trace's startedAt (descending).
+ * Within each group, traces maintain their original order.
+ */
+export function groupTracesByThread(traces: SpanRecord[]): GroupedTraces {
+  const threadMap = new Map<string, SpanRecord[]>();
+  const ungrouped: SpanRecord[] = [];
+
+  for (const trace of traces) {
+    if (trace.threadId) {
+      const existing = threadMap.get(trace.threadId);
+      if (existing) {
+        existing.push(trace);
+      } else {
+        threadMap.set(trace.threadId, [trace]);
+      }
+    } else {
+      ungrouped.push(trace);
+    }
+  }
+
+  const groups: ThreadGroup[] = Array.from(threadMap.entries()).map(([threadId, traces]) => ({
+    threadId,
+    traces,
+  }));
+
+  // Sort groups by the most recent trace in each group (descending)
+  groups.sort((a, b) => {
+    const aLatest = Math.max(...a.traces.map(t => new Date(t.startedAt).getTime()));
+    const bLatest = Math.max(...b.traces.map(t => new Date(t.startedAt).getTime()));
+    return bLatest - aLatest;
+  });
+
+  return { groups, ungrouped };
+}

--- a/packages/playground/src/domains/observability/hooks/use-traces.tsx
+++ b/packages/playground/src/domains/observability/hooks/use-traces.tsx
@@ -40,16 +40,28 @@ export function getTracesNextPageParam(
   return undefined;
 }
 
-/** Deduplicates traces by traceId across all loaded pages, keeping the first occurrence. */
-export function selectUniqueTraces(data: { pages: ListTracesResponse[] }) {
+type TracesPageResponse = ListTracesResponse & { threadTitles?: Record<string, string> };
+
+/** Deduplicates traces by traceId across all loaded pages, keeping the first occurrence.
+ *  Also merges threadTitles from all pages for thread grouping display. */
+export function selectUniqueTraces(data: { pages: TracesPageResponse[] }) {
   const seen = new Set<string>();
-  return data.pages
+  const spans = data.pages
     .flatMap(page => page.spans ?? [])
     .filter(span => {
       if (seen.has(span.traceId)) return false;
       seen.add(span.traceId);
       return true;
     });
+
+  const threadTitles: Record<string, string> = {};
+  for (const page of data.pages) {
+    if (page.threadTitles) {
+      Object.assign(threadTitles, page.threadTitles);
+    }
+  }
+
+  return { spans, threadTitles };
 }
 
 export const useTraces = ({ filters }: TracesFilters) => {

--- a/packages/playground/src/pages/observability/index.tsx
+++ b/packages/playground/src/pages/observability/index.tsx
@@ -57,7 +57,7 @@ export default function Observability() {
   const scoreId = searchParams.get('scoreId');
 
   const {
-    data: traces = [],
+    data: tracesData,
     isLoading: isTracesLoading,
     isFetchingNextPage,
     hasNextPage,
@@ -82,6 +82,9 @@ export default function Observability() {
       }),
     },
   });
+
+  const traces = tracesData?.spans ?? [];
+  const threadTitles = tracesData?.threadTitles ?? {};
 
   // Sync URL traceId to state
   if (traceId && traceId !== selectedTraceId) {
@@ -249,6 +252,7 @@ export default function Observability() {
                 isFetchingNextPage={isFetchingNextPage}
                 hasNextPage={hasNextPage}
                 groupByThread={groupByThread}
+                threadTitles={threadTitles}
               />
             )}
           </div>

--- a/packages/playground/src/pages/observability/index.tsx
+++ b/packages/playground/src/pages/observability/index.tsx
@@ -43,6 +43,7 @@ export default function Observability() {
   });
   const [selectedDateFrom, setSelectedDateFrom] = useState<Date | undefined>(undefined);
   const [selectedDateTo, setSelectedDateTo] = useState<Date | undefined>(undefined);
+  const [groupByThread, setGroupByThread] = useState<boolean>(false);
   const [dialogIsOpen, setDialogIsOpen] = useState<boolean>(false);
   const { data: agents = {}, isLoading: isLoadingAgents } = useAgents();
   const { data: workflows, isLoading: isLoadingWorkflows } = useWorkflows();
@@ -126,6 +127,7 @@ export default function Observability() {
     setDialogIsOpen(false);
     setSelectedDateFrom(undefined);
     setSelectedDateTo(undefined);
+    setGroupByThread(false);
   };
 
   const handleDataChange = (value: Date | undefined, type: 'from' | 'to') => {
@@ -230,6 +232,8 @@ export default function Observability() {
               selectedDateFrom={selectedDateFrom}
               selectedDateTo={selectedDateTo}
               isLoading={isTracesLoading || isLoadingAgents || isLoadingWorkflows}
+              groupByThread={groupByThread}
+              onGroupByThreadChange={setGroupByThread}
             />
 
             {isTracesLoading ? (
@@ -244,6 +248,7 @@ export default function Observability() {
                 filtersApplied={Boolean(filtersApplied)}
                 isFetchingNextPage={isFetchingNextPage}
                 hasNextPage={hasNextPage}
+                groupByThread={groupByThread}
               />
             )}
           </div>


### PR DESCRIPTION
## Description

Adds a `groupTracesByThread` utility for the Observability tab that clusters traces by their conversation `threadId`. Groups are sorted by most recent trace activity (descending), and traces without a `threadId` are placed in a separate ungrouped bucket. This lays the groundwork for a "Group by thread" toggle in Studio.

<img width="1895" height="892" alt="image" src="https://github.com/user-attachments/assets/901e5c53-5382-40cc-ad15-5b1f3982faa2" />


## Related Issue(s)

Closes #14004

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works