### PR TITLE
fix: update e2e tests to match new tools page add/remove UI

### DIFF
--- a/packages/playground/e2e/tests/cms/agents/create/page.spec.ts
+++ b/packages/playground/e2e/tests/cms/agents/create/page.spec.ts
@@ -315,20 +315,21 @@ test.describe('Agent Creation Persistence - Tools', () => {
     // Navigate to tools page via sidebar
     await clickSidebarLink(page, 'Tools');
 
-    // Wait for tools to load
-    await expect(page.getByText('weatherInfo')).toBeVisible({ timeout: 10000 });
+    // Click "Add Tools" to open the popover with available tools
+    await expect(page.getByRole('button', { name: 'Add Tools' })).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'Add Tools' }).click();
 
-    // Toggle the first tool switch
-    const firstSwitch = page.getByRole('switch').first();
-    await firstSwitch.click();
+    // Select weatherInfo from the popover
+    await expect(page.getByText('weatherInfo')).toBeVisible({ timeout: 5000 });
+    await page.getByText('weatherInfo').click();
 
     const agentId = await createAgentAndGetId(page);
 
-    // Verify on edit page
+    // Verify on edit page — selected tool should appear as an entity
     await page.goto(`/cms/agents/${agentId}/edit/tools`);
     await page.waitForTimeout(2000);
 
-    await expect(page.getByRole('switch').first()).toBeChecked({ timeout: 10000 });
+    await expect(page.getByText('weatherInfo')).toBeVisible({ timeout: 10000 });
   });
 });
 
@@ -699,9 +700,14 @@ test.describe('Comprehensive Persistence Test', () => {
     // === Tools ===
     await clickSidebarLink(page, 'Tools');
     await page.waitForTimeout(1000);
-    const toolSwitches = page.getByRole('switch');
-    if ((await toolSwitches.count()) > 0) {
-      await toolSwitches.first().click();
+    // Tools use add/remove pattern — click "Add Tools" and select the first tool
+    const addToolsBtn = page.getByRole('button', { name: 'Add Tools' });
+    if (await addToolsBtn.isVisible()) {
+      await addToolsBtn.click();
+      const firstToolOption = page.getByRole('button').filter({ hasText: 'weatherInfo' });
+      if (await firstToolOption.isVisible()) {
+        await firstToolOption.click();
+      }
     }
 
     // === Workflows ===
@@ -747,7 +753,7 @@ test.describe('Comprehensive Persistence Test', () => {
     // === Verify Tools ===
     await page.goto(`/cms/agents/${agentId}/edit/tools`);
     await page.waitForTimeout(2000);
-    await expect(page.getByRole('switch').first()).toBeChecked({ timeout: 10000 });
+    await expect(page.getByText('weatherInfo')).toBeVisible({ timeout: 10000 });
 
     // === Verify Workflows ===
     await page.goto(`/cms/agents/${agentId}/edit/workflows`);


### PR DESCRIPTION
## Summary

The tools page UI was redesigned from switch toggles to an add/remove pattern with a popover. The e2e tests were still using the old switch-based interaction, causing two test failures:

- `persists selected tools`
- `persists all fields across all pages` (tools section)

## Changes

Updated both tests to:
- Click the **"Add Tools"** button to open the popover
- Select `weatherInfo` from the popover options
- Verify persistence by checking the tool name is visible as an entity card (instead of checking a switch is checked)

## Test Plan

- The two previously failing e2e tests should now pass
- No other tests are affected (workflows, agents, scorers, memory pages still use switches)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned tool selection workflow in agent creation using an "Add Tools" popover interface for streamlined tool management.

* **Tests**
  * Updated E2E tests to validate the updated tool selection interaction model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->