### PR TITLE
fix(s3vectors): adapt to @aws-sdk/client-s3vectors v3.1005.0 type changes

### DIFF
--- a/stores/s3vectors/src/vector/index.ts
+++ b/stores/s3vectors/src/vector/index.ts
@@ -265,17 +265,17 @@ export class S3Vectors extends MastraVector<S3VectorsFilter> {
 
       const vectors = (out.vectors ?? []).filter(v => !!v?.key);
 
-      // If includeVector is requested and some results lack data, fetch only the missing ones.
+      // Query results don't include vector data; fetch via GetVectors when requested.
       let dataMap: Record<string, number[] | undefined> | undefined;
       if (includeVector) {
-        const missingKeys = vectors.filter(v => !v.data?.float32 && v.key).map(v => v.key!) as string[];
+        const keys = vectors.filter(v => v.key).map(v => v.key!) as string[];
 
-        if (missingKeys.length > 0) {
+        if (keys.length > 0) {
           const got = await this.client.send(
             new GetVectorsCommand({
               ...this.bucketParams(),
               indexName,
-              keys: missingKeys,
+              keys,
               returnData: true,
               returnMetadata: false,
             }),
@@ -297,7 +297,7 @@ export class S3Vectors extends MastraVector<S3VectorsFilter> {
         if (md !== undefined) result.metadata = md;
 
         if (includeVector) {
-          const vec = (v.data?.float32 as number[] | undefined) ?? dataMap?.[id];
+          const vec = dataMap?.[id];
           if (vec !== undefined) result.vector = vec;
         }
 


### PR DESCRIPTION
## Summary

`@aws-sdk/client-s3vectors` v3.1005.0 removed the `data` property from `QueryOutputVector`. This broke the `@mastra/s3vectors` build with:

```
TS2339: Property 'data' does not exist on type 'QueryOutputVector'.
```

## Changes

- Removed references to `v.data?.float32` on query result vectors, since the SDK no longer returns vector data inline from `QueryVectorsCommand`
- When `includeVector` is requested, all keys are now fetched via `GetVectorsCommand` (the existing fallback path)
- No public API changes — this is purely adapting to an upstream SDK type change

## Test plan

- `pnpm turbo build --filter @mastra/s3vectors` passes cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved vector data retrieval to consistently fetch all relevant data when requested, ensuring reliable and complete data availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->