### PR TITLE
ci: checkout PR head SHA in prebuild workflow

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
 
       - name: Setup custom action


### PR DESCRIPTION
The prebuild workflow was checking out the merge commit instead of the actual PR head SHA, which could cause cache misses and incorrect build artifacts.

Uses `github.event.pull_request.head.sha` to ensure we build from the correct commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve build process alignment with pull request revisions. This is a technical infrastructure improvement with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->