### PR TITLE
fix(changeset-cli): only update peer deps on major core bumps

### DIFF
--- a/packages/_changeset-cli/src/ui/getSummary.ts
+++ b/packages/_changeset-cli/src/ui/getSummary.ts
@@ -12,7 +12,7 @@ export function getSummary(updatedPackagesList: string[], updatedPeerDeps: Updat
   }
 
   if (updatedPeerDeps.directUpdatedPackages.length > 0) {
-    const directUpdatedPackagesList = updatedPeerDeps.directUpdatedPackages.map(pkg => `${pkg}: minor`);
+    const directUpdatedPackagesList = updatedPeerDeps.directUpdatedPackages.map(pkg => `${pkg}: major`);
     summaryOutput += `${[''].concat(directUpdatedPackagesList).join('\n  - ')}`;
   }
   if (updatedPeerDeps.indirectUpdatedPackages.length > 0) {

--- a/packages/_changeset-cli/src/versions/updatePeerDependencies.test.ts
+++ b/packages/_changeset-cli/src/versions/updatePeerDependencies.test.ts
@@ -7,7 +7,7 @@ const packages = {
   '@mastra/core': {
     packageJson: {
       name: '@mastra/core',
-      version: '0.20.1',
+      version: '1.2.1',
     },
     dir: '/packages/core',
     relativeDir: 'packages/core',
@@ -15,9 +15,9 @@ const packages = {
   '@mastra/server': {
     packageJson: {
       name: '@mastra/server',
-      version: '0.20.1',
+      version: '1.2.1',
       peerDependencies: {
-        '@mastra/core': '>=0.20.0-0 <0.21.0-0',
+        '@mastra/core': '>=1.0.0-0 <2.0.0-0',
       },
     },
     dir: '/packages/server',
@@ -26,9 +26,9 @@ const packages = {
   '@mastra/memory': {
     packageJson: {
       name: '@mastra/memory',
-      version: '0.10.0',
+      version: '1.0.0',
       peerDependencies: {
-        '@mastra/core': '>=0.20.0-0 <0.21.0-0',
+        '@mastra/core': '>=1.0.0-0 <2.0.0-0',
       },
     },
     dir: '/packages/memory',
@@ -37,7 +37,7 @@ const packages = {
   '@mastra/standalone': {
     packageJson: {
       name: '@mastra/standalone',
-      version: '0.1.0',
+      version: '1.1.0',
     },
     dir: '/packages/standalone',
     relativeDir: 'packages/standalone',
@@ -110,17 +110,17 @@ vi.mock('node:fs');
 vi.mock('@changesets/write');
 
 describe('updatePeerDependencies', () => {
-  it('should update all packages when core got bumped to minor', async () => {
+  it('should update nothing when core got bumped to minor', async () => {
     const versionBumps: VersionBumps = {
       '@mastra/core': 'minor',
     };
     const updatedPeerDeps = await updatePeerDependencies(versionBumps);
 
     expect(updatedPeerDeps.directUpdatedPackages).toEqual([]);
-    expect(updatedPeerDeps.indirectUpdatedPackages).toEqual(['@mastra/server', '@mastra/memory']);
+    expect(updatedPeerDeps.indirectUpdatedPackages).toEqual([]);
   });
 
-  it('should update only direct packages when core got bumped to patch', async () => {
+  it('should update nothing when core got bumped to patch', async () => {
     const versionBumps: VersionBumps = {
       '@mastra/core': 'patch',
     };
@@ -130,17 +130,17 @@ describe('updatePeerDependencies', () => {
     expect(updatedPeerDeps.indirectUpdatedPackages).toEqual([]);
   });
 
-  it('should update "@mastra/memory" when "@mastra/server" got bumped to minor', async () => {
+  it('should update nothing when "@mastra/server" got bumped to minor', async () => {
     const versionBumps: VersionBumps = {
       '@mastra/server': 'minor',
     };
     const updatedPeerDeps = await updatePeerDependencies(versionBumps);
 
     expect(updatedPeerDeps.directUpdatedPackages).toEqual([]);
-    expect(updatedPeerDeps.indirectUpdatedPackages).toEqual(['@mastra/server', '@mastra/memory']);
+    expect(updatedPeerDeps.indirectUpdatedPackages).toEqual([]);
   });
 
-  it('should update nothing when "@mastra/server" version got bumped to patch', async () => {
+  it('should update nothing when "@mastra/server" got bumped to patch', async () => {
     const versionBumps: VersionBumps = {
       '@mastra/server': 'patch',
     };
@@ -150,7 +150,7 @@ describe('updatePeerDependencies', () => {
     expect(updatedPeerDeps.indirectUpdatedPackages).toEqual([]);
   });
 
-  it('should update nothing when "@mastra/memory" version got bumped to minor', async () => {
+  it('should update nothing when "@mastra/memory" got bumped to minor', async () => {
     const versionBumps: VersionBumps = {
       '@mastra/memory': 'minor',
     };
@@ -160,7 +160,7 @@ describe('updatePeerDependencies', () => {
     expect(updatedPeerDeps.indirectUpdatedPackages).toEqual([]);
   });
 
-  it('should update nothing when "@mastra/memory" version got bumped to patch', async () => {
+  it('should update nothing when "@mastra/memory" got bumped to patch', async () => {
     const versionBumps: VersionBumps = {
       '@mastra/memory': 'patch',
     };
@@ -170,10 +170,20 @@ describe('updatePeerDependencies', () => {
     expect(updatedPeerDeps.indirectUpdatedPackages).toEqual([]);
   });
 
-  it('should update all packages when core & server got bumped to minor', async () => {
+  it('should update all packages when core got bumped to major', async () => {
     const versionBumps: VersionBumps = {
-      '@mastra/core': 'minor',
-      '@mastra/server': 'minor',
+      '@mastra/core': 'major',
+    };
+    const updatedPeerDeps = await updatePeerDependencies(versionBumps);
+
+    expect(updatedPeerDeps.directUpdatedPackages).toEqual([]);
+    expect(updatedPeerDeps.indirectUpdatedPackages).toEqual(['@mastra/server', '@mastra/memory']);
+  });
+
+  it('should update all packages when core & server got bumped to major', async () => {
+    const versionBumps: VersionBumps = {
+      '@mastra/core': 'major',
+      '@mastra/server': 'major',
     };
     const updatedPeerDeps = await updatePeerDependencies(versionBumps);
 
@@ -181,14 +191,25 @@ describe('updatePeerDependencies', () => {
     expect(updatedPeerDeps.indirectUpdatedPackages).toEqual(['@mastra/memory']);
   });
 
-  it('should update only direct packages when core & server got bumped to patch', async () => {
+  it('should update nothing when core & server got bumped to minor', async () => {
+    const versionBumps: VersionBumps = {
+      '@mastra/core': 'minor',
+      '@mastra/server': 'minor',
+    };
+    const updatedPeerDeps = await updatePeerDependencies(versionBumps);
+
+    expect(updatedPeerDeps.directUpdatedPackages).toEqual([]);
+    expect(updatedPeerDeps.indirectUpdatedPackages).toEqual([]);
+  });
+
+  it('should update nothing when core & server got bumped to patch', async () => {
     const versionBumps: VersionBumps = {
       '@mastra/core': 'patch',
       '@mastra/server': 'patch',
     };
     const updatedPeerDeps = await updatePeerDependencies(versionBumps);
 
-    expect(updatedPeerDeps.directUpdatedPackages).toEqual(['@mastra/server']);
+    expect(updatedPeerDeps.directUpdatedPackages).toEqual([]);
     expect(updatedPeerDeps.indirectUpdatedPackages).toEqual([]);
   });
 });

--- a/packages/_changeset-cli/src/versions/updatePeerDependencies.ts
+++ b/packages/_changeset-cli/src/versions/updatePeerDependencies.ts
@@ -27,9 +27,7 @@ export function getDefaultUpdatedPeerDependencies(): UpdatedPeerDependencies {
 }
 
 function getNextMajorVersion(version: string): string | null {
-  const isZeroVersion = version.startsWith('0.');
-  const bumpType = isZeroVersion ? 'minor' : 'major';
-  return semver.inc(version, bumpType);
+  return semver.inc(version, 'major');
 }
 
 async function validateAndPrepareContext(versionBumps: VersionBumps, spinner: any): Promise<UpdateContext | null> {
@@ -80,20 +78,11 @@ async function validateAndPrepareContext(versionBumps: VersionBumps, spinner: an
 
   const coreBump = bumpsFromRelease[corePackage];
 
-  // if core got bumped because of a linked package we don't have to update peer dependencies.
-  if (coreBump === 'patch' && !versionBumps[corePackage]) {
-    spinner.stop(color.dim('Core package not bumped, skipping peer dependency updates.'));
+  // Only update peer dependencies when core gets a major bump.
+  // In 1.x, minor and patch bumps are non-breaking and don't require peer dep range changes.
+  if (coreBump !== 'major') {
+    spinner.stop(color.dim('Core package not bumped to major, skipping peer dependency updates.'));
     return null;
-  }
-
-  if (coreBump === 'patch' && Object.keys(versionBumps).length === 1) {
-    spinner.stop(color.dim('Only core package bumped, skipping peer dependency updates.'));
-    return null;
-  }
-
-  // When core is not bumped, we don't have to update peer dependencies to minor.
-  if (!versionBumps[corePackage]) {
-    versionBumps = {} as VersionBumps;
   }
 
   const packages = await getPublicPackages();
@@ -135,10 +124,6 @@ function collectIndirectUpdates(
   directUpdatedPackages: Map<string, PackageJson>,
 ): Map<string, PackageJson> {
   const indirectUpdatedPackages = new Map<string, PackageJson>();
-
-  if (context.coreBump === 'patch') {
-    return indirectUpdatedPackages;
-  }
 
   for (const pkg of context.packages) {
     if (pkg.packageJson.name === corePackage) continue;
@@ -202,7 +187,7 @@ export async function updatePeerDependencies(versionBumps: VersionBumps): Promis
   applyUpdatesToFiles(directUpdatedPackages, context.packagesByName);
 
   // Create changeset for direct updates
-  await createChangesetForUpdates(directUpdatedPackages, 'minor', context.nextCoreVersion);
+  await createChangesetForUpdates(directUpdatedPackages, 'major', context.nextCoreVersion);
 
   // Collect indirect updates
   (s as any).message = 'Updating indirect peer dependencies';


### PR DESCRIPTION
## Summary

Now that Mastra is on 1.x, minor and patch bumps are non-breaking and don't require peer dependency range changes. Previously the CLI treated minor bumps as breaking (correct for 0.x semver) and aggressively updated peer dep ranges on every minor core bump.

## Changes

- **`getNextMajorVersion`** — Remove 0.x special case, always use `major`
- **`validateAndPrepareContext`** — Skip peer dep updates unless core bump is `major`
- **`collectIndirectUpdates`** — Remove redundant patch guard (unreachable now)
- Direct peer dep update changesets now use `major` bump type instead of `minor`
- Summary UI labels direct updates as `major` instead of `minor`
- Tests updated to use 1.x versions and expectations

## Test plan

```
cd packages/_changeset-cli && pnpm test
```

All 10 tests pass — covering minor, patch, and major bumps for core, server, and memory packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Peer dependency updates are now correctly classified as major version changes instead of minor.
  * Tightened validation logic so peer dependency updates only occur on major version bumps.

* **Tests**
  * Updated test expectations to align with revised peer dependency update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->