### PR TITLE
fix(docs): complete JSON-LD structured data for /learn section

### DIFF
--- a/docs/src/learn/course.ts
+++ b/docs/src/learn/course.ts
@@ -18,6 +18,7 @@ AI agents are the next platform shift. Understanding how to build them is now a 
       durationMin: 5,
       status: 'published',
       youtubeId: 'G8tXjcseNjg',
+      publishedDate: '2026-03-04T00:00:00Z',
       module: 'Agents',
       preview: {
         intro:
@@ -40,6 +41,7 @@ AI agents are the next platform shift. Understanding how to build them is now a 
       durationMin: 5,
       status: 'published',
       youtubeId: 'RaqlPrGBscw',
+      publishedDate: '2026-03-04T00:00:00Z',
       module: 'Agents',
       preview: {
         intro:
@@ -62,6 +64,7 @@ AI agents are the next platform shift. Understanding how to build them is now a 
       durationMin: 4,
       status: 'published',
       youtubeId: 'lDKFFWLmt1Q',
+      publishedDate: '2026-03-04T00:00:00Z',
       module: 'Agents',
       preview: {
         intro:
@@ -84,6 +87,7 @@ AI agents are the next platform shift. Understanding how to build them is now a 
       durationMin: 5,
       status: 'published',
       youtubeId: 'lwhJxPl_loQ',
+      publishedDate: '2026-03-04T00:00:00Z',
       module: 'Agents',
       preview: {
         intro:
@@ -108,6 +112,7 @@ AI agents are the next platform shift. Understanding how to build them is now a 
       durationMin: 7,
       status: 'published',
       youtubeId: 'P8voCXTIGVI',
+      publishedDate: '2026-03-04T00:00:00Z',
       module: 'Tools',
       preview: {
         intro:
@@ -125,6 +130,7 @@ AI agents are the next platform shift. Understanding how to build them is now a 
       durationMin: 3,
       status: 'published',
       youtubeId: 'PBtct9tG19k',
+      publishedDate: '2026-03-04T00:00:00Z',
       module: 'Tools',
       preview: {
         intro:
@@ -142,6 +148,7 @@ AI agents are the next platform shift. Understanding how to build them is now a 
       durationMin: 7,
       status: 'published',
       youtubeId: 'CMofx-DhpoY',
+      publishedDate: '2026-03-04T00:00:00Z',
       module: 'Tools',
       preview: {
         intro:
@@ -159,6 +166,7 @@ AI agents are the next platform shift. Understanding how to build them is now a 
       durationMin: 7,
       status: 'published',
       youtubeId: 'b8rNHmL4s2s',
+      publishedDate: '2026-03-04T00:00:00Z',
       module: 'Tools',
       preview: {
         intro:

--- a/docs/src/learn/pages/LearnLandingPage.tsx
+++ b/docs/src/learn/pages/LearnLandingPage.tsx
@@ -48,19 +48,25 @@ function LandingContent() {
               name: 'Mastra',
               url: 'https://mastra.ai',
             },
-            instructor: {
-              '@type': 'Person',
-              name: 'Guil Hernandez',
-              url: 'https://www.linkedin.com/in/guiljh/',
-              image: 'https://mastra.ai/img/guil-hernandez.jpg',
-              jobTitle: 'Developer Educator',
-              description: 'Over a decade building and teaching software, with courses used by 500,000+ learners.',
-            },
             isAccessibleForFree: true,
+            offers: {
+              '@type': 'Offer',
+              price: 0,
+              priceCurrency: 'USD',
+              category: 'Free',
+            },
             hasCourseInstance: {
               '@type': 'CourseInstance',
               courseMode: 'online',
               courseWorkload: 'PT90M',
+              instructor: {
+                '@type': 'Person',
+                name: 'Guil Hernandez',
+                url: 'https://www.linkedin.com/in/guiljh/',
+                image: 'https://mastra.ai/img/guil-hernandez.jpg',
+                jobTitle: 'Developer Educator',
+                description: 'Over a decade building and teaching software, with courses used by 500,000+ learners.',
+              },
             },
           })}
         </script>

--- a/docs/src/learn/pages/LessonPage.tsx
+++ b/docs/src/learn/pages/LessonPage.tsx
@@ -138,6 +138,7 @@ export default function LessonPage() {
                 name: lesson.title,
                 description: seoDescription,
                 thumbnailUrl: ogImageUrl.toString(),
+                uploadDate: lesson.publishedDate,
                 embedUrl: `https://www.youtube.com/embed/${lesson.youtubeId}`,
                 contentUrl: `https://www.youtube.com/watch?v=${lesson.youtubeId}`,
                 duration: `PT${lesson.durationMin}M`,

--- a/docs/src/learn/types.ts
+++ b/docs/src/learn/types.ts
@@ -6,6 +6,7 @@ export type Lesson = {
   durationMin: number
   status: LessonStatus
   youtubeId?: string
+  publishedDate?: string
   preview: { intro: string; bullets: string[] }
   module: string
   seo?: { title?: string; description?: string }


### PR DESCRIPTION
Fixes three Schema.org validation errors in the /learn section's structured data:

## Course JSON-LD
- **`instructor` not recognized**: Moved `instructor` from `Course` level into `hasCourseInstance` → `CourseInstance`, where Schema.org defines it
- **`offers` required**: Added an `Offer` with `price: 0` / `priceCurrency: USD` since the course is free

## VideoObject JSON-LD
- **`uploadDate` required**: Added `publishedDate` field to the `Lesson` type and set all published lessons to `2026-03-04T00:00:00Z`, used as `uploadDate` in the VideoObject

## Files changed
- `docs/src/learn/types.ts` — added optional `publishedDate` to `Lesson`
- `docs/src/learn/course.ts` — added `publishedDate` to all 8 published lessons
- `docs/src/learn/pages/LearnLandingPage.tsx` — fixed Course JSON-LD
- `docs/src/learn/pages/LessonPage.tsx` — added `uploadDate` to VideoObject JSON-LD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added publication dates to eight lessons in the learning course
  * Updated course metadata with pricing and offering information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->