### PR TITLE
fix: add x-mastra-dev-playground to CORS allowed headers

### DIFF
--- a/.changeset/small-brooms-end.md
+++ b/.changeset/small-brooms-end.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed CORS preflight blocking dev playground requests by adding the `x-mastra-dev-playground` header to the allowed CORS headers list. This resolves the browser error when the playground UI (running on a different port) makes requests to the Mastra dev server.

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -186,7 +186,13 @@ export async function createHonoServer(
       credentials: hasAuth ? true : false,
       maxAge: 3600,
       ...server?.cors,
-      allowHeaders: ['Content-Type', 'Authorization', 'x-mastra-client-type', ...(server?.cors?.allowHeaders ?? [])],
+      allowHeaders: [
+        'Content-Type',
+        'Authorization',
+        'x-mastra-client-type',
+        'x-mastra-dev-playground',
+        ...(server?.cors?.allowHeaders ?? []),
+      ],
       exposeHeaders: ['Content-Length', 'X-Requested-With', ...(server?.cors?.exposeHeaders ?? [])],
     };
     app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000), cors(corsConfig));


### PR DESCRIPTION
## Summary

The dev playground UI sends the `x-mastra-dev-playground` header on requests to local URLs (set in `@mastra/react`'s `mastra-client-context.tsx`), but the deployer's CORS configuration didn't include it in `allowHeaders`. This caused browsers to block all preflight requests from the playground with:

```
Access to fetch at 'http://localhost:4111/api/mcp/v0/servers' from origin 'http://localhost:5173'
has been blocked by CORS policy: Request header field x-mastra-dev-playground is not allowed
by Access-Control-Allow-Headers in preflight response.
```

## Change

Added `x-mastra-dev-playground` to the `allowHeaders` array in the deployer's CORS middleware config (`packages/deployer/src/server/index.ts`).

## Test Plan

1. Run `pnpm dev:ui` from `examples/agent`
2. Open the playground in the browser
3. Verify no CORS errors in the console and the UI loads correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CORS errors preventing the dev playground from communicating with the dev server when running on different ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->