### PR TITLE
fix: fix schema-compat build errors from Standard Schema PR

### DIFF
--- a/.changeset/fix-schema-compat-build.md
+++ b/.changeset/fix-schema-compat-build.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed build errors introduced by the Standard Schema PR: resolved TS2322 generic type mismatch in `toStandardSchema` and added missing `@internal/ai-sdk-v5` to the type generation bundled set.

--- a/packages/schema-compat/src/standard-schema/standard-schema.ts
+++ b/packages/schema-compat/src/standard-schema/standard-schema.ts
@@ -115,7 +115,7 @@ export function toStandardSchema<T = unknown>(schema: PublicSchema<T>): Standard
   // First check: if already StandardSchemaWithJSON, return as-is
   // This handles ArkType, Zod v4 (when it has jsonSchema), and pre-wrapped schemas
   if (isStandardSchemaWithJSON(schema)) {
-    return schema;
+    return schema as StandardSchemaWithJSON<T>;
   }
 
   // Check for Zod v3 schemas (need wrapping to add JSON Schema support)

--- a/packages/schema-compat/tsup.config.ts
+++ b/packages/schema-compat/tsup.config.ts
@@ -20,6 +20,9 @@ export default defineConfig({
   },
   sourcemap: true,
   onSuccess: async () => {
-    await generateTypes(process.cwd(), new Set(['@internal/ai-sdk-v4', '@internal/ai-v6', '@types/json-schema']));
+    await generateTypes(
+      process.cwd(),
+      new Set(['@internal/ai-sdk-v4', '@internal/ai-sdk-v5', '@internal/ai-v6', '@types/json-schema']),
+    );
   },
 });


### PR DESCRIPTION
## Problem

The Standard Schema PR (#12238) left `schema-compat` with a broken build on `main`:

1. **`TS2322`** — `isStandardSchemaWithJSON` type guard returns `StandardSchemaWithJSON` without the generic `<T>`, so the return from `toStandardSchema<T>` loses the type parameter
2. **`TS2307`** — `@internal/ai-sdk-v5` is imported in `schema.types.ts` but wasn't in the `generateTypes` bundled set, causing `Cannot find module` during `.d.ts` generation

## Fix

- Cast `isStandardSchemaWithJSON` return to `StandardSchemaWithJSON<T>`
- Add `@internal/ai-sdk-v5` to `generateTypes` bundled set in `tsup.config.ts`

## Verification

- `schema-compat` build passes clean (was broken on `main`)
- All 138 schema-compat tests pass (130 + 8 skipped)
- All 20 `workspace-safety.test.ts` tests pass (were failing on `main` due to stale build)
