### PR TITLE
fix(core): handle Anthropic Programmatic Tool Calling streams

### DIFF
--- a/.changeset/good-peas-listen.md
+++ b/.changeset/good-peas-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed stream freezing when using Anthropic's Programmatic Tool Calling (PTC). Streams that contain only tool-input streaming chunks (without explicit tool-call chunks) now correctly synthesize tool-call events and complete without hanging. See [#12390](https://github.com/mastra-ai/mastra/issues/12390).

--- a/packages/core/src/loop/test-utils/options.ts
+++ b/packages/core/src/loop/test-utils/options.ts
@@ -4916,6 +4916,15 @@ export function optionsTests({ loopFn, runId }: { loopFn: typeof loop; runId: st
           {
             "from": "AGENT",
             "payload": {
+              "providerMetadata": undefined,
+              "toolCallId": "2",
+            },
+            "runId": "test-run-id",
+            "type": "tool-call-input-streaming-end",
+          },
+          {
+            "from": "AGENT",
+            "payload": {
               "args": {
                 "value": "test",
               },

--- a/packages/core/src/loop/test-utils/tools.ts
+++ b/packages/core/src/loop/test-utils/tools.ts
@@ -952,6 +952,80 @@ export function toolsTests({ loopFn, runId }: { loopFn: typeof loop; runId: stri
       const textChunks = chunks.filter((c: any) => c.type === 'text-delta');
       expect(textChunks.length).toBeGreaterThan(0);
     });
+
+    it('should complete stream when PTC sends only tool-input streaming (no explicit tool-call chunk)', async () => {
+      // Regression: PTC from code execution sends tool-input-start/delta/end only;
+      // without synthesizing a tool-call the stream would freeze.
+      const result = loopFn({
+        methodType: 'stream',
+        runId,
+        messageList: createMessageListWithUserMessage(),
+        models: createTestModels({
+          stream: convertArrayToReadableStream([
+            {
+              type: 'response-metadata',
+              id: 'id-0',
+              modelId: 'claude-code-model',
+              timestamp: new Date(0),
+            },
+            {
+              type: 'tool-input-start',
+              id: 'call-1',
+              toolName: 'str_replace_editor',
+              providerExecuted: true,
+            },
+            {
+              type: 'tool-input-delta',
+              id: 'call-1',
+              delta: '{"command":"view","path":"/src/app.ts"}',
+            },
+            {
+              type: 'tool-input-end',
+              id: 'call-1',
+            },
+            {
+              type: 'tool-result',
+              toolCallId: 'call-1',
+              toolName: 'str_replace_editor',
+              result: {
+                content: '// app.ts content',
+                line_count: 1,
+              },
+              providerExecuted: true,
+            },
+            {
+              type: 'text-delta',
+              id: 'text-1',
+              delta: 'Done.',
+            },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: testUsage,
+            },
+          ]),
+        }),
+        tools: {},
+        ...defaultSettings(),
+      });
+
+      const stream = result.fullStream;
+      const chunks = await convertAsyncIterableToArray(stream);
+
+      const toolResultChunk = chunks.find((c: any) => c.type === 'tool-result');
+      expect(toolResultChunk).toBeDefined();
+      expect((toolResultChunk as any)?.payload?.result).toEqual({
+        content: '// app.ts content',
+        line_count: 1,
+      });
+      expect((toolResultChunk as any)?.payload?.providerExecuted).toBe(true);
+
+      const textChunks = chunks.filter((c: any) => c.type === 'text-delta');
+      expect(textChunks.length).toBeGreaterThan(0);
+
+      const finishChunk = chunks.find((c: any) => c.type === 'finish');
+      expect(finishChunk).toBeDefined();
+    });
   });
 
   describe('toModelOutput', () => {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -253,6 +253,11 @@ async function processOutputStream<OUTPUT = undefined>({
         break;
       }
 
+      case 'tool-call-input-streaming-end': {
+        safeEnqueue(controller, chunk);
+        break;
+      }
+
       case 'reasoning-start': {
         runState.setState({
           isReasoning: true,
@@ -432,6 +437,7 @@ async function processOutputStream<OUTPUT = undefined>({
         'tool-call',
         'tool-call-input-streaming-start',
         'tool-call-delta',
+        'tool-call-input-streaming-end',
         'raw',
       ].includes(chunk.type)
     ) {
@@ -1049,11 +1055,18 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
       }
 
       /**
-       * Add tool calls to the message list
+       * Add tool calls to the message list.
+       * For PTC (programmatic tool calling from code execution), merge matching tool-result
+       * so providerExecuted tool calls include output for the tool-call-step.
        */
-
-      const toolCalls = outputStream._getImmediateToolCalls()?.map(chunk => {
-        return chunk.payload;
+      const toolResultChunks = outputStream._getImmediateToolResults() ?? [];
+      const toolCalls = (outputStream._getImmediateToolCalls() ?? []).map(chunk => {
+        const payload = { ...chunk.payload };
+        if (payload.providerExecuted) {
+          const match = toolResultChunks.find(t => t.payload.toolCallId === payload.toolCallId);
+          if (match) payload.output = match.payload.result;
+        }
+        return payload;
       });
 
       if (toolCalls.length > 0) {

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -20,8 +20,10 @@ import type {
   LLMStepResult,
   MastraModelOutputOptions,
   MastraOnFinishCallbackArgs,
+  ProviderMetadata,
   StreamTransport,
   StepTripwireData,
+  ToolCallChunk,
 } from '../types';
 import { safeClose, safeEnqueue } from './input';
 import { createJsonTextStreamTransformer, createObjectStreamTransformer } from './output-format-handlers';
@@ -180,6 +182,10 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
   #bufferedFiles: LLMStepResult<OUTPUT>['files'] = [];
   #toolCallArgsDeltas: Record<string, LLMStepResult<OUTPUT>['text'][]> = {};
   #toolCallDeltaIdNameMap: Record<string, string> = {};
+  #toolCallStreamingMeta: Record<
+    string,
+    { toolName: string; providerExecuted?: boolean; providerMetadata?: ProviderMetadata }
+  > = {};
   #toolCalls: LLMStepResult<OUTPUT>['toolCalls'] = [];
   #toolResults: LLMStepResult<OUTPUT>['toolResults'] = [];
   #warnings: LLMStepResult<OUTPUT>['warnings'] = [];
@@ -436,7 +442,51 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               break;
             case 'tool-call-input-streaming-start':
               self.#toolCallDeltaIdNameMap[chunk.payload.toolCallId] = chunk.payload.toolName;
+              self.#toolCallStreamingMeta[chunk.payload.toolCallId] = {
+                toolName: chunk.payload.toolName,
+                providerExecuted: chunk.payload.providerExecuted,
+                providerMetadata: chunk.payload.providerMetadata,
+              };
               break;
+            case 'tool-call-input-streaming-end': {
+              const toolCallId = chunk.payload.toolCallId;
+              const meta = self.#toolCallStreamingMeta[toolCallId];
+              const deltaParts = self.#toolCallArgsDeltas[toolCallId];
+              let args: Record<string, unknown> = {};
+              if (deltaParts?.length) {
+                try {
+                  const merged = deltaParts.join('');
+                  args = typeof merged === 'string' && merged.length > 0 ? JSON.parse(merged) : {};
+                } catch {
+                  args = {};
+                }
+              }
+              delete self.#toolCallStreamingMeta[toolCallId];
+              delete self.#toolCallArgsDeltas[toolCallId];
+              delete self.#toolCallDeltaIdNameMap[toolCallId];
+              if (meta?.providerExecuted) {
+                const synthetic: ToolCallChunk = {
+                  type: 'tool-call',
+                  runId: chunk.runId,
+                  from: chunk.from,
+                  payload: {
+                    toolCallId,
+                    toolName: meta.toolName,
+                    args,
+                    providerExecuted: meta.providerExecuted,
+                    providerMetadata: meta.providerMetadata,
+                  },
+                };
+                self.#toolCalls.push(synthetic);
+                self.#bufferedByStep.toolCalls.push(synthetic);
+                self.#emitChunk(chunk);
+                controller.enqueue(chunk);
+                self.#emitChunk(synthetic);
+                controller.enqueue(synthetic);
+                return;
+              }
+              break;
+            }
             case 'tool-call-delta':
               if (!self.#toolCallArgsDeltas[chunk.payload.toolCallId]) {
                 self.#toolCallArgsDeltas[chunk.payload.toolCallId] = [];
@@ -1519,6 +1569,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
       bufferedFiles: this.#bufferedFiles,
       toolCallArgsDeltas: this.#toolCallArgsDeltas,
       toolCallDeltaIdNameMap: this.#toolCallDeltaIdNameMap,
+      toolCallStreamingMeta: this.#toolCallStreamingMeta,
       toolCalls: this.#toolCalls,
       toolResults: this.#toolResults,
       warnings: this.#warnings,
@@ -1542,6 +1593,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
     this.#bufferedFiles = state.bufferedFiles;
     this.#toolCallArgsDeltas = state.toolCallArgsDeltas;
     this.#toolCallDeltaIdNameMap = state.toolCallDeltaIdNameMap;
+    this.#toolCallStreamingMeta = state.toolCallStreamingMeta ?? {};
     this.#toolCalls = state.toolCalls;
     this.#toolResults = state.toolResults;
     this.#warnings = state.warnings;


### PR DESCRIPTION
Mastra streams froze when Anthropic's Programmatic Tool Calling (PTC) sent only `tool-input-streaming-*` chunks without explicit `tool-call` chunks. The stream pipeline didn't know how to synthesize a `tool-call` event from streaming metadata alone, so it hung waiting for one that never came.

Now `output.ts` tracks metadata from `tool-call-input-streaming-start` and synthesizes a proper `tool-call` chunk when `tool-call-input-streaming-end` arrives — but only when `providerExecuted` is true, so non-PTC streams (which already get an explicit `tool-call` from the AI SDK) aren't affected.

```ts
// Before: stream hangs forever on PTC tool calls
const result = await agent.generate('check the weather');
// After: stream completes, tool results are returned
const result = await agent.generate('check the weather');
```

4 files changed. Regression test simulates a pure PTC stream. All 229 loop + 109 stream tests pass.

Closes #12390

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stream freezing when using Anthropic's Programmatic Tool Calling, ensuring streams complete correctly when containing tool-input events without explicit tool-call chunks.

* **Tests**
  * Added test coverage for provider-executed tool streaming scenarios to prevent regression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->