### PR TITLE
fix: handle unquoted date values in tool call arguments

### DIFF
--- a/.changeset/vast-turtles-sing.md
+++ b/.changeset/vast-turtles-sing.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed tryRepairJson to handle unquoted date values (e.g. 2026-04-15) in tool call arguments. LLMs like Claude Sonnet sometimes produce bare date values without quotes, causing JSON.parse to fail and tool calls to silently lose all arguments. The repair function now detects and quotes date-like values matching YYYY-MM-DD and YYYY-MM-DDTHH:MM:SS patterns. See https://github.com/mastra-ai/mastra/issues/14230

--- a/packages/core/src/stream/aisdk/v5/transform.test.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.test.ts
@@ -307,6 +307,29 @@ describe('convertFullStreamChunkToMastra', () => {
       }
     });
 
+    it('should repair JSON with unquoted date values in tool args (issue #14230)', () => {
+      const chunk: StreamPart = {
+        type: 'tool-call',
+        toolCallId: 'call-repair-dates',
+        toolName: 'edit_milestone',
+        input: '{"milestoneId": "abc123", "name": "Sprint 1", "dueStart": 2026-04-15, "dueEnd": 2026-06-30}',
+        providerExecuted: false,
+      };
+
+      const result = convertFullStreamChunkToMastra(chunk, { runId: 'test-run-123' });
+
+      expect(result).toBeDefined();
+      expect(result?.type).toBe('tool-call');
+      if (result?.type === 'tool-call') {
+        expect(result.payload.args).toEqual({
+          milestoneId: 'abc123',
+          name: 'Sprint 1',
+          dueStart: '2026-04-15',
+          dueEnd: '2026-06-30',
+        });
+      }
+    });
+
     it('should repair JSON with trailing commas', () => {
       const chunk: StreamPart = {
         type: 'tool-call',
@@ -467,6 +490,31 @@ describe('convertFullStreamChunkToMastra', () => {
     it('should fix property names with _ prefix', () => {
       const result = tryRepairJson('{_id:"123",_type:"user"}');
       expect(result).toEqual({ _id: '123', _type: 'user' });
+    });
+
+    it('should quote unquoted date values like YYYY-MM-DD (issue #14230)', () => {
+      const result = tryRepairJson(
+        '{"milestoneId": "abc123", "name": "Sprint 1", "dueStart": 2026-04-15, "dueEnd": 2026-06-30}',
+      );
+      expect(result).toEqual({
+        milestoneId: 'abc123',
+        name: 'Sprint 1',
+        dueStart: '2026-04-15',
+        dueEnd: '2026-06-30',
+      });
+    });
+
+    it('should quote unquoted date value before closing brace (issue #14230)', () => {
+      const result = tryRepairJson('{"date": 2026-04-15}');
+      expect(result).toEqual({ date: '2026-04-15' });
+    });
+
+    it('should quote unquoted datetime values with time component (issue #14230)', () => {
+      const result = tryRepairJson('{"start": 2026-04-15T09:00:00, "end": 2026-04-15T17:00:00}');
+      expect(result).toEqual({
+        start: '2026-04-15T09:00:00',
+        end: '2026-04-15T17:00:00',
+      });
     });
   });
 

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -82,6 +82,11 @@ export function tryRepairJson(input: string): Record<string, any> | null {
   // e.g. {"a":1,} → {"a":1}
   repaired = repaired.replace(/,(\s*[}\]])/g, '$1');
 
+  // Fix 5: Unquoted date/datetime values (issue #14230)
+  // e.g. {"dueStart": 2026-04-15} → {"dueStart": "2026-04-15"}
+  // e.g. {"start": 2026-04-15T09:00:00} → {"start": "2026-04-15T09:00:00"}
+  repaired = repaired.replace(/:\s*(\d{4}-\d{2}-\d{2}(?:T[\d:]+)?)\s*([,}])/g, ': "$1"$2');
+
   try {
     return JSON.parse(repaired);
   } catch {


### PR DESCRIPTION
## Description

Fixed tryRepairJson to handle unquoted date values (e.g., 2026-04-15) in tool call arguments. LLMs sometimes produce bare date values without quotes, causing JSON.parse to fail and tool calls to silently lose all arguments. The repair function now detects and quotes date-like values matching YYYY-MM-DD and YYYY-MM-DDTHH:MM:SS patterns.

## Related Issue(s)

Fixes #14230

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date value handling in tool call arguments. Unquoted date values (e.g., 2026-04-15) are now automatically quoted to prevent JSON parsing errors and ensure tool arguments are preserved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->