### PR TITLE
Return spanId alongside traceId for agent and workflow executions

### DIFF
--- a/.changeset/flat-seals-observe.md
+++ b/.changeset/flat-seals-observe.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+`@mastra/core`: patch
+
+Added `spanId` alongside `traceId` on `agent.stream()`, `agent.generate()`, and workflow execution results so integrations can query observability vendors by run root span ID (for example, optimized Braintrust root span lookups)

--- a/.changeset/flat-seals-observe.md
+++ b/.changeset/flat-seals-observe.md
@@ -4,4 +4,4 @@
 
 `@mastra/core`: patch
 
-Added `spanId` alongside `traceId` on `agent.stream()`, `agent.generate()`, and workflow execution results so integrations can query observability vendors by run root span ID (for example, optimized Braintrust root span lookups)
+Added `spanId` alongside `traceId` across user-facing execution results that return tracing identifiers (including agent stream/generate and workflow run results) so integrations can query observability vendors by run root span ID

--- a/docs/src/content/en/docs/observability/tracing/exporters/braintrust.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/braintrust.mdx
@@ -94,6 +94,21 @@ new BraintrustExporter({
 })
 ```
 
+## Querying Braintrust with returned `spanId`
+
+Mastra execution results now return both `traceId` and `spanId` when tracing is enabled. For Braintrust, use `spanId` as the root span identifier when searching for traces because Braintrust root-span queries are typically faster than trace-id queries.
+
+```typescript title="src/mastra/usage.ts"
+const result = await agent.stream('Summarize this ticket')
+
+console.log('Mastra trace ID:', result.traceId)
+console.log('Braintrust root span ID:', result.spanId)
+
+// Use result.spanId in your Braintrust lookup/query path
+```
+
+The same applies to `agent.generate()` and workflow run results (`run.start()`, `run.stream()` final state, `run.resume()`).
+
 ## Related
 
 - [Tracing Overview](/docs/observability/tracing/overview)

--- a/docs/src/content/en/docs/observability/tracing/exporters/braintrust.mdx
+++ b/docs/src/content/en/docs/observability/tracing/exporters/braintrust.mdx
@@ -96,7 +96,7 @@ new BraintrustExporter({
 
 ## Querying Braintrust with returned `spanId`
 
-Mastra execution results now return both `traceId` and `spanId` when tracing is enabled. For Braintrust, use `spanId` as the root span identifier when searching for traces because Braintrust root-span queries are typically faster than trace-id queries.
+For Braintrust, use `spanId` as the root span identifier when searching for traces because Braintrust root-span queries are typically faster than trace-id queries.
 
 ```typescript title="src/mastra/usage.ts"
 const result = await agent.stream('Summarize this ticket')

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -873,7 +873,7 @@ All options are optional — if not specified, they fall back to the defaults sh
 
 ## Retrieving trace IDs
 
-When you execute agents or workflows with tracing enabled, responses include a `traceId` and `spanId` (the run root span) that you can use to look up data in your observability platform. This is especially helpful for backends that optimize root-span queries, such as Braintrust. This is useful for debugging, customer support, or correlating traces with other events in your system.
+When you execute agents or workflows with tracing enabled, responses include a `traceId` and `spanId` (the run root span) that you can use to look up data in your observability platform. This is useful for debugging, customer support, or correlating traces with other events in your system.
 
 ### Agent Trace IDs
 
@@ -884,13 +884,13 @@ Both `generate` and `stream` return `traceId` and `spanId`:
 const result = await agent.generate('Hello')
 
 console.log('Trace ID:', result.traceId)
-console.log('Span ID:', result.spanId) // root span ID for this generate execution
+console.log('Span ID:', result.spanId)
 
 // Using stream
 const streamResult = await agent.stream('Tell me a story')
 
 console.log('Trace ID:', streamResult.traceId)
-console.log('Span ID:', streamResult.spanId) // root span ID for this stream execution
+console.log('Span ID:', streamResult.spanId)
 ```
 
 ### Workflow Trace IDs
@@ -907,7 +907,7 @@ const result = await run.start({
 })
 
 console.log('Trace ID:', result.traceId)
-console.log('Span ID:', result.spanId) // workflow run root span ID
+console.log('Span ID:', result.spanId)
 
 // Or stream the workflow
 const { stream, getWorkflowState } = run.stream({

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -873,27 +873,29 @@ All options are optional — if not specified, they fall back to the defaults sh
 
 ## Retrieving trace IDs
 
-When you execute agents or workflows with tracing enabled, the response includes a `traceId` that you can use to look up the full trace in your observability platform. This is useful for debugging, customer support, or correlating traces with other events in your system.
+When you execute agents or workflows with tracing enabled, responses include a `traceId` and `spanId` (the run root span) that you can use to look up data in your observability platform. This is especially helpful for backends that optimize root-span queries, such as Braintrust. This is useful for debugging, customer support, or correlating traces with other events in your system.
 
 ### Agent Trace IDs
 
-Both `generate` and `stream` methods return the trace ID in their response:
+Both `generate` and `stream` return `traceId` and `spanId`:
 
 ```ts
 // Using generate
 const result = await agent.generate('Hello')
 
 console.log('Trace ID:', result.traceId)
+console.log('Span ID:', result.spanId) // root span ID for this generate execution
 
 // Using stream
 const streamResult = await agent.stream('Tell me a story')
 
 console.log('Trace ID:', streamResult.traceId)
+console.log('Span ID:', streamResult.spanId) // root span ID for this stream execution
 ```
 
 ### Workflow Trace IDs
 
-Workflow executions also return trace IDs:
+Workflow executions also return `traceId` and `spanId`:
 
 ```ts
 // Create a workflow run
@@ -905,6 +907,7 @@ const result = await run.start({
 })
 
 console.log('Trace ID:', result.traceId)
+console.log('Span ID:', result.spanId) // workflow run root span ID
 
 // Or stream the workflow
 const { stream, getWorkflowState } = run.stream({
@@ -914,6 +917,7 @@ const { stream, getWorkflowState } = run.stream({
 // Get the final state which includes the trace ID
 const finalState = await getWorkflowState()
 console.log('Trace ID:', finalState.traceId)
+console.log('Span ID:', finalState.spanId)
 ```
 
 ### Using Trace IDs

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -873,29 +873,27 @@ All options are optional — if not specified, they fall back to the defaults sh
 
 ## Retrieving trace IDs
 
-When you execute agents or workflows with tracing enabled, responses include a `traceId` and `spanId` (the run root span) that you can use to look up data in your observability platform. This is useful for debugging, customer support, or correlating traces with other events in your system.
+When you execute agents or workflows with tracing enabled, the response includes a `traceId` that you can use to look up the full trace in your observability platform. This is useful for debugging, customer support, or correlating traces with other events in your system.
 
 ### Agent Trace IDs
 
-Both `generate` and `stream` return `traceId` and `spanId`:
+Both `generate` and `stream` methods return the trace ID in their response:
 
 ```ts
 // Using generate
 const result = await agent.generate('Hello')
 
 console.log('Trace ID:', result.traceId)
-console.log('Span ID:', result.spanId)
 
 // Using stream
 const streamResult = await agent.stream('Tell me a story')
 
 console.log('Trace ID:', streamResult.traceId)
-console.log('Span ID:', streamResult.spanId)
 ```
 
 ### Workflow Trace IDs
 
-Workflow executions also return `traceId` and `spanId`:
+Workflow executions also return trace IDs:
 
 ```ts
 // Create a workflow run
@@ -907,7 +905,6 @@ const result = await run.start({
 })
 
 console.log('Trace ID:', result.traceId)
-console.log('Span ID:', result.spanId)
 
 // Or stream the workflow
 const { stream, getWorkflowState } = run.stream({
@@ -917,7 +914,6 @@ const { stream, getWorkflowState } = run.stream({
 // Get the final state which includes the trace ID
 const finalState = await getWorkflowState()
 console.log('Trace ID:', finalState.traceId)
-console.log('Span ID:', finalState.spanId)
 ```
 
 ### Using Trace IDs

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -1096,6 +1096,13 @@ console.log(`Remaining requests: ${remainingRequests}, Remaining tokens: ${remai
       'The trace ID associated with this execution when Tracing is enabled. Use this to correlate logs and debug execution flow.',
   },
   {
+    name: 'spanId',
+    type: 'string',
+    isOptional: true,
+    description:
+      'The root span ID associated with this execution when Tracing is enabled. Use this for span-level lookup and correlation.',
+  },
+  {
     name: 'messages',
     type: 'MastraDBMessage[]',
     description: 'All messages from this execution including input, memory history, and response.',

--- a/docs/src/content/en/reference/agents/network.mdx
+++ b/docs/src/content/en/reference/agents/network.mdx
@@ -323,6 +323,13 @@ await agent.network(`
               'The trace ID associated with this execution when Tracing is enabled. Use this to correlate logs and debug execution flow.',
           },
           {
+            name: 'spanId',
+            type: 'string',
+            isOptional: true,
+            description:
+              'The root span ID associated with this execution when Tracing is enabled. Use this for span-level lookup and correlation.',
+          },
+          {
             name: 'onStepFinish',
             type: '(event: any) => Promise<void> | void',
             isOptional: true,

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -831,6 +831,13 @@ const stream = await agent.stream('message for agent')
     description:
       'The trace ID associated with this execution when Tracing is enabled. Use this to correlate logs and debug execution flow.',
   },
+  {
+    name: 'spanId',
+    type: 'string',
+    isOptional: true,
+    description:
+      'The root span ID associated with this execution when Tracing is enabled. Use this for span-level lookup and correlation.',
+  },
 ]}
 />
 

--- a/docs/src/content/en/reference/workflows/run-methods/restart.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/restart.mdx
@@ -130,6 +130,13 @@ const restartedResult = await run.restart()
     description:
       'The trace ID associated with this execution when Tracing is enabled. Use this to correlate logs and debug execution flow.',
   },
+  {
+    name: 'spanId',
+    type: 'string',
+    isOptional: true,
+    description:
+      'The root span ID associated with this execution when Tracing is enabled. Use this for span-level lookup and correlation.',
+  },
 ]}
 />
 

--- a/docs/src/content/en/reference/workflows/run-methods/resume.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/resume.mdx
@@ -171,6 +171,13 @@ if (result.status === 'suspended') {
     description:
       'The trace ID associated with this execution when Tracing is enabled. Use this to correlate logs and debug execution flow.',
   },
+  {
+    name: 'spanId',
+    type: 'string',
+    isOptional: true,
+    description:
+      'The root span ID associated with this execution when Tracing is enabled. Use this for span-level lookup and correlation.',
+  },
 ]}
 />
 

--- a/docs/src/content/en/reference/workflows/run-methods/start.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/start.mdx
@@ -162,6 +162,13 @@ const result = await run.start({
     description:
       'The trace ID associated with this execution when Tracing is enabled. Use this to correlate logs and debug execution flow.',
   },
+  {
+    name: 'spanId',
+    type: 'string',
+    isOptional: true,
+    description:
+      'The root span ID associated with this execution when Tracing is enabled. Use this for span-level lookup and correlation.',
+  },
 ]}
 />
 

--- a/docs/src/content/en/reference/workflows/run-methods/timeTravel.mdx
+++ b/docs/src/content/en/reference/workflows/run-methods/timeTravel.mdx
@@ -205,6 +205,13 @@ const result = await run.timeTravel({
     description:
       'The trace ID associated with this execution when Tracing is enabled. Use this to correlate logs and debug execution flow.',
   },
+  {
+    name: 'spanId',
+    type: 'string',
+    isOptional: true,
+    description:
+      'The root span ID associated with this execution when Tracing is enabled. Use this for span-level lookup and correlation.',
+  },
 ]}
 />
 

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -958,6 +958,7 @@ export class AgentLegacyHandler {
     const beforeResult = await before();
     const { messageList, requestContext: contextWithMemory } = beforeResult;
     const traceId = beforeResult.agentSpan?.externalTraceId;
+    const spanId = beforeResult.agentSpan?.id;
 
     // Check for tripwire and return early if triggered
     if (beforeResult.tripwire) {
@@ -997,6 +998,7 @@ export class AgentLegacyHandler {
         experimental_providerMetadata: undefined,
         tripwire: beforeResult.tripwire,
         traceId,
+        spanId,
       };
 
       return tripwireResult as unknown as OUTPUT extends undefined
@@ -1071,6 +1073,7 @@ export class AgentLegacyHandler {
           experimental_providerMetadata: undefined,
           tripwire: outputProcessorResult.tripwire,
           traceId,
+          spanId,
         };
 
         return tripwireResult as unknown as OUTPUT extends undefined
@@ -1134,6 +1137,7 @@ export class AgentLegacyHandler {
       }
 
       result.traceId = traceId;
+      (result as any).spanId = spanId;
 
       return result as any;
     }
@@ -1199,6 +1203,7 @@ export class AgentLegacyHandler {
         experimental_providerMetadata: undefined,
         tripwire: outputProcessorResult.tripwire,
         traceId,
+        spanId,
       };
 
       return tripwireResult as unknown as OUTPUT extends undefined
@@ -1233,6 +1238,7 @@ export class AgentLegacyHandler {
     }
 
     result.traceId = traceId;
+    (result as any).spanId = spanId;
 
     return result as any;
   }
@@ -1291,6 +1297,7 @@ export class AgentLegacyHandler {
 
     const beforeResult = await before();
     const traceId = beforeResult.agentSpan?.externalTraceId;
+    const spanId = beforeResult.agentSpan?.id;
 
     // Check for tripwire and return early if triggered
     if (beforeResult.tripwire) {
@@ -1340,6 +1347,7 @@ export class AgentLegacyHandler {
         steps: undefined,
         experimental_providerMetadata: undefined,
         traceId,
+        spanId,
         toAIStream: () =>
           Promise.resolve('').then(() => {
             const emptyStream = new (globalThis as any).ReadableStream({
@@ -1428,6 +1436,7 @@ export class AgentLegacyHandler {
       });
 
       streamResult.traceId = traceId;
+      (streamResult as any).spanId = spanId;
 
       return streamResult as unknown as
         | StreamTextResult<any, OUTPUT extends ZodSchema ? z.infer<OUTPUT> : unknown>
@@ -1506,6 +1515,7 @@ export class AgentLegacyHandler {
     });
 
     (streamObjectResult as any).traceId = traceId;
+    (streamObjectResult as any).spanId = spanId;
 
     return streamObjectResult as StreamObjectResult<OUTPUT extends ZodSchema ? OUTPUT : never> & TracingProperties;
   }

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -972,6 +972,8 @@ export interface TracingContext {
 export type TracingProperties = {
   /** Trace ID used on the execution (if the execution was traced). */
   traceId?: string;
+  /** Root span ID used on the execution (if the execution was traced). */
+  spanId?: string;
 };
 
 // ============================================================================

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -169,5 +169,34 @@ describe('MastraModelOutput', () => {
       // Custom chunk should appear before the finish chunk
       expect(customIndex).toBeLessThan(finishIndex);
     });
+
+    it('should include traceId and spanId in the final stream result when tracing context exists', async () => {
+      const runId = 'test-run';
+      const messageList = new MessageList({ threadId: 'test-thread' });
+
+      const stream = createChunkStream([createStepFinishChunk(runId), createFinishChunk(runId)]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: {
+          runId,
+          tracingContext: {
+            currentSpan: {
+              id: 'mastra-root-span-id',
+              externalTraceId: 'mastra-trace-id',
+            },
+          } as any,
+        },
+      });
+
+      await output.consumeStream();
+      const result = await output.result;
+
+      expect(result.traceId).toBe('mastra-trace-id');
+      expect(result.spanId).toBe('mastra-root-span-id');
+    });
   });
 });

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -127,6 +127,8 @@ export type FullOutput<OUTPUT = undefined> = {
   };
   /** Trace ID for observability */
   traceId: string | undefined;
+  /** Span ID for observability (root span ID for a top-level agent execution) */
+  spanId: string | undefined;
   /** Run ID for this execution */
   runId: string | undefined;
   /** Payload for resuming suspended tool calls */
@@ -249,6 +251,10 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
    * Trace ID used on the execution (if the execution was traced).
    */
   public traceId?: string;
+  /**
+   * Span ID used on the execution (if the execution was traced).
+   */
+  public spanId?: string;
   public messageId: string;
 
   constructor({
@@ -276,6 +282,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
     this.#returnScorerData = !!options.returnScorerData;
     this.runId = options.runId;
     this.traceId = options.tracingContext?.currentSpan?.externalTraceId;
+    this.spanId = options.tracingContext?.currentSpan?.id;
 
     this.#model = _model;
 
@@ -1332,6 +1339,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
       tripwire: this.#tripwire,
       ...(scoringData ? { scoringData } : {}),
       traceId: this.traceId,
+      spanId: this.spanId,
       runId: this.runId,
       suspendPayload: await this.suspendPayload,
       resumeSchema: await this.resumeSchema,

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -2943,6 +2943,7 @@ export class Run<
     });
 
     const traceId = workflowSpan?.externalTraceId;
+    const spanId = workflowSpan?.id;
     const inputDataToUse = await this._validateInput(inputData);
     const initialStateToUse = await this._validateInitialState(initialState ?? ({} as TState));
     await this._validateRequestContext(requestContext as RequestContext);
@@ -2972,6 +2973,7 @@ export class Run<
     }
 
     result.traceId = traceId;
+    result.spanId = spanId;
     return result;
   }
 
@@ -3719,6 +3721,7 @@ export class Run<
     });
 
     const traceId = workflowSpan?.externalTraceId;
+    const spanId = workflowSpan?.id;
 
     const executionResultPromise = this.executionEngine
       .execute<TState, TInput, WorkflowResult<TState, TInput, TOutput, TSteps>>({
@@ -3753,6 +3756,7 @@ export class Run<
           this.closeStreamAction?.().catch(() => {});
         }
         result.traceId = traceId;
+        result.spanId = spanId;
         return result;
       });
 
@@ -3853,6 +3857,7 @@ export class Run<
     });
 
     const traceId = workflowSpan?.externalTraceId;
+    const spanId = workflowSpan?.id;
 
     const result = await this.executionEngine.execute<TState, TInput, WorkflowResult<TState, TInput, TOutput, TSteps>>({
       workflowId: this.workflowId,
@@ -3875,6 +3880,7 @@ export class Run<
     }
 
     result.traceId = traceId;
+    result.spanId = spanId;
     return result;
   }
 
@@ -3985,6 +3991,7 @@ export class Run<
     });
 
     const traceId = workflowSpan?.externalTraceId;
+    const spanId = workflowSpan?.id;
 
     const result = await this.executionEngine.execute<TState, TInput, WorkflowResult<TState, TInput, TOutput, TSteps>>({
       workflowId: this.workflowId,
@@ -4009,6 +4016,7 @@ export class Run<
     }
 
     result.traceId = traceId;
+    result.spanId = spanId;
     return result;
   }
 


### PR DESCRIPTION
### Motivation

- Provide the root span identifier (`spanId`) along with `traceId` so integrations can query observability backends (e.g., Braintrust) by run root span for faster root-span lookups and better correlation.

### Description

- Add `spanId` to tracing types (`TracingProperties` and `SpanIds`) and expose it on model/stream outputs by adding `spanId` to `FullOutput` and `MastraModelOutput`.
- Populate `spanId` from active spans in agent legacy handlers (`generateLegacy`/`streamLegacy`) and in workflow run paths (`run.start`, `run.stream` final state, `run.resume`, `_restart`, `_timeTravel`, etc.).
- Update docs to document `spanId` usage and Braintrust guidance, and add a changeset noting the patch.
- Add a unit test to assert that `traceId` and `spanId` are included in final stream results when a tracing context exists.

### Testing

- Ran the core unit tests including `packages/core/src/stream/base/output.test.ts` where the new test asserting `traceId` and `spanId` passed (`pnpm test` / test suite completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b30102ee048322987b2035be80e69e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added spanId to agent.generate(), agent.stream(), workflow run results, and relevant run methods/parameters — exposes a root span identifier alongside traceId.
* **Documentation**
  * Updated tracing docs with examples and guidance (including vendor lookup guidance) showing how to use spanId across agent and workflow flows.
* **Tests**
  * Added a test ensuring spanId is included in final stream results when tracing is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->