### PR TITLE
feat(core): add metadata filtering for message queries

### DIFF
--- a/.changeset/cold-spiders-rescue.md
+++ b/.changeset/cold-spiders-rescue.md
@@ -1,0 +1,16 @@
+---
+'@mastra/cloudflare-d1': minor
+'@mastra/clickhouse': minor
+'@mastra/cloudflare': minor
+'@mastra/server': minor
+'@mastra/dynamodb': minor
+'@mastra/mongodb': minor
+'@mastra/upstash': minor
+'@mastra/convex': minor
+'@mastra/libsql': minor
+'@mastra/lance': minor
+'@mastra/mssql': minor
+'@mastra/pg': minor
+---
+
+Update peer dependencies to match core package version bump (1.11.0)

--- a/.changeset/olive-mugs-buy.md
+++ b/.changeset/olive-mugs-buy.md
@@ -1,0 +1,17 @@
+---
+'@mastra/core': minor
+'@mastra/cloudflare-d1': patch
+'@mastra/clickhouse': patch
+'@mastra/cloudflare': patch
+'@mastra/server': patch
+'@mastra/dynamodb': patch
+'@mastra/mongodb': patch
+'@mastra/upstash': patch
+'@mastra/convex': patch
+'@mastra/libsql': patch
+'@mastra/lance': patch
+'@mastra/mssql': patch
+'@mastra/pg': patch
+---
+
+Added metadata filtering support for `listMessages` and `listMessagesByResourceId`. You can now filter messages by metadata key-value pairs using the `filter.metadata` option. All specified key-value pairs must match (AND logic). Supported value types are string, number, boolean, and null. See #12260 for details.

--- a/docs/src/content/en/docs/memory/message-history.mdx
+++ b/docs/src/content/en/docs/memory/message-history.mdx
@@ -198,6 +198,19 @@ const { messages } = await memory.recall({
 })
 ```
 
+Filter messages by metadata:
+
+```typescript
+const { messages } = await memory.recall({
+  threadId: 'thread-123',
+  filter: {
+    metadata: { category: 'billing', priority: 1 },
+  },
+})
+```
+
+All specified key-value pairs must match (AND logic). Supported value types are string, number, boolean, and null.
+
 Fetch a single message by ID:
 
 ```typescript

--- a/docs/src/content/en/reference/memory/recall.mdx
+++ b/docs/src/content/en/reference/memory/recall.mdx
@@ -60,9 +60,9 @@ await memory?.recall({ threadId: 'user-123' })
   },
   {
     name: 'filter',
-    type: '{ dateRange?: { start?: Date; end?: Date; startExclusive?: boolean; endExclusive?: boolean } }',
+    type: '{ dateRange?: { start?: Date; end?: Date; startExclusive?: boolean; endExclusive?: boolean }; metadata?: Record<string, unknown> }',
     description:
-      'Filter options for message retrieval. Currently supports `dateRange` to filter messages by creation date. Use `startExclusive` or `endExclusive` to exclude boundary dates (useful for cursor-based pagination).',
+      'Filter options for message retrieval. Supports `dateRange` to filter messages by creation date (use `startExclusive` or `endExclusive` to exclude boundary dates for cursor-based pagination), and `metadata` to filter by message metadata key-value pairs. All specified metadata pairs must match (AND logic). Supported value types are string, number, boolean, and null.',
     isOptional: true,
   },
   {

--- a/packages/core/src/storage/domains/memory/base.ts
+++ b/packages/core/src/storage/domains/memory/base.ts
@@ -72,7 +72,7 @@ export abstract class MemoryStorage extends StorageDomain {
   async listMessagesByResourceId(_args: StorageListMessagesByResourceIdInput): Promise<StorageListMessagesOutput> {
     throw new Error(
       `Resource-scoped message listing is not implemented by this storage adapter (${this.constructor.name}). ` +
-        `Use an adapter that supports Observational Memory (pg, libsql, mongodb) or disable observational memory.`,
+        `Use an adapter that supports Observational Memory (pg, libsql, mongodb, cloudflare-d1, mssql) or disable observational memory.`,
     );
   }
 

--- a/packages/core/src/storage/domains/memory/inmemory.ts
+++ b/packages/core/src/storage/domains/memory/inmemory.ts
@@ -144,6 +144,17 @@ export class InMemoryMemory extends MemoryStorage {
     // Apply date filtering
     threadMessages = filterByDateRange(threadMessages, (msg: any) => new Date(msg.createdAt), filter?.dateRange);
 
+    // Apply metadata filtering (AND logic - all key-value pairs must match)
+    this.validateMetadataKeys(filter?.metadata);
+    if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+      threadMessages = threadMessages.filter((msg: any) => {
+        const content = safelyParseJSON(msg.content);
+        const msgMetadata = content?.metadata;
+        if (!msgMetadata) return false;
+        return Object.entries(filter.metadata!).every(([key, value]) => jsonValueEquals(msgMetadata[key], value));
+      });
+    }
+
     // Sort thread messages before pagination
     threadMessages.sort((a: any, b: any) => {
       const isDateField = field === 'createdAt' || field === 'updatedAt';
@@ -326,6 +337,17 @@ export class InMemoryMemory extends MemoryStorage {
 
     // Apply date filtering
     messages = filterByDateRange(messages, (msg: any) => new Date(msg.createdAt), filter?.dateRange);
+
+    // Apply metadata filtering (AND logic - all key-value pairs must match)
+    this.validateMetadataKeys(filter?.metadata);
+    if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+      messages = messages.filter((msg: any) => {
+        const content = safelyParseJSON(msg.content);
+        const msgMetadata = content?.metadata;
+        if (!msgMetadata) return false;
+        return Object.entries(filter.metadata!).every(([key, value]) => jsonValueEquals(msgMetadata[key], value));
+      });
+    }
 
     // Sort messages
     messages.sort((a: any, b: any) => {

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -100,6 +100,12 @@ type StorageListMessagesOptions = {
        */
       endExclusive?: boolean;
     };
+    /**
+     * Filter messages by metadata key-value pairs.
+     * Matches against the metadata field inside message content.
+     * All specified key-value pairs must match (AND logic).
+     */
+    metadata?: Record<string, unknown>;
   };
   orderBy?: StorageOrderBy<'createdAt'>;
 };

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -88,7 +88,7 @@
   "author": "",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@mastra/core": ">=1.7.1-0 <2.0.0-0",
+    "@mastra/core": ">=1.11.0-0 <2.0.0-0",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {

--- a/packages/server/src/server/schemas/memory.ts
+++ b/packages/server/src/server/schemas/memory.ts
@@ -118,6 +118,7 @@ const filterSchema = z.preprocess(
         })
         .optional(),
       roles: z.array(z.string()).optional(),
+      metadata: z.record(z.string(), z.unknown()).optional(),
     })
     .optional(),
 );

--- a/stores/_test-utils/src/domains/memory/messages-list.ts
+++ b/stores/_test-utils/src/domains/memory/messages-list.ts
@@ -635,6 +635,118 @@ export function createMessagesListTest({ storage }: { storage: MastraStorage }) 
       });
     });
 
+    describe('metadata filtering', () => {
+      let metaThread: StorageThreadType;
+      let metaMessages: MastraDBMessage[];
+
+      beforeEach(async () => {
+        metaThread = createSampleThread();
+        await memoryStorage.saveThread({ thread: metaThread });
+
+        const now = Date.now();
+        metaMessages = [
+          createSampleMessageV2({
+            threadId: metaThread.id,
+            resourceId: metaThread.resourceId,
+            content: { content: 'Msg A', metadata: { category: 'greeting', priority: 1 } },
+            createdAt: new Date(now + 1000),
+          }),
+          createSampleMessageV2({
+            threadId: metaThread.id,
+            resourceId: metaThread.resourceId,
+            content: { content: 'Msg B', metadata: { category: 'farewell', priority: 2 } },
+            createdAt: new Date(now + 2000),
+          }),
+          createSampleMessageV2({
+            threadId: metaThread.id,
+            resourceId: metaThread.resourceId,
+            content: { content: 'Msg C', metadata: { category: 'greeting', priority: 3, flagged: true } },
+            createdAt: new Date(now + 3000),
+          }),
+          createSampleMessageV2({
+            threadId: metaThread.id,
+            resourceId: metaThread.resourceId,
+            content: { content: 'Msg D' },
+            createdAt: new Date(now + 4000),
+          }),
+        ];
+        await memoryStorage.saveMessages({ messages: metaMessages });
+      });
+
+      it('should filter messages by a single metadata key', async () => {
+        const result = await memoryStorage.listMessages({
+          threadId: metaThread.id,
+          filter: { metadata: { category: 'greeting' } },
+        });
+        expect(result.messages).toHaveLength(2);
+        const contents = result.messages.map((m: any) => m.content.content);
+        expect(contents).toContain('Msg A');
+        expect(contents).toContain('Msg C');
+      });
+
+      it('should filter messages by multiple metadata keys (AND logic)', async () => {
+        const result = await memoryStorage.listMessages({
+          threadId: metaThread.id,
+          filter: { metadata: { category: 'greeting', flagged: true } },
+        });
+        expect(result.messages).toHaveLength(1);
+        expect((result.messages[0] as any).content.content).toBe('Msg C');
+      });
+
+      it('should filter messages by numeric metadata value', async () => {
+        const result = await memoryStorage.listMessages({
+          threadId: metaThread.id,
+          filter: { metadata: { priority: 2 } },
+        });
+        expect(result.messages).toHaveLength(1);
+        expect((result.messages[0] as any).content.content).toBe('Msg B');
+      });
+
+      it('should return empty when metadata filter matches nothing', async () => {
+        const result = await memoryStorage.listMessages({
+          threadId: metaThread.id,
+          filter: { metadata: { category: 'nonexistent' } },
+        });
+        expect(result.messages).toHaveLength(0);
+        expect(result.total).toBe(0);
+      });
+
+      it('should combine metadata filter with dateRange filter', async () => {
+        const now = Date.now();
+        const result = await memoryStorage.listMessages({
+          threadId: metaThread.id,
+          filter: {
+            metadata: { category: 'greeting' },
+            dateRange: { start: new Date(now + 2500) },
+          },
+        });
+        // Only Msg C has category=greeting AND is after now+2500
+        expect(result.messages).toHaveLength(1);
+        expect((result.messages[0] as any).content.content).toBe('Msg C');
+      });
+
+      it('should combine metadata filter with pagination', async () => {
+        const result = await memoryStorage.listMessages({
+          threadId: metaThread.id,
+          filter: { metadata: { category: 'greeting' } },
+          perPage: 1,
+          page: 0,
+        });
+        expect(result.messages).toHaveLength(1);
+        expect(result.total).toBe(2);
+        expect(result.hasMore).toBe(true);
+      });
+
+      it('should return correct total when filtering by metadata', async () => {
+        const result = await memoryStorage.listMessages({
+          threadId: metaThread.id,
+          filter: { metadata: { category: 'farewell' } },
+        });
+        expect(result.messages).toHaveLength(1);
+        expect(result.total).toBe(1);
+      });
+    });
+
     describe('listMessagesByResourceId (resource-scoped queries)', () => {
       // Skip for adapters that don't support OM/resource-scoped queries
       beforeEach(ctx => {
@@ -838,6 +950,89 @@ export function createMessagesListTest({ storage }: { storage: MastraStorage }) 
         expect(result.hasMore).toBe(true);
         expect(result.page).toBe(0);
         expect(result.perPage).toBe(2);
+      });
+
+      it('should filter by metadata when querying by resourceId', async () => {
+        const metaResourceId = `meta-resource-${Date.now()}`;
+        const metaThreadA = createSampleThread({ resourceId: metaResourceId });
+        const metaThreadB = createSampleThread({ resourceId: metaResourceId });
+        await memoryStorage.saveThread({ thread: metaThreadA });
+        await memoryStorage.saveThread({ thread: metaThreadB });
+
+        const now = Date.now();
+        const resourceMessages = [
+          createSampleMessageV2({
+            threadId: metaThreadA.id,
+            resourceId: metaResourceId,
+            content: { content: 'RA1', metadata: { source: 'email' } },
+            createdAt: new Date(now + 1000),
+          }),
+          createSampleMessageV2({
+            threadId: metaThreadA.id,
+            resourceId: metaResourceId,
+            content: { content: 'RA2', metadata: { source: 'chat' } },
+            createdAt: new Date(now + 2000),
+          }),
+          createSampleMessageV2({
+            threadId: metaThreadB.id,
+            resourceId: metaResourceId,
+            content: { content: 'RB1', metadata: { source: 'email', important: true } },
+            createdAt: new Date(now + 3000),
+          }),
+        ];
+        await memoryStorage.saveMessages({ messages: resourceMessages });
+
+        const result = await memoryStorage.listMessagesByResourceId({
+          resourceId: metaResourceId,
+          filter: { metadata: { source: 'email' } },
+          perPage: false,
+        });
+
+        expect(result.messages).toHaveLength(2);
+        const contents = result.messages.map((m: any) => m.content.content);
+        expect(contents).toContain('RA1');
+        expect(contents).toContain('RB1');
+      });
+
+      it('should combine metadata filter with dateRange when querying by resourceId', async () => {
+        const metaResourceId2 = `meta-resource2-${Date.now()}`;
+        const metaThread2 = createSampleThread({ resourceId: metaResourceId2 });
+        await memoryStorage.saveThread({ thread: metaThread2 });
+
+        const now = Date.now();
+        const msgs = [
+          createSampleMessageV2({
+            threadId: metaThread2.id,
+            resourceId: metaResourceId2,
+            content: { content: 'Early email', metadata: { source: 'email' } },
+            createdAt: new Date(now + 1000),
+          }),
+          createSampleMessageV2({
+            threadId: metaThread2.id,
+            resourceId: metaResourceId2,
+            content: { content: 'Late email', metadata: { source: 'email' } },
+            createdAt: new Date(now + 5000),
+          }),
+          createSampleMessageV2({
+            threadId: metaThread2.id,
+            resourceId: metaResourceId2,
+            content: { content: 'Late chat', metadata: { source: 'chat' } },
+            createdAt: new Date(now + 6000),
+          }),
+        ];
+        await memoryStorage.saveMessages({ messages: msgs });
+
+        const result = await memoryStorage.listMessagesByResourceId({
+          resourceId: metaResourceId2,
+          filter: {
+            metadata: { source: 'email' },
+            dateRange: { start: new Date(now + 3000) },
+          },
+          perPage: false,
+        });
+
+        expect(result.messages).toHaveLength(1);
+        expect((result.messages[0] as any).content.content).toBe('Late email');
       });
     });
 

--- a/stores/clickhouse/package.json
+++ b/stores/clickhouse/package.json
@@ -48,7 +48,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.11.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/clickhouse/src/storage/domains/memory/index.ts
+++ b/stores/clickhouse/src/storage/domains/memory/index.ts
@@ -270,6 +270,19 @@ export class MemoryStorageClickhouse extends MemoryStorage {
         dataParams.toDate = endDate;
       }
 
+      // Add metadata filters if provided (AND logic)
+      // Message metadata is nested inside content column at content.metadata
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        this.validateMetadataKeys(filter.metadata);
+        let metadataIndex = 0;
+        for (const [key, value] of Object.entries(filter.metadata)) {
+          const paramName = `metadata${metadataIndex}`;
+          dataQuery += ` AND JSONExtractRaw(content, 'metadata', '${key}') = {${paramName}:String}`;
+          dataParams[paramName] = JSON.stringify(value);
+          metadataIndex++;
+        }
+      }
+
       // Build ORDER BY clause
       const { field, direction } = this.parseOrderBy(orderBy, 'ASC');
       dataQuery += ` ORDER BY "${field}" ${direction}`;
@@ -328,6 +341,17 @@ export class MemoryStorageClickhouse extends MemoryStorage {
         const endOp = filter.dateRange.endExclusive ? '<' : '<=';
         countQuery += ` AND createdAt ${endOp} parseDateTime64BestEffort({toDate:String}, 3)`;
         countParams.toDate = endDate;
+      }
+
+      // Add metadata filters to count query (AND logic)
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        let metadataIndex = 0;
+        for (const [key, value] of Object.entries(filter.metadata)) {
+          const paramName = `metadata${metadataIndex}`;
+          countQuery += ` AND JSONExtractRaw(content, 'metadata', '${key}') = {${paramName}:String}`;
+          countParams[paramName] = JSON.stringify(value);
+          metadataIndex++;
+        }
       }
 
       const countResult = await this.client.query({

--- a/stores/cloudflare-d1/package.json
+++ b/stores/cloudflare-d1/package.json
@@ -49,7 +49,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.11.0-0 <2.0.0-0"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/stores/cloudflare-d1/src/storage/domains/memory/index.ts
+++ b/stores/cloudflare-d1/src/storage/domains/memory/index.ts
@@ -17,6 +17,7 @@ import {
 import type {
   StorageResourceType,
   StorageListMessagesInput,
+  StorageListMessagesByResourceIdInput,
   StorageListMessagesOutput,
   StorageListThreadsInput,
   StorageListThreadsOutput,
@@ -959,6 +960,246 @@ export class MemoryStorageD1 extends MemoryStorage {
           details: {
             threadId: Array.isArray(threadId) ? threadId.join(',') : threadId,
             resourceId: resourceId ?? '',
+          },
+        },
+        error,
+      );
+      this.logger?.error?.(mastraError.toString());
+      this.logger?.trackException?.(mastraError);
+      return {
+        messages: [],
+        total: 0,
+        page,
+        perPage: perPageForResponse,
+        hasMore: false,
+      };
+    }
+  }
+
+  public async listMessagesByResourceId(
+    args: StorageListMessagesByResourceIdInput,
+  ): Promise<StorageListMessagesOutput> {
+    const { resourceId, include, filter, perPage: perPageInput, page = 0, orderBy } = args;
+
+    if (!resourceId || typeof resourceId !== 'string' || resourceId.trim().length === 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('CLOUDFLARE_D1', 'LIST_MESSAGES', 'INVALID_QUERY'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { resourceId: resourceId ?? '' },
+        },
+        new Error('resourceId is required'),
+      );
+    }
+
+    if (page < 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('CLOUDFLARE_D1', 'LIST_MESSAGES', 'INVALID_PAGE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { page },
+        },
+        new Error('page must be >= 0'),
+      );
+    }
+
+    const perPage = normalizePerPage(perPageInput, 40);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    try {
+      const fullTableName = this.#db.getTableName(TABLE_MESSAGES);
+
+      let query = `
+        SELECT id, content, role, type, createdAt, thread_id AS threadId, resourceId
+        FROM ${fullTableName}
+        WHERE resourceId = ?
+      `;
+      const queryParams: any[] = [resourceId];
+
+      const dateRange = filter?.dateRange;
+      if (dateRange?.start) {
+        const startDate =
+          dateRange.start instanceof Date ? serializeDate(dateRange.start) : serializeDate(new Date(dateRange.start));
+        const startOp = dateRange.startExclusive ? '>' : '>=';
+        query += ` AND createdAt ${startOp} ?`;
+        queryParams.push(startDate);
+      }
+
+      if (dateRange?.end) {
+        const endDate =
+          dateRange.end instanceof Date ? serializeDate(dateRange.end) : serializeDate(new Date(dateRange.end));
+        const endOp = dateRange.endExclusive ? '<' : '<=';
+        query += ` AND createdAt ${endOp} ?`;
+        queryParams.push(endDate);
+      }
+
+      // Add metadata filters if provided (AND logic)
+      // Message metadata is nested inside content column at content.metadata
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        this.validateMetadataKeys(filter.metadata);
+        for (const [key, value] of Object.entries(filter.metadata)) {
+          if (value !== null && typeof value === 'object') {
+            throw new MastraError(
+              {
+                id: createStorageErrorId('CLOUDFLARE_D1', 'LIST_MESSAGES', 'INVALID_METADATA_VALUE'),
+                domain: ErrorDomain.STORAGE,
+                category: ErrorCategory.USER,
+                text: `Metadata filter value for key "${key}" must be a scalar type (string, number, boolean, or null), got ${Array.isArray(value) ? 'array' : 'object'}`,
+                details: { key, valueType: Array.isArray(value) ? 'array' : 'object' },
+              },
+              new Error('Invalid metadata filter value type'),
+            );
+          }
+
+          if (value === null) {
+            query += ` AND json_extract(content, '$.metadata.${key}') IS NULL`;
+          } else if (typeof value === 'boolean') {
+            query += ` AND json_extract(content, '$.metadata.${key}') = ?`;
+            queryParams.push(value ? 1 : 0);
+          } else {
+            query += ` AND json_extract(content, '$.metadata.${key}') = ?`;
+            queryParams.push(value);
+          }
+        }
+      }
+
+      // Build ORDER BY clause
+      const { field, direction } = this.parseOrderBy(orderBy, 'ASC');
+      query += ` ORDER BY "${field}" ${direction}`;
+
+      // Apply pagination
+      if (perPage !== Number.MAX_SAFE_INTEGER) {
+        query += ` LIMIT ? OFFSET ?`;
+        queryParams.push(perPage, offset);
+      }
+
+      const results = await this.#db.executeQuery({ sql: query, params: queryParams });
+
+      // Parse message content
+      const paginatedMessages = (isArrayOfRecords(results) ? results : []).map((message: Record<string, any>) => {
+        const processedMsg: Record<string, any> = {};
+        for (const [key, value] of Object.entries(message)) {
+          if (key === `type` && value === `v2`) continue;
+          processedMsg[key] = deserializeValue(value);
+        }
+        return processedMsg;
+      });
+
+      const paginatedCount = paginatedMessages.length;
+
+      // Get total count
+      let countQuery = `SELECT count() as count FROM ${fullTableName} WHERE resourceId = ?`;
+      const countParams: any[] = [resourceId];
+
+      if (dateRange?.start) {
+        const startDate =
+          dateRange.start instanceof Date ? serializeDate(dateRange.start) : serializeDate(new Date(dateRange.start));
+        const startOp = dateRange.startExclusive ? '>' : '>=';
+        countQuery += ` AND createdAt ${startOp} ?`;
+        countParams.push(startDate);
+      }
+
+      if (dateRange?.end) {
+        const endDate =
+          dateRange.end instanceof Date ? serializeDate(dateRange.end) : serializeDate(new Date(dateRange.end));
+        const endOp = dateRange.endExclusive ? '<' : '<=';
+        countQuery += ` AND createdAt ${endOp} ?`;
+        countParams.push(endDate);
+      }
+
+      // Add metadata filters to count query (must match data query)
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        for (const [key, value] of Object.entries(filter.metadata)) {
+          if (value === null) {
+            countQuery += ` AND json_extract(content, '$.metadata.${key}') IS NULL`;
+          } else if (typeof value === 'boolean') {
+            countQuery += ` AND json_extract(content, '$.metadata.${key}') = ?`;
+            countParams.push(value ? 1 : 0);
+          } else {
+            countQuery += ` AND json_extract(content, '$.metadata.${key}') = ?`;
+            countParams.push(value);
+          }
+        }
+      }
+
+      const countResult = (await this.#db.executeQuery({ sql: countQuery, params: countParams })) as {
+        count: number;
+      }[];
+      const total = countResult?.[0]?.count ?? 0;
+
+      // Only return early if there are no messages AND no includes to process
+      if (total === 0 && paginatedMessages.length === 0 && (!include || include.length === 0)) {
+        return {
+          messages: [],
+          total: 0,
+          page,
+          perPage: perPageForResponse,
+          hasMore: false,
+        };
+      }
+
+      // Add included messages with context (if any), excluding duplicates
+      const messageIds = new Set(paginatedMessages.map((m: any) => m.id));
+      if (include && include.length > 0) {
+        const includeMessages = await this._getIncludedMessages(include);
+
+        if (includeMessages) {
+          // Deduplicate: only add messages that aren't already in the paginated results
+          for (const includeMsg of includeMessages) {
+            if (!messageIds.has(includeMsg.id)) {
+              paginatedMessages.push(includeMsg);
+              messageIds.add(includeMsg.id);
+            }
+          }
+        }
+      }
+
+      // Use MessageList for proper deduplication and format conversion to V2
+      const list = new MessageList().add(paginatedMessages as MastraMessageV1[] | MastraDBMessage[], 'memory');
+      let finalMessages = list.get.all.db();
+
+      // Sort all messages (paginated + included) for final output
+      finalMessages = finalMessages.sort((a, b) => {
+        const isDateField = field === 'createdAt' || field === 'updatedAt';
+        const aValue = isDateField ? new Date((a as any)[field]).getTime() : (a as any)[field];
+        const bValue = isDateField ? new Date((b as any)[field]).getTime() : (b as any)[field];
+
+        // Handle tiebreaker for stable sorting
+        if (aValue === bValue) {
+          return a.id.localeCompare(b.id);
+        }
+
+        if (typeof aValue === 'number' && typeof bValue === 'number') {
+          return direction === 'ASC' ? aValue - bValue : bValue - aValue;
+        }
+        // Fallback to string comparison for non-numeric fields
+        return direction === 'ASC'
+          ? String(aValue).localeCompare(String(bValue))
+          : String(bValue).localeCompare(String(aValue));
+      });
+
+      const hasMore = perPageInput === false ? false : offset + paginatedCount < total;
+
+      return {
+        messages: finalMessages,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore,
+      };
+    } catch (error: any) {
+      const mastraError = new MastraError(
+        {
+          id: createStorageErrorId('CLOUDFLARE_D1', 'LIST_MESSAGES', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          text: `Failed to list messages for resource ${resourceId}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          details: {
+            resourceId,
           },
         },
         error,

--- a/stores/cloudflare-d1/src/storage/domains/memory/index.ts
+++ b/stores/cloudflare-d1/src/storage/domains/memory/index.ts
@@ -778,6 +778,36 @@ export class MemoryStorageD1 extends MemoryStorage {
         queryParams.push(endDate);
       }
 
+      // Add metadata filters if provided (AND logic)
+      // Message metadata is nested inside content column at content.metadata
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        this.validateMetadataKeys(filter.metadata);
+        for (const [key, value] of Object.entries(filter.metadata)) {
+          if (value !== null && typeof value === 'object') {
+            throw new MastraError(
+              {
+                id: createStorageErrorId('CLOUDFLARE_D1', 'LIST_MESSAGES', 'INVALID_METADATA_VALUE'),
+                domain: ErrorDomain.STORAGE,
+                category: ErrorCategory.USER,
+                text: `Metadata filter value for key "${key}" must be a scalar type (string, number, boolean, or null), got ${Array.isArray(value) ? 'array' : 'object'}`,
+                details: { key, valueType: Array.isArray(value) ? 'array' : 'object' },
+              },
+              new Error('Invalid metadata filter value type'),
+            );
+          }
+
+          if (value === null) {
+            query += ` AND json_extract(content, '$.metadata.${key}') IS NULL`;
+          } else if (typeof value === 'boolean') {
+            query += ` AND json_extract(content, '$.metadata.${key}') = ?`;
+            queryParams.push(value ? 1 : 0);
+          } else {
+            query += ` AND json_extract(content, '$.metadata.${key}') = ?`;
+            queryParams.push(value);
+          }
+        }
+      }
+
       // Build ORDER BY clause
       const { field, direction } = this.parseOrderBy(orderBy, 'ASC');
       query += ` ORDER BY "${field}" ${direction}`;
@@ -825,6 +855,21 @@ export class MemoryStorageD1 extends MemoryStorage {
         const endOp = dateRange.endExclusive ? '<' : '<=';
         countQuery += ` AND createdAt ${endOp} ?`;
         countParams.push(endDate);
+      }
+
+      // Add metadata filters to count query (must match data query)
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        for (const [key, value] of Object.entries(filter.metadata)) {
+          if (value === null) {
+            countQuery += ` AND json_extract(content, '$.metadata.${key}') IS NULL`;
+          } else if (typeof value === 'boolean') {
+            countQuery += ` AND json_extract(content, '$.metadata.${key}') = ?`;
+            countParams.push(value ? 1 : 0);
+          } else {
+            countQuery += ` AND json_extract(content, '$.metadata.${key}') = ?`;
+            countParams.push(value);
+          }
+        }
       }
 
       const countResult = (await this.#db.executeQuery({ sql: countQuery, params: countParams })) as {

--- a/stores/cloudflare/package.json
+++ b/stores/cloudflare/package.json
@@ -50,7 +50,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.11.0-0 <2.0.0-0"
   },
   "homepage": "https://mastra.ai",
   "repository": {

--- a/stores/cloudflare/src/storage/domains/memory/index.ts
+++ b/stores/cloudflare/src/storage/domains/memory/index.ts
@@ -13,9 +13,11 @@ import {
   createStorageErrorId,
   ensureDate,
   filterByDateRange,
+  jsonValueEquals,
   MemoryStorage,
   normalizePerPage,
   calculatePagination,
+  safelyParseJSON,
   serializeDate,
   TABLE_MESSAGES,
   TABLE_RESOURCES,
@@ -851,6 +853,17 @@ export class MemoryStorageCloudflare extends MemoryStorage {
         msg => new Date(msg.createdAt),
         filter?.dateRange,
       );
+
+      // Apply metadata filtering (AND logic - all key-value pairs must match)
+      this.validateMetadataKeys(filter?.metadata);
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        filteredThreadMessages = filteredThreadMessages.filter((msg: any) => {
+          const content = safelyParseJSON(msg.content);
+          const msgMetadata = content?.metadata;
+          if (!msgMetadata) return false;
+          return Object.entries(filter.metadata!).every(([key, value]) => jsonValueEquals(msgMetadata[key], value));
+        });
+      }
 
       // Get total count for pagination
       const total = filteredThreadMessages.length;

--- a/stores/convex/package.json
+++ b/stores/convex/package.json
@@ -64,7 +64,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.11.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/convex/src/storage/domains/memory/index.ts
+++ b/stores/convex/src/storage/domains/memory/index.ts
@@ -4,6 +4,7 @@ import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import {
   filterByDateRange,
+  jsonValueEquals,
   MemoryStorage,
   TABLE_MESSAGES,
   TABLE_RESOURCES,
@@ -230,6 +231,17 @@ export class MemoryConvex extends MemoryStorage {
 
     // Apply date range filter
     rows = filterByDateRange(rows, row => new Date(row.createdAt), filter?.dateRange);
+
+    // Apply metadata filtering (AND logic - all key-value pairs must match)
+    this.validateMetadataKeys(filter?.metadata);
+    if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+      rows = rows.filter((row: any) => {
+        const content = safelyParseJSON(row.content);
+        const msgMetadata = content?.metadata;
+        if (!msgMetadata) return false;
+        return Object.entries(filter.metadata!).every(([key, value]) => jsonValueEquals(msgMetadata[key], value));
+      });
+    }
 
     rows.sort((a, b) => {
       const aValue =

--- a/stores/dynamodb/package.json
+++ b/stores/dynamodb/package.json
@@ -42,7 +42,7 @@
     "electrodb": "^3.5.3"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.11.0-0 <2.0.0-0"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/stores/dynamodb/src/storage/domains/memory/index.ts
+++ b/stores/dynamodb/src/storage/domains/memory/index.ts
@@ -5,9 +5,11 @@ import type { StorageThreadType, MastraMessageV1, MastraDBMessage } from '@mastr
 import {
   createStorageErrorId,
   filterByDateRange,
+  jsonValueEquals,
   MemoryStorage,
   normalizePerPage,
   calculatePagination,
+  safelyParseJSON,
   TABLE_THREADS,
   TABLE_MESSAGES,
   TABLE_RESOURCES,
@@ -415,6 +417,17 @@ export class MemoryStorageDynamoDB extends MemoryStorage {
         (msg: MastraDBMessage) => new Date(msg.createdAt),
         filter?.dateRange,
       );
+
+      // Apply metadata filtering (AND logic - all key-value pairs must match)
+      this.validateMetadataKeys(filter?.metadata);
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        allThreadMessages = allThreadMessages.filter((msg: any) => {
+          const content = safelyParseJSON(msg.content);
+          const msgMetadata = content?.metadata;
+          if (!msgMetadata) return false;
+          return Object.entries(filter.metadata!).every(([key, value]) => jsonValueEquals(msgMetadata[key], value));
+        });
+      }
 
       // Sort messages by the specified field and direction
       allThreadMessages.sort((a: MastraDBMessage, b: MastraDBMessage) => {

--- a/stores/lance/package.json
+++ b/stores/lance/package.json
@@ -44,7 +44,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.11.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/lance/src/storage/domains/memory/index.ts
+++ b/stores/lance/src/storage/domains/memory/index.ts
@@ -5,9 +5,11 @@ import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { MastraMessageV1, MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import {
   createStorageErrorId,
+  jsonValueEquals,
   MemoryStorage,
   normalizePerPage,
   calculatePagination,
+  safelyParseJSON,
   TABLE_MESSAGES,
   TABLE_RESOURCES,
   TABLE_THREADS,
@@ -373,12 +375,23 @@ export class StoreMemoryLance extends MemoryStorage {
 
       const whereClause = conditions.join(' AND ');
 
-      // Get total count
-      const total = await table.countRows(whereClause);
-
-      // Step 1: Get paginated messages from the thread first (without excluding included ones)
+      // Step 1: Get all messages matching SQL-level filters
       const query = table.query().where(whereClause);
       let allRecords = await query.toArray();
+
+      // Apply metadata filtering in-memory (Lance doesn't support nested JSON path queries in SQL WHERE)
+      this.validateMetadataKeys(filter?.metadata);
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        allRecords = allRecords.filter((record: any) => {
+          const content = safelyParseJSON(record.content);
+          const msgMetadata = content?.metadata;
+          if (!msgMetadata) return false;
+          return Object.entries(filter.metadata!).every(([key, value]) => jsonValueEquals(msgMetadata[key], value));
+        });
+      }
+
+      // Get total count after metadata filtering
+      const total = allRecords.length;
 
       // Sort records
       allRecords.sort((a, b) => {

--- a/stores/libsql/package.json
+++ b/stores/libsql/package.json
@@ -43,7 +43,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.11.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -292,6 +292,34 @@ export class MemoryLibSQL extends MemoryStorage {
         );
       }
 
+      // Add metadata filters if provided (AND logic)
+      // Message metadata is nested inside content column at content.metadata
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        this.validateMetadataKeys(filter.metadata);
+        for (const [key, value] of Object.entries(filter.metadata)) {
+          if (value === null) {
+            conditions.push(`json_extract(content, '$.metadata.${key}') IS NULL`);
+          } else if (typeof value === 'boolean') {
+            conditions.push(`json_extract(content, '$.metadata.${key}') = ?`);
+            queryParams.push(value ? 1 : 0);
+          } else if (typeof value === 'number') {
+            conditions.push(`json_extract(content, '$.metadata.${key}') = ?`);
+            queryParams.push(value);
+          } else if (typeof value === 'string') {
+            conditions.push(`json_extract(content, '$.metadata.${key}') = ?`);
+            queryParams.push(value);
+          } else {
+            throw new MastraError({
+              id: createStorageErrorId('LIBSQL', 'LIST_MESSAGES', 'INVALID_METADATA_VALUE'),
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.USER,
+              text: `Metadata filter value for key "${key}" must be a scalar type (string, number, boolean, or null), got ${typeof value}`,
+              details: { key, valueType: typeof value },
+            });
+          }
+        }
+      }
+
       const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
       // Get total count
@@ -454,6 +482,34 @@ export class MemoryLibSQL extends MemoryStorage {
         queryParams.push(
           filter.dateRange.end instanceof Date ? filter.dateRange.end.toISOString() : filter.dateRange.end,
         );
+      }
+
+      // Add metadata filters if provided (AND logic)
+      // Message metadata is nested inside content column at content.metadata
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        this.validateMetadataKeys(filter.metadata);
+        for (const [key, value] of Object.entries(filter.metadata)) {
+          if (value === null) {
+            conditions.push(`json_extract(content, '$.metadata.${key}') IS NULL`);
+          } else if (typeof value === 'boolean') {
+            conditions.push(`json_extract(content, '$.metadata.${key}') = ?`);
+            queryParams.push(value ? 1 : 0);
+          } else if (typeof value === 'number') {
+            conditions.push(`json_extract(content, '$.metadata.${key}') = ?`);
+            queryParams.push(value);
+          } else if (typeof value === 'string') {
+            conditions.push(`json_extract(content, '$.metadata.${key}') = ?`);
+            queryParams.push(value);
+          } else {
+            throw new MastraError({
+              id: createStorageErrorId('LIBSQL', 'LIST_MESSAGES', 'INVALID_METADATA_VALUE'),
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.USER,
+              text: `Metadata filter value for key "${key}" must be a scalar type (string, number, boolean, or null), got ${typeof value}`,
+              details: { key, valueType: typeof value },
+            });
+          }
+        }
       }
 
       const whereClause = `WHERE ${conditions.join(' AND ')}`;

--- a/stores/mongodb/package.json
+++ b/stores/mongodb/package.json
@@ -50,7 +50,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.11.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -10,6 +10,7 @@ import {
   normalizePerPage,
   calculatePagination,
   safelyParseJSON,
+  jsonValueEquals,
   TABLE_MESSAGES,
   TABLE_RESOURCES,
   TABLE_THREADS,
@@ -303,24 +304,54 @@ export class MemoryStorageMongoDB extends MemoryStorage {
         query.createdAt = { ...query.createdAt, [endOp]: formatDateForMongoDB(filter.dateRange.end) };
       }
 
-      // Get total count
-      const total = await collection.countDocuments(query);
+      // Validate metadata filter keys
+      const hasMetadataFilter = filter?.metadata && Object.keys(filter.metadata).length > 0;
+      if (hasMetadataFilter) {
+        this.validateMetadataKeys(filter?.metadata);
+      }
 
+      let total: number;
       const messages: any[] = [];
 
-      // Step 1: Get paginated messages from the thread first (without excluding included ones)
-      if (perPage !== 0) {
+      if (hasMetadataFilter) {
+        // When filtering by metadata, we must fetch all matching messages first because
+        // content (which contains metadata) is stored as a JSON string in MongoDB and
+        // cannot be queried with native MongoDB operators. We filter in JS then paginate.
         const sortObj: any = { [field]: sortOrder };
-        let cursor = collection.find(query).sort(sortObj).skip(offset);
+        const allRows = await collection.find(query).sort(sortObj).toArray();
+        const allParsed = allRows.map((row: any) => this.parseRow(row));
 
-        // Only apply limit if not unlimited
-        // MongoDB's .limit(0) means "no limit" (returns all), not "return 0 documents"
-        if (perPageInput !== false) {
-          cursor = cursor.limit(perPage);
+        // Apply metadata filtering (AND logic - all key-value pairs must match)
+        const filtered = allParsed.filter((msg: MastraDBMessage) => {
+          const msgMetadata = (msg.content as MastraMessageContentV2)?.metadata;
+          if (!msgMetadata) return false;
+          return Object.entries(filter!.metadata!).every(([key, value]) => jsonValueEquals(msgMetadata[key], value));
+        });
+
+        total = filtered.length;
+
+        if (perPage !== 0) {
+          const end = perPageInput === false ? filtered.length : offset + perPage;
+          messages.push(...filtered.slice(offset, end));
         }
+      } else {
+        // No metadata filter — use efficient DB-level pagination
+        total = await collection.countDocuments(query);
 
-        const dataResult = await cursor.toArray();
-        messages.push(...dataResult.map((row: any) => this.parseRow(row)));
+        // Step 1: Get paginated messages from the thread first (without excluding included ones)
+        if (perPage !== 0) {
+          const sortObj: any = { [field]: sortOrder };
+          let cursor = collection.find(query).sort(sortObj).skip(offset);
+
+          // Only apply limit if not unlimited
+          // MongoDB's .limit(0) means "no limit" (returns all), not "return 0 documents"
+          if (perPageInput !== false) {
+            cursor = cursor.limit(perPage);
+          }
+
+          const dataResult = await cursor.toArray();
+          messages.push(...dataResult.map((row: any) => this.parseRow(row)));
+        }
       }
 
       // Only return early if there are no messages AND no includes to process
@@ -465,24 +496,54 @@ export class MemoryStorageMongoDB extends MemoryStorage {
         query.createdAt = { ...query.createdAt, [endOp]: formatDateForMongoDB(filter.dateRange.end) };
       }
 
-      // Get total count
-      const total = await collection.countDocuments(query);
+      // Validate metadata filter keys
+      const hasMetadataFilter = filter?.metadata && Object.keys(filter.metadata).length > 0;
+      if (hasMetadataFilter) {
+        this.validateMetadataKeys(filter?.metadata);
+      }
 
+      let total: number;
       const messages: any[] = [];
 
-      // Step 1: Get paginated messages
-      if (perPage !== 0) {
+      if (hasMetadataFilter) {
+        // When filtering by metadata, we must fetch all matching messages first because
+        // content (which contains metadata) is stored as a JSON string in MongoDB and
+        // cannot be queried with native MongoDB operators. We filter in JS then paginate.
         const sortObj: any = { [field]: sortOrder };
-        let cursor = collection.find(query).sort(sortObj).skip(offset);
+        const allRows = await collection.find(query).sort(sortObj).toArray();
+        const allParsed = allRows.map((row: any) => this.parseRow(row));
 
-        // Only apply limit if not unlimited
-        // MongoDB's .limit(0) means "no limit" (returns all), not "return 0 documents"
-        if (perPageInput !== false) {
-          cursor = cursor.limit(perPage);
+        // Apply metadata filtering (AND logic - all key-value pairs must match)
+        const filtered = allParsed.filter((msg: MastraDBMessage) => {
+          const msgMetadata = (msg.content as MastraMessageContentV2)?.metadata;
+          if (!msgMetadata) return false;
+          return Object.entries(filter!.metadata!).every(([key, value]) => jsonValueEquals(msgMetadata[key], value));
+        });
+
+        total = filtered.length;
+
+        if (perPage !== 0) {
+          const end = perPageInput === false ? filtered.length : offset + perPage;
+          messages.push(...filtered.slice(offset, end));
         }
+      } else {
+        // No metadata filter — use efficient DB-level pagination
+        total = await collection.countDocuments(query);
 
-        const dataResult = await cursor.toArray();
-        messages.push(...dataResult.map((row: any) => this.parseRow(row)));
+        // Step 1: Get paginated messages
+        if (perPage !== 0) {
+          const sortObj: any = { [field]: sortOrder };
+          let cursor = collection.find(query).sort(sortObj).skip(offset);
+
+          // Only apply limit if not unlimited
+          // MongoDB's .limit(0) means "no limit" (returns all), not "return 0 documents"
+          if (perPageInput !== false) {
+            cursor = cursor.limit(perPage);
+          }
+
+          const dataResult = await cursor.toArray();
+          messages.push(...dataResult.map((row: any) => this.parseRow(row)));
+        }
       }
 
       // Only return early if there are no messages AND no includes to process

--- a/stores/mssql/package.json
+++ b/stores/mssql/package.json
@@ -48,7 +48,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.11.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/mssql/src/storage/domains/memory/index.ts
+++ b/stores/mssql/src/storage/domains/memory/index.ts
@@ -689,12 +689,50 @@ export class MemoryMSSQL extends MemoryStorage {
         ...buildDateRangeFilter(filter?.dateRange, 'createdAt'),
       };
 
-      const { sql: actualWhereClause = '', params: whereParams } = prepareWhereClause(
+      const { sql: baseWhereClause = '', params: whereParams } = prepareWhereClause(
         filters,
         TABLE_SCHEMAS[TABLE_MESSAGES],
       );
+
+      // Add metadata filters if provided (AND logic)
+      // Message metadata is nested inside content column at content.metadata
+      let metadataWhereClause = '';
+      const metadataParams: Record<string, any> = {};
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        this.validateMetadataKeys(filter.metadata);
+        let metadataIndex = 0;
+        for (const [key, value] of Object.entries(filter.metadata)) {
+          if (value !== null && typeof value === 'object') {
+            throw new MastraError({
+              id: createStorageErrorId('MSSQL', 'LIST_MESSAGES', 'INVALID_METADATA_VALUE'),
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.USER,
+              text: `Metadata filter value for key "${key}" must be a scalar type (string, number, boolean, or null), got ${Array.isArray(value) ? 'array' : 'object'}`,
+              details: { key, valueType: Array.isArray(value) ? 'array' : 'object' },
+            });
+          }
+
+          if (value === null) {
+            metadataWhereClause += ` AND JSON_VALUE(content, '$.metadata.${key}') IS NULL`;
+          } else {
+            const paramName = `msgMeta${metadataIndex}`;
+            metadataWhereClause += ` AND JSON_VALUE(content, '$.metadata.${key}') = @${paramName}`;
+            if (typeof value === 'string') {
+              metadataParams[paramName] = value;
+            } else if (typeof value === 'boolean') {
+              metadataParams[paramName] = value ? 'true' : 'false';
+            } else {
+              metadataParams[paramName] = String(value);
+            }
+          }
+          metadataIndex++;
+        }
+      }
+
+      const actualWhereClause = baseWhereClause + metadataWhereClause;
       const bindWhereParams = (req: sql.Request) => {
         Object.entries(whereParams).forEach(([paramName, paramValue]) => req.input(paramName, paramValue));
+        Object.entries(metadataParams).forEach(([paramName, paramValue]) => req.input(paramName, paramValue));
       };
 
       // Get total count

--- a/stores/mssql/src/storage/domains/memory/index.ts
+++ b/stores/mssql/src/storage/domains/memory/index.ts
@@ -15,6 +15,7 @@ import {
 import type {
   StorageResourceType,
   StorageListMessagesInput,
+  StorageListMessagesByResourceIdInput,
   StorageListMessagesOutput,
   StorageListThreadsInput,
   StorageListThreadsOutput,
@@ -836,6 +837,208 @@ export class MemoryMSSQL extends MemoryStorage {
           details: {
             threadId: Array.isArray(threadId) ? threadId.join(',') : threadId,
             resourceId: resourceId ?? '',
+          },
+        },
+        error,
+      );
+      this.logger?.error?.(mastraError.toString());
+      this.logger?.trackException?.(mastraError);
+      return {
+        messages: [],
+        total: 0,
+        page,
+        perPage: perPageForResponse,
+        hasMore: false,
+      };
+    }
+  }
+
+  public async listMessagesByResourceId(
+    args: StorageListMessagesByResourceIdInput,
+  ): Promise<StorageListMessagesOutput> {
+    const { resourceId, include, filter, perPage: perPageInput, page = 0, orderBy } = args;
+
+    if (!resourceId || typeof resourceId !== 'string' || resourceId.trim().length === 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('MSSQL', 'LIST_MESSAGES', 'INVALID_QUERY'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { resourceId: resourceId ?? '' },
+        },
+        new Error('resourceId is required'),
+      );
+    }
+
+    if (page < 0) {
+      throw new MastraError({
+        id: createStorageErrorId('MSSQL', 'LIST_MESSAGES', 'INVALID_PAGE'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        text: 'Page number must be non-negative',
+        details: { resourceId, page },
+      });
+    }
+
+    const perPage = normalizePerPage(perPageInput, 40);
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    try {
+      // Determine sort field and direction
+      const { field, direction } = this.parseOrderBy(orderBy, 'ASC');
+      const orderByStatement = `ORDER BY [${field}] ${direction}, [seq_id] ${direction}`;
+
+      const tableName = getTableName({ indexName: TABLE_MESSAGES, schemaName: getSchemaName(this.schema) });
+      const baseQuery = `SELECT seq_id, id, content, role, type, [createdAt], thread_id AS threadId, resourceId FROM ${tableName}`;
+
+      const filters: Record<string, any> = {
+        resourceId,
+        ...buildDateRangeFilter(filter?.dateRange, 'createdAt'),
+      };
+
+      const { sql: baseWhereClause = '', params: whereParams } = prepareWhereClause(
+        filters,
+        TABLE_SCHEMAS[TABLE_MESSAGES],
+      );
+
+      // Add metadata filters if provided (AND logic)
+      // Message metadata is nested inside content column at content.metadata
+      let metadataWhereClause = '';
+      const metadataParams: Record<string, any> = {};
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        this.validateMetadataKeys(filter.metadata);
+        let metadataIndex = 0;
+        for (const [key, value] of Object.entries(filter.metadata)) {
+          if (value !== null && typeof value === 'object') {
+            throw new MastraError({
+              id: createStorageErrorId('MSSQL', 'LIST_MESSAGES', 'INVALID_METADATA_VALUE'),
+              domain: ErrorDomain.STORAGE,
+              category: ErrorCategory.USER,
+              text: `Metadata filter value for key "${key}" must be a scalar type (string, number, boolean, or null), got ${Array.isArray(value) ? 'array' : 'object'}`,
+              details: { key, valueType: Array.isArray(value) ? 'array' : 'object' },
+            });
+          }
+
+          if (value === null) {
+            metadataWhereClause += ` AND JSON_VALUE(content, '$.metadata.${key}') IS NULL`;
+          } else {
+            const paramName = `resMeta${metadataIndex}`;
+            metadataWhereClause += ` AND JSON_VALUE(content, '$.metadata.${key}') = @${paramName}`;
+            if (typeof value === 'string') {
+              metadataParams[paramName] = value;
+            } else if (typeof value === 'boolean') {
+              metadataParams[paramName] = value ? 'true' : 'false';
+            } else {
+              metadataParams[paramName] = String(value);
+            }
+          }
+          metadataIndex++;
+        }
+      }
+
+      const actualWhereClause = baseWhereClause + metadataWhereClause;
+      const bindWhereParams = (req: sql.Request) => {
+        Object.entries(whereParams).forEach(([paramName, paramValue]) => req.input(paramName, paramValue));
+        Object.entries(metadataParams).forEach(([paramName, paramValue]) => req.input(paramName, paramValue));
+      };
+
+      // Get total count
+      const countRequest = this.pool.request();
+      bindWhereParams(countRequest);
+      const countResult = await countRequest.query(`SELECT COUNT(*) as total FROM ${tableName}${actualWhereClause}`);
+      const total = parseInt(countResult.recordset[0]?.total, 10) || 0;
+
+      const fetchBaseMessages = async (): Promise<any[]> => {
+        const request = this.pool.request();
+        bindWhereParams(request);
+
+        if (perPageInput === false) {
+          const result = await request.query(`${baseQuery}${actualWhereClause} ${orderByStatement}`);
+          return result.recordset || [];
+        }
+
+        request.input('offset', offset);
+        request.input('limit', perPage > 2147483647 ? sql.BigInt : sql.Int, perPage);
+        const result = await request.query(
+          `${baseQuery}${actualWhereClause} ${orderByStatement} OFFSET @offset ROWS FETCH NEXT @limit ROWS ONLY`,
+        );
+        return result.recordset || [];
+      };
+
+      // Get paginated messages
+      const baseRows = perPage === 0 ? [] : await fetchBaseMessages();
+      const messages: any[] = [...baseRows];
+      const seqById = new Map<string, number>();
+      messages.forEach(msg => {
+        if (typeof msg.seq_id === 'number') seqById.set(msg.id, msg.seq_id);
+      });
+
+      // Only return early if there are no messages AND no includes to process
+      if (total === 0 && messages.length === 0 && (!include || include.length === 0)) {
+        return {
+          messages: [],
+          total: 0,
+          page,
+          perPage: perPageForResponse,
+          hasMore: false,
+        };
+      }
+
+      // Add included messages with context (if any), excluding duplicates
+      if (include?.length) {
+        const messageIds = new Set(messages.map(m => m.id));
+        const includeMessages = await this._getIncludedMessages({ include });
+        if (includeMessages) {
+          for (const msg of includeMessages) {
+            if (!messageIds.has(msg.id)) {
+              messages.push(msg);
+              messageIds.add(msg.id);
+              if (typeof msg.seq_id === 'number') seqById.set(msg.id, msg.seq_id);
+            }
+          }
+        }
+      }
+
+      const paginatedCount = baseRows.length;
+
+      // Parse and format messages to V2
+      const formatted = this._parseAndFormatMessages(messages, 'v2') as MastraDBMessage[];
+
+      // Sort all messages (paginated + included) for final output
+      const finalMessages = formatted.sort((a, b) => {
+        const seqA = seqById.get(a.id);
+        const seqB = seqById.get(b.id);
+        if (seqA != null && seqB != null) {
+          return direction === 'ASC' ? seqA - seqB : seqB - seqA;
+        }
+        const isDateField = field === 'createdAt' || field === 'updatedAt';
+        const aValue = isDateField ? new Date((a as any)[field]).getTime() : (a as any)[field];
+        const bValue = isDateField ? new Date((b as any)[field]).getTime() : (b as any)[field];
+        if (typeof aValue === 'number' && typeof bValue === 'number') {
+          return direction === 'ASC' ? aValue - bValue : bValue - aValue;
+        }
+        return direction === 'ASC'
+          ? String(aValue).localeCompare(String(bValue))
+          : String(bValue).localeCompare(String(aValue));
+      });
+
+      const hasMore = perPageInput === false ? false : offset + paginatedCount < total;
+
+      return {
+        messages: finalMessages,
+        total,
+        page,
+        perPage: perPageForResponse,
+        hasMore,
+      };
+    } catch (error) {
+      const mastraError = new MastraError(
+        {
+          id: createStorageErrorId('MSSQL', 'LIST_MESSAGES', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: {
+            resourceId,
           },
         },
         error,

--- a/stores/pg/package.json
+++ b/stores/pg/package.json
@@ -54,7 +54,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.4.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.11.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -829,8 +829,19 @@ export class MemoryPG extends MemoryStorage {
 
       if (filter?.dateRange?.end) {
         const endOp = filter.dateRange.endExclusive ? '<' : '<=';
-        conditions.push(`COALESCE("createdAtZ", "createdAt") ${endOp} $${paramIndex++}`);
+        conditions.push(`COALESCE("createdAtZ", "createdAt") ${endOp} ${paramIndex++}`);
         queryParams.push(filter.dateRange.end);
+      }
+
+      // Add metadata filters if provided (AND logic)
+      // Message metadata is nested inside content column at content.metadata
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        this.validateMetadataKeys(filter.metadata);
+        for (const [key, value] of Object.entries(filter.metadata)) {
+          conditions.push(`content::jsonb -> 'metadata' @> ${paramIndex}::jsonb`);
+          queryParams.push(JSON.stringify({ [key]: value }));
+          paramIndex++;
+        }
       }
 
       const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
@@ -840,7 +851,7 @@ export class MemoryPG extends MemoryStorage {
       const total = parseInt(countResult.count, 10);
 
       const limitValue = perPageInput === false ? total : perPage;
-      const dataQuery = `${selectStatement} FROM ${tableName} ${whereClause} ${orderByStatement} LIMIT $${paramIndex++} OFFSET $${paramIndex++}`;
+      const dataQuery = `${selectStatement} FROM ${tableName} ${whereClause} ${orderByStatement} LIMIT ${paramIndex++} OFFSET ${paramIndex++}`;
       const rows = await this.#db.client.manyOrNone(dataQuery, [...queryParams, limitValue, offset]);
       const messages: MessageRowFromDB[] = [...(rows || [])];
 
@@ -993,8 +1004,19 @@ export class MemoryPG extends MemoryStorage {
 
       if (filter?.dateRange?.end) {
         const endOp = filter.dateRange.endExclusive ? '<' : '<=';
-        conditions.push(`"createdAt" ${endOp} $${paramIndex++}`);
+        conditions.push(`"createdAt" ${endOp} ${paramIndex++}`);
         queryParams.push(filter.dateRange.end);
+      }
+
+      // Add metadata filters if provided (AND logic)
+      // Message metadata is nested inside content column at content.metadata
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        this.validateMetadataKeys(filter.metadata);
+        for (const [key, value] of Object.entries(filter.metadata)) {
+          conditions.push(`content::jsonb -> 'metadata' @> ${paramIndex}::jsonb`);
+          queryParams.push(JSON.stringify({ [key]: value }));
+          paramIndex++;
+        }
       }
 
       const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
@@ -1004,7 +1026,7 @@ export class MemoryPG extends MemoryStorage {
       const total = parseInt(countResult.count, 10);
 
       const limitValue = perPageInput === false ? total : perPage;
-      const dataQuery = `${selectStatement} FROM ${tableName} ${whereClause} ${orderByStatement} LIMIT $${paramIndex++} OFFSET $${paramIndex++}`;
+      const dataQuery = `${selectStatement} FROM ${tableName} ${whereClause} ${orderByStatement} LIMIT ${paramIndex++} OFFSET ${paramIndex++}`;
       const rows = await this.#db.client.manyOrNone(dataQuery, [...queryParams, limitValue, offset]);
       const messages: MessageRowFromDB[] = [...(rows || [])];
 

--- a/stores/upstash/package.json
+++ b/stores/upstash/package.json
@@ -47,7 +47,7 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@mastra/core": ">=1.0.0-0 <2.0.0-0"
+    "@mastra/core": ">=1.11.0-0 <2.0.0-0"
   },
   "files": [
     "dist",

--- a/stores/upstash/src/storage/domains/memory/index.ts
+++ b/stores/upstash/src/storage/domains/memory/index.ts
@@ -12,6 +12,8 @@ import {
   createStorageErrorId,
   ensureDate,
   filterByDateRange,
+  jsonValueEquals,
+  safelyParseJSON,
 } from '@mastra/core/storage';
 import type {
   StorageResourceType,
@@ -693,6 +695,17 @@ export class StoreMemoryUpstash extends MemoryStorage {
         (msg: MastraDBMessage) => new Date(msg.createdAt),
         filter?.dateRange,
       );
+
+      // Apply metadata filtering (AND logic - all key-value pairs must match)
+      this.validateMetadataKeys(filter?.metadata);
+      if (filter?.metadata && Object.keys(filter.metadata).length > 0) {
+        messagesData = messagesData.filter((msg: any) => {
+          const content = safelyParseJSON(msg.content);
+          const msgMetadata = content?.metadata;
+          if (!msgMetadata) return false;
+          return Object.entries(filter.metadata!).every(([key, value]) => jsonValueEquals(msgMetadata[key], value));
+        });
+      }
 
       // Determine sort field and direction, default to ASC (oldest first)
       const { field, direction } = this.parseOrderBy(orderBy, 'ASC');


### PR DESCRIPTION
## Summary

Adds metadata filtering support for `listMessages` and `listMessagesByResourceId` across all storage backends.

Users can now filter messages by metadata key-value pairs using the `filter.metadata` option. All specified key-value pairs must match (AND logic). Supported value types are string, number, boolean, and null.

### Example usage

```typescript
const { messages } = await memory.recall({
  threadId: 'thread-123',
  filter: {
    metadata: { category: 'billing', priority: 1 },
  },
})
```

## Changes

**Core (`@mastra/core`)**
- Added `metadata?: Record<string, unknown>` to `StorageListMessagesOptions.filter`
- Added `validateMetadataKeys` method to base MemoryStorage class
- Implemented metadata filtering in InMemory storage

**Server (`@mastra/server`)**
- Added `metadata` to the filter schema

**SQL-level filtering (query-time)**
- **PostgreSQL**: Uses `content::jsonb -> 'metadata' @> $N::jsonb`
- **LibSQL**: Uses `json_extract(content, '$.metadata.<key>')`
- **Cloudflare D1**: Uses `json_extract(content, '$.metadata.<key>')`
- **MSSQL**: Uses `JSON_VALUE(content, '$.metadata.<key>')`
- **ClickHouse**: Uses `JSONExtractRaw(content, 'metadata', '<key>')`

**In-memory filtering (post-fetch)**
- Cloudflare KV, Convex, DynamoDB, LanceDB, Upstash

**Tests**
- 9 new shared tests covering:
  - Single and multi-key metadata filters
  - Numeric and boolean metadata values
  - Empty result sets
  - Pagination with metadata filter
  - Date range + metadata filter combination
  - Resource-scoped metadata filtering (`listMessagesByResourceId`)

**Documentation**
- Updated message-history docs with metadata filter example
- Updated `recall()` reference to include metadata in filter type

## Test plan

- All 49 `metadata`-related tests pass against LibSQL (in-memory SQLite)
- Tests are in the shared test suite (`stores/_test-utils`) so they run for all backends

Closes #12260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metadata filtering for message history: filter by multiple key-value pairs (AND semantics) supporting string, number, boolean, and null.

* **Documentation**
  * Added examples and reference docs showing metadata filtering for message recall and listing.

* **Tests**
  * Expanded test coverage for metadata filtering across list operations, pagination, and date ranges.

* **Chores**
  * Updated peer dependency requirements to align packages with core v1.11.0+.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->