### PR TITLE
fix(playground): update agent tools E2E tests to match add/remove UI

### DIFF
--- a/packages/playground/e2e/tests/cms/agents/create/page.spec.ts
+++ b/packages/playground/e2e/tests/cms/agents/create/page.spec.ts
@@ -315,12 +315,12 @@ test.describe('Agent Creation Persistence - Tools', () => {
     // Navigate to tools page via sidebar
     await clickSidebarLink(page, 'Tools');
 
-    // Wait for tools to load
-    await expect(page.getByText('weatherInfo')).toBeVisible({ timeout: 10000 });
+    // Click "Add Tools" to open popover and select weatherInfo
+    await page.getByRole('button', { name: 'Add Tools' }).click({ timeout: 10000 });
+    await page.getByText('weatherInfo').click();
 
-    // Toggle the first tool switch
-    const firstSwitch = page.getByRole('switch').first();
-    await firstSwitch.click();
+    // Verify it appears in the selected list
+    await expect(page.getByLabel('Remove weatherInfo')).toBeVisible({ timeout: 5000 });
 
     const agentId = await createAgentAndGetId(page);
 
@@ -328,7 +328,7 @@ test.describe('Agent Creation Persistence - Tools', () => {
     await page.goto(`/cms/agents/${agentId}/edit/tools`);
     await page.waitForTimeout(2000);
 
-    await expect(page.getByRole('switch').first()).toBeChecked({ timeout: 10000 });
+    await expect(page.getByText('weatherInfo')).toBeVisible({ timeout: 10000 });
   });
 });
 
@@ -698,11 +698,11 @@ test.describe('Comprehensive Persistence Test', () => {
 
     // === Tools ===
     await clickSidebarLink(page, 'Tools');
-    await page.waitForTimeout(1000);
-    const toolSwitches = page.getByRole('switch');
-    if ((await toolSwitches.count()) > 0) {
-      await toolSwitches.first().click();
-    }
+    await page.getByRole('button', { name: 'Add Tools' }).click({ timeout: 10000 });
+    const firstToolOption = page.locator('[data-radix-popper-content-wrapper] button').first();
+    await firstToolOption.waitFor({ state: 'visible', timeout: 5000 });
+    await firstToolOption.click();
+    await expect(page.getByLabel(/^Remove /).first()).toBeVisible({ timeout: 5000 });
 
     // === Workflows ===
     await clickSidebarLink(page, 'Workflows');
@@ -747,7 +747,7 @@ test.describe('Comprehensive Persistence Test', () => {
     // === Verify Tools ===
     await page.goto(`/cms/agents/${agentId}/edit/tools`);
     await page.waitForTimeout(2000);
-    await expect(page.getByRole('switch').first()).toBeChecked({ timeout: 10000 });
+    await expect(page.getByLabel(/^Remove /).first()).toBeVisible({ timeout: 10000 });
 
     // === Verify Workflows ===
     await page.goto(`/cms/agents/${agentId}/edit/workflows`);


### PR DESCRIPTION
## Summary

The agent tools page was redesigned (commit c9242dbaa5, Feb 18) from switch-based toggles to an "Add Tools" popover with remove buttons. Several subsequent commits further refined this pattern but the E2E tests were not updated.

### Changes

- **`persists selected tools` test**: Now clicks "Add Tools" popover, selects `weatherInfo`, and verifies via `Remove weatherInfo` aria-label
- **`persists all fields across all pages` test**: Create section uses popover flow; verify section checks for `Remove` button presence

### Test Plan

Both tests pass locally:
```
npx playwright test -c e2e/playwright.config.ts --grep "persists selected tools"    # ✅ 13.4s
npx playwright test -c e2e/playwright.config.ts --grep "persists all fields"          # ✅ 25.3s
```

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-6) <noreply@mastra.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Modernized the Tools selection interface with an Add Tools popover workflow, streamlining the process of managing tools in agent configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->