### PR TITLE
chore: add missing changesets for build type error fixes (#14226)

### DIFF
--- a/.changeset/brave-foxes-jump.md
+++ b/.changeset/brave-foxes-jump.md
@@ -2,4 +2,4 @@
 '@mastra/mcp': patch
 ---
 
-Added explicit return type annotations to MCP resource methods to fix TypeScript declaration emit errors (TS2742) when resolving `zod` types from `.pnpm` paths.
+Fixed TypeScript compilation errors when using MCP resource methods in projects with pnpm workspaces.

--- a/.changeset/brave-foxes-jump.md
+++ b/.changeset/brave-foxes-jump.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Added explicit return type annotations to MCP resource methods to fix TypeScript declaration emit errors (TS2742) when resolving `zod` types from `.pnpm` paths.

--- a/.changeset/calm-owls-rest.md
+++ b/.changeset/calm-owls-rest.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Added agent ID validation in the A2A handler to return a structured error when the parameter is missing.

--- a/.changeset/calm-owls-rest.md
+++ b/.changeset/calm-owls-rest.md
@@ -2,4 +2,4 @@
 '@mastra/deployer': patch
 ---
 
-Added agent ID validation in the A2A handler to return a structured error when the parameter is missing.
+Fixed Agent-to-Agent requests to return a clear error message when the agent ID parameter is missing.

--- a/.changeset/cool-birds-dance.md
+++ b/.changeset/cool-birds-dance.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed `onStepFinish` and `onFinish` callback type parameters to use `Tools` (ToolSet) instead of `inferOutput<Output>`, and added a type cast for `createOpenRouter()` return to bridge structurally equivalent `LanguageModelV2` types across AI SDK versions.
+Fixed TypeScript type errors in `onStepFinish` and `onFinish` callbacks, and resolved compatibility issues with `createOpenRouter()` across different AI SDK versions.

--- a/.changeset/cool-birds-dance.md
+++ b/.changeset/cool-birds-dance.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `onStepFinish` and `onFinish` callback type parameters to use `Tools` (ToolSet) instead of `inferOutput<Output>`, and added a type cast for `createOpenRouter()` return to bridge structurally equivalent `LanguageModelV2` types across AI SDK versions.


### PR DESCRIPTION
## Summary

Adds the missing changesets for PR #14226 which fixed build type errors across three packages.

### Changesets added

- **`@mastra/core`** (patch): Fixed `onStepFinish`/`onFinish` callback type parameters and added a type cast for `createOpenRouter()` return.
- **`@mastra/mcp`** (patch): Added explicit return type annotations to resource methods to fix TS2742 declaration emit errors.
- **`@mastra/deployer`** (patch): Added agent ID validation in the A2A handler.

### Test Plan

No code changes — changeset files only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved TypeScript compilation/emit errors affecting resource method usage in workspace setups.
  * Agent-to-agent requests now return clear, validated error messages when required agent parameters are missing.

* **Improvements**
  * Strengthened callback typings to improve type safety and compatibility across different SDK versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->