### PR TITLE
fix(core): apply JSON sanitization and repair to streaming tool-call delta reassembly

### DIFF
--- a/.changeset/fix-streaming-tool-call-json-parse.md
+++ b/.changeset/fix-streaming-tool-call-json-parse.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed streaming tool calls with large or complex JSON arguments intermittently failing to parse. When tool-call arguments arrived as streamed deltas, malformed JSON (trailing LLM tokens, trailing commas, missing quotes) was silently discarded, causing tools to receive empty input and triggering unnecessary retries. The streaming path now applies the same sanitization and repair that non-streaming tool calls already use.

--- a/.changeset/fix-streaming-tool-call-json-parse.md
+++ b/.changeset/fix-streaming-tool-call-json-parse.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed streaming tool calls with large or complex JSON arguments intermittently failing to parse. When tool-call arguments arrived as streamed deltas, malformed JSON (trailing LLM tokens, trailing commas, missing quotes) was silently discarded, causing tools to receive empty input and triggering unnecessary retries. The streaming path now applies the same sanitization and repair that non-streaming tool calls already use.
+Fixed streamed tool-call arguments being silently discarded when the JSON was slightly malformed, causing tools to receive empty input and triggering unnecessary retries. Tool-call arguments are now sanitized and repaired consistently across both streaming and non-streaming paths.

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -89,6 +89,37 @@ export function tryRepairJson(input: string): Record<string, any> | null {
   }
 }
 
+/**
+ * Parses a raw tool-call input string into an object, applying sanitization
+ * and repair as needed.
+ *
+ * Pipeline: sanitize LLM tokens → JSON.parse → repair common malformations.
+ *
+ * @returns The parsed object, or undefined if the input is empty or unrecoverable.
+ *          When parsing fails on substantive input, logs an error for diagnostics.
+ */
+export function parseToolCallInput(raw: string): Record<string, any> | undefined {
+  if (!raw) {
+    return undefined;
+  }
+
+  const sanitized = sanitizeToolCallInput(raw);
+  if (!sanitized) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(sanitized);
+  } catch {
+    const repaired = tryRepairJson(sanitized);
+    if (repaired) {
+      return repaired;
+    }
+    console.error('Error converting tool call input to JSON', { input: raw });
+    return undefined;
+  }
+}
+
 export type StreamPart =
   | Exclude<LanguageModelV2StreamPart, { type: 'finish' }>
   | {
@@ -209,27 +240,7 @@ export function convertFullStreamChunkToMastra(value: StreamPart, ctx: { runId: 
       };
 
     case 'tool-call': {
-      let toolCallInput: Record<string, any> | undefined = undefined;
-
-      if (value.input) {
-        const sanitized = sanitizeToolCallInput(value.input);
-        if (sanitized) {
-          try {
-            toolCallInput = JSON.parse(sanitized);
-          } catch {
-            // JSON.parse failed — attempt to repair common LLM JSON errors
-            const repaired = tryRepairJson(sanitized);
-            if (repaired) {
-              toolCallInput = repaired;
-            } else {
-              console.error('Error converting tool call input to JSON', {
-                input: value.input,
-              });
-              toolCallInput = undefined;
-            }
-          }
-        }
-      }
+      const toolCallInput = parseToolCallInput(value.input);
 
       return {
         type: 'tool-call',

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -71,6 +71,154 @@ function createFinishChunk(runId: string): ChunkType {
 }
 
 describe('MastraModelOutput', () => {
+  describe('streaming tool-call delta reassembly', () => {
+    function createToolCallDeltaSequence(
+      runId: string,
+      toolCallId: string,
+      toolName: string,
+      deltas: string[],
+    ): ChunkType[] {
+      const chunks: ChunkType[] = [];
+
+      chunks.push({
+        type: 'tool-call-input-streaming-start',
+        runId,
+        from: ChunkFrom.AGENT,
+        payload: { toolCallId, toolName, providerExecuted: false },
+      } as ChunkType);
+
+      for (const delta of deltas) {
+        chunks.push({
+          type: 'tool-call-delta',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: { toolCallId, argsTextDelta: delta },
+        } as ChunkType);
+      }
+
+      chunks.push({
+        type: 'tool-call-input-streaming-end',
+        runId,
+        from: ChunkFrom.AGENT,
+        payload: { toolCallId },
+      } as ChunkType);
+
+      return chunks;
+    }
+
+    async function collectToolCallArgs(deltas: string[], toolName = 'edit_files'): Promise<any> {
+      const runId = 'test-run';
+      const toolCallId = 'call-1';
+
+      const stream = createChunkStream([
+        ...createToolCallDeltaSequence(runId, toolCallId, toolName, deltas),
+        createStepFinishChunk(runId),
+        createFinishChunk(runId),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList: new MessageList({ threadId: 'test-thread' }),
+        messageId: 'msg-1',
+        options: { runId },
+      });
+
+      const chunks: ChunkType[] = [];
+      for await (const chunk of output.fullStream) {
+        chunks.push(chunk);
+      }
+
+      const toolCallChunk = chunks.find(c => c.type === 'tool-call');
+      expect(toolCallChunk).toBeDefined();
+      return (toolCallChunk as any).payload.args;
+    }
+
+    it('should reassemble valid JSON from multiple deltas', async () => {
+      const expected = {
+        summary: 'update readme',
+        files: [{ path: 'README.md', edits: [{ old_string: 'old', new_string: 'new' }] }],
+      };
+      const fullStr = JSON.stringify(expected);
+      const deltas = [fullStr.slice(0, 30), fullStr.slice(30, 60), fullStr.slice(60)];
+
+      const args = await collectToolCallArgs(deltas);
+      expect(args).toEqual(expected);
+    });
+
+    it('should reassemble large nested JSON (~2000 chars) from many small deltas', async () => {
+      const expected = {
+        summary: 'Multi-file refactor for authentication module',
+        files: Array.from({ length: 5 }, (_, i) => ({
+          path: `src/auth/handler-${i}.ts`,
+          edits: Array.from({ length: 3 }, (_, j) => ({
+            old_string: `const oldVar${j} = authenticate(request.headers['x-token-${j}'])`,
+            new_string: `const newVar${j} = await verifyToken(request.cookies.get('session-${j}'))`,
+          })),
+        })),
+      };
+      const fullStr = JSON.stringify(expected);
+      expect(fullStr.length).toBeGreaterThan(1500);
+
+      const deltas: string[] = [];
+      for (let i = 0; i < fullStr.length; i += 50) {
+        deltas.push(fullStr.slice(i, i + 50));
+      }
+
+      const args = await collectToolCallArgs(deltas);
+      expect(args).toEqual(expected);
+    });
+
+    it('should strip trailing LLM tokens and parse successfully', async () => {
+      const expected = {
+        summary: 'fix bug',
+        files: [{ path: 'src/index.ts', edits: [{ old_string: 'a', new_string: 'b' }] }],
+      };
+      const withToken = JSON.stringify(expected) + '<|endoftext|>';
+      const deltas = [withToken.slice(0, withToken.length - 5), withToken.slice(withToken.length - 5)];
+
+      const args = await collectToolCallArgs(deltas);
+      expect(args).toEqual(expected);
+    });
+
+    it('should repair JSON with trailing comma', async () => {
+      const deltas = ['{"summary":"fix",', '"files":[],', '}'];
+
+      const args = await collectToolCallArgs(deltas);
+      expect(args).toEqual({ summary: 'fix', files: [] });
+    });
+
+    it('should repair JSON with missing opening quote on property name', async () => {
+      const deltas = ['{"command":"git diff",', 'description":"show changes"}'];
+
+      const args = await collectToolCallArgs(deltas, 'run_command');
+      expect(args).toEqual({ command: 'git diff', description: 'show changes' });
+    });
+
+    it('should return undefined for unrecoverable truncated JSON', async () => {
+      const fullStr = JSON.stringify({
+        summary: 'update',
+        files: [{ path: 'a.ts', edits: [{ old_string: 'x', new_string: 'y' }] }],
+      });
+      const truncated = fullStr.slice(0, -10);
+      const deltas = [truncated.slice(0, 40), truncated.slice(40)];
+
+      const args = await collectToolCallArgs(deltas);
+      expect(args).toBeUndefined();
+    });
+
+    it('should return undefined when no deltas are received', async () => {
+      const args = await collectToolCallArgs([]);
+      expect(args).toBeUndefined();
+    });
+
+    it('should handle single-field tool calls from a single delta', async () => {
+      const expected = { path: 'some/file.md' };
+      const args = await collectToolCallArgs([JSON.stringify(expected)]);
+      expect(args).toEqual(expected);
+    });
+  });
+
   describe('writer in output processors (outer context)', () => {
     it('should pass a defined writer to processOutputResult', async () => {
       let receivedWriter: ProcessorStreamWriter | undefined;

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -217,6 +217,68 @@ describe('MastraModelOutput', () => {
       const args = await collectToolCallArgs([JSON.stringify(expected)]);
       expect(args).toEqual(expected);
     });
+
+    it('should backfill args from final tool-call chunk when delta parsing fails', async () => {
+      const runId = 'test-run';
+      const toolCallId = 'call-backfill';
+      const toolName = 'edit_files';
+      const expected = { summary: 'fix', files: [] };
+
+      // Malformed deltas that will fail parsing
+      const truncated = '{"summary":"fix","files":[';
+      const deltaChunks: ChunkType[] = [
+        {
+          type: 'tool-call-input-streaming-start',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: { toolCallId, toolName, providerExecuted: false },
+        } as ChunkType,
+        {
+          type: 'tool-call-delta',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: { toolCallId, argsTextDelta: truncated },
+        } as ChunkType,
+        {
+          type: 'tool-call-input-streaming-end',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: { toolCallId },
+        } as ChunkType,
+      ];
+
+      // Final tool-call chunk from AI SDK with correctly assembled args
+      const finalToolCall: ChunkType = {
+        type: 'tool-call',
+        runId,
+        from: ChunkFrom.AGENT,
+        payload: { toolCallId, toolName, args: expected, providerExecuted: false },
+      } as ChunkType;
+
+      const stream = createChunkStream([
+        ...deltaChunks,
+        finalToolCall,
+        createStepFinishChunk(runId),
+        createFinishChunk(runId),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList: new MessageList({ threadId: 'test-thread' }),
+        messageId: 'msg-1',
+        options: { runId },
+      });
+
+      const chunks: ChunkType[] = [];
+      for await (const chunk of output.fullStream) {
+        chunks.push(chunk);
+      }
+
+      const toolCallChunks = chunks.filter(c => c.type === 'tool-call');
+      expect(toolCallChunks.length).toBe(1);
+      expect((toolCallChunks[0] as any).payload.args).toEqual(expected);
+    });
   });
 
   describe('writer in output processors (outer context)', () => {

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -14,6 +14,7 @@ import { ProcessorState, ProcessorRunner } from '../../processors/runner';
 import type { WorkflowRunStatus } from '../../workflows';
 import { DelayedPromise, consumeStream } from '../aisdk/v5/compat';
 import type { ConsumeStreamOptions } from '../aisdk/v5/compat';
+import { parseToolCallInput } from '../aisdk/v5/transform';
 import type {
   ChunkType,
   LanguageModelUsage,
@@ -453,14 +454,10 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               const toolCallId = chunk.payload.toolCallId;
               const meta = self.#toolCallStreamingMeta[toolCallId];
               const deltaParts = self.#toolCallArgsDeltas[toolCallId];
-              let args: Record<string, unknown> = {};
+              let args: Record<string, unknown> | undefined;
               if (deltaParts?.length) {
-                try {
-                  const merged = deltaParts.join('');
-                  args = typeof merged === 'string' && merged.length > 0 ? JSON.parse(merged) : {};
-                } catch {
-                  args = {};
-                }
+                const merged = deltaParts.join('');
+                args = parseToolCallInput(merged);
               }
               delete self.#toolCallStreamingMeta[toolCallId];
               delete self.#toolCallArgsDeltas[toolCallId];

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -549,6 +549,9 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 // Merge properties from the real tool-call onto the synthetic one.
                 // The AI SDK's streaming path emits tool-input-start without providerMetadata
                 // but includes it on the final tool-call chunk (e.g., OpenAI's fc_* itemId).
+                if (chunk.payload.args != null && existingSynthetic.payload.args == null) {
+                  existingSynthetic.payload.args = chunk.payload.args;
+                }
                 if (chunk.payload.providerMetadata && !existingSynthetic.payload.providerMetadata) {
                   existingSynthetic.payload.providerMetadata = chunk.payload.providerMetadata;
                 }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

The streaming tool-call path in `MastraModelOutput` (`output.ts`) assembles argument deltas with `deltaParts.join('')` then runs a bare `JSON.parse` , with no sanitization or repair. When LLM providers append trailing tokens (`<|endoftext|>`), produce trailing commas, or drop quotes, `JSON.parse` fails and args silently become `{}`. The non-streaming path in `transform.ts` already had `sanitizeToolCallInput` + `tryRepairJson` but the streaming path was never updated.

This PR extracts a shared `parseToolCallInput()` function (sanitize → parse → repair → log) and uses it in both paths so they can never diverge again. On unrecoverable input, args are now `undefined` instead of `{}` so callers can distinguish failure from empty input.

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #14179

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming tool-call arguments are now robustly sanitized and repaired, preventing silent loss of malformed JSON (trailing tokens/commas, missing quotes) and reducing unnecessary retries.

* **Tests**
  * Added comprehensive streaming tool-call tests covering multi-chunk reassembly, malformed JSON repairs, truncation, and edge cases.

* **Documentation**
  * Changelog entry documenting the streaming tool-call JSON parsing fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->