### PR TITLE
fix: update OpenRouter and constants tests for User-Agent header

### DIFF
--- a/packages/core/src/llm/model/gateways/constants.test.ts
+++ b/packages/core/src/llm/model/gateways/constants.test.ts
@@ -11,6 +11,7 @@ describe('MASTRA_USER_AGENT', () => {
   });
 
   it('should match the expected format', () => {
-    expect(MASTRA_USER_AGENT).toMatch(/^mastra\/\d+\.\d+/);
+    // With __MASTRA_VERSION__ defined: "mastra/X.Y.Z", without: "mastra"
+    expect(MASTRA_USER_AGENT).toMatch(/^mastra(\/\d+\.\d+.*)?$/);
   });
 });

--- a/packages/core/src/llm/model/router-openrouter-headers.test.ts
+++ b/packages/core/src/llm/model/router-openrouter-headers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Agent } from '../../agent/index.js';
 import { createMockModel } from '../../test-utils/llm-mock.js';
+import { MASTRA_USER_AGENT } from './gateways/constants.js';
 
 // Mock the @openrouter/ai-sdk-provider-v5 module BEFORE importing it
 vi.mock('@openrouter/ai-sdk-provider-v5', async () => {
@@ -54,6 +55,7 @@ describe('ModelRouter - OpenRouter Headers Support', () => {
       expect(createOpenRouter).toHaveBeenCalledWith({
         apiKey: 'test-openrouter-key',
         headers: {
+          'User-Agent': MASTRA_USER_AGENT,
           'HTTP-Referer': 'http://my-service/',
           'X-Title': 'my-application-name',
         },
@@ -85,6 +87,7 @@ describe('ModelRouter - OpenRouter Headers Support', () => {
       expect(createOpenRouter).toHaveBeenCalledWith({
         apiKey: 'test-openrouter-key',
         headers: {
+          'User-Agent': MASTRA_USER_AGENT,
           'HTTP-Referer': 'https://myapp.com',
           'X-Title': 'MyApp',
         },
@@ -101,10 +104,12 @@ describe('ModelRouter - OpenRouter Headers Support', () => {
 
       await agent.generate('test', { maxSteps: 1 });
 
-      // Verify createOpenRouter was called without headers
+      // Verify createOpenRouter was called with only the default User-Agent header
       expect(createOpenRouter).toHaveBeenCalledWith({
         apiKey: 'test-openrouter-key',
-        headers: undefined,
+        headers: {
+          'User-Agent': MASTRA_USER_AGENT,
+        },
       });
     });
 
@@ -130,6 +135,7 @@ describe('ModelRouter - OpenRouter Headers Support', () => {
       expect(createOpenRouter).toHaveBeenCalledWith({
         apiKey: customApiKey,
         headers: {
+          'User-Agent': MASTRA_USER_AGENT,
           'HTTP-Referer': 'https://example.com',
           'X-Title': 'Example App',
         },
@@ -158,6 +164,7 @@ describe('ModelRouter - OpenRouter Headers Support', () => {
       expect(createOpenRouter).toHaveBeenCalledWith({
         apiKey: 'test-openrouter-key',
         headers: {
+          'User-Agent': MASTRA_USER_AGENT,
           'HTTP-Referer': 'https://myapp.com',
           'X-Title': 'My Application',
           'X-Custom-Header': 'custom-value',
@@ -186,6 +193,7 @@ describe('ModelRouter - OpenRouter Headers Support', () => {
       expect(createOpenRouter).toHaveBeenCalledWith({
         apiKey: 'test-openrouter-key',
         headers: {
+          'User-Agent': MASTRA_USER_AGENT,
           'HTTP-Referer': 'https://dynamic.com',
           'X-Title': 'Dynamic App',
         },
@@ -227,12 +235,14 @@ describe('ModelRouter - OpenRouter Headers Support', () => {
       expect(createOpenRouter).toHaveBeenNthCalledWith(1, {
         apiKey: 'test-openrouter-key',
         headers: {
+          'User-Agent': MASTRA_USER_AGENT,
           'X-Title': 'App1',
         },
       });
       expect(createOpenRouter).toHaveBeenNthCalledWith(2, {
         apiKey: 'test-openrouter-key',
         headers: {
+          'User-Agent': MASTRA_USER_AGENT,
           'X-Title': 'App2',
         },
       });
@@ -300,6 +310,7 @@ describe('ModelRouter - OpenRouter Headers Support', () => {
       expect(createOpenRouter).toHaveBeenCalledWith({
         apiKey: 'custom-key-no-env',
         headers: {
+          'User-Agent': MASTRA_USER_AGENT,
           'HTTP-Referer': 'http://my-service/',
           'X-Title': 'my-application-name',
         },

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -9,5 +9,5 @@
 export * from './types';
 export * from './no-op';
 export * from './utils';
-export { wrapMastra } from './context';
+export { wrapMastra, isMastra } from './context';
 export { createObservabilityContext, resolveObservabilityContext } from './context-factory';

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -11,12 +11,13 @@ import {
   jsonSchema,
 } from '@mastra/schema-compat';
 import { z } from 'zod/v4';
-import { Mastra } from '../..';
 import { MastraBase } from '../../base';
 import { ErrorCategory, MastraError, ErrorDomain } from '../../error';
+import type { Mastra } from '../../mastra';
 import {
   SpanType,
   wrapMastra,
+  isMastra,
   executeWithContext,
   EntityType,
   getOrCreateSpan,
@@ -362,7 +363,7 @@ export class CoreToolBuilder extends MastraBase {
         tracingPolicy: options.tracingPolicy,
         tracingContext: tracingContext,
         requestContext: toolRequestContext,
-        mastra: options.mastra instanceof Mastra ? options.mastra : undefined,
+        mastra: options.mastra && isMastra(options.mastra) ? (options.mastra as Mastra) : undefined,
       });
 
       try {

--- a/packages/core/src/workflows/default.ts
+++ b/packages/core/src/workflows/default.ts
@@ -832,7 +832,9 @@ export class DefaultExecutionEngine extends ExecutionEngine {
                 spanId: workflowSpan.id,
                 parentSpanId: workflowSpan.getParentSpanId(),
               }
-            : undefined;
+            : result.status === 'suspended'
+              ? {}
+              : undefined;
 
         await this.persistStepUpdate({
           workflowId,


### PR DESCRIPTION
## Problem

Tests in `router-openrouter-headers.test.ts` (8 failures) and `constants.test.ts` (1 failure) were failing because `MASTRA_USER_AGENT` is now automatically injected into all gateway requests including OpenRouter.

## Changes

- **`router-openrouter-headers.test.ts`**: Updated all 8 test expectations to include the `User-Agent: MASTRA_USER_AGENT` header in `createOpenRouter` call assertions
- **`constants.test.ts`**: Fixed format regex to accept both `mastra` (test env without `__MASTRA_VERSION__`) and `mastra/X.Y.Z` (build env)

## Test Plan

- All 9 tests in `router-openrouter-headers.test.ts` pass
- All 3 tests in `constants.test.ts` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated MASTRA version detection to accept both versioned and unversioned formats.
  * Expanded OpenRouter tests to ensure a consistent User-Agent header is included across all configurations.
* **Bug Fixes**
  * Improved tracing behavior: suspended workflow results now preserve tracing context to better link spans when resumed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->