### PR TITLE
Fix exponential backoff delay calculation in fetchWithRetry

### DIFF
--- a/.changeset/proud-jeans-beg.md
+++ b/.changeset/proud-jeans-beg.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed exponential backoff delay in fetchWithRetry that was multiplied by 1000 twice, causing retries to always hit the 10-second cap instead of properly scaling from 2s → 4s → 8s → 10s.
+`fetchWithRetry` now backs off in sequence 2s → 4s → 8s and then caps at 10s.

--- a/.changeset/proud-jeans-beg.md
+++ b/.changeset/proud-jeans-beg.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed exponential backoff delay in fetchWithRetry that was multiplied by 1000 twice, causing retries to always hit the 10-second cap instead of properly scaling from 2s → 4s → 8s → 10s.

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { MastraError } from './error';
 import { ConsoleLogger } from './logger';
@@ -346,6 +346,11 @@ it('should log correctly for Vercel tool execution', async () => {
 });
 
 describe('fetchWithRetry', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
   it('should use exponential backoff delays capped at 10 seconds', async () => {
     const delays: number[] = [];
 
@@ -361,19 +366,17 @@ describe('fetchWithRetry', () => {
     const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
     vi.stubGlobal('fetch', mockFetch);
 
-    await expect(fetchWithRetry('https://example.com', {}, 4)).rejects.toThrow();
+    // Use 5 retries so computed backoff 1000 * 2^4 = 16000 exceeds the 10000 cap
+    await expect(fetchWithRetry('https://example.com', {}, 5)).rejects.toThrow();
 
-    // With the bug (1000 * Math.pow(2, retryCount) * 1000), delays would be:
-    //   2_000_000, 4_000_000, 8_000_000 — all far exceeding 10_000
-    // Correct delays should be: 2000, 4000, 8000
-    expect(delays.length).toBe(3); // 4 max retries = 3 retry delays
+    // Delays: 2000 (2^1), 4000 (2^2), 8000 (2^3), 10000 (2^4=16000 capped to 10000)
+    expect(delays.length).toBe(4); // 5 max retries = 4 retry delays
     for (const delay of delays) {
       expect(delay).toBeLessThanOrEqual(10000);
     }
     expect(delays[0]).toBe(2000); // 1000 * 2^1
     expect(delays[1]).toBe(4000); // 1000 * 2^2
     expect(delays[2]).toBe(8000); // 1000 * 2^3
-
-    vi.restoreAllMocks();
+    expect(delays[3]).toBe(10000); // 1000 * 2^4 = 16000, capped at 10000
   });
 });

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -6,7 +6,7 @@ import { ConsoleLogger } from './logger';
 import { RequestContext } from './request-context';
 import { toStandardSchema } from './schema';
 import { createTool, isVercelTool } from './tools';
-import { makeCoreTool, maskStreamTags, resolveSerializedZodOutput } from './utils';
+import { fetchWithRetry, makeCoreTool, maskStreamTags, resolveSerializedZodOutput } from './utils';
 
 describe('maskStreamTags', () => {
   async function* makeStream(chunks: string[]) {
@@ -343,4 +343,37 @@ it('should log correctly for Vercel tool execution', async () => {
   expect(debugSpy).toHaveBeenCalledWith('[Agent:testAgent] - Executing tool testTool', expect.any(Object));
 
   debugSpy.mockRestore();
+});
+
+describe('fetchWithRetry', () => {
+  it('should use exponential backoff delays capped at 10 seconds', async () => {
+    const delays: number[] = [];
+
+    vi.spyOn(globalThis, 'setTimeout').mockImplementation(((fn: () => void, delay?: number) => {
+      if (delay && delay > 100) {
+        delays.push(delay);
+      }
+      // Execute callback immediately so the test completes
+      if (typeof fn === 'function') fn();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    await expect(fetchWithRetry('https://example.com', {}, 4)).rejects.toThrow();
+
+    // With the bug (1000 * Math.pow(2, retryCount) * 1000), delays would be:
+    //   2_000_000, 4_000_000, 8_000_000 — all far exceeding 10_000
+    // Correct delays should be: 2000, 4000, 8000
+    expect(delays.length).toBe(3); // 4 max retries = 3 retry delays
+    for (const delay of delays) {
+      expect(delay).toBeLessThanOrEqual(10000);
+    }
+    expect(delays[0]).toBe(2000); // 1000 * 2^1
+    expect(delays[1]).toBe(4000); // 1000 * 2^2
+    expect(delays[2]).toBe(8000); // 1000 * 2^3
+
+    vi.restoreAllMocks();
+  });
 });

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -638,7 +638,7 @@ export async function fetchWithRetry(
         break;
       }
 
-      const delay = Math.min(1000 * Math.pow(2, retryCount) * 1000, 10000);
+      const delay = Math.min(1000 * Math.pow(2, retryCount), 10000);
       await new Promise(resolve => setTimeout(resolve, delay));
     }
   }


### PR DESCRIPTION
## Description

The `fetchWithRetry` utility had a bug where the exponential backoff delay was multiplied by 1000 twice, resulting in delays of millions of milliseconds instead of the intended 2s, 4s, 8s, capped at 10s. This caused all retries to immediately hit the maximum 10-second cap.

## Related Issue(s)

Fixes #14150

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected exponential backoff for retries: delays now progress as 2s → 4s → 8s with a cap at 10s, ensuring expected retry timing.

* **Tests**
  * Added tests validating the retry/backoff behavior and the 10s cap across multiple retry attempts.

* **Documentation**
  * Added a patch release note describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->