### PR TITLE
docs: fix maxSteps default value from 1 to 5

### DIFF
--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -262,7 +262,7 @@ console.log(response.text)
 
 ## Using `maxSteps`
 
-The `maxSteps` parameter controls the maximum number of sequential LLM calls an agent can make. Each step includes generating a response, executing any tool calls, and processing the result. Limiting steps helps prevent infinite loops, reduce latency, and control token usage for agents that use tools. The default is 1, but can be increased:
+The `maxSteps` parameter controls the maximum number of sequential LLM calls an agent can make. Each step includes generating a response, executing any tool calls, and processing the result. Limiting steps helps prevent infinite loops, reduce latency, and control token usage for agents that use tools. The default is 5, but can be increased:
 
 ```typescript
 const response = await testAgent.generate('Help me organize my day', {


### PR DESCRIPTION
## Description

Fixed incorrect documentation stating that the default `maxSteps` value for agents is 1. The actual default is 5 as defined in [`packages/core/src/llm/model/model.loop.ts:104`](https://github.com/mastra-ai/mastra/blob/b8837ee77e/packages/core/src/llm/model/model.loop.ts#L104).

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent configuration documentation to reflect new default `maxSteps` value of 5 (previously 1)
  * Revised example code snippets to demonstrate typical maxSteps usage scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->