### PR TITLE
fix: resolve build type errors across core, mcp, and deployer packages

### DIFF
--- a/.changeset/cli-analytics-improvements.md
+++ b/.changeset/cli-analytics-improvements.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/cli': patch
+'mastra': patch
 ---
 
 Added dev session duration tracking on shutdown, package manager detection in analytics system properties, and component selection event tracking in the `create` command for both interactive and CLI-args paths.

--- a/packages/core/src/llm/model/base.types.ts
+++ b/packages/core/src/llm/model/base.types.ts
@@ -74,7 +74,7 @@ type GenerateTextOptions<Tools extends ToolSet, Output extends ZodSchema | JSONS
   MastraCustomLLMOptionsKeys | 'model' | 'onStepFinish'
 > &
   MastraCustomLLMOptions & {
-    onStepFinish?: GenerateTextOnStepFinishCallback<inferOutput<Output>>;
+    onStepFinish?: GenerateTextOnStepFinishCallback<Tools>;
     experimental_output?: Output;
   };
 
@@ -138,8 +138,8 @@ type StreamTextOptions<Tools extends ToolSet, Output extends ZodSchema | JSONSch
   MastraCustomLLMOptionsKeys | 'model' | 'onStepFinish' | 'onFinish'
 > &
   MastraCustomLLMOptions & {
-    onStepFinish?: StreamTextOnStepFinishCallback<inferOutput<Output>>;
-    onFinish?: StreamTextOnFinishCallback<inferOutput<Output>>;
+    onStepFinish?: StreamTextOnStepFinishCallback<Tools>;
+    onFinish?: StreamTextOnFinishCallback<Tools>;
     experimental_output?: Output;
   };
 

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -213,7 +213,7 @@ export class ModelsDevGateway extends MastraModelGateway {
       case 'groq':
         return createGroq({ apiKey, headers: mastraHeaders })(modelId);
       case 'openrouter':
-        return createOpenRouter({ apiKey, headers: mastraHeaders })(modelId);
+        return createOpenRouter({ apiKey, headers: mastraHeaders })(modelId) as unknown as GatewayLanguageModel;
       case 'xai':
         return createXai({ apiKey, headers: mastraHeaders })(modelId);
       case 'deepseek':

--- a/packages/deployer/src/server/handlers/a2a.ts
+++ b/packages/deployer/src/server/handlers/a2a.ts
@@ -13,7 +13,7 @@ import { stream } from 'hono/streaming';
 
 export async function getAgentCardByIdHandler(c: Context) {
   const mastra: Mastra = c.get('mastra');
-  const agentId = c.req.param('agentId');
+  const agentId = c.req.param('agentId')!;
   const requestContext: RequestContext = c.get('requestContext');
 
   const result = await getOriginalAgentCardByIdHandler({
@@ -27,7 +27,7 @@ export async function getAgentCardByIdHandler(c: Context) {
 
 export async function getAgentExecutionHandler(c: Context) {
   const mastra: Mastra = c.get('mastra');
-  const agentId = c.req.param('agentId');
+  const agentId = c.req.param('agentId')!;
   const requestContext: RequestContext = c.get('requestContext');
   const taskStore: InMemoryTaskStore = c.get('taskStore');
   const logger = mastra.getLogger();

--- a/packages/deployer/src/server/handlers/a2a.ts
+++ b/packages/deployer/src/server/handlers/a2a.ts
@@ -13,7 +13,10 @@ import { stream } from 'hono/streaming';
 
 export async function getAgentCardByIdHandler(c: Context) {
   const mastra: Mastra = c.get('mastra');
-  const agentId = c.req.param('agentId')!;
+  const agentId = c.req.param('agentId');
+  if (!agentId) {
+    return c.json({ error: { message: 'Missing required parameter: agentId', code: 'bad_request' } }, 400);
+  }
   const requestContext: RequestContext = c.get('requestContext');
 
   const result = await getOriginalAgentCardByIdHandler({
@@ -27,7 +30,10 @@ export async function getAgentCardByIdHandler(c: Context) {
 
 export async function getAgentExecutionHandler(c: Context) {
   const mastra: Mastra = c.get('mastra');
-  const agentId = c.req.param('agentId')!;
+  const agentId = c.req.param('agentId');
+  if (!agentId) {
+    return c.json({ error: { message: 'Missing required parameter: agentId', code: 'bad_request' } }, 400);
+  }
   const requestContext: RequestContext = c.get('requestContext');
   const taskStore: InMemoryTaskStore = c.get('taskStore');
   const logger = mastra.getLogger();

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -13,7 +13,15 @@ import { getDefaultEnvironment, StdioClientTransport } from '@modelcontextprotoc
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { DEFAULT_REQUEST_TIMEOUT_MSEC } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import type { GetPromptResult, ListPromptsResult, LoggingLevel } from '@modelcontextprotocol/sdk/types.js';
+import type {
+  EmptyResult,
+  GetPromptResult,
+  ListPromptsResult,
+  ListResourcesResult,
+  ListResourceTemplatesResult,
+  LoggingLevel,
+  ReadResourceResult,
+} from '@modelcontextprotocol/sdk/types.js';
 import {
   CallToolResultSchema,
   ListResourcesResultSchema,
@@ -543,35 +551,35 @@ export class InternalMastraMCPClient extends MastraBase {
     this.log('debug', 'Successfully reconnected to MCP server');
   }
 
-  async listResources() {
+  async listResources(): Promise<ListResourcesResult> {
     this.log('debug', `Requesting resources from MCP server`);
     return await this.client.request({ method: 'resources/list' }, ListResourcesResultSchema, {
       timeout: this.timeout,
     });
   }
 
-  async readResource(uri: string) {
+  async readResource(uri: string): Promise<ReadResourceResult> {
     this.log('debug', `Reading resource from MCP server: ${uri}`);
     return await this.client.request({ method: 'resources/read', params: { uri } }, ReadResourceResultSchema, {
       timeout: this.timeout,
     });
   }
 
-  async subscribeResource(uri: string) {
+  async subscribeResource(uri: string): Promise<EmptyResult> {
     this.log('debug', `Subscribing to resource on MCP server: ${uri}`);
     return await this.client.request({ method: 'resources/subscribe', params: { uri } }, EmptyResultSchema, {
       timeout: this.timeout,
     });
   }
 
-  async unsubscribeResource(uri: string) {
+  async unsubscribeResource(uri: string): Promise<EmptyResult> {
     this.log('debug', `Unsubscribing from resource on MCP server: ${uri}`);
     return await this.client.request({ method: 'resources/unsubscribe', params: { uri } }, EmptyResultSchema, {
       timeout: this.timeout,
     });
   }
 
-  async listResourceTemplates() {
+  async listResourceTemplates(): Promise<ListResourceTemplatesResult> {
     this.log('debug', `Requesting resource templates from MCP server`);
     return await this.client.request({ method: 'resources/templates/list' }, ListResourceTemplatesResultSchema, {
       timeout: this.timeout,


### PR DESCRIPTION
## Summary

Fixes multiple type errors that were causing `pnpm build` to fail.

### Changes

**`packages/core/src/llm/model/base.types.ts`**
- `GenerateTextOptions.onStepFinish` and `StreamTextOptions.onStepFinish`/`onFinish` callbacks were incorrectly parameterized with `inferOutput<Output>` (a Zod-inferred type) instead of `Tools` (a `ToolSet`). The AI SDK callbacks expect `StepResult<Tools>`, not a structured output type.

**`packages/core/src/llm/model/gateways/models-dev.ts`**
- `createOpenRouter()` returns a model typed against `@ai-sdk/provider@3.0.7` (via `ai@6.x`), but `GatewayLanguageModel` expects `LanguageModelV2` from `@ai-sdk/provider@2.0.1`. Added a cast since the types are structurally equivalent across versions.

**`packages/mcp/src/client/client.ts`**
- Added explicit return type annotations (`ListResourcesResult`, `ReadResourceResult`, `EmptyResult`, `ListResourceTemplatesResult`) to resource methods to fix TS2742 errors where TypeScript couldn't reference `zod` from `.pnpm` paths during declaration emit.

**`packages/deployer/src/server/handlers/a2a.ts`**
- Non-null asserted `agentId` from `c.req.param('agentId')` since it's always present in the route.

### Test Plan
- `pnpm build` passes for `@mastra/core`, `@mastra/mcp`, and `@mastra/deployer`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for callback handling and made resource-related API return types explicit for clearer developer experience.

* **Bug Fixes**
  * Added early validation to ensure agent ID is provided, returning a structured error when missing.

* **New Features**
  * Analytics enhancements: dev session duration tracking, package manager detection, and component selection event tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->