### PR TITLE
fix: resolve Windows path separator mismatch in commonjs-tsc-fixer

### DIFF
--- a/.changeset/fix-commonjs-fixer-windows-paths.md
+++ b/.changeset/fix-commonjs-fixer-windows-paths.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix `build:patch-commonjs` failing on Windows due to path separator mismatch in `commonjs-tsc-fixer.js`

--- a/.changeset/fix-commonjs-fixer-windows-paths.md
+++ b/.changeset/fix-commonjs-fixer-windows-paths.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fix `build:patch-commonjs` failing on Windows due to path separator mismatch in `commonjs-tsc-fixer.js`
+Fix build failures on Windows when running `build:patch-commonjs` during `pnpm run setup`

--- a/scripts/commonjs-tsc-fixer.js
+++ b/scripts/commonjs-tsc-fixer.js
@@ -2,6 +2,11 @@ import { readFile, writeFile, rm, mkdir } from 'node:fs/promises';
 import { dirname, join, relative } from 'node:path';
 import { globby } from 'globby';
 
+/** Convert Windows backslashes to posix forward slashes */
+function slash(p) {
+  return p.replaceAll('\\', '/');
+}
+
 async function cleanupDtsFiles() {
   const rootPath = process.cwd();
   const files = await globby('./*.d.ts', { cwd: rootPath });
@@ -31,28 +36,20 @@ async function writeDtsFiles() {
           // For wildcard patterns, derive the subpath relative to dist/
           const dir = dirname(file);
           const distRoot = join(rootPath, 'dist');
-          const subPath = relative(distRoot, dir).replaceAll('\\', '/');
+          const subPath = slash(relative(distRoot, dir));
           const filename = key.replace('*', subPath);
 
           const targetPath = join(rootPath, filename) + '.d.ts';
           await mkdir(dirname(targetPath), { recursive: true });
 
-          await writeFile(
-            targetPath,
-            `export * from './${relative(dirname(targetPath), file)
-              .replace(/[/\\]index\.d\.ts$/, '')
-              .replaceAll('\\', '/')}';`,
-          );
+          const relPath = slash(relative(dirname(targetPath), file)).replace('/index.d.ts', '');
+          await writeFile(targetPath, `export * from './${relPath}';`);
         } else {
           const targetPath = join(rootPath, key) + '.d.ts';
           await mkdir(dirname(targetPath), { recursive: true });
 
-          await writeFile(
-            targetPath,
-            `export * from './${relative(dirname(targetPath), file)
-              .replace(/[/\\]index\.d\.ts$/, '')
-              .replaceAll('\\', '/')}';`,
-          );
+          const relPath = slash(relative(dirname(targetPath), file)).replace('/index.d.ts', '');
+          await writeFile(targetPath, `export * from './${relPath}';`);
         }
       }
     }

--- a/scripts/commonjs-tsc-fixer.js
+++ b/scripts/commonjs-tsc-fixer.js
@@ -28,9 +28,11 @@ async function writeDtsFiles() {
 
       for (const file of matches) {
         if (key.endsWith('*')) {
-          // For wildcard patterns, add the directory
+          // For wildcard patterns, derive the subpath relative to dist/
           const dir = dirname(file);
-          const filename = key.replace('*', dir.replace(join(rootPath, 'dist/'), ''));
+          const distRoot = join(rootPath, 'dist');
+          const subPath = relative(distRoot, dir).replaceAll('\\', '/');
+          const filename = key.replace('*', subPath);
 
           const targetPath = join(rootPath, filename) + '.d.ts';
           await mkdir(dirname(targetPath), { recursive: true });

--- a/scripts/commonjs-tsc-fixer.js
+++ b/scripts/commonjs-tsc-fixer.js
@@ -39,7 +39,7 @@ async function writeDtsFiles() {
 
           await writeFile(
             targetPath,
-            `export * from './${relative(dirname(targetPath), file).replace('/index.d.ts', '').replaceAll('\\', '/')}';`,
+            `export * from './${relative(dirname(targetPath), file).replace(/[/\\]index\.d\.ts$/, '').replaceAll('\\', '/')}';`,
           );
         } else {
           const targetPath = join(rootPath, key) + '.d.ts';
@@ -47,7 +47,7 @@ async function writeDtsFiles() {
 
           await writeFile(
             targetPath,
-            `export * from './${relative(dirname(targetPath), file).replace('/index.d.ts', '').replaceAll('\\', '/')}';`,
+            `export * from './${relative(dirname(targetPath), file).replace(/[/\\]index\.d\.ts$/, '').replaceAll('\\', '/')}';`,
           );
         }
       }

--- a/scripts/commonjs-tsc-fixer.js
+++ b/scripts/commonjs-tsc-fixer.js
@@ -39,7 +39,9 @@ async function writeDtsFiles() {
 
           await writeFile(
             targetPath,
-            `export * from './${relative(dirname(targetPath), file).replace(/[/\\]index\.d\.ts$/, '').replaceAll('\\', '/')}';`,
+            `export * from './${relative(dirname(targetPath), file)
+              .replace(/[/\\]index\.d\.ts$/, '')
+              .replaceAll('\\', '/')}';`,
           );
         } else {
           const targetPath = join(rootPath, key) + '.d.ts';
@@ -47,7 +49,9 @@ async function writeDtsFiles() {
 
           await writeFile(
             targetPath,
-            `export * from './${relative(dirname(targetPath), file).replace(/[/\\]index\.d\.ts$/, '').replaceAll('\\', '/')}';`,
+            `export * from './${relative(dirname(targetPath), file)
+              .replace(/[/\\]index\.d\.ts$/, '')
+              .replaceAll('\\', '/')}';`,
           );
         }
       }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

The `build:patch-commonjs` step fails on Windows because `globby({ absolute: true })` returns forward-slash paths while `path.join()` returns backslash paths. The `String.replace()` used to strip the `dist/` prefix does a literal match, so the replacement silently fails when separators differ. This leaves the full absolute path in `filename`, and `join(rootPath, absolutePath)` produces a doubled path like `D:\foo\D:\foo\dist`, causing an ENOENT error on `mkdir`.

Replaced the fragile `String.replace()` with `path.relative()`, which normalizes separators internally and works correctly on both Windows and Linux.

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #14013

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform consistency of generated TypeScript declaration files by normalizing path separators and refining wildcard export path resolution. This ensures consistent .d.ts output on Windows and other OSes, reducing build inconsistencies while preserving existing public APIs and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->