### PR TITLE
fix(server): allow thread ownership transfer in trusted server contexts

### DIFF
--- a/.changeset/green-sheep-peel.md
+++ b/.changeset/green-sheep-peel.md
@@ -2,4 +2,24 @@
 '@mastra/server': patch
 ---
 
-Added support for thread ownership transfer (resourceId reassignment) in trusted server contexts. When `MASTRA_RESOURCE_ID_KEY` is not set by middleware, thread updates can now change the `resourceId` to transfer ownership between resources. When middleware sets the resource ID, ownership remains locked for multi-tenant security. See [#13327](https://github.com/mastra-ai/mastra/issues/13327).
+Server-side thread ownership transfer via `resourceId` reassignment.
+
+When no middleware sets `MASTRA_RESOURCE_ID_KEY`, the thread update endpoint now accepts a `resourceId` field to transfer ownership between resources. When middleware is present, `resourceId` remains locked for multi-tenant security.
+
+```typescript
+// Transfer thread ownership from one user to another (server-side only)
+const response = await fetch('/api/memory/threads/thread-123', {
+  method: 'PATCH',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ resourceId: 'new-owner-id' }),
+});
+```
+
+Or using the client SDK from trusted server code:
+
+```typescript
+const thread = client.getMemoryThread('my-agent', 'thread-123');
+await thread.update({ resourceId: 'new-owner-id' });
+```
+
+See [#13327](https://github.com/mastra-ai/mastra/issues/13327).

--- a/.changeset/green-sheep-peel.md
+++ b/.changeset/green-sheep-peel.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Added support for thread ownership transfer (resourceId reassignment) in trusted server contexts. When `MASTRA_RESOURCE_ID_KEY` is not set by middleware, thread updates can now change the `resourceId` to transfer ownership between resources. When middleware sets the resource ID, ownership remains locked for multi-tenant security. See [#13327](https://github.com/mastra-ai/mastra/issues/13327).

--- a/docs/src/content/en/docs/server/middleware.mdx
+++ b/docs/src/content/en/docs/server/middleware.mdx
@@ -153,9 +153,12 @@ With this middleware, the server automatically:
 - **Filters thread listing** to only return threads owned by the user
 - **Validates thread access** and returns 403 if accessing another user's thread
 - **Forces thread creation** to use the authenticated user's ID
+- **Prevents thread ownership transfer** by locking the `resourceId` to the middleware-set value
 - **Validates message operations** including deletion, ensuring messages belong to owned threads
 
 Even if a client passes `?resourceId=other-user-id`, the middleware-set value takes precedence. Attempts to access threads or messages owned by other users will return a 403 error.
+
+When `MASTRA_RESOURCE_ID_KEY` is **not** set (trusted server context), thread ownership can be transferred by passing a new `resourceId` when updating a thread. This is useful for server-side operations like moving a thread from one user to another after your own authorization checks.
 
 #### Using `MASTRA_THREAD_ID_KEY`
 

--- a/docs/src/content/en/reference/client-js/memory.mdx
+++ b/docs/src/content/en/reference/client-js/memory.mdx
@@ -67,6 +67,8 @@ const updated = await thread.update({
 
 Passing `resourceId` transfers thread ownership. This only works in a trusted server context where `MASTRA_RESOURCE_ID_KEY` is not set by middleware. When middleware sets the resource ID, the value is locked and cannot be changed through updates.
 
+**Important:** Passing `resourceId` to transfer ownership should only be done from server-side code you control, not from browser or client-side code. If you expose this to untrusted clients, use middleware that sets `MASTRA_RESOURCE_ID_KEY` to lock `resourceId` and prevent unauthorized transfers.
+
 ### Delete Thread
 
 Delete a thread and its messages:

--- a/docs/src/content/en/reference/client-js/memory.mdx
+++ b/docs/src/content/en/reference/client-js/memory.mdx
@@ -65,6 +65,8 @@ const updated = await thread.update({
 })
 ```
 
+Passing `resourceId` transfers thread ownership. This only works in a trusted server context where `MASTRA_RESOURCE_ID_KEY` is not set by middleware. When middleware sets the resource ID, the value is locked and cannot be changed through updates.
+
 ### Delete Thread
 
 Delete a thread and its messages:

--- a/docs/src/content/en/reference/client-js/memory.mdx
+++ b/docs/src/content/en/reference/client-js/memory.mdx
@@ -67,7 +67,11 @@ const updated = await thread.update({
 
 Passing `resourceId` transfers thread ownership. This only works in a trusted server context where `MASTRA_RESOURCE_ID_KEY` is not set by middleware. When middleware sets the resource ID, the value is locked and cannot be changed through updates.
 
-**Important:** Passing `resourceId` to transfer ownership should only be done from server-side code you control, not from browser or client-side code. If you expose this to untrusted clients, use middleware that sets `MASTRA_RESOURCE_ID_KEY` to lock `resourceId` and prevent unauthorized transfers.
+:::important
+
+Passing `resourceId` to transfer ownership should only be done from server-side code you control, not from browser or client-side code. If you expose this to untrusted clients, use middleware that sets `MASTRA_RESOURCE_ID_KEY` to lock `resourceId` and prevent unauthorized transfers.
+
+:::
 
 ### Delete Thread
 

--- a/docs/src/content/en/reference/server/routes.mdx
+++ b/docs/src/content/en/reference/server/routes.mdx
@@ -138,6 +138,7 @@ Server adapters register these routes when you call `server.init()`. All routes 
 | `GET` | `/api/memory/threads` | List threads |
 | `GET` | `/api/memory/threads/:threadId` | Get thread |
 | `POST` | `/api/memory/threads` | Create thread |
+| `PATCH` | `/api/memory/threads/:threadId` | Update thread |
 | `DELETE` | `/api/memory/threads/:threadId` | Delete thread |
 | `POST` | `/api/memory/threads/:threadId/clone` | Clone thread |
 | `GET` | `/api/memory/threads/:threadId/messages` | Get thread messages |
@@ -152,6 +153,18 @@ Server adapters register these routes when you call `server.init()`. All routes 
   metadata?: Record<string, unknown>;
 }
 ```
+
+### Update thread request body
+
+```typescript prettier:false
+{
+  title?: string;
+  metadata?: Record<string, unknown>;
+  resourceId?: string;             // Transfer ownership (trusted server context only)
+}
+```
+
+When `MASTRA_RESOURCE_ID_KEY` is set by middleware, the `resourceId` field is locked to the middleware value and cannot be changed. In a trusted server context (no middleware), passing a new `resourceId` transfers thread ownership.
 
 ### Clone thread request body
 

--- a/docs/src/course/03-agent-memory/07-understanding-memory-threads.md
+++ b/docs/src/course/03-agent-memory/07-understanding-memory-threads.md
@@ -15,7 +15,7 @@ Without these identifiers, your agent would have no way to know which conversati
 
 ## Thread ID and Resource ID Relationship
 
-**Important:** Each thread has an owner (its `resourceId`) that is set when the thread is created. Once created, a thread's owner cannot be changed.
+**Important:** Each thread has an owner (its `resourceId`) that is set when the thread is created. In a trusted server context (when `MASTRA_RESOURCE_ID_KEY` is not set by middleware), the thread's owner can be reassigned by passing a new `resourceId` to `thread.update()`. When `MASTRA_RESOURCE_ID_KEY` is set by middleware, the thread's owner is locked and cannot be changed.
 
 The relationship works like this:
 

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -16,6 +16,8 @@ import {
   DELETE_MESSAGES_ROUTE,
   DELETE_THREAD_ROUTE,
   UPDATE_THREAD_ROUTE,
+  GET_WORKING_MEMORY_ROUTE,
+  UPDATE_WORKING_MEMORY_ROUTE,
   getTextContent,
 } from './memory';
 import { createTestServerContext } from './test-utils';
@@ -1829,6 +1831,479 @@ describe('Memory Handlers', () => {
             threadId: 'transfer-thread',
           }),
         ).rejects.toThrow(new HTTPException(403, { message: 'Access denied: thread belongs to a different resource' }));
+      });
+    });
+
+    describe('Memory scoping after resourceId transfer', () => {
+      describe('Working memory (resource scope) after transfer', () => {
+        it('should not leak old owner working memory to new owner after transfer', async () => {
+          const wmStorage = new InMemoryStore();
+          const wmMemory = new MockMemory({ storage: wmStorage, enableWorkingMemory: true });
+          const wmAgent = new Agent({
+            id: 'test-agent',
+            name: 'test-agent',
+            instructions: 'test-instructions',
+            model: {} as any,
+            memory: wmMemory,
+          });
+          const mastra = new Mastra({
+            logger: false,
+            agents: { 'test-agent': wmAgent },
+          });
+
+          // user-a creates a thread and stores working memory
+          await wmMemory.createThread({ threadId: 'wm-transfer-thread', resourceId: 'user-a' });
+
+          await UPDATE_WORKING_MEMORY_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'wm-transfer-thread',
+            resourceId: 'user-a',
+            workingMemory: '# User Profile\n- Name: Alice\n- Preferences: dark mode',
+            memoryConfig: { workingMemory: { enabled: true, scope: 'resource' } },
+          });
+
+          // Verify user-a can read their working memory
+          const beforeTransfer = await GET_WORKING_MEMORY_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'wm-transfer-thread',
+            resourceId: 'user-a',
+            memoryConfig: { workingMemory: { enabled: true, scope: 'resource' } },
+          });
+          expect(beforeTransfer.workingMemory).toContain('Alice');
+          expect(beforeTransfer.source).toBe('resource');
+
+          // Transfer thread to user-b
+          await UPDATE_THREAD_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'wm-transfer-thread',
+            resourceId: 'user-b',
+          });
+
+          // New owner (user-b) should NOT see user-a's working memory
+          const afterTransfer = await GET_WORKING_MEMORY_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'wm-transfer-thread',
+            resourceId: 'user-b',
+            memoryConfig: { workingMemory: { enabled: true, scope: 'resource' } },
+          });
+          expect(afterTransfer.workingMemory).toBeNull();
+          expect(afterTransfer.source).toBe('resource');
+        });
+
+        it('should preserve old owner working memory (not deleted) after transfer', async () => {
+          const wmStorage = new InMemoryStore();
+          const wmMemory = new MockMemory({ storage: wmStorage, enableWorkingMemory: true });
+          const wmAgent = new Agent({
+            id: 'test-agent',
+            name: 'test-agent',
+            instructions: 'test-instructions',
+            model: {} as any,
+            memory: wmMemory,
+          });
+          const mastra = new Mastra({
+            logger: false,
+            agents: { 'test-agent': wmAgent },
+          });
+
+          await wmMemory.createThread({ threadId: 'wm-thread-1', resourceId: 'user-a' });
+
+          await UPDATE_WORKING_MEMORY_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'wm-thread-1',
+            resourceId: 'user-a',
+            workingMemory: '# User Profile\n- Name: Alice',
+            memoryConfig: { workingMemory: { enabled: true, scope: 'resource' } },
+          });
+
+          // Transfer the thread
+          await UPDATE_THREAD_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'wm-thread-1',
+            resourceId: 'user-b',
+          });
+
+          // user-a still has another thread - their working memory is still intact
+          await wmMemory.createThread({ threadId: 'wm-thread-2', resourceId: 'user-a' });
+          const userAMemory = await GET_WORKING_MEMORY_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'wm-thread-2',
+            resourceId: 'user-a',
+            memoryConfig: { workingMemory: { enabled: true, scope: 'resource' } },
+          });
+          expect(userAMemory.workingMemory).toContain('Alice');
+        });
+      });
+
+      describe('Working memory (thread scope) after transfer', () => {
+        it('should preserve thread-scoped working memory after resourceId transfer', async () => {
+          const wmStorage = new InMemoryStore();
+          const wmMemory = new MockMemory({ storage: wmStorage, enableWorkingMemory: true });
+          const wmAgent = new Agent({
+            id: 'test-agent',
+            name: 'test-agent',
+            instructions: 'test-instructions',
+            model: {} as any,
+            memory: wmMemory,
+          });
+          const mastra = new Mastra({
+            logger: false,
+            agents: { 'test-agent': wmAgent },
+          });
+
+          await wmMemory.createThread({ threadId: 'wm-thread-scope', resourceId: 'user-a' });
+
+          // Store thread-scoped working memory
+          await UPDATE_WORKING_MEMORY_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'wm-thread-scope',
+            resourceId: 'user-a',
+            workingMemory: '# Thread Context\n- Topic: Project Alpha',
+            memoryConfig: { workingMemory: { enabled: true, scope: 'thread' } },
+          });
+
+          // Transfer thread to user-b
+          await UPDATE_THREAD_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'wm-thread-scope',
+            resourceId: 'user-b',
+          });
+
+          // Thread-scoped working memory survives the transfer (keyed by threadId, not resourceId)
+          const afterTransfer = await GET_WORKING_MEMORY_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'wm-thread-scope',
+            resourceId: 'user-b',
+            memoryConfig: { workingMemory: { enabled: true, scope: 'thread' } },
+          });
+          expect(afterTransfer.workingMemory).toContain('Project Alpha');
+          expect(afterTransfer.source).toBe('thread');
+        });
+      });
+
+      describe('Working memory access denial after transfer', () => {
+        it('should deny old owner access to working memory on transferred thread', async () => {
+          const wmStorage = new InMemoryStore();
+          const wmMemory = new MockMemory({ storage: wmStorage, enableWorkingMemory: true });
+          const wmAgent = new Agent({
+            id: 'test-agent',
+            name: 'test-agent',
+            instructions: 'test-instructions',
+            model: {} as any,
+            memory: wmMemory,
+          });
+          const mastra = new Mastra({
+            logger: false,
+            agents: { 'test-agent': wmAgent },
+          });
+
+          await wmMemory.createThread({ threadId: 'wm-denied-thread', resourceId: 'user-a' });
+
+          // Transfer to user-b
+          await UPDATE_THREAD_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'wm-denied-thread',
+            resourceId: 'user-b',
+          });
+
+          // Old owner (user-a) tries to read working memory via middleware-enforced context
+          await expect(
+            GET_WORKING_MEMORY_ROUTE.handler({
+              ...createTestContextWithReservedKeys({ mastra, resourceId: 'user-a' }),
+              agentId: 'test-agent',
+              threadId: 'wm-denied-thread',
+              resourceId: undefined as any,
+              memoryConfig: { workingMemory: { enabled: true, scope: 'resource' } },
+            }),
+          ).rejects.toThrow(
+            new HTTPException(403, { message: 'Access denied: thread belongs to a different resource' }),
+          );
+
+          // Old owner (user-a) tries to update working memory via middleware-enforced context
+          await expect(
+            UPDATE_WORKING_MEMORY_ROUTE.handler({
+              ...createTestContextWithReservedKeys({ mastra, resourceId: 'user-a' }),
+              agentId: 'test-agent',
+              threadId: 'wm-denied-thread',
+              resourceId: undefined as any,
+              workingMemory: '# Hacked\n- Should not succeed',
+              memoryConfig: { workingMemory: { enabled: true, scope: 'resource' } },
+            }),
+          ).rejects.toThrow(
+            new HTTPException(403, { message: 'Access denied: thread belongs to a different resource' }),
+          );
+        });
+      });
+
+      describe('Observational memory scoping after transfer (storage level)', () => {
+        it('should not leak resource-scoped observational memory to new owner after transfer', async () => {
+          // Directly test InMemoryStore OM scoping to verify data isolation
+          const omStorage = new InMemoryStore();
+          const memoryStore = await omStorage.getStore('memory');
+
+          // Simulate OM records for user-a (resource scope: threadId=null)
+          await memoryStore!.initializeObservationalMemory({
+            threadId: null,
+            resourceId: 'user-a',
+            scope: 'resource',
+            config: {},
+          });
+
+          // Verify user-a has an OM record
+          const userARecord = await memoryStore!.getObservationalMemory(null, 'user-a');
+          expect(userARecord).not.toBeNull();
+          expect(userARecord!.resourceId).toBe('user-a');
+
+          // user-b has no OM record
+          const userBRecord = await memoryStore!.getObservationalMemory(null, 'user-b');
+          expect(userBRecord).toBeNull();
+
+          // This proves that after transferring a thread from user-a to user-b,
+          // user-b's resource-scoped OM lookup (null, 'user-b') will NOT see user-a's data
+        });
+
+        it('should keep thread-scoped observational memory accessible by threadId after transfer', async () => {
+          const omStorage = new InMemoryStore();
+          const memoryStore = await omStorage.getStore('memory');
+
+          // Simulate thread-scoped OM record
+          await memoryStore!.initializeObservationalMemory({
+            threadId: 'om-thread-1',
+            resourceId: 'user-a',
+            scope: 'thread',
+            config: {},
+          });
+
+          // Thread-scoped OM is keyed by threadId, not resourceId
+          const record = await memoryStore!.getObservationalMemory('om-thread-1', 'user-a');
+          expect(record).not.toBeNull();
+          expect(record!.threadId).toBe('om-thread-1');
+
+          // After transfer, the thread's resourceId changes but the OM key uses threadId
+          // So the same lookup with new resourceId still finds it (key is thread:om-thread-1)
+          const recordAfterTransfer = await memoryStore!.getObservationalMemory('om-thread-1', 'user-b');
+          expect(recordAfterTransfer).not.toBeNull();
+          expect(recordAfterTransfer!.threadId).toBe('om-thread-1');
+        });
+
+        it('should isolate observational memory history between resources', async () => {
+          const omStorage = new InMemoryStore();
+          const memoryStore = await omStorage.getStore('memory');
+
+          // user-a has resource-scoped OM with history
+          await memoryStore!.initializeObservationalMemory({
+            threadId: null,
+            resourceId: 'user-a',
+            scope: 'resource',
+            config: {},
+          });
+
+          // user-b has no OM history
+          const userBHistory = await memoryStore!.getObservationalMemoryHistory(null, 'user-b');
+          expect(userBHistory).toHaveLength(0);
+
+          // user-a's history is independent
+          const userAHistory = await memoryStore!.getObservationalMemoryHistory(null, 'user-a');
+          expect(userAHistory).toHaveLength(1);
+        });
+      });
+
+      describe('Message listing after transfer', () => {
+        it('should allow new owner to access transferred thread (ownership check passes)', async () => {
+          const mastra = new Mastra({
+            logger: false,
+            agents: { 'test-agent': mockAgent },
+          });
+
+          // user-a creates thread with messages
+          await mockMemory.createThread({ threadId: 'msg-transfer-thread', resourceId: 'user-a' });
+          await SAVE_MESSAGES_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            messages: [
+              {
+                id: 'pre-transfer-msg',
+                role: 'user' as const,
+                createdAt: new Date(),
+                threadId: 'msg-transfer-thread',
+                resourceId: 'user-a',
+                content: {
+                  format: 2,
+                  parts: [{ type: 'text', text: 'Message before transfer' }],
+                  content: 'Message before transfer',
+                },
+              },
+            ] as MastraDBMessage[],
+          });
+
+          // Transfer to user-b
+          await UPDATE_THREAD_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'msg-transfer-thread',
+            resourceId: 'user-b',
+          });
+
+          // New owner (user-b) passes thread ownership check but message-level
+          // resourceId filtering means only messages authored by user-b are returned.
+          // Messages authored by the old owner (user-a) are filtered out because
+          // listMessages filters by the caller's resourceId when provided.
+          const result = await LIST_MESSAGES_ROUTE.handler({
+            ...createTestContextWithReservedKeys({ mastra, resourceId: 'user-b' }),
+            agentId: 'test-agent',
+            threadId: 'msg-transfer-thread',
+            page: 0,
+            perPage: 10,
+          });
+          expect(result.messages).toHaveLength(0);
+        });
+
+        it('should return all messages in transferred thread when no resourceId filter is set', async () => {
+          const mastra = new Mastra({
+            logger: false,
+            agents: { 'test-agent': mockAgent },
+          });
+
+          // user-a creates thread with messages
+          await mockMemory.createThread({ threadId: 'msg-transfer-thread-2', resourceId: 'user-a' });
+          await SAVE_MESSAGES_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            messages: [
+              {
+                id: 'pre-transfer-msg-2',
+                role: 'user' as const,
+                createdAt: new Date(),
+                threadId: 'msg-transfer-thread-2',
+                resourceId: 'user-a',
+                content: {
+                  format: 2,
+                  parts: [{ type: 'text', text: 'Message before transfer' }],
+                  content: 'Message before transfer',
+                },
+              },
+            ] as MastraDBMessage[],
+          });
+
+          // Transfer to user-b
+          await UPDATE_THREAD_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'msg-transfer-thread-2',
+            resourceId: 'user-b',
+          });
+
+          // In a trusted server context (no middleware), all messages are returned
+          // regardless of message-level resourceId
+          const result = await LIST_MESSAGES_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'msg-transfer-thread-2',
+            page: 0,
+            perPage: 10,
+          });
+          expect(result.messages).toHaveLength(1);
+          expect(result.messages[0].id).toBe('pre-transfer-msg-2');
+        });
+
+        it('should deny old owner from listing messages on transferred thread', async () => {
+          const mastra = new Mastra({
+            logger: false,
+            agents: { 'test-agent': mockAgent },
+          });
+
+          await mockMemory.createThread({ threadId: 'msg-denied-thread', resourceId: 'user-a' });
+          await SAVE_MESSAGES_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            messages: [
+              {
+                id: 'secret-msg',
+                role: 'user' as const,
+                createdAt: new Date(),
+                threadId: 'msg-denied-thread',
+                resourceId: 'user-a',
+                content: {
+                  format: 2,
+                  parts: [{ type: 'text', text: 'Secret message' }],
+                  content: 'Secret message',
+                },
+              },
+            ] as MastraDBMessage[],
+          });
+
+          // Transfer to user-b
+          await UPDATE_THREAD_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'msg-denied-thread',
+            resourceId: 'user-b',
+          });
+
+          // Old owner (user-a) is denied access
+          await expect(
+            LIST_MESSAGES_ROUTE.handler({
+              ...createTestContextWithReservedKeys({ mastra, resourceId: 'user-a' }),
+              agentId: 'test-agent',
+              threadId: 'msg-denied-thread',
+              page: 0,
+              perPage: 10,
+            }),
+          ).rejects.toThrow(
+            new HTTPException(403, { message: 'Access denied: thread belongs to a different resource' }),
+          );
+        });
+
+        it('should deny old owner from saving new messages to transferred thread', async () => {
+          const mastra = new Mastra({
+            logger: false,
+            agents: { 'test-agent': mockAgent },
+          });
+
+          await mockMemory.createThread({ threadId: 'msg-save-denied-thread', resourceId: 'user-a' });
+
+          // Transfer to user-b
+          await UPDATE_THREAD_ROUTE.handler({
+            ...createTestServerContext({ mastra }),
+            agentId: 'test-agent',
+            threadId: 'msg-save-denied-thread',
+            resourceId: 'user-b',
+          });
+
+          // Old owner tries to save a message
+          await expect(
+            SAVE_MESSAGES_ROUTE.handler({
+              ...createTestContextWithReservedKeys({ mastra, resourceId: 'user-a' }),
+              agentId: 'test-agent',
+              messages: [
+                {
+                  id: 'unauthorized-msg',
+                  role: 'user' as const,
+                  createdAt: new Date(),
+                  threadId: 'msg-save-denied-thread',
+                  resourceId: 'user-a',
+                  content: {
+                    format: 2,
+                    parts: [{ type: 'text', text: 'Unauthorized message' }],
+                    content: 'Unauthorized message',
+                  },
+                },
+              ] as MastraDBMessage[],
+            }),
+          ).rejects.toThrow(
+            new HTTPException(403, { message: 'Access denied: thread belongs to a different resource' }),
+          );
+        });
       });
     });
 

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -1773,6 +1773,45 @@ describe('Memory Handlers', () => {
           }),
         ).rejects.toThrow(new HTTPException(403, { message: 'Access denied: thread belongs to a different resource' }));
       });
+
+      it('should prevent resourceId reassignment when middleware sets MASTRA_RESOURCE_ID_KEY', async () => {
+        const mastra = new Mastra({
+          logger: false,
+          agents: { 'test-agent': mockAgent },
+        });
+
+        await mockMemory.createThread({ threadId: 'user-a-thread', resourceId: 'user-a' });
+
+        const result = await UPDATE_THREAD_ROUTE.handler({
+          ...createTestContextWithReservedKeys({ mastra, resourceId: 'user-a' }),
+          agentId: 'test-agent',
+          threadId: 'user-a-thread',
+          resourceId: 'user-b', // Client tries to reassign to user-b
+          title: 'Updated Title',
+        });
+
+        // resourceId should remain user-a (middleware value takes precedence)
+        expect(result.resourceId).toBe('user-a');
+        expect(result.title).toBe('Updated Title');
+      });
+
+      it('should allow resourceId reassignment in trusted server context (no middleware)', async () => {
+        const mastra = new Mastra({
+          logger: false,
+          agents: { 'test-agent': mockAgent },
+        });
+
+        await mockMemory.createThread({ threadId: 'transfer-thread', resourceId: 'user-a' });
+
+        const result = await UPDATE_THREAD_ROUTE.handler({
+          ...createTestServerContext({ mastra }),
+          agentId: 'test-agent',
+          threadId: 'transfer-thread',
+          resourceId: 'user-b', // Transfer ownership to user-b
+        });
+
+        expect(result.resourceId).toBe('user-b');
+      });
     });
 
     describe('SAVE_MESSAGES_ROUTE - resourceId validation', () => {

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -1811,6 +1811,24 @@ describe('Memory Handlers', () => {
         });
 
         expect(result.resourceId).toBe('user-b');
+
+        // Verify new owner (user-b) can read the transferred thread
+        const readResult = await GET_THREAD_BY_ID_ROUTE.handler({
+          ...createTestContextWithReservedKeys({ mastra, resourceId: 'user-b' }),
+          agentId: 'test-agent',
+          threadId: 'transfer-thread',
+        });
+        expect(readResult.id).toBe('transfer-thread');
+        expect(readResult.resourceId).toBe('user-b');
+
+        // Verify old owner (user-a) is rejected from reading the transferred thread
+        await expect(
+          GET_THREAD_BY_ID_ROUTE.handler({
+            ...createTestContextWithReservedKeys({ mastra, resourceId: 'user-a' }),
+            agentId: 'test-agent',
+            threadId: 'transfer-thread',
+          }),
+        ).rejects.toThrow(new HTTPException(403, { message: 'Access denied: thread belongs to a different resource' }));
       });
     });
 

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -1,6 +1,7 @@
 import type { Agent, MastraDBMessage } from '@mastra/core/agent';
 import type { RequestContext } from '@mastra/core/di';
 import type { MastraMemory } from '@mastra/core/memory';
+import { MASTRA_RESOURCE_ID_KEY } from '@mastra/core/request-context';
 import type { MastraStorage, MemoryStorage } from '@mastra/core/storage';
 import { generateEmptyFromSchema } from '@mastra/core/utils';
 import { HTTPException } from '../http-exception';
@@ -926,7 +927,7 @@ export const UPDATE_THREAD_ROUTE = createRoute({
   handler: async ({ mastra, agentId, threadId, title, metadata, resourceId, requestContext }) => {
     try {
       const effectiveThreadId = getEffectiveThreadId(requestContext, threadId);
-      const effectiveResourceId = getEffectiveResourceId(requestContext, resourceId);
+      const contextResourceId = requestContext?.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
       const memory = await getMemoryFromContext({ mastra, agentId, requestContext });
 
       const updatedAt = new Date();
@@ -941,14 +942,19 @@ export const UPDATE_THREAD_ROUTE = createRoute({
       if (!thread) {
         throw new HTTPException(404, { message: 'Thread not found' });
       }
-      await validateThreadOwnership(thread, effectiveResourceId);
+
+      // When middleware sets MASTRA_RESOURCE_ID_KEY, validate ownership and prevent reassignment.
+      // When no middleware is present (trusted server context), allow resourceId reassignment
+      // by only validating against the middleware-set value, not the client-provided one.
+      await validateThreadOwnership(thread, contextResourceId);
 
       const updatedThread = {
         ...thread,
         title: title || thread.title,
         metadata: metadata || thread.metadata,
-        // Don't allow changing resourceId if effectiveResourceId is set (prevents reassigning threads)
-        resourceId: effectiveResourceId || resourceId || thread.resourceId,
+        // If middleware set the resourceId, lock it (prevents reassignment from untrusted clients).
+        // Otherwise, allow the client-provided resourceId for ownership transfer in trusted contexts.
+        resourceId: contextResourceId || resourceId || thread.resourceId,
         createdAt: thread.createdAt,
         updatedAt,
       };


### PR DESCRIPTION
Thread ownership (`resourceId`) was previously immutable once set. This is correct when middleware enforces multi-tenant isolation, but too restrictive for trusted server-side code that needs to transfer threads between users.

**Before:** `resourceId` locked by `effectiveResourceId` (middleware OR client value) — no transfer possible
**After:** Only the middleware-set `contextResourceId` locks ownership. Without middleware, client-provided `resourceId` is accepted for transfer.

```ts
// Trusted server context (no middleware) — transfer works
await thread.update({ resourceId: 'new-owner' });

// With middleware — resourceId locked to authenticated user
await thread.update({ resourceId: 'other-user' }); // ignored, stays as middleware value
```

2 new tests, doc updates for middleware, routes, client-js, and course material.

Closes #13327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled thread ownership transfer by supplying a new resourceId from trusted server contexts; added routes to update threads and add messages.

* **Documentation**
  * Clarified when ownership can be transferred vs locked by middleware; advises performing transfers only from trusted server-side code.

* **Tests**
  * Added comprehensive tests covering ownership lock, transfers, memory scoping, and message access after transfer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->