### PR TITLE
fix: remove duplicate retry loop from model fallback logic

### DIFF
--- a/.changeset/thirty-eggs-tan.md
+++ b/.changeset/thirty-eggs-tan.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed model fallback retry behavior. Non-retryable errors (401, 403) are no longer retried on the same model before falling back. Retryable errors (429, 500) are now only retried by a single layer (p-retry) instead of being duplicated across two layers, preventing (maxRetries + 1)² total calls. The per-model maxRetries setting now correctly controls how many times p-retry retries on that specific model before the fallback loop moves to the next model.

--- a/packages/core/src/agent/__tests__/credential-error-fallback.test.ts
+++ b/packages/core/src/agent/__tests__/credential-error-fallback.test.ts
@@ -241,14 +241,10 @@ describe('Credential/Auth Error Fallback', () => {
   });
 
   describe('retry behavior for non-retryable errors', () => {
-    it('should not retry non-retryable 401 on the same model (maxRetries should be ignored)', async () => {
-      // BUG: executeStreamWithFallbackModels retries all errors regardless of isRetryable.
-      // The p-retry layer in execute.ts correctly checks isRetryable, but the outer
-      // retry loop in llm-execution-step.ts does not, causing redundant retries
-      // for non-retryable errors like 401/403.
-      //
-      // Expected: primaryCallCount === 1 (no retry for non-retryable error)
-      // Actual:   primaryCallCount === 4 (maxRetries + 1 attempts)
+    it('should not retry non-retryable 401 on the same model', async () => {
+      // Non-retryable errors (401/403) should not be retried - p-retry correctly
+      // checks isRetryable and skips retries. The outer fallback loop only handles
+      // model switching, not retries.
       const primary = createCountingErrorModel(401, 'Unauthorized', false);
       const secondaryModel = createSuccessModel('Fallback success');
 
@@ -268,14 +264,8 @@ describe('Credential/Auth Error Fallback', () => {
       // Fallback works correctly
       expect(fullText).toBe('Fallback success');
 
-      // BUG: 401 (isRetryable: false) is retried maxRetries times by the outer loop.
-      // The outer executeStreamWithFallbackModels loop does not check isRetryable,
-      // so it retries all errors including non-retryable ones.
-      // Current behavior: 4 calls (1 initial + 3 retries)
-      // Expected behavior: 1 call (no retries for non-retryable errors)
-      expect(primary.getCallCount()).toBe(4); // Documents current (buggy) behavior
-      // TODO: After fix, this should be:
-      // expect(primary.getCallCount()).toBe(1);
+      // 401 (isRetryable: false) is not retried - only 1 call to the primary model
+      expect(primary.getCallCount()).toBe(1);
     });
 
     it('should retry retryable 429 on the same model before falling back', async () => {
@@ -296,15 +286,9 @@ describe('Credential/Auth Error Fallback', () => {
       const fullText = await result.text;
 
       expect(fullText).toBe('Fallback success');
-      // BUG: Retries are duplicated across two layers:
-      // - Layer 1 (p-retry in execute.ts): retries maxRetries times for retryable errors
-      // - Layer 2 (executeStreamWithFallbackModels): also retries maxRetries times
-      // Result: (maxRetries + 1) * (maxRetries + 1) = 3 * 3 = 9 calls instead of 3
-      // Current behavior: 9 calls (double retry)
-      // Expected behavior: 3 calls (1 initial + 2 retries, single layer)
-      expect(primary.getCallCount()).toBe(9); // Documents current (buggy) behavior
-      // TODO: After fix, this should be:
-      // expect(primary.getCallCount()).toBe(3);
+      // Retries are handled by a single layer (p-retry in execute.ts) which respects isRetryable.
+      // With maxRetries: 2, we get 3 calls (1 initial + 2 retries) before falling back.
+      expect(primary.getCallCount()).toBe(3);
     });
   });
 });

--- a/packages/core/src/agent/__tests__/model-list.test.ts
+++ b/packages/core/src/agent/__tests__/model-list.test.ts
@@ -355,7 +355,9 @@ function modelListTests(version: 'v1' | 'v2') {
 
         const fullText = await streamResult.text;
         expect(fullText).toBe('Hello, Premium Title');
-        expect(streamErrorFn).toHaveBeenCalledTimes(4);
+        // Stream-read errors are not retried on the same model - the fallback loop
+        // tries each model once and moves on to the next on error.
+        expect(streamErrorFn).toHaveBeenCalledTimes(1);
         expect(usedModelName).toBe('premium');
       });
 
@@ -477,8 +479,9 @@ function modelListTests(version: 'v1' | 'v2') {
 
         const fullText = await streamResult.text;
         expect(fullText).toBe('Hello, Premium Title');
-        expect(streamErrorFn).toHaveBeenCalledTimes(4);
-        expect(streamErrorFn2).toHaveBeenCalledTimes(3);
+        // Stream-read errors are not retried on the same model - each model is tried once
+        expect(streamErrorFn).toHaveBeenCalledTimes(1);
+        expect(streamErrorFn2).toHaveBeenCalledTimes(1);
         expect(usedModelName).toBe('premium');
       });
 
@@ -601,7 +604,8 @@ function modelListTests(version: 'v1' | 'v2') {
 
         const fullText = await streamResult.text;
         expect(fullText).toBe('Hello, Premium Title');
-        expect(streamErrorFn).toHaveBeenCalledTimes(4);
+        // Stream-read errors are not retried on the same model - each model is tried once
+        expect(streamErrorFn).toHaveBeenCalledTimes(1);
         expect(streamErrorFn2).toHaveBeenCalledTimes(0);
         expect(usedModelName).toBe('premium');
       });
@@ -758,7 +762,8 @@ function modelListTests(version: 'v1' | 'v2') {
 
         const fullText = await streamResult.text;
         expect(fullText).toBe('Hello, Premium Title');
-        expect(streamErrorFn).toHaveBeenCalledTimes(4);
+        // Stream-read errors are not retried on the same model - each model is tried once
+        expect(streamErrorFn).toHaveBeenCalledTimes(1);
         expect(premiumModel2Fn).toHaveBeenCalledTimes(0);
         expect(usedModelName).toBe('premium');
       });

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -460,47 +460,31 @@ function executeStreamWithFallbackModels<T>(
     let lastError: unknown;
     for (const modelConfig of models) {
       index++;
-      const maxRetries = modelConfig.maxRetries || 0;
-      let attempt = 0;
 
       if (done) {
         break;
       }
 
-      while (attempt <= maxRetries) {
-        try {
-          const isLastModel = attempt === maxRetries && index === models.length;
-          const result = await callback(modelConfig, isLastModel);
-          finalResult = result;
-          done = true;
-          break;
-        } catch (err) {
-          // TripWire errors should be re-thrown immediately - they are intentional aborts
-          // from processors (e.g., processInputStep) and should not trigger model retries
-          if (err instanceof TripWire) {
-            throw err;
-          }
-
-          lastError = err;
-          attempt++;
-
-          logger?.error(`Error executing model ${modelConfig.model.modelId}, attempt ${attempt}====`, err);
-
-          // If we've exhausted all retries for this model, break and try the next model
-          if (attempt > maxRetries) {
-            break;
-          }
-
-          // Add exponential backoff before retrying to avoid hammering the API
-          // This helps with rate limiting and gives transient failures time to recover
-          const delayMs = Math.min(1000 * Math.pow(2, attempt - 1), 10000); // 1s, 2s, 4s, 8s, max 10s
-          await new Promise(resolve => setTimeout(resolve, delayMs));
+      try {
+        const isLastModel = index === models.length;
+        const result = await callback(modelConfig, isLastModel);
+        finalResult = result;
+        done = true;
+      } catch (err) {
+        // TripWire errors should be re-thrown immediately - they are intentional aborts
+        // from processors (e.g., processInputStep) and should not trigger model retries
+        if (err instanceof TripWire) {
+          throw err;
         }
+
+        lastError = err;
+
+        logger?.error(`Error executing model ${modelConfig.model.modelId}`, err);
       }
     }
     if (typeof finalResult === 'undefined') {
       const lastErrMsg = lastError instanceof Error ? lastError.message : String(lastError);
-      const errorMessage = `Exhausted all fallback models and reached the maximum number of retries. Last error: ${lastErrMsg}`;
+      const errorMessage = `Exhausted all fallback models. Last error: ${lastErrMsg}`;
       logger?.error(errorMessage);
       throw new Error(errorMessage, { cause: lastError });
     }
@@ -836,7 +820,9 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
                 toolChoice: currentStep.toolChoice,
                 activeTools: currentStep.activeTools as string[] | undefined,
                 options,
-                modelSettings: currentStep.modelSettings,
+                // Per-model maxRetries takes precedence over global modelSettings.maxRetries
+                // This ensures p-retry uses the correct retry count for each model in the fallback chain
+                modelSettings: { ...currentStep.modelSettings, maxRetries: modelConfig.maxRetries },
                 includeRawChunks,
                 structuredOutput: currentStep.structuredOutput,
                 // Merge headers: modelConfig headers first, then modelSettings overrides them


### PR DESCRIPTION
## Summary

Fixes the two bugs documented in #13991.

**Bug 1:** Non-retryable errors (401, 403) were retried `maxRetries` times by the outer `executeStreamWithFallbackModels` loop, even though they should not be retried. This caused `maxRetries + 1` attempts on the same model instead of 1.

**Bug 2:** Retryable errors (429, 500) were retried by both the inner `p-retry` layer and the outer fallback loop, causing `(maxRetries + 1)²` total calls instead of `maxRetries + 1`.

## Changes

- **`llm-execution-step.ts`** — Removed the retry `while` loop from `executeStreamWithFallbackModels`. The outer loop now only handles model fallback (trying the next model on error). Per-model `maxRetries` is merged into `modelSettings` so the inner `p-retry` layer (in `execute.ts`) handles all retries with proper `isRetryable` checking.
- **`credential-error-fallback.test.ts`** — Updated the two tests that documented the bugs to expect the correct behavior.
- **`model-list.test.ts`** — Updated 4 tests that relied on the buggy retry counts.

## Test Plan

All tests pass:
- `credential-error-fallback.test.ts` — 10/10 ✅
- `dynamic-model-fallback.test.ts` — 12/12 ✅
- `model-list.test.ts` — 20/20 (10 skipped v1) ✅
- `save-and-errors.test.ts` — 34/34 (2 skipped) ✅
- `llm-mapping-step.test.ts` — 21/21 ✅
- `tool-call-step.test.ts` — 10/10 ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved error handling: non-retryable errors (401, 403) no longer retry on the same model before attempting fallbacks
* Optimized retry behavior: reduced duplicate retry attempts for retryable errors (429, 500)
* Enhanced per-model retry configuration to work correctly with fallback logic
* Clarified error messages on fallback exhaustion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->