### PR TITLE
fix(core): avoid replaying stale provider-executed tool calls

### DIFF
--- a/.changeset/giant-moons-stare.md
+++ b/.changeset/giant-moons-stare.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed replay of stale provider-executed web search tool calls in follow-up requests.

--- a/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter-provider-executed.test.ts
@@ -182,6 +182,35 @@ describe('sanitizeV5UIMessages — provider-executed tool handling', () => {
     expect(toolCallIds).not.toContain('call-2');
   });
 
+  it('should not replay stale provider-executed input-available parts after a later assistant message', () => {
+    const firstAssistant = makeMessage([
+      makeToolPart({
+        type: 'tool-web_search_20250305',
+        toolCallId: 'call-1',
+        state: 'input-available',
+        input: { query: 'initial query' },
+        providerExecuted: true,
+      }),
+    ]);
+
+    const laterAssistant = {
+      ...makeMessage([
+        {
+          type: 'text',
+          text: 'Here is the latest answer',
+        } as any,
+      ]),
+      id: 'msg-2',
+    } as AIV5Type.UIMessage;
+
+    const result = sanitizeV5UIMessages([firstAssistant, laterAssistant], true);
+
+    // First message is dropped because its only provider-executed input-available part is stale.
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe('msg-2');
+    expect(result[0]!.parts).toEqual([{ type: 'text', text: 'Here is the latest answer' }]);
+  });
+
   it('should not filter provider-executed tools when filterIncompleteToolCalls is false', () => {
     const msg = makeMessage([
       makeToolPart({

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -53,8 +53,10 @@ export function sanitizeV5UIMessages(
   filterIncompleteToolCalls = false,
 ): AIV5Type.UIMessage[] {
   const msgs = messages
-    .map(m => {
+    .map((m, messageIndex) => {
       if (m.parts.length === 0) return false;
+
+      const hasLaterAssistantMessage = messages.slice(messageIndex + 1).some(next => next.role === 'assistant');
 
       // When building a prompt TO the LLM (filterIncompleteToolCalls=true),
       // check if this message contains OpenAI reasoning parts (rs_* itemIds).
@@ -114,9 +116,12 @@ export function sanitizeV5UIMessages(
             return true;
           }
           // Provider-executed tools (e.g. Anthropic web_search) remain in input-available state
-          // because no client-side result is added. Keep them so the provider API sees the
-          // server_tool_use block and can execute the deferred tool on the next request.
-          if (p.state === 'input-available' && p.providerExecuted) return true;
+          // because no client-side result is added. Keep them only for the latest assistant turn;
+          // once there's a later assistant message, replaying older server_tool_use parts is stale
+          // and can cause provider API errors due to mismatched tool/result history.
+          if (p.state === 'input-available' && p.providerExecuted) {
+            return !hasLaterAssistantMessage;
+          }
           return false;
         }
 


### PR DESCRIPTION
## Summary
- avoid replaying stale provider-executed input-available tool parts from older assistant messages when building follow-up prompts
- keep provider-executed input-available parts only on the latest assistant turn
- add a regression test in `output-converter-provider-executed.test.ts` for stale history replay

## Test Plan
- pnpm --filter @mastra/core test -- src/agent/message-list/conversion/output-converter-provider-executed.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a bug where web search tool calls from earlier messages were being replayed in subsequent requests. This resolves duplicate search operations and ensures cleaner conversation histories in multi-turn interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes https://github.com/mastra-ai/mastra/issues/14148