### PR TITLE
fix: remove manual schema-compat injection from deployer

### DIFF
--- a/.changeset/cyan-ravens-post.md
+++ b/.changeset/cyan-ravens-post.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Removed manual injection of `@mastra/schema-compat` dependency during deployment. This is no longer needed as `@mastra/core` now properly declares it as a direct dependency.

--- a/.changeset/cyan-ravens-post.md
+++ b/.changeset/cyan-ravens-post.md
@@ -2,4 +2,8 @@
 '@mastra/deployer': patch
 ---
 
-Removed manual injection of `@mastra/schema-compat` dependency during deployment. This is no longer needed as `@mastra/core` now properly declares it as a direct dependency.
+---
+`@mastra/deployer`: patch
+---
+
+Fixed deployment dependency resolution so required schema compatibility packages are resolved automatically.

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -370,11 +370,6 @@ export abstract class Bundler extends MastraBundler {
       }
     }
 
-    if (dependenciesToInstall.has('@mastra/core') && !dependenciesToInstall.has('@mastra/schema-compat')) {
-      const coreVersion = dependenciesToInstall.get('@mastra/core') || 'latest';
-      dependenciesToInstall.set('@mastra/schema-compat', coreVersion);
-    }
-
     try {
       await this.writePackageJson(join(outputDirectory, this.outputDir), dependenciesToInstall);
 


### PR DESCRIPTION
## Problem

The deployer bundler was manually injecting `@mastra/schema-compat` as a dependency whenever `@mastra/core` was present. This workaround is no longer needed since `@mastra/core` now properly declares `@mastra/schema-compat` as a direct dependency.

## Changes

- Removed the block in `packages/deployer/src/bundler/index.ts` that manually added `@mastra/schema-compat` with the same version as `@mastra/core`

## Test Plan

- Deployer will resolve `@mastra/schema-compat` transitively through `@mastra/core`'s dependency tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deployment dependency resolution so required schema-compatibility packages are resolved automatically during deploys.

* **Chores**
  * Stopped auto-injecting the schema-compatibility dependency during deployment; it is now declared directly in the core package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->