### PR TITLE
fix(server): move @mastra/schema-compat to devDependencies

### DIFF
--- a/.changeset/many-paws-wash.md
+++ b/.changeset/many-paws-wash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Moved @mastra/schema-compat from dependencies to devDependencies. This reduces the install footprint for consumers since schema-compat is only needed at build time.

--- a/.changeset/many-paws-wash.md
+++ b/.changeset/many-paws-wash.md
@@ -2,4 +2,4 @@
 '@mastra/server': patch
 ---
 
-Moved @mastra/schema-compat from dependencies to devDependencies. This reduces the install footprint for consumers since schema-compat is only needed at build time.
+Fixed an unnecessary runtime dependency in `@mastra/server`, reducing install size for consumers. Moved `@mastra/schema-compat` from dependencies to devDependencies since it is only needed at build time.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -110,6 +110,7 @@
     "@internal/types-builder": "workspace:*",
     "@mastra/agent-builder": "workspace:*",
     "@mastra/core": "workspace:*",
+    "@mastra/schema-compat": "workspace:*",
     "@types/node": "22.19.13",
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
@@ -133,7 +134,6 @@
     "node": ">=22.13.0"
   },
   "dependencies": {
-    "@mastra/schema-compat": "workspace:*",
     "hono": "^4.11.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4161,9 +4161,6 @@ importers:
 
   packages/server:
     dependencies:
-      '@mastra/schema-compat':
-        specifier: workspace:*
-        version: link:../schema-compat
       hono:
         specifier: ^4.11.9
         version: 4.11.9
@@ -4192,6 +4189,9 @@ importers:
       '@mastra/core':
         specifier: workspace:*
         version: link:../core
+      '@mastra/schema-compat':
+        specifier: workspace:*
+        version: link:../schema-compat
       '@types/node':
         specifier: 22.19.13
         version: 22.19.13


### PR DESCRIPTION
## Summary

Moves `@mastra/schema-compat` from `dependencies` to `devDependencies` in `@mastra/server`.

`@mastra/schema-compat` is only needed at build time, not at runtime. This change reduces the install footprint for consumers of the package.

## Changes

- `packages/server/package.json`: Moved `@mastra/schema-compat` from `dependencies` to `devDependencies`

## Test Plan

- CI should pass with no regressions since schema-compat is still available during build/test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced runtime dependency footprint for the server, lowering install size for users.
* **Documentation**
  * Added a release note entry documenting the dependency cleanup and its user impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->