### PR TITLE
fix(processors): pass writer to output processors in all execution paths

### DIFF
--- a/.changeset/brave-clouds-mate.md
+++ b/.changeset/brave-clouds-mate.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed writer being undefined in processOutputStream when output processors run on data-\* chunks in the workflow loop stream. This ensures custom output processors (like guardrail processors) can emit stream events via writer.custom() in all execution paths.
+Fixed `writer` being undefined in `processOutputStream` for all output processors. The root cause was that `processPart` in `ProcessorRunner` did not pass the `writer` to `executeWorkflowAsProcessor` in the outputStream phase. Since all user processors are wrapped into workflows via `combineProcessorsIntoWorkflow`, this meant no processor ever received a `writer`. Custom output processors (like guardrail processors) can now reliably use `writer.custom()` to emit stream events.

--- a/.changeset/brave-clouds-mate.md
+++ b/.changeset/brave-clouds-mate.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed writer being undefined in processOutputStream when output processors run on data-\* chunks in the workflow loop stream. This ensures custom output processors (like guardrail processors) can emit stream events via writer.custom() in all execution paths.

--- a/packages/core/src/agent/agent-writer-repro.test.ts
+++ b/packages/core/src/agent/agent-writer-repro.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Reproduction test for writer being undefined in processOutputStream.
+ *
+ * Tests every chunk type that flows through processOutputStream to verify
+ * writer is always defined. This covers the full agent.stream() path
+ * (handleChatStream → agent.stream() → workflowLoopStream → MastraModelOutput).
+ */
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
+import type { Processor, ProcessorStreamWriter } from '../processors/index';
+import type { ChunkType } from '../stream/types';
+import { Agent } from './index';
+
+describe('writer availability in processOutputStream (end-to-end)', () => {
+  it('should pass a defined writer for every chunk type during agent.stream()', async () => {
+    const writerByChunkType = new Map<string, ProcessorStreamWriter | undefined>();
+
+    class WriterCaptureProcessor implements Processor {
+      readonly id = 'writer-capture';
+      readonly name = 'Writer Capture';
+
+      async processOutputStream({ part, writer }: { part: ChunkType; writer?: ProcessorStreamWriter }) {
+        // Record the writer value for each chunk type we see
+        writerByChunkType.set(part.type, writer);
+        return part;
+      }
+    }
+
+    const mockModel = new MockLanguageModelV2({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'Hello world' },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          },
+        ]),
+        rawCall: { rawPrompt: [], rawSettings: {} },
+        warnings: [],
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'Test agent',
+      model: mockModel as any,
+      outputProcessors: [new WriterCaptureProcessor()],
+    });
+
+    const stream = await agent.stream('test message');
+
+    // Consume the full stream
+    for await (const _chunk of stream.fullStream) {
+      // just consume
+    }
+
+    // Verify we actually saw chunks
+    expect(writerByChunkType.size).toBeGreaterThan(0);
+
+    // Log status for each chunk type
+    for (const [chunkType, writer] of writerByChunkType) {
+      console.log(`  ${chunkType}: writer=${writer ? 'DEFINED' : 'UNDEFINED'}`);
+    }
+
+    // Check writer is defined for EVERY chunk type that went through processOutputStream
+    for (const [chunkType, writer] of writerByChunkType) {
+      expect(writer, `writer should be defined for chunk type "${chunkType}"`).toBeDefined();
+      expect(typeof writer!.custom, `writer.custom should be a function for chunk type "${chunkType}"`).toBe(
+        'function',
+      );
+    }
+
+    // Log which chunk types we verified (useful for debugging)
+    console.log('Chunk types verified with writer:', [...writerByChunkType.keys()]);
+  });
+});

--- a/packages/core/src/loop/workflows/stream.test.ts
+++ b/packages/core/src/loop/workflows/stream.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MessageList } from '../../agent/message-list';
+import type { Processor, ProcessorStreamWriter } from '../../processors';
+import { ChunkFrom } from '../../stream/types';
+import type { ChunkType } from '../../stream/types';
+
+// Capture the outputWriter passed to createAgenticLoopWorkflow so we can
+// invoke it directly in tests without spinning up a real agentic loop.
+let capturedOutputWriter: ((chunk: ChunkType) => Promise<void>) | undefined;
+
+vi.mock('./agentic-loop', () => ({
+  createAgenticLoopWorkflow: (params: any) => {
+    capturedOutputWriter = params.outputWriter;
+
+    return {
+      __registerMastra: vi.fn(),
+      deleteWorkflowRunById: vi.fn().mockResolvedValue(undefined),
+      createRun: vi.fn().mockResolvedValue({
+        start: vi.fn().mockImplementation(async () => {
+          // Simulate the agentic loop emitting a data-* chunk
+          await capturedOutputWriter!({
+            type: 'data-moderation',
+            data: { flagged: true },
+            runId: 'run-1',
+            from: ChunkFrom.AGENT,
+          } as ChunkType);
+
+          return {
+            status: 'success',
+            result: {
+              output: { steps: [], usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+              stepResult: { reason: 'stop', warnings: [], isContinued: false },
+              metadata: {},
+              messages: { nonUser: [], all: [] },
+            },
+          };
+        }),
+      }),
+    };
+  },
+}));
+
+const { workflowLoopStream } = await import('./stream');
+
+describe('workflowLoopStream', () => {
+  it('should pass a defined writer to output processors when processing data-* chunks', async () => {
+    let receivedWriter: ProcessorStreamWriter | undefined;
+
+    const processor: Processor = {
+      id: 'writer-capture',
+      name: 'Writer Capture',
+      processOutputStream: async ({ part, writer }) => {
+        receivedWriter = writer;
+        return part;
+      },
+    };
+
+    const messageList = new MessageList({ threadId: 'test-thread' });
+
+    const stream = workflowLoopStream({
+      messageId: 'msg-1',
+      runId: 'run-1',
+      startTimestamp: Date.now(),
+      agentId: 'test-agent',
+      messageList,
+      models: [{ model: {} as any, toolChoice: undefined }],
+      outputProcessors: [processor],
+      _internal: {},
+      streamState: { serialize: () => ({}), deserialize: () => {} },
+      methodType: 'stream',
+    });
+
+    // Consume the stream
+    const reader = stream.getReader();
+    const chunks: ChunkType[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (value) chunks.push(value);
+      if (done) break;
+    }
+
+    // The processor should have received a defined writer
+    expect(receivedWriter).toBeDefined();
+    expect(typeof receivedWriter!.custom).toBe('function');
+
+    // Verify the data-* chunk was emitted
+    const dataChunk = chunks.find(c => c.type === 'data-moderation');
+    expect(dataChunk).toBeDefined();
+  });
+});

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -46,6 +46,13 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
         : undefined;
       const dataChunkProcessorStates = hasOutputProcessors ? new Map<string, ProcessorState>() : undefined;
 
+      // Create a ProcessorStreamWriter so output processors can emit custom chunks back to the stream
+      const dataChunkStreamWriter = {
+        custom: async (data: { type: string }) => {
+          safeEnqueue(controller, data as ChunkType<OUTPUT>);
+        },
+      };
+
       const outputWriter = async (chunk: ChunkType<OUTPUT>) => {
         // Handle data-* chunks (custom data chunks from writer.custom())
         // These need to be persisted to storage, not just streamed
@@ -67,6 +74,7 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
               requestContext,
               messageList,
               0,
+              dataChunkStreamWriter,
             );
 
             if (blocked) {

--- a/packages/core/src/processors/runner.ts
+++ b/packages/core/src/processors/runner.ts
@@ -429,6 +429,7 @@ export class ProcessorRunner {
               },
               observabilityContext,
               requestContext,
+              writer,
             );
 
             // Extract the processed part from the result if it exists


### PR DESCRIPTION
## Summary

Fixes `writer` being `undefined` inside `processOutputStream` for all output processors (e.g. GuardRailProcessor) when using `agent.stream()`. This was reported as still broken after PRs #13056 and #13454.

## Root Cause

There are two gaps where `writer` was not being passed through:

### 1. Primary: `processPart` in `ProcessorRunner` (runner.ts)

`combineProcessorsIntoWorkflow` in `agent.ts` wraps **all** user processors into workflows via `createWorkflow` + `createStep(processor)`. This means in `processPart`, every processor hits the `isProcessorWorkflow` branch (line 405), never the regular processor branch (line 457+).

The workflow branch called `executeWorkflowAsProcessor` **without** the `writer` parameter:

```typescript
// BEFORE (runner.ts:420-432)
const result = await this.executeWorkflowAsProcessor(
  processorOrWorkflow,
  { phase: 'outputStream', part, streamParts, state, messageList, retryCount },
  observabilityContext,
  requestContext,
  // ← writer was missing here (5th parameter)
);
```

Without `writer`, the chain breaks:
- `executeWorkflowAsProcessor` sets `outputWriter: undefined` (line 187)
- `workflow.ts:764` sets `processorWriter = undefined`
- `workflow.ts:792` puts `writer: undefined` into `baseContext`
- `workflow.ts:1047` calls `processOutputStream({ ...baseContext })` — writer is undefined

**Fix**: Pass `writer` as the 5th argument to `executeWorkflowAsProcessor`.

### 2. Secondary: `data-*` chunks in workflow loop stream (stream.ts)

The `outputWriter` callback in `workflowLoopStream` processes `data-*` chunks (custom data emitted via `writer.custom()`) through output processors, but didn't create or pass a `ProcessorStreamWriter` to `processPart`.

**Fix**: Create a `dataChunkStreamWriter` that enqueues chunks back into the stream controller, and pass it as the 7th argument to `processPart`.

## Why previous PRs didn't fix this

PRs #13056 and #13454 added writer plumbing and a test in `runner.test.ts` that called `processPart` directly with a bare `Processor` object. That test exercised the **regular processor branch** (line 457+) of `processPart`, which correctly passes writer. But in production, `combineProcessorsIntoWorkflow` wraps all processors into workflows, so they always hit the **workflow branch** (line 405) instead — which was the one missing writer. The test gave false confidence by testing a code path that's never actually reached in the real agent pipeline. That misleading test has been removed in this PR.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/processors/runner.ts` | Pass `writer` to `executeWorkflowAsProcessor` in the `outputStream` phase of `processPart` |
| `packages/core/src/loop/workflows/stream.ts` | Create `dataChunkStreamWriter` and pass to `processPart` for `data-*` chunks |
| `packages/core/src/processors/runner.test.ts` | Remove misleading test that tested writer on bare processors via `processPart` (a code path never hit in production) |
| `packages/core/src/agent/agent-writer-repro.test.ts` | End-to-end test: creates an Agent with a mock model + WriterCaptureProcessor, verifies `writer` is defined for every chunk type through the full `agent.stream()` pipeline |
| `packages/core/src/loop/workflows/stream.test.ts` | Unit test: verifies `writer` is defined when output processors run on `data-*` chunks in workflowLoopStream |
| `.changeset/brave-clouds-mate.md` | Patch changeset for `@mastra/core` |

## Test plan

- [x] `agent-writer-repro.test.ts` — end-to-end verification that writer=DEFINED for all chunk types through `agent.stream()` (response-metadata, text-start, text-delta, text-end, finish)
- [x] `stream.test.ts` — verifies writer is passed for data-* chunks in the workflow loop stream
- [x] `runner.test.ts` — 42 existing tests still pass after removing the misleading test
- [x] `output.test.ts` — existing output stream tests still pass
- [ ] Manual verification with a GuardRailProcessor using `writer.custom()` in `processOutputStream`

🤖 Generated with [Claude Code](https://claude.com/claude-code)