### PR TITLE
Fix Trace snapshots after #11959 merged

### DIFF
--- a/observability/mastra/src/__snapshots__/agent-processors-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-processors-trace.json
@@ -1,19 +1,19 @@
 {
   "__structure__": [
     "agent_run: \"agent run: 'test-agent'\"",
-    "\u251c\u2500\u2500 processor_run: \"input processor: validator\"",
-    "\u2502   \u2514\u2500\u2500 agent_run: \"agent run: 'validator-agent'\"",
-    "\u2502       \u2514\u2500\u2500 model_generation: \"llm: 'mock-model-id'\"",
-    "\u2502           \u2514\u2500\u2500 model_step: \"step: 0\"",
-    "\u2502               \u2514\u2500\u2500 model_chunk: \"chunk: 'text'\"",
-    "\u251c\u2500\u2500 model_generation: \"llm: 'mock-model-id'\"",
-    "\u2502   \u2514\u2500\u2500 model_step: \"step: 0\"",
-    "\u2502       \u2514\u2500\u2500 model_chunk: \"chunk: 'text'\"",
-    "\u2514\u2500\u2500 processor_run: \"output processor: summarizer\"",
-    "    \u2514\u2500\u2500 agent_run: \"agent run: 'summarizer-agent'\"",
-    "        \u2514\u2500\u2500 model_generation: \"llm: 'mock-model-id'\"",
-    "            \u2514\u2500\u2500 model_step: \"step: 0\"",
-    "                \u2514\u2500\u2500 model_chunk: \"chunk: 'text'\""
+    "├── processor_run: \"input processor: validator\"",
+    "│   └── agent_run: \"agent run: 'validator-agent'\"",
+    "│       └── model_generation: \"llm: 'mock-model-id'\"",
+    "│           └── model_step: \"step: 0\"",
+    "│               └── model_chunk: \"chunk: 'text'\"",
+    "├── model_generation: \"llm: 'mock-model-id'\"",
+    "│   └── model_step: \"step: 0\"",
+    "│       └── model_chunk: \"chunk: 'text'\"",
+    "└── processor_run: \"output processor: summarizer\"",
+    "    └── agent_run: \"agent run: 'summarizer-agent'\"",
+    "        └── model_generation: \"llm: 'mock-model-id'\"",
+    "            └── model_step: \"step: 0\"",
+    "                └── model_chunk: \"chunk: 'text'\""
   ],
   "spans": [
     {

--- a/observability/mastra/src/__snapshots__/agent-processors-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-processors-trace.json
@@ -1,19 +1,19 @@
 {
   "__structure__": [
     "agent_run: \"agent run: 'test-agent'\"",
-    "├── processor_run: \"input processor: validator\"",
-    "│   └── agent_run: \"agent run: 'validator-agent'\"",
-    "│       └── model_generation: \"llm: 'mock-model-id'\"",
-    "│           └── model_step: \"step: 0\"",
-    "│               └── model_chunk: \"chunk: 'text'\"",
-    "├── model_generation: \"llm: 'mock-model-id'\"",
-    "│   └── model_step: \"step: 0\"",
-    "│       └── model_chunk: \"chunk: 'text'\"",
-    "└── processor_run: \"output processor: summarizer\"",
-    "    └── agent_run: \"agent run: 'summarizer-agent'\"",
-    "        └── model_generation: \"llm: 'mock-model-id'\"",
-    "            └── model_step: \"step: 0\"",
-    "                └── model_chunk: \"chunk: 'text'\""
+    "\u251c\u2500\u2500 processor_run: \"input processor: validator\"",
+    "\u2502   \u2514\u2500\u2500 agent_run: \"agent run: 'validator-agent'\"",
+    "\u2502       \u2514\u2500\u2500 model_generation: \"llm: 'mock-model-id'\"",
+    "\u2502           \u2514\u2500\u2500 model_step: \"step: 0\"",
+    "\u2502               \u2514\u2500\u2500 model_chunk: \"chunk: 'text'\"",
+    "\u251c\u2500\u2500 model_generation: \"llm: 'mock-model-id'\"",
+    "\u2502   \u2514\u2500\u2500 model_step: \"step: 0\"",
+    "\u2502       \u2514\u2500\u2500 model_chunk: \"chunk: 'text'\"",
+    "\u2514\u2500\u2500 processor_run: \"output processor: summarizer\"",
+    "    \u2514\u2500\u2500 agent_run: \"agent run: 'summarizer-agent'\"",
+    "        \u2514\u2500\u2500 model_generation: \"llm: 'mock-model-id'\"",
+    "            \u2514\u2500\u2500 model_step: \"step: 0\"",
+    "                \u2514\u2500\u2500 model_chunk: \"chunk: 'text'\""
   ],
   "spans": [
     {
@@ -35,7 +35,9 @@
         },
         "input": "  Hello! How are you?  ",
         "output": {
-          "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+          "text": {
+            "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+          },
           "files": []
         }
       },
@@ -55,6 +57,9 @@
             "attributes": {
               "processorExecutor": "workflow",
               "processorIndex": 0
+            },
+            "metadata": {
+              "runId": "<runId-1>"
             },
             "input": {
               "phase": "input",
@@ -128,7 +133,9 @@
                 },
                 "input": "Validate:   Hello! How are you?  ",
                 "output": {
-                  "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                  "text": {
+                    "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                  },
                   "files": []
                 }
               },
@@ -185,7 +192,9 @@
                       "files": [],
                       "reasoning": [],
                       "sources": [],
-                      "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                      "text": {
+                        "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                      },
                       "warnings": []
                     }
                   },
@@ -213,6 +222,7 @@
                           "finishReason": "stop"
                         },
                         "metadata": {
+                          "runId": "<runId-2>",
                           "modelMetadata": {
                             "modelId": "mock-model-id",
                             "modelVersion": "v2",
@@ -221,7 +231,9 @@
                         },
                         "input": {},
                         "output": {
-                          "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                          "text": {
+                            "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                          },
                           "toolCalls": []
                         }
                       },
@@ -242,8 +254,13 @@
                               "chunkType": "text",
                               "sequenceNumber": 0
                             },
+                            "metadata": {
+                              "runId": "<runId-2>"
+                            },
                             "output": {
-                              "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] }
+                              "text": {
+                                "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                              }
                             }
                           }
                         }
@@ -307,7 +324,9 @@
               "files": [],
               "reasoning": [],
               "sources": [],
-              "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+              "text": {
+                "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+              },
               "warnings": []
             }
           },
@@ -335,6 +354,7 @@
                   "finishReason": "stop"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -343,7 +363,9 @@
                 },
                 "input": {},
                 "output": {
-                  "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                  "text": {
+                    "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                  },
                   "toolCalls": []
                 }
               },
@@ -364,8 +386,13 @@
                       "chunkType": "text",
                       "sequenceNumber": 0
                     },
+                    "metadata": {
+                      "runId": "<runId-1>"
+                    },
                     "output": {
-                      "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] }
+                      "text": {
+                        "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                      }
                     }
                   }
                 }
@@ -389,6 +416,9 @@
               "processorExecutor": "workflow",
               "processorIndex": 0
             },
+            "metadata": {
+              "runId": "<runId-1>"
+            },
             "input": {
               "phase": "outputResult",
               "messageCount": 1
@@ -411,7 +441,9 @@
                     "content": [
                       {
                         "type": "text",
-                        "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] }
+                        "text": {
+                          "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                        }
                       }
                     ]
                   }
@@ -424,7 +456,9 @@
                 ]
               },
               "result": {
-                "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                "text": {
+                  "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                },
                 "usage": {
                   "inputTokens": 15,
                   "outputTokens": 25,
@@ -440,8 +474,12 @@
                   "content": {
                     "format": 2,
                     "parts": ["[Circular]"],
-                    "content": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
-                    "metadata": { "modelId": "mock-model-id" }
+                    "metadata": {
+                      "modelId": "mock-model-id"
+                    },
+                    "content": {
+                      "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                    }
                   },
                   "createdAt": "<date>"
                 }
@@ -467,9 +505,13 @@
                 "metadata": {
                   "runId": "<runId-3>"
                 },
-                "input": { "__or__": ["Summarize: Mock V2 generate response", "Summarize: Mock V2 stream response"] },
+                "input": {
+                  "__or__": ["Summarize: Mock V2 generate response", "Summarize: Mock V2 stream response"]
+                },
                 "output": {
-                  "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                  "text": {
+                    "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                  },
                   "files": []
                 }
               },
@@ -528,7 +570,9 @@
                       "files": [],
                       "reasoning": [],
                       "sources": [],
-                      "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                      "text": {
+                        "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                      },
                       "warnings": []
                     }
                   },
@@ -556,6 +600,7 @@
                           "finishReason": "stop"
                         },
                         "metadata": {
+                          "runId": "<runId-3>",
                           "modelMetadata": {
                             "modelId": "mock-model-id",
                             "modelVersion": "v2",
@@ -564,7 +609,9 @@
                         },
                         "input": {},
                         "output": {
-                          "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                          "text": {
+                            "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                          },
                           "toolCalls": []
                         }
                       },
@@ -585,8 +632,13 @@
                               "chunkType": "text",
                               "sequenceNumber": 0
                             },
+                            "metadata": {
+                              "runId": "<runId-3>"
+                            },
                             "output": {
-                              "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] }
+                              "text": {
+                                "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                              }
                             }
                           }
                         }

--- a/observability/mastra/src/__snapshots__/agent-structured-output-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-structured-output-trace.json
@@ -32,7 +32,9 @@
         },
         "input": "Return a list of items separated by commas",
         "output": {
-          "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+          "text": {
+            "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+          },
           "object": {
             "items": "test structured output"
           },
@@ -95,7 +97,9 @@
               },
               "reasoning": [],
               "sources": [],
-              "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+              "text": {
+                "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+              },
               "warnings": []
             }
           },
@@ -123,6 +127,7 @@
                   "finishReason": "stop"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -131,7 +136,9 @@
                 },
                 "input": {},
                 "output": {
-                  "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                  "text": {
+                    "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                  },
                   "toolCalls": [],
                   "object": {
                     "items": "test structured output"
@@ -155,8 +162,13 @@
                       "chunkType": "text",
                       "sequenceNumber": 0
                     },
+                    "metadata": {
+                      "runId": "<runId-1>"
+                    },
                     "output": {
-                      "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] }
+                      "text": {
+                        "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                      }
                     }
                   }
                 },
@@ -175,6 +187,9 @@
                     "attributes": {
                       "chunkType": "object",
                       "sequenceNumber": 1
+                    },
+                    "metadata": {
+                      "runId": "<runId-1>"
                     },
                     "output": {
                       "items": "test structured output"
@@ -201,13 +216,24 @@
               "processorExecutor": "legacy",
               "processorIndex": 0
             },
+            "metadata": {
+              "runId": "<runId-1>"
+            },
             "input": {
-              "totalChunks": { "__or__": [5, 3] },
-              "accumulatedText": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] }
+              "totalChunks": {
+                "__or__": [5, 3]
+              },
+              "accumulatedText": {
+                "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+              }
             },
             "output": {
-              "totalChunks": { "__or__": [5, 3] },
-              "accumulatedText": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] }
+              "totalChunks": {
+                "__or__": [5, 3]
+              },
+              "accumulatedText": {
+                "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+              }
             }
           },
           "children": [
@@ -332,6 +358,7 @@
                           "finishReason": "stop"
                         },
                         "metadata": {
+                          "runId": "<runId-2>",
                           "modelMetadata": {
                             "modelId": "mock-model-id",
                             "modelVersion": "v2",
@@ -364,6 +391,9 @@
                               "chunkType": "object",
                               "sequenceNumber": 0
                             },
+                            "metadata": {
+                              "runId": "<runId-2>"
+                            },
                             "output": {}
                           }
                         },
@@ -382,6 +412,9 @@
                             "attributes": {
                               "chunkType": "text",
                               "sequenceNumber": 1
+                            },
+                            "metadata": {
+                              "runId": "<runId-2>"
                             },
                             "output": {
                               "items": "test structured output"

--- a/observability/mastra/src/__snapshots__/agent-tool-call-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-tool-call-trace.json
@@ -32,7 +32,9 @@
         },
         "input": "Calculate 5 + 3",
         "output": {
-          "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+          "text": {
+            "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+          },
           "files": []
         }
       },
@@ -90,7 +92,9 @@
               "files": [],
               "reasoning": [],
               "sources": [],
-              "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+              "text": {
+                "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+              },
               "warnings": []
             }
           },
@@ -118,6 +122,8 @@
                   "finishReason": "tool-calls"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
+                  "resourceId": "test-resource-id",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -157,6 +163,10 @@
                       "chunkType": "tool-call",
                       "sequenceNumber": 0
                     },
+                    "metadata": {
+                      "runId": "<runId-1>",
+                      "resourceId": "test-resource-id"
+                    },
                     "output": {
                       "toolName": "calculator",
                       "toolCallId": "call-calc-1",
@@ -185,6 +195,10 @@
                       "toolType": "tool",
                       "success": true
                     },
+                    "metadata": {
+                      "runId": "<runId-1>",
+                      "resourceId": "test-resource-id"
+                    },
                     "input": {
                       "operation": "add",
                       "a": 5,
@@ -212,6 +226,8 @@
                       "sequenceNumber": 1
                     },
                     "metadata": {
+                      "runId": "<runId-1>",
+                      "resourceId": "test-resource-id",
                       "toolCallId": "call-calc-1",
                       "toolName": "calculator"
                     },
@@ -245,6 +261,8 @@
                   "finishReason": "stop"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
+                  "resourceId": "test-resource-id",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -253,7 +271,9 @@
                 },
                 "input": {},
                 "output": {
-                  "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                  "text": {
+                    "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                  },
                   "toolCalls": []
                 }
               },
@@ -274,8 +294,14 @@
                       "chunkType": "text",
                       "sequenceNumber": 0
                     },
+                    "metadata": {
+                      "runId": "<runId-1>",
+                      "resourceId": "test-resource-id"
+                    },
                     "output": {
-                      "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] }
+                      "text": {
+                        "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                      }
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/agent-workflow-direct-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-direct-trace.json
@@ -31,7 +31,9 @@
         },
         "input": "Execute the simpleWorkflow with test input",
         "output": {
-          "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+          "text": {
+            "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+          },
           "files": []
         }
       },
@@ -88,7 +90,9 @@
               "files": [],
               "reasoning": [],
               "sources": [],
-              "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+              "text": {
+                "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+              },
               "warnings": []
             }
           },
@@ -116,6 +120,7 @@
                   "finishReason": "tool-calls"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -155,6 +160,9 @@
                       "chunkType": "tool-call",
                       "sequenceNumber": 0
                     },
+                    "metadata": {
+                      "runId": "<runId-1>"
+                    },
                     "output": {
                       "toolName": "workflow-simpleWorkflow",
                       "toolCallId": "call-workflow-1",
@@ -182,6 +190,9 @@
                       "toolDescription": "Workflow: simpleWorkflow",
                       "toolType": "tool",
                       "success": true
+                    },
+                    "metadata": {
+                      "runId": "<runId-1>"
                     },
                     "input": {
                       "inputData": {
@@ -237,6 +248,9 @@
                             "attributes": {
                               "status": "success"
                             },
+                            "metadata": {
+                              "runId": "<runId-2>"
+                            },
                             "input": {
                               "input": "test input"
                             },
@@ -266,6 +280,7 @@
                       "sequenceNumber": 1
                     },
                     "metadata": {
+                      "runId": "<runId-1>",
                       "toolCallId": "call-workflow-1",
                       "toolName": "workflow-simpleWorkflow"
                     },
@@ -302,6 +317,7 @@
                   "finishReason": "stop"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -310,7 +326,9 @@
                 },
                 "input": {},
                 "output": {
-                  "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                  "text": {
+                    "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                  },
                   "toolCalls": []
                 }
               },
@@ -331,8 +349,13 @@
                       "chunkType": "text",
                       "sequenceNumber": 0
                     },
+                    "metadata": {
+                      "runId": "<runId-1>"
+                    },
                     "output": {
-                      "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] }
+                      "text": {
+                        "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                      }
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/agent-workflow-tool-trace.json
+++ b/observability/mastra/src/__snapshots__/agent-workflow-tool-trace.json
@@ -33,7 +33,9 @@
         },
         "input": "Execute the simpleWorkflow with test input",
         "output": {
-          "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+          "text": {
+            "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+          },
           "files": []
         }
       },
@@ -67,7 +69,9 @@
               }
             },
             "metadata": {
-              "runId": "<runId-1>"
+              "runId": "<runId-1>",
+              "id1": 123,
+              "id2": "tacos"
             },
             "input": {
               "messages": [
@@ -90,7 +94,9 @@
               "files": [],
               "reasoning": [],
               "sources": [],
-              "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+              "text": {
+                "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+              },
               "warnings": []
             }
           },
@@ -118,6 +124,9 @@
                   "finishReason": "tool-calls"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
+                  "id1": 123,
+                  "id2": "tacos",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -158,6 +167,11 @@
                       "chunkType": "tool-call",
                       "sequenceNumber": 0
                     },
+                    "metadata": {
+                      "runId": "<runId-1>",
+                      "id1": 123,
+                      "id2": "tacos"
+                    },
                     "output": {
                       "toolName": "workflowExecutor",
                       "toolCallId": "call-workflow-1",
@@ -187,12 +201,16 @@
                       "toolType": "tool",
                       "success": true
                     },
+                    "metadata": {
+                      "runId": "<runId-1>",
+                      "id1": 123,
+                      "id2": "tacos"
+                    },
                     "input": {
                       "workflowId": "simpleWorkflow",
                       "input": {
                         "input": "test input"
-                      },
-                      "suspendedToolRunId": ""
+                      }
                     },
                     "output": {
                       "result": {
@@ -217,7 +235,9 @@
                           "status": "success"
                         },
                         "metadata": {
-                          "runId": "<runId-2>"
+                          "runId": "<runId-2>",
+                          "id1": 123,
+                          "id2": "tacos"
                         },
                         "input": {
                           "input": "test input"
@@ -241,6 +261,11 @@
                             "entityId": "simple-step",
                             "attributes": {
                               "status": "success"
+                            },
+                            "metadata": {
+                              "runId": "<runId-2>",
+                              "id1": 123,
+                              "id2": "tacos"
                             },
                             "input": {
                               "input": "test input"
@@ -271,6 +296,9 @@
                       "sequenceNumber": 1
                     },
                     "metadata": {
+                      "runId": "<runId-1>",
+                      "id1": 123,
+                      "id2": "tacos",
                       "toolCallId": "call-workflow-1",
                       "toolName": "workflowExecutor"
                     },
@@ -306,6 +334,9 @@
                   "finishReason": "stop"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
+                  "id1": 123,
+                  "id2": "tacos",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -314,7 +345,9 @@
                 },
                 "input": {},
                 "output": {
-                  "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                  "text": {
+                    "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                  },
                   "toolCalls": []
                 }
               },
@@ -335,8 +368,15 @@
                       "chunkType": "text",
                       "sequenceNumber": 0
                     },
+                    "metadata": {
+                      "runId": "<runId-1>",
+                      "id1": 123,
+                      "id2": "tacos"
+                    },
                     "output": {
-                      "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] }
+                      "text": {
+                        "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                      }
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/model-step-timing-trace.json
+++ b/observability/mastra/src/__snapshots__/model-step-timing-trace.json
@@ -109,6 +109,7 @@
                   "finishReason": "stop"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -137,6 +138,9 @@
                     "attributes": {
                       "chunkType": "text",
                       "sequenceNumber": 0
+                    },
+                    "metadata": {
+                      "runId": "<runId-1>"
                     },
                     "output": {
                       "text": "Hello world"

--- a/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace.json
+++ b/observability/mastra/src/__snapshots__/multi-step-text-accumulation-trace.json
@@ -115,6 +115,7 @@
                   "finishReason": "tool-calls"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -154,6 +155,9 @@
                       "chunkType": "text",
                       "sequenceNumber": 0
                     },
+                    "metadata": {
+                      "runId": "<runId-1>"
+                    },
                     "output": {
                       "text": "Let me calculate that for you. "
                     }
@@ -174,6 +178,9 @@
                     "attributes": {
                       "chunkType": "tool-call",
                       "sequenceNumber": 1
+                    },
+                    "metadata": {
+                      "runId": "<runId-1>"
                     },
                     "output": {
                       "toolName": "calculator",
@@ -203,6 +210,9 @@
                       "toolType": "tool",
                       "success": true
                     },
+                    "metadata": {
+                      "runId": "<runId-1>"
+                    },
                     "input": {
                       "operation": "add",
                       "a": 5,
@@ -230,6 +240,7 @@
                       "sequenceNumber": 2
                     },
                     "metadata": {
+                      "runId": "<runId-1>",
                       "toolCallId": "call-calc-1",
                       "toolName": "calculator"
                     },
@@ -263,6 +274,7 @@
                   "finishReason": "stop"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -291,6 +303,9 @@
                     "attributes": {
                       "chunkType": "text",
                       "sequenceNumber": 0
+                    },
+                    "metadata": {
+                      "runId": "<runId-1>"
                     },
                     "output": {
                       "text": "The result of 5 + 3 is 8."

--- a/observability/mastra/src/__snapshots__/tags-call-overrides-defaults-trace.json
+++ b/observability/mastra/src/__snapshots__/tags-call-overrides-defaults-trace.json
@@ -61,7 +61,8 @@
               }
             },
             "metadata": {
-              "runId": "<runId-1>"
+              "runId": "<runId-1>",
+              "source": "call"
             },
             "input": {
               "messages": [
@@ -112,6 +113,8 @@
                   "finishReason": "stop"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
+                  "source": "call",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -140,6 +143,10 @@
                     "attributes": {
                       "chunkType": "text",
                       "sequenceNumber": 0
+                    },
+                    "metadata": {
+                      "runId": "<runId-1>",
+                      "source": "call"
                     },
                     "output": {
                       "text": "Mock V2 generate response"

--- a/observability/mastra/src/__snapshots__/tags-from-default-options-trace.json
+++ b/observability/mastra/src/__snapshots__/tags-from-default-options-trace.json
@@ -111,6 +111,7 @@
                   "finishReason": "stop"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -139,6 +140,9 @@
                     "attributes": {
                       "chunkType": "text",
                       "sequenceNumber": 0
+                    },
+                    "metadata": {
+                      "runId": "<runId-1>"
                     },
                     "output": {
                       "text": "Mock V2 generate response"

--- a/observability/mastra/src/__snapshots__/tags-from-generate-call-trace.json
+++ b/observability/mastra/src/__snapshots__/tags-from-generate-call-trace.json
@@ -111,6 +111,7 @@
                   "finishReason": "stop"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -139,6 +140,9 @@
                     "attributes": {
                       "chunkType": "text",
                       "sequenceNumber": 0
+                    },
+                    "metadata": {
+                      "runId": "<runId-1>"
                     },
                     "output": {
                       "text": "Mock V2 generate response"

--- a/observability/mastra/src/__snapshots__/tags-from-stream-default-options-trace.json
+++ b/observability/mastra/src/__snapshots__/tags-from-stream-default-options-trace.json
@@ -111,6 +111,7 @@
                   "finishReason": "stop"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -139,6 +140,9 @@
                     "attributes": {
                       "chunkType": "text",
                       "sequenceNumber": 0
+                    },
+                    "metadata": {
+                      "runId": "<runId-1>"
                     },
                     "output": {
                       "text": "Mock V2 stream response"

--- a/observability/mastra/src/__snapshots__/tags-preserved-with-other-options-trace.json
+++ b/observability/mastra/src/__snapshots__/tags-preserved-with-other-options-trace.json
@@ -61,7 +61,8 @@
               }
             },
             "metadata": {
-              "runId": "<runId-1>"
+              "runId": "<runId-1>",
+              "someKey": "someValue"
             },
             "input": {
               "messages": [
@@ -112,6 +113,8 @@
                   "finishReason": "stop"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
+                  "someKey": "someValue",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -140,6 +143,10 @@
                     "attributes": {
                       "chunkType": "text",
                       "sequenceNumber": 0
+                    },
+                    "metadata": {
+                      "runId": "<runId-1>",
+                      "someKey": "someValue"
                     },
                     "output": {
                       "text": "Mock V2 generate response"

--- a/observability/mastra/src/__snapshots__/tool-child-spans-trace.json
+++ b/observability/mastra/src/__snapshots__/tool-child-spans-trace.json
@@ -30,7 +30,9 @@
         },
         "input": "Use child span tool to process test-data",
         "output": {
-          "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+          "text": {
+            "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+          },
           "files": []
         }
       },
@@ -87,7 +89,9 @@
               "files": [],
               "reasoning": [],
               "sources": [],
-              "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+              "text": {
+                "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+              },
               "warnings": []
             }
           },
@@ -115,6 +119,7 @@
                   "finishReason": "tool-calls"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -152,6 +157,9 @@
                       "chunkType": "tool-call",
                       "sequenceNumber": 0
                     },
+                    "metadata": {
+                      "runId": "<runId-1>"
+                    },
                     "output": {
                       "toolName": "childSpanTool",
                       "toolCallId": "call-child-span-1",
@@ -178,6 +186,9 @@
                       "toolType": "tool",
                       "success": true
                     },
+                    "metadata": {
+                      "runId": "<runId-1>"
+                    },
                     "input": {
                       "input": "test-data"
                     },
@@ -199,6 +210,7 @@
                         "entityType": "tool",
                         "entityId": "childSpanTool",
                         "metadata": {
+                          "runId": "<runId-1>",
                           "childOperation": "data-processing",
                           "inputValue": "test-data",
                           "processedValue": "processed-test-data"
@@ -226,6 +238,7 @@
                       "sequenceNumber": 1
                     },
                     "metadata": {
+                      "runId": "<runId-1>",
                       "toolCallId": "call-child-span-1",
                       "toolName": "childSpanTool"
                     },
@@ -259,6 +272,7 @@
                   "finishReason": "stop"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -267,7 +281,9 @@
                 },
                 "input": {},
                 "output": {
-                  "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                  "text": {
+                    "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                  },
                   "toolCalls": []
                 }
               },
@@ -288,8 +304,13 @@
                       "chunkType": "text",
                       "sequenceNumber": 0
                     },
+                    "metadata": {
+                      "runId": "<runId-1>"
+                    },
                     "output": {
-                      "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] }
+                      "text": {
+                        "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                      }
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/tool-metadata-trace.json
+++ b/observability/mastra/src/__snapshots__/tool-metadata-trace.json
@@ -29,7 +29,9 @@
         },
         "input": "Use metadata tool to process some data",
         "output": {
-          "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+          "text": {
+            "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+          },
           "files": []
         }
       },
@@ -86,7 +88,9 @@
               "files": [],
               "reasoning": [],
               "sources": [],
-              "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+              "text": {
+                "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+              },
               "warnings": []
             }
           },
@@ -114,6 +118,7 @@
                   "finishReason": "tool-calls"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -151,6 +156,9 @@
                       "chunkType": "tool-call",
                       "sequenceNumber": 0
                     },
+                    "metadata": {
+                      "runId": "<runId-1>"
+                    },
                     "output": {
                       "toolName": "metadataTool",
                       "toolCallId": "call-metadata-1",
@@ -178,6 +186,7 @@
                       "success": true
                     },
                     "metadata": {
+                      "runId": "<runId-1>",
                       "toolOperation": "metadata-processing",
                       "inputValue": "some data",
                       "customFlag": true,
@@ -208,6 +217,7 @@
                       "sequenceNumber": 1
                     },
                     "metadata": {
+                      "runId": "<runId-1>",
                       "toolCallId": "call-metadata-1",
                       "toolName": "metadataTool"
                     },
@@ -241,6 +251,7 @@
                   "finishReason": "stop"
                 },
                 "metadata": {
+                  "runId": "<runId-1>",
                   "modelMetadata": {
                     "modelId": "mock-model-id",
                     "modelVersion": "v2",
@@ -249,7 +260,9 @@
                 },
                 "input": {},
                 "output": {
-                  "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                  "text": {
+                    "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                  },
                   "toolCalls": []
                 }
               },
@@ -270,8 +283,13 @@
                       "chunkType": "text",
                       "sequenceNumber": 0
                     },
+                    "metadata": {
+                      "runId": "<runId-1>"
+                    },
                     "output": {
-                      "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] }
+                      "text": {
+                        "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                      }
                     }
                   }
                 }

--- a/observability/mastra/src/__snapshots__/workflow-agent-step-trace.json
+++ b/observability/mastra/src/__snapshots__/workflow-agent-step-trace.json
@@ -29,7 +29,9 @@
           "prompt": "Hello from workflow"
         },
         "output": {
-          "response": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] }
+          "response": {
+            "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+          }
         }
       },
       "children": [
@@ -48,11 +50,16 @@
             "attributes": {
               "status": "success"
             },
+            "metadata": {
+              "runId": "<runId-1>"
+            },
             "input": {
               "prompt": "Hello from workflow"
             },
             "output": {
-              "response": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] }
+              "response": {
+                "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+              }
             }
           },
           "children": [
@@ -76,7 +83,9 @@
                 },
                 "input": "Hello from workflow",
                 "output": {
-                  "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                  "text": {
+                    "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                  },
                   "files": []
                 }
               },
@@ -133,7 +142,9 @@
                       "files": [],
                       "reasoning": [],
                       "sources": [],
-                      "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                      "text": {
+                        "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                      },
                       "warnings": []
                     }
                   },
@@ -161,6 +172,7 @@
                           "finishReason": "stop"
                         },
                         "metadata": {
+                          "runId": "<runId-2>",
                           "modelMetadata": {
                             "modelId": "mock-model-id",
                             "modelVersion": "v2",
@@ -169,7 +181,9 @@
                         },
                         "input": {},
                         "output": {
-                          "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] },
+                          "text": {
+                            "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                          },
                           "toolCalls": []
                         }
                       },
@@ -190,8 +204,13 @@
                               "chunkType": "text",
                               "sequenceNumber": 0
                             },
+                            "metadata": {
+                              "runId": "<runId-2>"
+                            },
                             "output": {
-                              "text": { "__or__": ["Mock V2 generate response", "Mock V2 stream response"] }
+                              "text": {
+                                "__or__": ["Mock V2 generate response", "Mock V2 stream response"]
+                              }
                             }
                           }
                         }

--- a/observability/mastra/src/__snapshots__/workflow-branching-trace.json
+++ b/observability/mastra/src/__snapshots__/workflow-branching-trace.json
@@ -53,6 +53,12 @@
             "attributes": {
               "status": "success"
             },
+            "metadata": {
+              "resourceId": "test-resource-id",
+              "runId": "<runId-1>",
+              "id1": 123,
+              "id2": "tacos"
+            },
             "input": {
               "value": 15
             },
@@ -77,6 +83,12 @@
               "conditionCount": 2,
               "truthyIndexes": [0],
               "selectedSteps": ["process-high"]
+            },
+            "metadata": {
+              "resourceId": "test-resource-id",
+              "runId": "<runId-1>",
+              "id1": 123,
+              "id2": "tacos"
             },
             "input": {
               "branch": "high"
@@ -104,6 +116,12 @@
                   "conditionIndex": 0,
                   "result": true
                 },
+                "metadata": {
+                  "resourceId": "test-resource-id",
+                  "runId": "<runId-1>",
+                  "id1": 123,
+                  "id2": "tacos"
+                },
                 "input": {
                   "branch": "high"
                 },
@@ -126,6 +144,12 @@
                   "conditionIndex": 1,
                   "result": false
                 },
+                "metadata": {
+                  "resourceId": "test-resource-id",
+                  "runId": "<runId-1>",
+                  "id1": 123,
+                  "id2": "tacos"
+                },
                 "input": {
                   "branch": "high"
                 },
@@ -146,6 +170,12 @@
                 "entityId": "process-high",
                 "attributes": {
                   "status": "success"
+                },
+                "metadata": {
+                  "resourceId": "test-resource-id",
+                  "runId": "<runId-1>",
+                  "id1": 123,
+                  "id2": "tacos"
                 },
                 "input": {
                   "branch": "high"

--- a/observability/mastra/src/__snapshots__/workflow-child-spans-trace.json
+++ b/observability/mastra/src/__snapshots__/workflow-child-spans-trace.json
@@ -45,6 +45,9 @@
             "attributes": {
               "status": "success"
             },
+            "metadata": {
+              "runId": "<runId-1>"
+            },
             "input": {
               "value": "child-span-test"
             },
@@ -66,6 +69,7 @@
                 "entityType": "workflow_step",
                 "entityId": "child-span",
                 "metadata": {
+                  "runId": "<runId-1>",
                   "childOperation": "processing",
                   "inputValue": "child-span-test",
                   "endValue": "pizza"

--- a/observability/mastra/src/__snapshots__/workflow-create-step-agent-trace.json
+++ b/observability/mastra/src/__snapshots__/workflow-create-step-agent-trace.json
@@ -50,6 +50,9 @@
             "attributes": {
               "status": "success"
             },
+            "metadata": {
+              "runId": "<runId-1>"
+            },
             "input": {
               "query": "test query"
             },
@@ -72,6 +75,9 @@
             "entityId": "workflow-agent",
             "attributes": {
               "status": "success"
+            },
+            "metadata": {
+              "runId": "<runId-1>"
             },
             "input": {
               "prompt": "test query"
@@ -185,6 +191,7 @@
                           "finishReason": "stop"
                         },
                         "metadata": {
+                          "runId": "<runId-2>",
                           "modelMetadata": {
                             "modelId": "mock-model-id",
                             "modelVersion": "v2",
@@ -214,6 +221,9 @@
                               "chunkType": "text",
                               "sequenceNumber": 0
                             },
+                            "metadata": {
+                              "runId": "<runId-2>"
+                            },
                             "output": {
                               "text": "Test response from agent"
                             }
@@ -241,6 +251,9 @@
             "entityId": "mapping_<mapping-2>",
             "attributes": {
               "status": "success"
+            },
+            "metadata": {
+              "runId": "<runId-1>"
             },
             "input": {
               "text": "Test response from agent"

--- a/observability/mastra/src/__snapshots__/workflow-metadata-in-step-trace.json
+++ b/observability/mastra/src/__snapshots__/workflow-metadata-in-step-trace.json
@@ -45,6 +45,7 @@
               "status": "success"
             },
             "metadata": {
+              "runId": "<runId-1>",
               "customValue": "tacos",
               "stepType": "metadata-test",
               "executionTime": "<date>"

--- a/observability/mastra/src/__snapshots__/workflow-registered-nested-trace.json
+++ b/observability/mastra/src/__snapshots__/workflow-registered-nested-trace.json
@@ -46,6 +46,9 @@
             "attributes": {
               "status": "success"
             },
+            "metadata": {
+              "runId": "<runId-1>"
+            },
             "input": {
               "input": "nested test"
             },
@@ -94,6 +97,9 @@
                     "entityId": "simple-step",
                     "attributes": {
                       "status": "success"
+                    },
+                    "metadata": {
+                      "runId": "<runId-2>"
                     },
                     "input": {
                       "input": "nested test"

--- a/observability/mastra/src/__snapshots__/workflow-tool-as-step-trace.json
+++ b/observability/mastra/src/__snapshots__/workflow-tool-as-step-trace.json
@@ -46,6 +46,9 @@
             "attributes": {
               "status": "success"
             },
+            "metadata": {
+              "runId": "<runId-1>"
+            },
             "input": {
               "operation": "add",
               "a": 5,

--- a/observability/mastra/src/__snapshots__/workflow-unregistered-nested-trace.json
+++ b/observability/mastra/src/__snapshots__/workflow-unregistered-nested-trace.json
@@ -50,6 +50,9 @@
               "loopType": "dowhile",
               "totalIterations": 1
             },
+            "metadata": {
+              "runId": "<runId-1>"
+            },
             "input": {
               "input": "test unregistered workflow as step"
             },
@@ -72,6 +75,9 @@
                 "entityId": "simple-workflow",
                 "attributes": {
                   "status": "success"
+                },
+                "metadata": {
+                  "runId": "<runId-1>"
                 },
                 "input": {
                   "input": "test unregistered workflow as step"
@@ -122,6 +128,9 @@
                         "attributes": {
                           "status": "success"
                         },
+                        "metadata": {
+                          "runId": "<runId-1>"
+                        },
                         "input": {
                           "input": "test unregistered workflow as step"
                         },
@@ -149,6 +158,9 @@
                 "attributes": {
                   "conditionIndex": 0
                 },
+                "metadata": {
+                  "runId": "<runId-1>"
+                },
                 "input": {},
                 "output": false
               }
@@ -169,6 +181,9 @@
             "entityId": "mapping_<mapping-1>",
             "attributes": {
               "status": "success"
+            },
+            "metadata": {
+              "runId": "<runId-1>"
             },
             "input": {
               "output": "test unregistered workflow as step processed"


### PR DESCRIPTION
## Description

This PR updates trace snapshots to include `runId` and other metadata fields in various span records. The changes ensure that metadata is properly captured and propagated through the trace hierarchy, including:

- Adding `runId` to processor spans, model call spans, and stream chunk spans
- Adding custom metadata fields (e.g., `id1`, `id2`, `resourceId`, `source`) to spans where applicable
- Reformatting JSON objects for consistency (multi-line formatting for `__or__` fields and nested objects)
- Removing `suspendedToolRunId` field from workflow executor tool inputs

These changes reflect updates to how metadata is tracked and included in observability traces across agents, workflows, and tools.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

https://claude.ai/code/session_01UTkEEvrCTnGPgiNZFCxmrU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced trace snapshots with improved metadata collection for observability, adding run identifiers and resource tracking across agent, workflow, and model execution traces to improve debugging and performance analysis capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->