### PR TITLE
fix(deployer): scope gzip compression to studio assets only

### DIFF
--- a/.changeset/fix-gzip-studio-only.md
+++ b/.changeset/fix-gzip-studio-only.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed gzip compression being applied globally to all API routes, causing JSON responses to be unreadable by clients that don't auto-decompress. Compression is now scoped to studio static assets only.

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -199,7 +199,6 @@ export async function createHonoServer(
     app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000), cors(corsConfig));
   }
 
-
   // Health check endpoint (before auth middleware so it's publicly accessible)
   app.get(
     '/health',

--- a/packages/deployer/src/server/index.ts
+++ b/packages/deployer/src/server/index.ts
@@ -199,20 +199,6 @@ export async function createHonoServer(
     app.use('*', timeout(server?.timeout ?? 3 * 60 * 1000), cors(corsConfig));
   }
 
-  // Enable gzip/deflate compression for all responses (except SSE endpoints)
-  app.use('*', async (c, next) => {
-    if (c.req.path.endsWith('/refresh-events')) {
-      return next();
-    }
-    return compress()(c, next);
-  });
-  // Ensure Vary: Accept-Encoding is set for proper caching behavior
-  app.use('*', async (c, next) => {
-    await next();
-    if (c.res.headers.get('Content-Encoding')) {
-      c.res.headers.append('Vary', 'Accept-Encoding');
-    }
-  });
 
   // Health check endpoint (before auth middleware so it's publicly accessible)
   app.get(
@@ -347,6 +333,9 @@ export async function createHonoServer(
         });
       },
     );
+
+    // Enable gzip/deflate compression for studio static assets only
+    app.use(`${studioBasePath}/assets/*`, compress());
 
     // Studio routes - these should come after API routes
     // Serve static assets from studio directory


### PR DESCRIPTION
## Problem

The `compress()` middleware from #13945 was applied globally to **all routes** (`app.use('*', compress())`), causing API responses (e.g. `/api/tools`) to return gzip-encoded bodies. Clients like Cloudflare Workers that don't auto-decompress received raw gzip bytes instead of JSON, breaking E2E deployer tests:

```
SyntaxError: Unexpected token '', "�      "... is not valid JSON
```

Failing jobs: https://github.com/mastra-ai/mastra/actions/runs/22981108652

## Fix

Move `compress()` from global middleware to only the studio assets route (`${studioBasePath}/assets/*`) where it's actually needed for the large JS/CSS bundles. API routes are no longer compressed at the application level.

## Changes

- **Removed**: Global `compress()` middleware + SSE exclusion logic + Vary header wrapper
- **Added**: Scoped `compress()` on `${studioBasePath}/assets/*` inside the `if (options?.studio)` block

## Test Plan

- E2E deployer tests should pass (Cloudflare wrangler `/api/tools` returns valid JSON)
- Studio assets still served compressed (verify via `Content-Encoding: gzip` header on .js/.css files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed global response compression so it no longer applies to all routes or JSON responses; compression is now scoped to studio static assets only.
* **Chores**
  * Added a patch-level changeset documenting the compression scoping change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->