### PR TITLE
fix: match git author in changeset workflow to Renovate config

### DIFF
--- a/.github/workflows/sync_renovate-changesets.yml
+++ b/.github/workflows/sync_renovate-changesets.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Configure git
         shell: bash
         run: |
-          git config --global user.name 'daneatmastra'
-          git config --global user.email 'dane@mastra.ai'
+          git config --global user.name 'Dane - AI (Mastra)'
+          git config --global user.email '199639756+daneatmastra@users.noreply.github.com'
 
       - name: Create/Update Changesets
         uses: 'wardpeet/changesets-dependencies-action@1ac684b9885a8e9bb1d24f09fd2c253b36b3700d'


### PR DESCRIPTION
## Problem

After recent Renovate configuration changes, we're still seeing 'Edited/Blocked Notification' warnings on Renovate PRs:

> Renovate will not automatically rebase this PR, because it does not recognize the last commit author and assumes somebody else may have edited the PR.

## Root Cause

The `sync_renovate-changesets.yml` workflow was using a different git author than what's configured in `renovate.json`:

- **Workflow**: `daneatmastra <dane@mastra.ai>`
- **Renovate config**: `Dane - AI (Mastra) <199639756+daneatmastra@users.noreply.github.com>`

When the changeset workflow commits to Renovate PRs, Renovate sees a different author and stops auto-rebasing.

## Solution

Updated the workflow to use the exact same git author as `renovate.json`:
- Name: `Dane - AI (Mastra)`
- Email: `199639756+daneatmastra@users.noreply.github.com`

This ensures Renovate recognizes changeset commits as its own and continues auto-rebasing.

## Testing

This will take effect on the next Renovate PRs. Existing PRs with the warning can be manually rebased via the checkbox or will be fixed in the next update cycle after this merges.