### PR TITLE
fix: use relative paths in server adapter test helpers

### DIFF
--- a/server-adapters/_test-utils/src/test-helpers.ts
+++ b/server-adapters/_test-utils/src/test-helpers.ts
@@ -831,7 +831,7 @@ Follow these instructions for the test skill.
   const workspace = new Workspace({
     id: 'test-workspace',
     filesystem,
-    skills: ['/skills'],
+    skills: ['skills'],
     bm25: true, // Enable BM25 search for index/unindex operations
   });
 
@@ -1119,22 +1119,22 @@ function getRouteSpecificPathDefaults(route: ServerRoute): {
     routePath.includes('/fs/delete') ||
     routePath.includes('/fs/stat')
   ) {
-    return { query: { path: '/test-file.txt' }, body: { path: '/test-file.txt' } };
+    return { query: { path: 'test-file.txt' }, body: { path: 'test-file.txt' } };
   }
 
   // Directory operations need directory paths
   if (routePath.includes('/fs/list')) {
-    return { query: { path: '/' } };
+    return { query: { path: '.' } };
   }
 
   // mkdir needs a new path to create
   if (routePath.includes('/fs/mkdir')) {
-    return { body: { path: '/new-test-dir' } };
+    return { body: { path: 'new-test-dir' } };
   }
 
   // Index/unindex operations
   if (routePath.includes('/workspace/index') || routePath.includes('/workspace/unindex')) {
-    return { query: { path: '/test-file.txt' }, body: { path: '/test-file.txt' } };
+    return { query: { path: 'test-file.txt' }, body: { path: 'test-file.txt' } };
   }
 
   return {};


### PR DESCRIPTION
## Problem

PR #13804 (`refactor/no-virtual-root`) changed path semantics so that leading-slash paths are treated as absolute host paths. The server adapter test helpers were still using the old virtual-root convention (`/test-file.txt`, `/`, `/new-test-dir`), which now gets blocked by `LocalFilesystem` containment → HTTP 403.

This caused 18 test failures across Fastify, Hono, and Express adapter test suites.

## Fix

Updated all test path defaults in `server-adapters/_test-utils/src/test-helpers.ts` to use relative paths:
- `/test-file.txt` → `test-file.txt`
- `/` → `.`
- `/new-test-dir` → `new-test-dir`
- `skills: ['/skills']` → `skills: ['skills']`

## Verification

All 150 workspace tests pass on each adapter:
- ✅ Fastify: 150 passed
- ✅ Hono: 150 passed
- ✅ Express: 150 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test utilities to use relative file paths instead of absolute paths for improved portability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->