### PR TITLE
Revert "Fix agent loop not continuing when `onIterationComplete` returns `continue: true`"

### DIFF
--- a/.changeset/crisp-eyes-invite.md
+++ b/.changeset/crisp-eyes-invite.md
@@ -1,5 +1,0 @@
----
-'@mastra/core': patch
----
-
-Fix agent loop not continuing when `onIterationComplete` returns `continue: true`

--- a/packages/core/src/agent/__tests__/supervisor-integration.test.ts
+++ b/packages/core/src/agent/__tests__/supervisor-integration.test.ts
@@ -234,6 +234,7 @@ describe('Supervisor Pattern Integration Tests', () => {
         maxSteps: 3,
         onIterationComplete: (ctx: IterationCompleteContext) => {
           iterations.push(ctx.iteration);
+          return { continue: true };
         },
       });
 
@@ -560,7 +561,7 @@ describe('Supervisor Pattern Integration Tests', () => {
 
     it('should accept iteration complete hook configuration', async () => {
       const iterationHook = vi.fn(() => {
-        return undefined;
+        return { continue: true };
       });
 
       const agent = new Agent({
@@ -1609,6 +1610,7 @@ describe('Supervisor Pattern - onIterationComplete Hook Integration', () => {
       maxSteps: 5,
       onIterationComplete: (ctx: IterationCompleteContext) => {
         iterations.push(ctx.iteration);
+        return { continue: true };
       },
     });
 
@@ -2036,103 +2038,12 @@ describe('Supervisor Pattern - onIterationComplete Hook Integration', () => {
       },
     });
 
-    expect(iterationCount).toBe(2);
-  });
-
-  it('should allow onIterationComplete continue:true to override final stop in stream (issue #14134)', async () => {
-    const iterations: number[] = [];
-    let callCount = 0;
-
-    const agent = new Agent({
-      id: 'continue-override-stream-agent',
-      name: 'Continue Override Stream Agent',
-      instructions: 'You may take multiple turns.',
-      model: new MockLanguageModelV2({
-        doGenerate: async () => {
-          callCount++;
-          if (callCount === 1) {
-            return {
-              rawCall: { rawPrompt: null, rawSettings: {} },
-              finishReason: 'stop',
-              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
-              text: 'First response ',
-              content: [{ type: 'text', text: 'First response ' }],
-              warnings: [],
-            };
-          }
-
-          return {
-            rawCall: { rawPrompt: null, rawSettings: {} },
-            finishReason: 'stop',
-            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
-            text: 'Second response',
-            content: [{ type: 'text', text: 'Second response' }],
-            warnings: [],
-          };
-        },
-        doStream: async () => {
-          callCount++;
-          const currentCall = callCount;
-          const responseText = currentCall === 1 ? 'First response ' : 'Second response';
-
-          return {
-            rawCall: { rawPrompt: null, rawSettings: {} },
-            warnings: [],
-            stream: convertArrayToReadableStream([
-              { type: 'stream-start', warnings: [] },
-              {
-                type: 'response-metadata',
-                id: `id-${currentCall}`,
-                modelId: 'mock-model-id',
-                timestamp: new Date(0),
-              },
-              { type: 'text-start', id: `text-${currentCall}` },
-              { type: 'text-delta', id: `text-${currentCall}`, delta: responseText },
-              { type: 'text-end', id: `text-${currentCall}` },
-              {
-                type: 'finish',
-                finishReason: 'stop',
-                usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
-              },
-            ]),
-          };
-        },
-      }),
-      memory: new MockMemory(),
-    });
-
-    const mastra = new Mastra({
-      agents: {
-        'continue-override-stream-agent': agent,
-      },
-      storage: new InMemoryStore(),
-    });
-
-    const testAgent = mastra.getAgent('continue-override-stream-agent');
-
-    const result = await testAgent.stream('Take multiple turns', {
-      maxSteps: 5,
-      onIterationComplete: ctx => {
-        iterations.push(ctx.iteration);
-        if (ctx.iteration === 1) {
-          return { continue: true };
-        }
-      },
-    });
-
-    const reader = result.fullStream.getReader();
-    while (true) {
-      const { done } = await reader.read();
-      if (done) break;
-    }
-
-    const text = await result.text;
-
-    // When the model returns stop (isFinal), the hook's continue:true should be
-    // able to request another iteration in the streaming supervisor loop.
-    expect(iterations).toEqual([1, 2]);
-    expect(callCount).toBe(2);
-    expect(text).toBe('First response Second response');
+    // When the model returns stop (isFinal), the loop ends after that iteration
+    // even if the hook returns continue: true with feedback. Feedback only adds
+    // a user message for the *next* iteration when the loop would naturally continue
+    // (e.g. during a tool-call sequence). Here the model says stop on iteration 1
+    // so the loop ends and the hook is called exactly once.
+    expect(iterationCount).toBe(1);
   });
 
   it('should accept onIterationComplete configuration without errors', async () => {

--- a/packages/core/src/loop/workflows/agentic-loop/index.ts
+++ b/packages/core/src/loop/workflows/agentic-loop/index.ts
@@ -202,16 +202,6 @@ export function createAgenticLoopWorkflow<Tools extends ToolSet = ToolSet, OUTPU
               }
             } else if (iterationResult.continue === false && !hasFinishedSteps) {
               hasFinishedSteps = true;
-            } else if (
-              iterationResult.continue === true &&
-              (hasFinishedSteps || !typedInputData.stepResult?.isContinued)
-            ) {
-              if ((rest.maxSteps && accumulatedSteps.length < rest.maxSteps) || !rest.maxSteps) {
-                hasFinishedSteps = false;
-                if (typedInputData.stepResult) {
-                  typedInputData.stepResult.isContinued = true;
-                }
-              }
             }
           }
         } catch (error) {


### PR DESCRIPTION
Reverts mastra-ai/mastra#14155

this is causing the agent loop to exit early when it shouldn't, I noticed it in mastracode

<img width="1040" height="1101" alt="Screenshot 2026-03-11 at 9 43 25 AM" src="https://github.com/user-attachments/assets/6bf585b6-d7bd-4469-82e0-b9b525d41d9f" />

doesn't actually seem to be related to active tool calls:
<img width="2542" height="732" alt="Screenshot 2026-03-11 at 9 45 52 AM" src="https://github.com/user-attachments/assets/e382fb0b-f637-4983-8c72-4a0f5e4e95a3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent loop continuation behavior to properly handle explicit continuation signals when using `onIterationComplete` callbacks
  * Simplified iteration state management for more consistent agent execution flow with streaming and feedback mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->