### PR TITLE
fix: dane PR commands - pnpm setup, alias support, and merge-main command

### DIFF
--- a/.github/actions/setup-pnpm-node/action.yaml
+++ b/.github/actions/setup-pnpm-node/action.yaml
@@ -10,6 +10,10 @@ inputs:
     description: 'Should use package manager cache'
     required: false
     default: 'true'
+  package-json-file:
+    description: 'Path to package.json for reading packageManager version (useful when checkout is not at workspace root)'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -18,6 +22,7 @@ runs:
       name: Install pnpm
       with:
         run_install: false
+        package_json_file: ${{ inputs.package-json-file || 'package.json' }}
 
     - name: Setup Node.js 22.x
       uses: actions/setup-node@v6

--- a/.github/workflows/dane-pr-commands.yml
+++ b/.github/workflows/dane-pr-commands.yml
@@ -14,7 +14,8 @@ jobs:
     name: Check permission & parse command
     if: >-
       github.event.issue.pull_request &&
-      contains(github.event.comment.body, '@dane-ai-mastra')
+      (contains(github.event.comment.body, '@dane-ai-mastra') ||
+       contains(github.event.comment.body, '@daneatmastra'))
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -64,15 +65,15 @@ jobs:
             }
 
             // Parse the command from the comment body
-            const match = comment.body.match(/@dane-ai-mastra\s+(\S+)/);
+            const match = comment.body.match(/@(?:dane-ai-mastra|daneatmastra)\s+\/?(\S+)/);
             if (!match) {
-              core.info('No command found after @dane-ai-mastra mention');
+              core.info('No command found after @dane-ai-mastra or @daneatmastra mention');
               core.setOutput('authorized', 'false');
               return;
             }
 
             const command = match[1];
-            const supportedCommands = ['fix-ci', 'fix-lint', 'pr-comments'];
+            const supportedCommands = ['fix-ci', 'fix-lint', 'pr-comments', 'merge-main'];
 
             if (!supportedCommands.includes(command)) {
               // Sanitize for safe display — only allow alphanumeric, hyphens, underscores
@@ -133,6 +134,7 @@ jobs:
         uses: ./trusted/.github/actions/setup-pnpm-node
         with:
           install-dependencies: 'false'
+          package-json-file: trusted/package.json
 
       - name: Install dependencies (trusted)
         run: pnpm install --frozen-lockfile

--- a/scripts/gh-dane-command/index.ts
+++ b/scripts/gh-dane-command/index.ts
@@ -21,6 +21,12 @@ const SUPPORTED_COMMANDS: Record<string, string> = {
   'fix-ci': 'gh-fix-ci',
   'fix-lint': 'gh-fix-lint',
   'pr-comments': 'gh-pr-comments',
+  'merge-main': '',
+};
+
+// Commands with inline prompts instead of .claude/commands/ templates
+const INLINE_PROMPTS: Record<string, string> = {
+  'merge-main': `Please merge latest origin/main in and fix conflicts to the best of your ability. If you are struggling with fixing conflicts please throw an error and stop saying that the conflicts are too complex to fix without making mistakes.`,
 };
 
 async function main(): Promise<never> {
@@ -42,7 +48,7 @@ async function main(): Promise<never> {
   }
 
   const commandFileName = SUPPORTED_COMMANDS[commandName];
-  if (!commandFileName) {
+  if (commandFileName === undefined) {
     const available = Object.keys(SUPPORTED_COMMANDS).join(', ');
     console.error(`Error: Unknown command "${commandName}". Available commands: ${available}`);
     process.exit(1);
@@ -53,27 +59,34 @@ async function main(): Promise<never> {
   const trustedRoot = resolve(import.meta.dirname, '..', '..');
   const prWorkspace = process.env.PR_WORKSPACE || trustedRoot;
 
-  // Load the command template from TRUSTED code, not the PR branch
-  const commandPath = resolve(trustedRoot, '.claude', 'commands', `${commandFileName}.md`);
+  let prompt: string;
 
-  let template: string;
-  try {
-    template = readFileSync(commandPath, 'utf-8');
-  } catch (err) {
-    console.error(`Error: Could not read command file at ${commandPath}: ${err}`);
-    process.exit(1);
+  if (INLINE_PROMPTS[commandName]) {
+    // Inline prompt — no template file needed
+    prompt = INLINE_PROMPTS[commandName];
+  } else {
+    // Load the command template from TRUSTED code, not the PR branch
+    const commandPath = resolve(trustedRoot, '.claude', 'commands', `${commandFileName}.md`);
+
+    let template: string;
+    try {
+      template = readFileSync(commandPath, 'utf-8');
+    } catch (err) {
+      console.error(`Error: Could not read command file at ${commandPath}: ${err}`);
+      process.exit(1);
+    }
+
+    // Process the template (replaces $ARGUMENTS, $1, !`shell`, @file references)
+    const commandMeta: SlashCommandMetadata = {
+      name: commandFileName,
+      description: '',
+      template,
+      sourcePath: commandPath,
+    };
+
+    const args = [prNumber];
+    prompt = await processSlashCommand(commandMeta, args, trustedRoot);
   }
-
-  // Process the template (replaces $ARGUMENTS, $1, !`shell`, @file references)
-  const commandMeta: SlashCommandMetadata = {
-    name: commandFileName,
-    description: '',
-    template,
-    sourcePath: commandPath,
-  };
-
-  const args = [prNumber];
-  const prompt = await processSlashCommand(commandMeta, args, trustedRoot);
 
   console.log(`Running command: ${commandName} (file: ${commandFileName}.md)`);
   console.log(`PR: #${prNumber}`);


### PR DESCRIPTION
## Summary

Fixes the `@dane-ai-mastra` PR command bot which was failing with:
> No pnpm version is specified. Please specify it by one of the following ways: - in the GitHub Action config with the key 'version' - in the package.json with the key 'packageManager'

### Changes

1. **Fix pnpm version detection** — The `dane-pr-commands.yml` workflow checks out the repo into a `trusted/` subdirectory, so `pnpm/action-setup@v4` couldn't find `package.json` at the workspace root. Added a `package-json-file` input to the `setup-pnpm-node` composite action and pass `trusted/package.json` from the dane workflow.

2. **Support `@daneatmastra` alias** — Both `@dane-ai-mastra` and `@daneatmastra` now trigger the workflow.

3. **Allow `/` prefix on commands** — `@daneatmastra /fix-ci` and `@daneatmastra fix-ci` both work.

4. **Add `merge-main` command** — New inline-prompt command that merges `origin/main` into the PR branch and resolves conflicts. Added an `INLINE_PROMPTS` map to the runner script for commands that don't need a `.claude/commands/` template file.

### Test plan

- Trigger the bot with `@daneatmastra fix-ci` on a PR to verify pnpm fix + alias
- Trigger with `@dane-ai-mastra /merge-main` to verify slash prefix + new command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow configuration for improved flexibility in setup processes.
  * Extended PR command handling to recognize additional command variations and support new merge operations.
  * Improved command processing pipeline to support both template-based and inline command definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->