### PR TITLE
feat: standardize tool error payloads with ToolError interface

### DIFF
--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -608,6 +608,36 @@ describe('createLLMMappingStep tool execution error self-recovery (issue #9815)'
     expect(result.stepResult.isContinued).toBe(true);
   });
 
+  it('should store thrown errors as ToolError-shaped objects in the persisted message', async () => {
+    const inputData: ToolCallOutput[] = [
+      {
+        toolCallId: 'call-1',
+        toolName: 'myTool',
+        args: {},
+        result: undefined,
+        error: new Error('something went wrong'),
+      },
+    ];
+
+    await llmMappingStep.execute(createExecuteParams(inputData));
+
+    expect(messageList.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({
+          parts: [
+            expect.objectContaining({
+              type: 'tool-invocation',
+              toolInvocation: expect.objectContaining({
+                result: { error: true, message: 'something went wrong' },
+              }),
+            }),
+          ],
+        }),
+      }),
+      'response',
+    );
+  });
+
   it('should continue the loop when a tool execution error occurs alongside successful tool results', async () => {
     // Mixed scenario: one tool succeeds, one throws at runtime.
     // The model should see both the success and the error, and be allowed to retry.

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -8,6 +8,7 @@ import { ProcessorRunner } from '../../../processors/runner';
 import type { ChunkType, ProviderMetadata } from '../../../stream/types';
 import { ChunkFrom } from '../../../stream/types';
 import { createStep } from '../../../workflows';
+import type { ToolError } from '../../../tools/validation';
 import type { OuterLLMRun } from '../../types';
 import { llmIterationOutputSchema, toolCallOutputSchema } from '../schema';
 
@@ -161,7 +162,7 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
                     toolCallId: toolCallErrorResult.toolCallId,
                     toolName: sanitizeToolName(toolCallErrorResult.toolName),
                     args: toolCallErrorResult.args,
-                    result: toolCallErrorResult.error?.message ?? toolCallErrorResult.error,
+                    result: { error: true, message: toolCallErrorResult.error?.message ?? String(toolCallErrorResult.error) } satisfies ToolError,
                   },
                   ...(toolCallErrorResult.providerMetadata
                     ? { providerMetadata: toolCallErrorResult.providerMetadata as ProviderMetadata }

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -3,4 +3,4 @@ export * from './types';
 export * from './ui-types';
 export { isVercelTool, isProviderDefinedTool } from './toolchecks';
 export { ToolStream } from './stream';
-export { type ValidationError } from './validation';
+export { type ToolError, type ValidationError } from './validation';

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -44,9 +44,12 @@ export type FormattedValidationErrors<T = unknown> = {
   fields: T extends object ? { [K in keyof T]?: FormattedValidationErrors<T[K]> } : unknown;
 };
 
-export interface ValidationError<T = unknown> {
+export interface ToolError {
   error: true;
   message: string;
+}
+
+export interface ValidationError<T = unknown> extends ToolError {
   validationErrors: FormattedValidationErrors<T>;
 }
 /**

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -44,11 +44,20 @@ export type FormattedValidationErrors<T = unknown> = {
   fields: T extends object ? { [K in keyof T]?: FormattedValidationErrors<T[K]> } : unknown;
 };
 
+/**
+ * Base interface for structured tool errors returned to the model.
+ * Used to signal that a tool call failed, allowing the model to self-correct.
+ */
 export interface ToolError {
   error: true;
   message: string;
 }
 
+/**
+ * Structured validation error returned when tool input, output, or suspend data
+ * fails schema validation. Extends `ToolError` so the model receives a consistent
+ * error shape regardless of whether the failure was a validation or a runtime throw.
+ */
 export interface ValidationError<T = unknown> extends ToolError {
   validationErrors: FormattedValidationErrors<T>;
 }


### PR DESCRIPTION
## Description
When a tool throws an error during agent execution, the error is now stored in the message as a structured object 
```
{ error: true, message: "..." }
```
instead of a plain string. This aligns with how `ValidationError` (input/output validation failures) are already represented, since `ValidationError` now extends the new `ToolError` base interface.

<!-- Provide a brief description of the changes in this PR -->

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tool call error payloads now use a consistent structured error shape across the SDK; validation error types inherit this common shape.
* **Tests**
  * Added tests ensuring thrown tool errors are persisted and emitted using the standardized error structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->