### PR TITLE
fix(mcp): resolve tsx binary locally instead of using npx in stdio tests

### DIFF
--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -1983,6 +1983,10 @@ describe('MastraMCPClient fetch with requestContext', () => {
 });
 
 describe('MastraMCPClient - Stdio stderr and cwd forwarding', () => {
+  // Resolve the tsx CLI binary from the workspace instead of using npx -y,
+  // which can be flaky in CI when tsx needs to be downloaded on-the-fly.
+  const tsxCli = path.join(path.dirname(require.resolve('tsx/package.json')), 'dist', 'cli.mjs');
+
   it('should pipe stderr instead of inheriting it when stderr is set to "pipe"', async () => {
     const STDERR_MARKER = 'noisy-server: startup log';
 
@@ -1992,8 +1996,8 @@ describe('MastraMCPClient - Stdio stderr and cwd forwarding', () => {
     const client = new InternalMastraMCPClient({
       name: 'noisy',
       server: {
-        command: 'npx',
-        args: ['-y', 'tsx', path.join(__dirname, '..', '__fixtures__/noisy-server.ts')],
+        command: process.execPath,
+        args: [tsxCli, path.join(__dirname, '..', '__fixtures__/noisy-server.ts')],
         stderr: 'pipe',
       },
     });
@@ -2016,8 +2020,8 @@ describe('MastraMCPClient - Stdio stderr and cwd forwarding', () => {
     const client = new InternalMastraMCPClient({
       name: 'cwd-test',
       server: {
-        command: 'npx',
-        args: ['-y', 'tsx', path.join(__dirname, '..', '__fixtures__/cwd-reporter.ts')],
+        command: process.execPath,
+        args: [tsxCli, path.join(__dirname, '..', '__fixtures__/cwd-reporter.ts')],
         cwd: targetDir,
       },
     });


### PR DESCRIPTION
## Problem

The test `should pipe stderr instead of inheriting it when stderr is set to "pipe"` was failing in CI with `McpError: Connection closed`.

The tests spawned child MCP server processes using `npx -y tsx`, which is flaky in CI because:
- `npx -y` may need to download `tsx` on-the-fly, adding latency
- With `stderr: 'pipe'`, any npx download/install output goes into the pipe rather than the terminal, interfering with the MCP handshake
- If the download fails or takes too long, the child process closes before the connection completes

Failing run: https://github.com/mastra-ai/mastra/actions/runs/22986136677/job/66736895646

## Fix

Resolve the `tsx` CLI binary directly from the workspace `node_modules` (already a devDependency) and use `process.execPath` (node) to run it, eliminating `npx` entirely.

- **Before:** `command: 'npx'`, `args: ['-y', 'tsx', ...]`
- **After:** `command: process.execPath`, `args: [tsxCli, ...]` where `tsxCli` is resolved via `require.resolve('tsx/package.json')`

## Test Plan

All 48 tests in `packages/mcp/src/client/client.test.ts` pass locally, including both fixed tests:
- `should pipe stderr instead of inheriting it when stderr is set to "pipe"`
- `should forward cwd option to the child process`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by switching from dynamic npm-based CLI invocation to workspace-resolved invocation, eliminating flakiness from transient dependency downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->