### PR TITLE
fix(core): persist step messages to storage when savePerStep is enabled

### DIFF
--- a/.changeset/open-pots-strive.md
+++ b/.changeset/open-pots-strive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `savePerStep: true` not actually persisting messages to storage during step execution. Previously, `onStepFinish` only accumulated messages in the in-memory MessageList but never flushed them to the storage backend. The only persistence path was `executeOnFinish`, which is skipped when the stream is aborted. Now messages are flushed to storage after each completed step, so they survive page refreshes and stream aborts. Fixes https://github.com/mastra-ai/mastra/issues/13984

--- a/packages/core/src/agent/__tests__/save-and-errors.test.ts
+++ b/packages/core/src/agent/__tests__/save-and-errors.test.ts
@@ -1527,3 +1527,137 @@ function saveAndErrorTests(version: 'v1' | 'v2') {
 
 saveAndErrorTests('v1');
 saveAndErrorTests('v2');
+
+/**
+ * Regression test for https://github.com/mastra-ai/mastra/issues/13984
+ *
+ * savePerStep: true does not actually persist messages to storage during step execution.
+ * It only accumulates messages in the in-memory MessageList via saveStepMessages(),
+ * which calls messageList.add() but never calls saveQueueManager.flushMessages().
+ *
+ * The actual persistence only happens in executeOnFinish, which is gated by
+ * !abortSignal.aborted. This means if the stream is aborted mid-generation,
+ * executeOnFinish is skipped and NO messages are persisted — including the user's
+ * original message.
+ */
+describe('savePerStep should persist messages during step execution (issue #13984)', () => {
+  it('should persist messages from completed steps when stream is aborted', async () => {
+    let doStreamCallCount = 0;
+
+    // Model that produces a tool call on first invocation, then text on second
+    const toolCallModel = new MockLanguageModelV2({
+      doStream: async () => {
+        doStreamCallCount++;
+        if (doStreamCallCount === 1) {
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'echo-tool',
+                input: '{"input": "hello"}',
+                providerExecuted: false,
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              },
+            ]),
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+          };
+        }
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'Response after tool' },
+            { type: 'text-end', id: 'text-1' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 },
+            },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
+    });
+
+    const mockMemory = new MockMemory();
+    const saveMessagesSpy = vi.spyOn(mockMemory, 'saveMessages');
+
+    const echoTool = createTool({
+      id: 'echo-tool',
+      description: 'Echoes the input',
+      inputSchema: z.object({ input: z.string() }),
+      execute: async input => ({ output: input.input }),
+    });
+
+    const agent = new Agent({
+      id: 'save-per-step-abort-agent',
+      name: 'Save Per Step Abort Test',
+      instructions: 'test',
+      model: toolCallModel,
+      memory: mockMemory,
+      tools: { 'echo-tool': echoTool },
+    });
+
+    const abortController = new AbortController();
+    let stepFinishCount = 0;
+
+    const result = await agent.stream('test message', {
+      memory: {
+        thread: 'thread-save-per-step-abort',
+        resource: 'resource-save-per-step-abort',
+      },
+      savePerStep: true,
+      abortSignal: abortController.signal,
+      onStepFinish: async () => {
+        stepFinishCount++;
+        if (stepFinishCount === 1) {
+          // Abort after the first step completes (simulating page refresh).
+          // At this point savePerStep should have already persisted the user message
+          // and the first step's response to storage.
+          abortController.abort();
+        }
+      },
+    });
+
+    // Consume the stream (may throw due to abort)
+    try {
+      for await (const _chunk of result.fullStream) {
+        // consume
+      }
+    } catch {
+      // Expected: stream may error on abort
+    }
+
+    // Wait a tick for any async persistence to complete
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    // The first step completed and onStepFinish fired with savePerStep: true.
+    // The abort signal then fired, causing executeOnFinish to be skipped.
+    //
+    // BUG: saveMessages should have been called at least once during step execution
+    // to persist the user message and/or the first step's response messages.
+    // Currently, onStepFinish only calls messageList.add() via saveStepMessages()
+    // but never calls saveQueueManager.flushMessages(), so nothing is persisted.
+    // executeOnFinish (the only persistence path) is gated by !abortSignal.aborted.
+    expect(stepFinishCount).toBeGreaterThanOrEqual(1);
+    expect(saveMessagesSpy).toHaveBeenCalled();
+
+    // Verify the persisted messages include the user's original message
+    const recalled = await mockMemory.recall({
+      threadId: 'thread-save-per-step-abort',
+      resourceId: 'resource-save-per-step-abort',
+    });
+    expect(recalled.messages.length).toBeGreaterThan(0);
+    expect(recalled.messages.some(m => m.role === 'user')).toBe(true);
+  });
+});

--- a/packages/core/src/agent/workflows/prepare-stream/index.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/index.ts
@@ -120,6 +120,7 @@ export function createPrepareStreamWorkflow<OUTPUT = undefined>({
     agentSpan,
     agentId,
     methodType,
+    saveQueueManager,
   });
 
   return createWorkflow({

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -10,6 +10,7 @@ import { StructuredOutputProcessor } from '../../../processors';
 import type { RequestContext } from '../../../request-context';
 import type { Step } from '../../../workflows';
 import type { InnerAgentExecutionOptions } from '../../agent.types';
+import type { SaveQueueManager } from '../../save-queue';
 import { getModelOutputForTripwire } from '../../trip-wire';
 import type { AgentMethodType } from '../../types';
 import { isSupportedLanguageModel } from '../../utils';
@@ -26,6 +27,7 @@ interface MapResultsStepOptions<OUTPUT = undefined> {
   agentSpan: Span<SpanType.AGENT_RUN>;
   agentId: string;
   methodType: AgentMethodType;
+  saveQueueManager?: SaveQueueManager;
   /**
    * Shared processor state map that persists across agent turns.
    */
@@ -43,6 +45,7 @@ export function createMapResultsStep<OUTPUT = undefined>({
   agentSpan,
   agentId,
   methodType,
+  saveQueueManager,
 }: MapResultsStepOptions<OUTPUT>): Step<
   string,
   unknown,
@@ -89,6 +92,15 @@ export function createMapResultsStep<OUTPUT = undefined>({
             messageList: memoryData.messageList!,
             runId,
           });
+
+          // Flush accumulated messages to persistent storage so they survive
+          // an abort/disconnect.  Without this, saveStepMessages only adds to
+          // the in-memory MessageList and the only persistence path is
+          // executeOnFinish which is gated by !abortSignal.aborted.
+          // See: https://github.com/mastra-ai/mastra/issues/13984
+          if (saveQueueManager && memoryData.thread?.id) {
+            await saveQueueManager.flushMessages(memoryData.messageList!, memoryData.thread.id, memoryConfig);
+          }
         }
 
         return options.onStepFinish?.({ ...props, runId });

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -93,11 +93,6 @@ export function createMapResultsStep<OUTPUT = undefined>({
             runId,
           });
 
-          // Flush accumulated messages to persistent storage so they survive
-          // an abort/disconnect.  Without this, saveStepMessages only adds to
-          // the in-memory MessageList and the only persistence path is
-          // executeOnFinish which is gated by !abortSignal.aborted.
-          // See: https://github.com/mastra-ai/mastra/issues/13984
           if (saveQueueManager && memoryData.thread?.id) {
             await saveQueueManager.flushMessages(memoryData.messageList!, memoryData.thread.id, memoryConfig);
           }


### PR DESCRIPTION
## Description

Fixed issue #13984 where `savePerStep: true` wasn't actually persisting messages to storage during step execution. The problem was that `onStepFinish` callback in the map-results-step only added messages to the in-memory MessageList via `saveStepMessages()` but never flushed them to persistent storage via `saveQueueManager.flushMessages()`. This meant that when streams were aborted or pages were refreshed, the user's original message and any in-progress responses would be lost since `executeOnFinish` (the main persistence path) is gated by `!abortSignal.aborted`.

The fix makes the SaveQueueManager available to the map-results-step and calls `flushMessages()` after `saveStepMessages()` to immediately persist accumulated messages, ensuring they survive page refreshes and stream aborts.

## Related Issue(s)

Fixes #13984

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * savePerStep now reliably persists messages to storage after each step, ensuring data survives page refreshes and aborted streams.

* **Tests**
  * Added a regression test validating per-step persistence when streams are aborted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->