### PR TITLE
fix(core): prevent infinite loop when finishReason is tool-calls with no tool calls

### DIFF
--- a/.changeset/fix-empty-tool-calls-loop.md
+++ b/.changeset/fix-empty-tool-calls-loop.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed infinite loop when LLM returns `finishReason: "tool-calls"` with no actual tool calls.
+
+Some providers (e.g. Anthropic) can return `stop_reason: "tool_use"` with an empty `content` array. Previously, the agent loop treated this as a continuation signal, causing it to call the model repeatedly with the same messages until `maxSteps` was exhausted. The loop now correctly treats `finishReason: "tool-calls"` with no pending tool calls as equivalent to `"stop"`.

--- a/packages/core/src/agent/__tests__/empty-tool-calls-loop.test.ts
+++ b/packages/core/src/agent/__tests__/empty-tool-calls-loop.test.ts
@@ -1,0 +1,175 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { createTool } from '../../tools';
+import { Agent } from '../agent';
+
+/**
+ * Regression tests for issue #12581:
+ * Anthropic models can return `stop_reason: "tool_use"` (mapped to `finishReason: "tool-calls"`)
+ * with an empty `content` array — no actual tool call chunks. This caused an infinite loop
+ * because the shouldContinue logic treated `finishReason: "tool-calls"` as a continuation
+ * signal, but there were no tool calls to execute, so the model would be called again
+ * with the same messages and produce the same empty response indefinitely.
+ *
+ * The fix: treat `finishReason: "tool-calls"` with no pending tool calls as equivalent
+ * to `finishReason: "stop"`.
+ */
+describe('empty tool-calls infinite loop (#12581)', () => {
+  const lookupTool = createTool({
+    id: 'lookup',
+    description: 'Look up information',
+    inputSchema: z.object({ query: z.string() }),
+    execute: async ({ query }) => ({ found: true, data: `Result for: ${query}` }),
+  });
+
+  it('should stop when finishReason is tool-calls but no tool calls are present (generate)', async () => {
+    let callCount = 0;
+
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async () => {
+        callCount++;
+        // Simulate Anthropic returning stop_reason: "tool_use" with empty content
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'tool-calls' as const,
+          usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+          content: [], // Empty — no tool calls despite finishReason
+          warnings: [],
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-empty-tool-calls',
+      name: 'Test Agent',
+      instructions: 'You are a helpful assistant.',
+      model: mockModel,
+      tools: { lookup: lookupTool },
+    });
+
+    await agent.generate('Hello', { maxSteps: 5 });
+
+    // Without the fix, this would loop 5 times (maxSteps).
+    // With the fix, the model should only be called once.
+    expect(callCount).toBe(1);
+  });
+
+  it('should stop when finishReason is tool-calls but no tool calls are present (stream)', async () => {
+    let callCount = 0;
+
+    const mockModel = new MockLanguageModelV2({
+      doStream: async () => {
+        callCount++;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: `id-${callCount}`, modelId: 'mock-model-id', timestamp: new Date(0) },
+            // No tool-call chunks — just a finish with finishReason: 'tool-calls'
+            {
+              type: 'finish',
+              finishReason: 'tool-calls' as const,
+              usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-empty-tool-calls-stream',
+      name: 'Test Agent',
+      instructions: 'You are a helpful assistant.',
+      model: mockModel,
+      tools: { lookup: lookupTool },
+    });
+
+    const result = await agent.stream('Hello', { maxSteps: 5 });
+
+    // Consume the stream to completion
+    await result.text;
+
+    // Without the fix, this would loop 5 times (maxSteps).
+    // With the fix, the model should only be called once.
+    expect(callCount).toBe(1);
+  });
+
+  it('should still continue when finishReason is tool-calls AND actual tool calls are present', async () => {
+    let callCount = 0;
+
+    const mockModel = new MockLanguageModelV2({
+      doStream: async () => {
+        callCount++;
+
+        if (callCount === 1) {
+          // Step 1: Model calls a tool (normal behavior)
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'response-metadata',
+                id: `id-${callCount}`,
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'lookup',
+                input: JSON.stringify({ query: 'test' }),
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls' as const,
+                usage: { inputTokens: 10, outputTokens: 15, totalTokens: 25 },
+              },
+            ]),
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+          };
+        } else {
+          // Step 2: Model responds with text (done)
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'response-metadata',
+                id: `id-${callCount}`,
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-start', id: 'text-1' },
+              { type: 'text-delta', id: 'text-1', delta: 'Done' },
+              { type: 'text-end', id: 'text-1' },
+              {
+                type: 'finish',
+                finishReason: 'stop' as const,
+                usage: { inputTokens: 20, outputTokens: 5, totalTokens: 25 },
+              },
+            ]),
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+          };
+        }
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-real-tool-calls',
+      name: 'Test Agent',
+      instructions: 'You are a helpful assistant.',
+      model: mockModel,
+      tools: { lookup: lookupTool },
+    });
+
+    const result = await agent.stream('Look up test', { maxSteps: 5 });
+
+    // Consume the stream to completion
+    await result.text;
+
+    // The loop should continue past step 1 (tool call) and stop at step 2 (text response)
+    expect(callCount).toBe(2);
+  });
+});

--- a/packages/core/src/agent/__tests__/supervisor-integration.test.ts
+++ b/packages/core/src/agent/__tests__/supervisor-integration.test.ts
@@ -1543,25 +1543,13 @@ describe('Supervisor Pattern - onIterationComplete Hook Integration', () => {
               stream: convertArrayToReadableStream([
                 { type: 'stream-start', warnings: [] },
                 { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+                { type: 'tool-input-start', id: 'call-1', toolName: 'simple-tool' },
+                { type: 'tool-input-delta', id: 'call-1', delta: '{"input":"test"}' },
                 {
-                  type: 'tool-call-start',
-                  id: 'call-1',
+                  type: 'tool-call',
                   toolCallId: 'call-1',
                   toolName: 'simple-tool',
-                },
-                {
-                  type: 'tool-call-args-delta',
-                  id: 'call-1',
-                  toolCallId: 'call-1',
-                  toolName: 'simple-tool',
-                  argsDelta: '{"input":"test"}',
-                },
-                {
-                  type: 'tool-call-end',
-                  id: 'call-1',
-                  toolCallId: 'call-1',
-                  toolName: 'simple-tool',
-                  args: { input: 'test' },
+                  input: '{"input":"test"}',
                 },
                 {
                   type: 'finish',
@@ -1663,25 +1651,13 @@ describe('Supervisor Pattern - onIterationComplete Hook Integration', () => {
             stream: convertArrayToReadableStream([
               { type: 'stream-start', warnings: [] },
               { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+              { type: 'tool-input-start', id: `call-${callCount}`, toolName: 'counter-tool' },
+              { type: 'tool-input-delta', id: `call-${callCount}`, delta: `{"count":${callCount}}` },
               {
-                type: 'tool-call-start',
-                id: `call-${callCount}`,
+                type: 'tool-call',
                 toolCallId: `call-${callCount}`,
                 toolName: 'counter-tool',
-              },
-              {
-                type: 'tool-call-args-delta',
-                id: `call-${callCount}`,
-                toolCallId: `call-${callCount}`,
-                toolName: 'counter-tool',
-                argsDelta: `{"count":${callCount}}`,
-              },
-              {
-                type: 'tool-call-end',
-                id: `call-${callCount}`,
-                toolCallId: `call-${callCount}`,
-                toolName: 'counter-tool',
-                args: { count: callCount },
+                input: `{"count":${callCount}}`,
               },
               {
                 type: 'finish',
@@ -1749,25 +1725,13 @@ describe('Supervisor Pattern - onIterationComplete Hook Integration', () => {
               stream: convertArrayToReadableStream([
                 { type: 'stream-start', warnings: [] },
                 { type: 'response-metadata', id: `id-${callCount}`, modelId: 'mock-model-id', timestamp: new Date(0) },
+                { type: 'tool-input-start', id: `call-${callCount}`, toolName: 'lookup-tool' },
+                { type: 'tool-input-delta', id: `call-${callCount}`, delta: `{"query":"item-${callCount}"}` },
                 {
-                  type: 'tool-call-start',
-                  id: `call-${callCount}`,
+                  type: 'tool-call',
                   toolCallId: `call-${callCount}`,
                   toolName: 'lookup-tool',
-                },
-                {
-                  type: 'tool-call-args-delta',
-                  id: `call-${callCount}`,
-                  toolCallId: `call-${callCount}`,
-                  toolName: 'lookup-tool',
-                  argsDelta: `{"query":"item-${callCount}"}`,
-                },
-                {
-                  type: 'tool-call-end',
-                  id: `call-${callCount}`,
-                  toolCallId: `call-${callCount}`,
-                  toolName: 'lookup-tool',
-                  args: { query: `item-${callCount}` },
+                  input: `{"query":"item-${callCount}"}`,
                 },
                 {
                   type: 'finish',
@@ -1855,25 +1819,13 @@ describe('Supervisor Pattern - onIterationComplete Hook Integration', () => {
             stream: convertArrayToReadableStream([
               { type: 'stream-start', warnings: [] },
               { type: 'response-metadata', id: `id-${callCount}`, modelId: 'mock-model-id', timestamp: new Date(0) },
+              { type: 'tool-input-start', id: `call-${callCount}`, toolName: 'fetch-tool' },
+              { type: 'tool-input-delta', id: `call-${callCount}`, delta: `{"id":"${callCount}"}` },
               {
-                type: 'tool-call-start',
-                id: `call-${callCount}`,
+                type: 'tool-call',
                 toolCallId: `call-${callCount}`,
                 toolName: 'fetch-tool',
-              },
-              {
-                type: 'tool-call-args-delta',
-                id: `call-${callCount}`,
-                toolCallId: `call-${callCount}`,
-                toolName: 'fetch-tool',
-                argsDelta: `{"id":"${callCount}"}`,
-              },
-              {
-                type: 'tool-call-end',
-                id: `call-${callCount}`,
-                toolCallId: `call-${callCount}`,
-                toolName: 'fetch-tool',
-                args: { id: `${callCount}` },
+                input: `{"id":"${callCount}"}`,
               },
               {
                 type: 'finish',

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1284,10 +1284,14 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
       // - OR finishReason indicates more work (e.g., tool-use)
       // Provider-executed tools (e.g. web_search) are handled server-side — the response already
       // contains both the tool execution and the text output, so no additional loop iteration is needed.
+      //
+      // Edge case: some providers (e.g. Anthropic) can return finishReason 'tool-calls' with an empty
+      // content array — no actual tool call chunks. Treat this as 'stop' to prevent an infinite loop.
       const hasPendingToolCalls = toolCalls && toolCalls.some(tc => !tc.providerExecuted);
+      const effectiveFinishReason = finishReason === 'tool-calls' && !hasPendingToolCalls ? 'stop' : finishReason;
       const shouldContinue =
         shouldRetry ||
-        (!tripwireTriggered && (hasPendingToolCalls || !['stop', 'error', 'length'].includes(finishReason)));
+        (!tripwireTriggered && (hasPendingToolCalls || !['stop', 'error', 'length'].includes(effectiveFinishReason)));
 
       // Increment processor retry count if we're retrying
       const nextProcessorRetryCount = shouldRetry ? currentProcessorRetryCount + 1 : currentProcessorRetryCount;


### PR DESCRIPTION
## Problem

An LLM can return `finishReason: "tool-calls"` with no actual tool call blocks in the response. This has been observed with `claude-sonnet-4-5` (possibly via a proxy/gateway like Groq), where the raw response contains `stop_reason: "tool_use"` but `content: []`.

When this happens, the agent loop's `shouldContinue` logic treated `finishReason: "tool-calls"` as a continuation signal. But since there were no tool calls to execute, the model was called again with the same messages, producing the same empty response — an infinite loop until `maxSteps` was exhausted.

## Fix

In `llm-execution-step.ts`, the `shouldContinue` logic now computes an `effectiveFinishReason`: if `finishReason` is `"tool-calls"` but there are no pending (non-provider-executed) tool calls, treat it as `"stop"`.

## Tests

Added 3 regression tests in `empty-tool-calls-loop.test.ts`:
1. **generate()** — empty tool-calls stops after 1 model call
2. **stream()** — empty tool-calls stops after 1 model call
3. **sanity check** — real tool calls still continue the loop normally

Closes #12581