### PR TITLE
fix(core): stop dowhile loop for client tools without execute function

### DIFF
--- a/.changeset/swift-cloths-slide.md
+++ b/.changeset/swift-cloths-slide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent loop not stopping for client tools without an execute function. When a tool created with createTool() has no execute function (intended for client-side execution), the agent's do-while loop would incorrectly continue calling the model repeatedly. The loop now properly detects that client tools without execute should stop the loop and return control to the caller. Fixes #14093

--- a/.changeset/swift-cloths-slide.md
+++ b/.changeset/swift-cloths-slide.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed agent loop not stopping for client tools without an execute function. When a tool created with createTool() has no execute function (intended for client-side execution), the agent's do-while loop would incorrectly continue calling the model repeatedly. The loop now properly detects that client tools without execute should stop the loop and return control to the caller. Fixes #14093
+Agents now return control to the caller after invoking client-only tools, preventing repeated model calls. Previously, tools without a server-side execute function caused the agent loop to continue indefinitely. Fixes #14093

--- a/packages/core/src/agent/__tests__/tools.test.ts
+++ b/packages/core/src/agent/__tests__/tools.test.ts
@@ -1388,3 +1388,364 @@ describe('requireApproval property preservation', () => {
     }
   });
 });
+
+describe('client tools without execute should not cause infinite loop', () => {
+  it('should stop the dowhile loop when a tool has no execute function (stream)', async () => {
+    let doStreamCallCount = 0;
+
+    const model = new MockLanguageModelV3({
+      doGenerate: async () => ({
+        finishReason: 'tool-calls' as const,
+        usage: {
+          inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+          outputTokens: { total: 20, text: 20, reasoning: undefined },
+        },
+        content: [
+          {
+            type: 'tool-call' as const,
+            toolCallId: 'call-client-1',
+            toolName: 'clientAction',
+            input: '{"value":"test"}',
+          },
+        ],
+        warnings: [],
+      }),
+      doStream: async () => {
+        doStreamCallCount++;
+        return {
+          stream: convertArrayToReadableStreamV3([
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'response-metadata',
+              id: `id-${doStreamCallCount}`,
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+            {
+              type: 'tool-call',
+              toolCallId: `call-client-${doStreamCallCount}`,
+              toolName: 'clientAction',
+              input: '{"value":"test"}',
+              providerExecuted: false,
+            },
+            {
+              type: 'finish',
+              finishReason: 'tool-calls',
+              usage: {
+                inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+                outputTokens: { total: 20, text: 20, reasoning: undefined },
+              },
+            },
+          ]),
+        };
+      },
+    });
+
+    // Create a tool WITHOUT an execute function (client-side tool)
+    const clientAction = createTool({
+      id: 'clientAction',
+      description: 'A client-side tool with no execute function',
+      inputSchema: z.object({
+        value: z.string(),
+      }),
+      // No execute function!
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent for client tools',
+      model,
+      tools: { clientAction },
+    });
+
+    const result = await agent.stream('Use the client action tool', {
+      maxSteps: 5,
+    });
+
+    for await (const _ of result.fullStream) {
+      // consume the stream
+    }
+
+    // The model should only be called ONCE. If the dowhile loop doesn't stop,
+    // it would be called multiple times (up to maxSteps).
+    expect(doStreamCallCount).toBe(1);
+  });
+
+  it('should stop the dowhile loop when a tool has no execute function (generate)', async () => {
+    let doGenerateCallCount = 0;
+
+    const model = new MockLanguageModelV3({
+      doGenerate: async () => {
+        doGenerateCallCount++;
+        return {
+          finishReason: 'tool-calls' as const,
+          usage: {
+            inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+            outputTokens: { total: 20, text: 20, reasoning: undefined },
+          },
+          content: [
+            {
+              type: 'tool-call' as const,
+              toolCallId: `call-client-${doGenerateCallCount}`,
+              toolName: 'clientAction',
+              input: '{"value":"test"}',
+            },
+          ],
+          warnings: [],
+        };
+      },
+      doStream: async () => ({
+        stream: convertArrayToReadableStreamV3([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-client-1',
+            toolName: 'clientAction',
+            input: '{"value":"test"}',
+            providerExecuted: false,
+          },
+          {
+            type: 'finish',
+            finishReason: 'tool-calls',
+            usage: {
+              inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+              outputTokens: { total: 20, text: 20, reasoning: undefined },
+            },
+          },
+        ]),
+      }),
+    });
+
+    // Create a tool WITHOUT an execute function (client-side tool)
+    const clientAction = createTool({
+      id: 'clientAction',
+      description: 'A client-side tool with no execute function',
+      inputSchema: z.object({
+        value: z.string(),
+      }),
+      // No execute function!
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent for client tools',
+      model,
+      tools: { clientAction },
+    });
+
+    const result = await agent.generate('Use the client action tool', {
+      maxSteps: 5,
+    });
+
+    // The model should only be called ONCE. If the dowhile loop doesn't stop,
+    // it would be called multiple times (up to maxSteps).
+    expect(doGenerateCallCount).toBe(1);
+    expect(result.toolCalls.length).toBeGreaterThan(0);
+  });
+
+  it('should stop the loop when mixed tools are called (one with execute, one without)', async () => {
+    let doStreamCallCount = 0;
+
+    const model = new MockLanguageModelV3({
+      doGenerate: async () => ({
+        finishReason: 'tool-calls' as const,
+        usage: {
+          inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+          outputTokens: { total: 20, text: 20, reasoning: undefined },
+        },
+        content: [
+          {
+            type: 'tool-call' as const,
+            toolCallId: 'call-exec-1',
+            toolName: 'executableTool',
+            input: '{"value":"test"}',
+          },
+          {
+            type: 'tool-call' as const,
+            toolCallId: 'call-client-1',
+            toolName: 'clientAction',
+            input: '{"value":"test"}',
+          },
+        ],
+        warnings: [],
+      }),
+      doStream: async () => {
+        doStreamCallCount++;
+        return {
+          stream: convertArrayToReadableStreamV3([
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'response-metadata',
+              id: `id-${doStreamCallCount}`,
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-exec-1',
+              toolName: 'executableTool',
+              input: '{"value":"test"}',
+              providerExecuted: false,
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-client-1',
+              toolName: 'clientAction',
+              input: '{"value":"test"}',
+              providerExecuted: false,
+            },
+            {
+              type: 'finish',
+              finishReason: 'tool-calls',
+              usage: {
+                inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+                outputTokens: { total: 20, text: 20, reasoning: undefined },
+              },
+            },
+          ]),
+        };
+      },
+    });
+
+    const executableTool = createTool({
+      id: 'executableTool',
+      description: 'A tool with an execute function',
+      inputSchema: z.object({ value: z.string() }),
+      execute: async () => ({ result: 'executed' }),
+    });
+
+    const clientAction = createTool({
+      id: 'clientAction',
+      description: 'A client-side tool with no execute function',
+      inputSchema: z.object({ value: z.string() }),
+      // No execute function!
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent for mixed tools',
+      model,
+      tools: { executableTool, clientAction },
+    });
+
+    const result = await agent.stream('Use both tools', {
+      maxSteps: 5,
+    });
+
+    for await (const _ of result.fullStream) {
+      // consume the stream
+    }
+
+    // When a client tool (no execute) is present alongside an executable tool,
+    // the loop should stop after 1 call because the system needs to return
+    // control to the client for the client tool's result.
+    expect(doStreamCallCount).toBe(1);
+  });
+
+  it('should continue the loop when tool has execute and finishReason is stop (regression for #14043)', async () => {
+    let doStreamCallCount = 0;
+
+    const model = new MockLanguageModelV3({
+      doGenerate: async () => ({
+        finishReason: 'stop' as const,
+        usage: {
+          inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+          outputTokens: { total: 20, text: 20, reasoning: undefined },
+        },
+        content: [
+          {
+            type: 'tool-call' as const,
+            toolCallId: 'call-exec-1',
+            toolName: 'myTool',
+            input: '{"value":"test"}',
+          },
+        ],
+        warnings: [],
+      }),
+      doStream: async () => {
+        doStreamCallCount++;
+        if (doStreamCallCount === 1) {
+          // First call: model returns tool call with finishReason 'stop'
+          return {
+            stream: convertArrayToReadableStreamV3([
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'response-metadata',
+                id: `id-${doStreamCallCount}`,
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              {
+                type: 'tool-call',
+                toolCallId: `call-exec-${doStreamCallCount}`,
+                toolName: 'myTool',
+                input: '{"value":"test"}',
+                providerExecuted: false,
+              },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: {
+                  inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+                  outputTokens: { total: 20, text: 20, reasoning: undefined },
+                },
+              },
+            ]),
+          };
+        }
+        // Second call: model returns text (done)
+        return {
+          stream: convertArrayToReadableStreamV3([
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'response-metadata',
+              id: `id-${doStreamCallCount}`,
+              modelId: 'mock-model-id',
+              timestamp: new Date(0),
+            },
+            { type: 'text', text: 'Done' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: {
+                inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+                outputTokens: { total: 20, text: 20, reasoning: undefined },
+              },
+            },
+          ]),
+        };
+      },
+    });
+
+    const myTool = createTool({
+      id: 'myTool',
+      description: 'A tool with an execute function',
+      inputSchema: z.object({ value: z.string() }),
+      execute: async () => ({ result: 'executed' }),
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent',
+      model,
+      tools: { myTool },
+    });
+
+    const result = await agent.stream('Use the tool', {
+      maxSteps: 5,
+    });
+
+    for await (const _ of result.fullStream) {
+      // consume the stream
+    }
+
+    // The model should be called TWICE even with finishReason 'stop',
+    // because the tool has an execute function and should be processed.
+    expect(doStreamCallCount).toBe(2);
+  });
+});

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1280,20 +1280,23 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
 
       // isContinued should be true if:
       // - shouldRetry is true (processor requested retry)
-      // - OR there are non-provider-executed tool calls with execute functions to process
-      //   (some LLMs return finishReason 'stop' even with tool calls)
-      // - OR finishReason indicates more work (e.g., tool-use)
+      // - AND no client tool calls are present (client tools must return to the caller)
+      // - AND either there are pending server-side tool calls to process,
+      //   or finishReason indicates more work (e.g., tool-use)
       // Provider-executed tools (e.g. web_search) are handled server-side — the response already
       // contains both the tool execution and the text output, so no additional loop iteration is needed.
       // Client tools without execute are meant for client-side execution — the loop should stop
-      // and return control to the caller.
+      // and return control to the caller, even in mixed batches with server tools.
       const resolveTool = (toolName: string) =>
         stepTools?.[toolName] || Object.values(stepTools || {})?.find((t: any) => 'id' in t && t.id === toolName);
+      const hasClientToolCalls =
+        toolCalls && toolCalls.some(tc => !tc.providerExecuted && !resolveTool(tc.toolName)?.execute);
       const hasPendingToolCalls =
-        toolCalls && toolCalls.some(tc => !tc.providerExecuted && resolveTool(tc.toolName)?.execute);
+        toolCalls && toolCalls.some(tc => !tc.providerExecuted && !!resolveTool(tc.toolName)?.execute);
       const shouldContinue =
         shouldRetry ||
         (!tripwireTriggered &&
+          !hasClientToolCalls &&
           (hasPendingToolCalls || !['stop', 'error', 'length', 'tool-calls'].includes(finishReason)));
 
       // Increment processor retry count if we're retrying

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1280,14 +1280,21 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
 
       // isContinued should be true if:
       // - shouldRetry is true (processor requested retry)
-      // - OR there are non-provider-executed tool calls to process (some LLMs return finishReason 'stop' even with tool calls)
+      // - OR there are non-provider-executed tool calls with execute functions to process
+      //   (some LLMs return finishReason 'stop' even with tool calls)
       // - OR finishReason indicates more work (e.g., tool-use)
       // Provider-executed tools (e.g. web_search) are handled server-side — the response already
       // contains both the tool execution and the text output, so no additional loop iteration is needed.
-      const hasPendingToolCalls = toolCalls && toolCalls.some(tc => !tc.providerExecuted);
+      // Client tools without execute are meant for client-side execution — the loop should stop
+      // and return control to the caller.
+      const resolveTool = (toolName: string) =>
+        stepTools?.[toolName] || Object.values(stepTools || {})?.find((t: any) => 'id' in t && t.id === toolName);
+      const hasPendingToolCalls =
+        toolCalls && toolCalls.some(tc => !tc.providerExecuted && resolveTool(tc.toolName)?.execute);
       const shouldContinue =
         shouldRetry ||
-        (!tripwireTriggered && (hasPendingToolCalls || !['stop', 'error', 'length'].includes(finishReason)));
+        (!tripwireTriggered &&
+          (hasPendingToolCalls || !['stop', 'error', 'length', 'tool-calls'].includes(finishReason)));
 
       // Increment processor retry count if we're retrying
       const nextProcessorRetryCount = shouldRetry ? currentProcessorRetryCount + 1 : currentProcessorRetryCount;


### PR DESCRIPTION
## Summary

When a tool created with `createTool()` has no `execute` function (intended for client-side execution), the agent's `dowhile` loop incorrectly continued calling the model repeatedly. This led to repeated model calls up to `maxSteps` instead of returning control to the caller after the first iteration.

## Root Cause

In `llm-execution-step.ts`, the `hasPendingToolCalls` check only verified that tool calls weren't provider-executed, but didn't check whether the resolved tool actually has an `execute` function. Client tools (created without `execute`) would always pass this check, keeping the loop alive.

## Changes

**`packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts`**
- Added `resolveTool` helper to look up tools by name or ID (matching existing tool resolution logic)
- Refined `hasPendingToolCalls` to also check `resolveTool(tc.toolName)?.execute` — tools without execute no longer count as pending
- Added `'tool-calls'` to the stop-reasons list as a secondary safety check

**`packages/core/src/agent/__tests__/tools.test.ts`** — 4 new tests:
- Tool without execute stops loop (stream mode)
- Tool without execute stops loop (generate mode)
- Mixed tools (one with execute, one without) stops loop
- Regression test for #14043: tool WITH execute and `finishReason: 'stop'` still continues the loop

## Verification

- TypeScript compiles clean (`tsc --noEmit`)
- All 28 tool tests pass (1 skipped)
- All 142 loop tests pass (no regressions)

Closes #14093

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an infinite loop in agent execution when tools intended for client-only use lacked a server execute path; the agent now stops and returns control to the caller instead of repeatedly invoking the model.

* **Tests**
  * Added end-to-end tests covering client-only tool scenarios across streaming and generation flows, mixed tool configurations, and regression cases to ensure correct termination and single model invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->