### PR TITLE
fix(core): strip callProviderMetadata.openai when reasoning is stripped

### DIFF
--- a/.changeset/deep-eels-act.md
+++ b/.changeset/deep-eels-act.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed OpenAI reasoning models (e.g. gpt-5-mini) failing with "function*call was provided without its required reasoning item" when the agent loops back after a tool call. The issue was that callProviderMetadata.openai carrying fc*\* item IDs was not being stripped alongside reasoning parts, causing the AI SDK to send item_reference instead of inline function_call content.

--- a/.changeset/deep-eels-act.md
+++ b/.changeset/deep-eels-act.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed OpenAI reasoning models (e.g. gpt-5-mini) failing with "function*call was provided without its required reasoning item" when the agent loops back after a tool call. The issue was that callProviderMetadata.openai carrying fc*\* item IDs was not being stripped alongside reasoning parts, causing the AI SDK to send item_reference instead of inline function_call content.
+Fixed OpenAI reasoning models (e.g. gpt-5-mini) failing with "function_call was provided without its required reasoning item" when the agent loops back after a tool call. The issue was that `callProviderMetadata.openai` carrying `fc_*` item IDs was not being stripped alongside reasoning parts, causing the AI SDK to send `item_reference` instead of inline `function_call` content.

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -130,21 +130,36 @@ export function sanitizeV5UIMessages(
       const sanitized = {
         ...m,
         parts: safeParts.map(part => {
-          // When OpenAI reasoning was stripped, also clear providerMetadata.openai from
-          // remaining parts. Text parts carry msg_* itemIds that reference the stripped
-          // rs_* reasoning items — if retained, the SDK sends item_reference instead of
-          // inline content, and the API rejects the orphaned reference.
-          // Tool-invocation parts carry fc_* itemIds that are independent from reasoning
-          // rs_* items — preserve them so the SDK uses item_reference for tool calls.
-          if (hasOpenAIReasoning && !AIV5.isToolUIPart(part) && 'providerMetadata' in part && part.providerMetadata) {
-            const meta = part.providerMetadata as Record<string, unknown>;
-            if ('openai' in meta) {
-              const { openai: _, ...restMeta } = meta;
-              part = {
-                ...part,
-                providerMetadata:
-                  Object.keys(restMeta).length > 0 ? (restMeta as typeof part.providerMetadata) : undefined,
-              };
+          // When OpenAI reasoning was stripped, clear openai metadata from ALL remaining
+          // parts so the SDK sends inline content instead of item_reference. This covers:
+          //   - providerMetadata.openai on text/reasoning parts (msg_*/rs_* itemIds)
+          //   - callProviderMetadata.openai on tool parts (fc_* itemIds used by convertToModelMessages)
+          // Without paired reasoning items, OpenAI rejects orphaned item_references with:
+          //   "function_call was provided without its required reasoning item"
+          if (hasOpenAIReasoning) {
+            if ('providerMetadata' in part && part.providerMetadata) {
+              const meta = part.providerMetadata as Record<string, unknown>;
+              if ('openai' in meta) {
+                const { openai: _, ...restMeta } = meta;
+                part = {
+                  ...part,
+                  providerMetadata:
+                    Object.keys(restMeta).length > 0 ? (restMeta as typeof part.providerMetadata) : undefined,
+                };
+              }
+            }
+            if ('callProviderMetadata' in part && part.callProviderMetadata) {
+              const callMeta = part.callProviderMetadata as Record<string, unknown>;
+              if ('openai' in callMeta) {
+                const { openai: _, ...restCallMeta } = callMeta;
+                part = {
+                  ...part,
+                  callProviderMetadata:
+                    Object.keys(restCallMeta).length > 0
+                      ? (restCallMeta as typeof part.callProviderMetadata)
+                      : undefined,
+                } as typeof part;
+              }
             }
           }
 


### PR DESCRIPTION
## Problem

OpenAI reasoning models (e.g. `gpt-5-mini`) fail with:

> `function_call was provided without its required reasoning item`

when the agent loops back after a tool call.

## Root Cause

When building the LLM prompt from conversation history, we correctly strip OpenAI reasoning parts (`rs_*`) to avoid item pairing errors. We also strip `providerMetadata.openai` from text parts. However, tool UI parts carry the `fc_*` item IDs through a **separate field**: `callProviderMetadata.openai`.

The conversion flow is:
1. DB → UI: `AIV5Adapter` copies `part.providerMetadata` → `callProviderMetadata` on tool parts
2. UI → Model: AI SDK's `convertToModelMessages` maps `callProviderMetadata` → `providerOptions`
3. Model → API: OpenAI provider reads `providerOptions.openai.itemId` and sends `item_reference` instead of inline `function_call`

Since the paired `rs_*` reasoning item was stripped, OpenAI rejects the orphaned `item_reference`.

## Fix

Strip `openai` metadata from both `providerMetadata` and `callProviderMetadata` on all parts when reasoning is stripped. This forces the AI SDK to send full inline `function_call` content instead of `item_reference`, which works without the reasoning context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed failures in OpenAI reasoning models (e.g., gpt-5-mini) when agents loop back after tool calls. Metadata associated with reasoning and tool call parts is now stripped consistently, preventing incorrect emission of item references and ensuring function call content is delivered inline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->