### PR TITLE
fix: infinite loop in schemaExpectsDate causing server adapter tests to stall

### DIFF
--- a/server-adapters/_test-utils/src/test-helpers.ts
+++ b/server-adapters/_test-utils/src/test-helpers.ts
@@ -963,6 +963,8 @@ function schemaExpectsDate(schema: any, path: string[] = []): boolean {
     } else if (typeName === 'ZodDefault') {
       schema = def.innerType;
     }
+    typeName = getZodTypeName(schema);
+    def = getZodDef(schema);
   }
 
   typeName = getZodTypeName(schema);
@@ -971,13 +973,12 @@ function schemaExpectsDate(schema: any, path: string[] = []): boolean {
   // If we have a path, navigate to that field
   if (path.length > 0) {
     if (typeName === 'ZodObject') {
-      console.log('def', def);
       const shape = typeof def.shape === 'function' ? def.shape() : def.shape;
       const fieldSchema = shape[path[0]];
       return schemaExpectsDate(fieldSchema, path.slice(1));
     } else if (typeName === 'ZodArray') {
       // For arrays, check the element type (ignore the array index in path)
-      return schemaExpectsDate(typeName, path.slice(1));
+      return schemaExpectsDate(def.element, path.slice(1));
     }
     return false;
   }


### PR DESCRIPTION
`schemaExpectsDate()` in `server-adapters/_test-utils/src/test-helpers.ts` had two bugs that caused all server adapter test suites (koa, express, hono, fastify) to hang indefinitely in CI.

**Bug 1: infinite while loop** — the loop unwraps wrapper types (ZodEffects, ZodOptional, etc.) by reassigning `schema`, but never re-read `typeName`/`def`, so the loop condition stayed true forever:

```ts
// before — typeName never changes, loops forever
while (typeName === "ZodEffects" || ...) {
  schema = def.innerType;
}

// after
while (typeName === "ZodEffects" || ...) {
  schema = def.innerType;
  typeName = getZodTypeName(schema);
  def = getZodDef(schema);
}
```

**Bug 2: wrong recursive arg** — the ZodArray branch passed `typeName` (a string like `"ZodArray"`) instead of `def.element` (the actual element schema), so date fields inside arrays were never detected:

```ts
// before
return schemaExpectsDate(typeName, path.slice(1));

// after
return schemaExpectsDate(def.element, path.slice(1));
```

Also removed a stray `console.log("def", def)`.

Verified all 1739 koa tests pass with clean process exit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of type handling for nested array structures in validation logic.

* **Chores**
  * Removed debug logging from internal utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->