### PR TITLE
fix(core): preserve reasoning content when tool-input-start arrives before reasoning-end

### DIFF
--- a/.changeset/fix-reasoning-flush.md
+++ b/.changeset/fix-reasoning-flush.md
@@ -2,6 +2,8 @@
 '@mastra/core': patch
 ---
 
-Fix reasoning content lost in multi-turn requests with thinking models (kimi-k2.5, DeepSeek-R1, OpenRouter) via OpenAI-compatible providers.
+`@mastra/core`: patch
 
-Some providers emit `tool-input-start` before `reasoning-end`, causing accumulated reasoning deltas to be discarded. Reasoning content is now flushed to the message list before clearing, and the late `reasoning-end` no longer adds a duplicate empty message.
+Fixed reasoning content being lost in multi-turn conversations with thinking models (kimi-k2.5, DeepSeek-R1) when using OpenAI-compatible providers (e.g., OpenRouter).
+
+Previously, reasoning content could be discarded during streaming, causing 400 errors when the model tried to continue the conversation. Multi-turn conversations now preserve reasoning content correctly across all turns.

--- a/.changeset/fix-reasoning-flush.md
+++ b/.changeset/fix-reasoning-flush.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fix reasoning content lost in multi-turn requests with thinking models (kimi-k2.5, DeepSeek-R1, OpenRouter) via OpenAI-compatible providers.
+
+Some providers emit `tool-input-start` before `reasoning-end`, causing accumulated reasoning deltas to be discarded. Reasoning content is now flushed to the message list before clearing, and the late `reasoning-end` no longer adds a duplicate empty message.

--- a/packages/core/src/agent/__tests__/reasoning-interleaved.test.ts
+++ b/packages/core/src/agent/__tests__/reasoning-interleaved.test.ts
@@ -283,4 +283,107 @@ describe('Reasoning with Interleaved Chunks (Issue #11480)', () => {
       expect(detail.text).toBe(reasoningParts.join(''));
     }
   });
+
+  /**
+   * Test for GitHub issue #13635:
+   * When tool-input-start arrives before reasoning-end (from flush()),
+   * reasoning content is lost because reasoningDeltas are cleared without being saved.
+   *
+   * This happens with OpenAI-compatible thinking models (kimi-k2.5, DeepSeek-R1)
+   * where the provider's flush() emits reasoning-end AFTER tool-input chunks.
+   *
+   * Chunk order: reasoning-start → reasoning-delta × N → tool-input-start → tool-input-delta → tool-call → reasoning-end
+   *
+   * @see https://github.com/mastra-ai/mastra/issues/13635
+   */
+  it('should preserve reasoning content when tool-input-start arrives before reasoning-end', async () => {
+    const reasoningText = 'I need to call a tool to get the weather data for Paris.';
+    const toolCallId = 'call_123';
+    const toolName = 'get_weather';
+
+    const model = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        content: [
+          { type: 'reasoning', text: reasoningText },
+          { type: 'tool-call', toolCallId, toolName, input: '{}' },
+        ],
+        warnings: [],
+      }),
+      doStream: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          {
+            type: 'response-metadata',
+            id: 'response-1',
+            modelId: 'mock-reasoning-tool-model',
+            timestamp: new Date(0),
+          },
+          // Reasoning starts
+          { type: 'reasoning-start', id: 'reasoning-1' },
+          { type: 'reasoning-delta', id: 'reasoning-1', delta: reasoningText },
+          // TOOL-INPUT-START ARRIVES BEFORE REASONING-END
+          // This is the exact sequence from issue #13635
+          {
+            type: 'tool-input-start',
+            id: toolCallId,
+            toolName,
+          },
+          { type: 'tool-input-delta', id: toolCallId, delta: '{}' },
+          {
+            type: 'tool-call',
+            toolCallId,
+            toolName,
+            input: '{}',
+          },
+          // reasoning-end arrives AFTER tool chunks (from provider flush())
+          { type: 'reasoning-end', id: 'reasoning-1' },
+          {
+            type: 'finish',
+            finishReason: 'tool-calls',
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          },
+        ]),
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'reasoning-tool-interleave-test',
+      name: 'Reasoning Tool Interleave Test',
+      instructions: 'You are a helpful assistant.',
+      model,
+    });
+
+    const response = await agent.stream('What is the weather in Paris?');
+    await response.consumeStream();
+
+    const dbMessages = response.messageList.get.all.db();
+    const assistantMessages = dbMessages.filter(m => m.role === 'assistant');
+    const allParts = assistantMessages.flatMap(m => m.content.parts);
+
+    // Find reasoning parts with non-empty text
+    const reasoningParts = allParts.filter(
+      p => p.type === 'reasoning' && p.details?.some((d: any) => d.type === 'text' && d.text.length > 0),
+    );
+
+    // At least one reasoning part should have the actual reasoning text
+    expect(reasoningParts.length).toBeGreaterThan(0);
+
+    const reasoningPart = reasoningParts[0];
+    expect(reasoningPart.details).toBeDefined();
+    expect(reasoningPart.details.length).toBeGreaterThan(0);
+
+    const detail = reasoningPart.details[0];
+    expect(detail.type).toBe('text');
+    if (detail.type === 'text') {
+      // THIS IS THE KEY ASSERTION for issue #13635
+      // Before the fix, this would be empty because reasoningDeltas were cleared
+      // when tool-input-start arrived, before reasoning-end could save them
+      expect(detail.text).toBe(reasoningText);
+    }
+  });
 });

--- a/packages/core/src/agent/__tests__/reasoning-interleaved.test.ts
+++ b/packages/core/src/agent/__tests__/reasoning-interleaved.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { simulateReadableStream } from '../../test-utils/llm-mock';
 import { Agent } from '../agent';
 import { MockLanguageModelV2, convertArrayToReadableStream } from './mock-model';
 
@@ -302,52 +303,39 @@ describe('Reasoning with Interleaved Chunks (Issue #11480)', () => {
     const toolName = 'get_weather';
 
     const model = new MockLanguageModelV2({
-      doGenerate: async () => ({
-        rawCall: { rawPrompt: null, rawSettings: {} },
-        finishReason: 'stop',
-        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
-        content: [
-          { type: 'reasoning', text: reasoningText },
-          { type: 'tool-call', toolCallId, toolName, input: '{}' },
-        ],
-        warnings: [],
-      }),
       doStream: async () => ({
-        rawCall: { rawPrompt: null, rawSettings: {} },
-        warnings: [],
-        stream: convertArrayToReadableStream([
-          { type: 'stream-start', warnings: [] },
-          {
-            type: 'response-metadata',
-            id: 'response-1',
-            modelId: 'mock-reasoning-tool-model',
-            timestamp: new Date(0),
-          },
-          // Reasoning starts
-          { type: 'reasoning-start', id: 'reasoning-1' },
-          { type: 'reasoning-delta', id: 'reasoning-1', delta: reasoningText },
-          // TOOL-INPUT-START ARRIVES BEFORE REASONING-END
-          // This is the exact sequence from issue #13635
-          {
-            type: 'tool-input-start',
-            id: toolCallId,
-            toolName,
-          },
-          { type: 'tool-input-delta', id: toolCallId, delta: '{}' },
-          {
-            type: 'tool-call',
-            toolCallId,
-            toolName,
-            input: '{}',
-          },
-          // reasoning-end arrives AFTER tool chunks (from provider flush())
-          { type: 'reasoning-end', id: 'reasoning-1' },
-          {
-            type: 'finish',
-            finishReason: 'tool-calls',
-            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
-          },
-        ]),
+        stream: simulateReadableStream({
+          chunks: [
+            {
+              type: 'response-metadata',
+              id: 'response-1',
+              modelId: 'mock-reasoning-tool-model',
+              timestamp: new Date(0),
+            },
+            { type: 'reasoning-start', id: 'reasoning-1' },
+            { type: 'reasoning-delta', id: 'reasoning-1', delta: reasoningText },
+            // tool-input-start arrives BEFORE reasoning-end (from provider flush())
+            {
+              type: 'tool-input-start',
+              id: toolCallId,
+              toolName,
+            },
+            { type: 'tool-input-delta', id: toolCallId, delta: '{}' },
+            {
+              type: 'tool-call',
+              toolCallId,
+              toolName,
+              input: '{}',
+            },
+            // reasoning-end arrives late from provider flush()
+            { type: 'reasoning-end', id: 'reasoning-1' },
+            {
+              type: 'finish',
+              finishReason: 'tool-calls',
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            },
+          ],
+        }),
       }),
     });
 
@@ -365,25 +353,18 @@ describe('Reasoning with Interleaved Chunks (Issue #11480)', () => {
     const assistantMessages = dbMessages.filter(m => m.role === 'assistant');
     const allParts = assistantMessages.flatMap(m => m.content.parts);
 
-    // Find reasoning parts with non-empty text
-    const reasoningParts = allParts.filter(
-      p => p.type === 'reasoning' && p.details?.some((d: any) => d.type === 'text' && d.text.length > 0),
-    );
+    // Find all reasoning parts
+    const allReasoningParts = allParts.filter((p: any) => p.type === 'reasoning');
 
-    // At least one reasoning part should have the actual reasoning text
-    expect(reasoningParts.length).toBeGreaterThan(0);
+    // Should have exactly one reasoning part (no duplicate empty message from late reasoning-end)
+    expect(allReasoningParts.length).toBe(1);
 
-    const reasoningPart = reasoningParts[0];
+    const reasoningPart = allReasoningParts[0] as any;
     expect(reasoningPart.details).toBeDefined();
     expect(reasoningPart.details.length).toBeGreaterThan(0);
 
     const detail = reasoningPart.details[0];
     expect(detail.type).toBe('text');
-    if (detail.type === 'text') {
-      // THIS IS THE KEY ASSERTION for issue #13635
-      // Before the fix, this would be empty because reasoningDeltas were cleared
-      // when tool-input-start arrived, before reasoning-end could save them
-      expect(detail.text).toBe(reasoningText);
-    }
+    expect(detail.text).toBe(reasoningText);
   });
 });

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -182,6 +182,7 @@ async function processOutputStream<OUTPUT = undefined>({
                 providerMetadata: runState.state.providerOptions,
               },
             ],
+            ...buildResponseModelMetadata(runState),
           },
           createdAt: new Date(),
         };
@@ -336,6 +337,15 @@ async function processOutputStream<OUTPUT = undefined>({
       }
 
       case 'reasoning-end': {
+        // If reasoning was already flushed by the guard (e.g. tool-input-start arrived
+        // before reasoning-end from provider flush), skip the duplicate empty message.
+        // This only affects OpenAI-compatible providers; the native OpenAI Responses API
+        // sends reasoning-end in order, so the item_reference fix (#9005) is unaffected.
+        if (!runState.state.isReasoning) {
+          safeEnqueue(controller, chunk);
+          break;
+        }
+
         // Always store reasoning, even if empty - OpenAI requires item_reference for tool calls
         // See: https://github.com/mastra-ai/mastra/issues/9005
         const message: MastraDBMessage = {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -162,6 +162,32 @@ async function processOutputStream<OUTPUT = undefined>({
       chunk.type !== 'text-start' &&
       runState.state.isReasoning
     ) {
+      // Flush reasoning deltas before clearing, same pattern as textDeltas above.
+      // Some providers (e.g., OpenAI-compatible reasoning models like kimi-k2.5, DeepSeek-R1)
+      // emit tool-input-start before reasoning-end (which arrives from flush()).
+      // Without this flush, reasoningDeltas are lost and reasoning_content becomes empty,
+      // causing 400 errors on subsequent turns that require reasoning_content echo-back.
+      // See: https://github.com/mastra-ai/mastra/issues/13635
+      if (runState.state.reasoningDeltas.length) {
+        const message: MastraDBMessage = {
+          id: messageId,
+          role: 'assistant',
+          content: {
+            format: 2,
+            parts: [
+              {
+                type: 'reasoning' as const,
+                reasoning: '',
+                details: [{ type: 'text', text: runState.state.reasoningDeltas.join('') }],
+                providerMetadata: runState.state.providerOptions,
+              },
+            ],
+          },
+          createdAt: new Date(),
+        };
+        messageList.add(message, 'response');
+      }
+
       runState.setState({
         isReasoning: false,
         reasoningDeltas: [],


### PR DESCRIPTION
## Summary

Fixes #13635. Based on #13982 by @MaxwellCalkin.

OpenAI-compatible thinking models (kimi-k2.5, DeepSeek-R1, OpenRouter reasoning models) may emit `tool-input-start` before `reasoning-end` (which arrives from the provider's `flush()` handler). The guard code in `llm-execution-step.ts` was clearing `reasoningDeltas` without saving them first, causing `reasoning_content` to be lost and 400 errors on subsequent turns.

## Changes

**`llm-execution-step.ts`**:
- Flush accumulated `reasoningDeltas` to `messageList` before the guard clears them (same pattern as `textDeltas`)
- Skip the late `reasoning-end` when reasoning was already flushed (prevents an empty reasoning part from being merged into the message via `MessageMerger`). This doesn't affect the OpenAI Responses API `item_reference` fix (#9005) since native OpenAI sends chunks in order.

**`reasoning-interleaved.test.ts`**:
- Regression test for the `tool-input-start` before `reasoning-end` scenario
- Asserts exactly 1 reasoning part with content (no extra empty part from late `reasoning-end`)

## Attribution

First commit is cherry-picked from #13982 by @MaxwellCalkin. Second commit adds the empty-part prevention guard and tightened test assertions.

## Test Plan

```bash
cd packages/core && npx vitest run src/agent/__tests__/reasoning-interleaved.test.ts
# 4 passed
cd packages/core && npx vitest run src/agent/agent.test.ts
# 162 passed, 5 skipped
cd packages/core && npx vitest run src/loop/workflows/agentic-execution/
# 31 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved reasoning content in multi-turn conversations with thinking models and OpenAI-compatible providers to avoid loss and subsequent 400 errors.
  * Prevented duplicate empty reasoning messages from appearing on later turns.

* **Documentation**
  * Added a changelog entry describing the reasoning-content preservation behavior.

* **Tests**
  * Added tests confirming reasoning is preserved when tool-input and reasoning chunks arrive interleaved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->