### PR TITLE
(docs) Reorder memory types in documentation

### DIFF
--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -14,9 +14,9 @@ Memory enables your agent to remember user messages, agent replies, and tool res
 Mastra supports four complementary memory types:
 
 - [**Message history**](/docs/memory/message-history) - keeps recent messages from the current conversation so they can be rendered in the UI and used to maintain short-term continuity within the exchange.
+- [**Observational memory**](/docs/memory/observational-memory) - uses background Observer and Reflector agents to maintain a dense observation log that replaces raw message history as it grows, keeping the context window small while preserving long-term memory across conversations.
 - [**Working memory**](/docs/memory/working-memory) - stores persistent, structured user data such as names, preferences, and goals.
 - [**Semantic recall**](/docs/memory/semantic-recall) - retrieves relevant messages from older conversations based on semantic meaning rather than exact keywords, mirroring how humans recall information by association. Requires a [vector database](/docs/memory/semantic-recall#storage-configuration) and an [embedding model](/docs/memory/semantic-recall#embedder-configuration).
-- [**Observational memory**](/docs/memory/observational-memory) - uses background Observer and Reflector agents to maintain a dense observation log that replaces raw message history as it grows, keeping the context window small while preserving long-term memory across conversations.
 
 If the combined memory exceeds the model's context limit, [memory processors](/docs/memory/memory-processors) can filter, trim, or prioritize content so the most relevant information is preserved.
 
@@ -25,9 +25,9 @@ If the combined memory exceeds the model's context limit, [memory processors](/d
 Choose a memory option to get started:
 
 - [Message history](/docs/memory/message-history)
+- [Observational memory](/docs/memory/observational-memory)
 - [Working memory](/docs/memory/working-memory)
 - [Semantic recall](/docs/memory/semantic-recall)
-- [Observational memory](/docs/memory/observational-memory)
 
 ## Storage
 
@@ -50,5 +50,5 @@ This visibility helps you understand why an agent made specific decisions and ve
 ## Next steps
 
 - Learn more about [Storage](/docs/memory/storage) providers and configuration options
-- Add [Message history](/docs/memory/message-history), [Working memory](/docs/memory/working-memory), [Semantic recall](/docs/memory/semantic-recall), or [Observational memory](/docs/memory/observational-memory)
+- Add [Message history](/docs/memory/message-history), [Observational memory](/docs/memory/observational-memory), [Working memory](/docs/memory/working-memory), or [Semantic recall](/docs/memory/semantic-recall)
 - Visit [Memory configuration reference](/reference/memory/memory-class) for all available options


### PR DESCRIPTION
Reordered the memory types in the overview documentation to place Observational memory immediately after Message history. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated memory type documentation to include Observational memory and reorganized its placement throughout the overview and Getting Started sections for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->