### PR TITLE
fix: propagate __MASTRA_VERSION__ define to vitest unit project

### DIFF
--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
   test: {
     projects: [
       {
+        define: {
+          __MASTRA_VERSION__: JSON.stringify(pkg.version),
+        },
         resolve: {
           alias: {
             '@internal/workflow-test-utils': path.resolve(__dirname, '../../workflows/_test-utils/src'),

--- a/server-adapters/_test-utils/src/test-helpers.ts
+++ b/server-adapters/_test-utils/src/test-helpers.ts
@@ -963,6 +963,8 @@ function schemaExpectsDate(schema: any, path: string[] = []): boolean {
     } else if (typeName === 'ZodDefault') {
       schema = def.innerType;
     }
+    typeName = getZodTypeName(schema);
+    def = getZodDef(schema);
   }
 
   typeName = getZodTypeName(schema);
@@ -971,13 +973,12 @@ function schemaExpectsDate(schema: any, path: string[] = []): boolean {
   // If we have a path, navigate to that field
   if (path.length > 0) {
     if (typeName === 'ZodObject') {
-      console.log('def', def);
       const shape = typeof def.shape === 'function' ? def.shape() : def.shape;
       const fieldSchema = shape[path[0]];
       return schemaExpectsDate(fieldSchema, path.slice(1));
     } else if (typeName === 'ZodArray') {
       // For arrays, check the element type (ignore the array index in path)
-      return schemaExpectsDate(typeName, path.slice(1));
+      return schemaExpectsDate(def.element, path.slice(1));
     }
     return false;
   }


### PR DESCRIPTION
The `define: { __MASTRA_VERSION__ }` block was at the root level of `packages/core/vitest.config.ts`, but Vitest projects don't inherit root-level `define`. The unit test project never replaced `__MASTRA_VERSION__`, so `MASTRA_USER_AGENT` fell back to `"mastra"` instead of `"mastra/x.y.z"`.

Moved the `define` into the unit test project config so the replacement applies during test transformation.

Broken since #13087 was introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to ensure version information is consistently available across test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->