### PR TITLE
feat: add @dane-ai-mastra PR slash commands for automated CI actions

### DIFF
--- a/.github/workflows/dane-pr-commands.yml
+++ b/.github/workflows/dane-pr-commands.yml
@@ -1,0 +1,211 @@
+name: 'Dane PR Commands'
+
+on:
+  issue_comment:
+    types: [created]
+
+# Only one command per PR at a time — cancel older pending runs
+concurrency:
+  group: dane-pr-command-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-permission:
+    name: Check permission & parse command
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@dane-ai-mastra')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    outputs:
+      authorized: ${{ steps.check.outputs.authorized }}
+      command: ${{ steps.check.outputs.command }}
+      pr_number: ${{ steps.check.outputs.pr_number }}
+    steps:
+      - name: Checkout (sparse — only .github/actions)
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+
+      - name: Generate GitHub App token
+        id: app_token
+        uses: ./.github/actions/app-auth
+        with:
+          app-id: ${{ vars.DANE_APP_ID }}
+          private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+
+      - name: Check org membership & parse command
+        id: check
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app_token.outputs.token }}
+          script: |
+            const comment = context.payload.comment;
+            const username = comment.user.login;
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.issue.number;
+
+            // Check org membership FIRST — reject non-members before revealing anything
+            try {
+              await github.rest.orgs.checkMembershipForUser({
+                org: owner,
+                username,
+              });
+            } catch (error) {
+              if (error.status === 404) {
+                core.info(`User ${username} is not an org member — ignoring`);
+                core.setOutput('authorized', 'false');
+                return;
+              }
+              throw error;
+            }
+
+            // Parse the command from the comment body
+            const match = comment.body.match(/@dane-ai-mastra\s+(\S+)/);
+            if (!match) {
+              core.info('No command found after @dane-ai-mastra mention');
+              core.setOutput('authorized', 'false');
+              return;
+            }
+
+            const command = match[1];
+            const supportedCommands = ['fix-ci', 'fix-lint', 'pr-comments'];
+
+            if (!supportedCommands.includes(command)) {
+              // Sanitize for safe display — only allow alphanumeric, hyphens, underscores
+              const safeCommand = command.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 50);
+              core.info(`Unknown command: ${safeCommand}`);
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body: `Unknown command \`${safeCommand}\`. Available commands: ${supportedCommands.map(c => `\`${c}\``).join(', ')}`,
+              });
+              core.setOutput('authorized', 'false');
+              return;
+            }
+
+            // Authorized — react with 👀
+            await github.rest.reactions.createForIssueComment({
+              owner,
+              repo,
+              comment_id: comment.id,
+              content: 'eyes',
+            });
+
+            core.setOutput('authorized', 'true');
+            core.setOutput('command', command);
+            core.setOutput('pr_number', String(prNumber));
+            core.info(`Authorized: ${username} running "${command}" on PR #${prNumber}`);
+
+  run-command:
+    name: Run @dane-ai-mastra command
+    needs: check-permission
+    if: needs.check-permission.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      # ── Trusted code from the default branch ──────────────────────────
+      # We checkout the default branch first and build from it so that
+      # the runner script, command templates, and all dependencies come
+      # from trusted code — NOT from the PR branch (which could be from
+      # an external fork and contain malicious modifications).
+      - name: Checkout default branch (trusted code)
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: trusted
+
+      - name: Set up Dane App auth
+        id: app_token
+        uses: ./trusted/.github/actions/app-auth
+        with:
+          app-id: ${{ vars.DANE_APP_ID }}
+          private-key: ${{ secrets.DANE_APP_PRIVATE_KEY }}
+
+      - name: Set up pnpm & Node.js
+        uses: ./trusted/.github/actions/setup-pnpm-node
+        with:
+          install-dependencies: 'false'
+
+      - name: Install dependencies (trusted)
+        run: pnpm install --frozen-lockfile
+        working-directory: trusted
+
+      - name: Build packages (trusted)
+        run: pnpm build
+        working-directory: trusted
+        env:
+          TURBO_TELEMETRY_DISABLED: '1'
+
+      # ── PR branch checkout (untrusted) ────────────────────────────────
+      # Only the working tree is from the PR. The runner script and
+      # all mastracode imports still resolve from trusted/.
+      - name: Checkout PR branch
+        uses: actions/checkout@v5
+        with:
+          path: pr-workspace
+
+      - name: Switch PR workspace to PR branch
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          PR_NUMBER: ${{ needs.check-permission.outputs.pr_number }}
+        working-directory: pr-workspace
+        run: gh pr checkout "$PR_NUMBER"
+
+      # ── Run the command from trusted code against the PR workspace ────
+      - name: Run command
+        env:
+          COMMAND_NAME: ${{ needs.check-permission.outputs.command }}
+          PR_NUMBER: ${{ needs.check-permission.outputs.pr_number }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+          PR_WORKSPACE: ${{ github.workspace }}/pr-workspace
+        working-directory: trusted
+        run: npx tsx scripts/gh-dane-command/index.ts
+
+      - name: React on success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app_token.outputs.token }}
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              ...context.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+
+      - name: React on failure
+        if: failure()
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ needs.check-permission.outputs.pr_number }}
+          COMMAND_NAME: ${{ needs.check-permission.outputs.command }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ steps.app_token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            await github.rest.reactions.createForIssueComment({
+              owner,
+              repo,
+              comment_id: context.payload.comment.id,
+              content: 'confused',
+            });
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const command = process.env.COMMAND_NAME;
+            const runUrl = process.env.RUN_URL;
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body: `The \`${command}\` command failed. Check the [workflow run](${runUrl}) for details.`,
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,3 +144,26 @@ For complex reproductions, you may also need to:
 - **Network traces**: For integration issues, include relevant network request/response data
 
 A well-crafted minimal reproduction is the best way to get your issue resolved quickly.
+
+## Automated PR commands
+
+Mastra maintainers (organization members) can trigger automated CI commands by commenting on a pull request with `@dane-ai-mastra` followed by a command name.
+
+### Available commands
+
+| Command | Description |
+| --- | --- |
+| `@dane-ai-mastra fix-ci` | Diagnoses and fixes GitHub Actions CI failures on the PR branch |
+| `@dane-ai-mastra fix-lint` | Runs formatting/linting fixes and pushes a commit |
+| `@dane-ai-mastra pr-comments` | Addresses PR review comments and CodeRabbit suggestions |
+
+### How it works
+
+1. Comment on a PR with one of the commands above
+2. The bot reacts with 👀 to acknowledge the request
+3. The command runs in a GitHub Actions workflow with full repo access
+4. On success, the bot reacts with 🚀. On failure, it reacts with 😕 and posts an error comment.
+
+### Who can use it
+
+Only members of the Mastra GitHub organization can trigger these commands. Comments from non-members are ignored.

--- a/scripts/gh-dane-command/index.ts
+++ b/scripts/gh-dane-command/index.ts
@@ -1,0 +1,118 @@
+/**
+ * GitHub Actions runner script for @dane-ai-mastra PR commands.
+ *
+ * Reads a command name and PR number from environment variables,
+ * loads the corresponding .claude/commands/ template, processes it,
+ * and sends it to a headless MastraCode harness for execution.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { createMastraCode } from '../../mastracode/src/index.js';
+import { runHeadless } from '../../mastracode/src/headless.js';
+import { processSlashCommand } from '../../mastracode/src/utils/slash-command-processor.js';
+import type { SlashCommandMetadata } from '../../mastracode/src/utils/slash-command-loader.js';
+import { releaseAllThreadLocks } from '../../mastracode/src/utils/thread-lock.js';
+import { setupDebugLogging } from '../../mastracode/src/utils/debug-log.js';
+
+// Supported commands and their corresponding .claude/commands/ file names
+const SUPPORTED_COMMANDS: Record<string, string> = {
+  'fix-ci': 'gh-fix-ci',
+  'fix-lint': 'gh-fix-lint',
+  'pr-comments': 'gh-pr-comments',
+};
+
+async function main(): Promise<never> {
+  const commandName = process.env.COMMAND_NAME;
+  const prNumber = process.env.PR_NUMBER;
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+
+  if (!commandName) {
+    console.error('Error: COMMAND_NAME environment variable is required');
+    process.exit(1);
+  }
+  if (!prNumber || !/^\d+$/.test(prNumber)) {
+    console.error('Error: PR_NUMBER environment variable must be a positive integer');
+    process.exit(1);
+  }
+  if (!apiKey) {
+    console.error('Error: ANTHROPIC_API_KEY environment variable is required');
+    process.exit(1);
+  }
+
+  const commandFileName = SUPPORTED_COMMANDS[commandName];
+  if (!commandFileName) {
+    const available = Object.keys(SUPPORTED_COMMANDS).join(', ');
+    console.error(`Error: Unknown command "${commandName}". Available commands: ${available}`);
+    process.exit(1);
+  }
+
+  // Trusted repo root = where this script lives (default branch checkout)
+  // PR workspace = where the AI agent will operate (PR branch checkout)
+  const trustedRoot = resolve(import.meta.dirname, '..', '..');
+  const prWorkspace = process.env.PR_WORKSPACE || trustedRoot;
+
+  // Load the command template from TRUSTED code, not the PR branch
+  const commandPath = resolve(trustedRoot, '.claude', 'commands', `${commandFileName}.md`);
+
+  let template: string;
+  try {
+    template = readFileSync(commandPath, 'utf-8');
+  } catch (err) {
+    console.error(`Error: Could not read command file at ${commandPath}: ${err}`);
+    process.exit(1);
+  }
+
+  // Process the template (replaces $ARGUMENTS, $1, !`shell`, @file references)
+  const commandMeta: SlashCommandMetadata = {
+    name: commandFileName,
+    description: '',
+    template,
+    sourcePath: commandPath,
+  };
+
+  const args = [prNumber];
+  const prompt = await processSlashCommand(commandMeta, args, trustedRoot);
+
+  console.log(`Running command: ${commandName} (file: ${commandFileName}.md)`);
+  console.log(`PR: #${prNumber}`);
+  console.log(`Trusted root: ${trustedRoot}`);
+  console.log(`PR workspace: ${prWorkspace}`);
+  console.log('---');
+
+  // Initialize MastraCode with yolo mode (auto-approve everything)
+  // cwd points to the PR workspace so the AI agent operates on the PR branch,
+  // while this script and all imports come from the trusted default branch.
+  const result = await createMastraCode({ cwd: prWorkspace, initialState: { yolo: true } });
+  const { harness, mcpManager, authStorage } = result;
+
+  // Inject the Anthropic API key into auth storage
+  authStorage.set('anthropic', { type: 'api_key', key: apiKey });
+
+  if (mcpManager?.hasServers()) {
+    await mcpManager.init();
+  }
+
+  setupDebugLogging();
+  await harness.init();
+
+  // Run headless with a 10 minute timeout
+  const exitCode = await runHeadless(harness, {
+    prompt,
+    format: 'default',
+    continue_: false,
+    timeout: 600,
+  });
+
+  // Cleanup
+  releaseAllThreadLocks();
+  await Promise.allSettled([mcpManager?.disconnect(), harness?.stopHeartbeats()]);
+
+  process.exit(exitCode);
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error instanceof Error ? error.stack || error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/gh-dane-command/package.json
+++ b/scripts/gh-dane-command/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "gh-dane-command",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.ts",
+  "license": "Apache-2.0",
+  "description": "GitHub Actions runner for @dane-ai-mastra PR slash commands"
+}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow and runner script that lets Mastra org members trigger automated CI commands by commenting on PRs with `@dane-ai-mastra <command>`.

### Available commands

| Command | Description |
| --- | --- |
| `@dane-ai-mastra fix-ci` | Diagnoses and fixes CI failures on the PR branch |
| `@dane-ai-mastra fix-lint` | Runs formatting/linting fixes and pushes a commit |
| `@dane-ai-mastra pr-comments` | Addresses PR review comments and CodeRabbit suggestions |

### How it works

1. A maintainer comments on a PR with a command
2. The workflow validates the commenter is an org member
3. The bot reacts with 👀 to acknowledge
4. The command runs in a GitHub Actions workflow via a headless MastraCode harness
5. On success: 🚀 reaction. On failure: 😕 reaction + error comment.

### Changes

- **`.github/workflows/dane-pr-commands.yml`** — New workflow triggered by `issue_comment` events, with authorization checks and command dispatch
- **`scripts/gh-dane-command/index.ts`** — Runner script that loads command templates from `.claude/commands/`, processes them, and executes via headless MastraCode
- **`scripts/gh-dane-command/package.json`** — Package manifest for the runner script
- **`CONTRIBUTING.md`** — Documents the new PR commands for contributors

### Security

- Only org members can trigger commands (verified via GitHub API)
- Command templates are loaded from the trusted default branch, not the PR branch
- The AI agent operates in the PR workspace but all code comes from the trusted checkout

### Test plan

- Verify the workflow triggers on `@dane-ai-mastra` comments in a test PR
- Confirm non-org-member comments are ignored
- Test each command (`fix-ci`, `fix-lint`, `pr-comments`) on a real PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated PR commands triggered by commenting @dane-ai-mastra on pull requests
  * Available commands: fix-ci, fix-lint, and pr-comments
  * Restricted to organization members; workflow provides visual feedback via reactions

* **Documentation**
  * Added guidance on using automated PR commands in contributor documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->