### PR TITLE
Fix generateEmptyFromSchema nested object initialization

### DIFF
--- a/.changeset/fix-generate-empty-from-schema-14152.md
+++ b/.changeset/fix-generate-empty-from-schema-14152.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `generateEmptyFromSchema` so working memory schema initialization handles pre-parsed JSON schema objects, nested object properties, and schema defaults correctly.

--- a/.changeset/fix-generate-empty-from-schema-14152.md
+++ b/.changeset/fix-generate-empty-from-schema-14152.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed `generateEmptyFromSchema` so working memory schema initialization handles pre-parsed JSON schema objects, nested object properties, and schema defaults correctly.
+Fix working memory schema initialization in `@mastra/core` so pre-parsed JSON schema objects, nested object properties, and schema defaults are handled correctly.

--- a/packages/core/src/processors/memory/working-memory.test.ts
+++ b/packages/core/src/processors/memory/working-memory.test.ts
@@ -173,6 +173,75 @@ describe('WorkingMemory', () => {
       expect(resultMessages[0].content).toContain('# User Information');
     });
 
+    it('should use shared schema defaults for parsed json templates', async () => {
+      const processor = new WorkingMemory({
+        storage: mockStorage,
+        scope: 'thread',
+        template: {
+          format: 'json',
+          content: {
+            type: 'object',
+            properties: {
+              user: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                  age: { type: 'number' },
+                  subscribed: { type: 'boolean' },
+                },
+              },
+              metadata: {
+                type: 'object',
+                default: { source: 'system' },
+              },
+            },
+          } as unknown as string,
+        },
+      });
+
+      const threadId = 'thread-123';
+
+      requestContext.set('MastraMemory', {
+        thread: { id: threadId, resourceId: 'resource-1', title: 'Test', createdAt: new Date(), updatedAt: new Date() },
+        resourceId: 'resource-1',
+      });
+
+      vi.mocked(mockStorage.getThreadById).mockResolvedValue({
+        id: threadId,
+        resourceId: 'resource-1',
+        title: 'Test Thread',
+        metadata: { workingMemory: null },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const messages: MastraDBMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: { format: 2, parts: [{ type: 'text', text: 'Hello' }] },
+          createdAt: new Date(),
+        },
+      ];
+
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+      const result = await processor.processInput({
+        messages,
+        messageList,
+        abort: () => {
+          throw new Error('Aborted');
+        },
+        requestContext,
+      });
+
+      const resultMessages = result instanceof MessageList ? result.get.all.aiV5.prompt() : result;
+      expect(resultMessages[0].content).toContain('"age": 0');
+      expect(resultMessages[0].content).toContain('"subscribed": false');
+      expect(resultMessages[0].content).toContain('"metadata": {');
+      expect(resultMessages[0].content).toContain('"source": "system"');
+    });
+
     it('should use custom template when provided', async () => {
       const customTemplate: WorkingMemoryTemplate = {
         format: 'markdown',

--- a/packages/core/src/processors/memory/working-memory.ts
+++ b/packages/core/src/processors/memory/working-memory.ts
@@ -152,28 +152,6 @@ export class WorkingMemory implements Processor {
     return messageList;
   }
 
-  private generateEmptyFromSchema(schema: any): Record<string, any> | null {
-    try {
-      if (typeof schema === 'object' && schema !== null) {
-        const empty: Record<string, any> = {};
-        for (const key in schema) {
-          if (schema[key]?.type === 'object') {
-            empty[key] = this.generateEmptyFromSchema(schema[key].properties);
-          } else if (schema[key]?.type === 'array') {
-            empty[key] = [];
-          } else {
-            empty[key] = '';
-          }
-        }
-        return empty;
-      }
-
-      return generateEmptyFromSchema(schema);
-    } catch {
-      return null;
-    }
-  }
-
   private getWorkingMemoryToolInstruction({
     template,
     data,
@@ -181,8 +159,14 @@ export class WorkingMemory implements Processor {
     template: WorkingMemoryTemplate;
     data: string | null;
   }): string {
-    const emptyWorkingMemoryTemplateObject =
-      template.format === 'json' ? this.generateEmptyFromSchema(template.content) : null;
+    let emptyWorkingMemoryTemplateObject: Record<string, any> | null = null;
+    if (template.format === 'json') {
+      try {
+        emptyWorkingMemoryTemplateObject = generateEmptyFromSchema(template.content as string | Record<string, any>);
+      } catch {
+        emptyWorkingMemoryTemplateObject = null;
+      }
+    }
     const hasEmptyWorkingMemoryTemplateObject =
       emptyWorkingMemoryTemplateObject && Object.keys(emptyWorkingMemoryTemplateObject).length > 0;
 

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -6,7 +6,7 @@ import { ConsoleLogger } from './logger';
 import { RequestContext } from './request-context';
 import { toStandardSchema } from './schema';
 import { createTool, isVercelTool } from './tools';
-import { makeCoreTool, maskStreamTags, resolveSerializedZodOutput } from './utils';
+import { generateEmptyFromSchema, makeCoreTool, maskStreamTags, resolveSerializedZodOutput } from './utils';
 
 describe('maskStreamTags', () => {
   async function* makeStream(chunks: string[]) {
@@ -150,6 +150,79 @@ describe('resolveSerializedZodOutput', () => {
     expect(() => result.parse({ name: 'test' })).not.toThrow();
     expect(() => result.parse({ name: 123 })).toThrow();
     expect(() => result.parse({})).toThrow();
+  });
+});
+
+describe('generateEmptyFromSchema', () => {
+  it('should accept pre-parsed schema objects', () => {
+    expect(
+      generateEmptyFromSchema({
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          active: { type: 'boolean' },
+        },
+      }),
+    ).toEqual({
+      name: '',
+      active: false,
+    });
+  });
+
+  it('should recursively populate nested object properties', () => {
+    expect(
+      generateEmptyFromSchema(
+        JSON.stringify({
+          type: 'object',
+          properties: {
+            user: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                age: { type: 'number' },
+                preferences: {
+                  type: 'object',
+                  properties: {
+                    theme: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      ),
+    ).toEqual({
+      user: {
+        name: '',
+        age: 0,
+        preferences: {
+          theme: '',
+        },
+      },
+    });
+  });
+
+  it('should respect schema defaults', () => {
+    expect(
+      generateEmptyFromSchema({
+        type: 'object',
+        properties: {
+          status: { type: 'string', default: 'active' },
+          retries: { type: 'integer', default: 3 },
+          metadata: {
+            type: 'object',
+            default: { source: 'system' },
+            properties: {
+              source: { type: 'string' },
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      status: 'active',
+      retries: 3,
+      metadata: { source: 'system' },
+    });
   });
 });
 

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -224,6 +224,29 @@ describe('generateEmptyFromSchema', () => {
       metadata: { source: 'system' },
     });
   });
+
+  it('should clone object and array defaults', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        metadata: {
+          type: 'object',
+          default: { source: 'system' },
+        },
+        tags: {
+          type: 'array',
+          default: ['memory'],
+        },
+      },
+    };
+
+    const generated = generateEmptyFromSchema(schema);
+    generated.metadata.source = 'user';
+    generated.tags.push('custom');
+
+    expect(schema.properties.metadata.default).toEqual({ source: 'system' });
+    expect(schema.properties.tags.default).toEqual(['memory']);
+  });
 });
 
 describe('makeCoreTool', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -99,23 +99,50 @@ export function deepEqual(a: unknown, b: unknown): boolean {
   return false;
 }
 
-export function generateEmptyFromSchema(schema: string) {
-  try {
-    const parsedSchema = JSON.parse(schema);
-    if (!parsedSchema || parsedSchema.type !== 'object' || !parsedSchema.properties) return {};
-    const obj: Record<string, any> = {};
-    const TYPE_DEFAULTS = {
-      string: '',
-      array: [],
-      object: {},
-      number: 0,
-      integer: 0,
-      boolean: false,
-    };
-    for (const [key, prop] of Object.entries<any>(parsedSchema.properties)) {
-      obj[key] = TYPE_DEFAULTS[prop.type as keyof typeof TYPE_DEFAULTS] ?? null;
+function generateEmptyValueFromSchemaProperty(prop: any): any {
+  if (!prop || typeof prop !== 'object') return null;
+  if (Object.prototype.hasOwnProperty.call(prop, 'default')) return prop.default;
+
+  if (Array.isArray(prop.type)) {
+    const firstConcreteType = prop.type.find((type: unknown) => type !== 'null');
+    if (firstConcreteType) {
+      return generateEmptyValueFromSchemaProperty({ ...prop, type: firstConcreteType });
     }
-    return obj;
+  }
+
+  switch (prop.type) {
+    case 'string':
+      return '';
+    case 'array':
+      return [];
+    case 'object':
+      return generateEmptyFromParsedSchema(prop);
+    case 'number':
+    case 'integer':
+      return 0;
+    case 'boolean':
+      return false;
+    default:
+      return null;
+  }
+}
+
+function generateEmptyFromParsedSchema(parsedSchema: any): Record<string, any> {
+  if (!parsedSchema || parsedSchema.type !== 'object' || !parsedSchema.properties) return {};
+
+  const obj: Record<string, any> = {};
+
+  for (const [key, prop] of Object.entries<any>(parsedSchema.properties)) {
+    obj[key] = generateEmptyValueFromSchemaProperty(prop);
+  }
+
+  return obj;
+}
+
+export function generateEmptyFromSchema(schema: string | Record<string, any>) {
+  try {
+    const parsedSchema = typeof schema === 'string' ? JSON.parse(schema) : schema;
+    return generateEmptyFromParsedSchema(parsedSchema);
   } catch {
     return {};
   }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -99,9 +99,25 @@ export function deepEqual(a: unknown, b: unknown): boolean {
   return false;
 }
 
+/**
+ * Clones schema defaults so generated templates can be mutated safely.
+ */
+function cloneSchemaDefault<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value;
+
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/**
+ * Generates an empty value for a single JSON schema property definition.
+ */
 function generateEmptyValueFromSchemaProperty(prop: any): any {
   if (!prop || typeof prop !== 'object') return null;
-  if (Object.prototype.hasOwnProperty.call(prop, 'default')) return prop.default;
+  if (Object.prototype.hasOwnProperty.call(prop, 'default')) return cloneSchemaDefault(prop.default);
 
   if (Array.isArray(prop.type)) {
     const firstConcreteType = prop.type.find((type: unknown) => type !== 'null');
@@ -127,6 +143,9 @@ function generateEmptyValueFromSchemaProperty(prop: any): any {
   }
 }
 
+/**
+ * Builds an empty object for a parsed JSON schema object definition.
+ */
 function generateEmptyFromParsedSchema(parsedSchema: any): Record<string, any> {
   if (!parsedSchema || parsedSchema.type !== 'object' || !parsedSchema.properties) return {};
 
@@ -139,6 +158,9 @@ function generateEmptyFromParsedSchema(parsedSchema: any): Record<string, any> {
   return obj;
 }
 
+/**
+ * Generates an empty object from a JSON schema string or parsed schema object.
+ */
 export function generateEmptyFromSchema(schema: string | Record<string, any>) {
   try {
     const parsedSchema = typeof schema === 'string' ? JSON.parse(schema) : schema;


### PR DESCRIPTION
## Description

Fixes `generateEmptyFromSchema` so working memory schema initialization behaves correctly when the input schema is already parsed and when it contains nested object properties.

This change:
- accepts both stringified and pre-parsed JSON schema objects
- recursively initializes nested object properties instead of returning empty `{}` placeholders
- respects schema `default` values during initialization
- adds regression tests covering all three cases

## Related Issue(s)

Fixes #14152

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema initialization to correctly handle pre-parsed JSON schema objects, with improved support for nested properties and default value handling.
* **Behavioral Improvements**
  * Memory handling now applies shared schema defaults for parsed templates, ensuring defaulted fields appear in generated content.
* **Public API**
  * generateEmptyFromSchema now accepts both schema strings and parsed schema objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->