### PR TITLE
chore(docs): Add missing Composite storage items

### DIFF
--- a/.changeset/fix-storage-domain-docs.md
+++ b/.changeset/fix-storage-domain-docs.md
@@ -1,0 +1,9 @@
+---
+"@mastra/core": patch
+---
+
+Fixed storage documentation for composite storage and storage domains.
+
+- Updated the composite storage reference to list all supported domains in `MastraCompositeStore`.
+- Added missing `editor` and additional `domains.*` configuration fields to the options table.
+- Updated storage overview docs to describe domain coverage and align with current storage capabilities.

--- a/.changeset/fix-storage-domain-docs.md
+++ b/.changeset/fix-storage-domain-docs.md
@@ -5,5 +5,4 @@
 Fixed storage documentation for composite storage and storage domains.
 
 - Updated the composite storage reference to list all supported domains in `MastraCompositeStore`.
-- Added missing `editor` and additional `domains.*` configuration fields to the options table.
 - Updated storage overview docs to describe domain coverage and align with current storage capabilities.

--- a/.changeset/fix-storage-domain-docs.md
+++ b/.changeset/fix-storage-domain-docs.md
@@ -1,8 +1,0 @@
----
-"@mastra/core": patch
----
-
-Fixed storage documentation for composite storage and storage domains.
-
-- Updated the composite storage reference to list all supported domains in `MastraCompositeStore`.
-- Updated storage overview docs to describe domain coverage and align with current storage capabilities.

--- a/docs/src/content/en/docs/memory/storage.mdx
+++ b/docs/src/content/en/docs/memory/storage.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Storage | Memory"
-description: Configure storage for Mastra's memory system to persist conversations, workflows, and traces.
+description: Configure storage for Mastra to persist conversations and other runtime state.
 packages:
   - "@mastra/core"
   - "@mastra/libsql"
@@ -14,7 +14,7 @@ import TabItem from "@theme/TabItem";
 
 # Storage
 
-For agents to remember previous interactions, Mastra needs a database. Use a storage adapter for one of the [supported databases](#supported-providers) and pass it to your Mastra instance.
+For agents to remember previous interactions, Mastra needs a storage adapter. Use one of the [supported providers](#supported-providers) and pass it to your Mastra instance.
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
@@ -40,7 +40,7 @@ Relative paths like `file:./mastra.db` resolve based on each process's working d
 
 This configures instance-level storage, which all agents share by default. You can also configure [agent-level storage](#agent-level-storage) for isolated data boundaries.
 
-Mastra automatically creates the necessary tables on first interaction. See the [core schema](/reference/storage/overview#core-schema) for details on what gets created, including tables for messages, threads, resources, workflows, traces, and evaluation datasets.
+Mastra automatically initializes the necessary storage structures on first interaction. See [Storage Overview](/reference/storage/overview) for domain coverage and the schema used by the built-in database-backed domains.
 
 ## Supported providers
 
@@ -67,7 +67,7 @@ Storage can be configured at the instance level (shared by all agents) or at the
 
 ### Instance-level storage
 
-Add storage to your Mastra instance so all agents, workflows, observability traces and scores share the same memory provider:
+Add storage to your Mastra instance so all agents, workflows, observability traces, and scores share the same storage backend:
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
@@ -89,7 +89,7 @@ This is useful when all primitives share the same storage backend and have simil
 
 #### Composite storage
 
-[Composite storage](/reference/storage/composite) is an alternative way to configure instance-level storage. Use `MastraCompositeStore` to set the `memory` domain (and any other [domains](/reference/storage/composite#storage-domains) you need) to different storage providers.
+[Composite storage](/reference/storage/composite) is an alternative way to configure instance-level storage. Use `MastraCompositeStore` to route `memory` and any other [supported domains](/reference/storage/composite#storage-domains) to different storage providers.
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'

--- a/docs/src/content/en/reference/storage/composite.mdx
+++ b/docs/src/content/en/reference/storage/composite.mdx
@@ -114,13 +114,6 @@ export const mastra = new Mastra({
     isOptional: true,
   },
   {
-    name: 'editor',
-    type: 'MastraCompositeStore',
-    description:
-      'Optional shorthand for routing editor domains (`agents`, `promptBlocks`, `scorerDefinitions`, `mcpClients`, `mcpServers`, `workspaces`, `skills`) to one storage adapter.',
-    isOptional: true,
-  },
-  {
     name: 'domains',
     type: 'object',
     description:

--- a/docs/src/content/en/reference/storage/composite.mdx
+++ b/docs/src/content/en/reference/storage/composite.mdx
@@ -28,7 +28,7 @@ npm install @mastra/pg@latest @mastra/libsql@latest
 
 ## Storage domains
 
-Mastra organizes storage into five specialized domains, each handling a specific type of data. Each domain can be backed by a different storage adapter, and domain classes are exported from each storage package.
+Mastra organizes storage into domains, each handling a specific type of data. Each domain can be backed by a different storage adapter, and domain classes are exported from each storage package.
 
 | Domain | Description |
 | - | - |
@@ -37,6 +37,23 @@ Mastra organizes storage into five specialized domains, each handling a specific
 | `scores` | Evaluation results from Mastra's evals system. Scores and metrics are persisted here for analysis and comparison over time. |
 | `observability` | Telemetry data including traces and spans. Agent interactions, tool calls, and LLM requests generate spans collected into traces for debugging and performance analysis. |
 | `agents` | Agent configurations for stored agents. Enables agents to be defined and updated at runtime without code deployments. |
+| `datasets` | Evaluation datasets used for experiment runs. Stores dataset definitions, schemas, and versioned items. |
+| `experiments` | Experiment runs and per-item experiment results linked to datasets and targets. |
+| `promptBlocks` | Versioned prompt block entities used by the editor runtime. |
+| `scorerDefinitions` | Versioned scorer definitions used by eval workflows and editor tooling. |
+| `mcpClients` | Versioned MCP client definitions and configuration. |
+| `mcpServers` | Versioned MCP server definitions and transport configuration. |
+| `workspaces` | Versioned workspace entities used to group editor resources. |
+| `skills` | Versioned skill definitions for editor-managed skills. |
+| `blobs` | Content-addressable blob storage used by published skills and other versioned editor artifacts. |
+
+Mastra resolves domains in this order: `domains` overrides, then `editor` for `agents`, `promptBlocks`, `scorerDefinitions`, `mcpClients`, `mcpServers`, `workspaces`, and `skills`, then `default` as a fallback. Configure `blobs` separately with `domains.blobs`.
+
+:::note
+
+`MastraCompositeStore` accepts all of the domain keys above, but storage adapter support varies by package. You can mix adapters per domain, but only for domains implemented and exported by those adapters. For example, `memory: new MemoryLibSQL(...)` and `workflows: new WorkflowsPG(...)` is valid because both packages export those domain classes.
+
+:::
 
 ## Usage
 
@@ -106,10 +123,17 @@ export const mastra = new Mastra({
     isOptional: true,
   },
   {
+    name: 'editor',
+    type: 'MastraCompositeStore',
+    description:
+      'Optional shorthand for routing editor domains (`agents`, `promptBlocks`, `scorerDefinitions`, `mcpClients`, `mcpServers`, `workspaces`, `skills`) to one storage adapter.',
+    isOptional: true,
+  },
+  {
     name: 'domains',
     type: 'object',
     description:
-      'Individual domain overrides. Each domain can come from a different storage adapter. These take precedence over the default storage.',
+      'Individual domain overrides. Each domain can come from a different storage adapter. These take precedence over both `editor` and `default` storage.',
     isOptional: true,
   },
   {
@@ -140,6 +164,60 @@ export const mastra = new Mastra({
     name: 'domains.agents',
     type: 'AgentsStorage',
     description: 'Storage for stored agent configurations.',
+    isOptional: true,
+  },
+  {
+    name: 'domains.datasets',
+    type: 'DatasetsStorage',
+    description: 'Storage for dataset metadata, dataset items, and dataset versions.',
+    isOptional: true,
+  },
+  {
+    name: 'domains.experiments',
+    type: 'ExperimentsStorage',
+    description: 'Storage for experiment runs and per-item experiment results.',
+    isOptional: true,
+  },
+  {
+    name: 'domains.promptBlocks',
+    type: 'PromptBlocksStorage',
+    description: 'Storage for versioned prompt block entities.',
+    isOptional: true,
+  },
+  {
+    name: 'domains.scorerDefinitions',
+    type: 'ScorerDefinitionsStorage',
+    description: 'Storage for versioned scorer definition entities.',
+    isOptional: true,
+  },
+  {
+    name: 'domains.mcpClients',
+    type: 'MCPClientsStorage',
+    description: 'Storage for versioned MCP client entities.',
+    isOptional: true,
+  },
+  {
+    name: 'domains.mcpServers',
+    type: 'MCPServersStorage',
+    description: 'Storage for versioned MCP server entities.',
+    isOptional: true,
+  },
+  {
+    name: 'domains.workspaces',
+    type: 'WorkspacesStorage',
+    description: 'Storage for versioned workspace entities.',
+    isOptional: true,
+  },
+  {
+    name: 'domains.skills',
+    type: 'SkillsStorage',
+    description: 'Storage for versioned skill entities.',
+    isOptional: true,
+  },
+  {
+    name: 'domains.blobs',
+    type: 'BlobStore',
+    description: 'Content-addressable blob storage used by published skills and other versioned editor artifacts.',
     isOptional: true,
   },
   {

--- a/docs/src/content/en/reference/storage/composite.mdx
+++ b/docs/src/content/en/reference/storage/composite.mdx
@@ -163,48 +163,6 @@ export const mastra = new Mastra({
     isOptional: true,
   },
   {
-    name: 'domains.promptBlocks',
-    type: 'PromptBlocksStorage',
-    description: 'Storage for versioned prompt block entities.',
-    isOptional: true,
-  },
-  {
-    name: 'domains.scorerDefinitions',
-    type: 'ScorerDefinitionsStorage',
-    description: 'Storage for versioned scorer definition entities.',
-    isOptional: true,
-  },
-  {
-    name: 'domains.mcpClients',
-    type: 'MCPClientsStorage',
-    description: 'Storage for versioned MCP client entities.',
-    isOptional: true,
-  },
-  {
-    name: 'domains.mcpServers',
-    type: 'MCPServersStorage',
-    description: 'Storage for versioned MCP server entities.',
-    isOptional: true,
-  },
-  {
-    name: 'domains.workspaces',
-    type: 'WorkspacesStorage',
-    description: 'Storage for versioned workspace entities.',
-    isOptional: true,
-  },
-  {
-    name: 'domains.skills',
-    type: 'SkillsStorage',
-    description: 'Storage for versioned skill entities.',
-    isOptional: true,
-  },
-  {
-    name: 'domains.blobs',
-    type: 'BlobStore',
-    description: 'Content-addressable blob storage used by published skills and other versioned editor artifacts.',
-    isOptional: true,
-  },
-  {
     name: 'disableInit',
     type: 'boolean',
     description: 'When true, automatic initialization is disabled. You must call init() explicitly.',

--- a/docs/src/content/en/reference/storage/composite.mdx
+++ b/docs/src/content/en/reference/storage/composite.mdx
@@ -100,7 +100,7 @@ export const mastra = new Mastra({
 
 <PropertiesTable
   content={[
-      'Individual domain overrides. Each domain can come from a different storage adapter. These take precedence over the default storage.',
+  {
     name: 'id',
     type: 'string',
     description: 'Unique identifier for this storage instance.',

--- a/docs/src/content/en/reference/storage/composite.mdx
+++ b/docs/src/content/en/reference/storage/composite.mdx
@@ -114,59 +114,66 @@ export const mastra = new Mastra({
     isOptional: true,
   },
   {
+    name: 'disableInit',
+    type: 'boolean',
+    description: 'When true, automatic initialization is disabled. You must call init() explicitly.',
+    isOptional: true,
+  },
+  {
     name: 'domains',
     type: 'object',
     description:
       'Individual domain overrides. Each domain can come from a different storage adapter. These take precedence over both `editor` and `default` storage.',
     isOptional: true,
-  },
-  {
-    name: 'domains.memory',
-    type: 'MemoryStorage',
-    description: 'Storage for threads, messages, and resources.',
-    isOptional: true,
-  },
-  {
-    name: 'domains.workflows',
-    type: 'WorkflowsStorage',
-    description: 'Storage for workflow snapshots.',
-    isOptional: true,
-  },
-  {
-    name: 'domains.scores',
-    type: 'ScoresStorage',
-    description: 'Storage for evaluation scores.',
-    isOptional: true,
-  },
-  {
-    name: 'domains.observability',
-    type: 'ObservabilityStorage',
-    description: 'Storage for traces and spans.',
-    isOptional: true,
-  },
-  {
-    name: 'domains.agents',
-    type: 'AgentsStorage',
-    description: 'Storage for stored agent configurations.',
-    isOptional: true,
-  },
-  {
-    name: 'domains.datasets',
-    type: 'DatasetsStorage',
-    description: 'Storage for dataset metadata, dataset items, and dataset versions.',
-    isOptional: true,
-  },
-  {
-    name: 'domains.experiments',
-    type: 'ExperimentsStorage',
-    description: 'Storage for experiment runs and per-item experiment results.',
-    isOptional: true,
-  },
-  {
-    name: 'disableInit',
-    type: 'boolean',
-    description: 'When true, automatic initialization is disabled. You must call init() explicitly.',
-    isOptional: true,
+    properties: [
+      {
+        type: 'object',
+        parameters: [
+          {
+            name: 'memory',
+            type: 'MemoryStorage',
+            description: 'Storage for threads, messages, and resources.',
+            isOptional: true,
+          },
+          {
+            name: 'workflows',
+            type: 'WorkflowsStorage',
+            description: 'Storage for workflow snapshots.',
+            isOptional: true,
+          },
+          {
+            name: 'scores',
+            type: 'ScoresStorage',
+            description: 'Storage for evaluation scores.',
+            isOptional: true,
+          },
+          {
+            name: 'observability',
+            type: 'ObservabilityStorage',
+            description: 'Storage for traces and spans.',
+            isOptional: true,
+          },
+          {
+            name: 'agents',
+            type: 'AgentsStorage',
+            description: 'Storage for stored agent configurations.',
+            isOptional: true,
+          },
+          {
+            name: 'datasets',
+            type: 'DatasetsStorage',
+            description: 'Storage for dataset metadata, dataset items, and dataset versions.',
+            isOptional: true,
+          },
+          {
+            name: 'experiments',
+            type: 'ExperimentsStorage',
+            description: 'Storage for experiment runs and per-item experiment results.',
+            isOptional: true,
+          },
+        ],
+      },
+    ],
   },
 ]}
 />

--- a/docs/src/content/en/reference/storage/composite.mdx
+++ b/docs/src/content/en/reference/storage/composite.mdx
@@ -39,15 +39,6 @@ Mastra organizes storage into domains, each handling a specific type of data. Ea
 | `agents` | Agent configurations for stored agents. Enables agents to be defined and updated at runtime without code deployments. |
 | `datasets` | Evaluation datasets used for experiment runs. Stores dataset definitions, schemas, and versioned items. |
 | `experiments` | Experiment runs and per-item experiment results linked to datasets and targets. |
-| `promptBlocks` | Versioned prompt block entities used by the editor runtime. |
-| `scorerDefinitions` | Versioned scorer definitions used by eval workflows and editor tooling. |
-| `mcpClients` | Versioned MCP client definitions and configuration. |
-| `mcpServers` | Versioned MCP server definitions and transport configuration. |
-| `workspaces` | Versioned workspace entities used to group editor resources. |
-| `skills` | Versioned skill definitions for editor-managed skills. |
-| `blobs` | Content-addressable blob storage used by published skills and other versioned editor artifacts. |
-
-Mastra resolves domains in this order: `domains` overrides, then `editor` for `agents`, `promptBlocks`, `scorerDefinitions`, `mcpClients`, `mcpServers`, `workspaces`, and `skills`, then `default` as a fallback. Configure `blobs` separately with `domains.blobs`.
 
 :::note
 

--- a/docs/src/content/en/reference/storage/composite.mdx
+++ b/docs/src/content/en/reference/storage/composite.mdx
@@ -100,7 +100,7 @@ export const mastra = new Mastra({
 
 <PropertiesTable
   content={[
-  {
+      'Individual domain overrides. Each domain can come from a different storage adapter. These take precedence over the default storage.',
     name: 'id',
     type: 'string',
     description: 'Unique identifier for this storage instance.',

--- a/docs/src/content/en/reference/storage/overview.mdx
+++ b/docs/src/content/en/reference/storage/overview.mdx
@@ -25,7 +25,6 @@ Not every storage adapter implements every domain. Composite storage lets you mi
 | `workflows` | Workflow run snapshots used for suspend and resume. |
 | `scores` | Evaluation score records from eval runs. |
 | `observability` | Traces and spans used by observability exporters and Studio. |
-| `agents` | Versioned stored-agent entities. |
 | `datasets` | Dataset records, versioned items, and dataset versions used by experiments. |
 | `experiments` | Experiment runs and per-item experiment results. |
 | `promptBlocks` | Versioned prompt block entities. |

--- a/docs/src/content/en/reference/storage/overview.mdx
+++ b/docs/src/content/en/reference/storage/overview.mdx
@@ -11,7 +11,32 @@ import TabItem from "@theme/TabItem";
 
 # Storage Overview
 
-Mastra requires the following tables to be present in the database.
+Mastra storage is organized into domains. Each domain owns a set of tables or collections. Depending on your adapter and configuration, you may use all domains or only a subset.
+
+## Storage domains
+
+`MastraCompositeStore` can route the following domain keys:
+
+Not every storage adapter implements every domain. Composite storage lets you mix adapters per domain when the adapter packages export the corresponding domain classes.
+
+| Domain | Description |
+| - | - |
+| `memory` | Conversation persistence: messages, threads, and resources (including working memory). |
+| `workflows` | Workflow run snapshots used for suspend and resume. |
+| `scores` | Evaluation score records from eval runs. |
+| `observability` | Traces and spans used by observability exporters and Studio. |
+| `agents` | Versioned stored-agent entities. |
+| `datasets` | Dataset records, versioned items, and dataset versions used by experiments. |
+| `experiments` | Experiment runs and per-item experiment results. |
+| `promptBlocks` | Versioned prompt block entities. |
+| `scorerDefinitions` | Versioned scorer definition entities. |
+| `mcpClients` | Versioned MCP client entities. |
+| `mcpServers` | Versioned MCP server entities. |
+| `workspaces` | Versioned workspace entities. |
+| `skills` | Versioned skill entities. |
+| `blobs` | Content-addressable blob storage used by published skills and other versioned editor artifacts. |
+
+The schema definitions below cover the built-in database-backed tables documented for `memory`, `workflows`, `scores`, and `observability`. Other domains, and non-database adapters, use implementation-specific storage structures.
 
 ## Core Schema
 

--- a/docs/src/content/en/reference/storage/overview.mdx
+++ b/docs/src/content/en/reference/storage/overview.mdx
@@ -27,13 +27,6 @@ Not every storage adapter implements every domain. Composite storage lets you mi
 | `observability` | Traces and spans used by observability exporters and Studio. |
 | `datasets` | Dataset records, versioned items, and dataset versions used by experiments. |
 | `experiments` | Experiment runs and per-item experiment results. |
-| `promptBlocks` | Versioned prompt block entities. |
-| `scorerDefinitions` | Versioned scorer definition entities. |
-| `mcpClients` | Versioned MCP client entities. |
-| `mcpServers` | Versioned MCP server entities. |
-| `workspaces` | Versioned workspace entities. |
-| `skills` | Versioned skill entities. |
-| `blobs` | Content-addressable blob storage used by published skills and other versioned editor artifacts. |
 
 The schema definitions below cover the built-in database-backed tables documented for `memory`, `workflows`, `scores`, and `observability`. Other domains, and non-database adapters, use implementation-specific storage structures.
 


### PR DESCRIPTION
hey, as i was going through the code, i noticed a bunch of storage adapter domains weren't documented, and that missing information didn't make it into my plans, so i figured it would be helpful to get them onto the site for the next person.

## Description

- document the full set of `MastraCompositeStore` domain keys supported on `main`
- add the missing `editor` shorthand and `domains.*` configuration fields to the composite storage reference
- clarify domain resolution order: `domains > editor > default`
- clarify that adapter support varies by package even though composite storage accepts all domain keys
- tighten storage overview and memory storage wording so it does not overstate database-only behavior
- include a changeset for the docs correction

## Related Issue(s)

- N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Validation

- `cd docs && pnpm run validate`
- `cd docs && pnpm run build` (passes; existing broken-anchor warnings are unrelated to this change)
- `cd docs && pnpm exec remark --no-stdout --frail --quiet --ext mdx src/content/en/docs/memory/storage.mdx src/content/en/reference/storage/composite.mdx src/content/en/reference/storage/overview.mdx`
- `cd docs && scripts/vale/bin/vale src/content/en/docs/memory/storage.mdx src/content/en/reference/storage/composite.mdx src/content/en/reference/storage/overview.mdx` (warnings only, no errors)
- `pnpm exec prettier --check docs/src/content/en/docs/memory/storage.mdx docs/src/content/en/reference/storage/composite.mdx docs/src/content/en/reference/storage/overview.mdx .changeset/fix-storage-domain-docs.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated storage documentation with improved terminology and clearer descriptions
  * Added documentation for new storage domains: datasets and experiments
  * Refined storage configuration structure and examples for better clarity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->