### PR TITLE
fix(server): return graceful responses for memory endpoints without memory config

### DIFF
--- a/.changeset/gold-radios-attack.md
+++ b/.changeset/gold-radios-attack.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed memory API endpoints (`/memory/config` and `/memory/threads/:threadId/working-memory`) returning 400 errors when agents don't have memory configured. These endpoints now return graceful null responses instead of throwing, preventing console error noise in the playground/studio. Fixes regression of #11765.

--- a/packages/server/src/server/handlers/memory.test.ts
+++ b/packages/server/src/server/handlers/memory.test.ts
@@ -8,6 +8,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HTTPException } from '../http-exception';
 import {
   GET_MEMORY_STATUS_ROUTE,
+  GET_MEMORY_CONFIG_ROUTE,
+  GET_WORKING_MEMORY_ROUTE,
   LIST_THREADS_ROUTE,
   GET_THREAD_BY_ID_ROUTE,
   SAVE_MESSAGES_ROUTE,
@@ -183,6 +185,71 @@ describe('Memory Handlers', () => {
 
       // This is the expected behavior - graceful empty response
       expect(result).toEqual({ messages: [], uiMessages: [] });
+    });
+  });
+
+  /**
+   * Issue #11765 (regression): GET_MEMORY_CONFIG_ROUTE should gracefully handle agents without memory
+   *
+   * The playground UI calls GET /memory/config?agentId=<agentId> for all agents.
+   * When memory is not configured, this should return null config instead of throwing HTTPException(400).
+   */
+  describe('getMemoryConfigHandler - Issue #11765 regression', () => {
+    it('should return null config when agent has no memory configured (not throw)', async () => {
+      const agentWithoutMemory = new Agent({
+        id: 'no-memory-agent',
+        name: 'Agent Without Memory',
+        instructions: 'test-instructions',
+        model: {} as any,
+      });
+
+      const mastra = new Mastra({
+        logger: false,
+        agents: { 'no-memory-agent': agentWithoutMemory },
+      });
+
+      const result = await GET_MEMORY_CONFIG_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        agentId: 'no-memory-agent',
+      });
+
+      expect(result).toEqual({ config: null });
+    });
+  });
+
+  /**
+   * Issue #11765 (regression): GET_WORKING_MEMORY_ROUTE should gracefully handle agents without memory
+   *
+   * The playground UI calls GET /memory/threads/:threadId/working-memory?agentId=<agentId>.
+   * When memory is not configured, this should return null instead of throwing HTTPException(400).
+   */
+  describe('getWorkingMemoryHandler - Issue #11765 regression', () => {
+    it('should return null working memory when agent has no memory configured (not throw)', async () => {
+      const agentWithoutMemory = new Agent({
+        id: 'no-memory-agent',
+        name: 'Agent Without Memory',
+        instructions: 'test-instructions',
+        model: {} as any,
+      });
+
+      const mastra = new Mastra({
+        logger: false,
+        agents: { 'no-memory-agent': agentWithoutMemory },
+      });
+
+      const result = await GET_WORKING_MEMORY_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        agentId: 'no-memory-agent',
+        threadId: 'test-thread',
+        resourceId: 'test-resource',
+      });
+
+      expect(result).toEqual({
+        workingMemory: null,
+        source: 'thread',
+        workingMemoryTemplate: null,
+        threadExists: false,
+      });
     });
   });
 

--- a/packages/server/src/server/handlers/memory.ts
+++ b/packages/server/src/server/handlers/memory.ts
@@ -397,7 +397,9 @@ export const GET_MEMORY_CONFIG_ROUTE = createRoute({
       const memory = await getMemoryFromContext({ mastra, agentId, requestContext });
 
       if (!memory) {
-        throw new HTTPException(400, { message: 'Memory is not initialized' });
+        // Return null config when memory is not configured (Issue #11765)
+        // This allows the playground UI to gracefully handle agents without memory
+        return { config: null };
       }
 
       // Get the merged configuration (defaults + custom)
@@ -780,7 +782,9 @@ export const GET_WORKING_MEMORY_ROUTE = createRoute({
       const memory = await getMemoryFromContext({ mastra, agentId, requestContext });
       validateBody({ threadId: effectiveThreadId });
       if (!memory) {
-        throw new HTTPException(400, { message: 'Memory is not initialized' });
+        // Return null working memory when memory is not configured (Issue #11765)
+        // This allows the playground UI to gracefully handle agents without memory
+        return { workingMemory: null, source: 'thread' as const, workingMemoryTemplate: null, threadExists: false };
       }
       const thread = await memory.getThreadById({ threadId: effectiveThreadId! });
       if (thread) {

--- a/packages/server/src/server/schemas/memory.ts
+++ b/packages/server/src/server/schemas/memory.ts
@@ -381,12 +381,14 @@ const observationalMemoryConfigSchema = z.object({
  * MemoryConfig is complex with many optional fields - using passthrough
  */
 export const memoryConfigResponseSchema = z.object({
-  config: z.object({
-    lastMessages: z.union([z.number(), z.literal(false)]).optional(),
-    semanticRecall: z.union([z.boolean(), z.any()]).optional(),
-    workingMemory: z.any().optional(),
-    observationalMemory: observationalMemoryConfigSchema.optional(),
-  }),
+  config: z
+    .object({
+      lastMessages: z.union([z.number(), z.literal(false)]).optional(),
+      semanticRecall: z.union([z.boolean(), z.any()]).optional(),
+      workingMemory: z.any().optional(),
+      observationalMemory: observationalMemoryConfigSchema.optional(),
+    })
+    .nullable(),
 });
 
 /**


### PR DESCRIPTION
## Description

Fixed memory API endpoints (`/memory/config` and `/memory/threads/:threadId/working-memory`) returning 400 errors when agents don't have memory configured. These endpoints now return graceful null responses instead of throwing, preventing console error spam in the playground/studio.

This resolves a regression of #11765 where the playground UI unconditionally calls memory endpoints for all agents, causing error logs even though the agents function correctly.

## Related Issue(s)

Fixes #11765

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Memory API endpoints now gracefully handle agents without memory configuration, returning null/empty responses (instead of 400 errors), reducing console error noise in the playground/studio and addressing a regression.

* **Tests**
  * Added regression tests to ensure memory endpoints return stable null responses when no memory is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->