### PR TITLE
fix: stabilize tokenx-related test regressions

### DIFF
--- a/packages/memory/src/processors/observational-memory/__tests__/mid-loop-observation.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/mid-loop-observation.test.ts
@@ -347,8 +347,11 @@ describe('Mid-Loop Observation', () => {
       expect(recordAfterStep0?.activeObservations).toBeFalsy();
 
       // Step 1: Add more messages to cross threshold and trigger mid-step activation.
-      // Add 15 more messages (~750 tokens) to push total past 1000 threshold.
-      for (let i = 0; i < 15; i++) {
+      // Add 25 more messages (~1250 tokens) to push total well past 1000 threshold.
+      // We use a generous count so that the activation safety check
+      // (projectedRemaining <= maxRemaining) is satisfied even with tokenx's
+      // ~2-5% variance compared to tiktoken.
+      for (let i = 0; i < 25; i++) {
         const msg = createTestMessage(
           `Cross threshold ${i}: `.padEnd(200, 'y'),
           i % 2 === 0 ? 'user' : 'assistant',

--- a/stores/_test-utils/src/domains/memory/messages-list.ts
+++ b/stores/_test-utils/src/domains/memory/messages-list.ts
@@ -84,14 +84,13 @@ export function createMessagesListTest({ storage }: { storage: MastraStorage }) 
 
     it('should persist and reload token estimates written by token counting', async () => {
       const counter = new TokenCounter();
-      const encoder = (counter as any).encoder;
-      const originalEncode = encoder.encode.bind(encoder);
-      let encodeCalls = 0;
+      const originalCountString = counter.countString.bind(counter);
+      let countStringCalls = 0;
 
       try {
-        encoder.encode = (...args: any[]) => {
-          encodeCalls += 1;
-          return originalEncode(...args);
+        counter.countString = (...args: any[]) => {
+          countStringCalls += 1;
+          return originalCountString(...args);
         };
 
         const cachedMessage = createSampleMessageV2({
@@ -109,7 +108,7 @@ export function createMessagesListTest({ storage }: { storage: MastraStorage }) 
         });
 
         const firstCount = counter.countMessage(cachedMessage);
-        const callsAfterFirst = encodeCalls;
+        const callsAfterFirst = countStringCalls;
         const firstEstimate = (cachedMessage.content as any).parts[0].providerMetadata?.mastra?.tokenEstimate;
 
         expect(firstCount).toBeGreaterThan(0);
@@ -127,11 +126,11 @@ export function createMessagesListTest({ storage }: { storage: MastraStorage }) 
         expect((reloaded!.content as any).parts[0].providerMetadata?.mastra?.tokenEstimate).toEqual(firstEstimate);
 
         const secondCount = counter.countMessage(reloaded!);
-        const callsAfterSecond = encodeCalls;
+        const callsAfterSecond = countStringCalls;
         expect(secondCount).toBe(firstCount);
         expect(callsAfterSecond - callsAfterFirst).toBe(1);
       } finally {
-        encoder.encode = originalEncode;
+        counter.countString = originalCountString;
       }
     });
 

--- a/stores/_test-utils/src/domains/memory/messages-list.ts
+++ b/stores/_test-utils/src/domains/memory/messages-list.ts
@@ -88,9 +88,9 @@ export function createMessagesListTest({ storage }: { storage: MastraStorage }) 
       let countStringCalls = 0;
 
       try {
-        counter.countString = (...args: any[]) => {
+        counter.countString = (text: string) => {
           countStringCalls += 1;
-          return originalCountString(...args);
+          return originalCountString(text);
         };
 
         const cachedMessage = createSampleMessageV2({


### PR DESCRIPTION
This fixes two test regressions caused by the tokenx migration.

The observational memory regression test was calibrated too tightly around tiktoken-era token counts, so it now pushes the step-1 input further past the threshold.

Before:
```ts
for (let i = 0; i < 15; i++) {
```

After:
```ts
for (let i = 0; i < 25; i++) {
```

The shared memory messages-list test also depended on `TokenCounter` exposing an internal `encoder`, which no longer exists under tokenx.

Before:
```ts
const encoder = (counter as any).encoder;
const originalEncode = encoder.encode.bind(encoder);
```

After:
```ts
const originalCountString = counter.countString.bind(counter);
counter.countString = (...args: any[]) => {
  countStringCalls += 1;
  return originalCountString(...args);
};
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of observation tests by increasing the message threshold to reduce flakiness from token-count variance.
  * Updated token-counting test utilities to track encoding-counts more accurately and adjusted related assertions and reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->