### PR TITLE
fix(playground-ui): enable independent scrolling for agent playground panels

### DIFF
--- a/.changeset/calm-needles-study.md
+++ b/.changeset/calm-needles-study.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed agent playground panels growing together when content overflows. Left and right columns now scroll independently.

--- a/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-view.tsx
+++ b/packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-view.tsx
@@ -151,7 +151,7 @@ export function AgentPlaygroundView({
   });
 
   return (
-    <div className="flex flex-col h-full bg-surface2">
+    <div className="flex flex-col h-full overflow-hidden bg-surface2">
       <Group className="flex-1 min-h-0" defaultLayout={defaultLayout} onLayoutChange={onLayoutChange}>
         {/* Left panel - Version Bar + Configuration + Action Bar */}
         <Panel id="playground-config" minSize={30} defaultSize={50} className="overflow-hidden">


### PR DESCRIPTION
## Summary

Adds `overflow-hidden` to the `AgentPlaygroundView` wrapper div so the left (config) and right (test chat/experiment) panels scroll independently instead of growing together.

### Problem

When one panel's content grew tall (e.g. a long chat conversation), the outer container expanded beyond the viewport. This caused the CSS Grid `1fr` row — which resolves to `minmax(auto, 1fr)` — to grow with it, stretching **both** panels since they reference the same row height.

### Fix

Adding `overflow-hidden` to the `AgentPlaygroundView` wrapper prevents it from growing beyond its grid area. Each panel's internal `ScrollArea` / `overflow-y-scroll` then handles scrolling independently.

### Changed files

- `packages/playground-ui/src/domains/agents/components/agent-playground/agent-playground-view.tsx`

### Test plan

1. Open an agent's Playground tab
2. Add enough content to the left config panel (long system prompt, many tools) to overflow
3. Switch to the Test Chat tab on the right and send several messages to create a long conversation
4. Verify each column scrolls independently — scrolling one does not affect the other
5. Verify the resizable panel separator still works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent playground layout so left and right panels no longer grow together on content overflow; columns now scroll independently.
* **Style**
  * Improved overflow handling in the agent playground view for a cleaner, more stable visual presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->