### PR TITLE
fix(core): include workspace in ToolOptions for workspace and skill tools

### DIFF
--- a/.changeset/nice-zoos-relax.md
+++ b/.changeset/nice-zoos-relax.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workspace tools (e.g. `mastra_workspace_list_files`, `mastra_workspace_read_file`) throwing `WorkspaceNotAvailableError` when the workspace context was not provided at runtime. Workspace is now baked into tool options at build time, so workspace tools work reliably in all execution paths.

--- a/.changeset/nice-zoos-relax.md
+++ b/.changeset/nice-zoos-relax.md
@@ -2,4 +2,6 @@
 '@mastra/core': patch
 ---
 
-Fixed workspace tools (e.g. `mastra_workspace_list_files`, `mastra_workspace_read_file`) throwing `WorkspaceNotAvailableError` when the workspace context was not provided at runtime. Workspace is now baked into tool options at build time, so workspace tools work reliably in all execution paths.
+Fixed workspace tools such as `mastra_workspace_list_files` and `mastra_workspace_read_file` failing with `WorkspaceNotAvailableError` in some execution paths.
+
+Workspace tools now work consistently across execution paths.

--- a/packages/core/src/agent/__tests__/workspace-tool-context.test.ts
+++ b/packages/core/src/agent/__tests__/workspace-tool-context.test.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import { Mastra } from '../../mastra';
 import { RequestContext } from '../../request-context';
 import { createTool } from '../../tools';
+import { WORKSPACE_TOOLS } from '../../workspace/constants';
 import { LocalFilesystem } from '../../workspace/filesystem';
 import { Workspace } from '../../workspace/workspace';
 import { Agent } from '../agent';
@@ -670,6 +671,84 @@ describe('Dynamic workspace configuration', () => {
 
     expect(toolCall?.result?.workspaceId).toBe('async-workspace');
     expect(capturedWorkspaceId).toBe('async-workspace');
+  });
+});
+
+/**
+ * Regression test for GH-14203: listWorkspaceTools() must include workspace
+ * in ToolOptions when converting workspace tools via makeCoreTool().
+ *
+ * CoreToolBuilder.createExecute() resolves workspace as:
+ *   workspace: execOptions.workspace ?? options.workspace
+ *
+ * The agent pipeline's tool-call-step.ts provides execOptions.workspace at
+ * runtime, but options.workspace (the build-time fallback) was missing because
+ * listWorkspaceTools() didn't include workspace in ToolOptions. This test
+ * gets the CoreTools produced by listWorkspaceTools() and calls execute
+ * directly WITHOUT workspace in execOptions, verifying the build-time fallback.
+ */
+describe('Workspace tools receive workspace via ToolOptions fallback (GH-14203)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workspace-options-fallback-'));
+    await fs.writeFile(path.join(tempDir, 'hello.txt'), 'hello from fallback test');
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('should provide workspace through ToolOptions when execOptions.workspace is absent', async () => {
+    const filesystem = new LocalFilesystem({ basePath: tempDir });
+    const workspace = new Workspace({
+      id: 'options-fallback-workspace',
+      name: 'Options Fallback Workspace',
+      filesystem,
+    });
+
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        content: [{ type: 'text', text: 'done' }],
+        warnings: [],
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'tooloptions-fallback-agent',
+      name: 'ToolOptions Fallback Agent',
+      instructions: 'test',
+      model: mockModel,
+      workspace,
+    });
+
+    // Get the CoreTools that listWorkspaceTools() produces — these have
+    // workspace baked into ToolOptions at build time (the fix).
+    const coreTools = await (agent as any).listWorkspaceTools({
+      requestContext: new RequestContext(),
+    });
+
+    const listFilesCoreTool = coreTools[WORKSPACE_TOOLS.FILESYSTEM.LIST_FILES];
+    expect(listFilesCoreTool).toBeDefined();
+    expect(listFilesCoreTool.execute).toBeDefined();
+
+    // Call execute WITHOUT workspace in execOptions — simulates execution
+    // outside the normal agent pipeline (no tool-call-step.ts runtime injection).
+    const result = await listFilesCoreTool.execute!({ path: '.' }, {
+      toolCallId: 'test-call-1',
+      messages: [],
+    } as any);
+
+    expect(result).toBeDefined();
+    expect(typeof result).toBe('string');
+    expect(result).toContain('hello.txt');
   });
 });
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2126,6 +2126,7 @@ export class Agent<
           model: await this.getModel({ requestContext }),
           tracingPolicy: this.#options?.tracingPolicy,
           requireApproval: (toolObj as any).requireApproval,
+          workspace,
         };
         const convertedToCoreTool = makeCoreTool(toolObj, options, undefined, autoResumeSuspendedTools);
         convertedWorkspaceTools[toolName] = convertedToCoreTool;
@@ -2192,6 +2193,7 @@ export class Agent<
           model: await this.getModel({ requestContext }),
           tracingPolicy: this.#options?.tracingPolicy,
           requireApproval: false, // Skill tools never require approval
+          workspace,
         };
         const convertedToCoreTool = makeCoreTool(toolObj, options, undefined, autoResumeSuspendedTools);
         convertedSkillTools[toolName] = convertedToCoreTool;


### PR DESCRIPTION
## Description

`listWorkspaceTools()` and `listSkillTools()` in `agent.ts` were not passing `workspace` into the `ToolOptions` given to `makeCoreTool()`. `CoreToolBuilder.createExecute()` resolves workspace as:

```
workspace: execOptions.workspace ?? options.workspace
```

Without `options.workspace` set at build time, workspace tools only worked when the runtime pipeline (`tool-call-step.ts`) injected `execOptions.workspace`. This made them fragile — any execution path that skipped runtime injection would cause `WorkspaceNotAvailableError`.

The fix adds `workspace` to `ToolOptions` in both methods, so workspace is always available as a build-time fallback.

## Related Issue(s)

Fixes #14203

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed failures in workspace-related tools by ensuring workspace context is available at tool build time, making workspace operations reliable when not provided at execution time.

* **Tests**
  * Added regression tests to validate consistent workspace-tool behavior across execution scenarios.

* **Chores**
  * Applied a patch version bump for the core package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Post-merge Investigation: Regression Origin

The regression was introduced in commit `d5f0d8d6a0` (PR #13440, Feb 26, 2026), which removed the `wrapTool()` closure wrapper from `packages/core/src/workspace/tools/tools.ts` and also removed workspace injection from `wrapWithReadTracker()`.

In **≤ 1.8.0**, `wrapTool()` injected workspace into every workspace tool's execute context via closure:

```ts
const enrichedContext = { ...context, workspace: context?.workspace ?? workspace };
```

This guaranteed workspace was always available regardless of how the tool was invoked.

In **1.9.0**, this wrapper was deleted under the assumption that the framework already provides workspace on `ToolExecutionContext`. However, `agent.ts` never included `workspace` in the `ToolOptions` passed to `makeCoreTool()`, so the only remaining path was runtime injection via `tool-call-step.ts` — which only works through the agentic loop. Any other invocation path hit `WorkspaceNotAvailableError`.

This PR fixes the gap by ensuring `workspace` is set in `ToolOptions` at build time.