### PR TITLE
fix(schema-compat): replace CJS require with ESM import for zod/v4

### DIFF
--- a/.changeset/fix-zod4-esm-import.md
+++ b/.changeset/fix-zod4-esm-import.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+Fixed Zod 4 schema conversions failing in ESM projects with the error `"z.toJSONSchema is not available. Ensure zod >= 3.25.0 is installed."` This affected structured outputs, tool input schemas, and workflow step schemas when using Zod 4 in a project with `"type": "module"`.

--- a/packages/schema-compat/src/standard-schema/adapters/zod-v4.ts
+++ b/packages/schema-compat/src/standard-schema/adapters/zod-v4.ts
@@ -1,4 +1,5 @@
 import type { StandardSchemaV1, StandardJSONSchemaV1 } from '@standard-schema/spec';
+import { toJSONSchema } from 'zod/v4';
 import type { StandardSchemaWithJSON, StandardSchemaWithJSONProps } from '../standard-schema.types';
 
 /**
@@ -27,11 +28,6 @@ function convertToJsonSchema(
   options: StandardJSONSchemaV1.Options,
   adapterOptions: ZodV4AdapterOptions,
 ): Record<string, unknown> {
-  const toJSONSchema = getToJSONSchema();
-  if (!toJSONSchema) {
-    throw new Error('z.toJSONSchema is not available. Ensure zod >= 3.25.0 is installed.');
-  }
-
   const target = SUPPORTED_TARGETS.has(options.target) ? options.target : 'draft-07';
 
   const jsonSchemaOptions: Record<string, unknown> = {
@@ -47,27 +43,7 @@ function convertToJsonSchema(
     jsonSchemaOptions.override = adapterOptions.override;
   }
 
-  return toJSONSchema(zodSchema, jsonSchemaOptions) as Record<string, unknown>;
-}
-
-/**
- * Cached reference to z.toJSONSchema from zod/v4.
- */
-let _toJSONSchema: ((schema: unknown, options?: unknown) => unknown) | null = null;
-let _toJSONSchemaResolved = false;
-
-function getToJSONSchema(): ((schema: unknown, options?: unknown) => unknown) | null {
-  if (_toJSONSchemaResolved) {
-    return _toJSONSchema;
-  }
-  try {
-    const zv4 = require('zod/v4');
-    _toJSONSchema = typeof zv4.toJSONSchema === 'function' ? zv4.toJSONSchema : null;
-  } catch {
-    _toJSONSchema = null;
-  }
-  _toJSONSchemaResolved = true;
-  return _toJSONSchema;
+  return toJSONSchema(zodSchema as Parameters<typeof toJSONSchema>[0], jsonSchemaOptions) as Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Replace `require('zod/v4')` with a static ESM `import { toJSONSchema } from 'zod/v4'` in the zod-v4 standard-schema adapter. The bare `require()` call was being bundled by tsup into a `__require` shim that fails in pure ESM runtimes (where `require` is undefined), causing all Zod 4 schema conversions (structuredOutput, tool inputSchema, workflow step schemas) to throw `"z.toJSONSchema is not available"`. Removed the now-unnecessary lazy-loading cache (`_toJSONSchema`, `_toJSONSchemaResolved`, `getToJSONSchema()`).

## Related Issue(s)
<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->
Fixes #14217

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Zod 4 schema conversions failing in ESM projects. Structured outputs, tool input schemas, and workflow step schemas now work correctly when using Zod 4 in modules with `"type": "module"`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->