### PR TITLE
fix(core): extend TrailingAssistantGuard to all request types for Claude 4.6

### DIFF
--- a/packages/core/src/agent/__tests__/structured-output-memory.test.ts
+++ b/packages/core/src/agent/__tests__/structured-output-memory.test.ts
@@ -20,7 +20,7 @@ import { MockLanguageModelV2, convertArrayToReadableStream } from './mock-model'
  * This test reproduces the issue at the agent level by simulating the network loop's
  * behavior: passing an assistant-role message as input with structuredOutput + memory.
  */
-describe('Structured output with memory - assistant message in final position (#12800)', () => {
+describe('Trailing assistant message guard (#12800)', () => {
   it('should not send prompt ending with assistant message when input is assistant-role with structuredOutput and memory', async () => {
     const threadId = randomUUID();
     const resourceId = 'user-12800';
@@ -326,6 +326,129 @@ describe('Structured output with memory - assistant message in final position (#
       `Expected last message role to NOT be 'assistant', but got 'assistant'. ` +
         `This causes Anthropic API error: "When using output format, pre-filling the ` +
         `assistant response is not supported." ` +
+        `Message roles in prompt: ${prompt.map((m: any) => m.role).join(', ')}`,
+    ).not.toBe('assistant');
+  });
+
+  it('should not send prompt ending with assistant message even WITHOUT structuredOutput (plain streaming)', async () => {
+    const threadId = randomUUID();
+    const resourceId = 'user-prefill-plain';
+
+    const mockMemory = new MockMemory();
+
+    // Track what prompts are sent to the model
+    const capturedPrompts: any[] = [];
+
+    const mockModel = new MockLanguageModelV2({
+      provider: 'anthropic',
+      modelId: 'claude-opus-4-6',
+      doGenerate: async options => {
+        capturedPrompts.push(options.prompt);
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          content: [{ type: 'text', text: 'Hello!' }],
+          warnings: [],
+        };
+      },
+      doStream: async options => {
+        capturedPrompts.push((options as any).prompt);
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'response-metadata',
+              id: 'response-1',
+              modelId: 'mock-model',
+              timestamp: new Date(0),
+            },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'Hello!' },
+            { type: 'text-end', id: 'text-1' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            },
+          ]),
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'plain-streaming-prefill-test',
+      name: 'Plain Agent',
+      instructions: 'You are a helpful assistant.',
+      model: mockModel,
+      memory: mockMemory,
+    });
+
+    await mockMemory.createThread({ threadId, resourceId });
+
+    // Pre-populate memory ending with an assistant message
+    const now = new Date();
+    await mockMemory.saveMessages({
+      messages: [
+        {
+          id: randomUUID(),
+          role: 'user' as const,
+          content: {
+            format: 2 as const,
+            parts: [{ type: 'text' as const, text: 'Hello' }],
+          },
+          threadId,
+          createdAt: new Date(now.getTime() - 2000),
+          resourceId,
+          type: 'text' as const,
+        },
+        {
+          id: randomUUID(),
+          role: 'assistant' as const,
+          content: {
+            format: 2 as const,
+            parts: [{ type: 'text' as const, text: 'Hi there!' }],
+          },
+          threadId,
+          createdAt: new Date(now.getTime() - 1000),
+          resourceId,
+          type: 'text' as const,
+        },
+      ],
+    });
+
+    // Call with an assistant-role input but NO structuredOutput.
+    // This simulates the scenario where memory + assistant input produces
+    // a trailing assistant message during plain streaming.
+    const response = await agent.stream(
+      [
+        {
+          role: 'assistant' as const,
+          content: 'Let me help you with that...',
+        },
+      ],
+      {
+        memory: {
+          thread: threadId,
+          resource: resourceId,
+        },
+        // No structuredOutput — plain streaming
+      },
+    );
+
+    await response.consumeStream();
+
+    // The critical assertion: Claude 4.6 rejects assistant prefill in ALL cases,
+    // not just structured output.
+    expect(capturedPrompts.length).toBeGreaterThan(0);
+    const prompt = capturedPrompts[0]!;
+    const lastMessage = prompt[prompt.length - 1];
+    expect(
+      lastMessage.role,
+      `Expected last message role to NOT be 'assistant', but got 'assistant'. ` +
+        `Claude 4.6 rejects assistant message prefill regardless of structured output. ` +
         `Message roles in prompt: ${prompt.map((m: any) => m.role).join(', ')}`,
     ).not.toBe('assistant');
   });

--- a/packages/core/src/processors/trailing-assistant-guard.ts
+++ b/packages/core/src/processors/trailing-assistant-guard.ts
@@ -38,12 +38,12 @@ export function isMaybeClaude46(
 }
 
 /**
- * Guards against trailing assistant messages when using native structured output
- * with Anthropic Claude 4.6.
+ * Guards against trailing assistant messages with Anthropic Claude 4.6.
  *
- * Claude 4.6 rejects requests where the last message is an assistant message when
- * using output format (structured output), interpreting it as pre-filling the response.
- * This processor appends a user message to prevent that error.
+ * Claude 4.6 rejects requests where the last message is an assistant message,
+ * interpreting it as pre-filling the response. This applies to all request types,
+ * not just structured output. This processor appends a user message to prevent
+ * that error.
  *
  * This processor should only be added when the agent uses a Claude 4.6 model.
  * Use {@link isMaybeClaude46} to check before adding.
@@ -55,13 +55,13 @@ export class TrailingAssistantGuard implements Processor<'trailing-assistant-gua
   readonly name = 'Trailing Assistant Guard';
 
   processInputStep({ messages, structuredOutput }: ProcessInputStepArgs): ProcessInputStepResult | undefined {
+    const lastMessage = messages[messages.length - 1];
+    if (!lastMessage || lastMessage.role !== 'assistant') return;
+
     const willUseResponseFormat =
       structuredOutput?.schema && !structuredOutput?.model && !structuredOutput?.jsonPromptInjection;
 
-    if (!willUseResponseFormat) return;
-
-    const lastMessage = messages[messages.length - 1];
-    if (!lastMessage || lastMessage.role !== 'assistant') return;
+    const promptText = willUseResponseFormat ? 'Generate the structured response.' : 'Continue.';
 
     return {
       messages: [
@@ -71,7 +71,7 @@ export class TrailingAssistantGuard implements Processor<'trailing-assistant-gua
           role: 'user' as const,
           content: {
             format: 2 as const,
-            parts: [{ type: 'text' as const, text: 'Generate the structured response.' }],
+            parts: [{ type: 'text' as const, text: promptText }],
           },
           createdAt: new Date(),
         },

--- a/packages/core/src/processors/trailing-assistant-guard.ts
+++ b/packages/core/src/processors/trailing-assistant-guard.ts
@@ -58,10 +58,7 @@ export class TrailingAssistantGuard implements Processor<'trailing-assistant-gua
     const lastMessage = messages[messages.length - 1];
     if (!lastMessage || lastMessage.role !== 'assistant') return;
 
-    const willUseResponseFormat =
-      structuredOutput?.schema && !structuredOutput?.model && !structuredOutput?.jsonPromptInjection;
-
-    const promptText = willUseResponseFormat ? 'Generate the structured response.' : 'Continue.';
+    const promptText = structuredOutput?.schema ? 'Generate the structured response.' : 'Continue.';
 
     return {
       messages: [


### PR DESCRIPTION
## Summary

- Claude 4.6 rejects assistant message prefill in **all** request types, not just structured output. The existing `TrailingAssistantGuard` only fired when `structuredOutput.schema` was set, leaving normal streaming/generate calls vulnerable to the API error: *"This model does not support assistant message prefill. The conversation must end with a user message."*
- This extends the guard to append a synthetic user message whenever the last message is an assistant message, regardless of structured output. Uses `"Continue."` for plain requests and `"Generate the structured response."` for structured output (unchanged).
- Adds a regression test for the non-structured-output case.

## Context

The original `TrailingAssistantGuard` (PR #12835) was scoped to structured output because that was the initially reported scenario. However, Claude Opus 4.6 enforces the no-prefill restriction universally. This surfaces in practice during the agentic loop — e.g., after tool approval/resume, when memory loads a conversation ending with an assistant message, or when the network routing agent constructs an assistant-role prompt.

## Test plan

- [x] Existing structured output tests pass (no behavioral change for that path)
- [ ] New test: `should not send prompt ending with assistant message even WITHOUT structuredOutput (plain streaming)` — verifies the guard fires for non-structured-output cases with Claude 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trailing assistant-message guard now applies universally across all request types (including plain streaming), ensuring assistant-prefill messages are consistently rejected and prompts end in a user message when required.

* **Tests**
  * Added and updated test coverage to verify assistant message prefill rejection in plain streaming and other scenarios, reinforcing the guard's behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->