### PR TITLE
fix: set Renovate gitAuthor to match PAT token owner

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "gitAuthor": "Dane - AI (Mastra) <199639756+daneatmastra@users.noreply.github.com>",
   "rangeStrategy": "bump",
   "extends": [
     ":dependencyDashboard",


### PR DESCRIPTION
## Problem

Renovate was committing as `renovate-bot` but the API token (`RENOVATE_PAT`) belongs to `daneatmastra`. This mismatch caused:
- "Edited/Blocked Notification" errors on Renovate PRs
- Renovate couldn't recognize its own commits, preventing automatic rebase

See: https://github.com/mastra-ai/mastra/pull/13797

## Fix

Added `gitAuthor` to `renovate.json` set to `daneatmastra`'s GitHub noreply email, so commits are authored by the same identity as the token owner.

## Test Plan

- Renovate's next run should author commits as `daneatmastra`
- Existing and new Renovate PRs should no longer show "Edited/Blocked" status
- Automatic rebase should work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to specify the automation author for dependency management updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->